### PR TITLE
refactor(examples): single HTML-reference-inventory pass per page (rf2-6a3rgx)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -336,8 +336,10 @@ function listExampleIndexHtml(root = EXAMPLES_ROOT, { io = fs } = {}) {
 
 // ---------------------------------------------------------------------------
 // Reference extraction. We hand-roll focused regexes rather than pull in an
-// HTML/CSS parser — the only shapes we read are attribute-quoted hrefs/srcs,
-// the og:image meta content, and CSS @import url(...) targets.
+// HTML/CSS parser — the only shapes we read are href/src (quoted or unquoted)
+// attributes, srcset/imagesrcset candidate lists, a <video> poster, the
+// og:image meta content, and CSS @import / url(...) targets. Each page's HTML is
+// tokenized ONCE by extractHtmlReferenceInventory below (rf2-6a3rgx).
 // ---------------------------------------------------------------------------
 
 // True for references the resolver does not check on disk: absolute URLs
@@ -427,14 +429,28 @@ function parseSrcset(value) {
 // regardless of the value's quoting. HTML attribute order is insignificant
 // (rf2-cnu7qy) and HTML5 permits unquoted values (`<script src=main.js>`), so
 // the value form is one of: "double" | 'single' | bare-unquoted. The unquoted
-// form ends at the first whitespace / `>` / quote / `=` (rf2-3dzb6h). Returns
-// null when the attribute is absent.
+// form ends at the first whitespace / `>` / quote / `=` (rf2-3dzb6h). The name
+// match is BOUNDARY-SAFE (a `-`/word char may not immediately precede it), so a
+// `data-src` / `data-poster` / `aria-*` lazy-load hook is never misread as the
+// bare `src`/`poster` attribute. Returns null when the attribute is absent.
 function attr(tag, name) {
   const m = tag.match(
-    new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>"'=]+))`, 'i'),
+    new RegExp(`(?<![-\\w])${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>"'=]+))`, 'i'),
   );
   if (!m) return null;
   return m[2] != null ? m[2] : m[3] != null ? m[3] : m[4] != null ? m[4] : null;
+}
+
+// Read a srcset / imagesrcset candidate list off a tag. QUOTED only — a
+// candidate list carries spaces and commas, so there is no meaningful unquoted
+// form — and boundary-safe like attr() so a `data-srcset` lazy-load hook is not
+// misread (rf2-arkvq8). Returns the raw attribute value, or null when absent.
+function srcsetAttr(tag, name) {
+  const m = tag.match(
+    new RegExp(`(?<![-\\w])${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i'),
+  );
+  if (!m) return null;
+  return m[2] != null ? m[2] : m[3];
 }
 
 // Strip CSS block comments `/* … */` from a source before scanning it for live
@@ -445,15 +461,32 @@ function stripCssComments(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-// Extract every ASSET-BEARING reference from an index.html's source, TAGGED
-// with the element/attribute it came from, so the direct-HTML network policy
-// (rf2-bf4vdy) can distinguish a remote asset fetch (rejected) from harmless
-// navigation/metadata (exempt). Returns [{ ref, source }] — `ref` is the
-// query/hash-stripped target, `source` a human-readable origin (e.g.
-// `<script src>`, `<link rel=stylesheet href>`, `<img src>`, `og:image`).
-// Order-preserving; de-duplicated on (ref, source).
+// Build the page's complete HTML reference inventory in ONE pass over its tags
+// (rf2-6a3rgx). Every supported reference shape — a quoted OR unquoted attribute
+// (rf2-3dzb6h), each srcset/imagesrcset candidate + a <video> poster
+// (rf2-arkvq8), and an order-independent og:image meta (rf2-cnu7qy) — is
+// tokenized EXACTLY ONCE here, replacing the three competing extractors that
+// each re-parsed the same HTML and had to be taught every new shape separately.
+// Returns three views over the single walk:
 //
-// What counts as asset-bearing:
+//   {
+//     localRefs,   // string[]  — every LOCAL-RESOLUTION candidate the page names
+//     assets,      // [{ ref, source }] — the tagged LOAD-TIME asset subset
+//     ogImages,    // string[]  — the og:image content value(s)
+//   }
+//
+// localRefs is the broad "resolve it on disk / is the required asset present?"
+// view: generic href/src on ANY element (so an <a href> or a rel="canonical"
+// still lands here — the generic local-href handling — filtered later by
+// isExternalRef) plus every srcset/imagesrcset candidate, the <video> poster,
+// and the og:image content. Query/hash-stripped, de-duplicated, in document
+// order (href/src, then srcset/imagesrcset candidates, then poster, then
+// og:image).
+//
+// assets is the subset that is an ACTUAL load-time fetch, TAGGED with a
+// human-readable origin so the direct-HTML network policy (rf2-bf4vdy) can
+// distinguish a remote asset fetch (rejected) from harmless navigation/metadata
+// (exempt). What counts as asset-bearing:
 //   - <script src=...>                          (always a fetch)
 //   - <link rel="<asset rel>" href=...>         (stylesheet/preload/icon/…)
 //   - <link ... imagesrcset=...>                (responsive preload candidates)
@@ -462,139 +495,115 @@ function stripCssComments(css) {
 //   - <video poster=...>                        (poster-still image fetch)
 //   - <meta property="og:image" content=...>    (social-preview fetch)
 // An <a href> / a <link rel="canonical"> / any non-asset element href is pure
-// navigation and is intentionally NOT returned. srcset/imagesrcset each expand
-// to their candidate URLs; the poster is a single image fetch (rf2-arkvq8).
-function extractAssetRefs(html) {
-  const out = [];
-  const seen = new Set();
-  const push = (raw, source) => {
-    if (!raw) return;
-    const clean = raw.split(/[?#]/)[0].trim();
-    if (!clean) return;
-    const key = `${source} ${clean}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    out.push({ ref: clean, source });
+// navigation and is intentionally absent from `assets`. De-duplicated on
+// (source, ref); element order (scripts, links, media, og). assets ⊆ localRefs
+// as ref-sets — every load-time asset is also a local candidate.
+//
+// ogImages is the social-preview target the raster contract (rf2-lr4am3)
+// checks. De-duplicated, document order.
+function extractHtmlReferenceInventory(html) {
+  const clean = (raw) => (raw == null ? null : raw.split(/[?#]/)[0].trim());
+
+  // localRefs is assembled from ordered buckets so its document order is stable
+  // regardless of how the shapes interleave across elements; the final de-dup
+  // keeps each ref's first occurrence.
+  const hrefSrc = [];
+  const srcsetRefs = [];
+  const posterRefs = [];
+  const ogRefs = [];
+  // assets keeps element order (scripts, then links, then media, then og), each
+  // source's refs in read order.
+  const scriptAssets = [];
+  const linkAssets = [];
+  const mediaAssets = [];
+  const ogAssets = [];
+
+  const addRef = (bucket, raw) => {
+    const c = clean(raw);
+    if (c) bucket.push(c);
   };
+  const addAsset = (bucket, raw, source) => {
+    const c = clean(raw);
+    if (c) bucket.push({ ref: c, source });
+  };
+  const mediaEls = new Set(['img', 'source', 'video', 'audio', 'track']);
 
-  // <script src=...> — always an asset fetch.
-  for (const m of html.matchAll(/<script\b[^>]*>/gi)) {
-    const src = attr(m[0], 'src');
-    if (src) push(src, '<script src>');
-  }
-
-  // <link rel="..." href=...> — asset-bearing only for the rels above. A
-  // `<link rel="preload" as="image" imagesrcset=...>` also carries a responsive
-  // candidate list (like <img srcset>) and often has NO href, so imagesrcset is
-  // handled independently of the href/rel gate (rf2-arkvq8).
-  for (const m of html.matchAll(/<link\b[^>]*>/gi)) {
+  for (const m of html.matchAll(/<([a-zA-Z][a-zA-Z0-9:-]*)[^>]*>/g)) {
     const tag = m[0];
-    const rel = (attr(tag, 'rel') || '').toLowerCase().trim();
-    const tokens = rel.split(/\s+/).filter(Boolean);
-    const isAsset = tokens.some((t) => ASSET_LINK_RELS.has(t));
-    const href = attr(tag, 'href');
-    if (href && isAsset) push(href, `<link rel="${rel || '(none)'}" href>`);
-    const imagesrcset = attr(tag, 'imagesrcset');
-    if (imagesrcset) {
-      for (const u of parseSrcset(imagesrcset)) {
-        push(u, `<link rel="${rel || '(none)'}" imagesrcset>`);
+    const el = m[1].toLowerCase();
+
+    // Generic local-resolution refs off EVERY element (preserves the broad
+    // local-href handling: an <a href> / rel="canonical" href lands here too).
+    addRef(hrefSrc, attr(tag, 'href'));
+    addRef(hrefSrc, attr(tag, 'src'));
+    for (const u of parseSrcset(srcsetAttr(tag, 'srcset') || '')) addRef(srcsetRefs, u);
+    for (const u of parseSrcset(srcsetAttr(tag, 'imagesrcset') || '')) addRef(srcsetRefs, u);
+    addRef(posterRefs, attr(tag, 'poster'));
+
+    // Tagged load-time asset shapes — categorize ONLY the actual fetches.
+    if (el === 'script') {
+      addAsset(scriptAssets, attr(tag, 'src'), '<script src>');
+    } else if (el === 'link') {
+      const rel = (attr(tag, 'rel') || '').toLowerCase().trim();
+      const label = rel || '(none)';
+      const isAsset = rel.split(/\s+/).filter(Boolean).some((t) => ASSET_LINK_RELS.has(t));
+      // A `<link rel="preload" as="image" imagesrcset=...>` carries a responsive
+      // candidate list (like <img srcset>) and often has NO href, so imagesrcset
+      // is asset-bearing independently of the href/rel gate (rf2-arkvq8).
+      if (isAsset) addAsset(linkAssets, attr(tag, 'href'), `<link rel="${label}" href>`);
+      for (const u of parseSrcset(srcsetAttr(tag, 'imagesrcset') || '')) {
+        addAsset(linkAssets, u, `<link rel="${label}" imagesrcset>`);
+      }
+    } else if (mediaEls.has(el)) {
+      addAsset(mediaAssets, attr(tag, 'src'), `<${el} src>`);
+      if (el === 'img' || el === 'source') {
+        for (const u of parseSrcset(srcsetAttr(tag, 'srcset') || '')) {
+          addAsset(mediaAssets, u, `<${el} srcset>`);
+        }
+      }
+      if (el === 'video') addAsset(mediaAssets, attr(tag, 'poster'), '<video poster>');
+    } else if (el === 'meta') {
+      // Order-independent: a `content`-before-`property` og:image meta is
+      // equally valid and must be seen (rf2-cnu7qy).
+      if ((attr(tag, 'property') || '').toLowerCase() === 'og:image') {
+        const content = clean(attr(tag, 'content'));
+        if (content) {
+          ogRefs.push(content);
+          ogAssets.push({ ref: content, source: 'og:image' });
+        }
       }
     }
   }
 
-  // <img|source|video|audio|track src=...> — media fetch. <img>/<source> also
-  // carry a `srcset` candidate list and <video> a `poster` still, each a
-  // load-time image fetch (rf2-arkvq8).
-  for (const m of html.matchAll(/<(img|source|video|audio|track)\b[^>]*>/gi)) {
-    const tag = m[0];
-    const el = m[1].toLowerCase();
-    const src = attr(tag, 'src');
-    if (src) push(src, `<${el} src>`);
-    if (el === 'img' || el === 'source') {
-      const srcset = attr(tag, 'srcset');
-      if (srcset) for (const u of parseSrcset(srcset)) push(u, `<${el} srcset>`);
+  const dedupe = (list) => {
+    const seen = new Set();
+    const out = [];
+    for (const v of list) {
+      if (!seen.has(v)) {
+        seen.add(v);
+        out.push(v);
+      }
     }
-    if (el === 'video') {
-      const poster = attr(tag, 'poster');
-      if (poster) push(poster, '<video poster>');
-    }
-  }
-
-  // <meta property="og:image" content=...> — social-preview fetch.
-  for (const og of extractOgImageRefs(html)) {
-    push(og, 'og:image');
-  }
-
-  return out;
-}
-
-// Extract every asset reference from an index.html's source: <link href>,
-// <script src>, and the og:image <meta content>. Order-preserving,
-// de-duplicated. Query/hash suffixes are stripped for on-disk resolution.
-function extractHtmlRefs(html) {
-  const refs = [];
-  const push = (raw) => {
-    if (!raw) return;
-    const clean = raw.split(/[?#]/)[0].trim();
-    if (clean && !refs.includes(clean)) refs.push(clean);
+    return out;
   };
-  // href=... / src=... on <link> (and any element — anchors are in-page or
-  // external and get filtered by isExternalRef downstream). Double-quoted,
-  // single-quoted, AND bare unquoted values (`<script src=main.js>`), since
-  // HTML5 permits the unquoted form (rf2-3dzb6h).
-  for (const m of html.matchAll(
-    /\b(?:href|src)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>"'=]+))/gi,
-  )) {
-    push(m[2] != null ? m[2] : m[3] != null ? m[3] : m[4]);
-  }
-  // srcset / imagesrcset candidate lists (<img>/<source> + preload <link>) —
-  // each candidate URL must resolve on disk like a plain src (rf2-arkvq8). The
-  // negative lookbehind keeps a `data-srcset` (lazy-load) attribute out.
-  for (const m of html.matchAll(
-    /(?<![-\w])(?:imagesrcset|srcset)\s*=\s*("([^"]*)"|'([^']*)')/gi,
-  )) {
-    for (const u of parseSrcset(m[2] != null ? m[2] : m[3])) push(u);
-  }
-  // <video poster="..."> — the poster still resolves on disk like a src
-  // (rf2-arkvq8). The lookbehind excludes a `data-poster` attribute; the
-  // unquoted alternative mirrors href/src (rf2-3dzb6h).
-  for (const m of html.matchAll(
-    /(?<![-\w])poster\s*=\s*("([^"]*)"|'([^']*)'|([^\s>"'=]+))/gi,
-  )) {
-    push(m[2] != null ? m[2] : m[3] != null ? m[3] : m[4]);
-  }
-  // <meta property="og:image" content="..."> — ORDER-INDEPENDENT. HTML
-  // attribute order is insignificant, so a `content`-before-`property` meta is
-  // equally valid and must be seen (rf2-cnu7qy). Scan each <meta> tag and read
-  // its attributes positionally via the shared order-independent attr helper,
-  // rather than a single regex that hard-codes property-before-content.
-  for (const m of html.matchAll(/<meta\b[^>]*>/gi)) {
-    const tag = m[0];
-    if ((attr(tag, 'property') || '').toLowerCase() !== 'og:image') continue;
-    push(attr(tag, 'content'));
-  }
-  return refs;
-}
+  const dedupeAssets = (list) => {
+    const seen = new Set();
+    const out = [];
+    for (const a of list) {
+      const key = `${a.source} ${a.ref}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(a);
+      }
+    }
+    return out;
+  };
 
-// Extract the og:image content value(s) specifically — the social-preview
-// target a link-preview scraper would fetch. Used to enforce the raster
-// contract (an SVG og:image renders no preview card). Query/hash stripped.
-function extractOgImageRefs(html) {
-  const out = [];
-  // ORDER-INDEPENDENT: HTML attribute order is insignificant, so a
-  // `content`-before-`property` og:image meta is valid and MUST be visible to
-  // the raster contract + the network policy (rf2-cnu7qy). Scan each <meta> tag
-  // and read `property`/`content` positionally via the shared attr helper
-  // instead of a single regex that requires property-before-content.
-  for (const m of html.matchAll(/<meta\b[^>]*>/gi)) {
-    const tag = m[0];
-    if ((attr(tag, 'property') || '').toLowerCase() !== 'og:image') continue;
-    const raw = attr(tag, 'content');
-    if (!raw) continue;
-    const clean = raw.split(/[?#]/)[0].trim();
-    if (clean && !out.includes(clean)) out.push(clean);
-  }
-  return out;
+  return {
+    localRefs: dedupe([...hrefSrc, ...srcsetRefs, ...posterRefs, ...ogRefs]),
+    assets: dedupeAssets([...scriptAssets, ...linkAssets, ...mediaAssets, ...ogAssets]),
+    ogImages: dedupe(ogRefs),
+  };
 }
 
 // Extract local @import targets from a CSS source. Handles both
@@ -1290,7 +1299,11 @@ function scanPage(io, indexAbsPath, opts = {}) {
     return { relIndex, errors, refs: [] };
   }
 
-  const refs = extractHtmlRefs(html);
+  // ONE parse per page (rf2-6a3rgx): the single inventory pass yields every view
+  // this scan needs — the broad local-resolution refs (steps 1-2), the tagged
+  // load-time asset refs (step 0 network policy), and the og:image refs (step 3
+  // raster contract) — so the page's HTML is tokenized exactly once.
+  const { localRefs: refs, assets, ogImages } = extractHtmlReferenceInventory(html);
   const pageDir = path.dirname(indexAbsPath);
   const seenCss = new Set();
 
@@ -1302,7 +1315,7 @@ function scanPage(io, indexAbsPath, opts = {}) {
   //    allowlisted with a reason (fail-closed — EXTERNAL_HTML_REF_ALLOWLIST).
   //    Only http(s)/protocol-relative refs are network deps; data: URIs are
   //    inlined and pure navigation (#fragment / mailto: / a-href) is exempt.
-  for (const { ref, source } of extractAssetRefs(html)) {
+  for (const { ref, source } of assets) {
     if (!isNetworkRef(ref)) continue;
     if (Object.prototype.hasOwnProperty.call(externalHtmlRefAllowlist, ref)) continue;
     errors.push(
@@ -1367,7 +1380,7 @@ function scanPage(io, indexAbsPath, opts = {}) {
   //    scrapers (Facebook / X / LinkedIn / Slack / Discord) ignore an SVG
   //    og:image and render no large preview card — a failure mode invisible to
   //    a pure "the referenced file exists" check. (rf2-lr4am3)
-  for (const og of extractOgImageRefs(html)) {
+  for (const og of ogImages) {
     // Remote targets are governed separately by the direct-HTML network
     // allowlist. Their URL suffix is not reliable evidence of the response
     // media type, so this source-file extension check applies only to local refs.
@@ -1727,9 +1740,7 @@ module.exports = {
   isExampleHostPage,
   isExternalRef,
   isNetworkRef,
-  extractHtmlRefs,
-  extractAssetRefs,
-  extractOgImageRefs,
+  extractHtmlReferenceInventory,
   parseSrcset,
   extractCssImports,
   extractCssUrls,

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -39,9 +39,7 @@ const {
   isExampleHostPage,
   isExternalRef,
   isNetworkRef,
-  extractHtmlRefs,
-  extractAssetRefs,
-  extractOgImageRefs,
+  extractHtmlReferenceInventory,
   parseSrcset,
   extractCssImports,
   extractCssUrls,
@@ -431,20 +429,6 @@ function fullIo(overrides = {}) {
 
 // ---- extraction primitives ----------------------------------------------
 
-it('extractHtmlRefs picks up link/script/og:image refs, de-duped', () => {
-  const refs = extractHtmlRefs(goodHtml());
-  assert.ok(refs.includes('_shared/img/favicon.svg'));
-  assert.ok(refs.includes('_shared/css/style.css'));
-  assert.ok(refs.includes('_shared/img/og.png'));
-  assert.ok(refs.includes('main.js'));
-});
-
-it('extractHtmlRefs strips ?query and #hash for on-disk resolution', () => {
-  const refs = extractHtmlRefs('<link href="a.css?v=2"><link href="b.css#x">');
-  assert.ok(refs.includes('a.css'));
-  assert.ok(refs.includes('b.css'));
-});
-
 it('extractCssImports handles url() and bare-string @import forms', () => {
   const imports = extractCssImports(
     "@import url('a.css'); @import \"b.css\"; @import url(c.css);",
@@ -471,39 +455,6 @@ it('isNetworkRef flags only http(s)/protocol-relative — not data:/mailto:/#fra
   assert.ok(!isNetworkRef('tel:+123'));
   assert.ok(!isNetworkRef('#frag'));
   assert.ok(!isNetworkRef('_shared/css/style.css'));
-});
-
-// ---- direct-HTML asset-ref tagging (rf2-bf4vdy) -------------------------
-
-it('extractAssetRefs tags script src, asset link href, img/media src, og:image', () => {
-  const html = [
-    '<script src="https://cdn.example.com/sdk.js"></script>',
-    '<link rel="stylesheet" href="https://cdn.example.com/x.css">',
-    '<link rel="icon" href="_shared/img/favicon.svg">',
-    '<img src="https://img.example.com/hero.png">',
-    '<video src="//media.example.com/clip.mp4"></video>',
-    '<meta property="og:image" content="https://og.example.com/card.png">',
-  ].join('\n');
-  const tagged = extractAssetRefs(html);
-  const byRef = Object.fromEntries(tagged.map((t) => [t.ref, t.source]));
-  assert.ok(byRef['https://cdn.example.com/sdk.js'].includes('script'));
-  assert.ok(byRef['https://cdn.example.com/x.css'].includes('link'));
-  assert.ok(byRef['_shared/img/favicon.svg'].includes('link'));
-  assert.ok(byRef['https://img.example.com/hero.png'].includes('img'));
-  assert.ok(byRef['//media.example.com/clip.mp4'].includes('video'));
-  assert.strictEqual(byRef['https://og.example.com/card.png'], 'og:image');
-});
-
-it('extractAssetRefs does NOT treat an <a href> or rel=canonical as an asset', () => {
-  const html = [
-    '<a href="https://example.com/docs">docs</a>',
-    '<link rel="canonical" href="https://example.com/page">',
-    '<link rel="alternate" href="https://example.com/rss">',
-  ].join('\n');
-  const refs = extractAssetRefs(html).map((t) => t.ref);
-  assert.ok(!refs.includes('https://example.com/docs'), 'anchors are navigation, not assets');
-  assert.ok(!refs.includes('https://example.com/page'), 'rel=canonical is metadata, not an asset');
-  assert.ok(!refs.includes('https://example.com/rss'), 'rel=alternate is metadata, not an asset');
 });
 
 // ---- srcset + video poster refs (rf2-arkvq8) ----------------------------
@@ -548,48 +499,196 @@ it('parseSrcset tolerates extra whitespace and stray commas', () => {
   );
 });
 
-it('extractHtmlRefs picks up srcset / imagesrcset candidates + video poster', () => {
-  const refs = extractHtmlRefs(
-    [
+// ---------------------------------------------------------------------------
+// HTML reference inventory (rf2-6a3rgx) — the SINGLE extraction pass. ONE
+// table-driven suite replaces the three former per-extractor matrices
+// (extractHtmlRefs / extractAssetRefs / extractOgImageRefs), each of which had
+// to be taught every new shape independently. Every supported shape is asserted
+// once against extractHtmlReferenceInventory's three views:
+//   - localRefs : broad on-disk-resolution candidates (generic href handling)
+//   - assets    : the tagged LOAD-TIME fetch subset (network policy input)
+//   - ogImages  : the social-preview targets (raster contract input)
+// Coverage: quoting (double/single/unquoted), attribute order, query/hash
+// stripping, srcset, imagesrcset, <video> poster, navigation-vs-asset, og:image
+// (incl. content-before-property), and de-duplication.
+// ---------------------------------------------------------------------------
+
+// All `source` strings an asset ref was tagged with (a ref carried by more than
+// one origin — e.g. an icon <link> AND an og:image meta — keeps each).
+const assetSources = (assets, ref) => assets.filter((a) => a.ref === ref).map((a) => a.source);
+
+const INVENTORY_CASES = [
+  {
+    name: 'quoting/order/OG — link + script + og:image in document bucket order',
+    html: goodHtml(),
+    localExact: [
+      '_shared/img/favicon.svg',
+      '_shared/css/style.css',
+      'main.js',
+      '_shared/img/og.png',
+    ],
+    assetSourceIncludes: {
+      'main.js': 'script',
+      '_shared/img/favicon.svg': 'link',
+      '_shared/css/style.css': 'link',
+    },
+    assetSourceExact: { '_shared/img/og.png': 'og:image' },
+    ogExact: ['_shared/img/og.png'],
+  },
+  {
+    name: 'query/hash stripped for on-disk resolution',
+    html: '<link rel="stylesheet" href="a.css?v=2"><link rel="icon" href="b.css#x">',
+    localExact: ['a.css', 'b.css'],
+    localExcludes: ['a.css?v=2', 'b.css#x'],
+  },
+  {
+    name: 'single-quoted attribute values',
+    html: "<link rel='icon' href='_shared/img/favicon.svg'>",
+    localIncludes: ['_shared/img/favicon.svg'],
+    assetSourceIncludes: { '_shared/img/favicon.svg': 'link' },
+  },
+  {
+    name: 'unquoted values (HTML5, rf2-3dzb6h) — script src + rel=stylesheet href',
+    html: '<script src=main.js></script><link rel=stylesheet href=base.css>',
+    localIncludes: ['main.js', 'base.css'],
+    assetSourceIncludes: { 'main.js': 'script', 'base.css': 'link' },
+  },
+  {
+    name: 'unquoted REMOTE script src + protocol-relative link href tagged (rf2-3dzb6h)',
+    html:
+      '<script src=https://cdn.evil/x.js></script>\n' +
+      '<link rel=stylesheet href=//cdn.evil/x.css>',
+    assetSourceIncludes: { 'https://cdn.evil/x.js': 'script', '//cdn.evil/x.css': 'link' },
+  },
+  {
+    name: 'srcset / imagesrcset candidates + <video> poster, local (rf2-arkvq8)',
+    html: [
       '<img srcset="_shared/img/hero-320.png 320w, _shared/img/hero-640.png 640w">',
       '<source srcset="_shared/img/pic@2x.png 2x">',
       '<link rel="preload" as="image" imagesrcset="_shared/img/pre-1.png 1x">',
       '<video poster="_shared/img/poster.png"><source src="clip.mp4"></video>',
     ].join('\n'),
-  );
-  for (const ref of [
-    '_shared/img/hero-320.png',
-    '_shared/img/hero-640.png',
-    '_shared/img/pic@2x.png',
-    '_shared/img/pre-1.png',
-    '_shared/img/poster.png',
-  ]) {
-    assert.ok(refs.includes(ref), `expected ${ref} in refs, got: ${refs.join(', ')}`);
-  }
-});
-
-it('extractHtmlRefs does NOT treat data-srcset / data-poster (lazy-load) as refs', () => {
-  const refs = extractHtmlRefs(
-    '<img data-srcset="lazy.png 2x" data-poster="lazy-poster.png">',
-  );
-  assert.ok(!refs.includes('lazy.png'), 'data-srcset must not be read as a srcset');
-  assert.ok(!refs.includes('lazy-poster.png'), 'data-poster must not be read as a poster');
-});
-
-it('extractAssetRefs tags srcset candidates, imagesrcset, and the video poster', () => {
-  const tagged = extractAssetRefs(
-    [
+    localIncludes: [
+      '_shared/img/hero-320.png',
+      '_shared/img/hero-640.png',
+      '_shared/img/pic@2x.png',
+      '_shared/img/pre-1.png',
+      '_shared/img/poster.png',
+    ],
+    assetSourceIncludes: {
+      '_shared/img/hero-320.png': 'srcset',
+      '_shared/img/pre-1.png': 'imagesrcset',
+    },
+    assetSourceExact: { '_shared/img/poster.png': '<video poster>' },
+  },
+  {
+    name: 'remote srcset / imagesrcset / poster tagged with their origin (rf2-arkvq8)',
+    html: [
       '<img srcset="https://img.example.com/a-320.png 320w, https://img.example.com/a-640.png 640w">',
       '<link rel="preload" as="image" imagesrcset="https://img.example.com/pre.png 1x">',
       '<video poster="https://img.example.com/still.png"></video>',
     ].join('\n'),
-  );
-  const byRef = Object.fromEntries(tagged.map((t) => [t.ref, t.source]));
-  assert.ok(byRef['https://img.example.com/a-320.png'].includes('srcset'));
-  assert.ok(byRef['https://img.example.com/a-640.png'].includes('srcset'));
-  assert.ok(byRef['https://img.example.com/pre.png'].includes('imagesrcset'));
-  assert.strictEqual(byRef['https://img.example.com/still.png'], '<video poster>');
-});
+    assetSourceIncludes: {
+      'https://img.example.com/a-320.png': 'srcset',
+      'https://img.example.com/a-640.png': 'srcset',
+      'https://img.example.com/pre.png': 'imagesrcset',
+    },
+    assetSourceExact: { 'https://img.example.com/still.png': '<video poster>' },
+  },
+  {
+    name: 'data-src / data-srcset / data-poster lazy-load hooks are NOT references',
+    html: '<img data-src="lazy.jpg" data-srcset="lazy.png 2x" data-poster="lazy-poster.png">',
+    localExact: [],
+    assetExcludes: ['lazy.jpg', 'lazy.png', 'lazy-poster.png'],
+  },
+  {
+    name: 'navigation — <a href> + rel=canonical/alternate are local refs but NOT assets',
+    html: [
+      '<a href="https://example.com/docs">docs</a>',
+      '<link rel="canonical" href="https://example.com/page">',
+      '<link rel="alternate" href="https://example.com/rss">',
+    ].join('\n'),
+    localIncludes: [
+      'https://example.com/docs',
+      'https://example.com/page',
+      'https://example.com/rss',
+    ],
+    assetExcludes: [
+      'https://example.com/docs',
+      'https://example.com/page',
+      'https://example.com/rss',
+    ],
+  },
+  {
+    name: 'og:image content-BEFORE-property is order-independent (rf2-cnu7qy)',
+    html: '<meta content="_shared/img/og.png" property="og:image">',
+    ogExact: ['_shared/img/og.png'],
+    localIncludes: ['_shared/img/og.png'],
+    assetSourceExact: { '_shared/img/og.png': 'og:image' },
+  },
+  {
+    name: 'og:image content-first REMOTE card is tagged (rf2-cnu7qy)',
+    html: '<meta content="https://og.example.com/card.png" property="og:image">',
+    ogExact: ['https://og.example.com/card.png'],
+    localIncludes: ['https://og.example.com/card.png'],
+    assetSourceExact: { 'https://og.example.com/card.png': 'og:image' },
+  },
+  {
+    name: 'dedup — a repeated src collapses to one local ref and one asset',
+    html: '<img src="x.png"><img src="x.png">',
+    localExact: ['x.png'],
+    assetSourceExact: { 'x.png': '<img src>' },
+  },
+  {
+    name: 'dedup — same ref from distinct origins keeps BOTH tagged assets',
+    html:
+      '<link rel="icon" href="_shared/img/og.png">' +
+      '<meta property="og:image" content="_shared/img/og.png">' +
+      '<meta property="og:image" content="_shared/img/og.png">',
+    localExact: ['_shared/img/og.png'],
+    ogExact: ['_shared/img/og.png'],
+    // (source, ref) de-dup: the icon-link and og:image origins are distinct, so
+    // both survive; the duplicate og meta collapses.
+    assetSourceSet: { '_shared/img/og.png': ['<link rel="icon" href>', 'og:image'] },
+  },
+];
+
+for (const c of INVENTORY_CASES) {
+  it(`inventory — ${c.name}`, () => {
+    const { localRefs, assets, ogImages } = extractHtmlReferenceInventory(c.html);
+    if (c.localExact) assert.deepStrictEqual(localRefs, c.localExact, 'localRefs');
+    for (const r of c.localIncludes || []) {
+      assert.ok(localRefs.includes(r), `localRefs must include '${r}', got: ${localRefs.join(', ')}`);
+    }
+    for (const r of c.localExcludes || []) {
+      assert.ok(!localRefs.includes(r), `localRefs must NOT include '${r}', got: ${localRefs.join(', ')}`);
+    }
+    if (c.ogExact) assert.deepStrictEqual(ogImages, c.ogExact, 'ogImages');
+    for (const [ref, sub] of Object.entries(c.assetSourceIncludes || {})) {
+      const srcs = assetSources(assets, ref);
+      assert.ok(
+        srcs.length === 1 && srcs[0].includes(sub),
+        `asset '${ref}' must be tagged with a single source containing '${sub}', got: ${JSON.stringify(srcs)}`,
+      );
+    }
+    for (const [ref, src] of Object.entries(c.assetSourceExact || {})) {
+      assert.deepStrictEqual(assetSources(assets, ref), [src], `asset '${ref}' exact source`);
+    }
+    for (const [ref, srcs] of Object.entries(c.assetSourceSet || {})) {
+      assert.deepStrictEqual(
+        assetSources(assets, ref).sort(),
+        [...srcs].sort(),
+        `asset '${ref}' source set`,
+      );
+    }
+    for (const r of c.assetExcludes || []) {
+      assert.ok(
+        !assets.some((a) => a.ref === r),
+        `assets must NOT include '${r}', got: ${JSON.stringify(assets)}`,
+      );
+    }
+  });
+}
 
 it('TEETH: a missing LOCAL srcset candidate is reported (rf2-arkvq8)', () => {
   // The page references two responsive candidates; the 640w one is absent on
@@ -1466,11 +1565,6 @@ it('TEETH: a stale exemption (page DOES reference the exempt asset) is flagged',
 
 // ---- TEETH: social-preview RASTER contract (rf2-lr4am3) -----------------
 
-it('extractOgImageRefs returns the og:image content value(s)', () => {
-  const refs = extractOgImageRefs(goodHtml());
-  assert.deepStrictEqual(refs, ['_shared/img/og.png']);
-});
-
 it('TEETH: an SVG og:image is flagged as a non-raster social-preview asset', () => {
   // The exact pre-fix failure mode: the file exists, every required-asset
   // check passes, but the og:image is an SVG that scrapers will not render.
@@ -1983,7 +2077,7 @@ it('LIVE: no real example page ships an SVG (or otherwise non-raster) og:image',
   const offenders = [];
   for (const idx of realIndexes) {
     const html = fs.readFileSync(idx, 'utf8');
-    for (const og of extractOgImageRefs(html)) {
+    for (const og of extractHtmlReferenceInventory(html).ogImages) {
       if (isExternalRef(og)) continue;
       const ext = path.extname(og).toLowerCase();
       if (!['.png', '.jpg', '.jpeg', '.webp', '.gif'].includes(ext)) {
@@ -2229,25 +2323,6 @@ it('the build-output main.js is never resolved on disk', () => {
 // SVG/remote card was INVISIBLE to the raster contract, disk resolution, and the
 // network policy.
 
-it('rf2-cnu7qy: extractOgImageRefs sees a content-BEFORE-property og:image', () => {
-  assert.deepStrictEqual(
-    extractOgImageRefs('<meta content="_shared/img/og.png" property="og:image">'),
-    ['_shared/img/og.png'],
-  );
-});
-
-it('rf2-cnu7qy: extractHtmlRefs + extractAssetRefs see a content-first og:image', () => {
-  const html = '<meta content="https://og.example.com/card.png" property="og:image">';
-  assert.ok(extractHtmlRefs(html).includes('https://og.example.com/card.png'));
-  const tagged = extractAssetRefs(html);
-  assert.strictEqual(
-    Object.fromEntries(tagged.map((t) => [t.ref, t.source]))[
-      'https://og.example.com/card.png'
-    ],
-    'og:image',
-  );
-});
-
 it('TEETH rf2-cnu7qy: a content-first REMOTE og:image is REJECTED (was invisible)', () => {
   const html = goodHtml().replace(
     '<meta property="og:image" content="_shared/img/og.png">',
@@ -2279,22 +2354,6 @@ it('TEETH rf2-cnu7qy: a content-first SVG og:image trips the raster contract', (
 // HTML5 permits unquoted attribute values. The old quoted-only regexes missed
 // `<script src=main.js>` / `<link href=//cdn…>`, so an unquoted forbidden remote
 // dep shipped green and an unquoted broken local ref was never resolved on disk.
-
-it('rf2-3dzb6h: extractHtmlRefs reads an unquoted src/href', () => {
-  const refs = extractHtmlRefs('<script src=main.js></script><link href=base.css>');
-  assert.ok(refs.includes('main.js'));
-  assert.ok(refs.includes('base.css'));
-});
-
-it('rf2-3dzb6h: extractAssetRefs tags an unquoted remote script src + link href', () => {
-  const tagged = extractAssetRefs(
-    '<script src=https://cdn.evil/x.js></script>\n' +
-      '<link rel=stylesheet href=//cdn.evil/x.css>',
-  );
-  const byRef = Object.fromEntries(tagged.map((t) => [t.ref, t.source]));
-  assert.ok(byRef['https://cdn.evil/x.js'] && byRef['https://cdn.evil/x.js'].includes('script'));
-  assert.ok(byRef['//cdn.evil/x.css'] && byRef['//cdn.evil/x.css'].includes('link'));
-});
 
 it('TEETH rf2-3dzb6h: an unquoted remote <script src> is REJECTED (was invisible)', () => {
   const html = goodHtml().replace(


### PR DESCRIPTION
## What

`examples/scripts/check-examples-assets.cjs` parsed each example page **three times** — through `extractHtmlRefs`, `extractAssetRefs`, and `extractOgImageRefs`, all invoked by `scanPage`. Every new HTML shape (srcset/imagesrcset, `<video>` poster, content-first og:image, unquoted attributes) had to be taught to multiple extractors, and each shape carried its own duplicated test matrix.

Consolidated to **one** `extractHtmlReferenceInventory(html)` pass that walks the page's tags once and returns three views over the single walk:

```
{
  localRefs,  // string[]          — broad local-resolution candidates (generic href/src
              //                      on ANY element + srcset/imagesrcset + <video> poster
              //                      + og:image), query/hash-stripped, deduped, doc order
  assets,     // [{ ref, source }] — the tagged LOAD-TIME fetch subset (network-policy input)
  ogImages,   // string[]          — the og:image content value(s) (raster-contract input)
}
```

`scanPage` now computes the inventory **once** and consumes all three views (step 0 network policy ← `assets`; steps 1-2 resolution + required-asset ← `localRefs`; step 3 raster ← `ogImages`). `assets ⊆ localRefs` as ref-sets.

**Deleted exports:** `extractHtmlRefs`, `extractAssetRefs`, `extractOgImageRefs`.
**Added export:** `extractHtmlReferenceInventory`.

The three former per-extractor test matrices collapse into **one table-driven inventory suite** covering quoting / order / query / hash / srcset / imagesrcset / poster / navigation / OG / dedup.

## Coverage parity

Verified (throwaway parity harness against the `origin/main` extractors) that the inventory returns **identical** `localRefs` (order included), `assets`, and `ogImages` to the old three-extractor union across all **35 real example pages** — zero mismatches. The srcset/poster/content-first-og behaviours are all preserved.

The only intended behavioural change: `data-src` / `data-srcset` / `data-poster` lazy-load hooks are now uniformly **boundary-safe** across every view. Previously the `assets` view misread `data-srcset` as a real `srcset` and `localRefs` misread `data-src` as a real `src` (cross-extractor drift). No real page uses these hooks and no test asserted their inclusion; the one existing `data-*` test asserts *exclusion*, which the new code satisfies.

**Untouched:** the `checkSvgWellFormed` + structural `validatePng` validators (rf2-3fc89f.27) and every other contract.

## Quality gates (foreground)

- `cd implementation && npm run test:script-policy` → **PASS** (exit 0; `check-examples-assets` suite green, incl. all 13 inventory table cases)
- `node examples/scripts/check-examples-assets.cjs` → **all 35 pages validate, 0 failures; _shared tree intact**

## Stance

Pre-alpha, no back-compat shims — ELEGANCE + CLARITY + CORRECTNESS: one parse per page, one inventory, the three competing exports deleted, one table-driven test suite.