### PR TITLE
fix(schemas): redact sensitive closed-map extra keys in path/reason (rf2-j538f7.13)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -756,10 +756,14 @@
       under a sensitive key would otherwise ship the secret in `:path` /
       `:reason` despite `:value` / `:explain` being redacted. When the key
       schema declares sensitivity, the key segment is scrubbed.
-    - `:map` keys, `:vector` / `:sequential` / `:tuple` / `:cat` / `:catn`
-      integer indices — navigable scalar locators; KEEP them so `:path`
-      stays a useful `get-in` locator for those shapes (the bead's regression
-      requirement).
+    - DECLARED `:map` keys, `:vector` / `:sequential` / `:tuple` / `:cat` /
+      `:catn` integer indices — navigable scalar locators; KEEP them so
+      `:path` stays a useful `get-in` locator for those shapes (the bead's
+      regression requirement). A `:map` segment that is NOT a declared child
+      is different (rf2-j538f7.13): a `[:map {:closed true} …]` extra-key
+      failure reports the CALLER-SUPPLIED extra key itself as the segment —
+      user data, possibly a credential — so the key-not-found branch fails
+      closed INCLUDING the current segment.
     - Transparent wrappers contribute NO `:in` segment — descend without
       consuming. `:maybe` is genuinely single-child (`[:maybe inner]`) so
       the lockstep walk continues precisely. `:and` / `:or` are MULTI-child
@@ -817,8 +821,8 @@
                 children (children-of schema)
                 seg      (nth in 0)]
             (cond
-              ;; `:map` — real app-db key; keep it and descend into the
-              ;; named child's tail schema.
+              ;; `:map` — a DECLARED key is a real app-db locator; keep it
+              ;; and descend into the named child's tail schema.
               (contains? name-bearing-ops op)
               (if-let [child (some (fn [c]
                                      (when (and (vector? c) (>= (count c) 2)
@@ -830,8 +834,19 @@
                                   (when (>= (count child) 3) (nth child 2))
                                   (nth child 1))]
                   (recur tail (subvec in 1) (conj out seg)))
-                ;; Key not found (shape drift) — fail-closed on the rest.
-                (fail-closed-tail (conj out seg) (subvec in 1)))
+                ;; Key not found — the segment is NOT a declared slot, so it
+                ;; cannot be proven a structural locator (rf2-j538f7.13). For
+                ;; a `[:map {:closed true} …]` extra-key failure Malli reports
+                ;; the CALLER-SUPPLIED EXTRA KEY VALUE itself as the `:in`
+                ;; segment — arbitrary user data (decoded JSON keys, headers,
+                ;; hostile input) that may itself be a credential. Keeping it
+                ;; (the earlier `(conj out seg)` shape) shipped the secret
+                ;; VERBATIM through `:path` / `:reason` despite `:value` /
+                ;; `:explain` being redacted. Fail closed INCLUDING the
+                ;; current segment; declared keys keep the precise branch
+                ;; above (an OPEN map never emits an extra-key error, so only
+                ;; undeclared / shape-drift segments land here).
+                (fail-closed-tail out in))
 
               ;; `:set` — the segment is the failing ELEMENT VALUE. ALWAYS
               ;; scrub (unnavigable + value-bearing) and descend into the

--- a/implementation/schemas/test/re_frame/schemas/walker_sanitize_path_fixtures.cljc
+++ b/implementation/schemas/test/re_frame/schemas/walker_sanitize_path_fixtures.cljc
@@ -1,0 +1,90 @@
+(ns re-frame.schemas.walker-sanitize-path-fixtures
+  "Shared, host-agnostic corpus for `sanitize-sensitive-path`'s closed-map
+  extra-key scrub (rf2-j538f7.13). Both the JVM test
+  (`re-frame.schemas-sensitive-test`) and the CLJS parity test
+  (`re-frame.schemas-sensitive-path-cljs-test`) assert these cases, so the
+  sanitizer is pinned to the SAME privacy behaviour on both runtimes —
+  `walker.cljc` is shared CLJC and redaction must not diverge by host.
+
+  Background — the sanitizer's `:map` arm keeps a DECLARED child key as a
+  navigable `get-in` locator. But for a Malli `[:map {:closed true} …]`
+  extra-key failure, the reported `:in` segment is the CALLER-SUPPLIED
+  EXTRA KEY VALUE itself — arbitrary user data (decoded JSON keys, headers,
+  hostile input) that may itself be a credential. The pre-fix key-not-found
+  branch `(conj out seg)`-ed that segment before fail-closing the tail,
+  shipping the secret verbatim through `:path` / `:reason`. The fix routes
+  the unknown segment into the same fail-closed scrub as set element values,
+  sensitive `:map-of` keys, and unresolved wrapper tails.
+
+  Every case is pure vector-form data (no compiled schemas), so the corpus
+  loads identically on the JVM and under `:node-test`."
+  )
+
+(def cases
+  "Each case: `{:desc … :schema … :in … :expected …}` —
+  `(sanitize-sensitive-path schema in)` must equal `expected` on BOTH hosts."
+  [;; ---- the rf2-j538f7.13 leak shape: sensitive closed-map EXTRA key ----
+   {:desc     "flat sensitive closed map — the undeclared extra key is user
+               data, not a declared slot; it is scrubbed to the sentinel"
+    :schema   [:map {:closed true :sensitive? true} [:known :int]]
+    :in       ["SECRET-KEY-7f93"]
+    :expected [:rf/redacted]}
+
+   {:desc     "hostile extra key of composite shape — a map carrying a secret
+               used AS the key is scrubbed whole (fail-closed is shape-blind)"
+    :schema   [:map {:closed true :sensitive? true} [:known :int]]
+    :in       [{:ssn "111-22-3333"}]
+    :expected [:rf/redacted]}
+
+   {:desc     "nested sensitive closed map — the outer DECLARED key stays a
+               navigable locator; the inner undeclared extra key is scrubbed"
+    :schema   [:map {:closed true}
+               [:profile [:map {:closed true :sensitive? true} [:known :int]]]]
+    :in       [:profile "SECRET-KEY-7f93"]
+    :expected [:profile :rf/redacted]}
+
+   {:desc     "unknown segment with a trailing tail — the ENTIRE remainder is
+               scrubbed (the unknown key and everything past it)"
+    :schema   [:map {:closed true :sensitive? true} [:known :int]]
+    :in       ["SECRET-KEY-7f93" :sub]
+    :expected [:rf/redacted :rf/redacted]}
+
+   ;; ---- regression controls: declared locators stay navigable ----------
+   {:desc     "declared map key of the SAME closed sensitive map is kept —
+               only the undeclared segment fails closed"
+    :schema   [:map {:closed true :sensitive? true} [:known :int]]
+    :in       [:known]
+    :expected [:known]}
+
+   {:desc     "deep declared chain — every declared map key keeps its precise
+               locator identity"
+    :schema   [:map [:a [:map [:b {:sensitive? true} :string]]]]
+    :in       [:a :b]
+    :expected [:a :b]}
+
+   ;; ---- regression controls: existing value-bearing scrubs unchanged ---
+   {:desc     "a :set failure's segment is the failing ELEMENT VALUE — always
+               scrubbed (rf2-ss06u.1); the declared outer map key survives"
+    :schema   [:map [:s [:set [:string {:sensitive? true}]]]]
+    :in       [:s "SECRET-SET-ELEMENT"]
+    :expected [:s :rf/redacted]}
+
+   {:desc     "a sensitive :map-of KEY is the secret itself — scrubbed; the
+               navigable inner declared map key survives (rf2-612mri)"
+    :schema   [:map-of [:string {:sensitive? true}] [:map [:age :int]]]
+    :in       ["secret-token-123" :age]
+    :expected [:rf/redacted :age]}
+
+   {:desc     "a NON-sensitive :map-of key stays a navigable locator — no
+               over-redaction of plain keyed containers"
+    :schema   [:map-of :string [:map [:secret {:sensitive? true} :string]]]
+    :in       ["plain-key" :secret]
+    :expected ["plain-key" :secret]}
+
+   {:desc     "a MULTI-child :or is ambiguous — the whole remaining tail fails
+               closed (rf2-jqx2at), unchanged by the closed-map fix"
+    :schema   [:or
+               [:map-of :int :int]
+               [:map-of [:string {:sensitive? true}] [:map [:age :int]]]]
+    :in       ["secret-token-123" :age]
+    :expected [:rf/redacted :rf/redacted]}])

--- a/implementation/schemas/test/re_frame/schemas_sensitive_path_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_path_cljs_test.cljs
@@ -1,0 +1,23 @@
+(ns re-frame.schemas-sensitive-path-cljs-test
+  "CLJS host-parity half of the sensitive closed-map extra-key scrub
+  (rf2-j538f7.13). `sanitize-sensitive-path` is pure and shared CLJC, so both
+  runtimes assert the SAME corpus
+  (`re-frame.schemas.walker-sanitize-path-fixtures`) against the SAME entry
+  point — a CLJS regression that diverged from the JVM privacy behaviour is
+  caught here. The JVM half (`re-frame.schemas-sensitive-test`) additionally
+  covers the end-to-end `validate-app-schema!` `:path` / `:reason` /
+  whole-trace egress.
+
+  The corpus is pure vector-form data (no compiled schemas), so it loads
+  identically under `:node-test`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.schemas.walker :as walker]
+            [re-frame.schemas.walker-sanitize-path-fixtures :as sanitize-fx]))
+
+(deftest cljs-sanitize-closed-map-extra-key-shared-corpus
+  (testing "rf2-j538f7.13 — the shared sanitize-sensitive-path corpus holds on
+            CLJS (closed-map extra keys scrub; declared locators survive;
+            prior set / :map-of / ambiguous-tail behaviour unchanged)"
+    (doseq [{:keys [desc schema in expected]} sanitize-fx/cases]
+      (is (= expected (walker/sanitize-sensitive-path schema in))
+          desc))))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -48,6 +48,10 @@
             [malli.core :as m]
             ;; White-box tests cover the internal path sanitizer.
             [re-frame.schemas.walker :as walker]
+            ;; Shared cross-host sanitizer corpus (rf2-j538f7.13) — the CLJS
+            ;; half (re-frame.schemas-sensitive-path-cljs-test) asserts the
+            ;; SAME cases so privacy behaviour cannot diverge by host.
+            [re-frame.schemas.walker-sanitize-path-fixtures :as sanitize-fx]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
@@ -2178,3 +2182,111 @@
         (is (not (-> v :tags :large?)) "no :large? stamp")
         (is (= [:api/x {:n "nope"}] (-> v :tags :value))
             ":value rides verbatim")))))
+
+;; ---- sensitive closed-map EXTRA KEY leak (rf2-j538f7.13) --------------------
+;; Malli reports a `[:map {:closed true} …]` extra-key failure with the
+;; CALLER-SUPPLIED EXTRA KEY VALUE itself as the `:in` segment — arbitrary user
+;; data (decoded JSON keys, typos, dynamic form names, headers, hostile input)
+;; that may itself be a credential. `sanitize-sensitive-path`'s key-not-found
+;; branch previously `(conj out seg)`-ed the unknown segment before fail-closing
+;; only the tail, so the secret key shipped VERBATIM through `:path` and
+;; `:reason` (and every serialized trace tag) even though `:value` / `:explain`
+;; / `:explain-humanized` were correctly redacted and the top-level `:sensitive?`
+;; stamp was present — a record that LOOKED redacted still carried the raw
+;; secret twice. The fix routes the unknown segment into the same fail-closed
+;; scrub as set element values, sensitive `:map-of` keys, and unresolved wrapper
+;; tails: only schema-DECLARED `:map` keys are proven structural locators. An
+;; open map never emits an extra-key error, so declared keys keep their precise
+;; branch and only undeclared / shape-drift segments fail closed. These fail
+;; before the fix (the secret rides in `:path` / `:reason`) and pass after.
+
+;; -- pure sanitizer: shared cross-host corpus (parity anchor; the CLJS half
+;;    is re-frame.schemas-sensitive-path-cljs-test) --
+
+(deftest sanitize-closed-map-extra-key-shared-corpus
+  (testing "rf2-j538f7.13 — the shared sanitize-sensitive-path corpus holds on
+            the JVM (closed-map extra keys scrub; declared locators survive;
+            prior set / :map-of / ambiguous-tail behaviour unchanged)"
+    (doseq [{:keys [desc schema in expected]} sanitize-fx/cases]
+      (is (= expected (walker/sanitize-sensitive-path schema in))
+          desc))))
+
+;; -- end-to-end via validate-app-schema! (:path / :reason / whole-trace egress) --
+
+(deftest app-db-validation-sensitive-closed-map-extra-key-scrubbed
+  (testing "rf2-j538f7.13 — a sensitive closed map's undeclared EXTRA key is
+            scrubbed from :path AND :reason; the secret key appears NOWHERE in
+            the emitted trace (deep whole-trace scan)"
+    (let [v (app-db-failure-trace
+              [:profile]
+              [:map {:closed true :sensitive? true} [:known :int]]
+              {:profile {:known 1 "SECRET-KEY-7f93" 2}}
+              :profile/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v)) "top-level :sensitive? stamp present")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      (is (= [:profile :rf/redacted] (-> v :tags :path))
+          ":path carries the :rf/redacted sentinel where the extra key was")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "SECRET-KEY-7f93"))
+          "the secret key does NOT appear in the generated :reason text")
+      (is (not (str/includes? (pr-str (:tags v)) "SECRET-KEY-7f93"))
+          "the secret key does NOT appear ANYWHERE in the emitted tags")
+      (is (not (str/includes? (pr-str v) "SECRET-KEY-7f93"))
+          "the secret key does NOT appear ANYWHERE in the whole trace event"))))
+
+(deftest app-db-validation-nested-sensitive-closed-map-extra-key-scrubbed
+  (testing "rf2-j538f7.13 — a NESTED sensitive closed map receives the same
+            protection: the declared outer key stays navigable; the inner
+            undeclared extra key is scrubbed everywhere"
+    (let [v (app-db-failure-trace
+              [:account]
+              [:map {:closed true}
+               [:profile [:map {:closed true :sensitive? true} [:known :int]]]]
+              {:account {:profile {:known 1 "NESTED-SECRET-4242" 2}}}
+              :account/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v)) "top-level :sensitive? stamp present")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      (is (= [:account :profile :rf/redacted] (-> v :tags :path))
+          "declared keys survive; the undeclared segment is the sentinel")
+      (is (not (str/includes? (pr-str (:tags v)) "NESTED-SECRET-4242"))
+          "the secret key does NOT appear anywhere in the emitted tags")
+      (is (not (str/includes? (pr-str v) "NESTED-SECRET-4242"))
+          "the secret key does NOT appear anywhere in the whole trace event"))))
+
+(deftest app-db-validation-hostile-extra-key-and-value-never-leak
+  (testing "rf2-j538f7.13 adversarial — a HOSTILE extra key (a credential-shaped
+            string) and its VALUE both stay out of the whole emitted trace; the
+            declared sibling's data does not leak either"
+    (let [hostile-key "Bearer eyJhbGciOiJIUzI1NiJ9.HOSTILE-TOKEN-9d41"
+          v           (app-db-failure-trace
+                        [:profile]
+                        [:map {:closed true :sensitive? true} [:known :int]]
+                        {:profile {:known 7 hostile-key "HOSTILE-VALUE-31337"}}
+                        :profile/hostile)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v)) "top-level :sensitive? stamp present")
+      (is (= [:profile :rf/redacted] (-> v :tags :path))
+          "the hostile key is the :rf/redacted sentinel in :path")
+      (is (not (str/includes? (pr-str v) "HOSTILE-TOKEN-9d41"))
+          "the hostile key does NOT appear anywhere in the whole trace event")
+      (is (not (str/includes? (pr-str v) "HOSTILE-VALUE-31337"))
+          "the hostile key's VALUE does NOT appear anywhere in the whole trace event"))))
+
+(deftest app-db-validation-non-sensitive-closed-map-extra-key-stays-precise
+  (testing "rf2-j538f7.13 regression — a NON-sensitive closed map's extra-key
+            failure is not stamped :sensitive? and its precise path rides
+            verbatim (the sanitizer only runs on sensitive failures — no
+            over-redaction of plain closed maps)"
+    (let [v (app-db-failure-trace
+              [:plain]
+              [:map {:closed true} [:known :int]]
+              {:plain {:known 1 "extra-key" 2}}
+              :plain/bad)]
+      (is (some? v) "a trace fired")
+      (is (not (contains? v :sensitive?))
+          "no :sensitive? stamp — nothing in the schema is sensitive")
+      (is (= [:plain "extra-key"] (-> v :tags :path))
+          "the extra key rides verbatim in :path — precise diagnostics kept"))))


### PR DESCRIPTION
## Summary

`sanitize-sensitive-path`'s `:map` key-not-found branch retained the current segment (`(conj out seg)`) before fail-closing only the tail. For a Malli `[:map {:closed true} ...]` extra-key failure, that segment is the caller-supplied EXTRA KEY VALUE itself — arbitrary user data (decoded JSON keys, typos, headers, hostile input) that may itself be a credential. On a sensitive failure the secret shipped verbatim through `:path` and `:reason` (and every serialized trace tag) even though `:value` / `:explain` / `:explain-humanized` were correctly redacted and the top-level `:sensitive?` stamp was present — a record that looked redacted still carried the raw secret twice.

**Fix** (`implementation/schemas/src/re_frame/schemas/walker.cljc`): the key-not-found branch now fails closed INCLUDING the current segment — only schema-DECLARED `:map` keys are proven structural locators. An open map never emits an extra-key error, so declared keys keep the precise branch and navigability is unchanged for every known shape; set / `:map-of` / ambiguous-tail scrubbing is untouched. The fix is local to the sanitizer per the bead design (`schema-sensitive-at?` already classified the failure sensitive; `validate-app-schema!` already routes both `:path` and `:reason` through the sanitized coordinate).

Before / after (sensitive closed map, hostile extra key):
- `:path` `[:profile "SECRET-KEY-7f93"]` → `[:profile :rf/redacted]`
- `:reason` carried the raw key → sentinel only; whole-trace scan is secret-free

## Tests

- Shared CLJC corpus `implementation/schemas/test/re_frame/schemas/walker_sanitize_path_fixtures.cljc` (10 cases: flat/nested/composite/tailed extra keys + declared-locator, set, `:map-of`, ambiguous-tail regression controls) asserted on BOTH hosts — JVM (`schemas_sensitive_test.clj`) and a new CLJS parity ns (`schemas_sensitive_path_cljs_test.cljs`, discovered by the `cljs-test$` regexp) — so privacy behaviour cannot diverge by runtime.
- End-to-end `validate-app-schema!` tests pin `:path [:profile :rf/redacted]`, secret-free `:reason` / complete tags / complete trace, `:value` / `:explain` still `:rf/redacted`, top-level `:sensitive?` still `true`.
- Adversarial regression test: a hostile credential-shaped extra key AND its value never appear anywhere in the whole emitted trace.
- Nested sensitive closed map gets the same protection; declared outer keys stay navigable.
- Non-sensitive closed-map control: extra key rides verbatim (no over-redaction; the sanitizer only runs on sensitive failures).
- rf2-3fc89f.12 operator-aware literal-opacity corpus untouched and passing.

## Quality gates

| Gate | Result |
| --- | --- |
| `clojure -M:test` (implementation/schemas) | PASS — 356 tests / 19,059 assertions, 0 failures, 0 errors (baseline before change: 351 / 19,026) |
| `npm run test:cljs` (implementation/) | PASS — 8,491 tests / 39,732 assertions, 0 failures, 0 errors (new CLJS parity ns confirmed compiled into the node-test build) |
| `npm run test:browser-schemas-boundary-prod` (advanced production-boundary build, per the bead's acceptance criteria) | PASS — 7 tests / 9 assertions, 0 failures, 0 errors |

`npm run test:elision` not run: the change is pure shared-CLJC walker logic inside the schemas artefact with no new requires and no tool/production-bundle boundary surface; the bead's named boundary gate is the advanced schemas-boundary-prod build, which ran above.

Closes rf2-j538f7.13.