### PR TITLE
fix(xray): frame-qualify typed-filter causal-lineage identity (rf2-3fc89f.25)

### DIFF
--- a/tools/xray/spec/020-Filter-Predicates.md
+++ b/tools/xray/spec/020-Filter-Predicates.md
@@ -64,6 +64,46 @@ only suppressing filters this doc models. (rf2-pjjwh — the `Clear Filters`
 Pills are removed individually via each pill's `✕`.) See
 [`018-Event-Spine.md` §7 Frame picker is a view scope](018-Event-Spine.md).
 
+### §3.1 Causal lineage under epoch-per-event — frame-qualified identity (rf2-3fc89f.25)
+
+Under epoch-per-event each dequeued event — including `:fx :dispatch`
+children and machine-internal transitions — is its OWN event-bundle
+(`re-frame.trace.projection/group-by-event` keys one record per
+`:rf.trace/dispatch-id`). A `:machine` / `:http-correlation` / `:fx` IN
+pill that matched ONLY the event-bundle carrying its tag would lose the
+link to the PARENT event that spawned the transition (a sibling
+event-bundle). So a directly-matching event-bundle pulls in its whole
+**spawning lineage**: itself plus every causal ancestor, walked UP the
+`:parent-dispatch-id` link to the root user event —
+`keep = matching event-bundles ∪ their ancestors`. OUT (hide) pills stay
+event-bundle-local so hiding a child never silently drops the ancestor
+that spawned it.
+
+**Event-bundle identity is the frame-qualified `[frame dispatch-id]`
+pair — normative and portable.** The published trace contract
+([`013-Trace-Consumer.md`](013-Trace-Consumer.md)) guarantees
+`dispatch-id` uniqueness only WITHIN a frame, so two frames may
+legitimately reuse the same dispatch-id (deterministic replay and
+per-frame id allocation make this live, not merely latent). The
+causal-lineage machinery therefore keys on the frame-qualified identity
+**end-to-end** — the one canonical helper
+`typed-predicates/event-bundle-identity` `⇒ [frame dispatch-id]` backs
+the ancestor index, the retained-key set, the membership check, AND the
+cycle guard. A parent resolves to `[frame parent-dispatch-id]`
+(`event-bundle-parent-identity`), since a parent and child always share a
+frame under epoch-per-event, so the ancestor walk never crosses into
+another frame that reuses the parent's dispatch-id. A bare-id identity is
+rejected: it cross-links unrelated frames' lineages (an IN pill could
+display an unrelated frame's event and attach the wrong causal ancestor).
+This is pre-alpha — there is NO compatibility fallback to id-only
+identity; the frame-qualified pair is the contract.
+
+The `:ungrouped` pseudo-event-bundle and any event-bundle with a nil
+dispatch-id are excluded from the causal index — they are not addressable
+causal nodes — regardless of frame. This is the same frame-isolation
+invariant already enforced in the Event Spine
+([`018-Event-Spine.md`](018-Event-Spine.md)) and Pair MCP event grouping.
+
 ## §4 Deferred kinds (rf2-piye4 — defer to v1.1)
 
 | kind             | rationale                                                    |

--- a/tools/xray/src/day8/re_frame2_xray/filters/typed_predicates.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/filters/typed_predicates.cljc
@@ -73,10 +73,11 @@
   typed pill on a child transition event-bundle ALSO keeps the spawning
   event's event-bundle. `keep = matching event-bundles ∪ their ancestors`. The
   walk is in `event-bundle-self-and-ancestors` (cycle-guarded,
-  root-terminated); `filter-event-bundles` builds the
-  `{dispatch-id → event-bundle}` index once and folds the IN-kept id set
-  in `in-kept-id-set`. OUT (hide) pills stay event-bundle-local so a hide
-  never silently drops the ancestor that spawned the hidden child.
+  root-terminated); `filter-event-bundles` builds the frame-qualified
+  `{[frame dispatch-id] → event-bundle}` index once and folds the IN-kept
+  identity set in `in-kept-identity-set`. OUT (hide) pills stay
+  event-bundle-local so a hide never silently drops the ancestor that
+  spawned the hidden child.
 
   Pure data → bool. JVM-runnable so the test corpus exercises every
   kind without a CLJS runtime."
@@ -256,20 +257,51 @@
 ;; SPAWNING LINEAGE: a `:machine` pill matches the transition CHILD
 ;; event-bundle, and we ALSO keep that child's ancestors (the spawning event
 ;; up to the root user event) — `keep = matching event-bundles ∪ their
-;; ancestors`. Event bundles key by `[frame dispatch-id]`; the parent link
-;; is dispatch-id only (parent + child always share a frame under
-;; epoch-per-event), so we index by dispatch-id and walk by id.
+;; ancestors`. Event bundles key by the frame-qualified `[frame dispatch-id]`
+;; identity (`event-bundle-identity`): the published trace contract
+;; guarantees dispatch-id uniqueness only WITHIN a frame, so a bare
+;; dispatch-id collides across frames and cross-links unrelated lineages.
+;; The parent link supplies only the dispatch-id, but parent + child always
+;; share a frame under epoch-per-event, so a parent resolves to
+;; `[frame parent-dispatch-id]` (`event-bundle-parent-identity`); the index,
+;; the retained-key set, the membership check, and the cycle guard all key
+;; on the full identity.
 
-(defn index-by-dispatch-id
-  "Build a `{dispatch-id → event-bundle}` index for ancestor walking. The
-  `:ungrouped` pseudo-event-bundle and any event-bundle with a nil dispatch-id
-  are excluded — they are not addressable causal nodes. Pure data."
+(defn event-bundle-identity
+  "Canonical frame-qualified identity of an event-bundle: the
+  `[frame dispatch-id]` pair. This is the ONE identity used end-to-end by
+  the causal-lineage machinery — the ancestor index, the retained-key set,
+  the membership check, and the cycle guard — so a dispatch-id that
+  collides ACROSS frames (allowed by the trace contract, which guarantees
+  dispatch-id uniqueness only WITHIN a frame) never cross-links two
+  frames' lineages. Pure data → vector."
+  [event-bundle]
+  [(:frame event-bundle) (:dispatch-id event-bundle)])
+
+(defn event-bundle-parent-identity
+  "Frame-qualified identity of `event-bundle`'s causal parent, or nil when
+  it has no parent link. The parent shares the child's frame under
+  epoch-per-event, so the identity is `[frame parent-dispatch-id]` —
+  matching the shape `event-bundle-identity` produces for the parent
+  bundle itself, so the ancestor walk stays within the child's frame.
+  Pure data → vector-or-nil."
+  [event-bundle]
+  (when-let [parent-id (:parent-dispatch-id event-bundle)]
+    [(:frame event-bundle) parent-id]))
+
+(defn index-by-identity
+  "Build a `{[frame dispatch-id] → event-bundle}` index for ancestor
+  walking, keyed by the canonical frame-qualified `event-bundle-identity`.
+  The `:ungrouped` pseudo-event-bundle and any event-bundle with a nil
+  dispatch-id are excluded — they are not addressable causal nodes.
+  Frame-qualified keys keep two frames that reuse a dispatch-id distinct,
+  so a later frame never overwrites an earlier frame's node. Pure data."
   [event-bundles]
   (persistent!
     (reduce (fn [acc event-bundle]
               (let [id (:dispatch-id event-bundle)]
                 (if (and (some? id) (not= :ungrouped id))
-                  (assoc! acc id event-bundle)
+                  (assoc! acc (event-bundle-identity event-bundle) event-bundle)
                   acc)))
             (transient {})
             event-bundles)))
@@ -277,36 +309,41 @@
 (defn event-bundle-self-and-ancestors
   "Return `event-bundle` followed by its causal ancestors, walking the
   `:parent-dispatch-id` link up to the root through `index` (a
-  `{dispatch-id → event-bundle}` map). Cycle-guarded (a malformed trace
-  with a parent loop terminates) and root-terminated (nil parent /
-  missing parent ends the walk). Pure data → vector, self-first."
+  `{[frame dispatch-id] → event-bundle}` map). The parent link resolves
+  through `event-bundle-parent-identity`, so the walk stays WITHIN the
+  child's frame and never crosses into another frame that reuses the
+  parent's dispatch-id. Cycle-guarded on the frame-qualified identity (a
+  malformed trace with a parent loop terminates) and root-terminated (nil
+  parent / missing parent ends the walk). Pure data → vector, self-first."
   [event-bundle index]
   (loop [c    event-bundle
          seen #{}
          acc  []]
     (if (or (nil? c)
-            (contains? seen (:dispatch-id c)))
+            (contains? seen (event-bundle-identity c)))
       acc
-      (let [parent-id (:parent-dispatch-id c)]
-        (recur (when (some? parent-id) (get index parent-id))
-               (conj seen (:dispatch-id c))
+      (let [parent-identity (event-bundle-parent-identity c)]
+        (recur (when (some? parent-identity) (get index parent-identity))
+               (conj seen (event-bundle-identity c))
                (conj acc c))))))
 
-(defn in-kept-id-set
-  "Compute the set of `:dispatch-id`s kept by the IN pills.
-  An event-bundle that DIRECTLY matches any IN pill pulls in its whole
-  spawning lineage — itself plus every causal ancestor (walked via
-  `index`). The union is what surfaces the spawning event's event-bundle
-  alongside the machine/http/fx transition event-bundle under
-  epoch-per-event. nil / empty `in` returns nil (the 'no IN filter,
-  keep everything' signal — distinct from an empty set, which means
-  'IN active but nothing matched'). Pure data → set-or-nil."
+(defn in-kept-identity-set
+  "Compute the set of frame-qualified `[frame dispatch-id]` identities kept
+  by the IN pills. An event-bundle that DIRECTLY matches any IN pill pulls
+  in its whole spawning lineage — itself plus every causal ancestor
+  (walked via `index`). The union is what surfaces the spawning event's
+  event-bundle alongside the machine/http/fx transition event-bundle under
+  epoch-per-event. Identities are frame-qualified, so a direct/ancestor
+  match in one frame never retains a same-id bundle in another frame.
+  nil / empty `in` returns nil (the 'no IN filter, keep everything' signal
+  — distinct from an empty set, which means 'IN active but nothing
+  matched'). Pure data → set-or-nil."
   [event-bundles index in]
   (when (seq in)
     (reduce (fn [kept event-bundle]
               (if (event-bundle-matches-any? event-bundle in)
                 (into kept
-                      (map :dispatch-id)
+                      (map event-bundle-identity)
                       (event-bundle-self-and-ancestors event-bundle index))
                 kept))
             #{}
@@ -321,13 +358,14 @@
   predicate dispatch so IN and OUT pills can be a mix of keyword
   patterns + typed predicates.
 
-  `in-kept-ids` is the precomputed set from `in-kept-id-set` — the
-  dispatch-ids kept by the IN pills, INCLUDING the spawning ancestors
-  of every directly-matching event-bundle. nil `in-kept-ids`
-  means no IN filter is active (keep every event-bundle subject to OUT). The
-  OUT test stays event-bundle-local — a hide pill suppresses only the
-  event-bundle carrying its tag, never its ancestors (so hiding a child's fx
-  does not silently drop the originating user event).
+  `in-kept-identities` is the precomputed set from `in-kept-identity-set`
+  — the frame-qualified `[frame dispatch-id]` identities kept by the IN
+  pills, INCLUDING the spawning ancestors of every directly-matching
+  event-bundle. nil `in-kept-identities` means no IN filter is active
+  (keep every event-bundle subject to OUT). The OUT test stays
+  event-bundle-local — a hide pill suppresses only the event-bundle
+  carrying its tag, never its ancestors (so hiding a child's fx does not
+  silently drop the originating user event).
 
   Pure data; JVM-runnable. The single-event-bundle arity falls back
   to direct (ancestor-free) IN matching for callers without the full
@@ -337,9 +375,9 @@
                      (event-bundle-matches-any? event-bundle in))
          out-hit (event-bundle-matches-any? event-bundle out)]
      (and in-ok? (not out-hit))))
-  ([event-bundle in-kept-ids {:keys [out]}]
-   (let [in-ok?  (or (nil? in-kept-ids)
-                     (contains? in-kept-ids (:dispatch-id event-bundle)))
+  ([event-bundle in-kept-identities {:keys [out]}]
+   (let [in-ok?  (or (nil? in-kept-identities)
+                     (contains? in-kept-identities (event-bundle-identity event-bundle)))
          out-hit (event-bundle-matches-any? event-bundle out)]
      (and in-ok? (not out-hit)))))
 
@@ -349,16 +387,17 @@
   `matcher/filter-event-bundles` that routes through typed-predicate
   dispatch.
 
-  Builds a `{dispatch-id → event-bundle}` index once, computes the IN-kept
-  id set (each directly-matching event-bundle pulls in its spawning
-  ancestors), then keeps event-bundles whose id is in that set
-  and which no OUT pill suppresses — so a typed pill on a child
-  transition event-bundle also keeps the spawning event's event-bundle under
-  epoch-per-event."
+  Builds a frame-qualified `{[frame dispatch-id] → event-bundle}` index
+  once, computes the IN-kept identity set (each directly-matching
+  event-bundle pulls in its spawning ancestors), then keeps event-bundles
+  whose frame-qualified identity is in that set and which no OUT pill
+  suppresses — so a typed pill on a child transition event-bundle also
+  keeps the spawning event's event-bundle under epoch-per-event, without a
+  same-id bundle in another frame leaking in."
   [event-bundles filters]
-  (let [index    (index-by-dispatch-id event-bundles)
-        kept-ids (in-kept-id-set event-bundles index (:in filters))]
-    (filterv #(keep-event-bundle? % kept-ids filters) event-bundles)))
+  (let [index           (index-by-identity event-bundles)
+        kept-identities (in-kept-identity-set event-bundles index (:in filters))]
+    (filterv #(keep-event-bundle? % kept-identities filters) event-bundles)))
 
 ;; ---- pill labels (presentation hooks) -----------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/filters/typed_predicates_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/filters/typed_predicates_test.cljc
@@ -382,6 +382,141 @@
           kept    (mapv :dispatch-id (typed/filter-event-bundles [a b] filters))]
       (is (= [1 2] kept)))))
 
+;; ---- frame-qualified lineage identity (rf2-3fc89f.25) --------------------
+;;
+;; The published trace contract guarantees dispatch-id uniqueness only
+;; WITHIN a frame, so two frames may legitimately reuse the same
+;; dispatch-id. The causal-lineage machinery keys on the frame-qualified
+;; `[frame dispatch-id]` identity end-to-end (index, retained-key set,
+;; membership check, cycle guard). A bare-id identity cross-links unrelated
+;; frames' lineages — these regressions FAIL on the pre-fix id-only code,
+;; which retains the unrelated same-id bundle from the other frame.
+
+(defn- mk-frame-cascade
+  "A cascade carrying a `:frame`, `:dispatch-id`, and optional causal-parent
+  link — the full frame-qualified identity shape."
+  [{:keys [frame dispatch-id parent-dispatch-id] :as opts}]
+  (-> (mk-cascade (dissoc opts :frame :dispatch-id :parent-dispatch-id))
+      (assoc :frame frame
+             :dispatch-id dispatch-id
+             :parent-dispatch-id parent-dispatch-id)))
+
+(deftest typed-filter-does-not-cross-link-frames-sharing-root-id
+  (testing "frame A and frame B reuse dispatch-id 1; a :machine pill whose
+            lineage roots at [A 1] must NOT retain the unrelated [B 1]
+            (id-only identity collides across frames)"
+    (let [a-root  (mk-frame-cascade {:frame :a :dispatch-id 1
+                                     :event [:a/root]})
+          b-root  (mk-frame-cascade {:frame :b :dispatch-id 1
+                                     :event [:b/root]})
+          a-child (mk-frame-cascade {:frame :a :dispatch-id 2
+                                     :parent-dispatch-id 1
+                                     :event   [:a/child]
+                                     :effects [(tagged {:machine-id :form})]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          kept    (mapv (juxt :frame :dispatch-id)
+                        (typed/filter-event-bundles [a-root b-root a-child] filters))]
+      (is (= [[:a 1] [:a 2]] kept)
+          "only frame A's lineage survives; frame B's same-id root is dropped"))))
+
+(deftest typed-filter-does-not-cross-link-frames-sharing-child-id
+  (testing "frame A's matching child and frame B's unrelated child both use
+            dispatch-id 2; the membership check must stay frame-qualified so
+            frame B's same-id child is not retained"
+    (let [a-root  (mk-frame-cascade {:frame :a :dispatch-id 1 :event [:a/root]})
+          a-child (mk-frame-cascade {:frame :a :dispatch-id 2
+                                     :parent-dispatch-id 1
+                                     :event   [:a/transition]
+                                     :effects [(tagged {:machine-id :form})]})
+          b-root  (mk-frame-cascade {:frame :b :dispatch-id 5 :event [:b/root]})
+          b-child (mk-frame-cascade {:frame :b :dispatch-id 2
+                                     :parent-dispatch-id 5
+                                     :event [:b/thing]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          kept    (mapv (juxt :frame :dispatch-id)
+                        (typed/filter-event-bundles
+                          [a-root a-child b-root b-child] filters))]
+      (is (= [[:a 1] [:a 2]] kept)
+          "frame B's same-id child is not swept in by the frame-A match"))))
+
+(deftest typed-fx-filter-frame-qualifies-lineage
+  (testing "an :fx IN-pill's lineage is frame-qualified too — frame B's
+            same-id root is not pulled into frame A's fx lineage"
+    (let [a-root  (mk-frame-cascade {:frame :a :dispatch-id 7 :event [:a/click]})
+          a-child (mk-frame-cascade {:frame :a :dispatch-id 8
+                                     :parent-dispatch-id 7
+                                     :event   [:a/work]
+                                     :effects [(tagged {:rf.fx/id :rf.http/managed})]})
+          b-root  (mk-frame-cascade {:frame :b :dispatch-id 7 :event [:b/root]})
+          filters {:in  [{:kind :fx :params {:fx-id :rf.http/managed}}]
+                   :out []}
+          kept    (mapv (juxt :frame :dispatch-id)
+                        (typed/filter-event-bundles [a-root a-child b-root] filters))]
+      (is (= [[:a 7] [:a 8]] kept)
+          "frame B's same-id [B 7] is not pulled into frame A's fx lineage"))))
+
+(deftest cross-frame-cycle-guard-is-frame-qualified
+  (testing "two frames each carry a 1↔2 parent loop reusing the same ids;
+            frame A's matching walk terminates within its own frame and frame
+            B (no machine) is untouched — the cycle guard is frame-qualified"
+    (let [a1 (mk-frame-cascade {:frame :a :dispatch-id 1 :parent-dispatch-id 2
+                                :event [:a1]})
+          a2 (mk-frame-cascade {:frame :a :dispatch-id 2 :parent-dispatch-id 1
+                                :event   [:a2]
+                                :effects [(tagged {:machine-id :form})]})
+          b1 (mk-frame-cascade {:frame :b :dispatch-id 1 :parent-dispatch-id 2
+                                :event [:b1]})
+          b2 (mk-frame-cascade {:frame :b :dispatch-id 2 :parent-dispatch-id 1
+                                :event [:b2]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          kept    (mapv (juxt :frame :dispatch-id)
+                        (typed/filter-event-bundles [a1 a2 b1 b2] filters))]
+      (is (= [[:a 1] [:a 2]] kept)
+          "frame A's cycle resolves to its own two nodes; frame B is untouched
+           despite reusing ids 1/2"))))
+
+(deftest out-pill-stays-frame-local-across-frames
+  (testing "an OUT pill hides only the tagged bundle (event-local), keeping
+            its ancestor, and never touches an unrelated frame reusing the id"
+    (let [a-parent (mk-frame-cascade {:frame :a :dispatch-id 1 :event [:a/click]})
+          a-child  (mk-frame-cascade {:frame :a :dispatch-id 2
+                                      :parent-dispatch-id 1
+                                      :event   [:a/work]
+                                      :effects [(tagged {:rf.fx/id :noisy/fx})]})
+          b-root   (mk-frame-cascade {:frame :b :dispatch-id 2 :event [:b/root]})
+          filters  {:in  []
+                    :out [{:kind :fx :params {:fx-id :noisy/fx}}]}
+          kept     (mapv (juxt :frame :dispatch-id)
+                         (typed/filter-event-bundles [a-parent a-child b-root] filters))]
+      (is (= [[:a 1] [:b 2]] kept)
+          "only frame A's tagged child is hidden; its parent AND frame B's
+           same-id bundle survive"))))
+
+(deftest ungrouped-and-nil-id-still-excluded-with-frames
+  (testing "the :ungrouped pseudo-bundle and nil-dispatch-id bundles remain
+            outside the causal index and are not retained by an IN pill's
+            lineage — unchanged by frame-qualification"
+    (let [root      (mk-frame-cascade {:frame :a :dispatch-id 1 :event [:a/root]})
+          child     (mk-frame-cascade {:frame :a :dispatch-id 2
+                                       :parent-dispatch-id 1
+                                       :event   [:a/child]
+                                       :effects [(tagged {:machine-id :form})]})
+          ungrouped (mk-frame-cascade {:frame nil :dispatch-id :ungrouped
+                                       :event [:rf.xray/ungrouped]})
+          nil-id    (mk-frame-cascade {:frame :a :dispatch-id nil
+                                       :event [:a/orphan]})
+          filters   {:in  [{:kind :machine :params {:machine-id :form}}]
+                     :out []}
+          kept      (mapv (juxt :frame :dispatch-id)
+                          (typed/filter-event-bundles
+                            [root child ungrouped nil-id] filters))]
+      (is (= [[:a 1] [:a 2]] kept)
+          ":ungrouped and nil-id bundles are excluded; only the machine
+           lineage survives"))))
+
 ;; ---- pill-label / pill-glyph --------------------------------------------
 
 (deftest pill-label-per-kind


### PR DESCRIPTION
## Summary

Xray's typed IN-filter causal-lineage machinery
(`tools/xray/src/day8/re_frame2_xray/filters/typed_predicates.cljc`)
reduced event-bundle identity to a bare `:dispatch-id`. The published
trace contract guarantees dispatch-id uniqueness only WITHIN a frame, so
two event bundles in DIFFERENT frames sharing a dispatch-id cross-linked
into a single lineage — an IN pill could display an unrelated frame's
event and attach the wrong causal ancestor. Latent under today's
process-global router counter; live under deterministic replay /
per-frame id allocation, and already reproducible with synthetic trace
data valid under the contract.

## Fix (per DESIGN)

One canonical identity helper `event-bundle-identity` ⇒
`[(:frame b) (:dispatch-id b)]`, used **end-to-end**:

- `index-by-identity` — the ancestor index keys on `[frame dispatch-id]`, so a later frame never overwrites an earlier frame's node.
- `event-bundle-self-and-ancestors` — the cycle guard keys on the frame-qualified identity, and the parent resolves via `event-bundle-parent-identity` ⇒ `[frame parent-dispatch-id]` (parent + child always share a frame under epoch-per-event), so the walk never crosses into another frame.
- `in-kept-identity-set` — the retained-key set holds `[frame dispatch-id]` identities.
- `keep-event-bundle?` — the membership check is frame-qualified.

`:ungrouped` / nil-dispatch-id exclusion and OUT-pill event-local
semantics are unchanged. **No compatibility fallback to id-only
identity** — pre-alpha; the frame-qualified pair is the portable
contract.

## Reproduce → fix evidence

Fixture (frame A root `[A 1]`, unrelated frame B root `[B 1]`, frame A
machine child `[A 2]` whose parent id is `1`), a `:machine` IN pill:

| | projection |
|---|---|
| pre-fix (origin/main) | `[[:a 1] [:b 1] [:a 2]]` — unrelated `[:b 1]` cross-linked in |
| fixed | `[[:a 1] [:a 2]]` — only frame A's lineage |

The three new regressions were run against the extracted pre-fix source
and each cross-linked the other frame's bundle (root-id share →
`[[:a 1] [:b 1] [:a 2]]`; child-id share → `[[:a 1] [:a 2] [:b 2]]`;
cross-frame cycle → `[[:a 1] [:a 2] [:b 1] [:b 2]]`); all pass on the
fix. New pure CLJC coverage: frames sharing a root id, frames sharing a
child id, an `:fx` variant, a frame-qualified cross-frame cycle guard,
frame-local OUT semantics, and `:ungrouped`/nil-id exclusion.

## Spec

`tools/xray/spec/020-Filter-Predicates.md` gains a normative §3.1 —
"Causal lineage under epoch-per-event — frame-qualified identity"
documenting the spawning-lineage pull-in, the `[frame dispatch-id]`
identity used end-to-end, parent resolution as `[frame
parent-dispatch-id]`, the `:ungrouped`/nil-id exclusion, and the
no-id-only-fallback stance.

## Quality gates (foreground, 0 failures)

- xray JVM `clojure -M:test` — **1239 tests, 5735 assertions, 0 failures**
- `npm run test:cljs` (node CLJS, incl. xray node-tests) — **8503 tests, 39377 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, exit 0**

## Stance

Pre-alpha; frame-qualified identity is the portable contract with NO
compat fallback to id-only; one canonical helper used end-to-end.
ELEGANCE + CLARITY + CORRECTNESS.

Closes rf2-3fc89f.25.
