### PR TITLE
fix(mcp-base): reject noncanonical Base64 cursor aliases identically on CLJ+CLJS (rf2-3fc89f.19)

### DIFF
--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -36,7 +36,7 @@ Base64-encode a UTF-8 string. `java.util.Base64` on the JVM, `js/Buffer` on CLJS
 
 ### `b64-decode s` — base64 string → string
 
-Inverse of `b64-encode`.
+Inverse of `b64-encode`. This is the **raw** host adapter and is deliberately lenient — `java.util.Base64/getDecoder` (JVM) throws on a non-alphabet character but ignores non-zero trailing pad bits, and `js/Buffer` (CLJS) silently drops non-alphabet characters and also ignores pad bits. Cursor decoding does **not** call it directly; it goes through the canonicalising `decode-canonical-b64` (see [§Canonical Base64 enforcement](#canonical-base64-enforcement)) so those host-lenient aliases are rejected.
 
 ### `parse-limit-arg raw default max` — int
 
@@ -55,7 +55,7 @@ Decode an opaque base64 cursor back to its EDN payload map.
 Returns:
 
 - `nil` — the cursor arg is absent (nil / undefined) or blank. The caller treats this as "start from the beginning" (offset 0 / head).
-- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, decoded to more than one EDN form, exceeded `max-cursor-bytes`, or failed the consumer's `valid?` predicate. Callers treat `::malformed` like a stale cursor — drop it and restart.
+- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, was a **noncanonical Base64 alias** (see [§Canonical Base64 enforcement](#canonical-base64-enforcement)), carried a tagged literal, decoded to more than one EDN form, exceeded `max-cursor-bytes`, or failed the consumer's `valid?` predicate. Callers treat `::malformed` like a stale cursor — drop it and restart.
 
 `valid?` is the consumer's payload-shape predicate. Story validates `:v`, natural `:offset`/`:total`, and a string `:sig`. Pair requires a present, non-nil `:after-id` of any EDN-printable type because epoch ids are opaque.
 
@@ -78,6 +78,17 @@ The `:reason` slot is the cross-MCP `vocab/cursor-stale-reason` (`:rf.mcp/cursor
 - `:message` — override the default human-readable message.
 - `:hint` — override the default recovery hint.
 - `:extra` — a map of additional structured slots to merge in (e.g. pair's `:requested-id` / `:head-id`).
+
+## Canonical Base64 enforcement
+
+The opaque token emitted by `encode-cursor` has **one** canonical standard-Base64 spelling — precisely what `b64-encode` produces. The accepted token format is **canonical standard Base64** (the RFC 4648 standard alphabet `A–Z a–z 0–9 + /` with `=` padding); URL-safe (`-`/`_`) and no-padding variants are **not** accepted — adding one would need an explicit, versioned wire contract.
+
+The raw host decoders do not enforce this, and they diverge:
+
+- `js/Buffer.from … "base64"` (CLJS) **silently drops** characters outside the standard alphabet — `ez!!p2…` decodes as if the `!!` were absent — whereas `java.util.Base64/getDecoder` (JVM) **throws** on them. So the alphabet-alias case alone was host-dependent: the same corrupted token was `::malformed` on story-mcp (JVM) but accepted on pair-mcp (CLJS).
+- **Both** hosts ignore non-zero **trailing pad bits**, so alternate pad-bit spellings (`Zg==`, `Zh==`, `Zi==` all decode to `"f"`) alias one logical token on both runtimes.
+
+`decode-canonical-b64` normalises this with **one shared rule**: decode with the raw `b64-decode`, then require the token to equal `b64-encode` of the decoded bytes — a round-trip against the local encoder, which is the sole source of every legitimate cursor spelling. Any inserted/appended non-alphabet character, extra/invalid padding, or alternate pad-bit spelling re-encodes to a **different** token and is rejected as `::malformed` **before** EDN parsing, **identically on CLJ and CLJS**. The round-trip is strictly stronger than a lexical alphabet/padding regex, which would still admit the alternate pad-bit spellings. The pre-decode `max-cursor-bytes` cap still runs first, and the `nil`/blank, tagged-literal, one-form, `map?`, and consumer `valid?` behaviours are unchanged. Pinned in `cursor_test/decode-cursor-rejects-noncanonical-base64-aliases` and its CLJS mirror `cursor-rejects-noncanonical-base64-aliases-cljs`.
 
 ## Tagged-literal rejection
 

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -17,10 +17,11 @@
 
   The cursor PAYLOAD differs by domain — story carries
   `{:v :offset :total :sig}`, pair carries `{:after-id :ms :until-ms
-  :frame}` — but the base64 codec, the EDN read with ALL-tagged-literal
-  rejection (built-in `#inst`/`#uuid` included) + size guard, the
-  `::malformed` recovery contract, the `:limit` clamp, and the
-  `cursor-stale-result` envelope are identical, so they live here once.
+  :frame}` — but the base64 codec, the canonical-Base64 enforcement
+  (host decoders are lenient — see `decode-canonical-b64`), the EDN read
+  with ALL-tagged-literal rejection (built-in `#inst`/`#uuid` included) +
+  size guard, the `::malformed` recovery contract, the `:limit` clamp, and
+  the `cursor-stale-result` envelope are identical, so they live here once.
   The codec is a `.cljc` reader-conditional even though `js/Buffer` and
   `java.util.Base64` differ — the reader-conditional bridges the two
   hosts cleanly, so the codec stays shared rather than consumer-side.
@@ -75,11 +76,74 @@
                (.toString "base64"))))
 
 (defn b64-decode
-  "Decode a base64 string back to UTF-8. Inverse of `b64-encode`."
+  "Decode a base64 string back to UTF-8. Inverse of `b64-encode`.
+
+  Host-lenient (this is the RAW adapter): `java.util.Base64/getDecoder`
+  (JVM) throws on a non-alphabet character but IGNORES non-zero trailing
+  pad bits, and `js/Buffer.from … \"base64\"` (CLJS) silently DROPS
+  non-alphabet characters AND ignores pad bits. Neither is
+  canonicalising, so several distinct tokens can decode to the same
+  bytes — see `decode-canonical-b64`, which the cursor path uses to
+  reject those aliases."
   [^String s]
   #?(:clj  (String. (.decode (Base64/getDecoder) s) "UTF-8")
      :cljs (-> (js/Buffer.from s "base64")
                (.toString "utf8"))))
+
+;; ---------------------------------------------------------------------------
+;; Canonical-Base64 enforcement — the ONE shared rule that closes the
+;; host-lenient alias gap around the raw codec above.
+;;
+;; Neither host decoder canonicalises. `js/Buffer` DROPS characters
+;; outside the standard alphabet (`ez!!p2…` decodes as if the `!!` were
+;; absent) where the JVM decoder THROWS — so the alphabet-alias case is
+;; itself host-DIVERGENT, breaking cursor.md's cross-host malformed
+;; contract. And BOTH hosts ignore non-zero trailing pad bits (`Zg==`,
+;; `Zh==`, `Zi==` all decode to "f"), so alternate pad-bit spellings
+;; alias one logical token on both. Multiple wire strings therefore map
+;; to one cursor position, weakening opacity/corruption detection and
+;; making malformed recovery depend on the serving runtime.
+;;
+;; Every legitimate opaque cursor is `(b64-encode (pr-str payload))`, so
+;; the local encoder is the SOLE source of a token's canonical spelling.
+;; `decode-canonical-b64` decodes, then requires the token to be EXACTLY
+;; what `b64-encode` re-produces from those bytes. This single
+;; host-agnostic round-trip equality rejects BOTH alias families — a
+;; lexical alphabet/padding grammar alone would still admit the alternate
+;; pad-bit spellings — IDENTICALLY on CLJ + CLJS.
+;; ---------------------------------------------------------------------------
+
+(defn- bad-b64!
+  "Throw the cursor-boundary noncanonical-Base64 rejection. The decoded
+  bytes re-encode to a DIFFERENT token than the one supplied — a
+  host-lenient alias (dropped non-alphabet char, alternate pad-bit
+  spelling), not the canonical spelling `b64-encode` emits. Caught by the
+  surrounding try in `decode-cursor` → `::malformed`."
+  []
+  (throw (ex-info ":rf.error/mcp-cursor-noncanonical-base64"
+                  {:rf.error/id :rf.error/mcp-cursor-noncanonical-base64
+                   :where       'mcp-base/decode-cursor
+                   :recovery    :no-recovery
+                   :reason      "cursor token is a noncanonical Base64 alias — not the canonical spelling the local encoder emits"})))
+
+(defn- decode-canonical-b64
+  "Base64-decode `s`, but ONLY if `s` is the canonical standard-Base64
+  spelling of its own bytes — i.e. exactly what `b64-encode` re-produces
+  from the decoded text. Rejects the host-lenient aliases both decoders
+  admit (js/Buffer drops non-alphabet chars; both hosts ignore non-zero
+  pad bits) via one shared round-trip-equality rule, identical on CLJ +
+  CLJS. Returns the decoded string, or throws `bad-b64!` (→ `::malformed`)
+  on a noncanonical alias.
+
+  On the JVM a non-alphabet character throws inside `b64-decode` first;
+  the equality gate additionally closes the pad-bit aliases both hosts
+  otherwise accept — so the gate is what makes rejection identical across
+  hosts, not merely a JVM-behaviour port."
+  [s]
+  (let [decoded (b64-decode s)]
+    (if (= s (b64-encode decoded))
+      decoded
+      (bad-b64!))))
 
 ;; ---------------------------------------------------------------------------
 ;; Limit clamp.
@@ -229,7 +293,9 @@
                       beginning' (offset 0 / head).
     - `::malformed` — the cursor exists but is not a well-formed,
                       `valid?`-passing payload map: it failed to
-                      base64/EDN-decode, carried a tagged literal,
+                      base64/EDN-decode, was a NONCANONICAL Base64 alias
+                      (a host-lenient spelling that is not what
+                      `b64-encode` would emit), carried a tagged literal,
                       decoded to MORE THAN ONE EDN form (a trailing
                       object after the payload map),
                       exceeded `max-cursor-bytes`, or its payload map
@@ -261,7 +327,7 @@
 
     :else
     (try
-      (let [v (read-edn-no-tags (b64-decode s))]
+      (let [v (read-edn-no-tags (decode-canonical-b64 s))]
         (if (and (map? v) (valid? v))
           v
           ::malformed))

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -430,6 +430,63 @@
                                    permissive?))))))
 
 ;; ---------------------------------------------------------------------------
+;; 6b. Cursor rejects NONCANONICAL Base64 aliases on CLJS too. `js/Buffer`
+;;     is the lenient host: it DROPS non-alphabet chars (so `ez!!p2…`
+;;     decodes as if the `!!` were absent — the JVM decoder THROWS on
+;;     those) AND, like the JVM, ignores non-zero pad bits. So a corrupted
+;;     / re-spelled token can alias one logical cursor. `decode-canonical-
+;;     b64` re-encodes the decoded bytes and requires token equality,
+;;     rejecting the aliases identically to the JVM. Mirrors
+;;     `cursor_test/decode-cursor-rejects-noncanonical-base64-aliases`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private b64-alphabet
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+
+(defn- pad-bit-alias
+  "Return a NONCANONICAL alias of canonical b64 `token` differing only in
+  the trailing pad bits (same decoded bytes, different spelling), or nil
+  if `token` carries no pad slack. `js/Buffer` ignores non-zero pad bits,
+  so the alias decodes to identical bytes under a different token — the
+  family a lexical grammar admits but the round-trip gate rejects.
+  Verbatim mirror of the JVM `cursor_test` helper."
+  [token]
+  (let [decoded (cursor/b64-decode token)
+        i       (dec (count (re-find #"[^=]+" token)))
+        orig    (nth token i)]
+    (some (fn [c]
+            (when (not= c orig)
+              (let [cand (str (subs token 0 i) c (subs token (inc i)))]
+                (when (= decoded (cursor/b64-decode cand)) cand))))
+          b64-alphabet)))
+
+(deftest cursor-rejects-noncanonical-base64-aliases-cljs
+  (let [payload   "{:v 1 :after-id \"e\"}"
+        canonical (cursor/b64-encode payload)
+        pair?     (fn [m] (and (map? m) (some? (:after-id m))))]
+    (testing "sanity: the canonical token still decodes to its payload map"
+      (is (= {:v 1 :after-id "e"} (cursor/decode-cursor canonical pair?))))
+    (testing "non-alphabet char INSERTED — js/Buffer would silently drop it — ⇒ ::malformed"
+      (let [inserted (str (subs canonical 0 2) "!!" (subs canonical 2))]
+        (is (not= inserted canonical))
+        (is (= :re-frame.mcp-base.cursor/malformed
+               (cursor/decode-cursor inserted pair?)))))
+    (testing "non-alphabet chars APPENDED ⇒ ::malformed"
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor (str canonical "!!!!") pair?))))
+    (testing "malformed / extra padding ⇒ ::malformed"
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor (str canonical "==") pair?))))
+    (testing "noncanonical pad-bit spelling ⇒ ::malformed (same rejection as the JVM)"
+      (let [alias (pad-bit-alias canonical)]
+        (is (some? alias) "the canonical token has pad slack to alias")
+        (is (not= alias canonical))
+        (is (= (cursor/b64-decode alias) (cursor/b64-decode canonical))
+            "the alias decodes to the SAME bytes — a true logical alias")
+        (is (= :re-frame.mcp-base.cursor/malformed
+               (cursor/decode-cursor alias pair?)))))))
+
+;; ---------------------------------------------------------------------------
 ;; 7. Shared with-indicators envelope helper under CLJS.
 ;;    The MUST-level "omit when zero" parity rule runs identically on
 ;;    both hosts; pin the CLJS half.

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -18,6 +18,28 @@
        (integer? (:total m))
        (string? (:sig m))))
 
+(def ^:private b64-alphabet
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+
+(defn- pad-bit-alias
+  "Return a NONCANONICAL alias of canonical b64 `token` that differs only
+  in the trailing pad bits (same decoded bytes, DIFFERENT spelling), or
+  nil if `token` carries no pad slack. Both `java.util.Base64` and
+  `js/Buffer` ignore non-zero pad bits, so such an alias decodes to
+  IDENTICAL bytes under a different token — the alias family a lexical
+  alphabet/padding grammar admits but the round-trip gate must reject.
+  Built from `b64-decode`, so the JVM and CLJS suites derive it the same
+  way. (Mirrored verbatim in `cljs_branches_cljs_test`.)"
+  [token]
+  (let [decoded (cursor/b64-decode token)
+        i       (dec (count (re-find #"[^=]+" token)))
+        orig    (nth token i)]
+    (some (fn [c]
+            (when (not= c orig)
+              (let [cand (str (subs token 0 i) c (subs token (inc i)))]
+                (when (= decoded (cursor/b64-decode cand)) cand))))
+          b64-alphabet)))
+
 ;; ---------------------------------------------------------------------------
 ;; base64 codec round-trip
 ;; ---------------------------------------------------------------------------
@@ -62,6 +84,40 @@
 
 (deftest decode-cursor-garbage-is-malformed
   (is (= ::cursor/malformed (cursor/decode-cursor "!!!not-base64-edn!!!" offset-cursor?))))
+
+(deftest decode-cursor-rejects-noncanonical-base64-aliases
+  ;; The host base64 DECODERS are lenient in DIFFERENT ways: `js/Buffer`
+  ;; DROPS characters outside the standard alphabet (where the JVM decoder
+  ;; THROWS), and BOTH hosts ignore non-zero trailing pad bits. So a
+  ;; corrupted / re-spelled token can decode to the SAME payload map under
+  ;; a DIFFERENT wire string — an alias. `decode-canonical-b64` re-encodes
+  ;; the decoded bytes and requires token equality with the local encoder,
+  ;; rejecting every alias identically on CLJ + CLJS BEFORE EDN parsing.
+  ;; (Mirrored in `cljs_branches_cljs_test/cursor-rejects-noncanonical-
+  ;; base64-aliases-cljs`.)
+  (let [payload   "{:v 1 :after-id \"e\"}"     ; a valid pair-style payload
+        canonical (cursor/b64-encode payload)
+        pair?     (fn [m] (and (map? m) (some? (:after-id m))))]
+    (testing "sanity: the canonical token still decodes to its payload map"
+      (is (= {:v 1 :after-id "e"} (cursor/decode-cursor canonical pair?))))
+    (testing "non-alphabet char INSERTED into a valid token ⇒ ::malformed"
+      (let [inserted (str (subs canonical 0 2) "!!" (subs canonical 2))]
+        (is (not= inserted canonical))
+        (is (= ::cursor/malformed (cursor/decode-cursor inserted pair?)))))
+    (testing "non-alphabet chars APPENDED to a valid token ⇒ ::malformed"
+      (is (= ::cursor/malformed (cursor/decode-cursor (str canonical "!!!!") pair?))))
+    (testing "malformed / extra padding ⇒ ::malformed"
+      (is (= ::cursor/malformed (cursor/decode-cursor (str canonical "==") pair?))))
+    (testing "noncanonical pad-bit spelling (a lexical grammar admits it) ⇒ ::malformed"
+      ;; This is the alias family a regex-only check would MISS and the one
+      ;; the OLD JVM decoder accepted (java.util.Base64 ignores pad bits):
+      ;; the alias decodes to the same valid map, so old code returned it.
+      (let [alias (pad-bit-alias canonical)]
+        (is (some? alias) "the canonical token has pad slack to alias")
+        (is (not= alias canonical))
+        (is (= (cursor/b64-decode alias) (cursor/b64-decode canonical))
+            "the alias decodes to the SAME bytes — a true logical alias")
+        (is (= ::cursor/malformed (cursor/decode-cursor alias pair?)))))))
 
 (deftest decode-cursor-oversize-is-malformed-before-parse
   (let [oversize (apply str (repeat (inc cursor/max-cursor-bytes) "a"))]


### PR DESCRIPTION
## Summary

The shared cursor codec (`re-frame.mcp-base.cursor`) decoded through the **raw** host Base64 adapters, which are lenient in **host-divergent** ways:

- `js/Buffer` (CLJS) silently **drops** characters outside the standard alphabet — `ez!!p2…` decodes as if the `!!` were absent — where `java.util.Base64/getDecoder` (JVM) **throws** on them.
- **Both** hosts ignore non-zero trailing **pad bits**, so alternate pad-bit spellings (`Zg==`, `Zh==`, `Zi==` all decode to `"f"`) alias one logical token on both runtimes.

So a corrupted / re-spelled continuation token could decode to the **same** payload map under a **different** wire string — an alias. The alphabet-alias case was accepted on pair-mcp (CLJS) but `::malformed` on story-mcp (JVM), violating `cursor.md`'s cross-host malformed contract and the namespace claim that codec/recovery behaviour is identical. Multiple wire strings aliased one cursor position, weakening opacity / corruption detection and making malformed recovery depend on the serving runtime.

## The canonicality rule

**One shared rule around the host primitive** (`decode-canonical-b64`): decode with the raw `b64-decode`, then require the token to equal `b64-encode` of the decoded bytes. The local encoder is the sole source of every legitimate cursor spelling, so this round-trip equality rejects **every** alias family — inserted/appended non-alphabet chars, extra/invalid padding, **and** alternate pad-bit spellings (which a lexical alphabet/padding regex alone would still admit) — **before** EDN parsing, **identically on CLJ + CLJS**.

Preserved unchanged: the pre-decode 1 KB `max-cursor-bytes` cap, and the `nil`/blank, tagged-literal, one-form, `map?`, and consumer `valid?` behaviours. **No** URL-safe / no-padding variants added (those would need an explicit versioned wire contract).

Both consumers (story-mcp, pair-mcp) route through `base-cursor/decode-cursor`, so the fix covers both transitively — a corrupted token now returns `::malformed` and the pagination handlers take their existing stale/malformed recovery path.

## Reproduce → fix evidence

Audit-derived (rf2-3fc89f.19) — reproduced **before** fixing:

- **CLJS/Node**: `ez!!p2…` (canonical `+ !!` inserted) decodes byte-for-byte to the original EDN via `Buffer.from`; old code accepted it. Re-encode of the decoded bytes ≠ the token.
- **Both hosts**: `Zg==`/`Zh==`/`Zi==` all decode to `"f"` — `java.util.Base64` also accepts pad-bit aliases on the JVM.
- **Regression-detector proof**: reverting only the source line, the new test **fails on old code** — CLJS **4 failures** (all four alias families; CLJS is fully lenient), JVM **1 failure** (the pad-bit alias — the JVM already threw on `!!`). Restored, both hosts are green.

## Quality gates (foreground, `tools/mcp-base`)

- JVM `clojure -M:test` → **267 tests / 886 assertions, 0 failures** (was 266/877)
- CLJS `npm run test:cljs` → **29 tests / 190 assertions, 0 failures, 0 warnings** (was 28/181)
- `check:descriptors` — **N/A** (the cursor codec is not descriptor-adjacent)

## Stance

Pre-alpha; MCP cursors are an AI-egress / wire boundary — canonicality enforced identically CLJ+CLJS. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS.

## Scope

Touches only `tools/mcp-base`: the cursor codec (`cursor.cljc`), its JVM (`cursor_test.clj`) + CLJS (`cljs_branches_cljs_test.cljs`) tests, and the `spec/cursor.md` contract doc.

## Follow-up (out of scope for this bead's boundary)

Bead AC#5 also asks for a focused **pair-mcp** pagination integration regression (corrupted token → structured stale/malformed recovery through the handler). That touches a different artefact (`tools/re-frame2-pair-mcp`) outside this worker's boundary; the shared-codec behaviour is fully pinned here (incl. a pair-style permissive predicate on both hosts). Recommend a separate bead for the pair-mcp handler-level regression.