### PR TITLE
fix(examples): resources SSR renders app as fragment — no nested doctype (rf2-3fc89f.30)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -278,7 +278,17 @@
            (let [final-db      (rf/app-db-value f)
                  final-runtime (:rf.db/runtime (rf/frame-state-value f))   ;; this is where :rf.runtime/resources lives
                  hiccup        ((rf/view :app/root))
-                 html          (rf/render-to-string hiccup {:doctype? true :emit-hash? true})
+                 ;; Render the app as a FRAGMENT, not a full document. The
+                 ;; `handle-request` envelope below owns the ONE document shell —
+                 ;; the outer `<!DOCTYPE html>`, `<head>` metadata, the payload
+                 ;; `<script>`, and `main.js`. The app render only fills
+                 ;; `<div id='app'>`, so it must NOT prepend its own doctype:
+                 ;; `:doctype? true` here would nest a second `<!DOCTYPE html>`
+                 ;; inside `#app`, and the response would be malformed HTML that
+                 ;; only survives via browser parser recovery. Keep
+                 ;; `:emit-hash? true` — the hydration hash the client verifies
+                 ;; still belongs on the fragment's root element.
+                 html          (rf/render-to-string hiccup {:emit-hash? true})
                  render-hash   (rf/render-tree-hash hiccup)
                  ;; (2) Build the payload exactly the way the Ring host does:
                  ;; the app-db slice through the fail-closed allowlist, and the

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -674,6 +674,36 @@
       (is (some? payload))
       (is (not (contains? payload :rf/frame-id))
           "the resources payload OMITS :rf/frame-id")
+      ;; ── Response document envelope (rf2-3fc89f.30) ───────────────────────
+      ;; `handle-request` owns the ONE document shell; the app renders as a
+      ;; FRAGMENT into `<div id='app'>`. A drift back to `:doctype? true` on
+      ;; the fragment emitter nests a SECOND `<!DOCTYPE html>` inside `#app` —
+      ;; malformed HTML the old code shipped, surviving only via browser parser
+      ;; recovery. Assert exactly one doctype, envelope-owned, at byte zero,
+      ;; the fragment beginning at the child of `#app`, with the hydration hash
+      ;; and the envelope's head/payload/main.js all preserved.
+      (let [body     (:body resp)
+            app-open (clojure.string/index-of body "<div id='app'>")]
+        (is (= 1 (count (re-seq #"(?i)<!doctype" body)))
+            "exactly one doctype in the whole response (envelope-owned; no nested)")
+        (is (clojure.string/starts-with? (clojure.string/lower-case body)
+                                          "<!doctype html>")
+            "the sole doctype sits at byte zero of the document")
+        (is (some? app-open)
+            "the response carries the `<div id='app'>` mount point")
+        (is (not (clojure.string/includes?
+                   (clojure.string/lower-case (subs body app-open)) "<!doctype"))
+            "no doctype occurs within or after `<div id='app'>` (app is a fragment)")
+        (is (clojure.string/includes? body "<div id='app'><div class=\"page\"")
+            "the first child of #app is the page root element (fragment, not a nested doc)")
+        (is (clojure.string/includes? body "data-rf-render-hash=")
+            "the fragment root carries data-rf-render-hash (`:emit-hash? true` retained)")
+        (is (clojure.string/includes? body "<title>Resources SSR demo</title>")
+            "envelope head metadata preserved")
+        (is (clojure.string/includes? body "id='__rf_payload'")
+            "payload script preserved")
+        (is (clojure.string/includes? body "<script src='/main.js'></script>")
+            "client boot script preserved"))
       ;; The runtime-db projection carries the loaded resource entry (the
       ;; allowed `:entries`, not the indexes).
       (let [entries (get-in payload [:rf/runtime-db :rf.runtime/resources :entries])]


### PR DESCRIPTION
## What

The runnable `examples/capabilities/ssr/resources_ssr` server handler emitted invalid nested-document markup. `handle-request` owns the outer document envelope — its own `<!DOCTYPE html><html>…<head>…</head><body><div id='app'>…` plus the payload `<script>` and `main.js`. But the app render passed `:doctype? true`, so `render-to-string` prepended a **second** `<!DOCTYPE html>` inside `#app`.

**The fix (per bead DESIGN):** keep `handle-request` as the document-envelope owner; render the app as a **fragment** — drop `:doctype? true`, retain `:emit-hash? true`. The handler's outer doctype and its hand-authored envelope are untouched; no nested `[:html …]` tree is introduced.

## Reproduce → fix evidence

Drove the real `handle-request` (canned-success resource stub) before the fix. Actual response body:

```
<!DOCTYPE html><html><head>…</head><body><div id='app'><!DOCTYPE html><div class="page" data-rf-render-hash="f1d63f7e">…
                                          ^^^^^^^^^^^^^^^ nested second doctype inside #app
```

`DOCTYPE COUNT: 2`. After the fix the response carries exactly one doctype (byte zero, envelope-owned); the first `#app` child is the page root `<div class="page" data-rf-render-hash=…>`; the payload script + `main.js` + hydration hash are all preserved.

The new envelope assertions **fail on the old code** (3 failures — doctype count `2`, a doctype inside `#app`, first-`#app`-child mismatch) and **pass on the fix**.

## Stance

Pre-alpha; ELEGANCE + CLARITY + CORRECTNESS. The handler owns the document envelope; the app renders as a fragment. One-line runtime change plus a regression guard; existing payload/hydration assertions untouched.

## Scope

- `examples/capabilities/ssr/resources_ssr/core.cljc` — `:doctype? true` → fragment render (`:emit-hash? true` retained), with an explanatory comment.
- `implementation/core/test/re_frame/examples_test.clj` — response-envelope assertions added beside the existing dynamic resources-SSR test; existing assertions preserved.

## Quality gates

- `examples/resources-ssr` Shadow build — `Build completed. (219 files, 218 compiled, 0 warnings, 13.58s)`
- Focused JVM: `clojure -M:test -d test -n re-frame.examples-test` from `implementation/core` — **14 tests / 74 assertions, 0 failures, 0 errors** (was 65 assertions; +9 envelope assertions).
- `cd implementation && npm run test:cljs` — **8503 tests / 39377 assertions, 0 failures, 0 errors**.

Closes rf2-3fc89f.30.
