### PR TITLE
chore(xray): retire machines-viz active-state pulse keyframes per ruling (rf2-wct1s8)

### DIFF
--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -387,12 +387,11 @@ xyflow canvas through the shared machines-viz **MachineChart**
 (`day8.re-frame2-machines-viz.chart`), mounted via the Xray-side
 [`panels/machine_canvas.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs)
 wrapper (per §021 §6.0) — not Stately Inspect, not native Reagent. Nodes,
-edges, current-state pulse, parallel-region containers, and final-state
-double-rings all come from that chart, which carries its own styling.
-[`panels/machines/xyflow_style.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/machines/xyflow_style.cljs)
-(+ `machines/topology.cljs`) is the self-contained, JVM-portable,
-unit-tested fallback projector / style catalogue — **not** on the live
-render path.
+edges, current-state highlight, parallel-region containers, and final-state
+double-rings all come from that chart, which carries its own styling. The
+former Xray-local fallback projector / style catalogue
+(`panels/machines/xyflow_style.cljs` + `machines/topology.cljs`) was
+DELETED (rf2-5fm165) — it had no live-render-path consumer.
 
 **Current-state precedence** — a 4-source walk-back resolves the
 machine's current state for the focused epoch:
@@ -402,10 +401,11 @@ machine's current state for the focused epoch:
 3. **Epoch-history walk-back** — scan the buffer back to the most-recent transition
 4. **Snapshot** — fall back to the substrate's per-frame machine state
 
-The resolved current state node carries the `rf-xray-machine-pulse`
-keyframe (1.2s ease-in-out, interpolated through
-`--rf-xray-motion-scale` so reduced-motion collapses it; §021
-§17.4.5).
+The resolved current state node carries a **static** highlight — a runtime
+accent border + a soft `box-shadow` glow ring + a faint header wash (§021
+§17.4.5). It does **not** pulse: Mike rejected the continuous active-state
+pulse (rf2-2sez0), so machines-viz locked "no continuous animation"; the
+old pulse keyframes were retired (rf2-wct1s8).
 
 The focused-epoch **transition row** is a single prominent row: a header
 verb `<before-state → after-state>` (larger / bolder / magenta, doubling

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1077,7 +1077,7 @@ for the work cost of rebuilding auto-layout / zoom-pan-fit from scratch.
 |---|---|
 | Nested state containment | xyflow's group/parent-node mechanic. Parent state renders as a containing rect; child states are nested xyflow nodes whose `parentNode` references the parent. |
 | Transition edge animation | xyflow's `animated: true` edge prop. Color via Xray palette (`:accent` — the single GitHub-blue accent — for "fired this epoch"; `:text-tertiary` for "registered but not fired this epoch"). |
-| Current-state highlight pulse | Custom node CSS class that applies the `pulse` keyframe (~1.2s ease-in-out; CSS-variable interpolated through `--rf-xray-motion-scale` so `prefers-reduced-motion` collapses it). Pulse outline color = `:green` (the panel-domain accent). |
+| Current-state highlight (static) | machines-viz signals the active state **statically** — a runtime accent border + a soft `box-shadow` glow ring + a faint header wash on the state box, never a continuous pulse. Mike rejected the continuous active-state pulse (rf2-2sez0; machines-viz `spec/Principles.md` "No continuous animation" — a looping pulse would compete with the transition highlights). |
 | Auto-layout | **elkjs** (the Eclipse Layout Kernel, `Layered` algorithm) runs as xyflow's layout backend inside `MachineChart` (2026-05-19 ELK lock — superseded the originally-sketched dagre `getLayoutedElements`). Async one-shot layout, cached per machine-id; recomputed only when topology changes. |
 | Zoom + pan + fit | xyflow's built-in `<Controls>` component ONLY (mounted `{:showZoom true :showFitView true :showInteractive false}`; xyflow positions it bottom-left). The cluster ships **zoom-in `+` / zoom-out `−` / fit-view `⛶`** buttons — no `NN%` zoom-readout chip, no `Reset` button, no custom Xray toolbar. Default framing: fit-on-mount via `:fitViewOptions {:padding 0.1}`; Xray re-frames on panel-entry by bumping the orthogonal `:fit-signal` nonce (rf2-6tw7t). See spec/007 §"Controls" for the authoritative reconciliation. |
 | Label-on-edge transitions | xyflow's `label` prop on edges; rendered inline on the edge, not in a side legend. Font: JetBrains Mono 10px (`:micro` size). |
@@ -1095,8 +1095,8 @@ panel, not a generic xyflow diagram):
               :color      (:text-primary tokens)    ; "#E8EAF0"
               :font-family mono-stack
               :font-size  (:body-tight type-scale)}
- :state-node-current {:border (str "2px solid " (:green tokens))
-                      :animation "rf-xray-machine-pulse 1.2s ease-in-out infinite"}
+ :state-node-current {:border (str "2px solid " (:accent tokens))    ; static accent border — no pulse (rf2-2sez0)
+                      :box-shadow (str "0 0 0 3px " (:accent tokens))} ; soft static glow ring
  :state-node-final   {:border (str "2px solid " (:green tokens))
                       :box-shadow (str "inset 0 0 0 1px " (:bg-2 tokens))}
  :region-container   {:background "transparent"
@@ -1174,7 +1174,7 @@ accent; the fired transition edge carries its **event label + guard + action inl
 │ │ │           guard: token? [pass]                        │   loading→error  ││
 │ │ │           do: fetch!                                  │                  ││
 │ │ └───────────────────────────────────────────────────────┘                 ││
-│ │  FROM = dashed/dim · TO = double-circle, mode-accent, pulse                 ││
+│ │  FROM = dashed/dim · TO = double-circle, mode-accent, static                ││
 │ │  fired edge = mode-accent 2px animated · registered = dim 1px · error = red ││
 │ │ ┌──────┐                                                                    ││
 │ │ │ + − ⛶ │ ← xyflow <Controls> (bottom-left)                                 ││
@@ -5439,7 +5439,6 @@ swapped.
 | Interaction feedback (hover, focus, press) | **≤ 200ms** (typical 120-180ms) | `ease-out` |
 | Panel switch / tab transition | ≤ 400ms — currently 180ms cross-fade (`theme/motion :fade-duration-ms`) | `ease-in-out` |
 | Diff flash on changed value | 400ms (`theme/motion :flash-duration-ms`) | `ease-out` |
-| Machine-state current-state pulse (§6) | 1.2s | `ease-in-out infinite` |
 | xyflow edge "fired this epoch" animation | xyflow built-in (≈ 1s loop) | xyflow default |
 
 All durations multiply through `var(--rf-xray-motion-scale, 1)` so
@@ -5491,7 +5490,7 @@ operators will see.
 │  │   │:empty │ ╴ ╴ ╴ ╴ ╴ ╴▷ │:populated │ ═════▶ │:submitting│  │ │
 │  │   ╰───────╯                ╰───────────╯  :submit ╰─────◉───╯  │ │
 │  │                              (last seen)            ↑ current   │ │
-│  │                                                     (pulses)    │ │
+│  │                                                     (static)    │ │
 │  │                                                                  │ │
 │  │   ╭──────────╮                                                  │ │
 │  │   │ :settled │ (registered; no path from current)               │ │
@@ -5506,7 +5505,7 @@ operators will see.
 │  │     ╭─╮ standard state                     :bg-2 + :border-def  │ │
 │  │     ╭═╮ final state                        :bg-2 + 2px :green   │ │
 │  │     ╭◉╮ current state                      :bg-2 + 2px :green   │ │
-│  │            + 1.2s pulse animation                                │ │
+│  │            + static glow, no loop                                │ │
 │  │   ┌──────┐                                                      │ │
 │  │   │ + − ⛶ │ ← xyflow <Controls> (bottom-left); zoom-±/fit only,  │ │
 │  │   └──────┘    no NN% chip, no Reset                              │ │
@@ -5531,7 +5530,7 @@ operators will see.
 |---|---|---|
 | Rounded rect (`border-radius: 6px`) | Standard state | `:standard` |
 | Rounded rect + 2px solid `:green` outer + 1px `:bg-2` inner gap (double-ring) | Final state | `:final` |
-| **Double-circle** (`border-radius: 50%`) in the mode `:accent` — 3px accent border + concentric inner-gap + inner-ring (stacked `inset` box-shadows) + 1.2s breathing pulse | Current / TO state (most recent visit) | `:current` |
+| **Double-circle** (`border-radius: 50%`) in the mode `:accent` — 3px accent border + concentric inner-gap + inner-ring (stacked `inset` box-shadows) + a static accent glow ring (**no pulse** — rf2-2sez0) | Current / TO state (most recent visit) | `:current` |
 | Dashed/dim circle (`border-radius: 50%`, `2px dashed :text-tertiary`, transparent fill) | FROM state — source of the focused fired transition | `:from` |
 | Rounded rect with dashed border (`2px dashed :border-default`) wrapping the focused FROM/TO pair | `active (compound)` focused-transition container | `:compound` |
 | Rounded rect with dashed border (`1px dashed :border-default`) | Parallel-region container | `:region` |
@@ -5544,8 +5543,10 @@ dimmed). `:compound` is distinct from `:region` — the former is the
 single focused-transition lens, the latter is the parallel-region sibling
 container. The accent double-circle replaces the former green single
 ring so the active node reads as the Stately/xstate convention the Figma
-fixes; it animates via `rf-xray-machine-pulse-active` (the accent
-counterpart of the green `rf-xray-machine-pulse`).
+fixes; it is a **static** affordance (accent border + inner rings + a soft
+box-shadow glow), **not** a continuous pulse — Mike rejected the active-state
+pulse (rf2-2sez0; machines-viz `spec/Principles.md` "No continuous animation":
+a looping pulse would compete with the transition highlights).
 
 **Parallel-machine node-ids are region-scoped (rf2-wnzha).** The sole
 projector (machines-viz `chart.layout/project-definition`) walks EVERY
@@ -5643,19 +5644,19 @@ machine-root / parallel-root nodes + `:history?` pseudo-states, per
 machine-level / parallel-root / region-`:on-done` fallback edges (real
 transitions the deleted Xray-local projector silently dropped).
 
-The `rf-xray-machine-pulse` keyframe (the green legacy pulse) and the
-`rf-xray-machine-pulse-active` keyframe (the mode-accent double-circle
-pulse per the Figma reconcile · rf2-ad7zx.10) live in the existing
-`theme/global_styles motion-css` block — alongside the diff-flash + fade
-keyframes under the same `prefers-reduced-motion` collapsing mechanic.
-They remain the spec/021 §6.2 Case C / §17.4.2 active-state pulse
-contract; the deleted `xyflow_style.cljs` was their in-tree applicator, so
-wiring them onto the live machines-viz current-state node is now an open
-follow-on (the keyframes are retained pending that wiring, not deleted).
-The active keyframe re-states the concentric inner-gap + inner-ring on
-every stop (box-shadow sets the whole property each frame) and rides
-`--rf-xray-accent` so the halo tracks the mode (orange Dynamic / cyan
-Static).
+The former active-state **pulse** keyframes were **retired** (rf2-wct1s8,
+per the rf2-2sez0 ruling). Mike rejected the continuous active-state pulse
+when he inspected the chart (rf2-2sez0, 2026-05-20); machines-viz locked
+the "No continuous animation" principle accordingly (`tools/machines-viz/
+spec/Principles.md`): the active state is signalled **statically** — a
+runtime accent border + a soft `box-shadow` glow ring + a faint header wash
+— because a looping pulse would compete with the once-per-event transition
+highlights. rf2-5fm165 had already deleted the keyframes' only in-tree
+applicator (`xyflow_style.cljs`), leaving them applicator-less; rather than
+wire a pulse Mike had already rejected, rf2-wct1s8 deleted the two keyframes
+(and their guard tests) from `theme/global_styles motion-css`. The live
+machines-viz current-state chrome (accent border, header wash, static glow,
+`data-active` attrs) is the contract.
 
 ### §17.5 Follow-on bead candidates (visual layer)
 
@@ -5713,8 +5714,9 @@ already drafted in §13.
   glyph palette + per-glyph color token + HCM remap. Worker implements
   against §17.1.5 + §17.1.3 mapping.
 
-- **rf2-?????** — *Xray: machine-state pulse keyframe.* Add
-  `rf-xray-machine-pulse` keyframe to `theme/global_styles motion-css`
-  alongside the existing flash + fade keyframes. 1.2s ease-in-out
-  infinite; interpolated through `--rf-xray-motion-scale` for
-  reduced-motion collapse. Gates: xyflow current-state node rendering.
+- **DONE (retired · rf2-wct1s8 / rf2-2sez0)** — *Xray: machine-state pulse
+  keyframe.* Originally sketched as an active-state pulse keyframe in
+  `theme/global_styles motion-css`. RETIRED, not shipped: Mike rejected the
+  continuous active-state pulse (rf2-2sez0), so machines-viz signals the
+  active state statically (accent border + glow ring + header wash) instead.
+  The applicator-less keyframes + their guard tests were deleted (rf2-wct1s8).

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -460,67 +460,6 @@
     "  from { opacity: 0; transform: translateY(2px); }\n"
     "  to   { opacity: 1; transform: translateY(0); }\n"
     "}\n"
-    ;; rf2-ezx8w — machine-state pulse (spec/021 §17.4.2 + §17.4.5).
-    ;; The active `:current` state node carries `:animation
-    ;; rf-xray-machine-pulse 1.2s ease-in-out infinite`. (rf2-5fm165 —
-    ;; the xray-local fallback style catalogue that applied this was
-    ;; deleted when machines-viz became the sole topology projector; the
-    ;; keyframe remains as the spec/021 active-state pulse contract.)
-    ;; The keyframe alternates `box-shadow` + `opacity` so the green
-    ;; outer ring gently breathes — subtle scale-less pulse that reads
-    ;; as "this is the live state" without becoming a strobe across
-    ;; multi-machine canvases.
-    ;;
-    ;; The 1.2s duration is documented in §17.2 (interaction-state
-    ;; matrix → animation timings) as the machine-state current-state
-    ;; pulse cadence. It runs through `--rf-xray-motion-scale` like
-    ;; every other Xray animation, so the `prefers-reduced-motion:
-    ;; reduce` seam (+ the rf2-ybjkx user override) collapses it to
-    ;; a single resolve frame.
-    ;;
-    ;; `0%` and `100%` carry the resting frame; the midpoint adds a
-    ;; faint green glow + a 0.85 opacity dip. The xyflow node's base
-    ;; rectangle stays painted at full opacity — only the box-shadow
-    ;; halo around it pulses (alternate-style breath rather than the
-    ;; node itself flickering).
-    "@keyframes rf-xray-machine-pulse {\n"
-    "  0%, 100% {\n"
-    "    box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.45);\n"
-    "  }\n"
-    "  50% {\n"
-    "    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0);\n"
-    "  }\n"
-    "}\n"
-    ;; rf2-ad7zx.10 — active-state DOUBLE-CIRCLE pulse (spec/021
-    ;; §6.2 Case C + §17.4.2). The Figma reconcile draws the focused
-    ;; TO / current state as a concentric double-circle in the single
-    ;; `:accent` (GitHub blue), not the former green single ring. The
-    ;; active `:current` state node carries `:animation
-    ;; rf-xray-machine-pulse-active 1.2s …`. (rf2-5fm165 — the xray-local
-    ;; fallback style catalogue that applied this was deleted when
-    ;; machines-viz became the sole topology projector; the keyframe
-    ;; remains as the spec/021 §6.2 Case C active-state pulse contract.)
-    ;;
-    ;; box-shadow sets the WHOLE property each frame, so the keyframe
-    ;; must re-state the STATIC concentric rings (inner `:bg-1` gap +
-    ;; inner accent ring — matching the `:current` node's base
-    ;; box-shadow) on every stop, then ADD the breathing outer halo as
-    ;; the trailing layer. `--rf-xray-accent` is the single GitHub-blue
-    ;; accent, so the halo is blue in both modes. Runs through
-    ;; `--rf-xray-motion-scale` like the green pulse, so the
-    ;; `prefers-reduced-motion` seam collapses it to a resolved frame.
-    "@keyframes rf-xray-machine-pulse-active {\n"
-    "  0%, 100% {\n"
-    "    box-shadow: inset 0 0 0 3px var(--rf-xray-bg-1),\n"
-    "                inset 0 0 0 5px var(--rf-xray-accent),\n"
-    "                0 0 0 0 color-mix(in srgb, var(--rf-xray-accent) 45%, transparent);\n"
-    "  }\n"
-    "  50% {\n"
-    "    box-shadow: inset 0 0 0 3px var(--rf-xray-bg-1),\n"
-    "                inset 0 0 0 5px var(--rf-xray-accent),\n"
-    "                0 0 0 5px color-mix(in srgb, var(--rf-xray-accent) 0%, transparent);\n"
-    "  }\n"
-    "}\n"
     ;; rf2-fxde5 — global `:focus-visible` focus ring. Xray-wide
     ;; keyboard-only focus indicator scoped to descendants of the
     ;; shell roots (`[data-testid="rf-xray-shell"]` for Dynamic,

--- a/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
@@ -112,61 +112,6 @@
           "the initial state lifts 2px below final → the new tab rises
            into place rather than appearing statically"))))
 
-;; ---- rf2-ezx8w — machine-state pulse keyframe --------------------------
-
-(deftest motion-css-declares-machine-pulse-keyframes
-  (testing "rf2-ezx8w — the active `:current` state node references
-            `rf-xray-machine-pulse` (spec/021 §17.4.2 active-state pulse
-            contract; rf2-5fm165 removed the xray-local fallback catalogue
-            that applied it). The keyframe MUST be declared in the injected
-            motion stylesheet so the animation resolves at paint time rather
-            than no-op'ing."
-    (let [css @#'gs/motion-css]
-      (is (re-find #"@keyframes\s+rf-xray-machine-pulse" css)
-          "keyframes block named rf-xray-machine-pulse exists"))))
-
-(deftest motion-css-machine-pulse-uses-green-halo
-  (testing "rf2-ezx8w / spec/021 §17.4 — the pulse halo rides the
-            `:green` token (rgba 74, 222, 128) — Xray's 'final / live
-            state' hue. The 0% / 100% resting frame is the inner ring;
-            the midpoint expands the box-shadow halo + dips alpha so
-            the green ring gently breathes. Subtle box-shadow pulse
-            rather than a scale or full-opacity flicker so multi-
-            machine canvases don't strobe."
-    (let [css @#'gs/motion-css]
-      ;; Resting frame — the halo at rest is solid green at moderate alpha.
-      (is (re-find #"0%,\s*100%\s*\{\s*box-shadow:\s*0\s+0\s+0\s+0\s+rgba\(74,\s*222,\s*128"
-                   css)
-          "resting box-shadow uses the :green token rgba")
-      ;; Midpoint — the halo expands + alpha drops toward zero.
-      (is (re-find #"50%\s*\{\s*box-shadow:\s*0\s+0\s+0\s+4px\s+rgba\(74,\s*222,\s*128,\s*0\)"
-                   css)
-          "midpoint box-shadow expands to 4px halo with 0 alpha"))))
-
-;; ---- rf2-ad7zx.10 — active double-circle pulse keyframe ----------------
-
-(deftest motion-css-declares-active-double-circle-pulse
-  (testing "rf2-ad7zx.10 / spec/021 §6.2 Case C — the Figma TO/current
-            state is a DOUBLE-CIRCLE in the mode accent. The active
-            `:current` state node references `rf-xray-machine-pulse-active`
-            (rf2-5fm165 removed the xray-local fallback catalogue that
-            applied it); the keyframe MUST exist so the animation resolves
-            rather than no-op'ing, AND it must re-state the static concentric
-            rings on every stop (since box-shadow sets the whole property
-            each frame) plus add the breathing accent halo."
-    (let [css @#'gs/motion-css]
-      (is (re-find #"@keyframes\s+rf-xray-machine-pulse-active" css)
-          "keyframes block named rf-xray-machine-pulse-active exists")
-      ;; Concentric rings restated on the resting frame.
-      (is (re-find #"inset 0 0 0 3px var\(--rf-xray-bg-1\)" css)
-          "inner gap ring painted in --rf-xray-bg-1")
-      (is (re-find #"inset 0 0 0 5px var\(--rf-xray-accent\)" css)
-          "inner accent ring painted in --rf-xray-accent (mode-tracking)")
-      ;; Breathing outer halo rides the accent var (orange Dynamic / cyan
-      ;; Static) — NOT the green token the legacy pulse uses.
-      (is (re-find #"color-mix\(in srgb, var\(--rf-xray-accent\)" css)
-          "outer halo color-mixes the mode accent, not :green"))))
-
 ;; ---- rf2-5kfxe.5 — prefers-reduced-motion seam --------------------------
 
 (deftest motion-css-declares-root-motion-scale-default


### PR DESCRIPTION
## Ruling (authoritative — rf2-wct1s8, operator-decided 2026-07-11)

**Option (b): RETIRE the `rf-xray-machine-pulse` + `rf-xray-machine-pulse-active`
keyframes — do NOT wire them.**

Background: rf2-5fm165 deleted the Xray-local fallback style catalogue
(`panels/machines/xyflow_style.cljs`), the *only* in-tree applicator of the two
active-state pulse keyframes in `theme/global_styles.cljs`. They became
applicator-less. The decision was wire (a) vs retire (b).

Ruling = retire, on decisive evidence that **Mike already rejected the
continuous active-state pulse**:
- Closed bead **rf2-2sez0** (2026-05-20, Mike inspected the chart).
- machines-viz spec LOCKED accordingly — `tools/machines-viz/spec/Principles.md`
  "No continuous animation": static affordance (accent border + soft box-shadow
  glow ring + faint header wash) + event-driven glints. An active pulse would
  compete with the once-per-event transition highlights.
- `:pulse-duration-ms` token retired; API.md carries retired-per-rf2-2sez0
  callouts; the Stately/XState comparator uses static active emphasis.
- `spec/021` was the **stale** side of the fork, not the authoritative contract.

## Changes

1. **`theme/global_styles.cljs`** — deleted both keyframes + their
   retained-pending-decision comments.
2. **`global_styles_cljs_test.cljs`** — deleted the 3 guard tests
   (`motion-css-declares-machine-pulse-keyframes`,
   `motion-css-machine-pulse-uses-green-halo`,
   `motion-css-declares-active-double-circle-pulse`).
3. **`tools/xray/spec/021-Dynamic-Panel-Designs.md`** — amended to the
   static-affordance contract, citing rf2-2sez0: §6.0 sketch (table row +
   `:state-node-current` style), §6.2 Case C annotation, §17.4.2 node-shape
   table + prose, §17.4.5 keyframe note, §17.5 follow-on bullet (now retired),
   plus consistency touch-ups to the §17.2 animation-timings row and the §17.4.1
   mockup annotations that depicted the retired pulse.
4. **`skills/re-frame2-xray/references/panels.md`** — fixed drift: removed the
   claim that the current-state node carries the pulse keyframe and the dead
   `xyflow_style.cljs` path reference.

Static current-state chrome in machines-viz (accent border, header wash, static
glow, `data-active` attrs) is the contract and stays untouched. Pre-alpha: no
back-compat shims.

## Quality gates

- `clojure -M:test` (tools/xray): **1239 tests, 5735 assertions, 0 failures,
  0 errors** — 3 guard tests confirmed removed, suite green.
- Residue grep `rf-xray-machine-pulse` over `tools/` + `skills/`: **0 matches**.
- `mkdocs build --strict` (repo root): **passed** (exit 0).
