### PR TITLE
fix(resources): explicit per-kind timer re-arm preserves sibling timers (rf2-3fc89f.10)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -577,12 +577,15 @@
         ;; when the resource declares a timer or a `:reply-to` continued.
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms poll-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   scoped-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  poll-delay-ms
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key scoped-key
+                             ;; a FULL reconcile names all three kinds — arm the
+                             ;; policied ones, cancel any whose policy is absent
+                             ;; (rf2-3fc89f.10)
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  poll-delay-ms}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (cond-> (vec timers-fx)
                           hit-cont-fx (conj hit-cont-fx))]
           (cond-> {:rf.db/runtime rdb'}
@@ -1481,8 +1484,10 @@
                      :else            :polled)
         ;; STOP (drop the poll) on a gone / owner-free entry; otherwise RE-ARM
         ;; the next interval (paused-hidden / coalesced / polled all keep the
-        ;; cadence alive). The re-arm fx is poll-only (nil stale / GC delays
-        ;; leave those kinds as-is in schedule-timers-handler).
+        ;; cadence alive). The re-arm fx names ONLY `:poll` (a PARTIAL re-arm):
+        ;; the sibling stale / GC timers are PRESERVED — they are absent from
+        ;; the `:timers` map, so `schedule-timers-handler` leaves them armed
+        ;; rather than cancelling them (rf2-3fc89f.10).
         re-arm?    (and interval (contains? #{:paused-hidden :coalesced :polled} decision))
         refetch?   (= :polled decision)]
     (trace/emit! :rf.event :rf.resource/poll-fired
@@ -1499,15 +1504,14 @@
                              :scope    (first resource-key)
                              :params   (nth resource-key 2)
                              :cause    poll-cause}]])
-          ;; re-arm the next poll (cancel-then-arm; poll kind only)
+          ;; re-arm the next poll — a PARTIAL re-arm naming ONLY `:poll`, so the
+          ;; sibling stale / GC timers are preserved (rf2-3fc89f.10)
           re-arm?
           (conj [:rf.resource/schedule-timers
-                 {:frame-id       frame-id
-                  :resource/key   resource-key
-                  :stale-delay-ms nil
-                  :gc-delay-ms    nil
-                  :poll-delay-ms  interval
-                  :server?        (state/server-frame? frame-id)}]))))))
+                 {:frame-id     frame-id
+                  :resource/key resource-key
+                  :timers       {:poll interval}
+                  :server?      (state/server-frame? frame-id)}]))))))
 
 ;; ---- invalidate-tags — exact tag invalidation -----------------------------
 
@@ -2329,12 +2333,15 @@
         ;; scheduling / §Polling.
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms poll-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   resource-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  poll-delay-ms
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key resource-key
+                             ;; a FULL reconcile names all three kinds — arm the
+                             ;; policied ones, cancel any whose policy is absent
+                             ;; (rf2-3fc89f.10)
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  poll-delay-ms}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx)))))))
@@ -2515,12 +2522,16 @@
           frame-id resource-key work-id (:status reply) (:reply-targets record) false)
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   resource-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  nil
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key resource-key
+                             ;; a first-load abort/error settle reconciles all
+                             ;; three kinds — arm stale/GC and CANCEL poll (an
+                             ;; errored/aborted entry is GC fodder, never a poll
+                             ;; target; a first load never armed one), rf2-3fc89f.10
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  nil}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
@@ -2591,12 +2602,16 @@
         ;; continued.
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   resource-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  nil
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key resource-key
+                             ;; a first-load abort/error settle reconciles all
+                             ;; three kinds — arm stale/GC and CANCEL poll (an
+                             ;; errored/aborted entry is GC fodder, never a poll
+                             ;; target; a first load never armed one), rf2-3fc89f.10
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  nil}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx)))))))
@@ -2832,12 +2847,15 @@
           frame-id resource-key work-id (:status reply) (:reply-targets record) false)
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms poll-delay-ms)
                           [:rf.resource/schedule-timers
-                           {:frame-id       frame-id
-                            :resource/key   resource-key
-                            :stale-delay-ms stale-delay-ms
-                            :gc-delay-ms    gc-delay-ms
-                            :poll-delay-ms  poll-delay-ms
-                            :server?        (state/server-frame? frame-id)}])
+                           {:frame-id     frame-id
+                            :resource/key resource-key
+                            ;; a FULL reconcile names all three kinds — arm the
+                            ;; policied ones, cancel any whose policy is absent
+                            ;; (rf2-3fc89f.10)
+                            :timers       {:stale stale-delay-ms
+                                           :gc    gc-delay-ms
+                                           :poll  poll-delay-ms}
+                            :server?      (state/server-frame? frame-id)}])
               fx        (cond-> []
                           timers-fx (conj timers-fx)
                           sweep-fx  (conj sweep-fx))
@@ -2971,12 +2989,16 @@
           frame-id resource-key work-id (:status reply) (:reply-targets record) false)
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   resource-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  nil
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key resource-key
+                             ;; a first-load abort/error settle reconciles all
+                             ;; three kinds — arm stale/GC and CANCEL poll (an
+                             ;; errored/aborted entry is GC fodder, never a poll
+                             ;; target; a first load never armed one), rf2-3fc89f.10
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  nil}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
@@ -3056,12 +3078,16 @@
           frame-id resource-key work-id (:status reply) (:reply-targets record) false)
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms)
                           [[:rf.resource/schedule-timers
-                            {:frame-id       frame-id
-                             :resource/key   resource-key
-                             :stale-delay-ms stale-delay-ms
-                             :gc-delay-ms    gc-delay-ms
-                             :poll-delay-ms  nil
-                             :server?        (state/server-frame? frame-id)}]])
+                            {:frame-id     frame-id
+                             :resource/key resource-key
+                             ;; a first-load abort/error settle reconciles all
+                             ;; three kinds — arm stale/GC and CANCEL poll (an
+                             ;; errored/aborted entry is GC fodder, never a poll
+                             ;; target; a first load never armed one), rf2-3fc89f.10
+                             :timers       {:stale stale-delay-ms
+                                            :gc    gc-delay-ms
+                                            :poll  nil}
+                             :server?      (state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
@@ -3236,13 +3262,13 @@
         (cond-> {:rf.db/runtime runtime-db}
           gc-delay
           (assoc :fx [[:rf.resource/schedule-timers
-                       {:frame-id       frame-id
-                        :resource/key   resource-key
-                        ;; reschedule the GC re-check ONLY (leave stale as-is —
-                        ;; nil disarms that kind in schedule-timers-handler)
-                        :stale-delay-ms nil
-                        :gc-delay-ms    gc-delay
-                        :server?        (state/server-frame? frame-id)}]]))))))
+                       {:frame-id     frame-id
+                        :resource/key resource-key
+                        ;; a PARTIAL re-arm naming ONLY `:gc`: the sibling stale
+                        ;; / poll timers are PRESERVED (absent from `:timers`),
+                        ;; not cancelled (rf2-3fc89f.10)
+                        :timers       {:gc gc-delay}
+                        :server?      (state/server-frame? frame-id)}]]))))))
 
 (defn stale-suppressed-handler
   "`:rf.resource.internal/stale-suppressed` — a late reply carrying a

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -1781,11 +1781,17 @@
             server?     (state/server-frame? frame-id)
             timer-fx    (mapv (fn [[scoped-key {:keys [stale-delay-ms gc-delay-ms]}]]
                                 [:rf.resource/schedule-timers
-                                 {:frame-id       frame-id
-                                  :resource/key   scoped-key
-                                  :stale-delay-ms stale-delay-ms
-                                  :gc-delay-ms    gc-delay-ms
-                                  :server?        server?}])
+                                 {:frame-id     frame-id
+                                  :resource/key scoped-key
+                                  ;; a mutation populate/patch reconciles the
+                                  ;; freshness kinds it recomputes — stale + GC.
+                                  ;; `:poll` is ABSENT, so an actively-polling
+                                  ;; entry the mutation writes into KEEPS its
+                                  ;; poll cadence (polling is owner-driven, not
+                                  ;; data-driven) — rf2-3fc89f.10
+                                  :timers       {:stale stale-delay-ms
+                                                 :gc    gc-delay-ms}
+                                  :server?      server?}])
                               timer-policies)
             ;; PHASE 6 (Spec 016 §Phase order) — the mutation completion
             ;; continuation. The instance + work-ledger row are now settled

--- a/implementation/resources/src/re_frame/resources/timers.cljc
+++ b/implementation/resources/src/re_frame/resources/timers.cljc
@@ -229,27 +229,42 @@
       (dispatch! [event-id payload]
                  {:frame frame-id :source :after-timer}))))
 
+(def ^:private scheduled-trace-id
+  "The per-kind `…-scheduled` trace op a fresh arm emits (gc-class — the Xray
+  lifecycle timeline pairs it with the kind's `…-fired` / `…-skipped` op). The
+  arm operation OWNS its trace (centralised in `schedule!`, rf2-3fc89f.10) so a
+  kind never mis-attributes a sibling's schedule."
+  {stale-kind :rf.resource/stale-scheduled
+   gc-kind    :rf.resource/gc-scheduled
+   poll-kind  :rf.resource/poll-scheduled})
+
 (defn schedule!
-  "Arm a host timer of `kind` for `[frame-id resource-key]` to fire in
-  `delay-ms`. Cancel-then-arm: any prior timer for the same `[key kind]` is
-  cancelled first, so a re-load reschedules rather than accumulating zombie
-  timers (the machine `:after` cancel-and-reschedule discipline). On fire the
-  timer dispatches the re-checking internal event (`dispatch-recheck!`) — the
-  HANDLER re-checks the durable entry before writing (the timer is advisory).
-  No-op for a non-positive `delay-ms` (a resource declaring no policy never
-  arms that kind). Returns the host handle (or nil when not armed). Per Spec
-  016 §Stale and GC scheduling."
+  "Reconcile the host timer of `kind` for `[frame-id resource-key]` to
+  `delay-ms` (cancel-then-arm). A POSITIVE `delay-ms` ARMS the kind — any prior
+  timer for the same `[key kind]` is cancelled first, so a reschedule replaces
+  rather than accumulates zombie timers (the machine `:after`
+  cancel-and-reschedule discipline). A NON-POSITIVE / nil `delay-ms` CANCELS
+  the kind: an EXPLICIT disarm (a resource declaring no policy for that kind, or
+  a policy removed by hot reload). On fire the timer dispatches the re-checking
+  internal event (`dispatch-recheck!`) — the HANDLER re-checks the durable
+  entry before writing (the timer is advisory). Emits the kind's
+  `:rf.resource/<kind>-scheduled` trace when a timer arms (the arm operation
+  owns its trace). Returns the host handle (or nil when the kind was cancelled
+  / disarmed). Per Spec 016 §Stale and GC scheduling / §Polling."
   [frame-id resource-key kind delay-ms]
-  ;; cancel any prior timer for this [key kind] (reschedule, not accumulate)
+  ;; cancel any prior timer for this [key kind] (reschedule / disarm, not accumulate)
   (cancel! frame-id resource-key kind)
   ;; Shared positive-delay-guarded arm (rf2-7x2lky) — the host-clock arm step
-  ;; both timer artefacts share. A non-positive / nil delay arms nothing (a
-  ;; resource declaring no policy for that kind). Returns the host handle or
-  ;; nil; the side-table bookkeeping below is resources-specific.
+  ;; both timer artefacts share. A non-positive / nil delay arms nothing,
+  ;; leaving the kind cancelled (the explicit disarm). Returns the host handle
+  ;; or nil; the side-table bookkeeping + trace below are resources-specific.
   (when-let [handle (managed-timer/arm!
                       (fn [] (dispatch-recheck! frame-id resource-key kind))
                       delay-ms)]
     (swap! timer-table assoc (timer-key frame-id resource-key kind) handle)
+    (trace/emit! :rf.event (scheduled-trace-id kind)
+                 {:rf.frame/id frame-id :resource/key resource-key
+                  :delay-ms delay-ms})
     handle))
 
 (defn release-frame!
@@ -301,50 +316,51 @@
   because a JVM CLIENT-mode runtime (the resources unit tests) must still arm
   timers, and the host-wide platform default is `:server`. fx handlers are
   binary `(fn [ctx args] …)` (Spec 002)."
-  {:doc "Arm the host-side stale / GC / poll timers for a settled resource
-entry, keyed by `[frame-id resource-key kind]`. Args:
-`{:frame-id … :resource/key … :stale-delay-ms … :gc-delay-ms …
-:poll-delay-ms … :server? …}`.
-Emitted by the success reply handler once an entry settles `:loaded` (the
-stale / GC delays are derived from the durable `:loaded-at` + the resource's
-`:stale-after-ms` / `:gc-after-ms`; the poll delay is the resource's
-`:poll-interval-ms` and is supplied ONLY when the settled entry is actively
-owned, EP-0020; `:server?` is read from the cascade frame's platform).
-Cancel-then-arm — a re-load reschedules. No-op under `:server? true` (SSR
-uses the blocking-drain wait point + lazy client revalidation, never
-wall-clock background timers). The fired timer dispatches a re-checking
-internal event; the handler re-checks the durable entry before writing (the
-timer is advisory). Per Spec 016 §Stale and GC scheduling / §Polling."})
+  {:doc "Reconcile the host-side stale / GC / poll timers for a resource entry,
+keyed by `[frame-id resource-key kind]`. Args:
+`{:frame-id … :resource/key … :timers {<kind> <delay-ms> …} :server? …}`
+where `<kind>` ∈ `#{:stale :gc :poll}`.
+The `:timers` map's KEYS are the kinds this emission reconciles: a key present
+with a POSITIVE delay ARMS that kind (cancel-then-arm), a key present with a
+nil / non-positive delay CANCELS it (an explicit disarm), and a kind ABSENT
+from the map is PRESERVED (left as-is). A FULL settlement (successful load /
+mutation settle) names ALL declared kinds — the stale / GC delays derived from
+the durable `:loaded-at` + `:stale-after-ms` / `:gc-after-ms`, the poll delay
+the `:poll-interval-ms` supplied only for an actively-owned entry (EP-0020) —
+so it also cancels a policy removed by hot reload. A PARTIAL re-arm (a poll
+tick / a GC skip) names ONLY its own kind, preserving its siblings
+(rf2-3fc89f.10). `:server?` is read from the cascade frame's platform. No-op
+under `:server? true` (SSR uses the blocking-drain wait point + lazy client
+revalidation, never wall-clock background timers). The fired timer dispatches a
+re-checking internal event; the handler re-checks the durable entry before
+writing (the timer is advisory). Per Spec 016 §Stale and GC scheduling /
+§Polling."})
 
 (defn schedule-timers-handler
-  "`:rf.resource/schedule-timers` fx handler. Arms the host-side stale + GC +
-  poll timers for `[frame-id resource-key]` from the supplied durable delays.
-  A non-positive / nil delay leaves that kind disarmed (a resource declaring
-  no `:stale-after-ms` / `:gc-after-ms` / `:poll-interval-ms` arms only the
-  others / none). No-op under SSR (`:server? true`) — a server render never
-  arms a wall-clock background timer. Emits a `:rf.resource/gc-scheduled` /
-  `:rf.resource/stale-scheduled` / `:rf.resource/poll-scheduled` trace
-  (gc-class — the Xray lifecycle timeline pairs them with
-  `:rf.resource/gc-fired` / `gc-skipped` / `stale-fired` / `poll-fired`) when
-  a timer arms. Per Spec 016 §Stale and GC scheduling / §Polling."
-  [_ctx {:keys [frame-id stale-delay-ms gc-delay-ms poll-delay-ms server?]
-         resource-key :resource/key}]
+  "`:rf.resource/schedule-timers` fx handler. Reconciles the host-side timer
+  side table for `[frame-id resource-key]` against the carried `:timers` map
+  `{kind → delay-ms}` (`kind` ∈ `#{:stale :gc :poll}`). Each kind PRESENT in
+  the map is reconciled by `schedule!` (a positive delay ARMS cancel-then-arm,
+  a nil / non-positive delay CANCELS — an explicit disarm); a kind ABSENT from
+  the map is PRESERVED — left exactly as it was armed.
+
+  This makes the two scheduling operations unambiguous (rf2-3fc89f.10): a
+  FULL-settlement reconcile (a successful load / mutation settle) names ALL the
+  kinds it owns — arming the policied ones and CANCELLING a kind whose policy
+  was dropped by hot reload — while a PARTIAL re-arm (a poll tick names only
+  `:poll`; a GC skip names only `:gc`) touches ONLY its own kind and thereby
+  leaves its siblings alive. `nil` is never overloaded to mean both preserve
+  and disarm: absence = preserve, a named nil = cancel.
+
+  No-op under SSR (`:server? true`) — a server render never arms a wall-clock
+  background timer. Each armed kind emits its own `:rf.resource/<kind>-scheduled`
+  trace (gc-class, centralised in `schedule!` — the Xray lifecycle timeline
+  pairs it with `:rf.resource/stale-fired` / `gc-fired` / `gc-skipped` /
+  `poll-fired`). Per Spec 016 §Stale and GC scheduling / §Polling."
+  [_ctx {:keys [frame-id server? timers] resource-key :resource/key}]
   (when-not server?
-    (let [stale-h (schedule! frame-id resource-key stale-kind stale-delay-ms)
-          gc-h    (schedule! frame-id resource-key gc-kind gc-delay-ms)
-          poll-h  (schedule! frame-id resource-key poll-kind poll-delay-ms)]
-      (when gc-h
-        (trace/emit! :rf.event :rf.resource/gc-scheduled
-                     {:rf.frame/id frame-id :resource/key resource-key
-                      :delay-ms gc-delay-ms}))
-      (when stale-h
-        (trace/emit! :rf.event :rf.resource/stale-scheduled
-                     {:rf.frame/id frame-id :resource/key resource-key
-                      :delay-ms stale-delay-ms}))
-      (when poll-h
-        (trace/emit! :rf.event :rf.resource/poll-scheduled
-                     {:rf.frame/id frame-id :resource/key resource-key
-                      :delay-ms poll-delay-ms}))))
+    (doseq [[kind delay-ms] timers]
+      (schedule! frame-id resource-key kind delay-ms)))
   nil)
 
 ;; ---- the cancel fx (entry removed — remove / clear-scope / GC) ------------

--- a/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
@@ -557,9 +557,9 @@
       (reply-aborted!)
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted on the page-0 abort settle")
-        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
-        (is (= 1000 (:stale-delay-ms args)) "stale timer armed at :stale-after-ms")
-        (is (nil? (:poll-delay-ms args)) "no poll timer for an aborted entry")))))
+        (is (= 5000 (get-in args [:timers :gc])) "GC timer armed at :gc-after-ms")
+        (is (= 1000 (get-in args [:timers :stale])) "stale timer armed at :stale-after-ms")
+        (is (nil? (get-in args [:timers :poll])) "no poll timer for an aborted entry")))))
 
 (deftest page-0-failure-arms-gc-and-stale-timers
   (testing "rf2-s54uzc — a page-0 FAILURE (non-abort) with no accumulated
@@ -578,9 +578,9 @@
         (is (nil? (:current-work e)) "no in-flight work after the error settle"))
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted on the page-0 :error settle")
-        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
-        (is (= 1000 (:stale-delay-ms args)) "stale timer armed at :stale-after-ms")
-        (is (nil? (:poll-delay-ms args)) "no poll timer for an errored entry")))))
+        (is (= 5000 (get-in args [:timers :gc])) "GC timer armed at :gc-after-ms")
+        (is (= 1000 (get-in args [:timers :stale])) "stale timer armed at :stale-after-ms")
+        (is (nil? (get-in args [:timers :poll])) "no poll timer for an errored entry")))))
 
 (deftest load-more-abort-keeps-loaded-no-rearm
   (testing "rf2-s54uzc guard — an ABORTED load-more (page N>0, feed already

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -550,8 +550,8 @@
       (is (= 1 (count @scheduled-timers)))
       (let [args (first @scheduled-timers)]
         (is (= k (:resource/key args)))
-        (is (= 60000 (:stale-delay-ms args)))
-        (is (= 300000 (:gc-delay-ms args)))))))
+        (is (= 60000 (get-in args [:timers :stale])))
+        (is (= 300000 (get-in args [:timers :gc])))))))
 
 (deftest no-explicit-policy-arms-default-gc-timer
   ;; rf2-bbpu11 (Option A) — absent :gc-after-ms no longer means "arm
@@ -559,7 +559,7 @@
   ;; default (300000ms), so a settle DOES arm a GC timer even though this
   ;; resource declares no explicit policy. :stale-after-ms is unaffected by
   ;; this bead — it keeps its own independent absent-default (never
-  ;; time-stale) — so :stale-delay-ms stays nil.
+  ;; time-stale) — so the settle's :timers :stale delay stays nil.
   (rf/reg-resource :np/article (article-spec) article-spec-request) ;; no :stale-after-ms / :gc-after-ms
   (let [scope {:user "u"}
         k     (state/scoped-resource-key scope :np/article {:slug "w"})]
@@ -572,8 +572,8 @@
       (is (= 1 (count @scheduled-timers)))
       (let [args (first @scheduled-timers)]
         (is (= k (:resource/key args)))
-        (is (nil? (:stale-delay-ms args)))
-        (is (= 300000 (:gc-delay-ms args)))))))
+        (is (nil? (get-in args [:timers :stale])))
+        (is (= 300000 (get-in args [:timers :gc])))))))
 
 (deftest gc-after-ms-never-arms-no-gc-timer
   ;; rf2-bbpu11 — the explicit, auditable opt-out: a resource that declares
@@ -658,8 +658,8 @@
         (is (nil? (:current-work e)) "no in-flight work after the error settle"))
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted on the :error settle")
-        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
-        (is (nil? (:poll-delay-ms args)) "no poll timer for an errored entry")))
+        (is (= 5000 (get-in args [:timers :gc])) "GC timer armed at :gc-after-ms")
+        (is (nil? (get-in args [:timers :poll])) "no poll timer for an errored entry")))
     (testing "the owner releases → owner-free + idle + :error; the fired GC
               re-check collects the errored entry (no longer leaked)"
       (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gce 1]}])
@@ -693,8 +693,8 @@
         (is (nil? (:current-work e)) "no in-flight work after the abort settle"))
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted on the abort settle")
-        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
-        (is (nil? (:poll-delay-ms args)) "no poll timer for an aborted entry")))
+        (is (= 5000 (get-in args [:timers :gc])) "GC timer armed at :gc-after-ms")
+        (is (nil? (get-in args [:timers :poll])) "no poll timer for an aborted entry")))
     (testing "the owner releases → owner-free + idle; the fired GC re-check
               collects the aborted entry (no longer leaked)"
       (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gca 1]}])
@@ -799,8 +799,8 @@
       (is (= 1 (count @scheduled-timers)) "exactly one reschedule fx emitted")
       (let [args (first @scheduled-timers)]
         (is (= k (:resource/key args)))
-        (is (= 1000 (:gc-delay-ms args)) "rescheduled with the resource's :gc-after-ms")
-        (is (nil? (:stale-delay-ms args)) "stale timer NOT re-armed on a GC skip")))
+        (is (= 1000 (get-in args [:timers :gc])) "rescheduled with the resource's :gc-after-ms")
+        (is (nil? (get-in args [:timers :stale])) "stale timer NOT re-armed on a GC skip")))
     (testing "the owner releases AFTER the original deadline; the rescheduled
               GC re-check now finds the entry owner-free + idle and collects it"
       (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gcr 1]}])
@@ -822,7 +822,7 @@
       (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key k}])
       (is (some? (entry k)) "in-flight entry kept (GC skipped)")
       (is (= 1 (count @scheduled-timers)) "one reschedule fx emitted")
-      (is (= 1000 (:gc-delay-ms (first @scheduled-timers)))))
+      (is (= 1000 (get-in (first @scheduled-timers) [:timers :gc]))))
     (testing "the in-flight work settles (a stale/aborted reply clears
               :current-work via the work-row terminal); once owner-free + idle
               the rescheduled GC re-check collects it"

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -493,8 +493,8 @@
       (let [args (first @scheduled-timers)]
         (is (= rkey (:resource/key args)))
         (is (= :rf/default (:frame-id args)))
-        (is (= 60000 (:stale-delay-ms args)))
-        (is (= 300000 (:gc-delay-ms args)) "a GC timer is armed for the populated entry")
+        (is (= 60000 (get-in args [:timers :stale])))
+        (is (= 300000 (get-in args [:timers :gc])) "a GC timer is armed for the populated entry")
         (is (false? (:server? args)) "client frame — not SSR-gated")))
     (testing "rf2-h4cv5e — the populated ownerless entry is GC-eligible: a
               fired GC timer (re-checking owners + generation) removes it"
@@ -529,8 +529,8 @@
       (is (= 1 (count @scheduled-timers)))
       (let [args (first @scheduled-timers)]
         (is (= rkey (:resource/key args)))
-        (is (= 60000 (:stale-delay-ms args)))
-        (is (= 300000 (:gc-delay-ms args)))))))
+        (is (= 60000 (get-in args [:timers :stale])))
+        (is (= 300000 (get-in args [:timers :gc])))))))
 
 (deftest success-populate-no-explicit-policy-arms-default-gc-timer
   ;; rf2-bbpu11 (Option A) — a populate of a resource declaring NO explicit
@@ -554,8 +554,8 @@
       (is (= 1 (count @scheduled-timers)))
       (let [args (first @scheduled-timers)]
         (is (= rkey (:resource/key args)))
-        (is (nil? (:stale-delay-ms args)))
-        (is (= 300000 (:gc-delay-ms args)))))))
+        (is (nil? (get-in args [:timers :stale])))
+        (is (= 300000 (get-in args [:timers :gc])))))))
 
 ;; ===========================================================================
 ;; 5. Failure settles :error

--- a/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
@@ -167,7 +167,7 @@
               :poll timer at :poll-interval-ms when it settles :loaded"
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted for the settled entry")
-        (is (= 5000 (:poll-delay-ms args)) "poll delay = :poll-interval-ms")))))
+        (is (= 5000 (get-in args [:timers :poll])) "poll delay = :poll-interval-ms")))))
 
 (deftest no-poll-policy-arms-no-poll-timer
   (rf/reg-resource :pl/nopoll (article-spec {:stale-after-ms 1000}) article-spec-request)
@@ -179,8 +179,8 @@
               poll timer (the stale timer still arms)"
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers still emitted (stale policy present)")
-        (is (nil? (:poll-delay-ms args)) "no poll delay (no poll policy)")
-        (is (= 1000 (:stale-delay-ms args)) "stale delay armed as usual")))))
+        (is (nil? (get-in args [:timers :poll])) "no poll delay (no poll policy)")
+        (is (= 1000 (get-in args [:timers :stale])) "stale delay armed as usual")))))
 
 (deftest owner-free-settle-arms-no-poll-timer
   ;; A poll never pins an owner-free entry: if the entry settles with no active
@@ -197,8 +197,8 @@
               poll never pins an owner-free entry); GC still arms"
       (is (empty? (:active-owners (entry k))) "entry is owner-free at settle")
       (let [args (last-schedule-for k)]
-        (is (nil? (:poll-delay-ms args)) "no poll timer armed for an owner-free entry")
-        (is (= 9000 (:gc-delay-ms args)) "GC timer armed as usual")))))
+        (is (nil? (get-in args [:timers :poll])) "no poll timer armed for an owner-free entry")
+        (is (= 9000 (get-in args [:timers :gc])) "GC timer armed as usual")))))
 
 (deftest fresh-skip-re-arms-polling-on-new-owner
   ;; rf2-k9u4h3 — an entry that settled `:loaded` while OWNER-FREE armed no poll
@@ -216,7 +216,7 @@
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :x 1]}])
     (succeed! k {:title "W"})
     (is (empty? (:active-owners (entry k))) "entry settled owner-free")
-    (is (nil? (:poll-delay-ms (last-schedule-for k)))
+    (is (nil? (get-in (last-schedule-for k) [:timers :poll]))
         "no poll timer armed at the owner-free settle (precondition)")
     (reset! scheduled-timers [])
     ;; a fresh ensure from a NEW live owner — served from cache (fresh-skip)
@@ -230,7 +230,7 @@
         (is (= #{[:route :r 2]} (:active-owners e)) "the new owner is leased"))
       (let [args (last-schedule-for k)]
         (is (some? args) "schedule-timers emitted for the revived entry")
-        (is (= 5000 (:poll-delay-ms args)) "poll re-armed at :poll-interval-ms")))))
+        (is (= 5000 (get-in args [:timers :poll])) "poll re-armed at :poll-interval-ms")))))
 
 (deftest fresh-skip-onto-owned-entry-does-not-re-arm
   ;; Guard against double-arm: a fresh-skip onto an entry that ALREADY has an
@@ -279,7 +279,7 @@
           (is (= (inc gen-before) (:generation e)) "forced a new generation")))
       (testing "Spec 016 §Polling — the tick re-arms the next poll"
         (let [args (last-schedule-for k)]
-          (is (= 5000 (:poll-delay-ms args)) "next poll re-armed at the interval"))))))
+          (is (= 5000 (get-in args [:timers :poll])) "next poll re-armed at the interval"))))))
 
 (deftest poll-tick-records-poll-cause-never-owner
   (rf/reg-resource :pc/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
@@ -351,7 +351,7 @@
       (is (= :loaded (:status (entry k))) "hidden tick did NOT refetch")
       (is (nil? (:current-work (entry k))) "no in-flight work while hidden")
       (let [args (last-schedule-for k)]
-        (is (= 5000 (:poll-delay-ms args)) "re-armed (resumes on tab return)")))))
+        (is (= 5000 (get-in args [:timers :poll])) "re-armed (resumes on tab return)")))))
 
 (deftest visible-tick-after-hidden-resumes-refetch
   (rf/reg-resource :hr/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
@@ -393,7 +393,7 @@
           (is (empty? @aborts) "no opportunistic abort (no churn)")))
       (testing "Spec 016 §Polling — a coalesced tick still RE-ARMS the next poll"
         (let [args (last-schedule-for k)]
-          (is (= 5000 (:poll-delay-ms args)) "coalesced tick re-armed the poll"))))))
+          (is (= 5000 (get-in args [:timers :poll])) "coalesced tick re-armed the poll"))))))
 
 ;; ===========================================================================
 ;; 6. Focus/reconnect coexistence — no double-fetch
@@ -462,7 +462,7 @@
               via timers/schedule!), it does not stack a second poll timer"
       (is (= {:title "W2"} (:data (entry k))) "new data landed")
       (let [args (last-schedule-for k)]
-        (is (= 5000 (:poll-delay-ms args)) "poll re-armed on the new settle")))))
+        (is (= 5000 (get-in args [:timers :poll])) "poll re-armed on the new settle")))))
 
 ;; ===========================================================================
 ;; 9. Background poll failure keeps polling

--- a/implementation/resources/test/re_frame/resources_timer_rearm_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_timer_rearm_cljs_test.cljc
@@ -1,0 +1,232 @@
+(ns re-frame.resources-timer-rearm-cljs-test
+  "Sibling-timer preservation across a PARTIAL timer re-arm (rf2-3fc89f.10).
+
+  The resource freshness-timer family has three kinds — `:stale`, `:gc`,
+  `:poll` — that share one host side table (`re-frame.resources.timers`). Two
+  distinct scheduling operations write it:
+
+    - FULL-SETTLEMENT RECONCILE — a successful load / mutation settle
+      reconciles ALL declared kinds: it arms the kinds carrying a positive
+      delay and CANCELS the kinds whose policy is absent (so a hot-reload that
+      dropped a policy leaves no lingering timer).
+    - PARTIAL RE-ARM — a poll tick re-arms ONLY `:poll`; a GC skip
+      (`:has-owner` / `:in-flight`) re-arms ONLY `:gc`. A partial re-arm MUST
+      leave the SIBLING kinds it does not name untouched.
+
+  Before rf2-3fc89f.10 the scheduling effect overloaded a nil per-kind delay
+  to mean BOTH \"preserve this sibling\" (partial re-arm) AND \"disarm this
+  kind\" (full settlement), so a poll re-arm silently cancelled the entry's GC
+  reaper (and a GC skip silently cancelled the entry's poll). The fix makes the
+  two operations explicit: the effect carries a `:timers` map keyed by kind —
+  a PRESENT key is reconciled (positive ⇒ arm, nil ⇒ cancel), an ABSENT key is
+  PRESERVED. These JVM+CLJS unit tests pin that contract at the timer substrate
+  (`schedule-timers-handler` + `timer-table`) and end-to-end through the poll /
+  GC re-check events. Per Spec 016 §Stale and GC scheduling / §Polling."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load-bearing side-effecting require: the façade registers the
+   ;; :rf.resource/* events (incl. the internal poll-fired / gc-fired events +
+   ;; the timer fxs) and the test-support reset hook that clears timer-table.
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.test-support]
+   [re-frame.resources.timers :as timers]
+   [re-frame.http.managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport (deterministic) ----------------------------------
+;;
+;; We do NOT override :rf.resource/schedule-timers — this suite drives the REAL
+;; timer side table so it can prove sibling handles survive a partial re-arm.
+;; We DO override the HTTP fxs with capturing no-ops so a poll-tick refetch does
+;; not touch a real endpoint, and arm long (never-firing) delays so no wall-
+;; clock timer fires during the test.
+
+(def ^:private long-ms 1000000)
+
+(defn- capturing-fixture [f]
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-fx :rf.http/managed-abort (fn [_ctx _work-id] nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(def ^:private frame-id :rf/default)
+
+(defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value frame-id)))
+(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+
+(defn- tkey [scoped-key kind] [frame-id (state/key-id scoped-key) kind])
+(defn- timer-handle [scoped-key kind] (get @timers/timer-table (tkey scoped-key kind)))
+(defn- armed? [scoped-key kind] (contains? @timers/timer-table (tkey scoped-key kind)))
+
+(defn- article-spec [overrides]
+  (merge {:scope         :rf.scope/from-caller
+          :params-schema [:map [:slug :string]]}
+         overrides))
+
+(def ^:private article-spec-request
+  (fn [{:keys [slug]} _ctx] {:request {:method :get :url (str "/api/articles/" slug)}}))
+
+(defn- ensure! [resource scope slug owner]
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource resource :scope scope :params {:slug slug} :owner owner}]))
+
+(defn- succeed! [scoped-key data]
+  (let [e (entry scoped-key)]
+    (rf/dispatch-sync [:rf.resource.internal/succeeded
+                       {:resource/key scoped-key :work/id (:current-work e)
+                        :generation (:generation e) :data data}])))
+
+(defn- poll-fired!
+  ([scoped-key] (poll-fired! scoped-key false))
+  ([scoped-key hidden?]
+   (rf/dispatch-sync [:rf.resource.internal/poll-fired
+                      {:resource/key scoped-key :hidden? hidden?}])))
+
+(defn- gc-fired! [scoped-key]
+  (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key scoped-key}]))
+
+;; ===========================================================================
+;; SUBSTRATE — the schedule-timers fx handler reconciles ONLY the named kinds
+;; ===========================================================================
+
+(defn- reconcile! [scoped-key timers-map]
+  (timers/schedule-timers-handler
+    nil {:frame-id frame-id :resource/key scoped-key :timers timers-map :server? false}))
+
+(deftest poll-only-rearm-preserves-sibling-stale-and-gc
+  (timers/reset-cache!)
+  (let [k [:rf.scope/global :tr/combo {:id 1}]]
+    ;; a full-settlement reconcile arms all three kinds
+    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
+    (is (armed? k timers/stale-kind) "stale armed")
+    (is (armed? k timers/gc-kind) "gc armed")
+    (is (armed? k timers/poll-kind) "poll armed")
+    (let [stale-h (timer-handle k timers/stale-kind)
+          gc-h    (timer-handle k timers/gc-kind)
+          poll-h  (timer-handle k timers/poll-kind)]
+      ;; a POLL-ONLY partial re-arm names ONLY :poll
+      (reconcile! k {timers/poll-kind long-ms})
+      (testing "rf2-3fc89f.10 — a poll-only re-arm PRESERVES the sibling stale
+                + GC handles (they are not named, so untouched)"
+        (is (= stale-h (timer-handle k timers/stale-kind)) "stale handle unchanged")
+        (is (= gc-h (timer-handle k timers/gc-kind)) "gc handle unchanged"))
+      (testing "the named :poll kind IS replaced (cancel-then-arm)"
+        (is (armed? k timers/poll-kind) "poll still armed")
+        (is (not= poll-h (timer-handle k timers/poll-kind)) "poll handle replaced")))
+    (timers/cancel-for-key! frame-id k)))
+
+(deftest gc-only-rearm-preserves-sibling-stale-and-poll
+  (timers/reset-cache!)
+  (let [k [:rf.scope/global :tr/combo2 {:id 1}]]
+    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
+    (let [stale-h (timer-handle k timers/stale-kind)
+          gc-h    (timer-handle k timers/gc-kind)
+          poll-h  (timer-handle k timers/poll-kind)]
+      ;; a GC-ONLY partial re-arm names ONLY :gc
+      (reconcile! k {timers/gc-kind long-ms})
+      (testing "rf2-3fc89f.10 — a GC-only re-arm PRESERVES the sibling stale +
+                poll handles"
+        (is (= stale-h (timer-handle k timers/stale-kind)) "stale handle unchanged")
+        (is (= poll-h (timer-handle k timers/poll-kind)) "poll handle unchanged"))
+      (testing "the named :gc kind IS replaced (cancel-then-arm)"
+        (is (armed? k timers/gc-kind) "gc still armed")
+        (is (not= gc-h (timer-handle k timers/gc-kind)) "gc handle replaced")))
+    (timers/cancel-for-key! frame-id k)))
+
+(deftest full-reconcile-cancels-a-kind-whose-policy-was-removed
+  ;; A full settlement names ALL declared kinds; a kind carrying a nil delay
+  ;; (its policy was dropped by a hot reload) is CANCELLED, not preserved.
+  (timers/reset-cache!)
+  (let [k [:rf.scope/global :tr/hotreload {:id 1}]]
+    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
+    (is (armed? k timers/poll-kind) "poll armed before reload")
+    ;; a later settle where the resource no longer declares a poll policy:
+    ;; poll is NAMED with a nil delay ⇒ explicit cancel; stale/gc re-armed.
+    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind nil})
+    (testing "rf2-3fc89f.10 — a NAMED nil-delay kind is CANCELLED (a removed
+              policy leaves no lingering timer); the still-declared kinds stay"
+      (is (not (armed? k timers/poll-kind)) "poll cancelled (policy removed)")
+      (is (armed? k timers/stale-kind) "stale still armed")
+      (is (armed? k timers/gc-kind) "gc still armed"))
+    (timers/cancel-for-key! frame-id k)))
+
+;; ===========================================================================
+;; EVENT LEVEL — a poll tick preserves the GC reaper; a GC skip keeps polling
+;; ===========================================================================
+
+(deftest poll-tick-preserves-the-gc-timer
+  ;; A resource with BOTH poll + GC policies. A settle arms poll + gc in the
+  ;; real side table. A poll tick re-arms poll ONLY — the GC reaper MUST
+  ;; survive (before the fix the poll re-arm's nil GC delay cancelled it, so an
+  ;; owner-free entry would later never be collected).
+  (rf/reg-resource :tre/pg (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
+                   article-spec-request)
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :tre/pg {:slug "w"})]
+    (ensure! :tre/pg scope "w" [:route :r 1])
+    (succeed! k {:title "W"})
+    (is (armed? k timers/gc-kind) "GC timer armed on settle")
+    (is (armed? k timers/poll-kind) "poll timer armed on settle")
+    (let [gc-h (timer-handle k timers/gc-kind)]
+      (poll-fired! k) ;; poll tick → background refetch + poll-only re-arm
+      (testing "rf2-3fc89f.10 — the GC timer is PRESERVED across a poll tick"
+        (is (armed? k timers/gc-kind) "GC timer still armed after the poll tick")
+        (is (= gc-h (timer-handle k timers/gc-kind)) "GC handle unchanged (not re-armed)"))
+      (testing "the poll timer IS re-armed (cancel-then-arm)"
+        (is (armed? k timers/poll-kind) "poll timer re-armed")))))
+
+(deftest gc-skip-while-owned-preserves-the-poll-timer
+  ;; A GC timer that fires while the entry is still OWNED skips collection and
+  ;; re-arms GC ONLY — the entry's active poll MUST survive (before the fix the
+  ;; GC re-arm's nil poll delay cancelled it, silently stopping periodic
+  ;; refresh on a still-owned, still-polling entry).
+  (rf/reg-resource :tre/gp (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
+                   article-spec-request)
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :tre/gp {:slug "w"})]
+    (ensure! :tre/gp scope "w" [:route :r 1])
+    (succeed! k {:title "W"})
+    (is (armed? k timers/poll-kind) "poll timer armed on settle")
+    (is (armed? k timers/gc-kind) "GC timer armed on settle")
+    (let [poll-h (timer-handle k timers/poll-kind)]
+      (gc-fired! k) ;; entry still owned → GC skip → gc-only re-arm
+      (is (some? (entry k)) "entry not collected (still owned)")
+      (testing "rf2-3fc89f.10 — the poll timer is PRESERVED across a GC skip"
+        (is (armed? k timers/poll-kind) "poll timer still armed after the GC skip")
+        (is (= poll-h (timer-handle k timers/poll-kind)) "poll handle unchanged"))
+      (testing "the GC timer IS re-armed (cancel-then-arm)"
+        (is (armed? k timers/gc-kind) "GC timer re-armed")))))
+
+(deftest poll-tick-then-release-still-collects-the-entry
+  ;; The end-to-end consequence the bug broke: on a combined poll+GC resource,
+  ;; after a poll tick the GC reaper must still be live so that when the last
+  ;; owner later releases, an owner-free + idle GC re-check collects the entry.
+  (rf/reg-resource :tre/pgc (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
+                   article-spec-request)
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :tre/pgc {:slug "w"})]
+    (ensure! :tre/pgc scope "w" [:lease :x 1])
+    (succeed! k {:title "W"})
+    (poll-fired! k)                 ;; poll tick (background refetch in flight)
+    ;; settle the poll refetch so the entry is idle again (owner-free-able)
+    (succeed! k {:title "W2"})
+    (is (armed? k timers/gc-kind) "GC timer survived the poll tick + resettle")
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :x 1]}])
+    (is (empty? (:active-owners (entry k))) "entry owner-free after release")
+    (gc-fired! k)                   ;; owner-free + idle → collected
+    (testing "rf2-3fc89f.10 — an owner-free + idle GC re-check collects the
+              entry (the reaper survived the intervening poll ticks)"
+      (is (nil? (entry k)) "entry collected by the surviving GC reaper"))))

--- a/spec/conformance/fixtures/resources-lease-release-gc.edn
+++ b/spec/conformance/fixtures/resources-lease-release-gc.edn
@@ -17,13 +17,14 @@
 ;; resource (`:res/no-gc-policy`) declares NO `:gc-after-ms` at all. Absent
 ;; normalizes AT REGISTRATION to the framework's finite default (300000ms) —
 ;; a settle now arms a REAL GC timer (`:rf.resource/schedule-timers` routed
-;; with `:gc-delay-ms 300000`) instead of silently arming nothing. `:stale-
-;; delay-ms` / `:poll-delay-ms` stay nil (this resource declares neither).
+;; with `:timers {:gc 300000}`) instead of silently arming nothing. The full
+;; reconcile names stale + poll too, both nil (this resource declares neither),
+;; rf2-3fc89f.10.
 
 {:fixture/id           :resources/lease-release-gc
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:resources/lease-gc}
- :fixture/doc          "ensure :res/article (owner [:lease :gc 1], gc-after 60s) → :loaded; release-owner drops the lease (owner-free + idle → GC-eligible); the fired GC re-check removes the entry. Traces: :rf.resource/owner-released then :rf.resource/gc-fired. The state sub then projects the :idle empty-state. A second resource (:res/no-gc-policy, no :gc-after-ms declared) proves the rf2-bbpu11 default-arming rule: its settle routes schedule-timers with the framework's default :gc-delay-ms 300000."
+ :fixture/doc          "ensure :res/article (owner [:lease :gc 1], gc-after 60s) → :loaded; release-owner drops the lease (owner-free + idle → GC-eligible); the fired GC re-check removes the entry. Traces: :rf.resource/owner-released then :rf.resource/gc-fired. The state sub then projects the :idle empty-state. A second resource (:res/no-gc-policy, no :gc-after-ms declared) proves the rf2-bbpu11 default-arming rule: its settle routes schedule-timers with the framework's default GC delay via :timers {:gc 300000}."
 
  :fixture/registry
  {:resource
@@ -72,8 +73,8 @@
                         :params {:slug "d"} :owner [:lease :gc 2] :cause :view-mount}]
 
   ;; Step 6: the reply settles :loaded — the :effects-routed expectation below
-  ;; is the proof: schedule-timers carries the DEFAULT :gc-delay-ms (300000),
-  ;; not nil, even though this resource never declared the key.
+  ;; is the proof: schedule-timers carries the DEFAULT GC delay (:timers {:gc
+  ;; 300000}), not nil, even though this resource never declared the key.
   [:rf.resource.internal/succeeded
    {:resource/key [:rf.scope/global :res/no-gc-policy {:slug "d"}]
     :work/id      [:rf.work/resource [:rf.scope/global :res/no-gc-policy {:slug "d"}] 2]
@@ -105,10 +106,12 @@
   ;; finite default (300000), not nil — the corpus-level proof that "no
   ;; policy declared" no longer means "arms nothing".
   :effects-routed
+  ;; rf2-3fc89f.10: the settle is a FULL reconcile — it names ALL three timer
+  ;; kinds in the `:timers` map (a present key with a positive delay arms, a
+  ;; present nil cancels; an absent key would preserve). Here stale + poll are
+  ;; nil (undeclared → cancel/none) and gc carries the finite default.
   [{:fx-id :rf.resource/schedule-timers
-    :args  {:frame-id       :rf/default
-            :resource/key   [:rf.scope/global :res/no-gc-policy {:slug "d"}]
-            :stale-delay-ms nil
-            :gc-delay-ms    300000
-            :poll-delay-ms  nil
-            :server?        false}}]}}
+    :args  {:frame-id     :rf/default
+            :resource/key [:rf.scope/global :res/no-gc-policy {:slug "d"}]
+            :timers       {:stale nil :gc 300000 :poll nil}
+            :server?      false}}]}}


### PR DESCRIPTION
## Summary

**P1 correctness bug (rf2-3fc89f.10, audit-derived).** The resource freshness-timer scheduling effect overloaded a nil per-kind delay to mean BOTH *preserve this sibling* (a partial poll/GC re-arm) AND *disarm this kind* (a full settlement). `schedule-timers-handler` unconditionally `schedule!`'d all three kinds (`:stale`/`:gc`/`:poll`), and `schedule!` cancels **before** it checks the delay sign — so:

- a **poll tick** re-armed `:poll` but its nil `:stale`/`:gc` delays **cancelled the entry's stale + GC timers**; the now-owner-free entry's GC reaper was gone, so it could **linger in cache indefinitely**;
- a **GC skip** (still-owned / in-flight) re-armed `:gc` but its nil `:poll` delay **cancelled the entry's active poll**, silently **stopping periodic refresh** on a still-owned entry.

## The fix (per the bead DESIGN)

Make full-settlement **reconcile** and partial **re-arm** explicit, non-ambiguous operations. The effect now carries a `:timers` map `{kind → delay}`:

- a kind **present** with a positive delay **arms** (cancel-then-arm); present with **nil** **cancels** (an explicit disarm);
- a kind **absent** is **preserved** — untouched.

nil is never overloaded: **absence = preserve, a named nil = cancel.**

- **Full settlement** (successful load / cache-hit revive / first-load error/abort / mutation populate) names the kinds it owns → still cancels a policy removed by hot reload.
- **Poll tick** names only `:poll`; **GC skip** names only `:gc` → siblings preserved.
- **Mutation populate/patch** reconciles `:stale`+`:gc` and **preserves** an actively-polling entry's `:poll` (polling is owner-driven, not data-driven — this also fixes a latent poll-cancel on mutation).
- Trace emission is **centralised in the kind-specific arm operation** (`schedule!`).

Stance: pre-alpha; no compat shim; ELEGANCE + CLARITY + CORRECTNESS.

## Reproduce → fix

New regression suite `resources_timer_rearm_cljs_test` (CLJC, JVM+CLJS):

- **poll tick preserves the GC timer** — fails on old code (GC handle `[Cancelled]`), passes now;
- **GC skip while owned preserves the poll timer** — fails on old code, passes now;
- full reconcile still **cancels a hot-reload-removed policy**;
- poll-only / GC-only substrate re-arms leave sibling handles **identical**;
- end-to-end: an owner-free + idle GC re-check still **collects** the entry after intervening poll ticks.

The `:resources/lease-release-gc` conformance golden was updated to the `:timers` shape (the fx contract it pins).

## Quality gates (all green, foreground)

- `implementation/resources`: `clojure -M:test` — **629 tests, 6250 assertions, 0 failures**
- `implementation`: `npm run test:cljs` — **8494 tests, 39284 assertions, 0 failures**
- core JVM + CLJS **conformance corpus** — **0 failures** (golden updated)
- `clj-kondo` — **0 errors** (5 pre-existing warnings in untouched code)

Closes rf2-3fc89f.10.