### PR TITLE
fix(story): distinct parent for login_form testbed deck — no :story.login collision (rf2-tijvbd)

### DIFF
--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -1172,10 +1172,10 @@ module.exports = {
       // The mode strip may rehydrate :test or :dev from localStorage;
       // we want :dev so the canvas mounts.
       await setMode(page, 'dev');
-      await waitForCanvas(page, ':story.login/submitting');
+      await waitForCanvas(page, ':story.login-form/submitting');
       await waitForValue(
         () =>
-          canvas(page, ':story.login/submitting')
+          canvas(page, ':story.login-form/submitting')
             .locator('[data-test="login-state-pill"]')
             .innerText()
             .catch(() => ''),
@@ -1188,7 +1188,7 @@ module.exports = {
       // The submit button reads "Signing in…" while the FSM is in
       // :submitting (the view's button-disabled-while-submitting
       // branch).
-      const submitBtn = canvas(page, ':story.login/submitting').locator('[data-test="login-submit"]');
+      const submitBtn = canvas(page, ':story.login-form/submitting').locator('[data-test="login-submit"]');
       await submitBtn.waitFor({ state: 'visible', timeout: 5000 });
       const submitText = (await submitBtn.innerText()).trim();
       if (!/signing in/i.test(submitText)) {
@@ -1200,13 +1200,13 @@ module.exports = {
       // (b) :error — machine drives idle → submitting → error and
       // surfaces the 401 error message under the form.
       await clickVariant(page, '/error');
-      await waitForCanvas(page, ':story.login/error');
+      await waitForCanvas(page, ':story.login-form/error');
       // The state-pill in the canvas reads "state: :error" — the
       // FSM's terminal state is observable directly via the view's
       // [data-test="login-state-pill"].
       await waitForValue(
         () =>
-          canvas(page, ':story.login/error')
+          canvas(page, ':story.login-form/error')
             .locator('[data-test="login-state-pill"]')
             .innerText()
             .catch(() => ''),
@@ -1219,7 +1219,7 @@ module.exports = {
       // The error message ("Invalid credentials.") is surfaced
       // under the form via [data-test="login-error"].
       await expectVisible(
-        canvas(page, ':story.login/error').locator('[data-test="login-error"]'),
+        canvas(page, ':story.login-form/error').locator('[data-test="login-error"]'),
         5000,
       );
 
@@ -1228,10 +1228,10 @@ module.exports = {
       // the retry path from the initial submit. Canvas state-pill
       // shows the terminal state.
       await clickVariant(page, '/submitting-retry');
-      await waitForCanvas(page, ':story.login/submitting-retry');
+      await waitForCanvas(page, ':story.login-form/submitting-retry');
       await waitForValue(
         () =>
-          canvas(page, ':story.login/submitting-retry')
+          canvas(page, ':story.login-form/submitting-retry')
             .locator('[data-test="login-state-pill"]')
             .innerText()
             .catch(() => ''),
@@ -1246,16 +1246,16 @@ module.exports = {
       // :authenticated rebuilds the machine on a fresh frame; the
       // prior :error / :submitting-retry state does NOT bleed in.
       await clickVariant(page, '/authenticated');
-      await waitForCanvas(page, ':story.login/authenticated');
+      await waitForCanvas(page, ':story.login-form/authenticated');
       // The welcome banner replaces the form — proves the FSM
       // landed in :authenticated, not :error or :submitting-retry.
       await expectVisible(
-        canvas(page, ':story.login/authenticated').locator('[data-test="login-welcome"]'),
+        canvas(page, ':story.login-form/authenticated').locator('[data-test="login-welcome"]'),
         10000,
       );
       await waitForValue(
         () =>
-          canvas(page, ':story.login/authenticated')
+          canvas(page, ':story.login-form/authenticated')
             .locator('[data-test="login-state-pill"]')
             .innerText()
             .catch(() => ''),

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -642,7 +642,7 @@ async function assertLoginStory(page, phase) {
     );
     await clickVariant(page, '/authenticated');
     await expectVisible(page.locator('[data-test="login-welcome"]'), 10000);
-    await clickWorkspace(page, ':Workspace.login/all-states');
+    await clickWorkspace(page, ':Workspace.login-form/all-states');
     await waitForValue(
       () => page.locator('[data-test="login-state-pill"]').count(),
       (count) => count >= 5,

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -6,11 +6,11 @@
   variants. The five states from the tutorial are exactly the
   variants below:
 
-    :story.login/idle              → the empty form
-    :story.login/submitting        → first submit, request in flight
-    :story.login/error             → server rejected creds
-    :story.login/submitting-retry  → user fixed the typo, re-submitted
-    :story.login/authenticated     → welcome banner
+    :story.login-form/idle             → the empty form
+    :story.login-form/submitting       → first submit, request in flight
+    :story.login-form/error            → server rejected creds
+    :story.login-form/submitting-retry → user fixed the typo, re-submitted
+    :story.login-form/authenticated    → welcome banner
 
   Every variant body is plain EDN — `:setup`, `:decorators`, `:script`,
   `:tags`, `:substrates`. No function-slots; no closures except in the
@@ -83,12 +83,12 @@
   ;; semantics on a real shape.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-mode :Mode.login/light
+  (story/reg-mode :Mode.login-form/light
     {:doc  "Light theme — the default. Matches the live page."
      :axis :theme
      :args {:theme :light}})
 
-  (story/reg-mode :Mode.login/dark
+  (story/reg-mode :Mode.login-form/dark
     {:doc  "Dark theme — for the design-review workspace."
      :axis :theme
      :args {:theme :dark}})
@@ -98,7 +98,7 @@
   ;; decorators, args, and tags.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story :story.login
+  (story/reg-story :story.login-form
     {:doc        "The login form — every state from the tutorial's
                  five-state scenario, as runnable variants."
      :component  :login-form.views/login-card
@@ -117,7 +117,7 @@
   ;; the state is what the variant's name says it is.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login/idle
+  (story/reg-variant :story.login-form/idle
     {:doc    "Fresh form, no inputs typed, no submit clicked. The
              entry state the user lands on when they navigate to
              `#/login` for the first time.
@@ -153,7 +153,7 @@
   ;; which is exactly what the tutorial's second state describes.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login/submitting
+  (story/reg-variant :story.login-form/submitting
     {:doc    "First submit; HTTP request in flight; inputs disabled,
              button reads 'Signing in…'. The fx-stub records the
              request and resolves nothing so the canvas locks in
@@ -176,7 +176,7 @@
   ;; error message surfaced.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login/error
+  (story/reg-variant :story.login-form/error
     {:doc    "Server rejected credentials. Form re-enabled; the error
              message is surfaced under the submit button; the
              'Cancel' button lets the user back out without retrying."
@@ -211,7 +211,7 @@
   ;; surfaces under the error.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login/submitting-retry
+  (story/reg-variant :story.login-form/submitting-retry
     {:doc    "The user corrected the typo and re-submitted. Distinct
              from :submitting because attempts > 0; the variant body
              sequences the failure then the retry, leaving the
@@ -243,7 +243,7 @@
   ;; the EDN-first contract is built for.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login/authenticated
+  (story/reg-variant :story.login-form/authenticated
     {:doc    "Server accepted credentials. The form is replaced by
              a welcome banner addressing the user by email; the
              :sign-out button routes back to :idle. This is the
@@ -268,25 +268,25 @@
   ;; Workspaces — the "five side-by-side" workspace from the tutorial.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-workspace :Workspace.login/all-states
+  (story/reg-workspace :Workspace.login-form/all-states
     {:doc      "The five states side-by-side. This is the design-
                 review surface from the tutorial's scenario step 3
                 — 'open a workspace that mounts all five side-by-side'."
      :layout   :grid
-     :variants [:story.login/idle
-                :story.login/submitting
-                :story.login/error
-                :story.login/submitting-retry
-                :story.login/authenticated]
+     :variants [:story.login-form/idle
+                :story.login-form/submitting
+                :story.login-form/error
+                :story.login-form/submitting-retry
+                :story.login-form/authenticated]
      :columns  3
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.login/auto-grid
+  (story/reg-workspace :Workspace.login-form/auto-grid
     {:doc     "Auto-enumerated grid — pulls every variant off
-              :story.login. New variants land here without touching
+              :story.login-form. New variants land here without touching
               this workspace."
      :layout  :variants-grid
-     :for     :story.login
+     :for     :story.login-form
      :columns 3
      :tags    #{:docs}}))
 

--- a/tools/story/testbeds/login_form/stories_cljs_test.cljs
+++ b/tools/story/testbeds/login_form/stories_cljs_test.cljs
@@ -29,6 +29,7 @@
   `reg-*` macros — so the side-table + the four projection subs are
   registered by the time the tests run."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.set        :as set]
             [re-frame.core      :as rf]
             [re-frame.frame     :as frame]
             [re-frame.machines  :as machines]
@@ -41,7 +42,15 @@
             [re-frame.test-support     :as test-support]
             [login-form.events]
             [login-form.subs]
-            [login-form.stories :as lf-stories]))
+            [login-form.stories :as lf-stories]
+            ;; The login EXAMPLE deck — co-loaded with this testbed under the
+            ;; consolidated node-test build. Required here for the
+            ;; distinct-parents regression below (rf2-tijvbd): its
+            ;; `register-all!` repopulates the `:story.login/*` variants the
+            ;; `before!` fixture's `clear-all!` wiped, so the disjointness
+            ;; assertion sees both decks. Already on the node-test classpath
+            ;; (the login-example seed test requires it too).
+            [login.stories :as login-stories]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -150,48 +159,95 @@
   (rf/compute-sub query-v frame-state))
 
 (deftest idle-variant-state-sub-resolves
-  (testing ":story.login/idle — `:login/state` resolves :idle off the
+  (testing ":story.login-form/idle — `:login/state` resolves :idle off the
             runtime-db snapshot (and the `:rf.assert/state-is` checkpoint
             passes)"
     (async done
-      (run-then done :story.login/idle
+      (run-then done :story.login-form/idle
         (fn [_ fs]
           (is (= :idle (sub-value [:login/state] fs))
               ":login/state read the live runtime-db snapshot, not nil"))))))
 
 (deftest submitting-variant-state-sub-resolves
-  (testing ":story.login/submitting — `:login/state` resolves :submitting"
+  (testing ":story.login-form/submitting — `:login/state` resolves :submitting"
     (async done
-      (run-then done :story.login/submitting
+      (run-then done :story.login-form/submitting
         (fn [_ fs]
           (is (= :submitting (sub-value [:login/state] fs))))))))
 
 (deftest error-variant-error-sub-resolves
-  (testing ":story.login/error — `:login/error` resolves the error message
+  (testing ":story.login-form/error — `:login/error` resolves the error message
             off the runtime-db snapshot (NOT nil from the dead app-db path)"
     (async done
-      (run-then done :story.login/error
+      (run-then done :story.login-form/error
         (fn [_ fs]
           (is (= :error (sub-value [:login/state] fs)))
           (is (= "Invalid credentials." (sub-value [:login/error] fs))
               ":login/error returned the live message, not nil"))))))
 
 (deftest submitting-retry-variant-attempts-sub-resolves
-  (testing ":story.login/submitting-retry — `:login/attempts` resolves the
+  (testing ":story.login-form/submitting-retry — `:login/attempts` resolves the
             incremented counter off the runtime-db snapshot"
     (async done
-      (run-then done :story.login/submitting-retry
+      (run-then done :story.login-form/submitting-retry
         (fn [_ fs]
           (is (= :submitting-retry (sub-value [:login/state] fs)))
           (is (= 1 (sub-value [:login/attempts] fs))
               ":login/attempts returned the live count, not the 0 default"))))))
 
 (deftest authenticated-variant-email-sub-resolves
-  (testing ":story.login/authenticated — `:login/email` resolves the
+  (testing ":story.login-form/authenticated — `:login/email` resolves the
             submitted handle off the runtime-db snapshot"
     (async done
-      (run-then done :story.login/authenticated
+      (run-then done :story.login-form/authenticated
         (fn [_ fs]
           (is (= :authenticated (sub-value [:login/state] fs)))
           (is (= "ada@example.com" (sub-value [:login/email] fs))
               ":login/email returned the live email, not nil"))))))
+
+;; ---- rf2-tijvbd: the two login decks own DISTINCT parents ----------------
+;;
+;; Regression guard for the parent-id collision (rf2-tijvbd). The login
+;; EXAMPLE deck (examples/core/login) owns the canonical `:story.login`; this
+;; testbed owns `:story.login-form`. Under the consolidated node-test build
+;; BOTH decks' `(register-all!)` fire at ns-load, so a shared parent id made
+;; `story/variants-of` return the UNION of both (they collided on
+;; `:story.login/submitting`). Co-load both decks here — the `before!` fixture
+;; already fired this testbed's `register-all!`; fire the example's too — and
+;; assert each `variants-of` returns ONLY its own deck's variants, with no
+;; shared variant id. Membership is `(= (namespace vid) (name story-id))`
+;; (story/registrar), so the distinct `"story.login"` / `"story.login-form"`
+;; namespaces keep the two sets disjoint. This goes RED if either deck is ever
+;; re-pointed back at the other's parent id.
+
+(def ^:private example-variant-ids
+  "The login EXAMPLE's seven canonical variants (examples/core/login/stories.cljs)."
+  #{:story.login/empty
+    :story.login/filled
+    :story.login/submitting
+    :story.login/invalid-credentials
+    :story.login/auth-error
+    :story.login/locked-out
+    :story.login/success})
+
+(def ^:private testbed-variant-ids
+  "This testbed's five variants."
+  #{:story.login-form/idle
+    :story.login-form/submitting
+    :story.login-form/error
+    :story.login-form/submitting-retry
+    :story.login-form/authenticated})
+
+(deftest login-decks-register-under-distinct-parents
+  (testing "story/variants-of returns ONLY each deck's own variants — the
+            example and testbed login decks no longer share a parent story id
+            or any variant id (rf2-tijvbd)"
+    (login-stories/register-all!)   ;; example → :story.login/*
+    (lf-stories/register-all!)      ;; testbed → :story.login-form/* (idempotent; fixture fired it)
+    (is (= testbed-variant-ids (story/variants-of :story.login-form))
+        "variants-of :story.login-form is exactly this testbed's five")
+    (is (= example-variant-ids (story/variants-of :story.login))
+        "variants-of :story.login is exactly the example's seven — no testbed variants leak in")
+    (is (empty? (set/intersection (story/variants-of :story.login)
+                                  (story/variants-of :story.login-form)))
+        "no variant id is shared between the two decks")))


### PR DESCRIPTION
## What & why

The login EXAMPLE deck (`examples/core/login/stories.cljs`) and the login_form
TESTBED deck (`tools/story/testbeds/login_form/stories.cljs`) both registered
their variants under the same parent story id `:story.login`, colliding on the
exact variant id `:story.login/submitting` — and on the shared workspaces
`:Workspace.login/all-states` + `:Workspace.login/auto-grid`. Under the
consolidated node-test build both decks co-load, so `story/variants-of
:story.login` returned the **union** of both decks (example's 7 ∪ testbed's 5,
deduped on the shared `submitting` = 11 ids) and whichever loaded last won the
Story side-table. Bead **rf2-tijvbd**.

## Stance

Pre-alpha; no back-compat shims. The two decks must have DISTINCT parents so
each `variants-of` returns only its own. The EXAMPLE deck keeps the canonical
`:story.login`; the **TESTBED** is renamed. Primary lenses: ELEGANCE + CLARITY +
CORRECTNESS. Membership is `(= (namespace vid) (name story-id))` (story
registrar), so distinct `"story.login"` / `"story.login-form"` namespaces make
the sets structurally disjoint.

## The rename (testbed deck only)

- `:story.login` → `:story.login-form`
- `:story.login/{idle,submitting,error,submitting-retry,authenticated}` → `:story.login-form/*`
- `:Workspace.login/{all-states,auto-grid}` → `:Workspace.login-form/*` (also collided)
- `:Mode.login/{light,dark}` → `:Mode.login-form/*` (kept the testbed cohesively namespaced)
- the auto-grid workspace's `:for` target → `:story.login-form`

App event/machine/sub ids (`:login/flow`, `:login/submit`, `:login/state`, …) are
the app's own — **untouched**. The build id (`:examples/login-form`, dev-http
`/login-form/`, init-fn `login-form.core/run`) is decoupled from the story parent
id and is **not** renamed (not hot-zone). The EXAMPLE deck and its
`login_example_seed` test are **untouched**.

## `variants-of` proof (acceptance)

Added an in-boundary regression deftest to the testbed's own CLJS test
(`stories_cljs_test.cljs`) — `login-decks-register-under-distinct-parents` —
that co-loads **both** decks and asserts, live under the node-test build:

- `variants-of :story.login-form` = exactly the testbed's 5 (`idle`, `submitting`, `error`, `submitting-retry`, `authenticated`)
- `variants-of :story.login` = exactly the example's 7 (`empty`, `filled`, `submitting`, `invalid-credentials`, `auth-error`, `locked-out`, `success`)
- their intersection is empty

This goes RED on the old code (old `variants-of :story.login` returned 11 ids, not 7).
Also updated the login-form browser tests (`story_browser_scenarios.cjs`,
`story_feature_load.cjs`) that name the old canvas/workspace ids.

## Quality gates

- `implementation` → `npm run test:cljs` (consolidated node-test build; co-loads both decks; runs the new regression test): **8540 tests / 39676 assertions, 0 failures, 0 errors**
- `tools/story` → `clojure -M:test`: **1774 tests / 6504 assertions, 0 failures, 0 errors**
- `npm run story:build` — N/A (builds only the `:story-static/counter-with-stories` target; the login_form testbed does not participate)
