### PR TITLE
refactor(mcp): centralize the sensitive-read posture mapping in mcp-base.egress (rf2-54y369)

### DIFF
--- a/tools/mcp-base/shadow-cljs.edn
+++ b/tools/mcp-base/shadow-cljs.edn
@@ -6,8 +6,9 @@
  {:cljs-test
   {:target    :node-test
    :output-to "out/cljs-test.js"
-   ;; Select the CLJS-only coverage ns and the .cljc dedup suite.
-   :ns-regexp "(dedup-test|cljs-test)$"
+   ;; Select the CLJS-only coverage ns and the cross-host .cljc suites
+   ;; (dedup + egress posture mapping).
+   :ns-regexp "(dedup-test|egress-test|cljs-test)$"
    :autorun   true
    ;; Silent-on-success reporter from the :cljs-test classpath.
    :main      re-frame.test-quiet.shadow-node/main}}}

--- a/tools/mcp-base/spec/egress.md
+++ b/tools/mcp-base/spec/egress.md
@@ -21,6 +21,7 @@ This namespace is the pure-data, framework-runtime-free mirror of the six-member
 - `profiles` — the closed six-member `:rf.egress/*` set.
 - `profile->size-opts` — the profile → `:rf.size/*` opt-set table.
 - `profile-size-opts` — the resolver (`[profile] → opt-set | nil`).
+- `mcp-tool-profile` — the shared MCP-tool posture mapping (`[sensitive-reads-allowed?] → :rf.egress/off-box-tool | :rf.egress/local-raw`). The pure two-value `if` both MCP servers' direct-read surfaces used to duplicate, centralized here so they cannot drift.
 
 `egress` does NOT own:
 
@@ -50,8 +51,11 @@ The opt-set keys are `vocab/include-sensitive-opt` / `vocab/include-large-opt` /
 | `profiles` | (def) | the closed `#{:rf.egress/…}` six-member set |
 | `profile->size-opts` | (def) | `{profile → {:rf.size/include-*? bool}}` table |
 | `profile-size-opts` | `[profile]` | the `:rf.size/*` floor map, or `nil` for an unknown / absent profile |
+| `mcp-tool-profile` | `[sensitive-reads-allowed?]` | `:rf.egress/off-box-tool` (false) or `:rf.egress/local-raw` (true) |
 
 `profile-size-opts` returns `nil` (not a permissive default) for an unknown or absent profile. Callers choose profiles from the closed `profiles` set; this resolver does not validate or throw for them.
+
+`mcp-tool-profile` is the pure posture→profile mapping the two MCP tool servers (story-mcp, re-frame2-pair-mcp) share on their direct-read surfaces: `false ⇒ :rf.egress/off-box-tool` (the default MCP/AI tool wire), `true ⇒ :rf.egress/local-raw` (the trusted-local operator's deliberate raw read). It performs NO permission check — the `sensitive-reads-allowed?` boolean is produced by each server's own operator-launch gate + per-call `:include-sensitive` opt-in, and each consumer calls this fn only AFTER that gate. Centralizing it here (rf2-54y369) removes the duplicated `if` each server previously carried (`story-mcp tools.egress/posture->profile`, `pair-mcp tools.elision/posture->profile`).
 
 ## Determinism + drift protection
 

--- a/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
@@ -104,3 +104,29 @@
   bundle."
   [profile]
   (get profile->size-opts profile))
+
+(defn mcp-tool-profile
+  "Map an MCP tool server's already-permission-gated sensitive-read
+  posture to its named `:rf.egress/*` boundary profile (EP-0015 §10).
+
+  `sensitive-reads-allowed?` is the boolean each server computes AFTER
+  its own operator-launch gate (`--allow-sensitive-reads`) AND per-call
+  `:include-sensitive` opt-in. This fn performs NO permission check — it
+  is the pure two-value posture→profile mapping that the two MCP tool
+  servers (story-mcp, re-frame2-pair-mcp) share:
+
+  - `false` (the published-build default, or a caller under the gate who
+    did not opt in) ⇒ `:rf.egress/off-box-tool` — the MCP/AI tool wire:
+    sensitive redacts, large elides, structural digests on.
+  - `true` (the trusted-local operator's deliberate raw read) ⇒
+    `:rf.egress/local-raw` — sensitive AND large pass through.
+
+  Both servers previously duplicated this exact `if` (story-mcp's
+  `tools.egress/posture->profile`, pair-mcp's
+  `tools.elision/posture->profile`); it lives here once so the two
+  cannot drift. Callers resolve the returned profile to its `:rf.size/*`
+  floor via `profile-size-opts`."
+  [sensitive-reads-allowed?]
+  (if sensitive-reads-allowed?
+    :rf.egress/local-raw
+    :rf.egress/off-box-tool))

--- a/tools/mcp-base/test/re_frame/mcp_base/egress_test.cljc
+++ b/tools/mcp-base/test/re_frame/mcp_base/egress_test.cljc
@@ -1,0 +1,58 @@
+(ns re-frame.mcp-base.egress-test
+  "Canonical cross-host tests for the shared `:rf.egress/*` posture
+  mapping. `mcp-tool-profile` is the ONE pure fn that maps an MCP tool
+  server's already-permission-gated sensitive-read posture to its named
+  boundary profile (EP-0015 §10). Both MCP servers (story-mcp,
+  re-frame2-pair-mcp) previously duplicated this exact two-value `if`;
+  the mapping now lives here once and is pinned here once.
+
+  `.cljc` so it runs on BOTH hosts: the JVM `:test` alias
+  (cognitect-labs test-runner) exercises the story-mcp runtime, and the
+  shadow-cljs `cljs-test` build (its `:ns-regexp` selects `egress-test`)
+  exercises the re-frame2-pair-mcp (Node) runtime — both consumers ship
+  the same mapping on the exact runtimes they run on.
+
+  The per-server permission GATE (`--allow-sensitive-reads` + per-call
+  `:include-sensitive`) stays an INTEGRATION test in each consumer; only
+  the pure posture→profile mapping is owned here."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.mcp-base.egress :as egress]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; mcp-tool-profile — the pure two-value posture→profile mapping.
+;;
+;; false ⇒ the off-box MCP/AI tool wire; true ⇒ the trusted-local raw
+;; read. The permission decision that produces the boolean is the
+;; consumer's job (and is tested there); this fn is pure.
+;; ---------------------------------------------------------------------------
+
+(deftest mcp-tool-profile-maps-posture-to-named-boundary
+  (testing "not-opted-in ⇒ the MCP/AI tool wire boundary"
+    (is (= :rf.egress/off-box-tool (egress/mcp-tool-profile false))))
+  (testing "trusted-local opt-in ⇒ the raw boundary"
+    (is (= :rf.egress/local-raw (egress/mcp-tool-profile true)))))
+
+(deftest mcp-tool-profile-returns-members-of-the-closed-enum
+  ;; Both values it can return MUST be members of the closed
+  ;; `:rf.egress/profile` vocabulary, so a profile rename in the shared
+  ;; table can never leave this mapping pointing at a phantom profile.
+  (is (contains? egress/profiles (egress/mcp-tool-profile false)))
+  (is (contains? egress/profiles (egress/mcp-tool-profile true))))
+
+(deftest mcp-tool-profile-resolves-to-the-documented-floors
+  ;; End-to-end posture → profile → `:rf.size/*` floor, so mcp-base owns
+  ;; BOTH values' resolved semantics (not just the profile keyword).
+  (testing "off-box default (false): sensitive redacts, large elides, digests on"
+    (let [floor (egress/profile-size-opts (egress/mcp-tool-profile false))]
+      (is (false? (get floor vocab/include-sensitive-opt)) "sensitive redacts off-box")
+      (is (false? (get floor vocab/include-large-opt)) "large elides under off-box-tool floor")
+      (is (true?  (get floor vocab/include-digests-opt))
+          "off-box-tool carries structural digests (§10 structural indicators)")))
+  (testing "trusted-local opt-in (true): sensitive AND large pass through"
+    (let [floor (egress/profile-size-opts (egress/mcp-tool-profile true))]
+      (is (true?  (get floor vocab/include-sensitive-opt)) "sensitive passes raw (operator opt-in)")
+      (is (true?  (get floor vocab/include-large-opt)) "local-raw includes large too")
+      (is (false? (get floor vocab/include-digests-opt))
+          "local-raw ships the raw value, no structural digest"))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
@@ -139,35 +139,15 @@
   [include-large? include-sensitive?]
   (not (and include-large? include-sensitive?)))
 
-(defn posture->profile
-  "Resolve the off-box egress POSTURE of a direct-read tool surface to a
-  named `:rf.egress/*` profile (EP-0015 §10).
-
-  `include-sensitive?` is the already-gated, already-opted-in boolean each
-  tool computes (`(and (raw-state-allowed?) per-call-include-sensitive)`):
-
-  - `false` (the published-build default, or a forgetful caller under the
-    gate) ⇒ `:rf.egress/off-box-tool` — the MCP/AI tool wire. Sensitive
-    redacts, large elides, structural digests on.
-  - `true`  (the trusted-local operator's deliberate raw read) ⇒
-    `:rf.egress/local-raw` — sensitive AND large pass through.
-
-  Revealing sensitive data is the operator's `local-raw` act and is
-  trace-visible (Spec 015 §Cross-tool visibility grain) — the
-  `--allow-sensitive-reads` launch log + the per-call opt-in are the
-  audit record of the reveal."
-  [include-sensitive?]
-  (if include-sensitive?
-    :rf.egress/local-raw
-    :rf.egress/off-box-tool))
-
 (defn elision-opts-edn
   "Render the elision opts map as an EDN string for inlining into a
   CLJS eval form sent over nREPL.
 
   Resolution (EP-0015 §10): the egress POSTURE
-  (`include-sensitive?`) names a `:rf.egress/*` profile via
-  `posture->profile`; the framework's `re-frame.projection/profile-size-opts`
+  (`include-sensitive?`) names a `:rf.egress/*` profile via the SHARED
+  cross-MCP mapping `re-frame.mcp-base.egress/mcp-tool-profile` (called
+  here only AFTER this server's `--allow-sensitive-reads` gate + per-call
+  opt-in); the framework's `re-frame.projection/profile-size-opts`
   resolves that profile to its `:rf.size/*` floor (the single source of
   truth — this server never re-derives the table). The `:elision` MCP arg
   composes on top as the explicit override: when `include-large?` is true
@@ -208,7 +188,7 @@
   ([include-large?]
    (elision-opts-edn include-large? false))
   ([include-large? include-sensitive?]
-   (let [profile (posture->profile include-sensitive?)
+   (let [profile (base-egress/mcp-tool-profile include-sensitive?)
          floor   (base-egress/profile-size-opts profile)]
      ;; The `:elision` arg is the EP-0015 §10 explicit override: a caller
      ;; turning elision OFF overlays `:rf.size/include-large? true` on the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
@@ -673,11 +673,11 @@
       (is (true? (:rf.size/include-large? parsed))
           "local-raw includes large too — the trusted-local boundary"))))
 
-(deftest posture->profile-maps-posture-to-named-boundary
-  ;; The posture→profile mapping is the explicit EP-0015 §10 naming:
-  ;; off-box-tool is the off-box default; local-raw is the
-  ;; trusted-local opt-in.
-  (is (= :rf.egress/off-box-tool (elision/posture->profile false))
-      "not-opted-in ⇒ the MCP/AI tool wire boundary")
-  (is (= :rf.egress/local-raw (elision/posture->profile true))
-      "trusted-local opt-in ⇒ the raw boundary"))
+;; NOTE the pure posture→profile mapping (`false ⇒ :rf.egress/off-box-tool`,
+;; `true ⇒ :rf.egress/local-raw`) now lives in the shared
+;; `re-frame.mcp-base.egress/mcp-tool-profile` and is pinned once in
+;; `re-frame.mcp-base.egress-test` (rf2-54y369). The
+;; `elision-opts-edn-resolves-named-egress-profiles` test above is the
+;; LOCAL integration test that this server's `elision-opts-edn` threads
+;; that mapping (via the gate-produced boolean) through to the correct
+;; `:rf.size/*` floor + `:elision` overlay.

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -150,34 +150,28 @@
 ;; cross-MCP `re-frame.mcp-base.egress` mirror (pinned byte-identical to
 ;; the framework `re-frame.projection` table by the mcp-conformance
 ;; wire-vocab gate). The boolean `include?` each tool computes
-;; (`(and (sensitive-reads-allowed?) per-call-include-sensitive)`) selects
-;; the boundary: not-opted-in ⇒ `:rf.egress/off-box-tool` (redact
-;; sensitive, elide large, structural digests on); the trusted-local
-;; opt-in ⇒ `:rf.egress/local-raw` (sensitive AND large pass through).
-;; The server expresses "which boundary is this", never a hand-rolled
-;; `:rf.size/*` combination.
+;; (`(and (sensitive-reads-allowed?) per-call-include-sensitive)`) is
+;; mapped to the boundary by the SHARED pure fn
+;; `re-frame.mcp-base.egress/mcp-tool-profile`: not-opted-in ⇒
+;; `:rf.egress/off-box-tool` (redact sensitive, elide large, structural
+;; digests on); the trusted-local opt-in ⇒ `:rf.egress/local-raw`
+;; (sensitive AND large pass through). The mapping lives in mcp-base so
+;; story-mcp and re-frame2-pair-mcp cannot drift; this server calls it
+;; only AFTER its own operator + per-call permission checks. The server
+;; expresses "which boundary is this", never a hand-rolled `:rf.size/*`
+;; combination.
 ;; ---------------------------------------------------------------------------
-
-(defn posture->profile
-  "Resolve the off-box egress posture to a named `:rf.egress/*` profile.
-  `include?` is the already-gated,
-  already-opted-in boolean: `false` ⇒ `:rf.egress/off-box-tool` (the
-  default MCP/AI tool wire); `true` ⇒ `:rf.egress/local-raw` (the
-  trusted-local operator's deliberate raw read). Mirror of
-  re-frame2-pair-mcp's `tools.elision/posture->profile`."
-  [include?]
-  (if include?
-    :rf.egress/local-raw
-    :rf.egress/off-box-tool))
 
 (defn posture->elision-opts
   "The `:rf.size/*` option set used by `elide-wire-value` for the
-  resolved egress posture — the named profile's
-  floor from the cross-MCP `mcp-base.egress` mirror. `:rf.egress/off-box-tool`
-  redacts sensitive + elides large + emits structural digests;
-  `:rf.egress/local-raw` opts both back in."
+  resolved egress posture — the named profile's floor from the cross-MCP
+  `mcp-base.egress` mirror. The posture→profile mapping is the shared
+  `re-frame.mcp-base.egress/mcp-tool-profile` (called here only AFTER this
+  server's permission gate). `:rf.egress/off-box-tool` redacts sensitive +
+  elides large + emits structural digests; `:rf.egress/local-raw` opts both
+  back in."
   [include?]
-  (base-egress/profile-size-opts (posture->profile include?)))
+  (base-egress/profile-size-opts (base-egress/mcp-tool-profile include?)))
 
 ;; ---------------------------------------------------------------------------
 ;; Path-based redaction
@@ -348,7 +342,7 @@
        :frame     variant-id
        :tree      tree
        :source-db app-db}
-      {:rf.egress/profile (posture->profile false)})))
+      {:rf.egress/profile (base-egress/mcp-tool-profile false)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Non-live runtime and captured values


### PR DESCRIPTION
## What

Story-MCP `tools.egress/posture->profile` and Pair-MCP `tools.elision/posture->profile` each duplicated the **identical** two-value map from an already-permission-gated boolean to `:rf.egress/local-raw` vs `:rf.egress/off-box-tool`. `mcp-base.egress` already owned the shared `:rf.egress/*` profile vocabulary + resolution table (`profile-size-opts`), so the posture mapping is the last drift risk between the two servers. This centralizes it.

### The pure fn

```clojure
(defn mcp-tool-profile
  "Map an MCP tool server's already-permission-gated sensitive-read
  posture to its named :rf.egress/* boundary profile (EP-0015 §10)."
  [sensitive-reads-allowed?]
  (if sensitive-reads-allowed?
    :rf.egress/local-raw
    :rf.egress/off-box-tool))
```

- `false` (published-build default / caller under the gate who did not opt in) ⇒ `:rf.egress/off-box-tool`
- `true`  (trusted-local operator's deliberate raw read) ⇒ `:rf.egress/local-raw`

The fn performs **no permission check** — it is the pure two-value mapping only. Both consumers call it **only AFTER** their existing operator-launch (`--allow-sensitive-reads`) + per-call `:include-sensitive` gate; the gate itself stays local (not moved into mcp-base).

### Consumer changes

- **story-mcp** `tools/egress.cljc`: removed the local `posture->profile`; `posture->elision-opts` and `scrub-rendered` now call `base-egress/mcp-tool-profile`.
- **re-frame2-pair-mcp** `tools/elision.cljs`: removed the local `posture->profile`; `elision-opts-edn` now calls `base-egress/mcp-tool-profile`.

### Tests moved / retained

- **Moved** the pure posture→profile mapping test to a cross-host `re-frame.mcp-base.egress-test` (`.cljc`, runs on JVM via `:test` + CLJS via the shadow `:ns-regexp`). mcp-base now owns both values (mapping + resolved `:rf.size/*` floors + closed-enum membership). Added `egress-test` to the mcp-base `:ns-regexp`.
- **Retained** each consumer's permission-gate / integration tests locally, incl. pair-mcp's `elision-opts-edn-resolves-named-egress-profiles` (proves the local helper still threads the mapping through to the correct floor + `:elision` overlay — the behaviour-unchanged proof).
- Removed pair-mcp's now-duplicate pure `posture->profile-maps-posture-to-named-boundary` test.

Also kept `tools/mcp-base/spec/egress.md` current (Scope + Surface table).

### Behaviour

Unchanged. Same profile for every posture, same resolved floors, same descriptor visibility / permission checks / wire bytes. The profile table (`profiles`, `profile->size-opts`) is untouched, so the mcp-conformance wire-vocab gate is unaffected.

## Stance

Pre-alpha, no back-compat shims. ONE pure profile fn in mcp-base; consumers delegate AFTER their own permission checks. ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE — removes the last cross-server drift risk in the egress posture mapping and gives it a single tested home.

## Quality gates

All foreground, 0 failures:

- `tools/mcp-base` `clojure -M:test` — 270 tests / 896 assertions, 0 failures
- `tools/mcp-base` `npm run test:cljs` — 32 tests / 200 assertions, 0 failures (egress-test now runs cross-host)
- `tools/story-mcp` `clojure -M:test` — 286 tests / 1494 assertions, 0 failures
- `tools/re-frame2-pair-mcp` `npm run test` — 1197 tests / 4116 assertions, 0 failures

Bead: rf2-54y369