### PR TITLE
fix(scripts): startLocalHttpServer awaits OWNED readiness by default — no foreign-tree false-green (rf2-3fc89f.14)

### DIFF
--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -618,9 +618,13 @@ test('publishOwnershipToken remove() preserves a newer overlapping run\'s replac
 // that replaces the per-caller `-a 127.0.0.1` argv-regex policy checks.
 
 // A fake bin that parses the http-server-shaped argv (positional root, `-a`,
-// `-p`), binds the requested host+port, serves 200 on any path, and records
-// the FULL composed argv (once listening) so the loopback/static composition
-// can be asserted directly.
+// `-p`), binds the requested host+port, and records the FULL composed argv
+// (once listening) so the loopback/static composition can be asserted directly.
+// It models a REAL static file server for the ownership sentinel: a request for
+// /.rf-harness-token is answered with the token file startLocalHttpServer
+// published under `root` (this is exactly how the real http-server serves the
+// dotfile — see serve-and-run-browser-tests.cjs), so the owned-readiness
+// handshake sees THIS run's token. Any other path -> 200 'ok'.
 const FAKE_HTTP_SERVER = `
 'use strict';
 const http = require('http');
@@ -634,10 +638,47 @@ for (let i = 0; i < argv.length; i++) {
   if (argv[i] === '-a') host = argv[i + 1];
   else if (argv[i] === '-p') port = Number(argv[i + 1]);
 }
-const server = http.createServer((_, res) => { res.writeHead(200); res.end('ok'); });
+const server = http.createServer((req, res) => {
+  const url = (req.url || '/').split('?')[0];
+  if (url === '/.rf-harness-token') {
+    try {
+      const body = fs.readFileSync(path.join(root, '.rf-harness-token'), 'utf8');
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(body);
+    } catch (_) {
+      res.writeHead(404);
+      res.end('no token');
+    }
+    return;
+  }
+  res.writeHead(200);
+  res.end('ok');
+});
 server.listen(port, host, () => {
   fs.writeFileSync(path.join(root, '.fake-argv.json'), JSON.stringify(argv));
 });
+`;
+
+// A fake that parses the http-server-shaped argv, tries to bind the SAME
+// host+port, and exits 3 on EADDRINUSE — exactly how real http-server loses the
+// port race to a stale/sibling listener that squatted the port between
+// resolveServePort() and this spawn. It never serves anything of this run's.
+const FAKE_HTTP_LOSES_BIND = `
+'use strict';
+const http = require('http');
+const argv = process.argv.slice(2);
+let host = '0.0.0.0';
+let port = 0;
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === '-a') host = argv[i + 1];
+  else if (argv[i] === '-p') port = Number(argv[i + 1]);
+}
+const server = http.createServer((_, res) => { res.writeHead(200); res.end('ours'); });
+server.once('error', (err) => {
+  process.stderr.write('fake http-server: bind failed ' + err.code + '\\n');
+  process.exit(3);
+});
+server.listen(port, host);
 `;
 
 // A fake that emits a known line synchronously (so the parent's bounded
@@ -798,11 +839,215 @@ test('startLocalHttpServer aborts fast on an early server exit rather than burni
       `the non-zero exit must be surfaced; got ${JSON.stringify(logged)}`,
     );
     assert.ok(
-      logged.some((l) => /did not become reachable on :/.test(l)),
-      'the unreachable diagnostic must still be logged on the abort path',
+      logged.some((l) => /exited before it became ready on :/.test(l)),
+      'the child-exited owned-readiness diagnostic must be logged on the abort path',
     );
   } finally {
     cleanup.cleanupSync();
+    rmTmp(dir);
+  }
+});
+
+// rf2-3fc89f.14 — OWNED readiness is startLocalHttpServer's DEFAULT lifecycle.
+// The prior implementation awaited unowned waitForHttpReady, so during the
+// non-atomic resolveServePort()->spawn port handoff a FOREIGN server already
+// listening on the target port could answer the liveness probe and be accepted
+// as ready:true — a latent false-green across three CI browser gates (directly
+// analogous to the Xray defect closed as rf2-84gzw). These tests pin the fix:
+// a foreign tree is rejected, a missing/non-directory root fails loudly, and
+// the per-run ownership token is published + torn down concurrency-safely.
+
+// The core repro as a unit test. A foreign server serving a DIFFERENT asset
+// tree already holds the port; the spawned http-server loses the bind and
+// exits. The helper must return ready:false (never true) — refused for an
+// ownership reason (token-mismatch) or the lost-bind child exit. This assertion
+// FAILS on the pre-fix code, which returned ready:true against the foreign tree.
+test('startLocalHttpServer refuses a foreign asset tree holding the port (rf2-3fc89f.14)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_LOSES_BIND, 'fake-http-loses-bind.cjs');
+  // Stand up the foreign server on a real loopback port; it answers every path
+  // (incl. /.rf-harness-token) with a tree this run never staged.
+  const foreign = http.createServer((_, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('FOREIGN-ASSET-TREE');
+  });
+  const port = await listenOnLoopback(foreign);
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const logged = [];
+  try {
+    const { ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 4000,
+      captureOutput: true,
+      log: (m) => logged.push(m),
+    });
+    assert.equal(
+      ready,
+      false,
+      'a foreign asset tree squatting the port must NOT be accepted as ready',
+    );
+    // The refusal must cite an ownership / child-exit reason — not merely
+    // "unreachable" (the foreign server WAS reachable).
+    assert.ok(
+      logged.some((l) =>
+        /a foreign server answered|exited before it became ready on :|never served this run's/.test(l),
+      ),
+      `the refusal must cite an ownership/child-exit reason; got ${JSON.stringify(logged)}`,
+    );
+  } finally {
+    await cleanup.cleanup();
+    await new Promise((r) => foreign.close(r));
+    rmTmp(dir);
+  }
+});
+
+// The owned happy path: the (token-serving) fake proves ready:true flows ONLY
+// once the responder serves this run's published token — i.e. owned readiness
+// succeeds for the server this harness actually launched.
+test('startLocalHttpServer accepts the server that serves this run\'s ownership token (rf2-3fc89f.14)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const tokenPath = path.join(dir, TOKEN_FILE_BASENAME);
+  try {
+    const { ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {},
+    });
+    assert.equal(ready, true, 'the owned server serving our token must be accepted');
+    // The token that gated readiness is exactly the one published under root.
+    assert.equal(
+      await fetchToken(port),
+      fs.readFileSync(tokenPath, 'utf8'),
+      'readiness must have matched the served token against the published sentinel',
+    );
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
+// Missing staging root fails LOUDLY (throws) before any spawn/browser work.
+// On the pre-fix code startLocalHttpServer never validated the root and never
+// threw — so assert.rejects FAILS on old code.
+test('startLocalHttpServer throws loudly when the staging root does not exist (rf2-3fc89f.14)', async () => {
+  const missing = path.join(
+    os.tmpdir(),
+    `rf2-missing-root-${crypto.randomBytes(6).toString('hex')}`,
+  );
+  assert.equal(fs.existsSync(missing), false, 'precondition: root must not exist');
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  await assert.rejects(
+    () =>
+      startLocalHttpServer({
+        cleanup,
+        httpServerBin: 'unused',
+        root: missing,
+        port: 1,
+        readyTimeoutMs: 500,
+      }),
+    /does not exist or is not a directory/,
+  );
+});
+
+test('startLocalHttpServer throws loudly when the staging root is a file, not a directory (rf2-3fc89f.14)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-notdir-'));
+  const filePath = path.join(dir, 'a-file');
+  fs.writeFileSync(filePath, 'x');
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  try {
+    await assert.rejects(
+      () =>
+        startLocalHttpServer({
+          cleanup,
+          httpServerBin: 'unused',
+          root: filePath,
+          port: 1,
+          readyTimeoutMs: 500,
+        }),
+      /does not exist or is not a directory/,
+    );
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+// The ownership token is torn down via the supplied cleanup handle, and its
+// removal is concurrency-safe: our cleanup unlinks OUR token but preserves a
+// newer overlapping run's replacement (the publishOwnershipToken contract,
+// exercised through startLocalHttpServer's default lifecycle).
+test('startLocalHttpServer cleanup removes only THIS run\'s ownership token (rf2-3fc89f.14)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const tokenPath = path.join(dir, TOKEN_FILE_BASENAME);
+  try {
+    const { ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {},
+    });
+    assert.equal(ready, true);
+    assert.ok(
+      fs.existsSync(tokenPath),
+      'startLocalHttpServer must publish the ownership token under root before serving',
+    );
+    const ourToken = fs.readFileSync(tokenPath, 'utf8');
+    // A NEWER overlapping run against the SAME root re-publishes its own token.
+    const newer = publishOwnershipToken(dir);
+    assert.notEqual(newer.token, ourToken, 'the two runs must have distinct nonces');
+    // Our cleanup must terminate the server AND run the registered token
+    // removal — which must NOT delete the newer run's token.
+    await cleanup.cleanup();
+    assert.ok(
+      fs.existsSync(tokenPath),
+      'our cleanup must preserve a newer overlapping run\'s replacement token',
+    );
+    assert.equal(fs.readFileSync(tokenPath, 'utf8'), newer.token);
+    // The newer run's own remove() cleans up its sentinel.
+    newer.remove();
+    assert.equal(fs.existsSync(tokenPath), false);
+  } finally {
+    rmTmp(dir);
+  }
+});
+
+test('startLocalHttpServer cleanup unlinks its own ownership token in the non-overlapping case (rf2-3fc89f.14)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const tokenPath = path.join(dir, TOKEN_FILE_BASENAME);
+  try {
+    const { ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {},
+    });
+    assert.equal(ready, true);
+    assert.ok(fs.existsSync(tokenPath), 'precondition: token published');
+    await cleanup.cleanup();
+    assert.equal(
+      fs.existsSync(tokenPath),
+      false,
+      'cleanup must unlink this run\'s ownership token',
+    );
+  } finally {
     rmTmp(dir);
   }
 });

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -213,14 +213,15 @@ for (const [base, dir] of GATE_LAUNCHERS) {
 // window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
 // (the JS-regex `[^]`-any-char gotcha).
 const LOOPBACK_BIND_RE = loopbackBindRe('HTTP_SERVER_BIN');
-// Ownership-token launchers compose the http-server argv inline
-// http-server argv inline (they publish + verify a per-run /.rf-harness-token
-// via waitForOwnedHttpReady, a handshake startLocalHttpServer does not yet
-// own). Each serves its bundle on loopback only (readiness probe + headless
-// browser both hit 127.0.0.1), so a future edit dropping the explicit
-// `-a 127.0.0.1` would silently re-expose the bundle on 0.0.0.0 and trip no
-// test. Tokenless launchers delegate this policy to startLocalHttpServer and
-// are covered by the caller-use guard below.
+// These launchers compose the http-server argv inline: they publish + verify a
+// per-run /.rf-harness-token via waitForOwnedHttpReady directly, rather than
+// routing through startLocalHttpServer. (startLocalHttpServer now performs that
+// same owned-readiness handshake by default for ITS callers — rf2-3fc89f.14 —
+// but these three don't call it.) Each serves its bundle on loopback only
+// (readiness probe + headless browser both hit 127.0.0.1), so a future edit
+// dropping the explicit `-a 127.0.0.1` would silently re-expose the bundle on
+// 0.0.0.0 and trip no test. startLocalHttpServer callers delegate this policy
+// to the shared owner and are covered by the caller-use guard below.
 const IMPL_LOOPBACK_LAUNCHERS = [
   ['serve-and-run-browser-tests.cjs', SCRIPTS_DIR],
   ['check-story-static.cjs', SCRIPTS_DIR],

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -457,8 +457,51 @@ function createHarnessCleanup(opts = {}) {
   };
 }
 
+// fs.statSync that swallows every error (missing path, ENOTDIR, a non-string
+// argument) into `null`, so a caller can branch on existence/type without a
+// try/catch at the call site.
+function statOrNull(target) {
+  try {
+    return fs.statSync(target);
+  } catch (_) {
+    return null;
+  }
+}
+
+// Human-readable diagnostic for each structured owned-readiness failure, so a
+// caller's log surfaces WHY the gate refused (a foreign tree, a tokenless
+// responder, an early child exit, or a plain timeout), not merely that it did.
+// The 'timeout' wording is preserved verbatim — it is the only outcome the
+// unowned path could ever produce, and callers/tests key on it.
+function ownedReadinessFailureDiagnostic(result, port, timeoutMs) {
+  switch (result.reason) {
+    case 'token-mismatch':
+      return (
+        `Refusing to run on :${port}: a foreign server answered but its ` +
+        `/${TOKEN_FILE_BASENAME} does not match this run's ownership token ` +
+        `(got ${JSON.stringify(result.got)}). The assets being served are NOT ` +
+        `the tree this run staged — a stale/sibling listener won the port.`
+      );
+    case 'token-never-served':
+      return (
+        `http-server became reachable on :${port} but never served this run's ` +
+        `/${TOKEN_FILE_BASENAME} within ${timeoutMs}ms; the served asset tree ` +
+        `may be inconsistent.`
+      );
+    case 'child-exited':
+      return (
+        `http-server exited before it became ready on :${port} ` +
+        `(likely a lost port bind or a failed start).`
+      );
+    case 'timeout':
+    default:
+      return `http-server did not become reachable on :${port} within ${timeoutMs}ms.`;
+  }
+}
+
 // Compose the canonical local-http-server lifecycle: shell-free spawn, tracked
-// teardown, early-exit detection, optional bounded output capture, readiness,
+// teardown, early-exit detection, optional bounded output capture, OWNED
+// readiness (ownership-token verification — reachability alone is never proof),
 // and failure diagnostics. Callers retain only command-specific work.
 //
 // The argv is fixed policy: `-a <host>` (loopback by default, NOT
@@ -475,7 +518,11 @@ function createHarnessCleanup(opts = {}) {
 //   - httpServerBin (required) — the resolved http-server bin path. Callers
 //                 resolve it themselves (usually lazily) so this module never
 //                 hard-depends on the http-server package being installed.
-//   - root       (required) — the directory to serve.
+//   - root       (required) — the directory to serve. MUST exist and be a
+//                 directory: a per-run ownership token is published under it
+//                 before spawn, and a missing/non-directory root fails loudly
+//                 (throws) before any browser work — a gate against a missing
+//                 asset tree is never valid.
 //   - port       (required) — the resolved, already-free port to bind.
 //   - host       — bind address (default '127.0.0.1').
 //   - cwd        — spawn cwd (where node_modules / http-server resolves).
@@ -506,9 +553,12 @@ function createHarnessCleanup(opts = {}) {
 //
 // Returns { server, ready, output, isDown }:
 //   - server  — the tracked ChildProcess (for the caller's own waits).
-//   - ready   — true once reachable; false on early-exit/timeout (the caller
-//               returns its non-zero verdict; the canonical diagnostics have
-//               already been printed).
+//   - ready   — true ONLY once the responder on `port` served this run's
+//               ownership token; false for EVERY non-owned outcome — a foreign
+//               responder (token-mismatch), a tokenless one (token-never-served),
+//               an early child exit (child-exited), or a timeout. The caller
+//               returns its non-zero verdict; the canonical reason-specific
+//               diagnostics have already been printed.
 //   - output  — the captured line buffer (empty unless captureOutput).
 //   - isDown  — () => boolean; the live server-exited flag.
 async function startLocalHttpServer(opts = {}) {
@@ -529,6 +579,39 @@ async function startLocalHttpServer(opts = {}) {
     log = (msg) => console.error(msg),
     failureTailLines = 40,
   } = opts;
+
+  // Owned readiness is the DEFAULT lifecycle (rf2-3fc89f.14): a local browser
+  // gate must proceed only after proving the responder on `port` serves THIS
+  // run's staged root — never a foreign/stale asset tree that squatted the port
+  // during the non-atomic resolveServePort()->spawn handoff. Fail loudly BEFORE
+  // any spawn if the staging root is missing or not a directory; a gate against
+  // a missing asset tree is never valid, and silently proceeding is how a stale
+  // build passes a browser check.
+  const rootStat = statOrNull(root);
+  if (!rootStat || !rootStat.isDirectory()) {
+    throw new Error(
+      `startLocalHttpServer: staging root does not exist or is not a ` +
+        `directory: ${JSON.stringify(root)}. Refusing to start a browser gate ` +
+        `against a missing asset tree.`,
+    );
+  }
+
+  // Publish the per-run ownership token under `root` BEFORE spawn, so
+  // http-server serves it the moment it starts serving the directory. Register
+  // its concurrency-safe `remove` for teardown — it only unlinks OUR token, so
+  // an overlapping run against the same root is never clobbered.
+  const published = publishOwnershipToken(root);
+  if (!published) {
+    // root passed the stat above but vanished before the token write (a
+    // teardown race). Still refuse loudly rather than fall back to unowned
+    // readiness.
+    throw new Error(
+      `startLocalHttpServer: staging root vanished before the ownership token ` +
+        `could be published: ${JSON.stringify(root)}.`,
+    );
+  }
+  const { token, remove } = published;
+  cleanup.addCleanup(remove);
 
   const args = [
     httpServerBin,
@@ -577,13 +660,20 @@ async function startLocalHttpServer(opts = {}) {
   const aborted = () =>
     down || (typeof isAborted === 'function' && isAborted());
 
-  const ready = await waitForHttpReady(port, Date.now() + readyTimeoutMs, {
-    isAborted: aborted,
-  });
-  if (!ready || aborted()) {
-    log(
-      `http-server did not become reachable on :${port} within ${readyTimeoutMs}ms.`,
-    );
+  // Readiness WITH ownership-token verification (rf2-84gzw / rf2-gkf9 shared
+  // primitive): reachability alone is NOT proof — a foreign responder that won
+  // the port race would answer the liveness probe and yield a false green.
+  // Accept ready:true ONLY when the responder serves this run's token; return
+  // ready:false for every other structured outcome, with a reason-specific
+  // diagnostic.
+  const result = await waitForOwnedHttpReady(
+    port,
+    token,
+    Date.now() + readyTimeoutMs,
+    { isAborted: aborted },
+  );
+  if (!result.ok) {
+    log(ownedReadinessFailureDiagnostic(result, port, readyTimeoutMs));
     for (const line of output.slice(-failureTailLines)) log(line);
     return { server, ready: false, output, isDown };
   }


### PR DESCRIPTION
## Summary

`startLocalHttpServer` (the shared local-http-server lifecycle owner in `implementation/scripts/lib/local-browser-harness.cjs`) proved readiness with the **unowned** `waitForHttpReady` — "some HTTP responder answered on the port". Because the `resolveServePort()` → spawn port handoff is necessarily non-atomic, a **foreign** server already listening on the target port could answer the liveness probe and be accepted as `ready:true` before the spawned http-server's bind failure/exit was observed. A logged exit afterward did not retract the verdict.

This is a **latent false-green across three CI browser gates** — `serve-and-run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`, `serve-and-run-adapter-smokes.cjs` (and `serve-example.cjs` could briefly announce/serve the foreign URL). A stale-but-API-compatible build could satisfy a browser check after the newly built server lost the port. Directly analogous to the Xray defect closed as **rf2-84gzw**.

## The fix — owned readiness is the DEFAULT lifecycle

Reuses the existing rf2-pgppmu token lifecycle (no new sentinel):

- **Before spawn**, `publishOwnershipToken(root)` writes a per-run nonce under `root`; its concurrency-safe `remove` is registered with the supplied cleanup handle (only ever unlinks *this* run's token).
- **Fail loudly** (throw) before any browser work when `root` is missing or not a directory.
- Await `waitForOwnedHttpReady(port, token, deadline, {isAborted})` instead of `waitForHttpReady`; return `ready:false` for **every** non-owned outcome (`token-mismatch` / `token-never-served` / `child-exited` / `timeout`) with a **reason-specific diagnostic**.

All four `startLocalHttpServer` callers get owned readiness for free — none reimplement token logic, and each already returns non-zero on `ready:false`. No opt-out was needed: every caller serves a real file-backed root, and the real `http-server` serves the `/.rf-harness-token` dotfile (proven by the five existing owned-readiness launchers using identical argv). The manual-primitive launchers (browser-tests, story-static, xray-gate, reagent-slim, tenant-switcher) are unchanged; one now-stale comment in `_script-spawn-policy.test.cjs` was corrected.

## Stance

Pre-alpha; owned readiness is now the DEFAULT (not each caller's optional responsibility). Reuses the existing token lifecycle — no new sentinel. ELEGANCE + CLARITY + CORRECTNESS.

## Reproduce → fix evidence

**Reproduced on pre-fix code** (foreign server serving `FOREIGN-ASSET-TREE` holds the port; the spawned fake loses the bind and exits 3):
```
ready = true   isDown() = true   fetched = "FOREIGN-ASSET-TREE"
(only diagnostic: "http-server exited unexpectedly (code=3)")  -> FALSE-GREEN
```

**After the fix** (same scenario):
```
ready = false   reason: token-mismatch
"Refusing to run on :PORT: a foreign server answered but its /.rf-harness-token
 does not match this run's ownership token ..."  -> REJECTED
```

**Real-`http-server` launcher smoke** (the exact bin the gates spawn): a legitimately staged root reaches `ready:true` (the real http-server serves the published token); a foreign server holding the port is rejected `ready:false`.

## Quality gates

Run in foreground, 0 failures:

- `npm run test:script-helpers` — `local-browser-harness tests: 40 passed` (34 original + 6 new: foreign-tree refusal, owned-token acceptance, missing-root throw, non-directory-root throw, concurrency-safe token cleanup, own-token cleanup).
- `npm run test:script-policy` — all policy suites green (incl. `_script-spawn-policy`, `_orchestrator-teardown-policy`, `_story-script-runners-policy`, `_serve-and-run-cli`).
- Real-`http-server` launcher smoke (foreground) — owned-readiness happy path + foreign-tree rejection both pass end-to-end with the actual `http-server` package.

New acceptance tests fail on the old code: the foreign-tree test asserted `ready:false` (old code returned `true`); the missing-root test asserts a throw (old code never validated the root).