### PR TITLE
fix(examples): repair XML-illegal SVG comments + real image-integrity validation (rf2-3fc89f.27)

### DIFF
--- a/examples/_shared/img/favicon.svg
+++ b/examples/_shared/img/favicon.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Shared 32x32 example favicon. Its paper, ink, and decorative amber literals
-  mirror the --ex-* palette in examples/_shared/css/style.css.
+  mirror the ex-* palette (the ex-* CSS custom properties) in
+  examples/_shared/css/style.css.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
   <rect width="32" height="32" rx="6" fill="#1A1814"/>

--- a/examples/_shared/img/og.svg
+++ b/examples/_shared/img/og.svg
@@ -2,12 +2,14 @@
 <!-- Editable source for the shared social card. Pages reference the rasterised
      examples/_shared/img/og.png, not this SVG. Re-export that file at 1200x630
      after changing this source.
-     Matches the shared 'Editorial Warm' identity in examples/_shared/css/style.css:
-       paper bg     #F7F3EC  (--ex-bg)
-       deep ink     #1A1814  (--ex-ink)        — display text + monogram
-       muted ink    #5C5448  (--ex-ink-muted)  — strapline
-        faint ink    #6E6654  (--ex-ink-faint)  — mono label
-        amber accent #C8741A  (--ex-accent)     — decorative rule + monogram bar
+     Matches the shared 'Editorial Warm' identity in examples/_shared/css/style.css.
+     Each hex mirrors one of the shared CSS custom properties (token names below
+     are shown without their leading double-dash prefix):
+       paper bg     #F7F3EC  (ex-bg)
+       deep ink     #1A1814  (ex-ink)        — display text + monogram
+       muted ink    #5C5448  (ex-ink-muted)  — strapline
+        faint ink    #6E6654  (ex-ink-faint)  — mono label
+        amber accent #C8741A  (ex-accent)     — decorative rule + monogram bar
      Keep these literals aligned with the CSS tokens; the shared-asset gate
      checks the source-art palette. -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -117,14 +117,23 @@
  *      (a) EXISTENCE: the required _shared files are present on disk (incl. the
  *          og.png raster + its og.svg source art) and structure.css remains
  *          reachable from style.css's @import.
- *      (b) OG RASTER HEADER: og.png has the PNG signature and an IHDR declaring
- *          the documented 1200x630 dimensions — a renamed SVG/text file or a
- *          wrong-size export fails, not just a missing file (rf2-mon7tz). This
- *          is a header check, not a full pixel decode or CRC validation.
- *      (c) OG SOURCE-ART PALETTE: og.svg carries no retired / sub-AA colour
+ *      (b) SVG WELL-FORMEDNESS: favicon.svg + og.svg are well-formed XML — no
+ *          illegal '--' inside a comment, no unterminated comment, no mismatched
+ *          /unclosed tags, a single <svg> root. A malformed comment makes strict
+ *          XML parsers AND Chrome render a <parsererror> (the favicon cannot show
+ *          and the OG source cannot be re-exported), which the old existence /
+ *          palette-literal checks missed (rf2-3fc89f.27).
+ *      (c) OG RASTER DECODE: og.png is a STRUCTURALLY COMPLETE, decodable PNG —
+ *          signature + IHDR (length 13) declaring the documented 1200x630
+ *          dimensions, every chunk bounded inside the file with a matching
+ *          CRC-32, at least one IDAT whose zlib stream actually inflates, and a
+ *          terminal IEND. A header prefix, a byte-flipped/corrupt chunk, or a
+ *          mid-stream truncation fails — not just a missing/renamed file
+ *          (rf2-mon7tz + full structural decode rf2-3fc89f.27).
+ *      (d) OG SOURCE-ART PALETTE: og.svg carries no retired / sub-AA colour
  *          literal as a live paint value, so the re-exported card cannot drift
  *          back below the shared palette's accessibility decisions (rf2-y82dk9).
- *      (d) NO REMOTE STYLING: style.css / structure.css carry no external
+ *      (e) NO REMOTE STYLING: style.css / structure.css carry no external
  *          @import (rf2-vou5mm) and no remote url() fetch (rf2-o18ava), checked
  *          here so the contract holds even for an unlinked shared stylesheet.
  *
@@ -169,6 +178,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const zlib = require('zlib');
 const { pageExemptions } = require('./examples-asset-manifest.cjs');
 const { walkDir, assertWalkComplete } = require('./walk-tree.cjs');
 
@@ -676,12 +686,46 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 const OG_PNG_WIDTH = 1200;
 const OG_PNG_HEIGHT = 630;
 
-// Validate that `data` has a PNG signature and an IHDR declaring the expected
-// dimensions. Returns { ok, width, height, reason }. A spec-conformant PNG
-// always opens with the 8-byte signature immediately followed by the IHDR
-// chunk (length=13, type='IHDR', then width:uint32be, height:uint32be), so
-// reading the dimensions needs no full decoder — just the first 24 bytes. This
-// intentionally does not validate later chunks, CRCs, or decoded pixel data.
+// Precomputed CRC-32 lookup table (IEEE 802.3 polynomial, reflected 0xEDB88320)
+// — the checksum every PNG chunk carries over its (type + data) bytes. Built
+// once at module load so validatePng can verify each chunk's CRC in one pass.
+const PNG_CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+// CRC-32 of a Buffer, matching the PNG chunk-CRC definition.
+function pngCrc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    c = PNG_CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+// Validate that `data` is a STRUCTURALLY COMPLETE, decodable PNG of the expected
+// dimensions — not merely a byte prefix that starts like one. Returns
+// { ok, width, height, reason }.
+//
+// The previous implementation read only the first 24 bytes (signature + IHDR
+// dims), so a 24-byte header prefix, a byte-flipped IDAT, or a mid-stream
+// truncation all reported ok:true — a FALSE-GREEN over a broken raster
+// (rf2-3fc89f.27). This walks the ENTIRE chunk stream and fails on any real
+// corruption:
+//   - the 8-byte PNG signature and an IHDR first chunk (length exactly 13),
+//   - every chunk fully inside the file (a declared length running past EOF is a
+//     truncation), with its stored CRC-32 matching the computed CRC over
+//     type+data (a corrupt/flipped byte fails here),
+//   - at least one IDAT chunk whose concatenated zlib stream actually INFLATES
+//     (a garbled compressed stream fails the real decode), and
+//   - a terminal IEND chunk with no trailing bytes after it.
+// Only then are the IHDR dimensions checked against the expected size.
+//
 // Accepts a Buffer or coerces a string fixture to one (latin1 preserves bytes).
 function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG_HEIGHT) {
   const buf = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'latin1');
@@ -691,12 +735,83 @@ function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG
   if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) {
     return { ok: false, reason: 'missing the 8-byte PNG signature (not a PNG file)' };
   }
-  // Bytes 8..16 are the IHDR chunk length (must be 13) + type ('IHDR').
+  // Bytes 8..16 are the IHDR chunk length + type ('IHDR'). A conformant PNG
+  // always opens with IHDR; check the type early so a non-IHDR first chunk
+  // reports that (rather than a downstream CRC/bounds symptom).
   if (buf.subarray(12, 16).toString('latin1') !== 'IHDR') {
-    return { ok: false, reason: "first chunk is not IHDR (malformed PNG header)" };
+    return { ok: false, reason: 'first chunk is not IHDR (malformed PNG header)' };
+  }
+  const ihdrLength = buf.readUInt32BE(8);
+  if (ihdrLength !== 13) {
+    return {
+      ok: false,
+      reason: `IHDR chunk length is ${ihdrLength}, expected 13 (malformed PNG header)`,
+    };
   }
   const width = buf.readUInt32BE(16);
   const height = buf.readUInt32BE(20);
+
+  // Walk the full chunk stream: [length:u32][type:4][data:length][crc:u32]*.
+  const idatParts = [];
+  let sawIdat = false;
+  let sawIend = false;
+  let offset = 8;
+  while (offset < buf.length) {
+    if (offset + 8 > buf.length) {
+      return { ok: false, width, height, reason: `truncated chunk header at byte ${offset}` };
+    }
+    const length = buf.readUInt32BE(offset);
+    const type = buf.subarray(offset + 4, offset + 8).toString('latin1');
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    const crcEnd = dataEnd + 4;
+    if (crcEnd > buf.length) {
+      return {
+        ok: false,
+        width,
+        height,
+        reason: `chunk '${type}' declares ${length} byte(s) but runs past end of file (truncated raster)`,
+      };
+    }
+    const storedCrc = buf.readUInt32BE(dataEnd);
+    const computedCrc = pngCrc32(buf.subarray(offset + 4, dataEnd));
+    if (storedCrc !== computedCrc) {
+      return {
+        ok: false,
+        width,
+        height,
+        reason: `chunk '${type}' CRC mismatch (stored 0x${storedCrc.toString(16)}, computed 0x${computedCrc.toString(16)}) — corrupt bytes`,
+      };
+    }
+    if (type === 'IDAT') {
+      sawIdat = true;
+      idatParts.push(buf.subarray(dataStart, dataEnd));
+    } else if (type === 'IEND') {
+      sawIend = true;
+      if (crcEnd !== buf.length) {
+        return { ok: false, width, height, reason: `${buf.length - crcEnd} trailing byte(s) after IEND` };
+      }
+    }
+    offset = crcEnd;
+  }
+  if (!sawIdat) {
+    return { ok: false, width, height, reason: 'no IDAT chunk (PNG carries no image data)' };
+  }
+  if (!sawIend) {
+    return { ok: false, width, height, reason: 'no terminal IEND chunk (truncated raster)' };
+  }
+  // The compressed image data must actually decode — a garbled zlib stream that
+  // still carried a valid CRC would otherwise pass. This is the "real decode".
+  try {
+    zlib.inflateSync(Buffer.concat(idatParts));
+  } catch (err) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason: `IDAT zlib stream does not decode (${(err && err.message) || err})`,
+    };
+  }
   if (width !== expectedWidth || height !== expectedHeight) {
     return {
       ok: false,
@@ -706,6 +821,152 @@ function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG
     };
   }
   return { ok: true, width, height };
+}
+
+// Cross-platform XML/SVG well-formedness check — a zero-dependency validator
+// that fails on the exact defects a lax "the file exists" / palette-literal scan
+// misses (rf2-3fc89f.27): an XML comment containing the illegal '--' sequence
+// (which every strict XML parser AND Chrome reject with a <parsererror>), an
+// unterminated comment, and broken element structure (mismatched / unclosed
+// tags, unquoted-run-away attributes, no root <svg>). Returns an array of
+// human-readable error strings (empty === well-formed); `name` prefixes each so
+// the caller can point at the offending file.
+//
+// It is a focused tokenizer, not a full XML processor: it validates the
+// well-formedness constraints that matter for these static art assets —
+// comments, processing instructions (<?xml … ?>), CDATA, markup declarations
+// (<!DOCTYPE …>), and element start/end/self-close nesting with quote-aware
+// attribute skipping — and confirms a single <svg> root. Text content and entity
+// references are intentionally not policed (they do not gate whether the SVG
+// parses/renders). Every shared SVG the gate ships is exercised by the LIVE
+// scan, so a real false-red would turn the always-run gate immediately.
+function checkSvgWellFormed(svg, name) {
+  const errors = [];
+  const n = svg.length;
+  const isWs = (c) => c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f';
+  const near = (p) => JSON.stringify(svg.slice(p, Math.min(n, p + 32)).replace(/\s+/g, ' '));
+  const stack = [];
+  let rootCount = 0;
+  let sawElement = false;
+  let i = 0;
+  while (i < n) {
+    const lt = svg.indexOf('<', i);
+    if (lt === -1) break; // remaining bytes are text content — not policed
+    i = lt;
+    if (svg.startsWith('<!--', i)) {
+      const end = svg.indexOf('-->', i + 4);
+      if (end === -1) {
+        errors.push(`${name}: unterminated XML comment (no '-->') near ${near(i)}`);
+        return errors;
+      }
+      const body = svg.slice(i + 4, end);
+      // XML forbids '--' inside a comment AND a '-' immediately before '-->'
+      // (which would form '--->'). Both make the document ill-formed.
+      if (body.includes('--') || body.endsWith('-')) {
+        errors.push(
+          `${name}: XML comment contains an illegal '--' sequence (XML comments ` +
+            `may not contain '--'); rewrite the comment near ${near(i)}`,
+        );
+      }
+      i = end + 3;
+      continue;
+    }
+    if (svg.startsWith('<![CDATA[', i)) {
+      const end = svg.indexOf(']]>', i + 9);
+      if (end === -1) {
+        errors.push(`${name}: unterminated CDATA section near ${near(i)}`);
+        return errors;
+      }
+      i = end + 3;
+      continue;
+    }
+    if (svg.startsWith('<?', i)) {
+      const end = svg.indexOf('?>', i + 2);
+      if (end === -1) {
+        errors.push(`${name}: unterminated processing instruction near ${near(i)}`);
+        return errors;
+      }
+      i = end + 2;
+      continue;
+    }
+    if (svg.startsWith('<!', i)) {
+      const end = svg.indexOf('>', i + 2);
+      if (end === -1) {
+        errors.push(`${name}: unterminated markup declaration near ${near(i)}`);
+        return errors;
+      }
+      i = end + 1;
+      continue;
+    }
+    // An element start / end / self-close tag.
+    let j = i + 1;
+    let isEnd = false;
+    if (svg[j] === '/') {
+      isEnd = true;
+      j++;
+    }
+    const nameStart = j;
+    while (j < n && !isWs(svg[j]) && svg[j] !== '>' && svg[j] !== '/') j++;
+    const tagName = svg.slice(nameStart, j);
+    if (!tagName) {
+      errors.push(`${name}: malformed tag (empty element name) near ${near(i)}`);
+      return errors;
+    }
+    // Scan to the closing '>', skipping quoted attribute values so a '>' inside
+    // an attribute does not end the tag early.
+    while (j < n) {
+      const c = svg[j];
+      if (c === '"' || c === "'") {
+        const quote = c;
+        j++;
+        while (j < n && svg[j] !== quote) j++;
+        if (j >= n) {
+          errors.push(`${name}: unterminated attribute value near ${near(i)}`);
+          return errors;
+        }
+        j++;
+        continue;
+      }
+      if (c === '>') break;
+      j++;
+    }
+    if (j >= n) {
+      errors.push(`${name}: unterminated tag <${tagName}…> near ${near(i)}`);
+      return errors;
+    }
+    const selfClose = svg[j - 1] === '/';
+    if (isEnd) {
+      if (selfClose) {
+        errors.push(`${name}: end tag </${tagName}> cannot be self-closing near ${near(i)}`);
+        return errors;
+      }
+      const open = stack.pop();
+      if (open === undefined) {
+        errors.push(`${name}: unexpected closing tag </${tagName}> with no open element`);
+        return errors;
+      }
+      if (open !== tagName) {
+        errors.push(
+          `${name}: mismatched closing tag </${tagName}> (expected </${open}>) near ${near(i)}`,
+        );
+        return errors;
+      }
+    } else {
+      sawElement = true;
+      if (stack.length === 0) rootCount++;
+      if (!selfClose) stack.push(tagName);
+    }
+    i = j + 1;
+  }
+  if (stack.length > 0) {
+    errors.push(`${name}: unclosed element <${stack[stack.length - 1]}> (missing its end tag)`);
+  }
+  if (!sawElement) {
+    errors.push(`${name}: no element found — not a well-formed SVG document`);
+  } else if (rootCount > 1) {
+    errors.push(`${name}: multiple root elements — an SVG document must have a single root`);
+  }
+  return errors;
 }
 
 // ---------------------------------------------------------------------------
@@ -1152,6 +1413,22 @@ function checkSharedTree(io, opts = {}) {
     }
   }
 
+  // SVG WELL-FORMEDNESS (rf2-3fc89f.27). Both shared SVGs (the favicon every
+  // page links + the editable OG source art) must be well-formed XML. A comment
+  // containing the illegal '--' sequence, an unterminated comment, or broken
+  // element nesting makes a strict XML parser AND Chrome emit a <parsererror>
+  // document — so the favicon cannot render and the OG source cannot be reliably
+  // re-exported — while the old existence/palette-literal checks stayed green.
+  // Validate the actual markup so a malformed shared SVG turns the gate RED.
+  for (const svgName of ['favicon.svg', 'og.svg']) {
+    const svgPath = path.join(sharedRoot, 'img', svgName);
+    const svg = readFileSafe(io, svgPath);
+    if (svg == null) continue; // a missing SVG is reported by the mustExist loop
+    for (const e of checkSvgWellFormed(svg, `examples/_shared/img/${svgName}`)) {
+      errors.push(e);
+    }
+  }
+
   // The shipped og.png is the social-preview RASTER every page references. A
   // bare existence check (above) would stay green if the bytes were replaced
   // by non-PNG content (a renamed SVG/text file) or a wrong-size export — both
@@ -1462,11 +1739,14 @@ module.exports = {
   scanPage,
   checkSharedTree,
   scanAll,
-  // og.png raster byte-validation (rf2-mon7tz)
+  // og.png raster byte-validation (rf2-mon7tz + full structural decode rf2-3fc89f.27)
   PNG_SIGNATURE,
   OG_PNG_WIDTH,
   OG_PNG_HEIGHT,
   validatePng,
+  pngCrc32,
+  // SVG well-formedness validation (rf2-3fc89f.27)
+  checkSvgWellFormed,
   // shared palette contrast + focus-indicator contract (rf2-febmqu + rf2-mon7tz)
   WCAG_AA_NORMAL_TEXT,
   WCAG_NON_TEXT,

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -54,6 +54,8 @@ const {
   EXAMPLES_ROOT,
   PNG_SIGNATURE,
   validatePng,
+  pngCrc32,
+  checkSvgWellFormed,
   OG_PNG_WIDTH,
   OG_PNG_HEIGHT,
   contrastRatio,
@@ -106,6 +108,35 @@ const VALID_OG_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAABLAAAAJ2CAIAAADAIuwLAAAACUlEQVR4nGMAAAABAAFe/335AAAAAElFTkSuQmCC',
   'base64',
 ).toString('latin1');
+
+// Build a STRUCTURALLY COMPLETE PNG (signature + IHDR + IDAT + IEND) at the
+// given dimensions, as a Buffer, for the full-structural-decode teeth
+// (rf2-3fc89f.27). Uses the scanner's own pngCrc32 to write correct chunk CRCs
+// and a real zlib stream for the IDAT, so validatePng's CRC + inflate checks see
+// a genuinely valid raster — the corrupt/truncated fixtures are then derived by
+// mutating this baseline, isolating exactly one defect each.
+const zlibForTests = require('zlib');
+function pngChunk(type, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const typeBuf = Buffer.from(type, 'latin1');
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(pngCrc32(Buffer.concat([typeBuf, data])));
+  return Buffer.concat([len, typeBuf, data, crc]);
+}
+function buildPng(width = OG_PNG_WIDTH, height = OG_PNG_HEIGHT) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type (truecolour)
+  return Buffer.concat([
+    Buffer.from(PNG_SIGNATURE),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlibForTests.deflateSync(Buffer.from([0, 0, 0, 0]))),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
 
 // An AA-safe, focus-accessible style.css that satisfies the shared contrast +
 // focus-indicator contracts (rf2-febmqu + rf2-mon7tz), for checkSharedTree
@@ -1633,6 +1664,211 @@ it('TEETH: checkSharedTree rejects a wrong-dimension og.png', () => {
     errors.some((e) => e.includes('og.png') && e.includes('800x600')),
     `expected a wrong-dimension og.png error, got: ${errors.join(' | ')}`,
   );
+});
+
+// ---- TEETH: og.png FULL STRUCTURAL DECODE (rf2-3fc89f.27) ----------------
+//
+// The pre-fix validatePng read only the first 24 bytes (signature + IHDR dims),
+// so a 24-byte header prefix, a byte-flipped IDAT, or a mid-stream truncation
+// all reported ok:true — a FALSE-GREEN over a structurally-broken raster. The
+// gate now walks the ENTIRE chunk stream: bounded chunks, per-chunk CRC-32, a
+// real IDAT zlib inflate, and a terminal IEND. Each fixture below isolates one
+// real corruption the old header sniff missed.
+
+it('validatePng accepts a freshly-built structurally-complete PNG', () => {
+  const v = validatePng(buildPng());
+  assert.ok(v.ok, `expected the built PNG to validate, got: ${v.reason}`);
+  assert.strictEqual(v.width, OG_PNG_WIDTH);
+  assert.strictEqual(v.height, OG_PNG_HEIGHT);
+});
+
+it('LIVE: the shipped og.png fully decodes (signature + chunks + CRC + IDAT inflate + IEND)', () => {
+  const fs = require('fs');
+  const bytes = fs.readFileSync(path.join(EXAMPLES_ROOT, '_shared', 'img', 'og.png'));
+  const v = validatePng(bytes);
+  assert.ok(v.ok, `the real og.png must fully decode, got: ${v.reason}`);
+  assert.strictEqual(v.width, OG_PNG_WIDTH);
+  assert.strictEqual(v.height, OG_PNG_HEIGHT);
+});
+
+it('TEETH: a 24-byte header-only prefix is REJECTED (the pre-fix false-green)', () => {
+  // Exactly the false-green the old header-sniff let through: signature + IHDR
+  // header + dimensions and nothing else. It must now fail (chunk runs past EOF).
+  const headerOnly = buildPng().subarray(0, 24);
+  const v = validatePng(headerOnly);
+  assert.ok(!v.ok, 'a 24-byte header prefix is not a complete PNG and must fail');
+  assert.ok(
+    /past end of file|truncated/.test(v.reason),
+    `expected a truncation failure, got: ${v.reason}`,
+  );
+});
+
+it('TEETH: a mid-IDAT truncation is REJECTED (declared chunk length runs past EOF)', () => {
+  // Cut the file INSIDE the IDAT chunk data (byte 45 is a few bytes into the
+  // IDAT payload, which starts at byte 41 = sig 8 + IHDR 25 + IDAT header 8).
+  // The IDAT chunk still declares its full length, which now runs past EOF. The
+  // old header-sniff stayed green on any prefix >= 24 bytes.
+  const truncated = buildPng().subarray(0, 45);
+  const v = validatePng(truncated);
+  assert.ok(!v.ok, 'a mid-stream truncation must fail');
+  assert.ok(
+    /past end of file|truncated/.test(v.reason),
+    `expected a truncation failure, got: ${v.reason}`,
+  );
+});
+
+it('TEETH: a byte-flipped IDAT (bad CRC) is REJECTED', () => {
+  // Flip a byte INSIDE the IDAT data without recomputing its CRC — the stored
+  // CRC no longer matches the computed CRC, so the chunk is corrupt. (The old
+  // sniff never read past byte 24, so a corrupt IDAT passed.)
+  const full = buildPng();
+  const corrupt = Buffer.from(full);
+  // IDAT data sits after sig(8) + IHDR(25) + IDAT length(4) + 'IDAT'(4) = 41.
+  corrupt[43] ^= 0xff;
+  const v = validatePng(corrupt);
+  assert.ok(!v.ok, 'a byte-flipped IDAT must fail the CRC check');
+  assert.ok(/CRC mismatch/.test(v.reason), `expected a CRC failure, got: ${v.reason}`);
+});
+
+it('TEETH: a PNG missing its terminal IEND is REJECTED', () => {
+  // Signature + IHDR + IDAT but no IEND chunk (the trailing 12-byte IEND chunk
+  // dropped). A conformant PNG always ends with IEND; its absence is a truncated
+  // raster. Every remaining chunk still has a valid CRC, so this isolates the
+  // missing-terminator defect rather than a bounds/CRC symptom.
+  const full = buildPng();
+  const noIend = full.subarray(0, full.length - 12); // drop the IEND chunk
+  const v = validatePng(noIend);
+  assert.ok(!v.ok, 'a PNG with no IEND must fail');
+  assert.ok(/IEND/.test(v.reason), `expected a missing-IEND failure, got: ${v.reason}`);
+});
+
+it('TEETH: checkSharedTree rejects a header-only (truncated) og.png', () => {
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }\n' +
+      RESPONSIVE_SHELL,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    // A header-only prefix — the exact false-green the pre-fix gate passed.
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: buildPng().subarray(0, 24).toString('latin1'),
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('og.png') && e.includes('not a valid')),
+    `expected checkSharedTree to reject the header-only og.png, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: SVG WELL-FORMEDNESS (rf2-3fc89f.27) --------------------------
+//
+// The pre-fix gate checked favicon.svg / og.svg only for existence and selected
+// palette literals — never XML well-formedness. Both shipped SVGs actually
+// contained an illegal '--' inside a comment (XML forbids it; strict parsers AND
+// Chrome render a <parsererror>), so the favicon could not render and the OG
+// source could not be re-exported, all while the gate stayed green. The gate now
+// validates the markup.
+
+it('checkSvgWellFormed accepts a well-formed SVG (prolog + comment + nesting + text)', () => {
+  const svg =
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<!-- a legal comment: em-dash — and single-hyphen ex-bg are fine -->\n' +
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+    '<rect width="32" height="32"/><g><text font-family="\'Inter\', sans-serif">re-frame2</text></g>' +
+    '</svg>';
+  assert.deepStrictEqual(
+    checkSvgWellFormed(svg, 'ok.svg'),
+    [],
+    'a well-formed SVG must produce no errors',
+  );
+});
+
+it('TEETH: checkSvgWellFormed flags an illegal double-hyphen inside a comment', () => {
+  const svg = '<svg><!-- mirror the --ex-* palette --><rect/></svg>';
+  const errors = checkSvgWellFormed(svg, 'bad.svg');
+  assert.ok(
+    errors.some((e) => e.includes("illegal '--'") && e.includes('bad.svg')),
+    `expected an illegal-comment error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: checkSvgWellFormed flags a mismatched / unclosed tag', () => {
+  assert.ok(
+    checkSvgWellFormed('<svg><rect></svg>', 'x.svg').some((e) => e.includes('mismatched closing tag')),
+    'a mismatched closing tag must be flagged',
+  );
+  assert.ok(
+    checkSvgWellFormed('<svg><g><rect/>', 'y.svg').some((e) => e.includes('unclosed element')),
+    'an unclosed element must be flagged',
+  );
+});
+
+it('TEETH: checkSvgWellFormed flags an unterminated comment and a non-SVG document', () => {
+  assert.ok(
+    checkSvgWellFormed('<svg><!-- never closed </svg>', 'u.svg').some((e) =>
+      e.includes('unterminated XML comment'),
+    ),
+    'an unterminated comment must be flagged',
+  );
+  assert.ok(
+    checkSvgWellFormed('   just text, no markup   ', 'n.svg').some((e) =>
+      e.includes('no element found'),
+    ),
+    'a document with no element must be flagged',
+  );
+});
+
+it('TEETH: checkSharedTree reports a targeted failure for a favicon.svg with a "--" comment', () => {
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }\n' +
+      RESPONSIVE_SHELL,
+    // The exact pre-fix defect: a '--' sequence inside the favicon comment.
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]:
+      '<svg xmlns="http://www.w3.org/2000/svg"><!-- mirror the --ex-* palette --><rect/></svg>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('favicon.svg') && e.includes("illegal '--'")),
+    `expected a targeted favicon well-formedness error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: checkSharedTree reports a targeted failure for a malformed og.svg structure', () => {
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }\n' +
+      RESPONSIVE_SHELL,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    // Broken structure: <rect> is never closed, then </svg> mismatches.
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]:
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect></svg>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('og.svg') && e.includes('mismatched closing tag')),
+    `expected a targeted og.svg structural error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('LIVE: the shipped favicon.svg and og.svg are well-formed XML', () => {
+  const fs = require('fs');
+  for (const name of ['favicon.svg', 'og.svg']) {
+    const svg = fs.readFileSync(path.join(EXAMPLES_ROOT, '_shared', 'img', name), 'utf8');
+    assert.deepStrictEqual(
+      checkSvgWellFormed(svg, `examples/_shared/img/${name}`),
+      [],
+      `the shipped ${name} must be well-formed XML`,
+    );
+  }
 });
 
 // ---- TEETH: shared palette CONTRAST contract (rf2-febmqu) ---------------


### PR DESCRIPTION
## Summary

Fixes **rf2-3fc89f.27** (P2). Both shared SVGs contained an XML-illegal `--`
sequence inside their comments, and the shared-tree image-integrity gate was
false-green (a 24-byte PNG header sniff instead of a real decode; no SVG
well-formedness check at all).

## Reproduce → fix evidence

**Defect 1 — XML-illegal SVG comments.** `favicon.svg` and `og.svg` each carried
`--ex-*` token references inside `<!-- … -->`. XML comments may not contain `--`:

- Strict `System.Xml.XmlDocument.Load` (and Chrome) rejected both:
  `An XML comment cannot contain '--' … Line 4/6`.
- The favicon every example links could not render as an SVG; the editable OG
  source could not be reliably re-exported.

Fix: rewrote the illegal `--` comment text in both files. **Artwork unchanged** —
only comment prose changed; the comment-stripped (rendered) markup is
byte-identical to `origin/main`, and both files now parse as well-formed XML
(`root=svg`).

**Defect 2 — false-green gate.** The gate never parsed the SVGs (existence +
palette-literal only), and `validatePng` read only 24 bytes:

```
real og.png (283967B)   -> {ok:true, 1200x630}   (genuinely healthy)
24-byte header prefix   -> {ok:true, 1200x630}   ← FALSE GREEN
corrupted IDAT byte     -> {ok:true, 1200x630}   ← FALSE GREEN
truncated to 200 bytes  -> {ok:true, 1200x630}   ← FALSE GREEN
```

Fix, scoped to shared image validity:
- **`checkSvgWellFormed`** — cross-platform, zero-dependency XML/SVG
  well-formedness validator (illegal `--` comments, unterminated comments,
  mismatched/unclosed tags, runaway attributes, single `<svg>` root), wired into
  `checkSharedTree` for `favicon.svg` + `og.svg`.
- **`validatePng`** — replaced the header sniff with a full structural decode:
  signature, IHDR length 13, every chunk bounded inside the file with a matching
  **CRC-32**, at least one **IDAT** whose zlib stream actually **inflates**, and a
  terminal **IEND**, then the 1200x630 dimension check. Uses Node's built-in
  `zlib`; **no new dependency**.
- Manifest/staging ownership and canonical `_shared/...` paths preserved.

New gate behaviour (all proven by tests): rejects a header-only prefix, a
mid-IDAT truncation, a byte-flipped (bad-CRC) IDAT, a missing-IEND PNG, and wrong
dimensions; rejects an injected illegal-`--` comment SVG and a malformed SVG
structure; the real assets pass.

## Quality gates (foreground)

- `cd implementation && npm run test:script-policy` → **EXIT 0** (includes
  `check-examples-assets.test.cjs`; +18 new teeth for SVG well-formedness + full
  PNG decode, all existing tests green).
- `node examples/scripts/check-examples-assets.cjs` → **EXIT 0** (35 pages +
  `_shared` tree intact; real SVGs parse well-formed, real og.png fully decodes).

## Stance

Pre-alpha; fix scoped to shared image validity; validation now actually verifies
(no false-green header sniff). ELEGANCE + CLARITY + CORRECTNESS.
