### PR TITLE
fix(core): suppress dispatch-later callback when cleanup wins during arming (rf2-j538f7.2)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -243,6 +243,14 @@
   The timer thunk drops its OWN slot BEFORE dispatching, so the table tracks
   exactly the pending set (a fired timer leaves no residue). Returns nil.
 
+  The slot is BOTH resource ownership (the cancellable host handle) AND the
+  callback's DISPATCH AUTHORITY (rf2-j538f7.2): the thunk dispatches ONLY when
+  it atomically removes a slot that was still present. If `release-frame!` /
+  `reset-dispatch-later-timers!` removed the reservation FIRST — cleanup won
+  DURING arming, even before `set-timeout!` returned this handle — the thunk
+  finds no slot in its winning `swap-vals!` snapshot and SUPPRESSES the
+  dispatch, since host cancellation cannot un-run an already-started thunk.
+
   TWO-PHASE, ATOMIC publication (rf2-3fc89f.3). A zero/immediate host callback
   (the JVM `ScheduledExecutorService` may run the thunk on its worker thread
   BEFORE `set-timeout!` returns) or a `release-frame!`/destroy racing the
@@ -271,20 +279,32 @@
     (swap! dispatch-later-timers assoc k arming-sentinel)
     (let [handle (interop/set-timeout!
                    (fn []
-                     ;; Drop our own slot first — the timer has fired, so its
-                     ;; handle is spent; a later `release-frame!` must not try
-                     ;; to cancel a fired handle, and the table must not retain
-                     ;; a fired timer. Removal precedes dispatch on BOTH the
-                     ;; sentinel window (immediate fire before publication) and
-                     ;; the ordinary armed slot.
-                     (swap! dispatch-later-timers dissoc k)
-                     ;; Sticky hook (rf2-f72pd) — the timer callback fires per
-                     ;; scheduled :dispatch-later. When the frame was destroyed
-                     ;; before the timer fired, this slot was already cancelled
-                     ;; + dropped by `release-frame!`, so this thunk never runs;
-                     ;; on the live path `dispatch!` enqueues into the frame.
-                     (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
-                       (dispatch! event opts)))
+                     ;; ATOMICALLY remove our own slot AND capture the winning
+                     ;; pre-swap snapshot (rf2-j538f7.2). The slot is BOTH the
+                     ;; resource-ownership handle AND this callback's DISPATCH
+                     ;; AUTHORITY: whoever removes it decides whether the deferred
+                     ;; event dispatches. `swap-vals!` yields the old map from the
+                     ;; winning CAS attempt; the dispatch side effect rides that
+                     ;; snapshot and NEVER runs inside the retriable swap fn
+                     ;; (`dissoc` is pure + idempotent). Removal precedes dispatch
+                     ;; on BOTH the sentinel window (immediate fire before
+                     ;; publication) and the ordinary armed slot.
+                     (let [[old _] (swap-vals! dispatch-later-timers dissoc k)]
+                       ;; Sticky hook (rf2-f72pd) — the timer callback fires per
+                       ;; scheduled :dispatch-later. Dispatch ONLY when our slot was
+                       ;; still present in the winning old snapshot. If
+                       ;; `release-frame!` / `reset-dispatch-later-timers!` removed
+                       ;; the reservation FIRST — cleanup won DURING arming, even
+                       ;; before `set-timeout!` returned this handle (a legal JVM
+                       ;; executor ordering) — this callback has LOST its authority
+                       ;; and must NOT fire a dead-on-arrival dispatch into the
+                       ;; torn-down frame (rf2-j538f7.2). Host cancellation cannot
+                       ;; un-run an already-started thunk, so the authority check IS
+                       ;; the suppression. On the live path the slot is present, so
+                       ;; `dispatch!` enqueues into the frame exactly once.
+                       (when (contains? old k)
+                         (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
+                           (dispatch! event opts)))))
                    ms)
           ;; PHASE 2 — publish the handle only if the reservation survived. The
           ;; swap fn is a pure CAS-derived replace-if-present; the cancel side

--- a/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
+++ b/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
@@ -307,3 +307,137 @@
       (is (zero? (count (timers-for-frame test-frame)))
           "the fired 0ms timer left no orphan/spent handle in the side table")
       (rf/destroy-frame! test-frame))))
+
+;; ===========================================================================
+;; rf2-j538f7.2 — CLEANUP-WINS-DURING-ARMING callback SUPPRESSION.
+;;
+;; A residual gap survives the rf2-3fc89f.3 two-phase reservation: when cleanup
+;; (`release-frame!` / `reset-dispatch-later-timers!`) removes the reservation
+;; DURING arming, yet the host executor STILL runs the timer thunk before
+;; `set-timeout!` returns its handle, the OLD thunk unconditionally dispatched a
+;; dead-on-arrival event into the torn-down frame. Host cancellation cannot
+;; un-run an already-started thunk, so the SLOT is treated as the thunk's
+;; DISPATCH AUTHORITY: the thunk dispatches ONLY when its winning `swap-vals!`
+;; snapshot still held its slot. These tests drive the composed interleaving
+;; DETERMINISTICALLY through the `interop/set-timeout!` seam — cleanup FIRST,
+;; then the callback, then the handle return.
+;; ===========================================================================
+
+(def ^:private authority-frame :rf2-j538f72/race)
+(def ^:private authority-event [:rf2-j538f72/target])
+
+(deftest dispatch-later-release-during-arming-suppresses-callback-dispatch
+  (testing "release-frame! wins DURING arming (removes the reservation) and the
+            host callback STILL fires before set-timeout! returns: the callback
+            has LOST its dispatch authority and dispatches NOTHING; the returned
+            handle is cancelled once and the side table is empty (rf2-j538f7.2
+            acceptance 1)"
+    (let [dispatched (atom [])
+          cleared    (atom [])
+          the-handle ::handle
+          opts       {:source :fx-dispatch-later :source-detail {:ms 600000}
+                      :frame  authority-frame}]
+      (with-dispatch-stub
+        (fn [ev op] (swap! dispatched conj [ev op]))
+        (fn []
+          (with-redefs [interop/set-timeout!
+                        (fn [f _ms]
+                          ;; Cleanup wins DURING arming: destroy removes the
+                          ;; reservation while the timer is still mid-schedule …
+                          (fx/release-frame! authority-frame)
+                          ;; … yet the host executor STILL runs the captured
+                          ;; callback before set-timeout! returns (a legal JVM
+                          ;; ordering the two-phase publish alone cannot suppress).
+                          (f)
+                          the-handle)
+                        interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+            (#'fx/arm-dispatch-later! authority-frame 600000 authority-event opts))))
+      (is (empty? @dispatched)
+          "the callback fired AFTER cleanup removed its reservation, so it had NO
+           dispatch authority and dispatched NOTHING (before the fix it dispatched
+           a dead-on-arrival event into the torn-down frame)")
+      (is (= [the-handle] @cleared)
+          "the publish phase found the reservation gone and CANCELLED the returned
+           handle exactly once (the arming sentinel was never passed to
+           clear-timeout!)")
+      (is (empty? (timers-for-frame authority-frame))
+          "no side-table entry survives — neither the callback nor the publish
+           phase reinstated a slot"))))
+
+(deftest dispatch-later-reset-during-arming-suppresses-callback-dispatch
+  (testing "the same composed interleaving through reset-dispatch-later-timers!
+            (a test-isolation reset winning DURING arming): the callback cannot
+            leak a dispatch into the next test/runtime generation, and the arming
+            SENTINEL is never passed to clear-timeout! (rf2-j538f7.2 acceptance 2)"
+    (let [dispatched (atom [])
+          cleared    (atom [])
+          the-handle ::handle
+          opts       {:source :fx-dispatch-later :source-detail {:ms 600000}
+                      :frame  authority-frame}]
+      (with-dispatch-stub
+        (fn [ev op] (swap! dispatched conj [ev op]))
+        (fn []
+          (with-redefs [interop/set-timeout!
+                        (fn [f _ms]
+                          ;; A test-isolation reset fires DURING arming — the
+                          ;; reset-hooks table clears every frame's timers between
+                          ;; tests, dropping the arming sentinel …
+                          (fx/reset-dispatch-later-timers!)
+                          ;; … but the captured callback still runs before
+                          ;; set-timeout! returns.
+                          (f)
+                          the-handle)
+                        interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+            (#'fx/arm-dispatch-later! authority-frame 600000 authority-event opts))))
+      (is (empty? @dispatched)
+          "the reset removed the reservation, so the callback had no authority and
+           could NOT leak a dispatch into the next test/runtime generation")
+      (is (= [the-handle] @cleared)
+          "the publish phase cancelled the returned handle; the arming SENTINEL was
+           NEVER passed to clear-timeout! (reset skips it)")
+      (is (empty? (timers-for-frame authority-frame))
+          "no residue in the side table"))))
+
+(deftest dispatch-later-armed-handle-destroy-then-late-callback-suppressed
+  (testing "an ORDINARY armed :dispatch-later (handle already PUBLISHED) that is
+            destroyed before it fires: release-frame! cancels the real host
+            handle, and even if the host already started the callback
+            (cancellation cannot un-run an in-progress thunk), the callback has
+            NO authority and dispatches NOTHING — no post-destroy dispatch, so no
+            :rf.error/frame-destroyed downstream (rf2-j538f7.2 acceptance 4)"
+    (let [dispatched  (atom [])
+          cleared     (atom [])
+          the-handle  ::armed-handle
+          captured-cb (atom nil)
+          opts        {:source :fx-dispatch-later :source-detail {:ms 600000}
+                       :frame  authority-frame}]
+      (with-dispatch-stub
+        (fn [ev op] (swap! dispatched conj [ev op]))
+        (fn []
+          (with-redefs [interop/set-timeout!
+                        (fn [f _ms]
+                          ;; Ordinary arm: capture the callback and return a real
+                          ;; handle WITHOUT firing — the handle publishes normally.
+                          (reset! captured-cb f)
+                          the-handle)
+                        interop/clear-timeout! (fn [h] (swap! cleared conj h) nil)]
+            (#'fx/arm-dispatch-later! authority-frame 600000 authority-event opts)
+            (is (= 1 (count (timers-for-frame authority-frame)))
+                "the armed handle is published under the frame's key")
+            ;; Destroy the frame: release-frame! cancels + drops the real handle.
+            (fx/release-frame! authority-frame)
+            (is (= [the-handle] @cleared)
+                "release-frame! cancelled the published host handle")
+            (is (empty? (timers-for-frame authority-frame))
+                "the frame's slot was dropped by release-frame!")
+            ;; The host executor already started the callback before cancellation
+            ;; landed — it runs ANYWAY. Callback authority must suppress it.
+            (@captured-cb))))
+      (is (empty? @dispatched)
+          "the post-destroy callback found no slot in its winning snapshot, so it
+           dispatched NOTHING into the torn-down frame — no dead-on-arrival event,
+           hence no :rf.error/frame-destroyed downstream (before the fix it
+           dispatched the dead event)")
+      (is (= [the-handle] @cleared)
+          "the handle was cancelled exactly once (by release-frame!); the
+           suppressed callback added no further cancellation"))))


### PR DESCRIPTION
## Summary

Closes a residual concurrency gap that survived the rf2-3fc89f.3 two-phase reservation (#5577). When frame cleanup (`release-frame!` / `reset-dispatch-later-timers!`) removes a `:dispatch-later` arming reservation **during** arming, yet the host executor still runs the timer thunk **before** `set-timeout!` returns its handle (a legal JVM `ScheduledExecutorService` ordering), the old callback unconditionally `dissoc`ed its slot and dispatched a dead-on-arrival event into the torn-down frame — surfacing a spurious `:rf.error/frame-destroyed` and stale trace traffic after normal teardown. Host cancellation cannot un-run an already-started thunk, so the two-phase publish alone could not suppress it.

## Fix

Treat the `dispatch-later-timers` slot as **both** resource ownership **and** the callback's **dispatch authority**. The timer thunk now removes its slot via `swap-vals!` and dispatches **only when its winning old snapshot still held the slot**. If cleanup removed the reservation first, the callback has lost authority and suppresses the dispatch. The `dissoc` swap fn is pure; the dispatch side effect rides the CAS-derived old snapshot, never inside the retriable swap. Reuses the existing arming-sentinel / two-phase machinery unchanged — the publish phase still cancels the returned handle when the reservation is gone, and immediate-fire exactly-once behaviour is preserved.

Touches only `implementation/core/src/re_frame/fx.cljc` (callback + docstring; ~13 net LOC of logic).

## Reproduce → fix

Deterministic JVM tests drive the composed interleaving through the `interop/set-timeout!` seam — cleanup FIRST, then the callback, then the handle return (no probabilistic scheduler stress):

- `dispatch-later-release-during-arming-suppresses-callback-dispatch` — `release-frame!` wins during arming, callback still fires → **zero** dispatch, handle cancelled once, empty table (acceptance 1).
- `dispatch-later-reset-during-arming-suppresses-callback-dispatch` — same through `reset-dispatch-later-timers!`; no leak into the next generation, sentinel never sent to `clear-timeout!` (acceptance 2).
- `dispatch-later-armed-handle-destroy-then-late-callback-suppressed` — ordinary armed (published) handle, destroy cancels it, host still starts the callback → suppressed, no post-destroy dispatch / no `:rf.error/frame-destroyed` (acceptance 4).

Verified all three **FAIL** on the pre-fix callback and **PASS** on the fix; the 7 existing rf2-3fc89f.3 / rf2-uxz52g tests (incl. immediate-fire exactly-once, acceptance 3) are preserved.

## Quality gates (foreground, all green)

- `clojure -M:test -n re-frame.dispatch-later-frame-destroy-test -n re-frame.fx-test -n re-frame.frame-lifecycle-test -n re-frame.frame-destroy-composed-test` → **95 tests / 470 assertions, 0 failures/errors** (baseline 92/459; +3 tests, +11 assertions).
- `clojure -M:test` (full core CLJ) → **1769 tests / 7736 assertions, 0 failures/errors**.
- `npm run test:cljs` (node-runtime CLJS) → **8481 tests / 39625 assertions, 0 failures/errors**.
- `clj-kondo --lint` (changed files) → **0 errors, 0 warnings**.
