### PR TITLE
fix(http): lifecycle-own external abort; remove invalid targetless helpers (rf2-3fc89f.9)

### DIFF
--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -111,12 +111,13 @@ See [Managed HTTP — Failures are a closed set](../async/http.md#failures-are-a
 
 Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx vector. Pure; no side effect — drop the result into `:fx`.
 
+Every helper takes `url` **and** a required `args` map. `args` MUST address the reply — supply `:reply-to`, `:on-success`, or `:on-failure` (an unaddressed request fails loud at dispatch with `:rf.error/http-no-reply-target`). `{:reply-to nil}` is the explicit fire-and-forget spelling. There is no URL-only arity: it would build an effect guaranteed to fail its own boundary validation.
+
 ### `get`
 
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/get url)
   (rf.http/get url args)
   ```
 - **Description**: Synthesise a GET fx vector. `args` merges top-level into the canonical args map, and the caller wins. The exception is `:request`: it merges with `{:method :get :url url}`, and the helper's `:method` and `:url` overwrite caller-supplied ones. All seven helpers share this merge contract.
@@ -126,7 +127,6 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/post url)
   (rf.http/post url args)
   ```
 - **Description**: POST. Pass `:body` in `args`.
@@ -143,7 +143,6 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/put url)
   (rf.http/put url args)
   ```
 - **Description**: PUT.
@@ -160,7 +159,6 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/delete url)
   (rf.http/delete url args)
   ```
 - **Description**: DELETE.
@@ -175,7 +173,6 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/patch url)
   (rf.http/patch url args)
   ```
 - **Description**: PATCH.
@@ -192,7 +189,6 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/head url)
   (rf.http/head url args)
   ```
 - **Description**: HEAD.
@@ -207,13 +203,12 @@ Call-site helpers that synthesise the canonical `[:rf.http/managed args-map]` fx
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (rf.http/options url)
   (rf.http/options url args)
   ```
 - **Description**: OPTIONS.
 - **Example**:
   ```clojure
-  {:fx [(rf.http/options "/api/items")]}
+  {:fx [(rf.http/options "/api/items" {:on-success [:api/capabilities]})]}
   ```
 
 The verb helpers require `[re-frame.http :as rf.http]` alongside `re-frame.core`. The namespace ships in the `day8/re-frame2-http` artefact — the same artefact as the fx.

--- a/docs/async/http.md
+++ b/docs/async/http.md
@@ -321,7 +321,7 @@ The canonical `[:rf.http/managed {:request {:method :get :url …} …}]` vector
 (rf.http/get "/api/items" {:on-success [:items/loaded]})
 ```
 
-Every verb is there — `rf.http/get` / `post` / `put` / `delete` / `patch` / `head` / `options` — each in a one-arg (`url`) and two-arg (`url args`) form. The helper pins `:method` and `:url`; everything else in the args map (`:decode`, `:retry`, `:on-success`, and the `:request` sub-keys like `:body` and `:headers`) passes straight through:
+Every verb is there — `rf.http/get` / `post` / `put` / `delete` / `patch` / `head` / `options` — each taking `url` and a required `args` map (`{:reply-to nil}` is the explicit fire-and-forget spelling; an unaddressed request fails loud with `:rf.error/http-no-reply-target`). The helper pins `:method` and `:url`; everything else in the args map (`:decode`, `:retry`, `:on-success`, and the `:request` sub-keys like `:body` and `:headers`) passes straight through:
 
 ```clojure
 (rf/reg-event :comment/create

--- a/implementation/http/src/re_frame/http.cljc
+++ b/implementation/http/src/re_frame/http.cljc
@@ -53,74 +53,77 @@
 (defn get
   "Spec 014 helper — build a GET `[:rf.http/managed args-map]` fx vector.
 
-  Single-arity form is the minimal call: just the URL.
+  `args` merges into the canonical args map (top-level merge; `:request`
+  itself is merged with `{:method :get :url url}`). Caller-supplied
+  `:method` and `:url` under `:request` are overwritten by the helper.
 
-  Multi-arity form merges `args` into the canonical args map (top-level
-  merge; `:request` itself is merged with `{:method :get :url url}`).
-  Caller-supplied `:method` and `:url` under `:request` are overwritten
-  by the helper.
+  `args` MUST address the reply: supply `:reply-to`, `:on-success`, or
+  `:on-failure` (rf2-et4c1s — an unaddressed request fails loud at dispatch
+  with `:rf.error/http-no-reply-target`). `{:reply-to nil}` is the explicit
+  fire-and-forget spelling. There is no one-argument arity: a URL-only call
+  would build an effect guaranteed to fail its own boundary validation
+  (rf2-3fc89f.9), so the args map is required.
 
   Example:
-    {:fx [(rf.http/get \"/api/items\")
-          (rf.http/get \"/api/items\" {:on-success [:items/loaded]})
+    {:fx [(rf.http/get \"/api/items\" {:on-success [:items/loaded]})
           (rf.http/get \"/api/items\"
                        {:on-success [:items/loaded]
                         :retry      retry-policy
                         :decode     ItemListSchema})]}"
-  ([url]      (build :get url {}))
-  ([url args] (build :get url args)))
+  [url args] (build :get url args))
 
 (defn post
   "Spec 014 helper — build a POST `[:rf.http/managed args-map]` fx vector.
 
-  Pass `:body` under `:request` (and optionally `:request-content-type
-  :json` to JSON-encode a clj coll, per Spec 014 §Body encoding):
+  `args` is required and MUST address the reply (`:reply-to` /
+  `:on-success` / `:on-failure`; `{:reply-to nil}` for explicit
+  fire-and-forget). Pass `:body` under `:request` (and optionally
+  `:request-content-type :json` to JSON-encode a clj coll, per Spec 014
+  §Body encoding):
 
     (rf.http/post \"/api/items\"
                   {:request    {:body new-item
                                 :request-content-type :json}
                    :on-success [:items/created]})"
-  ([url]      (build :post url {}))
-  ([url args] (build :post url args)))
+  [url args] (build :post url args))
 
 (defn put
   "Spec 014 helper — build a PUT `[:rf.http/managed args-map]` fx vector.
 
-  Same shape as `post`; PUT semantics. See Spec 014 §The args map."
-  ([url]      (build :put url {}))
-  ([url args] (build :put url args)))
+  Same shape as `post`; PUT semantics. `args` is required and MUST address
+  the reply. See Spec 014 §The args map."
+  [url args] (build :put url args))
 
 (defn delete
   "Spec 014 helper — build a DELETE `[:rf.http/managed args-map]` fx vector.
 
-  Single-arity: just the URL. Multi-arity: merge `args` into the
-  canonical envelope. Example:
+  `args` is required and MUST address the reply (`:reply-to` /
+  `:on-success` / `:on-failure`). Example:
 
     (rf.http/delete \"/api/items/42\"
                     {:on-success [:items/removed 42]})"
-  ([url]      (build :delete url {}))
-  ([url args] (build :delete url args)))
+  [url args] (build :delete url args))
 
 (defn patch
   "Spec 014 helper — build a PATCH `[:rf.http/managed args-map]` fx vector.
 
-  Same shape as `post` / `put`; PATCH semantics."
-  ([url]      (build :patch url {}))
-  ([url args] (build :patch url args)))
+  Same shape as `post` / `put`; PATCH semantics. `args` is required and
+  MUST address the reply."
+  [url args] (build :patch url args))
 
 (defn head
   "Spec 014 helper — build a HEAD `[:rf.http/managed args-map]` fx vector.
 
   HEAD requests typically don't carry `:decode` since the response has
-  no body; the caller can still set `:on-success` / `:on-failure` to
-  branch on status."
-  ([url]      (build :head url {}))
-  ([url args] (build :head url args)))
+  no body; the caller MUST still set `:on-success` / `:on-failure` (or
+  `:reply-to`) to address the reply and branch on status. `args` is
+  required."
+  [url args] (build :head url args))
 
 (defn options
   "Spec 014 helper — build an OPTIONS `[:rf.http/managed args-map]` fx
   vector. Rarely needed from user code (browsers issue OPTIONS as CORS
   preflight automatically), but provided for symmetry with the other
-  verbs and the rare case of explicit capability discovery."
-  ([url]      (build :options url {}))
-  ([url args] (build :options url args)))
+  verbs and the rare case of explicit capability discovery. `args` is
+  required and MUST address the reply."
+  [url args] (build :options url args))

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -72,6 +72,19 @@
   [reason]
   (contains? reply-suppressing-abort-reasons reason))
 
+(defn- detach-external-abort!
+  "Detach the request's external `:abort-signal` listener (rf2-3fc89f.9).
+  CLJS-only — the binding exists only when the caller supplied an
+  `:abort-signal` on a browser/Node host (the `:external-abort` slot the
+  shared lifecycle threads through ctx). Idempotent and a no-op on the JVM /
+  when absent. Called at EVERY terminal completion (natural success/failure
+  and every abort path) so a shared / parent `AbortController` never retains
+  a completed request's listener. Phase-to-phase ownership transfer detaches
+  the prior listener inside `bind-external-abort!` itself, not here."
+  [ctx]
+  #?(:cljs (transport-cljs/detach-external-abort! (:external-abort ctx)))
+  nil)
+
 (defn- dispatch-reply!
   "Threads the reply-payload through the per-frame `:after` interceptor
   chain (REVERSE registration order) BEFORE handing off to the
@@ -492,6 +505,11 @@
     ;; issuance, so the evict skips and the live successor keeps the id; only a
     ;; genuinely-quiescent id is dropped.
     (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+    ;; rf2-3fc89f.9 — terminal for this request: detach the external
+    ;; `:abort-signal` listener so a shared / parent controller retains no
+    ;; completed-request listener. Fires for every abort reason (this is the
+    ;; single choke both phase abort-fns route through).
+    (detach-external-abort! ctx)
     (cond
       ;; Supersede and epoch-restore reasons
       ;; suppress the reply (the cancellation replaces the original outcome; the
@@ -676,6 +694,10 @@
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it).
       (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
+      ;; (covers the success, accept-failure, and sample-(2) abort branches
+      ;; below; idempotent with the abort-path detach in `dispatch-aborted!`).
+      (detach-external-abort! ctx)
       (if-let [post-cas-abort (aborted-snapshot ctx)]
         ;; Sample (2): abort flipped between our pre-CAS sample and
         ;; our CAS-win. We hold the once-only token AND have cleared the
@@ -766,6 +788,10 @@
       ;; a superseded-then-reclassified attempt does not drop the successor's
       ;; live counter).
       (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
+      ;; (natural terminal failure + the abort-precedence reclassification;
+      ;; idempotent with the abort-path detach in `dispatch-aborted!`).
+      (detach-external-abort! ctx)
       ;; rf2-sixs3 — the redact + emit-error! + supersede-suppressed
       ;; dispatch tail is shared with finalise-success!'s sample-(2) abort
       ;; path via `emit-and-dispatch-failure!`. We have already won the
@@ -883,6 +909,19 @@
         ;; synchronously here, before the timer is armed, so the cell is
         ;; always populated by the time any abort can fire.
         _          (reset! handle-cell handle)
+        ;; rf2-3fc89f.9 — ownership transfer: rebind the external
+        ;; `:abort-signal` from the just-completed live-fetch handle onto THIS
+        ;; sleeping-backoff handle's canonical abort-fn, so a signal that fires
+        ;; DURING the backoff window cancels the pending retry (clears the
+        ;; timer + registry) immediately rather than being observed only when
+        ;; the next attempt starts. `bind-external-abort!` detaches the prior
+        ;; live-fetch listener first. An already-aborted signal fires the
+        ;; backoff abort-fn synchronously (winning `fired?`); the trailing
+        ;; `(when @fired? clear-timeout!)` below then disarms the armed timer.
+        #?@(:cljs
+            [_     (transport-cljs/bind-external-abort!
+                     (:external-abort ctx)
+                     (fn [] ((:abort-fn handle) :user)))])
         ;; Schedule AFTER registering so the request is cancellable the
         ;; instant the timer is armed. The callback wins/loses the same
         ;; `fired?` CAS: on a win it clears its own handle and proceeds;
@@ -1258,7 +1297,18 @@
         ;; routed through the normal `maybe-retry!` path so `:on-failure`,
         ;; retry policy, trace metadata, abort precedence, and sensitivity
         ;; redaction all stay consistent.
-        ctx-no-handle (assoc ctx :url url)
+        ;; rf2-3fc89f.9 — the external `:abort-signal` binding is a REQUEST-
+        ;; lifecycle object, created ONCE (attempt 1) and carried forward on
+        ;; ctx across retries/backoff so each phase rebinds the SAME signal
+        ;; onto the current handle. `make-external-abort` returns nil for no
+        ;; signal; the bind/detach helpers are no-ops on nil. CLJS-only — the
+        ;; JVM treats `:abort-signal` as a degraded no-op (a one-line trace via
+        ;; `check-cljs-only-keys!`), so no binding is made there.
+        external-abort #?(:cljs (or (:external-abort ctx)
+                                    (transport-cljs/make-external-abort abort-signal))
+                          :clj  nil)
+        ctx-no-handle (cond-> (assoc ctx :url url)
+                        external-abort (assoc :external-abort external-abort))
         ;; CLJS: per rf2-1jcpm always own an internal AbortController so
         ;; the per-attempt timeout fires even when the caller supplied
         ;; `:abort-signal`. `cljs-fetch` forwards the caller's signal into
@@ -1424,22 +1474,43 @@
         ;; happens synchronously here, before any fetch is issued, so the
         ;; cell is always populated by the time any abort can fire.
         _        (reset! handle-holder handle)
-        ctx'     (assoc ctx-no-handle :handle handle)
-        ;; Request preparation runs after the
-        ;; handle is registered (so abort precedence, the once-only reply
-        ;; guard, and registry cleanup all apply to a prep failure exactly
-        ;; as they do to a network failure) but BEFORE the platform fetch is
-        ;; issued. A throwing body thunk / encode failure becomes a
-        ;; `:rf.http/transport` reply routed through `maybe-retry!` rather
-        ;; than escaping as `:rf.error/fx-handler-exception`.
-        prep     (prepare-body! request)]
-    (if-let [prep-error (:error prep)]
-      ;; Body-prep failed — route through the normal retry/final-failure
-      ;; path on `ctx'` (which carries the registered `:handle`), so retry
-      ;; (when configured for `:rf.http/transport`), trace metadata, abort
-      ;; precedence, and the `:on-failure` reply shape all stay consistent.
-      (maybe-retry! ctx' prep-error)
-      (let [{:keys [enc-body headers]} (:ok prep)]
+        ;; rf2-3fc89f.9 — bind the external `:abort-signal` to THIS live-fetch
+        ;; handle's canonical abort-fn (`:reason :user`), detaching the prior
+        ;; phase's listener (ownership transfer). An ALREADY-aborted signal
+        ;; fires the abort-fn synchronously HERE — it wins the once-only CAS,
+        ;; aborts the internal controller, clears the registry, dispatches the
+        ;; canonical `:rf.http/aborted :reason :user` reply, and detaches its
+        ;; listener — so the `(when-not @finalised? …)` guard below skips body
+        ;; prep + transport entirely (no fresh attempt / body-thunk after
+        ;; cancellation, Spec 014 §Abort precedence). Must run AFTER
+        ;; `handle-holder` is published (the abort-fn reads `@handle-holder`).
+        #?@(:cljs
+            [_   (transport-cljs/bind-external-abort!
+                   external-abort
+                   (fn [] ((:abort-fn handle) :user)))])
+        ctx'     (assoc ctx-no-handle :handle handle)]
+    ;; rf2-3fc89f.9 — short-circuit when an already-aborted external signal
+    ;; won the CAS synchronously during the bind above: the request is already
+    ;; terminal (reply dispatched, registry cleared, listener detached), so
+    ;; running the body thunk / prep or issuing the transport would violate
+    ;; abort precedence. On the JVM (and when no signal aborted) `@finalised?`
+    ;; is false and the request proceeds normally.
+    (when-not @finalised?
+      ;; Request preparation runs after the
+      ;; handle is registered (so abort precedence, the once-only reply
+      ;; guard, and registry cleanup all apply to a prep failure exactly
+      ;; as they do to a network failure) but BEFORE the platform fetch is
+      ;; issued. A throwing body thunk / encode failure becomes a
+      ;; `:rf.http/transport` reply routed through `maybe-retry!` rather
+      ;; than escaping as `:rf.error/fx-handler-exception`.
+      (let [prep (prepare-body! request)]
+       (if-let [prep-error (:error prep)]
+        ;; Body-prep failed — route through the normal retry/final-failure
+        ;; path on `ctx'` (which carries the registered `:handle`), so retry
+        ;; (when configured for `:rf.http/transport`), trace metadata, abort
+        ;; precedence, and the `:on-failure` reply shape all stay consistent.
+        (maybe-retry! ctx' prep-error)
+        (let [{:keys [enc-body headers]} (:ok prep)]
         #?(:cljs
            (-> (transport-cljs/cljs-fetch
                            {:method              method
@@ -1453,7 +1524,11 @@
                             :referrer            (:referrer request)
                             :integrity           (:integrity request)
                             :timeout-ms          timeout-ms
-                            :abort-signal        abort-signal
+                            ;; rf2-3fc89f.9 — the external `:abort-signal` is
+                            ;; NOT forwarded into the attempt-local Fetch:
+                            ;; cancellation is lifecycle-owned (bound to the
+                            ;; handle's abort-fn above), which aborts THIS
+                            ;; `internal-controller` when it fires.
                             :internal-controller internal-controller
                             ;; The transport picks the Fetch
                             ;; body-reader (`.text()` vs `.blob()` /
@@ -1537,4 +1612,4 @@
                                       (maybe-retry! ctx' (transport-jvm/classify-jvm-error throwable timeout-ms (elapsed-ms)))
                                       (handle-response! ctx' result))))))
                (catch Throwable t
-                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))
+                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))))

--- a/implementation/http/src/re_frame/http/transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http/transport_cljs.cljc
@@ -77,16 +77,18 @@
      to `{:ok? bool :status N :status-text S :headers M :body-text S}` on
      transport-OK, or rejects with an ex-info classified by the caller.
 
-     The per-attempt timeout fires regardless of whether
-     the caller supplied `:abort-signal`. We always own
-     `internal-controller`; when the caller also supplies `:abort-signal`,
-     its `abort` event is forwarded to our controller, so:
-
-     - the caller can still cancel via their own signal, AND
-     - the timeout still arms.
-
-     The single `signal` Fetch accepts is always our internal one; any
-     caller signal funnels through `addEventListener` for cancellation.
+     `cljs-fetch` owns ONLY the internal `AbortController`
+     (`internal-controller`), whose `signal` is the single one Fetch
+     accepts. The caller's external `:abort-signal` is NOT wired here.
+     Per rf2-3fc89f.9, external cancellation is REQUEST-lifecycle-owned:
+     the shared lifecycle (`re-frame.http.transport`) binds the external
+     signal to the CURRENT phase handle's canonical `:abort-fn` (which
+     aborts THIS internal controller when it fires), so abort precedence,
+     the once-only reply CAS, registry cleanup, and backoff-timer
+     cancellation apply uniformly regardless of lifecycle phase — rather
+     than an attempt-local `internal-controller.abort()` that bypasses all
+     of them. The internal controller still arms the per-attempt timeout
+     independently of any external signal.
 
      `:sensitive?` and `:frame` are carried only so an
      invalid request header (a `Headers.append` `TypeError` on a bad name
@@ -96,7 +98,7 @@
      same managed-error contract `jvm-build-request` already honours on
      the JVM."
      [{:keys [method url headers body credentials mode redirect cache referrer
-              integrity timeout-ms abort-signal internal-controller decode
+              integrity timeout-ms internal-controller decode
               sensitive? frame]}]
      (let [init     #js {}
            _        (do (aset init "method" (str/upper-case (name method)))
@@ -150,23 +152,7 @@
                         (when referrer     (aset init "referrer"    referrer))
                         (when integrity    (aset init "integrity"   integrity))
                         (when internal-controller
-                          (aset init "signal" (.-signal internal-controller)))
-                         ;; Forward the caller's abort-signal into
-                        ;; our internal controller so the timeout still
-                        ;; fires when a caller signal is present.
-                        (when (and abort-signal internal-controller)
-                          (if (.-aborted abort-signal)
-                            (try (.abort internal-controller
-                                         (or (.-reason abort-signal) "caller-aborted"))
-                                 (catch :default _ nil))
-                            (.addEventListener
-                              abort-signal
-                              "abort"
-                              (fn []
-                                (try (.abort internal-controller
-                                             (or (.-reason abort-signal) "caller-aborted"))
-                                     (catch :default _ nil)))
-                              #js {:once true}))))
+                          (aset init "signal" (.-signal internal-controller))))
            timeout-handle (atom nil)
            ;; rf2-6ecc6 — a real measured elapsed for the synthetic
            ;; timeout, so CLJS `:elapsed-ms` carries the same SEMANTICS as
@@ -297,6 +283,72 @@
                            (when-let [h @timeout-handle] (js/clearTimeout h))
                            nil)))]
        promise)))
+
+;; ---- external AbortSignal → request-lifecycle binding (rf2-3fc89f.9) -------
+;;
+;; An external `:abort-signal` is a REQUEST-lifecycle cancellation source, not
+;; an attempt-local one. It must route to whichever canonical in-flight handle
+;; owns the CURRENT phase (live-fetch or sleeping-backoff) and flip that
+;; handle's `:aborted?` / `:finalised?` cells through its canonical
+;; `:abort-fn`, exactly like `:rf.http/managed-abort` / supersede /
+;; actor-destroy do — so abort precedence, the once-only reply CAS, registry
+;; cleanup, and backoff-timer cancellation all apply uniformly (Spec 014
+;; §`:abort-signal` external + §Abort precedence). The shared lifecycle
+;; (`re-frame.http.transport`) owns the binding lifecycle: it BINDS on entry
+;; to each phase (detaching the prior phase's listener) and DETACHES on every
+;; terminal path, so a long-lived shared/parent `AbortController` never
+;; accumulates completed-attempt listeners.
+;;
+;; The binding is a single mutable cell over ONE signal; `bind-external-abort!`
+;; swaps the live listener on phase-ownership transfer (never a second
+;; concurrent listener), and `detach-external-abort!` is idempotent.
+
+#?(:cljs
+   (defn make-external-abort
+     "Create the phase-neutral external-abort binding over `signal` (the
+     caller's `:abort-signal`). Returns a stateful binding value the shared
+     lifecycle threads through the request ctx (`:external-abort`) and rebinds
+     phase-by-phase, or nil when `signal` is nil (no external cancellation
+     source). The binding holds the signal plus the currently-attached
+     listener (nil until the first `bind-external-abort!`)."
+     [signal]
+     (when signal
+       (atom {:signal signal :listener nil}))))
+
+#?(:cljs
+   (defn detach-external-abort!
+     "Idempotently remove the currently-attached abort listener from the
+     binding's signal. A no-op on a nil binding or when no listener is
+     attached. Called on every phase-ownership transfer (before re-binding)
+     and on every terminal completion path, so a shared/parent signal retains
+     no completed-attempt listeners."
+     [binding]
+     (when binding
+       (let [{:keys [signal listener]} @binding]
+         (when listener
+           (.removeEventListener signal "abort" listener)
+           (swap! binding assoc :listener nil))))
+     nil))
+
+#?(:cljs
+   (defn bind-external-abort!
+     "Route the binding's signal `abort` event to `cancel!` — a 0-arg thunk
+     that fires the CURRENT phase handle's canonical `:abort-fn :user`. First
+     DETACHES any listener from a prior phase (ownership transfer), so exactly
+     one listener is ever live on the signal. If the signal is ALREADY
+     aborted, fires `cancel!` synchronously and attaches nothing — the caller
+     then short-circuits the rest of attempt/backoff setup once the canonical
+     abort has won its once-only CAS. A no-op on a nil binding."
+     [binding cancel!]
+     (when binding
+       (detach-external-abort! binding)
+       (let [signal (:signal @binding)]
+         (if (.-aborted signal)
+           (cancel!)
+           (let [listener (fn [_] (cancel!))]
+             (.addEventListener signal "abort" listener)
+             (swap! binding assoc :listener listener)))))
+     nil))
 
 #?(:cljs
    (defn- cross-origin?

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -70,10 +70,11 @@
         (aset js/globalThis "location" orig)))))
 
 (deftest get-helper-shape
-  (testing "(rf.http/get url) produces [:rf.http/managed {:request {:method :get :url url}}]"
+  (testing "(rf.http/get url {:reply-to nil}) produces [:rf.http/managed {:request {:method :get :url url} :reply-to nil}] — rf2-3fc89f.9 the URL-only arity is gone; args map required"
     (is (= [:rf.http/managed
-            {:request {:method :get :url "/api/items"}}]
-           (rf.http/get "/api/items")))))
+            {:request  {:method :get :url "/api/items"}
+             :reply-to nil}]
+           (rf.http/get "/api/items" {:reply-to nil})))))
 
 (deftest post-helper-shape
   (testing "(rf.http/post url args) merges :request body with helper's verb + url"
@@ -89,12 +90,12 @@
                           :on-success [:item/created]})))))
 
 (deftest put-delete-patch-head-options-shapes
-  (testing "every verb pins the right :method"
-    (is (= :put     (-> (rf.http/put     "/x") second :request :method)))
-    (is (= :delete  (-> (rf.http/delete  "/x") second :request :method)))
-    (is (= :patch   (-> (rf.http/patch   "/x") second :request :method)))
-    (is (= :head    (-> (rf.http/head    "/x") second :request :method)))
-    (is (= :options (-> (rf.http/options "/x") second :request :method)))))
+  (testing "every verb pins the right :method (args map required — rf2-3fc89f.9)"
+    (is (= :put     (-> (rf.http/put     "/x" {:reply-to nil}) second :request :method)))
+    (is (= :delete  (-> (rf.http/delete  "/x" {:reply-to nil}) second :request :method)))
+    (is (= :patch   (-> (rf.http/patch   "/x" {:reply-to nil}) second :request :method)))
+    (is (= :head    (-> (rf.http/head    "/x" {:reply-to nil}) second :request :method)))
+    (is (= :options (-> (rf.http/options "/x" {:reply-to nil}) second :request :method)))))
 
 (deftest top-level-keys-pass-through
   (testing ":decode, :accept, :retry, :timeout-ms, :request-id, :abort-signal pass through"
@@ -1118,4 +1119,454 @@
             (.catch (fn [e]
                       (restore)
                       (is false (str "rf2-065xo — unexpected: " e))
+                      (done))))))))
+
+;; ---- rf2-3fc89f.9 — lifecycle-owned external AbortSignal cancellation ------
+;;
+;; The external `:abort-signal` is a REQUEST-lifecycle cancellation source. It
+;; must route to whichever canonical handle owns the CURRENT phase (live-fetch
+;; or sleeping-backoff) through that handle's `:abort-fn :user`, flipping the
+;; same `:aborted?` / `:finalised?` precedence cells `:rf.http/managed-abort` /
+;; supersede / actor-destroy use — and DETACH on ownership transfer + every
+;; terminal path so a shared / parent controller never accumulates
+;; completed-attempt listeners. The pre-fix binding wired the signal only to an
+;; attempt-local `internal-controller`, so it bypassed abort precedence (a
+;; settled success could still land), never cancelled a sleeping backoff, and
+;; leaked its `{once:true}` listener on ordinary completion.
+
+;; ---- (a) binding-helper unit contract (fake AbortSignal / EventTarget) -----
+
+(defn- fake-abort-signal
+  "A minimal AbortSignal / EventTarget stand-in that RECORDS its live 'abort'
+  listeners so a test can prove they are attached / detached. Supports exactly
+  the surface `bind-external-abort!` / `detach-external-abort!` touch:
+  `.-aborted`, `.addEventListener`, `.removeEventListener`, plus a test-only
+  `:fire!` (dispatch to current listeners) and `:pre-abort!` (mark aborted
+  WITHOUT dispatching, to model an already-aborted signal). `:listener-count`
+  reports how many listeners are currently attached."
+  []
+  (let [listeners (atom [])
+        sig       (js-obj)]
+    (aset sig "aborted" false)
+    ;; The binding calls `.addEventListener signal "abort" listener` with
+    ;; exactly type + listener (no options), so a fixed 2-arg fn suffices.
+    (aset sig "addEventListener"
+          (fn [_type f] (swap! listeners conj f)))
+    (aset sig "removeEventListener"
+          (fn [_type f]
+            (swap! listeners (fn [ls] (vec (remove #(identical? % f) ls))))))
+    {:signal         sig
+     :listener-count (fn [] (count @listeners))
+     :pre-abort!     (fn [] (aset sig "aborted" true))
+     :fire!          (fn []
+                       (aset sig "aborted" true)
+                       (doseq [f @listeners] (f #js {})))}))
+
+(deftest external-abort-binding-attaches-one-listener-and-routes-to-current-handle
+  (testing "rf2-3fc89f.9 — `bind-external-abort!` attaches exactly ONE listener
+  on a non-aborted signal; firing the signal invokes the bound `cancel!`."
+    (let [{:keys [signal listener-count fire!]} (fake-abort-signal)
+          binding (transport-cljs/make-external-abort signal)
+          fired   (atom [])]
+      (is (some? binding) "a binding is created for a non-nil signal")
+      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :phase-1)))
+      (is (= 1 (listener-count)) "exactly one listener attached")
+      (is (empty? @fired) "cancel! not yet called — signal has not aborted")
+      (fire!)
+      (is (= [:phase-1] @fired) "firing the signal invokes the bound cancel!"))))
+
+(deftest external-abort-rebind-detaches-prior-phase-listener
+  (testing "rf2-3fc89f.9 — rebinding on phase-ownership transfer DETACHES the
+  prior phase's listener (never a second concurrent listener) and routes the
+  signal to the NEW phase handle's cancel!."
+    (let [{:keys [signal listener-count fire!]} (fake-abort-signal)
+          binding (transport-cljs/make-external-abort signal)
+          fired   (atom [])]
+      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :live-fetch)))
+      (is (= 1 (listener-count)))
+      ;; ownership transfer live-fetch → backoff
+      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :backoff)))
+      (is (= 1 (listener-count)) "still exactly one listener — the old one was detached")
+      (fire!)
+      (is (= [:backoff] @fired)
+          "the signal routes to the CURRENT (backoff) handle, not the stale live-fetch one"))))
+
+(deftest external-abort-detach-is-idempotent-and-removes-listener
+  (testing "rf2-3fc89f.9 — `detach-external-abort!` removes the listener and is
+  idempotent (a shared/parent signal retains no listener after terminal)."
+    (let [{:keys [signal listener-count]} (fake-abort-signal)
+          binding (transport-cljs/make-external-abort signal)]
+      (transport-cljs/bind-external-abort! binding (fn [] nil))
+      (is (= 1 (listener-count)))
+      (transport-cljs/detach-external-abort! binding)
+      (is (= 0 (listener-count)) "listener detached")
+      (transport-cljs/detach-external-abort! binding)
+      (is (= 0 (listener-count)) "detach is idempotent — no throw, still zero"))))
+
+(deftest external-abort-already-aborted-fires-synchronously-attaches-nothing
+  (testing "rf2-3fc89f.9 — binding an ALREADY-aborted signal fires cancel!
+  synchronously and attaches NO listener (the caller then short-circuits)."
+    (let [{:keys [signal listener-count pre-abort!]} (fake-abort-signal)
+          binding (transport-cljs/make-external-abort signal)
+          fired   (atom [])]
+      (pre-abort!)
+      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :sync)))
+      (is (= [:sync] @fired) "cancel! fired synchronously for an already-aborted signal")
+      (is (= 0 (listener-count)) "no listener attached — nothing to leak"))))
+
+(deftest external-abort-nil-signal-is-a-noop
+  (testing "rf2-3fc89f.9 — a nil `:abort-signal` yields a nil binding; bind /
+  detach are no-ops (the common no-external-signal request path)."
+    (is (nil? (transport-cljs/make-external-abort nil)))
+    (is (nil? (transport-cljs/bind-external-abort! nil (fn [] (is false "must not fire")))))
+    (is (nil? (transport-cljs/detach-external-abort! nil)))))
+
+;; ---- (b) end-to-end: fetch stub whose body promise the test controls -------
+
+(defn- with-controlled-body-fetch
+  "Stub `js/fetch` to resolve a 200 Response whose HEADERS resolve immediately
+  but whose `.text()` body reader returns a promise the TEST settles via the
+  returned `:resolve-body!`. `read-fired` is set true the moment `.text()` is
+  invoked (the framework has received the Response and is mid-finalisation,
+  reading the body). Models the acceptance-2 window: host promise about to
+  fulfil, framework not yet finalised. Returns `{:restore :resolve-body!}`."
+  [read-fired]
+  (let [orig         (.-fetch js/globalThis)
+        body-resolve (atom nil)
+        resp #js {:ok         true
+                  :status     200
+                  :statusText ""
+                  :headers    #js {:forEach (fn [cb] (cb "application/json" "content-type"))}
+                  :text       (fn []
+                                (reset! read-fired true)
+                                (js/Promise. (fn [res _] (reset! body-resolve res))))}]
+    (set! (.-fetch js/globalThis) (fn [_url _init] (js/Promise.resolve resp)))
+    {:restore       (fn [] (set! (.-fetch js/globalThis) orig))
+     :resolve-body! (fn [txt] (@body-resolve txt))}))
+
+(defn- next-macrotask
+  "A promise that resolves on the next `setTimeout 0` macrotask — used to let
+  every queued microtask (handle-response! → finalise-*) drain so a
+  suppressed second reply would have landed if the fix were wrong."
+  []
+  (js/Promise. (fn [resolve _] (js/setTimeout resolve 0))))
+
+(deftest cljs-external-abort-after-settle-before-finalise-cancels-once
+  (testing "rf2-3fc89f.9 acceptance 2 — an external signal that fires after the
+  host body promise fulfils but BEFORE framework finalisation reclassifies the
+  in-flight success to exactly one `:rf.http/aborted :reason :user` reply; no
+  success/decode/status/accept outcome lands (pre-fix the settled success won)."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [replies    (atom [])
+            read-fired (atom false)
+            {:keys [restore resolve-body!]} (with-controlled-body-fetch read-fired)
+            controller (js/AbortController.)]
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue/ext
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url "/x"}
+                    :decode     :json
+                    :abort-signal (.-signal controller)
+                    :request-id :ext
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/ext] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(when @read-fired true)
+              {:timeout-ms 2000 :label "cljs body reader reached"})
+            (.then (fn [_]
+                     ;; Host body promise fulfils, THEN the external signal fires
+                     ;; synchronously in the same turn — before handle-response!.
+                     (resolve-body! "{\"ok\":true}")
+                     (.abort controller)
+                     (test-support/poll-until
+                       #(seq @replies)
+                       {:timeout-ms 2000 :label "cljs external-abort cancel reply"})))
+            ;; Drain remaining microtasks so a wrongly-dispatched success would surface.
+            (.then (fn [_] (next-macrotask)))
+            (.then (fn [_]
+                     (is (= 1 (count @replies))
+                         "exactly one reply — the settled success is suppressed by abort precedence")
+                     (let [reply (first @replies)]
+                       (is (= :cancelled (:status reply)))
+                       (is (= :rf.http/aborted (get-in reply [:error :kind]))
+                           "the external signal flips the same precedence cell → :rf.http/aborted")
+                       (is (= :user (get-in reply [:error :reason]))))
+                     (is (empty? (registry/in-flight-snapshot))
+                         "the live-fetch handle is cleared")
+                     (restore)
+                     (done)))
+            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+
+(deftest cljs-external-abort-during-backoff-cancels-retry-and-does-not-reinvoke-thunk
+  (testing "rf2-3fc89f.9 acceptance 3 — an external signal that fires while the
+  request sleeps in the backoff window cancels the pending retry immediately
+  (timer cleared, registry emptied, one :rf.http/aborted :reason :user reply);
+  attempt N+1 is never issued and the per-attempt body thunk is not re-invoked."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [fetch-count (atom 0)
+            thunk-calls (atom 0)
+            replies     (atom [])
+            backoff-ms  80
+            controller  (js/AbortController.)
+            orig        (.-fetch js/globalThis)
+            resp        (fake-response {:status 500 :content-type "application/json"
+                                        :text-val "boom"})]
+        (set! (.-fetch js/globalThis)
+              (fn [_url _init] (swap! fetch-count inc) (js/Promise.resolve resp)))
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "/always-500"
+                                 :method :post
+                                 ;; per-attempt body thunk — counts invocations so
+                                 ;; "not re-invoked after cancel" is observable.
+                                 :body   (fn [] (swap! thunk-calls inc) "payload")}
+                    :decode     :json
+                    :retry      {:on           #{:rf.http/http-5xx}
+                                 :max-attempts 5
+                                 :backoff      {:base-ms backoff-ms :factor 1 :max-ms backoff-ms}}
+                    :abort-signal (.-signal controller)
+                    :request-id :race
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(let [handle (get (registry/in-flight-snapshot) :race)]
+                 (and (= 1 @fetch-count)
+                      (some? handle)
+                      ;; backoff handle is distinguishable by the ABSENCE of the
+                      ;; live-fetch handle's :finalised? cell.
+                      (nil? (:finalised? handle))))
+              {:timeout-ms 2000 :label "cljs backoff sleeping (external)"})
+            (.then (fn [_]
+                     (is (= 1 @thunk-calls) "attempt 1 invoked the body thunk exactly once")
+                     ;; External signal fires squarely inside the backoff window.
+                     (.abort controller)
+                     (is (empty? (registry/in-flight-snapshot))
+                         "the registry is cleared the instant the external signal cancels the backoff")
+                     (test-support/poll-until
+                       #(seq @replies)
+                       {:timeout-ms 2000 :label "cljs external abort reply"})))
+            (.then (fn [_]
+                     (let [reply (first @replies)]
+                       (is (= :cancelled (:status reply)))
+                       (is (= :rf.http/aborted (get-in reply [:error :kind])))
+                       (is (= :user (get-in reply [:error :reason]))))
+                     ;; Wait past the original backoff deadline: prove the timer
+                     ;; was cancelled (no attempt N+1, thunk not re-invoked).
+                     (js/Promise. (fn [resolve _] (js/setTimeout resolve (+ backoff-ms 120))))))
+            (.then (fn [_]
+                     (is (= 1 @fetch-count)
+                         "the retry MUST NOT fetch after an external abort during the backoff window")
+                     (is (= 1 @thunk-calls)
+                         "the per-attempt body thunk MUST NOT be re-invoked after cancellation")
+                     (is (= 1 (count @replies))
+                         "exactly one reply — the cancelled retry produced no second outcome")
+                     (set! (.-fetch js/globalThis) orig)
+                     (done)))
+            (.catch (fn [e]
+                      (set! (.-fetch js/globalThis) orig)
+                      (is false (str "rf2-3fc89f.9 — unexpected: " e))
+                      (done))))))))
+
+(deftest cljs-already-aborted-signal-short-circuits-attempt-setup
+  (testing "rf2-3fc89f.9 acceptance 3 — a request whose `:abort-signal` is
+  ALREADY aborted before attempt setup dispatches one :rf.http/aborted
+  :reason :user reply WITHOUT running the body thunk or issuing any fetch."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [replies     (atom [])
+            thunk-calls (atom 0)
+            controller  (js/AbortController.)
+            ;; fetch must never be reached — the abort short-circuits setup.
+            restore     (with-failing-fetch)]
+        (.abort controller)                     ;; pre-aborted BEFORE dispatch
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue/pre-aborted
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "/x"
+                                 :method :post
+                                 :body   (fn [] (swap! thunk-calls inc) "payload")}
+                    :decode     :json
+                    :abort-signal (.-signal controller)
+                    :request-id :pre
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/pre-aborted] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(seq @replies)
+              {:timeout-ms 2000 :label "cljs pre-aborted reply"})
+            (.then (fn [_] (next-macrotask)))
+            (.then (fn [_]
+                     (is (= 1 (count @replies)) "exactly one reply")
+                     (let [reply (first @replies)]
+                       (is (= :cancelled (:status reply)))
+                       (is (= :rf.http/aborted (get-in reply [:error :kind])))
+                       (is (= :user (get-in reply [:error :reason]))))
+                     (is (= 0 @thunk-calls)
+                         "the body thunk was NEVER invoked — attempt setup short-circuited")
+                     (is (empty? (registry/in-flight-snapshot)))
+                     (restore)
+                     (done)))
+            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+
+(deftest cljs-external-abort-racing-supersede-suppression-authoritative
+  (testing "rf2-3fc89f.9 acceptance 4 — when a same-id supersede WINS the race,
+  suppression stays authoritative: the superseded request delivers NO app reply
+  even though its external signal ALSO fires afterwards (once-only CAS)."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [replies-1  (atom [])
+            read-fired (atom false)
+            {:keys [restore]} (with-controlled-body-fetch read-fired)
+            controller (js/AbortController.)]
+        (rf/reg-event :reply/recorder-1 (fn [_ [_ p]] (swap! replies-1 conj p) {}))
+        (rf/reg-event :reply/recorder-2 (fn [_ _] {}))
+        (rf/reg-event :issue/one
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request {:url "/one"} :decode :json
+                    :abort-signal (.-signal controller)
+                    :request-id :dup
+                    :on-failure [:reply/recorder-1]
+                    :on-success [:reply/recorder-1]}]]}))
+        (rf/reg-event :issue/two            ;; same :request-id → supersedes :dup
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request {:url "/two"} :decode :json
+                    :request-id :dup
+                    :on-failure [:reply/recorder-2]
+                    :on-success [:reply/recorder-2]}]]}))
+        (rf/dispatch-sync [:issue/one] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(when @read-fired true)
+              {:timeout-ms 2000 :label "cljs request-1 in flight"})
+            (.then (fn [_]
+                     ;; Supersede FIRST (request 2 replaces request 1) …
+                     (reset! read-fired false)
+                     (rf/dispatch-sync [:issue/two] {:frame :rf/default})
+                     ;; … then the external signal fires — request 1 already
+                     ;; superseded + its listener detached, so this is a no-op.
+                     (.abort controller)
+                     (next-macrotask)))
+            (.then (fn [_] (next-macrotask)))
+            (.then (fn [_]
+                     (is (empty? @replies-1)
+                         "the superseded request delivered NO app reply — supersede suppression is authoritative even though the external signal fired")
+                     (restore)
+                     (done)))
+            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+
+(deftest cljs-external-abort-racing-managed-abort-single-outcome
+  (testing "rf2-3fc89f.9 acceptance 4 — an external signal and a
+  :rf.http/managed-abort fired against the SAME in-flight request route through
+  the one canonical handle; the once-only CAS yields exactly one :cancelled
+  outcome regardless of which fires first."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [replies    (atom [])
+            read-fired (atom false)
+            {:keys [restore]} (with-controlled-body-fetch read-fired)
+            controller (js/AbortController.)]
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request {:url "/x"} :decode :json
+                    :abort-signal (.-signal controller)
+                    :request-id :both
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/reg-event :do/managed-abort
+          (fn [_ _] {:fx [[:rf.http/managed-abort :both]]}))
+        (rf/dispatch-sync [:issue] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(when @read-fired true)
+              {:timeout-ms 2000 :label "cljs both-sources in flight"})
+            (.then (fn [_]
+                     ;; External signal wins; the managed-abort fx then finds a
+                     ;; handle whose once-only CAS is already spent → no-op.
+                     (.abort controller)
+                     (rf/dispatch-sync [:do/managed-abort] {:frame :rf/default})
+                     (test-support/poll-until
+                       #(seq @replies)
+                       {:timeout-ms 2000 :label "cljs single cancel reply"})))
+            (.then (fn [_] (next-macrotask)))
+            (.then (fn [_]
+                     (is (= 1 (count @replies))
+                         "exactly one terminal outcome despite two cancellation sources")
+                     (is (= :cancelled (:status (first @replies))))
+                     (is (= :user (get-in (first @replies) [:error :reason])))
+                     (is (empty? (registry/in-flight-snapshot)))
+                     (restore)
+                     (done)))
+            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+
+(deftest cljs-external-abort-listener-detached-on-natural-success-and-failure
+  (testing "rf2-3fc89f.9 acceptance 5 — after a NATURAL success and a natural
+  terminal failure that share ONE signal, no completed-attempt listeners
+  accumulate: the binding detaches on every terminal path."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [{:keys [signal listener-count]} (fake-abort-signal)
+            replies (atom [])
+            orig    (.-fetch js/globalThis)]
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue
+          (fn [_ [_ url]]
+            {:fx [[:rf.http/managed
+                   {:request {:url url} :decode :json
+                    :abort-signal signal        ;; ONE shared signal for both requests
+                    :request-id :shared
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        ;; --- request 1: natural SUCCESS (200) ---
+        (set! (.-fetch js/globalThis)
+              (fn [_url _init]
+                (js/Promise.resolve (fake-response {:status 200 :content-type "application/json"
+                                                    :text-val "{\"ok\":true}"}))))
+        (rf/dispatch-sync [:issue "/ok"] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(seq @replies) {:timeout-ms 2000 :label "cljs shared-signal success reply"})
+            (.then (fn [_]
+                     (is (= :ok (:status (first @replies))))
+                     (is (= 0 (listener-count))
+                         "the success terminal detached the external listener — none accumulates")
+                     ;; --- request 2: natural FAILURE (500, no retry) ---
+                     (reset! replies [])
+                     (set! (.-fetch js/globalThis)
+                           (fn [_url _init]
+                             (js/Promise.resolve (fake-response {:status 500 :content-type "application/json"
+                                                                 :text-val "boom"}))))
+                     (rf/dispatch-sync [:issue "/fail"] {:frame :rf/default})
+                     (test-support/poll-until
+                       #(seq @replies) {:timeout-ms 2000 :label "cljs shared-signal failure reply"})))
+            (.then (fn [_]
+                     (is (= :error (:status (first @replies))))
+                     (is (= :rf.http/http-5xx (get-in (first @replies) [:error :kind])))
+                     (is (= 0 (listener-count))
+                         "the failure terminal also detached — a shared signal retains no completed-attempt listeners")
+                     (set! (.-fetch js/globalThis) orig)
+                     (done)))
+            (.catch (fn [e]
+                      (set! (.-fetch js/globalThis) orig)
+                      (is false (str "rf2-3fc89f.9 — unexpected: " e))
                       (done))))))))

--- a/implementation/http/test/re_frame/http_test.clj
+++ b/implementation/http/test/re_frame/http_test.clj
@@ -8,49 +8,73 @@
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.http :as rf.http]))
 
-;; ---- 1. minimal form -------------------------------------------------------
+;; ---- 1. minimal form — args map required, reply must be addressed ----------
+;;
+;; rf2-3fc89f.9 / rf2-et4c1s — the one-argument (URL-only) arity was REMOVED:
+;; every `:rf.http/managed` request must address its reply (`:reply-to` /
+;; `:on-success` / `:on-failure`; omission fails loud at dispatch with
+;; `:rf.error/http-no-reply-target`). A URL-only helper manufactured an effect
+;; guaranteed to fail its own boundary validation, so it is gone. The minimal
+;; call is now `(verb url {:reply-to nil})` — the explicit fire-and-forget
+;; spelling.
 
 (deftest minimal-get
-  (testing "(get url) — just the URL, no extra args"
+  (testing "(get url {:reply-to nil}) — minimal explicit fire-and-forget form"
     (is (= [:rf.http/managed
-            {:request {:method :get :url "/api/items"}}]
-           (rf.http/get "/api/items")))))
+            {:request  {:method :get :url "/api/items"}
+             :reply-to nil}]
+           (rf.http/get "/api/items" {:reply-to nil})))))
 
 (deftest minimal-post
-  (testing "(post url) — just the URL, no extra args"
+  (testing "(post url {:reply-to nil}) — minimal explicit fire-and-forget form"
     (is (= [:rf.http/managed
-            {:request {:method :post :url "/api/items"}}]
-           (rf.http/post "/api/items")))))
+            {:request  {:method :post :url "/api/items"}
+             :reply-to nil}]
+           (rf.http/post "/api/items" {:reply-to nil})))))
 
 (deftest minimal-put
-  (testing "(put url) — just the URL"
+  (testing "(put url {:reply-to nil})"
     (is (= [:rf.http/managed
-            {:request {:method :put :url "/api/items/1"}}]
-           (rf.http/put "/api/items/1")))))
+            {:request  {:method :put :url "/api/items/1"}
+             :reply-to nil}]
+           (rf.http/put "/api/items/1" {:reply-to nil})))))
 
 (deftest minimal-delete
-  (testing "(delete url) — just the URL"
+  (testing "(delete url {:reply-to nil})"
     (is (= [:rf.http/managed
-            {:request {:method :delete :url "/api/items/1"}}]
-           (rf.http/delete "/api/items/1")))))
+            {:request  {:method :delete :url "/api/items/1"}
+             :reply-to nil}]
+           (rf.http/delete "/api/items/1" {:reply-to nil})))))
 
 (deftest minimal-patch
-  (testing "(patch url) — just the URL"
+  (testing "(patch url {:reply-to nil})"
     (is (= [:rf.http/managed
-            {:request {:method :patch :url "/api/items/1"}}]
-           (rf.http/patch "/api/items/1")))))
+            {:request  {:method :patch :url "/api/items/1"}
+             :reply-to nil}]
+           (rf.http/patch "/api/items/1" {:reply-to nil})))))
 
 (deftest minimal-head
-  (testing "(head url) — just the URL"
+  (testing "(head url {:reply-to nil})"
     (is (= [:rf.http/managed
-            {:request {:method :head :url "/api/items"}}]
-           (rf.http/head "/api/items")))))
+            {:request  {:method :head :url "/api/items"}
+             :reply-to nil}]
+           (rf.http/head "/api/items" {:reply-to nil})))))
 
 (deftest minimal-options
-  (testing "(options url) — just the URL"
+  (testing "(options url {:reply-to nil})"
     (is (= [:rf.http/managed
-            {:request {:method :options :url "/api/items"}}]
-           (rf.http/options "/api/items")))))
+            {:request  {:method :options :url "/api/items"}
+             :reply-to nil}]
+           (rf.http/options "/api/items" {:reply-to nil})))))
+
+(deftest one-arg-arity-is-removed
+  (testing "rf2-3fc89f.9 — the URL-only arity no longer exists; a caller MUST
+            supply the args map (fail-loud consistency with the reply-target
+            requirement). Every verb throws ArityException on a one-arg call."
+    (doseq [helper [rf.http/get rf.http/post rf.http/put rf.http/delete
+                    rf.http/patch rf.http/head rf.http/options]]
+      (is (thrown? clojure.lang.ArityException (helper "/x"))
+          "a one-argument helper call is an arity error"))))
 
 ;; ---- 2. on-success / on-failure pass through ------------------------------
 
@@ -210,7 +234,7 @@
   (testing "the fx vector is always [:rf.http/managed <args-map>]"
     (doseq [helper [rf.http/get rf.http/post rf.http/put rf.http/delete
                     rf.http/patch rf.http/head rf.http/options]]
-      (let [fx (helper "/x")]
+      (let [fx (helper "/x" {:reply-to nil})]
         (is (vector? fx))
         (is (= 2 (count fx)))
         (is (= :rf.http/managed (first fx)))
@@ -219,10 +243,10 @@
 
 (deftest verb-to-method-mapping
   (testing "each helper pins its verb keyword onto :request :method"
-    (is (= :get     (-> (rf.http/get     "/x") second :request :method)))
-    (is (= :post    (-> (rf.http/post    "/x") second :request :method)))
-    (is (= :put     (-> (rf.http/put     "/x") second :request :method)))
-    (is (= :delete  (-> (rf.http/delete  "/x") second :request :method)))
-    (is (= :patch   (-> (rf.http/patch   "/x") second :request :method)))
-    (is (= :head    (-> (rf.http/head    "/x") second :request :method)))
-    (is (= :options (-> (rf.http/options "/x") second :request :method)))))
+    (is (= :get     (-> (rf.http/get     "/x" {:reply-to nil}) second :request :method)))
+    (is (= :post    (-> (rf.http/post    "/x" {:reply-to nil}) second :request :method)))
+    (is (= :put     (-> (rf.http/put     "/x" {:reply-to nil}) second :request :method)))
+    (is (= :delete  (-> (rf.http/delete  "/x" {:reply-to nil}) second :request :method)))
+    (is (= :patch   (-> (rf.http/patch   "/x" {:reply-to nil}) second :request :method)))
+    (is (= :head    (-> (rf.http/head    "/x" {:reply-to nil}) second :request :method)))
+    (is (= :options (-> (rf.http/options "/x" {:reply-to nil}) second :request :method)))))


### PR DESCRIPTION
## Summary

Two audit-derived `implementation/http` correctness fixes (rf2-3fc89f.9).

### Finding 1 (P2) — external `:abort-signal` bypassed the canonical lifecycle abort path

**Before:** `transport_cljs.cljc` wired the external signal only to an *attempt-local* internal `AbortController` (`.abort` on one Fetch attempt). It never touched the canonical handle's `:aborted?`/`:finalised?` precedence cells, so cancellation was phase-dependent:
- a Fetch/body promise already fulfilled but not yet framework-finalised could still land **success** (abort lost the same-tick race — the precedence cell stayed nil);
- an abort during retry **backoff** was invisible to the sleeping handle/timer — deferred to the next attempt, which re-ran body prep;
- the `{once:true}` listener was never removed on ordinary completion — a shared/parent controller leaked one completed-attempt closure per request.

**Fix (per DESIGN):** cancellation is owned by the request state machine. A phase-neutral binding (`make-/bind-/detach-external-abort!` in `transport-cljs`) routes the external signal to whichever **canonical handle owns the current phase** via that handle's `:abort-fn :user`, and **detaches on ownership transfer + every terminal path**:
- created once per request, threaded through ctx (`:external-abort`), rebound in `run-attempt!` (live-fetch) and `schedule-backoff-handle!` (backoff); `bind-external-abort!` detaches the prior phase's listener before re-attaching;
- an already-aborted signal fires synchronously and the caller **short-circuits** body-prep / transport / timer creation;
- the once-only `:finalised?` CAS and supersede/actor-destroy suppression stay the authority (external abort is just another re-entrant source through the same choke);
- `cljs-fetch` no longer touches the external signal (the handle's abort-fn aborts the internal controller when it fires).

### Finding 2 (P3) — removed invalid targetless verb-helper sugar

The URL-only arity was removed from all seven helpers (`get`/`post`/`put`/`delete`/`patch`/`head`/`options`): a targetless helper manufactured an effect **guaranteed** to fail `:rf.error/http-no-reply-target` boundary validation. `args` is now required; `{:reply-to nil}` is the explicit fire-and-forget spelling. No implicit silent target was added.

## Reproduce → fix evidence

- **Acceptance 2** (`cljs-external-abort-after-settle-before-finalise-cancels-once`): stubbed fetch settles the Response, the test fulfils the body promise then fires the external signal in the same turn, before `handle-response!`. Pre-fix the settled success lands (`:ok`); post-fix exactly one `:rf.http/aborted :reason :user`. **Fails on old code.**
- **Acceptance 3**: external abort during backoff cancels immediately (timer cleared, registry empty, one reply), attempt N+1 never issued, per-attempt body thunk not re-invoked; plus an already-aborted-before-setup case proving the body thunk is never called.
- **Acceptance 4**: external signal racing same-id supersede (suppression stays authoritative) and racing `:rf.http/managed-abort` (once-only CAS → single outcome).
- **Acceptance 5**: fake AbortSignal/EventTarget proves listeners attach once, rebind swaps (never accumulates), detach is idempotent, already-aborted attaches nothing; a shared signal retains zero listeners after natural success and failure.

## Ownership binding

External `AbortSignal` `abort` event → `(:abort-fn <current-phase handle>) :user` → flips `:aborted?`, wins `:finalised?` CAS, clears registry, `dispatch-aborted!`. Detach on phase transfer (inside `bind-external-abort!`) and terminal (`dispatch-aborted!`, `finalise-success!`, `finalise-failure!`).

## Removed helpers

The one-argument `[url]` arities of `re-frame.http/{get,post,put,delete,patch,head,options}`. Callers now pass the args map (updated docstrings, `docs/api/re-frame.http.md`, `docs/async/http.md`, and tests). JVM `one-arg-arity-is-removed` test pins the removal (ArityException).

## Stance

Pre-alpha, fail-loud + managed-lifecycle; cancellation owned by the request state machine; removed invalid helper sugar rather than adding an implicit silent target. ELEGANCE + CLARITY + CORRECTNESS.

## Quality gates (foreground)

- `cd implementation/http && clojure -M:test` → **471 tests, 3681 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8514 tests, 39421 assertions, 0 failures, 0 errors** (includes the 8 new CLJS abort regressions + transport-cljs binding units)

## Boundary note

Touched `implementation/http/src` + `implementation/http/test/**` (the code fix) and — to satisfy acceptance 6 — the two HTTP-specific docs (`docs/api/re-frame.http.md`, `docs/async/http.md`), which are disjoint from all other in-flight workers. No manifest change: the manifest tracks vars (still present), not arities.
