### PR TITLE
fix(epoch): same-id listener replacement preserves the new callback's observation (rf2-j538f7.5)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -49,10 +49,13 @@
   between now and then."
   [record]
   (let [frame-id (:frame record)]
-    (doseq [[id f] (state/listeners-snapshot)]
-      (state/record-observation! id frame-id)
+    (doseq [[id {:keys [generation callback]}] (state/listeners-snapshot)]
+      ;; Stamp the observation against the EXACT generation being invoked, so a
+      ;; concurrent same-id replacement can neither erase this observation nor
+      ;; inherit it (rf2-j538f7.5).
+      (state/record-observation! id generation frame-id)
       (try
-        (f record)
+        (callback record)
         (catch #?(:clj Throwable :cljs :default) ex
           ;; Trace identity is qualified; the source record field is bare.
           (trace/emit-error! :rf.epoch.cb/listener-exception
@@ -225,10 +228,12 @@
   destroyed frames have empty history, so listener delivery is the only channel
   for this terminal partial record.
 
-  Each listener that observed the frame receives one silencing trace. The
-  observation, history, capture, last-settled, and mount-attribution entries are
-  then removed so a same-keyed replacement frame starts clean. Repeated destroys
-  are idempotent."
+  Each listener whose CURRENT generation observed the frame receives one
+  silencing trace (a stale observation from a since-replaced same-id generation
+  is skipped — `state/cbs-observing-frame` scopes the fan to the live
+  generation). The observation, history, capture, last-settled, and
+  mount-attribution entries are then removed so a same-keyed replacement frame
+  starts clean. Repeated destroys are idempotent."
   [frame-id fs-before fs-after committed-at]
   (when interop/debug-enabled?
     ;; A run-start distinguishes a real in-flight event from unrelated
@@ -244,10 +249,7 @@
           (assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                               (:event-id record) :halted-destroy)
           (notify-listeners! record))))
-    (let [silenced-cbs (->> (state/observations-snapshot)
-                            (keep (fn [[cb-id frames]]
-                                    (when (contains? frames frame-id) cb-id)))
-                            vec)]
+    (let [silenced-cbs (state/cbs-observing-frame frame-id)]
       (doseq [cb-id silenced-cbs]
         (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
                      {:frame  frame-id

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -12,13 +12,15 @@
                                                        :deps #{sub-id…}}}
                             (mount anchor and learned view read-set)
     capture-buffers         frame-id → vector<trace-event> (in-flight)
-    listeners               cb-id    → fn
-    observed-frames-by-cb   cb-id    → #{frame-id ...}
+    listeners               cb-id    → {:generation token :callback fn}
+    observed-frames-by-cb   cb-id    → {frame-id → generation-token}
 
   Capture buffers stay separate from rarely-written back-fill state because
   every trace emit updates them. Listener observations likewise stay separate
-  from the registry snapshot read on every fan-out. No operation requires an
-  atomic update across two of these stores."
+  from the registry snapshot read on every fan-out; they cohere through the
+  per-registration GENERATION token (see the listener-registry section) rather
+  than a cross-atom update, so no operation requires an atomic update across two
+  of these stores."
   (:require [re-frame.privacy :as privacy]))
 
 ;; ---- configuration --------------------------------------------------------
@@ -787,26 +789,68 @@
 
 ;; ---- listener registry ----------------------------------------------------
 
+;; A listener registration is ONE atomic unit: the callback plus the
+;; monotonically-increasing GENERATION token minted when it was installed.
+;;
+;;   listeners   cb-id → {:generation <token> :callback <fn>}
+;;
+;; Same-id replacement publishes a fresh generation (new token + callback) in a
+;; SINGLE swap, so a concurrent fan-out that snapshots the new generation and
+;; the registering thread can never tear the registration across two writes —
+;; the split-brain the two-swap predecessor suffered (rf2-j538f7.5). The token
+;; is drawn from a process-global monotonic counter so it is NEVER reused, not
+;; even across a drop-then-re-register of the same id; that closes the ABA
+;; window a per-id counter would leave (a recycled token could let a stale
+;; fan-out arm a fresh registration).
+(defonce ^:private listener-generation (atom 0))
+
+(defn- next-listener-generation
+  "Mint a fresh, process-unique listener generation token."
+  []
+  (swap! listener-generation inc))
+
 (defonce ^:private listeners (atom {}))
 
-;; Track which frames each callback has observed. When a
-;; frame is destroyed, every cb whose observed-frames set contains
-;; that frame receives a one-shot :rf.epoch.cb/silenced-on-frame-destroy
-;; trace. The frame is then dropped from the cb's entry so a
-;; re-registration of a same-keyed frame (e.g. a destroy-frame! +
-;; re-reg-frame reset of :app/main) can re-arm the silencing trace for a
-;; future destroy.
+;; Track which frames each callback GENERATION has observed. When a frame is
+;; destroyed, every cb whose CURRENT generation observed that frame receives a
+;; one-shot :rf.epoch.cb/silenced-on-frame-destroy trace. Each observation is
+;; STAMPED with the generation token that recorded it:
+;;
+;;   observed-frames-by-cb   cb-id → {frame-id → generation-token}
+;;
+;; Stamping the observation with its generation is what makes same-id
+;; replacement correct WITHOUT a cross-atom clear (the split-brain the two-swap
+;; predecessor suffered): a replacement simply mints a new token, so a stale
+;; OLD-generation observation is silently ignored by the token-scoped readers
+;; (`record-observation!` refuses to re-arm it; `cbs-observing-frame` skips it)
+;; and is overwritten the moment the NEW generation observes the same frame.
+;; The frame-id stays the map KEY, so `(contains? (get observed cb-id)
+;; frame-id)` still answers "did this cb ever observe the frame?" — the same
+;; question a bare set answered, now carrying the owning generation alongside.
+;; A same-keyed frame recreation re-arms because `drop-frame-observation!`
+;; removes the frame on the prior destroy and the recreated frame's cascade
+;; re-stamps it under the current generation.
 (defonce ^:private observed-frames-by-cb
-  ;; cb-id → #{frame-id ...}
+  ;; cb-id → {frame-id → generation-token}
   (atom {}))
 
 (defn put-listener!
-  "Install or replace `f` under `id`. Also clears `id`'s
-  observed-frames set so the new callback's silencing trace fires
-  fresh against frames the new callback observes."
+  "Install or replace `f` under `id` as a fresh listener GENERATION.
+
+  The callback and its freshly-minted generation token are published in ONE
+  atomic swap, so a same-id replacement can never be torn across two writes.
+  The observation ledger is deliberately NOT cleared here: observations are
+  stamped with the generation that recorded them (see `observed-frames-by-cb`),
+  so a stale OLD-generation observation is ignored by the token-scoped readers
+  and overwritten when the new generation re-observes the frame. This removes
+  the two-swap window in which a concurrent fan-out's fresh observation of the
+  new callback could be erased by a lagging second swap (rf2-j538f7.5), and its
+  mirror in which a stale old callback could re-arm the new registration.
+
+  Returns the id."
   [id f]
-  (swap! listeners assoc id f)
-  (swap! observed-frames-by-cb dissoc id)
+  (let [g (next-listener-generation)]
+    (swap! listeners assoc id {:generation g :callback f}))
   id)
 
 (defn drop-listener!
@@ -825,62 +869,87 @@
   nil)
 
 (defn listeners-snapshot
-  "Return the current `{cb-id → f}` map. Callers iterate this snapshot
-  for fan-out — taking the snapshot once isolates iteration from
-  concurrent `put-listener!` / `drop-listener!` updates."
+  "Return the current `{cb-id → {:generation g :callback f}}` registry map.
+  Callers iterate this snapshot for fan-out — taking it once isolates
+  iteration from concurrent `put-listener!` / `drop-listener!` updates, and
+  each entry carries its generation token so the fan-out can stamp its
+  observation against the exact generation it invoked."
   []
   @listeners)
 
 (defn observations-snapshot
-  "Return the current `{cb-id → #{frame-id ...}}` map."
+  "Return the current `{cb-id → {frame-id → generation-token}}` map."
   []
   @observed-frames-by-cb)
 
 (defn record-observation!
-  "Mark that the cb registered under `cb-id` has seen a record from
-  `frame-id`. Guards against re-firing the atom watcher on the
-  no-op case (cb already observes that frame) — for the common
-  long-lived listener observing the same frame on every cascade,
-  this is a single deref + membership check with no swap.
+  "Mark that the cb GENERATION `token` registered under `cb-id` has seen a
+  record from `frame-id`. `notify-listeners!` snapshots `[cb-id token callback]`
+  and calls this before invoking `callback`, so the observation is attributed to
+  the exact generation that consumed the record.
 
-  `notify-listeners!` iterates a listener snapshot, then calls this function
-  before
-  invoking the callback. If `unregister-epoch-listener!` removed the cb
-  between the snapshot and now, recording an observation would
-  RE-INTRODUCE bookkeeping for a cb that no longer exists — the stale
-  cb-id then lingers in `observed-frames-by-cb` and later receives a
-  bogus `:rf.epoch.cb/silenced-on-frame-destroy` trace on frame destroy.
-  The swap is therefore made conditional on the cb-id STILL being a live
-  listener AT RECORD TIME: the swap update fn re-reads the (live)
-  `listeners` map and refuses to (re)add an observation for a cb that has
-  since been dropped. The liveness check rides INSIDE the swap so the
-  drop-vs-record decision is taken against a consistent listener snapshot
-  on every CAS retry — a `drop-listener!` landing mid-swap is honoured."
-  [cb-id frame-id]
+  Two hazards this closes, both scoped by `token`:
+
+    * The recorded generation is no longer current — a same-id replacement
+      minted a new token, or `unregister-epoch-listener!` dropped the id
+      entirely. Re-adding the observation would either re-arm a retired
+      generation or, worse, arm the NEW generation for a frame it never
+      consumed. The swap therefore lands ONLY when `token` still equals the
+      live generation for `cb-id` (a dropped id has no entry, so no token
+      matches — this subsumes the rf2-7i872 unregister-liveness guard).
+
+    * A no-op re-observation of the same (cb, generation, frame) triple — the
+      steady-state hot path — must not fire the atom watcher. The outer guard
+      short-circuits before any swap when the frame is already stamped with
+      this token: one deref + lookup, no swap.
+
+  Both checks ride INSIDE the swap as well, so the decision is taken against a
+  consistent listener snapshot on every CAS retry — a replace/drop landing
+  mid-swap is honoured."
+  [cb-id token frame-id]
   (when frame-id
-    (let [current @observed-frames-by-cb]
-      (when (and (not (contains? (get current cb-id) frame-id))
-                 (contains? @listeners cb-id))
+    (let [observed @observed-frames-by-cb]
+      (when (and (not= token (get-in observed [cb-id frame-id]))
+                 (= token (:generation (get @listeners cb-id))))
         (swap! observed-frames-by-cb
                (fn [m]
-                 (if (or (contains? (get m cb-id) frame-id)
-                         ;; Liveness re-check inside the swap: a
-                         ;; `drop-listener!` that landed between the
-                         ;; outer guard and this CAS attempt must not be
-                         ;; undone by re-adding the cb's observation.
-                         (not (contains? @listeners cb-id)))
+                 (if (or (= token (get-in m [cb-id frame-id]))
+                         ;; Generation re-check inside the swap: a same-id
+                         ;; replacement or `drop-listener!` that landed between
+                         ;; the outer guard and this CAS attempt must not be
+                         ;; undone by arming a retired/replaced generation.
+                         (not= token (:generation (get @listeners cb-id))))
                    m
-                   (update m cb-id (fnil conj #{}) frame-id))))))))
+                   (assoc-in m [cb-id frame-id] token))))))))
+
+(defn cbs-observing-frame
+  "Return the cb-ids whose CURRENT generation observed `frame-id` — the frame
+  is stamped in the cb's observation ledger with the cb's live generation
+  token. A stale OLD-generation stamp (left by a since-replaced generation that
+  never re-observed the frame) is NOT returned, so a same-id replacement never
+  silences the new callback for a frame only the OLD callback consumed, and
+  never fails to silence a frame the new callback did consume. The one-shot
+  `:rf.epoch.cb/silenced-on-frame-destroy` fan is derived from this set."
+  [frame-id]
+  (let [observed @observed-frames-by-cb
+        live     @listeners]
+    (->> observed
+         (keep (fn [[cb-id frames]]
+                 (let [token (get frames frame-id ::absent)]
+                   (when (and (not= token ::absent)
+                              (= token (:generation (get live cb-id))))
+                     cb-id))))
+         vec)))
 
 (defn drop-frame-observation!
-  "Drop `frame-id` from every cb's observed-frames set. cbs whose set
-  goes empty as a result are dropped from the map entirely so the
-  map doesn't accrete keys to empty sets."
+  "Drop `frame-id` from every cb's observation ledger. cbs whose ledger goes
+  empty as a result are dropped from the map entirely so the map doesn't
+  accrete keys to empty ledgers."
   [frame-id]
   (swap! observed-frames-by-cb
          (fn [m]
            (reduce-kv (fn [acc cb-id frames]
-                        (let [frames' (disj frames frame-id)]
+                        (let [frames' (dissoc frames frame-id)]
                           (if (empty? frames')
                             (dissoc acc cb-id)
                             (assoc acc cb-id frames'))))

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -42,6 +42,7 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             ;; rf2-lo28u — schemas + the Malli adapter so a `:schema`-bearing
@@ -369,3 +370,57 @@
       (state/drop-frame-buffer! frame)
       (is (empty? (state/buffer-for frame))
           "rf2-bhglx — drop-frame-buffer! (terminal path) clears a stranded marker"))))
+
+;; ---- 7. Same-id listener replacement generation semantics (rf2-j538f7.5) ---
+;;
+;; CLJS cannot thread-preempt between swaps, so the two-thread erasure race the
+;; JVM suite drives cannot manifest here. But the generation-scoped bookkeeping
+;; the fix installs lives in `re-frame.epoch.state` (.cljc) and runs under CLJS
+;; too; this pins the sequential-interleaving contract on the CLJS runtime: a
+;; same-id replacement mints a fresh generation, a stale old-generation fan-out
+;; is refused, the new generation's observation survives the re-registration,
+;; and frame destroy silences only the live generation exactly once.
+
+(deftest same-id-replacement-generation-semantics-cljs
+  (testing "rf2-j538f7.5 — under CLJS' single-threaded runtime the listener
+            registry is generation-scoped: a stale old-generation observation is
+            refused, the new generation's observation survives a same-id
+            re-registration, and frame destroy silences only the live generation
+            exactly once"
+    (rf/reg-frame :j538/main {})
+    (rf/reg-frame :j538/other {})
+    (let [silences (atom [])]
+      (trace-tooling/register-listener! ::rec
+        (fn [ev]
+          (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+            (swap! silences conj (:tags ev)))))
+      ;; Gen 1 registered; capture its token (a stale fan-out snapshot).
+      (rf/register-listener! :epoch ::probe (fn [_] nil))
+      (let [gen1 (:generation (get (state/listeners-snapshot) ::probe))]
+        ;; Gen 1 observes :j538/main.
+        (epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 1})
+        (is (= [::probe] (state/cbs-observing-frame :j538/main))
+            "gen 1 is the live observer of :j538/main")
+        ;; Same-id replacement → gen 2.
+        (rf/register-listener! :epoch ::probe (fn [_] nil))
+        (let [gen2 (:generation (get (state/listeners-snapshot) ::probe))]
+          (is (not= gen1 gen2) "replacement minted a fresh generation")
+          ;; A stale gen-1 fan-out cannot arm the new registration.
+          (state/record-observation! ::probe gen1 :j538/other)
+          (is (not (contains? (get (state/observations-snapshot) ::probe) :j538/other))
+              "stale old-generation observation refused")
+          ;; The gen-1 stamp on :j538/main is no longer live.
+          (is (empty? (state/cbs-observing-frame :j538/main))
+              "the retired generation's :j538/main observation is not live")
+          ;; Gen 2 observes :j538/main — survives, stamped under gen 2.
+          (epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 2})
+          (is (= gen2 (get-in (state/observations-snapshot) [::probe :j538/main]))
+              "the new generation re-stamped :j538/main and its observation survives")
+          (is (= [::probe] (state/cbs-observing-frame :j538/main))
+              "gen 2 is the live observer of :j538/main")
+          ;; Destroy silences the live generation exactly once.
+          (rf/destroy-frame! :j538/main)
+          (is (= 1 (count (filter #(= :j538/main (:frame %)) @silences)))
+              "exactly one silencing trace for the live generation")))
+      (trace-tooling/unregister-listener! ::rec)
+      (rf/unregister-listener! :epoch ::probe))))

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -854,3 +854,111 @@
                              (pr-str (rf/app-db-value frame-id))
                              " ({:n 3} = the restore's write spliced into and "
                              "erased by the blocked transition — non-linearizable)"))))))))))))
+
+;; ---- Scenario 7 (rf2-j538f7.5) --------------------------------------------
+;;
+;; SAME-ID LISTENER REPLACEMENT vs FAN-OUT / DESTROY. Scenario 2 churns
+;; register/unregister of PER-THREAD ids and asserts only final listener-map
+;; emptiness + callback counts. It never churns the SAME id against fan-out and
+;; frame-destroy, so it cannot see the generation-scoped observation/silencing
+;; invariant rf2-j538f7.5 fixed: a same-id replacement must INSTALL the new
+;; generation's observation (never erase it via a stale second swap) and must
+;; never emit a torn double silence for one destroy.
+;;
+;; A single DRIVER owns the frame lifecycle (settle → destroy → recreate) so
+;; there is no frame-not-found race; N CHURNERS hammer `register-epoch-listener!`
+;; under ONE shared id, minting a fresh generation on every call. The contended
+;; seam is the listeners registry + the token-stamped observation ledger.
+;;
+;; Invariants:
+;;   1. No exception escapes any thread.
+;;   2. Each frame destroy emits AT MOST ONE silencing trace for the churned id
+;;      — a torn generation could double-count (or, per the pre-fix bug, drop it
+;;      to zero even for a live generation).
+;;   3. Deterministic tail (churn stopped): a fresh same-id registration's
+;;      fan-out observation SURVIVES, is stamped with the LIVE generation, and
+;;      its destroy silences EXACTLY once — the core false-negative the bug
+;;      produced under the two-swap replacement.
+;;
+;; CLJS is single-threaded; the race cannot manifest there — JVM-only.
+
+(def ^:private gen-churn-iters
+  (or (some-> (System/getenv "RF2_J538F75_ITERS") Long/parseLong)
+      500))
+
+(deftest same-id-replacement-vs-fanout-destroy-stress
+  (testing (str "same-id listener replacement churn vs " gen-churn-iters
+                " settle/destroy cycles — no torn double-silence, the live "
+                "generation's observation survives and silences exactly once "
+                "(rf2-j538f7.5)")
+    (rf/reg-frame :j538.gen/main {:doc "same-id replacement stress frame"})
+    (rf/reg-event :bump (fn [{:keys [db]} [_ i]] {:db (assoc db :last i)}))
+    (let [cb-id       ::churned
+          silence-cnt (atom 0)
+          errors      (atom [])
+          churn-stop  (atom false)
+          latch       (CountDownLatch. 1)
+          n-churners  (max 2 (quot n-threads 2))]
+      ;; Count silencing traces for the churned id (fired synchronously on the
+      ;; driver thread inside destroy-frame!, so the per-cycle delta is exact).
+      (rf/register-listener! :trace ::silence-rec
+                             (fn [ev]
+                               (when (and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                             (:operation ev))
+                                          (= cb-id (:cb-id (:tags ev))))
+                                 (swap! silence-cnt inc))))
+      ;; Seed one generation so fan-out has a listener from the start.
+      (rf/register-listener! :epoch cb-id (fn [_] nil))
+      (let [churners
+            (vec (for [_ (range n-churners)]
+                   (future
+                     (.await latch)
+                     (try
+                       (loop []
+                         (when-not @churn-stop
+                           (rf/register-listener! :epoch cb-id (fn [_] nil))
+                           (recur)))
+                       (catch Throwable t (swap! errors conj t))))))
+            driver
+            (future
+              (.await latch)
+              (try
+                (dotimes [i gen-churn-iters]
+                  (rf/dispatch-sync [:bump i] {:frame :j538.gen/main})
+                  (let [before @silence-cnt]
+                    (rf/destroy-frame! :j538.gen/main)
+                    (let [delta (- @silence-cnt before)]
+                      (when (> delta 1)
+                        (swap! errors conj
+                               (ex-info "torn double-silence for one destroy"
+                                        {:delta delta :cycle i})))))
+                  (rf/reg-frame :j538.gen/main {}))
+                (catch Throwable t (swap! errors conj t))
+                (finally (reset! churn-stop true))))]
+        (.countDown latch)
+        (is (not= ::timeout (await-future driver)) "driver completed within timeout")
+        (doseq [c churners]
+          (is (not= ::timeout (await-future c)) "churner completed within timeout"))
+
+        ;; --- Invariant 1 + 2: no thread threw, and no destroy double-silenced.
+        (is (empty? @errors)
+            (str "no thread threw and no destroy double-silenced; got "
+                 (count @errors) ": "
+                 (pr-str (mapv #(.getMessage ^Throwable %) (take 3 @errors)))))
+
+        ;; --- Invariant 3: deterministic tail with churn stopped. A fresh
+        ;;     same-id registration's fan-out observation survives, is stamped
+        ;;     with the live generation, and its destroy silences EXACTLY once.
+        (rf/register-listener! :epoch cb-id (fn [_] nil))
+        (rf/dispatch-sync [:bump -1] {:frame :j538.gen/main})
+        (let [obs  (get (state/observations-snapshot) cb-id)
+              live (:generation (get (state/listeners-snapshot) cb-id))]
+          (is (= live (get obs :j538.gen/main))
+              "the surviving observation is stamped with the LIVE generation")
+          (let [before @silence-cnt]
+            (rf/destroy-frame! :j538.gen/main)
+            (is (= 1 (- @silence-cnt before))
+                "the fresh generation's destroy silences EXACTLY once — the
+                 same-id-replacement erasure is fixed")))
+        (rf/unregister-listener! :epoch cb-id)
+        (rf/unregister-listener! :trace ::silence-rec)))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -661,32 +661,35 @@
       (is (= 1 @a) "the original listener no longer fires after re-register under the same key")
       (is (= 1 @b) "the replacement listener fires"))))
 
-;; ---- rf2-s60jx: multi-listener observed-frames + re-register dissoc ------
+;; ---- rf2-s60jx / rf2-j538f7.5: multi-listener observations + re-register gen --
 ;;
 ;; `notify-listeners!` invokes `record-observation!` once per listener per
-;; event settle, populating `observed-frames-by-cb[cb-id]` with each
-;; frame the cb has seen. Two contracts that weren't pinned:
+;; event settle, stamping `observed-frames-by-cb[cb-id][frame-id]` with the
+;; listener's live GENERATION token. Two contracts:
 ;;
-;;   1. Two listeners both observing the same frame on the same drain
-;;      land independent entries in `observed-frames-by-cb` — each cb's
-;;      set contains the frame-id.
+;;   1. Two listeners both observing the same frame on the same drain land
+;;      independent entries in `observed-frames-by-cb` — each cb's ledger maps
+;;      the frame to that cb's own generation token.
 ;;   2. Re-registering a listener under the same id (via
-;;      `register-epoch-listener!`) resets BOTH the listener entry AND the
-;;      observed-frames entry — so the new callback's silencing trace
-;;      fires fresh against frames it observes. The `dissoc` at
-;;      the fan-out path is the non-obvious half of the contract; a
-;;      future regression that drops it would leave stale observed-
-;;      frames bookkeeping under the new fn's id.
+;;      `register-epoch-listener!`) mints a FRESH generation. The prior
+;;      generation's observation is no longer live: a destroy after the
+;;      re-registration but before the new callback re-observes emits NO
+;;      silencing trace for that cb, and once the new callback DOES observe the
+;;      frame its silencing re-arms under the new generation. The token scoping
+;;      is what keeps the re-registration from inheriting the old generation's
+;;      ledger (the rf2-j538f7.5 mirror hazard) OR erasing a fresh observation.
 
-(deftest multi-listener-observed-frames-and-re-register-dissoc
-  (testing "two listeners both observing the same frame populate
-            independent observed-frames-by-cb entries; re-registering
-            under the same id resets BOTH the listener entry and the
-            observed-frames entry"
+(deftest multi-listener-observed-frames-and-re-register-generation
+  (testing "two listeners both observing the same frame land independent
+            observed-frames-by-cb entries stamped with each cb's generation;
+            re-registering under the same id mints a fresh generation whose
+            ledger is not live until the new callback observes, and re-arms
+            silencing under the new generation"
     (rf/reg-frame :test/main {})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [observed (deref #'state/observed-frames-by-cb)
+          recorded (record-trace!)
           a        (atom 0)
           b        (atom 0)
           c        (atom 0)]
@@ -700,30 +703,50 @@
 
       (let [snap @observed]
         (is (contains? (get snap ::w1) :test/main)
-            "::w1 has :test/main in its observed-frames")
+            "::w1 observed :test/main")
         (is (contains? (get snap ::w2) :test/main)
-            "::w2 has :test/main in its observed-frames")
-        (is (= #{:test/main} (get snap ::w1)))
-        (is (= #{:test/main} (get snap ::w2))))
+            "::w2 observed :test/main")
+        ;; each ledger stamps the frame with the cb's own live generation
+        (is (= (:generation (get (state/listeners-snapshot) ::w1))
+               (get-in snap [::w1 :test/main]))
+            "::w1's observation carries ::w1's generation token")
+        (is (= (:generation (get (state/listeners-snapshot) ::w2))
+               (get-in snap [::w2 :test/main]))
+            "::w2's observation carries ::w2's generation token")
+        (is (= #{::w1 ::w2} (set (state/cbs-observing-frame :test/main)))
+            "both cbs are live-generation observers of :test/main"))
 
-      ;; Re-register ::w1 under a different fn — the listener swap is
-      ;; well-tested by listener-same-key-replaces. Pin the OTHER half:
-      ;; the observed-frames dissoc.
+      ;; Re-register ::w1 under a different fn — mints a fresh generation. Its
+      ;; ledger entry for :test/main still carries the OLD generation token
+      ;; (not cleared), but that token is no longer live.
       (rf/register-listener! :epoch ::w1 (fn [_] (swap! c inc)))
-      (is (nil? (get @observed ::w1))
-          "re-register dissocs the prior observed-frames entry — new
-           cb starts with an empty observed-frames set")
+      (is (= [::w2] (state/cbs-observing-frame :test/main))
+          "immediately after re-register, only ::w2 (live gen) observes
+           :test/main — ::w1's retired generation is skipped, not silenced")
       (is (contains? (get @observed ::w2) :test/main)
           "::w2's entry is untouched — re-registration is scoped to ::w1")
 
-      ;; Drive a new cascade — both cbs fire; ::w1's observed-frames
-      ;; re-arms with :test/main.
+      ;; Drive a new cascade — the new ::w1 fn + ::w2 both fire; the new ::w1
+      ;; generation re-stamps :test/main.
       (rf/dispatch-sync [:seed] {:frame :test/main})
       (is (= 1 @a) "the original ::w1 fn does not fire — it was replaced")
       (is (= 1 @c) "the replacement ::w1 fn fires once")
       (is (= 2 @b) "::w2 keeps firing across both cascades")
-      (is (contains? (get @observed ::w1) :test/main)
-          "::w1's observed-frames re-armed with :test/main"))))
+      (is (= (:generation (get (state/listeners-snapshot) ::w1))
+             (get-in @observed [::w1 :test/main]))
+          "::w1's ledger re-stamped :test/main under the NEW generation")
+
+      ;; Destroy now silences BOTH cbs exactly once — no stale double-silence
+      ;; for the retired ::w1 generation, no false negative for either.
+      (rf/destroy-frame! :test/main)
+      (let [silenced (->> @recorded
+                          (filter #(= :rf.epoch.cb/silenced-on-frame-destroy
+                                      (:operation %)))
+                          (map #(:cb-id (:tags %))))]
+        (is (= #{::w1 ::w2} (set silenced))
+            "each live-generation observer silenced")
+        (is (= 2 (count silenced))
+            "exactly two silencing traces — no torn double-silence")))))
 
 (deftest listener-remove
   (testing "unregister-epoch-listener! stops the listener"
@@ -5197,20 +5220,22 @@
             taken, cb dropped, then record-observation! fires for the stale
             id.)"
     (rf/reg-frame :test/main {})
-    ;; Register then unregister a cb — it is GONE from the listener registry.
+    ;; Register a cb, capture its generation (as a fan-out snapshot would),
+    ;; then unregister — it is GONE from the listener registry.
     (rf/register-listener! :epoch ::ghost (fn [_] nil))
-    (rf/unregister-listener! :epoch ::ghost)
-    (is (not (contains? (state/listeners-snapshot) ::ghost))
-        "::ghost is no longer a registered listener")
+    (let [ghost-gen (:generation (get (state/listeners-snapshot) ::ghost))]
+      (rf/unregister-listener! :epoch ::ghost)
+      (is (not (contains? (state/listeners-snapshot) ::ghost))
+          "::ghost is no longer a registered listener")
 
-    ;; Simulate the racing fan-out: record-observation! is called for the
-    ;; now-stale ::ghost id (as notify-listeners! would for a snapshot taken
-    ;; before the unregister).
-    (state/record-observation! ::ghost :test/main)
+      ;; Simulate the racing fan-out: record-observation! is called for the
+      ;; now-stale ::ghost id + its snapshotted generation (as notify-listeners!
+      ;; would for a snapshot taken before the unregister).
+      (state/record-observation! ::ghost ghost-gen :test/main)
 
-    (is (not (contains? (state/observations-snapshot) ::ghost))
-        "no stale observed-frames-by-cb entry for the unregistered cb —
-         record-observation! refused to re-introduce bookkeeping for a dead cb")))
+      (is (not (contains? (state/observations-snapshot) ::ghost))
+          "no stale observed-frames-by-cb entry for the unregistered cb —
+           record-observation! refused to re-introduce bookkeeping for a dead cb"))))
 
 (deftest unregister-mid-fanout-no-bogus-silencing-trace
   (testing "rf2-7i872 — the precise unregister-mid-fan-out interleaving
@@ -5232,7 +5257,8 @@
       ;; any frame (put-listener! clears its observation ledger). It is live
       ;; in the registry when the fan-out snapshot is taken.
       (rf/register-listener! :epoch ::victim (fn [_] nil))
-      (let [;; (1) notify-listeners! takes the snapshot (includes ::victim).
+      (let [;; (1) notify-listeners! takes the snapshot (includes ::victim +
+            ;;     its generation token).
             snapshot (state/listeners-snapshot)]
         (is (contains? snapshot ::victim)
             "::victim is in the fan-out snapshot")
@@ -5241,10 +5267,10 @@
         (rf/unregister-listener! :epoch ::victim)
 
         ;; (3) notify-listeners! reaches the snapshot's ::victim entry and
-        ;; calls record-observation! for it (the loop iterates the stale
-        ;; snapshot). Replay that single step.
-        (doseq [[id _f] snapshot]
-          (state/record-observation! id :test/main)))
+        ;; calls record-observation! for it with the snapshotted generation
+        ;; (the loop iterates the stale snapshot). Replay that single step.
+        (doseq [[id {:keys [generation]}] snapshot]
+          (state/record-observation! id generation :test/main)))
 
       (is (not (contains? (state/listeners-snapshot) ::victim))
           "::victim was unregistered during fan-out")
@@ -5262,4 +5288,153 @@
         (is (empty? victim-silenced)
             "no bogus :rf.epoch.cb/silenced-on-frame-destroy trace for the
              unregistered ::victim cb")))))
+
+;; ============================================================================
+;;  rf2-j538f7.5 — same-id listener replacement generation race
+;; ============================================================================
+;;
+;; `put-listener!` previously published the new callback and cleared the prior
+;; observation ledger in TWO separate swaps. A concurrent `notify-listeners!`
+;; fan-out could, in the window between them, record the NEW callback's frame
+;; observation — which the registering thread's second swap then ERASED, so a
+;; later frame destroy emitted NO `:rf.epoch.cb/silenced-on-frame-destroy` for a
+;; callback that had genuinely consumed the frame (a false negative under
+;; ordinary JVM concurrency). The fix folds callback + monotonically-increasing
+;; GENERATION token into one atomic registration and stamps every observation
+;; with the recording generation, so a same-id replacement can neither erase a
+;; fresh observation nor let a stale one arm the new registration.
+
+(deftest same-id-replacement-preserves-new-callback-observation
+  (testing "rf2-j538f7.5 — a same-id listener replacement paused right after the
+            new callback is published records the NEW callback's frame
+            observation and does NOT erase it, so frame destroy emits exactly
+            one silencing trace for the new callback. Reproduction: a watch on
+            the private listeners atom parks the replacement thread at the
+            publish point; a record is fanned out while parked; then the
+            replacement is released. On the pre-fix two-swap code the second
+            swap erased the observation (zero silences); the fix preserves it."
+    (rf/reg-frame :j538/race {})
+    (let [fired          (atom 0)
+          recorded       (record-trace!)
+          published      (promise)
+          release        (java.util.concurrent.CountDownLatch. 1)
+          armed?         (atom false)
+          listeners-atom (deref #'state/listeners)]
+      ;; Register the OLD callback; it never observes :j538/race.
+      (rf/register-listener! :epoch ::probe (fn [_] nil))
+      ;; Park the NEXT listeners swap (the replacement's publish) until the main
+      ;; thread has fanned a record out.
+      (add-watch listeners-atom ::barrier
+                 (fn [_ _ _ _]
+                   (when (compare-and-set! armed? true false)
+                     (deliver published :published)
+                     (.await ^java.util.concurrent.CountDownLatch release))))
+      (reset! armed? true)
+      (let [replace-fut (future
+                          (rf/register-listener! :epoch ::probe
+                                                 (fn [_] (swap! fired inc))))]
+        (try
+          ;; Wait until the replacement has published the new generation and is
+          ;; parked at the barrier.
+          (is (= :published (deref published 5000 ::timeout))
+              "replacement published the new callback and parked")
+          ;; Fan out a record for :j538/race while the replacement is parked —
+          ;; the NEW callback runs and its observation must be recorded.
+          (epoch.listeners/notify-listeners! {:frame :j538/race :epoch-id 1})
+          (is (= 1 @fired) "the new callback ran during the fan-out")
+          (is (contains? (get (state/observations-snapshot) ::probe) :j538/race)
+              "the new callback's observation was recorded during the pause")
+          (finally
+            (.countDown release)
+            (is (not= ::timeout (deref replace-fut 5000 ::timeout))
+                "replacement thread completed")
+            (remove-watch listeners-atom ::barrier))))
+      ;; After the replacement completes, the observation must SURVIVE — the
+      ;; pre-fix second swap erased it here.
+      (is (contains? (get (state/observations-snapshot) ::probe) :j538/race)
+          "the new callback's observation survived the completed replacement")
+      (rf/destroy-frame! :j538/race)
+      (let [silenced (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                       (:operation %))
+                                   (= ::probe (:cb-id (:tags %)))
+                                   (= :j538/race (:frame (:tags %))))
+                             @recorded)]
+        (is (= 1 (count silenced))
+            "exactly one silencing trace for the replacement callback — the
+             observation was not erased by the same-id replacement"))
+      (rf/unregister-listener! :epoch ::probe))))
+
+(deftest stale-old-generation-fanout-cannot-arm-new-registration
+  (testing "rf2-j538f7.5 (mirror) — a fan-out that snapshotted the OLD
+            generation before a same-id replacement cannot add an observation to
+            the NEW registration: record-observation! with the stale generation
+            token is refused, and a later frame destroy emits no silencing trace
+            for a frame the new callback never consumed."
+    (rf/reg-frame :j538/mirror {})
+    (let [recorded (record-trace!)]
+      (rf/register-listener! :epoch ::probe (fn [_] nil))
+      (let [stale-gen (:generation (get (state/listeners-snapshot) ::probe))]
+        ;; Same-id replacement mints a new generation.
+        (rf/register-listener! :epoch ::probe (fn [_] nil))
+        (is (not= stale-gen (:generation (get (state/listeners-snapshot) ::probe)))
+            "same-id replacement minted a fresh generation")
+        ;; The stale fan-out records against the OLD generation — must be refused.
+        (state/record-observation! ::probe stale-gen :j538/mirror)
+        (is (not (contains? (get (state/observations-snapshot) ::probe) :j538/mirror))
+            "the stale old-generation observation was refused — the new
+             registration did not inherit it")
+        (is (empty? (state/cbs-observing-frame :j538/mirror))
+            "no live-generation observer of the frame")
+        (rf/destroy-frame! :j538/mirror)
+        (let [silenced (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                         (:operation %))
+                                     (= ::probe (:cb-id (:tags %))))
+                               @recorded)]
+          (is (empty? silenced)
+              "no silencing trace — the new callback never consumed the frame")))
+      (rf/unregister-listener! :epoch ::probe))))
+
+(deftest generation-scoped-observations-across-frames
+  (testing "rf2-j538f7.5 — old and new generations observing DIFFERENT frames:
+            replacement retires only the old generation's live observation, the
+            new observation survives, each destroy is a true positive/negative,
+            and same-key frame recreation re-arms."
+    (rf/reg-frame :j538/frame-a {})
+    (rf/reg-frame :j538/frame-b {})
+    (let [recorded  (record-trace!)
+          silences  (fn [frame]
+                      (count (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                              (:operation %))
+                                           (= frame (:frame (:tags %)))
+                                           (= ::probe (:cb-id (:tags %))))
+                                     @recorded)))]
+      (rf/register-listener! :epoch ::probe (fn [_] nil))
+      ;; Old generation observes frame-a.
+      (epoch.listeners/notify-listeners! {:frame :j538/frame-a :epoch-id 1})
+      (is (= [::probe] (state/cbs-observing-frame :j538/frame-a))
+          "old generation is the live observer of frame-a")
+      ;; Same-id replacement mints a new generation, which observes frame-b.
+      (rf/register-listener! :epoch ::probe (fn [_] nil))
+      (epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 2})
+      (is (empty? (state/cbs-observing-frame :j538/frame-a))
+          "frame-a's stale old-generation observation is no longer live")
+      (is (= [::probe] (state/cbs-observing-frame :j538/frame-b))
+          "the new generation's frame-b observation survives and is live")
+      ;; Destroy frame-a — the new callback never consumed it → no silence.
+      (rf/destroy-frame! :j538/frame-a)
+      (is (zero? (silences :j538/frame-a))
+          "frame-a destroy emits no silencing — true negative")
+      ;; Destroy frame-b — the live generation consumed it → exactly one silence.
+      (rf/destroy-frame! :j538/frame-b)
+      (is (= 1 (silences :j538/frame-b))
+          "frame-b destroy silences the live generation exactly once — true positive")
+      ;; Same-key recreation re-arms: recreate frame-b, observe, destroy → silence.
+      (rf/reg-frame :j538/frame-b {})
+      (epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 3})
+      (is (= [::probe] (state/cbs-observing-frame :j538/frame-b))
+          "same-key frame recreation re-arms the observation")
+      (rf/destroy-frame! :j538/frame-b)
+      (is (= 2 (silences :j538/frame-b))
+          "the recreated frame's destroy silences again — re-arm confirmed")
+      (rf/unregister-listener! :epoch ::probe))))
 


### PR DESCRIPTION
## Summary

Fixes **rf2-j538f7.5** — a same-id epoch listener replacement could erase the *new* callback's frame observation, so a later frame destroy emitted **no** `:rf.epoch.cb/silenced-on-frame-destroy` for a callback that had genuinely consumed the frame (a false negative under ordinary JVM concurrency, e.g. hot reload / same-id collector replacement).

Root cause: `put-listener!` published the new callback and then, in a **second** swap, cleared the observation ledger. A concurrent `notify-listeners!` fan-out landing in that window recorded the new callback's observation, which the second swap then erased.

## Fix (per the bead's DESIGN — two-atom + monotonic generation token)

The single-atom collapse the DESIGN prefers is blocked by an out-of-boundary consumer (`core` `frame-destroy-composed-test` reads `#'epoch-state/observed-frames-by-cb`), so this takes the DESIGN's explicit alternative:

- **`state`**: `listeners` is now `cb-id → {:generation token :callback fn}` — callback + a process-global monotonically-increasing generation token published in **one atomic swap**. `observed-frames-by-cb` is now `cb-id → {frame-id → generation-token}` (frame-id stays the map key, so `(contains? (get observed cb-id) frame-id)` still answers the same question). `record-observation!` is token-scoped and `put-listener!` no longer clears observations — a stale generation is *ignored*, never *erased*, and overwritten when the new generation re-observes. New `cbs-observing-frame` derives the silencing fan from the live generation only.
- **`listeners`**: `notify-listeners!` stamps each observation against the exact invoked generation; `on-frame-destroyed!` silences via `cbs-observing-frame`.

This closes both the original erase window **and** its mirror (a stale old-generation fan-out can no longer arm the new registration), and subsumes the prior rf2-7i872 unregister-liveness guard.

## Reproduce → fix

Deterministic JVM probe (watch on the private `listeners` atom parks the replacement thread at its publish point, a record is fanned out while parked, then the replacement is released):

- **Before** (raw two-swap code): `:during {::probe #{:race/frame}}` → `:after {:observations {} :silenced-candidates []}` — observation erased.
- **After**: observation survives stamped with the new generation; `cbs-observing-frame` returns `[::probe]` → exactly one silencing trace.

The new deftest `same-id-replacement-preserves-new-callback-observation` drives this same barrier through stable seams (`register-epoch-listener!` / `notify-listeners!` / `destroy-frame!` + a watch on the atom) and **fails on the pre-fix code** (observation erased → zero silences), passes on the fix.

## Tests added / updated (all 7 acceptance criteria)

- JVM barrier regression (AC1), mirror-ordering (AC2), cross-frame generation + same-key recreation (AC3).
- Updated the rf2-7i872 tests to the token-scoped `record-observation!` (AC4); existing same-key / exception-isolation / silencing tests preserved.
- `epoch_concurrency_stress_test` Scenario 7: same-id replacement churn vs settle/destroy — no torn double-silence + deterministic tail (AC5).
- CLJS sequential-interleaving coverage `same-id-replacement-generation-semantics-cljs` (AC6).

## Quality gates

- `cd implementation/epoch && clojure -M:test` → **384 tests / 2399 assertions / 0 failures / 0 errors** (+4 new JVM tests).
- `cd implementation && npm run test:cljs` → **8482 tests / 39632 assertions / 0 failures / 0 errors**.
- Out-of-boundary consumer `core` `frame-destroy-composed-test` → **8 tests / 62 assertions / 0 failures** (the `{frame-id → token}` map shape is `contains?`-compatible with its assertions).
- `clj-kondo --lint` on both changed source files → **0 errors, 0 warnings**.

Touches only `implementation/epoch/src` (listeners + state) and `implementation/epoch/test/**`.
