### PR TITLE
test: sweep 16 hand-rolled runtime resets onto make-reset-runtime-fixture (rf2-vyzqca)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
@@ -15,40 +15,21 @@
 
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest async use-fixtures]]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; Per cljs.test: async tests require fixtures supplied as a map
-;; (fn-form fixtures don't suspend across the async body). Wrap the
-;; snapshot/restore pattern as `{:before :after}`.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  ;; Per rf2-wkxng / rf2-6m0se: clear the per-frame schema registry so
-  ;; ns-load `reg-app-schema` calls from sibling test namespaces don't
-  ;; fire post-commit validation rollbacks against this test's frames.
-  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
-    (clear!))
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! helix-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; Async map-form fixture (a fn-form fixture's teardown would restore the
+;; registrar before an `(async done)` body completes). `make-reset-runtime-
+;; fixture` (`:async? true`) performs the snapshot/restore + frames-reset +
+;; adapter dispose/install this suite hand-rolled, and its pre-dispose reset
+;; clears the per-frame schema registry (per rf2-wkxng / rf2-6m0se: so ns-load
+;; `reg-app-schema` calls from sibling test namespaces don't fire post-commit
+;; validation rollbacks against this test's frames). `:ambient-frame nil`
+;; preserves the suite's no-ambient-scope behaviour.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter helix-adapter/adapter :async? true :ambient-frame nil}))
 
 (def ^:private cfg
   {:adapter      helix-adapter/adapter

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_resource_lease_dom_cljs_test.cljs
@@ -22,27 +22,16 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.helix :as helix-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; ---- MAP-form fixture (async-safe) -----------------------------------------
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! helix-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; ---- async map-form fixture (async-safe) -----------------------------------
+;; `make-reset-runtime-fixture` (`:async? true`) performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled. `:ambient-frame
+;; nil` preserves the no-ambient-scope behaviour (each test binds its own
+;; `*current-frame*` around the mount).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter helix-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- spy channels ----------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/adapter/mixed_family_lease_owner_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter/mixed_family_lease_owner_dom_cljs_test.cljs
@@ -44,7 +44,6 @@
             ;; The shared React-hook lease Var — the very one UIx / Helix
             ;; re-export. Exercised directly = the UIx/Helix family's behaviour.
             [re-frame.adapter.resource-lease :as resource-lease]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]
             ;; load-bearing side-effecting requires: register the
             ;; :rf.resource/* events + the managed-HTTP fx surface (overridden
@@ -54,41 +53,34 @@
             [re-frame.http.managed]
             [re-frame.schemas]))
 
-;; ---- fixture (MAP-form, async-safe) ---------------------------------------
-;; A function fixture would tear down mid-async (its `(f)` returns before the
-;; async body's `done`); the map `{:before :after}` form brackets the async
-;; completion. Installs the Reagent adapter + a REAL global resource whose
-;; transport is stubbed to a no-op, so ensure writes the :loading entry + owner
-;; deterministically without a live fetch.
+;; ---- async map-form fixture -----------------------------------------------
+;; `make-reset-runtime-fixture` (`:async? true`) performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled. `:ambient-frame
+;; nil` preserves the no-ambient-scope behaviour (both leases pin an explicit
+;; `:frame`). The `:init-fn` installs a no-op `:rf.http/managed` fx (so ensure
+;; never fetches) + a REAL global resource, so ensure writes the :loading entry
+;; + owner deterministically; both registrations roll back with the per-test
+;; registrar snapshot.
 
 (def ^:private lease-frame :rf/default)
 (def ^:private resource-id :rf.mixed-lease/feed)
 
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!)
-  ;; No real fetch — ensure only needs to write the :loading entry + attach the
-  ;; owner for the owner-index / release-owner assertions.
-  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (rf/reg-resource resource-id
-    {:scope         :rf.scope/global
-     :params-schema [:map [:page :int]]
-     :tags          (fn [_p _v] #{[:mixed-feed]})}
-    (fn [{:keys [page]} _ctx]
-      {:request {:method :get :url "/feed" :params {:page page}}})))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :async?        true
+     :ambient-frame nil
+     :init-fn       (fn []
+                      ;; No real fetch — ensure only needs to write the :loading
+                      ;; entry + attach the owner for the owner-index /
+                      ;; release-owner assertions.
+                      (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+                      (rf/reg-resource resource-id
+                        {:scope         :rf.scope/global
+                         :params-schema [:map [:page :int]]
+                         :tags          (fn [_p _v] #{[:mixed-feed]})}
+                        (fn [{:keys [page]} _ctx]
+                          {:request {:method :get :url "/feed" :params {:page page}}})))}))
 
 ;; ---- descriptors + runtime readers ----------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter/with_resource_lease_dom_cljs_test.cljs
@@ -22,30 +22,17 @@
             [re-frame.frame :as frame]
             [re-frame.router :as router]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; ---- MAP-form fixture (async-safe); pins the React-context tier ------------
-;; No ambient `*current-frame*` scope — the with-resource-lease under test
-;; must resolve the frame-provider's frame via the class React-context tier,
+;; ---- async map-form fixture; pins the React-context tier -------------------
+;; `make-reset-runtime-fixture` (`:async? true`) performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled. `:ambient-frame
+;; nil` keeps NO ambient `*current-frame*` scope — the `with-resource-lease`
+;; under test must resolve the frame-provider's frame via the React-context tier,
 ;; which an ambient :rf/default would shadow.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- spy channels ----------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/adapter_after_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_after_render_cljs_test.cljs
@@ -42,7 +42,6 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -53,28 +52,17 @@
 ;; currently-installed adapter (per `substrate-adapter/route-hook!`).
 ;; Other adapter ns'es loaded in the same test bundle publish the same
 ;; key, so we MUST install the Reagent adapter to make the routed closure
-;; dispatch to Reagent's reader rather than chain to a sibling. Mirrors
-;; the install/dispose pattern in `dispatch_frame_capture_cljs_test`.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  ;; Drain any after-render queue / pending fake-raf so an enqueued
-  ;; callback can't leak into a later test ns sharing the bundle.
-  (r/flush)
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; dispatch to Reagent's reader rather than chain to a sibling —
+;; `make-reset-runtime-fixture {:adapter reagent-adapter/adapter}` does the
+;; snapshot/restore + frames-reset + dispose/install. `:ambient-frame nil`
+;; preserves the suite's no-ambient-scope behaviour (no frame-scoped ops in
+;; the bodies). A composed teardown fixture drains Reagent's after-render
+;; queue / pending fake-raf (`r/flush`) so an enqueued callback can't leak
+;; into a later test ns sharing the bundle.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :ambient-frame nil})
+  (fn [test-fn] (try (test-fn) (finally (r/flush)))))
 
 ;; ---- (1) the hook is reachable through interop under the Reagent adapter ---
 

--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -32,37 +32,20 @@
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            ;; rf2-qwm0a — listener surface lives in
-            ;; `re-frame.trace.tooling` (production-DCE split).
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; Per cljs.test: async tests require fixtures supplied as a map
-;; (fn-form fixtures don't suspend across the async body, so the
-;; finally clause runs before the async work completes). Wrap the
-;; snapshot/restore pattern as `{:before :after}`. Mirrors the
-;; tools/story CLJS async-test idiom.
+;; Per cljs.test: async tests require fixtures supplied as a MAP — a
+;; fn-form fixture's teardown runs before an `(async done)` body
+;; completes, restoring the registrar mid-flight. `make-reset-runtime-
+;; fixture`'s `:async? true` map-form performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled.
+;; `:ambient-frame nil` preserves the suite's no-ambient-scope
+;; behaviour — every dispatch here carries an explicit `{:frame …}`.
 
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -86,57 +86,32 @@
             [re-frame.frame :as frame]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.views]
             [re-frame.views.owned-frame :as owned-frame])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
+;; MAP-FORM fixture (`:async? true`): cljs.test requires `:each` fixtures to be
+;; maps when the ns contains ANY `async` test (a fn-form fixture's teardown runs
+;; before the async body's `done` fires). Scenario-6-ensure (the hot-reload gate)
+;; + the genuine-unmount test advance macrotask windows across a real React
+;; lifecycle. `make-reset-runtime-fixture` performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled.
+;;
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` OPTS OUT of the fixture's default
 ;; ambient `*current-frame*` :rf/default scope. EVERY render-based test in this
 ;; suite pins the React-context tier (tier 2) of the resolution chain — a
 ;; reg-view inside a `frame-provider` must resolve the provider's frame, and a
 ;; reg-view with NO provider must fail closed with `:rf.error/no-frame-context`.
-;; The React renders below run SYNCHRONOUSLY inside `flushSync`, i.e. still
-;; inside the test body's dynamic extent; an ambient :rf/default scope would
-;; satisfy `current-frame-id` / `subscribe` / dispatch at tier 1 and the
-;; React-context tier under test would never be consulted. Opting the whole
-;; suite out keeps the resolution honest. (Scenario-3 + the prop-stringified
-;; cases additionally `(binding [*current-frame* nil] …)` for belt-and-braces;
-;; that is idempotent here.)
-;; MAP-FORM fixture (not the fn-form `make-reset-runtime-fixture`): cljs.test
-;; requires `:each` fixtures to be `{:before … :after …}` maps when the ns
-;; contains ANY `async` test (a fn-form fixture's wrapper returns — running
-;; its teardown — before the async body's `done` fires). Scenario-6-ensure (the
-;; hot-reload gate) + the genuine-unmount test below are async (they advance
-;; macrotask windows across a real React lifecycle). The before/after pair replicates
-;; the runtime reset `make-reset-runtime-fixture` performs for THIS suite:
-;; snapshot + restore the registrar, reset the frame registry + live-frame
-;; index, dispose/reinstall the Reagent adapter, clear trace listeners,
-;; ensure `:rf/default`. There is NO ambient `*current-frame*` binding —
-;; this suite pins the React-context tier (the `:ambient-frame nil` opt-out
-;; the fn-form fixture carried); an ambient :rf/default would shadow tier 2.
-;; Mirrors the established async-DOM fixture idiom in
-;; react_click_handler_frame_routing_cljs_test / dispatch_frame_capture.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; The React renders below run SYNCHRONOUSLY inside `flushSync`, i.e. still inside
+;; the test body's dynamic extent; an ambient :rf/default scope would satisfy
+;; `current-frame-id` / `subscribe` / dispatch at tier 1 and the React-context
+;; tier under test would never be consulted. Opting the whole suite out keeps the
+;; resolution honest. (Scenario-3 + the prop-stringified cases additionally
+;; `(binding [*current-frame* nil] …)` for belt-and-braces; that is idempotent.)
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
@@ -35,35 +35,28 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.test-support :as test-support]))
 
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! reagent-adapter/adapter)
-  (frame/ensure-default-frame!)
-  ;; Per the bead: the surrounding frame is :rf/xray. Register it and a
-  ;; reducer + sub that pivot on a per-frame slot so a routing leak is
-  ;; visible as 'reducer ran on wrong frame's db'.
-  (rf/reg-frame :rf/xray {:doc "Xray surrogate for the routing tests"})
-  (rf/reg-event :rf-tvu99/set-mode
-                   (fn [{:keys [db]} [_ mode]] {:db (assoc db :mode mode)}))
-  (rf/reg-sub      :rf-tvu99/mode
-                   (fn [db _] (get db :mode :diff))))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; Async map-form fixture (a fn-form fixture's teardown would restore the
+;; registrar before an `(async done)` body completes). `make-reset-runtime-
+;; fixture` performs the snapshot/restore + frames-reset + adapter
+;; dispose/install this suite hand-rolled; `:ambient-frame nil` preserves the
+;; suite's no-ambient-scope behaviour (each test drives an explicit
+;; `with-frame` / `{:frame …}`). The `:init-fn` registers the `:rf/xray`
+;; surrogate frame + a reducer/sub pivoting on a per-frame slot so a routing
+;; leak shows as 'reducer ran on the wrong frame's db'; those registrations
+;; roll back with the per-test registrar snapshot.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :async?        true
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (rf/reg-frame :rf/xray {:doc "Xray surrogate for the routing tests"})
+                      (rf/reg-event :rf-tvu99/set-mode
+                                    (fn [{:keys [db]} [_ mode]] {:db (assoc db :mode mode)}))
+                      (rf/reg-sub :rf-tvu99/mode
+                                  (fn [db _] (get db :mode :diff))))}))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -14,40 +14,21 @@
 
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest async use-fixtures]]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; Per cljs.test: async tests require fixtures supplied as a map
-;; (fn-form fixtures don't suspend across the async body). Wrap the
-;; snapshot/restore pattern as `{:before :after}`.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  ;; Per rf2-wkxng / rf2-6m0se: clear the per-frame schema registry so
-  ;; ns-load `reg-app-schema` calls from sibling test namespaces don't
-  ;; fire post-commit validation rollbacks against this test's frames.
-  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
-    (clear!))
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! uix-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; Async map-form fixture (a fn-form fixture's teardown would restore the
+;; registrar before an `(async done)` body completes). `make-reset-runtime-
+;; fixture` (`:async? true`) performs the snapshot/restore + frames-reset +
+;; adapter dispose/install this suite hand-rolled, and its pre-dispose reset
+;; clears the per-frame schema registry (per rf2-wkxng / rf2-6m0se: so ns-load
+;; `reg-app-schema` calls from sibling test namespaces don't fire post-commit
+;; validation rollbacks against this test's frames). `:ambient-frame nil`
+;; preserves the suite's no-ambient-scope behaviour.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter :async? true :ambient-frame nil}))
 
 (def ^:private cfg
   {:adapter      uix-adapter/adapter

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
@@ -30,27 +30,16 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
-;; ---- MAP-form fixture (async-safe) -----------------------------------------
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! uix-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
-
-(use-fixtures :each {:before before! :after after!})
+;; ---- async map-form fixture (async-safe) -----------------------------------
+;; `make-reset-runtime-fixture` (`:async? true`) performs the snapshot/restore +
+;; frames-reset + adapter dispose/install this suite hand-rolled. `:ambient-frame
+;; nil` preserves the no-ambient-scope behaviour (each test binds its own
+;; `*current-frame*` around the mount).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- spy channels ----------------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -49,35 +49,19 @@
             [re-frame.ssr.constants :as constants]
             [re-frame.ssr.streaming.constants :as wire]
             [re-frame.ssr.streaming.client :as streaming-client]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.trace.tooling :as trace-tooling]))
 
-;; Per cljs.test: async tests require fixtures supplied as a MAP (a
-;; fn-form fixture's `finally` runs before the async body completes,
-;; which cljs.test rejects — "Async tests require fixtures to be
-;; specified as maps"). One of the tests below is observer-driven
-;; (`cljs.test/async`), so the suite uses the map-form reset fixture —
-;; the same idiom as `re-frame.dispatch-fallthrough-warn-dom-cljs-test`.
-
-(def ^:private registrar-snapshot (atom nil))
-
-(defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (trace-tooling/clear-listeners!)
-  (substrate-adapter/install-adapter! reagent-slim-adapter/adapter)
-  (frame/ensure-default-frame!))
-
-(defn- after! []
-  (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
-    (reset! registrar-snapshot nil))
-  (reset! frame/frames {})
-  (trace-tooling/clear-listeners!))
-
-(use-fixtures :each {:before before! :after after!})
+;; Per cljs.test: async tests require fixtures supplied as a MAP (a fn-form
+;; fixture's teardown runs before the async body completes — "Async tests require
+;; fixtures to be specified as maps"). One of the tests below is observer-driven
+;; (`cljs.test/async`), so the suite uses `make-reset-runtime-fixture`'s
+;; `:async? true` map-form for the snapshot/restore + frames-reset + adapter
+;; dispose/install it hand-rolled. `:ambient-frame nil` preserves the
+;; no-ambient-scope behaviour (each test creates its own client frame).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
@@ -27,24 +27,16 @@
             [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.story.sub-overrides :as sub-overrides]))
 
-(def ^:private registrar-snapshot (atom nil))
-
+;; `make-reset-runtime-fixture` performs the snapshot/restore + frames-reset +
+;; adapter dispose/install this suite hand-rolled. `:ambient-frame nil` preserves
+;; the suite's no-ambient-scope behaviour — each render-based test binds its own
+;; `*current-frame* :rf/default` around the mount.
 (use-fixtures :each
-  {:before (fn []
-             (reset! registrar-snapshot (test-support/snapshot-registrar))
-             (reset! frame/frames {})
-             (substrate-adapter/dispose-adapter!)
-             (substrate-adapter/install-adapter! reagent-adapter/adapter)
-             (frame/ensure-default-frame!))
-   :after  (fn []
-             (when-let [snap @registrar-snapshot]
-               (test-support/restore-registrar! snap)
-               (reset! registrar-snapshot nil))
-             (reset! frame/frames {}))})
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :ambient-frame nil}))
 
 ;; ---- browser + act gate (mirrors react-shared-suite) ----------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -38,39 +38,26 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.palette :as palette]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-;; ---- fixture (map shape per cljs.test/async requirement) ---------------
-
-(def ^:private fixture-snap (atom nil))
-
-(defn- setup-runtime! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  (reset! fixture-snap (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (registry/register-xray-handlers!)
-  (frame/reg-frame :rf/xray {}))
-
-(defn- teardown-runtime! []
-  (when-let [snap @fixture-snap]
-    (test-support/restore-registrar! snap)
-    (reset! fixture-snap nil))
-  (reset! frame/frames {}))
-
+;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
+;; `make-reset-runtime-fixture` (snapshot/restore + frames-reset + adapter
+;; dispose/install) with Xray's own reset tier. `:tier :runtime` folds the
+;; sentinel + trace-collector + persisted-settings reset; `:async? true` is the
+;; map-form cljs.test/async requires; `:post-reset` re-registers Xray's
+;; :rf.xray/* handlers + the :rf/xray frame (rolled back with the per-test
+;; registrar snapshot).
 (use-fixtures :each
-  {:before setup-runtime!
-   :after  teardown-runtime!})
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :async?     true
+     :post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (frame/reg-frame :rf/xray {}))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 ;; The private expand-tree / hiccup-seq copies were semantically identical to

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
@@ -39,43 +39,32 @@
   (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]))
 
-;; ---- fixture (map shape per cljs.test/async requirement) ---------------
-
-(def ^:private fixture-snap (atom nil))
-
-(defn- setup-runtime! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (after-rings/stop-tick!)
-  ;; Snapshot the framework registrar so we can restore it post-test,
-  ;; matching the body of `test-support/make-reset-runtime-fixture`.
-  (reset! fixture-snap (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (registry/register-xray-handlers!)
-  (xray-test-support/install-test-overrides!)
-  (frame/reg-frame :rf/xray {}))
-
-(defn- teardown-runtime! []
-  (after-rings/stop-tick!)
-  (when-let [snap @fixture-snap]
-    (test-support/restore-registrar! snap)
-    (reset! fixture-snap nil))
-  (reset! frame/frames {}))
-
+;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
+;; `make-reset-runtime-fixture` (snapshot/restore + frames-reset + adapter
+;; dispose/install) with Xray's own reset tier. `:tier :all` folds the sentinel +
+;; trace-collector rings reset; `:async? true` is the map-form cljs.test/async
+;; requires; `:post-reset` re-registers Xray's :rf.xray/* handlers + the panel
+;; test-override seams + the :rf/xray frame (rolled back with the per-test
+;; registrar snapshot). A composed fixture brackets `after-rings/stop-tick!`
+;; before AND after each test — the off-render `tick-loop!` is an rAF loop the
+;; core runtime reset does not cancel, so a stale tick from one test must not
+;; survive into the next.
 (use-fixtures :each
-  {:before setup-runtime!
-   :after  teardown-runtime!})
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :all
+     :async?     true
+     :post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (xray-test-support/install-test-overrides!)
+                   (frame/reg-frame :rf/xray {}))})
+  {:before (fn [] (after-rings/stop-tick!))
+   :after  (fn [] (after-rings/stop-tick!))})
 
 ;; ---- fixture data (mirrors machine_after_rings_cljs_test.cljs) --------
 

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -18,38 +18,25 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.test-helpers :as th]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-;; ---- fixture (map shape per cljs.test/async requirement) ---------------
-
-(def ^:private fixture-snap (atom nil))
-
-(defn- setup-runtime! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  (reset! fixture-snap (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  (registry/register-xray-handlers!)
-  (frame/reg-frame :rf/xray {}))
-
-(defn- teardown-runtime! []
-  (when-let [snap @fixture-snap]
-    (test-support/restore-registrar! snap)
-    (reset! fixture-snap nil))
-  (reset! frame/frames {}))
-
+;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
+;; `make-reset-runtime-fixture` (snapshot/restore + frames-reset + adapter
+;; dispose/install) with Xray's own reset tier. `:tier :runtime` folds the
+;; sentinel + trace-collector + persisted-settings reset; `:async? true` is the
+;; map-form cljs.test/async requires; `:post-reset` re-registers Xray's
+;; :rf.xray/* handlers + the :rf/xray frame (rolled back with the per-test
+;; registrar snapshot).
 (use-fixtures :each
-  {:before setup-runtime!
-   :after  teardown-runtime!})
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :async?     true
+     :post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (frame/reg-frame :rf/xray {}))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 ;; The private expand-tree / hiccup-seq / find-by-testid copies were

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -41,42 +41,26 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
-;; ---- fixture (map shape per cljs.test/async requirement) ---------------
-
-(def ^:private fixture-snap (atom nil))
-
-(defn- setup-runtime! []
-  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
-  ;; settings reset into one call.
-  (xray-test-support/reset-runtime!)
-  ;; Capture the framework registrar so we can restore it post-test,
-  ;; matching the body of `test-support/make-reset-runtime-fixture`.
-  (reset! fixture-snap (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (substrate-adapter/dispose-adapter!)
-  (substrate-adapter/install-adapter! plain-atom/adapter)
-  (frame/ensure-default-frame!)
-  ;; Xray's :rf.xray/* registrations + the :rf/xray frame.
-  (registry/register-xray-handlers!)
-  (frame/reg-frame :rf/xray {}))
-
-(defn- teardown-runtime! []
-  (when-let [snap @fixture-snap]
-    (test-support/restore-registrar! snap)
-    (reset! fixture-snap nil))
-  (reset! frame/frames {}))
-
+;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
+;; `make-reset-runtime-fixture` (snapshot/restore + frames-reset + adapter
+;; dispose/install) with Xray's own reset tier. `:tier :runtime` folds the
+;; sentinel + trace-collector + persisted-settings reset; `:async? true` is the
+;; map-form cljs.test/async requires; `:post-reset` re-registers Xray's
+;; :rf.xray/* handlers + the :rf/xray frame (rolled back with the per-test
+;; registrar snapshot).
 (use-fixtures :each
-  {:before setup-runtime!
-   :after  teardown-runtime!})
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :async?     true
+     :post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (frame/reg-frame :rf/xray {}))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
 ;; The private expand-tree / hiccup-seq / find-by-testid copies were


### PR DESCRIPTION
Sweep (rf2-vyzqca): migrate the hand-rolled per-test runtime resets in the
adapter / SSR / Story / Xray DOM test suites onto the composed fixture that
already exists for exactly this — `re-frame.test-support/make-reset-runtime-fixture`
(and, for Xray, its established wrapper `day8.re-frame2-xray.test-support/make-xray-runtime-fixture`).

Each migrated suite previously hand-rolled the same `before!`/`after!` block:
`(snapshot-registrar)` + `(reset! frame/frames {})` + `dispose-adapter!` +
`install-adapter!` + `ensure-default-frame!`, with a matching `restore-registrar!`
teardown. That is precisely what the fixture composes. The corpus now teaches
ONE spelling of its dominant idiom.

## Stance

Pre-alpha; SOTA-masterpiece posture via ELEGANCE + CLARITY + CORRECTNESS. This is
**fixture plumbing only** — no test asserts anything different. Every change is
`use-fixtures` wiring plus dropping requires whose only call sites the fixture
absorbed. Diffs are −422/+203 lines across 16 files.

## What moved (16 files migrated)

**Reagent adapter (6)** — `dispatch_frame_capture`, `react_click_handler_frame_routing`,
`frame_provider_context_dom`, `adapter_after_render`, `adapter/mixed_family_lease_owner_dom`,
`adapter/with_resource_lease_dom`.
**UIx adapter (2)** — `uix_use_resource_lease_dom`, `uix_dispatch_frame_capture`.
**Helix adapter (2)** — `helix_use_resource_lease_dom`, `helix_dispatch_frame_capture`.
**SSR (1)** — `ssr/streaming_client_dom`.
**Story (1)** — `story/sub_overrides_render_dom`.
**Xray (4)** — `settings/popup_dispatch_routing`, `settings/editor_hint`,
`palette/dispatch_routing`, `panels/machine_after_rings_tick_loop`.

Mechanics preserved faithfully:
- Async (`cljs.test/async`) suites use `:async? true` (map-form).
- Every migrated suite kept its exact ambient-scope behaviour: async/map-form
  suites that never established `*current-frame*` pass `:ambient-frame nil`
  (frame_provider / with_resource_lease already documented needing this to keep
  the React-context tier honest); elision-adjacent nothing here needed it.
- `adapter_after_render` composes a second fn-fixture for its `r/flush` after-render
  drain; `machine_after_rings` composes a second map-fixture to bracket
  `after-rings/stop-tick!` (an rAF loop the core reset does not cancel).
- The four Xray suites adopt `make-xray-runtime-fixture` (the wrapper ~40 other
  Xray suites already use), threading their Xray-specific setup through its
  `:tier` + `:post-reset` hook.

No fixture-opts extension was needed — every bracket the suites required was
already expressible via existing options (`:async?`, `:ambient-frame`, `:init-fn`,
`:post-reset`, or a composed second fixture).

## Deliberately NOT migrated (6 files — raw primitives kept, each justified)

These compose something `make-reset-runtime-fixture` cannot express; leaving them
is permitted by the acceptance criteria's escape hatch.

- `implementation/core/.../reg_meta_noswallow_cljs_test.cljc` — registrar-only
  `clear-all!` + snapshot/restore (a full wipe, not the fixture's ns-load-preserving
  snapshot/restore).
- `implementation/core/.../event_emit_cljs_test.cljc` — `clear-all!`-based full
  reset with bespoke late-bind hook save/restore + cache invalidation.
- `implementation/machines/.../machine_algebra_view_test.clj` — ALREADY uses the
  fixture for `:each`; the raw snapshot/restore is a scoped in-test bracket around
  a deliberate `clear-all!`.
- `tools/story/testbeds/login_form/stories_cljs_test.cljs` and
  `tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs` — the Story
  testbed cluster uses the `story/clear-all!` idiom (= `registrar/clear-all!`) and
  relies on the EP-0026 source store staying **accumulated** across the bundle.
- `tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs` — I
  initially migrated this (it is snapshot/restore-based) but **reverted it**: it
  shares the counter-with-stories node-test bundle with `stories_cljs_test.cljs`,
  and `make-reset-runtime-fixture`'s source-store isolation resets the store to the
  migrated ns's baseline on teardown, stranding the sibling's later-registered app
  descriptors — its variant-frame image could no longer resolve `:counter/initialise`
  (16 failures, root-caused via a green-baseline diff). The counter-with-stories /
  login-form testbed cluster wants a **coordinated** migration (likely onto
  `re-frame.story.test-support`), not a one-file change. Recommend a follow-up bead.

Coordination: none of the migrated/skipped files overlap the in-flight c6xkmn
(machines `dispatch_to_system_fx` + `machines_system_id`) or #5546 (core+flows) work.

## Quality gates (foreground, affected suites)

- `cd implementation && npm run test:cljs` — **8481 tests, 39625 assertions, 0 failures, 0 errors** (on the rebased-onto-origin/main tree).
- `cd tools/story && clojure -M:test` — **1774 tests, 6504 assertions, 0 failures, 0 errors**.

The consolidated node-test bundle exercised by `test:cljs` covers the Story + Xray
node testbeds too, so the migrated Xray/SSR/Story-DOM suites are all gated there.
