### PR TITLE
fix(machines): lower-at-spawn! claim survives the boot snapshot commit (rf2-dr0pfi)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -921,18 +921,41 @@
               (handle-step-failure! ctx [transition/start-marker]
                                     "Machine initial-entry action threw."
                                     boot-result)
-              (do
-                ;; Lower a singleton's projection-relative `:sensitive` / `:large` `:data`
-                ;; declarations into the per-frame elision registry at its
-                ;; birth (first-boot). A singleton's actor-id IS its
-                ;; machine-id, installed lazily on first dispatch rather than
-                ;; via `spawn-fx` (which lowers spawned actors). Gated on the
-                ;; singleton-birth case — `:needs-bootstrap?` AND NOT
-                ;; `:existing-snap?` (a spawned actor carries a pre-seeded
-                ;; snapshot ⇒ `:existing-snap? true`, already lowered at spawn).
-                ;; Value-independent + idempotent, dropped at destroy /
-                ;; finalize. A spec declaring no classification is a no-op.
-                (when (and (:needs-bootstrap? ctx) (not (:existing-snap? ctx)))
+              (let [;; Singleton first-boot: a singleton's actor-id IS its
+                    ;; machine-id, installed lazily on first dispatch rather than
+                    ;; via `spawn-fx` (which lowers spawned actors). The birth
+                    ;; case is `:needs-bootstrap?` AND NOT `:existing-snap?` (a
+                    ;; spawned actor carries a pre-seeded snapshot ⇒
+                    ;; `:existing-snap? true`, already lowered at spawn).
+                    boot? (and (:needs-bootstrap? ctx) (not (:existing-snap? ctx)))
+                    ;; DURABLE-CLAIM guard (rf2-dr0pfi). `lower-at-spawn!` below
+                    ;; writes the singleton's classification claim OUT-OF-BAND
+                    ;; into the LIVE per-frame elision registry
+                    ;; (`swap-elision-slot!`), unioning `:source :machine` in
+                    ;; alongside any other owner. But the boot snapshot
+                    ;; `:rf.db/runtime` effect this handler returns below is built
+                    ;; from the `:rf.db/runtime` COEFFECT — captured BEFORE that
+                    ;; live swap. When an effect PRE-classified this same
+                    ;; snapshot path in a PRIOR event, that coeffect already
+                    ;; carries `[:rf.runtime/elision]` (effect-owner only), so the
+                    ;; returned effect value would INCLUDE a STALE registry.
+                    ;; `elision/reconcile-runtime-db-effect` reads an
+                    ;; effect-carried `:rf.runtime/elision` as an explicit
+                    ;; full-frame install and honours it VERBATIM at commit —
+                    ;; clobbering the machine owner the live swap just added
+                    ;; (benign: the effect owner survives so the path stays
+                    ;; redacted, but the machine is not itself a durable owner,
+                    ;; breaking the multi-owner union contract, rf2-wdm1vg). Drop
+                    ;; the key from the boot-commit base (local + `ctx`) so the
+                    ;; returned effect OMITS `:rf.runtime/elision` and the router
+                    ;; carries the LIVE (post-swap) registry — machine ∪ effect
+                    ;; owners — forward. The elision registry is written only
+                    ;; out-of-band; a machine snapshot commit never re-asserts it.
+                    runtime-db (cond-> runtime-db boot? (dissoc :rf.runtime/elision))
+                    ctx        (cond-> ctx        boot? (assoc :runtime-db runtime-db))]
+                ;; Value-independent + idempotent, dropped at destroy / finalize.
+                ;; A spec declaring no classification is a no-op.
+                (when boot?
                   (classification/lower-at-spawn! (:frame-id ctx) (:machine-id ctx)
                                                   (:machine ctx)))
               (result/with-ok [post-boot-snap boot-fx] boot-result

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -592,3 +592,72 @@
           "the effect claim SURVIVES the actor destroy — no fail-open")
       (is (not (some #(= :machine (:source %)) (owners)))
           "the machine's own owner is dropped by the source-scoped teardown"))))
+
+;; ---- (6) EFFECT-FIRST boot: the machine's own claim must land DURABLY ------
+;; rf2-dr0pfi — when an effect PRE-classifies a machine's absolute snapshot
+;; path BEFORE the singleton boots, the machine's own `:source :machine` claim
+;; (lowered LIVE by `classification/lower-at-spawn!` at first-boot) must SURVIVE
+;; the boot snapshot `:rf.db/runtime` commit. Before the fix, that commit was
+;; built from the STALE `:rf.db/runtime` coeffect — which already carried the
+;; effect's `[:rf.runtime/elision]` sub-tree — so the returned effect value
+;; INCLUDED `:rf.runtime/elision` (effect-owner only). At commit,
+;; `elision/reconcile-runtime-db-effect` reads an effect-carried
+;; `:rf.runtime/elision` as an explicit full-frame install and honours it
+;; VERBATIM, clobbering the machine owner the live swap had just unioned in.
+;; The effect owner survived (so the path stayed redacted — BENIGN, no leak),
+;; but the machine was NOT itself a durable owner, breaking the multi-owner
+;; union contract (rf2-wdm1vg): the machine and the effect are INDEPENDENT
+;; owners and BOTH must persist, so removing the effect's claim must leave the
+;; path redacted by the machine's surviving claim.
+
+(deftest machine-boot-claim-survives-when-effect-pre-classified
+  (testing "rf2-dr0pfi — an effect that PRE-classifies a machine's absolute
+            snapshot path does NOT prevent the machine's own :source :machine
+            claim from landing durably at first-boot; both owners union, and
+            the machine claim keeps the path redacted after the effect clears"
+    (let [mid       :rf.machine-redaction/effect-first-single
+          abs-token [:rf.runtime/machines :snapshots mid :data :token]
+          owners    #(get-in (snapshot-elision-reg) [:sensitive-declarations abs-token])]
+      (rf/reg-machine mid
+        {:sensitive [[:data :token]]
+         :initial   :anon
+         :data      {:token nil :retries 0}
+         :states    {:anon {:on {:login :authed}} :authed {}}})
+      ;; (1) The EFFECT classifies the absolute snapshot path FIRST — BEFORE the
+      ;; singleton is ever booted (the effect-first order, the bug's trigger:
+      ;; this is what seeds `:rf.runtime/elision` into the coeffect the boot
+      ;; handler later reads).
+      (rf/reg-event :rf.machine-redaction/ef-classify
+        (fn [{:keys [db]} _] {:db db :sensitive [abs-token]}))
+      (rf/dispatch-sync [:rf.machine-redaction/ef-classify])
+      (is (contains? (owners) {:source :effect})
+          "precondition: the effect's claim is standing before the machine boots")
+      (is (not (some #(= :machine (:source %)) (owners)))
+          "precondition: no machine owner yet (the singleton has not booted)")
+      ;; (2) Boot the singleton. `lower-at-spawn!` unions the machine owner into
+      ;; the LIVE registry; the fix keeps that claim through the boot commit.
+      (rf/dispatch-sync [mid [:rf.machine/noop]])
+      ;; THE KEY ASSERTION — FAILS on the pre-fix code: the machine owner was
+      ;; wiped by the stale-registry verbatim honour at the boot commit, leaving
+      ;; only the effect owner.
+      (is (some #(= :machine (:source %)) (owners))
+          "the machine IS a durable claim owner after boot (not only the effect)")
+      (is (contains? (owners) {:source :effect})
+          "the effect's claim UNIONS alongside — both owners retained")
+      ;; (3) Remove the EFFECT's claim. The machine's surviving claim must keep
+      ;; the path classified (independent removal — rf2-wdm1vg). On pre-fix code
+      ;; the path would go UNCLASSIFIED here (the only owner was the effect).
+      (rf/reg-event :rf.machine-redaction/ef-clear
+        (fn [{:keys [db]} _] {:db db :clear-sensitive [abs-token]}))
+      (rf/dispatch-sync [:rf.machine-redaction/ef-clear])
+      (is (not (contains? (owners) {:source :effect}))
+          "the effect owner is removed by its source-scoped clear")
+      (is (some #(= :machine (:source %)) (owners))
+          "the machine's own claim SURVIVES the effect clear — the path stays classified")
+      ;; (4) And egress STILL redacts via the machine's surviving claim alone.
+      (let [out  (classification/project-trace-event (machine-transition-event mid))
+            tags (:tags out)]
+        (is (= :rf/redacted (get-in tags [:after :data :token]))
+            "the machine's surviving claim keeps the value redacted after the effect cleared")
+        (is (not (.contains (pr-str out) "secret-jwt"))
+            "no secret leaks once only the machine claim remains")))))


### PR DESCRIPTION
## Summary

Fixes rf2-dr0pfi — a machine's own elision claim did not land durably at first-boot when an effect had **pre-classified** the same snapshot path in a prior event. Pre-existing and **benign** (no leak today), but a real break of the multi-owner union contract (rf2-wdm1vg): the machine was not itself a durable owner of its own classification.

## Root cause (reproduced)

- `classification/lower-at-spawn!` writes the singleton's `:source :machine` claim **out-of-band** into the LIVE per-frame elision registry via `elision/swap-elision-slot!`, unioning it with any existing owner.
- But the boot snapshot `:rf.db/runtime` effect the machine handler returns is built from the `:rf.db/runtime` **coeffect**, captured *before* that live swap. When an effect pre-classified this same path, the coeffect already carries `[:rf.runtime/elision]` (effect-owner only), so the returned effect value re-asserts a **stale** registry.
- At commit, `elision/reconcile-runtime-db-effect` treats an effect-carried `:rf.runtime/elision` as an explicit full-frame install and honours it **verbatim** — clobbering the machine owner the live swap just added.

Result: post-boot the owner-set was `#{{:source :effect}}` (machine owner absent); after the effect cleared its claim the path went **fully unclassified** and `secret-jwt-after` egressed raw. Benign only because the effect keeps the path redacted while it stands.

Spawned actors and non-boot steps are unaffected (spawn writes live out-of-band; steps do not mutate the registry mid-handler), so the fix is gated on the singleton first-boot case only.

## The fix

At singleton first-boot (`:needs-bootstrap?` and not `:existing-snap?`), drop `:rf.runtime/elision` from the boot-commit base (both the local `runtime-db` and `ctx`'s `:runtime-db`) so the returned `:rf.db/runtime` effect **omits** the registry key. The router's reconcile then carries the LIVE post-swap registry — the union of the machine owner and any effect owner — forward. The elision registry is written only out-of-band; a machine snapshot commit never re-asserts it. The effect's classification is left untouched.

## Stance

Pre-alpha, ELEGANCE + CLARITY + CORRECTNESS. The machine's claim now lands durably at boot **independent of the effect**, and the multi-owner union semantics hold in effect-first order (they already held in machine-first order).

## Reproduce → fix evidence

New acceptance test `machine-boot-claim-survives-when-effect-pre-classified` (effect-first order):
- **Fails on old code** — 4 assertions: machine owner absent post-boot; path unclassified after the effect clear; `secret-jwt-after` leaks raw at egress.
- **Passes on fixed code** — machine IS a durable owner post-boot; unions with the effect owner; removing the effect's claim leaves the path redacted by the machine's surviving claim.

Machine-only, effect-only, and machine-first-union orders remain covered by the existing tests in the same file.

## Quality gates (foreground, 0 failures)

- `cd implementation/machines && clojure -M:test` → **940 tests, 2961 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8534 tests, 39646 assertions, 0 failures, 0 errors** (machines + elision contract tests across substrates)

## Scope

Touches only `implementation/machines/src/.../lifecycle_fx/registration.cljc` (boot snapshot claim path) and `implementation/machines/test/.../machine_data_schema_redaction_test.clj`. Not hot-zone.
