### PR TITLE
fix: ignore undecodable checkout-root overrides; fall through to build root (rf2-3fc89f.24)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -4,8 +4,10 @@
   The input is a checkout root, supplied by `?checkout-root=` or the
   build-seeded `checkout-root` define. `resolve-source-root` appends the
   caller's tool-relative source subdirectory. Paths are normalized to forward
-  slashes; query decoding preserves literal `+` characters. Missing roots
-  resolve to nil so open-in-editor can remain a no-op."
+  slashes; query decoding preserves literal `+` characters. An undecodable
+  override is ignored — a bad query value cannot shadow a known root; it falls
+  through like a blank/missing one. Missing roots resolve to nil so
+  open-in-editor can remain a no-op."
   (:require [clojure.string :as str]))
 
 ;; @define {string}
@@ -16,16 +18,27 @@
   [s]
   (when (and (string? s) (seq (str/trim s))) s))
 
+(def ^:private decode-failed
+  "Sentinel returned by `decode-component` when percent-decoding fails. A
+  successful decode is always a string, so this keyword is unambiguously
+  distinct — callers branch on it to fall through instead of reusing malformed
+  raw bytes as a filesystem path."
+  ::decode-failed)
+
 (defn- decode-component
-  "Decode percent escapes, leaving malformed input unchanged."
+  "Percent-decode `v`, or return the `decode-failed` sentinel when `v` is not a
+  valid percent-encoding. Keeping failure distinguishable from a decoded string
+  is what stops a malformed override from being reused as a raw path."
   [v]
   (try
     (js/decodeURIComponent v)
-    (catch :default _ v)))
+    (catch :default _ decode-failed)))
 
 (defn- query-param-from-search
   "Return a decoded, trimmed query value or nil. Parsing is deliberately not
-  form-urlencoded: a literal `+` in a checkout path must remain `+`."
+  form-urlencoded: a literal `+` in a checkout path must remain `+`. A pair
+  whose key or value cannot be percent-decoded is skipped, so an undecodable
+  override cannot shadow a lower-tier root — resolution falls through instead."
   [search param-name]
   (when-let [s (non-blank search)]
     (let [s (cond-> s (str/starts-with? s "?") (subs 1))]
@@ -33,9 +46,9 @@
               (let [eq  (str/index-of pair "=")
                     k   (decode-component (if eq (subs pair 0 eq) pair))]
                 (when (= k param-name)
-                  (when-let [raw (non-blank (decode-component
-                                             (if eq (subs pair (inc eq)) "")))]
-                    (str/trim raw)))))
+                  (let [v (decode-component (if eq (subs pair (inc eq)) ""))]
+                    (when-let [raw (and (not= v decode-failed) (non-blank v))]
+                      (str/trim raw))))))
             (str/split s #"&")))))
 
 (defn- query-param

--- a/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
@@ -439,6 +439,80 @@
              (config/resolve-source-root "tools/xray/testbeds"))
           "+ survives canonicalisation; \\ → /"))))
 
+;; A malformed percent-escape must not be reused as a raw filesystem path.
+;; An undecodable override is ignored so resolution falls through to the
+;; build-time define, matching the blank/missing-override contract.
+
+(deftest query-param-from-search-ignores-undecodable-value
+  (testing "a value that cannot be percent-decoded yields nil (never the raw
+            undecoded bytes), so the override falls through to a lower tier"
+    (is (nil? (#'config/query-param-from-search
+               "?checkout-root=C%ZZrepo" "checkout-root"))
+        "an invalid %ZZ escape → nil, never the raw \"C%ZZrepo\"")
+    (is (nil? (#'config/query-param-from-search
+               "?checkout-root=%" "checkout-root"))
+        "a lone trailing % → nil")
+    (is (nil? (#'config/query-param-from-search
+               "?checkout-root=abc%2" "checkout-root"))
+        "an incomplete %2 escape → nil")))
+
+(deftest query-param-from-search-skips-undecodable-key
+  (testing "a pair whose KEY cannot be percent-decoded cannot masquerade as
+            checkout-root and does not block a later valid pair"
+    (is (= "/wanted"
+           (#'config/query-param-from-search
+            "?%ZZ=whatever&checkout-root=/wanted" "checkout-root"))
+        "the undecodable key is skipped; the later valid checkout-root wins")
+    (is (nil? (#'config/query-param-from-search
+               "?%ZZ=/nope" "checkout-root"))
+        "an undecodable key never matches the requested param")))
+
+(deftest query-param-from-search-unrelated-malformed-param-does-not-block
+  (testing "a malformed UNRELATED param value does not prevent a later valid
+            checkout-root from resolving"
+    (is (= "/wanted"
+           (#'config/query-param-from-search
+            "?other=C%ZZbad&checkout-root=/wanted" "checkout-root")))))
+
+(deftest resolve-source-root-undecodable-override-falls-through-to-define
+  (testing "acceptance #1: an undecodable ?checkout-root= override is ignored;
+            resolution falls through to the build-time define, never beneath
+            the malformed raw value"
+    (with-redefs [config/query-param
+                  (fn [param]
+                    (#'config/query-param-from-search
+                     "?checkout-root=C%ZZrepo" param))
+                  config/checkout-root "/home/dev/re-frame2"]
+      (let [resolved (config/resolve-source-root "tools/story/testbeds")]
+        (is (= "/home/dev/re-frame2/tools/story/testbeds" resolved)
+            "falls through to the build-time define")
+        (is (not (str/includes? resolved "C%ZZrepo"))
+            "the malformed raw value never appears in the resolved path")))))
+
+(deftest resolve-source-root-undecodable-override-nil-without-define
+  (testing "acceptance #2: with no build-time root, a malformed override
+            yields nil so open-in-editor degrades to its no-root behaviour"
+    (with-redefs [config/query-param
+                  (fn [param]
+                    (#'config/query-param-from-search
+                     "?checkout-root=C%ZZrepo" param))
+                  config/checkout-root ""]
+      (is (nil? (config/resolve-source-root "tools/story/testbeds"))))))
+
+(deftest decode-component-returns-sentinel-on-decode-failure
+  (testing "the pure seam: a valid escape decodes to a string; an invalid one
+            returns the distinct decode-failed sentinel, never the raw bytes"
+    (is (= "/a b" (#'config/decode-component "%2Fa%20b"))
+        "a valid escape decodes normally")
+    (is (= "a+b" (#'config/decode-component "a+b"))
+        "a literal + is preserved (not form-urlencoded)")
+    (is (= @#'config/decode-failed (#'config/decode-component "C%ZZrepo"))
+        "an invalid escape returns the sentinel")
+    (is (= @#'config/decode-failed (#'config/decode-component "%"))
+        "a lone % returns the sentinel")
+    (is (not (string? @#'config/decode-failed))
+        "the sentinel is not a string, so it can never equal a decoded value")))
+
 (deftest public-config-surface-stable
   (testing "the namespace exposes the resolver and checkout-root define"
     (is (fn? config/resolve-source-root))


### PR DESCRIPTION
-