### PR TITLE
feat(skill/pair-retro): bound retrospectives to one causally-ordered session (rf2-3fc89f.37)

### DIFF
--- a/skills/re-frame2-pair-retro/SKILL.md
+++ b/skills/re-frame2-pair-retro/SKILL.md
@@ -71,6 +71,19 @@ Diagnostic posture rules (evidence over vibes; symptom vs cause; direct/indirect
 
 Load [`../shared/retro-protocol.md`](../shared/retro-protocol.md) for the workflow shape — the diagnosis-first steps (read the evidence → identify friction candidates → route to the detection rule → surface findings with concrete evidence → cross-link the canonical fix → opt-in issue-filing → confident, no-hedging voice), plus the evidence-citation discipline, the untrusted-evidence and universal-redaction boundaries, the layer-routing rules, and the seven-section output shape. It is shared with `re-frame2-improver`; the pair-retro specialisation is below.
 
+### Session-evidence contract
+
+The diagnosis is only as trustworthy as the evidence boundary it runs on. Conversation order is not causal order; two builds, two frames, or two attach attempts are not one retry loop. Before reconstructing the timeline, bind the evidence to **one causally-ordered session**:
+
+1. **One evidence envelope.** Scope the retro to a single session — the user-stated session or recap, or the contiguous pair workflow serving one goal. When two plausible envelopes are present (two goals, two builds, a recap alongside a live session), **ask which session** to review rather than merging them.
+2. **Build a causal ledger, not a transcript-order list.** Associate each result with its **initiating call**, and keep the provenance the evidence carries: build id, frame id, the runtime-instance / freshness token (session sentinel), and whether a fact came from **native conversation turns** or a **user recap**. Arrival order alone is never causal order — a delayed or background result belongs to the call that issued it, not to whatever ran most recently.
+3. **Exclude unrelated activity.** Background **worker** runs, **CI** results, **shell** commands, **code-review** threads, and **app-authoring** edits are out of scope **unless the user** explicitly names one as pair-session friction. Red CI from another job is not this session's regression.
+4. **Supersession.** A later successful retry or an explicit target switch **supersedes** the earlier state; the earlier failure survives only as friction that actually cost effort, never presented as the **current / final tool state**.
+5. **Unknown over inferred.** A missing, truncated, unmatched, or still-running result is **`unknown/incomplete`** — **never** scored as a **success** or a **failure**. State the limitation, and ask for the missing result only when it would change a finding.
+6. **Attribution.** Keep recap claims marked as **user recap**; **never invent** turn numbers, timestamps, or tool-**payload** fields that were not supplied.
+
+This sharpens the protocol's step 1 (read the evidence in scope) and its evidence-discipline rule for the session shape — the reconstruction below runs on the bounded ledger, not the raw transcript.
+
 Pair-retro deltas:
 
 - **Reconstruct the session goal and a short timeline first** — the intended outcome, environment facts (platform, target repo, live runtime state, tooling constraints), and the turns where progress stalled, restarted, detoured, or needed a workaround (tool errors, empty/stale outputs, retries, clarification loops). Present the friction as a numbered list before classifying, and ask which to dig into.

--- a/skills/re-frame2-pair-retro/evals/README.md
+++ b/skills/re-frame2-pair-retro/evals/README.md
@@ -1,11 +1,22 @@
 # `re-frame2-pair-retro` skill — eval harness
 
-This directory holds the trigger-accuracy fixtures for the `re-frame2-pair-retro`
-meta-skill (`skills/re-frame2-pair-retro/SKILL.md`). The single `evals.json`
-file scores the skill's **activation boundary**: which prompts should trigger a
-`re-frame2-pair` retrospective and which should route elsewhere (vocab-only
-retros, live `re-frame2-pair` debugging, the `re-frame2-improver` static
-critique, greenfield `re-frame2-setup`, Story-recorder retros, etc.).
+This directory holds two eval harnesses for the `re-frame2-pair-retro`
+meta-skill (`skills/re-frame2-pair-retro/SKILL.md`):
+
+1. **`evals.json` — trigger-accuracy fixtures.** Scores the skill's
+   **activation boundary**: which prompts should trigger a `re-frame2-pair`
+   retrospective and which should route elsewhere (vocab-only retros, live
+   `re-frame2-pair` debugging, the `re-frame2-improver` static critique,
+   greenfield `re-frame2-setup`, Story-recorder retros, etc.).
+2. **`session-evidence-evals.json` + `score-session-evidence-eval.clj` —
+   behavioural session-evidence eval.** Scores agent **runtime behaviour**
+   against the `SKILL.md` §Session-evidence contract: does the retro bound to
+   one causally-ordered session, build a causal ledger (not a transcript-order
+   list), exclude unrelated worker/CI/shell/code-review/app-authoring activity,
+   mark superseded state as superseded, mark partial results unknown/incomplete,
+   and — when two plausible sessions are present — ask which to review rather
+   than merging them? Its document-runnable fixture is
+   [`fixtures/session-evidence-scoping.md`](fixtures/session-evidence-scoping.md).
 
 ## Repo-maintenance artifact, not shipped
 
@@ -61,3 +72,34 @@ is the reference: score the skill's activation decision against each entry's
 `should_trigger`, and tune the frontmatter `description` until train/held-out
 trigger accuracy holds. The harness is intentionally tool-agnostic —
 `evals.json` is just data; any runner that respects the schema works.
+
+## Behavioural session-evidence eval
+
+`session-evidence-evals.json` scores agent **runtime behaviour** — the
+tool-call sequence and the emitted text — against the `SKILL.md`
+§Session-evidence contract, distinct from the trigger-accuracy `evals.json`
+above (which scores only the activation decision). The agent-execution step
+(replay a fixture against a fresh skill session and capture the transcript) is
+manual/opt-in — no Claude-in-the-loop CI harness exists yet — but scoring is
+automated:
+
+1. Replay [`fixtures/session-evidence-scoping.md`](fixtures/session-evidence-scoping.md)
+   (Scenario A, then Scenario B) against a fresh `re-frame2-pair-retro`
+   session and capture the transcript per `session-evidence-evals.json`
+   §harness.transcript_schema (`{"eval_id": N, "tool_calls": [...], "output":
+   "..."}`).
+2. Score it: `bb skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj <transcript.json>`.
+3. Store the pass/fail artifact (the scorer's stdout JSON) alongside the change
+   that motivated the run.
+
+`bb .../score-session-evidence-eval.clj --self-test` validates the manifest +
+scorer on every run as a cheap guard that the eval machinery itself hasn't
+rotted. The always-on structural guard for the contract prose is
+`skills/shared/tests/retro_protocol_test.clj`, which pins the load-bearing
+phrasings of the contract and runs this scorer's `--self-test`. Not every
+clause is deterministically scoreable from the transcript; the manifest's
+`scored_vs_manual` block names the clauses that stay human-review-only.
+
+Like `evals.json`, this harness is a **repo-maintenance artifact** — it is
+**not shipped** (the `files` allow-list in `package.json` omits `evals/`), so a
+packaged-skill consumer never carries it.

--- a/skills/re-frame2-pair-retro/evals/fixtures/session-evidence-scoping.md
+++ b/skills/re-frame2-pair-retro/evals/fixtures/session-evidence-scoping.md
@@ -1,0 +1,147 @@
+# Fixture — session-evidence scoping (one causally-ordered session)
+
+**Contract under test:** `skills/re-frame2-pair-retro/SKILL.md`
+§Session-evidence contract.
+
+**Behavioural eval:** [`../session-evidence-evals.json`](../session-evidence-evals.json),
+scored by [`../score-session-evidence-eval.clj`](../score-session-evidence-eval.clj).
+
+**Surface:** document-runnable. Replay each scenario against a fresh
+agent invocation of `re-frame2-pair-retro`, capture the transcript per
+`../session-evidence-evals.json` §harness.transcript_schema, and score it.
+The eval grades that the retro **bounds to one session**, **builds a causal
+ledger** (not a transcript-order list), **excludes unrelated activity**,
+**marks superseded state as superseded**, **marks partial results
+unknown/incomplete**, and — when two plausible sessions are present —
+**asks which session** rather than merging them.
+
+---
+
+## Scenario A — interleaved builds, a delayed result, and unrelated noise
+
+Maps to eval id `1` (`session-evidence-scoping`).
+
+### Setup
+
+A single pair session, working one goal: chasing a `:cart/apply-coupon`
+bug in a re-frame2 app. Paste this recap (or replay the equivalent live
+turns) into the conversation as the evidence the skill is reviewing.
+
+> **The pair session (native turns).**
+>
+> - I asked to attach. `discover-app` ran against build `cart-dev-a` and
+>   came back `:reason :no-runtime-connected` — no browser tab was open on
+>   that build.
+> - I realised the app was actually served under build `cart-dev-b`.
+>   `discover-app` against `cart-dev-b` attached: build id `cart-dev-b`,
+>   session sentinel `sess-7f3c`, operating frame `:main`, healthy.
+> - I dispatched `:cart/apply-coupon` and walked the `:main` frame's epoch
+>   stream. The coupon code was ingested unvalidated — found the bug.
+>
+> **Interleaved, unrelated activity in the same conversation.**
+>
+> - A background worker's CI run for branch `invoice-export` reported
+>   3 specs red. (Nothing to do with the cart bug.)
+> - A code-review comment landed on an unrelated PR.
+> - I edited my app's top-level `README.md` (app-authoring), unrelated to
+>   the pair work.
+> - A **delayed** result from the earlier `cart-dev-a` `discover-app` call
+>   arrived late — after `cart-dev-b` was already healthy — still
+>   `:no-runtime-connected`.
+> - A `tools/list` probe I fired mid-session **never returned** (no result
+>   was ever matched back to that call).
+
+Then the user asks:
+
+> Retro on the re-frame2-pair session I just finished.
+
+### Expected behaviour
+
+- **Bound to the one goal.** The retro's scope is the `cart-dev-b` attach +
+  dispatch + epoch walk on the coupon bug. The `cart-dev-a`
+  `:no-runtime-connected` and the switch to `cart-dev-b` are part of that
+  one goal's attach friction — genuine friction that cost effort.
+- **Causal ledger.** The delayed `cart-dev-a` `:no-runtime-connected` is
+  bound to its **initiating call** (the `cart-dev-a` `discover-app`), not to
+  its late arrival time. Arrival order is not causal order.
+- **Supersession.** `cart-dev-b`'s successful attach **supersedes**
+  `cart-dev-a`'s `:no-runtime-connected`. The session did **not** end
+  "still not connected"; the current tool state is the healthy `cart-dev-b`
+  attach.
+- **Exclusion.** The `invoice-export` CI run, the code-review comment, and
+  the app `README.md` edit are **excluded** — they are not pair-session
+  friction, and the user did not name them as such.
+- **Unknown over inferred.** The never-returned `tools/list` probe is
+  marked `unknown/incomplete`, not scored as a success or a failure.
+- **Attribution.** Because the evidence came as a user recap, claims are
+  attributable as recap; the retro does not invent turn numbers,
+  timestamps, or tool-payload fields the recap did not supply.
+
+### Anti-expectations for Scenario A
+
+- Presents `cart-dev-a`'s superseded `:no-runtime-connected` as the
+  **current / final** tool state (ignores supersession).
+- Mis-binds the **delayed** `cart-dev-a` result by arrival order into a
+  "`cart-dev-b` regressed / went red after being healthy" claim.
+- Counts the unrelated `invoice-export` CI run (or the code-review /
+  app-authoring activity) as **this session's** friction or root cause.
+- Upgrades the never-returned `tools/list` probe into an inferred tool
+  failure (or silently assumes it succeeded).
+
+---
+
+## Scenario B — two plausible sessions (ask, don't merge)
+
+Maps to eval id `2` (`session-evidence-ambiguity-ask`).
+
+### Setup
+
+One conversation, **two distinct** pair sessions serving different goals:
+
+> - **Session 1:** paired on the `:cart/apply-coupon` bug against build
+>   `cart-dev-b` (dispatch + epoch walk).
+> - **Session 2 (later, same conversation):** a separate pair session on a
+>   `:auth/login` state machine against build `auth-dev` (restore-epoch +
+>   machine-viz).
+
+Then the user asks the under-specified:
+
+> Retro on my re-frame2-pair session.
+
+### Expected behaviour
+
+Two plausible evidence envelopes are present. The retro **asks which
+session** to review (the cart-coupon session or the auth-login session)
+rather than merging them into one friction list.
+
+### Anti-expectations for Scenario B
+
+- Merges the two sessions into one combined timeline / friction list
+  without asking.
+- Silently picks one session without flagging the ambiguity.
+
+---
+
+## The discriminator (what the agent has to get right)
+
+| Signal in the evidence | Correct handling | Regression |
+|---|---|---|
+| `cart-dev-a` `:no-runtime-connected`, then `cart-dev-b` attaches | `cart-dev-b` **supersedes** `cart-dev-a` | `cart-dev-a` shown as current/final state |
+| A delayed `cart-dev-a` result arriving after `cart-dev-b` is healthy | bound to the `cart-dev-a` **initiating call** | mis-bound by arrival → "`cart-dev-b` regressed" |
+| `invoice-export` CI / code-review / app README edit | **excluded** (not pair-session friction) | counted as this session's friction/cause |
+| `tools/list` probe never returned | `unknown/incomplete` | inferred success or failure |
+| Two distinct pair goals, under-specified retro ask | **ask** which session | merge into one retro |
+
+## Notes for replay
+
+- The evidence is a **user recap**, so the untrusted-evidence and
+  redaction boundaries in [`../../../shared/retro-protocol.md`](../../../shared/retro-protocol.md)
+  apply — findings paraphrase the recap and mask any secrets / internal
+  hosts / user-named paths before emission.
+- The build ids, session sentinel, and frame id are the causal-ledger
+  provenance tokens the contract names; a correct retro attributes each
+  result to the build/frame/call it came from rather than to transcript
+  order.
+- Scenario B is the ask-when-ambiguous half of contract rule 1; run it
+  separately from Scenario A (a different session shape, a different
+  correct behaviour).

--- a/skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj
+++ b/skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj
@@ -1,0 +1,331 @@
+#!/usr/bin/env bb
+;;;; score-session-evidence-eval.clj — scorer for the pair-retro
+;;;; SESSION-EVIDENCE behavioral eval.
+;;;;
+;;;; The `re-frame2-pair-retro` skill's §Session-evidence contract locks agent
+;;;; RUNTIME BEHAVIOUR: does the retro bound to ONE causally-ordered session,
+;;;; bind each result to its initiating call (a causal ledger, not
+;;;; transcript-order), mark superseded state as superseded, mark partial
+;;;; results unknown/incomplete, exclude unrelated CI/worker/code-review/
+;;;; app-authoring activity, and — when two plausible sessions are present —
+;;;; ask which to review rather than merging them? Eyeballing that is too easy
+;;;; to skip and too hard to compare across model/tooling changes.
+;;;;
+;;;; This scorer makes the contract EXECUTABLE. The agent-execution step
+;;;; (replay a fixture against a fresh skill session, capture the transcript)
+;;;; is manual/opt-in — no Claude-in-the-loop CI harness exists yet. But once a
+;;;; transcript is captured per the schema in `session-evidence-evals.json`
+;;;; §harness.transcript_schema, this scorer produces a machine-readable
+;;;; pass/fail artifact for the tool-call sequence + output checks, with a
+;;;; one-line reason per failed check.
+;;;;
+;;;; SIBLING, not a copy: the shared security scorer
+;;;; `skills/shared/tests/evals/score-behavioral-eval.clj` scores the three
+;;;; shared SECURITY fixtures (injection / redaction / edit-gate) and carries
+;;;; security-specific predicates (stable-placeholder identity, verbatim-recap
+;;;; reproduction). This scorer scores a pair-retro-specific CORRECTNESS /
+;;;; attribution boundary and implements only the four predicate classes this
+;;;; eval needs. It is self-contained because the shared scorer is hardwired to
+;;;; its own security manifest and runs as a script (not a require-able lib),
+;;;; and because this eval lives in the pair-retro skill's own (unshipped)
+;;;; evals/ tree.
+;;;;
+;;;; Capture a transcript like:
+;;;;   {"eval_id": 1,
+;;;;    "tool_calls": [{"name": "mcp__re-frame2-pair__discover-app",
+;;;;                    "args": "{:build :cart-dev-a}"}, ...],
+;;;;    "output": "…all agent-emitted text concatenated…"}
+;;;;
+;;;; Run:
+;;;;   bb skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj <transcript.json>
+;;;;   bb skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj --self-test
+;;;;
+;;;; Exit:  0 = all checks passed (or --self-test passed)
+;;;;        1 = at least one check failed
+;;;;        2 = usage / load error
+;;;;
+;;;; Output: machine-readable JSON report on stdout (store it as the artifact);
+;;;;         a human one-line-per-check summary on stderr.
+
+(ns score-session-evidence-eval
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private this-dir
+  (-> *file* io/file .getAbsoluteFile .getParentFile))
+
+(def ^:private manifest-file
+  (io/file this-dir "session-evidence-evals.json"))
+
+(defn- load-manifest []
+  (json/parse-string (slurp manifest-file) true))
+
+(defn- eval-by-id [manifest id]
+  (->> (:evals manifest)
+       (filter #(= id (:id %)))
+       first))
+
+;; ---------------------------------------------------------------------------
+;; Check predicates — each returns a seq of failure maps (empty = pass).
+;; A failure map: {:check <kw> :detail <str> :why <str>}
+;; ---------------------------------------------------------------------------
+
+(defn- tool-call-text [tc]
+  ;; A tool call is matched against its name + args concatenated, so a forbidden
+  ;; pattern can target either the tool name or its argument blob.
+  (str (:name tc) " " (:args tc)))
+
+(defn- check-forbidden-tool-calls [eval-spec transcript]
+  (for [{:keys [pattern why]} (:forbidden_tool_calls eval-spec)
+        tc                    (:tool_calls transcript)
+        :let [re   (re-pattern pattern)
+              text (tool-call-text tc)]
+        :when (re-find re text)]
+    {:check :forbidden-tool-call
+     :detail (str "tool call " (pr-str text) " matched forbidden /" pattern "/")
+     :why why}))
+
+(defn- check-forbidden-output-substrings [eval-spec transcript]
+  (let [out (str (:output transcript))]
+    (for [{:keys [value why]} (:forbidden_output_substrings eval-spec)
+          :when (str/includes? out value)]
+      {:check :forbidden-output-substring
+       :detail (str "raw forbidden substring present in output: " (pr-str value))
+       :why why})))
+
+(defn- check-forbidden-output-patterns [eval-spec transcript]
+  (let [out (str (:output transcript))]
+    (for [{:keys [pattern why]} (:forbidden_output_patterns eval-spec)
+          :let [re (re-pattern pattern)
+                m  (re-find re out)]
+          :when m]
+      {:check :forbidden-output-pattern
+       :detail (str "output matched forbidden /" pattern "/ at " (pr-str m))
+       :why why})))
+
+(defn- check-required-output-patterns [eval-spec transcript]
+  (let [out (str (:output transcript))]
+    (for [{:keys [pattern why]} (:required_output_patterns eval-spec)
+          :let [re (re-pattern pattern)]
+          :when (not (re-find re out))]
+      {:check :missing-required-output-pattern
+       :detail (str "output did NOT match required /" pattern "/")
+       :why why})))
+
+(defn- score-eval [eval-spec transcript]
+  (let [failures (concat
+                  (check-forbidden-tool-calls eval-spec transcript)
+                  (check-forbidden-output-substrings eval-spec transcript)
+                  (check-forbidden-output-patterns eval-spec transcript)
+                  (check-required-output-patterns eval-spec transcript))]
+    {:eval_id (:id eval-spec)
+     :name (:name eval-spec)
+     :fixture (:fixture eval-spec)
+     :pass (empty? failures)
+     :failures (vec failures)}))
+
+;; ---------------------------------------------------------------------------
+;; Driver
+;; ---------------------------------------------------------------------------
+
+(defn- score-transcript-file [path]
+  (let [manifest   (load-manifest)
+        transcript (json/parse-string (slurp path) true)
+        id         (:eval_id transcript)
+        eval-spec  (eval-by-id manifest id)]
+    (when-not eval-spec
+      (binding [*out* *err*]
+        (println (str "ERROR: transcript :eval_id " (pr-str id)
+                      " does not match any eval in session-evidence-evals.json")))
+      (System/exit 2))
+    (let [report (score-eval eval-spec transcript)]
+      ;; machine-readable artifact on stdout
+      (println (json/generate-string report {:pretty true}))
+      ;; human summary on stderr
+      (binding [*out* *err*]
+        (println (str "[" (if (:pass report) "PASS" "FAIL") "] eval " id
+                      " — " (:name report) " (" (:fixture report) ")"))
+        (doseq [f (:failures report)]
+          (println (str "  x " (name (:check f)) ": " (:detail f)
+                        "\n      -> " (:why f)))))
+      (System/exit (if (:pass report) 0 1)))))
+
+;; ---------------------------------------------------------------------------
+;; Self-test — validates the manifest is loadable + well-formed and that the
+;; scorer's predicate classes fire on crafted bad transcripts and pass on
+;; crafted good ones, WITHOUT needing a captured agent run. This is the
+;; always-on fast guard for the scorer itself; the structural prose locks live
+;; in skills/shared/tests/retro_protocol_test.clj, which also runs this
+;; --self-test.
+;; ---------------------------------------------------------------------------
+
+(defn- self-test []
+  (let [manifest (load-manifest)
+        errs (atom [])
+        check (fn [ok? msg] (when-not ok? (swap! errs conj msg)))
+        fires-detail? (fn [r kind needle]
+                        (some #(and (= kind (:check %))
+                                    (str/includes? (:detail %) needle))
+                              (:failures r)))
+        neg (fn [label r kind needle]
+              (check (false? (:pass r)) (str "negative case did NOT fail: " label))
+              (check (fires-detail? r kind needle)
+                     (str "negative case " label " did not fire " kind
+                          " naming " (pr-str needle) "; failures="
+                          (pr-str (:failures r)))))
+        pos (fn [label r]
+              (check (true? (:pass r))
+                     (str "known-good case " label " FAILED: " (pr-str (:failures r)))))
+        e1 (eval-by-id manifest 1)
+        e2 (eval-by-id manifest 2)]
+    ;; ---- manifest shape ----
+    (check (= "behavioral" (:eval_kind manifest)) "eval_kind is not \"behavioral\"")
+    (check (= 2 (count (:evals manifest)))
+           (str "expected 2 evals, got " (count (:evals manifest))))
+    (check (every? :fixture (:evals manifest)) "an eval is missing its :fixture pointer")
+    ;; every referenced fixture file exists on disk
+    (doseq [{:keys [fixture]} (:evals manifest)]
+      (check (.exists (io/file this-dir fixture))
+             (str "fixture file missing on disk: " fixture)))
+    ;; every regex compiles
+    (doseq [e (:evals manifest)
+            {:keys [pattern]} (concat (:forbidden_tool_calls e)
+                                      (:forbidden_output_patterns e)
+                                      (:required_output_patterns e))]
+      (try (re-pattern pattern)
+           (catch Exception ex
+             (swap! errs conj (str "bad regex /" pattern "/: " (.getMessage ex))))))
+
+    ;; =====================================================================
+    ;; EVAL 1 — one violation per negative, so no failure masks another.
+    ;; =====================================================================
+    ;; missing the causal-ledger framing (has supersede + unknown + exclusion)
+    (neg "eval1 missing causal ledger"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "cart-dev-b's attach supersedes cart-dev-a's "
+                                      "earlier result. Excluded the invoice-export CI "
+                                      "from another worker. The tools/list probe is "
+                                      "unknown/incomplete.")})
+         :missing-required-output-pattern "causal ledger")
+    ;; missing the supersession framing
+    (neg "eval1 missing supersession"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: the delayed result is bound to its "
+                                      "initiating call (cart-dev-a). Excluded the "
+                                      "invoice-export CI from another worker. The "
+                                      "tools/list probe is unknown/incomplete.")})
+         :missing-required-output-pattern "supersed")
+    ;; missing the unknown/incomplete framing
+    (neg "eval1 missing unknown"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: bound to its initiating call. "
+                                      "cart-dev-b supersedes cart-dev-a. Excluded the "
+                                      "invoice-export CI from another worker.")})
+         :missing-required-output-pattern "unknown")
+    ;; missing the exclusion framing
+    (neg "eval1 missing exclusion"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: bound to its initiating call. "
+                                      "cart-dev-b supersedes cart-dev-a. The tools/list "
+                                      "probe is unknown/incomplete.")})
+         :missing-required-output-pattern "exclud")
+    ;; superseded state presented as current/final
+    (neg "eval1 superseded-as-current"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: bound to its initiating call. "
+                                      "cart-dev-b's attach supersedes cart-dev-a; but the "
+                                      "session is still :no-runtime-connected. Excluded the "
+                                      "invoice-export CI. The tools/list probe is "
+                                      "unknown/incomplete.")})
+         :forbidden-output-pattern "no-runtime-connected")
+    ;; delayed cart-dev-a result mis-bound into a cart-dev-b regression
+    (neg "eval1 cart-dev-b regressed"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: bound to its initiating call. "
+                                      "cart-dev-b supersedes cart-dev-a, but then cart-dev-b "
+                                      "broke and went down. Excluded the invoice-export CI. "
+                                      "The tools/list probe is unknown/incomplete.")})
+         :forbidden-output-pattern "cart-dev-b")
+    ;; unrelated invoice-export CI framed as this session's root cause
+    (neg "eval1 CI as root cause"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Causal ledger: bound to its initiating call. "
+                                      "cart-dev-b supersedes cart-dev-a. The invoice-export "
+                                      "CI failure was the root cause of the session "
+                                      "friction; an unrelated worker run also appeared. The "
+                                      "tools/list probe is unknown/incomplete.")})
+         :forbidden-output-pattern "invoice-export")
+    ;; known-good eval 1
+    (pos "eval1"
+         (score-eval e1 {:eval_id 1
+                         :tool_calls []
+                         :output (str "Session scope: the cart-dev-b attach + "
+                                      ":cart/apply-coupon dispatch + :main epoch walk on the "
+                                      "coupon bug (session sentinel sess-7f3c). Causal "
+                                      "ledger: the delayed :no-runtime-connected is bound to "
+                                      "its initiating call, the earlier cart-dev-a "
+                                      "discover-app — not to its late arrival. cart-dev-b's "
+                                      "successful attach supersedes that earlier cart-dev-a "
+                                      "result; cart-dev-b stayed healthy throughout. Excluded "
+                                      "(not pair-session friction): the invoice-export CI run "
+                                      "from another worker, the code-review comment, and the "
+                                      "app README edit. The tools/list probe never returned, "
+                                      "so it is unknown/incomplete — not scored as success or "
+                                      "failure.")}))
+
+    ;; =====================================================================
+    ;; EVAL 2 — ask-when-ambiguous.
+    ;; =====================================================================
+    ;; missing the ask (produced a retro instead of asking)
+    (neg "eval2 missing ask"
+         (score-eval e2 {:eval_id 2
+                         :tool_calls []
+                         :output "I reviewed the pair work and produced a friction list."})
+         :missing-required-output-pattern "which session")
+    ;; merged the two sessions
+    (neg "eval2 merged sessions"
+         (score-eval e2 {:eval_id 2
+                         :tool_calls []
+                         :output (str "Which session do you want? Meanwhile I merged the "
+                                      "two sessions into one friction list.")})
+         :forbidden-output-pattern "merg")
+    ;; known-good eval 2
+    (pos "eval2"
+         (score-eval e2 {:eval_id 2
+                         :tool_calls []
+                         :output (str "Two plausible pair sessions are present (the "
+                                      "cart-coupon session and the auth-login session). "
+                                      "Which session should I retro?")}))
+
+    (if (seq @errs)
+      (do (binding [*out* *err*]
+            (println "SELF-TEST FAILED:")
+            (doseq [m @errs] (println "  x" m)))
+          (System/exit 1))
+      (do (println (str "SELF-TEST PASSED: session-evidence-evals.json well-formed; "
+                        "scorer predicates fire (isolated per predicate)."))
+          (System/exit 0)))))
+
+;; ---------------------------------------------------------------------------
+;; Entry
+;; ---------------------------------------------------------------------------
+
+(let [[arg] *command-line-args*]
+  (cond
+    (= "--self-test" arg) (self-test)
+    (nil? arg)            (do (binding [*out* *err*]
+                                (println "usage: score-session-evidence-eval.clj <transcript.json> | --self-test"))
+                              (System/exit 2))
+    (not (fs/exists? arg)) (do (binding [*out* *err*]
+                                 (println (str "ERROR: transcript file not found: " arg)))
+                               (System/exit 2))
+    :else                 (score-transcript-file arg)))

--- a/skills/re-frame2-pair-retro/evals/session-evidence-evals.json
+++ b/skills/re-frame2-pair-retro/evals/session-evidence-evals.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1",
+  "eval_kind": "behavioral",
+  "owner": "skills/re-frame2-pair-retro/SKILL.md",
+  "lock": "SKILL.md §Session-evidence contract",
+  "convention": "Behavioral eval for the pair-retro SESSION-EVIDENCE contract — a CORRECTNESS/attribution boundary (bound the retro to one causally-ordered session), distinct from the shared SECURITY behavioral evals (skills/shared/tests/evals/behavioral-evals.json: injection / redaction / edit-gate). This scores agent RUNTIME BEHAVIOUR — the tool-call sequence and the emitted text — against the fixture's §Expected / §Anti-expectation locks. Each eval is graded by score-session-evidence-eval.clj against a captured transcript (tool_calls[] + output). The agent-EXECUTION step (replay a fixture against a fresh skill session and capture the transcript) is manual/opt-in — no Claude-in-the-loop CI harness exists yet — but SCORING is automated: capture a transcript per the schema below and run `bb skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj <transcript.json>`. Repo-maintenance artifact; excluded from the npm package (see evals/README.md).",
+  "harness": {
+    "status": "opt-in / agent-execution-manual, scoring-automated",
+    "scorer": "skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj",
+    "gate": "The always-on structural guard is skills/shared/tests/retro_protocol_test.clj (it pins the contract prose in SKILL.md and runs this scorer's --self-test). Behaviour is not considered verified for a contract change until this eval has been replayed against a fresh session and scored, with the pass/fail artifact stored.",
+    "transcript_schema": {
+      "eval_id": "integer — matches one entry in evals[]",
+      "tool_calls": "array of {\"name\": string, \"args\": string} — the agent's tool-invocation sequence. Forbidden-tool-call predicates match against `name + \" \" + args`.",
+      "output": "string — the concatenation of ALL agent-emitted text (inline findings + any draft issue body + recap paraphrase)"
+    }
+  },
+  "scored_vs_manual": {
+    "note": "Every predicate below is machine-scored against a captured transcript. Clauses that stay HUMAN-REVIEW-ONLY (not deterministically checkable from the transcript schema) are listed so the scored/manual split is explicit.",
+    "manual_only": [
+      "eval 1 §Expected — that the causal binding is the RIGHT binding (the delayed result bound to the cart-dev-a call specifically) is human-reviewed; the scorer verifies only that a causal-ledger framing is present and that the two build-mixing regressions are absent.",
+      "eval 1 §Expected — that the app-authoring README edit and the code-review comment (as well as the CI job) are ALL excluded is human-reviewed; the scorer verifies that an exclusion is stated and that the invoice-export CI is not framed as this session's friction/cause.",
+      "eval 2 §Expected — that the clarifying question names BOTH candidate sessions is human-reviewed; the scorer verifies an ask-which-session framing is present and that no merge framing is emitted."
+    ]
+  },
+  "evals": [
+    {
+      "id": 1,
+      "name": "session-evidence-scoping",
+      "fixture": "fixtures/session-evidence-scoping.md",
+      "lock": "SKILL.md §Session-evidence contract (rules 2-5)",
+      "consuming_skills": ["re-frame2-pair-retro"],
+      "expectations": [
+        "Binds the delayed cart-dev-a result to its initiating call (causal ledger), not to arrival order.",
+        "Marks cart-dev-b's attach as superseding cart-dev-a's :no-runtime-connected; does not present the superseded state as current/final.",
+        "Excludes the interleaved invoice-export CI / code-review / app-authoring activity from the session scope.",
+        "Marks the never-returned tools/list probe as unknown/incomplete, not an inferred success or failure."
+      ],
+      "required_output_patterns": [
+        {"pattern": "(?i)causal ledger|initiating call|belongs to (its|the) (call|attach|build)|bound to (its|the) (call|attach|build)|attribut\\w+ to (the )?(cart-dev-a|earlier (call|attach))", "why": "must express the causal ledger — bind the delayed cart-dev-a result to its initiating call, not to arrival order (contract rule 2)."},
+        {"pattern": "(?i)supersed", "why": "must mark cart-dev-b's successful attach as superseding cart-dev-a's earlier :no-runtime-connected, not treat the two as one retry loop (contract rule 4)."},
+        {"pattern": "(?i)unknown|incomplete|still[- ]?running|never returned|unmatched", "why": "the never-returned tools/list probe must be marked unknown/incomplete, never inferred as success or failure (contract rule 5)."},
+        {"pattern": "(?i)exclud\\w+|out of scope|unrelated|not (this|the) session|another (job|worker|run)", "why": "must exclude the interleaved CI / worker / code-review / app-authoring noise from the session scope (contract rule 3)."}
+      ],
+      "forbidden_output_patterns": [
+        {"pattern": "(?i)(current|final|ended?|still)[^.\\n]{0,30}no-runtime-connected", "why": "cart-dev-a's :no-runtime-connected was superseded by cart-dev-b's attach; presenting it as the current/final tool state is the supersession regression (contract rule 4)."},
+        {"pattern": "(?i)cart-dev-b[^.\\n]{0,40}(regress|broke|went (red|down)|stopped working|failed after)", "why": "cart-dev-b was healthy; a delayed cart-dev-a result mis-bound by arrival order into a 'cart-dev-b regressed' claim is the causal-ledger regression (contract rules 2/4)."},
+        {"pattern": "(?i)invoice-export[^.\\n]{0,30}(is|was|as)\\s+(a |an |the )?(friction|regression|root cause)", "why": "the unrelated invoice-export CI job belongs to another worker run; counting it as this session's friction/root cause is the scope-bleed regression (contract rule 3)."}
+      ]
+    },
+    {
+      "id": 2,
+      "name": "session-evidence-ambiguity-ask",
+      "fixture": "fixtures/session-evidence-scoping.md",
+      "lock": "SKILL.md §Session-evidence contract (rule 1)",
+      "consuming_skills": ["re-frame2-pair-retro"],
+      "expectations": [
+        "With two plausible session envelopes present, asks which session to review rather than merging them."
+      ],
+      "required_output_patterns": [
+        {"pattern": "(?i)which session|which of the two|which one[^.\\n]{0,30}(review|retro)|which pair session|clarif", "why": "two plausible envelopes are present; the retro must ask which session to review rather than merging them (contract rule 1)."}
+      ],
+      "forbidden_output_patterns": [
+        {"pattern": "(?i)(combin\\w+|merg\\w+)[^.\\n]{0,40}(session|friction|timeline|finding)", "why": "combining/merging the two plausible sessions into one friction list/timeline is exactly the failure the ask-when-ambiguous rule prevents (contract rule 1)."}
+      ]
+    }
+  ]
+}

--- a/skills/shared/tests/retro_protocol_test.clj
+++ b/skills/shared/tests/retro_protocol_test.clj
@@ -1045,6 +1045,166 @@
                "label rules (rf2-dhnixf finding 3).")))))
 
 ;; ---------------------------------------------------------------------------
+;; Pair-retro session-evidence contract — bind a retrospective to ONE
+;; causally-ordered session (SKILL.md §Session-evidence contract).
+;;
+;; Without an evidence boundary + causal-attribution rule, an agent can merge
+;; two builds / two sessions into one retry loop, count a delayed background
+;; result as a late regression, attribute unrelated CI/worker/code-review/
+;; app-authoring activity to the pair session, present a superseded tool result
+;; as the current state, or upgrade a missing result into an inferred tool
+;; failure — corrupting the retro's primary output (observed friction, root
+;; cause, priority, and any drafted issue body). These assertions pin the
+;; load-bearing phrasings of the contract so a silent prose-weakening is caught
+;; by `bb`; the executable behavioural counterpart is the pair-retro
+;; session-evidence eval (scored by
+;; `re-frame2-pair-retro/evals/score-session-evidence-eval.clj`, whose
+;; --self-test the final assertion below runs as an always-on guard).
+;; ---------------------------------------------------------------------------
+
+(defn- session-evidence-section []
+  (section @pair-retro-skill-md "Analysis workflow and output shape"))
+
+(deftest pair-retro-session-evidence-contract-present
+  (testing "SKILL.md carries a §Session-evidence contract in the analysis workflow"
+    (is (str/includes? @pair-retro-skill-md "Session-evidence contract")
+        (str "re-frame2-pair-retro/SKILL.md dropped the §Session-evidence "
+             "contract. Without it the skill has no rule for bounding a "
+             "retrospective to one session, so an agent can merge unrelated "
+             "activity (other workers, CI, shell, code-review, app-authoring) "
+             "into a pair-session retro."))
+    (is (contains-any? (session-evidence-section)
+                       ["one causally-ordered session"])
+        (str "the §Session-evidence contract no longer frames the boundary as "
+             "ONE causally-ordered session — the cardinal phrasing that "
+             "distinguishes a causal ledger from a transcript-order list."))))
+
+(deftest pair-retro-session-evidence-one-envelope-and-ask
+  (testing "rule 1 — one evidence envelope, ask when two are plausible"
+    (let [s (session-evidence-section)]
+      (is (contains-any? s ["evidence envelope"])
+          "the single-evidence-envelope rule (contract rule 1) is missing.")
+      (is (contains-any? s ["ask which session"])
+          (str "the ask-when-ambiguous rule is missing — when two plausible "
+               "envelopes are present the skill must ask which session to "
+               "review rather than merging them (contract rule 1).")))))
+
+(deftest pair-retro-session-evidence-causal-ledger
+  (testing "rule 2 — causal ledger with provenance, not transcript order"
+    (let [s (session-evidence-section)]
+      (is (contains-any? s ["causal ledger"])
+          "the causal-ledger rule (contract rule 2) is missing.")
+      (is (contains-any? s ["initiating call"])
+          (str "the causal ledger no longer binds each result to its "
+               "initiating call — arrival order would then be mistaken for "
+               "causal order (contract rule 2)."))
+      (is (and (str/includes? s "build id")
+               (str/includes? s "frame id")
+               (contains-any? s ["runtime-instance" "freshness token"]))
+          (str "the causal ledger no longer names the provenance tokens it "
+               "must retain (build id / frame id / runtime-instance or "
+               "freshness token) (contract rule 2)."))
+      (is (and (contains-any? s ["native conversation turns" "native turns"])
+               (str/includes? s "user recap"))
+          (str "the causal ledger no longer distinguishes native conversation "
+               "turns from a user recap as evidence provenance (contract "
+               "rule 2).")))))
+
+(deftest pair-retro-session-evidence-excludes-unrelated-activity
+  (testing "rule 3 — exclude unrelated worker / CI / shell / code-review / app-authoring"
+    (let [s (session-evidence-section)]
+      (is (contains-any? s ["Exclude unrelated"])
+          "the exclude-unrelated-activity rule (contract rule 3) is missing.")
+      (is (and (str/includes? s "worker")
+               (str/includes? s "CI")
+               (str/includes? s "shell")
+               (str/includes? s "code-review")
+               (str/includes? s "app-authoring"))
+          (str "the exclusion rule no longer enumerates the unrelated activity "
+               "classes (worker / CI / shell / code-review / app-authoring) "
+               "that are out of scope by default (contract rule 3)."))
+      (is (contains-any? s ["unless the user"])
+          (str "the exclusion rule no longer carries the 'unless the user "
+               "explicitly names it as pair-session friction' carve-out "
+               "(contract rule 3).")))))
+
+(deftest pair-retro-session-evidence-supersession-and-unknown
+  (testing "rules 4-5 — supersession, and unknown over inferred"
+    (let [s (session-evidence-section)]
+      (is (contains-any? s ["supersed"])
+          (str "the supersession rule is missing — a later successful retry / "
+               "target switch supersedes the earlier state (contract rule 4)."))
+      (is (contains-any? s ["current / final tool state" "current/final tool state"
+                            "final tool state"])
+          (str "the supersession rule no longer forbids presenting a "
+               "superseded failure as the current/final tool state (contract "
+               "rule 4)."))
+      (is (contains-any? s ["unknown/incomplete" "unknown / incomplete"])
+          (str "the unknown-over-inferred rule is missing — a missing / "
+               "truncated / unmatched / still-running result is "
+               "unknown/incomplete (contract rule 5)."))
+      (is (and (contains-any? s ["never"])
+               (str/includes? s "success")
+               (str/includes? s "failure"))
+          (str "the unknown-over-inferred rule no longer forbids scoring a "
+               "partial result as a success or a failure (contract rule 5).")))))
+
+(deftest pair-retro-session-evidence-attribution
+  (testing "rule 6 — recap attribution, never invent turn ids / payload fields"
+    (let [s (session-evidence-section)]
+      (is (contains-any? s ["never invent"])
+          (str "the attribution rule no longer forbids inventing evidence "
+               "(contract rule 6)."))
+      (is (and (str/includes? s "turn")
+               (str/includes? s "payload"))
+          (str "the attribution rule no longer names turn numbers and "
+               "tool-payload fields as the things the skill must not invent "
+               "(contract rule 6).")))))
+
+(deftest pair-retro-session-evidence-scorer-self-tests
+  (testing "score-session-evidence-eval.clj exists and its --self-test passes"
+    (let [scorer (io/file skills-root
+                          "re-frame2-pair-retro/evals/score-session-evidence-eval.clj")]
+      (is (.exists scorer)
+          (str "re-frame2-pair-retro/evals/score-session-evidence-eval.clj "
+               "disappeared. It is the executable scorer that turns a captured "
+               "transcript into a pass/fail artifact for the session-evidence "
+               "contract — without it the contract reverts to eyeball-only."))
+      (when (.exists scorer)
+        (let [{:keys [exit out err]}
+              (shell/sh "bb" (.getPath scorer) "--self-test")]
+          (is (zero? exit)
+              (str "score-session-evidence-eval.clj --self-test failed (exit "
+                   exit "). The manifest is malformed or a scorer predicate "
+                   "stopped firing.\nstdout: " out "\nstderr: " err)))))))
+
+(deftest pair-retro-session-evidence-manifest-and-fixture-present
+  (testing "the session-evidence eval manifest + fixture are present and well-formed"
+    (let [manifest (io/file skills-root
+                            "re-frame2-pair-retro/evals/session-evidence-evals.json")
+          fixture  (io/file skills-root
+                            "re-frame2-pair-retro/evals/fixtures/session-evidence-scoping.md")]
+      (is (.exists manifest)
+          "re-frame2-pair-retro/evals/session-evidence-evals.json disappeared.")
+      (is (.exists fixture)
+          (str "the session-evidence fixture "
+               "(evals/fixtures/session-evidence-scoping.md) disappeared."))
+      (when (.exists manifest)
+        (let [m (json/parse-string (slurp manifest) true)]
+          (is (= "behavioral" (:eval_kind m))
+              "session-evidence-evals.json :eval_kind is no longer \"behavioral\".")
+          (is (= 2 (count (:evals m)))
+              (str "session-evidence-evals.json no longer has exactly 2 evals "
+                   "(the scoping scenario + the ask-when-ambiguous scenario)."))
+          (let [blob (slurp manifest)]
+            (is (str/includes? blob "supersed")
+                "manifest no longer scores the supersession rule.")
+            (is (str/includes? blob "unknown")
+                "manifest no longer scores the unknown-over-inferred rule.")
+            (is (contains-any? blob ["which session" "which of the two"])
+                "manifest no longer scores the ask-when-ambiguous rule.")))))))
+
+;; ---------------------------------------------------------------------------
 ;; Run
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The `re-frame2-pair-retro` diagnosis contract requires reconstructing a session goal + timeline, but the runtime-loaded instructions defined no **evidence boundary** or **causal-attribution** rule. In a conversation with multiple pair attempts, interleaved background/CI/worker activity, delayed results, or a user recap mixed with native turns, an agent could:

- merge two builds/sessions into one retry loop,
- count a delayed background result as a late regression (arrival order mistaken for causal order),
- attribute unrelated CI / worker / code-review / app-authoring activity to the pair session,
- present a superseded tool result as the current state, or
- upgrade a missing/unmatched result into an inferred failure.

That corrupts the retro's *primary* output — observed friction, root cause, priority, and any drafted GitHub issue body.

## The session-evidence contract

Added as a **pair-retro delta in `SKILL.md`** (`§Session-evidence contract`). All six rules are session/tool-call specific, so **nothing was added to the shared `retro-protocol.md`** — none of them benefits the `re-frame2-improver` consumer (which reviews a static code body, not a session with builds/frames/tool-results).

1. **One evidence envelope** — the user-stated session/recap or the contiguous pair workflow serving one goal; when two plausible envelopes exist, **ask which session** to review rather than merging them.
2. **Causal ledger, not transcript-order list** — bind each result to its **initiating call**; retain build id / frame id / runtime-instance (freshness) token; mark **native-turn vs user-recap** provenance. Arrival order is never causal order.
3. **Exclude unrelated activity** — background worker / CI / shell / code-review / app-authoring, unless the user names it as pair-session friction.
4. **Supersession** — a later successful retry / target switch supersedes the earlier state; a superseded failure is never the current/final tool state.
5. **Unknown over inferred** — a missing / truncated / unmatched / still-running result is `unknown/incomplete`, never scored success or failure.
6. **Attribution** — recap claims stay marked `user recap`; never invent turn numbers, timestamps, or tool-payload fields.

## Made executable

A **pair-retro behavioural eval** (a sibling to — not a copy of — the shared security scorer, since that scorer is hardwired to its security manifest and runs as a script):

- `evals/fixtures/session-evidence-scoping.md` — a document-runnable mixed-activity fixture: interleaved builds (`cart-dev-a` `:no-runtime-connected` → `cart-dev-b` attach), a **delayed** `cart-dev-a` result, an unrelated `invoice-export` CI run + code-review + app-authoring edit, and a **never-returned** `tools/list` probe. Scenario B adds two distinct sessions for the ask-when-ambiguous rule.
- `evals/session-evidence-evals.json` — the behavioural manifest; grades that the retro bounds to the one session, binds the delayed result to its initiating call, marks the superseded state superseded, marks the partial result unknown/incomplete, excludes the noise, and asks-when-ambiguous.
- `evals/score-session-evidence-eval.clj` — scorer with a `--self-test` that fires each predicate in isolation (good passes; each negative fails on the intended predicate).

Structural drift gate: `skills/shared/tests/retro_protocol_test.clj` gains assertions pinning the contract's load-bearing phrasings **and** runs the new scorer's `--self-test` as an always-on guard. `evals/README.md` documents the new harness (EXCLUDE-from-package stance preserved).

## Quality gates (foreground, 0 failures)

- `bb skills/shared/tests/retro_protocol_test.clj` — 60 tests, 124 assertions
- `bb skills/re-frame2-pair-retro/evals/score-session-evidence-eval.clj --self-test`
- `bb skills/shared/tests/evals/score-behavioral-eval.clj --self-test` (shared security scorer, unregressed)
- `bb skills/shared/tests/tool_pair_surfaces_test.clj` — 6 tests, 9 assertions
- `python scripts/check_skill_eval_docs.py` · `check_skill_eval_packaging.py` · `check_skill_mcp_drift.py` · `check_skill_pair_authoring_drift.py`
- `python scripts/check_doc_slugs.py` · `check_readme_inventories.py`
- `npm pack --dry-run` — 10-file package, `evals/` excluded

## Stance

Pre-alpha; ELEGANCE + CLARITY + CORRECTNESS. One evidence envelope + a causal ledger (not transcript order). No tracker ids in user-facing skill prose. Builds off latest `main` (post rf2-mwd6tf #5559 filing-mechanics dedup); does not touch `issue-filing.md` / `issue-template.md`.
