### PR TITLE
test(pair-mcp): handler-level noncanonical-cursor rejection integration regression (rf2-wxoc5b)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
@@ -19,7 +19,10 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.cursor :as cursor]
-            [re-frame2-pair-mcp.tools.watch-epochs :as we]))
+            [re-frame2-pair-mcp.tools.trace-window :as tw]
+            [re-frame2-pair-mcp.tools.watch-epochs :as we]
+            [re-frame.mcp-base.cursor :as base-cursor]
+            [re-frame.mcp-base.vocab :as base-vocab]))
 
 (def default-limit cursor/default-limit)
 
@@ -520,4 +523,165 @@
                                ;; And NOT the match-all empty map.
                                (is (not (re-find #"epoch-matches\? \{\}" form-str))
                                    "page-2 form must NOT degrade to match-all {}")
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Handler-level noncanonical-cursor rejection — the END-TO-END counterpart
+;; to the shared mcp-base codec pin (rf2-3fc89f.19 / #5519, AC#5).
+;;
+;; The mcp-base codec rejects a NONCANONICAL Base64 cursor alias: a
+;; re-spelled token that decodes to the SAME logical cursor on the
+;; host-lenient decoder — `js/Buffer` silently DROPS non-alphabet chars,
+;; and both hosts ignore non-zero trailing pad bits — but is NOT the
+;; canonical spelling `b64-encode` emits. `decode-canonical-b64` re-encodes
+;; the decoded bytes and demands token equality, so every alias fails BEFORE
+;; EDN parsing. `mcp-base`'s `cursor_test` / `cljs_branches_cljs_test` pin
+;; that at the `decode-cursor` UNIT boundary.
+;;
+;; This suite is the pair-mcp HANDLER counterpart AC#5 asked for: a
+;; noncanonical alias driven through the ACTUAL paginated tool handler
+;; (`watch-epochs` / `trace-window`) must surface the structured
+;; `:rf.mcp/cursor-stale` rejection rather than silently continue pagination
+;; from the alias's decoded position. The handler decodes the cursor BEFORE
+;; any runtime eval (so a nil conn reaches the rejection), translating the
+;; codec's `::malformed` into the same cursor-stale envelope a real
+;; ring-rotation age-out produces. These pins exercise that handler path,
+;; not the codec unit.
+;; ---------------------------------------------------------------------------
+
+(def ^:private b64-alphabet
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+
+;; A real, canonical pair cursor payload — an INTEGER `:after-id`, exactly
+;; the shape the reference epoch runtime emits (`(swap! counter inc)`), so
+;; every alias below is built from a token a genuine second-page
+;; continuation would actually carry.
+(def ^:private canonical-payload
+  {:v 1 :after-id 9 :ms 1000 :until-ms 1234567890 :frame :rf/default})
+
+(defn- inserted-char-alias
+  "A GUARANTEED noncanonical alias: splice two non-alphabet chars into the
+  canonical `token`. `js/Buffer` DROPS them on decode — the exact
+  host-lenient family the bug report flagged (`ez!!p2…`) — so the alias
+  decodes to the SAME bytes (thus the SAME logical cursor) under a DIFFERENT
+  wire string. No pad-slack dependency: it always exists. Mirrors the
+  construction the mcp-base CLJS suite proves rejected at the codec unit."
+  [token]
+  (str (subs token 0 2) "!!" (subs token 2)))
+
+(defn- pad-bit-alias
+  "A noncanonical alias of canonical `token` differing ONLY in the trailing
+  pad bits (same decoded bytes, DIFFERENT spelling), or nil if `token` has
+  no pad slack. Both hosts ignore non-zero pad bits, so the alias decodes to
+  IDENTICAL bytes — the family a lexical alphabet/padding grammar admits but
+  the round-trip-equality gate rejects. Verbatim mirror of the mcp-base
+  cursor suites' helper; here it feeds the HANDLER, not the codec unit."
+  [token]
+  (let [decoded (base-cursor/b64-decode token)
+        i       (dec (count (re-find #"[^=]+" token)))
+        orig    (nth token i)]
+    (some (fn [c]
+            (when (not= c orig)
+              (let [cand (str (subs token 0 i) c (subs token (inc i)))]
+                (when (= decoded (base-cursor/b64-decode cand)) cand))))
+          b64-alphabet)))
+
+(defn- assert-true-alias!
+  "Precondition: `alias` is a GENUINE noncanonical alias of `canonical` — a
+  DIFFERENT wire string that decodes (on the raw host-lenient codec) to the
+  SAME bytes, i.e. the SAME logical cursor. Proves the token under test is a
+  real alias that a naive host decoder would ACCEPT, not mere garbage the
+  handler would reject for unrelated reasons."
+  [alias canonical]
+  (is (some? alias) "the alias exists")
+  (is (not= alias canonical) "the alias is a DIFFERENT wire string than canonical")
+  (is (= (base-cursor/b64-decode alias) (base-cursor/b64-decode canonical))
+      "the alias decodes to the SAME bytes — a true logical alias, not garbage"))
+
+(defn- assert-cursor-stale-envelope!
+  "Assert an MCP result envelope carries the canonical cursor-rejection
+  shape: `:isError true` on the wire, and an EDN payload with
+  `{:ok? false :reason :rf.mcp/cursor-stale :tool <tool>}` — the same
+  structured recovery signal a real ring-rotation age-out surfaces."
+  [result tool]
+  (is (tu/error? result) "the envelope is flagged :isError on the wire")
+  (let [edn (tu/extract-edn result)]
+    (is (false? (:ok? edn)) ":ok? is false")
+    (is (= base-vocab/cursor-stale-reason (:reason edn))
+        ":reason is the cross-MCP :rf.mcp/cursor-stale")
+    (is (= tool (:tool edn)) ":tool names the rejecting paginated tool")))
+
+(deftest handler-rejects-inserted-char-cursor-alias-watch-epochs
+  (testing "a noncanonical (inserted-char) cursor alias driven through watch-epochs-tool is REJECTED as cursor-stale, not resumed from its decoded position"
+    (async done
+      (let [canonical (cursor/encode-cursor canonical-payload)
+            alias     (inserted-char-alias canonical)]
+        (assert-true-alias! alias canonical)
+        (-> (we/watch-epochs-tool nil (tu/args->js {:cursor alias}))
+            (.then (fn [result]
+                     (assert-cursor-stale-envelope! result "watch-epochs")
+                     (done))))))))
+
+(deftest handler-rejects-inserted-char-cursor-alias-trace-window
+  (testing "the same inserted-char alias driven through trace-window-tool is REJECTED as cursor-stale"
+    (async done
+      (let [canonical (cursor/encode-cursor canonical-payload)
+            alias     (inserted-char-alias canonical)]
+        (assert-true-alias! alias canonical)
+        (-> (tw/trace-window-tool nil (tu/args->js {:cursor alias}))
+            (.then (fn [result]
+                     (assert-cursor-stale-envelope! result "trace-window")
+                     (done))))))))
+
+(deftest handler-rejects-pad-bit-cursor-alias-watch-epochs
+  ;; The pad-bit family is the one a lexical alphabet/padding grammar would
+  ;; ADMIT and the old JVM decoder ACCEPTED (java.util.Base64 ignores pad
+  ;; bits) — only the decode→re-encode round-trip gate rejects it. Driving
+  ;; it end-to-end through the handler pins that the pair inherits the gate.
+  (testing "a noncanonical PAD-BIT cursor alias driven through watch-epochs-tool is REJECTED as cursor-stale"
+    (async done
+      (let [canonical (cursor/encode-cursor canonical-payload)
+            alias     (pad-bit-alias canonical)]
+        (assert-true-alias! alias canonical)
+        (-> (we/watch-epochs-tool nil (tu/args->js {:cursor alias}))
+            (.then (fn [result]
+                     (assert-cursor-stale-envelope! result "watch-epochs")
+                     (done))))))))
+
+(deftest handler-accepts-canonical-cursor-of-same-position-watch-epochs
+  ;; TEETH — the rejection is SPECIFIC to the noncanonical spelling, not a
+  ;; blanket "reject every cursor". The CANONICAL token for the SAME logical
+  ;; position (the identical decoded payload the aliases above carry) is NOT
+  ;; rejected: it drives past the cursor gate into the runtime eval and
+  ;; returns an ok page. Were the handler rejecting everything (or accepting
+  ;; aliases indiscriminately), this control would move in lock-step with
+  ;; the rejection tests and expose a hollow regression. Uses the probe-aware
+  ;; `with-form-capture!` stub so the post-gate runtime eval is hermetic.
+  (testing "the canonical cursor of the same position is accepted end-to-end (NOT cursor-stale)"
+    (async done
+      (let [forms     (atom [])
+            canonical (cursor/encode-cursor canonical-payload)
+            ;; A live, non-aged-out continuation: `:id-aged-out? false` keeps
+            ;; the handler off BOTH the pre-eval malformed path and the
+            ;; post-eval age-out path, so reaching an ok page proves the
+            ;; canonical cursor passed the gate cleanly.
+            canned    {:matches       []
+                       :id-aged-out?  false
+                       :requested-id  9
+                       :head-id       12
+                       :next-id       nil
+                       :history-count 3
+                       :since-count   1
+                       :remaining     0}]
+        (-> (with-form-capture! forms canned
+              (fn []
+                (-> (we/watch-epochs-tool nil (tu/args->js {:cursor canonical}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (not (tu/error? result))
+                                   "the canonical cursor is NOT surfaced as an error")
+                               (is (not= base-vocab/cursor-stale-reason (:reason edn))
+                                   "the canonical cursor is NOT rejected as cursor-stale")
+                               (is (true? (:ok? edn))
+                                   "the canonical cursor drives an ok page past the gate")
                                (done))))))))))))


### PR DESCRIPTION
## What

Adds the pair-mcp **handler-level** counterpart to the shared mcp-base cursor-canonicality pin (rf2-3fc89f.19 / #5519, AC#5). The codec worker pinned `decode-cursor`'s noncanonical-Base64 rejection at the **unit** boundary; AC#5 also wanted the **end-to-end** regression: a noncanonical cursor alias driven through the ACTUAL paginated tool handler must be REJECTED as `:rf.mcp/cursor-stale`, not silently resumed from its decoded position.

Test-only (`tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs`). The codec is already pinned upstream — no handler code change needed; the rejection path already existed.

### The regression

Four new `deftest`s exercise the real handler path (`watch-epochs-tool` / `trace-window-tool`), not the codec unit:

- **`handler-rejects-inserted-char-cursor-alias-watch-epochs`** and **`…-trace-window`** — splice two non-alphabet chars into a canonical token (the `js/Buffer`-drops-chars family the bug report flagged, `ez!!p2…`).
- **`handler-rejects-pad-bit-cursor-alias-watch-epochs`** — a trailing-pad-bit alias (the family a lexical grammar admits and the old JVM decoder accepted; only the decode→re-encode round-trip gate rejects it).
- **`handler-accepts-canonical-cursor-of-same-position-watch-epochs`** — positive control: the CANONICAL token of the same logical position is driven through the handler (probe-aware hermetic stub) and asserted **accepted** (ok page), proving the rejection is specific to the noncanonical spelling, not a blanket "reject every cursor".

Each rejection test builds a real integer-`:after-id` cursor (the shape the reference epoch runtime emits), asserts the alias is a **true logical alias** (different wire string, same host-lenient decoded bytes — not garbage), drives it through the handler with a `nil` conn (the rejection fires **before** any runtime eval), and asserts the canonical cursor-rejection envelope: `:isError` on the wire + `{:ok? false :reason :rf.mcp/cursor-stale :tool …}`.

## Stance

Pre-alpha; ELEGANCE + CLARITY + CORRECTNESS. Reuses the existing `with-form-capture!` harness and the mcp-base suites' proven `pad-bit-alias` construction; exercises the ACTUAL handler path, does not re-test the codec unit.

## Teeth proof

Temporarily disabled the codec's canonical gate (`decode-canonical-b64` → return decoded unconditionally) so the handler would ACCEPT the alias. Result: all three rejection tests FAILED (12 assertion failures) — the handler returned an `:ok? true` page (`:reason nil`) instead of `:rf.mcp/cursor-stale`. Reverted the gate; suite green again.

## Quality gates (foreground)

- `npm run test` (pair-mcp) — **1202 tests / 4142 assertions, 0 failures, 0 errors**
- `npm run check:descriptors` — **OK: tool-descriptors.edn in sync (30 tools)**
- `git status` after revert — only the test file changed (mcp-base fully reverted, no lockfile drift)

Closes rf2-wxoc5b.