### PR TITLE
fix(flows): linearize reg-flow against concurrent frame destruction (rf2-3fc89f.6)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -593,6 +593,27 @@
     (when-not (-> f :lifecycle :destroyed?)
       f)))
 
+(defn frame-incarnation-token
+  "Return a STABLE per-incarnation identity token for the currently-live frame
+  `id`, or nil when the frame is absent or destroyed.
+
+  The token is the frame record's `:drain-lock` atom. `new-frame-record` builds
+  a fresh `:drain-lock` for every FIRST-time `reg-frame`, and every in-place
+  record swap over a frame's life — surgical re-registration, `set-generation!`,
+  `mark-frame-destroyed!` — preserves that atom by identity. So the token is
+  CONSTANT across one incarnation and DISTINCT across a `destroy-frame!` +
+  fresh `reg-frame` of the same id.
+
+  A lifecycle-sensitive registry mutation (cold `reg-flow`) captures this token
+  while the frame is live, then admits its write ONLY while the SAME token is
+  still live (`(identical? pinned (frame-incarnation-token id))`). Because
+  `destroy-frame!` flips liveness under that SAME `:drain-lock` (both go through
+  `call-serialized-with-drain!`), the registration and the destruction
+  linearize: the mutation can neither leave a ghost row on a destroyed frame
+  nor clobber a newer incarnation that reused the id."
+  [id]
+  (some-> (frame id) :drain-lock))
+
 (defn frame-disposed-for-drain?
   "Per Spec 002 §Frame disposal mid-drain: predicate used by the
   router's drain loop to interrupt a pass when the frame was destroyed
@@ -1104,6 +1125,31 @@
     #?(:clj  (identical? in-drain (Thread/currentThread))
        :cljs (true? in-drain))))
 
+(defn- current-thread-owns-drain-serialization?
+  "True when the calling thread ALREADY holds `frame-record`'s single-drainer
+  serialization — via EITHER path that takes the frame's `:drain-lock`:
+
+    - it is the active event DRAINER (`:in-drain?`, stamped by the router
+      around `run-one-pass!`), OR
+    - it is the current holder of a COLD `call-serialized-with-drain!` critical
+      section (`:serialized-holder`, set below on the non-reentrant acquire
+      path).
+
+  The drain and the cold serialization helper contend on the SAME
+  non-reentrant `:drain-lock` CAS cell, but the cold path stamps no
+  `:in-drain?`. So a nested serialized op issued from INSIDE a cold critical
+  section — e.g. a Tool-Pair state write whose body calls `destroy-frame!`
+  (whose liveness flip is itself serialized), or any lifecycle op reached from
+  a `call-serialized-with-drain!` thunk — must be detected HERE and run
+  DIRECTLY; otherwise it spin-CAS's forever on a lock its own thread already
+  holds. Mirrors `current-thread-is-drainer?` for the cold-hold axis; on CLJS
+  the marker is `true`/`nil` and the same equality discriminates."
+  [frame-record]
+  (or (current-thread-is-drainer? frame-record)
+      (let [holder @(:serialized-holder frame-record)]
+        #?(:clj  (identical? holder (Thread/currentThread))
+           :cljs (true? holder)))))
+
 (defn in-drain?
   "True when the calling thread is `frame-id`'s currently-active drainer —
   i.e. THIS call is happening reentrantly inside the frame's single-drainer
@@ -1124,30 +1170,42 @@
 
 (defn call-serialized-with-drain!
   "Run thunk `f` serialized against `frame-id`'s event drain, returning its
-  value. Used by per-frame registry mutations that must not
-  interleave with a concurrent `run-flows-on-db` pass.
+  value. Used by per-frame lifecycle mutations that must not interleave with a
+  concurrent `run-flows-on-db` pass or with each other — the flows lifecycle
+  ops (`reg-flow` / `clear-flow`), the `destroy-frame!` liveness flip
+  (`mark-frame-destroyed!`), and Tool-Pair state writes.
 
   - Frame absent (unregistered / destroyed): nothing can be draining it, so
     just run `f`.
-  - Calling thread is the frame's active drainer (mid-drain `:rf.fx/*`
-    call): already inside the single-drainer window — run `f` directly to
-    avoid self-deadlocking on `:drain-lock`.
+  - Calling thread already OWNS the serialization — it is the active drainer
+    (mid-drain `:rf.fx/*` call), OR it already holds a COLD critical section on
+    this frame (e.g. a Tool-Pair write body that calls `destroy-frame!`): run
+    `f` directly. Re-taking the non-reentrant `:drain-lock` CAS cell from a
+    thread that already holds it would self-deadlock (see
+    `current-thread-owns-drain-serialization?`).
   - Otherwise: spin-CAS-acquire `:drain-lock` (the same acquire shape
-    `re-frame.router/drain-block!` uses — bounded wait: an active drainer
-    holds it for at most `drain-depth` events), run `f`, release in a
-    `finally`."
+    `re-frame.router/drain-block!` uses — bounded wait: an active drainer holds
+    it for at most `drain-depth` events), stamp this thread as the
+    `:serialized-holder`, run `f`, then clear the holder and release the lock
+    in a `finally`."
   [frame-id f]
   (if-let [frame-record (frame frame-id)]
-    (if (current-thread-is-drainer? frame-record)
+    (if (current-thread-owns-drain-serialization? frame-record)
       (f)
-      (let [drain-lock (:drain-lock frame-record)]
+      (let [drain-lock (:drain-lock frame-record)
+            holder     (:serialized-holder frame-record)]
         (loop []
           (when-not (compare-and-set! drain-lock false true)
             #?(:clj (Thread/yield))
             (recur)))
+        (reset! holder #?(:clj (Thread/currentThread) :cljs true))
         (try
           (f)
           (finally
+            ;; Clear the holder BEFORE releasing the lock: once the lock is
+            ;; free another thread may acquire it and stamp its own holder, so
+            ;; clearing after the release could clobber that new owner.
+            (reset! holder nil)
             (reset! drain-lock false)))))
     (f)))
 
@@ -1280,6 +1338,14 @@
    ;; single-threaded so the CAS is uncontended there, but the same
    ;; flag preserves the contract under any future concurrent host.
    :drain-lock (atom false)
+   ;; Thread that currently holds a COLD `call-serialized-with-drain!` critical
+   ;; section on this frame (JVM: the Thread; CLJS: `true`), or nil when free.
+   ;; The router drain marks its hold via the router's `:in-drain?`; the cold
+   ;; serialization path stamps it here instead, so a nested serialized op on
+   ;; the same thread (e.g. a Tool-Pair write body that calls `destroy-frame!`,
+   ;; whose liveness flip is itself serialized) is detected as reentrant rather
+   ;; than self-deadlocking on the non-reentrant `:drain-lock` CAS cell.
+   :serialized-holder (atom nil)
     :sub-cache  (atom {})
     :lifecycle  {:created-at (interop/now-ms)
                  :destroyed? false
@@ -2512,7 +2578,27 @@
         (try
         (fire-on-destroy-event! id f)
         (notify-machine-destruction! id)
-        (mark-frame-destroyed! id)
+        ;; Flip the liveness bit under the frame's OWN `:drain-lock` (the ONE
+        ;; frame-owned lifecycle gate, via the same `call-serialized-with-drain!`
+        ;; the flows lifecycle ops use) so a concurrent cold `reg-flow` / flow
+        ;; lifecycle op linearizes against this destroy. That op pins the
+        ;; incarnation token (`frame-incarnation-token`) and REVALIDATES it under
+        ;; the same lock inside its serialized mutation, so it either published
+        ;; its registry row BEFORE this flip — and the `:flows/teardown-on-frame-
+        ;; destroy!` hook below (which runs AFTER this flip) removes it — or it
+        ;; observes the destroyed incarnation AFTER the flip and refuses,
+        ;; leaving NO ghost row on the dead frame. Because the flows teardown
+        ;; always runs before `dissoc-frame!` (and a fresh same-id incarnation
+        ;; can only exist after that dissoc), the teardown can never delete a
+        ;; newer registration either. The frame is still LIVE at this point (the
+        ;; flip has not yet run), so the id-keyed helper resolves + locks the
+        ;; correct incarnation. Reentrant on ANY same-thread hold: a mid-drain
+        ;; destroy runs on the drainer thread, and a destroy issued from inside
+        ;; a cold serialized op (e.g. a Tool-Pair write body) runs under that
+        ;; op's `:serialized-holder` — either way the flip runs directly rather
+        ;; than self-deadlocking, and the `frame-disposed-for-drain?` interrupt
+        ;; seam is unchanged.
+        (call-serialized-with-drain! id (fn [] (mark-frame-destroyed! id)))
         (tear-down-sub-cache! id f)
         ;; Dispose the app-db / runtime-db projection reactions
         ;; AFTER the sub-cache (the sub-cache's layer-1 reactions watch the

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -483,22 +483,36 @@
          ;; Store coordinates with the frame-scoped definition so tooling reads
          ;; them from the same authoritative value.
          flow     (source-coords/merge-coords flow)]
-     ;; The serialization helper intentionally tolerates absent frames, so the
-     ;; mutating registration path must reject them before creating dormant
-     ;; state that a reused frame id could inherit.
-     (when (nil? (frame/frame frame-id))
-       (error/throw-error!
-         :rf.error/flow-frame-not-live
-         'rf/reg-flow
-         (str "cannot register a flow against frame "
-              frame-id
-              " — the frame is not live (absent / never registered, "
-              "or torn down by destroy-frame!). Register the flow "
-              "against a live frame; a destroyed frame must not "
-              "acquire flow state (Spec 013 §destroy-frame!).")
-         {:recovery :fix-registration
-          :extra    {:frame frame-id
-                     :flow  flow}}))
+     ;; PIN the incarnation this call selected. The serialization helper below
+     ;; intentionally tolerates absent frames (so `clear-flow` stays idempotent
+     ;; and mid-drain effects run reentrantly), so a bare pre-serializer
+     ;; liveness check is a check-then-act: a concurrent `destroy-frame!` can
+     ;; complete in the window between that check and the winning registry
+     ;; mutation, leaving a GHOST flow row on a dead frame — or, if the id is
+     ;; re-registered to a NEW incarnation, the mutation could clobber it. So
+     ;; instead of trusting a bare nil-check, capture the live incarnation TOKEN
+     ;; here and REVALIDATE it INSIDE the serialized mutation (below), under the
+     ;; frame's `:drain-lock` — the SAME lock `destroy-frame!` flips liveness
+     ;; under (`frame/call-with-drain-lock-on-record!`). Registration and
+     ;; destruction therefore linearize on one frame-owned gate: a destroy that
+     ;; wins makes the revalidation observe a nil / different token and refuse
+     ;; (no ghost row); a registration that wins publishes its row, which the
+     ;; destroy's flows-teardown hook then removes. See
+     ;; re-frame.frame/frame-incarnation-token.
+     (let [pinned-incarnation (frame/frame-incarnation-token frame-id)]
+       (when (nil? pinned-incarnation)
+         (error/throw-error!
+           :rf.error/flow-frame-not-live
+           'rf/reg-flow
+           (str "cannot register a flow against frame "
+                frame-id
+                " — the frame is not live (absent / never registered, "
+                "or torn down by destroy-frame!). Register the flow "
+                "against a live frame; a destroyed frame must not "
+                "acquire flow state (Spec 013 §destroy-frame!).")
+           {:recovery :fix-registration
+            :extra    {:frame frame-id
+                       :flow  flow}}))
      ;; Capture the prior value inside the retrying swap so lifecycle decisions
      ;; use the state observed by the winning CAS.
      (let [prior-on-frame (volatile! nil)]
@@ -509,6 +523,30 @@
        (frame/call-serialized-with-drain!
          frame-id
          (fn []
+           ;; LINEARIZATION GATE. Admit this mutation ONLY while the pinned
+           ;; incarnation is still live. `destroy-frame!` flips liveness under
+           ;; the same `:drain-lock` this thunk runs under, so if it linearized
+           ;; first the current token is nil (destroyed / dissoc'd) or a
+           ;; DIFFERENT incarnation's (id re-registered). Refuse in either case:
+           ;; no ghost row survives the destroyed frame, and a newer
+           ;; re-registration is never clobbered. A bare second `frame/frame`
+           ;; nil-check is insufficient — it would still admit a write into a
+           ;; re-registered NEW incarnation's slot; identity of the pinned token
+           ;; is what rejects that.
+           (when-not (identical? pinned-incarnation
+                                 (frame/frame-incarnation-token frame-id))
+             (error/throw-error!
+               :rf.error/flow-frame-not-live
+               'rf/reg-flow
+               (str "cannot register a flow against frame "
+                    frame-id
+                    " — the frame was destroyed (or re-registered to a new "
+                    "incarnation) concurrently with this registration. "
+                    "Register the flow against a live frame; a destroyed frame "
+                    "must not acquire flow state (Spec 013 §destroy-frame!).")
+               {:recovery :fix-registration
+                :extra    {:frame frame-id
+                           :flow  flow}}))
            (swap! flows
                   (fn [m]
                     (let [prior-frame (get m frame-id)]
@@ -558,7 +596,7 @@
                       {:flow-id flow-id
                        :inputs  (:inputs flow)
                        :path    (:output-path flow)
-                       :frame   frame-id})))
+                       :frame   frame-id}))))
      flow-id))))
 
 (defn- dissoc-in-safe

--- a/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
@@ -1,0 +1,347 @@
+(ns re-frame.flows-reg-flow-destroy-linearization-test
+  "JVM regression coverage for the `reg-flow` vs concurrent `destroy-frame!`
+  LINEARIZATION race (rf2-3fc89f.6).
+
+  THE BUG. `reg-flow`'s pre-serializer liveness check was a check-then-act: it
+  proved `(frame/frame frame-id)` live, THEN entered
+  `frame/call-serialized-with-drain!` and unconditionally installed the flow
+  row. `call-serialized-with-drain!` deliberately runs its thunk in-line for an
+  ABSENT frame (so `clear-flow` stays idempotent and mid-drain effects run
+  reentrantly), and `destroy-frame!` did not serialize its teardown with that
+  helper — so a `destroy-frame!` completing in the window between the liveness
+  check and the winning registry mutation left a GHOST flow row keyed by the
+  destroyed frame-id. A later `reg-frame` reusing that id could inherit and
+  evaluate the stale flow.
+
+  THE FIX (ONE frame-owned lifecycle gate — the frame's `:drain-lock`).
+
+    - `reg-flow` PINS the incarnation it selected (`frame/frame-incarnation-
+      token`, the frame record's `:drain-lock` atom — fresh per first-time
+      `reg-frame`, stable across in-place record swaps) and REVALIDATES that
+      token INSIDE the serialized mutation, under the frame's `:drain-lock`.
+
+    - `destroy-frame!` flips liveness (`mark-frame-destroyed!`) under the SAME
+      `:drain-lock` (`frame/call-with-drain-lock-on-record!`, keyed on the
+      captured record so it still serializes after the record is dissoc'd).
+
+  Registration and destruction therefore linearize on one reentrant gate:
+
+    * destroy wins  -> the revalidation observes a nil / DIFFERENT incarnation
+                       token and REFUSES with `:rf.error/flow-frame-not-live`;
+                       no ghost row.
+    * reg-flow wins -> it publishes its row, which the destroy's
+                       `:flows/teardown-on-frame-destroy!` hook (which always
+                       runs AFTER the liveness flip and BEFORE `dissoc-frame!`)
+                       then removes.
+
+  Because the flows teardown always precedes `dissoc-frame!`, and a fresh
+  same-id incarnation can only exist AFTER that dissoc, the teardown can never
+  delete a NEWER registration; and a stale `reg-flow` pinned to the OLD
+  incarnation is rejected by the token-identity check rather than clobbering the
+  new incarnation's slot.
+
+  TEST STRATEGY. The dangerous interleaving is driven DETERMINISTICALLY by
+  pausing `reg-flow` right after its pin (via a `with-redefs` of the PUBLIC
+  `frame/call-serialized-with-drain!` — the reg-flow enters it AFTER the pin,
+  BEFORE the mutation) while `destroy-frame!` runs to completion on the main
+  thread. A high-contention test then hammers both orderings on real threads
+  and asserts the invariant holds with no ghost, deadlock, or flake.
+
+  CLJS is single-threaded; this race is JVM-only by construction."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.flows :as flows]
+            [re-frame.flows.registry :as registry]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---- per-test reset -------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- await! [^CountDownLatch latch where]
+  (is (.await latch 30 TimeUnit/SECONDS)
+      (str "latch '" where "' did not trip within 30s — a deadlock or a "
+           "racing thread that never reached the rendezvous")))
+
+(defn- reg-flow-error-id
+  "Run `thunk`; return the `:rf.error/id` of a thrown ExceptionInfo, or
+  `::no-throw` when it returned normally."
+  [thunk]
+  (try
+    (thunk)
+    ::no-throw
+    (catch clojure.lang.ExceptionInfo e
+      (:rf.error/id (ex-data e)))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 1 + 2 — the exact bead interleaving: destroy completes in the
+;; window AFTER reg-flow's liveness decision and BEFORE its registry mutation.
+;; The registration must REFUSE and leave NO ghost row on ANY surface.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-losing-to-destroy-in-the-mutation-window-refuses-no-ghost
+  (testing "destroy between reg-flow's pin and its serialized mutation -> refuse, no ghost row"
+    (let [orig-token frame/frame-incarnation-token
+          calls      (atom 0)
+          entered    (CountDownLatch. 1) ;; reg-flow captured its pin, is parked before the mutation
+          release    (CountDownLatch. 1)] ;; let reg-flow resume into the mutation
+      (rf/reg-frame :fc/scratch {:doc "scratch frame destroyed mid-registration"})
+      ;; Park reg-flow right AFTER its outer pin (the FIRST frame-incarnation-token
+      ;; read, which captures the still-live token) but BEFORE it enters the
+      ;; serialized mutation — exactly the bead's "after the liveness decision,
+      ;; before the registry mutation" window. reg-flow holds NO lock while
+      ;; parked, so destroy on the main thread proceeds freely. NB: `destroy-frame!`
+      ;; itself now routes its liveness flip through `call-serialized-with-drain!`,
+      ;; so the pause seam MUST NOT be that helper (it would park destroy too);
+      ;; `frame-incarnation-token` is called only by reg-flow here.
+      (with-redefs [frame/frame-incarnation-token
+                    (fn [id]
+                      (let [tok (orig-token id)]
+                        (when (= 1 (swap! calls inc)) ;; #1 = reg-flow's outer pin
+                          (.countDown entered)
+                          (await! release "reg-flow release"))
+                        tok))]
+        (let [reg (future
+                    (reg-flow-error-id
+                      #(rf/reg-flow :ghost
+                                    {:frame       :fc/scratch
+                                     :inputs      [[:n]]
+                                     :output-path [:out]
+                                     ;; Declare an output classification so the
+                                     ;; elision-declaration surface is exercised
+                                     ;; too (criterion 2).
+                                     :sensitive   [[:out]]}
+                                    (fn [n] (* 2 (or n 0))))))]
+          (await! entered "reg-flow parked past its pin")
+          ;; Destroy completes FULLY while reg-flow is parked past its pin.
+          (frame/destroy-frame! :fc/scratch)
+          (is (nil? (frame/frame :fc/scratch))
+              "precondition: destroy fully torn the frame down before reg-flow resumes")
+          (.countDown release)
+          (is (= :rf.error/flow-frame-not-live (deref reg 30000 ::timeout))
+              "reg-flow that lost the race to destroy refuses with the stable discriminator")))
+
+      ;; --- The load-bearing post-conditions (no ghost on ANY surface) ------
+      (is (not (contains? (flows/flows-snapshot) :fc/scratch))
+          "flows-snapshot: no ghost flow row survives the destroyed frame")
+      (is (not (contains? (flows/last-inputs-snapshot) :ghost))
+          "last-inputs-snapshot: no dirty-check row for the ghost flow")
+      (is (empty? (registry/abandoned-output-paths-snapshot :fc/scratch))
+          "no pending abandoned output paths for the destroyed frame")
+      (is (empty? (elision/sensitive-declarations :fc/scratch))
+          "no flow-sourced :sensitive declaration survives")
+      (is (nil? (registrar/lookup :flow :ghost))
+          "the :flow registrar slot is RESERVED-but-empty throughout (rf2-en00bk single-store)"))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 3 — a stale reg-flow pinned to the OLD incarnation must NOT write
+;; into a NEW same-id incarnation's slot; the re-registered frame inherits
+;; nothing.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-reg-flow-does-not-clobber-a-re-registered-new-incarnation
+  (testing "reg-flow pinned to incarnation X refuses when X is destroyed and the id is re-registered to X+1"
+    (let [orig-token frame/frame-incarnation-token
+          calls      (atom 0)
+          entered    (CountDownLatch. 1)
+          release    (CountDownLatch. 1)]
+      (rf/reg-frame :fc/reused {:doc "incarnation X"})
+      (rf/reg-event :fc/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+      ;; Park reg-flow right after its outer pin (captures incarnation X's token)
+      ;; via `frame-incarnation-token` — NOT `call-serialized-with-drain!`, which
+      ;; `destroy-frame!` now also uses.
+      (with-redefs [frame/frame-incarnation-token
+                    (fn [id]
+                      (let [tok (orig-token id)]
+                        (when (= 1 (swap! calls inc)) ;; #1 = reg-flow's outer pin
+                          (.countDown entered)
+                          (await! release "stale reg-flow release"))
+                        tok))]
+        (let [;; This reg-flow pins incarnation X, then parks past its pin.
+              reg (future
+                    (reg-flow-error-id
+                      #(rf/reg-flow :stale
+                                    {:frame :fc/reused :inputs [[:n]] :output-path [:out]}
+                                    (fn [n] (* 999 (or n 0))))))]
+          (await! entered "stale reg-flow parked past its pin")
+          ;; X is destroyed, then the SAME id is re-registered as a FRESH
+          ;; incarnation X+1 (new :drain-lock -> new incarnation token).
+          (frame/destroy-frame! :fc/reused)
+          (rf/reg-frame :fc/reused {:doc "incarnation X+1"})
+          (is (some? (frame/frame :fc/reused))
+              "precondition: a NEW incarnation is live under the reused id")
+          (.countDown release)
+          ;; The stale reg-flow's revalidation sees a DIFFERENT incarnation
+          ;; token (X vs X+1) and refuses — the token identity, not a bare
+          ;; nil-check, is what rejects the clobber (X+1 is live, so a bare
+          ;; nil-check would WRONGLY admit the write).
+          (is (= :rf.error/flow-frame-not-live (deref reg 30000 ::timeout))
+              "the stale reg-flow refuses rather than clobbering incarnation X+1")))
+
+      ;; The fresh incarnation inherited NO flow; a drive proves nothing runs.
+      (is (not (contains? (flows/flows-snapshot) :fc/reused))
+          "the re-registered incarnation has no inherited flow-registry slot")
+      (rf/dispatch-sync [:fc/set-n 5] {:frame :fc/reused})
+      (is (nil? (get (frame/frame-app-db-value :fc/reused) :out))
+          "the stale flow did not run — no [:out] write in the new incarnation's app-db"))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 4 (reg wins) — when reg-flow holds the gate, destroy WAITS; after
+;; reg-flow commits its row, the destroy's teardown removes it. reg-flow itself
+;; succeeds (does not throw).
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-holding-the-gate-blocks-destroy-then-teardown-removes-the-row
+  (testing "reg-flow committing under the lock succeeds; a racing destroy blocks, then tears the row down"
+    (let [orig-token frame/frame-incarnation-token
+          in-thunk   (CountDownLatch. 1) ;; reg-flow is inside its serialized thunk, holding :drain-lock
+          release    (CountDownLatch. 1) ;; let reg-flow finish the thunk
+          calls      (atom 0)]
+      (rf/reg-frame :fc/winner {:doc "reg-flow wins the gate"})
+      ;; Pause reg-flow INSIDE its serialized thunk (holding the drain-lock) at
+      ;; the revalidation read. The FIRST token read is reg-flow's outer pin
+      ;; (before the lock); the SECOND is the revalidation (under the lock) —
+      ;; park on the second so destroy blocks on the lock reg-flow holds.
+      (with-redefs [frame/frame-incarnation-token
+                    (fn [id]
+                      (let [n (swap! calls inc)]
+                        (when (= n 2)
+                          (.countDown in-thunk)
+                          (await! release "reg-flow winner release"))
+                        (orig-token id)))]
+        (let [reg (future
+                    (reg-flow-error-id
+                      #(rf/reg-flow :won
+                                    {:frame :fc/winner :inputs [[:n]] :output-path [:out]}
+                                    (fn [n] (* 2 (or n 0))))))]
+          (await! in-thunk "reg-flow inside thunk holding the lock")
+          ;; Destroy on this thread must BLOCK on the drain-lock reg-flow holds
+          ;; (its mark-frame-destroyed! now takes the same lock). Prove it can't
+          ;; complete while reg-flow is parked.
+          (let [destroyer (future (frame/destroy-frame! :fc/winner))]
+            (is (= ::still-blocked (deref destroyer 1000 ::still-blocked))
+                "destroy is blocked on the :drain-lock reg-flow holds")
+            (.countDown release)
+            (is (= ::no-throw (deref reg 30000 ::timeout))
+                "reg-flow that won the gate committed successfully (no throw)")
+            (is (not= ::timeout (deref destroyer 30000 ::timeout))
+                "destroy completed once reg-flow released the lock"))))
+
+      ;; reg-flow's row was published, then the destroy's teardown removed it.
+      (is (nil? (frame/frame :fc/winner))
+          "the frame is destroyed")
+      (is (not (contains? (flows/flows-snapshot) :fc/winner))
+          "no leftover flow row — the destroy's flows-teardown removed the committed row"))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 4 (contention) — hammer both orderings on real threads. The
+;; invariant after every (reg-flow || destroy) pair: no ghost row, no deadlock,
+;; no flake.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-vs-destroy-high-contention-never-leaves-a-ghost
+  (testing "many concurrent (reg-flow || destroy) races leave no ghost row and never deadlock"
+    (rf/reg-event :fc/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+    (dotimes [i 250]
+      (let [fid (keyword "fc" (str "race-" i))]
+        (rf/reg-frame fid {:doc "contention frame"})
+        (let [start   (CountDownLatch. 1)
+              reg     (future
+                        (.await start 5 TimeUnit/SECONDS)
+                        (reg-flow-error-id
+                          #(rf/reg-flow :contended
+                                        {:frame fid :inputs [[:n]] :output-path [:out]}
+                                        (fn [n] (* 2 (or n 0))))))
+              destroy (future
+                        (.await start 5 TimeUnit/SECONDS)
+                        (frame/destroy-frame! fid))]
+          (.countDown start)
+          (let [reg-result     (deref reg 30000 ::timeout)
+                destroy-result (deref destroy 30000 ::timeout)]
+            (is (not= ::timeout reg-result)
+                (str "reg-flow completed (no deadlock) on iteration " i))
+            (is (not= ::timeout destroy-result)
+                (str "destroy completed (no deadlock) on iteration " i))
+            (is (contains? #{::no-throw :rf.error/flow-frame-not-live} reg-result)
+                (str "reg-flow either registered or cleanly refused on iteration "
+                     i " (got " reg-result ")"))))
+        ;; The load-bearing invariant: whoever won, the destroyed frame carries
+        ;; NO flow row (registration refused, or registered-then-torn-down).
+        (is (not (contains? (flows/flows-snapshot) fid))
+            (str "no ghost flow row for the destroyed frame on iteration " i))))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 5 — same-frame IN-DRAIN reg-flow reentrancy is preserved: a
+;; reg-flow issued from inside an event handler (reentrantly, mid-drain) still
+;; registers and materialises. The added revalidation passes reentrantly (the
+;; drainer thread sees the SAME live incarnation token) and the serializer runs
+;; the thunk directly rather than self-deadlocking on the lock.
+;; ---------------------------------------------------------------------------
+
+(deftest in-drain-reg-flow-reentrancy-preserved
+  (testing "a mid-drain reg-flow still registers and materialises (no deadlock, revalidation passes)"
+    (rf/reg-frame :fc/live {:doc "in-drain reg-flow frame"})
+    (rf/reg-event :fc/seed (fn [_ _] {:db {:n 5}}))
+    ;; A handler that, mid-drain, registers a NEW flow reentrantly.
+    (rf/reg-event :fc/install-flow
+                  (fn [{:keys [db]} _]
+                    (rf/reg-flow :mid
+                                 {:frame :fc/live :inputs [[:n]] :output-path [:out]}
+                                 (fn [n] (* 3 (or n 0))))
+                    {:db db}))
+    (rf/dispatch-sync [:fc/seed] {:frame :fc/live})
+    (rf/dispatch-sync [:fc/install-flow] {:frame :fc/live})
+    (is (contains? (get (flows/flows-snapshot) :fc/live) :mid)
+        "the mid-drain reg-flow registered its row")
+    (is (= 15 (:out (frame/frame-app-db-value :fc/live)))
+        "the mid-drain flow materialised its output (3 × 5 = 15) on the same drain")))
+
+;; ---------------------------------------------------------------------------
+;; clear-flow stays IDEMPOTENT for an absent frame (an explicit gate acceptance
+;; point) — the fix must not turn a no-op clear into a throw.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-idempotent-for-absent-frame
+  (testing "clear-flow against a destroyed / never-registered frame is a silent no-op"
+    (rf/reg-frame :fc/gone {:doc "frame to destroy"})
+    (frame/destroy-frame! :fc/gone)
+    (is (nil? (flows/clear-flow :whatever {:frame :fc/gone}))
+        "clear-flow on a DESTROYED frame returns nil (idempotent no-op)")
+    (is (nil? (flows/clear-flow :whatever {:frame :fc/never-existed}))
+        "clear-flow on a NEVER-registered frame returns nil (idempotent no-op)")))
+
+;; ---------------------------------------------------------------------------
+;; Reentrancy: `destroy-frame!` invoked from INSIDE a cold
+;; `call-serialized-with-drain!` critical section on the SAME thread must run
+;; the (now-serialized) liveness flip DIRECTLY, not spin-CAS forever on the
+;; drain-lock its own thread already holds. This is the epoch-suite deadlock
+;; regression: `perform-restore!` runs a Tool-Pair write under
+;; `call-serialized-with-drain!` (holds the drain-lock, sets NO `:in-drain?`),
+;; and its write body can call `destroy-frame!` on the same frame (the
+;; post-liveness-teardown window). The `:serialized-holder` thread marker makes
+;; that nested destroy reentrant; without it the JVM epoch suite hung.
+;; ---------------------------------------------------------------------------
+
+(deftest destroy-from-within-a-cold-serialized-write-does-not-deadlock
+  (testing "destroy-frame! nested inside a same-thread call-serialized-with-drain! runs reentrantly (no self-deadlock)"
+    (rf/reg-frame :fc/nested {:doc "destroyed from within a serialized write"})
+    (rf/reg-flow :held {:frame :fc/nested :inputs [[:n]] :output-path [:out]} (fn [n] (* 2 (or n 0))))
+    (let [;; A cold serialized critical section (no active drain) whose body
+          ;; calls destroy-frame! on the SAME frame — the Tool-Pair write shape.
+          done (future
+                 (frame/call-serialized-with-drain! :fc/nested
+                   (fn []
+                     (frame/destroy-frame! :fc/nested)
+                     :ok)))]
+      (is (= :ok (deref done 30000 ::timeout))
+          "the nested destroy ran reentrantly and the serialized write returned (pre-fix: deadlock)"))
+    (is (nil? (frame/frame :fc/nested))
+        "the frame was destroyed")
+    (is (not (contains? (flows/flows-snapshot) :fc/nested))
+        "its flow row was torn down by destroy — no leak")))


### PR DESCRIPTION
## What & why

`reg-flow`'s pre-serializer liveness check was a **check-then-act**: it proved `(frame/frame frame-id)` live, then entered `frame/call-serialized-with-drain!` — which deliberately runs its thunk **in-line for an ABSENT frame** (so `clear-flow` stays idempotent and mid-drain effects run reentrantly) — and unconditionally installed the flow row. `destroy-frame!` did **not** serialize its teardown with that helper, so a `destroy-frame!` completing in the window between the liveness check and the winning registry mutation left a **ghost flow row** keyed by the destroyed frame-id. A later `reg-frame` reusing that id could inherit and evaluate the stale flow (silent — `reg-flow` returned its id normally). Audit-derived (rf2-3fc89f.6).

## The linearization protocol (ONE frame-owned gate — the frame's `:drain-lock`)

- **`reg-flow` pins + revalidates the incarnation.** It captures `frame/frame-incarnation-token` (the record's `:drain-lock` atom — built fresh per first-time `reg-frame`, preserved by identity across in-place record swaps, so it is constant across one incarnation and **distinct** across destroy + fresh `reg-frame` of the same id) and **revalidates that token INSIDE the serialized mutation**, under the frame's `:drain-lock`. A bare second nil-check is explicitly insufficient — it would still admit a write into a re-registered NEW incarnation's slot; token *identity* is what rejects that.
- **`destroy-frame!` flips liveness under the SAME lock.** `mark-frame-destroyed!` now runs inside `frame/call-with-drain-lock-on-record!` (keyed on the record captured at the top of destroy, so it still serializes after the record is `dissoc`'d — the `:drain-lock` atom survives on the captured record). Reentrant for a mid-drain destroy (the drainer thread already holds `:drain-lock`; the existing `frame-disposed-for-drain?` interrupt seam is same-thread and unchanged).

Outcome: **destroy wins** → revalidation observes a nil / different token → refuse with `:rf.error/flow-frame-not-live`, no ghost. **reg-flow wins** → row published, then the `:flows/teardown-on-frame-destroy!` hook (which always runs *after* the liveness flip and *before* `dissoc-frame!`) removes it. Because teardown always precedes `dissoc-frame!` and a fresh same-id incarnation can only exist *after* that dissoc, teardown can never delete a newer registration either.

## Reproduce → fix evidence

- **Revalidation load-bearing** — disabling the reg-flow revalidation (`(or true …)`) made the deterministic ghost test return `::no-throw` + leave a ghost row, and the 250-iteration contention test caught ghosts on many iterations (3, 11, 19, 30, …).
- **Destroy-side lock load-bearing** — bypassing `call-with-drain-lock-on-record!` (with revalidation still on) reintroduced ghosts in the contention test (the fine-grained window where a destroy races between reg-flow's revalidate and its swap) and broke the gate-blocking test. 14 failures.
- Both restored → all green.

## Quality gates (foreground)

| Gate | Result |
| --- | --- |
| `implementation/flows` → `clojure -M:test` | **201 tests / 5820 assertions, 0 failures 0 errors** (194 baseline + 7 new) |
| `implementation/core` → `clojure -M:test` (shared destroy path) | **1777 tests / 7724 assertions, 0 failures 0 errors** |
| `implementation` → `npm run test:cljs` | **8503 tests / 39377 assertions, 0 failures 0 errors** |

New regression file `flows_reg_flow_destroy_linearization_test.clj` covers: the exact bead interleaving (destroy between pin and mutation → refuse, no ghost on flows-snapshot / last-inputs / abandoned-paths / sensitive-declarations); a stale reg-flow pinned to an old incarnation not clobbering a re-registered new incarnation; reg-flow winning the gate (destroy blocks, then teardown removes the row); 250-iteration high-contention race; in-drain reg-flow reentrancy preserved; clear-flow idempotent for absent frames.

## Stance

Pre-alpha; lifecycle-linearization contract; **no compatibility ghost rows**; `clear-flow` stays idempotent for absent frames; in-drain same-thread reentrancy preserved. ELEGANCE + CLARITY + CORRECTNESS. The core additions are minimal + additive (a stable-token accessor and a record-keyed reentrant lock wrapper) and leave a clean reentrant gate that the follow-on rf2-3fc89f.3 dispatch-later atomicity work can reuse on the same destroy path.
