### PR TITLE
fix(story/spec-006): re-scope Story live host to the pair per ruling B (rf2-3fc89f.22)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -5,9 +5,10 @@
   sleep for :duration-ms → stop-recording! → gen-play-snippet) per
   tools/story/spec/005-SOTA-Features.md §Test Codegen \"MCP wiring\".
 
-  This tool's job is the cross-process bridge: an agent calls it and
-  gets back the `(reg-variant ...)` snippet for whatever the canvas
-  dispatched during the recording window. The recorder itself does the
+  This tool's job is the agent-facing wrapper (a direct, in-process
+  call in the shared JVM — spec/006 §Architecture): an agent calls it
+  and gets back the `(reg-variant ...)` snippet for whatever the
+  canvas dispatched during the recording window. The recorder itself does the
   filter work (op-type :event/dispatched, frame scope, internal-ns
   suppression) — see `re-frame.story.recorder/recordable-event?`.
 

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -424,15 +424,17 @@ re-dispatch (wrapped as `[:dispatch-sync <vec>]`) under
 #### MCP wiring (adjacent bead)
 
 The story-mcp `record-as-variant` tool consumes the same recorder
-state through the cross-process Tool-Pair bridge (per
-[`006-MCP-Surface.md`](006-MCP-Surface.md)): the agent calls
-`start-recording!`, drives interactions via the existing MCP write
-surface (or asks the user to interact with the canvas), calls
-`stop-recording!`, and the snippet emitted by `gen-play-snippet` is
-returned as the tool's structured output for the agent to write
-back to the user's stories namespace. That bead is filed separately
-as a P2 follow-up; this spec locks the recorder's runtime contract
-so the MCP side can build against a stable surface.
+state through direct, in-process calls in the shared JVM (per
+[`006-MCP-Surface.md`](006-MCP-Surface.md) §Architecture): the agent
+calls `start-recording!`, drives interactions via the existing MCP
+write surface, calls `stop-recording!`, and the snippet emitted by
+`gen-play-snippet` is returned as the tool's structured output for
+the agent to write back to the user's stories namespace. Recording a
+live browser canvas — the user interacting with a running app — is
+pair-owned: the pair evaluates the same recorder primitives in the
+attached CLJS runtime (spec/006 §Two surfaces, one live door). This
+spec locks the recorder's runtime contract so both consumers build
+against a stable surface.
 
 #### Recorder sub-system map (rf2-oaxgh)
 
@@ -576,14 +578,15 @@ in the recorded `:play-script` body.
 
 #### MCP wiring
 
-The agent-facing path mirrors the Test Codegen flow: a story-mcp
-`save-current-as-variant` tool dispatches
-`:rf.story/save-current-as-variant` against the live Story process
-through the Tool-Pair bridge (per
-[`006-MCP-Surface.md`](006-MCP-Surface.md)), reads the snippet from
-the resulting dialog state, and returns the EDN form as structured
-output. Filed as a separate P3 follow-up; this spec locks the
-runtime contract so the MCP side can build against a stable surface.
+The agent-facing path mirrors the Test Codegen flow — and, because
+the save-as dialog is live Story-shell state, it is pair-owned: the
+pair dispatches `:rf.story/save-current-as-variant` in the attached
+browser runtime, reads the snippet from the resulting dialog state,
+and returns the EDN form (per
+[`006-MCP-Surface.md`](006-MCP-Surface.md) §Two surfaces, one live
+door). Filed as a separate P3 follow-up; this spec locks the
+runtime contract so the agent side can build against a stable
+surface.
 
 ## Design-system v1 ship list (chrome-identity differentiators)
 

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -23,7 +23,7 @@ evidence model — no second artifact model.
                                        │ - schema validation        │
                                        │ - bridges to ↓             │
                                        └──────┬────────────────────┘
-                                              │ in-process or pair-style
+                                              │ direct, in-process calls
                                               ▼
                                        ┌───────────────────────────┐
                                        │ tools/story/ runtime      │
@@ -34,12 +34,42 @@ evidence model — no second artifact model.
                                        └───────────────────────────┘
 ```
 
-The MCP server connects to a running app's story runtime via the
-existing Tool-Pair primitives (see
-[`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md)): nREPL-attached
-process, the agent reads the registry over the wire, runs variants,
-reads results back. The MCP server itself runs in the agent's
-process; the story runtime runs in the app.
+The stdio MCP server and the Story runtime it calls share **one JVM
+process**: the agent launches the server as a subprocess, and every
+tool call lands directly on `re-frame.story`'s CLJC public surface in
+that same process. Registrations, runs, and snapshots are
+process-local. Neither jar carries an nREPL, socket, or
+JVM-to-browser transport (per
+[`tools/story-mcp/spec/000-Vision.md`](../../story-mcp/spec/000-Vision.md)
+§Relationship to Story).
+
+### Two surfaces, one live door
+
+Agent access to Story splits across two artefacts by host (ruled
+2026-07-11, rf2-3fc89f.22):
+
+- **Story-MCP (`tools/story-mcp/`) — the headless JVM surface.**
+  Docs discovery, authoring guidance, gated writes, and headless
+  variant runs against the Story registry in its own process.
+  CLJS-only state — registered browser substrates, the a11y-panel
+  atom, and above all the registry of a RUNNING browser app — is not
+  reachable from this process; a read of such state returns an
+  explicit capability-unavailable error rather than a false-empty
+  result (rf2-3fc89f.21). The host reports that it cannot look, never
+  that the answer is empty.
+- **The pair (`tools/re-frame2-pair-mcp/`) — the live browser host.**
+  Inspecting or driving the Story runtime inside a running app goes
+  through the pair's nREPL / `cljs-eval` channel (per
+  [`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md)): the pair
+  evaluates `re-frame.story/*` calls in the attached CLJS runtime,
+  which reaches the registrations the browser heap actually holds —
+  registry reads, `run-variant`, frame-scoped dispatch, results. The
+  documented pair-side recipe is tracked as rf2-s99lw4; first-class
+  Story catalogue tools on the pair are a later, demand-gated option.
+
+Story-MCP does not own — and must not imply — a live-app connection;
+there is deliberately **one live door** (the pair), so Story ships no
+second transport.
 
 ## Story's public read primitives (consumed by MCP)
 
@@ -61,7 +91,9 @@ process; the story runtime runs in the app.
 ```
 
 Story's core jar exposes these without depending on stdio / JSON-RPC.
-The MCP jar consumes them via the Tool-Pair bridge.
+The MCP jar consumes them via direct, in-process calls in the shared
+JVM; a pair-attached agent consumes the same surface by evaluating the
+same calls in the live browser runtime (§Two surfaces, one live door).
 
 ### Wire-elision boundary — core is real-values-in, real-values-out
 
@@ -303,6 +335,7 @@ sentinel carried no discriminator information.
   own spec folder (wire protocol, tool registry, write-surface
   gating, design rationale).
 - [`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) — the runtime
-  contract for pair-shaped AI tools.
+  contract for pair-shaped AI tools; the pair is the live-browser
+  Story host (§Two surfaces, one live door).
 - [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §separate-mcp-jar —
   why the split.

--- a/tools/story/spec/015-Test-Coverage.md
+++ b/tools/story/spec/015-Test-Coverage.md
@@ -187,6 +187,16 @@ follow-up implementation bead, not here:
 
 ### MCP surface scenarios — spec/006
 
+**Labelling note (rf2-3fc89f.22).** Every row in this table is a
+**same-process public-API shape pin**: the JVM test seeds the Story
+registry and calls `re-frame.story/*` directly — the same direct,
+in-process invocation the MCP jar makes (spec/006 §Architecture).
+None of these rows is cross-process or bridge coverage, and no such
+bridge exists to cover: live-browser Story access is pair-owned
+(spec/006 §Two surfaces, one live door; recipe tracked as
+rf2-s99lw4). Story-MCP's own wire/tool/gate coverage lives in
+`tools/story-mcp/test/`.
+
 | Scenario | Setup | Acceptance | Test home | Status |
 |---|---|---|---|---|
 | Public read-Var surface resolves | Iterate spec/006 §read primitives; each resolves to a callable Var on `re-frame.story`. | Every named Var resolves AND is `fn?`. | `tools/story/test/re_frame/story_mcp_boundary_test.clj` §`public-read-surface-resolves`. | Covered |
@@ -197,7 +207,7 @@ follow-up implementation bead, not here:
 | Late-bind panel registration | Re-registering a panel under an id replaces the prior slot — the contract that lets any artefact ship a view under a panel-author's `:render` id. | Second `reg-story-panel` for the same id replaces `:render`/`:title`; shell picks the live view. | Same file §late-bind contract. | Covered |
 | list-stories / list-variants / list-modes shape | Seeded registry; invoke each list primitive. | Returns set of keyword ids; shape matches spec/006 read primitive table. | `tools/story/test/re_frame/story_mcp_surface_test.clj` §`list-stories-returns-id-set` + §`list-variants-returns-id-set` + §`list-modes-returns-id-set` (pin set-of-keyword shape AND `(list-modes) = (ids :mode)` alias). | Covered (rf2-1svim) |
 | render-story / run-variant from MCP perspective | Invoke `run-variant` against a seeded variant; assert return shape matches spec/002 + spec/006. | `{:frame ... :app-db ... :assertions ... :elapsed-ms ... :snapshot ... :decorators ...}` keys present. | `tools/story/test/re_frame/story_mcp_surface_test.clj` §`run-variant-return-shape-matches-spec` + §`run-variant-empty-play-still-returns-shape`. CROSS-REF: `story_runtime_test.clj` covers the lifecycle-side; this row covers the MCP-boundary shape contract. | Covered (rf2-1svim) |
-| dispatch-via-mcp end-to-end | Simulate MCP-bridge dispatch into a variant's frame; assert `app-db` reflects the dispatch. | Frame `app-db` carries the dispatched event's effect; default frame untouched (per-frame isolation holds). | `tools/story/test/re_frame/story_mcp_surface_test.clj` §`dispatch-via-mcp-writes-to-variant-frame-app-db` + §`dispatch-via-mcp-multiple-events-accumulate` (registered via `reg-variant*` the MCP write path; dispatch via `{:frame variant-id}` the Tool-Pair bridge invocation). | Covered (rf2-1svim) |
+| dispatch-via-mcp same-process round trip | Direct-call dispatch into a variant's frame (the shape the MCP jar's tools invoke in the shared JVM); assert `app-db` reflects the dispatch. | Frame `app-db` carries the dispatched event's effect; default frame untouched (per-frame isolation holds). | `tools/story/test/re_frame/story_mcp_surface_test.clj` §`dispatch-via-mcp-writes-to-variant-frame-app-db` + §`dispatch-via-mcp-multiple-events-accumulate` (registered via `reg-variant*` the MCP write path; dispatch via `{:frame variant-id}` — a same-process public-API shape pin, NOT bridge coverage). | Covered (rf2-1svim; relabelled rf2-3fc89f.22) |
 | story-state-snapshot identity stability | Invoke `snapshot-identity` for a variant; mutate args; identity changes. Mutate `:source` coords; identity unchanged. | Hash changes on render-relevant input change; unchanged on cosmetic-only edit. | `tools/story/test/re_frame/story_mcp_surface_test.clj` §`snapshot-identity-stable-across-cosmetic-edits` + §`snapshot-identity-changes-on-args-edit` + §`snapshot-identity-changes-on-active-modes` (MCP-perspective: cell-overrides + active-modes + cosmetic :source mutations exercised via the opts map). | Covered (rf2-1svim) |
 
 ### `:test` mode pane scenarios — spec/009

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -8,7 +8,9 @@
   `reg-story-panel` contract.
 
   The MCP jar (`tools/story-mcp/`) consumes Story's CLJC public surface
-  over the Tool-Pair bridge. The story-mcp tests at
+  via direct, in-process calls in the shared JVM (spec/006
+  §Architecture; live-browser access is pair-owned per §Two surfaces,
+  one live door). The story-mcp tests at
   `tools/story-mcp/test/` cover the MCP side — the wire envelope, the
   per-tool semantics, the write-gate contract. What the bead calls out
   as 'Story MCP boundary not covered' is the **Story side**: the

--- a/tools/story/test/re_frame/story_mcp_surface_test.clj
+++ b/tools/story/test/re_frame/story_mcp_surface_test.clj
@@ -15,12 +15,15 @@
     `run-variant` against a seeded variant; assert the return shape
     matches spec/002 + spec/006 (`{:frame :app-db :assertions
     :rendered-hiccup :elapsed-ms ...}`).
-  - **dispatch-via-mcp end-to-end** — register a variant via
-    `reg-variant*` (the MCP write path), then dispatch into the
+  - **dispatch-via-mcp same-process round trip** — register a variant
+    via `reg-variant*` (the MCP write path), then dispatch into the
     variant's frame with the `{:frame variant-id}` opts map (the
-    `re-frame.core/dispatch-sync` shape the Tool-Pair bridge invokes
-    against an allocated frame); assert the frame's `app-db` reflects
-    the dispatched event's effect.
+    `re-frame.core/dispatch-sync` shape the MCP jar's tools invoke
+    directly in the shared JVM); assert the frame's `app-db` reflects
+    the dispatched event's effect. These are same-process public-API
+    shape pins, NOT cross-process bridge coverage — no such bridge
+    exists; live-browser Story access is pair-owned (spec/006 §Two
+    surfaces, one live door; rf2-3fc89f.22).
   - **story-state-snapshot identity stability** — invoke
     `snapshot-identity` for a variant; mutating cell-overrides
     (render-relevant input) changes the identity hash; mutating the
@@ -121,8 +124,9 @@
 ;; underlying call. The shape an agent expects in the return slot is
 ;; specified by spec/002 §run-variant result map. This test pins the
 ;; shape from the MCP boundary's vantage: invoke run-variant the same
-;; way the Tool-Pair bridge would and assert every keyed slot of the
-;; documented return shape is present.
+;; way the MCP jar does (a direct, in-process call — spec/006
+;; §Architecture) and assert every keyed slot of the documented
+;; return shape is present.
 ;; ===========================================================================
 
 (deftest run-variant-return-shape-matches-spec
@@ -174,9 +178,10 @@
 ;;
 ;; The MCP write path: an agent calls `reg-variant*` (programmatic write
 ;; — no source coord), then drives a dispatch against the allocated
-;; frame via `(rf/dispatch-sync event {:frame variant-id})`. The Tool-
-;; Pair bridge invokes this exact shape; the test pins the round-trip
-;; from registration through dispatch through observable app-db change.
+;; frame via `(rf/dispatch-sync event {:frame variant-id})`. The MCP
+;; jar's tools invoke this exact shape in the shared JVM; the test pins
+;; the round-trip from registration through dispatch through observable
+;; app-db change — a same-process shape pin, not bridge coverage.
 ;; ===========================================================================
 
 (deftest dispatch-via-mcp-writes-to-variant-frame-app-db


### PR DESCRIPTION
## Summary

Implements the ruling on **rf2-3fc89f.22** (P1: "Provide live Story runtime host integration promised by spec/006").

**Ruling (B), Mike 2026-07-11 (recorded in the bead NOTES — the durable statement is repeated here):** the **pair** (`tools/re-frame2-pair-mcp`) is the live browser Story host — it already owns the hardened nREPL/`cljs-eval` channel and can reach `re-frame.story/*` in any attached browser heap. **Story-MCP stays the headless same-JVM docs/authoring/run surface.** Do NOT build a second live transport (one-live-door principle; a bridge would revert merged rf2-3fc89f.21 and contradict three merged specs — story-mcp/000-Vision, story/Principles §Tool-Pair-not-in-process-MCP, story/000-Vision — and no shared transport exists to borrow: the pair transport is Node/CLJS, Story-MCP is JVM, mcp-base owns no transport by design). The P1 resolves as **the-spec-lied-not-the-code**: `tools/story/spec/006-MCP-Surface.md` promised a Tool-Pair/nREPL bridge that was never the ruled topology.

## Changes

- **tools/story/spec/006-MCP-Surface.md** — deleted the bridge promise ("connects to a running app's story runtime via ... nREPL-attached process, reads the registry over the wire") and the `in-process or pair-style` connector ambiguity; the Architecture section now states the same-JVM reality plus a new **§Two surfaces, one live door**: story-mcp = headless JVM (capability-unavailable for browser state, per rf2-3fc89f.21), pair = live browser host (recipe tracked as rf2-s99lw4).
- **tools/story/spec/015-Test-Coverage.md §MCP surface scenarios** — coverage mislabel fixed: a labelling note states every row is a same-process public-API shape pin, NOT cross-process/bridge coverage; the `dispatch-via-mcp end-to-end` row is relabelled `same-process round trip` and its "Tool-Pair bridge invocation" claim removed. Tests kept.
- **tools/story/spec/005-SOTA-Features.md §MCP wiring** (recorder + save-as-variant) — live-canvas interactions are pair-owned; the story-mcp `record-as-variant` path is same-JVM.
- **tools/story/test/re_frame/story_mcp_surface_test.clj + story_mcp_boundary_test.clj** — docstrings/comments no longer claim the Tool-Pair bridge; relabelled as same-process shape pins.
- **tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc** — docstring no longer calls the tool "the cross-process bridge" (docstring-only).

Bead acceptance criteria were re-scoped to these reconciliation deliverables per ruling item (3) (originals assumed Option A / build-the-bridge).

## Follow-on

- **rf2-s99lw4** — Pair: document the live-browser Story recipe (drive `re-frame.story/*` via pair eval-cljs) against a running testbed; first-class Story catalogue tools on the pair remain a later, demand-bar-gated option.

## Quality gates

- `clojure -M:test` (tools/story): **1774 tests, 6504 assertions, 0 failures, 0 errors** — PASS
- `clojure -M:test` (tools/story-mcp): **286 tests, 1494 assertions, 0 failures, 0 errors** — PASS
- `mkdocs build --strict` (repo root): **built successfully** — PASS
- `npm run test:cljs`: skipped — no implementation/ code touched (spec + test-docstring + one story-mcp docstring only; no runtime behaviour changes).