### PR TITLE
fix(http,core): abort frame-owned managed HTTP during frame destruction (rf2-j538f7.8)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2497,6 +2497,11 @@
                                               caches — work-ledger host
                                               handles + generation
                                               high-water mark.
+         :http/on-frame-destroyed!          — abort the frame's plain
+                                              managed HTTP still in flight
+                                              (live fetch/future + sleeping
+                                              backoff handles), reply-
+                                              suppressed.
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
                                       machine cascade.
     6. dissoc-frame!                — remove from the `frames` atom.
@@ -2658,6 +2663,17 @@
         ;; destroyed frame in each host cache. No-op when re-frame.resources
         ;; is absent (the artefact is optional).
         (safe-call-hook! :resources/on-frame-destroyed! id)
+        ;; Abort the destroyed frame's still-in-flight PLAIN managed HTTP
+        ;; (rf2-j538f7.8) — ordinary event-handler `:rf.http/managed` work with
+        ;; no actor id, the exposed path that actor/resource teardown above does
+        ;; NOT catch. Each frame-stamped live fetch/future + sleeping-backoff
+        ;; handle is cancelled with the reply-suppressing `:reason
+        ;; :frame-destroyed` (no delivery into the now-destroyed frame), its
+        ;; external `:abort-signal` listener detaches, and both registry indexes
+        ;; clear. Ordered AFTER machines/resources so their more specific
+        ;; `:actor-destroyed` / ledger teardown wins first and this generic sweep
+        ;; no-ops on already-cleared handles. No-op when re-frame.http is absent.
+        (safe-call-hook! :http/on-frame-destroyed! id)
         ;; Cancel + drop the destroyed frame's still-pending
         ;; `:dispatch-later` host timers (rf2-uxz52g). Each arms a host-clock
         ;; timer whose thunk dispatches the deferred event into THIS frame;

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -675,6 +675,10 @@
     :producer-ns 're-frame.http.managed
     :design-bead "rf2-u5kmf8"
     :description "Epoch-restore host-transient quiesce for NON-resource managed HTTP. Consulted by `re-frame.epoch.tool-pair/perform-restore!` AFTER a successful install: aborts every in-flight `:rf.http/managed` request the restored frame issued with the reply-suppressing `:reason :epoch-restored` (no delivery to the original `:rf/reply-to`) and emits the EP-0011 `:status :stale` / `:rf.reply/work-status :suppressed` envelope facts. The non-ledger-backed counterpart of the resources work-id dangling, so a pre-restore in-flight reply cannot mutate the restored state (Managed-Effects §SSR, preload, hydration, and restore: \"epoch restore MUST NOT revive host work\")."}
+   {:key         :http/on-frame-destroyed!
+    :producer-ns 're-frame.http.managed
+    :design-bead "rf2-j538f7.8"
+    :description "Frame-DESTROY host-transient abort for managed HTTP. Consulted by core `frame/destroy-frame!` AFTER machine + resource teardown: aborts every in-flight `:rf.http/managed` request the destroyed frame issued with the reply-suppressing `:reason :frame-destroyed` (no delivery into the now-destroyed frame's `:rf/reply-to`) and emits the EP-0011 `:status :stale` / `:rf.reply/work-status :suppressed` envelope facts with `:recovery :suppressed-on-frame-destroy`. The frame-teardown counterpart of `:http/abort-in-flight-for-frame!` (epoch restore); catches the exposed PLAIN managed-HTTP path (ordinary event-handler issuance, no actor id) that actor/resource teardown does not, cancelling the live fetch/future or sleeping backoff timer, detaching any external `:abort-signal` listener, and clearing both indexes so no host I/O outlives the frame (Managed-Effects §Cancellation; the hard frame-ownership boundary for SSR per-request frames, Story/test variants, hot reload, and multi-frame apps)."}
    {:key         :http/register-managed-machine!
     :producer-ns 're-frame.http.managed
     :design-bead "rf2-ijm7"

--- a/implementation/http/src/re_frame/http/managed.cljc
+++ b/implementation/http/src/re_frame/http/managed.cljc
@@ -284,6 +284,12 @@
 ;; abort suppresses app replies and records stale-suppression facts. This remains
 ;; late-bound so the epoch artefact does not acquire an HTTP dependency.
 (late-bind/set-fn! :http/abort-in-flight-for-frame!       registry/abort-in-flight-for-frame!)
+;; Frame destroy aborts the destroyed frame's still-in-flight PLAIN managed HTTP
+;; (rf2-j538f7.8). Called from core `frame/destroy-frame!` AFTER machine +
+;; resource teardown, suppressing app replies (`:reason :frame-destroyed`) so no
+;; late completion routes into the dead frame. Late-bound so core does not
+;; acquire an HTTP dependency; the frame-teardown counterpart of the restore hook.
+(late-bind/set-fn! :http/on-frame-destroyed!              registry/abort-in-flight-on-frame-destroyed!)
 (late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
 (late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)
 (late-bind/set-fn! :http/clear-http-interceptor           clear-http-interceptor)

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -429,16 +429,20 @@
 ;; the resources reconcile, published as the `:http/abort-in-flight-for-frame!`
 ;; late-bind hook the epoch boundary fires AFTER a successful install.
 
-(defn- emit-restore-stale-trace!
+(defn- emit-frame-boundary-stale-trace!
   "Emit the canonical EP-0011 `:status :stale` / `:rf.reply/work-status :suppressed`
-  reply-envelope trace for one managed HTTP attempt aborted because epoch
-  restore unwound its timeline (rf2-u5kmf8), WITHOUT dispatching any app target.
+  reply-envelope trace for one managed HTTP attempt aborted at a FRAME-LIFECYCLE
+  boundary — epoch restore (rf2-u5kmf8) OR frame destruction (rf2-j538f7.8) —
+  WITHOUT dispatching any app target. `recovery` names the boundary
+  (`:suppressed-on-epoch-restore` vs `:suppressed-on-frame-destroy`) so the two
+  reply-suppressing boundaries stay discriminable on the trace stream while
+  sharing the identical carried-id-against-nil-current suppression gate.
   Mirrors `http-transport/emit-superseded-stale-trace!` (the supersede sibling):
   the carried work-id is the aborted attempt's identity; there is no current
-  work-id (restore replaces the attempt with nothing) so the gate suppresses the
-  carried id against a nil current. Gated on `debug-enabled?` like the other
-  `:rf.http/*` trace rows."
-  [handle]
+  work-id (the boundary replaces the attempt with nothing) so the gate
+  suppresses the carried id against a nil current. Gated on `debug-enabled?`
+  like the other `:rf.http/*` trace rows."
+  [handle recovery]
   (when interop/debug-enabled?
     (let [stale-ctx {:request-id   (:request-id handle)
                      :origin-event (:origin-event handle)
@@ -458,8 +462,40 @@
                             :rf.reply/work-kind             :http
                             :rf.reply/carried      (:rf.reply/carried trace)
                             :rf.reply/current      (:rf.reply/current trace)
-                            :recovery              :suppressed-on-epoch-restore}
+                            :recovery              recovery}
                      (:frame handle) (assoc :frame (:frame handle)))))))
+
+(defn- abort-frame-handles!
+  "Shared frame-scoped abort walk for the two reply-suppressing frame-lifecycle
+  boundaries: epoch restore (`:epoch-restored`) and frame destroy
+  (`:frame-destroyed`). Walks BOTH indexes (an anonymous-from-actor request is
+  only in `actor-in-flight`), filtering on the handle's `:frame` stamp, and
+  dedupes by identity so a handle present in both indexes fires once. For each
+  matching handle: emit the EP-0011 stale-suppression envelope facts with
+  `recovery`, then fire its `:abort-fn` with `reason` — a reply-suppressing
+  reason, so the late completion does NOT deliver to its original `:rf/reply-to`
+  target. The abort-fn cascade clears the registry slot via `clear-in-flight!`.
+
+  Snapshots the handles before firing so an abort-fn's own `clear-in-flight!`
+  swap cannot trip a concurrent-modification on the iteration. Each abort-fn is
+  fired defensively — a throwing one must not strand the rest. Idempotent and a
+  no-op for a frame with no in-flight managed HTTP (an app that issues none pays
+  nothing, and a second sweep over already-cleared indexes finds no handles).
+  Returns nil."
+  [frame-id reason recovery]
+  (when frame-id
+    (let [handles (->> (concat (vals @in-flight)
+                               (mapcat val @actor-in-flight))
+                       (filter #(= frame-id (:frame %)))
+                       (reduce (fn [acc h]
+                                 (if (some #(identical? % h) acc) acc (conj acc h)))
+                               []))]
+      (doseq [handle handles]
+        (emit-frame-boundary-stale-trace! handle recovery)
+        (when-let [abort-fn (:abort-fn handle)]
+          (try (abort-fn reason)
+               (catch #?(:clj Throwable :cljs :default) _ nil))))))
+  nil)
 
 (defn abort-in-flight-for-frame!
   "Abort every in-flight managed HTTP request issued by `frame-id`, because epoch
@@ -479,19 +515,34 @@
   with no in-flight managed HTTP (an app that issues none pays nothing). Returns
   nil."
   [frame-id]
-  (when frame-id
-    (let [handles (->> (concat (vals @in-flight)
-                               (mapcat val @actor-in-flight))
-                       (filter #(= frame-id (:frame %)))
-                       (reduce (fn [acc h]
-                                 (if (some #(identical? % h) acc) acc (conj acc h)))
-                               []))]
-      (doseq [handle handles]
-        (emit-restore-stale-trace! handle)
-        (when-let [abort-fn (:abort-fn handle)]
-          (try (abort-fn :epoch-restored)
-               (catch #?(:clj Throwable :cljs :default) _ nil))))))
-  nil)
+  (abort-frame-handles! frame-id :epoch-restored :suppressed-on-epoch-restore))
+
+(defn abort-in-flight-on-frame-destroyed!
+  "Abort every in-flight managed HTTP request issued by `frame-id`, because the
+  owning frame is being DESTROYED (rf2-j538f7.8). The frame-teardown counterpart
+  of `abort-in-flight-for-frame!` (epoch restore): the SAME frame-filtered,
+  identity-deduped, sibling-preserving walk over both indexes, but fires each
+  `:abort-fn` with `:reason :frame-destroyed` and stamps the stale-suppression
+  trace with `:recovery :suppressed-on-frame-destroy`.
+
+  Frame destroy is reply-suppressing: the target frame is already marked
+  destroyed, so dispatching a live cancellation reply into it is invalid.
+  `:frame-destroyed` is a member of `http-transport/reply-suppressing-abort-
+  reasons`, so the abort cascade cancels the live fetch/future or sleeping
+  backoff timer, detaches any external `:abort-signal` listener, clears both
+  registry indexes, and delivers NOTHING to the original `:rf/reply-to` target —
+  no `:rf.error/frame-destroyed` dispatch into the dead frame.
+
+  Published as the `:http/on-frame-destroyed!` late-bind hook and called from
+  core `frame/destroy-frame!` AFTER machine + resource teardown, so actor-owned
+  work gets its more specific `:actor-destroyed` semantics and resource-owned
+  work gets its ledger/lease cleanup first; this generic sweep then catches the
+  remaining PLAIN managed requests (ordinary event-handler issuance with no
+  actor id — the exposed path) and no-ops on any handle already cleared (the
+  already-empty indexes yield no handles). Does NOT overload `:epoch-restored`.
+  Idempotent; a no-op for a frame with no in-flight managed HTTP. Returns nil."
+  [frame-id]
+  (abort-frame-handles! frame-id :frame-destroyed :suppressed-on-frame-destroy))
 
 ;; ---- spawned-actor detection (rf2-ma0wvq inversion) -----------------------
 ;;

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -54,17 +54,22 @@
   restore unwound the timeline this request belonged to; per EP-0011 /
   Managed-Effects §restore (\"epoch restore MUST NOT revive host work\") a
   pre-restore completion MUST NOT deliver to its original `:rf/reply-to` target.
-  Both still emit their trace facts (the suppressed-attempt's stale envelope);
+  `:frame-destroyed` means the request's owning frame was DESTROYED
+  (rf2-j538f7.8): the target frame is already marked destroyed, so dispatching a
+  live cancellation reply into it is invalid — the late completion MUST NOT
+  deliver to its original `:rf/reply-to` target either.
+  All still emit their trace facts (the suppressed-attempt's stale envelope);
   only the app dispatch is suppressed.
 
   Cross-ref: this set gates only the REPLY. For `:request-id-superseded`
   the canonical EP-0011 stale-trace is NOT emitted here — it is emitted
   separately by `managed-handler` → `emit-superseded-stale-trace!` at
-  supersede time (the `:epoch-restored` sibling is emitted by
-  `http-registry/abort-in-flight-for-frame!`). `dispatch-aborted!` here
-  fires only the `:rf.http/aborted` error trace and then suppresses the
-  reply for these reasons."
-  #{:request-id-superseded :epoch-restored})
+  supersede time (the `:epoch-restored` / `:frame-destroyed` siblings are
+  emitted by `http-registry/abort-in-flight-for-frame!` /
+  `abort-in-flight-on-frame-destroyed!`). `dispatch-aborted!` here fires only
+  the `:rf.http/aborted` error trace and then suppresses the reply for these
+  reasons."
+  #{:request-id-superseded :epoch-restored :frame-destroyed})
 
 (defn reply-suppressing-abort-reason?
   "True when an `:rf.http/aborted` failure carrying `reason` must NOT dispatch

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -951,6 +951,79 @@
                       (is false (str "rf2-wj8vv — unexpected: " e))
                       (done))))))))
 
+;; ---- rf2-j538f7.8 — frame destroy aborts + suppresses managed HTTP (CLJS) --
+;;
+;; The CLJS counterpart of `re-frame.http-frame-destroy-abort-test` (the JVM
+;; CompletableFuture path). Proves the Fetch/backoff path: a plain managed
+;; request sleeping in the `js/setTimeout` backoff window when its OWNING FRAME
+;; is destroyed has its pending retry cancelled (no attempt N+1 fetch) and its
+;; outcome SUPPRESSED — unlike a `:rf.http/managed-abort` (which delivers a live
+;; `:cancelled` reply, reason `:user`), frame destroy fires the reply-suppressing
+;; `:reason :frame-destroyed`, so NO reply reaches the destroyed frame. Before the
+;; destroy-frame! → :http/on-frame-destroyed! wiring the backoff timer survived
+;; destroy and fired a second fetch into the dead frame.
+
+(deftest cljs-destroy-frame-cancels-backoff-and-suppresses-reply
+  (testing "rf2-j538f7.8 — destroying a frame with a managed request sleeping in
+            the backoff window cancels the pending retry (no second fetch) and
+            SUPPRESSES the reply (nothing delivered into the destroyed frame)"
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (rf/reg-frame :frame/req {:doc "the frame that owns the in-flight request"})
+      (http-managed/clear-all-in-flight!)
+      (let [fetch-count (atom 0)
+            replies     (atom [])
+            restore     (with-counting-500-fetch fetch-count)
+            backoff-ms  80]
+        (rf/reg-event :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url "/always-500"}
+                    :decode     :json
+                    :retry      {:on           #{:rf.http/http-5xx}
+                                 :max-attempts 5
+                                 :backoff      {:base-ms backoff-ms :factor 1
+                                                :max-ms  backoff-ms}}
+                    :request-id :destroy/race
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue] {:frame :frame/req})
+        ;; Poll until attempt #1 has fetched, failed 5xx, and the request is
+        ;; sleeping in the backoff window (the backoff handle lacks `:finalised?`,
+        ;; distinguishing it from a still-in-flight attempt).
+        (-> (test-support/poll-until
+              #(let [handle (get (registry/in-flight-snapshot) :destroy/race)]
+                 (and (= 1 @fetch-count)
+                      (some? handle)
+                      (nil? (:finalised? handle))))
+              {:timeout-ms 2000 :label "cljs backoff sleeping (destroy)"})
+            (.then (fn [_]
+                     (is (= :frame/req (:frame (registry/lookup-in-flight :destroy/race)))
+                         "precondition: the backoff handle carries its owning frame")
+                     ;; Destroy the owning frame via the REAL recipe.
+                     (rf/destroy-frame! :frame/req)
+                     (is (empty? (registry/in-flight-snapshot))
+                         "the registry cleared the instant the frame was destroyed")
+                     ;; Wait past the original backoff deadline: the retry must
+                     ;; never fetch again (timer cancelled) and no reply may land.
+                     (js/Promise.
+                       (fn [resolve _]
+                         (js/setTimeout resolve (+ backoff-ms 150))))))
+            (.then (fn [_]
+                     (is (= 1 @fetch-count)
+                         "the retry MUST NOT fetch after the owning frame is destroyed")
+                     (is (empty? @replies)
+                         "frame destroy SUPPRESSES the reply — nothing delivered into the destroyed frame")
+                     (restore)
+                     (done)))
+            (.catch (fn [e]
+                      (restore)
+                      (is false (str "rf2-j538f7.8 — unexpected: " e))
+                      (done))))))))
+
 ;; ---- rf2-065xo — managed body-prep failure delivery (CLJS) ----------------
 ;;
 ;; The JVM suite (re-frame.http-body-prep-failure-test) pins the same

--- a/implementation/http/test/re_frame/http_frame_destroy_abort_test.clj
+++ b/implementation/http/test/re_frame/http_frame_destroy_abort_test.clj
@@ -1,0 +1,223 @@
+(ns re-frame.http-frame-destroy-abort-test
+  "rf2-j538f7.8 — abort frame-owned PLAIN managed HTTP during frame destruction.
+
+  Frame destruction is the hard ownership boundary for SSR per-request frames,
+  Story/test variants, hot reload, and multi-frame apps. Every live fetch/future
+  and sleeping-backoff handle is frame-stamped, and HTTP already exposes a frame-
+  filtered abort walker — but core's `destroy-frame!` cleanup recipe never wired
+  plain managed HTTP into that walker (actor teardown reaps only actor-owned
+  work; resource teardown reaps only ledger-backed work). An ordinary event-
+  handler `:rf.http/managed` request (no actor id — the exposed path) therefore
+  survived frame destruction until network completion / timeout / retry
+  exhaustion, its late reply routing into an already-destroyed frame.
+
+  The fix publishes `:http/on-frame-destroyed!` (registry/abort-in-flight-on-
+  frame-destroyed!) and calls it from `frame/destroy-frame!` AFTER machine +
+  resource teardown. It reuses the same frame-filtered, identity-deduped,
+  sibling-preserving walk as the epoch-restore quiesce, but fires each abort-fn
+  with the reply-suppressing `:reason :frame-destroyed` and stamps the stale-
+  suppression trace with `:recovery :suppressed-on-frame-destroy`.
+
+  Strategy: the registry-level tests pin the walker's frame-scoping / reason /
+  idempotence against seeded handles; the end-to-end test issues a genuinely
+  in-flight blocking request from a named frame, calls the REAL `destroy-frame!`
+  (the actual failing path the bead names — before the wiring the registry slot
+  survives destroy), and proves the slot clears promptly and the late completion
+  delivers nothing."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as http-registry]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
+           [java.net InetSocketAddress]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- start-blocking-server!
+  [^CountDownLatch latch status content-type body]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/"
+                    (reify HttpHandler
+                      (handle [_ ex]
+                        (let [^HttpExchange ex ex]
+                          (.await latch 30 TimeUnit/SECONDS)
+                          (let [bs (.getBytes (str body) "UTF-8")]
+                            (when content-type
+                              (-> ex .getResponseHeaders (.set "Content-Type" content-type)))
+                            (try
+                              (.sendResponseHeaders ex status (long (count bs)))
+                              (with-open [os (.getResponseBody ex)]
+                                (.write os bs))
+                              (catch Throwable _ nil)))
+                          nil))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server :port (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [^HttpServer server]}]
+  (.stop server 0))
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-frame-destroy condition"})
+   true))
+
+;; ---- hook publication (crit 5) --------------------------------------------
+
+(deftest hook-published
+  (testing "rf2-j538f7.8 — the :http/on-frame-destroyed! hook is published and
+            resolves to the frame-destroy abort walker"
+    (is (some? (late-bind/get-fn :http/on-frame-destroyed!)))
+    (is (= http-registry/abort-in-flight-on-frame-destroyed!
+           (late-bind/get-fn :http/on-frame-destroyed!)))))
+
+;; ---- registry-level: frame-scoped abort + reason (crit 1) -----------------
+
+(deftest frame-destroy-aborts-only-the-frames-requests
+  (testing "rf2-j538f7.8 — abort-in-flight-on-frame-destroyed! fires each of the
+            destroyed frame's handles exactly once with :reason :frame-destroyed
+            and leaves a SIBLING frame's request byte-for-byte live"
+    (http-managed/clear-all-in-flight!)
+    (let [seen (atom [])
+          ;; production abort-fns clear their own slot via the finalise cascade;
+          ;; model that here so the sibling-survival + idempotence checks below
+          ;; observe the real post-abort index shape.
+          mk   (fn [frame-id request-id]
+                 (http-registry/seed-in-flight-for-test!
+                   request-id nil
+                   {:abort-fn   (fn [reason]
+                                  (swap! seen conj [frame-id reason])
+                                  (http-registry/clear-in-flight! request-id))
+                    :request-id request-id
+                    :url        "http://x/y"
+                    :frame      frame-id}))]
+      (mk :frame/a :req-a1)
+      (mk :frame/a :req-a2)
+      (mk :frame/b :req-b)
+      (http-registry/abort-in-flight-on-frame-destroyed! :frame/a)
+      (is (= #{[:frame/a :frame-destroyed]} (set @seen))
+          "only frame A's handles fired, each with :reason :frame-destroyed")
+      (is (= 2 (count @seen)) "both of frame A's requests were aborted, once each")
+      (is (nil? (http-registry/lookup-in-flight :req-a1))
+          "frame A's first request cleared from the index")
+      (is (nil? (http-registry/lookup-in-flight :req-a2))
+          "frame A's second request cleared from the index")
+      (is (= :frame/b (:frame (http-registry/lookup-in-flight :req-b)))
+          "the SIBLING frame's request remains live and untouched")
+      (http-managed/clear-all-in-flight!))))
+
+(deftest frame-destroy-noop-on-frame-with-no-requests
+  (testing "rf2-j538f7.8 — a frame with no in-flight managed HTTP is a clean no-op"
+    (http-managed/clear-all-in-flight!)
+    (is (nil? (http-registry/abort-in-flight-on-frame-destroyed! :frame/none)))
+    (is (nil? (http-registry/abort-in-flight-on-frame-destroyed! nil)))))
+
+;; ---- ordering / idempotence: no duplicate abort on a cleared handle (crit 4)
+
+(deftest frame-destroy-sweep-noop-on-already-cleared-handle
+  (testing "rf2-j538f7.8 — when an earlier teardown (actor-destroy / resource
+            teardown) already cleared a frame's HTTP slot, the later generic
+            frame-destroy sweep produces NO duplicate abort or stale trace"
+    (http-managed/clear-all-in-flight!)
+    (let [aborts (atom [])
+          traces (atom [])]
+      (try
+        (trace/register-listener! ::idem (fn [ev] (swap! traces conj ev)))
+        (http-registry/seed-in-flight-for-test!
+          :req/gone nil
+          {:abort-fn   (fn [reason] (swap! aborts conj reason))
+           :request-id :req/gone
+           :url        "http://x/y"
+           :frame      :frame/a})
+        ;; A more-specific teardown wins first and clears the slot WITHOUT the
+        ;; generic sweep's involvement.
+        (http-registry/clear-in-flight! :req/gone)
+        ;; The generic HTTP frame-destroy sweep then runs — and finds nothing.
+        (http-registry/abort-in-flight-on-frame-destroyed! :frame/a)
+        (is (empty? @aborts)
+            "the already-cleared handle is NOT aborted a second time")
+        (is (empty? (filter #(= :rf.http/stale-suppressed (:operation %)) @traces))
+            "no duplicate stale-suppressed trace for the already-cleared handle")
+        (finally
+          (trace/unregister-listener! ::idem)
+          (http-managed/clear-all-in-flight!))))))
+
+;; ---- end-to-end: destroy-frame! aborts a genuinely in-flight request -------
+;; (crit 2 — the adversarial regression: FAILS before the destroy-frame! wiring)
+
+(deftest destroy-frame-aborts-and-suppresses-in-flight-managed-http
+  (testing "rf2-j538f7.8 — a plain managed request in flight when its owning
+            frame is destroyed is aborted (registry slot clears promptly, before
+            the network releases — proving cancellation, not natural completion)
+            and its late completion is SUPPRESSED: NO :on-success / :on-failure
+            delivery into the destroyed frame, and an EP-0011 stale-suppressed
+            trace fires with :recovery :suppressed-on-frame-destroy"
+    (let [latch  (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{\"too\":\"late\"}")
+          replies (atom [])
+          traces  (atom [])]
+      (try
+        (trace/register-listener! ::j538f7 (fn [ev] (swap! traces conj ev)))
+        (rf/reg-frame :frame/req {:doc "the frame that owns the in-flight request"})
+        (rf/reg-event :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        ;; an ordinary event handler (no spawned actor) issues a plain managed
+        ;; request from :frame/req — the exact non-actor managed-HTTP shape the
+        ;; bead names as the exposed path.
+        (rf/reg-event :load
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    (str "http://127.0.0.1:" port "/slow")
+                                 :method :get}
+                    :decode     :json
+                    :request-id :destroy/req
+                    :on-success [:reply/recorder]
+                    :on-failure [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:load] {:frame :frame/req})
+        (await-condition! #(seq (http-managed/in-flight-snapshot)))
+        (is (= 1 (count (http-managed/in-flight-snapshot)))
+            "precondition: the request is in flight")
+        (is (= :frame/req (:frame (http-registry/lookup-in-flight :destroy/req)))
+            "precondition: the in-flight handle carries its originating frame")
+        ;; Destroy the owning frame via the REAL recipe — this is the wiring
+        ;; under test (before the fix, destroy-frame! left the slot in flight).
+        (rf/destroy-frame! :frame/req)
+        ;; The abort cascade clears the registry slot — and it clears while the
+        ;; server is STILL BLOCKED, so the clear is the abort, not a natural
+        ;; completion.
+        (await-condition! #(empty? (http-managed/in-flight-snapshot)))
+        (is (empty? (http-managed/in-flight-snapshot))
+            "the in-flight slot cleared promptly on frame destroy")
+        ;; Release the server so any late completion would arrive.
+        (.countDown latch)
+        ;; Timer-semantics window (rf2-fun38): prove the ABSENCE of any reply
+        ;; delivery — there is no positive signal to poll for a non-event.
+        (Thread/sleep 150)
+        (is (empty? @replies)
+            "the late post-destroy completion delivered NOTHING into the destroyed frame")
+        (let [stale (filter #(= :rf.http/stale-suppressed (:operation %)) @traces)
+              ev    (first stale)]
+          (is (seq stale)
+              "an EP-0011 stale-suppressed trace fired for the suppressed attempt")
+          ;; Per Spec 009 §Core fields the trace pipeline HOISTS :recovery out of
+          ;; :tags to the top-level event slot; the reply facts stay in :tags.
+          (is (= :suppressed-on-frame-destroy (:recovery ev))
+              "the recovery names frame destroy — NOT epoch restore")
+          (let [tags (:tags ev)]
+            (is (= :stale (:rf.reply/status tags))
+                "the suppressed attempt's reply status is :stale")
+            (is (= :suppressed (:rf.reply/work-status tags))
+                "its work-ledger status is :suppressed")
+            (is (= :frame/req (:frame tags))
+                "the trace names the destroyed frame")))
+        (finally
+          (trace/unregister-listener! ::j538f7)
+          (stop-server! srv))))))


### PR DESCRIPTION
## What

Wires plain frame-owned managed HTTP into `frame/destroy-frame!` so a destroyed frame's in-flight requests are aborted and reply-suppressed, closing the last host-transient effect the teardown recipe leaked.

`destroy-frame!` already released machines, schemas, flows, routing, resources and dispatch-later host work, but never touched plain `:rf.http/managed` requests. An ordinary event-handler request (no actor id — the exposed path actor/resource teardown does not catch) survived frame destruction until network completion / timeout / retry exhaustion; its late reply routed into an already-destroyed frame and its host handle + request/reply closures + optional external `AbortSignal` listener stayed retained under frame churn (SSR per-request frames, Story/test variants, hot reload, multi-frame apps).

## How

- **http/registry**: factored the frame-scoped abort walk (`snapshot both indexes → filter frame → identity-dedupe → abort each`) behind one shared `abort-frame-handles!` with two reply-suppressing entry points: existing `abort-in-flight-for-frame!` (epoch restore, `:epoch-restored` / `:suppressed-on-epoch-restore`) and new `abort-in-flight-on-frame-destroyed!` (frame destroy, `:frame-destroyed` / `:suppressed-on-frame-destroy`). The stale-suppression trace emitter is now `recovery`-parameterised so the two boundaries stay discriminable on the trace stream. Epoch-restore semantics are byte-for-byte unchanged.
- **http/transport**: `:frame-destroyed` joins `reply-suppressing-abort-reasons`, so the abort cancels the live fetch/future or sleeping backoff timer, detaches the external `:abort-signal` listener, clears both indexes, and delivers nothing into the dead frame (no `:rf.error/frame-destroyed` dispatch).
- **http/managed**: publishes `:http/on-frame-destroyed!` via `late-bind/set-fn!`.
- **core/frame**: ONE `safe-call-hook! :http/on-frame-destroyed!` call site in `destroy-frame!`, ordered AFTER `:resources/on-frame-destroyed!` (actor/resource teardown wins first; this generic sweep no-ops on already-cleared handles) + one cleanup-inventory docstring line.
- **core/late_bind/directory**: catalogue entry for the new key (keeps the late-bind drift gate green).

## Scope notes

- Acceptance-criterion 6 (the Spec 009/014 + schema-vocabulary row for the `:suppressed-on-frame-destroy` suppression reason) is DEFERRED to follow-up **rf2-19l2cu** to keep this PR off the hot-zone spec files. No `spec/*` edits here.
- The `core/frame.cljc` surface is surgical: one call site + one docstring line.

## Quality gates

All foreground, all green:

| Gate | Result |
|------|--------|
| `clojure -M:test` (implementation/http) | **476 tests / 3701 assertions — 0 failures, 0 errors** |
| `clojure -M:test` (implementation/core, incl. late-bind drift/directory) | **1769 tests / 7739 assertions — 0 failures, 0 errors** |
| `npm run test:cljs` (node CLJS) | **8492 tests / 39736 assertions — 0 failures, 0 errors** |
| `git diff --check` | clean |
| clj-kondo (changed files) | 0 errors (4 pre-existing transport warnings, none on touched lines) |

**Adversarial regression proven:** disabling the `destroy-frame!` call site makes `destroy-frame-aborts-and-suppresses-in-flight-managed-http` error (the in-flight registry slot never clears on destroy while the blocking server is held); restoring it passes. The registry-level walker tests pass in both states (walker is correct independent of the wiring — the gap was the teardown hook).

New tests:
- `re-frame.http-frame-destroy-abort-test` (JVM): hook publication; frame-scoped abort fires each handle once with `:frame-destroyed` and leaves siblings live; no-op on empty/nil frame; no duplicate abort on an already-cleared handle (actor/resource-wins-first ordering); end-to-end `destroy-frame!` on a blocking request — slot clears before the network releases, reply suppressed, EP-0011 stale trace with `:recovery :suppressed-on-frame-destroy`.
- `cljs-destroy-frame-cancels-backoff-and-suppresses-reply` (CLJS): a request sleeping in the backoff window when its owning frame is destroyed cancels the pending retry (no attempt N+1 fetch) and suppresses the reply.

Closes rf2-j538f7.8.
