### PR TITLE
chore(deps): centralize the Cognitect test-runner coordinate in test-quiet (rf2-cndjxo)

### DIFF
--- a/implementation/adapters/helix/deps.edn
+++ b/implementation/adapters/helix/deps.edn
@@ -21,9 +21,7 @@
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy, modeled on the Reagent / UIx adapters'

--- a/implementation/adapters/reagent-slim/deps.edn
+++ b/implementation/adapters/reagent-slim/deps.edn
@@ -18,9 +18,7 @@
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   :clein {:extra-deps {io.github.noahtheduke/clein

--- a/implementation/adapters/reagent/deps.edn
+++ b/implementation/adapters/reagent/deps.edn
@@ -13,9 +13,7 @@
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy, modeled on re-frame v1's release flow.

--- a/implementation/adapters/test-react/deps.edn
+++ b/implementation/adapters/test-react/deps.edn
@@ -25,7 +25,5 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/adapters/uix/deps.edn
+++ b/implementation/adapters/uix/deps.edn
@@ -28,9 +28,7 @@
          ;; uix.dom is used by tests and the testbed, not shipped adapter source.
          :extra-deps  {com.pitch/uix.dom {:mvn/version "1.4.4"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy, modeled on the Reagent adapter's flow.

--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -101,9 +101,7 @@
                        ;; asserts; the published core jar carries none of it.
                        day8/re-frame2-resources  {:local/root "../resources"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          ;; The default PR/local gate (incl. the fast-PR
          ;; spine `scripts/test-fast-pr.sh`, which runs this artefact)
          ;; EXCLUDES the heavy `^:stress` namespace
@@ -128,9 +126,7 @@
                  day8/re-frame2-ssr        {:local/root "../ssr"}
                  day8/re-frame2-epoch      {:local/root "../epoch"}
                  day8/re-frame2-resources  {:local/root "../resources"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy. The release workflow runs `clojure -M:clein deploy`

--- a/implementation/derivation-conformance/deps.edn
+++ b/implementation/derivation-conformance/deps.edn
@@ -38,7 +38,5 @@
                  day8/re-frame2-machines  {:local/root "../machines"}
                  ;; Resource and machine schemas need Malli on the JVM classpath.
                  day8/re-frame2-schemas   {:local/root "../schemas"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -25,9 +25,7 @@
                        ;; Publishes the resource egress hooks used by projection
                        ;; integration tests; production lookup is nil-safe.
                        day8/re-frame2-resources  {:local/root "../resources"}
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; The release workflow replaces the core `:local/root` with its Maven

--- a/implementation/event-conformance/deps.edn
+++ b/implementation/event-conformance/deps.edn
@@ -14,7 +14,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2 {:local/root "../core"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -22,9 +22,7 @@
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          ;; Keep the contention suite out of the default gate; `:slow-test`
          ;; selects it for nightly and rigorous-local runs.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
@@ -35,9 +33,7 @@
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-ssr        {:local/root "../ssr"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy.

--- a/implementation/http/deps.edn
+++ b/implementation/http/deps.edn
@@ -44,9 +44,7 @@
                        ;; machines remains a test-only dependency.
                        day8/re-frame2-machines   {:local/root "../machines"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy, modeled on the other optional artefacts.

--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -30,9 +30,7 @@
                        ;; `[:schemas :data]` validation tests reach the
                        ;; default Malli validator via `re-frame.schemas.malli`.
                        ;; Test-only: production remains schema-library agnostic.
-                       day8/re-frame2-schemas    {:local/root "../schemas"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-schemas    {:local/root "../schemas"}}
          ;; The default gate excludes slow and stress tests; `:slow-test`
          ;; below selects exactly those tests for rigorous/nightly runs.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
@@ -41,9 +39,7 @@
   :slow-test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 day8/re-frame2-schemas    {:local/root "../schemas"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-schemas    {:local/root "../schemas"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy. Modelled on re-frame v1's release flow.

--- a/implementation/reply-conformance/deps.edn
+++ b/implementation/reply-conformance/deps.edn
@@ -36,7 +36,5 @@
                  day8/re-frame2-resources {:local/root "../resources"}
                  day8/re-frame2-machines  {:local/root "../machines"}
                  day8/re-frame2-routing   {:local/root "../routing"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/resources/deps.edn
+++ b/implementation/resources/deps.edn
@@ -65,9 +65,7 @@
                        ;; cycle), and this is test-only so the resources
                        ;; production classpath stays machines-free —
                        ;; bundle-isolation holds.
-                       day8/re-frame2-machines   {:local/root "../machines"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-machines   {:local/root "../machines"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy. Modeled on re-frame v1's release flow.

--- a/implementation/routing/deps.edn
+++ b/implementation/routing/deps.edn
@@ -53,9 +53,7 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
                        ;; Silent-on-success test reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          ;; The default PR/local gate excludes the heavy
          ;; `^:stress` tests in `routing_concurrency_stress_test`
          ;; (5000-iter × 8-thread cross-frame nav). These were tagged
@@ -73,9 +71,7 @@
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-ssr        {:local/root "../ssr"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy. Modeled on re-frame v1's release flow.

--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -42,9 +42,7 @@
          ;; the fixture loads cleanly.
          :extra-deps  {day8/re-frame2-flows      {:local/root "../flows"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deployment.

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -41,7 +41,5 @@
  ;; [namespace var] row, never merely share a bare var name.
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/security/deps.edn
+++ b/implementation/security/deps.edn
@@ -22,7 +22,5 @@
                  ;; Default-suppress egress filter; test-only tool dependency.
                  day8/re-frame2-mcp-base {:local/root "../../tools/mcp-base"}
                  ;; Silent-on-success reporter.
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -37,9 +37,7 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; End-to-end tests observe bytes through a real Jetty
                        ;; host. These test dependencies are not published.
-                       ring/ring-jetty-adapter {:mvn/version "1.12.1"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       ring/ring-jetty-adapter {:mvn/version "1.12.1"}}
          ;; The default gate excludes live-host stress tests; the nightly
          ;; alias below runs only those excluded tests.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
@@ -54,9 +52,7 @@
                  day8/re-frame2-machines   {:local/root "../machines"}
                  day8/re-frame2-resources  {:local/root "../resources"}
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 ring/ring-jetty-adapter {:mvn/version "1.12.1"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 ring/ring-jetty-adapter {:mvn/version "1.12.1"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
                  "-i" ":slow" "-i" ":stress"]}
 

--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -57,9 +57,7 @@
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                       io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          ;; The default PR/local gate excludes the heavy
          ;; `^:slow` / `^:stress` namespaces (here: the 2000-request
          ;; `ssr_teardown_load_test`). `re-frame.test-quiet.runner` passes
@@ -82,9 +80,7 @@
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-machines   {:local/root "../machines"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deployment.


### PR DESCRIPTION
## Summary

`io.github.cognitect-labs/test-runner` was pinned **28×** across implementation `deps.edn` files: once canonically in `implementation/test-quiet/deps.edn`, once in the top-level `implementation/deps.edn` (hot-zone), and **26 duplicate coordinate/SHA maps** across the `:test`/`:slow-test` aliases of 20 per-artefact consumers. Every consumer already declares `day8/re-frame2-test-quiet {:local/root …}` in the same alias, so the Clojure CLI resolves the runner **transitively** — the direct pins were pure duplication.

This PR removes the 26 duplicate maps from the 20 per-artefact consumer `deps.edn` files, leaving **test-quiet as the sole runner coordinate/version owner** among per-artefact deps.

**Count: 28 → 2 remaining** (test-quiet canonical + top-level hot-zone, see below). Per-artefact owner is now exactly one: `test-quiet`.

### Preserved in every edited alias
- the local-root `day8/re-frame2-test-quiet` dep (the transitive path to the runner)
- test paths (`:extra-paths`)
- artefact-specific deps (schemas, ring-jetty-adapter, uix.dom, machines, …)
- runner options (`:main-opts` / `-i` / `-e` / `--dir` selectors)

### Scope / stance
Pre-alpha; **test-only version ownership, not a production dependency change** — no top-level `:deps` were touched, only `:test`/`:slow-test` `:extra-deps`. ELEGANCE + CLARITY + CORRECTNESS: one runner coordinate owner. Not hot-zone (per-artefact `deps.edn` only).

### ⚠ Top-level `implementation/deps.edn` left untouched by design
The top-level `implementation/deps.edn` is a **hot-zone file** and was explicitly excluded from this sweep's scope to keep it parallel-safe. It retains its own copy of the coordinate, so **2** coordinates remain rather than 1. Its `:test` alias also depends on `day8/re-frame2-test-quiet {:local/root "test-quiet"}`, so removing that last copy is a **safe, sequenced hot-zone follow-up** — flagged for the mayor to decide.

## Quality gates

Ran foreground (commit precedes gates; no stash).

**Real test runs (runner launched `re-frame.test-quiet.runner`, 0 failures / 0 errors):**
| Artefact | Alias | Result |
|---|---|---|
| test-quiet (self-test) | `:test` | 33 tests / 211 assertions |
| core | `:test` | 1777 tests / 7733 assertions |
| machines | `:test` | 939 tests / 2953 assertions |
| machines | `:slow-test` | 1 test / 35 assertions |
| schemas | `:test` | 351 tests / 19026 assertions |
| http | `:test` | 471 tests / 3681 assertions |
| ssr-ring | `:slow-test` | 3 tests / 33 assertions |

Two `:slow-test` aliases exercised (machines, ssr-ring).

**Resolution-checked** (the remaining 15 artefacts / all 26 affected aliases): `clojure -Spath -M:<alias>` succeeds and shows both `test-runner` **and** `test-quiet` on the classpath for every `:test` and `:slow-test` alias. Confirms valid EDN + transitive runner resolution.

Production dependency graphs unchanged (diff is confined to `:extra-deps` under test aliases).

Closes rf2-cndjxo.
