### PR TITLE
fix(mcp-conformance): enforce the closed rf.mcp/overflow wrapper across both result slots (rf2-3fc89f.20)

### DIFF
--- a/tools/mcp-conformance/lib/overflow-marker.cjs
+++ b/tools/mcp-conformance/lib/overflow-marker.cjs
@@ -1,0 +1,216 @@
+// Pure, side-effect-free parsing + validation for the canonical
+// `:rf.mcp/overflow` wire marker (rf2-3fc89f.20).
+//
+// ## Why this is a standalone helper
+//
+// The live gate `test/live-re-frame2-pair-overflow.cjs` used to carry the
+// overflow parsing/validation inline. That file's top-level SKIP path
+// (`runWithWatchdog.skip` when `$SHADOW_CLJS_NREPL_PORT` is unset) exits
+// the process before any function is reachable, so Node's `--test` unit
+// runner cannot exercise the parser directly. Extracting the pure logic
+// here makes every branch unit-testable without booting a server — the
+// live gate now imports from this module and adds only the on-the-wire
+// ceremony (SDK spawn, the real over-budget eval, dual-slot reads).
+//
+// ## The contract this enforces
+//
+// The JVM wire-vocab schema pins the wrapper as
+// `Overflow = [:map {:closed true} [:rf.mcp/overflow ReFrame2PairOverflowBody]]`
+// (`wire-vocab/.../schemas.clj`). CLOSED and SINGLE-KEY is load-bearing:
+// clients pattern-match on exactly one reserved top-level discriminator
+// key, so a mixed envelope such as
+// `{:rf.mcp/overflow {...} :unexpected "sibling"}` — which the pre-fix
+// extraction-only parser accepted, returning the inner body regardless of
+// siblings — is a contract break. The body itself stays OPEN/additive
+// (`ReFrame2PairOverflowBody` is `{:closed false}`): future additive
+// fields inside the marker are fine, extra keys OUTSIDE the wrapper are not.
+//
+// ## EDN vs structuredContent — one shape, two representations
+//
+// re-frame2-pair-mcp writes the SAME marker into BOTH result slots:
+//   - `content[0].text` — the `pr-str` EDN string; `edn-data` with
+//     `keywordAs: 'string'` parses `:rf.mcp/overflow` to the bare string
+//     `'rf.mcp/overflow'` and keyword values to bare strings.
+//   - `structuredContent` — the namespace-preserving `clj->js` projection
+//     (`tools/wire.cljs qualify-keywords`), a JS object whose top-level
+//     key is the same bare string `'rf.mcp/overflow'` and whose keyword
+//     values print identically.
+// Both therefore normalise to the SAME plain-object shape, so one
+// validator covers both slots and the two bodies can be compared for
+// semantic equality (`assertBodiesAgree`) to prove they cannot drift.
+
+'use strict';
+
+const { parseEDNString } = require('edn-data');
+
+// The single reserved top-level wrapper key. Sourced cross-MCP from
+// `re-frame.mcp-base.vocab/overflow-key`; on the JS side both slots
+// present it as this bare string (see the module header).
+const OVERFLOW_KEY = 'rf.mcp/overflow';
+
+// `edn-data` parse opts pinned for the whole harness: map → plain JS
+// object, keyword → bare string (no `:` prefix), set → array. The
+// bare-string keyword form matches Node's JSON-native sensibilities and
+// makes assertions read directly (`body.limit === 'reached'`).
+const EDN_PARSE_OPTS = { mapAs: 'object', keywordAs: 'string', setAs: 'array' };
+
+// Required-field table for `:rf.mcp/overflow` (re-frame2-pair-mcp shape). Each
+// row pins one Malli `ReFrame2PairOverflowBody` field, the expected value
+// shape, and a description for the error message. Adding / removing a
+// row MUST stay in lockstep with the Malli schema in
+// `wire-vocab/test/.../wire_vocab_test.clj` (`ReFrame2PairOverflowBody`); the
+// cross-encoding grep gate (`js-assertOverflowBody-pins-every-re-frame2-pair-
+// overflow-required-field`) reads THIS data table by name (it slurps this
+// file — see `live-re-frame2-pair-overflow-js-rel`) so a drift in either
+// direction trips the JVM-side test.
+const REQUIRED_FIELDS = [
+  ['limit',       (v) => v === 'reached',          'enum :reached'],
+  ['cap-tokens',  (v) => typeof v === 'number',    'int'],
+  ['token-count', (v) => typeof v === 'number',    'int'],
+  ['tool',        (v) => typeof v === 'string',    'string|keyword'],
+  ['hint',        (v) => typeof v === 'string',    'string|keyword'],
+];
+
+// A non-null, non-array object. EDN maps parse to plain objects; EDN
+// vectors AND sets parse to arrays (`setAs: 'array'`), so this rejects
+// both. `structuredContent` bodies are plain objects too.
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// Validate the OUTER parsed value is the CLOSED single-key overflow
+// wrapper — a non-array object whose OWN-KEY SET is EXACTLY
+// `["rf.mcp/overflow"]`. Returns the inner body on success; throws on any
+// other shape (missing key, a lookalike such as `rf.mcp/overflowed`,
+// an array/scalar, or ANY sibling top-level key). This is the guard the
+// pre-fix extraction-only parser lacked: it read `outer['rf.mcp/overflow']`
+// without ever checking it was the sole top-level key.
+function unwrapClosedOverflow(outer, ctx) {
+  if (!isPlainObject(outer)) {
+    throw new Error(
+      ctx + ': overflow wrapper is not a map: ' + JSON.stringify(outer),
+    );
+  }
+  const keys = Object.keys(outer);
+  if (keys.length !== 1 || keys[0] !== OVERFLOW_KEY) {
+    throw new Error(
+      ctx + ': overflow wrapper MUST be the CLOSED single-key map ' +
+        '{:' + OVERFLOW_KEY + ' ...}; got own-key set ' + JSON.stringify(keys) +
+        '. The JVM contract pins `Overflow` = [:map {:closed true} ' +
+        '[:rf.mcp/overflow ...]] — any sibling top-level key (or a ' +
+        'lookalike wrapper key) is a mixed-envelope violation a client ' +
+        'pattern-matching on the single reserved discriminator would ' +
+        'misclassify.',
+    );
+  }
+  return outer[OVERFLOW_KEY];
+}
+
+// Validate the parsed `:rf.mcp/overflow` body against the canonical
+// `ReFrame2PairOverflowBody` shape. The body is OPEN (additive fields are
+// permitted); only the required fields + the cross-field invariant are
+// enforced. Returns the body on success; throws otherwise.
+function assertOverflowBody(body, ctx) {
+  if (!isPlainObject(body)) {
+    throw new Error(ctx + ': overflow body is not a map: ' + JSON.stringify(body));
+  }
+  for (const [field, ok, desc] of REQUIRED_FIELDS) {
+    if (!ok(body[field])) {
+      throw new Error(
+        ctx + ': :' + field + ' MUST be ' + desc +
+          '; got ' + JSON.stringify(body[field]) +
+          '. (Schema: ReFrame2PairOverflowBody.' + field + ' : ' + desc + ')',
+      );
+    }
+  }
+  // Cross-field invariant: a tripped cap MUST report token-count
+  // strictly greater than cap-tokens. Malli's `[:map ...]` doesn't
+  // model cross-field relationships; this is the only gate.
+  if (body['token-count'] <= body['cap-tokens']) {
+    throw new Error(
+      ctx + ': :token-count MUST exceed :cap-tokens for a tripped cap; got ' +
+        body['token-count'] + ' ≤ ' + body['cap-tokens'],
+    );
+  }
+  return body;
+}
+
+// Validate an ALREADY-PARSED wrapper object (from either result slot) end
+// to end: closed single-key wrapper + body shape + invariant. Returns the
+// validated body.
+function validateOverflowWrapper(outer, ctx) {
+  const body = unwrapClosedOverflow(outer, ctx);
+  return assertOverflowBody(body, ctx);
+}
+
+// Parse the `content[0].text` EDN string into its outer value. Throws with
+// context on a non-string input or unparseable EDN — a real EDN reader
+// (`edn-data`) handles nested-map / escape-sequence shapes robustly.
+function parseOverflowText(text, ctx) {
+  if (typeof text !== 'string') {
+    throw new Error(ctx + ': overflow text is not a string: ' + JSON.stringify(text));
+  }
+  try {
+    return parseEDNString(text, EDN_PARSE_OPTS);
+  } catch (e) {
+    throw new Error(
+      ctx + ': overflow text is not parseable EDN: ' + e.message +
+        '\n  First 200 chars: ' + text.slice(0, 200),
+    );
+  }
+}
+
+// Convenience: parse the text slot and validate it as a closed overflow
+// wrapper, returning the validated body.
+function validateOverflowText(text, ctx) {
+  return validateOverflowWrapper(parseOverflowText(text, ctx), ctx);
+}
+
+// Recursively sort object keys so two structurally-equal bodies with
+// different key insertion order (EDN parse order vs `clj->js` projection
+// order) serialise identically for comparison.
+function canonicalize(v) {
+  if (Array.isArray(v)) return v.map(canonicalize);
+  if (isPlainObject(v)) {
+    const out = {};
+    for (const k of Object.keys(v).sort()) out[k] = canonicalize(v[k]);
+    return out;
+  }
+  return v;
+}
+
+// Structural equality of two marker bodies, order-insensitive.
+function bodiesEqual(a, b) {
+  return JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b));
+}
+
+// Assert the text-slot body and the structuredContent-slot body agree
+// exactly. The two slots carry projections of the SAME marker; a drift
+// (a field present in one but not the other, or a differing value) means
+// the dual representations diverged — a client reading structuredContent
+// would see a different marker than one reading the text. Throws on drift.
+function assertBodiesAgree(textBody, structuredBody, ctx) {
+  if (!bodiesEqual(textBody, structuredBody)) {
+    throw new Error(
+      ctx + ': overflow marker bodies DRIFTED between content[0].text and ' +
+        'structuredContent — the two slots MUST project the same marker.\n' +
+        '  content[0].text  : ' + JSON.stringify(canonicalize(textBody)) + '\n' +
+        '  structuredContent: ' + JSON.stringify(canonicalize(structuredBody)),
+    );
+  }
+}
+
+module.exports = {
+  OVERFLOW_KEY,
+  EDN_PARSE_OPTS,
+  REQUIRED_FIELDS,
+  isPlainObject,
+  unwrapClosedOverflow,
+  assertOverflowBody,
+  validateOverflowWrapper,
+  parseOverflowText,
+  validateOverflowText,
+  canonicalize,
+  bodiesEqual,
+  assertBodiesAgree,
+};

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -61,6 +61,10 @@ const TESTS = [
     argv: ['--test', 'test/token-match.test.cjs'],
   },
   {
+    name: 'overflow marker: closed single-key wrapper + dual-slot agreement',
+    argv: ['--test', 'test/overflow-marker.test.cjs'],
+  },
+  {
     name: 'universal isError and :ok? cross-check after dedup decoding',
     argv: ['--test', 'test/is-error-matches-ok.test.cjs'],
   },

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -79,18 +79,33 @@
 // through `runWithWatchdog.skip`, and the spawn+connect+teardown ceremony
 // is `_runner.cjs`'s `connectServer` / `closeQuietly` (the redaction arm's
 // second-server boot uses it directly). What is NOT shared — by design —
-// is each variant's data-driven field validator (`REQUIRED_FIELDS` +
-// `assertOverflowBody` here; `REQUIRED_PARAMS` + `assertProgressParams` in
-// subscribe). Each pins a DISTINCT Malli schema (`ReFrame2PairOverflowBody`
-// vs `ReFrame2PairProgressNotificationParams`) and the JVM cross-encoding
-// gate in `wire_vocab_test.clj` greps each function's literal source rows
-// by name — collapsing them into one generic helper would dissolve that
-// per-schema attribution and weaken the conformance contract.
+// is each variant's data-driven field validator: this variant's overflow
+// parsing/validation lives in the overflow-SPECIFIC `lib/overflow-marker.cjs`
+// (`REQUIRED_FIELDS` + `assertOverflowBody` + the closed-wrapper guard),
+// while subscribe keeps `REQUIRED_PARAMS` + `assertProgressParams` inline.
+// Each pins a DISTINCT Malli schema (`ReFrame2PairOverflowBody` vs
+// `ReFrame2PairProgressNotificationParams`) and the JVM cross-encoding gate
+// in `wire_vocab_test.clj` greps each validator's literal source rows by
+// name — collapsing them into one GENERIC helper would dissolve that
+// per-schema attribution and weaken the conformance contract. (The overflow
+// helper was extracted so its pure logic is unit-testable off the live
+// path; it is not shared with subscribe.)
 
 const path = require('node:path');
 const os = require('node:os');
-const { parseEDNString } = require('edn-data');
 const { runWithWatchdog } = require('./_runner.cjs');
+// Pure overflow parsing/validation lives in `lib/overflow-marker.cjs` so
+// it is unit-testable without booting a server (this file's top-level
+// SKIP path exits before any function is reachable). It owns the
+// CLOSED single-key wrapper enforcement, the `REQUIRED_FIELDS` body table,
+// the token-count invariant, and the dual-slot agreement check. The JVM
+// cross-encoding grep gate (`js-assertOverflowBody-pins-every-re-frame2-pair-
+// overflow-required-field`) slurps that helper's `REQUIRED_FIELDS` rows.
+const {
+  validateOverflowText,
+  validateOverflowWrapper,
+  assertBodiesAgree,
+} = require('../lib/overflow-marker.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -111,76 +126,6 @@ const DEFAULT_MAX_TOKENS = 5000;
 // (large enough to trip, not so large that an unrelated overflow
 // path kicks in first).
 const FORM_OVER_BUDGET = '(apply str (repeat 25000 "x"))';
-
-// `edn-data` parse opts pinned for the whole harness: map → plain JS
-// object, keyword → bare string (no `:` prefix), set → array. The
-// bare-string keyword form matches Node's JSON-native sensibilities and
-// makes assertions read directly (`body.limit === 'reached'`). Drift in
-// the EDN shape surfaces as a parse exception on a real EDN reader.
-const EDN_PARSE_OPTS = { mapAs: 'object', keywordAs: 'string', setAs: 'array' };
-
-// Required-field table for `:rf.mcp/overflow` (re-frame2-pair-mcp shape). Each
-// row pins one Malli `ReFrame2PairOverflowBody` field, the expected value
-// shape, and a description for the error message. Adding / removing a
-// row MUST stay in lockstep with the Malli schema in
-// `wire-vocab/test/.../wire_vocab_test.clj` (`ReFrame2PairOverflowBody`); the
-// cross-encoding grep gate (`js-assertOverflowBody-pins-every-re-frame2-pair-
-// overflow-required-field`) reads this same data table by name so a
-// drift in either direction trips the JVM-side test.
-const REQUIRED_FIELDS = [
-  ['limit',       (v) => v === 'reached',          'enum :reached'],
-  ['cap-tokens',  (v) => typeof v === 'number',    'int'],
-  ['token-count', (v) => typeof v === 'number',    'int'],
-  ['tool',        (v) => typeof v === 'string',    'string|keyword'],
-  ['hint',        (v) => typeof v === 'string',    'string|keyword'],
-];
-
-// Validate the parsed `:rf.mcp/overflow` body against the canonical
-// `ReFrame2PairOverflowBody` shape.
-function assertOverflowBody(body, ctx) {
-  if (!body || typeof body !== 'object') {
-    throw new Error(ctx + ': overflow body is not a map: ' + JSON.stringify(body));
-  }
-  for (const [field, ok, desc] of REQUIRED_FIELDS) {
-    if (!ok(body[field])) {
-      throw new Error(
-        ctx + ': :' + field + ' MUST be ' + desc +
-          '; got ' + JSON.stringify(body[field]) +
-          '. (Schema: ReFrame2PairOverflowBody.' + field + ' : ' + desc + ')',
-      );
-    }
-  }
-  // Cross-field invariant: a tripped cap MUST report token-count
-  // strictly greater than cap-tokens. Malli's `[:map ...]` doesn't
-  // model cross-field relationships; this is the only gate.
-  if (body['token-count'] <= body['cap-tokens']) {
-    throw new Error(
-      ctx + ': :token-count MUST exceed :cap-tokens for a tripped cap; got ' +
-        body['token-count'] + ' ≤ ' + body['cap-tokens'],
-    );
-  }
-}
-
-// Parse the canonical re-frame2-pair-mcp overflow marker from response
-// text. `edn-data` (~30KB, zero transitive deps) is a real EDN reader
-// that handles nested-map / escape-sequence shapes robustly. Returns the
-// inner body map (a plain JS object with bare-string keys) or null when
-// the marker is absent / the text is unparseable.
-function parseOverflowMarker(text) {
-  let outer;
-  try {
-    outer = parseEDNString(text, EDN_PARSE_OPTS);
-  } catch (_e) {
-    return null;
-  }
-  if (!outer || typeof outer !== 'object') return null;
-  // The marker is `{:rf.mcp/overflow {...}}` — with `keywordAs:
-  // 'string'` the top-level key arrives as the bare string
-  // `'rf.mcp/overflow'`. Any other shape (a longer envelope wrapping
-  // the marker, an `:ok? true` success that means apply-cap missed)
-  // is rejected.
-  return outer['rf.mcp/overflow'] || null;
-}
 
 // Pre-flight SKIP: route through the runner's shared skip helper so we
 // don't spawn a child or install a watchdog. Same posture as the sibling
@@ -253,11 +198,13 @@ runWithWatchdog(
     }
     console.log('OK   tools/call eval-cljs -> SDK accepts envelope, isError=false');
 
-    // 4. The content slot must hold the canonical `:rf.mcp/overflow`
-    // marker. We read the EDN text and parse the inner map. Any
-    // surrounding `{:ok? true :value "xxxxx..."}` reaching the wire
-    // would indicate `apply-cap` failed to trigger — the load-bearing
-    // bug this variant guards against.
+    // 4. The `content[0].text` slot must hold the canonical
+    // `:rf.mcp/overflow` marker. We read the EDN text and validate it as
+    // the CLOSED single-key wrapper — a surrounding `{:ok? true :value
+    // "xxxxx..."}` (apply-cap missed) OR a mixed envelope smuggling a
+    // sibling top-level key past the wrapper (the rf2-3fc89f.20 hole) is
+    // rejected. The friendly presence check first distinguishes "cap
+    // didn't trigger" from "cap triggered but shape wrong".
     const text = callResp.content?.[0]?.text;
     if (typeof text !== 'string') {
       throw new Error('content[0].text is not a string: ' + JSON.stringify(callResp));
@@ -271,20 +218,46 @@ runWithWatchdog(
     }
     console.log('OK   response text carries :rf.mcp/overflow marker key');
 
-    // 5. Schema-validate the marker body against the canonical
-    // ReFrame2PairOverflowBody shape pinned by wire-vocab. This is the
-    // cross-server vocabulary assertion: re-frame2-pair-mcp's wire emission
-    // MUST satisfy the same shape as the wire-vocab fixture.
-    const body = parseOverflowMarker(text);
-    if (!body) {
-      throw new Error(
-        'Could not parse `:rf.mcp/overflow` body from response text.\n' +
-          'First 500 chars: ' +
-          text.slice(0, 500),
-      );
-    }
-    assertOverflowBody(body, 'eval-cljs live overflow');
-    console.log('OK   marker body validates against canonical ReFrame2PairOverflowBody schema');
+    // 5. Validate the text-slot marker: closed single-key wrapper +
+    // canonical `ReFrame2PairOverflowBody` body + the token-count >
+    // cap-tokens invariant. This is the cross-server vocabulary
+    // assertion: re-frame2-pair-mcp's wire emission MUST satisfy the same
+    // shape as the wire-vocab fixture AND the JVM `Overflow` schema's
+    // `{:closed true}` single-key posture.
+    const textBody = validateOverflowText(text, 'eval-cljs live overflow (content[0].text)');
+    console.log('OK   content[0].text validates as the CLOSED :rf.mcp/overflow wrapper + body');
+
+    // 5b. Validate the SECOND result slot — `structuredContent`. Pair
+    // MCP writes the SAME marker into BOTH `content[0].text` (pr-str EDN)
+    // and `structuredContent` (the namespace-preserving `clj->js`
+    // projection, see `tools/cap.cljs build-overflow-result` →
+    // `wire/result`). Before rf2-3fc89f.20 the live gate never inspected
+    // structuredContent, so it could lose the namespace, gain siblings,
+    // or carry a different body while text stayed canonical and CI still
+    // reported green. `structuredContent` arrives as an already-parsed JS
+    // object whose top-level key is the bare string `"rf.mcp/overflow"`,
+    // so the SAME closed-wrapper validator applies.
+    const structured = callResp.structuredContent;
+    const structuredBody = validateOverflowWrapper(
+      structured,
+      'eval-cljs live overflow (structuredContent)',
+    );
+    console.log('OK   structuredContent validates as the CLOSED :rf.mcp/overflow wrapper + body');
+
+    // 5c. Prove the two slots agree. A drift (a field present in one but
+    // not the other, or a differing value) means the dual representations
+    // diverged — a client reading structuredContent would see a different
+    // marker than one reading the text.
+    assertBodiesAgree(
+      textBody,
+      structuredBody,
+      'eval-cljs live overflow (dual-slot)',
+    );
+    console.log('OK   content[0].text and structuredContent marker bodies agree');
+
+    // The semantic pins below read the text-slot body (byte-identical to
+    // the structured body per 5c).
+    const body = textBody;
 
     // 6. Pin the load-bearing semantic facts about the marker:
     //   - :cap-tokens MUST equal the documented default (5000).
@@ -298,7 +271,7 @@ runWithWatchdog(
     // EDN keywords as bare strings (no `:` prefix), so `body.foo` reads
     // directly. The Malli-side schema names the same fields as kebab-
     // case keywords; the cross-encoding gate in `wire_vocab_test.clj`
-    // greps for the JS-side substrings below.
+    // greps the `REQUIRED_FIELDS` rows in `lib/overflow-marker.cjs`.
     if (body['cap-tokens'] !== DEFAULT_MAX_TOKENS) {
       throw new Error(
         ':cap-tokens MUST equal default ' +

--- a/tools/mcp-conformance/test/overflow-marker.test.cjs
+++ b/tools/mcp-conformance/test/overflow-marker.test.cjs
@@ -1,0 +1,216 @@
+// Unit tests for `lib/overflow-marker.cjs` (rf2-3fc89f.20).
+//
+// ## The bug this pins
+//
+// The live gate `live-re-frame2-pair-overflow.cjs` used to parse the EDN and
+// return `outer['rf.mcp/overflow']` WITHOUT checking that key was the sole
+// top-level key. A mixed envelope
+// `{:rf.mcp/overflow {...valid body...} :unexpected "sibling"}` therefore
+// reached the body assertions and PASSED, even though the JVM contract pins
+// `Overflow = [:map {:closed true} [:rf.mcp/overflow ...]]` — CLOSED and
+// SINGLE-KEY, because clients pattern-match on exactly one reserved
+// discriminator key. The live gate also validated only `content[0].text`
+// and never `structuredContent`, so the two slots could drift silently.
+//
+// ## What this proves
+//
+// Test 1 is the RED-then-GREEN proof: it first shows the pre-fix
+// extraction-only logic (replicated inline) ACCEPTS the malformed mixed
+// envelope, then shows the new closed-wrapper validator REJECTS it. The
+// remaining tests cover the lookalike-key / array / multi-key / missing
+// rejections, additive-body acceptance, the required-field + token-count
+// invariants, and the dual-slot agreement check.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseEDNString } = require('edn-data');
+const {
+  EDN_PARSE_OPTS,
+  isPlainObject,
+  unwrapClosedOverflow,
+  assertOverflowBody,
+  validateOverflowWrapper,
+  validateOverflowText,
+  bodiesEqual,
+  assertBodiesAgree,
+} = require('../lib/overflow-marker.cjs');
+
+// A canonical, well-formed body reused across cases.
+function validBody(overrides) {
+  return Object.assign(
+    {
+      limit: 'reached',
+      'cap-tokens': 5000,
+      'token-count': 6250,
+      tool: 'eval-cljs',
+      hint: 'Slice the value at the call-site before returning.',
+    },
+    overrides,
+  );
+}
+
+// The exact malformed shape from the bead reproduction.
+const MALFORMED_MIXED_ENVELOPE =
+  '{:rf.mcp/overflow {:limit :reached :cap-tokens 5000 :token-count 6250 ' +
+  ':tool "eval-cljs" :hint "Slice"} :unexpected "sibling"}';
+
+// The pre-fix extraction-only logic, replicated so the RED half of test 1
+// can demonstrate the exact false-pass this bug allowed.
+function legacyExtractionOnly(text) {
+  let outer;
+  try {
+    outer = parseEDNString(text, EDN_PARSE_OPTS);
+  } catch (_e) {
+    return null;
+  }
+  if (!outer || typeof outer !== 'object') return null;
+  return outer['rf.mcp/overflow'] || null;
+}
+
+test('RED-then-GREEN: legacy extraction-only accepts an extra top-level sibling; the closed-wrapper validator rejects it', () => {
+  // RED: the pre-fix logic returns the valid inner body even though the
+  // envelope carries an unexpected sibling key — the exact false-green.
+  const legacy = legacyExtractionOnly(MALFORMED_MIXED_ENVELOPE);
+  assert.ok(
+    legacy && legacy.limit === 'reached',
+    'sanity: the extraction-only parser accepts the mixed envelope (the bug)',
+  );
+  // The outer genuinely has two top-level keys.
+  const outer = parseEDNString(MALFORMED_MIXED_ENVELOPE, EDN_PARSE_OPTS);
+  assert.deepEqual(Object.keys(outer).sort(), ['rf.mcp/overflow', 'unexpected']);
+  // GREEN: the closed-wrapper validator rejects the sibling key.
+  assert.throws(
+    () => validateOverflowText(MALFORMED_MIXED_ENVELOPE, 'test'),
+    /CLOSED single-key map/,
+    'closed-wrapper validator must reject a wrapper with a sibling top-level key',
+  );
+});
+
+test('unwrapClosedOverflow: rejects a lookalike wrapper key (rf.mcp/overflowed)', () => {
+  const outer = { 'rf.mcp/overflowed': validBody() };
+  assert.throws(() => unwrapClosedOverflow(outer, 'test'), /CLOSED single-key map/);
+});
+
+test('unwrapClosedOverflow: rejects a missing marker (empty map and a non-overflow envelope)', () => {
+  assert.throws(() => unwrapClosedOverflow({}, 'test'), /CLOSED single-key map/);
+  assert.throws(
+    () => unwrapClosedOverflow({ 'ok?': true, value: 'xxxxx' }, 'test'),
+    /CLOSED single-key map/,
+  );
+});
+
+test('unwrapClosedOverflow: rejects arrays and non-map scalars', () => {
+  assert.throws(() => unwrapClosedOverflow([validBody()], 'test'), /not a map/);
+  assert.throws(() => unwrapClosedOverflow(null, 'test'), /not a map/);
+  assert.throws(() => unwrapClosedOverflow('rf.mcp/overflow', 'test'), /not a map/);
+  assert.throws(() => unwrapClosedOverflow(42, 'test'), /not a map/);
+});
+
+test('unwrapClosedOverflow: rejects multiple top-level keys even when both look plausible', () => {
+  const outer = { 'rf.mcp/overflow': validBody(), 'rf.mcp/summary': { type: 'map' } };
+  assert.throws(() => unwrapClosedOverflow(outer, 'test'), /CLOSED single-key map/);
+});
+
+test('validateOverflowWrapper: accepts the canonical closed wrapper and returns the body', () => {
+  const body = validateOverflowWrapper({ 'rf.mcp/overflow': validBody() }, 'test');
+  assert.equal(body.tool, 'eval-cljs');
+  assert.equal(body['token-count'], 6250);
+});
+
+test('validateOverflowWrapper: accepts additive fields inside the (open) body', () => {
+  const body = validBody({ 'extra-field': 'ok', nested: { a: 1 } });
+  const out = validateOverflowWrapper({ 'rf.mcp/overflow': body }, 'test');
+  // The body is OPEN — additive keys survive validation untouched.
+  assert.equal(out['extra-field'], 'ok');
+  assert.deepEqual(out.nested, { a: 1 });
+});
+
+test('assertOverflowBody: rejects a body missing each required field', () => {
+  for (const field of ['limit', 'cap-tokens', 'token-count', 'tool', 'hint']) {
+    const body = validBody();
+    delete body[field];
+    assert.throws(
+      () => assertOverflowBody(body, 'test'),
+      new RegExp(':' + field + ' MUST be'),
+      'missing :' + field + ' must be rejected',
+    );
+  }
+});
+
+test('assertOverflowBody: rejects a wrong :limit enum and non-numeric token fields', () => {
+  assert.throws(() => assertOverflowBody(validBody({ limit: 'exceeded' }), 'test'), /:limit MUST be/);
+  assert.throws(() => assertOverflowBody(validBody({ 'cap-tokens': '5000' }), 'test'), /:cap-tokens MUST be/);
+  assert.throws(() => assertOverflowBody(validBody({ 'token-count': null }), 'test'), /:token-count MUST be/);
+});
+
+test('assertOverflowBody: rejects token-count <= cap-tokens (degenerate tripped cap)', () => {
+  // Equal is a violation: a tripped cap MUST strictly exceed the budget.
+  assert.throws(
+    () => assertOverflowBody(validBody({ 'cap-tokens': 5000, 'token-count': 5000 }), 'test'),
+    /token-count MUST exceed :cap-tokens/,
+  );
+  // Below the cap is a violation too.
+  assert.throws(
+    () => assertOverflowBody(validBody({ 'cap-tokens': 5000, 'token-count': 4999 }), 'test'),
+    /token-count MUST exceed :cap-tokens/,
+  );
+});
+
+test('validateOverflowText: parses a canonical EDN text slot and validates it', () => {
+  const text =
+    '{:rf.mcp/overflow {:limit :reached :cap-tokens 5000 :token-count 6250 ' +
+    ':tool "eval-cljs" :hint "Slice the value."}}';
+  const body = validateOverflowText(text, 'text-slot');
+  assert.equal(body.limit, 'reached');
+  assert.equal(body.tool, 'eval-cljs');
+});
+
+test('validateOverflowText: rejects garbage text and non-string input', () => {
+  // `edn-data` is lenient — most garbage parses to null/partial rather
+  // than throwing — so a truncated/garbage marker is rejected downstream
+  // as a non-overflow-wrapper. Either way the text is REJECTED, never
+  // accepted as a valid marker (the property that matters).
+  assert.throws(
+    () => validateOverflowText('{:rf.mcp/overflow', 'text-slot'),
+    /not a map|not parseable EDN|CLOSED single-key map/,
+  );
+  assert.throws(
+    () => validateOverflowText('}{ garbage', 'text-slot'),
+    /not a map|not parseable EDN|CLOSED single-key map/,
+  );
+  // A non-string text slot is rejected up front with clear context.
+  assert.throws(() => validateOverflowText(42, 'text-slot'), /not a string/);
+});
+
+test('assertBodiesAgree: accepts two order-different but structurally-equal bodies', () => {
+  const textBody = { limit: 'reached', 'cap-tokens': 5000, 'token-count': 6250, tool: 'eval-cljs', hint: 'x' };
+  // structuredContent projection would carry the same data in a different
+  // key order — bodiesEqual/assertBodiesAgree must be order-insensitive.
+  const structuredBody = { hint: 'x', tool: 'eval-cljs', 'token-count': 6250, 'cap-tokens': 5000, limit: 'reached' };
+  assert.equal(bodiesEqual(textBody, structuredBody), true);
+  assert.doesNotThrow(() => assertBodiesAgree(textBody, structuredBody, 'dual-slot'));
+});
+
+test('assertBodiesAgree: rejects dual-slot drift (differing value)', () => {
+  const textBody = validBody();
+  const structuredBody = validBody({ tool: 'snapshot' }); // drifted tool name
+  assert.equal(bodiesEqual(textBody, structuredBody), false);
+  assert.throws(() => assertBodiesAgree(textBody, structuredBody, 'dual-slot'), /DRIFTED/);
+});
+
+test('assertBodiesAgree: rejects dual-slot drift (extra field in one slot only)', () => {
+  const textBody = validBody();
+  const structuredBody = validBody({ 'leaked-sibling': 'only-in-structured' });
+  assert.equal(bodiesEqual(textBody, structuredBody), false);
+  assert.throws(() => assertBodiesAgree(textBody, structuredBody, 'dual-slot'), /DRIFTED/);
+});
+
+test('isPlainObject: distinguishes maps from arrays/null/scalars', () => {
+  assert.equal(isPlainObject({}), true);
+  assert.equal(isPlainObject([]), false);
+  assert.equal(isPlainObject(null), false);
+  assert.equal(isPlainObject('s'), false);
+  assert.equal(isPlainObject(1), false);
+});

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -917,7 +917,8 @@
 ;; ---------------------------------------------------------------------------
 ;; JS-vs-Malli `ReFrame2PairOverflowBody` cross-encoding sanity (rf2-0zqox).
 ;;
-;; `test/live-re-frame2-pair-overflow.cjs` hand-rolls `assertOverflowBody` as a JS
+;; `lib/overflow-marker.cjs` (imported by `test/live-re-frame2-pair-overflow.cjs`)
+;; hand-rolls `assertOverflowBody` as a JS
 ;; re-encoding of `ReFrame2PairOverflowBody`. The two encodings must agree on
 ;; the same contract — that's the whole point of pinning a vocabulary
 ;; conformance gate; a drift between the encodings is a vocabulary bug
@@ -944,8 +945,15 @@
 
 (def ^:private live-re-frame2-pair-overflow-js-rel
   "Relative path to the hand-rolled JS assertion. Single source of truth
-  — drift here surfaces against the slurp below."
-  "tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs")
+  — drift here surfaces against the slurp below.
+
+  rf2-3fc89f.20 extracted the pure overflow parsing/validation out of the
+  live gate into `lib/overflow-marker.cjs` (so its branches are
+  unit-testable off the SKIP-gated live path). The `REQUIRED_FIELDS` data
+  table + the token-count invariant this gate greps now live THERE; the
+  live `test/live-re-frame2-pair-overflow.cjs` imports them. Point the
+  slurp at the helper that owns the rows."
+  "tools/mcp-conformance/lib/overflow-marker.cjs")
 
 (def ^:private re-frame2-pair-overflow-js-required-grep-markers
   "Substrings the JS `assertOverflowBody` MUST contain to pin every


### PR DESCRIPTION
## What

The live overflow oracle (`test/live-re-frame2-pair-overflow.cjs`) had a load-bearing conformance false-green. Its `parseOverflowMarker` read `outer['rf.mcp/overflow']` **without** verifying that was the sole top-level key, so a mixed envelope such as `{:rf.mcp/overflow {...valid body...} :unexpected "sibling"}` reached the body assertions and **passed**. The gate also validated only `content[0].text` and **never** `structuredContent`, so the two result slots could drift (namespace loss, extra siblings, differing body) while the hermetic job stayed green.

The JVM contract pins the wrapper as `Overflow = [:map {:closed true} [:rf.mcp/overflow ReFrame2PairOverflowBody]]` (`wire-vocab/.../schemas.clj`) — CLOSED and SINGLE-KEY — because clients pattern-match on exactly one reserved discriminator key. The body itself stays OPEN/additive.

## Fix (per the bead design)

1. **`lib/overflow-marker.cjs`** (new) — the pure parsing/validation, side-effect-free so Node unit tests exercise every branch without the SKIP-gated live script. It validates the outer as a non-array object whose own-key set is **exactly** `["rf.mcp/overflow"]`, keeps the body open/additive while retaining the required-field types + the `token-count > cap-tokens` invariant, and adds a normalized dual-slot body-agreement check.
2. **Live gate** now validates BOTH `content[0].text` AND `structuredContent` as the closed wrapper, requires the namespace-preserving `rf.mcp/overflow` key in the structured slot, and asserts the two marker bodies agree.
3. **`test/overflow-marker.test.cjs`** (new) added to the authoritative `scripts/test-all.cjs` inventory → picked up by `npm run test:unit` + PR CI.
4. **JVM cross-encoding grep gate** repointed at `lib/overflow-marker.cjs`, which now owns the `REQUIRED_FIELDS` rows + the invariant it slurps.

## Stance

Pre-alpha; MCP wire markers are an AI-egress contract. The closed key set + dual-slot consistency are the load-bearing invariants here — enforce them at the gate. ELEGANCE + CLARITY + CORRECTNESS: pure helper, one validator covering both slots, no back-compat shims.

## Reproduce → fix evidence

Before (extraction-only logic), the exact bead reproduction:
```
$ node -e '<current parseOverflowMarker logic>' on
  "{:rf.mcp/overflow {...valid...} :unexpected \"sibling\"}"
top-level keys: ["rf.mcp/overflow","unexpected"]
CURRENT_ACCEPTS_MALFORMED body={"limit":"reached",...}
```
After: the `RED-then-GREEN` unit test replicates that extraction-only logic (shows it accepts), then proves the new closed-wrapper validator **rejects** the sibling key. Unit cases also reject a lookalike key (`rf.mcp/overflowed`), empty/non-overflow maps, arrays/non-maps, multiple top-level keys, each missing required field, `token-count <= cap-tokens`, and dual-slot drift (differing value / extra field in one slot); additive body fields are accepted.

## Quality gates

- `npm run test:unit` — **GREEN** (104 tests, 95 pass, 9 platform skips, 0 fail; +16 from the new suite via the `test-all.cjs` inventory).
- `clojure -M:test` (wire-vocab) — **GREEN** (100 tests, 1056 assertions, 0 failures, 0 errors; the repointed grep gate reads the helper's `REQUIRED_FIELDS`).
- Live gate SKIP path — clean exit 0 (helper `require` resolves); JS files `node --check` clean.
- `test:re-frame2-pair-live-hermetic-suite` — not run in this fresh worktree (it boots a full Chromium + shadow-cljs + nREPL pair fixture that isn't built here); it is the CI hermetic job's environment. The live gate's new logic delegates entirely to the unit-tested helper functions.

Closes rf2-3fc89f.20. Do not merge without review.
