### PR TITLE
fix(derivation): canonicalize observable edge order for permutation-determinism (rf2-3fc89f.1)

### DIFF
--- a/implementation/core/src/re_frame/derivation/graph.cljc
+++ b/implementation/core/src/re_frame/derivation/graph.cljc
@@ -64,7 +64,8 @@
   relocation seam): the graph is assembled from the per-family algebra
   views, which are themselves assembled from registration metadata, NOT
   (yet) from an EP-0013 app value."
-  (:require [re-frame.subs.tooling :as subs-tooling]))
+  (:require [re-frame.subs.tooling :as subs-tooling]
+            [re-frame.identity :as identity]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -628,11 +629,28 @@
 
 (defn- graph-edges
   "Every edge across the assembled `nodes` map, in `mode` (`:static` /
-  `:live`). Composes the common per-node `:input` edges (every family) with
-  each present family's `:edge-fn` extra edges (routes → `:param`
-  resource-activation + live realized owner edges; machines → `:selector`
-  edges), de-duplicated. `selector-targets` is threaded into the context
-  for the machine `:edge-fn`."
+  `:live`), in a CANONICAL total order. Composes the common per-node
+  `:input` edges (every family) with each present family's `:edge-fn` extra
+  edges (routes → `:param` resource-activation + live realized owner edges;
+  machines → `:selector` edges), de-duplicated. `selector-targets` is
+  threaded into the context for the machine `:edge-fn`.
+
+  DETERMINISTIC EDGE ORDER (rf2-3fc89f.1). The unsorted `input`/`extra`
+  concatenation inherits `nodes`-map iteration order and each `:edge-fn`'s
+  scan order, so logically identical graphs assembled under different
+  registration / projection insertion orders would emit edge PERMUTATIONS —
+  breaking the normative deterministic-assembly promise ([Derivations.md]
+  §Graph inspection) and any caller that serializes / diffs / hashes /
+  snapshots the explicitly vector-valued `:edges`. We therefore sort the
+  de-duplicated collection by `identity/canonical-bytes` of each COMPLETE
+  edge map: the CEDN-1 token string is a platform-stable TOTAL key (identical
+  on CLJ and CLJS, unlike host `hash`/`compare` over heterogeneous node
+  ids), and it is order-insensitive over each edge map's own keys (so it does
+  not itself depend on edge-map spelling — unlike `pr-str`). Sorting AFTER
+  `distinct` keeps duplicate-suppression semantics and every edge map's
+  contents / identity unchanged; we reorder the collection, never rewrite an
+  edge. (`:nodes` needs no such treatment — it is a map, already
+  order-insensitive under value equality.)"
   [mode nodes contributors selector-targets]
   (let [node-ids (keys nodes)
         ctx      {:mode mode :nodes nodes :node-ids node-ids
@@ -651,6 +669,7 @@
                   (present-families contributors))]
     (->> (concat input extra)
          distinct
+         (sort-by identity/canonical-bytes)
          vec)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -569,6 +569,142 @@
           "the live route → concrete resource :param edge"))))
 
 ;; ===========================================================================
+;; (c++) DETERMINISTIC CANONICAL EDGE ORDER under registration/projection
+;; permutation (rf2-3fc89f.1).
+;;
+;; [Derivations.md] §Graph inspection promises MECHANICAL, DETERMINISTIC
+;; assembly. The composer's `:edges` is an explicitly vector-valued collection
+;; that callers serialize / diff / hash / snapshot / display, so two logically
+;; identical graphs — the SAME nodes and the SAME edges, assembled under
+;; different projection / registration INSERTION orders — must produce the
+;; SAME ordered `:edges` vector (and the same whole graph value). Before the
+;; fix the composer inherited `nodes`-map iteration + each `:edge-fn`'s scan
+;; order, so a mere insertion-order permutation emitted an edge PERMUTATION.
+;;
+;; The fix sorts the de-duplicated edge collection by
+;; `re-frame.identity/canonical-bytes` of each COMPLETE edge map — a
+;; platform-stable TOTAL key (identical on CLJ and CLJS, and order-insensitive
+;; over each edge map's own keys, so it does not depend on nested-map SPELLING
+;; the way `pr-str` would). These synthetic contributors isolate that ordering
+;; from the family runtimes: two `:input` edges (subs `:b`,`:c` → `:a`, with
+;; `:b` declaring its `[:sub [:a]]` input TWICE so `distinct` must collapse it
+;; BEFORE canonicalization) and two family-owned `:param` edges (routes →
+;; resource nodes keyed by a NESTED EDN map spelled two ways).
+;; ===========================================================================
+
+(defn- perm-permutations
+  "All orderings of `coll` (small n; hand-rolled so this tier needs no
+  combinatorics dependency)."
+  [coll]
+  (if (<= (count coll) 1)
+    (list (vec coll))
+    (for [i    (range (count coll))
+          tail (perm-permutations (concat (take i coll) (drop (inc i) coll)))]
+      (into [(nth coll i)] tail))))
+
+(defn- perm-sub-node [id inputs]
+  {:id id :kind :derivation :inputs inputs
+   :output [:fact id] :storage :ephemeral :evaluation :on-demand})
+
+(defn- perm-res-key
+  "A route's resource-key — a NESTED EDN map spelled `:slug`-first or
+  `:locale`-first. Both spellings are the SAME identity; canonical ordering
+  must not depend on which the projection happened to build."
+  [slug slug-first?]
+  (if slug-first? {:slug slug :locale :en} {:locale :en :slug slug}))
+
+(defn- perm-route [route-id slug slug-first?]
+  {:id :rf/route :kind :process :refinement :route-fact
+   :route-id route-id :storage :runtime-db :evaluation :on-route :lifecycle :frame
+   :resource-edges [{:to [:resource (perm-res-key slug slug-first?)]
+                     :role :param :target :parametric}]})
+
+(defn- perm-contributors
+  "Synthetic STATIC contributors carrying the SAME nodes/edges but assembled
+  in `sub-order` / `route-order` insertion order, with each route's nested
+  resource-key map spelled per `slug-first?`."
+  [sub-order route-order slug-first?]
+  (let [subs   {:a (perm-sub-node :a [])
+                ;; `:b` declares its `[:sub [:a]]` input TWICE — `distinct`
+                ;; must suppress the duplicate before canonicalization.
+                :b (perm-sub-node :b [[:sub [:a]] [:sub [:a]]])
+                :c (perm-sub-node :c [[:sub [:a]]])}
+        routes {:r1 (perm-route :r1 "s1" slug-first?)
+                :r2 (perm-route :r2 "s2" slug-first?)}]
+    {:subs   {:live-shape :map
+              :static-fn  (constantly
+                            (reduce (fn [m k] (assoc m k (get subs k)))
+                                    (array-map) sub-order))}
+     :routes {:live-shape :node
+              :static-fn  (constantly
+                            (reduce (fn [m k] (assoc m k (get routes k)))
+                                    (array-map) route-order))}}))
+
+(def ^:private perm-expected-edges
+  "The canonical `:edges` vector — the byte-stable total order every
+  permutation and both nested-map spellings must produce, on CLJ and CLJS
+  alike. Pinned so a cross-platform divergence (or a regression to
+  iteration-order output) fails the gate; the two `:param` edges sort before
+  the two `:input` edges under the CEDN-1 key of each complete edge map."
+  [{:from [:rf/route :r1] :to [:resource {:slug "s1" :locale :en}]
+    :role :param :target :parametric}
+   {:from [:rf/route :r2] :to [:resource {:slug "s2" :locale :en}]
+    :role :param :target :parametric}
+   {:from [:sub :a] :to [:sub :b] :role :input}
+   {:from [:sub :a] :to [:sub :c] :role :input}])
+
+(deftest cplusplus-edge-order-is-canonical-across-registration-permutations
+  (let [baseline (graph/derivation-graph (perm-contributors [:a :b :c] [:r1 :r2] true))]
+    (testing "the de-duplicated edge SET is the four expected edges (the
+              duplicated `[:sub [:a]]` input on `:b` collapsed to ONE edge —
+              distinct runs BEFORE canonicalization)"
+      (is (= (set perm-expected-edges) (set (:edges baseline)))
+          "same edge set as expected")
+      (is (= 4 (count (:edges baseline)))
+          "four distinct edges — the duplicate input was suppressed"))
+    (testing "the `:edges` vector is the pinned canonical total order"
+      (is (= perm-expected-edges (:edges baseline))
+          "edges emit in canonical-bytes order, not iteration order"))
+    (testing "edge CONTENTS / identity are preserved — the sort reorders the
+              collection, it does not rewrite edges (the `:param` edge keeps
+              its nested resource key, `:role`, and `:target`)"
+      (let [param (first (filter #(= :param (:role %)) (:edges baseline)))]
+        (is (= [:resource {:locale :en :slug "s1"}] (:to param))
+            "the nested resource-key EDN rides through verbatim")
+        (is (= :parametric (:target param))
+            "the static route-resource `:target` marker is preserved")
+        (is (= [:rf/route :r1] (:from param))
+            "the route node id is the re-targeted `:from`")))
+    (testing "`:nodes` stays a MAP (order-insensitive under value equality)"
+      (is (map? (:nodes baseline))))
+    (testing "EVERY insertion-order permutation and BOTH nested-map spellings
+              produce the identical `:edges` VALUE and the identical whole
+              graph (registration/projection history is invisible)"
+      (doseq [sub-order   (perm-permutations [:a :b :c])
+              route-order (perm-permutations [:r1 :r2])
+              slug-first? [true false]]
+        (let [g (graph/derivation-graph
+                  (perm-contributors sub-order route-order slug-first?))]
+          (is (= perm-expected-edges (:edges g))
+              (str "edges must equal the canonical order for sub-order "
+                   sub-order " route-order " route-order
+                   " slug-first? " slug-first?))
+          (is (= baseline g)
+              (str "the whole graph value must be permutation-invariant for "
+                   sub-order " / " route-order " / " slug-first?)))))
+    (testing "SERIALIZATION pin: for a fixed spelling, every insertion-order
+              permutation serializes `:edges` byte-identically — the property
+              tools depend on when they diff / hash / snapshot the graph"
+      (doseq [slug-first? [true false]]
+        (let [serials (for [sub-order   (perm-permutations [:a :b :c])
+                            route-order (perm-permutations [:r1 :r2])]
+                        (pr-str (:edges (graph/derivation-graph
+                                          (perm-contributors sub-order route-order slug-first?)))))]
+          (is (= 1 (count (distinct serials)))
+              (str "all permutations must serialize `:edges` identically (slug-first? "
+                   slug-first? ")")))))))
+
+;; ===========================================================================
 ;; (d) WHOLE-VALUE — the semantic whole-value law (slice-1).
 ;; ===========================================================================
 


### PR DESCRIPTION
## What / why

`spec/Derivations.md` §Graph inspection promises **mechanical, deterministic** graph assembly, and `:edges` is an explicitly vector-valued collection that tools serialize / diff / hash / snapshot / display. But `graph-edges` emitted edges in `nodes`-map iteration + per-family `:edge-fn` scan order:

```clojure
(->> (concat input extra) distinct vec)   ; no canonical sort
```

So two **logically identical** graphs — same nodes, same edges — assembled under different registration / projection **insertion** orders produced edge **permutations** (and CLJ/CLJS map-iteration differences could defeat parity). `:nodes` (a map) was already order-insensitive.

## Reproduce → fix

Two `:subs` contributors, node `:a` plus `:b`/`:c` each declaring `[:sub [:a]]`, differing only in insertion order:

| | old code | fixed |
|---|---|---|
| `(= (:edges g1) (:edges g2))` | **false** (`[a→b, a→c]` vs `[a→c, a→b]`) | **true** |
| `(= (set edges) …)` | true | true |
| `(= g1 g2)` (whole graph) | **false** | **true** |
| `(= (:nodes g1) (:nodes g2))` | true | true |

## The fix

Sort the **de-duplicated** edge collection by `re-frame.identity/canonical-bytes` of each **complete** edge map:

```clojure
(->> (concat input extra) distinct (sort-by identity/canonical-bytes) vec)
```

The CEDN-1 token string is a **platform-stable total key** (identical on CLJ and CLJS, unlike host `hash`/`compare` over heterogeneous node ids) and is **order-insensitive over each edge map's own keys** (unlike `pr-str`, which would depend on nested-map spelling). Sorting runs **after** `distinct`, so duplicate-suppression semantics and every edge map's **contents / identity** are unchanged — the collection is reordered, edges are never rewritten. `:nodes` stays a map.

## Regression (cross-family CLJC conformance)

New `cplusplus-edge-order-is-canonical-across-registration-permutations` in `derivation_algebra_conformance_cljs_test.cljc` (runs in **both** the JVM `:test` alias and the shared CLJS node gate). Synthetic contributors give two `:input` edges (with a **duplicated** input that `distinct` must collapse *before* canonicalization) and two family-owned `:param` edges keyed by a **nested EDN map spelled two ways**. It asserts, across all insertion-order permutations × both spellings: the pinned canonical `:edges` vector, whole-graph value invariance, the expected edge set/count, preserved edge contents/identity, `:nodes` stays a map, and a byte-identical serialization pin. The test **fails on old code** (45 failures) and passes on the fix.

## Quality gates

- `cd implementation/derivation-conformance && clojure -M:test` → **21 tests, 503 assertions, 0 failures** (was 20 / 446)
- `cd implementation && npm run test:cljs` → **8504 tests, 39434 assertions, 0 failures** (the `.cljc` regression runs here too — canonical order is platform-stable)

## Stance

Pre-alpha; canonicalize **only** the observable edge collection after de-dup, via a platform-stable total EDN key; preserve edge contents/identity; `:nodes` stays a map. ELEGANCE + CLARITY + CORRECTNESS.

Closes rf2-3fc89f.1.
