### PR TITLE
fix(schemas): operator-aware opacity walk — literal operands are data, not child schemas (rf2-3fc89f.12)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -387,39 +387,137 @@
   [schema]
   (not (or (vector? schema) (keyword? schema))))
 
+;; ---- opacity-recursion operator classification ----------------------------
+;;
+;; The opacity walk (`schema-has-opaque-child?` / `opaque-nested-tail?`)
+;; recurses a vector-form schema's REAL child-schema positions to detect a
+;; nested opaque (compiled) value whose per-slot `:sensitive?` flag the
+;; pure-data walker cannot see. A Malli vector form is `[op props? & tail]`,
+;; but the tail is a child SCHEMA only for STRUCTURAL ops. For LITERAL / config
+;; ops the tail is DATA — `[:= 42]` holds the value `42`, `[:enum 1 2]` the
+;; members, `[:> 10]` a comparator bound, `[:re "x"]` a pattern, `[:ref ::k]`
+;; a reference — and the scalar primitives (`:int`, `:string`, …) carry no
+;; child schema at all. Recursing into those data operands is the rf2-3fc89f.12
+;; bug: an ordinary literal (`42`, `"x"`) reaches the opaque `:else` and the
+;; whole schema is false-flagged as carrying an opaque child. So the walk
+;; projects the true child schemas per operator instead of treating every tail
+;; element as a child. Classification is structural (no Malli/validator
+;; introspection) and covers the shipped Malli 0.20.1 default registry.
+
+;; Ops whose children are `[head props? child-schema]` ENTRIES — the head is a
+;; map key / dispatch value / branch name (data); only the entry tail is a real
+;; child position. Reuses the walker's `name-bearing-ops` (`:map`) and
+;; `dispatch-bearing-ops` (`:multi` / `:orn` / `:altn`) categories and adds the
+;; named sequence combinators (`:catn` / `:andn`). (`:catn` is entry-shaped for
+;; opacity even though the decl-path walk treats it as position-bearing — here
+;; only the child-schema position matters, which is the entry tail.)
+(def ^:private opacity-entry-ops
+  (into (into name-bearing-ops dispatch-bearing-ops) #{:catn :andn}))
+
+;; Ops whose children are BARE child schemas: homogeneous container element
+;; schemas (`:vector` `:set` `:sequential` `:seqable` `:every`); tuple / cat /
+;; alt / regex-quantifier elements (`:tuple` `:cat` `:alt` `:*` `:+` `:?`
+;; `:repeat`); transparent / combinator children (`:and` `:or` `:not` `:maybe`
+;; `:schema` `:malli.core/schema`); `:map-of` key + value schemas; and function
+;; schemas (`:->` `:=>` `:function`). Every tail element is a real schema
+;; position, so the walk descends each directly.
+(def ^:private opacity-bare-ops
+  #{:and :or :not :maybe
+    :vector :sequential :set :seqable :every
+    :tuple :cat :alt :* :+ :? :repeat
+    :schema :malli.core/schema :map-of
+    :-> :=> :function})
+
+;; Ops whose vector tail is DATA (a comparator bound, `:=` / `:enum` members,
+;; a regex pattern, a predicate fn, a registry reference) or which carry no
+;; child schema at all (scalar primitives). The opacity walk MUST NOT descend
+;; into these — their tails are operands, not child schemas.
+(def ^:private opacity-literal-ops
+  #{:= :not= :enum :< :<= :> :>= :re :fn :ref
+    :any :boolean :double :float :int :keyword :nil
+    :qualified-keyword :qualified-symbol :some :string :symbol :uuid})
+
+(defn- entry-child-schema
+  "Return the child SCHEMA of a Malli entry `[head props? schema]` (a `:map`
+  key entry or a `:multi` / `:orn` / `:altn` / `:andn` / `:catn` branch). The
+  head is data (key / dispatch value / name), so only the tail is a real child
+  position. Returns nil for a tail-less entry (nothing to walk), or a non-entry
+  value unchanged so a malformed opaque child is still inspected (fail-closed)."
+  [entry]
+  (if (and (vector? entry) (>= (count entry) 2))
+    (if (map? (nth entry 1))
+      (nth entry 2 nil)
+      (nth entry 1))
+    entry))
+
+(defn- opacity-child-schemas
+  "Operator-aware projection of the child SCHEMAS a vector-form schema exposes
+  to the opacity walk (see the operator-classification note above). Returns a
+  sequence of child schemas for a known structural op, an empty sequence for a
+  known literal / scalar op (its tail is data), or `::opaque` for an
+  unclassified op — the walk cannot prove that op's tail is not a
+  schema-bearing position, so it fails closed."
+  [schema]
+  (let [op (nth schema 0)]
+    (cond
+      (contains? opacity-literal-ops op) []
+      (contains? opacity-bare-ops op)    (children-of schema)
+      (contains? opacity-entry-ops op)
+      (into [] (comp (map entry-child-schema) (remove nil?))
+            (children-of schema))
+      :else ::opaque)))
+
 (defn- opaque-nested-tail?
-  "Private recursive helper for `schema-has-opaque-child?`. Identical to
-  `schema-opaque?`'s notion of opaque EXCEPT a bare fn or symbol reached
-  as a nested TAIL is NOT opaque here — see `schema-has-opaque-child?`'s
-  docstring for why a bare fn/symbol below the root is provably
-  flag-free. Only ever called on a value already reached by descending
-  through `children-of`, i.e. never on the caller's original root
-  argument — see `schema-has-opaque-child?` for the root/nested split."
+  "Private recursive helper for `schema-has-opaque-child?`. True when `schema`
+  — a value reached by descending into a real child-schema position — is an
+  opaque compiled value, OR a vector-form schema that (operator-awarely)
+  contains an opaque descendant, OR an unclassified operator shape (fail
+  closed). A bare keyword / fn / symbol reached here is NOT opaque: it is a
+  primitive schema or a predicate shorthand that provably carries no per-slot
+  props (the enclosing entry is the only place a flag could live, and the walk
+  inspects that entry before its tail). Literal / config operands (`:=` value,
+  `:enum` members, comparator bounds, `:re` pattern, `:ref` target) are DATA,
+  not child schemas, so the projection never descends into them. Only ever
+  called on a descended value, never on the caller's original root argument —
+  see `schema-has-opaque-child?` for the root/nested split."
   [schema]
   (cond
     (keyword? schema) false
     (fn? schema) false
     (symbol? schema) false
     (and (vector? schema) (pos? (count schema)))
-    (boolean (some opaque-nested-tail? (children-of schema)))
+    (let [children (opacity-child-schemas schema)]
+      (if (= ::opaque children)
+        true
+        (boolean (some opaque-nested-tail? children))))
     :else true))
 
 (defn schema-has-opaque-child?
-  "True when the root is opaque or a vector-form schema contains an opaque
-  descendant at any depth. Redaction and registration warnings use this
+  "True when the root is opaque, or a vector-form schema contains an opaque
+  descendant in a real child-schema position at any depth, or the root is an
+  unclassified operator shape. Redaction and registration warnings use this
   recursive predicate so a compiled child cannot hide inside a walkable root.
 
-  Root functions and symbols are opaque and fail closed. The same values used
-  as nested schema tails are considered flag-free because their enclosing
-  entry is the only place slot props can occur, and the walker inspects that
-  entry before its tail. Treating ordinary predicate tails as opaque would
-  conservatively redact every schema that uses Malli's predicate shorthand.
+  The recursion is OPERATOR-AWARE (rf2-3fc89f.12): it descends only the true
+  child-schema positions of each Malli operator. Literal / config operands
+  (`:=` value, `:enum` members, `:re` pattern, comparator bounds, `:ref`
+  target, scalar primitives) are DATA, not child schemas, so they are NOT
+  recursed into — an ordinary `[:= 42]` / `[:enum 1 2]` is fully walkable and
+  NOT opaque. An actual compiled value in a real schema position (a `:map`
+  slot's tail, a container element, a `:map-of` key/value, a `:cat`/`:tuple`
+  element, a `:multi`/`:orn` branch, …) still fails closed, as does a genuinely
+  unknown operator shape.
+
+  Root functions and symbols are opaque and fail closed (via `schema-opaque?`).
+  The same values used as nested schema tails are considered flag-free because
+  their enclosing entry is the only place slot props can occur, and the walker
+  inspects that entry before its tail.
 
   Returns boolean. Pure."
   [schema]
   (or (schema-opaque? schema)
       (and (vector? schema) (pos? (count schema))
-           (boolean (some opaque-nested-tail? (children-of schema))))))
+           (opaque-nested-tail? schema))))
 
 (defn- prefix?
   "True when `prefix` is a prefix of `path` (or equal). Both are

--- a/implementation/schemas/test/re_frame/schemas/walker_literal_operand_fixtures.cljc
+++ b/implementation/schemas/test/re_frame/schemas/walker_literal_operand_fixtures.cljc
@@ -1,0 +1,76 @@
+(ns re-frame.schemas.walker-literal-operand-fixtures
+  "Shared, host-agnostic corpus for the operator-aware schema-opacity walk
+  (rf2-3fc89f.12). Both the JVM parity test (`re-frame.schemas-walker-literal-
+  operand-test`) and the CLJS parity test (`re-frame.schemas-walker-literal-
+  operand-cljs-test`) read these vectors, so `schema-has-opaque-child?` is
+  pinned to the SAME classification on both runtimes.
+
+  Background — Spec 010 §The `:schema` value is opaque to re-frame: the opacity
+  walk recurses a vector-form Malli schema's REAL child-schema positions to
+  detect a nested opaque (compiled `m/schema`) value whose per-slot
+  `:sensitive?` flag the pure-data walker cannot see. A Malli vector form is
+  `[op props? & tail]`, but the tail is a child SCHEMA only for STRUCTURAL ops.
+  For LITERAL / config ops the tail is DATA (`[:= 42]` holds a value, `[:enum
+  1 2]` holds members, `[:> 10]` a comparator bound, `[:re \"x\"]` a pattern),
+  and recursing into it false-flags an ordinary literal as an opaque compiled
+  child — the rf2-3fc89f.12 bug. The walk is now operator-aware and projects
+  the true child schemas per op.
+
+  `m/schema` is `.cljc` and on both host classpaths (the schemas artefact deps
+  on metosin/malli; `re-frame.schemas.malli` requires it), so the compiled-
+  object opaque corpus loads identically on the JVM and under `:node-test`."
+  (:require [malli.core :as m]))
+
+(def not-opaque-forms
+  "Fully walkable schemas whose only vector tails are literal/config DATA (`:=`
+  value, `:enum` members, comparator bounds, `:re` pattern) or ordinary nested
+  schemas — NONE nests an opaque value, so `schema-has-opaque-child?` MUST be
+  false. The rf2-3fc89f.12 bug false-flagged every literal-operand form true."
+  [;; bare literal / comparator / regex operands
+   [:= 42] [:= "x"] [:= :kw] [:= 3.14]
+   [:enum 1 2 3] [:enum "a" "b"] [:enum :x :y]
+   [:> 10] [:>= 10] [:< 10] [:<= 10] [:not= 0]
+   [:re "a.*z"]
+   ;; literal operands nested in REAL structural positions
+   [:cat [:= :demo/e] [:= 42]]                     ;; event-vector schema
+   [:tuple [:= :k] [:enum 1 2]]
+   [:vector [:enum :a :b]]
+   [:set [:= 1]]
+   [:map-of :string [:= 7]]
+   [:map [:code [:enum 200 404]] [:pi [:= 3.14]] [:name :string]]
+   [:multi {:dispatch :t} [:a [:map [:t :keyword] [:n [:= 1]]]]]
+   [:orn [:lit [:= 42]] [:other :int]]
+   ;; plain walkable forms (no literal operands, no opaque child)
+   [:map [:id :int] [:name :string]]
+   [:string] [:int {:min 0}]
+   [:vector :string] [:tuple :int :string]
+   [:and :int [:> 0]] [:or :int :string]
+   [:maybe [:enum :a :b]]])
+
+(def opaque-forms
+  "Schemas that nest a GENUINELY opaque (compiled `m/schema`) value in a REAL
+  child-schema position — must fail closed (true) so an invisible per-slot
+  `:sensitive?` flag cannot hide behind an unintrospectable child. This is the
+  fail-closed guarantee the operator-aware walk MUST preserve."
+  [(m/schema [:string {:sensitive? true}])                  ;; root opaque
+   [:map [:token (m/schema [:string {:sensitive? true}])]]  ;; :map slot tail
+   [:map [:a :int] [:b (m/schema [:int])]]                  ;; later :map slot
+   [:vector (m/schema [:int])]                              ;; container element
+   [:set (m/schema [:int])]
+   [:sequential (m/schema [:int])]
+   [:cat [:= :e] (m/schema [:int])]                         ;; :cat element
+   [:tuple (m/schema [:int]) :string]                       ;; :tuple element
+   [:multi {:dispatch :t} [:a (m/schema [:map])]]           ;; :multi branch
+   [:orn [:x (m/schema [:int])]]                            ;; :orn branch
+   [:map-of (m/schema [:string]) :int]                      ;; :map-of key
+   [:map-of :string (m/schema [:int])]                      ;; :map-of value
+   [:and (m/schema [:int])]                                 ;; combinator child
+   [:or :int (m/schema [:string])]
+   [:maybe (m/schema [:int])]])
+
+(def unknown-op-forms
+  "Unclassified operator shapes — the walk cannot prove the tail is not a
+  schema-bearing position, so it fails CLOSED (true), matching the fail-closed
+  posture for genuinely unknown/unclassifiable operators."
+  [[:my/custom-op [:string]]
+   [:acme.registry/thing 1 2 3]])

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
@@ -1,0 +1,76 @@
+(ns re-frame.schemas-walker-literal-operand-cljs-test
+  "CLJS host-parity half of the operator-aware schema-opacity walk
+  (rf2-3fc89f.12). The classification is structural and identical on CLJ + CLJS,
+  so both runtimes assert the SAME shared corpus
+  (`re-frame.schemas.walker-literal-operand-fixtures`) against the SAME pure
+  entry points. The JVM half (`re-frame.schemas-walker-literal-operand-test`)
+  additionally covers the registration-warning and dev-validate egress paths;
+  this half pins the pure walker (`schema-has-opaque-child?`) and the always-on
+  boundary redactor (`redact-validation-tags`) — both host-agnostic pure
+  functions — so a CLJS regression that diverged from the JVM classification is
+  caught here.
+
+  `re-frame.schemas.malli` is required so `malli.core` (the fixtures'
+  compiled-schema dependency) is on the `:node-test` classpath, mirroring
+  `re-frame.schemas-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.walker-literal-operand-fixtures :as fx]))
+
+;; ---- pure walker: shared cross-host corpus (parity anchor) ----------------
+
+(deftest cljs-literal-operands-are-data-not-opaque
+  (testing "rf2-3fc89f.12 — literal/config operands and their structural forms
+            are walkable, so schema-has-opaque-child? is FALSE on CLJS too
+            (byte-identical classification with the JVM half)"
+    (doseq [s fx/not-opaque-forms]
+      (is (false? (schemas/schema-has-opaque-child? s))
+          (str "literal/walkable form must NOT be opaque: " (pr-str s))))))
+
+(deftest cljs-nested-compiled-values-still-fail-closed
+  (testing "rf2-3fc89f.12 — a nested compiled m/schema value in a real
+            child-schema position still fails closed (true) on CLJS"
+    (doseq [s fx/opaque-forms]
+      (is (true? (schemas/schema-has-opaque-child? s))
+          (str "nested compiled value must fail closed: " (pr-str s))))))
+
+(deftest cljs-unknown-operator-shapes-fail-closed
+  (testing "rf2-3fc89f.12 — an unclassified operator shape fails closed (true)
+            on CLJS"
+    (doseq [s fx/unknown-op-forms]
+      (is (true? (schemas/schema-has-opaque-child? s))
+          (str "unknown operator shape must fail closed: " (pr-str s))))))
+
+;; ---- always-on redact-validation-tags (host-agnostic egress parity) -------
+
+(deftest cljs-redact-validation-tags-non-sensitive-literal-rides-verbatim
+  (testing "rf2-3fc89f.12 — the always-on boundary redactor leaves a
+            non-sensitive literal/enum schema's tags verbatim on CLJS"
+    (let [tags {:value [:demo/e 99] :received [:demo/e 99] :explain :exp}]
+      (doseq [schema [[:cat [:= :demo/e] [:= 42]]
+                      [:cat [:= :demo/e] [:enum 1 2]]
+                      [:= 42]
+                      [:enum "a" "b"]]]
+        (let [out (schemas/redact-validation-tags schema tags)]
+          (is (= tags out)
+              (str "non-sensitive literal schema rides verbatim: " (pr-str schema)))
+          (is (not (contains? out :sensitive?))
+              (str "no :sensitive? stamp for: " (pr-str schema))))))))
+
+(deftest cljs-redact-validation-tags-sensitive-and-opaque-still-redact
+  (testing "rf2-3fc89f.12 — the boundary redactor still fails closed for a
+            :sensitive? slot AND for the nested-compiled corpus on CLJS"
+    (let [tags    {:value [:demo/e 99] :received [:demo/e 99] :explain :exp}
+          ;; an explicit vector-form sensitive slot + the shared opaque corpus
+          ;; (every entry nests a compiled child, so the redactor fails closed)
+          schemas [[:cat [:= :demo/e] [:map [:pw {:sensitive? true} :string]]]]]
+      (doseq [schema (concat schemas fx/opaque-forms)]
+        (let [out (schemas/redact-validation-tags schema tags)]
+          (is (true? (:sensitive? out))
+              (str "sensitive/opaque schema is stamped: " (pr-str schema)))
+          (is (= :rf/redacted (:value out))
+              (str "sensitive/opaque schema value redacted: " (pr-str schema)))
+          (is (not (str/includes? (pr-str out) "99"))
+              (str "no raw value survives redaction for: " (pr-str schema))))))))

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
@@ -1,0 +1,171 @@
+(ns re-frame.schemas-walker-literal-operand-test
+  "JVM tests for the operator-aware schema-opacity walk (rf2-3fc89f.12).
+
+  Bug: `re-frame.schemas.walker/schema-has-opaque-child?` recursed into EVERY
+  vector tail as if it were a child schema. For literal-bearing Malli operators
+  the tail is DATA, not a nested schema, so any non-keyword/non-fn/non-symbol
+  literal reached the opaque catch-all and was mis-classified as an opaque
+  compiled child. `[:= 42]`, `[:enum 1 2]`, `[:> 10]`, `[:re \"x\"]`,
+  `[:cat [:= :id] [:= 42]]` all reported `schema-has-opaque-child? => true`,
+  which stamped ordinary literal/enum validation failures `:sensitive?`,
+  redacted their inspectable values, and emitted a spurious
+  `:rf.warning/schema-walker-opaque` at registration.
+
+  Fix (DESIGN): an operator-aware child-schema projection recurses only real
+  child-schema positions; known literal/config operands are treated as data
+  (not recursed); a genuinely opaque value in a true schema-bearing position
+  and an unknown operator shape still fail closed. Classification is structural
+  (no Malli/validator introspection) and identical on CLJ + CLJS — the shared
+  corpus lives in `re-frame.schemas.walker-literal-operand-fixtures` and is
+  asserted on both runtimes (`...-cljs-test` is the CLJS half).
+
+  Every assertion below fails on the pre-fix walker and passes on the fixed
+  one; the last section pins the fail-closed guarantees the fix must preserve."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas.walker-literal-operand-fixtures :as fx]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- warnings-of [recorded operation]
+  (filterv (fn [ev] (and (= :warning (:op-type ev))
+                         (= operation (:operation ev))))
+           @recorded))
+
+;; ---- pure walker: shared cross-host corpus --------------------------------
+
+(deftest literal-operands-are-data-not-opaque
+  (testing "rf2-3fc89f.12 — literal/config operands (`:=` value, `:enum`
+            members, comparator bounds, `:re` pattern) and their enclosing
+            structural forms are fully walkable, so schema-has-opaque-child?
+            is FALSE (pre-fix: every one returned true)"
+    (doseq [s fx/not-opaque-forms]
+      (is (false? (schemas/schema-has-opaque-child? s))
+          (str "literal/walkable form must NOT be opaque: " (pr-str s))))))
+
+(deftest nested-compiled-values-still-fail-closed
+  (testing "rf2-3fc89f.12 — a genuinely opaque (compiled m/schema) value in a
+            REAL child-schema position (root, :map slot, container element,
+            :cat/:tuple element, :multi/:orn branch, :map-of key/value,
+            combinator child) still fails closed (true)"
+    (doseq [s fx/opaque-forms]
+      (is (true? (schemas/schema-has-opaque-child? s))
+          (str "nested compiled value must fail closed: " (pr-str s))))))
+
+(deftest unknown-operator-shapes-fail-closed
+  (testing "rf2-3fc89f.12 — an unclassified operator shape cannot be proven
+            walkable, so it fails closed (true)"
+    (doseq [s fx/unknown-op-forms]
+      (is (true? (schemas/schema-has-opaque-child? s))
+          (str "unknown operator shape must fail closed: " (pr-str s))))))
+
+;; ---- registration warning (ACCEPTANCE #2) ---------------------------------
+
+(deftest literal-vector-forms-do-not-warn-walker-opaque
+  (testing "rf2-3fc89f.12 — registering ordinary literal-bearing vector-form
+            schemas (`[:= 42]`, `[:enum ...]`, `[:cat [:= id] [:= v]]`) emits
+            NO :rf.warning/schema-walker-opaque (pre-fix: each warned once)"
+    (with-trace-recorder! [recorded]
+      (rf/reg-app-schema [:answer]  [:= 42])
+      (rf/reg-app-schema [:code]    [:enum 200 404])
+      (rf/reg-app-schema [:label]   [:enum "a" "b"])
+      (rf/reg-app-schema [:bound]   [:> 0])
+      (rf/reg-app-schema [:pattern] [:re "a.*z"])
+      (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
+          "literal-bearing vector forms are fully walkable — no opaque nudge"))))
+
+(deftest nested-compiled-child-still-warns-walker-opaque
+  (testing "rf2-3fc89f.12 — the once-per-process opaque-walker warning is
+            RETAINED for a vector-form schema that nests a real compiled child"
+    (with-trace-recorder! [recorded]
+      (rf/reg-app-schema [:token]
+                         [:map [:secret (m/schema [:string {:sensitive? true}])]])
+      (is (= 1 (count (warnings-of recorded :rf.warning/schema-walker-opaque)))
+          "a nested compiled child still triggers the walker-opaque warning"))))
+
+;; ---- validation egress: dev validate path (ACCEPTANCE #3) -----------------
+
+(defn- event-failure-trace
+  "Validate `event` against `schema` via the dev validate-event! path and
+  return the single :rf.error/schema-validation-failure trace."
+  [schema event]
+  (with-trace-recorder! [traces]
+    (schemas/validate-event! :demo/e event {:schema schema})
+    (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                   @traces))))
+
+(deftest non-sensitive-literal-event-failure-rides-verbatim
+  (testing "rf2-3fc89f.12 — a failing NON-sensitive literal event schema
+            (`[:cat [:= :demo/e] [:= 42]]`) preserves the failing value and is
+            NOT stamped :sensitive? (pre-fix: value redacted + :sensitive? true
+            because the walker false-flagged [:= 42] opaque)"
+    (let [v (event-failure-trace [:cat [:= :demo/e] [:= 42]] [:demo/e 99])]
+      (is (some? v) "a validation-failure trace fired")
+      (is (not (contains? v :sensitive?))
+          "no top-level :sensitive? stamp — nothing in the schema is sensitive")
+      (is (= [:demo/e 99] (-> v :tags :value))
+          ":value rides verbatim — the literal operand is data, not opaque")
+      (is (= [:demo/e 99] (-> v :tags :received))
+          ":received rides verbatim too")
+      (is (not= :rf/redacted (-> v :tags :explain))
+          ":explain is not spuriously redacted"))))
+
+(deftest non-sensitive-enum-event-failure-rides-verbatim
+  (testing "rf2-3fc89f.12 — a failing NON-sensitive :enum event schema
+            preserves the value and is not stamped sensitive"
+    (let [v (event-failure-trace
+              [:cat [:= :demo/e] [:enum "a" "b"]] [:demo/e "z"])]
+      (is (some? v))
+      (is (not (contains? v :sensitive?)))
+      (is (= [:demo/e "z"] (-> v :tags :value))))))
+
+(deftest sensitive-slot-still-redacts-through-event-path
+  (testing "rf2-3fc89f.12 — a genuinely :sensitive? payload slot is still
+            redacted + stamped through the event path (fix preserves it)"
+    (let [v (event-failure-trace
+              [:cat [:= :demo/e] [:map [:pw {:sensitive? true} :string]]]
+              [:demo/e {:pw 99}])]
+      (is (some? v))
+      (is (true? (:sensitive? v)) ":sensitive? stamped for the marked slot")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted"))))
+
+;; ---- validation egress: always-on redact-validation-tags (ACCEPTANCE #3) --
+;; The boundary / off-namespace emit sites reach the walker through the pure
+;; `redact-validation-tags` seam. It is host-agnostic, so the CLJS half asserts
+;; the identical cases (host parity for the always-on path).
+
+(deftest redact-validation-tags-non-sensitive-literal-rides-verbatim
+  (testing "rf2-3fc89f.12 — the always-on boundary redactor leaves a
+            non-sensitive literal/enum schema's tags verbatim and adds no
+            :sensitive? stamp (pre-fix: every slot scrubbed + stamped)"
+    (let [tags {:value [:demo/e 99] :received [:demo/e 99] :explain :exp}]
+      (doseq [schema [[:cat [:= :demo/e] [:= 42]]
+                      [:cat [:= :demo/e] [:enum 1 2]]
+                      [:= 42]
+                      [:enum "a" "b"]]]
+        (let [out (schemas/redact-validation-tags schema tags)]
+          (is (= tags out)
+              (str "non-sensitive literal schema rides verbatim: " (pr-str schema)))
+          (is (not (contains? out :sensitive?))
+              (str "no :sensitive? stamp for: " (pr-str schema))))))))
+
+(deftest redact-validation-tags-sensitive-and-opaque-still-redact
+  (testing "rf2-3fc89f.12 — the boundary redactor still fails closed for a
+            genuinely :sensitive? slot AND for a nested compiled/opaque child"
+    (let [tags {:value [:demo/e 99] :received [:demo/e 99] :explain :exp}]
+      (doseq [schema [[:cat [:= :demo/e] [:map [:pw {:sensitive? true} :string]]]
+                      [:map [:tok (m/schema [:string {:sensitive? true}])]]
+                      (m/schema [:string {:sensitive? true}])]]
+        (let [out (schemas/redact-validation-tags schema tags)]
+          (is (true? (:sensitive? out))
+              (str "sensitive/opaque schema is stamped: " (pr-str schema)))
+          (is (= :rf/redacted (:value out))
+              (str "sensitive/opaque schema value redacted: " (pr-str schema)))
+          (is (not (str/includes? (pr-str out) "99"))
+              (str "no raw value survives redaction for: " (pr-str schema))))))))


### PR DESCRIPTION
## Summary

The schema-opacity walk (`re-frame.schemas.walker/schema-has-opaque-child?` and its private recursion `opaque-nested-tail?`) recursed into **every** vector tail as if it were a child schema. For literal-bearing Malli operators the tail is **data**, not a nested schema, so any non-keyword/non-fn/non-symbol literal reached the opaque catch-all (`:else true`) and was mis-classified as an opaque compiled child.

This fix makes the recursion **operator-aware**: it projects the true child-schema positions per Malli operator, treats known literal/config operands as data, and preserves fail-closed handling for genuinely opaque values and unknown operator shapes.

## Reproduce → fix

On `origin/main` (P2 bug rf2-3fc89f.12), every literal-bearing form false-reported an opaque child:

```
[:= 42]                     => true
[:enum 1 2]                 => true
[:> 10]                     => true
[:re "a.*"]                 => true
[:cat [:= :demo/e] [:= 42]] => true
```

This false predicate stamped ordinary literal/enum validation failures `:sensitive?`, redacted their inspectable `:value`/`:received`/`:explain`, and emitted a spurious `:rf.warning/schema-walker-opaque` at registration (it feeds `validate.cljc`'s whole-payload decision and the always-on `redact-validation-tags` boundary seam, so it was reachable in production boundary-validation too).

After the fix:

```
[:= 42] / [:enum 1 2] / [:> 10] / [:re "a.*"] / [:cat [:= :demo/e] [:= 42]]  => false   (walkable, not opaque)
(m/schema [:string {:sensitive? true}])  nested in :map / :vector / :cat / :tuple / :multi / :map-of / :and  => true  (fail closed)
[:my/custom-op ...]  (unknown op)  => true  (fail closed)
```

**RED proof:** the new JVM test run against the pre-fix walker fails **35 / 76 assertions**; against the fix it is **0 failures**.

## Design / operator classification

A new `opacity-child-schemas` projection classifies every op in the shipped **Malli 0.20.1** default registry (structural only — no Malli/validator introspection):

- **entry-based** (`:map` + `:multi`/`:orn`/`:altn` reused from the walker's existing `name-bearing-ops`/`dispatch-bearing-ops`, plus `:catn`/`:andn`) — project the `[head props? schema]` entry **tail** (the head is a key/dispatch-value/name = data).
- **bare-child** (`:vector` `:set` `:sequential` `:seqable` `:every` `:tuple` `:cat` `:alt` `:*` `:+` `:?` `:repeat` `:and` `:or` `:not` `:maybe` `:schema` `:malli.core/schema` `:map-of` `:->` `:=>` `:function`) — recurse each child directly.
- **literal / config / scalar** (`:=` `:not=` `:enum` `:<` `:<=` `:>` `:>=` `:re` `:fn` `:ref` + scalar primitives `:any` `:boolean` `:double` `:float` `:int` `:keyword` `:nil` `:qualified-keyword` `:qualified-symbol` `:some` `:string` `:symbol` `:uuid`) — tail is **data**, not recursed.
- **unknown op** — cannot prove the tail is non-schema-bearing, so **fail closed** (opaque).

Fail-closed handling for an actual compiled/opaque value in any true schema-bearing position is preserved (a compiled `m/schema` object is not vector/keyword/fn → still opaque). CLJ + CLJS behaviour is identical.

## Stance

Pre-alpha, no back-compat shims. Structural walker (no Malli/validator introspection); CLJ+CLJS identical; fail-closed on genuine opacity / unknown operators. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. The fix over-narrows nothing — it stops the walk **over-redacting** ordinary literal/enum schemas while keeping the privacy fail-closed direction intact.

Touched only `implementation/schemas/src/re_frame/schemas/walker.cljc` (the opacity walker) + `implementation/schemas/test/**`.

## Tests

Shared host-agnostic corpus (`walker-literal-operand-fixtures.cljc`) asserted on **both** hosts:
- JVM `schemas-walker-literal-operand-test` — pure corpus + registration-warning (literal forms don't warn; nested-compiled still warns) + dev `validate-event!` egress + always-on `redact-validation-tags` egress (non-sensitive literal rides verbatim; sensitive/opaque still redacts).
- CLJS `schemas-walker-literal-operand-cljs-test` — same pure corpus + `redact-validation-tags` (host-parity anchor for the always-on boundary path).

## Quality gates

All run in the **foreground**, commit landed before gates:

- `cd implementation/schemas && clojure -M:test` → **351 tests / 19026 assertions, 0 failures, 0 errors** (baseline was 341 / 18,950; +10 tests from this PR).
- `cd implementation && npm run test:cljs` (CLJS node-test, cross-artefact parity) → **8508 tests / 39479 assertions, 0 failures, 0 errors**. Confirmed the new `-cljs-test` ns + shared `.cljc` fixtures compile and run in the node-test bundle.
- RED/GREEN: new JVM test fails 35/76 on the pre-fix walker, 0 failures on the fix.

CLJ/CLJS parity is pinned by the shared corpus asserted identically on both runtimes.

Do not merge — leaving for review per worker protocol.
