### PR TITLE
fix(mcp-conformance,mcp-base): prove child teardown + gate marker cache bypass (rf2-j538f7.19, rf2-j538f7.20)

### DIFF
--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -11,7 +11,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 - `with-indicators` — splice the `:dropped-sensitive` / `:elided-large` slots onto an envelope, enforcing the "omit when zero" MUST.
 - `marker-prefixes` — the rendered-text prefixes of the wire-bounded `:rf.mcp/cache-hit` / `:rf.mcp/overflow` envelopes (both flat and namespaced-map print forms).
-- `marker-text?` — wire-bounded marker detection on a rendered text string.
+- `marker-text?` — wire-bounded marker detection on a rendered text string; requires a complete, closed, single-key marker wrapper (leading-token pre-filter + structural confirmation).
 
 `envelope` does NOT own:
 
@@ -36,15 +36,18 @@ A zero / nil / absent count omits its slot entirely (the "omit when zero" MUST).
 
 ### `marker-prefixes` — vector of prefix strings
 
-Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH the flat and the namespaced-map print forms (see §Print-form parity below) so the detector works regardless of host or `*print-namespace-maps*`. The leading token must MATCH a marker key exactly — not merely begin with one (see `marker-text?` and §Exact-key match below).
+Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH the flat and the namespaced-map print forms (see §Print-form parity below) so the detector works regardless of host or `*print-namespace-maps*`. The leading token must MATCH a marker key exactly — not merely begin with one (see `marker-text?` and §Exact-key match below). This is the cheap **pre-filter** for `marker-text?`; a match still has to pass the §Closed-wrapper confirmation before it counts as a marker.
 
 ### `marker-text? text` — predicate
 
-Is `text` (the rendered EDN text of a response's first content slot) a wire-bounded `:rf.mcp/*` marker envelope?
+Is `text` (the rendered EDN text of a response's first content slot) a wire-bounded `:rf.mcp/*` marker envelope — a **complete, closed, single-key marker map**?
 
-Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns only the leading-token match logic, shared across hosts.
+Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns the shared recognition logic across hosts.
 
-Matches the EXACT marker key, not merely a prefix of it (see §Exact-key match below): a lookalike leading key such as `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` is NOT a marker.
+Two gates, **both required**:
+
+1. A cheap **leading-token pre-filter** — the EXACT marker key must be the first top-level key, not merely a prefix of it (see §Exact-key match below): a lookalike leading key such as `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` is NOT a marker.
+2. A **structural confirmation** — the whole `text` must parse to a closed single-key map whose sole key is a marker key and whose body is a map (see §Closed-wrapper confirmation below).
 
 Nil-safe: a nil / non-string `text` is not a marker.
 
@@ -66,6 +69,24 @@ Matching both keeps the detector host- and print-setting-agnostic.
 The detector matches the marker key EXACTLY — not merely as a prefix. After the leading marker-key text matches, the very next character must be an EDN token TERMINATOR (whitespace, `,`, or a map/vector/list/string delimiter) — proving the marker key ended exactly there and was not merely a prefix of a longer key. EDN keyword/symbol constituents (alphanumerics plus `* + ! - _ ' ? < > = . / : # & %`) immediately after the prefix mean the leading key is a LOOKALIKE, not the marker.
 
 A bare prefix match would also accept lookalike keys such as `:rf.mcp/overflowed`, allowing an ordinary payload to bypass cap enforcement. Requiring a token terminator preserves the real markers' short-circuit while rejecting lookalikes.
+
+## Closed-wrapper confirmation
+
+The leading-token match proves only the **first** key. That is not the invariant the fast-path skip relies on: "a marker is sub-cap **by construction**" holds only for a **complete, closed, single-key** marker map. A mixed wrapper whose first key is a real marker key but which carries an unexpected top-level sibling —
+
+```clojure
+{:rf.mcp/overflow {:limit :reached} :unexpected "<8K body>"}
+```
+
+— leads with a marker key yet is an arbitrary over-budget payload. Classifying it as an already-bounded marker would let a reserved-key-shaped or malformed handler result **bypass cap enforcement** (and skip cache bookkeeping) instead of being measured/replaced.
+
+So after the leading-token pre-filter matches, `marker-text?` **parses the whole rendered text** and requires:
+
+- exactly **one** top-level key,
+- that key is `vocab/cache-hit-key` or `vocab/overflow-key`, and
+- a **map** body (additive body fields are permitted where the conformance schema allows them — only the OUTER wrapper must be closed).
+
+The read reuses `cursor.md`'s host-agnostic *one form, EOF-exhausted, tagged-literals-rejected* technique (wrap as `[<text> <eof-sentinel>]`, require the read to yield exactly `[<one-form> <eof-sentinel>]`). This rejects — identically on `clojure.edn` (JVM) and `cljs.reader` (CLJS) — an extra top-level sibling, a trailing EDN form, an injected `]` truncation, any tagged literal (built-in `#inst`/`#uuid` or custom `#js`/`#foo`), and a non-map root/body. Anything that fails the confirmation is ordinary/malformed payload and continues through cap enforcement. The cheap path for genuinely generated markers is preserved: their pre-filter matches and the parse confirms a closed single-key map, with no overflow-of-overflow recursion.
 
 ## Indicator-field parity
 

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -28,7 +28,9 @@
   passes the string here, so the shape-specific accessor stays
   consumer-side while the prefix-detection logic is shared."
   (:require [clojure.string :as str]
-            [re-frame.mcp-base.vocab :as vocab]))
+            #?(:clj [clojure.edn :as edn])
+            [re-frame.mcp-base.vocab :as vocab])
+  #?(:cljs (:require [cljs.reader])))
 
 ;; ---------------------------------------------------------------------------
 ;; Indicator-field splice — the MUST-level 'omit when zero' rule.
@@ -148,26 +150,133 @@
          (key-terminator? (when (> (count text) plen)
                             (subs text plen (inc plen)))))))
 
+;; ---------------------------------------------------------------------------
+;; Structural confirmation — the CLOSED single-key wrapper, not just the
+;; leading token.
+;;
+;; The leading-token pre-filter above proves only the FIRST key. That is
+;; NOT the invariant the fast-path skip actually relies on: "a marker is
+;; sub-cap by construction" holds only for a COMPLETE, CLOSED, single-key
+;; marker envelope. A mixed wrapper such as
+;;   `{:rf.mcp/overflow {:limit :reached} :unexpected "<8K body>"}`
+;; leads with a real marker key yet carries an arbitrary top-level sibling.
+;; Classifying it as an already-bounded marker lets a reserved-key-shaped
+;; or malformed handler result BYPASS cap enforcement (and skip cache
+;; bookkeeping) rather than being measured/replaced — rf2-j538f7.20. So
+;; after the cheap pre-filter matches, we PARSE the whole rendered text and
+;; require a closed single-key marker map.
+;;
+;; The read reuses cursor.cljc's proven, host-agnostic "one form, EOF-
+;; exhausted, tagged-literals-rejected" technique: wrap as
+;; `[<text> <eof-sentinel>]` and require the read to yield EXACTLY
+;; `[<one-form> <eof-sentinel>]`. A trailing EDN form pushes the count past
+;; 2; an injected `]` truncates the read before the sentinel; any tagged
+;; literal (built-in `#inst`/`#uuid` or custom `#js`/`#foo`) throws. All
+;; three fall through to "not a marker". Runs identically on `clojure.edn`
+;; (JVM) and `cljs.reader` (CLJS).
+;; ---------------------------------------------------------------------------
+
+(def ^:private marker-keys
+  "The exact set of top-level keys a wire-bounded marker envelope may
+  carry — the two the cache + cap boundary steps emit. A closed
+  single-key map whose sole key is one of these (with a map body) is a
+  marker; anything else is ordinary / malformed payload."
+  #{vocab/cache-hit-key vocab/overflow-key})
+
+(defn- reject-marker-tag!
+  "Throw on any tagged literal encountered while reading marker text. A
+  genuine marker envelope is pure data (keywords, maps, strings, numbers);
+  a tagged literal is a smuggled host object / malformed payload, never a
+  marker. Caught by `read-one-closed-form` → `::invalid`."
+  []
+  (throw (ex-info "marker text carried a tagged literal — not a marker" {})))
+
+(def ^:private marker-no-tag-readers
+  "Reject the BUILT-IN `#inst` / `#uuid` tags, which have registered
+  readers on both hosts and would otherwise bypass `:default`. Mirrors
+  cursor.cljc's `no-tag-readers`."
+  {'inst (fn [_] (reject-marker-tag!))
+   'uuid (fn [_] (reject-marker-tag!))})
+
+(def ^:private marker-eof-sentinel
+  "Appended after the rendered text to assert the reader consumed the
+  WHOLE wrapped string (the string-host analog of an `:eof` read
+  sentinel). Qualified + unguessable so attacker text reproducing this
+  literal still cannot pass the exhaustion check."
+  ::marker-eof-sentinel)
+
+(defn- read-one-closed-form
+  "Read `text` as EXACTLY ONE EDN form — tagged literals rejected, EOF
+  exhausted (a trailing form ⇒ reject), `]`-injection defeated — via
+  cursor.cljc's wrap-and-sentinel technique. Returns the sole form, or
+  `::invalid` on any read failure / trailing content / tagged literal.
+  Never throws."
+  [text]
+  (try
+    (let [opts    {:readers marker-no-tag-readers
+                   :default (fn [_ _] (reject-marker-tag!))}
+          wrapped (str "[" text " " (pr-str marker-eof-sentinel) "]")
+          forms   #?(:clj  (edn/read-string opts wrapped)
+                     :cljs (cljs.reader/read-string opts wrapped))]
+      (if (and (vector? forms)
+               (= 2 (count forms))
+               (= marker-eof-sentinel (nth forms 1)))
+        (nth forms 0)
+        ::invalid))
+    (catch #?(:clj Throwable :cljs :default) _ ::invalid)))
+
+(defn- closed-marker-envelope?
+  "Structural confirmation that `text` renders a COMPLETE, CLOSED,
+  single-key `:rf.mcp/*` marker envelope: exactly one top-level key drawn
+  from `marker-keys`, with a map body. This proves the invariant the
+  fast-path skip relies on — the leading-token pre-filter proves only the
+  FIRST key, whereas this proves the WHOLE wrapper is closed (no extra
+  top-level sibling, no trailing form, no tagged literal, no non-map
+  root/body). A reserved-key-shaped or malformed payload therefore cannot
+  inherit the marker exemption and bypass cap enforcement (rf2-j538f7.20).
+  Additive body fields remain allowed — only the OUTER wrapper must be
+  closed."
+  [text]
+  (let [form (read-one-closed-form text)]
+    (and (map? form)
+         (= 1 (count form))
+         (let [[k body] (first form)]
+           (and (contains? marker-keys k)
+                (map? body))))))
+
 (defn marker-text?
   "Is `text` (the rendered EDN text of a response's first content slot)
-  a wire-bounded `:rf.mcp/*` marker envelope?
+  a wire-bounded `:rf.mcp/*` marker envelope — a COMPLETE, CLOSED,
+  single-key marker map?
 
   Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers —
   the two envelopes the cache + cap steps emit themselves. The
   consumer reads its own platform's content text (`:text` from a
   Clojure map, `j/get :text` from a JS object) and passes the string
-  here; this fn owns only the leading-token match logic, shared across
-  hosts.
+  here; this fn owns the shared recognition logic across hosts.
 
-  Matches the EXACT marker key, not merely a prefix of it:
-  a lookalike leading key such as `:rf.mcp/overflowed` or
-  `:rf.mcp/cache-hit-extra` is NOT a marker. The match requires the
-  marker key to be terminated by an EDN token terminator (the space
-  `pr-str` writes before the marker's value), so an over-budget payload
-  whose first key merely starts with a marker key still gets capped.
+  Two gates, both required:
+
+    1. A cheap leading-token PRE-FILTER — the EXACT marker key must be
+       the first top-level key (not merely a prefix of it): a lookalike
+       leading key such as `:rf.mcp/overflowed` or
+       `:rf.mcp/cache-hit-extra` is NOT a marker (see §Exact-key match
+       in envelope.md).
+    2. A structural CONFIRMATION — the whole `text` must parse to a
+       closed single-key map whose sole key is a marker key and whose
+       body is a map. The pre-filter proves only the FIRST key; this
+       proves the invariant the fast-path skip relies on: that the
+       marker is sub-cap BY CONSTRUCTION. A mixed wrapper with an
+       unexpected top-level sibling
+       (`{:rf.mcp/overflow {...} :unexpected \"<big>\"}`), a trailing
+       EDN form, a tagged literal, or a non-map root/body is NOT a
+       marker and continues through cap enforcement (rf2-j538f7.20).
+       Additive fields inside the body remain allowed — only the OUTER
+       wrapper must be closed.
 
   Nil-safe: a nil / non-string `text` is not a marker."
   [text]
   (boolean
     (and (string? text)
-         (some #(exact-marker-prefix? text %) marker-prefixes))))
+         (some #(exact-marker-prefix? text %) marker-prefixes)
+         (closed-marker-envelope? text))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -502,6 +502,52 @@
          (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 2}))))
 
 ;; ---------------------------------------------------------------------------
+;; 7b. marker-text? requires a CLOSED single-key wrapper on CLJS too
+;;     (rf2-j538f7.20). pair-mcp is a CLJS Node script and delegates
+;;     `wire/marker?` → `envelope/marker-text?`, then SKIPS both cache and cap
+;;     work for a marker-like result. A prefix-only recogniser let a
+;;     reserved-key-shaped payload with an unexpected top-level sibling bypass
+;;     the cap. The structural read (cursor's wrap-and-sentinel technique)
+;;     runs identically on `cljs.reader`, so the closed-wrapper gate must bite
+;;     on the CLJS runtime the pair server actually runs. CLJS `pr-str` emits
+;;     the FLAT form (default `*print-namespace-maps*` false), so these feed
+;;     the flat form the pair path really produces.
+;; ---------------------------------------------------------------------------
+
+(deftest marker-text?-requires-closed-single-key-wrapper-cljs
+  (testing "canonical closed markers the real builders emit STILL take the fast path"
+    (is (true? (envelope/marker-text?
+                 (pr-str {vocab/overflow-key {:limit :reached :token-count 9000
+                                              :cap-tokens 5000 :tool "snapshot"}}))))
+    (is (true? (envelope/marker-text?
+                 (pr-str {vocab/cache-hit-key {:hash "abc" :tool "snapshot"}}))))
+    (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached :extra :ok}}"))
+        "additive body fields are allowed — only the OUTER wrapper must be closed"))
+  (testing "RED-then-GREEN: an over-budget mixed wrapper with a top-level sibling is NOT a marker"
+    (let [big (apply str (repeat 8000 "x"))]
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/overflow-key {:limit :reached}
+                                       :unexpected big))))
+          "an 8K sibling under an overflow-keyed wrapper must be capped on CLJS, not skipped")
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/cache-hit-key {:tool "x"}
+                                       :unexpected big)))))))
+  (testing "trailing form / injected ] / tagged literal / non-map body ⇒ NOT a marker"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}} 42")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}}] {:junk 1}")))
+    ;; cljs.reader resolves built-in #inst/#uuid from its tag-table and would
+    ;; bypass :default without the :readers override — the marker read rejects
+    ;; every tag identically to the cursor path.
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:at #inst \"2024-01-01T00:00:00.000-00:00\"}}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow #js {:limit :reached}}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow \"not a map body\"}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}")) "truncated text"))
+  (testing "lookalike first key and ordinary payloads remain non-markers"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflowed {:limit :reached}}")))
+    (is (false? (envelope/marker-text? (pr-str {:trace [1 2 3]}))))
+    (is (false? (envelope/marker-text? nil)))))
+
+;; ---------------------------------------------------------------------------
 ;; 8. `sensitive.cljc` CLJS reader-conditional arms.
 ;;
 ;;    `re-frame.mcp-base.sensitive` is the spec/009 §Privacy default-suppress

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -138,3 +138,53 @@
     (is (true? (envelope/marker-text?
                  (binding [*print-namespace-maps* true]
                    (pr-str {vocab/cache-hit-key {:tool "x"}})))))))
+
+(deftest marker-text?-requires-closed-single-key-wrapper-not-just-first-key
+  ;; rf2-j538f7.20. The leading-token match proves only the FIRST key. The
+  ;; invariant the fast-path skip relies on — "a marker is sub-cap BY
+  ;; CONSTRUCTION" — holds only for a COMPLETE, CLOSED, single-key marker
+  ;; map. A mixed wrapper whose FIRST key is a real marker key but which
+  ;; carries an unexpected top-level SIBLING (or a trailing form / tagged
+  ;; literal / non-map body) is NOT a marker: it must fall through to cap
+  ;; measurement, never inherit the exemption. The pre-fix prefix-only
+  ;; recogniser returned true for every case below (the cap-bypass hole).
+  (testing "RED-then-GREEN: over-budget mixed wrapper with a top-level sibling ⇒ NOT a marker"
+    (let [big (apply str (repeat 8000 "x"))]
+      ;; The exact reproduction from the bead: reserved key FIRST, huge sibling.
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/overflow-key {:limit :reached}
+                                       :unexpected big))))
+          "an 8K sibling under an overflow-keyed wrapper must be capped, not skipped")
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/cache-hit-key {:tool "x"}
+                                       :unexpected big))))
+          "the same hole for cache-hit")))
+  (testing "extra top-level sibling ⇒ NOT a marker (both print forms)"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached} :unexpected 1}")))
+    (is (false? (envelope/marker-text? "#:rf.mcp{:overflow {:limit :reached}, :other/k 2}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/cache-hit {:tool \"x\"} :extra \"y\"}"))))
+  (testing "trailing EDN form after the closed marker ⇒ NOT a marker"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}} 42")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}} {:junk 1}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/cache-hit {:tool \"x\"}} :trailing")))
+    ;; `]`-injection cannot truncate the read early past the EOF sentinel.
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}}] {:junk 1}"))))
+  (testing "tagged literal in the body ⇒ NOT a marker (built-in and custom)"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:at #inst \"2024-01-01T00:00:00.000-00:00\"}}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow #js {:limit :reached}}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:id #uuid \"00000000-0000-0000-0000-000000000000\"}}"))))
+  (testing "missing / non-map body ⇒ NOT a marker"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow \"a string body\"}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow 42}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow nil}")))
+    (is (false? (envelope/marker-text? "{:rf.mcp/cache-hit [:not :a :map]}")))
+    ;; Truncated text (no closing brace) ⇒ read fails ⇒ NOT a marker.
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}"))))
+  (testing "non-map root that merely starts with a marker-key token ⇒ NOT a marker"
+    ;; A vector/list literal whose printed head could look marker-ish.
+    (is (false? (envelope/marker-text? "[:rf.mcp/overflow {:limit :reached}]"))))
+  (testing "the canonical closed markers the real builders emit STILL match"
+    (is (true? (envelope/marker-text? (pr-str (overflow-fixture)))))
+    (is (true? (envelope/marker-text? (pr-str {vocab/cache-hit-key {:tool "x" :hash "abc"}}))))
+    ;; Even under a tiny additive body — additive fields inside the body are fine.
+    (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached :extra :ok}}")))))

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -172,6 +172,48 @@ function waitForChildExit(child, hasExited) {
   });
 }
 
+// Race a `browser.close()` thunk against `ms`, PRESERVING the outcome —
+// unlike `settledWithin`, which collapses resolve / reject / timeout into a
+// single "did it finish in time" boolean (all `makeCleanup` needs for the
+// shadow-exit wait, and all the signal/watchdog paths need to bound
+// `cleanup()`). Browser GRADING is different: a close that RESOLVED is proof
+// of shutdown, but a close that REJECTED or TIMED OUT is tolerable only if
+// disconnection can be independently proven (rf2-j538f7.19) — so the caller
+// must know WHICH of the three happened. Returns:
+//   { kind: 'closed'  }          — close() settled successfully within the cap
+//   { kind: 'rejected', error }  — close() rejected within the cap
+//   { kind: 'timeout' }          — the cap elapsed before close() settled
+// Never throws (a sync throw from the thunk is normalised to 'rejected'); the
+// timer is unref'd so it can't keep the loop alive past a clean exit.
+function closeOutcomeWithin(closeThunk, ms) {
+  return new Promise((resolve) => {
+    let done = false;
+    const t = setTimeout(() => {
+      if (done) return;
+      done = true;
+      resolve({ kind: 'timeout' });
+    }, ms);
+    t.unref();
+    Promise.resolve().then(closeThunk).then(
+      () => { if (!done) { done = true; clearTimeout(t); resolve({ kind: 'closed' }); } },
+      (error) => { if (!done) { done = true; clearTimeout(t); resolve({ kind: 'rejected', error }); } },
+    );
+  });
+}
+
+// A browser is *provably* disconnected only if it exposes `isConnected()`
+// AND that returns false. Playwright's `Browser` has this method. A close
+// that rejected or exceeded its cap is acceptable ONLY when we can
+// independently observe the browser is gone; a missing method, a thrown
+// call, or a `true` result all mean "not proven" — the browser is graded
+// dirty so the run is not falsely certified hermetic (rf2-j538f7.19).
+function isBrowserProvablyDisconnected(browser) {
+  if (browser && typeof browser.isConnected === 'function') {
+    try { return browser.isConnected() === false; } catch { return false; }
+  }
+  return false;
+}
+
 // Spawn one INNER_TESTS child and resolve once its stdio is fully drained
 // AND it has terminated. Lives at module scope, taking `spawnFn` as a
 // dependency, so the regression harness (`inner-test-close-grading.test.cjs`)
@@ -249,10 +291,29 @@ function spawnAndGradeInnerTest({
 //                        the harness shrinks them so the test runs fast)
 //
 // Returns a `cleanup()` function whose promise:
-//   1. awaits `browser.close()`, bounded by `browserCloseMs`,
+//   1. awaits `browser.close()`, bounded by `browserCloseMs`, and GRADES it,
 //   2. SIGTERMs shadow then awaits its `exit` (or `shadowTermGraceMs`),
-//   3. SIGKILLs if still alive then awaits the final exit (or `shadowKillGraceMs`).
-// Idempotent: repeat/concurrent calls return the SAME in-flight promise.
+//   3. SIGKILLs if still alive then awaits the final exit (or `shadowKillGraceMs`),
+//      and GRADES the shadow on its OBSERVED exit — a successful `kill()` call
+//      is NOT proof of exit.
+// EVERY step is attempted regardless of an earlier step's failure; the result
+// is a structured, gradeable report — never a throw — so the normal path can
+// refuse to certify a run whose teardown could not prove the children were
+// reaped (rf2-j538f7.19), while the signal/watchdog paths that race
+// `cleanup()` against a hard cap never see an unhandled rejection.
+//
+// Resolves to `{ clean, browser, shadow, issues }`:
+//   clean   — true ⇔ the browser is proven closed/disconnected (or absent)
+//             AND shadow is proven exited (or absent/already-exited).
+//   browser — `{ attempted, state, clean, ... }` where state is one of
+//             'none' | 'closed' | 'disconnected' | 'dirty'.
+//   shadow  — `{ attempted, state, clean, signals }` where state is one of
+//             'none' | 'exited' | 'alive'.
+//   issues  — human-readable strings naming each dirty resource, the signals
+//             attempted, the timeouts, and the final observed state.
+// Idempotent: repeat/concurrent calls return the SAME in-flight promise and
+// therefore the SAME final report — no caller can observe success while
+// another observes failure.
 function makeCleanup(deps) {
   const {
     getBrowser,
@@ -269,27 +330,59 @@ function makeCleanup(deps) {
     if (cleanupPromise) return cleanupPromise;
     cleanupPromise = (async () => {
       logFn('cleanup requested');
-      // (1) Await the promise-returning browser close, bounded.
+      const issues = [];
+
+      // (1) Browser: await the promise-returning close, bounded, then GRADE
+      //     the outcome. A close that RESOLVES is proof of shutdown. A close
+      //     that rejects OR exceeds its cap is tolerated ONLY if the browser
+      //     independently reports `isConnected() === false`; otherwise the
+      //     browser is left DIRTY and the run must not certify hermetic.
       const browser = getBrowser();
-      if (browser) {
-        const closed = await settledWithin(
-          (async () => {
-            try { await browser.close(); }
-            catch (e) { logFn(`browser.close() rejected during cleanup: ${e && e.message}`); }
-          })(),
-          browserCloseMs,
-        );
-        if (!closed) {
-          logErrFn(
-            `browser.close() did not settle within ${browserCloseMs}ms — ` +
-              'continuing teardown',
-          );
+      let browserReport;
+      if (!browser) {
+        browserReport = { attempted: false, state: 'none', clean: true };
+      } else {
+        const outcome = await closeOutcomeWithin(() => browser.close(), browserCloseMs);
+        if (outcome.kind === 'closed') {
+          browserReport = { attempted: true, state: 'closed', clean: true };
+        } else {
+          const detail =
+            outcome.kind === 'rejected'
+              ? `browser.close() rejected (${outcome.error && outcome.error.message})`
+              : `browser.close() did not settle within ${browserCloseMs}ms`;
+          if (isBrowserProvablyDisconnected(browser)) {
+            // Close failed but the browser is provably gone — clean, said why.
+            logFn(`${detail}, but browser.isConnected() === false — treating as closed`);
+            browserReport = { attempted: true, state: 'disconnected', clean: true, note: detail };
+          } else {
+            const msg =
+              `${detail} and disconnection could NOT be proven ` +
+              '(no isConnected() === false) — browser left DIRTY';
+            logErrFn(msg);
+            issues.push(`browser: ${msg}`);
+            browserReport = { attempted: true, state: 'dirty', clean: false, error: detail };
+          }
         }
       }
-      // (2)+(3) SIGTERM shadow, await exit / grace, then SIGKILL + await.
+
+      // (2)+(3) Shadow: SIGTERM → await exit / grace → SIGKILL → await, then
+      //     GRADE on the OBSERVED exit only. A successful kill() call is NOT
+      //     proof of exit; the child is clean only if it actually emitted
+      //     `exit` (or had already exited). We do NOT claim "the OS will reap
+      //     it" — parent exit does not portably terminate a live child,
+      //     especially on Windows.
       const shadow = getShadow();
-      if (shadow && !hasShadowExited()) {
-        try { shadow.kill('SIGTERM'); } catch {}
+      let shadowReport;
+      if (!shadow || hasShadowExited()) {
+        shadowReport = {
+          attempted: false,
+          state: hasShadowExited() ? 'exited' : 'none',
+          clean: true,
+          signals: [],
+        };
+      } else {
+        const signals = [];
+        try { shadow.kill('SIGTERM'); signals.push('SIGTERM'); } catch {}
         const exitedOnTerm = await settledWithin(
           waitForChildExit(shadow, hasShadowExited),
           shadowTermGraceMs,
@@ -299,24 +392,74 @@ function makeCleanup(deps) {
             `shadow-cljs did not exit ${shadowTermGraceMs}ms after SIGTERM ` +
               '— escalating to SIGKILL',
           );
-          try { shadow.kill('SIGKILL'); } catch {}
-          const exitedOnKill = await settledWithin(
+          try { shadow.kill('SIGKILL'); signals.push('SIGKILL'); } catch {}
+          await settledWithin(
             waitForChildExit(shadow, hasShadowExited),
             shadowKillGraceMs,
           );
-          if (!exitedOnKill && !hasShadowExited()) {
-            logErrFn(
-              'shadow-cljs still has not reported exit after SIGKILL + ' +
-                `${shadowKillGraceMs}ms — abandoning (the OS will reap it; ` +
-                'we have done all we can within the cap)',
-            );
-          }
+        }
+        if (hasShadowExited()) {
+          shadowReport = { attempted: true, state: 'exited', clean: true, signals };
+        } else {
+          const msg =
+            `shadow-cljs still has NOT reported exit after ${signals.join('+')} ` +
+            `+ ${shadowKillGraceMs}ms grace — child left ALIVE (no observed exit)`;
+          logErrFn(msg);
+          issues.push(`shadow: ${msg}`);
+          shadowReport = { attempted: true, state: 'alive', clean: false, signals };
         }
       }
-      logFn('cleanup complete');
+
+      const clean = browserReport.clean && shadowReport.clean;
+      logFn(clean ? 'cleanup complete (clean)' : 'cleanup complete (DIRTY)');
+      return { clean, browser: browserReport, shadow: shadowReport, issues };
     })();
     return cleanupPromise;
   };
+}
+
+// Turn a settled cleanup report into the normal-path process outcome. The run
+// is certified GREEN (pass sentinel emitted, exit 0) ONLY when the teardown
+// proved every resource clean. A dirty/unknown teardown — a browser that
+// could not be confirmed closed/disconnected, or a shadow-cljs child with no
+// observed exit — is an ORCHESTRATION failure (exit 2) that emits NO pass
+// sentinel: the inner contract passed, but the harness could not guarantee
+// the hermetic isolation it exists to provide, so it must not falsely certify
+// a possibly-contaminating run (rf2-j538f7.19). Parameterised on its IO so the
+// grading test can assert the sentinel/exit-code mapping without booting
+// shadow-cljs + Chromium.
+function finalizeConformance(report, {
+  emitPass = (line) => console.log(line),
+  log: logFn = log,
+  logErr: logErrFn = logErr,
+  flush = flushDiagnostics,
+  count = INNER_TESTS.length,
+} = {}) {
+  if (report && report.clean === true) {
+    logFn(`RE-FRAME2-PAIR-MCP LIVE HERMETIC CONFORMANCE GREEN (${count} inner tests)`);
+    emitPass(`RE-FRAME2-PAIR-MCP live hermetic conformance passed (${count} inner tests).`);
+    return 0;
+  }
+  logErrFn(
+    'FAIL: all inner conformance tests passed but the hermetic TEARDOWN could ' +
+      'NOT be proven clean — refusing to certify a possibly non-hermetic run ' +
+      `(rf2-j538f7.19): ${describeDirty(report)}`,
+  );
+  flush();
+  return 2;
+}
+
+// One-line summary of a dirty/missing cleanup report for the failure log.
+function describeDirty(report) {
+  if (!report) return 'no cleanup report was produced';
+  const parts = [
+    `browser=${report.browser ? report.browser.state : 'unknown'}`,
+    `shadow=${report.shadow ? report.shadow.state : 'unknown'}`,
+  ];
+  if (report.issues && report.issues.length) {
+    parts.push('issues: ' + report.issues.join(' | '));
+  }
+  return parts.join(', ');
 }
 
 // Discriminate a containment-escape refusal (a candidate whose realpath
@@ -928,6 +1071,10 @@ async function main() {
     });
   }
 
+  // The graded teardown report the `finally` produces; `main()` returns it so
+  // the entrypoint can refuse to certify GREEN on a dirty/unknown teardown
+  // (rf2-j538f7.19).
+  let cleanupReport = null;
   try {
     // ---- Wait for nREPL port file ---------------------------------------
     log(
@@ -1129,15 +1276,20 @@ async function main() {
       }
       log(`${testFile} ran to completion (sentinel observed)`);
     }
-    log('RE-FRAME2-PAIR-MCP LIVE HERMETIC CONFORMANCE GREEN (' +
-      INNER_TESTS.length + ' inner tests)');
+    // NB: no GREEN sentinel is emitted here. The run is only certified GREEN
+    // once cleanup has PROVEN hermetic teardown — grading happens in
+    // `finalizeConformance` against the report the `finally` returns below
+    // (rf2-j538f7.19). Emitting GREEN before teardown could falsely certify a
+    // run that then leaks a browser / shadow-cljs child.
   } finally {
     // Await the async teardown before `main()` resolves/rejects: the
     // normal-exit path must not report success and `process.exit(0)` while
     // the browser-close promise is still settling or shadow-cljs has not
-    // yet exited.
-    await cleanup();
+    // yet exited. Capture the graded report so the entrypoint can refuse to
+    // certify a dirty/unknown teardown.
+    cleanupReport = await cleanup();
   }
+  return cleanupReport;
 }
 
 // Hard watchdog: if the orchestrator hangs past this, kill the process
@@ -1189,12 +1341,12 @@ watchdog.unref();
 // the watchdog timer from arming on `require` too.
 if (require.main === module) {
   main()
-    .then(() => {
+    .then((report) => {
       clearTimeout(watchdog);
-      console.log(
-        `RE-FRAME2-PAIR-MCP live hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
-      );
-      process.exit(0);
+      // GREEN + exit 0 ONLY if the teardown proved hermetic; a dirty/unknown
+      // cleanup report is an orchestration failure (exit 2) with NO pass
+      // sentinel (rf2-j538f7.19).
+      process.exit(finalizeConformance(report));
     })
     .catch((err) => {
       clearTimeout(watchdog);
@@ -1247,6 +1399,13 @@ if (require.main === module) {
 // still reports the file present, proving the runner now fails LOUD
 // instead of logging-and-continuing into a poll loop that would have
 // trusted the surviving stale file.
+// `finalizeConformance` + `describeDirty` are exported for the teardown-
+// grading regression harness (`hermetic-grading.test.cjs`, rf2-j538f7.19): it
+// drives the REAL grading decision against clean vs dirty cleanup reports,
+// proving a dirty teardown emits NO pass sentinel and returns orchestration
+// exit 2 while a clean teardown emits the sentinel exactly once and returns 0.
+// `closeOutcomeWithin` + `isBrowserProvablyDisconnected` back the browser
+// grading `runner-cleanup.test.cjs` exercises through `makeCleanup`.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1254,6 +1413,10 @@ module.exports = {
   isContainmentEscape,
   makeCleanup,
   settledWithin,
+  closeOutcomeWithin,
+  isBrowserProvablyDisconnected,
+  finalizeConformance,
+  describeDirty,
   waitForChildExit,
   spawnAndGradeInnerTest,
   wipeStalePortFileCandidate,

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -29,8 +29,12 @@ const TESTS = [
     argv: ['--test', 'test/runner-watchdog.test.cjs'],
   },
   {
-    name: 'hermetic async cleanup awaited teardown',
+    name: 'hermetic async cleanup awaited + graded teardown',
     argv: ['--test', 'test/runner-cleanup.test.cjs'],
+  },
+  {
+    name: 'hermetic teardown grading refuses green on a dirty cleanup',
+    argv: ['--test', 'test/hermetic-grading.test.cjs'],
   },
   {
     name: 'hermetic setup-command timeout',

--- a/tools/mcp-conformance/test/hermetic-grading.test.cjs
+++ b/tools/mcp-conformance/test/hermetic-grading.test.cjs
@@ -1,0 +1,114 @@
+// Entrypoint-level grading regression for the hermetic orchestrator
+// (rf2-j538f7.19).
+//
+// The bug: the normal path emitted its GREEN/pass sentinel and exited 0
+// BEFORE (and regardless of) the teardown outcome. A run whose six inner
+// conformance tests all passed could still leak a Chromium or shadow-cljs JVM
+// process and be certified green — "awaited and bounded" was only a TIMING
+// property, never graded.
+//
+// The fix routes the settled cleanup report through `finalizeConformance`,
+// which certifies GREEN (pass sentinel + exit 0) ONLY when the report proves
+// every resource clean, and otherwise emits NO pass sentinel and returns
+// orchestration exit 2. This test drives that REAL grading decision against
+// clean vs dirty reports — no shadow-cljs / Chromium boot required, because
+// `finalizeConformance` is a pure function of the report parameterised on its
+// IO. `makeCleanup`'s own report GRADING (rejected close, never-exiting
+// shadow, disconnection proof) is covered in `runner-cleanup.test.cjs`; this
+// file owns the report → (sentinel, exit-code) mapping.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const ORCH = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'run-re-frame2-pair-live-hermetic-suite.cjs',
+);
+
+const { finalizeConformance } = require(ORCH);
+
+// Capturing IO so the test observes exactly what the entrypoint would emit,
+// without any real console.log / process.exit / diagnostics flush.
+function captureIo() {
+  const io = {
+    passLines: [],
+    logLines: [],
+    errLines: [],
+    flushed: 0,
+  };
+  io.opts = {
+    emitPass: (l) => io.passLines.push(l),
+    log: (l) => io.logLines.push(l),
+    logErr: (l) => io.errLines.push(l),
+    flush: () => { io.flushed += 1; },
+    count: 6,
+  };
+  return io;
+}
+
+test('CLEAN report ⇒ pass sentinel emitted exactly once and exit 0 (rf2-j538f7.19 AC7)', () => {
+  const io = captureIo();
+  const code = finalizeConformance(
+    {
+      clean: true,
+      browser: { state: 'closed', clean: true },
+      shadow: { state: 'exited', clean: true },
+      issues: [],
+    },
+    io.opts,
+  );
+
+  assert.equal(code, 0, 'a proven-clean teardown is exit 0');
+  assert.equal(io.passLines.length, 1, 'the pass sentinel is emitted EXACTLY once');
+  assert.match(io.passLines[0], /live hermetic conformance passed/);
+  assert.match(io.passLines[0], /6 inner tests/);
+});
+
+test('DIRTY report (browser dirty + shadow alive) ⇒ NO pass sentinel and exit 2 (rf2-j538f7.19 AC7)', () => {
+  const io = captureIo();
+  const code = finalizeConformance(
+    {
+      clean: false,
+      browser: { state: 'dirty', clean: false, error: 'close rejected' },
+      shadow: { state: 'alive', clean: false, signals: ['SIGTERM', 'SIGKILL'] },
+      issues: ['browser: close rejected', 'shadow: no observed exit'],
+    },
+    io.opts,
+  );
+
+  assert.equal(code, 2, 'a teardown that could not be proven clean is orchestration exit 2, NOT 0');
+  assert.equal(io.passLines.length, 0, 'NO pass/GREEN sentinel may be emitted for a dirty teardown');
+  // The failure names the dirty resources so CI can see WHY it refused green.
+  const err = io.errLines.join('\n');
+  assert.match(err, /refusing to certify/);
+  assert.match(err, /browser=dirty/);
+  assert.match(err, /shadow=alive/);
+  assert.equal(io.flushed, 1, 'diagnostics are flushed on the failure path');
+});
+
+test('DIRTY via browser only (shadow clean) still refuses green (rf2-j538f7.19 AC2)', () => {
+  const io = captureIo();
+  const code = finalizeConformance(
+    {
+      clean: false,
+      browser: { state: 'dirty', clean: false },
+      shadow: { state: 'exited', clean: true },
+      issues: ['browser: still connected past cap'],
+    },
+    io.opts,
+  );
+  assert.equal(code, 2);
+  assert.equal(io.passLines.length, 0);
+});
+
+test('missing/undefined report is treated as DIRTY: exit 2, no sentinel (rf2-j538f7.19)', () => {
+  const io = captureIo();
+  const code = finalizeConformance(undefined, io.opts);
+  assert.equal(code, 2, 'no report at all cannot be certified green');
+  assert.equal(io.passLines.length, 0);
+});

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -171,6 +171,144 @@ test('makeCleanup HARD-CAPS a never-settling browser.close() instead of hanging 
   );
 });
 
+// ---------------------------------------------------------------------------
+// rf2-j538f7.19: the teardown must be GRADED, not merely awaited. A bounded
+// wait that cannot prove the children were reaped is a DIRTY teardown that the
+// normal path must refuse to certify green — the pre-fix `cleanup()` resolved
+// to `undefined` (no grading) so a leaked browser / shadow JVM was silently
+// blessed by the final `process.exit(0)`.
+// ---------------------------------------------------------------------------
+
+test('makeCleanup GRADES a rejected browser.close() + never-exiting shadow as DIRTY, after attempting BOTH (rf2-j538f7.19 AC1/AC3/AC6)', async () => {
+  // Browser close rejects and the browser has NO isConnected() — disconnection
+  // cannot be proven. Shadow ignores every signal and never emits exit. The
+  // OLD orchestrator resolved cleanup as successful (undefined) and certified
+  // this run GREEN; the fixed factory must record BOTH failures.
+  const closeCalls = [];
+  const browser = {
+    close: () => { closeCalls.push('close'); return Promise.reject(new Error('close failed')); },
+    // no isConnected() ⇒ disconnection NOT provable
+  };
+  const shadow = makeFakeShadow(); // never exits on any signal
+  const cleanup = makeCleanup({
+    getBrowser: () => browser,
+    getShadow: () => shadow,
+    hasShadowExited: () => shadow.exited,
+    log: () => {},
+    logErr: () => {},
+    browserCloseMs: 40,
+    shadowTermGraceMs: 30,
+    shadowKillGraceMs: 30,
+  });
+
+  const report = await cleanup();
+
+  // THE red-then-green teeth: pre-fix, `report` was `undefined`, so reading
+  // `.clean` here throws — the OLD orchestrator had NO gradeable outcome.
+  assert.equal(report.clean, false, 'a rejected close + never-exiting shadow must be graded DIRTY');
+  // BOTH steps were attempted before the failure was surfaced (AC1: all other
+  // resources are still cleaned before the failure is surfaced).
+  assert.deepEqual(closeCalls, ['close'], 'browser.close() must still be attempted');
+  assert.deepEqual(
+    shadow.killSignals,
+    ['SIGTERM', 'SIGKILL'],
+    'shadow teardown must still escalate SIGTERM→SIGKILL despite the browser failure',
+  );
+  // The report names both dirty resources with structured issues.
+  assert.equal(report.browser.state, 'dirty');
+  assert.equal(report.shadow.state, 'alive');
+  assert.equal(report.issues.length, 2, 'both failures recorded: ' + JSON.stringify(report.issues));
+});
+
+test('makeCleanup treats a rejected browser.close() as CLEAN when isConnected() proves disconnection (rf2-j538f7.19 AC1)', async () => {
+  // A close rejection is acceptable ONLY if disconnection can be independently
+  // proven. isConnected() === false is that proof.
+  const browser = {
+    close: () => Promise.reject(new Error('transport already closed')),
+    isConnected: () => false,
+  };
+  const cleanup = makeCleanup({
+    getBrowser: () => browser,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    log: () => {},
+    logErr: () => {},
+    browserCloseMs: 100,
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, true, 'a reject is tolerable when isConnected()===false proves the browser is gone');
+  assert.equal(report.browser.state, 'disconnected');
+});
+
+test('makeCleanup grades a browser close that exceeds its cap + stays connected as DIRTY (rf2-j538f7.19 AC2)', async () => {
+  // Never-settling close, and isConnected() still reports true — the browser
+  // is provably STILL connected past the cap ⇒ dirty, not a green pass-through.
+  const browser = {
+    close: () => new Promise(() => {}),
+    isConnected: () => true,
+  };
+  const cleanup = makeCleanup({
+    getBrowser: () => browser,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    log: () => {},
+    logErr: () => {},
+    browserCloseMs: 60,
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, false, 'a close that exceeds its cap while still connected is DIRTY');
+  assert.equal(report.browser.state, 'dirty');
+});
+
+test('makeCleanup grades a happy teardown (resolved close + already-exited shadow) as CLEAN (rf2-j538f7.19 AC4)', async () => {
+  const browser = { close: () => Promise.resolve() };
+  const cleanup = makeCleanup({
+    getBrowser: () => browser,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    log: () => {},
+    logErr: () => {},
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, true);
+  assert.equal(report.browser.state, 'closed');
+  assert.equal(report.shadow.state, 'exited');
+});
+
+test('makeCleanup grades a SIGTERM-exit shadow as CLEAN with the observed exit (rf2-j538f7.19 AC4)', async () => {
+  const shadow = makeFakeShadow({ exitOnTermMs: 20 });
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => shadow,
+    hasShadowExited: () => shadow.exited,
+    log: () => {},
+    logErr: () => {},
+    shadowTermGraceMs: 500,
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, true);
+  assert.equal(report.shadow.state, 'exited');
+  assert.deepEqual(report.shadow.signals, ['SIGTERM'], 'a child that exits on SIGTERM is never escalated to SIGKILL');
+});
+
+test('concurrent cleanup() callers observe the SAME graded report — no split success/failure (rf2-j538f7.19 AC5)', async () => {
+  const browser = { close: () => Promise.reject(new Error('x')) }; // dirty (no isConnected)
+  const shadow = makeFakeShadow(); // never exits ⇒ dirty
+  const cleanup = makeCleanup({
+    getBrowser: () => browser,
+    getShadow: () => shadow,
+    hasShadowExited: () => shadow.exited,
+    log: () => {},
+    logErr: () => {},
+    browserCloseMs: 30,
+    shadowTermGraceMs: 20,
+    shadowKillGraceMs: 20,
+  });
+  const [r1, r2] = await Promise.all([cleanup(), cleanup()]);
+  assert.equal(r1, r2, 'concurrent callers must receive the identical report object');
+  assert.equal(r1.clean, false, 'and both observe the same DIRTY verdict');
+});
+
 test('makeCleanup is idempotent: concurrent calls share one in-flight promise (rf2-7ckmwx finding 1)', async () => {
   const shadow = makeFakeShadow({ exitOnTermMs: 40 });
   const cleanup = makeCleanup({


### PR DESCRIPTION
Wave-2 correctness-review cluster: two P2 false-negatives in the MCP wire-boundary surface (`rf2-j538f7.19`, `rf2-j538f7.20`). One commit per bead.

## rf2-j538f7.19 — hermetic conformance certified green on a failed cleanup (`tools/mcp-conformance`)

The hermetic orchestrator awaited its bounded teardown but never **graded** the outcome. `makeCleanup` collapsed a browser-close rejection/timeout and a shadow-cljs child that survived `SIGTERM`+`SIGKILL` into a successful resolution, and the normal path emitted its GREEN/pass sentinel and `process.exit(0)` **before, and regardless of**, that outcome. A run whose inner conformance tests all passed could leak a Chromium or shadow JVM process — holding port 8030, nREPL ports, files, inherited stdio — and still be certified green, contaminating later runs.

- `makeCleanup` now always attempts every step and resolves to a structured, gradeable report `{clean, browser, shadow, issues}` — never a throw.
- Browser is clean only if `close()` resolved **or** `isConnected() === false` proves disconnection; shadow is clean only on an **observed** `exit` (a successful `kill()` call is not proof). No more "the OS will reap it".
- `main()` returns the report; new `finalizeConformance` certifies GREEN + exit 0 only when `clean === true`, otherwise emits **no** pass sentinel and returns orchestration **exit 2** naming the dirty resource, signals, and timeouts.
- Signal/watchdog paths still race `cleanup()` against `CLEANUP_HARD_CAP_MS` and preserve exit 130/2; `cleanup()` never rejects so no unhandled rejection.
- Adversarial coverage: `makeCleanup` grading tests (rejected close + never-exiting shadow ⇒ dirty; disconnection-proven reject ⇒ clean; over-cap-still-connected ⇒ dirty; happy paths ⇒ clean; concurrent callers share one report) and an entrypoint grading test proving a dirty report emits no sentinel and exits 2 while a clean one emits the sentinel once and exits 0.

## rf2-j538f7.20 — marker recognition validated only the first key, not the closed wrapper (`tools/mcp-base`)

`envelope/marker-text?` classified a response as an already-bounded `:rf.mcp/*` marker on a leading-token match alone. A mixed wrapper such as `{:rf.mcp/overflow {:limit :reached} :unexpected "<8K body>"}` leads with a real marker key yet carries an arbitrary top-level sibling — so it was treated as sub-cap-by-construction and **skipped cap enforcement** (and cache bookkeeping). Pair MCP delegates `wire/marker?` → `marker-text?` and short-circuits both steps on a positive, so a reserved-key-shaped or malformed handler result could bypass the egress cap.

- `marker-text?` keeps the cheap leading-token match as a **pre-filter** and adds a **structural confirmation**: parse the whole rendered text, require exactly one top-level key drawn from `{cache-hit-key, overflow-key}` with a map body.
- The read reuses `cursor.cljc`'s host-agnostic one-form / EOF-exhausted / tagged-literal-rejecting technique, so an extra top-level sibling, trailing EDN form, injected `]` truncation, any tagged literal, and a non-map root/body all fall through to cap enforcement — identically on `clojure.edn` (JVM) and `cljs.reader` (CLJS). Additive body fields stay allowed; only the OUTER wrapper must be closed. Genuine builders' markers still take the fast path, no overflow-of-overflow recursion.
- CLJ + CLJS regressions at the shared recogniser (the exact 8K-sibling reproduction plus trailing-form / injected-`]` / tagged-literal / non-map-body cases); `envelope.md` updated so "marker envelope" means the closed wrapper.

The mcp-base fix lands entirely in the **shared** recogniser that pair-mcp/story-mcp delegate to, so no sibling MCP tool is edited.

## Quality gates

All foreground, post-rebase on `origin/main`:

- `tools/mcp-conformance` `npm run test:unit` — **114 tests, 105 pass / 9 Windows platform skips / 0 fail** (+10 vs pre-fix 104).
- `tools/mcp-conformance/wire-vocab` `clojure -M:test` — **100 tests / 1056 assertions / 0 fail**.
- `tools/mcp-base` `clojure -M:test` — **271 tests / 917 assertions / 0 fail** (+21 assertions).
- `tools/mcp-base` `npm run test:cljs` — **33 tests / 214 assertions / 0 fail, 0 warnings** (+14 assertions).

**Skipped:** the hermetic live Pair suite (`run-re-frame2-pair-live-hermetic-suite.cjs`) needs a booted shadow-cljs fixture + headless Chromium — not run locally; relies on CI. Its `makeCleanup` / `finalizeConformance` grading logic is fully exercised in foreground by the new unit tests via the production factory + exported grading fn. The 9 mcp-conformance skips are pre-existing Windows platform skips.
