### PR TITLE
fix(ssr,ssr-ring): fail-closed teardown projection + structured Set-Cookie boundary (rf2-j538f7.15, rf2-j538f7.16)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -44,21 +44,28 @@
   (-> (URLEncoder/encode (str s) (.name StandardCharsets/UTF_8))
       (str/replace "+" "%20")))
 
-;; Cookie attributes are concatenated into a header value, so reject the
-;; CR/LF/NUL characters that can split headers. The shared predicate keeps
-;; the effect boundary and this last wire boundary on one grammar.
+;; Cookie attributes (:domain / :path / :max-age / :same-site) are
+;; concatenated VERBATIM after `; ` separators, so reject both the CR/LF/NUL
+;; header-splitting chars AND the raw `;` cookie-attribute delimiter — a `;`
+;; inside a value escapes its assigned attribute and fabricates extra
+;; attributes (SameSite=None, Secure, …). Cookie :value is exempt: it is
+;; percent-encoded upstream, so a `;` there stays data (`%3B`). The shared
+;; predicate keeps the effect boundary and this last wire boundary on one
+;; grammar.
 
 (defn- validate-attribute-string!
   [attr-key v]
   (let [s (str v)]
-    (when (http-validation/contains-injection-char? s)
+    (when (http-validation/contains-cookie-attr-injection-char? s)
       (error/throw-error!
         :rf.error/cookie-invalid-attribute
         'rf.ssr/cookie->set-cookie-header
         (str "cookie attribute " attr-key
-             " contains CR/LF/NUL — forbidden by"
-             " RFC 7230 §3.2.4 (header-splitting"
-             " injection). Strip CR/LF/NUL from the attribute value.")
+             " contains CR/LF/NUL or a `;` — forbidden by"
+             " RFC 7230 §3.2.4 (header-splitting injection) and"
+             " RFC 6265 §4.1.1 (the `;` is the cookie-attribute delimiter,"
+             " so it would fabricate extra Set-Cookie attributes). Strip"
+             " CR/LF/NUL and `;` from the attribute value.")
         {:recovery :remove-injection-chars-from-cookie-attr
          :extra    {:attribute attr-key
                     :value     v}}))
@@ -117,11 +124,14 @@
   Validation:
     - `:name` is checked against the RFC 6265 §4.1.1 token grammar — no
       CTLs / whitespace / separators. Throws `:rf.error/cookie-invalid-name`.
-    - `:domain` / `:path` / `:max-age` / `:same-site` are checked for
-      CR / LF / NUL before concatenation. Throws
+    - `:domain` / `:path` / `:max-age` / `:same-site` are concatenated
+      verbatim after `; ` separators, so they are checked for CR / LF / NUL
+      AND the raw `;` cookie-attribute delimiter before concatenation — a
+      `;` inside a value would escape its attribute and fabricate extra
+      attributes (`SameSite=None`, `Secure`, …). Throws
       `:rf.error/cookie-invalid-attribute`. `:value` is URL-encoded
-      upstream so any CR/LF/NUL in it ends up as `%0D` / `%0A` / `%00` —
-      no injection path through `:value`.
+      upstream so any CR/LF/NUL/`;` in it ends up as `%0D` / `%0A` / `%00`
+      / `%3B` — no injection path through `:value`.
     - `:expires` was already type-checked as `integer?`; no string
       content reaches the wire."
   [{:keys [name value max-age secure http-only same-site path domain expires]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
@@ -110,3 +110,39 @@
         "sanity: the ambient frame inside the body is B, not A")
     (let [payload (rf/with-frame ambient-frame (build-a))]
       (assert-frame-a-redacts payload "mismatched ambient B"))))
+
+;; ===========================================================================
+;; rf2-j538f7.15 — the non-streaming Ring wrapper fails CLOSED on a frame lost
+;; during teardown, mirroring the streaming builder. A frame whose route slice
+;; was captured while it was live must not have that slice ride RAW once the
+;; frame is destroyed between capture and projection — its classification
+;; authority is gone, so app-db + routing fail closed.
+;; ===========================================================================
+
+(deftest build-payload-fails-closed-on-destroyed-frame
+  (testing "rf2-j538f7.15 (acceptance #3) — ring.payload/build-payload called
+            with an EXPLICIT frame that was destroyed after its app-db /
+            runtime-db were captured fails closed: app-db redacts whole and the
+            classified route :current slice redacts, so no raw :query :token /
+            :params blob / app-db secret rides. Mirrors the streaming builder's
+            teardown-race fail-closed."
+    (setup-frames!)
+    (let [runtime-db (frame/frame-runtime-db-value server-frame)
+          app-db     {:secret "app-db-secret" :public "ok"}]
+      ;; Teardown race: the request frame is gone before the wrapper projects.
+      (rf/destroy-frame! server-frame)
+      (let [payload (payload/build-payload
+                      server-frame app-db runtime-db "hash"
+                      {:payload :rf.ssr.payload/whole-app-db})]
+        (is (= server-frame (:rf/frame-id payload))
+            "the payload still names frame A as its target")
+        (is (= :rf/redacted (:rf/app-db payload))
+            "app-db fails closed (project-app-db-egress redacts whole under the dead frame)")
+        (is (= :rf/redacted (get-in payload [:rf/runtime-db :rf.runtime/routing]))
+            "the routing slice fails closed via project-routing-egress")
+        (is (not (.contains (pr-str payload) "secret-oauth-token"))
+            "no raw route token survives")
+        (is (not (.contains (pr-str payload) "huge-callback-blob-value"))
+            "no raw route blob survives")
+        (is (not (.contains (pr-str payload) "app-db-secret"))
+            "no raw app-db secret survives")))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -132,6 +132,115 @@
       (is (str/includes? s "Domain=example.com"))
       (is (str/includes? s "Path=/articles")))))
 
+;; ===========================================================================
+;; rf2-j538f7.16 — a raw `;` in a structured cookie attribute is the RFC 6265
+;; cookie-attribute delimiter, so it escapes its assigned attribute and
+;; fabricates additional attributes (SameSite=None, Secure, Domain, …). The
+;; CR/LF/NUL-only gate accepted it. The attribute gate now rejects `;` too;
+;; cookie :value stays delimiter-tolerant because it is percent-encoded.
+;; ===========================================================================
+
+(deftest cookie-attribute-semicolon-injection-rejected
+  (testing "rf2-j538f7.16 — a `;` in :path forges extra Set-Cookie
+            attributes and must be rejected (the bead's public repro)"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/cookie-invalid-attribute"
+          (ssr-ring/cookie->set-cookie-header
+            {:name "sid" :value "abc" :path "/; SameSite=None; Secure"}))))
+
+  (testing "rf2-j538f7.16 — a `;` in string :max-age forges attributes (repro 2)"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/cookie-invalid-attribute"
+          (ssr-ring/cookie->set-cookie-header
+            {:name "sid" :value "abc" :max-age "3600; SameSite=None; Secure"}))))
+
+  (testing "rf2-j538f7.16 — a `;` in :domain is rejected"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/cookie-invalid-attribute"
+          (ssr-ring/cookie->set-cookie-header
+            {:name "sid" :value "abc" :domain "evil.com; Secure"}))))
+
+  (testing "rf2-j538f7.16 — a `;` in string :same-site is rejected"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/cookie-invalid-attribute"
+          (ssr-ring/cookie->set-cookie-header
+            {:name "sid" :value "abc" :same-site "Lax; Secure"}))))
+
+  (testing "rf2-j538f7.16 — the offending attribute + original value ride the
+            structured error payload"
+    (try
+      (ssr-ring/cookie->set-cookie-header
+        {:name "sid" :value "abc" :path "/; SameSite=None"})
+      (is false "expected a thrown :rf.error/cookie-invalid-attribute")
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :rf.error/cookie-invalid-attribute (:rf.error/id data))
+              "the catalogued attribute-injection id is thrown")
+          (is (= :path (:attribute data))
+              "the offending attribute (:path) rides the :attribute slot")
+          (is (= "/; SameSite=None" (:value data))
+              "the original attribute value rides the :value slot")))))
+
+  (testing "rf2-j538f7.16 — a `;` in cookie :value is DATA, not a delimiter:
+            it is percent-encoded (`%3B`), so it must NOT be over-rejected"
+    (let [s (ssr-ring/cookie->set-cookie-header
+              {:name "sid" :value "a;b" :path "/"})]
+      (is (str/includes? s "sid=a%3Bb")
+          "semicolon in :value serialises as %3B (data stays data)")
+      (is (not (str/includes? s "a;b"))
+          "the raw `;` does not survive into the wire value")
+      (is (str/includes? s "Path=/"))))
+
+  (testing "rf2-j538f7.16 — clean attributes (canonical `/` path, plain
+            domain, integer max-age) still serialise unchanged"
+    (let [s (ssr-ring/cookie->set-cookie-header
+              {:name    "sid"  :value "abc"
+               :path    "/app" :domain "example.com"
+               :max-age 3600   :same-site :none})]
+      (is (str/includes? s "Path=/app"))
+      (is (str/includes? s "Domain=example.com"))
+      (is (str/includes? s "Max-Age=3600"))
+      (is (str/includes? s "SameSite=None")))))
+
+;; rf2-j538f7.16 — end-to-end: a hostile `;`-bearing attribute value routed
+;; through the public :rf.server/set-cookie effect and the Ring handler MUST
+;; NOT emit a forged Secure/SameSite attribute; the structured failure routes
+;; through the fx error contract and no cookie header is written.
+(deftest handler-cookie-semicolon-attribute-cannot-forge-set-cookie
+  (testing "rf2-j538f7.16 — a `;`-bearing :path cannot smuggle SameSite=None;
+            Secure into the emitted Set-Cookie header"
+    (rf/reg-event :init/hostile-cookie
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name  "sid"
+                :value "abc"
+                :path  "/; SameSite=None; Secure"}]]}))
+    (rf/reg-view* :pages/hostile-cookie
+      (fn [] [:div "hostile"]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:initial-events [[:init/hostile-cookie]]
+                      :root-view [:pages/hostile-cookie]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          headers  (:headers response)
+          set-cookie (or (get headers "Set-Cookie") (get headers "set-cookie"))]
+      ;; The fx boundary rejects the hostile attribute, so no cookie is
+      ;; accumulated and no Set-Cookie header is emitted — the forged
+      ;; SameSite/Secure attributes never reach the wire.
+      (is (nil? set-cookie)
+          "hostile cookie is rejected at the fx boundary — no Set-Cookie header")
+      (when (some? set-cookie)
+        (let [wire (str/join "\n" (if (vector? set-cookie) set-cookie [set-cookie]))]
+          (is (not (str/includes? wire "SameSite=None"))
+              "no forged SameSite=None attribute")
+          (is (not (str/includes? wire "Secure"))
+              "no forged Secure attribute"))))))
+
 (deftest cookie-name-rfc6265-token-grammar
   (testing "rf2-rpedl §P2.4 — cookie :name violating the RFC 6265 §4.1.1
             token grammar throws :rf.error/cookie-invalid-name"

--- a/implementation/ssr/src/re_frame/ssr/http_validation.cljc
+++ b/implementation/ssr/src/re_frame/ssr/http_validation.cljc
@@ -9,13 +9,24 @@
   immediately before bytes reach the host. Keeping the predicates here makes
   that defence-in-depth policy portable without duplicating the grammars.
 
-  Two grammars:
+  Three grammars:
 
     - `injection-char-re`  — the three control chars RFC 7230 §3.2.4
                              forbids inside any header value (`\\r` / `\\n`
                              / `\\x00`). A value carrying one would split
                              the header on the wire (header-splitting
                              injection).
+    - `cookie-attr-injection-re` — the header-splitting chars PLUS the raw
+                             `;` cookie-attribute delimiter (RFC 6265
+                             §4.1.1). A Set-Cookie attribute (`:domain` /
+                             `:path` / `:max-age` / `:same-site` /
+                             `:expires`) is concatenated verbatim after a
+                             `; ` separator, so a `;` inside its value
+                             escapes the assigned attribute and fabricates
+                             additional attributes (`SameSite=None`,
+                             `Secure`, …). Cookie `:value` is exempt — the
+                             host serialiser percent-encodes it, so a `;`
+                             there stays data (`%3B`).
     - `token-name-re`      — RFC 7230 §3.2.6 `token` (= RFC 6265 §4.1.1
                              cookie-name): `1*tchar` where `tchar` is the
                              visible US-ASCII set MINUS the separators
@@ -24,7 +35,8 @@
                              the grammar is auditable in place; the `+`
                              quantifier rejects empty names.
 
-  Two predicates (`contains-injection-char?`, `valid-token-name?`) carry
+  Three predicates (`contains-injection-char?`,
+  `contains-cookie-attr-injection-char?`, `valid-token-name?`) carry
   the accept/reject decision; the THROW shape stays at each callsite
   because the two boundaries surface distinct `:where` tags that are part
   of each layer's documented contract — the fx boundary throws
@@ -48,6 +60,18 @@
   the wire and let an attacker forge second-and-later headers."
   #"[\r\n\x00]")
 
+(def cookie-attr-injection-re
+  "The RFC 7230 §3.2.4 header-splitting chars (CR / LF / NUL) PLUS the raw
+  `;` RFC 6265 §4.1.1 cookie-attribute delimiter. A Set-Cookie attribute
+  value (`:domain` / `:path` / `:max-age` / `:same-site` / `:expires`) is
+  concatenated verbatim after a `; ` separator, so a `;` inside the value
+  is itself a delimiter — it escapes the assigned attribute and fabricates
+  additional attributes (`SameSite=None`, `Secure`, `Max-Age=0`, …),
+  defeating the structured-cookie boundary. Cookie `:value` does NOT use
+  this grammar: the host serialiser percent-encodes it (`;` → `%3B`), so
+  data stays data."
+  #"[\r\n\x00;]")
+
 (def token-name-re
   "RFC 7230 §3.2.6 `token` grammar (= RFC 6265 §4.1.1 cookie-name):
   `1*tchar`, where `tchar` is the visible US-ASCII set MINUS the
@@ -64,6 +88,19 @@
   value is rendered for both the check and the error payload."
   [s]
   (boolean (re-find injection-char-re s)))
+
+(defn contains-cookie-attr-injection-char?
+  "True when string `s` carries a CR / LF / NUL (RFC 7230 §3.2.4
+  header-splitting) OR a `;` (the RFC 6265 §4.1.1 cookie-attribute
+  delimiter). The wire-grammar gate for Set-Cookie attributes concatenated
+  verbatim into the header line — `:domain` / `:path` / `:max-age` /
+  `:same-site` / `:expires`. NOT for cookie `:value`, which the host
+  serialiser percent-encodes; use `contains-injection-char?` there. Callers
+  `(str v)`-coerce before the check; this fn does NOT coerce so the caller
+  controls how a non-string value is rendered for both the check and the
+  error payload."
+  [s]
+  (boolean (re-find cookie-attr-injection-re s)))
 
 (defn valid-token-name?
   "True when string `s` is a non-empty RFC 7230 §3.2.6 `token` (the

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -374,24 +374,40 @@
   `re-frame.projection/project-egress` (over the shared `elide-wire-value`
   walker) — never a family-private elider.
 
-  No-live-frame ⇒ the slice rides VERBATIM, mirroring the sibling machines
-  snapshot projection (`re-frame.machines.ssr/project-snapshot-data` rides
-  verbatim when `frame-id` is nil). The route classification is a PATH-precise
-  redaction of declared `:query` / `:params` slots — like machines, it is not a
-  fail-closed whole-value scrub: with no live frame there are no route
-  declarations to apply, so the durable route slice (already allowlisted to
-  `:current`) passes through. A real server render always carries the live
-  request frame, so the projection runs against that frame's route declarations.
-  This is why we do NOT hand a kindless slice straight to `project-egress` with
-  a nil frame (which would fail closed and redact the whole `:current` slice to
-  `:rf/redacted`)."
+  Fail-closed on a lost frame (rf2-j538f7.15): an EXPLICIT `frame-id` is handed
+  STRAIGHT to `project-egress`, which is PATH-precise under a LIVE frame (an
+  unclassified route slice rides verbatim — only the declared `:query` /
+  `:params` slots redact / elide) and FAILS CLOSED under a destroyed /
+  re-registered / unresolvable one (the whole `:current` slice redacts to
+  `:rf/redacted`). This is the SAME fail-closed posture as
+  `project-app-db-egress`. It closes the teardown-race leak: a `:current` route
+  slice captured while its frame was live no longer rides RAW once that frame is
+  torn down (or re-registered under the same id) between capture and projection —
+  its classification authority is gone, so the slice fails closed rather than
+  serialising declared `:query` / `:params` under no policy. The PRIOR guard
+  rode the slice VERBATIM whenever the frame was not live, which is exactly the
+  leak: a stale explicit target shipped the raw classified route state.
+
+  A nil `frame-id` is the frameless / ambient-nil convenience (the one-arity
+  `project-runtime-db` called outside any frame): there is no frame policy to
+  lose, so the already-allowlisted durable `:current` slice rides VERBATIM.
+  Handing a nil frame to `project-egress` would fail closed and redact the whole
+  slice — wrong for genuinely frameless projection. The security-critical
+  builders always pass the live request frame explicitly, so the fail-closed arm
+  governs every real render; the verbatim arm is only the no-target convenience."
   [slice frame-id]
-  (if (and (some? frame-id) (some? (frame/frame frame-id)))
+  (if (some? frame-id)
+    ;; Explicit target: project-egress is precise under a live frame and fails
+    ;; closed (redacts whole) under a destroyed / re-registered / unresolvable
+    ;; one — no longer routed around (the former verbatim else-branch was the
+    ;; rf2-j538f7.15 leak).
     (projection/project-egress
       slice
       {:frame             frame-id
        :path              [:rf.runtime/routing]
        :rf.egress/profile :rf.egress/ssr-hydration})
+    ;; No explicit target (frameless / ambient-nil convenience): no frame policy
+    ;; to lose, so the allowlisted durable slice rides verbatim.
     slice))
 
 ;; ---- runtime-db hydration projection --------------------------------------
@@ -527,11 +543,27 @@
    (project-runtime-db runtime-db (frame/resolve-current-frame)))
   ([runtime-db frame-id]
    (when (map? runtime-db)
-    (let [project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
+    (let [;; rf2-j538f7.15 — an EXPLICIT `frame-id` that no longer resolves to a
+          ;; LIVE frame (destroyed, or re-registered under the same id, between
+          ;; the caller's state capture and this projection) has lost the
+          ;; per-frame elision registry that classifies every user-bearing
+          ;; runtime-db slice. Routing fails closed on its own (`project-routing-
+          ;; egress` delegates to `project-egress`, which redacts a dead-frame
+          ;; slice whole); but the MACHINES snapshot hook and the RESOURCE
+          ;; extension hook classify PRECISELY only under a live frame and would
+          ;; otherwise ride the captured, still-classified state VERBATIM under
+          ;; absent policy — so when the explicit target is stale we do NOT
+          ;; invoke them: the machines slice redacts whole and the resource slice
+          ;; is omitted. A nil `frame-id` is the frameless / ambient-nil
+          ;; convenience (no frame policy to lose) and stays precise, matching the
+          ;; established one-arity contract.
+          stale-target?    (and (some? frame-id) (nil? (frame/frame frame-id)))
+          project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
           machines-slice   (when (contains? runtime-db :rf.runtime/machines)
-                             (if project-machines
-                               (project-machines runtime-db frame-id)
-                               (:rf.runtime/machines runtime-db)))
+                             (cond
+                               stale-target?    :rf/redacted
+                               project-machines (project-machines runtime-db frame-id)
+                               :else            (:rf.runtime/machines runtime-db)))
           ;; Allowlist the durable routing keys (only `:current` rides; the
           ;; transient `:pending-navigation` / counter siblings stay off the
           ;; wire — fail-closed), THEN project the surviving slice against the
@@ -575,7 +607,13 @@
                   ;; hook is re-signatured `[runtime-db frame-id]`), so it projects
                   ;; under the same frame as every other slice, never a borrowed /
                   ;; mismatched ambient one — no `binding` rebind of ambient scope.
-                  (merge slice (extend-fn runtime-db frame-id))
+                  ;; rf2-j538f7.15 — but under a STALE explicit target its derived
+                  ;; `:entries` would ride verbatim under absent policy, so fail
+                  ;; closed by OMITTING the resource slice (do not invoke the hook
+                  ;; with a dead frame).
+                  (if stale-target?
+                    slice
+                    (merge slice (extend-fn runtime-db frame-id)))
                   slice)]
       (when (seq slice) slice)))))
 

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -235,30 +235,54 @@
 
 (defn- validate-cookie-attr!
   "Throw the catalogued `:rf.error/cookie-invalid-attribute` (Spec 009) if
-  the cookie attribute string contains CR / LF / NUL. Applied to EVERY
-  attribute a host adapter concatenates into the Set-Cookie wire form — the
-  members of `checked-cookie-attrs`. The value is `str`-coerced first because
-  callers legitimately pass non-string forms (`:max-age` as an int,
-  `:expires` as an epoch-millis long); the CR/LF/NUL ban applies to the
-  serialised form a host adapter would emit. The offending attribute rides
-  the payload's `:attribute` slot — the SAME error id + `{:attribute :value}`
-  emit shape the Ring materialiser throws, so the fx boundary and the wire serialiser share one catalogued
-  vocabulary: the injection class is one fact, and WHICH attribute carried the
-  injection char is data, not a distinct error id. Spec 011 §CRLF fail-fast mandates
-  checking EVERY attribute, not just :value — an attacker who controls any one
-  attribute must not be able to re-enter the header line as CRLF-bearing
-  payload)."
+  the cookie attribute string carries a forbidden wire-grammar char. Applied
+  to EVERY attribute a host adapter concatenates into the Set-Cookie wire
+  form — the members of `checked-cookie-attrs`.
+
+  Two grammars, one error id:
+    - `:value` is percent-encoded by the host serialiser, so it bans only
+      the CR / LF / NUL header-splitting chars (a `;` in `:value` is safe —
+      it serialises as `%3B`).
+    - every OTHER attribute (`:path` / `:domain` / `:max-age` /
+      `:same-site` / `:expires`) is concatenated VERBATIM after `; `
+      separators, so it additionally bans the raw `;` RFC 6265 §4.1.1
+      cookie-attribute delimiter — a `;` there escapes its attribute and
+      fabricates extra attributes (`SameSite=None`, `Secure`, `Max-Age=0`,
+      …), defeating the structured-cookie boundary.
+
+  The value is `str`-coerced first because callers legitimately pass
+  non-string forms (`:max-age` as an int, `:expires` as an epoch-millis
+  long); the ban applies to the serialised form a host adapter would emit.
+  The offending attribute rides the payload's `:attribute` slot — the SAME
+  error id + `{:attribute :value}` emit shape the Ring materialiser throws,
+  so the fx boundary and the wire serialiser share one catalogued
+  vocabulary: the injection class is one fact, and WHICH attribute carried
+  the injection char is data, not a distinct error id. Spec 011 §CRLF
+  fail-fast mandates checking EVERY attribute, not just :value — an attacker
+  who controls any one attribute must not be able to re-enter the header
+  line as CRLF- or delimiter-bearing payload)."
   [attr-key v]
-  (let [s (str v)]
-    (when (http-validation/contains-injection-char? s)
+  (let [s      (str v)
+        ;; `:value` is percent-encoded downstream, so `;` there is data;
+        ;; every other attribute is concatenated verbatim and must also
+        ;; reject the `;` cookie-attribute delimiter.
+        value? (= attr-key :value)
+        bad?   (if value?
+                 (http-validation/contains-injection-char? s)
+                 (http-validation/contains-cookie-attr-injection-char? s))]
+    (when bad?
       (error/throw-error!
         :rf.error/cookie-invalid-attribute
         'rf.ssr/response
         (str "cookie attribute " attr-key " " (pr-str s)
-             " contains CR/LF/NUL — forbidden by"
-             " RFC 7230 §3.2.4 (header-splitting"
-             " injection). Strip CR/LF/NUL from the cookie "
-             (name attr-key) ".")
+             (if value?
+               " contains CR/LF/NUL — forbidden by RFC 7230 §3.2.4"
+               (str " contains CR/LF/NUL or a `;` — forbidden by"
+                    " RFC 7230 §3.2.4 and RFC 6265 §4.1.1 (the `;` is the"
+                    " cookie-attribute delimiter)"))
+             " (header-splitting / attribute injection). Strip "
+             (if value? "CR/LF/NUL" "CR/LF/NUL and `;`")
+             " from the cookie " (name attr-key) ".")
         {:recovery :remove-injection-chars-from-cookie-attr
          :extra    {:attribute attr-key
                     :value     v}}))

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -638,31 +638,58 @@
   validates at handler-construction time so misconfigured deployments
   fail at boot rather than at first request."
   [frame-id render-hash {:as policy-opts}]
-  (let [app-db     (frame/frame-app-db-value frame-id)
+  (let [;; rf2-j538f7.15 — pin the frame's per-incarnation identity BEFORE
+        ;; reading its state. The app-db / runtime-db below are captured off the
+        ;; LIVE request frame and classified against THAT frame's per-frame
+        ;; elision registry by the projections that follow. An async host
+        ;; (disconnect / timeout / writer-error / cancellation cleanup) can
+        ;; destroy — or destroy AND re-register under the same id — the request
+        ;; frame between this capture and the projection; re-checking the
+        ;; incarnation token below detects both, so classified state is never
+        ;; serialized under an absent or SUBSTITUTED policy.
+        token      (frame/frame-incarnation-token frame-id)
+        app-db     (frame/frame-app-db-value frame-id)
         ;; EP-0001 (rf2-30kzz2): project the live runtime-db value to the
         ;; serializable `:rf/runtime-db` slice (machine snapshots, route slice,
         ;; elision declarations, SSR metadata) so the streamed final payload
         ;; hydrates a coherent frame-state, symmetric with the non-streaming
         ;; path. Transient side channels are excluded by `project-runtime-db`.
-        runtime-db (frame/frame-runtime-db-value frame-id)]
-    (payload-policy/build-payload
-     frame-id
-     ;; rf2-bt9kct — allowlist FIRST (`apply-policy`), THEN run the surviving
-     ;; slice through the centralized `:rf.egress/ssr-hydration` projection
-     ;; seeded at the request frame (defense-in-depth, EP-0015 §14) — symmetric
-     ;; with the non-streaming `re-frame.ssr.ring.payload/build-payload` so a
-     ;; frame-sensitive child inside an allowlisted key never rides the final
-     ;; `__rf_payload` raw.
-     (payload-policy/project-app-db-egress
-      (payload-policy/apply-policy app-db policy-opts)
-      frame-id)
-     render-hash
-     ;; rf2-3fc89f.15 — project the runtime-db under the EXPLICIT carried
-     ;; `frame-id` (the same target the app-db projection above uses), NOT an
-     ;; ambient one. A streaming build called outside `with-frame`, or under a
-     ;; different ambient frame, otherwise serialized classified route / machine
-     ;; / resource runtime state under nil / the wrong frame's policy.
-     (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))))
+        runtime-db (frame/frame-runtime-db-value frame-id)
+        ;; The captured state is coherent ONLY if the frame is STILL the same
+        ;; live incarnation it was at capture. A nil pin (frame already gone) or
+        ;; a changed token (destroyed / re-registered mid-assembly) fails closed.
+        coherent?  (and (some? token)
+                        (identical? token (frame/frame-incarnation-token frame-id)))]
+    (if coherent?
+      (payload-policy/build-payload
+       frame-id
+       ;; rf2-bt9kct — allowlist FIRST (`apply-policy`), THEN run the surviving
+       ;; slice through the centralized `:rf.egress/ssr-hydration` projection
+       ;; seeded at the request frame (defense-in-depth, EP-0015 §14) — symmetric
+       ;; with the non-streaming `re-frame.ssr.ring.payload/build-payload` so a
+       ;; frame-sensitive child inside an allowlisted key never rides the final
+       ;; `__rf_payload` raw.
+       (payload-policy/project-app-db-egress
+        (payload-policy/apply-policy app-db policy-opts)
+        frame-id)
+       render-hash
+       ;; rf2-3fc89f.15 — project the runtime-db under the EXPLICIT carried
+       ;; `frame-id` (the same target the app-db projection above uses), NOT an
+       ;; ambient one. A streaming build called outside `with-frame`, or under a
+       ;; different ambient frame, otherwise serialized classified route / machine
+       ;; / resource runtime state under nil / the wrong frame's policy.
+       (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))
+      ;; rf2-j538f7.15 — the request frame was destroyed / re-registered between
+      ;; state capture and projection: its classification authority is gone, so
+      ;; the captured app-db / runtime-db must NOT ship under absent / substituted
+      ;; policy. Fail closed — redact the whole app-db slice and omit the
+      ;; runtime-db — while still stamping the requested target so the client sees
+      ;; a well-formed, safe payload rather than a leak.
+      (payload-policy/build-payload
+       frame-id
+       :rf/redacted
+       render-hash
+       (assoc policy-opts :runtime-db nil)))))
 
 ;; ---- late-bind hook registration -----------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -2213,6 +2213,71 @@
           (is (= :max-age (:attribute (fx-error-extra traces :rf.error/cookie-invalid-attribute)))
               (str "hostile :max-age " (pr-str hostile) " rides the :attribute payload slot")))))))
 
+(deftest ssr-set-cookie-rejects-semicolon-attribute-delimiter
+  (testing "rf2-j538f7.16 / Spec 011 §Cookie shape: :rf.server/set-cookie
+            rejects a raw `;` in every VERBATIM-concatenated attribute
+            (:path / :domain / :max-age / :same-site / :expires). The `;` is
+            the RFC 6265 §4.1.1 cookie-attribute delimiter — a value carrying
+            one would escape its attribute and fabricate additional
+            attributes (SameSite=None, Secure, …), defeating the structured-
+            cookie boundary. The fx boundary is the single enforcement point
+            for non-Ring host adapters that serialise the accumulator
+            themselves; failures route through the one catalogued
+            :rf.error/cookie-invalid-attribute id with the offending
+            :attribute in the payload."
+    (doseq [[attr hostile] [[:path      "/; SameSite=None; Secure"]
+                            [:domain    "evil.com; Secure"]
+                            [:max-age   "3600; SameSite=None; Secure"]
+                            [:same-site "Lax; Secure"]
+                            [:expires   "Wed, 09 Jun 2027 10:18:14 GMT; Secure"]]]
+      (rf/reg-event :ck/semicolon-attr
+        (fn [_ _]
+          {:fx [[:rf.server/set-cookie
+                 (assoc {:name "sid" :value "abc"} attr hostile)]]}))
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:ck/semicolon-attr] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/cookie-invalid-attribute
+          (str "set-cookie with `;` in " attr " " (pr-str hostile)))
+        (is (= attr (:attribute (fx-error-extra traces :rf.error/cookie-invalid-attribute)))
+            (str "the offending attribute (" attr ") rides the :attribute payload slot"))
+        (is (empty? (:cookies (get-response f)))
+            (str "no cookie lands on the accumulator — `;` in " attr
+                 " is a rejected no-op")))))
+
+  (testing "rf2-j538f7.16 — a `;` in cookie :value is DATA (the host serialiser
+            percent-encodes it), so set-cookie ACCEPTS it and stores it
+            verbatim on the accumulator — no over-rejection"
+    (rf/reg-event :ck/semicolon-value
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie {:name "sid" :value "a;b" :path "/"}]]}))
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/semicolon-value] {:frame f})))
+          cookies (:cookies (get-response f))]
+      (is (empty? (fx-error-extra traces :rf.error/cookie-invalid-attribute))
+          "no cookie-invalid-attribute error for a `;` in :value")
+      (is (= 1 (count cookies)) "the cookie lands on the accumulator")
+      (is (= "a;b" (:value (first cookies)))
+          "the `;`-bearing :value is stored verbatim (encoding is host-adapter business)")))
+
+  (testing "rf2-j538f7.16 — :rf.server/delete-cookie runs the same delimiter
+            gate on :path and :domain (it is sugar over set-cookie)"
+    (doseq [attr [:path :domain]]
+      (rf/reg-event :ck/del-semicolon
+        (fn [_ _]
+          {:fx [[:rf.server/delete-cookie
+                 (assoc {:name "sid"} attr "x; Secure")]]}))
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:ck/del-semicolon] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/cookie-invalid-attribute
+          (str "delete-cookie with `;` in " attr))
+        (is (= attr (:attribute (fx-error-extra traces :rf.error/cookie-invalid-attribute)))
+            (str "delete-cookie `;` in " attr " rides the :attribute payload slot"))))))
+
 (deftest ssr-set-cookie-rejects-non-string-name-type
   (testing "rf2-9t17id — a cookie :name that is neither a string nor a Named
             (keyword / symbol) is rejected at the fx boundary with the

--- a/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
@@ -250,3 +250,134 @@
         (is (= "secret-oauth-token" (get-in current [:query :token]))
             "one-arity under ambient B applies B's (absent) policy — the
              documented fallback; explicit target is required for correctness")))))
+
+;; ===========================================================================
+;; rf2-j538f7.15 — fail closed when the payload projection loses its frame
+;; during teardown.
+;;
+;; The explicit-frame projectors above assume the carried frame stays LIVE
+;; through payload assembly. An async host (disconnect / timeout / writer-error
+;; / cancellation cleanup) can destroy — or destroy AND re-register under the
+;; same id — the request frame between the caller's state CAPTURE and the
+;; PROJECTION. The prior `project-routing-egress` (and the machines / resource
+;; hooks) rode the captured, still-classified state VERBATIM whenever the frame
+;; was no longer live: the payload was stamped for A yet its policy came from no
+;; live frame, so the classified route :query / machine :data rode RAW. These
+;; regressions prove the projection now fails CLOSED on a lost / substituted
+;; frame while a LIVE frame with no declarations still ships verbatim.
+;; ===========================================================================
+
+(deftest project-routing-egress-fails-closed-on-destroyed-frame
+  (testing "rf2-j538f7.15 — the route :current slice captured while frame A was
+            LIVE fails closed once A is destroyed, and is distinguished from the
+            live-frame precise projection and the frameless-nil passthrough"
+    (setup-frame-a!)
+    (let [slice (select-keys (:rf.runtime/routing (frame/frame-runtime-db-value server-frame))
+                             [:current])]
+      ;; Acceptance #6, first clause: a LIVE frame with declarations projects
+      ;; PRECISELY — the sensitive token redacts, the unclassified sibling rides.
+      (let [live (payload-policy/project-routing-egress slice server-frame)]
+        (is (= :rf/redacted (get-in live [:current :query :token]))
+            "LIVE frame A: declared sensitive :query :token redacts precisely")
+        (is (= "/dashboard" (get-in live [:current :query :return-to]))
+            "LIVE frame A: unclassified sibling rides verbatim"))
+      ;; Acceptance #6, frameless clause: a NIL frame-id is the frameless
+      ;; convenience — no frame policy to lose, so the slice rides verbatim.
+      (is (= slice (payload-policy/project-routing-egress slice nil))
+          "NIL frame: frameless passthrough (NOT fail-closed)")
+      ;; The teardown race: destroy A, then re-project the ALREADY-captured slice
+      ;; under the same EXPLICIT id. Acceptance #1 — fail closed.
+      (rf/destroy-frame! server-frame)
+      (let [dead (payload-policy/project-routing-egress slice server-frame)]
+        (is (= :rf/redacted dead)
+            "DESTROYED explicit frame: the whole :current slice fails closed")
+        (is (not (.contains (pr-str dead) "secret-oauth-token"))
+            "no raw route token survives the fail-closed projection")))))
+
+(deftest project-runtime-db-fails-closed-on-destroyed-frame
+  (testing "rf2-j538f7.15 (acceptance #4) — project-runtime-db on a frame
+            destroyed after runtime-db capture fails closed for BOTH the machine
+            snapshot :data and the routing :current slice; no raw classified
+            value survives, while a LIVE frame still projects them precisely"
+    (setup-frame-a!)
+    (let [rt (frame/frame-runtime-db-value server-frame)]
+      ;; sanity — LIVE A projects machine :data + route precisely
+      (let [live (payload-policy/project-runtime-db rt server-frame)]
+        (is (= :rf/redacted (get-in live [:rf.runtime/machines :snapshots machine-id :data :token]))
+            "LIVE frame A: machine snapshot :data :token redacts")
+        (is (= :rf/redacted (get-in live [:rf.runtime/routing :current :query :token]))
+            "LIVE frame A: route :current :query :token redacts"))
+      ;; teardown race
+      (rf/destroy-frame! server-frame)
+      (let [dead (payload-policy/project-runtime-db rt server-frame)]
+        (is (= :rf/redacted (:rf.runtime/machines dead))
+            "DESTROYED frame: the machines slice fails closed whole (the hook is
+             not invoked with a dead frame)")
+        (is (= :rf/redacted (:rf.runtime/routing dead))
+            "DESTROYED frame: the routing slice fails closed via project-routing-egress")
+        (doseq [secret ["secret-oauth-token" "huge-callback-blob-value"
+                        "secret-jwt-snapshot" "huge-blob-value"]]
+          (is (not (.contains (pr-str dead) secret))
+              (str "no raw classified value (" secret ") survives")))))))
+
+(deftest build-final-payload-fails-closed-on-teardown-race
+  (testing "rf2-j538f7.15 (acceptance #2) — the REAL streaming builder: frame A
+            is destroyed AFTER its runtime-db is captured but BEFORE projection
+            (an async-host teardown race, DR#4). build-final-payload fails closed
+            — app-db redacts whole, runtime-db omitted — even though the payload
+            is still stamped for A; no classified route / machine / app-db value
+            survives."
+    (setup-frame-a!)
+    (let [orig    frame/frame-runtime-db-value
+          payload (with-redefs [frame/frame-runtime-db-value
+                                (fn [fid]
+                                  ;; DR#4 interposition: capture the live
+                                  ;; runtime-db, THEN tear the frame down before
+                                  ;; the projection proceeds.
+                                  (let [v (orig fid)]
+                                    (rf/destroy-frame! server-frame)
+                                    v))]
+                    (streaming/build-final-payload
+                      server-frame "hash"
+                      {:payload :rf.ssr.payload/whole-app-db}))]
+      (is (= server-frame (:rf/frame-id payload))
+          "the payload still names frame A as its target")
+      (is (= :rf/redacted (:rf/app-db payload))
+          "app-db fails closed to :rf/redacted (the frame vanished before projection)")
+      (is (not (contains? payload :rf/runtime-db))
+          "the runtime-db slice is omitted — no durable frame-state under a dead frame")
+      (doseq [secret ["secret-oauth-token" "huge-callback-blob-value"
+                      "secret-jwt-snapshot" "huge-blob-value" "app-db-secret"]]
+        (is (not (.contains (pr-str payload) secret))
+            (str "no raw classified value (" secret ") survives the fail-closed payload"))))))
+
+(deftest build-final-payload-fails-closed-on-frame-reregistration
+  (testing "rf2-j538f7.15 (acceptance #5) — frame A destroyed AND re-registered
+            under the SAME id (a NEW incarnation with an absent policy) between
+            capture and projection must NOT substitute the new frame's policy for
+            the old frame's captured, classified data. The incarnation-token
+            check fails closed rather than shipping A-old's token under A-new's
+            wide-open registry."
+    (setup-frame-a!)
+    (let [orig    frame/frame-runtime-db-value
+          payload (with-redefs [frame/frame-runtime-db-value
+                                (fn [fid]
+                                  (let [v (orig fid)]
+                                    ;; destroy A, then re-register a FRESH A that
+                                    ;; declares nothing — a wide-open policy that
+                                    ;; WOULD ship A-old's secret raw if substituted.
+                                    (rf/destroy-frame! server-frame)
+                                    (rf/reg-frame server-frame {:platform :server})
+                                    v))]
+                    (streaming/build-final-payload
+                      server-frame "hash"
+                      {:payload :rf.ssr.payload/whole-app-db}))]
+      (is (= server-frame (:rf/frame-id payload))
+          "the payload still names frame A as its target")
+      (is (= :rf/redacted (:rf/app-db payload))
+          "app-db fails closed — the re-registered frame's absent policy is not substituted")
+      (is (not (contains? payload :rf/runtime-db))
+          "the runtime-db slice is omitted under the substituted incarnation")
+      (doseq [secret ["secret-oauth-token" "secret-jwt-snapshot" "app-db-secret"]]
+        (is (not (.contains (pr-str payload) secret))
+            (str "no raw classified value (" secret ") rides under the new-frame policy"))))))


### PR DESCRIPTION
Two-bead SSR-family correctness/privacy cluster from the Wave-2 post-remediation review. One commit per bead.

## rf2-j538f7.15 (P2) — Fail closed when SSR payload projection loses its frame during teardown

**Leak.** The runtime-db hydration projectors rode captured, still-classified state VERBATIM whenever the carried frame was no longer live. An async host (disconnect / timeout / writer-error / cancellation cleanup) can destroy — or destroy AND re-register under the same id — the request frame between the caller's state capture and the projection. The payload was still stamped `:rf/frame-id A` yet its policy came from no live frame, so a classified route `:query`/`:params` slice, machine snapshot `:data`, and resource `:entries` could ride `__rf_payload` RAW milliseconds after being redacted.

**Fix (fail closed on a lost frame).**
- `project-routing-egress` now delegates an EXPLICIT frame straight to `project-egress` (precise under a live frame, whole-value `:rf/redacted` under a destroyed / re-registered / unresolvable one) — matching `project-app-db-egress`. It no longer routes around `project-egress`'s fail-closed on a dead frame; that verbatim else-branch was the leak. A **nil** `frame-id` stays the frameless / ambient-nil convenience (verbatim), so the one-arity contract and all existing frameless tests are unchanged.
- `project-runtime-db` computes the stale-target case once and fails closed the hook-projected slices a live frame is required to classify precisely: the machines snapshot slice redacts whole, the resource-extension slice is omitted (the hooks are never invoked with a dead frame). These hooks live in the `machines`/`resources` artefacts (out of surface); guarding at the SSR orchestration layer closes the leak without touching them.
- `streaming/build-final-payload` pins the frame's **incarnation token** before reading its state and re-checks it before projecting. On identity loss (destroyed, or re-registered under the same id) it fails closed — app-db redacts whole, runtime-db omitted — so a re-registered frame's absent policy can never be substituted for the old frame's captured, classified data.
- The non-streaming Ring wrapper inherits fail-closed-on-dead-frame through the same projectors (no signature change needed).

Fail-closed by **redaction** (not a new error id), so no Spec 009 error-catalogue row is required.

## rf2-j538f7.16 (P2) — ssr-ring cookie attribute semicolon escapes structured Set-Cookie boundary

**Bug.** The Set-Cookie serialiser and the `:rf.server/set-cookie`/`delete-cookie` fx boundary validated attributes for CR/LF/NUL only. A raw `;` inside `:path`/`:domain`/`:max-age`/`:same-site`/`:expires` is the RFC 6265 §4.1.1 cookie-attribute delimiter, so it escaped its assigned attribute and fabricated additional attributes (`SameSite=None`, `Secure`, `Domain`, `Max-Age=0`) — defeating the structured-cookie boundary while staying on one Set-Cookie line.

**Fix.** A shared `contains-cookie-attr-injection-char?` predicate (CR/LF/NUL + `;`) in `re-frame.ssr.http-validation`, applied from both boundaries under the existing catalogued `:rf.error/cookie-invalid-attribute` id. Cookie `:value` stays delimiter-tolerant: the host serialiser percent-encodes it (`;` → `%3B`), so data stays data — no over-rejection.

## Scope note
Per the worktree brief, this PR is scoped to `implementation/ssr` + `implementation/ssr-ring` (src+test). The spec-doc updates the beads mention (Spec 011 §Cookie shape / §CRLF, the Spec 009 `:rf.error/cookie-invalid-attribute` catalogue text, and the Spec 011 payload-build liveness/teardown contract) are **outside that surface** and touch hot-zone files (009, Spec-Schemas), so they are deferred to a follow-up rather than edited in this parallel worker.

## Quality gates
All foreground, 0 failures / 0 errors:
- `implementation/ssr` `clojure -M:test` — 380 tests / 1611 assertions (+4 deftests / +27 assertions)
- `implementation/ssr-ring` `clojure -M:test` — 184 tests / 893 assertions (+1 deftest / +6 assertions)
- `implementation/ssr-ring` `clojure -M:slow-test` — 3 tests / 33 assertions
- `implementation` `npm run test:cljs` — 8491 tests / 39732 assertions