### PR TITLE
test(reply-conformance): pin terminal-time propagation + raw-value absence (rf2-3fc89f.7)

### DIFF
--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -32,6 +32,7 @@
   + `spec/Managed-Effects.md` §Tracing (the data-only trace summary)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
@@ -54,6 +55,11 @@
 
 (def ^:private frame-id :reply-egress/main)
 
+;; The raw sensitive token — the exact string that MUST NOT survive projection
+;; into any off-box / redacted wire slot. Named once so the sentinel predicate
+;; and the fixtures share a single source of truth.
+(def ^:private raw-token "bearer-SECRET-do-not-ship")
+
 (def ^:private big-string
   ;; Exceeds the default size threshold as well as carrying a declaration.
   (apply str (repeat 40000 \x)))
@@ -68,7 +74,7 @@
 
 ;; Payload fixtures use the classified coordinates directly.
 (defn- reply-body []
-  {:token      "bearer-SECRET-do-not-ship"
+  {:token      raw-token
    :blob       big-string
    :secret-big big-string
    :public     {:count 3}})
@@ -93,7 +99,7 @@
   {:status      :error
    :error       {:kind   :rf.http/http-5xx
                  :status 503
-                 :token  "bearer-SECRET-do-not-ship"
+                 :token  raw-token
                  :blob   big-string}
    :rf.reply/work-id     work-id
    :rf.reply/work-kind   :resource
@@ -102,6 +108,43 @@
 
 (defn- redacted? [v] (= privacy/redacted-sentinel v))
 (defn- large-marker? [v] (and (map? v) (contains? v :rf.size/large-elided)))
+
+;; ---------------------------------------------------------------------------
+;; Recursive raw-value-absence predicate (Finding 2, rf2-3fc89f.7).
+;;
+;; `large-marker?` proves a marker is PRESENT; it does NOT prove the raw value
+;; LEFT — a leaking marker representation or a reply-slot projection regression
+;; could carry `{:rf.size/large-elided true :raw <40k-string>}` and still pass a
+;; marker-presence check. This portable tree walk (no JVM-only walk API — it
+;; runs identically on both hosts) asserts the exact raw sentinel is absent from
+;; EVERY nested node of a projected slot, closing that fail-open gap.
+;; ---------------------------------------------------------------------------
+
+(defn- tree-contains?
+  "True iff any node reachable in `data` satisfies `pred`. Recurses map keys AND
+  vals, sequential collections, and sets; applies `pred` at every node."
+  [pred data]
+  (cond
+    (pred data)  true
+    (map? data)  (boolean (some (fn [[k v]] (or (tree-contains? pred k)
+                                                (tree-contains? pred v)))
+                                data))
+    (coll? data) (boolean (some #(tree-contains? pred %) data))
+    :else        false))
+
+(defn- embeds-raw-token?
+  "True iff the raw sensitive token survives anywhere in `data` — as a string
+  equal to OR embedding the original bearer token (a leaking representation
+  might wrap rather than replace it)."
+  [data]
+  (tree-contains? #(and (string? %) (str/includes? % raw-token)) data))
+
+(defn- embeds-raw-blob?
+  "True iff the raw 40k big-string survives anywhere in `data` (equal or
+  embedded). The legitimate `:rf.size/large-elided` marker carries only a
+  byte-count / type / handle, so it never trips this predicate."
+  [data]
+  (tree-contains? #(and (string? %) (str/includes? % big-string)) data))
 
 ;; ---------------------------------------------------------------------------
 ;; trace-summary projects every wire-bearing slot and preserves identity facts.
@@ -133,7 +176,25 @@
         (is (= :resource (:rf.reply/work-kind summary))     ":rf.reply/work-kind verbatim")
         (is (= :completed (:rf.reply/work-status summary))  ":rf.reply/work-status verbatim")
         (is (= frame-id (:rf.frame/id summary))    ":rf.frame/id verbatim")
-        (is (= completed-at-ms (:completed-at summary)) ":completed-at verbatim")))))
+        (is (= completed-at-ms (:completed-at summary)) ":completed-at verbatim"))
+      (testing "NO raw sensitive/large value survives in ANY projected wire slot"
+        ;; Marker/redaction PRESENCE is asserted above; this proves the raw
+        ;; value is ABSENT — recursively, so a value retained under a sibling
+        ;; key or embedded in a marker cannot slip through.
+        (is (not (embeds-raw-token? (:value summary)))
+            "the raw token is absent from the projected :value slot")
+        (is (not (embeds-raw-blob? (:value summary)))
+            "the raw 40k blob is absent from the projected :value slot")
+        (is (not (embeds-raw-token? (:correlation summary)))
+            "the raw token is absent from the projected :correlation slot")
+        (is (not (embeds-raw-blob? (:meta summary)))
+            "the raw blob is absent from the projected :meta slot")
+        ;; And nothing raw survives anywhere in the whole summary (identity
+        ;; facts carry no wire values).
+        (is (not (embeds-raw-token? summary))
+            "no raw token anywhere in the trace summary")
+        (is (not (embeds-raw-blob? summary))
+            "no raw blob anywhere in the trace summary")))))
 
 (deftest trace-summary-projects-the-error-failure-payload
   (testing "the :error payload is projected like the :value payload"
@@ -148,7 +209,14 @@
           "the family error :kind rides (not a declared wire path)")
       (is (= 503 (get-in summary [:error :status]))
           "the family error :status rides (not a declared wire path)")
-      (is (= work-id (:rf.reply/work-id summary)) ":rf.reply/work-id verbatim on an error reply"))))
+      (is (= work-id (:rf.reply/work-id summary)) ":rf.reply/work-id verbatim on an error reply")
+      (testing "NO raw sensitive/large value survives in the projected :error slot"
+        (is (not (embeds-raw-token? (:error summary)))
+            "the raw token is absent from the projected :error payload")
+        (is (not (embeds-raw-blob? (:error summary)))
+            "the raw blob is absent from the projected :error payload")
+        (is (not (embeds-raw-token? summary))
+            "no raw token anywhere in the error trace summary")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Sensitive classification wins over large classification.
@@ -179,7 +247,7 @@
     (let [unresolved (reply/trace-summary (ok-reply) {:frame :reply-egress/ghost})]
       (is (redacted? (:value unresolved))
           "an UNRESOLVED :frame opt fails closed — the whole :value slot redacts")
-      (is (not= "bearer-SECRET-do-not-ship" (get-in unresolved [:value :token]))
+      (is (not (embeds-raw-token? unresolved))
           "the raw token NEVER ships under an unresolved frame")
       ;; Identity facts are not wire slots and remain unchanged.
       (is (= work-id (:rf.reply/work-id unresolved))
@@ -202,7 +270,7 @@
             "the carried frame's large policy elides [:blob]")
         (is (= 3 (get-in summary [:value :public :count]))
             "the unmarked sibling passes through — per-leaf policy, not a whole-slot redact")
-        (is (not= "bearer-SECRET-do-not-ship" (get-in summary [:value :token]))
+        (is (not (embeds-raw-token? summary))
             "the raw token NEVER ships")
         (is (= frame-id (:rf.frame/id summary))
             "the carried :rf.frame/id remains an identity fact")
@@ -238,14 +306,26 @@
         (is (large-marker? (get-in out [:blob]))
             (str p ": the large reply-body leaf is elided"))
         (is (= 3 (get-in out [:public :count]))
-            (str p ": the unmarked sibling passes through"))))
+            (str p ": the unmarked sibling passes through"))
+        ;; Marker/redaction presence is asserted above; prove raw ABSENCE too —
+        ;; recursively, across the whole projected record.
+        (is (not (embeds-raw-token? out))
+            (str p ": the raw token does NOT survive project-egress anywhere"))
+        (is (not (embeds-raw-blob? out))
+            (str p ": the raw blob does NOT survive project-egress anywhere"))))
     (testing ":rf.egress/local-raw exposes classified fields"
       (let [out (rf/project-egress (reply-body)
                   {:frame frame-id :rf.egress/profile :rf.egress/local-raw})]
-        (is (= "bearer-SECRET-do-not-ship" (get-in out [:token]))
+        (is (= raw-token (get-in out [:token]))
             "local-raw keeps the token")
         (is (= big-string (get-in out [:blob]))
-            "local-raw keeps the large field")))))
+            "local-raw keeps the large field")
+        ;; The explicit positive control: the SAME sentinel predicate that must
+        ;; find nothing off-box MUST find the originals under local-raw.
+        (is (embeds-raw-token? out)
+            "local-raw is the positive control — the raw token IS present")
+        (is (embeds-raw-blob? out)
+            "local-raw is the positive control — the raw blob IS present")))))
 
 (deftest off-box-project-egress-fails-closed-on-an-unresolved-frame
   (testing "project-egress fails closed for an unresolved explicit frame"
@@ -253,8 +333,10 @@
                 {:frame :reply-egress/ghost :rf.egress/profile :rf.egress/off-box-tool})]
       (is (redacted? out)
           "an unresolved-frame off-box egress conservatively redacts the whole reply body")
-      (is (not= "bearer-SECRET-do-not-ship" (get-in out [:token]))
-          "the raw token NEVER ships under an unresolved frame"))))
+      (is (not (embeds-raw-token? out))
+          "the raw token NEVER ships under an unresolved frame")
+      (is (not (embeds-raw-blob? out))
+          "the raw blob NEVER ships under an unresolved frame"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Mapped targets have distinct ephemeral and durable representations; completed
@@ -297,11 +379,42 @@
   (testing "the raw fixture contains protected fields before projection"
     (mk-frame!)
     (let [reply (ok-reply)]
-      (is (= "bearer-SECRET-do-not-ship" (get-in reply [:value :token]))
+      (is (= raw-token (get-in reply [:value :token]))
           "the RAW reply carries the sensitive token (pre-projection)")
       (is (= big-string (get-in reply [:value :blob]))
           "the RAW reply carries the large blob (pre-projection)")
+      ;; The sentinel predicate finds the originals in the raw reply — its
+      ;; positive baseline (the redacted/projected outputs above must NOT).
+      (is (embeds-raw-token? reply)
+          "the sentinel predicate finds the raw token in the pre-projection reply")
+      (is (embeds-raw-blob? reply)
+          "the sentinel predicate finds the raw blob in the pre-projection reply")
       ;; The direct walker provides the expected projection result.
       (let [direct (elision/elide-wire-value (:value reply) {:frame frame-id})]
         (is (redacted? (get-in direct [:token]))
             "the shared walker redacts the token")))))
+
+;; ---------------------------------------------------------------------------
+;; Adversarial control (Finding 2): a marker map that STILL embeds the raw
+;; large value passes the superficial `large-marker?` presence check but is
+;; caught by the recursive sentinel predicate — proving the raw-value-absence
+;; gate has teeth that marker-presence alone lacks.
+;; ---------------------------------------------------------------------------
+
+(deftest sentinel-predicate-catches-a-marker-that-embeds-the-raw-value
+  (testing "a large-marker map that ALSO retains the raw big-string fools
+            large-marker? but the recursive sentinel predicate would go RED on it"
+    (let [leaking {:rf.size/large-elided true :raw big-string}]
+      ;; The fail-open gap: the superficial marker-presence check is satisfied.
+      (is (large-marker? leaking)
+          "large-marker? returns true for the leaking marker (the gap Finding 2 closes)")
+      ;; The recursive sentinel predicate catches the embedded raw value, so a
+      ;; raw-value-absence assertion built on it FAILS on this leaking shape.
+      (is (embeds-raw-blob? leaking)
+          "the sentinel predicate FINDS the raw blob the leaking marker embeds")))
+  (testing "a LEGITIMATE large-elided marker carries no raw value, so the
+            sentinel predicate does not false-positive on it"
+    (let [clean (elision/->marker big-string [:blob] {})]
+      (is (large-marker? clean) "a real marker is still a marker")
+      (is (not (embeds-raw-blob? clean))
+          "the real marker carries only a byte-count / type / handle — no raw blob"))))

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -191,30 +191,126 @@
   ;; The current work id names the superseding HTTP attempt.
   (http-reply/suppress http-ctx [:rf.work/http :article/by-id 2 1]))
 
-(defn- resource-stale-out []
-  (rreply/stale-reply
-    {:carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
-     :current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
-     :extra   {:rf.reply/work-id      [:rf.work/resource [:rf.scope/global :r {}] 4]
-               :rf.reply/work-kind    :resource
-               :rf.frame/id           :app/main
-               :rf.reply/stale-reason :resource/generation-mismatch}}))
+;; The stale-suppression outcomes are parameterized by an optional `extra-more`
+;; (resource / mutation) or `ctx-more` (route) map so the non-success stale
+;; time-pair (below) can thread `:completed-at` onto the suppress `:extra` /
+;; ctx and prove completion-time propagation + omission through the same shared
+;; suppress boundary. The 0-arg arity is the original no-extra outcome.
+(defn- resource-stale-out
+  ([] (resource-stale-out nil))
+  ([extra-more]
+   (rreply/stale-reply
+     {:carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
+      :current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
+      :extra   (merge {:rf.reply/work-id      [:rf.work/resource [:rf.scope/global :r {}] 4]
+                       :rf.reply/work-kind    :resource
+                       :rf.frame/id           :app/main
+                       :rf.reply/stale-reason :resource/generation-mismatch}
+                      extra-more)})))
 
-(defn- mutation-stale-out []
-  (rreply/stale-reply
-    {:carried {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 2] :generation 2}
-     :current {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 3] :generation 3}
-     :extra   {:rf.reply/work-id      [:rf.work/resource [:rf.mutation :form/save-1] 2]
-               :rf.reply/work-kind    :mutation
-               :rf.frame/id           :app/main
-               :rf.reply/stale-reason :mutation/superseded}}))
+(defn- mutation-stale-out
+  ([] (mutation-stale-out nil))
+  ([extra-more]
+   (rreply/stale-reply
+     {:carried {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 2] :generation 2}
+      :current {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 3] :generation 3}
+      :extra   (merge {:rf.reply/work-id      [:rf.work/resource [:rf.mutation :form/save-1] 2]
+                       :rf.reply/work-kind    :mutation
+                       :rf.frame/id           :app/main
+                       :rf.reply/stale-reason :mutation/superseded}
+                      extra-more)})))
 
-(defn- route-stale-out []
-  (route-reply/suppress {:route-id  :route/article
-                         :nav-token "nav-1"
-                         :loader-id :article/loaded
-                         :frame     :app/main}
-                        "nav-2"))
+(defn- route-stale-out
+  ([] (route-stale-out nil))
+  ([ctx-more]
+   (route-reply/suppress (merge {:route-id  :route/article
+                                 :nav-token "nav-1"
+                                 :loader-id :article/loaded
+                                 :frame     :app/main}
+                                ctx-more)
+                         "nav-2")))
+
+;; ---------------------------------------------------------------------------
+;; Non-success terminal completion-time pairs (Finding 1, rf2-3fc89f.7). The
+;; success tier already pairs `:completed-at` presence/omission across families;
+;; these extend the SAME propagation/omission gate to the non-success terminals
+;; whose owning builder contract ACCEPTS or DURABLY USES the causal completion
+;; time. Each `-with-time` builder supplies `completion-time-ms`; each
+;; `-no-time` builder omits it, so the shared gate proves both propagation and
+;; omission.
+;;
+;; Terminals EXCLUDED from the gate (see `time-pair-exclusions`): HTTP stale
+;; (`http-reply/suppress` hard-codes its stale `:extra` — no completion-time
+;; slot), machine cancel (`cancelled-actor-reply`) and timer cancel
+;; (`cancelled-timer-reply`) take no `:completed-at` parameter — an
+;; actor-destroy / timer-cancel terminal is a correlation row, not a causal
+;; completion that threads a fire-time. Documenting the exclusions keeps the
+;; gate from becoming an over-broad mandatory-field rule.
+;; ---------------------------------------------------------------------------
+
+;; HTTP failure/abort lower through `base-reply`, which threads `:completed-at`.
+(defn- http-error-with-time  [] (http-reply/failure-reply http-ctx a-failure))
+(defn- http-error-no-time    [] (http-reply/failure-reply (dissoc http-ctx :completed-at) a-failure))
+(defn- http-cancel-with-time [] (http-reply/failure-reply http-ctx an-abort))
+(defn- http-cancel-no-time   [] (http-reply/failure-reply (dissoc http-ctx :completed-at) an-abort))
+
+;; Resource/mutation failure/abort thread `:completed-at` from the opts map —
+;; the causal fact closed bug rf2-rl27r2 / PR #4473 repaired (pinned only
+;; family-locally before; this closes the umbrella gap Finding 1 names).
+(defn- resource-error-with-time []
+  (rreply/failure-reply resource-vp a-failure
+                        {:work-kind rreply/work-kind-resource :completed-at completion-time-ms}))
+(defn- resource-error-no-time []
+  (rreply/failure-reply resource-vp a-failure {:work-kind rreply/work-kind-resource}))
+(defn- resource-cancel-with-time []
+  (rreply/failure-reply resource-vp an-abort
+                        {:work-kind rreply/work-kind-resource :completed-at completion-time-ms}))
+(defn- resource-cancel-no-time []
+  (rreply/failure-reply resource-vp an-abort {:work-kind rreply/work-kind-resource}))
+
+(defn- mutation-error-with-time []
+  (rreply/failure-reply mutation-vp a-failure
+                        {:work-kind rreply/work-kind-mutation :completed-at completion-time-ms}))
+(defn- mutation-error-no-time []
+  (rreply/failure-reply mutation-vp a-failure {:work-kind rreply/work-kind-mutation}))
+(defn- mutation-cancel-with-time []
+  (rreply/failure-reply mutation-vp an-abort
+                        {:work-kind rreply/work-kind-mutation :completed-at completion-time-ms}))
+(defn- mutation-cancel-no-time []
+  (rreply/failure-reply mutation-vp an-abort {:work-kind rreply/work-kind-mutation}))
+
+;; Resource/mutation stale thread `:completed-at` via the suppress `:extra`.
+(defn- resource-stale-with-time [] (:reply (resource-stale-out {:completed-at completion-time-ms})))
+(defn- resource-stale-no-time   [] (:reply (resource-stale-out)))
+(defn- mutation-stale-with-time [] (:reply (mutation-stale-out {:completed-at completion-time-ms})))
+(defn- mutation-stale-no-time   [] (:reply (mutation-stale-out)))
+
+;; Machine spawn-error threads `:completed-at` through `base-reply`; `machine-ctx`
+;; already carries one, so the with-time builder reuses it directly.
+(defn- machine-error-with-time [] (m-reply/error-reply machine-ctx {:reason :bad-creds}))
+(defn- machine-error-no-time   [] (m-reply/error-reply (dissoc machine-ctx :completed-at) {:reason :bad-creds}))
+
+;; Machine spawn-stale threads `:completed-at` when the ctx supplies one
+;; (`machine-stale-reply` already carries it; this is its no-time companion).
+(defn- machine-stale-no-time []
+  (m-reply/stale-spawn-reply (assoc (dissoc machine-ctx :completed-at) :current-generation nil)))
+
+;; Timer `:after`-stale threads `:completed-at` when the firing dispatch
+;; supplied it (`after-stale-reply` above is its no-time companion).
+(defn- after-stale-reply-with-time []
+  (m-reply/after-stale-reply
+    {:actor-id        :a/multi
+     :state           :loading
+     :delay           30000
+     :decl-path       [:loading]
+     :scheduled-epoch 1
+     :current-epoch   2
+     :frame           :app/main
+     :completed-at    completion-time-ms}))
+
+;; Route stale threads `:completed-at` when the suppress ctx supplies one.
+(defn- route-stale-with-time [] (:reply (route-stale-out {:completed-at completion-time-ms})))
+(defn- route-stale-no-time   [] (:reply (route-stale-out)))
 
 (def ^:private families
   [{:family          :http
@@ -223,6 +319,12 @@
     :success-no-time http-success-no-time
     :error           #(http-reply/failure-reply http-ctx a-failure)
     :cancel          #(http-reply/failure-reply http-ctx an-abort)
+    ;; Non-success completion-time pairs (HTTP stale excluded — `suppress`
+    ;; hard-codes its `:extra` with work-id facts only).
+    :error-with-time  http-error-with-time
+    :error-no-time    http-error-no-time
+    :cancel-with-time http-cancel-with-time
+    :cancel-no-time   http-cancel-no-time
     ;; HTTP supersession is a stale completion of the earlier request attempt.
     :stale-out       http-stale-out
     :stale           #(:reply (http-stale-out))}
@@ -237,6 +339,12 @@
                                             {:work-kind rreply/work-kind-resource})
     :cancel          #(rreply/failure-reply resource-vp an-abort
                                             {:work-kind rreply/work-kind-resource})
+    :error-with-time  resource-error-with-time
+    :error-no-time    resource-error-no-time
+    :cancel-with-time resource-cancel-with-time
+    :cancel-no-time   resource-cancel-no-time
+    :stale-with-time  resource-stale-with-time
+    :stale-no-time    resource-stale-no-time
     :stale-out       resource-stale-out
     :stale           #(:reply (resource-stale-out))}
 
@@ -250,6 +358,12 @@
                                             {:work-kind rreply/work-kind-mutation})
     :cancel          #(rreply/failure-reply mutation-vp an-abort
                                             {:work-kind rreply/work-kind-mutation})
+    :error-with-time  mutation-error-with-time
+    :error-no-time    mutation-error-no-time
+    :cancel-with-time mutation-cancel-with-time
+    :cancel-no-time   mutation-cancel-no-time
+    :stale-with-time  mutation-stale-with-time
+    :stale-no-time    mutation-stale-no-time
     :stale-out       mutation-stale-out
     :stale           #(:reply (mutation-stale-out))}
 
@@ -261,6 +375,12 @@
     ;; Destroying an actor closes its work attempt with cancellation data.
     :cancel          #(m-reply/cancelled-actor-reply
                         (assoc machine-ctx :reason :explicit))
+    ;; Spawn-error + spawn-stale carry completion time; actor-destroy cancel
+    ;; does not (see `time-pair-exclusions`).
+    :error-with-time  machine-error-with-time
+    :error-no-time    machine-error-no-time
+    :stale-with-time  machine-stale-reply
+    :stale-no-time    machine-stale-no-time
     ;; Machine replies carry their stale gate directly in `:correlation`.
     :stale           machine-stale-reply}
 
@@ -280,6 +400,10 @@
                          :epoch     1
                          :frame     :app/main
                          :reason    :on-exit})
+    ;; The `:after`-stale timer carries completion time; timer-cancel does not
+    ;; (see `time-pair-exclusions`).
+    :stale-with-time  after-stale-reply-with-time
+    :stale-no-time    after-stale-reply
     ;; Timer replies carry their epoch gate directly in `:correlation`.
     :stale           after-stale-reply}
 
@@ -291,8 +415,49 @@
     :success-no-time route-success-no-time
     :error           nil
     :cancel          nil
+    :stale-with-time  route-stale-with-time
+    :stale-no-time    route-stale-no-time
     :stale-out       route-stale-out
     :stale           #(:reply (route-stale-out))}])
+
+;; ---------------------------------------------------------------------------
+;; The non-success terminal situations paired for the shared completion-time
+;; propagation/omission gate, and the terminals deliberately excluded from it.
+;; ---------------------------------------------------------------------------
+
+(def ^:private time-pair-situations
+  "Non-success terminal situations paired for the shared completion-time
+  propagation/omission gate (Finding 1). Each entry is
+  `[situation with-time-key no-time-key]`. The success tier owns its own pair
+  (`:success` / `:success-no-time`); these extend the SAME gate to the
+  non-success terminals whose owning builder contract accepts or durably uses
+  `:completed-at`. A family that omits a pair does not durably carry completion
+  time for that situation (see `time-pair-exclusions`)."
+  [[:error  :error-with-time  :error-no-time]
+   [:cancel :cancel-with-time :cancel-no-time]
+   [:stale  :stale-with-time  :stale-no-time]])
+
+(def ^:private time-pair-exclusions
+  "Terminal situations deliberately EXCLUDED from the completion-time
+  propagation/omission gate because their owning builder does not accept a
+  causal completion time — asserting one would impose an over-broad
+  mandatory-field rule. Each entry is `[family situation builder-thunk reason]`;
+  each builder is fed an input context that DOES carry a completion time, so the
+  companion test proves the builder omits `:completed-at` regardless."
+  [[:http    :stale  #(:reply (http-stale-out))
+    "http-reply/suppress hard-codes its stale :extra map (work-id facts only)"]
+   [:machine :cancel #(m-reply/cancelled-actor-reply (assoc machine-ctx :reason :explicit))
+    "cancelled-actor-reply takes no :completed-at parameter"]
+   [:timer   :cancel #(m-reply/cancelled-timer-reply
+                        {:actor-id     :a/multi
+                         :state        :loading
+                         :delay        30000
+                         :decl-path    [:loading]
+                         :epoch        1
+                         :frame        :app/main
+                         :completed-at completion-time-ms
+                         :reason       :on-exit})
+    "cancelled-timer-reply takes no :completed-at parameter"]])
 
 ;; ---------------------------------------------------------------------------
 ;; Universal envelope invariants across all supported situations.
@@ -418,6 +583,71 @@
                  (reply/validate-reply reply)))
         (is (= :ok (:status reply))
             (str family " no-time success is still :status :ok"))))))
+
+;; ---------------------------------------------------------------------------
+;; Causal completion time for the NON-SUCCESS terminals (Finding 1,
+;; rf2-3fc89f.7). The success tier above pins propagation/omission for
+;; `:status :ok`; this extends the SAME gate to the error / cancel / stale
+;; terminals whose owning builder durably uses `:completed-at`. Failure /
+;; cancellation / stale timestamps are causal replay/tooling evidence — a
+;; builder silently dropping or nil-filling `:completed-at` (the rf2-rl27r2
+;; regression class) while keeping status + work-id canonical is exactly the
+;; drift this closes. Terminals that do not durably carry completion time are
+;; excluded explicitly (`time-pair-exclusions`), not silently.
+;; ---------------------------------------------------------------------------
+
+(deftest completion-time-propagates-and-omits-across-nonsuccess-terminals
+  (testing "each non-success terminal that durably uses causal completion time
+            propagates a supplied :completed-at unchanged and omits it when absent"
+    (doseq [{:keys [family] :as f} families
+            [situation with-k no-k] time-pair-situations
+            :let [with-builder (get f with-k)
+                  no-builder    (get f no-k)]
+            :when (or with-builder no-builder)]
+      ;; A family declaring one half of a pair MUST declare both, so the gate
+      ;; proves BOTH propagation and omission (never a half-covered situation).
+      (is (and with-builder no-builder)
+          (str family " " situation " must declare BOTH " with-k " and " no-k
+               " — a completion-time pair proves propagation AND omission"))
+      (when (and with-builder no-builder)
+        (let [with-reply (with-builder)
+              no-reply   (no-builder)]
+          (testing (str family " / " situation " → supplied :completed-at propagates unchanged")
+            (is (contains? with-reply :completed-at)
+                (str family " " situation " with-time reply MUST carry :completed-at "
+                     "when the completion time was supplied"))
+            (is (= completion-time-ms (:completed-at with-reply))
+                (str family " " situation " with-time :completed-at must be the supplied "
+                     "causal time " completion-time-ms ", got " (:completed-at with-reply))))
+          (testing (str family " / " situation " → absent :completed-at omitted (never nil-filled)")
+            (is (not (contains? no-reply :completed-at))
+                (str family " " situation " no-time reply MUST OMIT :completed-at when no "
+                     "completion time was supplied — never nil-fill it (a nil sentinel "
+                     "would let a reducer derive a bogus durable timestamp). Got "
+                     (pr-str (:completed-at no-reply)))))
+          (testing (str family " / " situation " → both replies still validate")
+            (is (reply/valid-reply? with-reply)
+                (str family " " situation " with-time reply must validate: "
+                     (reply/validate-reply with-reply)))
+            (is (reply/valid-reply? no-reply)
+                (str family " " situation " no-time reply must validate: "
+                     (reply/validate-reply no-reply)))))))))
+
+(deftest excluded-terminals-omit-completion-time-even-when-supplied
+  (testing "a terminal whose builder does not accept a causal completion time
+            omits :completed-at even when its input context carries one — so
+            the propagation gate is correctly NOT applied to it (documenting the
+            exclusion instead of imposing an over-broad mandatory-field rule)"
+    (doseq [[family situation builder reason] time-pair-exclusions
+            :let [reply (builder)]]
+      (is (not (contains? reply :completed-at))
+          (str family " " situation " is excluded from the completion-time gate ("
+               reason ") — its reply MUST NOT carry :completed-at even when the "
+               "input context supplies one; got " (pr-str (:completed-at reply))))
+      ;; The excluded terminal is still a canonical, valid reply.
+      (is (reply/valid-reply? reply)
+          (str family " " situation " excluded terminal still validates: "
+               (reply/validate-reply reply))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Error shape: :status :error, a terminal failure work status, and a
@@ -592,4 +822,38 @@
                "FAIL on this reply, catching the nil-sentinel anti-pattern"))
       (is (nil? (:completed-at bad))
           (str family " control's :completed-at is the nil sentinel the gate "
+               "forbids")))))
+
+;; The same fail-closed controls for the NON-SUCCESS terminals — proving the
+;; shared `completion-time-propagates-and-omits-across-nonsuccess-terminals`
+;; gate has teeth on error / cancel / stale replies too, not only on success.
+(deftest nonsuccess-completion-time-gate-fails-closed-on-drop-and-nil-fill
+  (testing "a non-success terminal that DROPS its supplied :completed-at is
+            detected — the propagation gate's `(contains? …)` + value assertions
+            would go RED on it"
+    (doseq [{:keys [family] :as f} families
+            [situation with-k _] time-pair-situations
+            :let [with-builder (get f with-k)]
+            :when with-builder
+            :let [bad (drop-completion-time (with-builder))]]
+      ;; Completion time is optional, so the reply is otherwise still valid.
+      (is (reply/valid-reply? bad)
+          (str family " " situation " control still validates: " (reply/validate-reply bad)))
+      (is (not (contains? bad :completed-at))
+          (str family " " situation " control DROPPED :completed-at — the propagation "
+               "gate's `contains?` + value assertions would FAIL on this reply"))))
+  (testing "a non-success terminal that NIL-FILLS its no-time reply is detected —
+            the omit-when-absent gate's `(not (contains? …))` would go RED on a
+            present-but-nil slot"
+    (doseq [{:keys [family] :as f} families
+            [situation _ no-k] time-pair-situations
+            :let [no-builder (get f no-k)]
+            :when no-builder
+            :let [bad (nil-fill-completion-time (no-builder))]]
+      (is (contains? bad :completed-at)
+          (str family " " situation " control NIL-FILLED :completed-at (present-but-nil) — "
+               "the omit-when-absent gate's `(not (contains? …))` assertion would FAIL, "
+               "catching the nil-sentinel anti-pattern"))
+      (is (nil? (:completed-at bad))
+          (str family " " situation " control's :completed-at is the nil sentinel the gate "
                "forbids")))))


### PR DESCRIPTION
## Summary

Correctness-review test hardening (bead rf2-3fc89f.7) for the descriptor-driven reply-conformance suites. Closes two negative-assurance gaps the review found, **extending the existing matrix** — no second family matrix, no production change.

### Finding 1 — terminal-time propagation/omission (`reply_vocab_conformance_cljs_test.cljc`)
Before: `:completed-at` propagation/omission was pinned only for the `:success` tier; `:error` / `:cancel` / `:stale` had no with-time/no-time companions. A failure/cancel/stale builder could silently drop or nil-fill `:completed-at` (the rf2-rl27r2 regression class) and the umbrella tier stayed green.

- Added optional per-situation time pairs (`:error-with-time`/`:error-no-time`, `:cancel-*`, `:stale-*`) **only where the owning builder contract accepts or durably uses `:completed-at`**, and drive **one shared** propagation/omission assertion across them (`completion-time-propagates-and-omits-across-nonsuccess-terminals`).
- **Exclusions documented + verified** (`time-pair-exclusions`): HTTP stale (`http-reply/suppress` hard-codes its `:extra`), machine cancel (`cancelled-actor-reply`), and timer cancel (`cancelled-timer-reply`) take no `:completed-at` — asserting one would be an over-broad mandatory-field rule. `excluded-terminals-omit-completion-time-even-when-supplied` feeds each excluded builder a context that *does* carry a completion time and proves the reply omits it.
- Kept family-specific live-dispatch `:rf.cofx` coverage in each family artefact (untouched).

### Finding 2 — raw-value absence in projected egress (`reply_egress_projection_conformance_cljs_test.cljc`)
Before: `large-marker?` proved a marker was *present*, not that the raw value *left*. A leaking marker (`{:rf.size/large-elided true :raw <blob>}`) or a sibling-key retention could pass.

- Added a portable recursive sentinel predicate (`tree-contains?` + `embeds-raw-token?` / `embeds-raw-blob?`) and assert the raw token / 40k blob is **absent** from every projected `:value`/`:error`/`:correlation`/`:meta` slot and from every off-box / local-redacted `project-egress` result.
- Retained `:rf.egress/local-raw` as the explicit **positive control** — the same predicate MUST find the originals there.
- Adversarial control `sentinel-predicate-catches-a-marker-that-embeds-the-raw-value`: a leaking marker fools `large-marker?` but is caught by the sentinel; a legitimate `->marker` carries no raw value.

## Adversarial-control teeth proof
Ran twice with a producer/detector intentionally broken, then reverted:
- **Finding 1**: dropping a producer's `:completed-at` → propagation gate goes **RED (2 failures)**.
- **Finding 2**: neutering the recursive detector → leaking-marker + local-raw positive control + raw-reply baseline go **RED (3 failures)**.

Both reverts restore green.

## Quality gates
- `implementation/reply-conformance` JVM (`clojure -M:test`): **27 tests / 575 assertions, 0 failures, 0 errors**.
- `implementation` CLJS node gate (`npm run test:cljs`): **8543 tests / 39823 assertions, 0 failures, 0 errors**.

## Stance
Pre-alpha; additive extension of the descriptor family (not a second matrix); ELEGANCE + CLARITY + CORRECTNESS. Portable CLJC — no JVM-only walk API, no new production dependency. Test-only surface; spec/009 and the reply spec untouched (7avygn owns that surface this wave).
