### PR TITLE
fix(machines-viz): share-viewer rejects malformed definitions via canonical grammar gate (rf2-3fc89f.18)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -52,7 +52,8 @@
   Lock #5."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
-            [cognitect.transit :as transit]))
+            [cognitect.transit :as transit]
+            [day8.re-frame2-machines-viz.grammar :as grammar]))
 
 ;; ---------------------------------------------------------------------------
 ;; Constants
@@ -297,14 +298,23 @@
 ;; that accepted compound/parallel snapshots a keyword-only decoder
 ;; then refused — an undecodable URL).
 
-(defn- valid-definition?
-  "A MachineDefinition is either a flat/compound spec (`:initial` +
-  non-empty `:states`) or a parallel spec (`:type :parallel` +
-  non-empty `:regions`)."
-  [d]
-  (and (map? d)
-       (or (and (:initial d) (map? (:states d)) (seq (:states d)))
-           (and (= :parallel (:type d)) (map? (:regions d)) (seq (:regions d))))))
+;; The machine-definition SHAPE gate is the canonical Machines-Viz grammar
+;; predicate (rf2-3fc89f.18) — `grammar/valid-definition?`, the SAME gate the
+;; AI-generate / Mermaid / SCXML emitters + the chart projector share
+;; (rf2-egupfk unified them). The share boundary previously kept a PRIVATE,
+;; WEAKER copy that accepted any truthy flat `:initial` (even a string) and
+;; every non-empty parallel `:regions` map without validating region bodies,
+;; so a forged-but-valid-Transit share URL decoded `:ok` and was handed to
+;; `MachineChart` even though the definition is rejected everywhere else. The
+;; boundary now desugars (`grammar/desugar-grammar`, the SAME lowering the
+;; projectors apply — EP-0029 A4/A5) and routes the definition slot through
+;; `grammar/valid-definition?` in `valid-core-chart-state?` below, so decode
+;; FAILS CLOSED on a malformed definition. Only the definition SHAPE gate is
+;; shared with grammar; the closed-map / snapshot / privacy-sanitisation /
+;; value-free diagnostics stay LOCAL to share. `grammar` is the machines-viz-
+;; local, engine-INDEPENDENT validator (it :requires only clojure.string), so
+;; requiring it here does NOT pull the runtime machines artefact into this
+;; bundle-isolated tool.
 
 (defn- valid-state-path?
   "A compound `:state` arm: a non-empty vector of keywords naming the
@@ -348,6 +358,17 @@
   (and (map? s)
        (= #{:state} (set (keys s)))
        (valid-state-configuration? (:state s))))
+
+(defn- valid-definition?
+  "True when `d` is a projectable machine definition. Holds NO shape logic of
+  its own: it desugars `d` (`grammar/desugar-grammar` — the SAME EP-0029 A4/A5
+  lowering the projectors apply) and delegates the shape check to the canonical
+  `grammar/valid-definition?` gate — see the rationale comment above. Desugars
+  only to CHECK; the stored payload keeps the AUTHORED form
+  (`allowlist-chart-state` never desugars), so an authored `:timeout` /
+  `:choice` definition round-trips byte-identically."
+  [d]
+  (grammar/valid-definition? (grammar/desugar-grammar d)))
 
 (defn- valid-core-chart-state?
   "Validate the load-bearing ChartState slots (`:machine-id`,

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -22,6 +22,7 @@
             [clojure.string :as str]
             [clojure.walk]
             [cognitect.transit :as transit]
+            [day8.re-frame2-machines-viz.grammar :as grammar]
             [day8.re-frame2-machines-viz.share :as share]))
 
 ;; ---------------------------------------------------------------------------
@@ -547,6 +548,132 @@
           d (try (share/decode-share-url smuggled)
                  (catch :default e (ex-data e)))]
       (is (= :invalid-chart-state (:reason d))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-3fc89f.18 — malformed machine DEFINITIONS fail closed at the
+;; share/viewer trust boundary. The boundary previously carried a PRIVATE
+;; definition-shape predicate weaker than the canonical Machines-Viz grammar
+;; gate (`grammar/valid-definition?` — the SAME gate the AI / Mermaid / SCXML
+;; emitters + the chart projector share): it accepted any TRUTHY flat
+;; `:initial` (even a STRING) and every non-empty parallel `:regions` map
+;; WITHOUT validating the region bodies. A forged-but-valid-Transit share URL
+;; therefore decoded `:ok` and was handed to `MachineChart` even though the
+;; same definition is rejected everywhere else. The fix deletes the private
+;; copy and routes the definition slot through the canonical grammar gate
+;; (after the SAME `desugar-grammar` policy the projectors use), so decode
+;; FAILS CLOSED on a malformed definition.
+
+(def timeout-definition
+  "An authored `:timeout` / `:on-timeout` definition (EP-0029 A4). The share
+  stores the AUTHORED form; the boundary desugars to VALIDATE without
+  rewriting the stored payload — so the decoded definition is byte-identical
+  to the authored one."
+  {:initial :idle
+   :states  {:idle    {:timeout 5000 :on-timeout :expired :on {:go :done}}
+             :expired {:final? true}
+             :done    {:final? true}}})
+
+(def choice-definition
+  "An authored `:type :choice` transient state (EP-0029 A5). Round-trips in
+  authored form; the boundary desugars only to validate."
+  {:initial :evaluating
+   :states  {:evaluating {:type   :choice
+                          :choice [{:target :a :guard :ready?} {:target :b}]}
+             :a {:final? true}
+             :b {:final? true}}})
+
+(def valid-definitions
+  "Well-formed definitions the canonical grammar gate accepts (flat, compound,
+  parallel, and the two authored-sugar shapes)."
+  {:flat     idle-loading-success
+   :compound compound-definition
+   :parallel (:definition parallel-state)
+   :timeout  timeout-definition
+   :choice   choice-definition})
+
+(def malformed-definitions
+  "Machine definitions the canonical grammar gate REJECTS but the old private
+  share predicate ACCEPTED. Each is a well-formed Transit value (it survives
+  decode up to the schema check) but a malformed machine SHAPE — a non-keyword
+  / missing flat `:initial`, empty `:states`, or a malformed parallel region
+  body (missing keyword `:initial` / empty `:states`)."
+  {:flat-string-initial     {:initial "idle" :states {:idle {}}}
+   :flat-missing-initial     {:states {:idle {}}}
+   :flat-empty-states        {:initial :idle :states {}}
+   :parallel-empty-region    {:type :parallel :regions {:main {:states {}}}}
+   :parallel-string-initial  {:type :parallel :regions {:main {:initial "x" :states {:x {}}}}}
+   :parallel-no-initial      {:type :parallel :regions {:main {:states {:x {}}}}}})
+
+(defn- forge-definition-url
+  "Forge a share-URL whose `…/chart` carries `definition` verbatim (bypassing
+  the encoder's own validation) so decode-side fail-closed behaviour can be
+  exercised directly."
+  [definition]
+  (envelope->url
+    {:rf.machines-viz.share/v       "2"
+     :rf.machines-viz.share/chart   {:machine-id :demo :definition definition}
+     :rf.machines-viz.share/created 0}))
+
+(deftest decoded-malformed-definition-rejected-throwing
+  (testing "rf2-3fc89f.18 — a forged share-URL carrying a malformed machine
+            definition is rejected at decode with :invalid-chart-state (the
+            throwing API), fail-closed"
+    (doseq [[label definition] malformed-definitions]
+      (let [d (try (share/decode-share-url (forge-definition-url definition))
+                   (catch :default e (ex-data e)))]
+        (is (= :invalid-chart-state (:reason d))
+            (str "malformed definition " label " must fail closed at decode"))
+        (is (= :rf.machines-viz.share/decode-failed (:rf.error/id d)))))))
+
+(deftest decoded-malformed-definition-rejected-safe
+  (testing "rf2-3fc89f.18 — the SAFE decode API returns
+            {:error {:reason :invalid-chart-state}} — never :ok — for a
+            malformed definition (the viewer's ingestion API)"
+    (doseq [[label definition] malformed-definitions]
+      (let [{:keys [ok error]} (share/decode-share-url-safe (forge-definition-url definition))]
+        (is (nil? ok) (str "malformed definition " label " must NOT decode :ok"))
+        (is (= :invalid-chart-state (:reason error))
+            (str "malformed definition " label " surfaces a banner-friendly reason"))))))
+
+(deftest encode-rejects-malformed-definitions
+  (testing "rf2-3fc89f.18 — the encoder rejects the same malformed definitions
+            (encode/decode stay symmetric — the encoder never emits a payload
+            the decoder would reject)"
+    (doseq [[label definition] malformed-definitions]
+      (let [d (try (share/encode-share-url {:machine-id :demo :definition definition})
+                   (catch :default e (ex-data e)))]
+        (is (= :invalid-chart-state (:reason d))
+            (str "malformed definition " label " must be rejected at encode"))
+        (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d)))))))
+
+(deftest valid-definitions-round-trip-unchanged
+  (testing "rf2-3fc89f.18 — hardening the gate does NOT regress valid
+            definitions; flat / compound / parallel / timeout / choice authored
+            forms all round-trip UNCHANGED (share stores the authored form; the
+            boundary desugars only to validate, never rewriting the payload)"
+    (doseq [[label definition] valid-definitions]
+      (let [cs   {:machine-id :demo :definition definition}
+            back (:rf.machines-viz.share/chart
+                   (share/decode-share-url (share/encode-share-url cs)))]
+        (is (= definition (:definition back))
+            (str label " definition round-trips UNCHANGED (authored form preserved)"))))))
+
+(deftest share-definition-gate-agrees-with-canonical-grammar
+  (testing "rf2-3fc89f.18 — the share boundary accepts/rejects EXACTLY the
+            definitions the canonical Machines-Viz grammar gate does (the same
+            gate the AI / Mermaid / SCXML emitters + chart projector share), so
+            one machine value cannot be accepted by one surface and rejected by
+            another. Pins one table of valid + invalid shapes against the
+            canonical predicate so the boundaries cannot drift again."
+    (doseq [[label definition] (merge valid-definitions malformed-definitions)]
+      ;; `grammar/valid-definition?` is a truthy/falsy predicate (its last
+      ;; `and` term is `(seq …)` — a seq, not a literal boolean), so coerce
+      ;; both sides to booleans before comparing agreement.
+      (let [canonical? (boolean (grammar/valid-definition? (grammar/desugar-grammar definition)))
+            share-ok?  (some? (:ok (share/decode-share-url-safe (forge-definition-url definition))))]
+        (is (= canonical? share-ok?)
+            (str label ": share boundary must agree with the canonical grammar gate "
+                 "(canonical? " canonical? ", share-ok? " share-ok? ")"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-dplwxh — top-level ChartState is CLOSED on decode. The encoder

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
@@ -4,8 +4,23 @@
   exercised here; `decode-location` + `viewer-view` are pure given a
   URL / view-model, so they carry the coverage."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [cognitect.transit :as transit]
             [day8.re-frame2-machines-viz.share :as share]
             [day8.re-frame2-machines-viz.viewer :as viewer]))
+
+;; Forge a raw share-URL fragment from an arbitrary envelope (the public
+;; encoder would refuse a malformed definition, so decode-side fail-closed
+;; behaviour is exercised through a hand-crafted URL). Mirrors the encoder's
+;; transit-json → base64url step.
+(defn- envelope->url
+  [envelope]
+  (let [transit-str (transit/write (transit/writer :json) envelope)
+        b64 (-> (js/btoa (js/unescape (js/encodeURIComponent transit-str)))
+                (str/replace "+" "-")
+                (str/replace "/" "_")
+                (str/replace "=" ""))]
+    (str "https://x/viewer.html#machine=" b64)))
 
 (def chart-state
   {:machine-id :auth/login-flow
@@ -35,6 +50,35 @@
     (let [vm (viewer/decode-location "https://x/viewer.html#machine=@@@bad@@@")]
       (is (= :error (:status vm)))
       (is (contains? #{:malformed-fragment :malformed-payload} (:reason vm))))))
+
+(deftest decode-location-rejects-malformed-definition
+  (testing "rf2-3fc89f.18 — a share-URL carrying a MALFORMED machine definition
+            (a non-keyword flat :initial the canonical grammar gate rejects)
+            decodes to :status :error (fail-closed) and never yields
+            MachineChart props"
+    (let [url (envelope->url
+                {:rf.machines-viz.share/v       "2"
+                 :rf.machines-viz.share/chart   {:machine-id :demo
+                                                 :definition {:initial "idle"
+                                                              :states  {:idle {}}}}
+                 :rf.machines-viz.share/created 0})
+          vm  (viewer/decode-location url)]
+      (is (= :error (:status vm))
+          "a malformed definition must not reach the :ok / MachineChart path")
+      (is (= :invalid-chart-state (:reason vm)))
+      (is (nil? (:props vm)) "no MachineChart props are produced for a malformed definition")))
+  (testing "rf2-3fc89f.18 — a malformed PARALLEL region body (no keyword
+            :initial, empty :states) is likewise rejected at the viewer boundary"
+    (let [url (envelope->url
+                {:rf.machines-viz.share/v       "2"
+                 :rf.machines-viz.share/chart   {:machine-id :demo
+                                                 :definition {:type    :parallel
+                                                              :regions {:main {:states {}}}}}
+                 :rf.machines-viz.share/created 0})
+          vm  (viewer/decode-location url)]
+      (is (= :error (:status vm)))
+      (is (= :invalid-chart-state (:reason vm)))
+      (is (nil? (:props vm))))))
 
 (deftest viewer-view-dispatches-on-status
   (testing "viewer-view renders the right top-level shape per status"


### PR DESCRIPTION
## Summary

The share/viewer trust boundary carried a **private** `valid-definition?` shape predicate weaker than the canonical Machines-Viz grammar gate (`grammar/valid-definition?` — the same gate the AI-generate / Mermaid / SCXML emitters + the chart projector share, unified by rf2-egupfk). The private copy accepted **any truthy flat `:initial`** (even a `String`) and **every non-empty parallel `:regions` map without validating region bodies**, so a forged-but-valid-Transit share URL decoded `:ok` and was handed to `MachineChart` even though the same definition is rejected everywhere else. `viewer/decode-location` returned `:ok` on malformed input — it did not fail closed.

## Fix (per DESIGN)

- `require` `day8.re-frame2-machines-viz.grammar` from `share.cljs`; **delete the weak private shape copy**.
- Route the definition slot of `valid-core-chart-state?` through `grammar/valid-definition?` after the **same** `grammar/desugar-grammar` lowering the projectors apply (EP-0029 A4/A5).
- **Authored form preserved.** The boundary desugars only to *check* the shape; `allowlist-chart-state` never desugars, so the stored payload keeps the authored form and authored `:timeout` / `:choice` definitions round-trip byte-identically. `desugar-grammar` is pure / idempotent / nil-safe and never adds `:initial` / `:states` / `:regions`, so it cannot turn an invalid definition valid — **fail-closed holds**.
- **Bundle isolation preserved.** `grammar` is the machines-viz-local, engine-**independent** validator (it `:require`s only `clojure.string`), so this does **not** pull the runtime `machines` artefact into the bundle-isolated tool. Only the machine-definition SHAPE gate is shared; the closed-map / snapshot / privacy-sanitisation / value-free diagnostics stay LOCAL to `share`.

## Reproduce → fix evidence

Reproduction (before fix), forging v2 Transit envelopes, decoded `:ok` (the bug):
- `{:initial "idle" :states {:idle {}}}` (non-keyword flat `:initial`)
- `{:type :parallel :regions {:main {:states {}}}}` (region body: no keyword `:initial`, empty `:states`)
- `{:type :parallel :regions {:main {:initial "x" :states {:x {}}}}}` (region initial non-keyword)
- `{:type :parallel :regions {:main {:states {:x {}}}}}` (region body: no `:initial`)

All four now return `:invalid-chart-state` through both the throwing (`decode-share-url`) and safe (`decode-share-url-safe`) APIs, at encode, and via `viewer/decode-location` (`:status :error`, no `MachineChart` props). Already-caught cases (missing flat `:initial`, empty flat `:states`) stay rejected. Valid flat / compound / parallel / **timeout** / **choice** authored definitions round-trip **unchanged**. A pinned table asserts the share boundary agrees exactly with the canonical grammar gate so the surfaces cannot drift again.

## Quality gates (foreground, rebased on latest `origin/main`)

- `cd implementation && npm run test:cljs` — **8494 tests, 39313 assertions, 0 failures, 0 errors** (runs the new share + viewer `.cljs` tests via the `:node-test` build)
- `cd tools/machines-viz && clojure -M:test` — **605 tests, 2265 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:bundle-isolation` — **PASS** (22 artefact entries; 41 internal sentinels absent) + `uix-helix-reagent-free` **PASS** (no runtime-machines / re-frame.core leak into production bundles)

## Spec

Spec unchanged — internal validation hardening. The share/viewer public API, payload schema, and documented failure modes are unchanged; `:invalid-chart-state` already means "`:rf.machines-viz.share/chart` doesn't validate" and the schema already promises "anything not in the schema is ... rejected by the decoder." This fix realizes that documented decode-rejection guarantee for the definition slot (previously under-enforced by the weaker private predicate) without changing any public contract.

## Stance

Pre-alpha; the share-viewer is a bundle-isolated tool — decode **must fail closed** on malformed input. ELEGANCE + CLARITY + CORRECTNESS.

Closes rf2-3fc89f.18.
