### PR TITLE
fix(ssr): generated host serves the selected CSS scaffold via structured shell + contained assets (rf2-3fc89f.26)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
@@ -61,11 +61,11 @@
 
  :aliases
  {;; `clojure -X:server` boots the SSR/Jetty host (see server.clj). Reads
-  ;; :port + :static-root from :exec-args; override on the CLI, e.g.
+  ;; :port + :public-root from :exec-args; override on the CLI, e.g.
   ;; `clojure -X:server :port 9000`.
   :server
   {:exec-fn   {{namespace}}.server/-main
-   :exec-args {:port 8030 :static-root "resources/public/js"}}
+   :exec-args {:port 8030 :public-root "resources/public"}}
 
   ;; `clojure -M:test` runs the headless JVM SSR gate
   ;; (test/{{nested-dirs}}/ssr_test.clj) via the cognitect test-runner.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/server.clj
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/server.clj
@@ -1,7 +1,7 @@
 (ns {{namespace}}.server
   "SSR host — a Ring/Jetty server that renders {{name}} to HTML per
-   request, then serves the compiled client bundle so the browser can
-   hydrate it.
+   request, then serves the compiled client bundle + the CSS scaffold so
+   the browser can hydrate a styled page.
 
    Emitted by `day8/re-frame2-template` under `:include-ssr? true`. Run it
    with:
@@ -10,7 +10,8 @@
 
    and open http://127.0.0.1:8030. The client bundle is built separately
    with `npx shadow-cljs watch app` (or `release app`), which writes
-   `main.js` into the `:static-root` this server serves from.
+   `main.js` into `resources/public/js/` — under the `:static-root` this
+   server serves from.
 
    ## The shape
 
@@ -18,13 +19,27 @@
    handler. It owns the whole per-request lifecycle — frame create ->
    drain -> response read -> render -> frame destroy — and materialises
    the runtime's response accumulator into a Ring response. We wrap it in
-   a tiny composite handler that also serves two static routes:
+   a tiny composite handler that ALSO serves the static assets the live
+   shell references, all from one public root:
 
      GET /main.js        -> the compiled client bundle (so the page can
                             hydrate)
+     GET /css/…          -> the selected CSS scaffold (text/css)
+     GET /js/…           -> the client bundle + its dev hot-reload chunks
      GET /favicon.ico    -> 204 (keeps the browser's automatic favicon
                             request out of the SSR path)
      GET (anything else) -> ssr-handler renders the app
+
+   The live shell (`app-html-shell` below) is the ONE host page the SSR
+   path serves. It is composed from the framework's `default-html-shell`
+   via the structured `:head` / `:body-end` content-hooks, so the emitted
+   static `resources/public/index.html` is a reference only — the SSR
+   server never serves it. `:head` gains the stylesheet `<link>` (Tailwind
+   mode also the dev compiler); `:body-end` gains the Xray devtools host.
+   Everything else — the `#app` root, the `__rf_payload` hydration
+   `<script>`, the render/head hash markers, the `/main.js` bootstrap, and
+   the route-resolved `<head>` title + meta — is single-sourced by
+   `default-html-shell`.
 
    Reference: `implementation/ssr-ring/`'s `ssr-handler` docstring and its
    `ring_e2e_validator_test.clj` Jetty bring-up in the re-frame2 repo.
@@ -35,36 +50,130 @@
    Ring-shaped host — HttpKit, Pedestal, Reitit-ring — consumes the same
    `ssr-handler` without change; swap the `run-jetty` call for your host's
    equivalent. For production, put a real static-asset server / CDN in
-   front for `/main.js` and reverse-proxy the SSR route."
+   front for `/main.js` + `/css/` and reverse-proxy the SSR route."
   (:require [ring.adapter.jetty :as jetty]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [{{namespace}}.core :as app]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import [java.io File]))
 
-(defn- static-file-response
-  "Serve `filename` from `static-root` as a 200 with `content-type`, or
-   404 when it isn't there yet (e.g. the client bundle hasn't been built).
-   The 404 body names the fix so a first-run miss is self-explanatory."
-  [static-root filename content-type]
-  (let [f (io/file static-root filename)]
-    (if (.isFile f)
-      {:status  200
-       :headers {"Content-Type" content-type}
-       :body    f}
-      {:status  404
-       :headers {"Content-Type" "text/plain; charset=utf-8"}
-       :body    (str filename " not found under " static-root
-                     " — build the client bundle first "
-                     "(`npx shadow-cljs watch app`).")})))
+;; ---------------------------------------------------------------------------
+;; The live SSR shell — the selected CSS scaffold + Xray host, composed onto
+;; the framework shell via structured content-hooks (never string surgery on
+;; rendered HTML).
+;; ---------------------------------------------------------------------------
+
+(def ^:private tailwind?
+  "True when this project was scaffolded with `:css :tailwind`. The live
+   shell then ALSO loads the `@tailwindcss/browser` dev compiler, which
+   compiles the utilities used on the page at runtime — mirroring the SPA
+   scaffold's index.html. `{{css-name}}` is `\"tailwind\"` or `\"\"`
+   (deps-new substitution)."
+  (= "{{css-name}}" "tailwind"))
+
+(def ^:private head-assets
+  "Raw `<head>` HTML the live shell injects on every SSR response so the
+   selected CSS scaffold actually loads: the stylesheet `<link>`, plus — in
+   Tailwind mode — the `@tailwindcss/browser@4` dev compiler. Appended to the
+   route-resolved head model through the `:head` content-hook, so the title +
+   meta the route declares are preserved, not replaced."
+  (str
+    (when tailwind?
+      "<script src=\"https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4\"></script>")
+    "<link rel=\"stylesheet\" href=\"/css/app.css\">"))
+
+(def ^:private xray-host-aside
+  "The Xray devtools layout host, mirroring the SPA scaffold's index.html.
+   Injected via the `:body-end` content-hook so the LIVE SSR shell — not the
+   unused static index.html — carries the `[data-rf-xray-host]` mount the dev
+   Xray preload docks into. It sits OUTSIDE `#app`, so it never participates
+   in hydration."
+  "<aside class=\"rf2-xray-host\" data-rf-xray-host></aside>")
+
+(defn- app-html-shell
+  "The live SSR document shell. Delegates to the framework's
+   `default-html-shell` — which single-sources the doctype, the
+   `<html>`/`<body>` attribute bags, the route-resolved `<head>` (title +
+   meta), the `__rf_payload` hydration `<script>`, the render/head hash
+   markers, the `/main.js` bootstrap, and all attribute escaping — and
+   augments ONLY the two structured content-hooks: `:head` gains the
+   stylesheet link (+ Tailwind compiler), `:body-end` gains the Xray host.
+   Both are APPENDED to whatever the route resolved, never replaced."
+  [body-html payload-edn opts]
+  (ssr-ring/default-html-shell
+    body-html payload-edn
+    (-> opts
+        (update :head     (fn [resolved] (str resolved head-assets)))
+        (update :body-end (fn [resolved] (str resolved xray-host-aside))))))
+
+;; ---------------------------------------------------------------------------
+;; Static assets — served from one public root, with normalised containment so
+;; a URI can't traverse out of it.
+;; ---------------------------------------------------------------------------
+
+(defn- content-type-for
+  "The static Content-Type for `rel-path`, by extension. CSS is served as
+   `text/css`, the JS bundle + its chunks as `text/javascript`."
+  [rel-path]
+  (cond
+    (str/ends-with? rel-path ".css")  "text/css; charset=utf-8"
+    (str/ends-with? rel-path ".js")   "text/javascript; charset=utf-8"
+    (str/ends-with? rel-path ".map")  "application/json; charset=utf-8"
+    (str/ends-with? rel-path ".ico")  "image/x-icon"
+    (str/ends-with? rel-path ".json") "application/json; charset=utf-8"
+    :else                             "application/octet-stream"))
+
+(defn- contained-file
+  "Resolve `rel-path` under `public-root` and return the `java.io.File` IFF the
+   normalised (canonical, `..`-resolved) target stays WITHIN `public-root`.
+   Returns nil on any escape — the static-asset boundary rejects URI traversal
+   (`/css/../../secret`) rather than reading outside the configured root. The
+   containment check is path-component containment on canonical paths, not a
+   string prefix, so it is not fooled by sibling-prefix directories."
+  ^File [public-root rel-path]
+  (let [root (.getCanonicalFile (io/file public-root))
+        f    (.getCanonicalFile (io/file root rel-path))]
+    (when (.startsWith (.toPath f) (.toPath root))
+      f)))
+
+(defn- static-response
+  "Serve `rel-path` from `public-root` with normalised containment:
+
+     - contained + present -> 200, extension-derived Content-Type, file body
+     - contained + missing -> 404 (with an optional build hint)
+     - escapes public root -> 403
+
+   It NEVER falls through to the SSR renderer, so a static-looking asset
+   request can't come back as an SSR HTML document mislabelled CSS/JS."
+  ([public-root rel-path] (static-response public-root rel-path nil))
+  ([public-root rel-path not-found-hint]
+   (if-let [f (contained-file public-root rel-path)]
+     (if (.isFile f)
+       {:status  200
+        :headers {"Content-Type" (content-type-for rel-path)}
+        :body    f}
+       {:status  404
+        :headers {"Content-Type" "text/plain; charset=utf-8"}
+        :body    (or not-found-hint
+                     (str rel-path " not found under " public-root "."))})
+     {:status  403
+      :headers {"Content-Type" "text/plain; charset=utf-8"}
+      :body    "Forbidden: the requested asset path escapes the public root."})))
+
+;; ---------------------------------------------------------------------------
+;; The composite handler.
+;; ---------------------------------------------------------------------------
 
 (defn make-handler
-  "Build the composite Ring handler: static `/main.js` + favicon 204 +
-   the SSR renderer for everything else. `static-root` is the directory
-   `shadow-cljs` writes `main.js` into (the `:app` build's
-   `:output-dir`)."
-  [static-root]
+  "Build the composite Ring handler: the contained static assets under
+   `public-root` + a favicon 204 + the SSR renderer for everything else.
+   `public-root` is the directory that holds both the CSS scaffold
+   (`css/app.css`) and the `shadow-cljs`-built client bundle (`js/main.js`)
+   — `resources/public` by default."
+  [public-root]
   (let [ssr (ssr-ring/ssr-handler
               {:initial-events app/server-init-events
                :root-view      app/root-view
@@ -72,32 +181,47 @@
                ;; the allowlist form (recommended). `:payload` is REQUIRED
                ;; and fail-closed; omit it and construction throws
                ;; `:rf.error/ssr-missing-payload-policy`.
-               :payload        [:counter/value]})]
+               :payload        [:counter/value]
+               ;; The live shell loads the selected CSS scaffold + hosts Xray.
+               :html-shell     app-html-shell})]
     (fn handler [{:keys [uri request-method] :as request}]
       (cond
-        (and (= :get request-method) (= "/main.js" uri))
-        (static-file-response static-root "main.js" "text/javascript; charset=utf-8")
+        (not= :get request-method)
+        (ssr request)
 
-        (and (= :get request-method) (= "/favicon.ico" uri))
+        ;; The `/main.js` bootstrap the shell emits, served from js/main.js.
+        (= "/main.js" uri)
+        (static-response public-root "js/main.js"
+                         (str "main.js not found under " public-root "/js"
+                              " — build the client bundle first "
+                              "(`npx shadow-cljs watch app`)."))
+
+        (= "/favicon.ico" uri)
         {:status 204 :headers {} :body ""}
+
+        ;; The CSS scaffold + the client bundle's dev hot-reload chunks. Both
+        ;; go through the contained server so `..` can't escape public-root.
+        (or (str/starts-with? uri "/css/")
+            (str/starts-with? uri "/js/"))
+        (static-response public-root (subs uri 1))
 
         :else
         (ssr request)))))
 
 (defn -main
-  "Entry point for `clojure -X:server`. Reads `:port` + `:static-root`
-   from the alias's `:exec-args` (see deps.edn). Installs the JVM-side SSR
-   render adapter, then boots Jetty on 127.0.0.1."
-  [{:keys [port static-root]
-    :or   {port 8030 static-root "resources/public/js"}}]
+  "Entry point for `clojure -X:server`. Reads `:port` + `:public-root` from
+   the alias's `:exec-args` (see deps.edn). Installs the JVM-side SSR render
+   adapter, then boots Jetty on 127.0.0.1."
+  [{:keys [port public-root]
+    :or   {port 8030 public-root "resources/public"}}]
   ;; Install the JVM-side SSR render adapter (re-frame.ssr/adapter). The
   ;; server render path walks hiccup -> HTML on the JVM, so it seats the
   ;; SSR adapter, NOT the CLJS-only Reagent adapter (that one boots the
   ;; browser mount in core.cljc's :cljs branch).
   (rf/init! ssr/adapter)
   (println (str "SSR server for {{name}} on http://127.0.0.1:" port
-                " (serving client bundle from " static-root ")"))
-  (jetty/run-jetty (make-handler static-root)
+                " (serving static assets from " public-root ")"))
+  (jetty/run-jetty (make-handler public-root)
                    {:port  port
                     :host  "127.0.0.1"
                     :join? true}))

--- a/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
+++ b/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
@@ -22,7 +22,12 @@ render path vs the browser mount). See Spec 011 — SSR & Hydration.
 
 SSR runs two processes side by side: the **shadow-cljs watcher** compiles the
 client bundle (`main.js`), and the **JVM render server** (Ring/Jetty) renders
-each request to HTML and serves that bundle so the page can hydrate.
+each request to HTML and serves that bundle — plus the CSS scaffold under
+`/css/` — so the page arrives styled and can hydrate. The render server owns
+**one live shell**: it links `/css/app.css` (Tailwind mode also loads the
+`@tailwindcss/browser` dev compiler) and carries the Xray devtools host, so the
+static `resources/public/index.html` is a reference only — the SSR path never
+serves it.
 
 ```sh
 npm install
@@ -143,7 +148,10 @@ It boots the SSR adapter, drives the **real** `ssr-ring/ssr-handler` constructio
 with `render-to-string`, and asserts the HTML content plus the structural
 `data-rf-render-hash` marker the client compares against — no React / JSDOM, it
 runs end-to-end on the JVM. It also proves the per-request schema attach is live
-by rejecting a deliberately schema-violating commit on that same production path.
+by rejecting a deliberately schema-violating commit on that same production path,
+and drives `server.clj`'s composite handler to check the live shell links the CSS
+scaffold, `/css/app.css` is served as `text/css`, and a `../`-style asset request
+is contained under the public root (no URI traversal).
 
 ## Project layout
 
@@ -157,13 +165,13 @@ by rejecting a deliberately schema-violating commit on that same production path
 ├── lefthook.yml             ; pre-commit format + lint hook
 ├── .github/workflows/
 │   └── ci.yml               ; baseline GitHub Actions CI
-├── resources/public/
-│   ├── index.html           ; static host page (the SSR server renders its own shell per request)
-│   ├── css/app.css          ; minimal plain CSS
-│   └── js/                  ; shadow-cljs writes main.js here; server.clj's :static-root serves it
+├── resources/public/        ; server.clj's :public-root — one root, contained (no URI traversal)
+│   ├── index.html           ; static reference only — the SSR server renders + serves its OWN live shell
+│   ├── css/app.css          ; the stylesheet the live shell links + the server serves as text/css
+│   └── js/                  ; shadow-cljs writes main.js here; the server serves /main.js + /js/* from it
 ├── src/{{nested-dirs}}/
 │   ├── core.cljc            ; THE app — events / sub / schema / view, shared JVM render + CLJS hydration
-│   └── server.clj           ; the Ring / Jetty SSR host (:server alias entry point)
+│   └── server.clj           ; the Ring / Jetty SSR host — live shell (CSS + Xray host) + contained assets
 ├── test/{{nested-dirs}}/
 │   └── ssr_test.clj         ; headless JVM SSR gate (render-to-string + render-hash + schema enforcement)
 └── dev/

--- a/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
+++ b/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
@@ -3,7 +3,8 @@
 
    The direct render test exercises frame setup, rendering, and the hydration
    hash. The handler tests compile and drive server.clj's production path,
-   including schema attachment to the frame that ssr-handler creates.
+   including schema attachment to the frame that ssr-handler creates, the live
+   shell's CSS scaffold, and the contained static-asset serving.
 
    Run with `clojure -M:test`."
   (:require [clojure.test :refer [deftest is testing]]
@@ -14,6 +15,30 @@
             [{{namespace}}.core :as app]
             ;; Requiring the host keeps its API surface in the test build.
             [{{namespace}}.server :as server]))
+
+(def ^:private tailwind?
+  "This scaffold's `:css` mode — `{{css-name}}` is \"tailwind\" or \"\"."
+  (= "{{css-name}}" "tailwind"))
+
+(defn- body-str
+  "The response body as a String — the SSR path returns HTML strings, the
+   static-asset path returns java.io.File bodies."
+  [resp]
+  (let [b (:body resp)]
+    (cond
+      (string? b)                 b
+      (instance? java.io.File b)  (slurp b)
+      :else                       (str b))))
+
+(defn- ssr-html-fallthrough?
+  "True when `resp`'s body is a rendered SSR document — the signal that a
+   static/asset request wrongly fell through to the SSR renderer. Keyed on the
+   `<!DOCTYPE html>` document prefix, NOT a hydration marker like
+   `__rf_payload`: the compiled JS bundle legitimately embeds that marker
+   string (the client hydrator reads `getElementById(\"__rf_payload\")`), so it
+   can't distinguish a served bundle from an SSR page."
+  [resp]
+  (string/includes? (body-str resp) "<!DOCTYPE html>"))
 
 (deftest ssr-render-produces-hydration-ready-html
   (testing "the SSR server flow renders the counter to HTML with a render hash"
@@ -55,13 +80,78 @@
             :ssr/register-schema doesn't disturb the happy path, and
             requiring the host ns compiles server.clj"
     (rf/init! ssr/adapter)
-    ;; static-root is unused by the SSR route exercised here.
-    (let [handler (server/make-handler "resources/public/js")
+    (let [handler (server/make-handler "resources/public")
           resp    (handler {:uri "/" :request-method :get})]
       (is (= 200 (:status resp))
           "the production server/make-handler path renders a normal 200 response")
       (is (string/includes? (:body resp) "data-rf-render-hash")
           "the response body carries the render-hash tripwire"))))
+
+(deftest ssr-live-shell-loads-and-serves-the-css-scaffold
+  (testing "the live SSR shell (the one server.clj's make-handler serves —
+            NOT the unused static index.html) links the selected CSS scaffold,
+            the composite handler serves it with a CSS MIME, and the
+            static-asset boundary contains URI traversal"
+    (rf/init! ssr/adapter)
+    (let [handler (server/make-handler "resources/public")]
+
+      ;; -- the live shell links the CSS (Tailwind mode: + the dev compiler),
+      ;;    and preserves every hydration/head invariant --
+      (let [resp (handler {:uri "/" :request-method :get})
+            body (body-str resp)]
+        (is (= 200 (:status resp)) "the SSR / route renders a 200")
+        (is (string/includes? body "<link rel=\"stylesheet\" href=\"/css/app.css\">")
+            "the / response links the emitted CSS scaffold, so the page loads styled")
+        (when tailwind?
+          (is (string/includes? body "@tailwindcss/browser@4")
+              "Tailwind mode loads the @tailwindcss/browser dev compiler in the live shell"))
+        (is (string/includes? body "__rf_payload")
+            "the __rf_payload hydration script id is preserved")
+        (is (string/includes? body "id=\"app\"")
+            "the #app hydration root is preserved")
+        (is (string/includes? body "data-rf-render-hash")
+            "the render-hash tripwire is preserved")
+        (is (string/includes? body "src=\"/main.js\"")
+            "the /main.js bootstrap is preserved")
+        (is (string/includes? body "data-rf-xray-host")
+            "the live shell carries the [data-rf-xray-host] Xray host")
+        (is (string/includes? body "<title>")
+            "the route-resolved head title/meta survives the CSS injection (not clobbered)"))
+
+      ;; -- GET /css/app.css returns the emitted stylesheet, CSS MIME, NOT HTML --
+      (let [resp (handler {:uri "/css/app.css" :request-method :get})
+            body (body-str resp)]
+        (is (= 200 (:status resp)) "GET /css/app.css is served, not 404/SSR")
+        (is (= "text/css; charset=utf-8" (get-in resp [:headers "Content-Type"]))
+            "the stylesheet is served as text/css, not an SSR HTML document")
+        (is (not (ssr-html-fallthrough? resp))
+            "GET /css/app.css returns CSS bytes, NOT the SSR HTML app response")
+        (is (string/includes? body (if tailwind? "@import \"tailwindcss\"" "minimal stylesheet"))
+            "the served bytes are the emitted app.css entry"))
+
+      ;; -- /main.js keeps a JavaScript MIME (never an SSR HTML fallthrough) --
+      (let [resp (handler {:uri "/main.js" :request-method :get})]
+        (is (contains? #{200 404} (:status resp))
+            "the bundle route resolves (200 built / 404 not-yet-built), never SSR HTML")
+        (when (= 200 (:status resp))
+          (is (= "text/javascript; charset=utf-8" (get-in resp [:headers "Content-Type"]))
+              "the built bundle keeps a JavaScript MIME"))
+        (is (not (ssr-html-fallthrough? resp))
+            "the bundle route never falls through to an SSR HTML response"))
+
+      ;; -- static-asset containment: a ../-style URI cannot escape public root --
+      (let [resp (handler {:uri "/css/../../../../../../deps.edn" :request-method :get})]
+        (is (= 403 (:status resp))
+            "a ../-style traversal under /css is rejected (contained under public root)")
+        (is (not (ssr-html-fallthrough? resp))
+            "a traversal request does not fall through to an SSR HTML document"))
+
+      ;; -- a missing static asset is a 404, not a 200 SSR HTML document --
+      (let [resp (handler {:uri "/css/does-not-exist.css" :request-method :get})]
+        (is (= 404 (:status resp))
+            "a missing CSS asset returns 404, not a 200 SSR HTML document mislabelled CSS")
+        (is (not (ssr-html-fallthrough? resp))
+            "a missing-asset request does not fall through to SSR")))))
 
 (deftest ssr-handler-rejects-a-schema-violating-commit-on-the-real-path
   (testing "the REAL ssr-ring/ssr-handler path — the one server.clj actually

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -308,6 +308,10 @@
        ;; Keep selectors as keywords for `template-fn`; substitution values
        ;; are stringified by deps-new.
        :css-kw              css
+       ;; String form for flat `{{css-name}}` substitution — "tailwind" or
+       ;; "" (plain). The SSR `server.clj` reads it to decide whether the live
+       ;; shell also loads the Tailwind dev compiler.
+       :css-name            (if css (name css) "")
        :story-tag           (if include-story? ", with Story playground" "")
        ;; SSR emits a JVM test instead of the shared CLJS test.
        :test-script         (if include-ssr?

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -457,18 +457,27 @@
          (delete-recursively tmp))))))
 
 (defn- run-ssr-emitted-test!
-  "Compile both halves of an emitted SSR project.
+  "Compile both halves of an emitted SSR project, for the given `:css` mode
+   (nil = plain, `:tailwind` = the Tailwind cell).
 
    The browser build compiles core.cljc's hydration branch. `clojure -M:test`
-   runs the JVM render and Ring-handler tests, which are also what the emitted
-   npm test script and CI invoke. The browser compile needs project-local
-   node_modules; the tests themselves need no Node runtime or DOM."
-  []
-  (let [root (repo-root)
-        tmp  (tmp-dir "rf2-template-run-reagent-ssr-")]
+   runs the JVM render and Ring-handler tests — including the live-shell CSS
+   scaffold + contained static-asset serving (ssr_test.clj), which is what the
+   emitted npm test script and CI invoke. The browser compile needs
+   project-local node_modules; the tests themselves need no Node runtime or DOM.
+
+   Running BOTH css modes (plain + Tailwind) through the real make-handler is
+   what proves the documented `:css` + `:include-ssr?` combination composes on
+   the actual SSR response (rf2-3fc89f.26)."
+  ([] (run-ssr-emitted-test! nil))
+  ([css]
+   (let [root (repo-root)
+         tmp  (tmp-dir (str "rf2-template-run-reagent-ssr-"
+                            (if css (name css) "plain") "-"))]
     (try
       (let [proj (run-template-opts! tmp "acme/my-app"
-                                     {:substrate :reagent :include-ssr? true})]
+                                     (cond-> {:substrate :reagent :include-ssr? true}
+                                       css (assoc :css css)))]
         (rewrite-deps-for-local-run! root proj :reagent)
         (let [linked?   (link-node-modules! root proj)
               node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
@@ -520,7 +529,7 @@
                   (str "expected '0 failures, 0 errors' line in output. "
                        "Got:\n" out))))))
       (finally
-        (delete-recursively tmp)))))
+        (delete-recursively tmp))))))
 
 (defn- skip-if-disabled!
   "When the gate is off, record a passing assertion that documents the
@@ -631,6 +640,26 @@
               "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when @clojure-cli-available?
             (run-ssr-emitted-test!))))))
+
+(deftest reagent-ssr-tailwind-emitted-tests-run-test
+  ;; The {:include-ssr? true :css :tailwind} matrix cell run end-to-end
+  ;; (rf2-3fc89f.26). Same two-halves shape as the plain SSR cell above, but
+  ;; the Tailwind CSS overlay is in play — so the emitted ssr_test.clj's
+  ;; live-shell assertions run against the Tailwind head (the
+  ;; @tailwindcss/browser dev compiler + the Tailwind /css/app.css entry) on
+  ;; the REAL make-handler path. Running BOTH css modes through the real
+  ;; handler is what proves the documented `:css` + `:include-ssr?`
+  ;; combination composes on the actual SSR response, not just in the unused
+  ;; static index.html.
+  (testing "the emitted SSR+Tailwind Reagent app's client :cljs branch
+            compiles + its ssr_test.clj runs green via `clojure -M:test`
+            (the live shell loads the Tailwind compiler + serves the CSS)"
+    (if-not @enabled?
+      (skip-if-disabled! "reagent-ssr-tailwind")
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when @clojure-cli-available?
+            (run-ssr-emitted-test! :tailwind))))))
 
 ;; ===========================================================================
 ;; MANUAL setup-skill scaffold fixture

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -264,16 +264,32 @@
            meta-clause
            "(" sym-char ")"))))
 
+(def ^:private ^java.util.regex.Pattern import-fn-pattern
+  ;; The `re-frame.ssr.ring` facade re-exports vars from its impl nses via
+  ;; the `import-fn` macro (e.g. `(import-fn shell/default-html-shell)` defs
+  ;; `default-html-shell` at the facade, preserving the source var's
+  ;; `:doc`/`:arglists`). The literal `(def default-html-shell …)` is produced
+  ;; by macro-expansion, so the raw-source `def-pattern` scan never sees it.
+  ;; Recognise the re-exported NAME (the part after `alias/`) so a scaffold
+  ;; that consumes the facade symbol — the SSR `server.clj` calls
+  ;; `ssr-ring/default-html-shell` — resolves in the surface-drift audit
+  ;; instead of false-failing as a rename/cut.
+  #"\(import-fn\s+[^\s()/]+/([^\s()]+)\)")
+
 (defn- scan-defined-symbols
-  "Slurp+regex a single framework .cljc/.cljs source and return the
+  "Slurp+regex a single framework .cljc/.cljs/.clj source and return the
   set of symbols it introduces with a top-level `def` / `defn` /
   `defn-` / `defmacro` / `defmulti` / `defonce` / `defprotocol` /
-  `defrecord` / `deftype`. Memoised entry point is `defined-symbols`
-  below — direct callers should prefer that."
+  `defrecord` / `deftype`, PLUS the facade re-exports the
+  `re-frame.ssr.ring` `import-fn` macro emits. Memoised entry point is
+  `defined-symbols` below — direct callers should prefer that."
   [^java.io.File f]
-  (into #{}
-        (map (fn [[_ sym]] (symbol sym)))
-        (re-seq def-pattern (slurp f))))
+  (let [text (slurp f)]
+    (into (into #{}
+                (map (fn [[_ sym]] (symbol sym)))
+                (re-seq def-pattern text))
+          (map (fn [[_ sym]] (symbol sym)))
+          (re-seq import-fn-pattern text))))
 
 (def ^:private defined-symbols-cache
   ;; Keyed by canonical absolute path. The framework source tree is

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1172,9 +1172,10 @@
               (is (= 'acme.my-app.server/-main (:exec-fn server-alias))
                   ":server alias :exec-fn targets the emitted server ns")
               (is (map? (:exec-args server-alias))
-                  ":server alias carries :exec-args (port + static-root)")
-              (is (contains? (:exec-args server-alias) :static-root)
-                  ":server :exec-args carries a :static-root the server serves main.js from")))
+                  ":server alias carries :exec-args (port + public-root)")
+              (is (contains? (:exec-args server-alias) :public-root)
+                  ":server :exec-args carries a :public-root the server serves
+                   the bundle + CSS scaffold from (contained under it)")))
 
           ;; -- :test alias wiring — the headless JVM ssr_test.clj gate --
           ;; The SSR scaffold ships NO cljs.test suite, so `clojure -M:test`
@@ -1238,7 +1239,35 @@
             (is (.contains server-text "defn -main")
                 "server.clj exposes -main (the :server alias entry point)")
             (is (.contains server-text "[acme.my-app.core :as app]")
-                "server.clj requires the app's core ns by derived namespace"))
+                "server.clj requires the app's core ns by derived namespace")
+            ;; -- server.clj owns the ONE live-shell + static-asset contract:
+            ;;    the live shell loads the CSS scaffold + hosts Xray, and the
+            ;;    composite handler serves the stylesheet with normalised
+            ;;    containment (rf2-3fc89f.26) --
+            (is (.contains server-text ":html-shell")
+                "server.clj installs a custom :html-shell that loads the CSS scaffold")
+            (is (.contains server-text "default-html-shell")
+                "the live shell composes from the framework's default-html-shell
+                 (structured helper) rather than string-splicing rendered HTML")
+            (is (.contains server-text "/css/app.css")
+                "the live shell links the emitted /css/app.css stylesheet")
+            (is (.contains server-text "data-rf-xray-host")
+                "the live shell carries the [data-rf-xray-host] Xray host")
+            (is (.contains server-text "text/css")
+                "the composite handler serves the stylesheet with a text/css MIME")
+            (is (or (.contains server-text "getCanonicalFile")
+                    (.contains server-text "getCanonicalPath"))
+                "the static-asset serving normalises paths for containment (no URI traversal)")
+            (is (.contains server-text "public-root")
+                "server.clj serves static assets from a single public root")
+            ;; The Tailwind dev compiler is runtime-guarded by `tailwind?`,
+            ;; which the `{{css-name}}` substitution resolves. On the plain SSR
+            ;; path the guard is `(= \"\" \"tailwind\")` (false), so the
+            ;; compiler string — present in source but dead-guarded — is never
+            ;; emitted. (The Tailwind cell asserts the true-guard counterpart.)
+            (is (.contains server-text "(= \"\" \"tailwind\")")
+                "the plain SSR server's tailwind? guard resolves to false — the
+                 dev compiler is not loaded"))
 
           ;; -- ssr_test.clj is the headless JVM gate --
           (let [ssr-test-text (slurp (io/file root "test/acme/my_app/ssr_test.clj"))]
@@ -1290,6 +1319,62 @@
               (is (not (.contains readme-text spa-file))
                   (str "SSR README does NOT reference the SPA-shape source "
                        spa-file " — those slices are folded into core.cljc")))))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest include-ssr-tailwind-cell-test
+  ;; The {:include-ssr? true :css :tailwind} matrix cell (rf2-3fc89f.26).
+  ;; The plain SSR cell (include-ssr-true-reagent-test) asserts the
+  ;; substrate-invariant live-shell + static-asset contract; this cell adds
+  ;; the Tailwind-specific surface: the emitted server.clj loads the
+  ;; @tailwindcss/browser dev compiler in the LIVE shell (not just the unused
+  ;; static index.html), and the CSS overlay swaps in the Tailwind entry.
+  (testing ":include-ssr? true + :css :tailwind emits an SSR scaffold whose
+            LIVE shell loads the Tailwind compiler + serves the Tailwind CSS"
+    (let [tmp (tmp-dir "rf2-template-ssr-tailwind-")]
+      (try
+        (let [root (run-template-opts! tmp "acme/my-app"
+                                       {:substrate :reagent
+                                        :include-ssr? true
+                                        :css :tailwind})]
+          ;; The SSR sources are emitted (same as the plain SSR cell).
+          (is (file-exists? root "src/acme/my_app/core.cljc")
+              "core.cljc is emitted for the SSR+Tailwind cell")
+          (is (file-exists? root "src/acme/my_app/server.clj")
+              "server.clj is emitted for the SSR+Tailwind cell")
+          (is (file-exists? root "test/acme/my_app/ssr_test.clj")
+              "ssr_test.clj is emitted for the SSR+Tailwind cell")
+
+          ;; The Tailwind overlay swapped in the Tailwind CSS entry.
+          (let [css-text (slurp (io/file root "resources/public/css/app.css"))]
+            (is (.contains css-text "@import \"tailwindcss\"")
+                "the emitted app.css is the Tailwind v4 entry (:css :tailwind overlay)"))
+
+          ;; server.clj — the LIVE shell loads the Tailwind dev compiler AND
+          ;; links the CSS, so the actual SSR / response (NOT the unused
+          ;; index.html) carries both. This is the combination the API says
+          ;; composes (spec/API.md:113).
+          (let [server-text (slurp (io/file root "src/acme/my_app/server.clj"))]
+            (is (.contains server-text "@tailwindcss/browser")
+                "the SSR+Tailwind server.clj loads the @tailwindcss/browser dev
+                 compiler in the live shell (the documented combination works,
+                 not silently fails)")
+            ;; The tailwind? guard resolves to TRUE here (contrast the plain
+            ;; cell's `(= "" "tailwind")`), so the compiler is actually emitted.
+            (is (.contains server-text "(= \"tailwind\" \"tailwind\")")
+                "the SSR+Tailwind server's tailwind? guard resolves to true —
+                 the dev compiler is live on the SSR response")
+            (is (.contains server-text "/css/app.css")
+                "the SSR+Tailwind live shell links the Tailwind CSS entry")
+            (is (.contains server-text ":html-shell")
+                "the SSR+Tailwind server installs the custom CSS-loading shell")
+            (is (.contains server-text "text/css")
+                "the SSR+Tailwind handler serves the stylesheet with a text/css MIME"))
+
+          ;; The emitted README is still the SSR variant.
+          (let [readme-text (slurp (io/file root "README.md"))]
+            (is (.contains readme-text "clojure -X:server")
+                "SSR+Tailwind README documents the JVM host boot step")))
         (finally
           (delete-recursively tmp))))))
 


### PR DESCRIPTION
## Summary

The generated SSR scaffold (`tools/template`, `:include-ssr? true`) emitted a static `resources/public/index.html` — carrying the stylesheet link + Xray host — that the SSR render path **never served**. `server.clj`'s `make-handler` routed only `/main.js` + `/favicon.ico` and sent everything else to `ssr-handler`, whose default shell emits no stylesheet link. So:

- every generated SSR app started **unstyled** relative to its emitted scaffold,
- `GET /css/app.css` **fell through to the SSR renderer** and returned an HTML document (not CSS),
- the documented `:css :tailwind` + `:include-ssr?` combination (`spec/API.md:113` says `:css` composes with `:include-ssr?`) **silently did nothing** on the actual response — the Tailwind compiler lived only in the unused `index.html`.

Audit-derived (rf2-3fc89f.26).

## Reproduce → fix

Reproduced by generating a plain + Tailwind SSR app and driving the emitted `make-handler` directly.

**Before** (old `server.clj`):
- `GET /` → 200 SSR HTML with **no** `/css/app.css` link
- `GET /css/app.css` → 200 SSR **HTML** (fell through to SSR)
- `GET /css/../../../../../../deps.edn` → 200 SSR HTML (static-looking request fell through)

**After** (this PR):
- `GET /` → links `/css/app.css` (Tailwind: + `@tailwindcss/browser@4`), preserves `__rf_payload` / `#app` / `data-rf-render-hash` / `/main.js` / `[data-rf-xray-host]` / route title+meta
- `GET /css/app.css` → 200, `text/css; charset=utf-8`, the emitted stylesheet bytes
- `GET /css/../../…/deps.edn` → **403** (contained), never SSR
- `GET /css/missing.css` → **404** asset response, never SSR

## Stance

Pre-alpha; SOTA masterpiece via ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. The live shell is **composed from the framework's `default-html-shell`** via its structured `:head` / `:body-end` content-hooks — no HTML-string parsing/replacement, no re-implementation of the framework document envelope (doctype / html+body attrs / `__rf_payload` / hash markers / `/main.js` / escaping are all delegated and preserved). Static-asset serving is a **security boundary**: `getCanonicalFile` + `Path.startsWith` enforce normalised containment under the configured public root, so a URI cannot traverse out of it.

## What changed (all in `tools/template`)

- **`_reagent/server.clj`** — one live-shell + static-asset contract. A custom `:html-shell` appends the stylesheet link (+ Tailwind dev compiler, `{{css-name}}`-gated) to the *resolved* `:head` and the Xray host to `:body-end`. `make-handler` serves `/main.js` + `/css/*` + `/js/*` from one `public-root` with normalised containment (403 on escape, 404 on miss), CSS as `text/css`, bundle as JS MIME; everything else → SSR.
- **`_reagent/deps_with_ssr.edn`** — `:server` exec-args `:static-root` → `:public-root "resources/public"`.
- **`src/…/hooks.clj`** — adds the `:css-name` substitution value ("tailwind" / "").
- **`_shared/README_with_ssr.md`** — describes the live shell serving/linking CSS + hosting Xray; index.html is a static reference only.
- **`_shared/ssr_test.clj`** — new deftest drives the real `make-handler`: CSS link + `text/css` serving + traversal 403 + missing 404 + preserved hydration invariants (both CSS modes via `{{css-name}}`).
- **`test/…/template_test.clj`** — asserts the emitted shell/asset contract; new `:css :tailwind` + `:include-ssr?` matrix cell.
- **`test/…/emitted_test_run_test.clj`** — gated emitted-run harness parameterised over CSS mode; adds the Tailwind SSR cell (both modes through the real handler).
- **`test/…/template_emission_test.clj`** — the surface-drift audit now resolves the `re-frame.ssr.ring` facade's `import-fn` re-exports (so `ssr-ring/default-html-shell` resolves).

## Quality gates

- `cd tools/template && clojure -M:test` → **49 tests, 664 assertions, 0 failures**.
- `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` SSR cells (plain + Tailwind): `shadow compile app` + emitted `clojure -M:test` → **0 failures** (both CSS modes, real handler, with the bundle built).
- Emitted `server.clj` loads clean under `*warn-on-reflection* true` (no reflection warnings).

Note: this defect lives entirely in `tools/template` (the generated host), not `implementation/ssr` / `ssr-ring` — those are unchanged, so their artefact tests and the SSR example build are not affected by this PR.

Do NOT merge — awaiting review.