### PR TITLE
docs(skill): reg-machine is the sole authoring recipe; demote make-machine-handler to advanced (rf2-3fc89f.36)

### DIFF
--- a/scripts/check_skill_re_frame2_drift.py
+++ b/scripts/check_skill_re_frame2_drift.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""No-bead-id + verification-posture + launcher-canonical drift guard for the
-re-frame2 (authoring) skill.
+"""No-bead-id + verification-posture + launcher-canonical + machine-handler-
+recipe drift guard for the re-frame2 (authoring) skill.
 
 `spec/design.md` is the single normative source for the skill's locked
 decisions (L1–L11), file structure, cardinal rules, and verification posture;
 `spec/inputs.md` owns the canonical inputs and update procedure. The
 `spec/authoring-prompt.md` launcher orchestrates a reauthoring pass by
 *pointing at* those two files — it must not carry a second, drift-prone copy of
-the tree, the rules, or the locks. This guard protects three regressions the
+the tree, the rules, or the locks. This guard protects four regressions the
 existing automated guards did not catch (the no-bead-id guard was scoped to
 `skills/re-frame2-implementor` only):
 
@@ -48,6 +48,21 @@ existing automated guards did not catch (the no-bead-id guard was scoped to
      fails if the launcher stops citing a canonical file or grows a box-drawing
      tree / a "Locks to preserve verbatim" (or "Cardinal rules to bake in")
      block back.
+
+  4. **The machine-registration footgun.** The state-machine leaf and the API
+     cheatsheet taught the bare `(reg-event id meta (make-machine-handler spec))`
+     route as if it were a normal way to author a machine. That direct path does
+     NOT stamp the `:rf/machine?` / `:rf/machine` registration metadata or the
+     per-element source coordinates that machine introspection, `(machine-meta
+     id)`, visualisers, and Xray resolve through, and a `[:schemas :data]`-
+     bearing spec throws `:rf.error/machine-schema-requires-reg-machine` on it.
+     `reg-machine` is the sole normal application-authoring recipe — it already
+     registers the machine AS an event handler and stamps that metadata. This
+     guard rejects a POSITIVE fenced recipe that co-locates `reg-event` and
+     `make-machine-handler`, while ALLOWING an inline (non-fenced) implementation
+     warning that names the shape — so the retained advanced-note mention on
+     `reg-machine.md` / `api-cheatsheet.md` stays legal, but a copy-pasteable
+     footgun recipe cannot reappear in any user-facing leaf.
 
 Scanned leaves (globbed, so a new leaf is covered automatically):
     SKILL.md, README.md, references/**/*.md, patterns/**/*.md,
@@ -135,6 +150,58 @@ VERIFY_PROSE_RE = re.compile(
     r"|verifying\b.{0,40}\bis in scope",
     re.IGNORECASE,
 )
+
+# --- Rule 4: no positive bare `reg-event` + `make-machine-handler` recipe in a
+#     fenced code block (the machine-registration footgun). `reg-machine` is the
+#     sole normal application-authoring recipe; the bare direct path skips the
+#     `:rf/machine?` / source-coord stamp and trips
+#     `:rf.error/machine-schema-requires-reg-machine` on a `[:schemas :data]`
+#     spec. Scanned per-FENCED-BLOCK (the two tokens land on different lines of
+#     one block), so an inline single-backtick warning that names the shape in
+#     prose — the retained advanced-note mention — is allowed; only a
+#     copy-pasteable positive recipe is rejected.
+FENCE_RE = re.compile(r"^\s*```")
+REG_EVENT_TOKEN_RE = re.compile(r"\breg-event\b")
+MAKE_MACHINE_HANDLER_TOKEN_RE = re.compile(r"\bmake-machine-handler\b")
+MACHINE_HANDLER_MSG = (
+    "MACHINE-HANDLER-FOOTGUN: this fenced recipe registers a machine via the "
+    "bare `reg-event` + `make-machine-handler` route. That path does NOT stamp "
+    "the :rf/machine? / :rf/machine registration metadata or the per-element "
+    "source coordinates that machine introspection, (machine-meta id), "
+    "visualisers, and Xray resolve through, and a [:schemas :data]-bearing spec "
+    "throws :rf.error/machine-schema-requires-reg-machine on it. Author normal "
+    "machines with `rf/reg-machine` — the sole normal application-authoring "
+    "recipe; it already registers the machine AS an event handler. Demote "
+    "make-machine-handler to an inline advanced-note mention, never a positive "
+    "fenced recipe."
+)
+
+
+def machine_handler_recipe_problems(text: str) -> list[tuple[int, str]]:
+    """Rule 4 — a fenced code block that co-locates `reg-event` and
+    `make-machine-handler` is the machine-registration footgun (a positive
+    recipe for the metadata-skipping direct path). Returns
+    (opening-fence-lineno, message) tuples. Takes the whole file body so the
+    self-test can pass a fenced fixture directly; an inline single-backtick
+    mention in prose never enters a fenced block, so it is allowed."""
+    problems: list[tuple[int, str]] = []
+    in_block = False
+    block_start = 0
+    block_lines: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if FENCE_RE.match(line):
+            if not in_block:
+                in_block, block_start, block_lines = True, lineno, []
+            else:
+                body = "\n".join(block_lines)
+                if (REG_EVENT_TOKEN_RE.search(body)
+                        and MAKE_MACHINE_HANDLER_TOKEN_RE.search(body)):
+                    problems.append((block_start, MACHINE_HANDLER_MSG))
+                in_block, block_lines = False, []
+        elif in_block:
+            block_lines.append(line)
+    return problems
+
 
 # --- Rule 3: launcher points at BOTH canonical files, without regrowing the
 #     tree / locks sections. Operates on the whole authoring-prompt.md body
@@ -238,11 +305,17 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
     for path in files:
         if not path.is_file():
             continue
-        for lineno, line in enumerate(_slurp(path).splitlines(), start=1):
+        rel = path.relative_to(REPO_ROOT)
+        body = _slurp(path)
+        for lineno, line in enumerate(body.splitlines(), start=1):
             lines_checked += 1
-            rel = path.relative_to(REPO_ROOT)
             for label in beadid_problems(line) + posture_problems(line):
                 problems.append(f"{rel}:{lineno}: {label}\n    {line.strip()}")
+        # Rule 4 — the machine-registration footgun is a cross-line shape
+        # (reg-event and make-machine-handler on different lines of one fenced
+        # block), so it is scanned per-block rather than per-line.
+        for start_lineno, label in machine_handler_recipe_problems(body):
+            problems.append(f"{rel}:{start_lineno}: {label}")
 
     # Rule 3 — the launcher (authoring-prompt.md) is checked as a whole body,
     # not line-by-line, and lives under spec/ (out of the leaf scan above).
@@ -272,17 +345,19 @@ def run(*, verbose: bool, ci: bool) -> int:
 
     if verbose:
         print(
-            f"re-frame2 no-bead-id + verify-posture + launcher-canonical guard: "
-            f"scanned {len(files)} user-facing leaves ({lines_checked} lines) "
-            "plus the spec/authoring-prompt.md launcher."
+            "re-frame2 no-bead-id + verify-posture + launcher-canonical + "
+            f"machine-handler-recipe guard: scanned {len(files)} user-facing "
+            f"leaves ({lines_checked} lines) plus the spec/authoring-prompt.md "
+            "launcher."
         )
 
     if not problems:
         if verbose:
             print(
                 "re-frame2-drift: no bead-id leaks, no agent-run verification-"
-                "posture drift, and the launcher points at design.md + inputs.md "
-                "without regrowing the tree / locks."
+                "posture drift, no bare reg-event + make-machine-handler recipe, "
+                "and the launcher points at design.md + inputs.md without "
+                "regrowing the tree / locks."
             )
         return 0
 
@@ -293,8 +368,10 @@ def run(*, verbose: bool, ci: bool) -> int:
         f"\nre-frame2-drift: {len(problems)} drift issue(s) — keep internal "
         "bead ids out of the user-facing leaves (L10), keep the "
         "authoring-only verification posture (Q14 / L3: the author runs the "
-        "gates, the skill names them), and keep the launcher pointing at the "
-        "canonical design.md + inputs.md instead of re-holding the tree / locks."
+        "gates, the skill names them), author machines with reg-machine (not a "
+        "bare reg-event + make-machine-handler recipe), and keep the launcher "
+        "pointing at the canonical design.md + inputs.md instead of re-holding "
+        "the tree / locks."
     )
     return 1
 
@@ -443,6 +520,67 @@ def _self_test() -> int:
         launcher_problems,
         clean_launcher + "\n\n*Cardinal rules to bake in (these go in SKILL.md):*",
         dirty=True, label="G6 launcher regrew the cardinal-rules block",
+    )
+
+    # --- Rule 4: machine-registration footgun. `machine_handler_recipe_problems`
+    # takes the WHOLE body (the two tokens span lines of one fenced block), so
+    # these fixtures are multi-line prose with fences.
+    dirty_recipe = (
+        "Author the boot flow:\n\n"
+        "```clojure\n"
+        "(rf/reg-event :app/boot\n"
+        "  (re-frame.machines/make-machine-handler\n"
+        "    {:initial :configuring :states {}}))\n"
+        "```\n"
+    )
+    expect(
+        machine_handler_recipe_problems, dirty_recipe,
+        dirty=True, label="H1 fenced reg-event wrapping make-machine-handler",
+    )
+    dirty_recipe_alias = (
+        "```clojure\n"
+        "(rf/reg-event :ws/connection\n"
+        "  (machines/make-machine-handler\n"
+        "    {:initial :disconnected}))\n"
+        "```\n"
+    )
+    expect(
+        machine_handler_recipe_problems, dirty_recipe_alias,
+        dirty=True, label="H2 aliased machines/make-machine-handler recipe",
+    )
+    # CLEAN — the corrected reg-machine recipe.
+    clean_recipe = (
+        "Author it with reg-machine:\n\n"
+        "```clojure\n"
+        "(rf/reg-machine :app/boot\n"
+        "  {:initial :configuring :states {}})\n"
+        "(rf/dispatch [:app/boot [:rf.machine/start]])\n"
+        "```\n"
+    )
+    expect(
+        machine_handler_recipe_problems, clean_recipe,
+        dirty=False, label="I1 fenced reg-machine recipe (no footgun)",
+    )
+    # CLEAN — inline (non-fenced) advanced-note warning that names the shape.
+    clean_inline_warning = (
+        "> **Advanced — make-machine-handler.** Registering it by hand, "
+        "`(rf/reg-event id meta (make-machine-handler spec))`, does not stamp "
+        "the :rf/machine? metadata, and a [:schemas :data] spec throws "
+        ":rf.error/machine-schema-requires-reg-machine. Use reg-machine."
+    )
+    expect(
+        machine_handler_recipe_problems, clean_inline_warning,
+        dirty=False, label="I2 inline advanced-note warning prose is allowed",
+    )
+    # CLEAN — a fenced block with a plain reg-event and no machine handler.
+    clean_simple = (
+        "```clojure\n"
+        "(rf/reg-event :app/init (fn [_ _] {:fx [[:dispatch [:config/load]]]}))\n"
+        "```\n"
+    )
+    expect(
+        machine_handler_recipe_problems, clean_simple,
+        dirty=False, label="I3 fenced plain reg-event (no machine handler)",
     )
 
     if failures:

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -25,72 +25,71 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
 
 ## Canonical declaration (state-machine form)
 
-`make-machine-handler` lives on `re-frame.machines` (`(:require [re-frame.machines :as machines])`) — it is not on the `re-frame.core` façade. The `reg-machine` / `defmachine` registration macros stay on the `rf/` façade.
+`reg-machine` **is** the registration home for the boot machine — it registers the machine as an event handler and stamps the `:rf/machine?` / source-coordinate metadata the boot UI's `:rf/machine` sub and the tooling rely on, so author it with `reg-machine`, never wrap it by hand. (`reg-machine` / `defmachine` stay on the `rf/` façade; the lower-level `re-frame.machines/make-machine-handler` factory is an advanced schema-less escape hatch — see [`../references/state-machines/reg-machine.md`](../references/state-machines/reg-machine.md) §Driving a machine as a discrete event-driven flow.) The frame's `:initial-events` drive the machine by dispatching the nested `[:app/boot [:rf.machine/start]]` creation marker.
 
 ```clojure
-(rf/reg-event :app/boot
-  (machines/make-machine-handler
-    {:initial :configuring
-     :data    {:phase :configuring :config nil :user nil :error nil :phase-attempt 0}
+(rf/reg-machine :app/boot
+  {:initial :configuring
+   :data    {:phase :configuring :config nil :user nil :error nil :phase-attempt 0}
 
-     :guards
-     {:under-retry-limit? (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
+   :guards
+   {:under-retry-limit? (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
 
-     :actions
-     {:record-config (fn [{data :data [_ c] :event}] {:data (assoc data :config c)})
-      :record-user   (fn [{data :data [_ u] :event}] {:data (assoc data :user u)})
-      :record-error  (fn [{data :data [_ e] :event}] {:data (assoc data :error e)})
-      :bump-attempt  (fn [{:keys [data]}]            {:data (update data :phase-attempt inc)})
+   :actions
+   {:record-config (fn [{data :data [_ c] :event}] {:data (assoc data :config c)})
+    :record-user   (fn [{data :data [_ u] :event}] {:data (assoc data :user u)})
+    :record-error  (fn [{data :data [_ e] :event}] {:data (assoc data :error e)})
+    :bump-attempt  (fn [{:keys [data]}]            {:data (update data :phase-attempt inc)})
 
-      ;; CONSOLIDATED :entry — :set-phase + :resolve-initial-route in one fn.
-      ;; :entry slots accept one fn / id, never a vector; compose by returning
-      ;; both :data and :fx from one action.
-      :enter-routing
-      (fn [{:keys [data]}]
-        {:data (assoc data :phase :routing :phase-attempt 0)
-         :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
+    ;; CONSOLIDATED :entry — :set-phase + :resolve-initial-route in one fn.
+    ;; :entry slots accept one fn / id, never a vector; compose by returning
+    ;; both :data and :fx from one action.
+    :enter-routing
+    (fn [{:keys [data]}]
+      {:data (assoc data :phase :routing :phase-attempt 0)
+       :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
 
-      :phase-configuring (fn [{d :data}] {:data (assoc d :phase :configuring :phase-attempt 0)})
-      :phase-auth        (fn [{d :data}] {:data (assoc d :phase :authenticating)})
-      :phase-profile     (fn [{d :data}] {:data (assoc d :phase :loading-profile)})
-      :phase-hydrate     (fn [{d :data}] {:data (assoc d :phase :hydrating)})}
+    :phase-configuring (fn [{d :data}] {:data (assoc d :phase :configuring :phase-attempt 0)})
+    :phase-auth        (fn [{d :data}] {:data (assoc d :phase :authenticating)})
+    :phase-profile     (fn [{d :data}] {:data (assoc d :phase :loading-profile)})
+    :phase-hydrate     (fn [{d :data}] {:data (assoc d :phase :hydrating)})}
 
-     :states
-     {:configuring
-      {:entry  :phase-configuring
-       :spawn {:machine-id :rf.http/managed
-                :data       {:request {:method :get :url "/config"} :decode :json}}
-       :on     {:succeeded {:target :authenticating :action :record-config}
-                :failed    {:target :fatal-error    :action :record-error}}}
+   :states
+   {:configuring
+    {:entry  :phase-configuring
+     :spawn {:machine-id :rf.http/managed
+              :data       {:request {:method :get :url "/config"} :decode :json}}
+     :on     {:succeeded {:target :authenticating :action :record-config}
+              :failed    {:target :fatal-error    :action :record-error}}}
 
-      :authenticating
-      {:entry  :phase-auth
-       :spawn {:machine-id :auth/restore-session
-                ;; :spawn :data fn takes ONE context-map arg {:keys [snapshot event]};
-                ;; the parent's data lives at (:data snapshot), not the top-level arg.
-                :data       (fn [{:keys [snapshot]}] {:auth-url (-> snapshot :data :config :auth-url)})}
-       :on     {:succeeded {:target :loading-profile}
-                :failed    [{:guard :under-retry-limit? :target :retrying-auth :action :bump-attempt}
-                            {:target :auth-failed :action :record-error}]}}
+    :authenticating
+    {:entry  :phase-auth
+     :spawn {:machine-id :auth/restore-session
+              ;; :spawn :data fn takes ONE context-map arg {:keys [snapshot event]};
+              ;; the parent's data lives at (:data snapshot), not the top-level arg.
+              :data       (fn [{:keys [snapshot]}] {:auth-url (-> snapshot :data :config :auth-url)})}
+     :on     {:succeeded {:target :loading-profile}
+              :failed    [{:guard :under-retry-limit? :target :retrying-auth :action :bump-attempt}
+                          {:target :auth-failed :action :record-error}]}}
 
-      :retrying-auth {:after {2000 {:target :authenticating}}}
+    :retrying-auth {:after {2000 {:target :authenticating}}}
 
-      :loading-profile
-      {:entry  :phase-profile
-       :spawn {:machine-id :rf.http/managed
-                :data       (fn [{:keys [snapshot]}]
-                              {:request {:method :get :url (-> snapshot :data :config :profile-url)}
-                               :decode  :json})}
-       :on     {:succeeded {:target :hydrating :action :record-user}
-                :failed    {:target :profile-failed :action :record-error}}}
+    :loading-profile
+    {:entry  :phase-profile
+     :spawn {:machine-id :rf.http/managed
+              :data       (fn [{:keys [snapshot]}]
+                            {:request {:method :get :url (-> snapshot :data :config :profile-url)}
+                             :decode  :json})}
+     :on     {:succeeded {:target :hydrating :action :record-user}
+              :failed    {:target :profile-failed :action :record-error}}}
 
-      :hydrating {:entry :phase-hydrate :on {:hydrate/done {:target :routing}}}
-      :routing   {:entry :enter-routing :on {:rf.route/resolved {:target :ready}}}
+    :hydrating {:entry :phase-hydrate :on {:hydrate/done {:target :routing}}}
+    :routing   {:entry :enter-routing :on {:rf.route/resolved {:target :ready}}}
 
-      :ready          {:meta {:terminal? true}}
-      :auth-failed    {:meta {:terminal? true}}
-      :profile-failed {:meta {:terminal? true}}
-      :fatal-error    {:meta {:terminal? true}}}}))
+    :ready          {:meta {:terminal? true}}
+    :auth-failed    {:meta {:terminal? true}}
+    :profile-failed {:meta {:terminal? true}}
+    :fatal-error    {:meta {:terminal? true}}}})
 ```
 
 The frame's `:initial-events` dispatch `[:app/boot [:rf.machine/start]]` — the reserved creation marker that births the machine directly into its `:initial` state (`:configuring`) and runs that state's entry-cascade. The marker is a pure init-kick (it is never fed into an `:on` map as a trigger), so the machine self-initialises and starts working at birth — there is no idle parking spot waiting on the marker.

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -37,7 +37,7 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
 
 ## Canonical declaration
 
-`make-machine-handler` lives on `re-frame.machines` (`(:require [re-frame.machines :as machines])`) — it is not on the `re-frame.core` façade. The `reg-machine` / `defmachine` registration macros stay on the `rf/` façade.
+`reg-machine` **is** the registration home for the connection machine — it registers the machine as an event handler and stamps the `:rf/machine?` / source-coordinate metadata the `:rf/machine` sub, the declarative `:spawn` resolver, and the tooling rely on, so author it with `reg-machine`, never wrap it by hand. (`reg-machine` / `defmachine` stay on the `rf/` façade; the lower-level `re-frame.machines/make-machine-handler` factory is an advanced schema-less escape hatch — see [`../references/state-machines/reg-machine.md`](../references/state-machines/reg-machine.md) §Driving a machine as a discrete event-driven flow.)
 
 ```clojure
 ;; The socket actor is spawned on the :active parent, so the runtime binds its
@@ -49,92 +49,91 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
 (def socket-invoke-id [:active])
 (defn socket-id [data] (get-in data [:rf/spawned socket-invoke-id]))
 
-(rf/reg-event :ws/connection
-  (machines/make-machine-handler
-    {:initial :disconnected
-     ;; NOTE :cred-ref is an opaque pointer; the bearer is fetched
-     ;; client-side at actor spawn via your app's :auth.cred/fetch cofx
-     ;; (an app-prefixed registration — NOT a framework surface).
-     :data    {:url nil :cred-ref nil :retries 0 :max-retries 8
-               :base-ms 1000 :max-backoff-ms 30000
-               :subscriptions #{}
-               :queue [] :in-flight {} :error nil}
+(rf/reg-machine :ws/connection
+  {:initial :disconnected
+   ;; NOTE :cred-ref is an opaque pointer; the bearer is fetched
+   ;; client-side at actor spawn via your app's :auth.cred/fetch cofx
+   ;; (an app-prefixed registration — NOT a framework surface).
+   :data    {:url nil :cred-ref nil :retries 0 :max-retries 8
+             :base-ms 1000 :max-backoff-ms 30000
+             :subscriptions #{}
+             :queue [] :in-flight {} :error nil}
 
-     :guards
-     {:max-retries-exceeded? (fn [{data :data}] (>= (:retries data) (:max-retries data)))
-      :has-queued-messages?  (fn [{data :data}] (seq (:queue data)))
-      :current-socket?
-      ;; Connection-epoch check: reject events from a prior socket actor that
-      ;; may dispatch in flight while the cascade tears it down. A torn-down
-      ;; socket reads nil from :rf/spawned, so stragglers drop for free.
-      (fn [{data :data [_ {:keys [source-socket-id]}] :event}]
-        (let [live (socket-id data)]
-          (and (some? live) (= source-socket-id live))))}
+   :guards
+   {:max-retries-exceeded? (fn [{data :data}] (>= (:retries data) (:max-retries data)))
+    :has-queued-messages?  (fn [{data :data}] (seq (:queue data)))
+    :current-socket?
+    ;; Connection-epoch check: reject events from a prior socket actor that
+    ;; may dispatch in flight while the cascade tears it down. A torn-down
+    ;; socket reads nil from :rf/spawned, so stragglers drop for free.
+    (fn [{data :data [_ {:keys [source-socket-id]}] :event}]
+      (let [live (socket-id data)]
+        (and (some? live) (= source-socket-id live))))}
 
-     :actions
-     {:record-connection-opts (fn [{data :data [_ {:keys [url cred-ref]}] :event}]
-                                {:data (assoc data :url url :cred-ref cred-ref)})
-      :rotate-cred     (fn [{data :data [_ new-cred-ref] :event}]
-                         {:data (assoc data :cred-ref new-cred-ref)})
-      :bump-retry      (fn [{data :data}] {:data (update data :retries inc)})
-      :on-connected
-      ;; :entry takes one fn / id, never a vector — consolidate.
-      (fn [{data :data}]
-        {:data (assoc data :retries 0)
-         :fx   (mapv (fn [t] [:dispatch [(socket-id data) [:send {:type :subscribe :topic t}]]])
-                     (:subscriptions data))})
-      :flush-queue (fn [{data :data}] {:data (assoc data :queue [])
-                                 :fx (mapv (fn [m] [:dispatch [(socket-id data) [:send m]]])
-                                           (:queue data))})
-      :enqueue-message (fn [{data :data [_ m] :event}] {:data (update data :queue conj m)})}
+   :actions
+   {:record-connection-opts (fn [{data :data [_ {:keys [url cred-ref]}] :event}]
+                              {:data (assoc data :url url :cred-ref cred-ref)})
+    :rotate-cred     (fn [{data :data [_ new-cred-ref] :event}]
+                       {:data (assoc data :cred-ref new-cred-ref)})
+    :bump-retry      (fn [{data :data}] {:data (update data :retries inc)})
+    :on-connected
+    ;; :entry takes one fn / id, never a vector — consolidate.
+    (fn [{data :data}]
+      {:data (assoc data :retries 0)
+       :fx   (mapv (fn [t] [:dispatch [(socket-id data) [:send {:type :subscribe :topic t}]]])
+                   (:subscriptions data))})
+    :flush-queue (fn [{data :data}] {:data (assoc data :queue [])
+                               :fx (mapv (fn [m] [:dispatch [(socket-id data) [:send m]]])
+                                         (:queue data))})
+    :enqueue-message (fn [{data :data [_ m] :event}] {:data (update data :queue conj m)})}
 
+   :states
+   {:disconnected
+    {:on {:ws/connect {:target [:active] :action :record-connection-opts}
+          :ws/send    {:action :enqueue-message}}}
+
+    :active
+    {;; Socket actor anchored on the PARENT — lifetime spans all three leaves.
+     ;; The actor receives only :url + :cred-ref; it resolves the bearer
+     ;; via a client-only cofx inside its own JS context, then opens the
+     ;; socket. The bearer never re-enters dispatch. The runtime binds the
+     ;; newborn's id into :data under :rf/spawned [:active] — read via the
+     ;; socket-id helper above; no :on-spawn, no :exit cleanup (teardown
+     ;; clears the slot). See examples/patterns/websocket/connection.cljs.
+     :spawn  {:machine-id :websocket/socket
+               ;; :data fn takes ONE context-map arg {:keys [snapshot event]}.
+               :data       (fn [{snap :snapshot}] {:url      (-> snap :data :url)
+                                                   :cred-ref (-> snap :data :cred-ref)})}
+     :on      {:ws/closed      {:target :reconnecting :action :bump-retry}
+               :ws/fatal       {:target :failed}
+               :ws/send        {:action :enqueue-message}
+               :ws/rotate-cred {:action :rotate-cred}}
+     :initial :connecting
      :states
-     {:disconnected
-      {:on {:ws/connect {:target [:active] :action :record-connection-opts}
-            :ws/send    {:action :enqueue-message}}}
+     {:connecting     {:on {:ws/opened {:target :authenticating}}}
+      :authenticating {:entry :send-auth
+                       :on    {:ws/auth-ok     {:target :connected}
+                               :ws/auth-failed {:target [:failed]}}}
+      :connected      {:entry  :on-connected
+                       :always [{:guard :has-queued-messages? :action :flush-queue}]
+                       :on     {:ws/received {:guard :current-socket? :action :route-message}
+                                :ws/send     {:action :send-now}}}}}
 
-      :active
-      {;; Socket actor anchored on the PARENT — lifetime spans all three leaves.
-       ;; The actor receives only :url + :cred-ref; it resolves the bearer
-       ;; via a client-only cofx inside its own JS context, then opens the
-       ;; socket. The bearer never re-enters dispatch. The runtime binds the
-       ;; newborn's id into :data under :rf/spawned [:active] — read via the
-       ;; socket-id helper above; no :on-spawn, no :exit cleanup (teardown
-       ;; clears the slot). See examples/patterns/websocket/connection.cljs.
-       :spawn  {:machine-id :websocket/socket
-                 ;; :data fn takes ONE context-map arg {:keys [snapshot event]}.
-                 :data       (fn [{snap :snapshot}] {:url      (-> snap :data :url)
-                                                     :cred-ref (-> snap :data :cred-ref)})}
-       :on      {:ws/closed      {:target :reconnecting :action :bump-retry}
-                 :ws/fatal       {:target :failed}
-                 :ws/send        {:action :enqueue-message}
-                 :ws/rotate-cred {:action :rotate-cred}}
-       :initial :connecting
-       :states
-       {:connecting     {:on {:ws/opened {:target :authenticating}}}
-        :authenticating {:entry :send-auth
-                         :on    {:ws/auth-ok     {:target :connected}
-                                 :ws/auth-failed {:target [:failed]}}}
-        :connected      {:entry  :on-connected
-                         :always [{:guard :has-queued-messages? :action :flush-queue}]
-                         :on     {:ws/received {:guard :current-socket? :action :route-message}
-                                  :ws/send     {:action :send-now}}}}}
+    :reconnecting
+    {:always [{:guard :max-retries-exceeded? :target :failed}]
+     ;; fn-form delay — ONE context-map arg {:keys [snapshot]}; the snapshot's
+     ;; :data is at (:data snapshot). Re-evaluated each :reconnecting entry.
+     :after  {(fn [{:keys [snapshot]}]
+                (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
+                  (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
+              {:target [:active]}}
+     :on     {:ws/connect     {:target [:active] :action :record-connection-opts}
+              :ws/rotate-cred {:action :rotate-cred}
+              :ws/send        {:action :enqueue-message}}}
 
-      :reconnecting
-      {:always [{:guard :max-retries-exceeded? :target :failed}]
-       ;; fn-form delay — ONE context-map arg {:keys [snapshot]}; the snapshot's
-       ;; :data is at (:data snapshot). Re-evaluated each :reconnecting entry.
-       :after  {(fn [{:keys [snapshot]}]
-                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
-                    (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
-                {:target [:active]}}
-       :on     {:ws/connect     {:target [:active] :action :record-connection-opts}
-                :ws/rotate-cred {:action :rotate-cred}
-                :ws/send        {:action :enqueue-message}}}
-
-      :failed
-      {:on {:ws/connect     {:target [:active] :action :record-connection-opts}
-            :ws/rotate-cred {:action :rotate-cred}}}}}))
+    :failed
+    {:on {:ws/connect     {:target [:active] :action :record-connection-opts}
+          :ws/rotate-cred {:action :rotate-cred}}}}})
 ```
 
 Caller: `(rf/dispatch [:ws/connection [:ws/connect {:url "wss://api.example.com/ws" :cred-ref (current-session-cred-ref)}]])` — `current-session-cred-ref` returns an opaque pointer into the host-side credential vault. The bearer itself never crosses the dispatch boundary; the actor's app-side `:auth.cred/fetch` cofx (your prefix) resolves the pointer to a bearer at spawn time.

--- a/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
@@ -51,7 +51,7 @@ The `reg-event` metadata-map is the one **superset** middle slot — reflection 
 | `re-frame.machines/machine-by-system-id` | `(system-id)` / `(... frame-id)` — owned-ns surface, **not** on the `rf/` façade |
 | `re-frame.machines/dispatch-to-system` | `(system-id event)` / `(... frame-id)` — owned-ns surface, **not** on the `rf/` façade; the canonical action-side messaging surface is the reserved fx `[:rf.machine/dispatch-to-system [system-id event]]` (args are the one 2-element pair) |
 | `re-frame.machines/machine-transition` | `(machine snapshot event)` → `[snapshot' fx]` pure — owned-ns surface, **not** on the `rf/` façade |
-| `re-frame.machines/make-machine-handler` | `(machine)` → event-fx handler — owned-ns surface, **not** on the `rf/` façade |
+| `re-frame.machines/make-machine-handler` | `(machine)` → raw event-handler fn — owned-ns surface, **not** on the `rf/` façade. **Advanced / lower-level**: the schema-less factory `reg-machine` wraps for you. Registering it by hand (`reg-event id meta (make-machine-handler spec)`) does NOT stamp the `:rf/machine?` / `:rf/machine` metadata or source coords tools resolve through, and a `[:schemas :data]`-bearing spec throws `:rf.error/machine-schema-requires-reg-machine`. Author machines with `rf/reg-machine` (it already registers the machine AS an event handler) |
 
 ## Images and frames (EP-0023, `re-frame.core`)
 

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -176,21 +176,25 @@ Project off the snapshot with ordinary `reg-sub`:
   (fn sub-data [snap _] (get-in snap [:data :result])))
 ```
 
-## As an event handler
+## Driving a machine as a discrete event-driven flow
 
-When a machine drives a discrete event-driven flow (boot, websocket-connection lifecycle), wrap its declaration with `re-frame.machines/make-machine-handler` and register the result under `rf/reg-event`. (The `make-machine-handler` wrapper lives on the owning `re-frame.machines` namespace — it is not on the `re-frame.core` façade; the `reg-machine` / `defmachine` registration macros stay on the `rf/` façade.) The wrapper produces the event-handler fn that dispatches into the machine on every invocation:
+A machine that drives a discrete event-driven flow — application boot, a websocket-connection lifecycle — needs **no special registration form**. `reg-machine` already registers the machine **as an event handler** (see §Canonical signature above): author the flow with `reg-machine`, then drive it by dispatching the nested `[machine-id [:event-name & args]]` form. A frame's `:initial-events` births it at frame creation with the reserved creation marker:
 
 ```clojure
-(rf/reg-event :app/boot
-  (re-frame.machines/make-machine-handler
-    {:initial :configuring
-     :data    {:phase :configuring :config nil}
-     :states  ...
-     :guards  ...
-     :actions ...}))
+(rf/reg-machine :app/boot
+  {:initial :configuring
+   :data    {:phase :configuring :config nil}
+   :states  {...}
+   :guards  {...}
+   :actions {...}})
+
+;; drive it — e.g. from the frame's :initial-events:
+(rf/dispatch [:app/boot [:rf.machine/start]])
 ```
 
-`make-machine-handler` is the "wrap this machine as an event-handler" sugar. See `references/cross-cutting/api-cheatsheet.md` §Machines for the contract row; `patterns/boot.md` and `patterns/websocket.md` carry worked examples.
+When the flow also validates its **outer** event vector, pass the optional metadata MIDDLE slot — `(rf/reg-machine :app/boot {:schema BootEvent} boot-machine)`; when it validates its **`:data`**, declare `[:schemas :data]` inside the spec map (see [`machine-schemas.md`](machine-schemas.md)), which **requires** the `reg-machine` home. `patterns/boot.md` and `patterns/websocket.md` carry the worked flows.
+
+> **Advanced — `re-frame.machines/make-machine-handler`.** The lower-level factory that builds the raw event-handler fn `reg-machine` registers for you (owned by `re-frame.machines`, **not** on the `re-frame.core` façade; the `reg-machine` / `defmachine` registration macros stay on the `rf/` façade). It is a **schema-less escape hatch** for programmatic composition — **not** a normal authoring path. Registering it by hand, `(rf/reg-event id meta (make-machine-handler spec))`, does **not** stamp the `:rf/machine?` / `:rf/machine` registration metadata or the per-element source coordinates that machine introspection, `(machine-meta id)`, visualisers, and Xray resolve through — so the machine is invisible to those tools. And a spec carrying a `[:schemas :data]` schema **throws `:rf.error/machine-schema-requires-reg-machine`** on that path: the post-commit `:data` validator resolves the schema *through* the missing metadata stamp, so it would silently validate nothing — the framework fails loud at construction instead. Reach for it only when you genuinely need the bare handler fn programmatically; author normal machines with `reg-machine`. See `references/cross-cutting/api-cheatsheet.md` §Machines for the contract row.
 
 ## Querying registered machines
 


### PR DESCRIPTION
## What & why

The `skills/re-frame2` authoring skill taught a footgun: the bare
`(reg-event id meta (make-machine-handler spec))` route presented as a normal
way to author a state machine. That direct path does **not** stamp the
`:rf/machine?` / `:rf/machine` registration metadata or the per-element source
coordinates that machine introspection, `(machine-meta id)`, visualisers, and
Xray resolve through, and a `[:schemas :data]`-bearing spec throws
`:rf.error/machine-schema-requires-reg-machine` on it (guard in
`implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc`).

`rf/reg-machine` is the sole normal application-authoring recipe — it already
registers the machine **as an event handler** and stamps that metadata.

## Changes

- **`references/state-machines/reg-machine.md`** — the "As an event handler"
  positive recipe is replaced by the equivalent `reg-machine` declaration
  (with the optional metadata MIDDLE slot for an outer event `:schema`, and a
  note that `[:schemas :data]` requires the `reg-machine` home). `make-machine-handler`
  is demoted to an inline **advanced** note carrying the missing-metadata /
  source-coordinate consequences and the `:rf.error/machine-schema-requires-reg-machine`
  guard.
- **`references/cross-cutting/api-cheatsheet.md`** — the `make-machine-handler`
  row is relabelled **advanced / lower-level** with the same consequences + guard.
- **`patterns/boot.md` + `patterns/websocket.md`** — their "Canonical declaration"
  code blocks demonstrated the identical footgun and had **drifted from their own
  cited worked examples** (`examples/patterns/boot/boot.cljs` and
  `examples/patterns/websocket/connection.cljs` already register via
  `rf/reg-machine`; `boot.cljs` even carries a `[:schemas :data]` schema — exactly
  the case the footgun recipe would throw on). Both converted to `reg-machine`.
  This is required for the new all-leaves drift scan to pass on the corrected
  corpus (bead acceptance criterion), and it *removes* a divergence rather than
  creating one.
- **`scripts/check_skill_re_frame2_drift.py`** — new narrow **Rule 4**: rejects a
  positive bare `reg-event` + `make-machine-handler` recipe co-located in a
  **fenced code block** of any user-facing leaf, while **allowing** an inline
  (non-fenced) implementation-warning mention. Self-test fixtures cover both
  directions (H1/H2 footgun recipes flagged; I1 corrected `reg-machine` recipe,
  I2 inline advanced-note prose, I3 plain `reg-event` all clean).

No runtime behavior changed.

## Quality gates

Run in-foreground from the worktree; all green:

- `python scripts/check_skill_re_frame2_drift.py --self-test` → `self-test: all cases passed.` (exit 0)
- `python scripts/check_skill_re_frame2_drift.py --verbose` → clean, scanned 50 leaves (exit 0)
- `python scripts/check_skill_package_refs.py` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- `mkdocs --strict` → skipped (mkdocs not installed in this environment)
- Detector sanity: run against `origin/main` originals, Rule 4 flags the real
  footgun recipes (`reg-machine.md:183`, `boot.md:30`, `websocket.md:42`) and
  does not flag the corrected corpus.
- Converted `reg-machine` code blocks verified paren/brace/bracket-balanced.

## Stance

Pre-alpha; skill content generic to any consumer re-frame2 app. Teaches the
blessed recipe (`reg-machine`), not the footgun. No tracker ids in user-facing
skill prose. ELEGANCE + CLARITY + CORRECTNESS.
