### PR TITLE
fix(pair-mcp): single-flight connection/discovery transitions (rf2-3fc89f.23)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -352,6 +352,23 @@
   `:pending` is `{id resolve-fn}` for in-flight requests. `:closed?` is
   set when the socket terminates so subsequent calls re-open.
 
+  ## Single-flight connection ownership
+
+  `:generation` is a monotonic counter bumped on every connect attempt (and
+  by `close!`); it is the *authority token* for the connection. Socket
+  handlers (`attach-handlers!`) capture the generation they were wired for
+  and mutate conn state only while they still own it — a socket superseded
+  by a newer connect (or by `close!`) reads `owns?` false and can neither
+  fold bytes into the shared framing buffer nor flip `:closed?` on the live
+  connection.
+
+  `:connecting` is the in-flight-connect record `{:promise :socket :gen
+  :resolve :reject}` (or nil when no connect is in progress). It makes
+  `connect!` single-flight: the first caller opens the socket; every
+  concurrent caller awaits the same `:promise`, so exactly one
+  `net/createConnection` runs and exactly one socket is published per
+  transition.
+
   `:probed-builds` is the set of build-ids for which the re-frame2-pair runtime
   preload has been confirmed live on this socket generation.
   Cleared by `close!` (operator-initiated teardown) and reborn empty
@@ -389,14 +406,47 @@
          :pending           {}
          :closed?           true
          :session           nil
+         :generation        0
+         :connecting        nil
          :probed-builds     #{}
          :resolved-build-id nil
          :build-alias       {}}))
 
+(defn- owns?
+  "True when `gen` is still the conn's current connection generation — i.e.
+  the socket/handler tagged with `gen` is the authoritative one. A socket
+  superseded by a newer connect (or by `close!`, which bumps the
+  generation) reads false and MUST NOT mutate shared conn state
+  (framing buffer, `:socket`, `:closed?`, `:pending`)."
+  [conn-atom gen]
+  (= gen (:generation @conn-atom)))
+
+(defn- destroy-socket!
+  "Abandon a superseded / orphaned socket so it can never feed the current
+  connection. Prefers `.destroy` (drops the connection immediately); falls
+  back to `.end` for minimal fakes. Best-effort — teardown of a half-open
+  socket may throw, which we swallow."
+  [^js sock]
+  (try
+    (cond
+      (fn? (j/get sock :destroy)) (j/call sock :destroy)
+      (fn? (j/get sock :end))     (j/call sock :end)
+      :else                       nil)
+    (catch :default _ nil)))
+
 (defn attach-handlers!
-  "Wire up `data` / `error` / `close` on the freshly-connected socket.
-  Resolves pending requests on matching `:done` status; logs errors;
-  marks the conn closed on disconnect.
+  "Wire up `data` / `error` / `close` on the freshly-connected socket for
+  connection generation `gen`. Resolves pending requests on matching
+  `:done` status; logs errors; marks the conn closed on disconnect.
+
+  ## Ownership-aware — only the authoritative generation mutates state
+
+  Every callback first checks `owns?`: a socket superseded by a newer
+  connect (or torn down by `close!`, which bumps the generation) reads
+  false and does nothing. This is what makes the connection single-flight
+  safe end-to-end — a losing/stale socket can neither fold its bytes into
+  the shared framing buffer (so frames from two socket generations are
+  never concatenated) nor flip `:closed?` on the live connection.
 
   The `data` handler folds the incoming chunk into the buffer AND
   splits off any complete frames in a single `swap!` — two-swap
@@ -405,6 +455,10 @@
   but not yet the trimmed trailer, double-decoding the same frame.
   One atomic swap closes that window.
 
+  The 2-arity defaults `gen` to the conn's CURRENT generation — the shape
+  the transport tests attach with (no reconnect in play). Production
+  `connect!` passes the generation it captured for the socket.
+
   Public (not `defn-`) so `nrepl_test.cljs` can drive the data-folding
   + pending-id dispatch with a fake socket — feeding synthetic chunks
   and asserting pending handlers fire — without opening a real TCP
@@ -412,34 +466,43 @@
   method that records the callback per event name; see the test's
   `fake-socket` helper. This mirrors the `decode-all-frames`
   public-for-test precedent above."
-  [conn-atom ^js socket]
-  (j/call socket :on "data"
-    (fn [chunk]
-      (let [frames* (atom nil)
-            _       (swap! conn-atom
-                           (fn [c]
-                             (let [buf'           (js/Buffer.concat
-                                                    #js [(or (:buf c) (js/Buffer.alloc 0))
-                                                         chunk])
-                                   [frames rest'] (decode-all-frames buf')]
-                               (reset! frames* frames)
-                               (assoc c :buf rest'))))]
-        (doseq [frame (array-seq @frames*)]
-          (let [id      (j/get frame "id")
-                resolve (get (:pending @conn-atom) id)]
-            (when resolve
-              ;; Accumulate fields into the pending result. Each pending
-              ;; entry holds {:result (atom result-map) :resolve fn}.
-              ;; For brevity we store a single resolve fn that merges
-              ;; via a per-call atom — see send-eval! below.
-              (resolve frame)))))))
-  (j/call socket :on "error"
-    (fn [err]
-      (log! "socket error:" (.-message err))
-      (swap! conn-atom assoc :closed? true)))
-  (j/call socket :on "close"
-    (fn [_]
-      (swap! conn-atom assoc :closed? true))))
+  ([conn-atom socket] (attach-handlers! conn-atom socket (:generation @conn-atom)))
+  ([conn-atom ^js socket gen]
+   (j/call socket :on "data"
+     (fn [chunk]
+       ;; A superseded generation's late `data` must NOT touch the shared
+       ;; framing buffer — otherwise bytes from two TCP streams concatenate
+       ;; into one bencode buffer and corrupt frame assembly.
+       (when (owns? conn-atom gen)
+         (let [frames* (atom nil)
+               _       (swap! conn-atom
+                              (fn [c]
+                                (let [buf'           (js/Buffer.concat
+                                                       #js [(or (:buf c) (js/Buffer.alloc 0))
+                                                            chunk])
+                                      [frames rest'] (decode-all-frames buf')]
+                                  (reset! frames* frames)
+                                  (assoc c :buf rest'))))]
+           (doseq [frame (array-seq @frames*)]
+             (let [id      (j/get frame "id")
+                   resolve (get (:pending @conn-atom) id)]
+               (when resolve
+                 ;; Accumulate fields into the pending result. Each pending
+                 ;; entry holds {:result (atom result-map) :resolve fn}.
+                 ;; For brevity we store a single resolve fn that merges
+                 ;; via a per-call atom — see send-eval! below.
+                 (resolve frame))))))))
+   (j/call socket :on "error"
+     (fn [err]
+       ;; A stale socket's error must not mark the LIVE connection closed.
+       (when (owns? conn-atom gen)
+         (log! "socket error:" (.-message err))
+         (swap! conn-atom assoc :closed? true))))
+   (j/call socket :on "close"
+     (fn [_]
+       ;; Likewise a stale socket's late close must not flip the live conn.
+       (when (owns? conn-atom gen)
+         (swap! conn-atom assoc :closed? true))))))
 
 (defn connect!
   "Open the persistent socket. Returns a Promise resolving to the
@@ -475,30 +538,72 @@
   `__re_frame2_pair_runtime` marker lives in the browser's CLJS heap,
   which a JVM-side socket drop does not destroy (only a page reload
   does, and a page reload leaves the JVM nREPL socket — hence
-  `:closed?` — untouched). A negative probe re-runs downstream anyway."
+  `:closed?` — untouched). A negative probe re-runs downstream anyway.
+
+  ## Single-flight
+
+  Concurrent callers (two simultaneous first ops, say) must NOT each open a
+  socket. The first caller into the `:else` branch claims the `:connecting`
+  slot and bumps `:generation`; every concurrent caller returns that same
+  in-flight Promise. So exactly one `net/createConnection` runs and exactly
+  one socket is published per transition; nREPL then multiplexes the
+  concurrent ops by id over that one socket. A candidate that comes up after
+  it has been superseded (a newer connect, or a `close!`) is destroyed
+  rather than published."
   [conn-atom]
-  (let [{:keys [socket closed?]} @conn-atom]
-    (if (and socket (not closed?))
+  (let [{:keys [socket closed? connecting]} @conn-atom]
+    (cond
+      ;; Fast path — a healthy socket is already open.
+      (and socket (not closed?))
       (js/Promise.resolve conn-atom)
-      (js/Promise.
-        (fn [resolve reject]
-          (let [{:keys [host port]} @conn-atom
-                sock (net/createConnection #js {:host host :port port})]
-            (j/call sock :on "connect"
-              (fn []
-                ;; Transport-only: swap in the live socket, clear the
-                ;; closed flag, and reset the framing buffer. The build-id
-                ;; caches are deliberately PRESERVED across a same-port
-                ;; reopen — see the fn docstring for why and for where the
-                ;; genuine-different-build reset lives.
+
+      ;; Single-flight — a connect for THIS conn is already in progress;
+      ;; await the same Promise instead of opening a second socket.
+      (some? connecting)
+      (:promise connecting)
+
+      :else
+      (let [gen  (inc (:generation @conn-atom))
+            d    #js {}
+            p    (js/Promise. (fn [resolve reject]
+                                (set! (.-resolve d) resolve)
+                                (set! (.-reject d) reject)))
+            {:keys [host port]} @conn-atom
+            sock (net/createConnection #js {:host host :port port})]
+        ;; Claim the in-flight slot + bump the generation BEFORE wiring the
+        ;; socket callbacks, so a late `connect`/`error` can tell whether it
+        ;; is still the authoritative generation. Held synchronously, so a
+        ;; concurrent `connect!` in the same tick sees `:connecting` and
+        ;; awaits `p` rather than opening its own socket.
+        (swap! conn-atom assoc :generation gen
+               :connecting {:promise p :socket sock :gen gen
+                            :resolve (.-resolve d) :reject (.-reject d)})
+        (j/call sock :on "connect"
+          (fn []
+            (if (owns? conn-atom gen)
+              (do
+                ;; Transport-only publish: swap in the live socket, clear the
+                ;; closed flag + in-flight slot, and reset the framing buffer.
+                ;; The build-id caches are deliberately PRESERVED across a
+                ;; same-port reopen — see the fn docstring for why and for
+                ;; where the genuine-different-build reset lives.
                 (swap! conn-atom assoc :socket sock :closed? false
-                       :buf (js/Buffer.alloc 0))
-                (attach-handlers! conn-atom sock)
-                (resolve conn-atom)))
-            (j/call sock :once "error"
-              (fn [err]
-                (swap! conn-atom assoc :closed? true)
-                (reject err)))))))))
+                       :buf (js/Buffer.alloc 0) :connecting nil)
+                (attach-handlers! conn-atom sock gen)
+                ((.-resolve d) conn-atom))
+              ;; Superseded before we came up (a newer connect or a `close!`
+              ;; bumped the generation). Abandon this socket so it never
+              ;; feeds the current framing buffer, and settle our waiter onto
+              ;; the authoritative conn (send-op! re-reads `:socket`, so a
+              ;; nil-socket after close! reconnects/errors cleanly).
+              (do (destroy-socket! sock)
+                  ((.-resolve d) conn-atom)))))
+        (j/call sock :once "error"
+          (fn [err]
+            (when (owns? conn-atom gen)
+              (swap! conn-atom assoc :closed? true :connecting nil))
+            ((.-reject d) err)))
+        p))))
 
 (defn close!
   "Close the persistent socket. Idempotent. Drops the per-socket probe
@@ -506,12 +611,34 @@
   Also drops `:resolved-build-id` — the cached default for
   tool calls without an explicit `:build` arg — and `:build-alias`,
   the forgiving suffix→canonical resolution cache — so a
-  reconnect doesn't carry a stale build-id from the previous session."
+  reconnect doesn't carry a stale build-id from the previous session.
+
+  ## Operator teardown cannot be undone by a late candidate
+
+  `close!` bumps `:generation`, so any still-attached socket handlers AND
+  any in-flight connect's late `connect` callback read as superseded and
+  refuse to mutate conn state — a candidate that comes up after teardown is
+  destroyed, never published. It also tears down an in-flight candidate
+  socket and rejects its waiter so a caller blocked on the connect Promise
+  settles promptly rather than hanging."
   [conn-atom]
-  (when-let [^js sock (:socket @conn-atom)]
-    (try (.end sock) (catch :default _ nil)))
-  (swap! conn-atom assoc :socket nil :closed? true :pending {}
-         :probed-builds #{} :resolved-build-id nil :build-alias {}))
+  (let [{:keys [socket connecting]} @conn-atom]
+    (when socket
+      (try (.end ^js socket) (catch :default _ nil)))
+    ;; Tear down an in-flight candidate so it can't come up behind us.
+    (when-let [^js insock (:socket connecting)]
+      (destroy-socket! insock))
+    (swap! conn-atom (fn [c]
+                       (-> c
+                           (assoc :socket nil :closed? true :pending {}
+                                  :connecting nil
+                                  :probed-builds #{} :resolved-build-id nil
+                                  :build-alias {})
+                           (update :generation (fnil inc 0)))))
+    ;; Settle any waiter blocked on the in-flight connect (it will re-read a
+    ;; nil `:socket` and reconnect on the next call).
+    (when-let [rej (:reject connecting)]
+      (rej (js/Error. "nREPL connection closed during connect — retry to reconnect")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Op send / receive — multiplex by request id.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -113,13 +113,22 @@
   for diagnostics; it does NOT gate. While `:discovered?` is
   false, every tool call re-runs the cascade, so a recoverable failure
   (shadow not up at the first call) self-heals on a later call once the
-  operator starts the build."
-  (atom {:project-home    nil
-         :port-file       nil
-         :port            nil
-         :conn            nil
-         :discovered?     false
-         :discovery-error nil}))
+  operator starts the build.
+
+  `:transition` / `:transition-token` make discovery + endpoint replacement
+  single-flight (`ensure-connection!` / `run-transition!`): the first caller
+  to start a session transition stores its in-flight Promise here and a
+  unique ownership token; every concurrent caller awaits the same Promise
+  rather than launching a second discovery or a duplicate reconnect. The
+  completing transition clears the slot only if it still owns the token."
+  (atom {:project-home     nil
+         :port-file        nil
+         :port             nil
+         :conn             nil
+         :discovered?      false
+         :discovery-error  nil
+         :transition       nil
+         :transition-token nil}))
 
 (defn session-state-snapshot
   "Deref the private `session-state` for tests — read-only window onto
@@ -133,12 +142,14 @@
   tests so the lazy-discovery retry contract can be exercised from a
   known slate."
   []
-  (reset! session-state {:project-home    nil
-                         :port-file       nil
-                         :port            nil
-                         :conn            nil
-                         :discovered?     false
-                         :discovery-error nil}))
+  (reset! session-state {:project-home     nil
+                         :port-file        nil
+                         :port             nil
+                         :conn             nil
+                         :discovered?      false
+                         :discovery-error  nil
+                         :transition       nil
+                         :transition-token nil}))
 
 (defn mark-discovered-for-tests!
   "Stand in for `discover-and-cache!`'s success side effect — record a
@@ -311,6 +322,42 @@
                                :reason   port-not-found-hint
                                :hint     port-not-found-hint}))))))))
 
+(defn- run-transition!
+  "Start a single-flight session transition. `body-fn` is a 0-arg thunk
+  returning a Promise that performs the discovery / endpoint replacement
+  and resolves to the authoritative conn atom.
+
+  The in-flight Promise is stored in `session-state`'s `:transition` slot
+  (with a unique ownership token) BEFORE this returns, so a concurrent
+  `ensure-connection!` in the same tick observes it and awaits the SAME
+  Promise rather than launching a duplicate discovery/reconnect. On settle
+  (resolve or reject) the slot is cleared only if this transition still owns
+  the token — a `reset-session-state-for-tests!` (or any external reset) in
+  flight must not be clobbered by a stale completion."
+  [body-fn]
+  (let [token  (js/Object.)
+        settle (fn []
+                 (when (identical? token (:transition-token @session-state))
+                   (swap! session-state assoc :transition nil :transition-token nil)))
+        p      (-> (js/Promise.resolve nil)
+                   (.then (fn [_] (body-fn)))
+                   (.then (fn [v] (settle) v)
+                          (fn [e] (settle) (js/Promise.reject e))))]
+    (swap! session-state assoc :transition p :transition-token token)
+    p))
+
+(defn- run-discovery!
+  "Run the discovery cascade thunk and settle to the freshly-cached conn.
+  On failure, record `:discovery-error` (diagnostic only — the session is
+  NOT wedged; the next call re-runs discovery) and re-reject so the waiter
+  surfaces the structured error."
+  [launch-flags discover-fn]
+  (-> (discover-fn launch-flags)
+      (.then (fn [_] (:conn @session-state)))
+      (.catch (fn [e]
+                (swap! session-state assoc :discovery-error e)
+                (js/Promise.reject e)))))
+
 (defn ensure-connection!
   "Lazy-discovery entry: called before every tool dispatch. Three paths:
 
@@ -320,6 +367,15 @@
   3. Cached + port-file content changed (or vanished) — shadow was
      restarted; close the stale socket, swap in a NEW conn for the new
      port (or force re-discovery).
+
+  ## Single-flight transitions
+
+  Every state-changing path (first-call discovery, vanished-port
+  re-discovery, port-change replacement) runs under `run-transition!`, so
+  concurrent tool calls that observe the same pre-transition state share ONE
+  transition: exactly one discovery runs, the old conn is closed exactly
+  once, and exactly one authoritative conn is published. The fast path
+  (path 2) needs no transition — it only reads the cached conn.
 
   Path 3 is where the genuine \"operator restarted shadow against a
   different build\" reset happens: a restart almost always grabs a new
@@ -354,37 +410,42 @@
   uses the 1-arity, which threads in `discover-and-cache!`."
   ([launch-flags] (ensure-connection! launch-flags discover-and-cache!))
   ([launch-flags discover-fn]
-  (let [{:keys [discovered? port-file port conn]} @session-state]
+  (let [{:keys [discovered? port-file port conn transition]} @session-state]
     (cond
+      ;; A discovery / endpoint-replacement transition is already in flight —
+      ;; await the SAME Promise rather than starting a second one.
+      (some? transition)
+      transition
+
+      ;; First call (or post-invalidation) — run discovery single-flight.
       (not discovered?)
-      (-> (discover-fn launch-flags)
-          (.then (fn [_] (:conn @session-state)))
-          (.catch (fn [e]
-                    ;; Record the last failure for diagnostics only — the
-                    ;; next tool call re-runs discovery; a recoverable
-                    ;; failure (shadow not up yet) must not permanently
-                    ;; wedge the session.
-                    (swap! session-state assoc :discovery-error e)
-                    (js/Promise.reject e))))
+      (run-transition! (fn [] (run-discovery! launch-flags discover-fn)))
 
       :else
       (let [current-port (when port-file (nrepl/read-port-file port-file))]
         (cond
-          ;; The cached file vanished — shadow shut down. Force re-discovery.
+          ;; The cached file vanished — shadow shut down. Force re-discovery
+          ;; under a single transition (close the stale conn first).
           (and port-file (nil? current-port))
-          (do (log! "cached port file disappeared at" port-file "— re-discovering")
+          (run-transition!
+            (fn []
+              (log! "cached port file disappeared at" port-file "— re-discovering")
               (nrepl/close! conn)
               (swap! session-state assoc :discovered? false :conn nil
                      :discovery-error nil)
-              (ensure-connection! launch-flags discover-fn))
+              (run-discovery! launch-flags discover-fn)))
 
-          ;; Port changed — shadow restarted on a new ephemeral port.
+          ;; Port changed — shadow restarted on a new ephemeral port. Replace
+          ;; the endpoint under a single transition so the old conn is closed
+          ;; exactly once and exactly one fresh conn is published.
           (and current-port (not= current-port port))
-          (do (log! "nREPL port changed:" port "→" current-port "— reconnecting")
+          (run-transition!
+            (fn []
+              (log! "nREPL port changed:" port "→" current-port "— reconnecting")
               (nrepl/close! conn)
               (let [conn' (new-conn-for-port current-port)]
                 (swap! session-state assoc :port current-port :conn conn')
-                (js/Promise.resolve conn')))
+                (js/Promise.resolve conn'))))
 
           ;; Same port (or env/cwd path without project-home) — fast path.
           :else

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_single_flight_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_single_flight_test.cljs
@@ -1,0 +1,152 @@
+(ns re-frame2-pair-mcp.ensure-connection-single-flight-test
+  "Single-flight guard for session discovery + endpoint replacement
+  (rf2-3fc89f.23).
+
+  MCP permits concurrent tool calls, so two calls can observe the same
+  pre-transition session state — `:discovered? false`, or a cached port that
+  just changed. The OLD `ensure-connection!` did a bare check-then-act:
+  concurrent first calls each ran discovery, and concurrent port-change calls
+  each closed the old conn and published a fresh one. The fix routes every
+  state-changing path through `run-transition!`, so the FIRST caller becomes
+  the transition owner and every concurrent caller awaits the same Promise —
+  exactly one discovery, exactly one close of the old conn, exactly one
+  authoritative conn published.
+
+  The 2-arity `ensure-connection!` injects the discovery thunk so these
+  contracts are unit-testable without the npm SDK / a live shadow."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.server :as server]
+            ["fs" :as fs]))
+
+(use-fixtures :each
+  {:before (fn [] (server/reset-session-state-for-tests!))
+   :after  (fn [] (server/reset-session-state-for-tests!))})
+
+(defn- with-fs-read
+  "Install `stub-fn` as `fs.readFileSync`; returns a 0-arity restore thunk."
+  [stub-fn]
+  (let [orig (.-readFileSync fs)]
+    (set! (.-readFileSync fs) stub-fn)
+    (fn restore! [] (set! (.-readFileSync fs) orig))))
+
+(defn- reads-port
+  "A `readFileSync` stub returning `port` (as bytes) for ANY path — models a
+  cached port file whose content just changed to `port`."
+  [port]
+  (fn [^js _path] (js/Buffer.from (str port) "utf8")))
+
+(deftest concurrent-first-calls-run-discovery-exactly-once
+  (testing "two simultaneous pristine ensure-connection! calls share ONE discovery and resolve to the SAME conn"
+    (async done
+      (let [calls (atom 0)
+            conn  (nrepl/make-conn 6001 "127.0.0.1")
+            ;; Discovery resolves asynchronously (a real cascade awaits IO),
+            ;; so both callers are in flight before it settles.
+            discover-fn
+            (fn [_flags]
+              (swap! calls inc)
+              (-> (js/Promise.resolve nil)
+                  (.then (fn [_] (server/mark-discovered-for-tests! conn) :ok))))
+            p1 (server/ensure-connection! {} discover-fn)
+            p2 (server/ensure-connection! {} discover-fn)]
+        (is (some? (:transition (server/session-state-snapshot)))
+            "the transition slot is claimed while discovery is in flight")
+        (-> (js/Promise.all #js [p1 p2])
+            (.then (fn [^js rs]
+                     (is (= 1 @calls)
+                         "discovery ran EXACTLY once for two concurrent first calls")
+                     (is (identical? conn (aget rs 0)) "caller 1 got the discovered conn")
+                     (is (identical? conn (aget rs 1)) "caller 2 got the SAME conn")
+                     (is (true? (:discovered? (server/session-state-snapshot))))
+                     (is (nil? (:transition (server/session-state-snapshot)))
+                         "the transition slot is cleared after settle")
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+
+(deftest concurrent-port-change-calls-replace-endpoint-exactly-once
+  (testing "two simultaneous cached-port-change calls close the old conn ONCE and publish ONE replacement"
+    (async done
+      (let [end-count (atom 0)
+            old-conn  (nrepl/make-conn 7001 "127.0.0.1")
+            restore!  (with-fs-read (reads-port 7002))]  ; cached file now reads a NEW port
+        (swap! old-conn assoc
+               :socket (j/lit {:end (fn [] (swap! end-count inc) nil)})
+               :closed? false)
+        (server/set-discovered-for-tests!
+          {:conn old-conn :port 7001 :port-file "/proj/target/shadow-cljs/nrepl.port"
+           :project-home "/proj"})
+        (let [;; The replacement path must NOT invoke discovery — a rejecting
+              ;; thunk proves it isn't called.
+              never (fn [_] (js/Promise.reject (js/Error. "discovery must not run on a port change")))
+              p1    (server/ensure-connection! {} never)
+              p2    (server/ensure-connection! {} never)]
+          (-> (js/Promise.all #js [p1 p2])
+              (.then (fn [^js rs]
+                       (is (= 1 @end-count) "the old conn was closed EXACTLY once")
+                       (is (identical? (aget rs 0) (aget rs 1))
+                           "both callers got the SAME replacement conn")
+                       (is (= 7002 (:port @(aget rs 0))) "the replacement targets the new port")
+                       (is (= 7002 (:port (server/session-state-snapshot)))
+                           "session records the new port")
+                       (is (nil? (:transition (server/session-state-snapshot)))
+                           "the transition slot is cleared after settle")
+                       (restore!) (done)))
+              (.catch (fn [e] (restore!)
+                        (is false (str "unexpected reject: " (.-message e))) (done)))))))))
+
+(deftest concurrent-failed-discovery-rejects-all-then-retries
+  (testing "a shared discovery failure rejects every waiter, clears the slot, and a later call retries successfully"
+    (async done
+      (let [calls (atom 0)
+            err   (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
+                           {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found})
+            fail  (fn [_]
+                    (swap! calls inc)
+                    (-> (js/Promise.resolve nil) (.then (fn [_] (js/Promise.reject err)))))
+            p1    (server/ensure-connection! {} fail)
+            p2    (server/ensure-connection! {} fail)]
+        (-> (js/Promise.allSettled #js [p1 p2])
+            (.then (fn [^js results]
+                     (is (= 1 @calls)
+                         "one shared discovery for two concurrent first calls")
+                     (is (= "rejected" (j/get (aget results 0) :status)) "caller 1 rejected")
+                     (is (= "rejected" (j/get (aget results 1) :status)) "caller 2 rejected")
+                     (is (nil? (:transition (server/session-state-snapshot)))
+                         "the in-flight slot is cleared after the shared failure")
+                     (is (false? (:discovered? (server/session-state-snapshot)))
+                         "still not discovered — the session is not wedged")
+                     ;; A later call retries: slot clear, discovered? false.
+                     (let [conn  (nrepl/make-conn 6001 "127.0.0.1")
+                           ok-fn (fn [_]
+                                   (swap! calls inc)
+                                   (server/mark-discovered-for-tests! conn)
+                                   (js/Promise.resolve :ok))]
+                       (-> (server/ensure-connection! {} ok-fn)
+                           (.then (fn [c]
+                                    (is (= 2 @calls) "discovery RE-RAN on the retry")
+                                    (is (identical? conn c) "the retry resolved to the fresh conn")
+                                    (is (true? (:discovered? (server/session-state-snapshot))))
+                                    (done)))
+                           (.catch (fn [e2]
+                                     (is false (str "retry must succeed: " (.-message e2)))
+                                     (done)))))))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+
+(deftest fast-path-needs-no-transition
+  (testing "when the cached port-file still reads the same port, ensure-connection! returns the cached conn with no transition"
+    (async done
+      (let [conn     (nrepl/make-conn 7001 "127.0.0.1")
+            restore! (with-fs-read (reads-port 7001))]   ; unchanged
+        (server/set-discovered-for-tests!
+          {:conn conn :port 7001 :port-file "/proj/target/shadow-cljs/nrepl.port"
+           :project-home "/proj"})
+        (-> (server/ensure-connection! {} (fn [_] (js/Promise.reject (js/Error. "must not re-discover"))))
+            (.then (fn [resolved]
+                     (is (identical? conn resolved) "the cached conn is reused")
+                     (is (nil? (:transition (server/session-state-snapshot)))
+                         "the fast path never opened a transition")
+                     (restore!) (done)))
+            (.catch (fn [e] (restore!)
+                      (is false (str "fast path must not reject: " (.-message e))) (done))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -1136,3 +1136,240 @@
       ;; And the old conn is untouched — they're independent atoms.
       (is (= :examples/old-build (:resolved-build-id @old-conn))
           "the discarded conn keeps its state — no cross-conn mutation"))))
+
+;; ===========================================================================
+;; Single-flight connection + generation ownership (rf2-3fc89f.23).
+;;
+;; MCP permits concurrent tool calls, and `send-op!` calls `connect!` on
+;; EVERY op — so two simultaneous first ops both reach `connect!` before
+;; either socket comes up. The OLD code let each caller run
+;; `net/createConnection`, opening two live sockets whose handlers folded
+;; two TCP streams into one bencode buffer and whose stale close could mark
+;; the winner closed. The fix makes `connect!` single-flight (one socket per
+;; transition; concurrent callers share the same Promise) and tags every
+;; socket with a `:generation` so only the authoritative socket mutates conn
+;; state.
+;;
+;; Each fake socket gets its OWN callback map (unlike `connect-fake-socket`,
+;; which shares one) so two candidate sockets can be driven independently.
+;; ===========================================================================
+
+(defn- make-concurrency-fake
+  "A `net.Socket` stand-in whose event callbacks land in its OWN `cbs` atom,
+  and which records `write`/`end`/`destroy` on `flags` — so a test can drive
+  two candidate sockets independently and assert teardown."
+  [cbs flags]
+  (j/lit {:on      (fn [event cb] (swap! cbs assoc event cb) nil)
+          :once    (fn [event cb] (swap! cbs assoc event cb) nil)
+          :write   (fn [_] (swap! flags update :writes (fnil inc 0)) nil)
+          :end     (fn [] (swap! flags assoc :ended? true) nil)
+          :destroy (fn [] (swap! flags assoc :destroyed? true) nil)}))
+
+(defn- with-multi-create-connection!
+  "Install a `net.createConnection` stub that builds a DISTINCT fake socket
+  per call, appending `{:cbs :flags :socket}` to `sockets*`. Returns a
+  0-arity restore thunk."
+  [sockets*]
+  (let [orig (.-createConnection net)]
+    (set! (.-createConnection net)
+          (fn [_opts]
+            (let [cbs   (atom {})
+                  flags (atom {})
+                  sock  (make-concurrency-fake cbs flags)]
+              (swap! sockets* conj {:cbs cbs :flags flags :socket sock})
+              sock)))
+    (fn restore! [] (set! (.-createConnection net) orig))))
+
+(defn- fire-cb! [rec event & args]
+  (apply (get @(:cbs rec) event) args))
+
+(deftest connect!-single-flight-one-socket-for-concurrent-callers
+  ;; The core race: two concurrent `connect!` callers BEFORE either callback
+  ;; fires must open exactly ONE socket and share ONE Promise. On old code
+  ;; this asserted two createConnection calls.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          p1       (nrepl/connect! conn)
+          p2       (nrepl/connect! conn)]
+      (is (= 1 (count @sockets*))
+          "exactly ONE net.createConnection for two concurrent connect! callers")
+      (is (identical? p1 p2)
+          "both concurrent callers received the SAME in-flight Promise")
+      (is (some? (:connecting @conn)) "the in-flight slot is claimed while connecting")
+      ;; The single socket comes up.
+      (fire-cb! (first @sockets*) "connect")
+      (-> (js/Promise.all #js [p1 p2])
+          (.then (fn [^js results]
+                   (is (identical? conn (aget results 0)) "caller 1 resolved to the conn")
+                   (is (identical? conn (aget results 1)) "caller 2 resolved to the SAME conn")
+                   (is (some? (:socket @conn)) "exactly one socket published")
+                   (is (false? (:closed? @conn)) "the conn is live")
+                   (is (nil? (:connecting @conn)) "the in-flight slot is cleared on publish")
+                   (restore!) (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest concurrent-send-ops-multiplex-over-one-socket
+  ;; Two simultaneous `send-op!` calls share one connect, then register
+  ;; DISTINCT pending ids and write over the SAME socket — the multiplex the
+  ;; single-flight fix preserves. Ops are resolved by feeding each pending
+  ;; accumulator a `:done` frame directly (the send-op response-assembly seam
+  ;; the suite already uses), so the assertion doesn't depend on bencode
+  ;; wire round-tripping.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          p1       (nrepl/send-op! conn {"op" "eval" "code" "1"})
+          p2       (nrepl/send-op! conn {"op" "eval" "code" "2"})]
+      (is (= 1 (count @sockets*)) "one socket for two concurrent send-ops")
+      ;; Bring the shared socket up; let both send-op! .then bodies register.
+      (fire-cb! (first @sockets*) "connect")
+      (-> (js/Promise.resolve nil)
+          (.then (fn [_] nil))     ; flush send-op! connect continuations
+          (.then (fn [_]
+                   (is (= 2 (count (:pending @conn)))
+                       "both ops registered distinct pending ids on the ONE socket")
+                   (is (= 2 (:writes @(:flags (first @sockets*))))
+                       "both ops wrote to the single shared socket")
+                   ;; Resolve both ops via their registered on-frame accumulator.
+                   (doseq [on-frame (vals (:pending @conn))]
+                     (on-frame #js {"status" #js ["done"]}))
+                   (js/Promise.all #js [p1 p2])))
+          (.then (fn [^js rs]
+                   (is (= 2 (.-length rs)) "both ops resolved")
+                   (is (= {} (:pending @conn)) "pending drained on resolution")
+                   (restore!) (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest superseded-socket-callbacks-cannot-mutate-current-generation
+  ;; A losing/stale socket's data/error/close must be inert once a newer
+  ;; generation is live — the "a losing socket's later close marks the winner
+  ;; closed" corruption path, closed by the generation guard.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          p1       (nrepl/connect! conn)]        ; gen1 connect started
+      (fire-cb! (first @sockets*) "connect")     ; gen1 publishes
+      (-> p1
+          (.then (fn [_]
+                   ;; Transient hiccup on gen1 → reopen to gen2.
+                   (fire-cb! (first @sockets*) "close" nil)
+                   (is (true? (:closed? @conn)) "gen1's own close flips :closed?")
+                   (let [p2 (nrepl/connect! conn)]
+                     (fire-cb! (second @sockets*) "connect")  ; gen2 publishes
+                     p2)))
+          (.then (fn [_]
+                   (is (false? (:closed? @conn)) "gen2 is the live generation")
+                   (let [gen2-sock (:socket @conn)]
+                     ;; STALE gen1 callbacks fire late — all must be inert.
+                     (fire-cb! (first @sockets*) "close" nil)
+                     (is (false? (:closed? @conn))
+                         "a stale gen1 close cannot mark the live gen2 conn closed")
+                     (fire-cb! (first @sockets*) "error" (js/Error. "late gen1 error"))
+                     (is (false? (:closed? @conn))
+                         "a stale gen1 error cannot mark the live gen2 conn closed")
+                     (fire-cb! (first @sockets*) "data" (frame-buf {"id" "x" "value" "1"}))
+                     (is (zero? (.-length (:buf @conn)))
+                         "a stale gen1 data chunk never enters the live framing buffer")
+                     (is (identical? gen2-sock (:socket @conn))
+                         "the live socket is untouched by stale callbacks"))
+                   (restore!) (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest stale-generation-partial-frame-never-concatenated
+  ;; Bytes from two socket generations must never concatenate into one
+  ;; bencode buffer — a stale gen1 tail cannot complete a frame against
+  ;; gen2's fresh stream.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          full     (frame-buf {"id" "p1" "value" "7"})
+          mid      (js/Math.floor (/ (.-length full) 2))
+          head     (.slice full 0 mid)
+          tail     (.slice full mid)
+          p1       (nrepl/connect! conn)]
+      (fire-cb! (first @sockets*) "connect")
+      (-> p1
+          (.then (fn [_]
+                   ;; gen1 buffers a partial frame head.
+                   (fire-cb! (first @sockets*) "data" head)
+                   (is (pos? (.-length (:buf @conn))) "gen1 partial head buffered")
+                   ;; Hiccup + reopen to gen2.
+                   (fire-cb! (first @sockets*) "close" nil)
+                   (let [p2 (nrepl/connect! conn)]
+                     (fire-cb! (second @sockets*) "connect")
+                     p2)))
+          (.then (fn [_]
+                   (is (zero? (.-length (:buf @conn)))
+                       "gen2 publish reset the framing buffer (fresh stream)")
+                   (let [got* (atom nil)]
+                     (swap! conn assoc :pending {"p1" #(reset! got* %)})
+                     ;; The STALE gen1 tail must NOT complete the frame.
+                     (fire-cb! (first @sockets*) "data" tail)
+                     (is (nil? @got*)
+                         "a stale gen1 tail cannot concatenate onto gen2 to fake a frame")
+                     (is (zero? (.-length (:buf @conn)))
+                         "and it never entered the live buffer"))
+                   (restore!) (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest connect!-rejection-clears-in-flight-slot-and-next-call-retries
+  ;; A failed connect rejects the waiter, clears the in-flight slot, and the
+  ;; next call retries with a fresh socket — the non-sticky failure contract.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          orig-err (.-error js/console)
+          p1       (nrepl/connect! conn)]
+      (is (= 1 (count @sockets*)))
+      (is (some? (:connecting @conn)) "in-flight slot claimed")
+      (set! (.-error js/console) (fn [& _] nil))       ; silence the socket-error log
+      (fire-cb! (first @sockets*) "error" (js/Error. "ECONNREFUSED"))
+      (set! (.-error js/console) orig-err)
+      (-> p1
+          (.then (fn [_] (restore!) (is false "connect must reject") (done))
+                 (fn [e]
+                   (is (= "ECONNREFUSED" (.-message e)) "the waiter received the socket error")
+                   (is (nil? (:connecting @conn)) "the in-flight slot is cleared on rejection")
+                   (is (true? (:closed? @conn)) "conn marked closed")
+                   ;; A later call retries — opens a FRESH socket.
+                   (let [p2 (nrepl/connect! conn)]
+                     (is (= 2 (count @sockets*)) "the retry opened a fresh socket")
+                     (fire-cb! (second @sockets*) "connect")
+                     (-> p2
+                         (.then (fn [_]
+                                  (is (false? (:closed? @conn)) "the retry connected")
+                                  (restore!) (done)))
+                         (.catch (fn [e2] (restore!)
+                                   (is false (str "retry rejected: " (.-message e2))) (done)))))))))))
+
+(deftest close!-during-in-flight-connect-settles-waiter-and-orphans-candidate
+  ;; Operator teardown mid-connect: the conn ends closed, the in-flight
+  ;; candidate is destroyed, the waiter settles, and a LATE candidate connect
+  ;; cannot undo the close by publishing itself.
+  (async done
+    (let [sockets* (atom [])
+          restore! (with-multi-create-connection! sockets*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")
+          p1       (nrepl/connect! conn)]
+      (is (some? (:connecting @conn)) "connect in flight")
+      (nrepl/close! conn)
+      (is (true? (:closed? @conn)) "close! left the conn closed")
+      (is (nil? (:connecting @conn)) "close! cleared the in-flight slot")
+      (is (true? (:destroyed? @(:flags (first @sockets*))))
+          "close! destroyed the in-flight candidate socket")
+      (-> p1
+          (.then (fn [_] (restore!) (is false "the waiter must reject after close!") (done))
+                 (fn [_e]
+                   (is true "the waiter settled (rejected) via close!")
+                   ;; A LATE connect on the orphaned candidate must not publish.
+                   (fire-cb! (first @sockets*) "connect")
+                   (is (nil? (:socket @conn))
+                       "a late candidate connect cannot undo the close (no socket published)")
+                   (is (true? (:closed? @conn)) "still closed after the late candidate")
+                   (restore!) (done)))))))


### PR DESCRIPTION
Fixes **rf2-3fc89f.23** — pair-MCP connection/discovery transitions were not single-flight, so concurrent MCP tool calls raced.

## The bug (reproduced before fixing)

MCP permits concurrent tool calls, and `send-op!` calls `connect!` on every op. On `origin/main`, connection establishment and endpoint replacement did a bare check-then-act:

- **`nrepl/connect!`** — on a closed conn, every concurrent caller independently ran `net.createConnection`; nothing in the conn atom recorded an in-flight connect. Two live sockets folded two TCP streams into one bencode framing buffer, and a losing socket's late `close` could mark the winner closed.
- **`server/ensure-connection!`** — concurrent first calls all ran discovery; concurrent port-change calls all closed the old conn and published a fresh one.

The new tests **fail on the pre-fix source** (verified by reverting src, keeping tests):

```
FAIL connect!-single-flight-one-socket-for-concurrent-callers
  exactly ONE net.createConnection for two concurrent connect! callers
  expected: (= 1 (count @sockets*))   actual: (not (= 1 2))
  both concurrent callers received the SAME in-flight Promise
  expected: (identical? p1 p2)        actual: (not (identical? #Promise #Promise))
FAIL concurrent-first-calls-run-discovery-exactly-once
  discovery ran EXACTLY once      expected: (= 1 @calls)  actual: (not (= 1 2))
```

## The fix (ownership design)

**`nrepl.cljs`**
- `make-conn` gains `:generation` (a monotonic authority token) and `:connecting` (an in-flight-connect record `{:promise :socket :gen :resolve :reject}`).
- `connect!` is **single-flight**: the first caller claims `:connecting`, bumps `:generation`, and opens the one socket; every concurrent caller returns that same Promise. Exactly one `net.createConnection` and one published socket per transition. nREPL then multiplexes concurrent ops by id over the single socket.
- `attach-handlers!` is **generation-aware**: `data`/`error`/`close` mutate conn state only while `owns?` holds. A superseded socket can neither fold bytes into the live framing buffer (so frames from two generations never concatenate) nor flip `:closed?` on the winner. (2-arity retained, defaulting `gen` to the current generation, for the existing transport tests.)
- `close!` bumps `:generation`, destroys any in-flight candidate, and rejects its waiter — an operator teardown can't be undone by a late candidate `connect`, and a blocked caller settles promptly.

**`server.cljs`**
- `ensure-connection!` routes first-call discovery, vanished-port re-discovery, and port-change replacement through `run-transition!`, a session **single-flight** slot (`:transition` + ownership token cleared only if the completing transition still owns it). Concurrent callers share one transition: one discovery, one close of the old conn, one authoritative conn published. The same-port fast path needs no transition.

Request-id multiplexing and same-port cache semantics are unchanged; only discovery/connect transitions are serialized.

## Stance

Pre-alpha; single-flight ownership done correctly — no double-connect, retry-on-reject preserved (a rejected transition/connect clears ownership so the documented next-call retry holds). Primary lenses: ELEGANCE + CLARITY + CORRECTNESS.

## Quality gates (foreground)

- `npm run test` — **1198 tests, 4118 assertions, 0 failures, 0 errors** (up from 1188; +10 concurrency tests). Includes a two-caller concurrency regression for both `connect!` and `ensure-connection!`.
- `npm run check:descriptors` — **OK, 30 tools in sync**.

New tests: concurrent `connect!` opens one socket and shares one Promise; concurrent `send-op!` multiplex over it; stale-generation callbacks and partial frames are inert; a rejected connect clears the slot and the next call retries; `close!`-during-connect settles the waiter and orphans the candidate; concurrent discovery / port-change collapse to one transition; a failed shared discovery rejects every waiter then retries.

Do NOT merge.
