### PR TITLE
chore(deps): remove the last top-level test-runner coordinate — 28→1 (rf2-0sjm76)

### DIFF
--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -98,10 +98,15 @@
                  "../examples/patterns"
                  "../examples/real-apps"
                  "../examples/substrates"]
-   :extra-deps  {;; rf2-try1x — silent-on-success reporter.
-                 day8/re-frame2-test-quiet {:local/root "test-quiet"}
-                 io.github.cognitect-labs/test-runner
-                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   ;; rf2-0sjm76 — the Cognitect test-runner coordinate is no longer
+   ;; pinned here directly. The test-quiet artefact owns the single
+   ;; runner coordinate (implementation/test-quiet/deps.edn :deps); this
+   ;; alias resolves it TRANSITIVELY via the test-quiet local-root dep,
+   ;; and its `re-frame.test-quiet.runner` entry-point wraps the runner.
+   :extra-deps  {;; rf2-try1x — silent-on-success reporter. Also the sole
+                 ;; source of the cognitect test-runner coordinate on this
+                 ;; alias's classpath (transitive; rf2-0sjm76).
+                 day8/re-frame2-test-quiet {:local/root "test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Splint (rf2-4v147) — Mike-confirmed dual-linter posture


### PR DESCRIPTION
Removes the **last** direct `io.github.cognitect-labs/test-runner` coordinate
pinned in the top-level `implementation/deps.edn` `:test` alias. Sibling
rf2-cndjxo (#5563) centralizes the 20 per-artefact copies into
`implementation/test-quiet/deps.edn`; this finishes the dedup so **test-quiet
is the sole owner** of the runner coordinate (28 → 1).

The `:test` alias already declares `day8/re-frame2-test-quiet {:local/root "test-quiet"}`,
and `test-quiet`'s own top-level `:deps` carry the runner, so the coordinate now
resolves **transitively**. The `re-frame.test-quiet.runner` entry-point
(`:main-opts` unchanged), the test paths, and the runner options are all preserved.

## Stance
Pre-alpha; ONE runner-coordinate owner (test-quiet). This is a **test-alias-only**
change — production `:deps` are untouched, so no library-graph / published-artefact
impact. ELEGANCE + CLARITY + CORRECTNESS: single source of truth for the runner pin.

## Scope
Touches **only** the top-level `implementation/deps.edn` `:test` alias `:extra-deps`
(sole editor of this hot-zone file this wave). Does **not** touch any per-artefact
`deps.edn` (rf2-cndjxo owns those), production `:deps`, test paths, or `:main-opts`.

## Quality gates (foreground, from `implementation/`)
- **Resolution** — `clojure -Spath -M:test`: `test-quiet/src` on classpath **and**
  `io.github.cognitect-labs/test-runner` (sha `dfb30dd…`) present **transitively**
  via test-quiet. Direct-pin removal is safe.
- **Runner launches + representative suite** — `clojure -M:test -d flows/test -e :stress -e :slow`
  (top-level `:test` alias): `re-frame.test-quiet.runner` launched and reported
  **Ran 192 tests containing 4790 assertions. 0 failures, 0 errors.** (exit 0).
  A missing runner would throw at launch, not report a clean green summary.
- Production `:deps` graph unchanged (diff confined to the `:test` alias `:extra-deps`).

## Grep proof
After this change the top-level `implementation/deps.edn` is **absent** from the
coordinate list:

```
$ grep -rl "cognitect-labs/test-runner" implementation/*/deps.edn implementation/deps.edn
implementation/core/deps.edn
implementation/derivation-conformance/deps.edn
... (per-artefact copies — owned by rf2-cndjxo #5563, in flight)
implementation/test-quiet/deps.edn        <-- sole owner
# implementation/deps.edn  <-- NO LONGER LISTED (this PR)
```

The remaining per-artefact entries are removed by rf2-cndjxo (#5563), which has not
yet landed the code change on `main` (its merged commit `1b2a8d486` is beads-only).
Once both PRs land, only `implementation/test-quiet/deps.edn` retains the coordinate
— the 28 → 1 end-state.

Closes rf2-0sjm76.
