### PR TITLE
fix(machines,resources): suppress post-cleanup timer publish and cancellation successor erasure (rf2-j538f7.7, rf2-j538f7.10)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -174,6 +174,45 @@
       (try (subs/unsubscribe frame-id delay-key)
            (catch #?(:clj Throwable :cljs :default) _ nil)))))
 
+(defonce ^:private after-attempt-counter
+  ;; Monotonic per-arm attempt-token source (mirrors core's
+  ;; `dispatch-later-counter`, rf2-j538f7.2). Every `schedule-after-timer!`
+  ;; arm stamps its slot with a unique token, so a trailing cancellation of an
+  ;; OLD attempt can never claim a re-armed SUCCESSOR occupying the same reused
+  ;; `{:parent :spawn :delay}` key (rf2-j538f7.7), and a late-returning arm can
+  ;; detect that a cleanup already claimed its slot. The durable per-decl-path
+  ;; EPOCH remains the transition stale-gate (a dynamic-delay re-arm keeps the
+  ;; same epoch on purpose); this token is transient host-work OWNERSHIP only —
+  ;; never snapshot / replay / SSR-egress state.
+  (atom 0))
+
+(defn- next-attempt-token []
+  (swap! after-attempt-counter inc))
+
+(defn- claim-entry!
+  "Atomically remove the `[frame-id k]` slot IFF it still holds the attempt
+  identified by `token`, pruning an emptied inner frame-map. Returns the exact
+  entry removed — so the caller releases precisely what it claimed — or nil when
+  the slot no longer holds this attempt: a concurrent supersede / cleanup
+  already took it, or a fresh re-arm installed a SUCCESSOR under the same key.
+  The token check is what stops an old cancellation from deleting a successor it
+  never released (rf2-j538f7.7). The host side effect (release / host-clock
+  cancel) rides the returned value OUTSIDE the retriable swap, never inside it
+  (`swap-vals!` yields the pre-swap snapshot from the winning CAS attempt)."
+  [frame-id k token]
+  (let [[old _new]
+        (swap-vals! after-timers
+                    (fn [m]
+                      (if (= token (:token (get-in m [frame-id k])))
+                        (let [inner (dissoc (get m frame-id) k)]
+                          (if (empty? inner)
+                            (dissoc m frame-id)
+                            (assoc m frame-id inner)))
+                        m)))
+        claimed (get-in old [frame-id k])]
+    (when (= token (:token claimed))
+      claimed)))
+
 (defn- emit-cancelled!
   "Emit the unified `:rf.machine.timer/cancelled` trace for one
   cancellation site. Every cancellation path — state exit, machine
@@ -243,64 +282,24 @@
   `reason` (closed set: `:on-exit / :on-destroy / :on-resolution /
   :on-supersede / :on-frame-destroy / :on-restore`). Idempotent —
   a second call against the same `[frame-id k]` is a no-op (the entry
-  is gone so no trace fires)."
+  is gone so no trace fires).
+
+  Cancels the exact attempt observed: it reads the current occupant's
+  `:token` and atomically CLAIMS the slot only while that token is still
+  current (`claim-entry!`). If a concurrent re-arm published a SUCCESSOR under
+  the same key between the read and the claim, this cancellation leaves the
+  successor untouched and emits nothing — the successor's own arrival already
+  released the observed attempt, so the cancellation fires exactly once and
+  never deletes a successor it did not release (rf2-j538f7.7). A cancellation
+  that claims an ARMING sentinel (`:handle nil`, host clock not yet armed)
+  still emits the owed trace and releases the held subscription; the arming
+  thread's publish phase then finds its token gone and cancels the returned
+  host handle."
   [frame-id k reason]
   (when-let [entry (get-in @after-timers [frame-id k])]
-    (emit-cancelled! frame-id k entry reason)
-    (release-entry-resources! frame-id entry (:delay k))
-    ;; Drop the inner-table entry; drop the outer-table entry if this was
-    ;; the frame's last live timer so a frame that briefly held timers
-    ;; doesn't leave a stale empty map behind.
-    (swap! after-timers
-           (fn [m]
-             (let [inner (dissoc (get m frame-id) k)]
-               (if (empty? inner)
-                 (dissoc m frame-id)
-                 (assoc m frame-id inner)))))))
-
-(defn- reap-fired-entry!
-  "Reap a one-shot `:after` entry whose host-clock timer has just FIRED —
-  release its sub-reaction watcher + subscription registration and drop the
-  inner-table slot. Distinct from `cancel-after-timer-entry!`: a fired timer
-  was NOT cancelled (the host clock ran to completion), so this emits NO
-  `:rf.machine.timer/cancelled` trace — the fired/stale-after trace already
-  records the synthetic event's fate. This is the host-clock counterpart of
-  the cancellation paths: it exists so the COMMON case where a fire is
-  guard-suppressed (the synthetic event is discarded, the state does NOT
-  exit, so no `:on-exit` cancel ever runs) does not strand the entry — a leak
-  of the add-watch + held subscription ref-count, and — worse — a live
-  watcher that would re-arm a fresh timer for a one-shot that already
-  fired-and-was-discarded the next time the sub-vec delay's value changes.
-  Per XState v5 semantics a delayed transition's timer fires once per arming;
-  a guard-rejected fire does NOT re-schedule.
-
-  EPOCH-GUARDED. The reap runs only when the slot still holds THIS fire's
-  entry — same `:epoch` as the one the timer was armed at. A real-transition
-  fire exits the state, runs `:on-exit` cancel, and re-entry installs a FRESH
-  entry under the same key at a strictly-greater per-decl-path epoch; the
-  guard refuses to clobber that successor (and refuses to double-reap an
-  already-cancelled slot). Returns nil.
-
-  `vec`-snapshots nothing — a single `get-in` + a compare-and-dissoc swap that
-  re-reads the epoch inside the swap fn so a concurrent re-arm between the
-  read and the swap is not clobbered on the JVM target."
-  [frame-id k fired-epoch]
-  (when-let [entry (get-in @after-timers [frame-id k])]
-    (when (= fired-epoch (:epoch entry))
-      (release-entry-resources! frame-id entry (:delay k))
-      (swap! after-timers
-             (fn [m]
-               ;; Re-read the entry inside the swap: only dissoc when the slot
-               ;; STILL carries this fire's epoch, so a concurrent re-arm that
-               ;; landed a fresh entry between the outer read and this swap is
-               ;; preserved rather than dropped.
-               (if (= fired-epoch (:epoch (get-in m [frame-id k])))
-                 (let [inner (dissoc (get m frame-id) k)]
-                   (if (empty? inner)
-                     (dissoc m frame-id)
-                     (assoc m frame-id inner)))
-                 m)))))
-  nil)
+    (when-let [claimed (claim-entry! frame-id k (:token entry))]
+      (emit-cancelled! frame-id k claimed reason)
+      (release-entry-resources! frame-id claimed (:delay k)))))
 
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
@@ -403,101 +402,135 @@
                           :recovery     :skipped}))
 
           :else
-          (let [_ (when emit-scheduled-trace?
-                    (trace/emit! :rf.machine :rf.machine.timer/scheduled
-                                 (cond-> {;; the timer's owning actor INSTANCE;
-                                          ;; `:machine-id` is reserved for the
-                                          ;; registered TYPE.
-                                          :actor-id     parent-id
-                                          :state        state
-                                          :delay        resolved-ms
-                                          :delay-source delay-source
-                                          :epoch        epoch
-                                          :frame        frame-id}
-                                   ;; canonical subscription identity:
-                                   ;; `:rf.sub/id` + `:rf.sub/query-v`.
-                                   (= :sub delay-source)
-                                   (assoc :rf.sub/id      (first delay-key)
-                                          :rf.sub/query-v (vec delay-key)))))
-                handle
-                ;; Shared positive-delay-guarded arm — the host-clock arm
-                ;; step both timer artefacts share. `resolved-ms`
-                ;; is already known-positive here (the non-positive case was
-                ;; handled by the prior `cond` branch with the
-                ;; `:no-clock-configured` advisory), so the guard is a no-op
-                ;; pass-through; the machines-specific entry bookkeeping +
-                ;; sub-change watcher install below stay here.
-                (managed-timer/arm!
-                  (fn []
-                    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-                      ;; Stamp `:source :after-timer` on the timer-fired
-                      ;; dispatch so the Epoch panel's DISPATCH step labels
-                      ;; it "from :after timer", and Xray's L2 timeline can
-                      ;; prefix the row + per-source filter pills can
-                      ;; discriminate timer-fired cascades. `:after-timer`
-                      ;; is the single functional-origin discriminator
-                      ;; (closed-enum per Spec-Schemas
-                      ;; §`:rf/dispatch-envelope`).
-                      ;; Per Spec 005 §Hierarchy interaction: carry the
-                      ;; scheduling node's decl-path (`invoke-id`) so the
-                      ;; pure side routes the firing to the correct
-                      ;; per-path epoch — colliding delay-keys across
-                      ;; hierarchy levels (a parent and child both with
-                      ;; `:after {30000 ...}`) resolve unambiguously.
-                      (dispatch! [parent-id [:rf.machine.timer/after-elapsed
-                                              delay-key epoch (vec invoke-id)]]
-                                 {:frame              frame-id
-                                  :source             :after-timer}))
-                    ;; A one-shot `:after` timer fires exactly once per arming
-                    ;; (XState v5 §delayed transitions). Reap THIS fire's entry
-                    ;; — release the sub-reaction watcher + held subscription
-                    ;; ref-count and drop the slot — epoch-guarded so a
-                    ;; real-transition exit's re-armed successor (fresh entry,
-                    ;; strictly-greater epoch) is not clobbered. Without this,
-                    ;; a GUARD-SUPPRESSED fire (state does not exit, so no
-                    ;; `:on-exit` cancel runs) would strand the entry AND let a
-                    ;; later sub-vec value change re-arm a spent one-shot via
-                    ;; `on-sub-changed!`. The reap is silent — a fired timer
-                    ;; was not cancelled, so no `:cancelled` trace is emitted.
-                    ;; Runs AFTER the dispatch returns: in dispatch-sync the
-                    ;; transition (and its `:on-exit` cancel, if any) has
-                    ;; already executed, so the epoch guard sees the settled
-                    ;; slot; in async dispatch the guard still distinguishes
-                    ;; this entry from any future re-arm by epoch.
-                    (reap-fired-entry! frame-id k epoch))
-                  resolved-ms)
+          ;; TWO-PHASE, TOKEN-OWNED arm (rf2-j538f7.7; mirrors core
+          ;; `:dispatch-later`, rf2-j538f7.2). The host clock is armed BETWEEN
+          ;; reserving the slot and publishing the handle, so a concurrent
+          ;; cleanup (frame / actor / state-exit / restore / supersede) — or a
+          ;; host scheduler that fires the callback synchronously before
+          ;; `arm!` returns — can atomically CLAIM this attempt and leave the
+          ;; publish phase to find its token gone and cancel the orphan handle.
+          (let [token     (next-attempt-token)
                 watch-key (when (= :sub delay-source)
                             [::after-watch frame-id parent-id invoke-id delay-key])]
-            (when (and reaction watch-key)
-              ;; Surface `add-watch` exceptions rather than silently
-              ;; dropping them; the sub-changed re-resolution watcher won't
-              ;; fire if `add-watch` failed, so the author needs a signal
-              ;; that the dynamic-delay subscription is not actually wired
-              ;; up.
-              (try
-                (add-watch reaction watch-key
-                           (fn [_ _ old-v new-v]
-                             (on-sub-changed! frame-id parent-id invoke-id
-                                              delay-key state old-v new-v)))
-                (catch #?(:clj Throwable :cljs :default) e
-                  ;; Owning actor INSTANCE under `:actor-id`; canonical
-                  ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
-                  (trace/emit-error! :rf.error/machine-after-watch-failed
-                                     {:exception      e
-                                      :actor-id       parent-id
-                                      :rf.sub/id      (first delay-key)
-                                      :rf.sub/query-v (vec delay-key)
-                                      :frame          frame-id
-                                      :recovery       :static-delay}))))
+            (when emit-scheduled-trace?
+              (trace/emit! :rf.machine :rf.machine.timer/scheduled
+                           (cond-> {;; the timer's owning actor INSTANCE;
+                                    ;; `:machine-id` is reserved for the
+                                    ;; registered TYPE.
+                                    :actor-id     parent-id
+                                    :state        state
+                                    :delay        resolved-ms
+                                    :delay-source delay-source
+                                    :epoch        epoch
+                                    :frame        frame-id}
+                             ;; canonical subscription identity:
+                             ;; `:rf.sub/id` + `:rf.sub/query-v`.
+                             (= :sub delay-source)
+                             (assoc :rf.sub/id      (first delay-key)
+                                    :rf.sub/query-v (vec delay-key)))))
+            ;; PHASE 1 — RESERVE the slot with an arming sentinel (`:handle
+            ;; nil`) carrying this attempt's `:token`, BEFORE arming any host
+            ;; clock. The reaction + watch-key ride the sentinel so a claiming
+            ;; cleanup releases the held subscription ref-count even though the
+            ;; physical add-watch is deferred to publication.
             (swap! after-timers assoc-in [frame-id k]
-                   {:handle          handle
+                   {:handle          nil
                     :reaction        reaction
                     :sub-watcher-key watch-key
                     :resolved-ms     resolved-ms
                     :epoch           epoch
                     :state           state
-                    :delay-source    delay-source})
-            handle))))))
+                    :delay-source    delay-source
+                    :token           token})
+            (let [handle
+                  ;; Shared positive-delay-guarded arm — the host-clock arm
+                  ;; step both timer artefacts share. `resolved-ms` is already
+                  ;; known-positive here (the non-positive case was handled by
+                  ;; the prior `cond` branch), so the guard is a no-op
+                  ;; pass-through.
+                  (managed-timer/arm!
+                    (fn []
+                      ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
+                      ;; + reap in a single swap (mirrors core `:dispatch-later`,
+                      ;; rf2-j538f7.2). If a cleanup / supersede claimed the slot
+                      ;; first — even a synchronous host callback firing before
+                      ;; `arm!` returns, or a JVM cleanup racing the arm — this
+                      ;; fire has LOST authority: suppress the dead-on-arrival
+                      ;; dispatch and touch nothing (the claimer already released
+                      ;; our resources). On the live path the claim wins:
+                      (when-let [claimed (claim-entry! frame-id k token)]
+                        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                          ;; Stamp `:source :after-timer` so the Epoch panel's
+                          ;; DISPATCH step labels it "from :after timer" and
+                          ;; Xray's L2 timeline can prefix the row + per-source
+                          ;; filter pills can discriminate timer-fired cascades
+                          ;; (closed-enum per Spec-Schemas
+                          ;; §`:rf/dispatch-envelope`). Per Spec 005 §Hierarchy
+                          ;; interaction: carry the scheduling node's decl-path
+                          ;; (`invoke-id`) so the pure side routes the firing to
+                          ;; the correct per-path epoch — colliding delay-keys
+                          ;; across hierarchy levels resolve unambiguously.
+                          (dispatch! [parent-id [:rf.machine.timer/after-elapsed
+                                                 delay-key epoch (vec invoke-id)]]
+                                     {:frame  frame-id
+                                      :source :after-timer}))
+                        ;; A one-shot `:after` timer fires exactly once per
+                        ;; arming (XState §delayed transitions). Release THIS
+                        ;; fire's sub-reaction watcher + held subscription
+                        ;; ref-count (the host handle just fired, so its cancel
+                        ;; is a harmless no-op). This is what keeps a
+                        ;; GUARD-SUPPRESSED fire (no state exit → no `:on-exit`
+                        ;; cancel) from stranding the entry, and stops a spent
+                        ;; one-shot from re-arming on a later sub-vec change. The
+                        ;; release is silent — a fired timer was not cancelled,
+                        ;; so no `:cancelled` trace is emitted.
+                        (release-entry-resources! frame-id claimed (:delay k))))
+                    resolved-ms)
+                  ;; PHASE 2 — PUBLISH the host handle IFF this attempt still
+                  ;; owns the slot. `swap-vals!` is a pure replace-if-token-
+                  ;; present; the cancel/add-watch side effects below ride the
+                  ;; CAS-derived old snapshot, never inside the swap.
+                  [old _new]
+                  (swap-vals! after-timers
+                              (fn [m]
+                                (if (= token (:token (get-in m [frame-id k])))
+                                  (assoc-in m [frame-id k :handle] handle)
+                                  m)))
+                  owned? (= token (:token (get-in old [frame-id k])))]
+              (if owned?
+                (do
+                  ;; We own the now-armed slot — attach the dynamic-delay
+                  ;; change-watcher (a sub-value change cancels + reschedules).
+                  ;; Attached ONLY here so a publication that LOST to cleanup
+                  ;; never strands an orphan watcher on a released reaction.
+                  (when (and reaction watch-key)
+                    ;; Surface `add-watch` exceptions rather than silently
+                    ;; dropping them; the re-resolution watcher won't fire if
+                    ;; `add-watch` failed, so the author needs a signal the
+                    ;; dynamic-delay subscription is not actually wired up.
+                    (try
+                      (add-watch reaction watch-key
+                                 (fn [_ _ old-v new-v]
+                                   (on-sub-changed! frame-id parent-id invoke-id
+                                                    delay-key state old-v new-v)))
+                      (catch #?(:clj Throwable :cljs :default) e
+                        ;; Owning actor INSTANCE under `:actor-id`; canonical
+                        ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
+                        (trace/emit-error! :rf.error/machine-after-watch-failed
+                                           {:exception      e
+                                            :actor-id       parent-id
+                                            :rf.sub/id      (first delay-key)
+                                            :rf.sub/query-v (vec delay-key)
+                                            :frame          frame-id
+                                            :recovery       :static-delay}))))
+                  handle)
+                ;; A cleanup / supersede / synchronous fire claimed the sentinel
+                ;; while we armed — do NOT republish; cancel the orphan handle
+                ;; (idempotent even if it already fired). The claimer already
+                ;; released the reaction and emitted the single owed `:cancelled`
+                ;; trace (or, for a self-fire, dispatched + released silently).
+                (do (managed-timer/cancel! handle)
+                    nil)))))))))
 
 (defn after-schedule-fx
   "fx handler for `:rf.machine/after-schedule`. Per Spec 005 §Delayed

--- a/implementation/machines/test/re_frame/after_timer_arm_publish_race_test.cljc
+++ b/implementation/machines/test/re_frame/after_timer_arm_publish_race_test.cljc
@@ -1,0 +1,257 @@
+(ns re-frame.after-timer-arm-publish-race-test
+  "Adversarial ordering regressions for the machine `:after` timer two-phase
+  arm (rf2-j538f7.7). Two races the serial suite never exercised:
+
+    1. ARM-AFTER-CLEANUP — a host arm that returns AFTER a lifecycle cleanup
+       already ran must NOT publish a live timer onto a torn-down frame / actor
+       / exited state / restored frame. The fix RESERVES the slot with a
+       token-stamped arming sentinel (`:handle nil`) BEFORE arming, so a
+       concurrent cleanup atomically CLAIMS the attempt and the publish phase
+       finds its token gone and cancels the orphan handle.
+
+    2. OLD-CANCEL-DELETES-SUCCESSOR — a trailing cancellation of an OLD attempt
+       must NOT delete a re-armed SUCCESSOR occupying the same reused
+       `{:parent :spawn :delay}` key. The fix scopes every cancellation to the
+       exact attempt token it observed (`claim-entry!`), so a successor
+       published mid-cancellation survives untouched.
+
+  The races are only genuinely CONCURRENT on the JVM (CLJS `set-timeout!`
+  cannot fire before the caller yields), but the deterministic interleavings
+  here are driven with `with-redefs` — running the cleanup INSIDE the host-arm
+  stub (between reserve and publish), or firing the captured thunk synchronously
+  — so BOTH runtimes execute the identical reserve / publish / claim code and
+  the invariants hold on each. Per Spec 005 §Delayed `:after` transitions."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- fresh-handle
+  "A process-unique opaque host handle, distinguishable by `identical?` on both
+  runtimes (a fired `set-timeout!` id / `ScheduledFuture` stand-in)."
+  []
+  #?(:clj (Object.) :cljs #js {}))
+
+(defn- inner
+  "The `:rf/default` frame's inner `:after` timer table, or `{}`."
+  []
+  (get @timer/after-timers :rf/default {}))
+
+;; A literal-delay `:after` state — the host clock is stubbed, so the 1-hour
+;; delay never fires on its own; it lingers as an armed entry we can race.
+(def ^:private literal-spec
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:after {3600000 :done}}
+             :done    {}}})
+
+;; ===========================================================================
+;; RACE 1 — arm-after-cleanup: a cleanup that wins DURING arming leaves no
+;; surviving entry, and the late-returning arm cancels its orphan handle.
+;; ===========================================================================
+
+(defn- cancelled-listener [seen]
+  (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
+             (swap! seen conj ev))))
+
+(defn- run-arm-then-cleanup
+  "Arm the literal-delay `:after` timer, but run `(cleanup! frame k)` DURING the
+  host arm — after the slot is reserved, before the handle is published.
+  Returns `{:cancelled [handles] :traces [cancelled-events] :handle h}`."
+  [machine-id cleanup!]
+  (rf/reg-machine machine-id literal-spec)
+  (let [cancelled    (atom [])
+        traces       (atom [])
+        armed-handle (fresh-handle)
+        lkey         ::arm-cleanup-rec]
+    (trace-tooling/register-listener! lkey (cancelled-listener traces))
+    (try
+      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                    interop/schedule-after!
+                    (fn [_thunk _ms]
+                      ;; The slot is reserved (sentinel) but not yet published:
+                      ;; a lifecycle cleanup wins here.
+                      (let [[k _entry] (first (inner))]
+                        (cleanup! :rf/default k))
+                      armed-handle)]
+        (rf/dispatch-sync [machine-id [:go]]))
+      (finally (trace-tooling/unregister-listener! lkey)))
+    {:cancelled @cancelled :traces @traces :handle armed-handle}))
+
+(deftest arm-after-cleanup-leaves-no-entry-and-cancels-orphan-handle
+  (doseq [[label reason cleanup!]
+          [["frame destroy" :on-frame-destroy
+            (fn [frame _k] (timer/cancel-all-timers! frame))]
+           ["epoch restore" :on-restore
+            (fn [frame _k] (timer/cancel-frame-timers-on-restore! frame))]
+           ["actor destroy" :on-destroy
+            (fn [frame k] (timer/cancel-actor-timers! frame (:parent k)))]
+           ["state exit (:on-exit)" :on-exit
+            (fn [frame k] (timer/after-cancel-fx {:frame frame}
+                                                 {:rf/parent-id (:parent k)
+                                                  :rf/invoke-id (:spawn k)}))]]]
+    (testing (str "cleanup owner: " label)
+      (let [mid (keyword "armrace" (str (name reason)))
+            {:keys [cancelled traces handle]} (run-arm-then-cleanup mid cleanup!)]
+        (is (empty? (inner))
+            "no entry survives — the late arm did not publish onto a cleaned frame")
+        (is (some #(identical? handle %) cancelled)
+            "the orphan host handle returned by the late arm was cancelled")
+        (is (= 1 (count traces))
+            "exactly one :rf.machine.timer/cancelled trace (the cleanup claim)")
+        (is (= reason (:reason (:tags (first traces))))
+            (str "the single cancellation carries :reason " reason))))))
+
+(deftest arm-after-cleanup-sub-delay-balances-subscription-and-watcher
+  ;; A sub-vec dynamic delay: the arming sentinel carries the subscription
+  ;; reaction + watch-key, so a cleanup that claims it mid-arm releases the
+  ;; ref-count and detaches nothing-yet-attached; the late publish then cancels
+  ;; the orphan handle and installs NO watcher — a later sub change is inert.
+  (rf/reg-sub :armrace/dyn (fn [_db _] 5000))
+  (rf/reg-machine :armrace/sub
+                  {:initial :idle :data {}
+                   :states {:idle    {:on {:go :waiting}}
+                            :waiting {:after {[:armrace/dyn] :done}}
+                            :done    {}}})
+  (let [reaction     (atom 5000)
+        unsub-count  (atom 0)
+        cancelled    (atom [])
+        armed-handle (fresh-handle)]
+    (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                  subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+                                     ([_ _] (swap! unsub-count inc) nil))
+                  interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  interop/schedule-after!
+                  (fn [_thunk _ms]
+                    (timer/cancel-all-timers! :rf/default) ;; frame destroy mid-arm
+                    armed-handle)]
+      (rf/dispatch-sync [:armrace/sub [:go]])
+      (is (empty? (inner)) "no entry survives the mid-arm frame destroy")
+      (is (some #(identical? armed-handle %) @cancelled)
+          "the orphan host handle was cancelled")
+      (is (pos? @unsub-count)
+          "the held subscription ref-count was released (balanced)")
+      ;; A later sub-value change must NOT re-arm — no watcher was installed on
+      ;; the losing publication.
+      (let [arms-before (count @cancelled)]
+        (reset! reaction 9999)
+        (is (empty? (inner)) "a later sub change did not re-arm a spent attempt")
+        (is (= arms-before (count @cancelled))
+            "no fresh host work followed the inert sub change")))))
+
+;; ===========================================================================
+;; RACE 2 — old-cancel-deletes-successor: cancelling attempt A must not erase a
+;; successor B re-armed at the same key.
+;; ===========================================================================
+
+(deftest cancellation-of-old-attempt-does-not-delete-successor
+  ;; Arm A for real, then — DURING A's cancellation, at the moment its host
+  ;; handle is released — publish a successor B at the same reused key (the
+  ;; deterministic stand-in for a concurrent re-arm landing between A's read and
+  ;; its removal). A's cancellation must claim ONLY A (its own token) and leave
+  ;; B tracked and live.
+  (rf/reg-machine :succ/m literal-spec)
+  (let [hA        (fresh-handle)
+        hB        (fresh-handle)
+        cancelled (atom [])]
+    (with-redefs [interop/schedule-after! (fn [_thunk _ms] hA)]
+      (rf/dispatch-sync [:succ/m [:go]]))
+    (let [[k a-entry] (first (inner))
+          b-entry     (assoc a-entry :handle hB :token ::successor-token)]
+      (is (identical? hA (:handle a-entry)) "precondition: A armed with handle hA")
+      (with-redefs [interop/cancel-scheduled!
+                    (fn [h]
+                      (swap! cancelled conj h)
+                      ;; B lands at the same key while A's handle is being
+                      ;; released — the concurrent re-arm publishing a successor.
+                      (when (identical? h hA)
+                        (swap! timer/after-timers assoc-in [:rf/default k] b-entry))
+                      nil)]
+        ;; cancel A (actor destroy) — reads A, claims A by A's token, releases A
+        (timer/cancel-actor-timers! :rf/default (:parent k)))
+      (let [slot (get-in @timer/after-timers [:rf/default k])]
+        (is (= b-entry slot)
+            "successor B SURVIVES A's cancellation — the old cancel did not delete it")
+        (is (identical? hB (:handle slot)) "B's host handle is intact")
+        (is (some #(identical? hA %) @cancelled) "A's own handle was cancelled")
+        (is (not (some #(identical? hB %) @cancelled))
+            "B's handle was NOT cancelled by A's cancellation")))))
+
+;; ===========================================================================
+;; RACE 2b — same-epoch dynamic-delay re-arm: a STALE loser thunk (same durable
+;; epoch as the winner, because a dynamic-delay re-arm keeps the epoch) must not
+;; reap or dispatch against the winner. The per-attempt token distinguishes
+;; them where the epoch cannot.
+;; ===========================================================================
+
+(deftest same-epoch-loser-thunk-cannot-reap-or-dispatch-the-winner
+  (rf/reg-sub :lose/dyn (fn [_db _] 5000))
+  (rf/reg-machine :lose/m
+                  {:initial :idle :data {}
+                   ;; guard false → a fire is discarded, the state does not exit
+                   :guards {:no (fn [_] false)}
+                   :states {:idle    {:on {:go :waiting}}
+                            :waiting {:after {[:lose/dyn] {:guard :no :target :done}}}
+                            :done    {}}})
+  (let [reaction (atom 5000)
+        thunks   (atom [])]
+    (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                  subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                  interop/schedule-after! (fn [thunk _ms]
+                                            (swap! thunks conj thunk)
+                                            (fresh-handle))
+                  interop/cancel-scheduled! (fn [_h] nil)]
+      (rf/dispatch-sync [:lose/m [:go]])            ;; arm attempt-1 → thunk-1
+      (is (= 1 (count (inner))) "attempt-1 armed")
+      (is (= 1 (count @thunks)) "captured thunk-1")
+      (reset! reaction 6000)                        ;; sub change → re-arm attempt-2 → thunk-2
+      (is (= 1 (count (inner))) "still exactly one entry (attempt-1 superseded by attempt-2)")
+      (is (= 2 (count @thunks)) "captured thunk-2 (the same-epoch re-arm)")
+      (let [thunk-1 (first @thunks)
+            thunk-2 (second @thunks)]
+        ;; Fire the STALE loser (thunk-1). Its token no longer owns the slot, so
+        ;; its atomic claim fails: it neither reaps attempt-2 nor dispatches.
+        (thunk-1)
+        (is (= 1 (count (inner)))
+            "the stale loser thunk did NOT reap the winner (token guard, not epoch)")
+        (is (= 2 (count @thunks))
+            "the loser thunk lost dispatch authority — no phantom re-arm followed")
+        ;; Fire the winner (thunk-2). It owns the slot → claims + reaps it.
+        (thunk-2)
+        (is (empty? (inner)) "the winning thunk reaped its own entry")))))
+
+;; ===========================================================================
+;; SYNC-FIRE — a scheduler that invokes the callback synchronously inside the
+;; arm, before returning the handle, must not strand a spent entry.
+;; ===========================================================================
+
+(deftest synchronous-fire-during-arm-strands-no-spent-entry
+  (rf/reg-machine :sync/m
+                  {:initial :idle :data {}
+                   :guards {:no (fn [_] false)}
+                   :states {:idle    {:on {:go :waiting}}
+                            :waiting {:after {3600000 {:guard :no :target :done}}}
+                            :done    {}}})
+  (let [cancelled (atom [])]
+    (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  interop/schedule-after! (fn [thunk _ms]
+                                            (let [h (fresh-handle)]
+                                              ;; the host fires the callback
+                                              ;; synchronously BEFORE returning
+                                              (thunk)
+                                              h))]
+      (rf/dispatch-sync [:sync/m [:go]]))
+    (is (empty? (inner))
+        "the synchronous fire closed its sentinel — no spent entry was published")
+    (is (seq @cancelled)
+        "the post-arm publish found its token gone and cancelled the spent handle")))

--- a/implementation/resources/src/re_frame/resources/timers.cljc
+++ b/implementation/resources/src/re_frame/resources/timers.cljc
@@ -134,10 +134,11 @@
 ;; host-side generation allocator. Cleared per-frame on frame destroy.
 
 (defonce
-  ^{:doc "Host-side side table of NON-serializable stale / GC / poll timer
-   handles, keyed by `[frame-id resource-key kind]` (`kind` ∈
-   `#{:stale :gc :poll}`) → an opaque host handle from
-   `re-frame.interop/schedule-after!`. Transient host state (NOT runtime-db),
+  ^{:doc "Host-side side table of NON-serializable stale / GC / poll timers,
+   keyed by `[frame-id resource-key kind]` (`kind` ∈ `#{:stale :gc :poll}`) →
+   `{:token <int> :handle <host-handle-or-nil>}`, where the handle is an opaque
+   value from `re-frame.interop/schedule-after!` and `:handle nil` is a two-phase
+   ARMING sentinel (rf2-j538f7.10). Transient host state (NOT runtime-db),
    so an epoch restore cannot rewind / recycle it, and it never rides the SSR
    / hydration / epoch wire — freshness is re-derived from the durable entry
    timestamps, and a timer is only an advisory nudge whose handler re-checks
@@ -146,6 +147,26 @@
    5."}
   timer-table
   (atom {}))
+
+;; Each slot value is a small map `{:token <int> :handle <host-handle-or-nil>}`
+;; rather than a bare handle (rf2-j538f7.10). The `:token` is a unique per-arm
+;; ownership stamp (below); `:handle nil` marks an ARMING sentinel — the slot is
+;; reserved but the host clock has not yet returned a handle. Two-phase arming
+;; (reserve → publish) plus token-scoped cancellation make arm / cancel /
+;; frame-destroy linearizable against a reused `[frame rkey kind]` key.
+
+(defonce ^:private timer-attempt-counter
+  ;; Monotonic per-arm attempt-token source (mirrors core's
+  ;; `dispatch-later-counter`, rf2-j538f7.2, and the machines
+  ;; `after-attempt-counter`). Every `schedule!` arm stamps its slot with a
+  ;; unique token, so a trailing cancellation of an OLD attempt can never claim
+  ;; a re-armed SUCCESSOR occupying the same reused `[frame rkey kind]` slot,
+  ;; and a late-returning arm can detect that a cleanup already claimed its slot.
+  ;; Purely transient host-work OWNERSHIP — never runtime-db / SSR / epoch state.
+  (atom 0))
+
+(defn- next-attempt-token []
+  (swap! timer-attempt-counter inc))
 
 (defn- timer-key
   "The side-table key for `[frame-id resource-key kind]`. rf2-9e0tyq: the
@@ -162,12 +183,29 @@
   when none is armed). Idempotent. Returns nil. The durable freshness facts
   are untouched (a cancelled timer never means an entry became fresh — only
   that the advisory nudge will not fire). Per Spec 016 §Stale and GC
-  scheduling."
+  scheduling.
+
+  Cancels the exact attempt observed: it reads the current occupant's `:token`
+  and atomically CLAIMS the slot only while that token is still current
+  (`swap-vals!`). If a concurrent re-arm published a SUCCESSOR under the same
+  key between the read and the claim, this cancellation leaves the successor
+  untouched (its own arrival already released the observed attempt), so an old
+  cancellation never erases a successor it did not cancel (rf2-j538f7.10). An
+  ARMING sentinel (`:handle nil`) is dropped without a host cancel — the arming
+  thread's publish phase then finds its token gone and cancels the returned
+  handle. The host `cancel-scheduled!` rides the CAS-derived old snapshot,
+  never inside the retriable swap."
   [frame-id resource-key kind]
   (let [k (timer-key frame-id resource-key kind)]
-    (when-let [handle (get @timer-table k)]
-      (interop/cancel-scheduled! handle))
-    (swap! timer-table dissoc k))
+    (when-let [slot (get @timer-table k)]
+      (let [token      (:token slot)
+            [old _new] (swap-vals! timer-table
+                                   (fn [m] (if (= token (:token (get m k)))
+                                             (dissoc m k)
+                                             m)))
+            claimed    (get old k)]
+        (when (and (= token (:token claimed)) (:handle claimed))
+          (interop/cancel-scheduled! (:handle claimed))))))
   nil)
 
 (defn cancel-for-key!
@@ -254,18 +292,54 @@
   [frame-id resource-key kind delay-ms]
   ;; cancel any prior timer for this [key kind] (reschedule / disarm, not accumulate)
   (cancel! frame-id resource-key kind)
-  ;; Shared positive-delay-guarded arm (rf2-7x2lky) — the host-clock arm step
-  ;; both timer artefacts share. A non-positive / nil delay arms nothing,
-  ;; leaving the kind cancelled (the explicit disarm). Returns the host handle
-  ;; or nil; the side-table bookkeeping + trace below are resources-specific.
-  (when-let [handle (managed-timer/arm!
-                      (fn [] (dispatch-recheck! frame-id resource-key kind))
-                      delay-ms)]
-    (swap! timer-table assoc (timer-key frame-id resource-key kind) handle)
-    (trace/emit! :rf.event (scheduled-trace-id kind)
-                 {:rf.frame/id frame-id :resource/key resource-key
-                  :delay-ms delay-ms})
-    handle))
+  ;; A non-positive / nil delay arms nothing, leaving the kind cancelled (the
+  ;; explicit disarm — the shared positive-delay rule, rf2-7x2lky). Otherwise
+  ;; TWO-PHASE, TOKEN-OWNED arming (rf2-j538f7.10; mirrors core `:dispatch-later`,
+  ;; rf2-j538f7.2): reserve the slot BEFORE arming the host clock, then publish
+  ;; the handle only if this attempt still owns the slot, so a cleanup racing the
+  ;; arm can never be outrun by a late-returning handle.
+  (when (managed-timer/positive-delay? delay-ms)
+    (let [k     (timer-key frame-id resource-key kind)
+          token (next-attempt-token)]
+      ;; PHASE 1 — reserve an arming sentinel (`:handle nil`) so a concurrent
+      ;; cleanup can atomically claim this attempt.
+      (swap! timer-table assoc k {:token token :handle nil})
+      (let [handle
+            ;; Shared positive-delay-guarded arm (rf2-7x2lky) — a no-op guard
+            ;; pass-through here (already known positive).
+            (managed-timer/arm!
+              (fn []
+                ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY +
+                ;; self-reap in one swap (mirrors core `:dispatch-later`). If a
+                ;; cleanup / re-arm claimed the slot first — even a synchronous
+                ;; host callback firing before `arm!` returns — this fire lost
+                ;; authority: suppress the dead-on-arrival re-check dispatch and
+                ;; leave the successor untouched. On the live path the claim
+                ;; wins, drops the spent one-shot slot, and dispatches the
+                ;; advisory re-check (whose handler re-checks durable facts).
+                (let [[old _new] (swap-vals! timer-table
+                                             (fn [m] (if (= token (:token (get m k)))
+                                                       (dissoc m k)
+                                                       m)))]
+                  (when (= token (:token (get old k)))
+                    (dispatch-recheck! frame-id resource-key kind))))
+              delay-ms)
+            ;; PHASE 2 — publish the handle IFF this attempt still owns the slot.
+            ;; `swap-vals!` is a pure replace-if-token-present; the host cancel
+            ;; below rides the CAS-derived old snapshot, never inside the swap.
+            [old _new] (swap-vals! timer-table
+                                   (fn [m] (if (= token (:token (get m k)))
+                                             (assoc m k {:token token :handle handle})
+                                             m)))]
+        (if (= token (:token (get old k)))
+          (do (trace/emit! :rf.event (scheduled-trace-id kind)
+                           {:rf.frame/id frame-id :resource/key resource-key
+                            :delay-ms delay-ms})
+              handle)
+          ;; a cleanup / synchronous self-fire claimed the sentinel while we
+          ;; armed — cancel the orphan handle, publish nothing, emit no trace.
+          (do (interop/cancel-scheduled! handle)
+              nil))))))
 
 (defn release-frame!
   "Cancel + drop EVERY stale / GC / poll timer for a destroyed `frame-id`
@@ -279,10 +353,17 @@
   §Polling (frame destroy cancels all resource timers) / [Runtime-Subsystems]
   clause 5. Returns nil."
   [frame-id]
-  (doseq [[[fid rkey kind] handle] @timer-table]
-    (when (= fid frame-id)
-      (interop/cancel-scheduled! handle)
-      (swap! timer-table dissoc [fid rkey kind])))
+  ;; Remove the frame's slots ATOMICALLY (a single `swap-vals!`) and cancel the
+  ;; real host handles off the CAS-derived old snapshot — no host side effect
+  ;; runs inside the retriable swap. An ARMING sentinel (`:handle nil`, a timer
+  ;; mid-`arm!`) is dropped but NEVER passed to `cancel-scheduled!` — the arming
+  ;; caller's publish phase finds its vanished reservation and cancels the real
+  ;; handle itself, so the timer is cancelled exactly once with no orphan.
+  (let [[old _new] (swap-vals! timer-table
+                               (fn [m] (into {} (remove (fn [[[fid _ _] _]] (= fid frame-id))) m)))]
+    (doseq [[[fid _rkey _kind] slot] old
+            :when (and (= fid frame-id) (:handle slot))]
+      (interop/cancel-scheduled! (:handle slot))))
   nil)
 
 (defn reset-cache!
@@ -291,9 +372,13 @@
   `make-reset-runtime-fixture` clears it per test (host-side transient state,
   NOT cleared by the runtime / frames reset). Returns nil."
   []
-  (doseq [[_ handle] @timer-table]
-    (interop/cancel-scheduled! handle))
-  (reset! timer-table {})
+  ;; Clear the table ATOMICALLY (`reset-vals!`) and cancel the real host handles
+  ;; off the captured old snapshot. An ARMING sentinel (`:handle nil`) is dropped
+  ;; but never passed to `cancel-scheduled!`.
+  (let [[old _new] (reset-vals! timer-table {})]
+    (doseq [[_ slot] old
+            :when (:handle slot)]
+      (interop/cancel-scheduled! (:handle slot))))
   nil)
 
 ;; ---- the host-side scheduling fx (mirrors :rf.resource/commit-generation) -

--- a/implementation/resources/test/re_frame/resources_timer_arm_publish_race_test.cljc
+++ b/implementation/resources/test/re_frame/resources_timer_arm_publish_race_test.cljc
@@ -1,0 +1,168 @@
+(ns re-frame.resources-timer-arm-publish-race-test
+  "Adversarial ordering regressions for the resource stale / GC / poll timer
+  two-phase arm (rf2-j538f7.10). Two races the serial suite never exercised:
+
+    1. ARM-AFTER-CLEANUP — a host arm that returns AFTER a lifecycle cleanup
+       (`release-frame!` / `cancel-for-key!` / `reset-cache!`) already ran must
+       NOT publish live host work onto a torn-down frame / removed entry. The
+       fix RESERVES the `[frame rkey kind]` slot with a token-stamped arming
+       sentinel (`:handle nil`) BEFORE arming, so a concurrent cleanup
+       atomically CLAIMS the attempt and the publish phase finds its token gone
+       and cancels the orphan handle.
+
+    2. OLD-CANCEL-ERASES-SUCCESSOR — a trailing cancellation of an OLD attempt
+       must NOT erase a re-armed SUCCESSOR occupying the same reused
+       `[frame rkey kind]` slot. The fix scopes every cancellation to the exact
+       attempt token it observed, so a successor published mid-cancellation
+       survives with its handle intact.
+
+  The races are only genuinely CONCURRENT on the JVM, but the deterministic
+  interleavings here are driven with `with-redefs` — running the cleanup INSIDE
+  the host-arm stub (between reserve and publish), or firing the captured thunk
+  synchronously — so BOTH runtimes execute the identical reserve / publish /
+  claim code. Per Spec 016 §Stale and GC scheduling / §Polling."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.identity :as identity]
+   [re-frame.interop :as interop]
+   ;; load-bearing side-effecting require: the façade registers the resources
+   ;; events + the test-support reset hook that clears timer-table.
+   [re-frame.resources]
+   [re-frame.resources.test-support]
+   [re-frame.resources.timers :as timers]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter})))
+
+(defn- fresh-handle
+  "A process-unique opaque host handle, distinguishable by `identical?`."
+  []
+  #?(:clj (Object.) :cljs #js {}))
+
+(def ^:private frame :race/f)
+(defn- rkey [tag] [:rf.scope/global tag {:id 1}])
+(defn- tkey [rk kind] [frame (identity/canonical-bytes rk) kind])
+(defn- slot [rk kind] (get @timers/timer-table (tkey rk kind)))
+(defn- armed? [rk kind] (contains? @timers/timer-table (tkey rk kind)))
+
+;; ===========================================================================
+;; RACE 1 — arm-after-cleanup
+;; ===========================================================================
+
+(deftest arm-after-cleanup-leaves-no-slot-and-cancels-orphan-handle
+  (doseq [[label cleanup!]
+          [["release-frame!"  (fn [rk] (timers/release-frame! frame))]
+           ["cancel-for-key!" (fn [rk] (timers/cancel-for-key! frame rk))]
+           ["reset-cache!"    (fn [_]  (timers/reset-cache!))]]]
+    (testing (str "cleanup owner: " label)
+      (timers/reset-cache!)
+      (let [rk           (rkey :race/arm)
+            kind         timers/stale-kind
+            cancelled    (atom [])
+            armed-handle (fresh-handle)]
+        (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                      interop/schedule-after!
+                      (fn [_thunk _ms]
+                        ;; the slot is reserved (sentinel) but not yet
+                        ;; published: a cleanup wins here.
+                        (cleanup! rk)
+                        armed-handle)]
+          (timers/schedule! frame rk kind 60000))
+        (is (not (armed? rk kind))
+            "no slot survives — the late arm did not publish onto a cleaned frame")
+        (is (some #(identical? armed-handle %) @cancelled)
+            "the orphan host handle returned by the late arm was cancelled")))))
+
+;; ===========================================================================
+;; RACE 2 — old-cancel-erases-successor
+;; ===========================================================================
+
+(deftest cancellation-of-old-attempt-does-not-erase-successor
+  ;; Arm A for real, then — DURING A's cancellation, at the moment its host
+  ;; handle is released — publish a successor B at the same reused key (the
+  ;; deterministic stand-in for a concurrent re-arm landing between A's read and
+  ;; its removal). A's cancellation must claim ONLY A and leave B tracked.
+  (timers/reset-cache!)
+  (let [rk        (rkey :succ)
+        kind      timers/gc-kind
+        hA        (fresh-handle)
+        hB        (fresh-handle)
+        b-slot    {:token ::successor-token :handle hB}
+        cancelled (atom [])]
+    (with-redefs [interop/schedule-after! (fn [_thunk _ms] hA)]
+      (timers/schedule! frame rk kind 60000))
+    (let [k (tkey rk kind)]
+      (is (identical? hA (:handle (slot rk kind))) "precondition: A armed with hA")
+      (with-redefs [interop/cancel-scheduled!
+                    (fn [h]
+                      (swap! cancelled conj h)
+                      ;; B lands at the same key while A's handle is released —
+                      ;; the concurrent re-arm publishing a successor.
+                      (when (identical? h hA)
+                        (swap! timers/timer-table assoc k b-slot))
+                      nil)]
+        (timers/cancel! frame rk kind))
+      (is (= b-slot (get @timers/timer-table k))
+          "successor B SURVIVES A's cancellation — the old cancel did not erase it")
+      (is (identical? hB (:handle (get @timers/timer-table k))) "B's host handle is intact")
+      (is (some #(identical? hA %) @cancelled) "A's own handle was cancelled")
+      (is (not (some #(identical? hB %) @cancelled))
+          "B's handle was NOT cancelled by A's cancellation"))))
+
+;; ===========================================================================
+;; RACE 2b — a stale poll loser thunk cannot refetch or reap the winner after a
+;; same-kind re-arm (dispatch authority via the per-attempt token).
+;; ===========================================================================
+
+(deftest stale-poll-loser-thunk-cannot-reap-or-refetch-the-winner
+  (timers/reset-cache!)
+  (let [rk     (rkey :poll)
+        kind   timers/poll-kind
+        thunks (atom [])]
+    (with-redefs [interop/schedule-after! (fn [thunk _ms] (swap! thunks conj thunk) (fresh-handle))
+                  interop/cancel-scheduled! (fn [_h] nil)]
+      (timers/schedule! frame rk kind 60000)   ;; attempt-1 → thunk-1
+      (timers/schedule! frame rk kind 60000)   ;; attempt-2 (cancel-then-arm) → thunk-2
+      (is (= 2 (count @thunks)) "captured both arm thunks")
+      (is (armed? rk kind) "exactly one poll slot armed")
+      (let [thunk-1 (first @thunks)
+            thunk-2 (second @thunks)]
+        ;; Fire the STALE loser. Its token no longer owns the slot, so its
+        ;; atomic claim fails: it neither reaps the winner nor refetches (the
+        ;; re-check dispatch lives INSIDE the winning-claim branch, so a
+        ;; surviving slot proves the dispatch was suppressed).
+        (thunk-1)
+        (is (armed? rk kind) "the stale loser thunk did NOT reap the winner")
+        (is (= 2 (count @thunks)) "no phantom re-arm followed the loser fire")
+        ;; Fire the winner — it owns the slot → claims + self-reaps it.
+        (thunk-2)
+        (is (not (armed? rk kind)) "the winning thunk self-reaped its own slot")))))
+
+;; ===========================================================================
+;; SYNC-FIRE — a scheduler that fires the callback synchronously inside the arm,
+;; before returning the handle, strands no spent handle.
+;; ===========================================================================
+
+(deftest synchronous-fire-during-arm-strands-no-spent-handle
+  (timers/reset-cache!)
+  (let [rk        (rkey :sync)
+        kind      timers/stale-kind
+        cancelled (atom [])]
+    (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  interop/schedule-after! (fn [thunk _ms]
+                                            (let [h (fresh-handle)]
+                                              ;; the host fires synchronously
+                                              ;; BEFORE returning the handle
+                                              (thunk)
+                                              h))]
+      (timers/schedule! frame rk kind 60000))
+    (is (not (armed? rk kind))
+        "the synchronous fire closed its sentinel — no spent handle was published")
+    (is (seq @cancelled)
+        "the post-arm publish found its token gone and cancelled the spent handle")))


### PR DESCRIPTION
## What

Two sibling artefacts carried the same non-linearizable race between host-timer arming/cancellation and lifecycle cleanup. One symmetrical fix per artefact, one commit each.

- **rf2-j538f7.7** (`implementation/machines`, P2) — machine `:after` timers
- **rf2-j538f7.10** (`implementation/resources`, P2) — resource stale/GC/poll timers

Both premises were re-confirmed against current `origin/main`: the arm-after-cleanup and old-cancel-deletes-successor interleavings were reachable (the serial 940-/629-test suites never drove them).

## The two races (both artefacts)

1. **arm-after-cleanup** — the host clock was armed and *then* the entry/handle was published. A frame/actor destroy, state exit, epoch restore, or `release-frame!`/`cancel-for-key!`/`reset-cache!` running while the arm was in flight saw no slot and returned; the arm then published live host work onto a torn-down frame — leaking the host handle (plus, for machine sub-vec delays, the watcher + subscription ref-count).
2. **old-cancel-deletes-successor** — cancellation read one entry, released it, then *unconditionally* removed the key. A concurrent re-arm publishing a successor between those steps was erased without cancelling its handle.

## The fix

Mirrors the blessed core `:dispatch-later` two-phase arm (rf2-j538f7.2, `arm-dispatch-later!`). Core gets identity free from a unique-counter key; these two tables **reuse** a fixed key (`{:parent :spawn :delay}` / `[frame rkey kind]`) across re-arms, so a **per-attempt token** supplies the missing identity:

- **PHASE 1** reserves the slot with a token-stamped arming sentinel (`:handle nil`) *before* arming.
- **PHASE 2** publishes the handle via `swap-vals!` **only if the token still owns the slot**, else cancels the orphan handle. (Machines attaches the dynamic-delay watcher only on a won publication.)
- **Cancellation** (`claim-entry!` / `cancel!`) atomically removes a slot only while it still holds the observed token — an old cancel never deletes a successor; a stale fire loses **dispatch authority** (no dead-on-arrival dispatch/refetch after cleanup) and self-reaps by token.
- The durable per-decl-path **epoch** (machines) and the sibling present/absent-kind reconcile algebra (resources, rf2-3fc89f.10) are unchanged — the token is transient host-work ownership only, never runtime-db/SSR/epoch state. This is why a same-epoch dynamic-delay re-arm's stale loser cannot reap the winner.

The machines/resources fixes are deliberately symmetrical (same reserve→publish→token-claim shape); they differ only where the artefacts genuinely differ (machines' rich entry + watcher/subscription teardown + reply-envelope cancelled trace vs resources' `{:token :handle}` slot + silent cancel).

## Tests

Each artefact adds a `.cljc` adversarial-ordering regression suite (runs on JVM **and** CLJS) that drives the interleavings deterministically via `with-redefs` (cleanup run *inside* the arm stub; thunk fired synchronously):

- arm-then-cleanup across every cleanup owner (machines: frame/actor destroy, state exit, epoch restore, incl. subscription-balance; resources: `release-frame!`/`cancel-for-key!`/`reset-cache!`) — no surviving slot, orphan handle cancelled, exactly one cancelled trace with the right reason
- cancel-then-successor — a successor published mid-cancellation survives with its handle intact
- same-epoch / same-kind loser thunk cannot reap or dispatch against the winner
- synchronous fire during arm strands no spent entry/handle

## Quality gates

- `clojure -M:test` in `implementation/machines`: **945 tests / 2996 assertions / 0 failures / 0 errors** (+5 tests / +35 assertions)
- `clojure -M:test` in `implementation/resources`: **633 tests / 6268 assertions / 0 failures / 0 errors** (+4 tests / +18 assertions)
- `npm run test:cljs` (implementation): **8491 tests / 39732 assertions / 0 failures / 0 errors**
- clj-kondo on both changed src files: 0 errors, 0 warnings
- All re-run green after rebasing on latest `origin/main`.

## Risks

- Resources slot value shape changed from a bare handle to `{:token :handle}`. All in-artefact consumers (`cancel!`/`release-frame!`/`reset-cache!`) are updated; every existing resources test accesses the table by `contains?`, whole-value `=`/`not=`, or key-only — none crack the value open, so the change is transparent (629→633 tests still green).
- The physical `add-watch`/`remove-watch` (machines sub-delay) is an unavoidable side effect outside the atomic swap; it is attached only on a won publication and released by whoever claims the entry, so the residual window is JVM-only, nanosecond-scale, and no worse than the prior code — documented inline.