### PR TITLE
ci: route examples-asset-manifest changes through the browser-gate surface (rf2-78th1g)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -265,6 +265,28 @@ else
         adapter_testbed_smokes=true
         story_xray_browser=true
         ;;
+      examples/scripts/examples-asset-manifest.cjs)
+        # rf2-78th1g — false-green fix, mirroring the examples-staging.cjs
+        # case above. examples-asset-manifest.cjs is the SINGLE side-effect-free
+        # owner of every examples external-asset EXCEPTION (rf2-phpbo8): what
+        # extra static asset each departing example stages and which _shared
+        # asset it may omit. The staging helper examples-staging.cjs require's
+        # its `stagedAssetsByBuild` projection to decide what to STAGE before
+        # the browser gates run — and examples-staging.cjs itself fires BOTH
+        # browser-gate families (adapter_testbed_smokes via the adapter-smoke
+        # orchestrator, story_xray_browser via the two Story launchers). So a
+        # regression in the manifest data or its projection can break the files
+        # those gates serve, yet a PR touching only the manifest used to fall
+        # through to the generic examples/* case below (cljs_browser +
+        # cljs_node_test), skipping both Playwright gates it underpins — a CI
+        # false-green for this slice. Fire BOTH gates, exactly like the shared
+        # examples-staging.cjs case, so editing the manifest runs the browser
+        # gates that depend on it. (The static asset scanner
+        # check-examples-assets.cjs also require's `pageExemptions`, but it is
+        # not a CI gate, so no extra fan-out is warranted.)
+        adapter_testbed_smokes=true
+        story_xray_browser=true
+        ;;
       implementation/epoch/*)
         # rf2-ribu5a — false-green fix. Epoch is the ONLY per-feature
         # artefact wired into a LIVE MCP conformance gate: the

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -730,6 +730,29 @@ test('examples/scripts/examples-staging.cjs (shared staging helper) fires BOTH b
   );
 });
 
+// rf2-78th1g — examples-asset-manifest.cjs is the single side-effect-free
+// OWNER of every examples external-asset EXCEPTION (rf2-phpbo8). Its
+// stagedAssetsByBuild projection is require'd by examples-staging.cjs — the
+// shared staging helper that itself fires BOTH browser gates (rf2-eqjxya) — so
+// a regression in the manifest data or its projection can break the staged
+// output those gates serve before they run. Before this bead a manifest-only
+// PR fell through to the generic examples/* case (cljs_browser + cljs_node_test),
+// skipping both Playwright gates it underpins. Mirror the examples-staging.cjs
+// case: fire BOTH browser gates.
+test('examples/scripts/examples-asset-manifest.cjs (staging asset manifest) fires BOTH browser gates (rf2-78th1g)', () => {
+  const result = classify('examples/scripts/examples-asset-manifest.cjs');
+  assert.equal(
+    result.adapter_testbed_smokes,
+    'true',
+    'the manifest underpins examples-staging.cjs (imported by the adapter-smoke orchestrator); it must fire adapter_testbed_smokes',
+  );
+  assert.equal(
+    result.story_xray_browser,
+    'true',
+    'the manifest underpins examples-staging.cjs (imported by both Story launchers); it must fire story_xray_browser',
+  );
+});
+
 test('examples/scripts static-only scanners stay on the always-on JS harness path, no browser gate (rf2-y9o5e3)', () => {
   for (const file of [
     'examples/scripts/check-examples-assets.cjs',


### PR DESCRIPTION
## What & why

`examples/scripts/examples-asset-manifest.cjs` (rf2-phpbo8, #5452) is the single side-effect-free owner of every examples external-asset exception. Its `stagedAssetsByBuild` projection is `require`d by `examples-staging.cjs` (line 30) — the shared staging helper that fires **both** browser gates: `adapter_testbed_smokes` (via the adapter-smoke orchestrator) and `story_xray_browser` (via the two Story launchers).

A PR touching only the manifest previously fell through to the generic `examples/*` case in `.github/scripts/report-changed-surfaces.sh`, firing only `cljs_browser` + `cljs_node_test` and **skipping both Playwright gates it underpins** — a CI false-green for this slice (rf2-78th1g). A regression in the manifest data or its projection could break the staged output those gates serve before they run, yet merge green.

## The change

- Add ONE dedicated routing case for `examples/scripts/examples-asset-manifest.cjs`, placed **before** the generic `examples/*` fall-through, mirroring the existing `examples-staging.cjs` case (rf2-eqjxya) — fires `adapter_testbed_smokes=true` + `story_xray_browser=true`.
- Extend the classifier self-test `implementation/scripts/_changed-surfaces.test.cjs` (run by the always-on `test:script-policy` suite) with a matching assertion.

Scoped to `.github/scripts/report-changed-surfaces.sh` + its self-test. `.github/workflows/*` untouched (a separate held PR owns `test.yml`); no other routing case altered.

## Routing proof

| changed-file set | before | after |
| --- | --- | --- |
| `examples/scripts/examples-asset-manifest.cjs` | `cljs_browser` + `cljs_node_test` | `adapter_testbed_smokes` + `story_xray_browser` (identical to `examples-staging.cjs`) |
| `examples-staging.cjs` (reference) | `adapter_testbed_smokes` + `story_xray_browser` | unchanged |
| `examples/core/foo.cljs` (generic example control) | `cljs_browser` + `cljs_node_test` | unchanged |
| `implementation/deps.edn` (non-example control) | per-feature set | unchanged |

The manifest now produces byte-identical output to `examples-staging.cjs`; controls confirm no over-broad routing.

## Stance

Pre-alpha; the manifest's change-surface must mirror `examples-staging.cjs` (fire the browser gates). Minimal, correct routing edit — ELEGANCE + CLARITY + CORRECTNESS.

## Quality gates

- `node implementation/scripts/_changed-surfaces.test.cjs` → **112 passed** (incl. new manifest assertion)
- Manual routing: manifest → `adapter_testbed_smokes` + `story_xray_browser` (matches `examples-staging.cjs`); generic example + non-example controls unaffected
- `bash -n .github/scripts/report-changed-surfaces.sh` → clean

Bead: rf2-78th1g. Do not merge on my behalf.
