### PR TITLE
fix(examples): distinct RealWorld wire User vs token-free durable session-user (rf2-3fc89f.32)

### DIFF
--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -48,9 +48,13 @@
    [:stale-after-ms {:optional true} [:maybe :int]]])
 
 (def AuthSlice
-  "The auth slice. :user holds the current :User payload (or nil); :token is
-   the JWT (or nil). The auth machine's own snapshot lives elsewhere — over in
-   runtime-db at [:rf.runtime/machines :snapshots :auth/flow].
+  "The auth slice. :user holds the durable, token-free session user
+   (`ws/SessionUser` — the wire User minus its credential, since
+   `:auth/store-session` `dissoc`s the token before storing); :token is the JWT
+   (or nil). Validating :user against the wire `ws/User` here would demand the
+   very :token the durable copy deliberately drops, and post-commit validation
+   would roll the login back. The auth machine's own snapshot lives elsewhere —
+   over in runtime-db at [:rf.runtime/machines :snapshots :auth/flow].
 
    :return-to is the breadcrumb: the post-login bounce-back target the routing
    `:rf.route/entry-blocked` handler drops here (routing.cljs) when the
@@ -59,7 +63,7 @@
    exists for the brief window between that redirect and the next successful
    login."
   [:map
-   [:user      [:maybe ws/User]]
+   [:user      [:maybe ws/SessionUser]]
    [:token     [:maybe :string]]
    [:return-to {:optional true}
     [:map

--- a/examples/real-apps/realworld_resources/schema.cljs
+++ b/examples/real-apps/realworld_resources/schema.cljs
@@ -21,7 +21,8 @@
      https://github.com/gothinkster/realworld/tree/main/api"
   (:require [re-frame.core :as rf]
             ;; The shared wire contract — User/Profile/Article/Comment + the
-            ;; seven response envelopes. The auth slice below embeds `ws/User`.
+            ;; seven response envelopes. The auth slice below embeds the
+            ;; token-free `ws/SessionUser` (the durable half of the wire User).
             [realworld-shared.schema :as ws]
             ;; The schemas runtime. Loading it registers the hooks, so
             ;; rf/reg-app-schemas has something to resolve at the call site below.
@@ -38,13 +39,17 @@
 ;; app-schema.)
 
 (def AuthSlice
-  "The auth slice. :user holds the current User payload (or nil); :token is the
-   JWT (or nil). The resource cache scope isn't stored here — it's derived from
-   :user's :username by the named session resolver (see
+  "The auth slice. :user holds the durable, token-free session user
+   (`ws/SessionUser` — the wire User minus its credential, since
+   `:auth/store-session` `dissoc`s the token before storing); :token is the JWT
+   (or nil). Validating :user against the wire `ws/User` here would demand the
+   very :token the durable copy deliberately drops, and post-commit validation
+   would roll the login back. The resource cache scope isn't stored here — it's
+   derived from :user's :username by the named session resolver (see
    realworld-resources.scope). :return-to is the optional post-login bounce-back
    target the routing auth-guard stashes."
   [:map
-   [:user      [:maybe ws/User]]
+   [:user      [:maybe ws/SessionUser]]
    [:token     [:maybe :string]]
    [:return-to {:optional true}
     [:map

--- a/examples/real-apps/realworld_shared/schema.cljs
+++ b/examples/real-apps/realworld_shared/schema.cljs
@@ -7,10 +7,15 @@
    one app's app-db or machine state, so they are NOT part of the
    architecture comparison the two examples exist to draw. Extracting them here
    means the two apps validate responses against ONE definition and can never
-   quietly drift apart. Each app's own `schema.cljs` still owns its app-db slice
-   + machine `:data` schemas (those genuinely differ between the managed-HTTP and
-   resources architectures) and imports these wire shapes directly, exactly as
-   both apps already import `realworld-shared.avatar` / `realworld-shared.markdown`.
+   quietly drift apart. The one DURABLE shape that also belongs here is
+   `SessionUser` — the token-free user both apps persist at `[:auth :user]`,
+   which is mechanically the wire `User` minus its credential; deriving it once
+   beside the wire shape it mirrors keeps the wire/durable split in a single
+   place and is identical across both architectures. Each app's own `schema.cljs`
+   still owns its app-db slice + machine `:data` schemas (those genuinely differ
+   between the managed-HTTP and resources architectures) and imports these wire
+   shapes directly, exactly as both apps already import `realworld-shared.avatar`
+   / `realworld-shared.markdown`.
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api
@@ -43,11 +48,47 @@
    each app's own `:sensitive` classification — classification doesn't
    propagate, so every surface a secret touches has to declare it for itself.
    (The outbound Bearer header gets this for free, via the framework's built-in
-   carrier denylist.) See the keep-secrets how-to:
+   carrier denylist.) The DURABLE user an app stores at `[:auth :user]` is a
+   separate contract too — token-free, validated against `SessionUser` below,
+   not this wire shape. See the keep-secrets how-to:
    ../../../docs/core/how-to/keep-secrets-out-of-traces.md"
   [:map
    [:email    :string]
    [:token    {:sensitive? true} :string]
+   [:username :string]
+   [:bio      [:maybe :string]]
+   [:image    [:maybe :string]]])
+
+;; ----------------------------------------------------------------------------
+;; DURABLE DERIVATION — the token-free session user both apps STORE
+;; ----------------------------------------------------------------------------
+;;
+;; `User` above is the WIRE shape; `SessionUser` is what survives into durable
+;; app-db. They are deliberately DISTINCT contracts — this is the one durable
+;; shape that lives beside the wire shapes because it IS a wire shape minus its
+;; credential, and both apps store it identically.
+
+(def SessionUser
+  "The DURABLE session user — the wire `User` with the credential stripped off.
+
+   Wire and durable are DISTINCT contracts, and this is where they part. `User`
+   above REQUIRES `:token`, because a login / register / restore / settings reply
+   that arrives WITHOUT a JWT is a broken reply that decode must reject. But the
+   JWT is a credential, and durable app-db keeps it in exactly ONE classified
+   place — `[:auth :token]`. The identity an app stores at `[:auth :user]` is
+   written token-free (each app's `:auth/store-session` `dissoc`s it), so the
+   durable slice needs its OWN, token-free shape: this one. Validating the
+   durable user against the wire `User` would demand the very `:token` the app
+   deliberately dropped — post-commit validation would reject the token-free
+   commit and roll the whole login back.
+
+   This is the identity/profile half of `User` — every field EXCEPT the
+   credential. Keep the two in step: an identity field added to the wire `User`
+   belongs here too. Written as vector-form Malli (rather than a `malli.util`
+   derivation of `User`) so the schema-walker can still introspect every per-slot
+   flag when this embeds in an app's `AuthSlice`."
+  [:map
+   [:email    :string]
    [:username :string]
    [:bio      [:maybe :string]]
    [:image    [:maybe :string]]])

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -28,8 +28,19 @@
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
+            ;; Activate the default Malli validator (rf2-t0hq): without this
+            ;; require the CLJS default validator soft-passes and the durable
+            ;; AuthSlice regression below could never observe a rollback. This is
+            ;; the canonical app-boot opt-in for Malli app-schema validation.
+            [re-frame.schemas.malli]
+            [malli.core :as m]
             [re-frame.views]
             [re-frame.http.test-support]
+            ;; The shared WIRE contract (User / UserResponse) + this app's
+            ;; durable app-db schemas (AuthSlice), for the default-frame
+            ;; validator regression (rf2-3fc89f.32).
+            [realworld-shared.schema :as ws]
+            [realworld-http.schema :as app-schema]
             [realworld-http.core]
             ;; Loaded for its ns-load side effects: registers the routes (with
             ;; the `:can-enter [:realworld.routing/authed?]` auth gate on the
@@ -51,7 +62,8 @@
             ;; home-context-test (rf2-rq65wv).
             [realworld-http.tags :as tags]
             [realworld-http.ssr :as ssr])
-  (:require-macros [re-frame.core :refer [with-new-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]
+                   [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; ============================================================================
 ;; CANNED-STUB HELPERS
@@ -194,6 +206,77 @@
 
     (rf/dispatch-sync [:auth/flow [:auth/dismiss]] {:frame f})
     (is (= :idle (rf/compute-sub [:auth/state] (rf/frame-state-value f))))))
+
+;; ============================================================================
+;; auth — wire User vs token-free durable session-user (rf2-3fc89f.32)
+;; ============================================================================
+;;
+;; The correctness review found the durable AuthSlice validated its :user
+;; against the WIRE `ws/User`, which REQUIRES the sensitive :token — but
+;; `:auth/store-session` stores `(dissoc user :token)`, so the durable user is
+;; token-free. In the dev/default build where app schemas are active, the real
+;; post-commit validator rejects that commit and rolls the whole login back.
+;;
+;; Every OTHER login/session test above runs on an anonymous frame
+;; (`make-anon-frame-record!`), whose gensym'd id carries no registered app
+;; schema, so the validator never runs there — those tests stayed falsely green
+;; (the rf2-lo28u lesson: an acceptance test must hit the ACTUAL validated path).
+;; This regression registers the REAL production `AuthSlice` var on the test
+;; frame — the same var `reg-app-schemas` binds to `:rf/default` at ns-load — so
+;; the genuine post-commit validator participates on the genuine
+;; `:auth/store-session` commit.
+
+(defn- vec-map-slot-props
+  "The properties map of one slot in a vector-form Malli `[:map ...]`, or nil.
+   Reads the wire User's per-slot `:sensitive?` flag straight off the pure-data
+   schema, no Malli introspection needed."
+  [map-schema slot-key]
+  (some (fn [entry]
+          (when (and (vector? entry) (= slot-key (first entry)) (map? (second entry)))
+            (second entry)))
+        (rest map-schema)))
+
+(defn- durable-session-user-schema-test []
+  ;; --- WIRE contract UNCHANGED: a token-less reply is still REJECTED and the
+  ;;     token slot stays sensitive (the fix must not weaken decode) ---
+  (is (true? (m/validate ws/UserResponse
+                         {:user {:email "alice@example.com" :username "alice"
+                                 :token "jwt-abc" :bio nil :image nil}}))
+      "a complete login/register/restore/settings reply (with :token) still decodes")
+  (is (false? (m/validate ws/UserResponse
+                          {:user {:email "alice@example.com" :username "alice"
+                                  :bio nil :image nil}}))
+      "a token-LESS reply is STILL rejected by the wire schema — :token stays required")
+  (is (true? (:sensitive? (vec-map-slot-props ws/User :token)))
+      "the wire User's :token slot stays classified :sensitive? true")
+
+  ;; --- DURABLE contract: the token-free session user is stored AND validates
+  ;;     against the real AuthSlice under the real post-commit validator ---
+  (with-new-frame [f (frame/make-anon-frame-record! {})]
+    ;; Register the ACTUAL production AuthSlice on THIS frame so the post-commit
+    ;; validator consults it — the wiring the anon-frame tests route around.
+    (rf/reg-app-schema [:auth] {:frame f} app-schema/AuthSlice)
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
+                                              :username "alice"
+                                              :token "jwt-abc"
+                                              :bio nil :image nil}]
+                        {:frame f})
+      ;; RED on old code: AuthSlice embedded the wire `ws/User` (requires
+      ;; :token), the durable user is `(dissoc user :token)` → post-commit
+      ;; validation fails :where :app-db and the login rolls back.
+      (let [violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
+                                     (= :app-db (-> % :tags :where)))
+                               @traces)]
+        (is (empty? violations)
+            "the token-free durable AuthSlice validates — no :app-db schema-validation-failure"))
+      (let [db (rf/app-db-value f)]
+        (is (= "alice" (get-in db [:auth :user :username]))
+            "the durable session user is committed (no rollback)")
+        (is (not (contains? (get-in db [:auth :user]) :token))
+            "no token persists under [:auth :user] — the unclassified duplicate is avoided")
+        (is (= "jwt-abc" (get-in db [:auth :token]))
+            "the JWT rides its one classified durable home at [:auth :token]")))))
 
 ;; ============================================================================
 ;; articles — global feed loading + failure paths
@@ -1081,7 +1164,9 @@
   (testing "login failure surfaces error and dismiss returns to :idle"
     (login-failure-test))
   (testing ":auth.session/token is a recordable generator (not provided-at-dispatch)"
-    (session-token-cofx-shape-test)))
+    (session-token-cofx-shape-test))
+  (testing "durable AuthSlice user validates token-free; wire User still requires :token (rf2-3fc89f.32)"
+    (durable-session-user-schema-test)))
 
 (deftest realworld-articles-feed
   (testing "global feed loads and re-loads bumping :attempt"

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -47,6 +47,12 @@
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
+            ;; Activate the default Malli validator (rf2-t0hq): the CLJS default
+            ;; validator soft-passes without this require, so the durable
+            ;; AuthSlice regression below could never observe a rollback. The
+            ;; canonical app-boot opt-in for Malli app-schema validation.
+            [re-frame.schemas.malli]
+            [malli.core :as m]
             [re-frame.views]
             [re-frame.http.managed]
             [re-frame.http.test-support]
@@ -62,8 +68,14 @@
             [re-frame.trace.tooling :as trace-tooling]
             ;; the example's production source — chains in every feature ns.
             [realworld-resources.core :as core]
-            [realworld-resources.scope :as scope])
-  (:require-macros [re-frame.core :refer [with-new-frame]]))
+            [realworld-resources.scope :as scope]
+            ;; The shared WIRE contract (User / UserResponse) + this app's durable
+            ;; app-db schemas (AuthSlice), for the default-frame validator
+            ;; regression (rf2-3fc89f.32).
+            [realworld-shared.schema :as ws]
+            [realworld-resources.schema :as app-schema])
+  (:require-macros [re-frame.core :refer [with-new-frame]]
+                   [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; ============================================================================
 ;; FIXTURE
@@ -286,6 +298,68 @@
                (get-in (core/bearer-auth-interceptor ctx)
                        [:request :headers "Authorization"]))
             "the JWT from the auth slice rides every outbound request as a Bearer header")))))
+
+;; ============================================================================
+;; 2b. WIRE User vs token-free durable session-user (rf2-3fc89f.32)
+;; ============================================================================
+;;
+;; Same defect as the http variant: the durable AuthSlice validated its :user
+;; against the WIRE `ws/User`, which REQUIRES the sensitive :token, while
+;; `:auth/store-session` stores `(dissoc user :token)`. Under the active
+;; post-commit validator the token-free commit is rejected and the login rolls
+;; back. The suite's other auth tests run on anonymous frames (no registered app
+;; schema), so the validator never runs — falsely green (the rf2-lo28u lesson).
+;; This registers the REAL production `AuthSlice` on the test frame so the
+;; genuine validator participates on the genuine store-session commit.
+
+(defn- vec-map-slot-props
+  "The properties map of one slot in a vector-form Malli `[:map ...]`, or nil —
+   reads the wire User's per-slot `:sensitive?` flag off the pure-data schema."
+  [map-schema slot-key]
+  (some (fn [entry]
+          (when (and (vector? entry) (= slot-key (first entry)) (map? (second entry)))
+            (second entry)))
+        (rest map-schema)))
+
+(deftest durable-auth-user-validates-token-free-wire-user-still-requires-token
+  (testing "examples/real-apps/realworld_resources — the durable AuthSlice user
+            validates token-free against the real post-commit validator, while
+            the wire User still requires the sensitive :token (rf2-3fc89f.32)"
+    ;; WIRE contract UNCHANGED — token-less reply rejected, token slot sensitive.
+    (is (true? (m/validate ws/UserResponse
+                           {:user {:email "alice@example.com" :username "alice"
+                                   :token "jwt-abc" :bio nil :image nil}}))
+        "a complete login/register/restore/settings reply (with :token) still decodes")
+    (is (false? (m/validate ws/UserResponse
+                            {:user {:email "alice@example.com" :username "alice"
+                                    :bio nil :image nil}}))
+        "a token-LESS reply is STILL rejected by the wire schema — :token stays required")
+    (is (true? (:sensitive? (vec-map-slot-props ws/User :token)))
+        "the wire User's :token slot stays classified :sensitive? true")
+    ;; DURABLE contract — the token-free session user commits and validates.
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      ;; The REAL production AuthSlice on THIS frame → the real validator runs.
+      (rf/reg-app-schema [:auth] {:frame f} app-schema/AuthSlice)
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
+                                                :username "alice"
+                                                :token "jwt-abc"
+                                                :bio nil :image nil}]
+                          {:frame f})
+        ;; RED on old code: wire `ws/User` requires :token, the durable user is
+        ;; `(dissoc user :token)` → :app-db schema-validation-failure + rollback.
+        (let [violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
+                                       (= :app-db (-> % :tags :where)))
+                                 @traces)]
+          (is (empty? violations)
+              "the token-free durable AuthSlice validates — no :app-db schema-validation-failure"))
+        (let [db (rf/app-db-value f)]
+          (is (= "alice" (get-in db [:auth :user :username]))
+              "the durable session user is committed (no rollback)")
+          (is (not (contains? (get-in db [:auth :user]) :token))
+              "no token persists under [:auth :user] — the unclassified duplicate is avoided")
+          (is (= "jwt-abc" (get-in db [:auth :token]))
+              "the JWT rides its one classified durable home at [:auth :token]"))))))
 
 ;; ============================================================================
 ;; 3. MUTATION :populates / cross-scope :invalidates / :reply-to


### PR DESCRIPTION
## Summary

Both RealWorld examples (`realworld_http` + `realworld_resources`) validated the **durable** auth user against the **wire** `ws/User`, whose `:token` slot is **required** and `:sensitive?`. But `:auth/store-session` stores `(dissoc user :token)` — the durable user is token-free by design (the JWT lives once, classified, at `[:auth :token]`). In the dev/default build where app schemas are active, the real post-commit validator rejected that token-free commit at `[:auth :user :token]` (`got nil`) and **rolled the whole login back**: broken login/register/restore/settings, protected routes, session-scoped resources, and Bearer decoration. Audit-derived (rf2-3fc89f.32).

## The fix — keep wire and durable contracts DISTINCT

- **`realworld_shared/schema.cljs`** gains **`SessionUser`** — the token-free durable session user, the wire `User` **minus its credential**. Kept as vector-form Malli (not a `malli.util` derivation) so the schema-walker can still introspect every per-slot flag when it embeds in an app's `AuthSlice`.
- The wire **`User` is UNCHANGED**: `:token` stays **required** and `:sensitive?`, so login/register/restore/settings decode still **rejects** a token-less reply. `:token` was NOT made optional, and no duplicate unclassified token is reintroduced under `[:auth :user :token]`.
- Both apps' `AuthSlice` now embed `[:user [:maybe ws/SessionUser]]` instead of `[:user [:maybe ws/User]]`. Same model in both variants.

**Two schemas:**
- Wire: `ws/User` = `[:map [:email] [:token {:sensitive? true} :string] [:username] [:bio] [:image]]` (required token) — decode contract, unchanged.
- Durable: `ws/SessionUser` = `[:map [:email] [:username] [:bio] [:image]]` (no token) — `AuthSlice` `:user` contract.

## Reproduce → fix evidence (default-frame validator)

Per the rf2-lo28u lesson, the acceptance test must hit the **actual validated path**. Every existing login/session test runs on an anonymous frame (`make-anon-frame-record!`) whose gensym'd id carries no registered app schema, so the post-commit validator never runs there — falsely green. The new regression in each RealWorld adapter suite registers the **real production `AuthSlice` var** on the test frame (the same var `reg-app-schemas` binds to `:rf/default` at ns-load) and requires `re-frame.schemas.malli`, so the **genuine** validator participates on the **genuine** `:auth/store-session` commit.

- **RED (pre-fix schema):** both regressions FAIL — `:rf.error/schema-validation-failure :where :app-db` at `[:auth :user :token]`, `:rollback? true`, `:failing-id :auth/store-session`, reason `... got nil` (6 failures across the two suites).
- **GREEN (fix):** durable AuthSlice validates token-free; no token persists under `[:auth :user]`; JWT rides `[:auth :token]`; wire `UserResponse` still rejects a token-less reply and `:token` stays `:sensitive?`.

## Quality gates (foreground)

- `npx shadow-cljs compile examples/realworld examples/realworld-resources` → **0 warnings** (320 / 316 files).
- `npm run test:cljs` → **8489 tests, 39269 assertions, 0 failures, 0 errors** (both regressions green).
- `npm run test:security` → **93 tests, 673 assertions, 0 failures, 0 errors** (token classification intact).
- RED confirmation on reverted schema: **6 failures** (the two regressions), then restored to green.

## Stance

Pre-alpha; wire and durable contracts kept DISTINCT; the token is a credential (privacy boundary) with one classified home; examples idiomatic; ELEGANCE + CLARITY + CORRECTNESS. Touches only the two apps' auth schema/slice, the shared durable-user schema, and the two framework-tree regression suites (examples stay test-free).

Closes rf2-3fc89f.32.