### PR TITLE
test(xray): migrate remaining test suites onto make-xray-runtime-fixture (rf2-vj80u8 remainder)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
@@ -27,8 +27,6 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.core :as core]
             [day8.re-frame2-xray.mount :as mount]
@@ -39,18 +37,13 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds the sentinel + trace-collector
-  ;; + settings reset into one call. rf2-2thl2 — the settings reset
-  ;; matters because init! writes through to the persisted Settings atom;
-  ;; reset between tests so per-test mutations don't leak into the next
-  ;; test's read.
-  (xray-test-support/reset-runtime!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the `:runtime` reset tier —
+  ;; sentinels + trace-collector rings + the persisted Settings atom. rf2-2thl2
+  ;; — the settings reset matters because init! writes through to that atom,
+  ;; so per-test mutations must not leak into the next test's read.
+  (xray-test-support/make-xray-runtime-fixture {:tier :runtime}))
 
 (defn- setup-xray-frame!
   "Per-test boot: register handlers, allocate the :rf/xray frame."

--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -19,8 +19,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
@@ -29,18 +27,15 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  ;; Force-cleanup any stale drag-state from a previous test (the
-  ;; module-level defonce atom survives fixture reset).
-  (shell/col-divider-simulate-up!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8): plain-atom + the `:runtime`
+  ;; reset tier (sentinels + trace rings + persisted settings); `:post-reset`
+  ;; force-clears the module-level drag-state defonce (survives the runtime
+  ;; reset) so no stale drag leaks between tests. (`trace-collector` stays
+  ;; required for the `seed-trace-for-test!` seeding below.)
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn [] (shell/col-divider-simulate-up!))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -27,8 +27,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
@@ -37,18 +35,14 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  ;; Force-cleanup any stale seam-drag state from a previous test (the
-  ;; module-level defonce atom survives fixture reset).
-  (resize-handle/seam-simulate-up!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8): plain-atom + the `:runtime`
+  ;; reset tier (sentinels + trace rings + persisted settings); `:post-reset`
+  ;; force-clears the module-level seam-drag defonce (survives the runtime
+  ;; reset) so no stale drag leaks between tests.
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn [] (resize-handle/seam-simulate-up!))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
@@ -12,20 +12,17 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.filters :as filters]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
@@ -16,8 +16,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
@@ -25,16 +23,15 @@
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (spine-filters/clear-raw!)
-  (frame-switcher/clear!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset into one owner
+  ;; (plain-atom + the `:all` tier, which already covers the trace-collector
+  ;; rings the old init reset a SECOND time); `:post-reset` carries this
+  ;; suite's filter-state tail.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (spine-filters/clear-raw!)
+                   (frame-switcher/clear!))}))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
@@ -9,24 +9,21 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.filters :as filters]
             [day8.re-frame2-xray.filters.persistence :as persistence]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (persistence/clear!)
-  (config/set-filters-storage-key! nil)
-  (config/set-filter-seed! nil))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier) into one owner; `:post-reset` carries this suite's
+  ;; persistence-slate tail.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (persistence/clear!)
+                   (config/set-filters-storage-key! nil)
+                   (config/set-filter-seed! nil))}))
 
 (defn- xray-setup!
   "Register Xray handlers + the :rf/xray frame, then re-run the

--- a/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
@@ -7,20 +7,17 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.filters.pills :as pills]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.theme.tokens :refer [tokens]]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
@@ -13,21 +13,17 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/filters/typed_predicates_events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/typed_predicates_events_cljs_test.cljs
@@ -14,18 +14,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
@@ -20,25 +20,19 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.focus :as focus]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): plain-atom adapter
+  ;; + the `:all` reset tier — install (== preload's alias) + registry +
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
@@ -19,27 +19,23 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!)
-  (frame-switcher/clear!)
-  (frame-switcher/set-storage-key! nil))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount sentinels + the
+  ;; trace-collector rings; `:post-reset` carries this suite's tail.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (frame-switcher/clear!)
+                   (frame-switcher/set-storage-key! nil))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/init_filter_reset_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/init_filter_reset_cljs_test.cljs
@@ -30,8 +30,6 @@
   nor linger in storage after the reset hook runs."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.filters.persistence :as filters-persistence]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.mount :as mount]
@@ -61,19 +59,16 @@
   ;; localStorage into sibling test namespaces.
   (js-delete js/globalThis "window"))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  ;; Start every scenario from a clean localStorage so the seeding below
-  ;; is the only signal the init path can read.
-  (filters-persistence/clear!)
-  (spine-filters/clear-raw!)
-  (frame-switcher/clear!)
-  (static-persistence/clear!))
-
 (def ^:private runtime-fixture
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8): plain-atom + the `:all` reset
+  ;; tier; `:post-reset` starts every scenario from a clean localStorage so
+  ;; the seeding below is the only signal the init path can read.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (filters-persistence/clear!)
+                   (spine-filters/clear-raw!)
+                   (frame-switcher/clear!)
+                   (static-persistence/clear!))}))
 
 (defn- with-local-storage-stub
   "Install an in-memory `js/window.localStorage` for the test's duration,

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -32,8 +32,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
@@ -44,13 +42,12 @@
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -51,10 +51,8 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.mount :as mount]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -237,22 +235,18 @@
 ;; per-test cleanup also resets the mount-state defonce so a failing
 ;; transition test doesn't poison neighbours via stale singleton state.
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  ;; Per rf2-in6l2 the registry installs the trace-buffer mirror
-  ;; events (note-trace-event / clear-trace-buffer / sync-trace-buffer).
-  ;; `ensure-xray-frame!` (called inside `open!`) dispatches
-  ;; `:rf.xray/sync-trace-buffer` to seed the slot — that needs the
-  ;; event handlers installed.
-  (registry/register-xray-handlers!)
-  (config/set-auto-open! true)
-  (trace-collector/reset-for-test!)
-  (reset-mount-state!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already covers the trace-collector rings the old init
+  ;; reset a SECOND time) into one owner; `:post-reset` registers Xray's
+  ;; handlers (per rf2-in6l2 the registry installs the trace-buffer mirror
+  ;; events `open!` → `ensure-xray-frame!` dispatches to seed the slot),
+  ;; arms auto-open, and clears the mount-state defonce.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (config/set-auto-open! true)
+                   (reset-mount-state!))}))
 
 ;; -------------------------------------------------------------------------
 ;; (1) Predicates on a clean baseline

--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -23,12 +23,9 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.source-coords.open-endpoint :as open-endpoint]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -64,21 +61,18 @@
 ;; chip-render tests don't drive the runtime, so they pay only the
 ;; cheap snapshot/restore cost; the rf2-g5q8d tests below need the
 ;; clean runtime so registrations don't bleed between tests.
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-all!` now folds the trace-collector ring reset
-  ;; in; `reset-editor!` owns the settings reset + editor re-arm.
-  (xray-test-support/reset-all!)
-  (reset-editor!)
-  ;; rf2-wn3bh — pin the endpoint launcher to the synchronous always-fall-back
-  ;; stub so the URI / navigator assertions below exercise the deterministic
-  ;; fallback path (no real fetch). The endpoint-preference path is covered
-  ;; in its own block at the bottom of this file.
-  (open-endpoint/set-launcher! always-fall-back!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already covers the trace-collector rings) into one
+  ;; owner; `:post-reset` re-arms the editor default (settings reset + editor
+  ;; re-arm) and — rf2-wn3bh — pins the endpoint launcher to the synchronous
+  ;; always-fall-back stub so the URI / navigator assertions exercise the
+  ;; deterministic fallback path (no real fetch). The endpoint-preference
+  ;; path is covered in its own block at the bottom of this file.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (reset-editor!)
+                   (open-endpoint/set-launcher! always-fall-back!))}))
 
 (deftest open-chip-renders-anchor-with-href
   (testing "open-chip returns an <a> hiccup vector when source has :file"

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -31,8 +31,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.view :as settings-view]
@@ -44,15 +42,12 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the `:runtime` reset tier (sentinels
+  ;; + trace-collector rings + persisted settings). (`trace-collector` is
+  ;; still required for the `seed-trace-for-test!` seeding below.)
+  (xray-test-support/make-xray-runtime-fixture {:tier :runtime}))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
@@ -23,19 +23,16 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.palette.view :as view]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
@@ -20,31 +20,27 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.palette.recents :as recents]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- fixture -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  (config/set-project-root! nil)
-  ;; rf2-ybjkx — clear palette recents between tests so each scenario
-  ;; starts with a clean slate. localStorage degrades silently in Node
-  ;; runtimes (no window.localStorage); the clear is a no-op there.
-  (recents/clear!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount sentinels + the
+  ;; trace-collector rings; `:post-reset` carries this suite's tail.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (config/set-project-root! nil)
+                   ;; rf2-ybjkx — clear palette recents between tests so each
+                   ;; scenario starts clean. localStorage degrades silently in
+                   ;; Node (no window.localStorage); the clear is a no-op there.
+                   (recents/clear!))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -49,25 +49,19 @@
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-xray.panels.app-db-diff-state :as state]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- fixture data --------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
@@ -23,20 +23,17 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- frame + host-db setup ----------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -27,25 +27,20 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cc]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers (mirror other view tests) ---------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_consumer_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_consumer_cljs_test.cljs
@@ -46,26 +46,21 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.machines]                     ;; load the machines facade so reg-machine works
             [re-frame.machines.tooling :as machines-tooling]
             [re-frame.routing]                      ;; load routing so reg-route + navigate materialize a live route slice
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.derivation-graph :as derivation-graph]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -60,7 +60,6 @@
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
             [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.diff.engine :as diff]
             [day8.re-frame2-xray.panels.epoch.format :as fmt]
@@ -70,6 +69,7 @@
             [day8.re-frame2-xray.panels.machines.topology :as topo]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ============================================================================
@@ -161,15 +161,13 @@
 ;; fixture
 ;; ============================================================================
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount idempotency
+  ;; sentinels plus the trace-collector rings — over the Reagent adapter
+  ;; this suite renders through.
+  (xray-test-support/make-xray-runtime-fixture {:adapter reagent-adapter/adapter}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -34,23 +34,21 @@
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
             [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount idempotency
+  ;; sentinels plus the trace-collector rings — over the Reagent adapter
+  ;; this suite renders through.
+  (xray-test-support/make-xray-runtime-fixture {:adapter reagent-adapter/adapter}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -50,9 +50,9 @@
             [day8.re-frame2-xray.panels.machine-inspector-helpers :as mih]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
             ;; The SHARED machine specs the deck mounts — the harness drives
             ;; the IDENTICAL values (single source of truth, rf2-g27vv).
             [machine-epochs.machines :as machines]))
@@ -61,15 +61,13 @@
 ;; fixture + drivers
 ;; ============================================================================
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount idempotency
+  ;; sentinels plus the trace-collector rings — over the Reagent adapter
+  ;; this suite renders through.
+  (xray-test-support/make-xray-runtime-fixture {:adapter reagent-adapter/adapter}))
 
 (defn- setup!
   "Register the Xray handlers + trace collector, register every (non-throwing)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -43,24 +43,20 @@
             ;; pending-`:db` trace pair) is wired into the router.
             [re-frame.flows]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- fixture -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): plain-atom adapter
+  ;; + the `:all` reset tier — install (== preload's alias) + registry +
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -10,8 +10,6 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.test-helpers :as th]
-            [re-frame.test-support :as test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.theme.tokens :as tokens]
@@ -24,9 +22,10 @@
 ;; ---- fixtures -----------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-test-support/reset-all!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the inline
+  ;; `make-reset-runtime-fixture` + `reset-all!` init into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- helpers -----------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
@@ -33,9 +33,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.panels.trace :as trace]
             [day8.re-frame2-xray.registry :as registry]
@@ -46,15 +44,13 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` clears the
+  ;; suppressed-count.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (config/reset-suppressed-count!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 ;; Thin aliases over re-frame.test-helpers. The local

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
@@ -22,9 +22,6 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
@@ -35,15 +32,13 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (after-rings/stop-tick!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` stops any
+  ;; armed rAF tick loop. (`trace-collector` stays required for seeding.)
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (after-rings/stop-tick!))}))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -18,21 +18,18 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.panels.machine-canvas :as mc]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; (core `make-reset-runtime-fixture` + Xray `reset-all!`) into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier — install/registry/
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -32,25 +32,19 @@
             [re-frame.schemas]
             [re-frame.schemas.malli]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
-            [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers -----------------------------------------------------
 ;; Thin aliases over re-frame.test-helpers so the local call sites read

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
@@ -10,8 +10,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -19,16 +17,16 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/set-egress-profile! config/default-egress-profile)
-  (config/reset-suppressed-count!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already covers the trace-collector rings the old init
+  ;; reset a SECOND time) into one owner; `:post-reset` pins the egress
+  ;; profile + clears the suppressed-count. (`trace-collector` stays required
+  ;; for the `seed-trace-for-test!` seeding below.)
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/set-egress-profile! config/default-egress-profile)
+                   (config/reset-suppressed-count!))}))
 
 (defn- seed-buffer! [evs]
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -22,24 +22,19 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.palette.subs :as palette-subs]
             [day8.re-frame2-xray.panels.resources :as resources]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers (mirror routing_cljs_test) --------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -51,24 +51,19 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.palette.subs :as palette-subs]
             [day8.re-frame2-xray.panels.routing :as routing]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers (mirror issues_ribbon_view_cljs_test) ---------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -44,9 +44,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
@@ -55,9 +53,11 @@
 ;; ---- fixtures -----------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-test-support/reset-all!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the inline
+  ;; `make-reset-runtime-fixture` + `reset-all!` init into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier. (`trace-collector`
+  ;; stays required for the `seed-trace-for-test!` seeding below.)
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers ----------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -32,8 +32,6 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.panels :as panels]
@@ -51,14 +49,13 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time. (`trace-collector` is still required
+  ;; for the `seed-trace-for-test!` seeding below.)
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- render-stub helper -------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -56,12 +56,9 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.focus :as focus]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.self-noise :as self-noise]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -69,20 +66,19 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  ;; rf2-5m5n2 — reset the project-root prefix atom so a sibling test
-  ;; that set it (e.g. `open_in_editor_cljs_test.cljs`) doesn't leak
-  ;; into the registry tests' URI assertions.
-  (config/set-project-root! nil))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
+  ;; tier — install (== preload's alias) + registry + mount sentinels + the
+  ;; trace-collector rings; `:post-reset` carries the config resets.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   ;; rf2-5m5n2 — reset the project-root prefix atom so a
+                   ;; sibling test that set it (e.g.
+                   ;; `open_in_editor_cljs_test.cljs`) doesn't leak into the
+                   ;; registry tests' URI assertions.
+                   (config/set-project-root! nil))}))
 
 ;; ---- helpers ------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -23,8 +23,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
@@ -34,18 +32,14 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  ;; Force-cleanup any stale drag-state from a previous test (the
-  ;; module-level defonce atom survives fixture reset).
-  (resize-handle/simulate-up!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8): plain-atom + the `:runtime`
+  ;; reset tier (sentinels + trace rings + persisted settings); `:post-reset`
+  ;; force-clears the module-level drag-state defonce (survives the runtime
+  ;; reset) so no stale drag leaks between tests.
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn [] (resize-handle/simulate-up!))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/sensitive_trace_loop_cljs_test.cljs
@@ -36,8 +36,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
@@ -46,30 +44,28 @@
 
 ;; ---- fixtures -----------------------------------------------------------
 ;;
-;; `make-reset-runtime-fixture` snapshots/restores the registrar around each
-;; test, clears trace listeners, and disposes the substrate adapter. The
-;; init-fn flips Xray's idempotency sentinels, re-registers the trace
-;; collector (so each test runs against the SAME wiring the production
-;; preload installs), and clears the per-process buffer + counter +
-;; flag so each test starts from the baseline.
-
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (registry/register-xray-handlers!)
-  ;; Allocate the :rf/xray frame so `note-suppressed!`'s dispatch
-  ;; guard passes. Without the frame, `note-suppressed!` skips the
-  ;; dispatch entirely — which would mask the loop scenario.
-  (frame/reg-frame :rf/xray {})
-  ;; Re-install the trace collector. The fixture above cleared it.
-  (preload/register-trace-collector!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  (config/set-egress-profile! config/default-egress-profile))
+;; `make-xray-runtime-fixture` (rf2-vj80u8) runs the `:all` reset tier
+;; (Xray install/registry/mount sentinels + trace-collector rings) over the
+;; plain-atom adapter; `:post-reset` re-registers Xray's handlers + the
+;; `:rf/xray` frame, RE-installs the trace collector (the reset above cleared
+;; it, so each test runs against the SAME wiring the production preload
+;; installs), and clears the per-process counter + egress profile so each
+;; test starts from the baseline.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset
+     (fn []
+       (registry/register-xray-handlers!)
+       ;; Allocate the :rf/xray frame so `note-suppressed!`'s dispatch
+       ;; guard passes. Without the frame, `note-suppressed!` skips the
+       ;; dispatch entirely — which would mask the loop scenario.
+       (frame/reg-frame :rf/xray {})
+       ;; Re-install the trace collector. The reset tier above cleared it.
+       (preload/register-trace-collector!)
+       (trace-collector/reset-for-test!)
+       (config/reset-suppressed-count!)
+       (config/set-egress-profile! config/default-egress-profile))}))
 
 ;; ---- helpers ------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -21,8 +21,6 @@
             [re-frame.core :as rf]
             [re-frame.epoch.state :as epoch-state]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as effects]
@@ -30,11 +28,6 @@
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
 ;; ---- fixture -----------------------------------------------------------
-
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!))
 
 (defn- ensure-stub-shell-root! []
   ;; Some node test runtimes provide js/document; create the
@@ -54,12 +47,15 @@
         (.removeChild (.-parentNode el) el)))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn []
-                (xray-init!)
-                (effects/detach-auto-open-watcher!)
-                (remove-stub-shell-root!))}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8): plain-atom adapter + the
+  ;; `:runtime` reset tier (sentinels + trace rings + persisted settings);
+  ;; `:post-reset` detaches the auto-open watcher + tears down the stub shell
+  ;; root so neither leaks between tests.
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn []
+                   (effects/detach-auto-open-watcher!)
+                   (remove-stub-shell-root!))}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -19,9 +19,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
@@ -30,15 +28,11 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the `:runtime` reset tier
+  ;; (sentinels + trace-collector rings + the persisted settings atom).
+  (xray-test-support/make-xray-runtime-fixture {:tier :runtime}))
 
 (defn- setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -44,10 +44,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.shell :as shell]
@@ -62,15 +59,14 @@
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` clears the
+  ;; suppressed-count. (`trace-collector` is still required for the
+  ;; `seed-trace-for-test!` seeding throughout this suite.)
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (config/reset-suppressed-count!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -24,25 +24,19 @@
             [re-frame.epoch :as epoch-api]
             [re-frame.epoch.state :as epoch-state]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus-resolver]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.spine :as spine]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
+  ;; `xray-init!` (preload/registry/trace three-liner): plain-atom adapter
+  ;; + the `:all` reset tier — install (== preload's alias) + registry +
+  ;; mount idempotency sentinels plus the trace-collector rings.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -16,23 +16,19 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (spine-filters/clear-raw!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` carries the
+  ;; raw-mute-slate tail.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (spine-filters/clear-raw!))}))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
@@ -13,8 +13,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
@@ -23,20 +21,18 @@
             [day8.re-frame2-xray.static.machines.panel :as panel]
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
-
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  (static-persistence/clear!)
-  (ls/clear!))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` carries the
+  ;; suppressed-count + static-persistence + machines-localStorage slate.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (static-persistence/clear!)
+                   (ls/clear!))}))
 
 (declare expand-tree)
 

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -30,8 +30,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
@@ -39,22 +37,20 @@
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.static.shell :as static-shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  (static-persistence/clear!)
-  (ls/clear!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` carries the
+  ;; suppressed-count + static-persistence + machines-localStorage slate.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (static-persistence/clear!)
+                   (ls/clear!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -38,24 +38,19 @@
             [re-frame.machines :as machines]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.sim :as sim]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -36,24 +36,19 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.routes.panel :as panel]
             [day8.re-frame2-xray.static.shell :as static-shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers -----------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_nav_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_nav_cljs_test.cljs
@@ -13,24 +13,19 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.routes.panel :as panel]
             [day8.re-frame2-xray.static.routes.simulate-nav :as simulate-nav]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers -----------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
@@ -18,23 +18,18 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.routes.panel :as panel]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- hiccup walkers -----------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -37,29 +37,25 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.static.shell :as static-shell]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-suppressed-count!)
-  (static-persistence/clear!))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier, which already resets the trace-collector rings the old
+  ;; init reset a SECOND time) into one owner; `:post-reset` carries the
+  ;; suppressed-count + static-persistence slate.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (static-persistence/clear!))}))
 
 ;; ---- hiccup walker (mirrors shell_cljs_test) ----------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/sub_reactivity.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/sub_reactivity.cljs
@@ -72,35 +72,21 @@
   (:require [cljs.test :refer-macros [use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- per-test reset -----------------------------------------------------
 
-(defn xray-init!
-  "Reset every Xray idempotency sentinel + clear the trace-bus atom so
-  the next register-xray-handlers! call wires a fresh registrar. Test-
-  only — never call from production code.
-
-  Mirrors the init-fn the existing app_db_diff_cljs_test.cljs corpus
-  uses; lifted into this helper ns so per-panel reactivity tests share
-  one canonical reset shape."
-  []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
-
 (def fixture
-  "`use-fixtures :each` value for sub-reactivity tests. Wires
-  test-support/make-reset-runtime-fixture with the plain-atom adapter and
-  the Xray init-fn. Usage:
+  "`use-fixtures :each` value for sub-reactivity tests. The canonical
+  `make-xray-runtime-fixture` (Xray test-support, rf2-vj80u8) composes
+  core `make-reset-runtime-fixture` (plain-atom adapter) with the `:all`
+  reset tier — Xray's install + registry + mount idempotency sentinels
+  plus the trace-collector rings — so each test starts from a fresh
+  registrar and a clean trace bus. Usage:
 
       (use-fixtures :each h/fixture)"
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- frame setup --------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/two_instance_isolation_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/two_instance_isolation_cljs_test.cljs
@@ -36,21 +36,16 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
-
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
+  ;; into one owner: plain-atom adapter + the default `:all` reset tier,
+  ;; which already includes the trace-collector ring reset the old init
+  ;; called a SECOND, redundant time.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; The two shell-instance frame-ids. `cell-a` uses the production
 ;; default (`shell/default-frame-id` == `:rf/xray`) so the singleton

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -30,17 +30,16 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-inspector-popup :as edn-inspector-popup]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn [] (xray-test-support/reset-all!))}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the inline
+  ;; `make-reset-runtime-fixture` + `reset-all!` init into one owner:
+  ;; plain-atom adapter + the default `:all` reset tier.
+  (xray-test-support/make-xray-runtime-fixture))
 
 ;; ---- helpers ------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
@@ -20,23 +20,20 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
 
 ;; ---- fixture ------------------------------------------------------------
 
-(defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (rt/clear!)
-  (rt/set-storage-key! nil))
-
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn xray-init!}))
+  ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the reset (plain-atom +
+  ;; `:all` tier) into one owner; `:post-reset` carries the column-widths
+  ;; persistence slate.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (rt/clear!)
+                   (rt/set-storage-key! nil))}))
 
 (defn- xray-setup!
   "Register Xray handlers + the :rf/xray frame, then re-run the


### PR DESCRIPTION
## Summary

Completes the **fixture-centralization axis** of rf2-vj80u8. The exemplar `make-xray-runtime-fixture` (Xray test-support, composing core `make-reset-runtime-fixture` + a named reset tier + a `:post-reset` hook) landed in #5461 along with the 3 Static-panel exemplar suites. This PR migrates the **remaining bespoke `xray-init!` sites** across `tools/xray/test/**` onto that one owner.

**55 fixture sites migrated** (54 test suites + the shared `test_helpers/sub_reactivity.cljs` fixture helper — which ripples to all 9 per-panel reactivity suites).

Each migration:
- Replaces the per-suite `(defn- xray-init! …)` + `(test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter :init-fn xray-init!})` boilerplate with `(xray-test-support/make-xray-runtime-fixture …)`.
- Maps the old init body onto the fixture's params: default `:all` tier (sentinels + trace rings) / `:tier :runtime` (adds persisted settings) / `:adapter reagent-adapter/adapter` for the 3 Reagent-render epoch suites; every domain-specific tail (`spine-filters/clear-raw!`, `persistence/clear!`, `static-persistence/clear!`, `ls/clear!`, config resets, frame-switcher clears, `recents/clear!`, `after-rings/stop-tick!`, mount-state + handler re-registration, localStorage seeding, endpoint-launcher stub, …) carried through `:post-reset`.
- Drops the **redundant second `trace-collector/reset-for-test!`** (the `:all` tier already folds it), the legacy `preload/registry/trace` three-liner bundles, and the now-unused `plain-atom` / core `test-support` / stale `preload` / redundant `trace-collector` requires.

## Left bespoke (per-file judgment — NOT forced onto the fixture)

| File | Reason |
|---|---|
| `preload_cljs_test.cljs` | Behaviour under test IS the preload idempotency/reset sentinels — the low-level `preload/reset-for-test!` path is the subject, not scaffolding. |
| `preload_decoupling_cljs_test.cljs` | Bespoke full-boot `clear-world!` (install + registry + trace + trace-tooling listeners + epoch-state listeners + config + `mount/teardown!` + `keybinding/detach!`) is the faithful "fresh boot" the facade-vs-entrypoint decoupling contract asserts against; deliberately wider than any tier. |
| `runtime_cljs_test.cljs` | `runtime-init!` = `runtime/reset-for-test!` only — resets the Xray runtime-accessor ns, which is not one of the fixture's sentinels/all/runtime tiers; doesn't fit the tier model. |
| `settings/popup_dispatch_routing_cljs_test.cljs` | Hand-rolled inline reset (not `make-reset-runtime-fixture`) with a `cljs.test/async` map-form fixture, kept deliberately for a React-context render-timing reason. |

The many plain `{:adapter plain-atom/adapter}` core-fixture users (edn-inspector suites, `app_db_diff_events/subs/state`, `panels_e2e/*`, `control_axes_e2e/*`, …) were **out of scope** — they never carried a bespoke Xray `xray-init!` / reset tier, so they are already canonical core-fixture users.

## Not in this PR (remaining rf2-vj80u8 axis)

The **private hiccup-walker de-duplication** (`find-by-testid` / `hiccup-seq` / `expand-tree` / `collect-text` private copies → `re-frame.test-helpers` directly, ~38 files) is a separate, per-file-semantic axis and is **not** touched here — it warrants its own reviewable batch. rf2-vj80u8 should stay open for it.

## Stance

Pre-alpha; ELEGANCE + CLARITY + CORRECTNESS. Migrated what cleanly fits; left the 4 genuinely-bespoke sites with a one-line comment each rather than contorting the fixture or losing any suite's specific reset behaviour.

## Xray spec

Spec unchanged because test-fixture internals — no contract surface touched.

## Quality gates

All foreground, on the rebased branch:

- `tools/xray $ clojure -M:test` — **1233 tests, 5729 assertions, 0 failures, 0 errors**
- `implementation $ npm run test:cljs` (the node-test build includes `tools/xray/test` — this is where the migrated `.cljs` fixtures actually run) — **8465 tests, 39156 assertions, 0 failures, 0 errors**
- `implementation $ npm run test:bundle-isolation` — **PASS** (41 internal sentinels absent from production bundles; core test-helpers + Xray test-support proven absent — the rf2-vj80u8 acceptance criterion)
- `implementation $ npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (13 matrix rows; no routes-epochs flake)