### PR TITLE
docs(template): teach the current :reply-to HTTP form, not the retired co-located reply (rf2-f3lg06)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -515,7 +515,7 @@ the canonical call shape per
 [Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md).
 Uncomment and adapt when your app starts talking to a backend.
 
-**The `(:rf/reply msg)` payload in the example IS the framework-wide
+**The `reply` the exemplar handler reads IS the framework-wide
 managed-async model — the same envelope every managed-async surface
 uses.** Every managed-HTTP completion delivers the framework's
 [uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
@@ -533,12 +533,18 @@ reply `:status` vocabulary:
 | `:cancelled` | abort | `:cancelled? true`, `:cancel/reason`, `:rf.http/aborted` under `:error` |
 | `:stale` | superseded / late | **never delivered to your app target** — stale replies are suppressed before dispatch |
 
-`:rf.http/managed` accepts `:on-success` / `:on-failure` (and the
-co-located `(:rf/reply msg)` form) as pure ROUTING sugar over the one
-direct reply target `:rf/reply-to`; **both receive this identical
-canonical map** — they only choose whether the reply lands on two named
-handlers or one branching handler. Full contract:
-[Spec 014 §Reply payload shape](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#reply-payload-shape--the-one-canonical-envelope).
+Every `:rf.http/managed` request MUST address its reply. `:reply-to` is
+the unified authoring key — one event vector for **both** the success
+and the failure reply, the app branching on `:status` (the same
+call-site key resources / mutations use); the exemplar above uses it.
+`:on-success` / `:on-failure` are the split ROUTING sugar over the one
+`:reply-to` target (an explicit `nil` silences a branch); **both styles
+receive this identical canonical map** — they only choose whether the
+reply lands on two named handlers or one branching handler. Omitting all
+three fails loud at fx-call time with `:rf.error/http-no-reply-target` —
+there is no co-located default that silently routes the reply back to
+the dispatching event. Full contract:
+[Spec 014 §Reply addressing](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#reply-addressing).
 Any non-HTTP managed-async surface you build (machines, resources,
 timers) reports completion through this same envelope's `:status` /
 `:value` / `:error` / `:completed-at`, with mandatory stale suppression.


### PR DESCRIPTION
## What

The `tools/template` root README HTTP section taught a **retired** co-located reply form (`(:rf/reply msg)` read back on the originating event) and named the internal `:rf/reply-to` descriptor as if it were the app-facing key. That contract was retired pre-alpha (et4c1s / #5449). The template's own `events.cljs` exemplar was already rewritten to the current `:reply-to` form by rf2-qnwy3q (#5481) — so the README prose was out of sync with the very example it narrates.

This rewrites the two offending passages so the README teaches the CURRENT contract:

- `:reply-to` is the **unified authoring key** — one event vector for both the success and the failure reply; the app branches on `:status`. The exemplar uses it.
- `:on-success` / `:on-failure` are the **split routing sugar over the one `:reply-to` target** (an explicit `nil` silences a branch); both styles receive the identical canonical envelope.
- Omitting all three fails loud at fx-call time with `:rf.error/http-no-reply-target` — there is no co-located default that silently routes the reply back to the dispatching event.

### Before / after

- **Before**: "*The `(:rf/reply msg)` payload in the example IS the framework-wide managed-async model…*" and "*`:rf.http/managed` accepts `:on-success` / `:on-failure` (and the co-located `(:rf/reply msg)` form) as pure ROUTING sugar over the one direct reply target `:rf/reply-to`*".
- **After**: "*The `reply` the exemplar handler reads IS the framework-wide managed-async model…*" and a `:reply-to`-first paragraph that names `:on-success` / `:on-failure` as split sugar over the one `:reply-to` target, plus the explicit `:rf.error/http-no-reply-target` fail-loud rule.

No retired `:rf/reply` / `:rf/reply-to` / co-located-read residue remains in the README.

## Canonical source

The current contract was derived from the merged canonical docs, not memory:

- `docs/api/re-frame.http.md` §Reply addressing (line 88: the co-located default "*was retired pre-alpha; the framework never silently addresses the reply*"; `{:reply-to nil}` is the explicit fire-and-forget spelling).
- `docs/async/http.md` §Handling the reply (`:reply-to` unified spelling; `:on-success`/`:on-failure` split sugar; omitting all → `:rf.error/http-no-reply-target`).
- `spec/014-HTTPRequests.md` §Reply addressing (`:reply-to` is the public authoring key; `:rf/reply-to` is the internal descriptor).
- The template's own `_shared/events.cljs` exemplar (already on the `:reply-to` form).

## Stance

Pre-alpha; docs teach the CURRENT contract, derived from the canonical shipped source. ELEGANCE + CLARITY + CORRECTNESS. Scope: `tools/template` root README HTTP section only.

## Quality gates

- `python scripts/check_doc_slugs.py` → exit 0.
- `tools/template` `clojure -M:test` → **49 tests, 664 assertions, 0 failures, 0 errors** (includes the README HTTP-section content assertions in `template_test.clj` — `sugar over the one`, `uniform reply envelope`, `:ok`/`:cancelled`/`:stale`, `Managed-Effects.md`, `:sensitive?`, and the no-`compatibility sugar` guard).
- `mkdocs build --strict` — N/A: the template README is a template resource, not in `mkdocs.yml`, and its links are all external GitHub URLs.

Closes rf2-f3lg06.