### PR TITLE
fix(core): two-phase atomic dispatch-later timer publication vs immediate-fire + destroy (rf2-3fc89f.3)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -213,32 +213,70 @@
 
 (defonce
   ^{:private true
-    :doc "Host-side side table of pending `:dispatch-later` timer handles,
-   keyed by `[frame-id timer-id]` → an opaque host handle from
-   `re-frame.interop/set-timeout!`. Transient host state (NOT runtime-db),
-   so an epoch restore cannot rewind / recycle it and it never rides the
-   SSR / hydration / epoch wire. A fired timer drops its own entry;
-   `release-frame!` cancels + drops every still-pending timer for a
-   destroyed frame (frame/destroy-frame! via the `:fx/on-frame-destroyed!`
-   late-bind hook). Mirrors `re-frame.resources.timers/timer-table`."}
+    :doc "Host-side side table of pending `:dispatch-later` timers, keyed by
+   `[frame-id timer-id]`. A slot holds EITHER the `arming-sentinel` (the timer
+   is mid-`set-timeout!` — RESERVED but not yet PUBLISHED) OR the opaque host
+   handle from `re-frame.interop/set-timeout!` (armed). Transient host state
+   (NOT runtime-db), so an epoch restore cannot rewind / recycle it and it never
+   rides the SSR / hydration / epoch wire. A fired timer drops its own entry;
+   `release-frame!` cancels + drops every still-pending timer for a destroyed
+   frame (frame/destroy-frame! via the `:fx/on-frame-destroyed!` late-bind hook).
+   Mirrors `re-frame.resources.timers/timer-table`."}
   dispatch-later-timers
   (atom {}))
+
+(def ^:private arming-sentinel
+  "Placeholder value held in `dispatch-later-timers` for the window between
+  RESERVING a `[frame-id timer-id]` slot and PUBLISHING the real host handle
+  returned by `set-timeout!` (two-phase arm, rf2-3fc89f.3). Distinct from every
+  host handle — a `ScheduledFuture` on the JVM, a numeric id on CLJS — so
+  `release-frame!` / `reset-dispatch-later-timers!` can tell an in-flight arming
+  from an installed handle and NEVER pass it to `clear-timeout!` (a sentinel is
+  not a cancellable host object). The arming caller's publish phase cancels the
+  real handle when it finds the reservation already gone."
+  ::arming)
 
 (defn- arm-dispatch-later!
   "Arm a `:dispatch-later` host timer that dispatches `event` with `opts`
   after `ms`, RETAINING its handle in `dispatch-later-timers` under
   `[frame-id timer-id]` so `release-frame!` can cancel it on frame destroy.
   The timer thunk drops its OWN slot BEFORE dispatching, so the table tracks
-  exactly the pending set (a fired timer leaves no residue). Returns nil."
+  exactly the pending set (a fired timer leaves no residue). Returns nil.
+
+  TWO-PHASE, ATOMIC publication (rf2-3fc89f.3). A zero/immediate host callback
+  (the JVM `ScheduledExecutorService` may run the thunk on its worker thread
+  BEFORE `set-timeout!` returns) or a `release-frame!`/destroy racing the
+  schedule would, under a publish-AFTER-`set-timeout!` scheme, either orphan a
+  spent handle (the thunk `dissoc`s an absent slot, then the caller `assoc`s the
+  already-fired handle forever) or publish a handle past cleanup:
+
+    1. RESERVE `[frame-id timer-id]` with `arming-sentinel` BEFORE scheduling,
+       so the thunk and `release-frame!` always have a slot to remove.
+    2. After `set-timeout!` returns, atomically REPLACE the reservation with the
+       real handle ONLY IF the reservation still exists (`swap-vals!` — the swap
+       fn is pure; the host side effect rides the CAS-derived old snapshot, never
+       inside the retriable swap). If the thunk fired or destroy removed it
+       first, DO NOT reinsert — CANCEL the returned handle (safe even if it
+       already completed).
+
+  CLJ + CLJS run identical code; the race is only reachable on the JVM (CLJS
+  `js/setTimeout` cannot fire before the caller yields), but the reservation
+  keeps both platforms leak-free and behaviourally identical."
   [frame-id ms event opts]
   (let [timer-id (swap! dispatch-later-counter inc)
-        k        [frame-id timer-id]
-        handle   (interop/set-timeout!
+        k        [frame-id timer-id]]
+    ;; PHASE 1 — reserve the slot BEFORE scheduling. The sentinel is not a host
+    ;; handle: `release-frame!` / `reset-dispatch-later-timers!` drop it without
+    ;; passing it to `clear-timeout!`.
+    (swap! dispatch-later-timers assoc k arming-sentinel)
+    (let [handle (interop/set-timeout!
                    (fn []
                      ;; Drop our own slot first — the timer has fired, so its
                      ;; handle is spent; a later `release-frame!` must not try
                      ;; to cancel a fired handle, and the table must not retain
-                     ;; a fired timer.
+                     ;; a fired timer. Removal precedes dispatch on BOTH the
+                     ;; sentinel window (immediate fire before publication) and
+                     ;; the ordinary armed slot.
                      (swap! dispatch-later-timers dissoc k)
                      ;; Sticky hook (rf2-f72pd) — the timer callback fires per
                      ;; scheduled :dispatch-later. When the frame was destroyed
@@ -247,8 +285,17 @@
                      ;; on the live path `dispatch!` enqueues into the frame.
                      (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
                        (dispatch! event opts)))
-                   ms)]
-    (swap! dispatch-later-timers assoc k handle)
+                   ms)
+          ;; PHASE 2 — publish the handle only if the reservation survived. The
+          ;; swap fn is a pure CAS-derived replace-if-present; the cancel side
+          ;; effect below reads the old snapshot, never runs inside the swap.
+          [old _] (swap-vals! dispatch-later-timers
+                              (fn [m] (if (contains? m k) (assoc m k handle) m)))]
+      (when-not (contains? old k)
+        ;; The thunk (immediate/0ms fire) or destroy already removed the
+        ;; reservation — do NOT reinsert the spent/orphan handle; cancel it
+        ;; (idempotent even on an already-completed handle).
+        (interop/clear-timeout! handle)))
     nil))
 
 (defn release-frame!
@@ -258,12 +305,21 @@
   never fires a dead-on-arrival dispatch into the torn-down frame, and its
   armed host handle + captured closure are released promptly rather than
   leaking until the delay elapses. Idempotent — a frame with no pending
-  timers is a no-op. Returns nil."
+  timers is a no-op. Returns nil.
+
+  Removes the frame's slots ATOMICALLY (a single `swap-vals!`) and cancels the
+  real host handles off the CAS-derived old snapshot — no host side effect runs
+  inside the retriable swap. An `arming-sentinel` slot (a timer mid-`set-timeout!`,
+  rf2-3fc89f.3) is dropped but NEVER passed to `clear-timeout!` — the arming
+  caller's publish phase finds the vanished reservation and cancels the real
+  handle itself, so the timer is cancelled exactly once with no orphan."
   [frame-id]
-  (doseq [[[fid _tid :as k] handle] @dispatch-later-timers]
-    (when (= fid frame-id)
-      (interop/clear-timeout! handle)
-      (swap! dispatch-later-timers dissoc k)))
+  (let [[old _] (swap-vals! dispatch-later-timers
+                            (fn [m]
+                              (into {} (remove (fn [[[fid _tid] _]] (= fid frame-id))) m)))]
+    (doseq [[[fid _tid] handle] old
+            :when (and (= fid frame-id) (not (= handle arming-sentinel)))]
+      (interop/clear-timeout! handle)))
   nil)
 
 (defn reset-dispatch-later-timers!
@@ -272,11 +328,18 @@
   so the shared CLJS `make-reset-runtime-fixture` reset-hooks table clears it
   per test — host-side transient state the runtime / frames reset does not
   touch, so without this a stale armed timer from a sibling test could fire
-  mid-next-test. Returns nil."
+  mid-next-test. Returns nil.
+
+  Clears the table ATOMICALLY (`reset-vals!`) and cancels the real host handles
+  off the captured old snapshot. An `arming-sentinel` slot (a timer
+  mid-`set-timeout!`, rf2-3fc89f.3) is dropped but NEVER passed to
+  `clear-timeout!` — its arming caller's publish phase cancels the real handle
+  when it finds the reservation gone."
   []
-  (doseq [[_ handle] @dispatch-later-timers]
-    (interop/clear-timeout! handle))
-  (reset! dispatch-later-timers {})
+  (let [[old _] (reset-vals! dispatch-later-timers {})]
+    (doseq [[_ handle] old
+            :when (not (= handle arming-sentinel))]
+      (interop/clear-timeout! handle)))
   nil)
 
 ;; Publish the frame-destroy cleanup + test-isolation reset through the

--- a/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
+++ b/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
@@ -31,6 +31,8 @@
             [re-frame.fx :as fx]
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.registrar :as registrar]
             [re-frame.error-emit :as error-emit]
@@ -62,6 +64,20 @@
   [frame-id]
   (->> @@(resolve 're-frame.fx/dispatch-later-timers)
        (filter (fn [[[fid _tid] _handle]] (= fid frame-id)))))
+
+(defn- with-dispatch-stub
+  "Run `body-fn` with the `:router/dispatch!` late-bind hook replaced by `stub`,
+  restoring the real router hook afterward. Lets the deterministic two-phase
+  publication tests COUNT the deferred dispatch synchronously without routing
+  through the async router drain (whose scheduling would make the count timing-
+  dependent). `stub` has the runtime dispatch signature `(fn [event opts] ...)`."
+  [stub body-fn]
+  (let [real (late-bind/get-fn :router/dispatch!)]
+    (try
+      (late-bind/set-fn! :router/dispatch! stub)
+      (body-fn)
+      (finally
+        (late-bind/set-fn! :router/dispatch! real)))))
 
 ;; ===========================================================================
 ;; (white-box) the armed handle is retained, then cancelled + dropped on
@@ -156,4 +172,138 @@
       (is (zero? (count (timers-for-frame test-frame)))
           "a fired timer drops its own side-table slot — no leak on the live
            path either")
+      (rf/destroy-frame! test-frame))))
+
+;; ===========================================================================
+;; rf2-3fc89f.3 — TWO-PHASE atomic publication vs immediate-fire + destroy.
+;;
+;; The publish-AFTER-set-timeout! scheme retained a spent handle forever when a
+;; zero/immediate host callback (the JVM ScheduledExecutorService may run the
+;; thunk on its worker thread BEFORE `set-timeout!` returns) fired before the
+;; handle was published, and could publish a handle PAST a frame destroy that
+;; raced the schedule. These tests drive both interleavings DETERMINISTICALLY
+;; through the `interop/set-timeout!` seam (not a flaky probability stress).
+;; ===========================================================================
+
+(def ^:private race-frame :rf2-3fc89f3/race)
+
+(deftest dispatch-later-immediate-fire-leaves-no-orphan-handle
+  (testing "a zero/immediate host callback that fires BEFORE the handle is
+            published removes the arming reservation and leaves NO orphan/spent
+            handle in the side table; the deferred event dispatches exactly
+            once and the spent handle is CANCELLED, not orphaned (rf2-3fc89f.3
+            acceptance 1)"
+    (let [dispatched   (atom [])
+          cleared      (atom [])
+          spent-handle ::spent-handle
+          event        [:rf2-3fc89f3/target]
+          opts         {:source :fx-dispatch-later :source-detail {:ms 0}}]
+      (with-dispatch-stub
+        (fn [ev op] (swap! dispatched conj [ev op]))
+        (fn []
+          ;; Force the pathological ordering: the host runs the timer thunk
+          ;; SYNCHRONOUSLY (as the real executor may for a 0ms delay) BEFORE
+          ;; returning its handle — the immediate-fire-before-publication race.
+          (with-redefs [interop/set-timeout!   (fn [f _ms] (f) spent-handle)
+                        interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+            (#'fx/arm-dispatch-later! race-frame 0 event opts))))
+      (is (= [[event opts]] @dispatched)
+          "the deferred event dispatched exactly once, with its event + opts
+           (:source / :source-detail) propagated verbatim")
+      (is (empty? (timers-for-frame race-frame))
+          "no orphan/spent handle retained — the publish phase saw the vanished
+           reservation and did NOT reinsert the spent handle (before the fix the
+           table retained {[race-frame 1] ::spent-handle})")
+      (is (= [spent-handle] @cleared)
+          "the publish phase CANCELLED the spent handle (safe even though it had
+           already completed) rather than leaking it forever"))))
+
+(deftest dispatch-later-destroy-between-reserve-and-publish-cancels-handle
+  (testing "a frame destroy that lands BETWEEN the reservation and the handle
+            publication removes the visible reservation without cancelling a
+            sentinel; the publish phase then CANCELS the returned handle, no
+            event dispatches, and nothing is published past cleanup
+            (rf2-3fc89f.3 acceptance 2 + 4)"
+    (let [dispatched (atom [])
+          cleared    (atom [])
+          the-handle ::live-handle
+          event      [:rf2-3fc89f3/target]
+          opts       {:source :fx-dispatch-later :source-detail {:ms 600000}}]
+      (with-dispatch-stub
+        (fn [ev op] (swap! dispatched conj [ev op]))
+        (fn []
+          (with-redefs [interop/set-timeout!
+                        (fn [_f _ms]
+                          ;; The arming reservation is VISIBLE here (phase 1 ran
+                          ;; before set-timeout!). Destroy the frame mid-schedule:
+                          ;; release-frame! must DROP the reservation but NEVER
+                          ;; pass the arming SENTINEL to clear-timeout!. Then we
+                          ;; return the real handle (publication happens next).
+                          (is (= 1 (count (timers-for-frame race-frame)))
+                              "the arming reservation is visible mid-set-timeout!")
+                          (fx/release-frame! race-frame)
+                          (is (empty? @cleared)
+                              "release-frame! did NOT cancel the arming sentinel
+                               (nothing cleared yet)")
+                          the-handle)
+                        interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+            (#'fx/arm-dispatch-later! race-frame 600000 event opts))))
+      (is (= [the-handle] @cleared)
+          "the publish phase found the reservation gone (destroy removed it) and
+           CANCELLED the returned handle; the arming SENTINEL was NEVER passed to
+           clear-timeout! (release-frame! skips it)")
+      (is (empty? @dispatched)
+          "no deferred event dispatched into the destroyed frame")
+      (is (empty? (timers-for-frame race-frame))
+          "no handle published after cleanup — the reservation was gone, so the
+           publish phase declined to reinsert"))))
+
+(deftest release-and-reset-never-cancel-the-arming-sentinel
+  (testing "release-frame! and reset-dispatch-later-timers! DROP an in-progress
+            arming reservation but NEVER pass the sentinel to clear-timeout!,
+            while still cancelling real handles (rf2-3fc89f.3 acceptance 4)"
+    (let [sentinel @#'fx/arming-sentinel
+          timers    @(resolve 're-frame.fx/dispatch-later-timers)
+          cleared   (atom [])]
+      ;; release-frame! over a frame whose only slot is an arming reservation.
+      (reset! timers {[race-frame 1] sentinel})
+      (with-redefs [interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+        (fx/release-frame! race-frame))
+      (is (empty? @cleared)
+          "release-frame! dropped the arming reservation WITHOUT cancelling the
+           sentinel (a sentinel is not a cancellable host object)")
+      (is (empty? (timers-for-frame race-frame))
+          "the reservation slot was removed")
+      ;; reset-dispatch-later-timers! over a mixed table (sentinel + real handle).
+      (reset! cleared [])
+      (reset! timers {[race-frame 2] sentinel
+                      [race-frame 3] ::real-handle})
+      (with-redefs [interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+        (fx/reset-dispatch-later-timers!))
+      (is (= [::real-handle] @cleared)
+          "reset cancelled the REAL handle but NEVER the arming sentinel")
+      (is (empty? @timers)
+          "the table is fully cleared"))))
+
+(deftest dispatch-later-zero-delay-live-path-fires-once-no-residue
+  (testing "a real 0ms :dispatch-later on a LIVE frame fires the deferred event
+            exactly once and leaves no side-table residue — the immediate-fire
+            path is leak-free through the real host executor, no stress needed
+            (rf2-3fc89f.3 acceptance 3)"
+    (let [target-ran (atom 0)]
+      (rf/reg-frame test-frame {:doc "rf2-3fc89f.3 zero-delay live-path frame"})
+      (rf/reg-event :rf2-uxz52g/target
+        (fn [{:keys [db]} _] (swap! target-ran inc) {:db db}))
+      (rf/reg-event :rf2-uxz52g/arm-now
+        (fn [_ _] {:fx [[:dispatch-later {:ms 0 :event [:rf2-uxz52g/target]}]]}))
+
+      (rf/dispatch-sync [:rf2-uxz52g/arm-now] {:frame test-frame})
+      ;; Let the 0ms host timer fire and the deferred event drain.
+      (Thread/sleep 200)
+
+      (is (= 1 @target-ran)
+          "the 0ms timer fired the deferred target exactly once through the real
+           executor")
+      (is (zero? (count (timers-for-frame test-frame)))
+          "the fired 0ms timer left no orphan/spent handle in the side table")
       (rf/destroy-frame! test-frame))))


### PR DESCRIPTION
## Summary

`:dispatch-later` published its host-timer handle to the `dispatch-later-timers`
side table only **after** `interop/set-timeout!` returned. On the JVM the
`ScheduledExecutorService` may run a zero/immediate timer thunk on its worker
thread *before* the caller resumes, and `release-frame!`/destroy can race the
schedule. Under the publish-after scheme that either:

- **orphaned a spent handle** — the thunk `dissoc`s a slot that isn't in the
  table yet, then the caller `assoc`s the already-fired handle, which can never
  self-remove (its callback already ran) — unbounded retention under repeated
  immediate dispatches in a long-lived JVM/SSR process; or
- **published a handle past cleanup** — a destroy between `set-timeout!` and the
  `assoc` misses the cancel, then the caller installs the handle after the frame
  is gone (dead-on-arrival dispatch + leaked handle).

CLJS (`js/setTimeout`) can't fire before the caller yields, so this is a
CLJ/CLJS parity race the code must close identically on both.

## The two-phase reservation

1. **RESERVE** `[frame-id timer-id]` with `arming-sentinel` (distinct from every
   host handle — a `ScheduledFuture` / numeric id) **before** `set-timeout!`, so
   the thunk and `release-frame!` always have a slot to remove.
2. **PUBLISH** after `set-timeout!` returns: a single `swap-vals!` replaces the
   reservation with the real handle **only if it still exists** (CAS-derived —
   the swap fn is pure, the cancel side effect rides the old snapshot, never
   inside the retriable swap). If the thunk fired (immediate race) or destroy
   removed it first, it does **not** reinsert and **cancels** the returned handle
   (idempotent even on a completed handle).

`release-frame!` and `reset-dispatch-later-timers!` now remove atomically
(`swap-vals!` / `reset-vals!`) and **never** pass the arming sentinel to
`clear-timeout!` — the arming caller's publish phase cancels the real handle
when it finds the reservation gone. Event opts/source propagation and the
fired-before-dispatch removal order are unchanged; CLJ + CLJS share the `.cljc`.

## Reproduce → fix evidence

Temporarily reverting only `arm-dispatch-later!` to the old publish-after body
(keeping the sentinel def so the ns still compiles) makes the new deterministic
tests fail exactly on the two interleavings — **5 failures**:

- immediate-fire: table retained `{[race-frame N] ::spent-handle}` (orphan), spent handle never cancelled;
- destroy-mid-arm: no reservation visible mid-`set-timeout!`, handle published past cleanup, never cancelled.

Restoring the two-phase body: **0 failures**.

## Tests (deterministic, driven through the `interop/set-timeout!` seam — no stress probability)

- `dispatch-later-immediate-fire-leaves-no-orphan-handle` — synchronous-fire seam: exactly one dispatch (opts propagated verbatim), no orphan, spent handle cancelled (acceptance 1).
- `dispatch-later-destroy-between-reserve-and-publish-cancels-handle` — destroy mid-`set-timeout!` while the reservation is visible: handle cancelled, no dispatch, nothing published past cleanup, sentinel never passed to `clear-timeout!` (acceptance 2 + 4).
- `release-and-reset-never-cancel-the-arming-sentinel` — both cleanup fns drop a sentinel without cancelling it, while still cancelling real handles (acceptance 4).
- `dispatch-later-zero-delay-live-path-fires-once-no-residue` — real 0ms timer on a live frame fires once, no residue (acceptance 3).
- Existing delayed live-frame / fired-entry-cleanup / destroy-before-fire assertions retained.

## Quality gates

- `clojure -M:test -n re-frame.dispatch-later-frame-destroy-test -n re-frame.fx-test -n re-frame.frame-lifecycle-test -n re-frame.frame-destroy-composed-test` — **92 tests, 459 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (core CLJS suite) — **8481 tests, 39626 assertions, 0 failures, 0 errors** (CLJ/CLJS parity)
- `clj-kondo --lint` on both changed files — **0 errors, 0 warnings**

## Stance

Pre-alpha; explicit two-phase reservation; CAS-derived state (no side effects inside a retriable `swap!`); CLJ + CLJS identical; ELEGANCE + CLARITY + CORRECTNESS. Different core mechanism from the just-merged reg-flow drain-lock gate (this is the timer side table); `release-frame!`/destroy path respects the landed reentrant serialization gate (untouched here).

Closes rf2-3fc89f.3.
