### PR TITLE
fix(test-quiet): serialize the JVM stderr ring across both channels — no StringBuilder race (rf2-3fc89f.17)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -431,13 +431,28 @@
   (`install-summary-replay-hook!`); on green the buffer is dropped."
   ^java.io.Writer [^StringBuilder sb]
   (let [append! (fn [^String s]
-                  (.append sb s)
-                   ;; Trim from the front once past the cap so the ring
-                   ;; keeps the most-recent context (the characters nearest a
-                  ;; failure), matching the CLJS ring's newest-N policy.
-                  (let [n (.length sb)]
-                    (when (> n stderr-buffer-cap)
-                      (.delete sb 0 (- n stderr-buffer-cap)))))]
+                  ;; Serialize the WHOLE append-plus-front-trim transaction on
+                  ;; `sb`'s own monitor. Both JVM stderr channels funnel here —
+                  ;; `*err*` via one PrintWriter and raw `System.err` via the
+                  ;; `System/setErr` PrintStream bridge (see `-main`) — and those
+                  ;; two wrappers serialize only their OWN calls under DISTINCT
+                  ;; locks, so without this shared monitor a write from each
+                  ;; channel can interleave inside this body: a `.append` racing
+                  ;; a front-trim `.delete` tears StringBuilder's internal
+                  ;; count/array and throws ArrayIndexOutOfBoundsException from an
+                  ;; otherwise-valid test. StringBuilder (unlike StringBuffer) has
+                  ;; no synchronized methods, so nothing else contends for this
+                  ;; monitor; the summary snapshot in
+                  ;; `install-summary-replay-hook!` locks on the SAME `sb`, so a
+                  ;; red replay never reads a half-applied mutation.
+                  (locking sb
+                    (.append sb s)
+                    ;; Trim from the front once past the cap so the ring
+                    ;; keeps the most-recent context (the characters nearest a
+                    ;; failure), matching the CLJS ring's newest-N policy.
+                    (let [n (.length sb)]
+                      (when (> n stderr-buffer-cap)
+                        (.delete sb 0 (- n stderr-buffer-cap))))))]
     (proxy [java.io.Writer] []
       (write
         ([x]
@@ -496,16 +511,26 @@
   (let [prior-summary (get-method clojure.test/report :summary)]
     (defmethod clojure.test/report :summary [m]
       (let [{:keys [fail error]} m]
-        (when (and (pos? (+ (or fail 0) (or error 0)))
-                   (pos? (.length sb)))
-          (let [captured (.toString sb)]
-            (.write real-err
-                    (str "\n[test-quiet] buffered stderr replayed"
-                         " because the run was RED:\n"))
-            (.write real-err captured)
-            (when-not (.endsWith captured "\n")
-              (.write real-err "\n"))
-            (.flush real-err))))
+        (when (pos? (+ (or fail 0) (or error 0)))
+          ;; Snapshot the ring under `sb`'s monitor — the SAME lock every
+          ;; writer in `buffering-stderr-writer` takes — so the `.length`
+          ;; guard and the `.toString` copy observe a consistent ring rather
+          ;; than a mutation half-applied by a still-live background writer.
+          ;; Copy out under the lock, then do the (unbounded) real-err replay
+          ;; I/O OUTSIDE it so a writer is never blocked on the replay. An
+          ;; empty ring yields `nil` and replays nothing, exactly as the prior
+          ;; `(pos? (.length sb))` guard did.
+          (let [captured (locking sb
+                           (when (pos? (.length sb))
+                             (.toString sb)))]
+            (when captured
+              (.write real-err
+                      (str "\n[test-quiet] buffered stderr replayed"
+                           " because the run was RED:\n"))
+              (.write real-err captured)
+              (when-not (.endsWith captured "\n")
+                (.write real-err "\n"))
+              (.flush real-err)))))
       ;; Delegate to the prior :summary so the canonical
       ;; "Ran N tests…/K failures, J errors." line still prints.
       (when prior-summary (prior-summary m)))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -1159,3 +1159,85 @@
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
           (is (str/includes? err "buffered stderr replayed because the run was RED")
               (str "the replay must be labelled; got stderr:\n" err)))))))
+
+;; ----------------------------------------------------------------------
+;; Concurrent dual-channel red run — the process exits for the INTENTIONAL
+;; assertion, not an internal buffer exception.
+;;
+;; `-main` routes the test thread's `*err*` (a PrintWriter) and raw
+;; process-global `System.err` (a `System/setErr` PrintStream bridge) into
+;; ONE StringBuilder ring. The two wrappers hold DISTINCT locks, so before
+;; the ring's writes were serialized on a shared monitor, overlapping
+;; writes from the two channels could tear the StringBuilder and throw
+;; `ArrayIndexOutOfBoundsException` mid-run — a reporter bug that changes a
+;; failing run's exit/diagnostics. This drives the REAL `-main` against a
+;; fixture that writes through BOTH channels concurrently past the ring cap,
+;; then fails an assertion, and proves: the process exits 1 for the
+;; assertion (not an internal buffer exception), the FAIL block survives,
+;; the red replay is well formed, and no `ArrayIndexOutOfBoundsException`
+;; leaks from the ring. The in-process trial harness
+;; (`re-frame.test-quiet-stderr-ring-concurrency-test`) reliably trips the
+;; underlying race; this is the end-to-end counterpart through the real
+;; runner + `:summary` replay hook.
+
+(deftest concurrent-dual-channel-red-exits-for-assertion-not-buffer-exception
+  (testing "joined concurrent *err* + raw System.err writes on a red run: exit 1, no buffer exception, replay well formed"
+    (with-fixture-dir
+      (fn [dir]
+        ;; The background writer is a raw Thread (NOT a future) so it writes
+        ;; through the process-global System.err bridge, independent of the
+        ;; test thread's *err* binding; the test thread writes through *err*.
+        ;; 6 x 50 000 chars per channel (~300 KB) drives the front-trim past
+        ;; the 256 KiB cap while both channels are live — the exact overlap
+        ;; the race needs. Both are released together on a promise and JOINED
+        ;; before the failing assertion, so the replay content is settled.
+        (write-fixture! dir "concurrent_dual_channel_red_test"
+                        "concurrent-dual-channel-red-test"
+                        (str "(deftest a-concurrent-dual-channel-failing-test"
+                             " (let [gate (promise)"
+                             "       big (apply str (repeat 50000 \\Z))"
+                             "       t (Thread. (fn [] @gate"
+                             "                    (dotimes [_ 6] (.println System/err big))"
+                             "                    (.println System/err \"SYS-TAIL-CONCURRENT-MARKER\")))]"
+                             "   (.start t)"
+                             "   (deliver gate :go)"
+                             "   (binding [*out* *err*]"
+                             "     (dotimes [_ 6] (println big))"
+                             "     (println \"ERR-TAIL-CONCURRENT-MARKER\"))"
+                             "   (.join t)"
+                             "   (is (= :expected-marker :actual-marker))))"))
+        (let [{:keys [exit out err timed-out?]} (run-runner dir)
+              both (str out err)]
+          (is (not timed-out?)
+              "the concurrent dual-channel run must terminate, not hang")
+          ;; CORE pin: the process exits 1 for the intentional ASSERTION —
+          ;; not a torn-buffer exception (which could change the exit path).
+          (is (= 1 exit)
+              (str "the concurrent dual-channel suite is red; must exit 1 for"
+                   " the intentional assertion; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "FAIL in (a-concurrent-dual-channel-failing-test)")
+              (str "the FAIL block for the intentional assertion must reach"
+                   " stdout — proving the process failed for the assertion,"
+                   " not an internal buffer exception; got:\n" out))
+          ;; No torn-StringBuilder exception may surface anywhere: the whole
+          ;; point of the fix is that the ring never throws from concurrent
+          ;; writes.
+          (is (not (str/includes? both "ArrayIndexOutOfBoundsException"))
+              (str "a concurrent dual-channel red run must NOT throw from the"
+                   " stderr ring; got\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          ;; The red replay is well formed: labelled, and it carries the
+          ;; newest buffered context. The two channels' floods total ~600 KB
+          ;; past the 256 KiB cap, so which channel's tail marker survives the
+          ;; front-trim depends on the interleaving; the LAST write overall is
+          ;; always one of the two tail markers, so at least one must survive.
+          (is (str/includes? err "buffered stderr replayed because the run was RED")
+              (str "the red replay must be labelled; got stderr:\n"
+                   (subs err 0 (min 400 (count err)))))
+          (is (or (str/includes? err "ERR-TAIL-CONCURRENT-MARKER")
+                  (str/includes? err "SYS-TAIL-CONCURRENT-MARKER"))
+              (str "the replay must retain the NEWEST buffered context — at"
+                   " least one channel's tail marker must survive the ring;"
+                   " got stderr tail:\n"
+                   (subs err (max 0 (- (count err) 400)) (count err)))))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_stderr_ring_concurrency_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_stderr_ring_concurrency_test.clj
@@ -1,0 +1,156 @@
+(ns re-frame.test-quiet-stderr-ring-concurrency-test
+  "Concurrency regression for the JVM runner's central stderr ring
+  (`re-frame.test-quiet.runner`).
+
+  `-main` funnels BOTH JVM stderr channels into one
+  `java.lang.StringBuilder` ring: the test-driver thread's `*err*` through
+  a `PrintWriter`, and raw process-global `System.err` through a
+  `System/setErr` `PrintStream` over an `OutputStream` bridge. Those two
+  wrappers each serialize only their OWN calls, under DISTINCT locks — so
+  before this fix a write from each channel could interleave inside
+  `buffering-stderr-writer`'s append-plus-front-trim transaction and tear
+  the StringBuilder's internal count/array, throwing
+  `ArrayIndexOutOfBoundsException` from an otherwise-valid test (a reporter
+  bug reddening a passing suite). `install-summary-replay-hook!` also read
+  the ring (`.length`/`.toString`) with no coordination, so a red replay
+  could snapshot a half-applied mutation.
+
+  These tests reconstruct the EXACT production wiring in-process (the
+  private ring writer + a `PrintWriter` for `*err*` + the same
+  `OutputStream`->`PrintStream` UTF-8 bridge for `System.err`), release two
+  writers together past the ring cap over many trials, and prove: neither
+  channel throws, the ring stays at or below `stderr-buffer-cap`, each
+  channel's newest tail write survives, and a `locking`-coordinated
+  snapshot taken CONCURRENTLY with the writers (the shape
+  `install-summary-replay-hook!` uses) never observes a torn ring. The
+  real `:summary` hook is covered end-to-end by the subprocess red fixture
+  in `re-frame.test-quiet-runner-contract-test`.
+
+  On the pre-fix (unsynchronized) runner these trials throw
+  `ArrayIndexOutOfBoundsException` intermittently (~1 in 5 trials in the
+  originating audit); the trial counts here make that detection reliable."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.test-quiet.runner]))
+
+(def ^:private stderr-buffer-cap
+  "The runner's private ring cap (256 KiB, characters)."
+  @#'re-frame.test-quiet.runner/stderr-buffer-cap)
+
+(defn- make-wiring
+  "Reconstruct `-main`'s stderr wiring over a fresh ring: returns
+  `{:sb :err-channel :sys-channel}` where `:err-channel` is the
+  `*err*`-side `PrintWriter` and `:sys-channel` is the `System.err`-side
+  UTF-8 `PrintStream` over the identical `OutputStream` bridge `-main`
+  installs. Both funnel into the same private `buffering-stderr-writer`
+  over `:sb`."
+  []
+  (let [sb         (StringBuilder.)
+        buffered-w (#'re-frame.test-quiet.runner/buffering-stderr-writer sb)
+        ;; `*err*` channel — a PrintWriter, exactly as `-main` binds `*err*`.
+        err-channel (java.io.PrintWriter. buffered-w)
+        ;; `System.err` channel — the same OutputStream->PrintStream(UTF-8)
+        ;; bridge `-main` installs via `System/setErr`.
+        sys-bridge  (proxy [java.io.OutputStream] []
+                      (write
+                        ([b]
+                         (.write buffered-w (String. (byte-array [(unchecked-byte b)]))))
+                        ([b off len]
+                         (.write buffered-w (String. ^bytes b (int off) (int len))))))
+        sys-channel (java.io.PrintStream. sys-bridge true "UTF-8")]
+    {:sb sb :err-channel err-channel :sys-channel sys-channel}))
+
+(def ^:private big-line
+  "A single write comfortably larger than the 256 KiB ring cap, so every
+  write drives the front-trim `.delete` — the mutation the concurrent
+  `.append` races. 400,000 chars matches the audit's repro payload."
+  (apply str (repeat 400000 \x)))
+
+(deftest concurrent-dual-channel-writes-do-not-corrupt-the-ring
+  (testing "releasing *err* and raw System.err writers together past the cap never throws or exceeds the cap"
+    (let [trials       30
+          writes-each  3
+          failures     (atom [])]
+      (dotimes [t trials]
+        (let [{:keys [sb err-channel sys-channel]} (make-wiring)
+              gate (promise)
+              ;; Release both channels together so their writes overlap
+              ;; inside the shared ring's append+trim.
+              f-err (future @gate
+                            (dotimes [_ writes-each] (.println err-channel big-line)))
+              f-sys (future @gate
+                            (dotimes [_ writes-each] (.println sys-channel big-line)))]
+          (deliver gate :go)
+          (let [thrown (try @f-err @f-sys nil
+                            (catch Throwable e e))]
+            (when thrown
+              (swap! failures conj [t (.getMessage ^Throwable thrown)])))
+          ;; After the concurrent flood, write ONE distinct newest marker per
+          ;; channel (sequentially — no race on the markers themselves) and
+          ;; prove each channel's newest write survives inside a bounded ring.
+          (.println err-channel (str "ERR-TAIL-" t))
+          (.println sys-channel (str "SYS-TAIL-" t))
+          ;; Bind booleans / the length BEFORE asserting so clojure.test's
+          ;; `actual:` form never embeds the up-to-256-KiB ring string — a
+          ;; failing trial stays readable rather than dumping the whole ring.
+          (let [ring      (locking sb (.toString sb))
+                ring-len  (.length sb)
+                err-tail? (str/includes? ring (str "ERR-TAIL-" t))
+                sys-tail? (str/includes? ring (str "SYS-TAIL-" t))]
+            (is (<= ring-len stderr-buffer-cap)
+                (str "the ring must stay at or below the " stderr-buffer-cap
+                     "-char cap after a concurrent flood; got " ring-len
+                     " chars on trial " t))
+            (is err-tail?
+                (str "the *err* channel's newest write must survive the ring on"
+                     " trial " t " (ring-len=" ring-len ")"))
+            (is sys-tail?
+                (str "the System.err channel's newest write must survive the"
+                     " ring on trial " t " (ring-len=" ring-len ")")))))
+      (is (empty? @failures)
+          (str "concurrent writes through the two JVM stderr channels must"
+               " never throw (a torn StringBuilder is a reporter bug that"
+               " reddens a passing test); got throwing trials: "
+               (pr-str @failures))))))
+
+(deftest summary-snapshot-during-concurrent-writes-is-consistent
+  (testing "a locking-coordinated ring snapshot taken concurrently with writers never tears"
+    (let [{:keys [sb err-channel sys-channel]} (make-wiring)
+          gate         (promise)
+          writer-errs  (atom [])
+          snap-errs    (atom [])
+          snaps        (atom [])
+          writes-each  40
+          f-err (future @gate
+                        (try (dotimes [_ writes-each] (.println err-channel big-line))
+                             (catch Throwable e (swap! writer-errs conj (.getMessage e)))))
+          f-sys (future @gate
+                        (try (dotimes [_ writes-each] (.println sys-channel big-line))
+                             (catch Throwable e (swap! writer-errs conj (.getMessage e)))))
+          ;; The snapshotter mirrors EXACTLY what `install-summary-replay-hook!`
+          ;; does: read the ring under `sb`'s monitor. It must never observe a
+          ;; half-applied append+trim, so every snapshot is a valid String
+          ;; bounded by the cap.
+          f-snap (future
+                   @gate
+                   (loop []
+                     (when (or (not (realized? f-err)) (not (realized? f-sys)))
+                       (try
+                         (let [captured (locking sb
+                                          (when (pos? (.length sb)) (.toString sb)))]
+                           (when captured (swap! snaps conj (.length ^String captured))))
+                         (catch Throwable e (swap! snap-errs conj (.getMessage e))))
+                       (recur))))]
+      (deliver gate :go)
+      @f-err @f-sys @f-snap
+      (is (empty? @writer-errs)
+          (str "concurrent writers must not throw; got: " (pr-str @writer-errs)))
+      (is (empty? @snap-errs)
+          (str "a locking-coordinated snapshot must never tear on a concurrent"
+               " write; got: " (pr-str @snap-errs)))
+      (is (pos? (count @snaps))
+          "the snapshotter must have observed the ring at least once mid-flood")
+      (is (every? #(<= % stderr-buffer-cap) @snaps)
+          (str "every mid-flood snapshot must be bounded by the cap; got a"
+               " snapshot over " stderr-buffer-cap ": "
+               (pr-str (remove #(<= % stderr-buffer-cap) @snaps)))))))


### PR DESCRIPTION
## What & why

The JVM quiet runner (`re-frame.test-quiet.runner`) funnels **both** JVM stderr channels into one `java.lang.StringBuilder` ring:

- the test-driver thread's `*err*` via a `PrintWriter`, and
- raw process-global `System.err` via a `System/setErr` `PrintStream` over an `OutputStream` bridge.

Those two wrappers each serialize only their **own** calls, under **distinct** locks. So `buffering-stderr-writer`'s unguarded `append`-plus-front-trim transaction could interleave a write from each channel and tear the `StringBuilder`'s internal `count`/array — throwing `ArrayIndexOutOfBoundsException` from an otherwise-valid test (a reporter bug reddening a passing suite). `install-summary-replay-hook!` also read the ring (`.length`/`.toString`) with no coordination, so a red replay could snapshot a half-applied mutation.

Audit-derived (rf2-3fc89f.17). **Reproduced before fixing.**

## The fix (lock design)

Serialize **all** ring access on `sb`'s own monitor:

- every `append`+trim in `buffering-stderr-writer` now runs inside `(locking sb …)`;
- the summary snapshot in `install-summary-replay-hook!` takes the **same** `(locking sb …)`, copies the ring out under the lock, then does the (unbounded) real-err replay I/O **outside** the lock so a writer is never blocked on the replay.

Both channels thus funnel through one boundary instead of relying on the unrelated `PrintWriter`/`PrintStream` locks. `StringBuilder` (unlike `StringBuffer`) has no synchronized methods, so nothing else contends for the monitor. Lock ordering is always `[PrintWriter|PrintStream lock] → sb monitor` (never the reverse), so no deadlock is introduced.

The ≤256 KiB ring cap and the green-drop / red-replay snapshot semantics are preserved. **Test results are unchanged** — only the writes are made atomic.

## Reproduce → fix evidence

Standalone probe mirroring `-main`'s exact wiring (one ring, the private writer, a `PrintWriter` for `*err*` + the identical UTF-8 `PrintStream` bridge for `System.err`), two futures released together each printing a 400,000-char line, 20 trials:

- **pre-fix:** `4/20` trials threw `ArrayIndexOutOfBoundsException: arraycopy: last source index 408192 out of bounds for byte[400000]`.
- **post-fix:** `0` failures across `80` trials (4 runs × 20).

Regression tests run against the pre-fix source (`git checkout origin/main -- runner.clj`):

- **28/30** trials in `concurrent-dual-channel-writes-do-not-corrupt-the-ring` threw AIOOBE; **35 failures** across the 2 in-process concurrency tests.

Against the fixed source: green across repeated runs.

## Regression coverage

- `re-frame.test-quiet-stderr-ring-concurrency-test` (new): reconstructs the exact production wiring in-process, releases both channels together past the cap over 30 trials, and proves neither throws, the ring stays ≤ cap, each channel's newest tail survives, and a `locking`-coordinated snapshot taken **concurrently** with the writers never tears.
- `re-frame.test-quiet-runner-contract-test` (extended): a real-runner **red** fixture writing through both channels concurrently past the cap, proving the process exits `1` for the intentional assertion (not an internal buffer exception) and the red replay stays well formed.

## Quality gates

- `cd implementation/test-quiet && clojure -M:test` — **green, twice**: `Ran 33 tests containing 211 assertions. 0 failures, 0 errors.` (baseline was 30 tests / 110 assertions; +3 tests here).
- Concurrency namespace stress-run 5× in isolation — all green.
- Standalone repro probe 4× post-fix — 0/80 AIOOBE.
- New regression tests confirmed to **fail** on the pre-fix source and **pass** on the fixed source.

## Stance

Pre-alpha; test-infrastructure correctness (a reporter bug must never redden a passing test). ELEGANCE + CLARITY + CORRECTNESS. Gates run in the foreground; committed before gates; no stash.

Touches only `implementation/test-quiet/src/re_frame/test_quiet/runner.clj` + `implementation/test-quiet/test/**`. Not a hot-zone file. Do not merge — for review.
