### PR TITLE
fix(examples): seed login slice via a composed Story fragment in every variant (rf2-3fc89f.28)

### DIFF
--- a/examples/core/login/stories.cljs
+++ b/examples/core/login/stories.cljs
@@ -87,13 +87,16 @@
 ;; canned-success stub (which just echoes the request's `:value` slot back as
 ;; the payload).
 ;;
-;; So this driver walks the real form path: seed the draft (email via
-;; `:auth.login/edit-field`, password via the classified `:auth.login/edit-
-;; password`), then dispatch `:auth.login/submit-form`. Same real fx (right
-;; there in Xray's Side Effects panel), and the canned stub answers it — no
-;; app-side override needed. The reply `:value` happens to be nil (we sent
-;; none), but that's fine: the welcome banner keys off the `:auth/authenticated`
-;; tag, not the payload, so the flow still settles happily at `:authed`.
+;; The slice itself is seeded once, up front, by the composed
+;; `:fragment.login/form-base` fragment (every variant pulls it in via
+;; `:compose`), so this driver need not initialise it — it just walks the
+;; real form path: type the draft (email via `:auth.login/edit-field`,
+;; password via the classified `:auth.login/edit-password`), then dispatch
+;; `:auth.login/submit-form`. Same real fx (right there in Xray's Side
+;; Effects panel), and the canned stub answers it — no app-side override
+;; needed. The reply `:value` happens to be nil (we sent none), but that's
+;; fine: the welcome banner keys off the `:auth/authenticated` tag, not the
+;; payload, so the flow still settles happily at `:authed`.
 ;; ---------------------------------------------------------------------------
 
 (rf/reg-event :login.story/submit
@@ -105,8 +108,7 @@
          `:auth.login/success` follow-on lands the flow at `:authed`. The whole
          chain shows in Xray's Epoch / Trace / Side Effects panels."}
   (fn handler-story-submit [_ [_ creds]]
-    {:fx [[:dispatch [:auth.login/initialise-form]]
-          [:dispatch [:auth.login/edit-field :email (:email creds)]]
+    {:fx [[:dispatch [:auth.login/edit-field :email (:email creds)]]
           [:dispatch [:auth.login/edit-password {:value (:password creds)}]]
           [:dispatch [:auth.login/submit-form]]]}))
 
@@ -166,6 +168,28 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
+  ;; reg-fragment — the shared form-base. Every login variant runs in its own
+  ;; fresh `:preset :story` frame with no application `:initial-events`, so
+  ;; each must seed the login-form slice itself before its variant-specific
+  ;; setup runs — exactly as the live app does at boot. Rather than copy the
+  ;; initializer into seven `:setup` vectors, we register it ONCE here and
+  ;; `:compose` it into every variant below. The plan compiler appends a
+  ;; composed fragment's `:setup` BEFORE the variant's own, so the slice is
+  ;; fully initialised (controlled inputs, complete bookkeeping fields) the
+  ;; moment the variant's own events run. The event stays the single source
+  ;; of the defaults — no defaults map is duplicated in Story, no `:db-seed`.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-fragment :fragment.login/form-base
+    {:doc   "Seeds the login-form slice to its standard form-recipe defaults
+            via the example's own `:auth.login/initialise-form` (the single
+            source of those defaults — the same event the live app runs at
+            boot). Composed into every login variant so each isolated frame
+            boots with a fully-initialised, controlled-input slice before its
+            variant-specific setup runs."
+     :setup [[:auth.login/initialise-form]]})
+
+  ;; -------------------------------------------------------------------------
   ;; reg-variant — the reachable states, one per variant. The house style
   ;; here: drive each into place with real events, never by hand-poking the
   ;; db (`:db-seed`) or faking subs (`:sub-overrides`). What you see is what
@@ -178,7 +202,8 @@
   ;; `[:rf.runtime/machines :snapshots :auth.login/flow]` slot sits nil until
   ;; the first real event, and there'd be nothing to render.
   (story/reg-variant :story.login/empty
-    {:doc        "Fresh form, nothing typed, no submit clicked — the
+    {:compose    [:fragment.login/form-base]
+     :doc        "Fresh form, nothing typed, no submit clicked — the
                  `:idle` entry state a user lands on. Email + password
                  inputs + an enabled 'Sign in' button."
      :setup      [[:auth.login/flow [:auth.login/dismiss]]]
@@ -192,7 +217,8 @@
   ;; machine stays `:idle`, and the inputs show the seeded draft as their
   ;; `:value`. No shortcuts.
   (story/reg-variant :story.login/filled
-    {:doc        "Both fields filled in, nothing submitted yet — the form
+    {:compose    [:fragment.login/form-base]
+     :doc        "Both fields filled in, nothing submitted yet — the form
                  mid-edit. The draft was typed into the app-db login-form slice
                  via real edit events (email via `:auth.login/edit-field`,
                  password via the classified `:auth.login/edit-password`), so
@@ -212,7 +238,8 @@
   ;; (`:auth/busy`) — inputs disabled, button reading "Signing in…". A
   ;; freeze-frame of the in-flight moment.
   (story/reg-variant :story.login/submitting
-    {:doc        "First submit; the HTTP request is in flight. Inputs
+    {:compose    [:fragment.login/form-base]
+     :doc        "First submit; the HTTP request is in flight. Inputs
                  are disabled and the button reads 'Signing in…'. The
                  fx-stub records the `:rf.http/managed` request and
                  resolves nothing, so the canvas locks in `:submitting`."
@@ -228,12 +255,12 @@
   ;; machine never leaves `:idle` and the form shows what's wrong under each
   ;; input.
   (story/reg-variant :story.login/invalid-credentials
-    {:doc        "A bad draft (bad email + too-short password) is caught by
+    {:compose    [:fragment.login/form-base]
+     :doc        "A bad draft (bad email + too-short password) is caught by
                  `submit-form`'s pre-submit `Credentials` validation: field
                  errors surface under each input, `:submit-attempted?` latches,
                  and nothing is dispatched, so the flow stays at `:idle`."
-     :setup      [[:auth.login/initialise-form]
-                  [:auth.login/flow [:auth.login/dismiss]]
+     :setup      [[:auth.login/flow [:auth.login/dismiss]]
                   [:auth.login/edit-field :email "nope"]
                   [:auth.login/edit-password {:value "short"}]
                   [:auth.login/submit-form]]
@@ -247,7 +274,8 @@
   ;; state without being at the mercy of timing. The flow settles at
   ;; `:error-shown`, error message and all.
   (story/reg-variant :story.login/auth-error
-    {:doc        "Server rejected the credentials. The form is re-enabled and
+    {:compose    [:fragment.login/form-base]
+     :doc        "Server rejected the credentials. The form is re-enabled and
                  the error message surfaces under the submit button
                  (`:error-shown`). The machine is driven into `:submitting` with
                  a credential-free `:submit` signal and the manually-driven
@@ -264,7 +292,8 @@
   ;; shortcut to "three strikes already used", so this variant simply walks
   ;; the path: submit → failure, four times over, until the limit is spent.
   (story/reg-variant :story.login/locked-out
-    {:doc        "Too many failed attempts — the `:under-retry-limit`
+    {:compose    [:fragment.login/form-base]
+     :doc        "Too many failed attempts — the `:under-retry-limit`
                  guard fails on the fourth failure and the flow reaches
                  the terminal `:locked-out` state, firing the
                  `:lock-account` request (visible in Xray's Side Effects
@@ -292,7 +321,8 @@
   ;; `:authed`. Open this one, hit Ctrl+Shift+C, and watch the full chain march
   ;; across Xray's Epoch / Trace / Side Effects panels.
   (story/reg-variant :story.login/success
-    {:doc        "Server accepted the credentials. The form is replaced
+    {:compose    [:fragment.login/form-base]
+     :doc        "Server accepted the credentials. The form is replaced
                  by the 'Welcome!' banner (`:authed`). The full
                  auth-submit cascade — submit → `:rf.http/managed` →
                  canned reply → `:success` — runs through real events;

--- a/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
@@ -1,0 +1,108 @@
+(ns re-frame.story.login-example-seed-cljs-test
+  "Regression: every variant of the login example's Story deck
+   (examples/core/login/stories.cljs) must seed the login-form slice
+   BEFORE its own variant-specific setup runs (rf2-3fc89f.28).
+
+   The live app boots the slice via `:auth.login/initialise-form` (the
+   single source of the form defaults). Each Story variant, however, runs
+   in its OWN fresh `:preset :story` frame with no application
+   `:initial-events`, so the variant's compiled `:setup` program is the
+   only application-state seed. Before the fix, four variants (`empty`,
+   `filled`, `auth-error`, `locked-out`) never seeded the slice at all, so
+   their inputs rendered uncontrolled (nil `:value`) and machine
+   transitions ran against a missing `[:auth :login-form]` slice; the
+   `submitting` / `success` variants seeded only as a side effect of the
+   `:login.story/submit` driver, and `invalid-credentials` carried a
+   one-off inline seed.
+
+   The fix registers ONE `:fragment.login/form-base` fragment whose
+   `:setup` is `[[:auth.login/initialise-form]]` and composes it into every
+   variant. Because the plan compiler appends a composed fragment's `:setup`
+   BEFORE the variant's own (spec/017 §`:compose`; re-frame.story.compose-test),
+   the compiled `[:world :setup]` of EVERY variant must LEAD with
+   `[:auth.login/initialise-form]`. This test compiles each registered
+   variant plan (a pure data → data compile, no host) and asserts exactly
+   that — so it goes RED if the shared initializer is absent from any
+   variant OR ordered after that variant's own setup.
+
+   Scope note: the ids are enumerated explicitly rather than read from
+   `story/variants-of :story.login`, because the `login_form` TESTBED deck
+   (tools/story/testbeds/login_form) also registers variants under the same
+   `:story.login` parent — this test guards only the login EXAMPLE's seven.
+
+   Lives in the Story test tree (not under examples/, which is test-free
+   per rf2-8cevm; and not under implementation/, which must not `:require`
+   from tools/). It is CLJS-only, so the JVM `clojure -M:test` story gate
+   ignores it; it runs under the consolidated `npm run test:cljs` node-test
+   build, whose classpath carries both `../tools/story/src` and
+   `../examples/core`."
+  (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.plan :as plan]
+            ;; login.stories transitively requires login.core; require it
+            ;; too so this ns is self-sufficient (mirrors the nine-states +
+            ;; example-login-form-slice regression namespaces).
+            [login.core]
+            [login.stories :as login-stories]))
+
+;; Re-fire the login deck's registrations before each test so the variant
+;; + fragment side-table entries are the EXAMPLE's (register-all! is
+;; idempotent). This also re-asserts the example's `:story.login/submitting`
+;; over the login_form testbed's same-id variant. Compiling a plan is pure —
+;; no adapter / frame / DOM needed.
+(use-fixtures :each {:before (fn [] (login-stories/register-all!))})
+
+(def ^:private raw-seed-step
+  "The fragment's authored `:setup` step — a bare event vector naming the
+   example's own `:auth.login/initialise-form` (the single source of the
+   login-form defaults, the event the live app runs at boot)."
+  [:auth.login/initialise-form])
+
+(def ^:private compiled-seed-step
+  "The same step as it appears in a compiled `[:world :setup]`: the plan
+   compiler coerces every bare event-vector setup step to a tagged
+   `[:dispatch <event-vec>]` (re-frame.story.play.runner/coerce-script)."
+  [:dispatch raw-seed-step])
+
+(def ^:private example-variant-ids
+  "The login EXAMPLE's seven canonical variants (examples/core/login/stories.cljs)."
+  [:story.login/empty
+   :story.login/filled
+   :story.login/submitting
+   :story.login/invalid-credentials
+   :story.login/auth-error
+   :story.login/locked-out
+   :story.login/success])
+
+(deftest fragment-is-registered-with-the-single-seed-event
+  (testing ":fragment.login/form-base seeds the slice via the example's own
+            initialise-form event (no duplicated defaults map in Story)"
+    (let [frag (story/handler-meta :fragment :fragment.login/form-base)]
+      (is (some? frag) ":fragment.login/form-base is registered")
+      (is (= [raw-seed-step] (:setup frag))
+          "the fragment's :setup is exactly the initialise-form event — the
+           event stays the single source of defaults"))))
+
+(deftest every-login-variant-seeds-the-slice-before-its-own-setup
+  (testing "every login-example variant's compiled plan LEADS its setup with
+            [:auth.login/initialise-form] (composed fragment first, variant
+            setup after) — RED if a variant omits the seed or orders it late"
+    (doseq [vid example-variant-ids]
+      (is (some? (story/handler-meta :variant vid))
+          (str vid " is registered"))
+      (let [setup (get-in (plan/variant-plan vid) [:world :setup])]
+        (is (= compiled-seed-step (first setup))
+            (str vid " must seed the login-form slice FIRST; got: "
+                 (pr-str (first setup))))))))
+
+(deftest the-seed-appears-exactly-once-per-variant
+  (testing "no per-variant duplication: after composing the fragment, each
+            variant's compiled setup runs the seed event exactly ONCE (the
+            redundant inline / driver seeds were removed)"
+    (doseq [vid example-variant-ids]
+      (let [setup (get-in (plan/variant-plan vid) [:world :setup])
+            seeds (filter #(= compiled-seed-step %) setup)]
+        (is (= 1 (count seeds))
+            (str vid " seeds the slice exactly once (via the composed "
+                 "fragment) — no duplicated initialise-form in the setup; got "
+                 (count seeds)))))))


### PR DESCRIPTION
## What & why

The login Story showcase (`examples/core/login/stories.cljs`) allocated a fresh `:preset :story` frame per variant but never ran `[:auth.login/initialise-form]` in it. The live app seeds that slice at boot; the variants did not. So four variants (`empty`, `filled`, `auth-error`, `locked-out`) rendered `login-form` against a **missing** `[:auth :login-form]` slice — `:value` was nil (uncontrolled inputs, React uncontrolled→controlled warnings on first edit) and machine transitions ran over an uninitialised slice. `submitting`/`success` seeded only as a side effect of the `:login.story/submit` driver, and `invalid-credentials` carried a one-off inline seed.

## The fix (composition, not copy-paste)

Register **one** `:fragment.login/form-base` fragment whose `:setup` is `[[:auth.login/initialise-form]]`, and `:compose` it into all seven variants. Per spec/017 §`:compose`, the plan compiler appends a composed fragment's `:setup` **before** the variant's own — so every compiled `[:world :setup]` now leads with the seed and the slice is fully initialised (controlled inputs, complete bookkeeping fields) before the variant's own events run.

- The **event stays the single source of the defaults** — no defaults map duplicated in Story, no `:db-seed`.
- Removed the now-redundant inline seeds from `:story.login/invalid-credentials` and from the `:login.story/submit` driver, so the slice is seeded **exactly once per variant** (via the fragment).
- `login/core.cljs` is **untouched** — the standalone `#/` app and its existing initialization path are unchanged. Built on the merged credential-free machine shape (rf2-3fc89f.33).

## Stance

Pre-alpha; no back-compat shims. Used Story's COMPOSITION vocabulary (a shared fragment) rather than pasting the initializer into seven setup vectors. Primary lenses: ELEGANCE + CLARITY + CORRECTNESS.

## Reproduce → fix evidence

New CLJS regression `re-frame.story.login-example-seed-cljs-test` compiles all seven variant plans and asserts each `[:world :setup]` leads with `[:dispatch [:auth.login/initialise-form]]` (bare event vectors are coerced to `[:dispatch …]` by the plan compiler).

- **Before the fix (RED):** `14 failures` — the fragment is absent, and 6 of 7 variants do not lead with the seed (only `invalid-credentials`, which had an inline seed, passed):
  ```
  :story.login/empty   must seed FIRST; got: [:dispatch [:auth.login/flow [:auth.login/dismiss]]]
  :story.login/filled  must seed FIRST; got: [:dispatch [:auth.login/flow [:auth.login/dismiss]]]
  :story.login/submitting  got: [:dispatch [:login.story/submit …]]
  :story.login/auth-error  got: [:dispatch [:auth.login/flow [:auth.login/submit]]]
  :story.login/locked-out  got: [:dispatch [:auth.login/flow [:auth.login/submit]]]
  :story.login/success     got: [:dispatch [:login.story/submit …]]
  ```
- **After the fix (GREEN):** `Ran 3 tests containing 23 assertions. 0 failures, 0 errors.`

The test lives in the Story test tree (examples are test-free per rf2-8cevm; `implementation/` must not `:require` from `tools/`). It is CLJS-only, so the JVM `clojure -M:test` story gate ignores it; it runs under the consolidated `npm run test:cljs`.

## Quality gates

- **Login Story build** (`shadow-cljs release examples/login-with-stories`): `Build completed. (667 files, 606 compiled, 0 warnings, 66s)`. (The lone Closure `unknown JSDoc tag` parse notice is a pre-existing third-party externs annotation on advanced builds, not a CLJS warning.)
- **`npm run test:cljs`** (full node-test): `Ran 8511 tests containing 39429 assertions. 0 failures, 0 errors.` — includes the new regression, the existing login slice/machine tests, the login_form testbed test, and the Story compose/plan tests.
- The `story_open_in_editor_cljs_test` undeclared-var warnings seen during the node-test compile are in a file on `origin/main` that this PR does not touch (pre-existing, unrelated).

## Follow-ups filed

- The login **example** deck and the `login_form` **testbed** deck both register variants under the shared parent `:story.login` (colliding on `:story.login/submitting`). Out of scope here; filed as a follow-up.
- Whether the machine-backed login should retain its write-only slice `:status` (canonical/mirrored-login concern). Out of scope; filed as a follow-up.