### PR TITLE
fix(test-react): roll back children when parent render throws during mount (rf2-3fc89f.2)

### DIFF
--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -181,6 +181,39 @@
         (swap! active-mounts disj mount)))
     nil))
 
+(defn- force-teardown-record!
+  "Forcibly tear a single mount record down, bypassing the public
+  render-depth unmount guard. Records a `:forced-teardown` phase, flips
+  `mounted?` off, clears the render tree, and removes the record from
+  `active-mounts`. Idempotent via the `mounted?` guard.
+
+  This is the ONE place the forced-teardown steps live, shared by
+  `dispose-adapter!` (a flat drain of the whole live forest) and the
+  failed-render rollback in `mount-tree!` (a recursive subtree drain). Sharing
+  it keeps the two forced paths from drifting — e.g. one clearing a field the
+  other forgets. Forced teardown is the escape hatch the render-depth guard
+  deliberately cannot block; it must NOT route through the public unmount thunk
+  (which correctly rejects unmount-during-render)."
+  [mount]
+  (when @(:mounted? mount)
+    (log-phase! mount :forced-teardown)
+    (reset! (:mounted? mount) false)
+    (reset! (:render-tree mount) nil)
+    (swap! active-mounts disj mount)))
+
+(defn- roll-back-speculative-children!
+  "Roll back every mount `parent` speculatively mounted during a render that
+  then threw. Each such child completed its own mount (so it is registered in
+  `active-mounts` with `mounted?` true) and was appended to `parent`'s
+  `:children`, but `parent` itself never registered — leaving the children
+  unreachable via the public unmount surface. Walk that recorded `:children`
+  subtree GRANDCHILDREN-first (mirroring React's leaf-upward teardown) and
+  force-tear each record down. Used only by `mount-tree!`'s failed-render path."
+  [parent]
+  (doseq [child @(:children parent)]
+    (roll-back-speculative-children! child)
+    (force-teardown-record! child)))
+
 (defn- mount-tree!
   "The internal mount seam. Builds the `MountedComponent`, runs the
   constructor → render → did-mount lifecycle, registers it in
@@ -191,7 +224,12 @@
 
   If invoked while a parent's render body is running (i.e. via `mount-child!`,
   with `*rendering-mount*` bound) the new mount is appended to that parent's
-  `:children`, so unmounting the parent later cascades to it."
+  `:children`, so unmounting the parent later cascades to it.
+
+  Initial mount is TRANSACTIONAL: if `run-render!` throws (the render body
+  raised), any children the failed render already mounted are rolled back
+  before the original exception is rethrown — a failed mount registers nothing
+  and leaks nothing."
   [render-tree]
   (let [self-ref (atom nil)   ; forward ref so the thunk can disj the FINAL record
         base     (->MountedComponent
@@ -207,7 +245,24 @@
     ;; :unmount-fn, so the skeleton would not match the registered record).
     (reset! self-ref mount)
     (log-phase! mount :constructor)
-    (run-render! mount render-tree)
+    (try
+      (run-render! mount render-tree)
+      (catch #?(:clj Throwable :cljs :default) render-error
+        ;; The initial render threw. Any children the render speculatively
+        ;; mounted via `mount-child!` already registered in `active-mounts`
+        ;; (with `mounted?` true) and were recorded under this mount's
+        ;; `:children`, but this parent never reaches the `active-mounts conj`
+        ;; below — so those children would leak, unreachable via the public
+        ;; unmount surface. Roll them back so the failed initial mount is
+        ;; transactional. `run-render!` already restored `render-depth` through
+        ;; its own `finally`, so the rollback runs with the guard state correct.
+        ;; Run the rollback in its OWN try so a defect there can never MASK the
+        ;; render exception — the render error is what the caller must see.
+        (try
+          (roll-back-speculative-children! mount)
+          (catch #?(:clj Throwable :cljs :default) _rollback-error
+            nil))
+        (throw render-error)))
     (log-phase! mount :did-mount)
     (swap! active-mounts conj mount)
     mount))
@@ -297,17 +352,17 @@
   ;;
   ;; Drain flat over active-mounts: children are themselves registered in
   ;; active-mounts (mount-tree! adds every mount, parent or child), so a flat
-  ;; walk drains the whole forest without recursing through :children. We do
-  ;; NOT route through the public unmount thunk (it would throw on the
-  ;; render-depth guard) — forced teardown is the
-  ;; escape hatch the guard deliberately cannot block.
+  ;; walk drains the whole forest without recursing through :children.
+  ;; `force-teardown-record!` — the SAME primitive the failed-render rollback
+  ;; uses — performs the per-record teardown, so disposal and rollback cannot
+  ;; drift. It does NOT route through the public unmount thunk (which would
+  ;; throw on the render-depth guard) — forced teardown is the escape hatch the
+  ;; guard deliberately cannot block. The trailing `reset! active-mounts #{}` is
+  ;; belt-and-suspenders: the primitive already disj'd each drained record.
   ;;
   (subs-cache/clear-all-frame-sub-caches!)
   (doseq [mount @active-mounts]
-    (when @(:mounted? mount)
-      (log-phase! mount :forced-teardown)
-      (reset! (:mounted? mount) false)
-      (reset! (:render-tree mount) nil)))
+    (force-teardown-record! mount))
   (reset! active-mounts #{})
   ;; Normal renders restore this in finally; disposal also repairs test code
   ;; that bypassed the public driver.

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -516,6 +516,187 @@
       (test-react/unmount! mount))))
 
 ;; ----------------------------------------------------------------------------
+;; B.4 — Transactional failed initial mount (rf2-3fc89f.2)
+;; ----------------------------------------------------------------------------
+;;
+;; Bug class: a parent's render body mounts a child (registered in the live
+;; forest) and then THROWS. Because `mount-tree!` registered the child during
+;; the render but never reaches the parent's own registration, a naive
+;; implementation leaves the child mounted yet unreachable — `mount!` returned
+;; no handle, so nothing can tear it down until whole-adapter disposal. That
+;; phantom live mount is exactly the lifecycle imbalance Test-React exists to
+;; catch, so it corrupts the harness's core purpose.
+;;
+;; The fix makes initial mount TRANSACTIONAL: a failed render rolls back every
+;; child it speculatively mounted (nested descendants too), removing them from
+;; the live forest before the ORIGINAL render exception is rethrown — without
+;; masking that exception and without weakening the sync-unmount-during-render
+;; guard (B.1). Each of the following pins one property the fix guarantees; on
+;; the pre-fix code every leak assertion FAILS (the child / subtree survives).
+
+(deftest failed-initial-render-rolls-back-mounted-child-rf2-3fc89f2
+  (testing "a parent render that mounts a child and then throws is
+            transactional: the ORIGINAL render exception escapes unmasked,
+            no render is left in flight, the live forest is empty, and the
+            speculatively-mounted child is torn down (not a phantom live mount)"
+    (let [child-ref (atom nil)]
+      ;; The render body mounts a child (registering it in the live forest),
+      ;; captures its handle, then throws a distinctively-tagged exception.
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #"boom-parent-render"
+            (test-react/mount!
+              {:rf/component
+               (fn [_parent]
+                 (reset! child-ref (test-react/mount-child! [:span "child"]))
+                 (throw (ex-info "boom-parent-render" {})))}))
+          "the ORIGINAL render exception propagates — rollback never masks it")
+      (is (false? (test-react/rendering?))
+          "run-render!'s finally restored render-depth to zero on unwind")
+      (is (zero? (count (test-react/mounted-roots)))
+          "the live forest is empty — the child mounted before the throw was
+           rolled back, not leaked as a phantom live mount (this FAILS pre-fix)")
+      (is (false? @(:mounted? @child-ref))
+          "the child record itself was torn down (mounted? flipped false)")
+      (is (= 1 (phase-count @child-ref :forced-teardown))
+          "the rollback recorded a :forced-teardown on the child — teardown
+           logging is preserved, not a silent drop")
+      (is (nil? (test-react/current-render-tree @child-ref))
+          "the child's render tree was cleared by the forced teardown"))))
+
+(deftest failed-initial-render-rolls-back-nested-subtree-rf2-3fc89f2
+  (testing "the rollback reaches NESTED descendants: parent → child →
+            grandchild, then the parent throws. The whole speculative subtree
+            (child AND grandchild) is removed, leaf-upward, not just the direct
+            child"
+    (let [child-ref      (atom nil)
+          grandchild-ref (atom nil)]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #"boom-nested-parent"
+            (test-react/mount!
+              {:rf/component
+               (fn [_parent]
+                 (reset! child-ref
+                         (test-react/mount-child!
+                           {:rf/component
+                            (fn [_child]
+                              (reset! grandchild-ref
+                                      (test-react/mount-child! [:span "leaf"])))}))
+                 (throw (ex-info "boom-nested-parent" {})))}))
+          "the original render exception escapes")
+      (is (zero? (count (test-react/mounted-roots)))
+          "no descendant leaks — child AND grandchild both left the forest
+           (pre-fix this is 2)")
+      (is (and (false? @(:mounted? @child-ref))
+               (false? @(:mounted? @grandchild-ref)))
+          "both the direct child and the nested grandchild were torn down")
+      (is (and (= 1 (phase-count @child-ref :forced-teardown))
+               (= 1 (phase-count @grandchild-ref :forced-teardown)))
+          "each rolled-back level recorded exactly one :forced-teardown")
+      (let [gc-seq    (phase-first-seq @grandchild-ref :forced-teardown)
+            child-seq (phase-first-seq @child-ref :forced-teardown)]
+        (is (< gc-seq child-seq)
+            "rollback ran leaf-upward: the grandchild tore down STRICTLY before
+             the child, mirroring React's children-first teardown order")))))
+
+(deftest failed-child-render-rolls-back-its-own-descendants-rf2-3fc89f2
+  (testing "the throw can originate in a nested render: parent mounts child,
+            child mounts grandchild then the CHILD throws. The grandchild is
+            rolled back and the whole attempt leaves the forest empty — the
+            child's own mount-tree! is transactional before its failure
+            unwinds through the parent"
+    (let [grandchild-ref (atom nil)]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #"boom-child-render"
+            (test-react/mount!
+              {:rf/component
+               (fn [_parent]
+                 (test-react/mount-child!
+                   {:rf/component
+                    (fn [_child]
+                      (reset! grandchild-ref
+                              (test-react/mount-child! [:span "leaf"]))
+                      (throw (ex-info "boom-child-render" {})))}))}))
+          "the child's render exception propagates out through the parent")
+      (is (false? (test-react/rendering?))
+          "every nested run-render! finally unwound render-depth to zero")
+      (is (zero? (count (test-react/mounted-roots)))
+          "the grandchild the failing child mounted was rolled back — no
+           orphaned descendant survives the nested failure")
+      (is (false? @(:mounted? @grandchild-ref))
+          "the grandchild record was torn down by the child's own rollback"))))
+
+(deftest failed-mount-leaves-no-did-mount-and-spares-live-sibling-rf2-3fc89f2
+  (testing "a failed initial mount records NO :did-mount for the throwing
+            parent, registers nothing in the live forest, and does not disturb
+            a separate root that was already live before the failed mount"
+    (let [survivor  (test-react/mount! [:div "survivor"])
+          parent-ref (atom nil)
+          child-ref  (atom nil)]
+      (is (= 1 (count (test-react/mounted-roots)))
+          "precondition: exactly the survivor root is live")
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #"boom-with-sibling"
+            (test-react/mount!
+              {:rf/component
+               (fn [parent]
+                 (reset! parent-ref parent)
+                 (reset! child-ref (test-react/mount-child! [:span "child"]))
+                 (throw (ex-info "boom-with-sibling" {})))}))
+          "the failed mount throws its original exception")
+      (is (zero? (phase-count @parent-ref :did-mount))
+          "the throwing parent never reached :did-mount — a failed render does
+           NOT emit the mount-completed phase")
+      (is (= [survivor] (test-react/mounted-roots))
+          "the ONLY live root is the pre-existing survivor: the parent never
+           registered and the child was rolled back — no hidden leaked record
+           remains in the live forest for a later test to trip over")
+      (is (true? @(:mounted? survivor))
+          "the separate live root was untouched by the failed mount's rollback")
+      (is (zero? (phase-count survivor :forced-teardown))
+          "the survivor took no forced teardown — rollback is scoped to the
+           failed parent's own speculative children")
+      (is (false? @(:mounted? @child-ref))
+          "the speculative child is torn down, not a manually-cleanable phantom")
+      ;; Clean up the survivor so the fixture's drain has nothing to force.
+      (test-react/unmount! survivor))))
+
+(deftest rollback-does-not-mask-guard-and-spares-guard-target-rf2-3fc89f2
+  (testing "the transactional rollback COMPOSES with the B.1 guard: a render
+            body that mounts a tracked child and then synchronously unmounts a
+            SEPARATE live root still trips :rf.error/sync-unmount-during-render
+            (rollback does not mask that guard error), the guard's target root
+            stays mounted (the guard refused the unmount), and the tracked
+            child the same body mounted IS rolled back"
+    (let [target    (test-react/mount! [:div.panel "target"])
+          child-ref (atom nil)]
+      (is (= 1 (count (test-react/mounted-roots)))
+          "precondition: only the guard's target root is live")
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #":rf.error/sync-unmount-during-render"
+            (test-react/mount!
+              {:rf/component
+               (fn [_host]
+                 ;; Mount a tracked child (registers in the forest), THEN trip
+                 ;; the sync-unmount-during-render guard on a separate root.
+                 (reset! child-ref (test-react/mount-child! [:span "child"]))
+                 (test-react/unmount! target))}))
+          "the guard error — NOT the rollback — is what escapes; rollback does
+           not swallow or replace the render body's exception")
+      (is (true? @(:mounted? target))
+          "the guard refused the synchronous unmount — the target root survives")
+      (is (= [target] (test-react/mounted-roots))
+          "only the target is live: the host never registered and its tracked
+           child was rolled back despite the render failing via the guard")
+      (is (false? @(:mounted? @child-ref))
+          "the child mounted before the guard tripped was rolled back too")
+      (test-react/unmount! target))))
+
+;; ----------------------------------------------------------------------------
 ;; C. Harness-contract guards (rf2-ynjts.6)
 ;; ----------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
## What & why

A Test-React parent whose render body mounts a child (via `mount-child!`) and then **throws** left that child registered in `active-mounts` with `mounted?` true, yet unreachable: `mount!` returned no handle, so nothing could tear it down until whole-adapter disposal. `mount-tree!` registered each child during the render but bailed before its own registration and did no rollback, so the lifecycle simulator reported a **phantom live mount** — exactly the imbalance Test-React exists to catch, turned into a false diagnostic (rf2-3fc89f.2, audit-derived).

## The fix

- **Initial mount is now transactional.** `mount-tree!` wraps `run-render!`; on throw it rolls back every child the failed render speculatively mounted — recursing **grandchildren-first** through the recorded `:children` subtree (nested descendants handled) — then **rethrows the original render exception**.
- **The original exception is never masked.** The rollback runs in its own `try`; a defect there is swallowed so the render error is always what the caller sees.
- **The public sync-unmount-during-render guard is untouched.** `run-render!`'s existing `finally` restores `render-depth`, so rollback runs with correct guard state and never routes through the public unmount thunk (which correctly rejects unmount-during-render).
- **Shared forced-teardown primitive.** Rollback and `dispose-adapter!` now share one private `force-teardown-record!` so the two forced paths (failed-mount rollback + adapter disposal) can't drift on which fields they clear. Forced teardown remains the escape hatch the render-depth guard deliberately cannot block.

Change is confined to the test-only Test-React adapter (`src` + its CLJC test) — a non-published, bundle-isolated fixture.

## Reproduce → fix evidence

JVM probe (the bead's canonical reproduction), **before** the fix:

| case | `mounted-roots` before | after fix |
|---|---|---|
| single child, parent throws | 1 (leak) | 0 |
| nested child+grandchild, parent throws | 2 (leak) | 0 |
| live sibling + failed mount | 2 (sibling + leak) | 1 (sibling only) |

`rendering?` was already `false` pre-fix (run-render!'s finally restores depth); the sibling correctly survives.

Five new CLJC regressions (all **fail on pre-fix source** — verified by reverting `src` to `origin/main`: 13 failures + 1 error):
1. single-child rollback + original exception escapes unmasked
2. nested subtree rolled back leaf-upward (grandchild `:forced-teardown` seq < child's)
3. a throw originating in a nested **child** render rolls back its own grandchild
4. failed parent emits **no** `:did-mount`; a pre-existing live sibling is spared (scoped rollback)
5. composition with the B.1 guard: `:rf.error/sync-unmount-during-render` escapes (not masked), guard target survives, the tracked child the same body mounted is rolled back

## Quality gates (foreground)

- **Test-React JVM suite** (`clojure -M:test`): **29 tests, 114 assertions, 0 failures, 0 errors** (was 24/87).
- **CLJS node suite** (`npm run test:cljs`): **8519 tests, 39592 assertions, 0 failures, 0 errors** (includes reagent-slim CLJS coverage).
- **clj-kondo** on the changed source: 0 errors, 0 warnings.

The shared primitive is private to the Test-React namespace (not cross-adapter), so reagent-slim/adapter-smoke browser gates are not implicated; reagent-slim CLJS ran green within `test:cljs`.

## Stance

Pre-alpha; ELEGANCE + CLARITY + CORRECTNESS. Initial mount made transactional without weakening the public sync-unmount-during-render guard and without masking the original render exception.
