### PR TITLE
fix(routing): reconcile the browser URL listener on ownership transfer (rf2-3fc89f.11)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -379,19 +379,23 @@
 ;; Frame teardown reaches all routing-owned host-side state through one
 ;; optional late-bound hook.
 (defn- release-routing-host-caches!
-  "Release a destroyed frame's scroll and allocator caches, remove the
-  browser listener when the frame owns it, and drop the frame's URL claim.
-  The `:routing/on-frame-destroyed!` teardown body."
+  "Release a destroyed frame's scroll and allocator caches, drop the frame's
+  URL claim, and reconcile the browser URL listener. The
+  `:routing/on-frame-destroyed!` teardown body."
   [frame-id]
   (scroll/release-frame! frame-id)
   (nav-counters/release-frame! frame-id)
-  ;; Remove before dropping the claim: the ownership check must still resolve
-  ;; the destroyed frame. Non-owners never installed a listener. A successor
-  ;; binding is installed by its frame-registration lifecycle, not by teardown.
-  #?(:cljs
-     (when (= frame-id (nav-fx/url-owner-frame-id))
-       (history/remove-url-listener!)))
+  ;; Drop the destroyed frame's URL claim FIRST so `url-owner-frame-id` resolves
+  ;; to the successor claimant (or nil), THEN reconcile the browser listener via
+  ;; the single strategy-aware op. Reconciliation rebinds to the successor's
+  ;; strategy when a live claimant remains (the ownership-transfer fix), tears
+  ;; the listener down when no successor remains, and leaves the incumbent
+  ;; instance untouched when a non-owner frame is destroyed. `frame-id` is passed
+  ;; as the EXCLUDED owner: this hook runs BEFORE core's `unregister-frame!`, so
+  ;; the destroyed frame's `:url-bound? true` registry entry still lingers and
+  ;; must not resolve as the owner via the claim-free fallback.
   (nav-fx/drop-url-claim! frame-id)
+  #?(:cljs (history/reconcile-url-listener! frame-id))
   nil)
 
 (late-bind/set-fn! :routing/on-frame-destroyed! release-routing-host-caches!)

--- a/implementation/routing/src/re_frame/routing/history.cljc
+++ b/implementation/routing/src/re_frame/routing/history.cljc
@@ -11,35 +11,58 @@
   synchronously to the explicitly declared URL owner; there is no default-
   frame fallback for an absent owner.
 
-  `on-frame-registered!` resolves the URL owner AT (RE-)REGISTRATION TIME
-  via `url-owner-frame-id` and, when the just-(re)registered frame IS the
-  owner, (re)installs `install-url-listener!`. Each installed callback
-  resolves its dispatch target again when it fires. The strategy itself is
-  selected at install time, so changing URL ownership or strategy is a frame-
-  registration operation. This is symmetric with `:rf.nav/push-url`: the
-  same explicitly declared owner drives both directions.
+  ONE STRATEGY-AWARE RECONCILIATION OP owns the listener. `reconcile-url-
+  listener!` resolves the CURRENT URL owner (`url-owner-frame-id`) and its
+  `:url-strategy`, compares them to the OWNER + STRATEGY of the listener that
+  is actually installed (tracked in `history-listener-atom`), and establishes
+  EXACTLY ONE matching listener — or none:
 
-  The listener is one of the URL-strategy consult points.
-  `install-url-listener!` resolves the URL owner's `:url-strategy` (default
-  `history-url-strategy`) and
-  installs THAT strategy's browser listener — `popstate` for a history
-  app, `hashchange` for a hash app — decoding each browser-driven change
-  to a path-form URL before dispatching `:rf.route/handle-url-change`.
+    - no owner            → tear down any installed listener (leave none);
+    - owner+strategy match the installed listener → LEAVE it untouched (so a
+      losing-duplicate registration never disturbs the incumbent instance, and
+      a repeated reconcile never stacks a second listener);
+    - otherwise           → tear the installed listener down and install the
+      current owner's strategy listener, then sync the current URL into the
+      owner's slice.
 
-  `on-frame-registered!` installs from `re-frame.frame/reg-frame`'s
-  POST-CREATE lifecycle hook (`:routing/on-frame-registered!`, fired AFTER
-  the frame container exists and, on first registration, after
-  `:initial-events` ran — the registrar's OWN `:frame` registration hook,
-  `re-frame.routing.url-bound/check-url-bound-exclusivity!`, fires too
-  early: `registrar/register!` runs BEFORE the frame container is created,
-  so an install from there would dispatch the initial sync into a
-  not-yet-live frame) and `re-frame.routing/release-routing-host-caches!`
-  removes it from `frame/destroy-frame!`'s teardown when the destroyed
-  frame was the URL owner. A losing duplicate `:url-bound? true`
-  registration (`id` is NOT the resolved owner —
-  `re-frame.routing.url-bound` already emitted
-  `:rf.error/duplicate-url-binding`) never reaches `install-url-listener!`
-  at all — it must never install a second, wrong listener.
+  Because the decision is OWNERSHIP-driven (not tied to which frame just
+  (re)registered), the SAME op both installs the successor when the incumbent
+  relinquishes/destroys its binding while another live claimant remains, AND
+  rewires the SAME owner when only its `:url-strategy` changed (hot-reload).
+  Each installed callback re-resolves its dispatch target when it fires, so
+  Back/Forward always drives whichever frame currently owns the URL — symmetric
+  with `:rf.nav/push-url`: one explicitly declared owner, both directions.
+
+  The listener is one of the URL-strategy consult points: the reconcile op
+  resolves the URL owner's `:url-strategy` (default `history-url-strategy`) and
+  installs THAT strategy's browser listener — `popstate` for a history app,
+  `hashchange` for a hash app — decoding each browser-driven change to a
+  path-form URL before dispatching `:rf.route/handle-url-change`.
+
+  Reconciliation runs from TWO lifecycle points:
+
+    - `on-frame-registered!` — `re-frame.frame/reg-frame`'s POST-CREATE hook
+      (`:routing/on-frame-registered!`, fired AFTER the frame container exists
+      and, on first registration, after `:initial-events` ran — the registrar's
+      OWN `:frame` registration hook,
+      `re-frame.routing.url-bound/check-url-bound-exclusivity!`, fires too
+      early: `registrar/register!` runs BEFORE the frame container is created,
+      so an install from there would dispatch the initial sync into a
+      not-yet-live frame). It reconciles after every (re-)registration, so a
+      post-registration claim change (an owner opting out with `:url-bound?
+      false` while a successor is live) rebinds to the successor's strategy.
+    - `re-frame.routing/release-routing-host-caches!` —
+      `frame/destroy-frame!`'s teardown hook. It drops the destroyed frame's
+      URL claim and then reconciles, passing the destroyed id as the EXCLUDED
+      owner (the frame is still in the registrar here — `unregister-frame!`
+      runs after this hook — so its lingering `:url-bound? true` entry must not
+      resolve as the owner). A destroyed owner with a live successor rebinds to
+      it; a destroyed owner with no successor leaves no listener.
+
+  A losing duplicate `:url-bound? true` registration (`id` is NOT the resolved
+  owner — `re-frame.routing.url-bound` already emitted
+  `:rf.error/duplicate-url-binding`) leaves the resolved owner unchanged, so
+  reconciliation is a no-op and the incumbent listener instance is untouched.
 
   Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.router :as router]
@@ -61,124 +84,158 @@
 
 #?(:cljs
    (defonce ^:private history-listener-atom
-     ;; Holds the installed listener TEARDOWN thunk so a re-install
-     ;; (`install-url-listener!` called twice — e.g. hot-reload) tears the
-     ;; prior listener down rather than stacking listeners. The strategy's
-     ;; `:install-listener!` returns the teardown; we hold it here.
+     ;; Holds the INSTALLED-LISTENER RECORD `{:owner frame-id :strategy strat
+     ;; :teardown thunk}`, or `nil` when nothing is installed. `reconcile-url-
+     ;; listener!` compares the current URL owner + strategy to `:owner` /
+     ;; `:strategy` here to decide whether the installed listener already
+     ;; matches (leave it — no re-install, no stacking) or must be torn down and
+     ;; replaced. The strategy's `:install-listener!` returns the `:teardown`
+     ;; thunk we hold for that teardown. CLJS-only host state — deliberately
+     ;; OUTSIDE runtime-db (the listener is a host resource, not app state).
      (atom nil)))
 
 #?(:cljs
-   (defn install-url-listener!
-     "Install the current URL owner's browser URL-change
-     listener, then sync the current URL into that frame's route slice at
-     `[:rf.runtime/routing :current]`. This is the single strategy-aware
-     engine `on-frame-registered!` drives automatically from the
-     `:url-bound?` frame lifecycle — it replaces the hand-rolled `popstate` /
-     `hashchange` wiring apps used to write themselves.
-
-     The listener kind is chosen by the URL owner's `:url-strategy`
-     (default `history-url-strategy`): a HISTORY app gets a `popstate`
-     listener, a HASH app gets a `hashchange` listener. Each browser-driven
-     change is DECODED to a PATH-FORM URL by the strategy's `:decode`, then
-     dispatched as `:rf.route/handle-url-change` — so the route cascade stays
-     path-form regardless of the address-bar form.
-
-     Per Spec 012 §Multi-frame routing the dispatch is targeted at
-     `(url-owner-frame-id)` resolved AT FIRE TIME, so it tracks whichever
-     single frame currently owns the URL, including `:rf/default` only when it
-     explicitly declares `:url-bound? true`. This is the
-     inbound (browser → app) counterpart of the outbound `:rf.nav/push-url`
-     gate: one owner, both directions. `url-owner-frame-id` returns nil when
-     no frame declared `:url-bound? true`; the callback then skips the
-     dispatch (installing a listener with no declared owner is a
-     routing-config no-op, not a default-frame write).
-
-     The STRATEGY (which browser event, which decode) is resolved from the
-     current URL owner's `:url-strategy` at install time; the OWNER (dispatch
-     target) is always re-resolved per fire, so Back/Forward keeps tracking
-     ownership even if it changes after install.
-
-     Idempotent: re-installing tears down the previously-installed listener
-     (hot-reload / re-registration safe — `on-frame-registered!` calls this on
-     every (re-)registration where `id` is the resolved owner). Returns
-     `nil`. CLJS-only; the JVM half is a no-op (`:require`-able from `.cljc`
-     boot code without a reader conditional).
-
-     Both the initial sync and each change dispatch use `dispatch-sync!`: a
-     `popstate` / `hashchange` event always fires on the browser's macrotask
-     loop, never nested inside a re-frame drain, so the run-to-completion
-     update is safe and the slice (and rendered body) restore synchronously
-     within the same browser turn — no intermediate paint on the stale route.
-     This mirrors the locked routing-history contract (the
-     `popstate-via-window-listener-cljs` test dispatches `dispatch-sync`)."
+   (defn- teardown-current!
+     "Tear down the currently-installed listener (if any) via its held
+     teardown thunk and clear the record. Idempotent."
      []
-     (let [strat (strategy/url-strategy-for-frame-id (nav-fx/url-owner-frame-id))
-           w (when (exists? js/window) js/window)
+     (when-let [teardown (:teardown @history-listener-atom)]
+       (try (teardown) (catch :default _ nil)))
+     (reset! history-listener-atom nil)
+     nil))
+
+#?(:cljs
+   (defn- install-listener-for-owner!
+     "Tear down any installed listener, then install `owner`'s `strat` browser
+     URL-change listener, record `{:owner :strategy :teardown}`, and sync the
+     current URL into the owner's route slice at `[:rf.runtime/routing
+     :current]`.
+
+     The listener kind is the strategy's (`popstate` for history, `hashchange`
+     for hash); each browser-driven change is DECODED to a PATH-FORM URL by the
+     strategy's `:decode` then dispatched as `:rf.route/handle-url-change`, so
+     the route cascade stays path-form regardless of the address-bar form.
+
+     The dispatch targets `(url-owner-frame-id)` re-resolved AT FIRE TIME, so
+     Back/Forward always drives whichever frame currently owns the URL even if
+     ownership changes after install. Both the initial sync and each change
+     dispatch use `dispatch-sync!`: a `popstate` / `hashchange` fires on the
+     browser's macrotask loop, never nested inside a re-frame drain, so the
+     run-to-completion update is safe and the slice restores synchronously
+     within the same browser turn (the locked routing-history contract)."
+     [owner strat]
+     (let [w (when (exists? js/window) js/window)
            decode (:decode strat)
            install-listener! (:install-listener! strat)
-           ;; The dispatch targets the EXPLICITLY-declared URL owner resolved
-           ;; AT FIRE TIME with the strategy-decoded
-           ;; path-form URL. Skips when no owner is declared.
            dispatch-to-owner!
            (fn [path-url]
-             (when-let [owner (nav-fx/url-owner-frame-id)]
+             (when-let [o (nav-fx/url-owner-frame-id)]
                (router/dispatch-sync! [:rf.route/handle-url-change path-url]
-                                      {:frame owner})))]
+                                      {:frame o})))]
        (when w
-         ;; Tear down any prior listener (hot-reload / re-registration safe)
-         ;; before installing.
-         (when-let [teardown @history-listener-atom]
-           (try (teardown) (catch :default _ nil)))
-         ;; The strategy installs its browser listener and returns a 0-arg
-         ;; teardown thunk we hold for the next re-install / removal.
-         (reset! history-listener-atom (install-listener! dispatch-to-owner!)))
-       ;; Initial sync: hydrate the owner's slice from the current URL so
-       ;; a deep link / reload lands on the right route on first paint.
+         (teardown-current!)
+         (reset! history-listener-atom
+                 {:owner    owner
+                  :strategy strat
+                  :teardown (install-listener! dispatch-to-owner!)}))
+       ;; Initial sync: hydrate the owner's slice from the current URL so a deep
+       ;; link / reload / ownership transfer lands on the right route.
        (dispatch-to-owner! (decode))
        nil)))
 
 #?(:cljs
+   (defn reconcile-url-listener!
+     "THE single strategy-aware listener reconciliation op. Resolve the current
+     URL owner (`url-owner-frame-id`) and its `:url-strategy`, compare them to
+     the owner + strategy of the listener actually installed
+     (`history-listener-atom`), and establish EXACTLY ONE matching listener — or
+     none:
+
+       - no current owner                              → tear down any installed
+                                                          listener (leave none);
+       - current owner + strategy MATCH the installed  → leave the installed
+                                                          listener instance
+                                                          UNTOUCHED (no
+                                                          re-install, no
+                                                          stacking, no re-sync);
+       - otherwise (owner changed, or same owner's
+         strategy changed — hot-reload rewire)         → tear the installed
+                                                          listener down and
+                                                          install the current
+                                                          owner's strategy
+                                                          listener + initial
+                                                          sync.
+
+     `excluded-id` (destroy path) is a frame whose registry entry still lingers
+     mid-teardown (`re-frame.frame/destroy-frame!` runs this hook BEFORE
+     `unregister-frame!`): its stale `:url-bound? true` entry could otherwise be
+     resolved as the sole owner by the claim-free fallback even though its claim
+     was just dropped, so a resolved owner equal to `excluded-id` is treated as
+     no owner.
+
+     Ownership-driven, so ONE op serves both lifecycle points: it installs the
+     successor when the incumbent relinquishes/is destroyed while a live
+     claimant remains, and rewires the same owner when only its strategy
+     changed. A losing-duplicate registration does not change the resolved
+     owner, so reconciliation is a no-op — the incumbent's listener instance is
+     preserved. Returns `nil`."
+     ([] (reconcile-url-listener! nil))
+     ([excluded-id]
+      (let [resolved  (nav-fx/url-owner-frame-id)
+            owner     (when (not= resolved excluded-id) resolved)
+            strat     (when owner (strategy/url-strategy-for-frame-id owner))
+            installed @history-listener-atom]
+        (cond
+          ;; No declared owner (or the only resolvable candidate is the frame
+          ;; being torn down) → ensure no listener remains.
+          (nil? owner)
+          (teardown-current!)
+
+          ;; The installed listener already matches the current owner AND
+          ;; strategy → leave the exact instance untouched.
+          (and (= owner (:owner installed))
+               (= strat (:strategy installed)))
+          nil
+
+          ;; Ownership transferred, or the same owner's strategy changed →
+          ;; establish the matching listener (tears down the prior one first).
+          :else
+          (install-listener-for-owner! owner strat))
+        nil))))
+
+#?(:cljs
    (defn remove-url-listener!
-     "Tear down the
-     browser URL-change listener installed by `install-url-listener!`
-     (whichever kind the strategy wired — `popstate` or `hashchange`), via
-     the teardown thunk it returned. No-op when none is installed. Called by
-     `re-frame.routing/release-routing-host-caches!` (the
-     `:routing/on-frame-destroyed!` teardown hook) when the destroyed frame
-     was the URL owner, AND published as the `:routing/reset-url-listener!`
-     test-isolation hook (the shared `make-reset-runtime-fixture` reset-hook
-     table calls it between tests — a raw `frame/frames` reset does not run
-     `destroy-frame!`'s teardown chain, so a leftover installed listener
-     would otherwise survive into the next test)."
+     "Tear down the browser URL-change listener (whichever kind the strategy
+     wired — `popstate` or `hashchange`) unconditionally. No-op when none is
+     installed. Published as the `:routing/reset-url-listener!` test-isolation
+     hook (the shared `make-reset-runtime-fixture` reset-hook table calls it
+     between tests — a raw `frame/frames` reset does not run `destroy-frame!`'s
+     teardown chain, so a leftover installed listener would otherwise survive
+     into the next test). The `:routing/on-frame-destroyed!` teardown reconciles
+     instead (`reconcile-url-listener!`), which tears the destroyed owner's
+     listener down as part of resolving the successor (or none)."
      []
-     (when-let [teardown @history-listener-atom]
-       (try (teardown) (catch :default _ nil))
-       (reset! history-listener-atom nil))
-     nil))
+     (teardown-current!)))
 
 #?(:cljs
    (defn on-frame-registered!
-     "Post-(re-)registration frame-lifecycle hook. When the
-     just-(re)registered frame `id` is the RESOLVED URL owner
-     (`url-owner-frame-id`), (re)install its `:url-strategy` browser
-     listener via `install-url-listener!` — idempotent, so a re-registration
-     rewires cleanly (e.g. a hot-reloaded `:url-strategy` change, or a frame
-     that newly opts into `:url-bound? true`).
+     "Post-(re-)registration frame-lifecycle hook: reconcile the browser URL
+     listener (`reconcile-url-listener!`). Ownership-driven, so it does the
+     right thing on every registration path — first URL owner installs; a frame
+     newly opting into `:url-bound? true` installs; an owner re-registering with
+     a changed `:url-strategy` rewires once; an owner opting OUT with
+     `:url-bound? false` while a successor is live rebinds to the successor's
+     strategy; and a losing-duplicate `:url-bound? true` registration (the
+     resolved owner is unchanged — `re-frame.routing.url-bound` already emitted
+     `:rf.error/duplicate-url-binding`) or an ordinary non-url-bound frame is a
+     no-op, leaving the incumbent listener instance untouched.
 
-     A losing duplicate `:url-bound? true` registration (`id` is NOT the
-     resolved owner — `re-frame.routing.url-bound` already emitted
-     `:rf.error/duplicate-url-binding`) or an ordinary non-url-bound frame is
-     a no-op: this must never install a second, wrong listener (Spec 012
-     §Multi-frame routing — the existing owner is unchanged).
-
-     Published as the `:routing/on-frame-registered!` late-bind hook,
-     invoked by `re-frame.frame/reg-frame` AFTER the frame container exists
-     (and, on first registration, after `:initial-events` ran) — the
-     registrar's OWN `:frame` registration hook
-     (`re-frame.routing.url-bound/check-url-bound-exclusivity!`) fires too
-     early for an install: `registrar/register!` runs BEFORE the frame
-     container is created, so a listener installed from there would dispatch
-     its initial sync into a not-yet-live frame."
-     [id]
-     (when (= id (nav-fx/url-owner-frame-id))
-       (install-url-listener!))))
+     Published as the `:routing/on-frame-registered!` late-bind hook, invoked by
+     `re-frame.frame/reg-frame` AFTER the frame container exists (and, on first
+     registration, after `:initial-events` ran) — the registrar's OWN `:frame`
+     registration hook (`re-frame.routing.url-bound/check-url-bound-
+     exclusivity!`) fires too early for an install: `registrar/register!` runs
+     BEFORE the frame container is created, so a listener installed from there
+     would dispatch its initial sync into a not-yet-live frame."
+     [_id]
+     (reconcile-url-listener!)))

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -582,6 +582,160 @@
                        (first (get-in @*history-state* [:listeners "popstate"])))
           "the duplicate's registration did not tear down + reinstall the incumbent's listener"))))
 
+;; =========================================================================
+;; rf2-3fc89f.11: URL-listener RECONCILIATION on ownership TRANSFER
+;; =========================================================================
+;;
+;; When URL ownership transfers between frames — the incumbent owner is
+;; DESTROYED, or RELINQUISHES its binding by re-registering `:url-bound? false`
+;; — while another live `:url-bound? true` claimant remains, the browser
+;; URL-change listener must REBIND to the new owner's strategy. Before the fix
+;; the destroy path removed the incumbent's listener and installed nothing (a
+;; live successor was left with ZERO browser listeners), and the re-registration
+;; opt-out path left the incumbent's stale listener in place (a history→hash
+;; handoff kept `popstate` and never installed `hashchange`). The single
+;; strategy-aware `reconcile-url-listener!` op, invoked after post-registration
+;; claim changes AND after destroyed-owner claim removal, establishes exactly
+;; one matching listener (or none).
+
+(deftest url-ownership-transfer-on-destroy-rebinds-listener-cljs-rf2-3fc89f-11
+  (testing "rf2-3fc89f.11: destroying the URL owner rebinds the browser listener
+            to the live successor claimant — exactly one popstate listener,
+            url-owner resolves to B, and Back drives B's route slice (the bug
+            left ZERO listeners after the destroy)"
+    (rf/reg-route :hist/home     {} "/")
+    (rf/reg-route :hist/cart     {} "/cart")
+    (rf/reg-route :hist/checkout {} "/checkout")
+    ;; A first-claims the URL (history strategy) → owns + installs popstate. B is
+    ;; a later live :url-bound? true claimant (a losing duplicate the registry
+    ;; retains and orders AFTER A).
+    (rf/reg-frame :owner/a {:url-bound? true})
+    (rf/reg-frame :owner/b {:url-bound? true})
+    (is (= :owner/a (routing/url-owner-frame-id))
+        "A is the first-claimed URL owner")
+    (is (= 1 (count (get-in @*history-state* [:listeners "popstate"])))
+        "A's popstate listener installed automatically on create")
+
+    ;; Destroy A: ownership transfers to the live claimant B; the listener rebinds.
+    (rf/destroy-frame! :owner/a)
+    (is (= :owner/b (routing/url-owner-frame-id))
+        "ownership resolved to the surviving claimant B")
+    (is (= 1 (count (get-in @*history-state* [:listeners "popstate"])))
+        "exactly one popstate listener remains, rebound to B (was ZERO under the bug)")
+
+    ;; B owns the URL now: forward nav pushes, Back drives B's slice through the
+    ;; rebound listener.
+    (rf/dispatch-sync [:rf.route/navigate :hist/cart]     {:frame :owner/b})
+    (rf/dispatch-sync [:rf.route/navigate :hist/checkout] {:frame :owner/b})
+    (is (= ["/" "/cart" "/checkout"] (:entries @*history-state*))
+        "B, the new owner, drives outbound pushState")
+    (.back (.-history js/globalThis.window))
+    (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+    (is (= :hist/cart
+           (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :owner/b)) [:rf.runtime/routing :current])))
+        "Back drove the NEW owner B's slice to /cart via the rebound popstate listener")))
+
+(deftest url-ownership-transfer-on-destroy-cross-strategy-rebinds-cljs-rf2-3fc89f-11
+  (testing "rf2-3fc89f.11: when the successor uses a DIFFERENT strategy,
+            destroying the owner tears the old popstate down and installs the
+            successor's hashchange — a hashchange updates B from the
+            hash-decoded path"
+    (rf/reg-route :hist/home   {} "/")
+    (rf/reg-route :hist/active {} "/active")
+    ;; A = history owner (popstate); B = hash claimant (hashchange).
+    (rf/reg-frame :owner/a {:url-bound? true})
+    (rf/reg-frame :owner/b {:url-bound? true :url-strategy routing/hash-url-strategy})
+    (is (= :owner/a (routing/url-owner-frame-id)))
+    (is (= 1 (count (get-in @*history-state* [:listeners "popstate"])))
+        "A installed a popstate listener")
+    (is (empty? (get-in @*history-state* [:listeners "hashchange"]))
+        "no hashchange listener yet — A is a history owner")
+
+    (rf/destroy-frame! :owner/a)
+    (is (= :owner/b (routing/url-owner-frame-id))
+        "ownership resolved to the hash claimant B")
+    (is (empty? (get-in @*history-state* [:listeners "popstate"]))
+        "the history owner's popstate listener was torn down on transfer")
+    (is (= 1 (count (get-in @*history-state* [:listeners "hashchange"])))
+        "the successor's hash strategy installed exactly one hashchange listener")
+
+    ;; Move the browser hash to #/active; the rebound hashchange listener decodes
+    ;; #/active → /active and updates B.
+    (.pushState js/globalThis.window.history nil "" "#/active")
+    (.dispatchEvent js/globalThis.window #js {:type "hashchange"})
+    (is (= :hist/active
+           (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :owner/b)) [:rf.runtime/routing :current])))
+        "the rebound hashchange listener decoded #/active → /active and drove B")))
+
+(deftest url-ownership-transfer-on-reregistration-cross-strategy-cljs-rf2-3fc89f-11
+  (testing "rf2-3fc89f.11: when the incumbent HISTORY owner opts OUT via
+            re-registration (:url-bound? false) while a live HASH claimant B
+            remains, the listener rebinds to B's hashchange strategy WITHOUT B
+            re-registering — a history→hash handoff must not keep the stale
+            popstate"
+    (rf/reg-route :hist/home   {} "/")
+    (rf/reg-route :hist/active {} "/active")
+    (rf/reg-frame :owner/a {:url-bound? true})   ;; history owner, popstate
+    (rf/reg-frame :owner/b {:url-bound? true :url-strategy routing/hash-url-strategy})
+    (is (= :owner/a (routing/url-owner-frame-id)))
+    (is (= 1 (count (get-in @*history-state* [:listeners "popstate"]))))
+    (is (empty? (get-in @*history-state* [:listeners "hashchange"])))
+
+    ;; A opts out; B (hash) becomes owner without re-registering.
+    (rf/reg-frame :owner/a {:url-bound? false})
+    (is (= :owner/b (routing/url-owner-frame-id))
+        "ownership fell through to the still-bound hash claimant B")
+    (is (empty? (get-in @*history-state* [:listeners "popstate"]))
+        "A's stale popstate listener was torn down (history→hash handoff)")
+    (is (= 1 (count (get-in @*history-state* [:listeners "hashchange"])))
+        "B's hash strategy installed exactly one hashchange listener")
+
+    (.pushState js/globalThis.window.history nil "" "#/active")
+    (.dispatchEvent js/globalThis.window #js {:type "hashchange"})
+    (is (= :hist/active
+           (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :owner/b)) [:rf.runtime/routing :current])))
+        "the rebound hashchange listener drove B from the hash-decoded path")))
+
+(deftest same-owner-strategy-change-rewires-once-cljs-rf2-3fc89f-11
+  (testing "rf2-3fc89f.11 (preserve): re-registering the SAME owner with a
+            changed :url-strategy rewires exactly once — the history popstate is
+            torn down, exactly one hashchange installed, no double listener"
+    (rf/reg-route :hist/home   {} "/")
+    (rf/reg-route :hist/active {} "/active")
+    (rf/reg-frame :owner/a {:url-bound? true})   ;; history → popstate
+    (is (= 1 (count (get-in @*history-state* [:listeners "popstate"]))))
+    ;; Same owner re-registers with the hash strategy (hot-reload strategy swap).
+    (rf/reg-frame :owner/a {:url-bound? true :url-strategy routing/hash-url-strategy})
+    (is (= :owner/a (routing/url-owner-frame-id))
+        "A is still the owner across the strategy change")
+    (is (empty? (get-in @*history-state* [:listeners "popstate"]))
+        "the old history popstate listener was torn down")
+    (is (= 1 (count (get-in @*history-state* [:listeners "hashchange"])))
+        "exactly one hashchange listener installed — rewired once, not stacked")
+    (.pushState js/globalThis.window.history nil "" "#/active")
+    (.dispatchEvent js/globalThis.window #js {:type "hashchange"})
+    (is (= :hist/active
+           (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :owner/a)) [:rf.runtime/routing :current])))
+        "the rewired hashchange listener drives the same owner A")))
+
+(deftest destroying-non-owner-leaves-incumbent-listener-untouched-cljs-rf2-3fc89f-11
+  (testing "rf2-3fc89f.11 (preserve): reconciliation on a NON-owner frame
+            destroy leaves the incumbent owner's listener instance untouched —
+            owner unchanged → no tear-down + reinstall, no stacking"
+    (rf/reg-route :hist/home {} "/")
+    (rf/reg-frame :owner/a {:url-bound? true})       ;; owner, popstate
+    (rf/reg-frame :owner/b {:url-bound? true})       ;; losing duplicate (claimed after A)
+    (let [incumbent (first (get-in @*history-state* [:listeners "popstate"]))]
+      (is (some? incumbent) "A's popstate listener is installed")
+      ;; Destroy the NON-owner duplicate B — A keeps the URL.
+      (rf/destroy-frame! :owner/b)
+      (is (= :owner/a (routing/url-owner-frame-id))
+          "A is still the owner after the non-owner B is destroyed")
+      (is (identical? incumbent (first (get-in @*history-state* [:listeners "popstate"])))
+          "the incumbent's popstate listener instance was NOT torn down + reinstalled")
+      (is (= 1 (count (get-in @*history-state* [:listeners "popstate"])))
+          "still exactly one popstate listener — no stacking"))))
+
 ;; ---- rf2-9vgyp7: first-load / deep-link route hydration at frame create ----
 ;;
 ;; The URL-owning frame's LIFECYCLE (rf2-g8pbwg) drives the initial URL sync: a


### PR DESCRIPTION
## Summary

Fixes **rf2-3fc89f.11** (P2): when URL ownership transfers between frames — the incumbent `:url-bound?` owner is destroyed, or relinquishes its binding by re-registering `:url-bound? false` — while another live `:url-bound? true` claimant remains, the browser URL-change listener was **not** rebound to the new owner/strategy.

Introduces **one strategy-aware `reconcile-url-listener!` op** (per the bead's DESIGN — no point-fixes). It resolves the current URL owner + its `:url-strategy`, compares them to the owner/strategy of the listener actually installed (tracked in the CLJS-only `history-listener-atom`), and establishes **exactly one matching listener (or none)**:

- no owner → tear down any installed listener (leave none);
- owner + strategy match the installed listener → leave the exact instance **untouched** (no re-install, no stacking, no re-sync);
- otherwise (owner changed, or same owner's strategy changed) → tear down + install the current owner's strategy listener + initial sync.

It is invoked from **both** frame-lifecycle points:
- `on-frame-registered!` (post-registration) — so an owner opting out with `:url-bound? false` while a successor is live rebinds to the successor's strategy.
- `release-routing-host-caches!` (destroyed-owner claim removal) — drop the claim first, then reconcile, passing the destroyed id as the **excluded owner** (the frame is still in the registrar here — `unregister-frame!` runs after this hook — so its lingering `:url-bound? true` entry must not resolve as owner via the claim-free fallback).

## Stance
Pre-alpha; one strategy-aware reconciliation op (not point-fixes); frame locality preserved; ELEGANCE + CLARITY + CORRECTNESS. Listener host state stays a CLJS-only `defonce` atom **outside** runtime-db; listener installation is **not** moved into the registrar's pre-container registration hook.

## Reproduce → fix evidence
Reverting only the two source files to `origin/main` and running the CLJS suite with the new tests: **7 failures across exactly 3 deftests** — all three bug-repro tests:
- `url-ownership-transfer-on-destroy-rebinds-listener-cljs` — destroying the owner left **ZERO** popstate listeners (successor unbound).
- `url-ownership-transfer-on-destroy-cross-strategy-rebinds-cljs` — history→hash successor never got a `hashchange` listener.
- `url-ownership-transfer-on-reregistration-cross-strategy-cljs` — owner opting out kept the stale `popstate`, never installed the successor's `hashchange`.

With the fix, all three pass. The two **preserve** tests pass on both old and new code:
- `same-owner-strategy-change-rewires-once` — hot-reload strategy swap rewires once (popstate→hashchange), no double listener.
- `destroying-non-owner-leaves-incumbent-listener-untouched` — a non-owner destroy leaves the incumbent listener instance untouched (`identical?`), no stacking.

The existing `duplicate-url-bound-frame-does-not-reinstall-listener-cljs` (losing-duplicate leaves incumbent untouched) and `url-bound-frame-lifecycle-installs-on-create-and-removes-on-destroy-cljs` (no successor → no listener) continue to pass.

## Quality gates (foreground)
- `implementation/routing` JVM: `clojure -M:test` → **393 tests, 1758 assertions, 0 failures, 0 errors**.
- `implementation`: `npm run test:cljs` → **8506 tests, 39385 assertions, 0 failures, 0 errors**.

## Scope
Touched only `implementation/routing/src` (`history.cljc` reconciliation op + `:url-bound?` lifecycle invocation in `routing.cljc`) and `implementation/routing/test/**`. Not hot-zone.