### PR TITLE
refactor(ssr): thread explicit frame through ring payload + projection hook — finish the clean break (rf2-f02diw)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -622,7 +622,7 @@
    {:key         :ssr/extend-runtime-db-projection
     :producer-ns 're-frame.resources.ssr
     :design-bead "rf2-p10npe"
-    :description "Cross-feature LATE-BOUND SSR hydration-payload runtime-db projection extension (Spec 016 §SSR and hydration). Takes the full runtime-db value, returns a {subsystem-key durable-projection} map SSR's project-runtime-db merges into its allowlist-shaped slice; the Resources artefact projects ONLY the durable :entries of :rf.runtime/resources (per-entry redacted/omitted by the resource's :sensitive?/:large? classification; the reverse indexes are recomputable-from-entries). Resources is the first publisher; consumed by re-frame.ssr.payload-policy/project-runtime-db."}
+    :description "Cross-feature LATE-BOUND SSR hydration-payload runtime-db projection extension (Spec 016 §SSR and hydration). Takes the full runtime-db value + the EXPLICIT carried SSR frame-id ([runtime-db frame-id], rf2-f02diw — the projection target is threaded, never a borrowed ambient scope), returns a {subsystem-key durable-projection} map SSR's project-runtime-db merges into its allowlist-shaped slice; the Resources artefact projects ONLY the durable :entries of :rf.runtime/resources (per-entry redacted/omitted by the resource's :sensitive?/:large? classification against that frame's registry; the reverse indexes are recomputable-from-entries). Resources is the first publisher; consumed by re-frame.ssr.payload-policy/project-runtime-db."}
    {:key         :resources/drain-blocking-ssr!
     :producer-ns 're-frame.resources.ssr
     :design-bead "rf2-er7qx2"

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -443,10 +443,15 @@
 
   This is the body behind the `:ssr/extend-runtime-db-projection` hook.
 
-  Resolves the SSR frame from the in-effect carried-frame scope (the shared
-  `rf/elide-wire-value` walker reads it) so the resource's declared
-  projection-relative sensitive / large declarations in the frame registry
-  govern the per-entry projection. The
+  The SSR frame is the EXPLICIT `frame-id` the consumer threads (rf2-f02diw):
+  the two-arity `[runtime-db frame-id]` is the canonical form and the security-
+  critical `payload-policy/project-runtime-db` calls it with the same target it
+  stamps the payload `:rf/frame-id`, so the resource's declared projection-
+  relative sensitive / large declarations in THAT frame's registry govern the
+  per-entry projection — never a borrowed / mismatched ambient scope. The
+  one-arity `[runtime-db]` is a convenience that resolves the ambient scope
+  frame, sound only at a call site already inside the matching `rf/with-frame`
+  (e.g. a direct unit-test caller). The
   projection NEVER ships all of `:rf.db/runtime` — only the
   `:rf.runtime/resources` `:entries` (Spec 016 §SSR and hydration: \"Do not
   serialize all of `:rf.db/runtime` by default\").
@@ -456,25 +461,30 @@
   tokens in the wire key (`project-scoped-key`), so the raw identity never
   rides any more than its data does (Spec 016 clause 4). A `:serialize`
   resource's key rides verbatim."
-  [runtime-db]
-  (let [resources (get runtime-db state/resources-key)
-        entries   (:entries resources)]
-    (if (seq entries)
-      (let [frame-id (frame/resolve-current-frame)
-            clock-ms (interop/epoch-now-ms)
-            ;; rf2-9e0tyq — the projected wire entries are RE-KEYED on the byte
-            ;; `key-id` of each entry's PROJECTED `:resource/key` (the wire
-            ;; entry's own `:resource/key`, set by `project-entry`), so the
-            ;; client installs them under the same byte identity it will then
-            ;; `recompute-indexes` over. `entries` here is keyed on the byte
-            ;; `key-id`; the scoped-key vector is read from each entry.
-            wired    (into {}
-                           (map (fn [[_k-id entry]]
-                                  (let [wire-entry (first (project-entry frame-id clock-ms entry))]
-                                    [(state/key-id (:resource/key wire-entry)) wire-entry])))
-                           entries)]
-        {state/resources-key {:entries wired}})
-      {})))
+  ([runtime-db]
+   ;; Convenience: project under the AMBIENT scope frame. Sound only at a call
+   ;; site already inside the frame's own `with-frame` (ambient == the target) —
+   ;; e.g. a direct unit-test caller. The security-critical SSR consumer passes
+   ;; the explicit target (rf2-f02diw).
+   (project-resources-runtime-db runtime-db (frame/resolve-current-frame)))
+  ([runtime-db frame-id]
+   (let [resources (get runtime-db state/resources-key)
+         entries   (:entries resources)]
+     (if (seq entries)
+       (let [clock-ms (interop/epoch-now-ms)
+             ;; rf2-9e0tyq — the projected wire entries are RE-KEYED on the byte
+             ;; `key-id` of each entry's PROJECTED `:resource/key` (the wire
+             ;; entry's own `:resource/key`, set by `project-entry`), so the
+             ;; client installs them under the same byte identity it will then
+             ;; `recompute-indexes` over. `entries` here is keyed on the byte
+             ;; `key-id`; the scoped-key vector is read from each entry.
+             wired    (into {}
+                            (map (fn [[_k-id entry]]
+                                   (let [wire-entry (first (project-entry frame-id clock-ms entry))]
+                                     [(state/key-id (:resource/key wire-entry)) wire-entry])))
+                            entries)]
+         {state/resources-key {:entries wired}})
+       {}))))
 
 ;; ---- server blocking drain (Spec 016 §SSR and hydration steps 3-4) --------
 ;;

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -46,10 +46,12 @@
 
   The optional `runtime-db` arg is the frame's live
   runtime-db value; it is projected via `payload-policy/project-runtime-db`
-  (the serializable durable slice — machine snapshots, route `:current` slice,
-  elision declarations, SSR metadata) and rides the payload as
-  `:rf/runtime-db` so the client `:rf/hydrate` handler installs a coherent
-  frame-state. nil / empty runtime-db omits the optional key.
+  under the EXPLICIT `frame-id` (rf2-f02diw — the same target the app-db
+  projection uses, never the ambient scope), yielding the serializable durable
+  slice — machine snapshots, route `:current` slice, elision declarations, SSR
+  metadata — that rides the payload as `:rf/runtime-db` so the client
+  `:rf/hydrate` handler installs a coherent frame-state. nil / empty runtime-db
+  omits the optional key.
 
   The non-streaming wrapper over the shared
   `re-frame.ssr.payload-policy/build-payload`: it is handed `app-db` +
@@ -66,4 +68,12 @@
      (payload-policy/apply-policy app-db policy-opts)
      frame-id)
     render-hash
-    (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db)))))
+    ;; rf2-f02diw — project the runtime-db under the EXPLICIT carried `frame-id`
+    ;; (the same target the `project-app-db-egress` above uses), NOT an ambient
+    ;; one. Mirrors the streaming builder (`streaming/build-final-payload`,
+    ;; rf2-3fc89f.15): the non-streaming wrapper must not rely on a MATCHING
+    ;; `rf/with-frame` being ambient at the build site to project classified
+    ;; route / machine / resource runtime state under the right frame's policy.
+    ;; The host's request-frame binding stays a correctness convenience for other
+    ;; code, never the projector's target authority (finishing the clean break).
+    (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
@@ -1,0 +1,112 @@
+(ns re-frame.ssr.ring.payload-explicit-frame-test
+  "rf2-f02diw — the NON-streaming Ring hydration payload wrapper
+  (`re-frame.ssr.ring.payload/build-payload`) must project the runtime-db slice
+  under the EXPLICIT carried frame-id, never the ambient `rf/with-frame` scope.
+
+  Before the clean break the wrapper called the one-arity
+  `payload-policy/project-runtime-db`, which resolved the projection frame
+  AMBIENTLY (`frame/resolve-current-frame`) — while its sibling app-db
+  projection (`project-app-db-egress`) already ran at the explicit target. A
+  build run OUTSIDE a matching `rf/with-frame` (ambient nil) or under a
+  DIFFERENT ambient frame therefore projected the durable route `:current`
+  slice under no / the wrong frame's policy: `project-routing-egress` fails
+  OPEN with no live frame, so a classified `:query :token` rode the hydration
+  blob RAW. The host structural fix (rf2-p026f5) MASKED this by binding the
+  request frame around the build, but the wrapper itself was unsound —
+  rf2-f02diw threads the explicit frame so correctness no longer depends on a
+  matching ambient binding.
+
+  These regressions drive `ring.payload/build-payload` directly with an
+  explicit server frame A carrying a classified route slice, once with NO
+  ambient scope and once under a MISMATCHED ambient frame B, and prove frame
+  A's route classification redacts the token regardless of ambient scope. They
+  would FAIL on the pre-clean-break one-arity wrapper — the token would ride
+  raw."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.ssr.ring.payload :as payload]
+            [re-frame.ssr.ring.test-support :as ts]))
+
+(use-fixtures :each ts/reset-runtime)
+
+(def ^:private server-frame :review/ssr-ring-target)
+(def ^:private ambient-frame :review/other-ambient)
+(def ^:private route-id      :route/oauth-callback)
+
+(defn- frame-a-runtime-db
+  "Frame A's live runtime-db: the per-frame elision registry classifying the
+  durable route `:query :token` SENSITIVE + `:params :payload` LARGE — as the
+  ABSOLUTE `[:rf.runtime/routing :current …]` paths route activation lowers —
+  plus the durable `:current` route slice carrying the raw secret + blob. Only
+  frame A declares these; frame B (the mismatched ambient) declares nothing, so
+  a projection run under B would leak the raw token."
+  []
+  (-> {}
+      (elision/apply-classification-effects
+        {:sensitive [[:rf.runtime/routing :current :query :token]]
+         :large     [[:rf.runtime/routing :current :params :payload]]})
+      (assoc :rf.runtime/routing
+             {:current            {:route-id route-id
+                                   :query    {:token     "secret-oauth-token"
+                                              :return-to "/dashboard"}
+                                   :params   {:payload "huge-callback-blob-value"}}
+              :pending-navigation {:id "pn-1"}})))
+
+(defn- setup-frames! []
+  (rf/reg-frame server-frame
+    {:doc      "rf2-f02diw non-streaming ring explicit-frame regression frame A"
+     :platform :server})
+  ;; Frame B exists as a real (registered) ambient frame with NO classifications
+  ;; — the strongest "wrong frame" case: projecting the route slice under B
+  ;; consults B's empty registry and the token would ride verbatim.
+  (rf/reg-frame ambient-frame
+    {:doc      "rf2-f02diw mismatched ambient frame B (no classifications)"
+     :platform :server})
+  (frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
+
+(defn- build-a
+  "Call the non-streaming Ring wrapper for frame A, reading A's live runtime-db
+  value and handing it in as the wrapper's `runtime-db` arg. app-db is empty so
+  the test isolates the runtime-db route projection."
+  []
+  (payload/build-payload
+    server-frame {} (frame/frame-runtime-db-value server-frame) "hash"
+    {:payload :rf.ssr.payload/whole-app-db}))
+
+(defn- assert-frame-a-redacts [payload where]
+  (let [current (get-in payload [:rf/runtime-db :rf.runtime/routing :current])]
+    (is (= server-frame (:rf/frame-id payload))
+        (str where ": the payload names frame A as its target"))
+    (is (= :rf/redacted (get-in current [:query :token]))
+        (str where ": route-declared sensitive :query :token redacted under frame A"))
+    (is (contains? (get-in current [:params :payload]) :rf.size/large-elided)
+        (str where ": route-declared large :params :payload elided under frame A"))
+    (is (= "/dashboard" (get-in current [:query :return-to]))
+        (str where ": the unclassified route sibling rides verbatim"))
+    (is (not (.contains (pr-str payload) "secret-oauth-token"))
+        (str where ": no raw route token survives anywhere in the payload"))
+    (is (not (.contains (pr-str payload) "huge-callback-blob-value"))
+        (str where ": no raw route blob survives"))))
+
+(deftest build-payload-honours-explicit-frame-outside-with-frame
+  (testing "ring.payload/build-payload called OUTSIDE any rf/with-frame projects
+            the runtime-db under the EXPLICIT frame A — the classified route
+            :query / :params redact/elide, no raw secret rides (rf2-f02diw). On
+            the pre-clean-break one-arity wrapper resolve-current-frame → nil,
+            project-routing-egress fails OPEN, and the token would ride raw."
+    (setup-frames!)
+    (let [payload (binding [frame/*current-frame* nil] (build-a))]
+      (assert-frame-a-redacts payload "outside with-frame"))))
+
+(deftest build-payload-explicit-frame-wins-over-ambient
+  (testing "with a DIFFERENT frame ambient (B) and frame A passed explicitly,
+            frame A's route classification wins — the wrapper THREADS the
+            explicit target rather than borrowing the ambient scope (rf2-f02diw).
+            Under B's empty registry the token would otherwise ride raw."
+    (setup-frames!)
+    (is (= ambient-frame (rf/with-frame ambient-frame (frame/resolve-current-frame)))
+        "sanity: the ambient frame inside the body is B, not A")
+    (let [payload (rf/with-frame ambient-frame (build-a))]
+      (assert-frame-a-redacts payload "mismatched ambient B"))))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -515,10 +515,11 @@
   `rf/with-frame` (ambient == target). The security-critical builders MUST pass
   the explicit target.
 
-  The late-bound `:ssr/extend-runtime-db-projection` hook (resources) resolves
-  its OWN frame ambiently; the two-arity binds the explicit target as the
-  ambient scope around that call so the extension projects under the SAME frame
-  as every other slice — never a borrowed / mismatched ambient scope."
+  The late-bound `:ssr/extend-runtime-db-projection` hook (resources) takes the
+  explicit target as a second parameter (`[runtime-db frame-id]`, rf2-f02diw);
+  the two-arity threads the same `frame-id` into it so the extension projects
+  under the SAME frame as every other slice — never a borrowed / mismatched
+  ambient scope."
   ([runtime-db]
    ;; Convenience: project under the AMBIENT scope frame. Correct only when the
    ;; call site is inside the frame's own `with-frame` (ambient == the target).
@@ -569,12 +570,12 @@
           ;; `:tag-index` / `:owner-index` are recomputable-from-entries
           ;; and need not ride the wire — Spec 016 §Restore and replay).
           slice (if-let [extend-fn (late-bind/get-fn :ssr/extend-runtime-db-projection)]
-                  ;; The extension hook (resources) resolves its OWN frame
-                  ;; ambiently — bind the EXPLICIT target as the ambient scope so
-                  ;; it projects under the same frame as every other slice, never
-                  ;; a borrowed / mismatched ambient one (rf2-3fc89f.15).
-                  (merge slice (binding [frame/*current-frame* frame-id]
-                                 (extend-fn runtime-db)))
+                  ;; The extension hook (resources) takes the EXPLICIT target as a
+                  ;; second parameter (rf2-f02diw — finishing the clean break: the
+                  ;; hook is re-signatured `[runtime-db frame-id]`), so it projects
+                  ;; under the same frame as every other slice, never a borrowed /
+                  ;; mismatched ambient one — no `binding` rebind of ambient scope.
+                  (merge slice (extend-fn runtime-db frame-id))
                   slice)]
       (when (seq slice) slice)))))
 

--- a/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
@@ -1,6 +1,11 @@
 (ns re-frame.ssr-runtime-db-explicit-frame-test
-  "rf2-3fc89f.15 — the SSR runtime-db hydration projection must honour the
-  EXPLICIT carried frame, never an ambient one.
+  "rf2-3fc89f.15 / rf2-f02diw — the SSR runtime-db hydration projection must
+  honour the EXPLICIT carried frame, never an ambient one. rf2-f02diw finishes
+  the clean break: the `:ssr/extend-runtime-db-projection` resource hook is
+  re-signatured `[runtime-db frame-id]` and the projector THREADS the target
+  into it as an argument rather than a `binding` rebind of ambient scope — the
+  `build-final-payload-explicit-frame-wins-over-ambient` stub below asserts the
+  hook receives A as its parameter while ambient stays B.
 
   `re-frame.ssr.streaming/build-final-payload` carries an explicit `frame-id`
   and reads BOTH partitions of the frame-state container by it. Its app-db
@@ -168,16 +173,22 @@
             machine snapshot :data, AND the resource-extension hook — the whole
             payload projects under ONE frame (A), never the ambient B"
     (setup-frame-a!)
-    (let [captured-hook-frame (atom :unset)
+    (let [captured-hook-frame   (atom :unset)
+          captured-hook-ambient (atom :unset)
           orig-hook (late-bind/get-fn :ssr/extend-runtime-db-projection)]
       (try
-        ;; A stub resource-extension hook records the frame it resolves
-        ;; ambiently — proving the projector reconciles the ambient scope to the
-        ;; explicit target A before invoking a hook that resolves its own frame
-        ;; (resources isn't on this artefact's classpath, so we stub its seam).
+        ;; A stub resource-extension hook records BOTH the frame-id PARAMETER it
+        ;; is threaded AND the ambient scope in effect when it runs — proving the
+        ;; projector passes the explicit target A as an ARGUMENT (rf2-f02diw
+        ;; clean break: the hook is `[runtime-db frame-id]`), never via a
+        ;; borrowed ambient rebind (resources isn't on this artefact's classpath,
+        ;; so we stub its seam). A one-arity stub here would ARITY-ERROR against
+        ;; the consumer's `(extend-fn runtime-db frame-id)` — the two args ARE
+        ;; the proof the frame is threaded.
         (late-bind/set-fn! :ssr/extend-runtime-db-projection
-                           (fn [_runtime-db]
-                             (reset! captured-hook-frame (frame/resolve-current-frame))
+                           (fn [_runtime-db frame-id]
+                             (reset! captured-hook-frame frame-id)
+                             (reset! captured-hook-ambient (frame/resolve-current-frame))
                              {}))
         ;; Ambient is frame B (the fixture's `:rf/default` scope); we pass A.
         (is (= :rf/default (frame/resolve-current-frame))
@@ -189,7 +200,12 @@
               snap    (get-in payload [:rf/runtime-db :rf.runtime/machines
                                        :snapshots machine-id])]
           (is (= server-frame @captured-hook-frame)
-              "the resource-extension hook resolves the EXPLICIT target A, not ambient B")
+              "the resource-extension hook is THREADED the EXPLICIT target A as
+               its frame-id argument (rf2-f02diw), not ambient B")
+          (is (= :rf/default @captured-hook-ambient)
+              "the hook's ambient scope is UNTOUCHED (still B :rf/default) — the
+               explicit frame arrives as a PARAMETER, not a borrowed ambient
+               rebind: the clean break removed the `binding` around the call")
           (is (= :rf/redacted (get-in payload [:rf/app-db :secret]))
               "app-db :secret redacted under frame A's declaration")
           (is (= "ok" (get-in payload [:rf/app-db :public]))


### PR DESCRIPTION
## Summary

Follow-up to **rf2-3fc89f.15** (#5511), which closed the streaming-builder runtime-db leak but scoped out AC#3/AC#4. Completes the SSR explicit-frame clean break. Both paths were already **correct today** (they run inside a matching `with-frame` per rf2-p026f5/tbr67x) — this is **hardening**: remove the ambient reliance so correctness no longer depends on a matching lexical binding being in scope at the projection site.

## The two paths hardened

**1. Non-streaming ring payload** — `re-frame.ssr.ring.payload/build-payload` now projects the runtime-db under the **explicit** carried `frame-id` (the same target its `project-app-db-egress` already uses), mirroring the streaming builder `streaming/build-final-payload`. It no longer calls the one-arity ambient-resolving `project-runtime-db`.

**2. Resource projection hook** — `:ssr/extend-runtime-db-projection` is **re-signatured `[runtime-db frame-id]`**:
- Publisher `re-frame.resources.ssr/project-resources-runtime-db` takes the frame as a **parameter** instead of `frame/resolve-current-frame`.
- Consumer `re-frame.ssr.payload-policy/project-runtime-db` **threads the explicit frame in as an argument** instead of a `binding` rebind of `*current-frame*` — the ambient scope is now untouched.
- A one-arity ambient convenience remains for direct unit-test callers (matches the merged `project-runtime-db` precedent from #5511).
- The `re-frame.late-bind.directory` description is updated to the new contract.

## Re-signatured hook + callers

| Surface | Before | After |
| --- | --- | --- |
| `project-resources-runtime-db` (publisher) | `[runtime-db]`, `frame-id = (resolve-current-frame)` | `[runtime-db frame-id]` (+ 1-arity ambient convenience) |
| `project-runtime-db` (consumer) | `(binding [*current-frame* frame-id] (extend-fn runtime-db))` | `(extend-fn runtime-db frame-id)` |
| `ring.payload/build-payload` | `(project-runtime-db runtime-db)` | `(project-runtime-db runtime-db frame-id)` |
| late-bind directory `:description` | "Takes the full runtime-db value" | "Takes the full runtime-db value + the EXPLICIT carried SSR frame-id" |

## Proof (would FAIL if the frame weren't threaded)

- **New** `ssr-ring/.../payload_explicit_frame_test.clj` drives `build-payload` with an explicit frame A carrying a classified route slice, once with **no ambient scope** and once under a **mismatched ambient frame B**; asserts frame A's classification redacts the token regardless of ambient. **Negative control confirmed**: reverting the wrapper to one-arity fails both tests (raw `secret-oauth-token` leaks).
- `ssr_runtime_db_explicit_frame_test.clj`'s resource-hook stub is now two-arity and asserts it receives A **as its parameter** while ambient stays B (`:rf/default`).

## Quality gates (foreground, 0 failures)

| Gate | Result |
| --- | --- |
| `implementation/resources` `clojure -M:test` | 629 tests / 6250 assertions — 0 failures, 0 errors |
| `implementation/ssr` `clojure -M:test` | 375 tests / 1562 assertions — 0 failures, 0 errors |
| `implementation/ssr-ring` `clojure -M:test` | 181 tests / 872 assertions — 0 failures, 0 errors |
| `implementation` `npm run test:cljs` | 8514 tests / 39565 assertions — 0 failures, 0 errors |

## Stance

Pre-alpha; pass the frame **explicitly**, don't rely on ambient `with-frame` scope. ELEGANCE + CLARITY + CORRECTNESS. No back-compat shims.