### PR TITLE
test(xray): dedup private hiccup-walkers onto re-frame.test-helpers (rf2-vj80u8 walker axis)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -19,6 +19,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
@@ -41,48 +42,14 @@
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {}))
 
-;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid / find-all-by-testid-
+;; prefix copies were semantically identical to `re-frame.test-helpers`; tests
+;; call `th/find-by-testid` / `th/find-by-testid-prefix` directly (rf2-vj80u8 —
+;; no Xray walker facade).
 
 (defn- style-of [node]
-  (when (and (vector? node) (map? (second node)))
-    (:style (second node))))
+  (:style (th/attrs node)))
 
 ;; ---- trace-bus helpers (one cascade so the L2 list renders) -------------
 
@@ -106,13 +73,13 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
       (let [tree     (shell/shell-view)
-            dividers (find-all-by-testid-prefix
+            dividers (th/find-by-testid-prefix
                        tree "rf-xray-event-list-col-divider-")]
-        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-source"))
+        (is (some? (th/find-by-testid tree "rf-xray-event-list-col-divider-source"))
             "source-column divider renders")
-        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-timestamp"))
+        (is (some? (th/find-by-testid tree "rf-xray-event-list-col-divider-timestamp"))
             "timestamp-column divider renders")
-        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-duration"))
+        (is (some? (th/find-by-testid tree "rf-xray-event-list-col-divider-duration"))
             "duration-column divider renders")
         ;; Each divider appears at least once in the header + once per
         ;; row, so we expect at minimum 6 (one row + header = 2 instances
@@ -145,8 +112,8 @@
       (rf/dispatch-sync [:rf.xray/set-event-list-col-width :timestamp 120]))
     (rf/with-frame :rf/xray
       (let [tree        (shell/shell-view)
-            h-timestamp (find-by-testid tree "rf-xray-event-list-col-timestamp")
-            r-time      (find-by-testid tree "rf-xray-row-time-chip")]
+            h-timestamp (th/find-by-testid tree "rf-xray-event-list-col-timestamp")
+            r-time      (th/find-by-testid tree "rf-xray-row-time-chip")]
         (is (some? h-timestamp) "header timestamp cell renders")
         (is (some? r-time)      "row time chip renders")
         (is (= "120px" (:width (style-of h-timestamp)))
@@ -163,12 +130,12 @@
     (trace-collector/seed-trace-for-test! (timer-cascade-trace-ev 1 [:poll/tick]))
     (rf/with-frame :rf/xray
       (let [tree     (shell/shell-view)
-            h-source (find-by-testid tree "rf-xray-event-list-col-source")
-            r-source (find-by-testid tree "rf-xray-row-origin-after-timer")
-            h-time   (find-by-testid tree "rf-xray-event-list-col-timestamp")
-            r-time   (find-by-testid tree "rf-xray-row-time-chip")
-            h-dur    (find-by-testid tree "rf-xray-event-list-col-duration")
-            r-dur    (find-by-testid tree "rf-xray-row-duration")]
+            h-source (th/find-by-testid tree "rf-xray-event-list-col-source")
+            r-source (th/find-by-testid tree "rf-xray-row-origin-after-timer")
+            h-time   (th/find-by-testid tree "rf-xray-event-list-col-timestamp")
+            r-time   (th/find-by-testid tree "rf-xray-row-time-chip")
+            h-dur    (th/find-by-testid tree "rf-xray-event-list-col-duration")
+            r-dur    (th/find-by-testid tree "rf-xray-row-duration")]
         (is (= "52px" (:width (style-of h-source)) (:width (style-of r-source)))
             "source column defaults to 52px on header + row")
         (is (= "76px" (:width (style-of h-time)) (:width (style-of r-time)))
@@ -370,7 +337,7 @@
                                       ([ev _opts] (swap! dispatches conj ev) nil))]
       (rf/with-frame :rf/xray
         (let [tree    (shell/shell-view)
-              divider (find-by-testid
+              divider (th/find-by-testid
                         tree "rf-xray-event-list-col-divider-source")
               handler (:on-double-click (second divider))]
           (is (fn? handler)
@@ -390,7 +357,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
       (let [tree    (shell/shell-view)
-            divider (find-by-testid
+            divider (th/find-by-testid
                       tree "rf-xray-event-list-col-divider-source")
             props   (second divider)]
         (is (= "separator" (:role props)))

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -27,6 +27,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
@@ -48,47 +49,21 @@
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {}))
 
-;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies this file
+;; carried were semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
+;; `all-testids` (every carried testid in pre-order, for the DOM-order seam
+;; assertion) is not exposed by test-helpers, so it is expressed over
+;; `th/find-by-testid-prefix` with the empty-prefix (matches every string
+;; testid, depth-first).
 
 (defn- all-testids
   "Return the testids of every hiccup node in `tree` that carries one,
   in pre-order. Used to assert DOM-order — the seam must sit between
   `rf-xray-event-list` and `rf-xray-tab-bar`."
   [tree]
-  (->> tree
-       hiccup-seq
-       (keep (fn [node]
-               (when (and (vector? node) (map? (second node)))
-                 (:data-testid (second node)))))))
+  (map (comp :data-testid th/attrs) (th/find-by-testid-prefix tree "")))
 
 ;; ---- SeamHandle component shape ----------------------------------------
 
@@ -159,7 +134,7 @@
     (setup!)
     (rf/with-frame :rf/xray
       (let [tree  (shell/shell-view {:mode :inline})
-            list  (find-by-testid tree "rf-xray-event-list")
+            list  (th/find-by-testid tree "rf-xray-event-list")
             style (:style (second list))]
         (is (some? list) "event-list container present")
         (is (nil? (:resize style))
@@ -406,7 +381,7 @@
       (rf/dispatch-sync [:rf.xray/set-events-list-height-px 360]))
     (rf/with-frame :rf/xray
       (let [tree  (shell/shell-view {:mode :inline})
-            list  (find-by-testid tree "rf-xray-event-list")
+            list  (th/find-by-testid tree "rf-xray-event-list")
             style (:style (second list))]
         (is (= "360px" (:height style))
             "list :height updates to the persisted seam-handle value")))))

--- a/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
@@ -12,6 +12,7 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.filters :as filters]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.registry :as registry]
@@ -256,38 +257,17 @@
 ;; (8) Modal positioning (rf2-om6fa)
 ;; -------------------------------------------------------------------------
 
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (tree-seq (some-fn vector? seq?) seq (expand-tree tree))))
+;; ---- hiccup helpers -----------------------------------------------------
+;; The private expand-tree / find-by-testid copies were semantically identical
+;; to `re-frame.test-helpers`; tests call `th/find-by-testid` directly
+;; (rf2-vj80u8 — no Xray walker facade). `testids-with-prefix` (the SET of
+;; carried testids matching a prefix) is expressed over `th/find-by-testid-
+;; prefix`; `all-strings` / `placeholder-values` below are not exposed by
+;; test-helpers, so they walk `th/expand-tree` directly.
 
 (defn- testids-with-prefix [tree prefix]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
-       (keep (fn [node]
-               (when (and (vector? node) (map? (second node)))
-                 (:data-testid (second node)))))
-       (filter #(and (string? %) (str/starts-with? % prefix)))
-       (into #{})))
+  (into #{} (map (comp :data-testid th/attrs))
+        (th/find-by-testid-prefix tree prefix)))
 
 (deftest backdrop-defaults-to-fixed-positioning
   (testing "with no :rf.xray/modal-positioning slot set, the edit
@@ -297,7 +277,7 @@
     (frame-dispatch [:rf.xray/open-edit-popup {:source :add :mode :in}])
     (rf/with-frame :rf/xray
       (let [rendered (filters/Modal)
-            backdrop (find-by-testid rendered "rf-xray-edit-popup-backdrop")
+            backdrop (th/find-by-testid rendered "rf-xray-edit-popup-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
         (is (= "fixed" (:position style)))
@@ -314,7 +294,7 @@
     (frame-dispatch [:rf.xray/set-modal-positioning :absolute])
     (rf/with-frame :rf/xray
       (let [rendered (filters/Modal)
-            backdrop (find-by-testid rendered "rf-xray-edit-popup-backdrop")
+            backdrop (th/find-by-testid rendered "rf-xray-edit-popup-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
         (is (= "absolute" (:position style)))
@@ -342,15 +322,15 @@
     (rf/with-frame :rf/xray
       (let [rendered (filters/Modal)]
         ;; Kept surfaces.
-        (is (some? (find-by-testid rendered "rf-xray-edit-popup-mode-in"))
+        (is (some? (th/find-by-testid rendered "rf-xray-edit-popup-mode-in"))
             "Mode IN radio present")
-        (is (some? (find-by-testid rendered "rf-xray-edit-popup-mode-out"))
+        (is (some? (th/find-by-testid rendered "rf-xray-edit-popup-mode-out"))
             "Mode OUT radio present")
-        (is (some? (find-by-testid rendered "rf-xray-edit-popup-pattern"))
+        (is (some? (th/find-by-testid rendered "rf-xray-edit-popup-pattern"))
             "Pattern input present")
-        (is (some? (find-by-testid rendered "rf-xray-edit-popup-cancel"))
+        (is (some? (th/find-by-testid rendered "rf-xray-edit-popup-cancel"))
             "Cancel button present")
-        (is (some? (find-by-testid rendered "rf-xray-edit-popup-save"))
+        (is (some? (th/find-by-testid rendered "rf-xray-edit-popup-save"))
             "Add filter / Apply button present")
         ;; Excised surface — no scope checkboxes of any key.
         (is (= #{} (testids-with-prefix rendered "rf-xray-edit-popup-scope-"))
@@ -367,14 +347,14 @@
 (defn- all-strings
   "Every string literal in the expanded hiccup tree."
   [tree]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
+  (->> (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree))
        (filter string?)
        (into #{})))
 
 (defn- placeholder-values
   "Every `:placeholder` attribute value in the expanded tree."
   [tree]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
+  (->> (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree))
        (keep (fn [node]
                (when (and (vector? node) (map? (second node)))
                  (:placeholder (second node)))))

--- a/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
@@ -16,6 +16,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
@@ -56,50 +57,18 @@
                    :frame       frame-id
                    :rf.trace/dispatch-id id}}))
 
-;; ---- hiccup helpers (mirrors spine_filters_cljs_test) -------------------
-
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup helpers -----------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid / text-of copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` / `th/text-content` directly (rf2-vj80u8 — no Xray
+;; walker facade). `count-by-testid` is a thin count over `th/find-all-by-testid`.
 
 (defn- count-by-testid
   "How many nodes in the expanded tree carry `testid` — used to assert a
   committed pill renders EXACTLY once (rf2-ad7zx.18: the hidden-message
   no longer re-renders the pills as cause chips)."
   [tree testid]
-  (count (filter (fn [node]
-                   (and (vector? node)
-                        (map? (second node))
-                        (= testid (:data-testid (second node)))))
-                 (hiccup-seq tree))))
-
-(defn- text-of
-  "Concatenate the string leaves under a node — good enough to assert
-  the count message reads as expected."
-  [node]
-  (apply str (filter string? (hiccup-seq node))))
+  (count (th/find-all-by-testid tree testid)))
 
 ;; -------------------------------------------------------------------------
 ;; (1) sub composition
@@ -192,17 +161,17 @@
   (frame-dispatch [:rf.xray/add-filter :out {:pattern :noise/tick}])
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)
-          indicator (find-by-testid tree "rf-xray-filters-hidden-indicator")
-          count-node (find-by-testid tree "rf-xray-filters-hidden-count")]
+          indicator (th/find-by-testid tree "rf-xray-filters-hidden-indicator")
+          count-node (th/find-by-testid tree "rf-xray-filters-hidden-count")]
       (is (some? indicator) "banner renders when rows are hidden")
       ;; rf2-pjjwh — the Clear Filters button is retired; the warning
       ;; carries the count only.
-      (is (nil? (find-by-testid tree "rf-xray-filters-hidden-clear"))
+      (is (nil? (th/find-by-testid tree "rf-xray-filters-hidden-clear"))
           "Clear filters button is retired (rf2-pjjwh)")
       ;; rf2-3f2di A5 — the bar-2 warning reads `N events filtered out`
       ;; (authority reference events-ribbon), superseding the prior
       ;; `N events hidden by filters` copy.
-      (is (re-find #"1 event filtered out" (text-of count-node))))))
+      (is (re-find #"1 event filtered out" (th/text-content count-node))))))
 
 (deftest hidden-message-does-not-duplicate-the-committed-pills
   (testing "rf2-ad7zx.18 — per the Figma EventsRibbon mock the hidden-state
@@ -221,14 +190,14 @@
         (is (= 1 (count-by-testid tree "rf-xray-filter-pill-out-0"))
             "the committed pill renders exactly once (left cluster)")
         ;; the duplicate cause-chip cluster is gone.
-        (is (nil? (find-by-testid tree "rf-xray-filters-hidden-causes"))
+        (is (nil? (th/find-by-testid tree "rf-xray-filters-hidden-causes"))
             "no duplicate cause-chip cluster in the hidden-message")
-        (is (nil? (find-by-testid tree "rf-xray-filters-hidden-pill-0"))
+        (is (nil? (th/find-by-testid tree "rf-xray-filters-hidden-pill-0"))
             "no duplicate pill chip in the hidden-message")
         ;; the count survives; Clear Filters is retired (rf2-pjjwh).
-        (is (some? (find-by-testid tree "rf-xray-filters-hidden-count"))
+        (is (some? (th/find-by-testid tree "rf-xray-filters-hidden-count"))
             "the hidden count is kept")
-        (is (nil? (find-by-testid tree "rf-xray-filters-hidden-clear"))
+        (is (nil? (th/find-by-testid tree "rf-xray-filters-hidden-clear"))
             "Clear Filters is retired (rf2-pjjwh)")))))
 
 (deftest indicator-absent-when-nothing-hidden
@@ -237,7 +206,7 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:b]))
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)]
-      (is (nil? (find-by-testid tree "rf-xray-filters-hidden-indicator"))
+      (is (nil? (th/find-by-testid tree "rf-xray-filters-hidden-indicator"))
           "no banner when filtered == raw"))))
 
 ;; -------------------------------------------------------------------------
@@ -280,9 +249,9 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 3 [:noise/tick]))
   (frame-dispatch [:rf.xray/add-filter :out {:pattern :noise/tick}])
   (rf/with-frame :rf/xray
-    (is (some? (find-by-testid (shell/shell-view)
+    (is (some? (th/find-by-testid (shell/shell-view)
                                "rf-xray-filters-hidden-indicator")))
     (rf/dispatch-sync [:rf.xray/clear-all-filters])
-    (is (nil? (find-by-testid (shell/shell-view)
+    (is (nil? (th/find-by-testid (shell/shell-view)
                               "rf-xray-filters-hidden-indicator"))
         "banner gone after Clear filters")))

--- a/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
@@ -7,6 +7,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.filters.pills :as pills]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.theme.tokens :refer [tokens]]
@@ -24,46 +25,11 @@
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
-
-(defn- text-nodes [tree]
-  (->> (hiccup-seq tree)
-       (filter string?)
-       (apply str)))
+;; The private expand-tree / hiccup-seq / find-by-testid / find-all-by-testid-
+;; prefix / text-nodes copies were semantically identical to
+;; `re-frame.test-helpers`; tests call `th/find-by-testid`,
+;; `th/find-by-testid-prefix` and `th/text-content` directly (rf2-vj80u8 — no
+;; Xray walker facade).
 
 ;; -------------------------------------------------------------------------
 ;; (1) Empty filters — no committed pills in the cluster
@@ -77,17 +43,17 @@
 (deftest empty-filters-render-empty-cluster
   (xray-setup!)
   (let [tree (pills/pills-view rf/dispatch {:filters {:in [] :out []}})]
-    (is (some? (find-by-testid tree "rf-xray-ribbon-filters"))
+    (is (some? (th/find-by-testid tree "rf-xray-ribbon-filters"))
         "cluster element always present")
-    (is (nil? (find-by-testid tree "rf-xray-filter-add"))
+    (is (nil? (th/find-by-testid tree "rf-xray-filter-add"))
         "add-pill is NOT part of the committed-pills cluster (moved to bar-1)")
-    (is (empty? (find-all-by-testid-prefix tree "rf-xray-filter-pill-"))
+    (is (empty? (th/find-by-testid-prefix tree "rf-xray-filter-pill-"))
         "no pill rows when both buckets are empty")))
 
 (deftest add-pill-renders-standalone
   (xray-setup!)
   (let [tree (pills/add-pill rf/dispatch)]
-    (is (some? (find-by-testid tree "rf-xray-filter-add"))
+    (is (some? (th/find-by-testid tree "rf-xray-filter-add"))
         "add-pill renders the `[ + ]` affordance standalone (bar-1 mount)")))
 
 ;; -------------------------------------------------------------------------
@@ -99,19 +65,19 @@
   (let [filters {:in  [{:pattern ":auth/*"} {:pattern ":order/*"}]
                  :out [{:pattern ":mouse-move"}]}
         tree    (pills/pills-view rf/dispatch {:filters filters})]
-    (is (some? (find-by-testid tree "rf-xray-filter-pill-in-0")))
-    (is (some? (find-by-testid tree "rf-xray-filter-pill-in-1")))
-    (is (some? (find-by-testid tree "rf-xray-filter-pill-out-0")))
-    (is (nil? (find-by-testid tree "rf-xray-filter-pill-out-1"))
+    (is (some? (th/find-by-testid tree "rf-xray-filter-pill-in-0")))
+    (is (some? (th/find-by-testid tree "rf-xray-filter-pill-in-1")))
+    (is (some? (th/find-by-testid tree "rf-xray-filter-pill-out-0")))
+    (is (nil? (th/find-by-testid tree "rf-xray-filter-pill-out-1"))
         "no extra OUT pill")))
 
 (deftest in-pill-shows-pattern-text
   (xray-setup!)
   (let [tree (pills/pills-view rf/dispatch {:filters {:in [{:pattern ":auth/*"}]
                                           :out []}})
-        pill (find-by-testid tree "rf-xray-filter-pill-in-0")]
+        pill (th/find-by-testid tree "rf-xray-filter-pill-in-0")]
     (is (some? pill))
-    (is (re-find #":auth/\*" (text-nodes pill))
+    (is (re-find #":auth/\*" (th/text-content pill))
         "pill renders the pattern")))
 
 (deftest pill-body-has-no-leading-mode-glyph
@@ -125,10 +91,10 @@
     (let [tree    (pills/pills-view rf/dispatch
                     {:filters {:in  [{:pattern ":auth/*"}]
                                :out [{:pattern ":mouse-move"}]}})
-          in-body (find-by-testid tree "rf-xray-filter-pill-in-0-body")
-          out-body (find-by-testid tree "rf-xray-filter-pill-out-0-body")
-          in-text  (text-nodes in-body)
-          out-text (text-nodes out-body)]
+          in-body (th/find-by-testid tree "rf-xray-filter-pill-in-0-body")
+          out-body (th/find-by-testid tree "rf-xray-filter-pill-out-0-body")
+          in-text  (th/text-content in-body)
+          out-text (th/text-content out-body)]
       (is (some? in-body))
       (is (some? out-body))
       (is (not (re-find #"^\s*\+" in-text))
@@ -150,8 +116,8 @@
     (xray-setup!)
     (let [tree   (pills/pills-view rf/dispatch {:filters {:in  [{:pattern ":auth/*"}]
                                               :out [{:pattern ":mouse-move"}]}})
-          in     (find-by-testid tree "rf-xray-filter-pill-in-0")
-          out    (find-by-testid tree "rf-xray-filter-pill-out-0")
+          in     (th/find-by-testid tree "rf-xray-filter-pill-in-0")
+          out    (th/find-by-testid tree "rf-xray-filter-pill-out-0")
           in-st  (:style (second in))
           out-st (:style (second out))]
       ;; include = green border + green ink + transparent bg.
@@ -169,9 +135,9 @@
       (is (= "transparent" (:background out-st))
           "exclude pill background is transparent")
       ;; each carries a remove `×` button.
-      (is (some? (find-by-testid tree "rf-xray-filter-pill-in-0-remove"))
+      (is (some? (th/find-by-testid tree "rf-xray-filter-pill-in-0-remove"))
           "include pill has a remove `×`")
-      (is (some? (find-by-testid tree "rf-xray-filter-pill-out-0-remove"))
+      (is (some? (th/find-by-testid tree "rf-xray-filter-pill-out-0-remove"))
           "exclude pill has a remove `×`"))))
 
 ;; -------------------------------------------------------------------------
@@ -186,7 +152,7 @@
                                  ([ev _opts] (swap! dispatches conj ev) nil))]
       (let [tree (pills/pills-view rf/dispatch {:filters {:in [{:pattern ":auth/*"}]
                                               :out []}})
-            body (find-by-testid tree "rf-xray-filter-pill-in-0-body")
+            body (th/find-by-testid tree "rf-xray-filter-pill-in-0-body")
             handler (:on-click (second body))]
         (is (some? body) "pill body is addressable")
         (when handler (handler nil))))
@@ -213,7 +179,7 @@
       (let [tree (pills/pills-view rf/dispatch {:filters {:in  []
                                               :out [{:pattern ":mouse-move"}
                                                     {:pattern ":anim-frame"}]}})
-            x (find-by-testid tree "rf-xray-filter-pill-out-1-remove")
+            x (th/find-by-testid tree "rf-xray-filter-pill-out-1-remove")
             handler (:on-click (second x))]
         (is (some? x) "remove button addressable")
         (when handler (handler nil))))
@@ -231,7 +197,7 @@
                                  ([ev _opts] (swap! dispatches conj ev) nil))]
       ;; rf2-3f2di A5 — the add-pill is now a standalone bar-1 affordance.
       (let [tree (pills/add-pill rf/dispatch)
-            add  (find-by-testid tree "rf-xray-filter-add")
+            add  (th/find-by-testid tree "rf-xray-filter-add")
             handler (:on-click (second add))]
         (is (some? add))
         (when handler (handler nil))))
@@ -253,7 +219,7 @@
                                                 {:pattern ":b"}
                                                 {:pattern ":c"}]
                                           :out [{:pattern ":d"}]}})
-        cluster (find-by-testid tree "rf-xray-ribbon-filters")
+        cluster (th/find-by-testid tree "rf-xray-ribbon-filters")
         title   (:title (second cluster))]
     (is (some? cluster))
     (is (re-find #"IN: 3 patterns" title))
@@ -282,7 +248,7 @@
                 (throw (js/Error. "window.prompt called — stub regression")))))
       (try
         (let [tree (pills/pills-view rf/dispatch {:filters {:in [] :out []}})
-              add  (find-by-testid tree "rf-xray-filter-add")
+              add  (th/find-by-testid tree "rf-xray-filter-add")
               handler (:on-click (second add))]
           (when handler (handler nil)))
         (is (not @prompt-called?)

--- a/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
@@ -13,6 +13,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -29,32 +30,10 @@
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {}))
 
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 (defn- dispatch-trace-ev [id event-vec]
   {:id           id
@@ -92,7 +71,7 @@
                                         ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
           (let [tree (shell/shell-view)
-                row  (find-by-testid tree "rf-xray-event-row-7")
+                row  (th/find-by-testid tree "rf-xray-event-row-7")
                 h    (:on-context-menu (second row))]
             (is (some? row) "row mounted")
             (is (fn? h) "row has on-context-menu handler")
@@ -149,14 +128,14 @@
   (rf/with-frame :rf/xray
     ;; Sanity — all three rows present pre-filter.
     (let [tree (shell/shell-view)]
-      (is (some? (find-by-testid tree "rf-xray-event-row-1")))
-      (is (some? (find-by-testid tree "rf-xray-event-row-2")))
-      (is (some? (find-by-testid tree "rf-xray-event-row-3"))))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-1")))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-2")))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-3"))))
     ;; Install the OUT pill via the canonical add-filter event.
     (rf/dispatch-sync [:rf.xray/add-filter :out {:pattern :mouse-move}])
     ;; Re-render and assert :mouse-move dropped.
     (let [tree (shell/shell-view)]
-      (is (some? (find-by-testid tree "rf-xray-event-row-1")))
-      (is (nil? (find-by-testid tree "rf-xray-event-row-2"))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-1")))
+      (is (nil? (th/find-by-testid tree "rf-xray-event-row-2"))
           "row 2 (:mouse-move) filtered out")
-      (is (some? (find-by-testid tree "rf-xray-event-row-3"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-3"))))))

--- a/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
@@ -19,6 +19,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.registry :as registry]
@@ -258,34 +259,13 @@
 ;; (6) View — frame-switcher-view reads the contract
 ;; -------------------------------------------------------------------------
 
-(defn- expand-tree
-  "Walk `tree` and replace every fn-component vector with its rendered
-  result. Mirror of the shell tests' walker — keeps the hiccup-only
-  assertions terse."
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
+;; The private expand-tree / find-by-testid copies were semantically identical
+;; to `re-frame.test-helpers`; tests call `th/find-by-testid` directly
+;; (rf2-vj80u8 — no Xray walker facade). `hiccup-seq` (depth-first nodes over
+;; the expanded tree) is not exposed by test-helpers, so it is kept as a thin
+;; wrapper over `th/expand-tree` for the `:option`-node filter below.
 (defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+  (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
 (deftest view-renders-frame-dropdown-button-always
   (testing "rf2-pjjwh — the Figma chrome ribbon ALWAYS shows a frame
@@ -298,9 +278,9 @@
     (setup!)
     (rf/with-frame :rf/xray
       (let [tree    (frame-switcher/frame-switcher-view {})
-            button  (find-by-testid tree "rf-xray-ribbon-frame")
-            label   (find-by-testid tree "rf-xray-ribbon-frame-label")
-            picker  (find-by-testid tree "rf-xray-ribbon-frame-picker")
+            button  (th/find-by-testid tree "rf-xray-ribbon-frame")
+            label   (th/find-by-testid tree "rf-xray-ribbon-frame-label")
+            picker  (th/find-by-testid tree "rf-xray-ribbon-frame-picker")
             options (filter (fn [n]
                               (and (vector? n) (= :option (first n))))
                             (hiccup-seq tree))]
@@ -308,7 +288,7 @@
         (is (some? label) "the frame label renders")
         (is (= ":app/main" (last label))
             "the button face shows the currently-selected frame value (rf2-pjjwh)")
-        (is (some? (find-by-testid tree "rf-xray-ribbon-frame-chevron"))
+        (is (some? (th/find-by-testid tree "rf-xray-ribbon-frame-chevron"))
             "the `▾` chevron renders, marking it a dropdown")
         (is (some? picker) "the native <select> overlay is present for a11y")
         (is (not (:disabled (second picker)))
@@ -332,8 +312,8 @@
     (setup!)
     (rf/with-frame :rf/xray
       (let [tree   (frame-switcher/frame-switcher-view {})
-            picker (find-by-testid tree "rf-xray-ribbon-frame-picker")
-            label  (find-by-testid tree "rf-xray-ribbon-frame-label")]
+            picker (th/find-by-testid tree "rf-xray-ribbon-frame-picker")
+            label  (th/find-by-testid tree "rf-xray-ribbon-frame-label")]
         (is (some? picker) "dropdown renders for multi-frame")
         (is (= :select (first picker))
             "it's a <select>, not a custom multi-select")

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -32,6 +32,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
@@ -54,53 +55,19 @@
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- hiccup walk helpers ------------------------------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-by-id [tree id]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= id (:id (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- props [hiccup]
-  (when (and (vector? hiccup) (map? (second hiccup)))
-    (second hiccup)))
+;; The private expand-tree / hiccup-seq / find-by-testid / find-by-id / props
+;; copies this file carried were semantically identical to
+;; `re-frame.test-helpers`; the assertions below call `th/find-by-testid`,
+;; `th/find-by-attr` (keyed on :id) and `th/attrs` directly (rf2-vj80u8 — no
+;; Xray walker facade).
 
 (defn- assert-dialog-contract!
   "Common assertions: the dialog node must carry role + aria-modal,
   and either aria-label or aria-labelledby resolving to a real id
   in the same tree."
   [tree dialog-testid label]
-  (let [dialog (find-by-testid tree dialog-testid)
-        attrs  (props dialog)]
+  (let [dialog (th/find-by-testid tree dialog-testid)
+        attrs  (th/attrs dialog)]
     (is (some? dialog) (str label ": dialog wrapper renders"))
     (is (= "dialog" (:role attrs))
         (str label ": role=\"dialog\""))
@@ -109,7 +76,7 @@
     (let [labelled-by (:aria-labelledby attrs)
           label-attr  (:aria-label attrs)]
       (is (or (and labelled-by
-                   (some? (find-by-id tree labelled-by)))
+                   (some? (th/find-by-attr tree :id labelled-by)))
               (and (string? label-attr) (seq label-attr)))
           (str label ": accessible name set — either aria-labelledby
                 points at a heading id rendered in the same tree, or
@@ -130,8 +97,8 @@
   requires. A renderer that shipped role/aria-modal but dropped the
   `:ref` would now fail here rather than staying green."
   [tree dialog-testid label]
-  (let [dialog (find-by-testid tree dialog-testid)
-        attrs  (props dialog)]
+  (let [dialog (th/find-by-testid tree dialog-testid)
+        attrs  (th/attrs dialog)]
     (is (some? dialog) (str label ": dialog wrapper renders"))
     (is (fn? (:ref attrs))
         (str label ": dialog node attaches a :ref (the a11y/dialog-ref
@@ -160,8 +127,8 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
-          close (find-by-testid tree "rf-xray-settings-close")]
-      (is (string? (:aria-label (props close)))
+          close (th/find-by-testid tree "rf-xray-settings-close")]
+      (is (string? (:aria-label (th/attrs close)))
           "Settings close ✕ carries an aria-label"))))
 
 ;; -------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -31,6 +31,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.view :as settings-view]
@@ -55,47 +56,18 @@
 
 ;; ---- hiccup walker (mirrors shell-cljs-test) ----------------------------
 
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
+;; ---- hiccup helpers -----------------------------------------------------
+;; The private expand-tree / find-by-testid / find-by-id / find-all-with-pred
+;; copies were semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade). The
+;; unused find-by-id / find-all-with-pred were dropped. `hiccup-seq`
+;; (depth-first nodes over the expanded tree) is not exposed by test-helpers,
+;; so it is kept as a thin wrapper over `th/expand-tree` for the option/
+;; string-leaf filters below. `props` aliases `th/attrs`.
 (defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
+  (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-by-id [tree id]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= id (:id (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-with-pred [tree pred]
-  (filterv pred (hiccup-seq tree)))
-
-(defn- props [hiccup]
-  (when (and (vector? hiccup) (map? (second hiccup)))
-    (second hiccup)))
+(def ^:private props th/attrs)
 
 ;; -------------------------------------------------------------------------
 ;; (1) rf2-plajx — shell root landmark
@@ -108,7 +80,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree  (shell/shell-view)
-            shell (find-by-testid tree "rf-xray-shell")
+            shell (th/find-by-testid tree "rf-xray-shell")
             attrs (props shell)]
         (is (some? shell) "shell root mounts")
         (is (= "region" (:role attrs))
@@ -132,11 +104,11 @@
     (rf/with-frame :rf/xray
       (let [tree         (shell/shell-view)
             active-tab   :epoch ;; default (post rf2-5gl5r — supersedes :event)
-            tab-button   (find-by-testid tree (str "rf-xray-tab-" (name active-tab)))
+            tab-button   (th/find-by-testid tree (str "rf-xray-tab-" (name active-tab)))
             tab-attrs    (props tab-button)
             expected-id  (str "rf-xray-tab-button-" (name active-tab))
             panel-id     (str "rf-xray-tabpanel-" (name active-tab))
-            panel        (find-by-testid tree (str "rf-xray-detail-panel-" (name active-tab)))
+            panel        (th/find-by-testid tree (str "rf-xray-detail-panel-" (name active-tab)))
             panel-attrs  (props panel)]
         (is (= expected-id (:id tab-attrs))
             "tab button id matches the documented shape")
@@ -155,11 +127,11 @@
     (rf/with-frame :rf/xray
       (let [tree        (static-shell/surface)
             active-tab  :machines ;; the default Static tab
-            tab-button  (find-by-testid tree (str "rf-xray-static-tab-" (name active-tab)))
+            tab-button  (th/find-by-testid tree (str "rf-xray-static-tab-" (name active-tab)))
             tab-attrs   (props tab-button)
             expected-id (str "rf-xray-static-tab-button-" (name active-tab))
             panel-id    (str "rf-xray-static-tabpanel-" (name active-tab))
-            panel       (find-by-testid tree (str "rf-xray-static-detail-panel-" (name active-tab)))
+            panel       (th/find-by-testid tree (str "rf-xray-static-detail-panel-" (name active-tab)))
             panel-attrs (props panel)]
         (is (= expected-id (:id tab-attrs))
             "Static tab button id matches the documented shape")
@@ -181,7 +153,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (let [tree   (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
-          strip  (find-by-testid tree "rf-xray-settings-tab-strip")
+          strip  (th/find-by-testid tree "rf-xray-settings-tab-strip")
           attrs  (props strip)]
       (is (= "tablist" (:role attrs))
           "Settings tab strip is a tablist")
@@ -201,7 +173,7 @@
           ;; WAI-ARIA tab contract.
           tab-ids  [:general :keybindings :buffer :diff]]
       (doseq [tid tab-ids]
-        (let [button (find-by-testid tree
+        (let [button (th/find-by-testid tree
                        (str "rf-xray-settings-tab-" (name tid)))
               attrs  (props button)]
           (is (= "tab" (:role attrs))
@@ -216,8 +188,8 @@
               (str "tab " tid " carries aria-controls pointing at "
                    "its body tabpanel"))))
       ;; Default active tab is :general; selected reflects that.
-      (let [general (find-by-testid tree "rf-xray-settings-tab-general")
-            buffer  (find-by-testid tree "rf-xray-settings-tab-buffer")]
+      (let [general (th/find-by-testid tree "rf-xray-settings-tab-general")
+            buffer  (th/find-by-testid tree "rf-xray-settings-tab-buffer")]
         (is (= "true" (:aria-selected (props general)))
             "active tab (:general) carries aria-selected=\"true\"")
         (is (= "false" (:aria-selected (props buffer)))
@@ -231,7 +203,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
-          body  (find-by-testid tree "rf-xray-settings-body")
+          body  (th/find-by-testid tree "rf-xray-settings-body")
           attrs (props body)]
       (is (= "tabpanel" (:role attrs))
           "body wrapper is a tabpanel")
@@ -253,7 +225,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
-          input (find-by-testid tree "rf-xray-settings-epoch-history-input")
+          input (th/find-by-testid tree "rf-xray-settings-epoch-history-input")
           ;; The label sits in the same <div> field; find by html-for.
           label (some (fn [node]
                         (when (and (vector? node)
@@ -296,7 +268,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree   (frame-switcher/frame-switcher-view nil)
-            picker (find-by-testid tree "rf-xray-ribbon-frame-picker")]
+            picker (th/find-by-testid tree "rf-xray-ribbon-frame-picker")]
         (is (some? picker)
             "the <select> picker renders when ≥2 frames are present")
         (is (and (string? (:aria-label (props picker)))
@@ -337,7 +309,7 @@
       (rf/dispatch-sync [:rf.xray/note-sensitive-suppressed :rf/default]))
     (rf/with-frame :rf/xray
       (let [tree      (shell/shell-view)
-            indicator (find-by-testid tree "rf-xray-redacted-indicator")
+            indicator (th/find-by-testid tree "rf-xray-redacted-indicator")
             ;; the glyph is the first <span> child carrying aria-hidden
             glyph     (some (fn [node]
                               (when (and (vector? node)
@@ -362,7 +334,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree      (shell/shell-view)
-            event-tab (find-by-testid tree "rf-xray-tab-event")
+            event-tab (th/find-by-testid tree "rf-xray-tab-event")
             glyph     (some (fn [node]
                               (when (and (vector? node)
                                          (= :span (first node))

--- a/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
@@ -23,6 +23,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.palette.view :as view]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
@@ -38,45 +39,14 @@
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {}))
 
-(declare expand-tree)
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid / find-all-by-testid-
+;; prefix / props copies were semantically identical to
+;; `re-frame.test-helpers`; tests call `th/find-by-testid` /
+;; `th/find-by-testid-prefix` directly (rf2-vj80u8 — no Xray walker facade).
+;; `props` is a thin alias over `th/attrs`.
 
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filter (fn [node]
-            (when (and (vector? node)
-                       (map? (second node)))
-              (let [t (:data-testid (second node))]
-                (and (string? t)
-                     (.startsWith t prefix)))))
-          (hiccup-seq tree)))
-
-(defn- props [hiccup]
-  (when (and (vector? hiccup) (map? (second hiccup)))
-    (second hiccup)))
+(def ^:private props th/attrs)
 
 ;; ---- (1) dialog wrapper ARIA --------------------------------------------
 
@@ -87,7 +57,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree   (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          dialog (find-by-testid tree "rf-xray-palette-dialog")]
+          dialog (th/find-by-testid tree "rf-xray-palette-dialog")]
       (is (some? dialog) "the dialog wrapper renders")
       (is (= "dialog" (:role (props dialog))))
       (is (= "true"   (:aria-modal (props dialog))))
@@ -105,7 +75,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree  (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          input (find-by-testid tree "rf-xray-palette-input")
+          input (th/find-by-testid tree "rf-xray-palette-input")
           attrs (props input)]
       (is (some? input))
       (is (= "combobox" (:role attrs)))
@@ -123,8 +93,8 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree    (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          input   (find-by-testid tree "rf-xray-palette-input")
-          listbox (find-by-testid tree "rf-xray-palette-list")]
+          input   (th/find-by-testid tree "rf-xray-palette-input")
+          listbox (th/find-by-testid tree "rf-xray-palette-list")]
       (is (= (:aria-controls (props input))
              (:id (props listbox)))
           "aria-controls round-trips to listbox id"))))
@@ -139,7 +109,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          ul   (find-by-testid tree "rf-xray-palette-list")]
+          ul   (th/find-by-testid tree "rf-xray-palette-list")]
       (is (some? ul) "the list wrapper renders")
       ;; Default palette open populates results (>0 commands registered)
       ;; so the listbox role should be set.
@@ -155,7 +125,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          rows (find-all-by-testid-prefix tree "rf-xray-palette-row-")]
+          rows (th/find-by-testid-prefix tree "rf-xray-palette-row-")]
       (is (seq rows) "the palette renders at least one row")
       (doseq [row rows]
         (let [attrs (props row)]
@@ -174,7 +144,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
     (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          rows (find-all-by-testid-prefix tree "rf-xray-palette-row-")
+          rows (th/find-by-testid-prefix tree "rf-xray-palette-row-")
           ids  (mapv (comp :id props) rows)]
       (is (= (count ids) (count (set ids)))
           "every row id is unique within the rendered list"))))
@@ -187,7 +157,7 @@
       (rf/dispatch-sync [:rf.xray/palette-open])
       (rf/dispatch-sync [:rf.xray/palette-cursor-set 0]))
     (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          rows (find-all-by-testid-prefix tree "rf-xray-palette-row-")
+          rows (th/find-by-testid-prefix tree "rf-xray-palette-row-")
           selected (filter #(= "true" (:aria-selected (props %))) rows)]
       (is (= 1 (count selected))
           "exactly one row carries aria-selected=true"))))
@@ -201,8 +171,8 @@
       (rf/dispatch-sync [:rf.xray/palette-open])
       (rf/dispatch-sync [:rf.xray/palette-cursor-set 0]))
     (let [tree     (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
-          input    (find-by-testid tree "rf-xray-palette-input")
-          rows     (find-all-by-testid-prefix tree "rf-xray-palette-row-")
+          input    (th/find-by-testid tree "rf-xray-palette-input")
+          rows     (th/find-by-testid-prefix tree "rf-xray-palette-row-")
           active   (some (fn [row]
                            (when (= "true" (:aria-selected (props row)))
                              (:id (props row))))

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -40,6 +40,7 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.palette :as palette]
             [day8.re-frame2-xray.registry :as registry]
@@ -71,32 +72,14 @@
   {:before setup-runtime!
    :after  teardown-runtime!})
 
-;; ---- hiccup walker (mirrors popup_dispatch_routing test) ---------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq copies were semantically identical to
+;; `re-frame.test-helpers`; the walk delegates to `th/find-by-testid`
+;; (rf2-vj80u8 — no Xray walker facade). The `with-frame` wrapper is retained
+;; deliberately (NOT a walker difference):
 (defn- find-by-testid [tree testid]
   ;; EP-0002 (rf2-bd4div): walking the rendered tree RE-INVOKES nested
-  ;; component fns (`expand-tree`), and those render-time `rf/subscribe`s
+  ;; component fns (`th/expand-tree`), and those render-time `rf/subscribe`s
   ;; resolve through the surrounding frame. The palette mounts in the
   ;; `:rf/xray` own-frame, so the expansion must run under that scope —
   ;; ambient (no-scope) re-expansion would raise `:rf.error/no-frame-context`
@@ -104,12 +87,7 @@
   ;; click-time HANDLER is still invoked OUTSIDE any scope — that is the
   ;; real click-fires-after-render path under test.)
   (rf/with-frame :rf/xray
-    (some (fn [node]
-            (when (and (vector? node)
-                       (map? (second node))
-                       (= testid (:data-testid (second node))))
-              node))
-          (hiccup-seq tree))))
+    (th/find-by-testid tree testid)))
 
 ;; ---- click-time helpers ------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
@@ -23,6 +23,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
             [day8.re-frame2-xray.registry :as registry]
@@ -63,41 +64,11 @@
     (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])))
 
 ;; ---- hiccup walk helpers ------------------------------------------------
-
-(declare expand-tree)
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (let [result (apply (first tree) (rest tree))]
-      ;; Form-2 Reagent components return an inner fn; re-call with
-      ;; the same args (Reagent's re-render contract). rf2-oqa60 —
-      ;; the edn-inspector widget is form-2 to stabilise mount-id.
-      (expand-tree
-        (if (fn? result)
-          (apply result (rest tree))
-          result)))
-    (vector? tree) (mapv expand-tree tree)
-    (seq? tree)    (map expand-tree tree)
-    :else          tree))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- text-content
-  "Flatten all string leaves of a hiccup subtree into one string —
-  enough to assert the rendered value text shows up."
-  [tree]
-  (->> (hiccup-seq tree)
-       (filter string?)
-       (apply str)))
+;; The private expand-tree (form-2 aware) / hiccup-seq / find-by-testid /
+;; text-content copies were semantically identical to `re-frame.test-helpers`
+;; (`th/expand-tree` handles the form-2 edn-inspector widget too); tests call
+;; `th/find-by-testid` / `th/text-content` directly (rf2-vj80u8 — no Xray
+;; walker facade).
 
 (defn- read-value-sub []
   (rf/with-frame :rf/xray
@@ -157,19 +128,19 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/open-segment-inspector [:user]]))
     (let [tree   (rf/with-frame :rf/xray (segment-inspector/Popup))
-          title  (find-by-testid tree "rf-xray-segment-inspector-title")
-          body   (find-by-testid tree "rf-xray-segment-inspector-body")]
+          title  (th/find-by-testid tree "rf-xray-segment-inspector-title")
+          body   (th/find-by-testid tree "rf-xray-segment-inspector-body")]
       (is (some? tree) "Popup renders when open")
       (is (some? title) "header title node renders")
       (is (some? body) "body node renders")
       ;; The header echoes the inspected path so the user knows what
       ;; they are looking at.
-      (let [title-text (text-content title)]
+      (let [title-text (th/text-content title)]
         (is (re-find #":user" title-text)
             "header title did not echo the inspected path"))
       ;; The body renders the sliced value — the user's name appears
       ;; somewhere in the projected tree.
-      (let [body-text (text-content body)]
+      (let [body-text (th/text-content body)]
         (is (re-find #"ada" body-text)
             "body did not render the sliced value's content")))))
 
@@ -181,8 +152,8 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/open-segment-inspector []]))
     (let [tree  (rf/with-frame :rf/xray (segment-inspector/Popup))
-          title (find-by-testid tree "rf-xray-segment-inspector-title")]
-      (is (re-find #"root" (text-content title))
+          title (th/find-by-testid tree "rf-xray-segment-inspector-title")]
+      (is (re-find #"root" (th/text-content title))
           "root-path header title did not read '(root)'"))))
 
 (deftest popup-closed-renders-nothing

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -23,6 +23,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
@@ -45,36 +46,10 @@
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {}))
 
-;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 ;; ---- mount on :inline / short-circuit on others ------------------------
 
@@ -108,7 +83,7 @@
     (setup!)
     (rf/with-frame :rf/xray
       (let [tree (shell/shell-view {:mode :inline})]
-        (is (some? (find-by-testid tree "rf-xray-resize-handle"))
+        (is (some? (th/find-by-testid tree "rf-xray-resize-handle"))
             "resize handle present in :inline mode")))))
 
 (deftest shell-omits-resize-handle-in-popout
@@ -116,7 +91,7 @@
     (setup!)
     (rf/with-frame :rf/xray
       (let [tree (shell/shell-view {:mode :popout})]
-        (is (nil? (find-by-testid tree "rf-xray-resize-handle"))
+        (is (nil? (th/find-by-testid tree "rf-xray-resize-handle"))
             "resize handle absent in :popout mode")))))
 
 ;; ---- drag lifecycle ----------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -17,6 +17,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -50,36 +51,10 @@
   {:before setup-runtime!
    :after  teardown-runtime!})
 
-;; ---- hiccup walker (mirrors popup_dispatch_routing) --------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 ;; ---- events + sub -------------------------------------------------------
 
@@ -108,11 +83,11 @@
     (let [rendered (editor-hint/Toast)]
       (is (some? rendered)
           "Toast renders hiccup when editor-hint-open? is true")
-      (is (find-by-testid rendered "rf-xray-editor-hint-toast")
+      (is (th/find-by-testid rendered "rf-xray-editor-hint-toast")
           "the toast root is present")
-      (is (find-by-testid rendered "rf-xray-editor-hint-open-settings")
+      (is (th/find-by-testid rendered "rf-xray-editor-hint-open-settings")
           "the 'Open Settings' button is present")
-      (is (find-by-testid rendered "rf-xray-editor-hint-dismiss")
+      (is (th/find-by-testid rendered "rf-xray-editor-hint-dismiss")
           "the dismiss ✕ button is present"))))
 
 ;; ---- open-settings wiring ----------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -43,6 +43,7 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
@@ -77,36 +78,10 @@
   {:before setup-runtime!
    :after  teardown-runtime!})
 
-;; ---- hiccup walker (mirrors popup_cljs_test) ---------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup walker ------------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 ;; ---- click-time helpers ------------------------------------------------
 
@@ -147,7 +122,7 @@
             `{:frame :rf/xray}` opt on the dispatch, the click would
             land on :rf/default and the modal would stay open."
     (let [rendered  (render-open-modal)
-          close-btn (find-by-testid rendered "rf-xray-settings-close")
+          close-btn (th/find-by-testid rendered "rf-xray-settings-close")
           handler   (on-click close-btn)]
       (is (some? handler) "close button exposes an :on-click handler")
       (handler (fake-event)) ; outside any with-frame — same as a browser click
@@ -167,7 +142,7 @@
             :rf/xray frame-provider's render context still closes the
             modal."
     (let [rendered (render-open-modal)
-          backdrop (find-by-testid rendered "rf-xray-settings-backdrop")
+          backdrop (th/find-by-testid rendered "rf-xray-settings-backdrop")
           handler  (on-click backdrop)]
       (is (some? handler) "backdrop exposes an :on-click handler")
       (handler (fake-event))
@@ -184,7 +159,7 @@
   (testing "rf2-smvvz — Esc keydown from OUTSIDE the :rf/xray frame-
             provider's render context still closes the modal."
     (let [rendered (render-open-modal)
-          dialog   (find-by-testid rendered "rf-xray-settings-dialog")
+          dialog   (th/find-by-testid rendered "rf-xray-settings-dialog")
           handler  (on-key-down dialog)]
       (is (some? handler) "dialog exposes an :on-key-down handler")
       (handler (fake-key-event "Escape"))
@@ -209,7 +184,7 @@
             assertion is independent of which tab is clicked as long
             as it differs from the default :general)."
     (let [rendered (render-open-modal)
-          tab-node (find-by-testid rendered "rf-xray-settings-tab-buffer")
+          tab-node (th/find-by-testid rendered "rf-xray-settings-tab-buffer")
           handler  (on-click tab-node)]
       (is (some? handler) "buffer tab exposes an :on-click handler")
       (handler (fake-event))

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -44,6 +44,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -69,55 +70,21 @@
     {:post-reset (fn [] (config/reset-suppressed-count!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree
-  "Walk `tree` and replace every fn-component vector with its rendered
-  result (recursively). Pure keyword-headed hiccup passes through;
-  nil / strings / numbers / maps pass through. Vectors whose head is
-  `rf/frame-provider` (or any other non-fn keyword-headed form) walk
-  their children but don't get invoked."
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
+;; The private expand-tree / find-by-testid / find-all-by-testid-prefix /
+;; find-all-by-testid copies were semantically identical to
+;; `re-frame.test-helpers` and alias straight through (rf2-vj80u8 — no Xray
+;; walker facade). `hiccup-seq` (depth-first nodes over the expanded tree) is
+;; not exposed by test-helpers, so it is kept as a thin wrapper over
+;; `th/expand-tree` for the `:option`-node filter below. `text-nodes` is left
+;; bespoke: it collects STRING leaves only, whereas `th/text-content` also
+;; folds in numbers — shell asserts exact/empty text, so the distinction is
+;; load-bearing.
 (defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
+  (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
-
-(defn- find-all-by-testid [tree testid]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (= testid (:data-testid (second node)))))
-           (hiccup-seq tree)))
+(def ^:private find-by-testid            th/find-by-testid)
+(def ^:private find-all-by-testid        th/find-all-by-testid)
+(def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
 
 (defn- text-nodes
   "Flatten the rendered tree's string leaves into one concatenated

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -16,6 +16,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
@@ -53,34 +54,10 @@
                   :frame       :rf/default
                   :rf.trace/dispatch-id id}})
 
-;; ---- hiccup helpers (copied from existing right-click integration test) --
-
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+;; ---- hiccup helpers -----------------------------------------------------
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 ;; -------------------------------------------------------------------------
 ;; (1) Pure helpers
@@ -252,16 +229,16 @@
   (rf/with-frame :rf/xray
     ;; All three rows render pre-mute.
     (let [tree (shell/shell-view)]
-      (is (some? (find-by-testid tree "rf-xray-event-row-1")))
-      (is (some? (find-by-testid tree "rf-xray-event-row-2")))
-      (is (some? (find-by-testid tree "rf-xray-event-row-3"))))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-1")))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-2")))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-3"))))
     (rf/dispatch-sync [:rf.xray/mute-event-id :user/mouse-move])
     ;; Row 2 (:user/mouse-move) disappears.
     (let [tree (shell/shell-view)]
-      (is (some? (find-by-testid tree "rf-xray-event-row-1")))
-      (is (nil? (find-by-testid tree "rf-xray-event-row-2"))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-1")))
+      (is (nil? (th/find-by-testid tree "rf-xray-event-row-2"))
           "muted row stripped from L2 list")
-      (is (some? (find-by-testid tree "rf-xray-event-row-3"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-event-row-3"))))))
 
 ;; -------------------------------------------------------------------------
 ;; (7) Row context menu open / close state
@@ -295,9 +272,9 @@
                    {:event-id :user/mouse-move :x 100 :y 200}])
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)
-          menu (find-by-testid tree "rf-xray-row-context-menu")
-          mute (find-by-testid tree "rf-xray-row-context-menu-mute")
-          hide (find-by-testid tree "rf-xray-row-context-menu-hide-event-type")]
+          menu (th/find-by-testid tree "rf-xray-row-context-menu")
+          mute (th/find-by-testid tree "rf-xray-row-context-menu-mute")
+          hide (th/find-by-testid tree "rf-xray-row-context-menu-hide-event-type")]
       (is (some? menu) "menu mounts when slot is set")
       (is (some? mute) "menu carries 'Mute' item")
       (is (some? hide) "menu carries 'Always hide…' item")
@@ -324,10 +301,10 @@
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)
-          dialog (find-by-testid tree "rf-xray-mute-manager-dialog")
-          list   (find-by-testid tree "rf-xray-mute-manager-list")
-          row-a  (find-by-testid tree "rf-xray-mute-manager-row-:a/x")
-          row-b  (find-by-testid tree "rf-xray-mute-manager-row-:b/y")]
+          dialog (th/find-by-testid tree "rf-xray-mute-manager-dialog")
+          list   (th/find-by-testid tree "rf-xray-mute-manager-list")
+          row-a  (th/find-by-testid tree "rf-xray-mute-manager-row-:a/x")
+          row-b  (th/find-by-testid tree "rf-xray-mute-manager-row-:b/y")]
       (is (some? dialog) "manager dialog mounts")
       (is (some? list) "manager renders the list section")
       (is (some? row-a) "row for :a/x")
@@ -338,8 +315,8 @@
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
     (let [tree  (shell/shell-view)
-          empty (find-by-testid tree "rf-xray-mute-manager-empty")
-          list  (find-by-testid tree "rf-xray-mute-manager-list")]
+          empty (th/find-by-testid tree "rf-xray-mute-manager-empty")
+          list  (th/find-by-testid tree "rf-xray-mute-manager-list")]
       (is (some? empty) "empty-state copy mounts when no ids muted")
       (is (nil? list) "list section absent when empty"))))
 
@@ -351,7 +328,7 @@
   (xray-setup!)
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)
-          ind  (find-by-testid tree "rf-xray-ribbon-mute-indicator")]
+          ind  (th/find-by-testid tree "rf-xray-ribbon-mute-indicator")]
       (is (nil? ind) "indicator absent when no event-ids muted"))))
 
 (deftest ribbon-mute-indicator-shows-when-mute-set-nonempty
@@ -360,8 +337,8 @@
   (frame-dispatch [:rf.xray/mute-event-id :b])
   (rf/with-frame :rf/xray
     (let [tree (shell/shell-view)
-          ind  (find-by-testid tree "rf-xray-ribbon-mute-indicator")
-          cnt  (find-by-testid tree "rf-xray-ribbon-mute-indicator-count")]
+          ind  (th/find-by-testid tree "rf-xray-ribbon-mute-indicator")
+          cnt  (th/find-by-testid tree "rf-xray-ribbon-mute-indicator-count")]
       (is (some? ind) "indicator mounts when mute set is non-empty")
       (is (some? cnt))
       (is (= "2" (nth cnt 2))
@@ -392,7 +369,7 @@
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
           (let [tree     (shell/shell-view)
-                mute-btn (find-by-testid tree "rf-xray-row-context-menu-mute")
+                mute-btn (th/find-by-testid tree "rf-xray-row-context-menu-mute")
                 handler  (:on-click (second mute-btn))]
             (is (fn? handler) "'Mute' button has on-click handler")
             (when handler (handler #js {:stopPropagation (fn [] nil)}))))
@@ -412,11 +389,11 @@
         (rf/dispatch-sync [:rf.xray/mute-event-id :user/mouse-move])
         (rf/dispatch-sync [:rf.xray/close-row-context-menu])
         (let [tree (shell/shell-view)]
-          (is (some? (find-by-testid tree "rf-xray-event-row-1")))
-          (is (nil? (find-by-testid tree "rf-xray-event-row-2"))
+          (is (some? (th/find-by-testid tree "rf-xray-event-row-1")))
+          (is (nil? (th/find-by-testid tree "rf-xray-event-row-2"))
               "muted row dropped from L2")
-          (is (nil? (find-by-testid tree "rf-xray-row-context-menu"))
+          (is (nil? (th/find-by-testid tree "rf-xray-row-context-menu"))
               "menu closed after click"))
         (let [tree (shell/shell-view)
-              ind  (find-by-testid tree "rf-xray-ribbon-mute-indicator")]
+              ind  (th/find-by-testid tree "rf-xray-ribbon-mute-indicator")]
           (is (some? ind) "ribbon mute indicator visible"))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
@@ -13,6 +13,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
@@ -34,34 +35,14 @@
                    (static-persistence/clear!)
                    (ls/clear!))}))
 
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-    (vector? tree) (mapv expand-tree tree)
-    (seq? tree)    (map expand-tree tree)
-    :else          tree))
-
+;; The private expand-tree / find-by-testid copies were semantically identical
+;; to `re-frame.test-helpers`; tests call `th/find-by-testid` directly
+;; (rf2-vj80u8 — no Xray walker facade). The unused find-all-by-testid was
+;; dropped. `hiccup-seq` (depth-first nodes over the expanded tree) is not
+;; exposed by test-helpers, so it is kept as a thin wrapper over
+;; `th/expand-tree` for the string-leaf extraction below.
 (defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid [tree testid]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (= testid (:data-testid (second node)))))
-           (hiccup-seq tree)))
+  (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)
@@ -94,7 +75,7 @@
   (seed-snapshots! {}) ;; no live instances
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (nil? (find-by-testid tree "rf-xray-static-machines-row-pips"))
+      (is (nil? (th/find-by-testid tree "rf-xray-static-machines-row-pips"))
           "no pip cluster when live-count is zero"))))
 
 (deftest pip-cluster-renders-dots-for-one-live-instance
@@ -103,7 +84,7 @@
   (seed-snapshots! {:m/a {:state :idle}})
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          pips (find-by-testid tree "rf-xray-static-machines-row-pips")]
+          pips (th/find-by-testid tree "rf-xray-static-machines-row-pips")]
       (is (some? pips) "pip cluster mounts for live machine"))))
 
 ;; -------------------------------------------------------------------------
@@ -115,13 +96,13 @@
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          btn  (find-by-testid tree "rf-xray-static-machines-sort")
+          btn  (th/find-by-testid tree "rf-xray-static-machines-sort")
           text (->> btn hiccup-seq (filter string?) (apply str))]
       (is (re-find #"Name" text) "default sort axis is Name")))
   (frame-dispatch [:rf.xray.static.machines/cycle-sort])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          btn  (find-by-testid tree "rf-xray-static-machines-sort")
+          btn  (th/find-by-testid tree "rf-xray-static-machines-sort")
           text (->> btn hiccup-seq (filter string?) (apply str))]
       (is (re-find #"States" text)))))
 
@@ -156,7 +137,7 @@
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
     (let [tree   (panel/panel)
-          rows-el (find-by-testid tree "rf-xray-static-machines-rows")
+          rows-el (th/find-by-testid tree "rf-xray-static-machines-rows")
           attrs  (second rows-el)]
       (is (= "listbox" (:role attrs)))
       (is (string? (:aria-label attrs))))))
@@ -167,7 +148,7 @@
   (frame-dispatch [:rf.xray.static.machines/select :m/a])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          row-a (find-by-testid tree "rf-xray-static-machines-row-a")
+          row-a (th/find-by-testid tree "rf-xray-static-machines-row-a")
           attrs (second row-a)]
       ;; Note: machine-id is :m/a so name = "a", testid suffix matches.
       (is (= "true" (:aria-selected attrs))))))
@@ -181,13 +162,13 @@
   (seed-machines! [:foo/a :foo/b :bar/c])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          count-el (find-by-testid tree "rf-xray-static-machines-count")
+          count-el (th/find-by-testid tree "rf-xray-static-machines-count")
           text (->> count-el hiccup-seq (filter string?) (apply str))]
       (is (re-find #"3 machines" text))))
   (frame-dispatch [:rf.xray.static.machines/set-search "foo"])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          count-el (find-by-testid tree "rf-xray-static-machines-count")
+          count-el (th/find-by-testid tree "rf-xray-static-machines-count")
           text (->> count-el hiccup-seq (filter string?) (apply str))]
       (is (re-find #"2 / 3" text)))))
 
@@ -201,4 +182,4 @@
   (frame-dispatch [:rf.xray.static.machines/set-search "nonexistent"])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-machines-no-results"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-no-results"))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -30,6 +30,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
@@ -53,46 +54,11 @@
                    (ls/clear!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
-
-(declare expand-tree)
-
-(defn- expand-tree [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
-
-(defn- text-nodes [tree]
-  (->> (hiccup-seq tree)
-       (filter string?)
-       (apply str)))
+;; The private expand-tree / hiccup-seq / find-by-testid / find-all-by-testid-
+;; prefix / text-nodes copies were semantically identical to
+;; `re-frame.test-helpers`; tests call `th/find-by-testid`,
+;; `th/find-by-testid-prefix` and `th/text-content` directly (rf2-vj80u8 — no
+;; Xray walker facade).
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -133,10 +99,10 @@
     (seed-machines! [:m/a :m/b])
     (rf/with-frame :rf/xray
       (let [tree (static-shell/surface)]
-        (is (some? (find-by-testid tree "rf-xray-static-machines-panel"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-panel"))
             "panel mounts on default :machines tab")
         ;; Placeholder card MUST be gone now that the panel is live.
-        (is (nil? (find-by-testid tree "rf-xray-static-placeholder-machines"))
+        (is (nil? (th/find-by-testid tree "rf-xray-static-placeholder-machines"))
             "placeholder no longer mounts")))))
 
 ;; -------------------------------------------------------------------------
@@ -152,7 +118,7 @@
                         :bar/upload   {:states {:x {}}}})
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)
-            rows (find-all-by-testid-prefix tree "rf-xray-static-machines-row-")
+            rows (th/find-by-testid-prefix tree "rf-xray-static-machines-row-")
             ;; Filter rows-only — the row testid prefix matches the
             ;; per-row id chips too, so we keep only the outer row buttons
             ;; (they carry `:data-machine-id` on the attrs map).
@@ -165,10 +131,10 @@
     (seed-machines! [])
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)]
-        (is (some? (find-by-testid tree "rf-xray-static-machines-empty"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-empty"))
             "empty-state card present")
         (is (re-find #"No machines registered"
-                     (text-nodes (find-by-testid tree
+                     (th/text-content (th/find-by-testid tree
                                                  "rf-xray-static-machines-empty"))))))))
 
 ;; -------------------------------------------------------------------------
@@ -238,14 +204,14 @@
   (seed-snapshots! {:m/a {:state :a}})
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-machines-detail-header")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-detail-title")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-detail-source-coord")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-detail-state-count")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-detail-live-count")))
-      (let [text (text-nodes (find-by-testid tree "rf-xray-static-machines-detail-state-count"))]
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-detail-header")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-detail-title")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-detail-source-coord")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-detail-state-count")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-detail-live-count")))
+      (let [text (th/text-content (th/find-by-testid tree "rf-xray-static-machines-detail-state-count"))]
         (is (re-find #"3 states" text)))
-      (let [text (text-nodes (find-by-testid tree "rf-xray-static-machines-detail-live-count"))]
+      (let [text (th/text-content (th/find-by-testid tree "rf-xray-static-machines-detail-live-count"))]
         (is (re-find #"1 live" text))))))
 
 (deftest detail-header-degrades-when-source-coord-missing
@@ -254,7 +220,7 @@
   (seed-definitions! {:m/a {:states {:a {}}}}) ;; no :source-coord
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (nil? (find-by-testid tree "rf-xray-static-machines-detail-source-coord"))
+      (is (nil? (th/find-by-testid tree "rf-xray-static-machines-detail-source-coord"))
           "source-coord chip is suppressed when the slot is missing"))))
 
 ;; -------------------------------------------------------------------------
@@ -266,17 +232,17 @@
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-machines-pill-topology")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-pill-sim")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-pill-instances")))
-      (is (some? (find-by-testid tree "rf-xray-static-machines-pill-cascade"))))))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-pill-topology")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-pill-sim")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-pill-instances")))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-pill-cascade"))))))
 
 (deftest sub-strip-default-is-topology
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          pill (find-by-testid tree "rf-xray-static-machines-pill-topology")]
+          pill (th/find-by-testid tree "rf-xray-static-machines-pill-topology")]
       (is (= "true" (:aria-selected (second pill)))
           "Topology is the default active pill"))))
 
@@ -286,8 +252,8 @@
   (frame-dispatch [:rf.xray.static.machines/set-sub-mode :m/a :sim])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          sim  (find-by-testid tree "rf-xray-static-machines-pill-sim")
-          topo (find-by-testid tree "rf-xray-static-machines-pill-topology")]
+          sim  (th/find-by-testid tree "rf-xray-static-machines-pill-sim")
+          topo (th/find-by-testid tree "rf-xray-static-machines-pill-topology")]
       (is (= "true"  (:aria-selected (second sim))))
       (is (= "false" (:aria-selected (second topo)))))))
 
@@ -300,7 +266,7 @@
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)
-          pill (find-by-testid tree "rf-xray-static-machines-pill-cascade")
+          pill (th/find-by-testid tree "rf-xray-static-machines-pill-cascade")
           attrs (second pill)]
       (is (= true (:disabled attrs))
           "Cascade button is disabled")
@@ -324,12 +290,12 @@
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)]
         ;; The old placeholder is gone.
-        (is (nil? (find-by-testid
+        (is (nil? (th/find-by-testid
                     tree "rf-xray-static-machines-sim-placeholder"))
             "old placeholder card no longer mounts")
         ;; The real Sim body is mounted; no-definition variant since
         ;; the test fixture seeds no :states map.
-        (is (some? (find-by-testid
+        (is (some? (th/find-by-testid
                      tree "rf-xray-static-machines-sim-no-definition"))
             "real Sim body's no-definition hint mounts in :sim mode")))))
 
@@ -362,9 +328,9 @@
                                      :states  {:idle {:on {:start :running}}
                                                :running {}}}}])
       (let [tree (panel/panel)]
-        (is (some? (find-by-testid tree "rf-xray-static-machines-sim-body"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-sim-body"))
             "real Sim body wrapper mounts")
-        (is (some? (find-by-testid tree "rf-xray-static-machines-sim-rail"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-sim-rail"))
             "Sim rail mounts when sim-state is populated")))))
 
 ;; -------------------------------------------------------------------------
@@ -406,13 +372,13 @@
                             :states  {:idle {} :done {}}}})
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (some? (find-by-testid tree "rf-xray-static-machines-topology"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-topology"))
           "Topology mode mounts as the default body")
-      (is (some? (find-by-testid tree "rf-xray-static-machines-topology-chart"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-topology-chart"))
           "chart wrapper mounts")
       ;; The SVG itself is rendered by chart-svg/render with the testid
       ;; we passed in.
-      (is (some? (find-by-testid tree "rf-xray-static-machines-topology-svg"))
+      (is (some? (th/find-by-testid tree "rf-xray-static-machines-topology-svg"))
           "SVG primitive mounts"))))
 
 (deftest topology-mode-shows-no-definition-hint-when-missing
@@ -422,7 +388,7 @@
   (seed-definitions! {})
   (rf/with-frame :rf/xray
     (let [tree (panel/panel)]
-      (is (some? (find-by-testid tree
+      (is (some? (th/find-by-testid tree
                                  "rf-xray-static-machines-topology-no-definition"))))))
 
 ;; -------------------------------------------------------------------------
@@ -438,14 +404,14 @@
                               :states  {:idle {} :done {}}}})
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)]
-        (is (some? (find-by-testid tree "rf-xray-machine-canvas-host"))
+        (is (some? (th/find-by-testid tree "rf-xray-machine-canvas-host"))
             "the chart is now wrapped in the interactive canvas-host")
         ;; rf2-gpzb4 (xyflow migration): the host-side controls toolbar
         ;; is gone — xyflow renders its own `<Controls>` component
         ;; inside the chart. The inner-testid still threads through
         ;; via the `:inner-testid` prop so existing static-panel
         ;; selectors keep working.
-        (is (some? (find-by-testid tree "rf-xray-static-machines-topology-svg"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-topology-svg"))
             ":inner-testid forwards through Chart to the xyflow root")))))
 
 (deftest topology-mode-omits-view-mode-toggle-on-static
@@ -460,7 +426,7 @@
                               :states  {:idle {} :done {}}}})
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)]
-        (is (nil? (find-by-testid tree
+        (is (nil? (th/find-by-testid tree
                                   "rf-xray-machine-canvas-view-mode-toggle"))
             "the retired view-mode toggle never mounts on static")))))
 
@@ -476,10 +442,10 @@
                               :source-coord {:file "src/m_a.cljs" :line 12}}})
     (rf/with-frame :rf/xray
       (let [tree (panel/panel)]
-        (is (some? (find-by-testid tree
+        (is (some? (th/find-by-testid tree
                                    "rf-xray-static-machines-topology-toolbar"))
             "static chart-toolbar still mounts above the canvas")
-        (is (some? (find-by-testid tree
+        (is (some? (th/find-by-testid tree
                                    "rf-xray-static-machines-topology-popout"))
             "Pop-out affordance still present")))))
 

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -37,6 +37,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
@@ -59,42 +60,9 @@
 
 ;; ---- hiccup walker (mirrors shell_cljs_test) ----------------------------
 
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filterv (fn [node]
-             (and (vector? node)
-                  (map? (second node))
-                  (when-let [tid (:data-testid (second node))]
-                    (= 0 (.indexOf tid prefix)))))
-           (hiccup-seq tree)))
+;; The private expand-tree / hiccup-seq / find-by-testid copies were
+;; semantically identical to `re-frame.test-helpers`; tests call
+;; `th/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -204,17 +172,17 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree (static-shell/surface)]
-        (is (some? (find-by-testid tree "rf-xray-static-surface"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-surface"))
             "Static surface envelope present")
-        (is (some? (find-by-testid tree "rf-xray-static-ribbon"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-ribbon"))
             "L1 ribbon present")
-        (is (some? (find-by-testid tree "rf-xray-static-tab-bar"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-tab-bar"))
             "L3 tab bar present")
         ;; default tab is :machines → detail panel testid carries the tab name
-        (is (some? (find-by-testid tree "rf-xray-static-detail-panel-machines"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-detail-panel-machines"))
             "L4 detail panel present (default :machines tab)")
         ;; CRITICAL: no L2 event list in Static mode
-        (is (nil? (find-by-testid tree "rf-xray-event-list"))
+        (is (nil? (th/find-by-testid tree "rf-xray-event-list"))
             "no L2 event list (Static is event-INDEPENDENT)")))))
 
 (deftest static-ribbon-mounts-mode-pill-frame-picker-and-right-icons
@@ -227,24 +195,24 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree (static-shell/surface)]
-        (is (some? (find-by-testid tree "rf-xray-mode-pill"))
+        (is (some? (th/find-by-testid tree "rf-xray-mode-pill"))
             "mode pill present at ribbon-left")
         ;; L1 frame picker mounts in Static (the picker collapses to a
         ;; flat label when only one frame is available — match either
         ;; the `<select>` or the label fallback).
-        (is (or (some? (find-by-testid tree "rf-xray-ribbon-frame-picker"))
-                (some? (find-by-testid tree "rf-xray-ribbon-frame")))
+        (is (or (some? (th/find-by-testid tree "rf-xray-ribbon-frame-picker"))
+                (some? (th/find-by-testid tree "rf-xray-ribbon-frame")))
             "L1 frame picker present (picker `<select>` or label fallback)")
-        (is (some? (find-by-testid tree "rf-xray-static-ribbon-icons"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-ribbon-icons"))
             "right icons cluster present")
-        (is (some? (find-by-testid tree "rf-xray-static-icon-settings"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-icon-settings"))
             "settings icon present")
-        (is (some? (find-by-testid tree "rf-xray-static-icon-close"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-icon-close"))
             "close icon present")
         ;; Spine-coupled clusters MUST NOT mount in Static surface
-        (is (nil? (find-by-testid tree "rf-xray-ribbon-nav"))
+        (is (nil? (th/find-by-testid tree "rf-xray-ribbon-nav"))
             "no nav cluster")
-        (is (nil? (find-by-testid tree "rf-xray-ribbon-filters"))
+        (is (nil? (th/find-by-testid tree "rf-xray-ribbon-filters"))
             "no filter pills")))))
 
 ;; -------------------------------------------------------------------------
@@ -265,7 +233,7 @@
     (rf/with-frame :rf/xray
       (let [tree (static-shell/surface)]
         (doseq [tab-id expected-static-tab-ids]
-          (is (some? (find-by-testid tree (str "rf-xray-static-tab-" (name tab-id))))
+          (is (some? (th/find-by-testid tree (str "rf-xray-static-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))
 
 (deftest static-tab-bar-uses-tablist-aria
@@ -275,7 +243,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree    (static-shell/surface)
-            tab-bar (find-by-testid tree "rf-xray-static-tab-bar")
+            tab-bar (th/find-by-testid tree "rf-xray-static-tab-bar")
             attrs   (second tab-bar)]
         (is (= "tablist" (:role attrs))
             "container carries role='tablist'")
@@ -283,7 +251,7 @@
             "container has an accessible name"))
       (let [tree (static-shell/surface)]
         (doseq [tab-id expected-static-tab-ids]
-          (let [btn   (find-by-testid tree (str "rf-xray-static-tab-" (name tab-id)))
+          (let [btn   (th/find-by-testid tree (str "rf-xray-static-tab-" (name tab-id)))
                 attrs (second btn)]
             (is (= "tab" (:role attrs))
                 (str "tab " tab-id " carries role='tab'"))
@@ -304,9 +272,9 @@
     (rf/with-frame :rf/xray
       (frame-dispatch [:rf.xray.static/select-tab :machines])
       (let [tree (static-shell/surface)]
-        (is (some? (find-by-testid tree "rf-xray-static-machines-panel"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-machines-panel"))
             "live Machines panel mounts")
-        (is (nil? (find-by-testid tree "rf-xray-static-placeholder-machines"))
+        (is (nil? (th/find-by-testid tree "rf-xray-static-placeholder-machines"))
             "no placeholder card renders for :machines")))))
 
 ;; -------------------------------------------------------------------------
@@ -375,12 +343,12 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree (mode-pill/mode-pill)]
-        (is (some? (find-by-testid tree "rf-xray-mode-pill"))
+        (is (some? (th/find-by-testid tree "rf-xray-mode-pill"))
             "the select control is present")
         (is (= :select (first tree)) "the control is a native <select>")
-        (is (some? (find-by-testid tree "rf-xray-mode-pill-dynamic"))
+        (is (some? (th/find-by-testid tree "rf-xray-mode-pill-dynamic"))
             "Dynamic option present")
-        (is (some? (find-by-testid tree "rf-xray-mode-pill-static"))
+        (is (some? (th/find-by-testid tree "rf-xray-mode-pill-static"))
             "Static option present")))))
 
 (deftest mode-dropdown-reflects-active-mode
@@ -415,11 +383,11 @@
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
       (let [tree (shell/surface-composer)]
-        (is (some? (find-by-testid tree "rf-xray-static-surface"))
+        (is (some? (th/find-by-testid tree "rf-xray-static-surface"))
             "Static surface mounts")
-        (is (nil? (find-by-testid tree "rf-xray-ribbon"))
+        (is (nil? (th/find-by-testid tree "rf-xray-ribbon"))
             "Dynamic ribbon does NOT mount")
-        (is (nil? (find-by-testid tree "rf-xray-event-list"))
+        (is (nil? (th/find-by-testid tree "rf-xray-event-list"))
             "Dynamic L2 event list does NOT mount")))))
 
 (deftest surface-composer-renders-dynamic-when-mode-dynamic
@@ -429,9 +397,9 @@
     (frame-dispatch [:rf.xray/set-mode :dynamic])
     (rf/with-frame :rf/xray
       (let [tree (shell/surface-composer)]
-        (is (some? (find-by-testid tree "rf-xray-ribbon"))
+        (is (some? (th/find-by-testid tree "rf-xray-ribbon"))
             "Dynamic ribbon mounts")
-        (is (nil? (find-by-testid tree "rf-xray-static-surface"))
+        (is (nil? (th/find-by-testid tree "rf-xray-static-surface"))
             "Static surface does NOT mount")))))
 
 (deftest ribbon-always-mounts-mode-pill
@@ -441,7 +409,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree (shell/ribbon nil)]
-        (is (some? (find-by-testid tree "rf-xray-mode-pill"))
+        (is (some? (th/find-by-testid tree "rf-xray-mode-pill"))
             "mode pill mounts in the Dynamic ribbon unconditionally")))))
 
 ;; -------------------------------------------------------------------------
@@ -464,8 +432,8 @@
     (frame-dispatch [:rf.xray/set-mode :dynamic])
     (rf/with-frame :rf/xray
       (let [tree (shell/surface-composer)]
-        (is (or (some? (find-by-testid tree "rf-xray-ribbon-frame-picker"))
-                (some? (find-by-testid tree "rf-xray-ribbon-frame")))
+        (is (or (some? (th/find-by-testid tree "rf-xray-ribbon-frame-picker"))
+                (some? (th/find-by-testid tree "rf-xray-ribbon-frame")))
             "L1 frame picker (or single-frame label) present in Dynamic")))))
 
 (deftest l1-frame-picker-mounts-in-static-mode
@@ -478,8 +446,8 @@
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
       (let [tree (shell/surface-composer)]
-        (is (or (some? (find-by-testid tree "rf-xray-ribbon-frame-picker"))
-                (some? (find-by-testid tree "rf-xray-ribbon-frame")))
+        (is (or (some? (th/find-by-testid tree "rf-xray-ribbon-frame-picker"))
+                (some? (th/find-by-testid tree "rf-xray-ribbon-frame")))
             "L1 frame picker (or single-frame label) present in Static")))))
 
 ;; -------------------------------------------------------------------------


### PR DESCRIPTION
Second (final) axis of **rf2-vj80u8 "Centralize Xray test scaffolding"** — the **private hiccup-walker dedup**. The fixture axis merged in #5515; this completes the bead.

## What changed

Replaced the semantically-matching private hiccup-walker copies across `tools/xray/test/**` with direct `re-frame.test-helpers` (`th/*`) calls — **no Xray walker facade**. Deleted the now-dead private `expand-tree` / `hiccup-seq` / `find-by-testid` / `find-all-by-testid*` / `text-nodes` / `collect-text` / `props` / `find-by-id` copies.

**20 files deduped.** Three shapes, all matching the exemplar/precedent already on `main` (Static-panel exemplar #5461 + `trace_view`):

- **Full delete-direct** (walker used only inside `find-*`): call `th/find-by-testid` / `th/find-by-testid-prefix` / `th/find-all-by-testid` / `th/text-content` / `th/attrs` / `th/find-by-attr` directly. Files: `modals_aria`, `events_list_seam`, `spine_filters`, `resize_handle`, `settings/editor_hint`, `filters/right_click_integration`, `filters/hidden_indicator`, `filters/pills`, `static/machines/panel`, `event_list_resizable_cols`, `palette/aria`, `panels/app_db_segment_inspector`, `static/shell`, `settings/popup_dispatch_routing`, `filters/edit_popup`.
- **Rebuild** (file uses `hiccup-seq` directly — not exposed by test-helpers): keep a one-line `hiccup-seq` over `th/expand-tree`, delete the private `expand-tree`, route `find-*` to `th/*`. Files: `shell`, `p3_polish_aria`, `frame_switcher`, `static/machines/browse_list`.
- **Frame-scoped wrapper** kept deliberately (not a walker difference): `palette/dispatch_routing` retains its `with-frame` wrapper but delegates the walk to `th/find-by-testid`.

Bespoke helpers with no canonical equivalent were expressed over the exposed primitives where clean (`all-testids` / `testids-with-prefix` → `th/find-by-testid-prefix`; `count-by-testid` → count over `th/find-all-by-testid`), or kept as thin one-liners over the canonical-backed `hiccup-seq` (`find-all-with-pred`, `all-strings`, `placeholder-values`).

## Left bespoke (genuine semantic difference — per-file judgment, noted in-file)

These carry a walker that does **not** match `th/*` semantics, so per the pre-alpha stance they stay:

- **Non-expanding raw walkers** (`tree-seq` with no fn-component expansion — `th/find-by-testid` expands form-1/2/3, which is a real behavioural change and, on form-2 leaves like `edn-inspector`, errors): `panels/app_db_diff_state`, `panels/cancellation_cascade`, `panels/machine_canvas`, `panels/routing`, `panels/resources`, `static/routes/simulate_url`, `static/routes/simulate_nav`, `static/machines/sim`, `views/edn_inspector_popup_wireup`.
- **Structural-only expansion** (`panels/app_db_diff` — expands the keyed wrapper but deliberately leaves the `edn-inspector` leaf un-expanded), **root-only expansion + `find-all-by-role`** (`static/routes/panel`).
- **`walk-hiccup`/`collect-text` on non-expanded trees, asserting on form-2 mount forms**: `views/edn_inspector`, `views/edn_inspector_default_formatters`, `views/edn_inspector_protocol`, `views/edn_inspector_popup`, `views/edn_widget`, `theme/section`.

`shell`'s `text-nodes` is likewise kept bespoke: it folds **string** leaves only, whereas `th/text-content` also folds in numbers — `shell` asserts exact/empty text, so the distinction is load-bearing.

## Stance

Pre-alpha; no back-compat shims. ELEGANCE + CLARITY + CORRECTNESS. Only replaced where canonical `re-frame.test-helpers` semantics **match**; genuinely-different walkers left in place with a one-line rationale each.

## Xray spec

Test internals only — **spec unchanged**. Not hot-zone.

## Quality gates (foreground, on the rebased-onto-`origin/main` branch)

- `cd tools/xray && clojure -M:test` → **1233 tests, 5729 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` (node-test build runs `tools/xray/test`) → **8494 tests, 39313 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` → **PASS** (41 internal sentinels absent from prod bundles; uix/helix reagent-free)
- `npm run test:xray-feature-gate` → **16 scenarios, 0 failures**, 13 matrix rows
