### PR TITLE
fix(ssr-ring): collapse case-insensitive response headers into one Ring key (rf2-3fc89f.16)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -14,9 +14,28 @@
 
 (set! *warn-on-reflection* true)
 
+(defn existing-header-key
+  "Return the key already present in Ring header map `m` whose name matches
+  `k` case-insensitively (RFC 7230 §3.2 — header field names are
+  case-insensitive tokens), or nil when no case variant is present. The
+  first-seen spelling is the one retained, so `merge-pair-into-header-map`
+  folds later case variants back under this returned key. Mirrors the
+  lower-case matching rule `strip-header` uses so both single-source the
+  case-insensitive header-name comparison."
+  [m k]
+  (let [target (str/lower-case (str k))]
+    (some (fn [ek] (when (= target (str/lower-case (str ek))) ek))
+          (keys m))))
+
 (defn merge-pair-into-header-map
   "Fold a `[name value]` header pair into the accumulating Ring headers
   map. Repeated names preserve order in a vector.
+
+  Header field names are case-insensitive (RFC 7230 §3.2), so pairs whose
+  names differ only by ASCII case are ONE logical header: they collapse
+  under the first-seen spelling (the stable emitted key) with their values
+  kept in declaration order. This mirrors `strip-header`'s case-insensitive
+  rule and honours the ns docstring's case-insensitive name-match promise.
 
   Ring requires strings or vectors of strings. Because schema validation is
   optional, this wire boundary unconditionally stringifies non-nil scalar
@@ -38,11 +57,14 @@
                                    "a caller bug")
                   :recovery   :coerced-to-string}))
   (let [v*       (if (or (nil? v) (string? v)) v (str v))
-        existing (get m k)]
+        ;; Fold under the first-seen spelling of this logical header so
+        ;; case variants (Vary / vary / VARY) land in ONE Ring map entry.
+        key*     (or (existing-header-key m k) k)
+        existing (get m key*)]
     (cond
-      (nil? existing)        (assoc m k v*)
-      (vector? existing)     (assoc m k (conj existing v*))
-      :else                  (assoc m k [existing v*]))))
+      (nil? existing)        (assoc m key* v*)
+      (vector? existing)     (assoc m key* (conj existing v*))
+      :else                  (assoc m key* [existing v*]))))
 
 (defn append-set-cookies
   "For every cookie map in the response's :cookies vector, append one

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -399,6 +399,105 @@
           "the override Content-Type is set — the map was never nulled"))))
 
 ;; ===========================================================================
+;; merge-pair-into-header-map — case-insensitive collapse (rf2-3fc89f.16)
+;;
+;; HTTP header field names are case-insensitive (RFC 7230 §3.2), and the
+;; ns docstring already promises a case-insensitive name match. Pairs whose
+;; names differ only by ASCII case are ONE logical header: they collapse
+;; under the first-seen spelling with values in declaration order, exactly
+;; like same-case repeats. `:rf.server/append-header` preserves the caller's
+;; spelling, so mixed-case pairs are reachable through the public effect.
+;; Before this fix the fold used a case-SENSITIVE `(get m k)` and emitted a
+;; separate map entry per casing — a non-deterministic Ring header model.
+;; ===========================================================================
+
+(deftest mixed-case-names-collapse-into-one-first-seen-key
+  (testing "rf2-3fc89f.16: pairs differing only by ASCII case are ONE logical
+            header — they collapse under the first-seen spelling with values
+            in declaration order (the case-insensitive fold)"
+    (is (= {"Vary" ["Accept" "Origin"]}
+           (-> {}
+               (headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (headers/merge-pair-into-header-map ["vary" "Origin"])))
+        "second-seen lower-case `vary` folds under the first-seen `Vary` key")
+    (is (= {"Vary" ["Accept" "Origin" "Accept-Encoding"]}
+           (-> {}
+               (headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (headers/merge-pair-into-header-map ["vary" "Origin"])
+               (headers/merge-pair-into-header-map ["VARY" "Accept-Encoding"])))
+        "three casings collapse to one key; values stay in declaration order")))
+
+(deftest mixed-case-fold-retains-first-seen-spelling-not-latest
+  (testing "rf2-3fc89f.16: the emitted key is the FIRST-seen spelling; a
+            later case variant does NOT rename the key"
+    (is (= ["Origin" "Accept"]
+           (get (-> {}
+                    (headers/merge-pair-into-header-map ["vary" "Origin"])
+                    (headers/merge-pair-into-header-map ["Vary" "Accept"]))
+                "vary"))
+        "first-seen lower-case `vary` is the stable emitted key")))
+
+(deftest mixed-case-content-type-collapses-under-nil-override
+  (testing "rf2-3fc89f.16 (accept #2): mixed-case Content-Type with a nil
+            handler override collapses to exactly one logical key carrying
+            both values in order (vector semantics follow append-header)"
+    (let [result (headers/headers->ring-map+content-type-override
+                   [["content-type" "text/html"]
+                    ["Content-Type" "application/json"]]
+                   nil)
+          ct-keys (filter (fn [k] (= "content-type" (str/lower-case (str k))))
+                          (keys result))]
+      (is (= 1 (count ct-keys))
+          "exactly one logical content-type key with a nil override")
+      (is (= ["text/html" "application/json"] (get result (first ct-keys)))
+          "both values survive in declaration order under the first-seen key"))))
+
+(deftest mixed-case-content-type-with-override-strips-every-casing
+  (testing "rf2-3fc89f.16 (accept #2): a non-nil override still strips every
+            prior spelling and emits one canonical `Content-Type` scalar"
+    (let [result (headers/headers->ring-map+content-type-override
+                   [["content-type" "text/html"]
+                    ["Content-Type" "application/json"]]
+                   "text/xml; charset=utf-8")
+          ct-keys (filter (fn [k] (= "content-type" (str/lower-case (str k))))
+                          (keys result))]
+      (is (= 1 (count ct-keys)) "exactly one content-type key after override")
+      (is (= "Content-Type" (first ct-keys)) "the canonical spelling is emitted")
+      (is (= "text/xml; charset=utf-8" (get result "Content-Type"))
+          "the override value wins — no casing survivor, no vector"))))
+
+(deftest mixed-case-set-cookie-append-collapses-under-existing-key
+  (testing "rf2-3fc89f.16 (accept #3): structured cookies appended to a
+            pre-existing differently-cased Set-Cookie entry yield ONE logical
+            key preserving every value in order"
+    (let [result (headers/append-set-cookies
+                   {"set-cookie" "pre=1"}
+                   [{:name "session" :value "abc"}
+                    {:name "theme" :value "dark"}])
+          sc-keys (filter (fn [k] (= "set-cookie" (str/lower-case (str k))))
+                          (keys result))
+          sc      (get result (first sc-keys))]
+      (is (= 1 (count sc-keys))
+          "the lower-case `set-cookie` pre-existing key absorbs the cookies")
+      (is (= "set-cookie" (first sc-keys)) "first-seen spelling is retained")
+      (is (= 3 (count sc)) "the pre-existing value plus both cookies are present")
+      (is (= "pre=1" (first sc)) "the pre-existing value stays first (declaration order)")
+      (is (some #(str/starts-with? % "session=abc") sc))
+      (is (some #(str/starts-with? % "theme=dark") sc)))))
+
+(deftest same-case-header-fold-behaviour-unchanged
+  (testing "rf2-3fc89f.16: the case-insensitive fold leaves same-case
+            singleton/scalar/vector behaviour exactly as before"
+    (is (= {"Vary" "Accept"}
+           (headers/merge-pair-into-header-map {} ["Vary" "Accept"]))
+        "a singleton stays a scalar")
+    (is (= {"Vary" ["Accept" "Cookie"]}
+           (-> {}
+               (headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (headers/merge-pair-into-header-map ["Vary" "Cookie"])))
+        "same-case repeats still promote to an ordered vector")))
+
+;; ===========================================================================
 ;; merge-pair-into-header-map — dev-gated warning on a non-string value
 ;;
 ;; rf2-b0jlr: a non-string header value reaching the fold is host-dependent

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2122,6 +2122,50 @@
             "X-Audit append-header reached the wire (multi-valued)")))))
 
 ;; ===========================================================================
+;; rf2-3fc89f.16 — mixed-case append-header pairs collapse to ONE Ring key
+;;
+;; `:rf.server/append-header` preserves the caller's supplied spelling, so an
+;; app can append the same logical header under inconsistent casing (`Vary`
+;; then `vary`). HTTP field names are case-insensitive (RFC 7230 §3.2), so
+;; the materialiser must fold them into ONE Ring map entry with both values
+;; in declaration order — not two entries a downstream proxy/servlet might
+;; merge, overwrite, or emit independently (dropping a Vary cache dimension).
+;; ===========================================================================
+
+(deftest mixed-case-append-header-collapses-to-one-wire-key
+  (testing "rf2-3fc89f.16 (accept #5): mixed-case :rf.server/append-header
+            effects for one logical header materialise to exactly one Ring
+            key carrying every value in declaration order"
+    (rf/reg-event :vary/emit
+      {:platforms #{:server}}
+      (fn [{:keys [db]} _]
+        {:db db
+         :fx [[:rf.server/append-header {:name "Vary" :value "Accept"}]
+              [:rf.server/append-header {:name "vary" :value "Origin"}]
+              [:rf.server/append-header {:name "VARY" :value "Accept-Encoding"}]]}))
+
+    (rf/reg-view* :pages/vary
+      (fn [] [:div.page [:h1 "vary"]]))
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:vary/emit]]
+                      :root-view      [:pages/vary]
+                      :payload        :rf.ssr.payload/whole-app-db})
+          response (handler {:uri            "/vary"
+                             :request-method :get
+                             :headers        {}})
+          headers  (:headers response)
+          vary-keys (filter (fn [k] (= "vary" (str/lower-case (str k))))
+                            (keys headers))
+          vary-val  (get headers (first vary-keys))]
+      (is (= 200 (:status response)) "drain settled cleanly")
+      (is (= 1 (count vary-keys))
+          "exactly one logical Vary key on the wire — no case-variant duplicates")
+      (is (vector? vary-val) "three appends → a vector of values")
+      (is (= ["Accept" "Origin" "Accept-Encoding"] vary-val)
+          "every value present in declaration order under the first-seen key"))))
+
+;; ===========================================================================
 ;; rf2-nncni3 / rf2-depii — Content-Type override strips any casing (no dup)
 ;;
 ;; `headers->ring-map+content-type-override` force-replaces the accumulator's


### PR DESCRIPTION
## Summary

`re-frame.ssr.ring.headers/merge-pair-into-header-map` folded repeated response-header pairs with a case-**sensitive** `(get m k)`, so pairs differing only by ASCII case materialised as two Ring map entries. HTTP field names are case-**insensitive** (RFC 7230 §3.2), the same namespace already enforces that rule in `strip-header`, and the ns docstring already promises a case-insensitive name match. Mixed-case pairs are reachable through the public `:rf.server/append-header` effect (`response.cljc` preserves the caller's spelling).

The fix folds each pair under the **first-seen spelling** of its logical header, matched case-insensitively via a new `existing-header-key` that mirrors `strip-header`'s lower-case rule. Case variants collapse into one entry with values in **declaration order**; `append-set-cookies` and the content-type override inherit the fix. Same-case / singleton / non-string-coercion / Content-Length-strip behaviour is unchanged.

## Reproduce → fix evidence

Before (from `implementation/ssr-ring`):
```
(headers/headers->ring-map+content-type-override [["Vary" "Accept"] ["vary" "Origin"]] nil)
=> {"Vary" "Accept", "vary" "Origin"}          ; TWO entries
(headers/headers->ring-map+content-type-override [["content-type" "text/html"] ["Content-Type" "application/json"]] nil)
=> {"content-type" "text/html", "Content-Type" "application/json"}   ; TWO entries
```

After:
```
=> {"Vary" ["Accept" "Origin"]}                          ; ONE key, first-seen spelling, declaration order
=> {"content-type" ["text/html" "application/json"]}     ; ONE key, first-seen spelling
;; with a non-nil override → {"Content-Type" "text/xml"} (strips every casing, one canonical scalar)
;; pre-existing lower-case set-cookie + structured cookies → one "set-cookie" key, order preserved
```

## Regression coverage

- `pipeline_materialiser_test`: case-variant collapse (double + triple casing), first-seen-key retention (later variant does NOT rename), mixed-case Content-Type under nil + non-nil override, pre-existing lower-case Set-Cookie append, and a same-case-unchanged guard.
- `ring_test`: handler-level regression dispatching mixed-case `:rf.server/append-header` (`Vary` / `vary` / `VARY`) and asserting exactly one wire key with `["Accept" "Origin" "Accept-Encoding"]` in order.

All new unit assertions fail on the old case-sensitive fold.

## Quality gates (foreground)

- `cd implementation/ssr-ring && clojure -M:test` → **179 tests / 859 assertions, 0 failures, 0 errors** (baseline was 172/839; +7 regression tests)
- `cd implementation/ssr && clojure -M:test` → **375 tests / 1561 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — N/A: `headers.clj` is a JVM-only `.clj` (the Ring host adapter is server-side); the change has no CLJS/`.cljc` surface.

## Stance

Pre-alpha, correctness-first: the fix matches the HTTP spec (RFC 7230 §3.2) and the file's own existing case-insensitive rule (`strip-header`), single-sourced via `existing-header-key`. Elegance + clarity: one small structural fold, no behavioural change to correct paths. Touches only `implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj` and its two test files.

Closes rf2-3fc89f.16.