### PR TITLE
fix(machines-viz): recursive canonical grammar matches runtime validity (rf2-j538f7.18)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -51,7 +51,7 @@ registry).
 | Prop | Required | Default | Meaning |
 |---|---|---|---|
 | `:machine-id` | no | `nil` | Identifies the machine. Surfaces as the chart's aria-label and on every per-node `:data` payload (read by tests + hosts). |
-| `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
+| `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. A **structurally-invalid** definition (rf2-j538f7.18) is REJECTED by the canonical recursive grammar gate INSIDE `chart.layout/project-definition` BEFORE graph construction — nothing reaches ELK and no orphan edges to absent nodes are created; the chart renders a distinct **invalid-definition** placeholder (`data-testid "…-invalid-definition"`, `data-invalid-definition "<:rf.error/machine-* category>"`) carrying the value-free defect category + structural path. The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
 | `:current-state` | no | `nil` | The live snapshot `:state` value for the active-state highlight. Accepts all three Spec 005 `:state` arms: a flat keyword (`:authing`), a hierarchical path (`[:auth :authing]`), **or a parallel region-map** (`{:data :loading :form :neutral}`). For a region-map the chart lights up **every** active region leaf simultaneously (the multi-active highlight — see [§Parallel multi-active highlight](#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)). `nil` renders no highlight. |
 | `:from-highlight` | no | `nil` | Focused-event lens origin (a `:state` value). |
 | `:to-highlight` | no | `nil` | Focused-event lens landing (a `:state` value). |
@@ -1689,7 +1689,7 @@ Failure modes:
 | `:malformed-payload` | Decoded bytes aren't valid transit. |
 | `:missing-envelope` | The payload is missing `:rf.machines-viz.share/v` or `:rf.machines-viz.share/chart`. |
 | `:unknown-version` | `:rf.machines-viz.share/v` is newer than the decoder knows. |
-| `:invalid-chart-state` | `:rf.machines-viz.share/chart` doesn't validate. |
+| `:invalid-chart-state` | `:rf.machines-viz.share/chart` doesn't validate. The `:definition` slot is checked by the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18), so a forged URL carrying a definition that is structurally invalid BELOW the root (a nested compound missing `:initial`, a dangling target, an unknown bare node key) fails closed at BOTH encode and decode, not just a shallow root-shape violation. |
 
 ### Pipeline
 
@@ -2168,7 +2168,7 @@ sentence, and `ex-message` leads with the sentence and trails the
 
 | `:rf.error/id` | Meaning |
 |---|---|
-| `:scxml/invalid-spec` | Input spec missing `:initial` / `:states` (or `:type :parallel` / `:regions`). |
+| `:scxml/invalid-spec` | Input spec fails the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18): not just a missing root `:initial` / `:states` (or `:type :parallel` / `:regions`), but any structural defect the runtime machine contract rejects at `reg-machine` — a nested compound missing `:initial`, a dangling / malformed transition target, an unknown bare node / spawn key, a malformed history / final-state / `:tags` / `:after`-delay shape. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id). |
 | `:scxml/parse-error`  | Input XML is malformed or missing the `<scxml>` root. |
 
 ## AI-generate-a-machine (v1.1, rf2-1bncf)
@@ -2228,8 +2228,21 @@ resolver) from the parse/validate step (this ns). The fn:
 2. Hands the prompt to `:resolver` and waits for a string response.
 3. Strips fenced code blocks (```clojure / ```edn / bare) tolerantly,
    so the LLM may emit prose around the EDN form.
-4. Parses the EDN form and validates it carries `:initial` + non-
-   empty `:states` (or `:type :parallel` + non-empty `:regions`).
+4. Parses the EDN form and validates it against the **canonical
+   recursive grammar gate** (`grammar/valid-definition?` — rf2-j538f7.18),
+   the single projectability predicate the share boundary, Mermaid, SCXML,
+   and the chart projector all share. This is a **recursive** check, not a
+   shallow root-shape one: it walks the root, every parallel region, and
+   every compound descendant and REJECTS a definition the runtime machine
+   contract would reject at `reg-machine` — a nested compound missing
+   `:initial`, a dangling / malformed transition target, an unknown bare
+   node / spawn key, a malformed history / final-state / `:tags` /
+   `:after`-delay shape, or a mutually-exclusive parallel shape. So the
+   returned spec is genuinely `reg-machine`-registrable (the contract line
+   above), not merely shallowly well-formed. On rejection the thrown
+   `:ai-generate/invalid-spec` carries the value-free
+   `grammar/definition-summary` under `:spec-summary`, whose `:defect`
+   `:category` is the runtime's canonical `:rf.error/machine-*` id.
 
 ### Reserved namespaces
 
@@ -2252,7 +2265,7 @@ sentence, and `ex-message` leads with the sentence and trails the
 |---|---|
 | `:ai-generate/no-resolver`  | `:resolver` opt was not provided. |
 | `:ai-generate/parse-failed` | Resolver output could not be parsed as EDN. |
-| `:ai-generate/invalid-spec` | Parsed value was not a valid machine shape. |
+| `:ai-generate/invalid-spec` | Parsed value failed the canonical **recursive** grammar gate (`grammar/valid-definition?`) — see step 4 above. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id). |
 
 ### Determinism
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -1443,6 +1443,39 @@
                          :border-radius "6px"}}
            "Machine definition is not introspectable — no topology to render."]
 
+          ;; rf2-j538f7.18 — a structurally-invalid definition was REJECTED by
+          ;; the recursive grammar gate (`chart.layout/project-definition`)
+          ;; BEFORE graph construction, so nothing reached ELK. Render a
+          ;; rejection placeholder carrying the value-free canonical defect
+          ;; category (`:rf.error/machine-*`) + structural path — never the raw
+          ;; definition. Must precede the empty-nodes branch (a rejected
+          ;; definition also has empty `:nodes`).
+          (:definition-error parsed)
+          (let [{:keys [defect]} (:definition-error parsed)]
+            [:div {:data-testid         (str testid "-invalid-definition")
+                   :data-machine-id     (str machine-id)
+                   :data-invalid-definition (str (:category defect))
+                   :role                "img"
+                   :aria-label          (str "State machine"
+                                             (when machine-id (str ": " (name machine-id)))
+                                             " has an invalid definition"
+                                             (when (:category defect)
+                                               (str " (" (name (:category defect)) ")"))
+                                             ".")
+                   :style {:padding       "16px"
+                           :font-family   tokens/sans-stack
+                           :font-size     "12px"
+                           :color         (:text-tertiary tokens/tokens)
+                           :background    (:bg-2 tokens/tokens)
+                           :border        (str "1px dashed " (:border-default tokens/tokens))
+                           :border-radius "6px"}}
+             (str "Machine definition is structurally invalid"
+                  (when (:category defect)
+                    (str " — " (name (:category defect))))
+                  (when (seq (:path defect))
+                    (str " at " (pr-str (:path defect))))
+                  " — nothing to render.")])
+
           (empty? (:nodes parsed))
           [:div {:data-testid (str testid "-empty")
                  :data-machine-id (str machine-id)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -1363,23 +1363,38 @@
   ;; edge) and `:type :choice` / `:choice` → `:always` (A5, renders the
   ;; candidate edges). The runtime drives the same lowered forms. Idempotent
   ;; + nil-safe.
-  (let [definition (g/desugar-grammar definition)
-        graph (cond
-                (nil? definition)
-                {:nodes [] :edges [] :initial-path nil}
+  (let [definition (g/desugar-grammar definition)]
+    (cond
+      ;; rf2-j538f7.18 — REJECT a structurally-invalid definition BEFORE graph
+      ;; construction, so a malformed direct host prop (a nested compound missing
+      ;; `:initial`, a dangling transition target, an unknown bare node key, …)
+      ;; never reaches ELK or creates edges to absent nodes. The result carries a
+      ;; value-FREE `:definition-error` (the same `grammar/definition-summary` the
+      ;; emitters/share stash — its `:defect` category = the engine's
+      ;; `:rf.error/machine-*` id) instead of nodes/edges, and `MachineChart`
+      ;; renders a rejection placeholder. A nil definition is NOT an error (it is
+      ;; the "no definition" empty-state placeholder), so it skips this gate.
+      (and (some? definition) (g/definition-defect definition))
+      {:nodes [] :edges [] :initial-path nil
+       :definition-error (g/definition-summary definition)}
 
-                (= :parallel (:type definition))
-                (project-parallel definition)
+      :else
+      (let [graph (cond
+                    (nil? definition)
+                    {:nodes [] :edges [] :initial-path nil}
 
-                :else
-                (project-flat definition))]
-    ;; rf2-skhlw2.1 — surface each guard / action / entry / exit ref's
-    ;; declared `:rf.cofx/requires` (EP-0017 consumer attachment) onto the
-    ;; edges + nodes BEFORE the synthetic root-container wraps the graph (so
-    ;; the wrapper's `:path []` node is never resolved). A no-op for a
-    ;; machine that declares no requires.
-    (-> (attach-cofx-requires definition graph)
-        wrap-in-root-container)))
+                    (= :parallel (:type definition))
+                    (project-parallel definition)
+
+                    :else
+                    (project-flat definition))]
+        ;; rf2-skhlw2.1 — surface each guard / action / entry / exit ref's
+        ;; declared `:rf.cofx/requires` (EP-0017 consumer attachment) onto the
+        ;; edges + nodes BEFORE the synthetic root-container wraps the graph (so
+        ;; the wrapper's `:path []` node is never resolved). A no-op for a
+        ;; machine that declares no requires.
+        (-> (attach-cofx-requires definition graph)
+            wrap-in-root-container)))))
 
 (defn synthetic-node?
   "True when `node` is synthetic layout chrome rather than an occupiable

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -127,7 +127,12 @@
         sp-ms        (update :after #(merge {sp-ms (:on-timeout spawn)} %))))))
 
 (defn- walk-states-timeouts [states]
-  (when states
+  ;; `map?`-guarded (not just truthy) so a MALFORMED non-map `:states` (a
+  ;; pathological direct-host prop) degrades to nil rather than throwing in
+  ;; `reduce-kv` — the recursive validator that desugars first must be able to
+  ;; REJECT such input, not crash on it. Well-formed inputs are unchanged (the
+  ;; desugar-parity corpus never carries a non-map `:states`).
+  (when (map? states)
     (reduce-kv
       (fn [acc k node]
         (assoc acc k (let [n (desugar-node-timeouts node)]
@@ -147,8 +152,8 @@
           def'  (cond-> (dissoc definition :timeout :on-timeout)
                   (contains? root' :after) (assoc :after (:after root')))]
       (cond-> def'
-        (:states def')  (update :states walk-states-timeouts)
-        (:regions def') (update :regions
+        (:states def')        (update :states walk-states-timeouts)
+        (map? (:regions def')) (update :regions
                                 (fn [regions]
                                   (reduce-kv
                                     (fn [acc rn body]
@@ -191,7 +196,8 @@
     (-> node (assoc :always (:choice node)) (dissoc :type :choice))))
 
 (defn- walk-states-choice [states]
-  (when states
+  ;; `map?`-guarded — see `walk-states-timeouts`.
+  (when (map? states)
     (reduce-kv
       (fn [acc k node]
         (assoc acc k (let [n (desugar-node-choice node)]
@@ -209,8 +215,8 @@
   (if-not (map? definition)
     definition
     (cond-> definition
-      (:states definition)  (update :states walk-states-choice)
-      (:regions definition) (update :regions
+      (:states definition)        (update :states walk-states-choice)
+      (map? (:regions definition)) (update :regions
                                     (fn [regions]
                                       (reduce-kv
                                         (fn [acc rn body]
@@ -274,20 +280,25 @@
   (and (map? definition)
        (= :parallel (:type definition))))
 
+(declare definition-defect)
+
 (defn valid-definition?
-  "True when `definition` is a machine shape every emitter can project: a
-  parallel root (`:type :parallel`) with a non-empty `:regions` map whose
-  region bodies are EACH a `valid-state-tree?`, OR a flat / compound
-  `valid-state-tree?`. The single shape gate the three emitters share so
-  they never drift on which definitions they accept — keyword `:initial`,
-  well-formed parallel regions."
+  "True when `definition` is a machine shape every emitter can project —
+  RECURSIVELY (rf2-j538f7.18). Delegates to `definition-defect`: a definition
+  is valid iff it carries no structural projectability defect.
+
+  This is NO LONGER a shallow minimum-shape check. Pre-fix it validated only
+  the ROOT (or parallel-region roots) as a `valid-state-tree?`, so it blessed
+  structurally-invalid-but-shallowly-ok definitions — a nested compound
+  missing `:initial`, a dangling transition target, an unknown bare node key —
+  and every boundary that delegates here (share encode/decode, AI generation,
+  Mermaid, SCXML, the chart projector) inherited the same false positive. It
+  now walks root, parallel regions and every compound descendant, mirroring the
+  runtime `re-frame.machines.lifecycle-fx.validation/validate-machine!` for the
+  projectable structural invariants. See `definition-defect` for the full
+  contract + the documented viz-vs-engine divergences."
   [definition]
-  (if (parallel-definition? definition)
-    (let [regions (:regions definition)]
-      (and (map? regions)
-           (seq regions)
-           (every? valid-state-tree? (vals regions))))
-    (valid-state-tree? definition)))
+  (nil? (definition-defect definition)))
 
 (defn definition-summary
   "EP-0015 / Spec 015 §exception-path residual (rf2-8nzxib) — a value-FREE
@@ -297,19 +308,29 @@
   the top-level key SET, parallel?, and child counts — never the values.
   The single summary the three emitters share so their thrown-error
   diagnostics agree (each stashes it under its own surface-specific ex-data
-  key: `:spec-summary` / `:definition-summary`)."
+  key: `:spec-summary` / `:definition-summary`).
+
+  rf2-j538f7.18 — when the definition carries a structural defect the summary
+  also carries the value-free `:defect` (the FIRST `definition-defect` — its
+  `:category` = the engine's `:rf.error/machine-*` id, plus a structural
+  `:path` and, for key/target defects, the offending keys / slot), so every
+  surface that stashes this summary carries the CANONICAL defect category while
+  keeping its own surface-specific error id."
   [definition]
-  (if (map? definition)
-    (cond-> {:type     :map
-             :keys     (vec (sort-by str (keys definition)))
-             :parallel (parallel-definition? definition)}
-      (map? (:states definition))  (assoc :state-count  (count (:states definition)))
-      (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
-    (cond
-      (nil? definition)        {:type :nil}
-      (sequential? definition) {:type  (if (vector? definition) :vector :seq)
-                                :count (count definition)}
-      :else                    {:type :value})))
+  (let [defect (definition-defect definition)
+        base   (if (map? definition)
+                 (cond-> {:type     :map
+                          :keys     (vec (sort-by str (keys definition)))
+                          :parallel (parallel-definition? definition)}
+                   (map? (:states definition))  (assoc :state-count  (count (:states definition)))
+                   (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
+                 (cond
+                   (nil? definition)        {:type :nil}
+                   (sequential? definition) {:type  (if (vector? definition) :vector :seq)
+                                             :count (count definition)}
+                   :else                    {:type :value}))]
+    (cond-> base
+      defect (assoc :defect defect))))
 
 (defn parent-path
   "The parent path of `path` (its `pop`); `[]` for an empty/top-level
@@ -377,6 +398,433 @@
          (every? vector? target))        (vec target)
     (vector? target)                     [target]
     :else                                []))
+
+;; ---------------------------------------------------------------------------
+;; RECURSIVE projectability validation — rf2-j538f7.18
+;; ---------------------------------------------------------------------------
+;;
+;; `valid-definition?` / `definition-defect` recursively enforce the
+;; runtime-relevant STRUCTURAL PROJECTABILITY contract, so every ingestion /
+;; export boundary that delegates here (share encode/decode, AI generation,
+;; Mermaid, SCXML, and the chart projector) gives the SAME accept/reject answer
+;; the runtime machine contract would — no longer the pre-fix SHALLOW
+;; minimum-shape check that blessed structurally-invalid-but-shallowly-ok
+;; definitions (nested compounds missing `:initial`, dangling transition
+;; targets, unknown bare node keys, …).
+;;
+;; The walker MIRRORS
+;; `re-frame.machines.lifecycle-fx.validation/validate-machine!` for the
+;; PROJECTABLE invariants. machines-viz stays bundle-isolated (this ns
+;; `:require`s only `clojure.string`), so the engine grammar/target-resolution
+;; is RE-STATED here, not required; a TEST-ONLY parity corpus pins the mirror
+;; against the engine oracle (`engine-grammar-parity-test`).
+;;
+;; Enforced (recursively, over root + parallel regions + every compound
+;; descendant):
+;;   - keyword state/region ids + non-empty `:states` maps;
+;;   - compound-`:initial` PRESENCE (`machine-compound-state-missing-initial`);
+;;   - transition `:target` shape + resolution for `:on` / `:after` /
+;;     `:always` / `:on-done` / `:spawn :on-error`
+;;     (`machine-bad-target` / `machine-unresolved-target`);
+;;   - unknown BARE node / spawn keys — NAMESPACED keys pass
+;;     (`machine-unknown-node-key` / `machine-unknown-spawn-key`);
+;;   - `:final?` shape (`machine-final-state-compound` / `-has-transitions` /
+;;     `machine-output-key-without-final` / `machine-error-flag-without-final`);
+;;   - `:tags` set-of-keywords (`machine-bad-tags`);
+;;   - single `:spawn` XOR `:machine-id` / `:definition`
+;;     (`machine-spawn-bad-shape`);
+;;   - `:after` delay-key shape (`machine-bad-after-delay`);
+;;   - history pseudo-state placement / closed key-set /
+;;     at-most-one-per-compound / `:default-target` resolution
+;;     (`machine-history-*`);
+;;   - mutually exclusive `:type :parallel` shape + non-nested regions
+;;     (`machine-parallel-bad-shape` / `-nested-not-supported`).
+;;
+;; The `:category` on each returned defect IS the engine's `:rf.error/machine-*`
+;; id, so a surface can carry the CANONICAL defect category while keeping its
+;; own surface-specific error id.
+;;
+;; DOCUMENTED viz-vs-engine divergences (out of scope — either runtime-WIRING
+;; not projectable topology, viz-STRICTER by necessity, or bounded complexity;
+;; pinned in the parity test's divergence set so a future change that
+;; accidentally aligns/diverges them is caught):
+;;   - guard / action / `:on-spawn` keyword REF resolution (needs the machine
+;;     registry — runtime wiring, not projectable topology);
+;;   - a non-parallel root `:after` (the engine rejects it as unschedulable;
+;;     the viz still PROJECTS it as a machine-root anchor);
+;;   - viz-STRICTER root shape: the viz REQUIRES a keyword root `:initial` +
+;;     non-empty `:states` (and non-empty region `:states`) — it needs an
+;;     initial-marker to project — whereas the engine resolves a missing / late
+;;     `:initial` lazily at runtime;
+;;   - the parallel-root region-qualified `:on` / `:after` / `:on-done` target
+;;     grammar + full `:spawn-all` shape (bounded complexity — a VALID
+;;     spawn-all still projects; a malformed one is simply not rejected here).
+
+(def ^:private known-state-node-keys
+  "Closed BARE key vocabulary a state-node may declare — bundle-isolated mirror
+  of the engine's `validation/known-state-node-keys`. Namespaced keys are the
+  open extension carve-out. `:type :history` / `:type :choice` pseudo-states
+  carry their own key-sets and are skipped by the node-key check."
+  #{:type :deep? :default-target :regions :region-order
+    :initial :states :data :schemas :internal-events
+    :guards :actions :on-spawn-actions
+    :entry :exit
+    :spawn :spawn-all
+    :always :after :choice :timeout :on-timeout :on :on-done
+    :tags :final? :output-key :error?
+    :meta :source-coords :source-code})
+
+(def ^:private known-machine-root-extra-keys
+  "Keys legal ONLY on the machine ROOT beyond `known-state-node-keys` — mirror
+  of the engine's `validation/known-machine-root-extra-keys`."
+  #{:doc :sensitive :large :schema :raise-depth-limit :always-depth-limit})
+
+(def ^:private known-spawn-spec-keys
+  "Closed BARE key vocabulary a single `:spawn` spec may declare — mirror of the
+  engine's `validation/known-spawn-spec-keys` (the retired `:timeout-ms` slot is
+  excluded from the unknown-key scan so it never surfaces as an unknown key)."
+  #{:machine-id :definition :data :id-prefix :on-spawn :on-done :on-error
+    :start :fixed-actor-id :system-id :timeout :on-timeout
+    :id :source-coords :source-code})
+
+(def ^:private history-pseudo-keys
+  "Closed key-set a `:type :history` pseudo-state may carry."
+  #{:type :deep? :default-target})
+
+(defn node-at
+  "Descend a `:states` map down absolute `path`, returning the leaf node (or nil
+  if `path` doesn't resolve). Bundle-isolated mirror of
+  `re-frame.machines.grammar/node-at`; an empty path resolves to nil (the scope
+  root is the `states` map itself, not a node)."
+  [states path]
+  (loop [m states p (vec path)]
+    (cond
+      (empty? p) nil
+      :else (let [n (get m (first p))]
+              (cond
+                (nil? n)        nil
+                (= 1 (count p)) n
+                :else           (recur (:states n) (rest p)))))))
+
+(defn transition-value-form
+  "Classify a transition-table slot value into its grammar form — bundle-
+  isolated mirror of `re-frame.machines.grammar/transition-value-form` (the
+  recogniser the runtime target validator discriminates on)."
+  [v]
+  (cond
+    (nil? v)     :nil
+    (keyword? v) :keyword
+    (and (vector? v) (seq v) (every? map? v)) :candidate-vector
+    (vector? v)  :vec-target
+    (map? v)     :map
+    :else        :other))
+
+(defn candidate-maps
+  "Normalise a transition slot value to its candidate maps — bundle-isolated
+  mirror of `re-frame.machines.grammar/candidate-maps` (`:nil` → `[{}]`,
+  malformed → nil). Used to explode an `:always` slot the way the runtime
+  target validator does. Distinct from the projector's `transition-candidates`
+  (which mapcat-explodes a mixed vector) — this matches the engine's normaliser
+  so the VALIDATOR agrees with `validate-machine!`."
+  [v]
+  (case (transition-value-form v)
+    :nil              [{}]
+    :keyword          [{:target v}]
+    :candidate-vector v
+    :vec-target       [{:target v}]
+    :map              [v]
+    :other            nil))
+
+(defn candidate-targets
+  "Normalise a transition slot value to the seq of `:target`s it declares, each
+  tagged `:present?` (whether the `:target` KEY was present) — bundle-isolated
+  mirror of `re-frame.machines.grammar/candidate-targets` (the shape the runtime
+  target VALIDATOR consumes)."
+  [v]
+  (case (transition-value-form v)
+    :keyword          [{:present? true :target v}]
+    :candidate-vector (mapv (fn [m] {:present? (contains? m :target) :target (:target m)}) v)
+    :vec-target       [{:present? true :target v}]
+    :map              [{:present? (contains? v :target) :target (:target v)}]
+    []))
+
+(defn- compound?
+  "A node is compound iff it declares a non-empty `:states` map."
+  [node]
+  (and (map? (:states node)) (seq (:states node))))
+
+(defn- resolves-to-state?
+  "True iff `target` resolves to a real node under `owning-path` within `scope`
+  (a `:states` map). A keyword names a direct child of the owning compound; a
+  vector is an absolute path from the (region) root. Mirror of the engine's
+  `validation/resolves-to-state?`."
+  [scope owning-path target]
+  (cond
+    (keyword? target) (some? (node-at scope (conj (vec owning-path) target)))
+    (vector? target)  (and (seq target) (some? (node-at scope target)))
+    :else             false))
+
+(defn- unknown-bare-keys
+  "The BARE keys of `m` not in `known` (a namespaced key is the open extension
+  carve-out and never flagged)."
+  [m known]
+  (->> (keys m) (remove #(namespace %)) (remove known) vec))
+
+;; ---- per-node defect checks (each returns a value-free defect map or nil) --
+
+(defn- node-keys-defect [path node at-root?]
+  (when (and (map? node)
+             (not (history-node? node))
+             (not (choice-node? node)))
+    (let [known     (cond-> known-state-node-keys
+                       at-root? (into known-machine-root-extra-keys))
+          offending (unknown-bare-keys node known)]
+      (when (seq offending)
+        {:category :rf.error/machine-unknown-node-key :path (vec path) :keys offending}))))
+
+(defn- tags-defect [path node]
+  (when (contains? node :tags)
+    (let [tags (:tags node)]
+      (when-not (and (set? tags) (every? keyword? tags))
+        {:category :rf.error/machine-bad-tags :path (vec path)}))))
+
+(defn- compound-initial-defect [path node]
+  (when (and (compound? node) (not (contains? node :initial)))
+    {:category :rf.error/machine-compound-state-missing-initial :path (vec path)}))
+
+(defn- final-state-defect [path node]
+  (cond
+    (true? (:final? node))
+    (cond
+      (or (contains? node :states) (contains? node :initial))
+      {:category :rf.error/machine-final-state-compound :path (vec path)}
+      (some #(contains? node %) [:on :always :after :spawn :spawn-all])
+      {:category :rf.error/machine-final-state-has-transitions :path (vec path)})
+    (contains? node :output-key)
+    {:category :rf.error/machine-output-key-without-final :path (vec path)}
+    (contains? node :error?)
+    {:category :rf.error/machine-error-flag-without-final :path (vec path)}))
+
+(defn- spawn-defect [path node]
+  (let [spec (:spawn node)]
+    (when (map? spec)
+      (let [has-id?   (contains? spec :machine-id)
+            has-def?  (contains? spec :definition)
+            offending (vec (remove #{:timeout-ms}
+                                   (unknown-bare-keys spec known-spawn-spec-keys)))]
+        (cond
+          (or (and has-id? has-def?) (and (not has-id?) (not has-def?)))
+          {:category :rf.error/machine-spawn-bad-shape :path (vec path)}
+          (seq offending)
+          {:category :rf.error/machine-unknown-spawn-key :path (vec path) :keys offending})))))
+
+(defn- valid-after-delay-key?
+  "A static `:after` map KEY is well-formed iff a positive integer (literal ms),
+  a non-empty vector (subscription vector), or a fn — mirror of the engine's
+  `validation/valid-after-delay-key?`."
+  [k]
+  (boolean (or (and (integer? k) (pos? k)) (and (vector? k) (seq k)) (fn? k))))
+
+(defn- after-delay-defect [path node]
+  (some (fn [[k _]]
+          (when-not (valid-after-delay-key? k)
+            {:category :rf.error/machine-bad-after-delay :path (vec path)}))
+        (:after node)))
+
+(defn- always-entries
+  "A node's `:always` normalised to candidate maps (absent / explicit-nil →
+  [], mirroring the engine's `validation/always-entries`)."
+  [node]
+  (let [a (:always node)]
+    (if (nil? a) [] (or (candidate-maps a) []))))
+
+(defn- target-defect
+  "Defect for one transition `:target` against `scope` (the region / machine
+  `:states`) and `path` (the declaring node's absolute path). nil / `:same-state`
+  is fine; an empty vector / non-keyword-non-vector is a malformed SHAPE; a
+  keyword / vector that names no declared node is UNRESOLVED. Mirror of the
+  engine's `validation/validate-target!`."
+  [scope path slot target]
+  (cond
+    (nil? target)                       nil
+    (= :same-state target)              nil
+    (and (vector? target) (empty? target))
+    {:category :rf.error/machine-bad-target :path (vec path) :slot slot}
+    (or (keyword? target) (vector? target))
+    (when-not (resolves-to-state? scope (vec (drop-last path)) target)
+      {:category :rf.error/machine-unresolved-target :path (vec path) :slot slot})
+    :else
+    {:category :rf.error/machine-bad-target :path (vec path) :slot slot}))
+
+(defn- transition-target-defect [scope path node]
+  (let [check (fn [slot v]
+                (some (fn [{:keys [present? target]}]
+                        (when present? (target-defect scope path slot target)))
+                      (candidate-targets v)))]
+    (or (some (fn [[_ v]] (check :on v)) (:on node))
+        (some (fn [[_ v]] (check :after v)) (:after node))
+        (some (fn [entry] (check :always entry)) (always-entries node))
+        (when (contains? node :on-done) (check :on-done (:on-done node)))
+        (when-let [oe (get-in node [:spawn :on-error])] (check :spawn/on-error oe)))))
+
+(defn- node-defect
+  "First defect on one MAP state-node at `path` within `scope` (its region /
+  flat `:states`). History pseudo-states contribute no defect here (their own
+  placement / key-set / default-target rules run in `history-scope-defect`; the
+  node-key check already skips them)."
+  [scope path node]
+  ;; Check ORDER mirrors the engine's `validate-machine!` intra-node precedence
+  ;; (keys / tags / spawn shape earliest; `:final?` shape BEFORE compound-
+  ;; `:initial`; targets; delay keys), so when a single node carries more than
+  ;; one defect the viz reports the SAME `:rf.error/machine-*` category the
+  ;; runtime would.
+  (or (node-keys-defect path node false)
+      (tags-defect path node)
+      (spawn-defect path node)
+      (final-state-defect path node)
+      (compound-initial-defect path node)
+      (transition-target-defect scope path node)
+      (after-delay-defect path node)))
+
+(defn- walk-scope-nodes
+  "`[abs-path node]` for every MAP node under `states`, recursing through
+  `:states`. Paths are scope-relative (region names never enter a within-scope
+  path)."
+  [states]
+  (letfn [(walk [path nodes]
+            (mapcat (fn [[k n]]
+                      (when (map? n)
+                        (cons [(conj path k) n]
+                              (when (map? (:states n))
+                                (walk (conj path k) (:states n))))))
+                    nodes))]
+    (when (map? states) (walk [] states))))
+
+;; ---- history-scope defects (mirror validation/validate-history-scope!) -----
+
+(defn- history-nodes-with-path [states]
+  (letfn [(walk [path nodes]
+            (mapcat (fn [[k n]]
+                      (when (map? n)
+                        (let [p (conj path k)]
+                          (concat (when (history-node? n) [[p n]])
+                                  (when (map? (:states n)) (walk p (:states n)))))))
+                    nodes))]
+    (when (map? states) (walk [] states))))
+
+(defn- history-node-defect [scope path node]
+  (let [owning-path (vec (drop-last path))]
+    (cond
+      (empty? owning-path)
+      {:category :rf.error/machine-history-misplaced :path (vec path)}
+      (seq (remove history-pseudo-keys (keys node)))
+      {:category :rf.error/machine-history-extra-keys :path (vec path)
+       :keys (vec (remove history-pseudo-keys (keys node)))}
+      (and (contains? node :default-target)
+           (not (resolves-to-state? scope owning-path (:default-target node))))
+      {:category :rf.error/machine-history-bad-default-target :path (vec path)})))
+
+(defn- compound-states-pairs
+  "`[compound-key states-map]` for the scope root (`:rf/root`) + every nested
+  compound inside `states`. Used for the at-most-one-history-per-compound check."
+  [states]
+  (letfn [(walk [pairs nodes]
+            (reduce (fn [acc [k n]]
+                      (if (and (map? n) (map? (:states n)) (seq (:states n)))
+                        (-> acc (conj [k (:states n)]) (walk (:states n)))
+                        acc))
+                    pairs nodes))]
+    (walk [[:rf/root states]] states)))
+
+(defn- history-scope-defect [scope]
+  (or (some (fn [[path node]] (history-node-defect scope path node))
+            (history-nodes-with-path scope))
+      (some (fn [[_ states-map]]
+              (let [hk (->> states-map (keep (fn [[k n]] (when (history-node? n) k))) vec)]
+                (when (> (count hk) 1)
+                  {:category :rf.error/machine-history-duplicate :path []})))
+            (compound-states-pairs scope))))
+
+;; ---- root / region / parallel shape ----------------------------------------
+
+(defn- root-on-target-defect
+  "The non-parallel root's OWN `:on` (the ancestor-fallback slot, decl-path
+  `[]`) target resolution — mirror of the engine's root `:on` branch in
+  `validate-transition-targets!`."
+  [scope d]
+  (some (fn [[_ v]]
+          (some (fn [{:keys [present? target]}]
+                  (when present? (target-defect scope [] :on target)))
+                (candidate-targets v)))
+        (:on d)))
+
+(defn- flat-defect [d]
+  (cond
+    (not (keyword? (:initial d)))
+    {:category :rf.error/machine-missing-initial :path []}
+    (not (and (map? (:states d)) (seq (:states d))))
+    {:category :rf.error/machine-missing-states :path []}
+    :else
+    (let [scope (:states d)]
+      (or (node-keys-defect [] d true)
+          (tags-defect [] d)
+          (some (fn [[path node]] (node-defect scope path node)) (walk-scope-nodes scope))
+          (history-scope-defect scope)
+          (root-on-target-defect scope d)))))
+
+(defn- region-defect [region-name body]
+  (cond
+    (not (keyword? region-name))
+    {:category :rf.error/machine-parallel-bad-shape :path [region-name]}
+    (not (and (map? body) (seq body)))
+    {:category :rf.error/machine-parallel-bad-shape :path [region-name]}
+    (= :parallel (:type body))
+    {:category :rf.error/machine-parallel-nested-not-supported :path [region-name]}
+    (not (keyword? (:initial body)))
+    {:category :rf.error/machine-parallel-bad-shape :path [region-name]}
+    (not (and (map? (:states body)) (seq (:states body))))
+    {:category :rf.error/machine-parallel-bad-shape :path [region-name]}
+    :else
+    (let [scope (:states body)]
+      (or (node-keys-defect [region-name] body false)
+          (tags-defect [region-name] body)
+          (some (fn [[path node]]
+                  (or (when (= :parallel (:type node))
+                        {:category :rf.error/machine-parallel-nested-not-supported :path (vec path)})
+                      (node-defect scope path node)))
+                (walk-scope-nodes scope))
+          (history-scope-defect scope)))))
+
+(defn- parallel-defect [d]
+  (let [regions (:regions d)]
+    (cond
+      (not (and (map? regions) (seq regions)))
+      {:category :rf.error/machine-parallel-bad-shape :path []}
+      (or (contains? d :initial) (contains? d :states))
+      {:category :rf.error/machine-parallel-bad-shape :path []}
+      :else
+      (or (node-keys-defect [] d true)
+          (some (fn [[region-name body]] (region-defect region-name body)) regions)))))
+
+(defn definition-defect
+  "Return the FIRST structural projectability defect of `definition` as a
+  value-FREE map `{:category <:rf.error/machine-*> :path <state-id vector> …}`
+  (key/target defects add `:keys` / `:slot`), or nil when the definition is
+  projectable. Desugars (`desugar-grammar` — EP-0029 A4/A5) FIRST so a
+  `:timeout` / `:choice` authoring form is validated on its lowered shape, then
+  recursively mirrors the runtime machine contract's projectable invariants —
+  see the section comment above for the full enforced list + the documented
+  viz-vs-engine divergences.
+
+  Pure; nil-safe (a nil / non-map desugars unchanged → `machine-bad-definition`).
+  The single source of truth `valid-definition?`, `definition-summary`, and every
+  emitter / share / chart shape gate delegate to."
+  [definition]
+  (let [d (desugar-grammar definition)]
+    (cond
+      (not (map? d))           {:category :rf.error/machine-bad-definition :path []}
+      (parallel-definition? d) (parallel-defect d)
+      :else                    (flat-defect d))))
 
 ;; ---------------------------------------------------------------------------
 ;; Name rendering — fn-tolerant guard / action / event labels

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -65,7 +65,7 @@
   (rf2-k647w); since tag pills retired in favour of a hover-only
   tooltip, the same fixture exercises the new attr-surface."
   {:initial :idle
-   :states  {:idle    {:tags [:initial-tag] :on {:start :loading}}
+   :states  {:idle    {:tags #{:initial-tag} :on {:start :loading}}
              :loading {:on {:done :idle}}}})
 
 (def ^:private namespaced-tag-machine
@@ -73,7 +73,7 @@
   tag-identity-preservation fix is assertable (the visible label + the
   `data-tag` attr must read `door/open`, not the truncated `open`)."
   {:initial :open
-   :states  {:open {:tags [:door/open] :on {:close :shut}}
+   :states  {:open {:tags #{:door/open} :on {:close :shut}}
              :shut {}}})
 
 (def ^:private machine-level-on-machine

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -972,15 +972,57 @@
       (is (true? (:final? boom))))))
 
 (deftest project-definition-error-flag-needs-final
-  (testing "rf2-b4loj — a stray :error? on a NON-final node never lights the
-            ring: :error? is gated on :final? so it stays false"
-    (let [{:keys [nodes]} (layout/project-definition
-                           {:initial :a
-                            :states  {:a {:error? true :on {:go :b}}
-                                      :b {}}})
-          a (first (filter #(= [:a] (:path %)) nodes))]
-      (is (false? (:final? a)))
-      (is (false? (:error? a)) ":error? requires :final?"))))
+  (testing "rf2-b4loj + rf2-j538f7.18 — a stray :error? on a NON-final node is
+            now REJECTED by the recursive grammar gate (:error? is only
+            meaningful on a :final? state). project-definition rejects the
+            machine BEFORE graph construction and returns a value-free
+            :definition-error carrying the canonical
+            :rf.error/machine-error-flag-without-final defect, rather than
+            projecting the node with :error? silently gated to false."
+    (let [result (layout/project-definition
+                  {:initial :a
+                   :states  {:a {:error? true :on {:go :b}}
+                             :b {}}})]
+      (is (empty? (:nodes result))
+          "no nodes/edges are projected for the rejected machine (no ELK, no orphans)")
+      (is (empty? (:edges result)))
+      (is (= :rf.error/machine-error-flag-without-final
+             (get-in result [:definition-error :defect :category]))
+          ":error? on a non-final node surfaces the canonical error-flag-without-final defect"))))
+
+(deftest project-definition-rejects-structurally-invalid-before-elk
+  (testing "rf2-j538f7.18 — a structurally-invalid definition is REJECTED
+            before graph construction: no nodes / edges are produced (nothing
+            reaches ELK, no orphan edges to absent nodes), and the result
+            carries the value-free canonical defect category so the chart
+            renders a rejection placeholder"
+    (doseq [[label definition expected]
+            [["nested compound missing :initial"
+              {:initial :outer :states {:outer {:states {:inner {}}}}}
+              :rf.error/machine-compound-state-missing-initial]
+             ["dangling transition target"
+              {:initial :idle :states {:idle {:on {:go :missing}}}}
+              :rf.error/machine-unresolved-target]
+             ["unknown bare node key"
+              {:initial :idle :states {:idle {:on-entry :oops}}}
+              :rf.error/machine-unknown-node-key]]]
+      (let [{:keys [nodes edges definition-error]} (layout/project-definition definition)]
+        (is (empty? nodes) (str label ": no nodes reach ELK"))
+        (is (empty? edges) (str label ": no orphan edges to absent nodes"))
+        (is (= expected (get-in definition-error [:defect :category]))
+            (str label ": carries the canonical defect category"))
+        ;; the value-free summary never leaks a raw node/value.
+        (is (some? (:keys definition-error))
+            (str label ": carries the structural top-level key set")))))
+
+  (testing "a nil definition is NOT an error (it is the empty-state placeholder),
+            and a VALID definition still projects nodes"
+    (is (nil? (:definition-error (layout/project-definition nil))))
+    (is (empty? (:nodes (layout/project-definition nil))))
+    (let [{:keys [nodes definition-error]}
+          (layout/project-definition {:initial :a :states {:a {:on {:go :b}} :b {}}})]
+      (is (nil? definition-error) "a valid definition carries no :definition-error")
+      (is (seq nodes) "a valid definition still projects nodes"))))
 
 ;; ---- :on-done (XState onDone) completion edge (rf2-41goo) ---------------
 ;;

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -2164,7 +2164,7 @@
             dropped one)."
     (let [machine {:initial :a
                    :states  {:a       {}
-                             :initial {:states {:a {}}}}}
+                             :initial {:initial :a :states {:a {}}}}}
           parsed  (layout/project-definition machine)
           graph   (projection/xyflow-graph parsed {} {})
           real-initial-a (layout/node-id [:initial :a])              ;; "initial__a"
@@ -2197,7 +2197,10 @@
     (let [machine {:initial :a
                    :states  {:a     {:on {:go :b}}
                              :b     {}
-                             :event {:states {:a {:states {:b {:states {:go {}}}}}}}}}
+                             :event {:initial :a
+                                     :states {:a {:initial :b
+                                                  :states {:b {:initial :go
+                                                               :states {:go {}}}}}}}}}
           parsed  (layout/project-definition machine)
           graph   (projection/xyflow-graph parsed {} {})
           real-event-path (layout/node-id [:event :a :b :go])        ;; "event__a__b__go"
@@ -3117,7 +3120,7 @@
   sibling (mirrors testdeck `:authenticating → :failed`)."
   {:initial :outer
    :states  {:outer  {:initial :inner
-                      :states  {:inner {:on {:escape :sibling}}}}
+                      :states  {:inner {:on {:escape [:sibling]}}}}
              :sibling {}}})
 
 (deftest xyflow-graph-flags-cross-hierarchy-edge

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -448,7 +448,8 @@
                  :states  {:a1 {:on {:go :a2}}
                            :a2 {:final? true}}}
              :b {:initial :b1
-                 :states  {:b1 {:on {:go :b2}}}}}})
+                 :states  {:b1 {:on {:go :b2}}
+                           :b2 {:final? true}}}}})
 
 (deftest region-on-done-target-bearing-surfaced-by-mermaid-and-scxml
   (testing "rf2-f8fgz5 — a region's own top-level :on-done with a keyword
@@ -694,3 +695,53 @@
       (is (not (leaks? md)) "mermaid summary omits the :data secret")
       (is (not (leaks? sd)) "scxml summary omits the :data secret")
       (is (not (leaks? ad)) "ai summary omits the :data secret"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-j538f7.18 — every ingestion / export surface REJECTS a RECURSIVELY-
+;; invalid definition (the pre-fix shallow gate blessed all three). Each surface
+;; keeps its own error id AND carries the CANONICAL defect category
+;; (:rf.error/machine-*) in its value-free summary, so a tool can map one defect
+;; onto its surface-specific error without re-walking the (possibly value-
+;; carrying) definition.
+
+(def ^:private recursively-invalid-definitions
+  {:nested-compound-no-initial
+   {:def      {:initial :outer :states {:outer {:states {:inner {}}}}}
+    :category :rf.error/machine-compound-state-missing-initial}
+   :dangling-target
+   {:def      {:initial :idle :states {:idle {:on {:go :missing}}}}
+    :category :rf.error/machine-unresolved-target}
+   :unknown-node-key
+   {:def      {:initial :idle :states {:idle {:on-entry :oops}}}
+    :category :rf.error/machine-unknown-node-key}})
+
+(defn- throws-ex [f]
+  (try (f) nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e)))
+
+(deftest recursively-invalid-rejected-by-every-surface
+  (doseq [[label {:keys [def category]}] recursively-invalid-definitions]
+    (testing (str (name label) " — chart projection rejects BEFORE ELK (no orphan nodes/edges)")
+      (let [{:keys [nodes edges definition-error]} (layout/project-definition def)]
+        (is (empty? nodes) (str label ": no nodes reach ELK"))
+        (is (empty? edges) (str label ": no orphan edges to absent nodes"))
+        (is (= category (get-in definition-error [:defect :category]))
+            (str label ": chart carries the canonical defect category"))))
+    (testing (str (name label) " — Mermaid rejects, carrying the canonical defect category")
+      (let [ex (throws-ex #(mermaid/emit def))]
+        (is (some? ex) (str label ": mermaid throws"))
+        (is (= :mermaid/invalid-definition (:rf.error/id (ex-data ex))))
+        (is (= category (get-in (ex-data ex) [:definition-summary :defect :category]))
+            (str label ": mermaid's summary carries the canonical defect category"))))
+    (testing (str (name label) " — SCXML rejects, carrying the canonical defect category")
+      (let [ex (throws-ex #(scxml/spec->scxml def))]
+        (is (some? ex) (str label ": scxml throws"))
+        (is (= :scxml/invalid-spec (:rf.error/id (ex-data ex))))
+        (is (= category (get-in (ex-data ex) [:spec-summary :defect :category]))
+            (str label ": scxml's summary carries the canonical defect category"))))
+    (testing (str (name label) " — AI generation no longer returns a runtime-rejected spec as 'validated'")
+      (let [resolver (fn [_] (pr-str def))
+            ex       (throws-ex #(ai/generate-machine "x" {:resolver resolver}))]
+        (is (some? ex) (str label ": ai throws"))
+        (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex))))
+        (is (= category (get-in (ex-data ex) [:spec-summary :defect :category]))
+            (str label ": ai's summary carries the canonical defect category"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
@@ -41,6 +41,7 @@
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.grammar :as g]
             [re-frame.machines.choice :as choice]
+            [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.timeout :as timeout]
             [re-frame.machines.transition :as transition]))
@@ -397,3 +398,109 @@
       (is (= (choice/desugar-choices m)
              (g/desugar-choices m))
           (str ":choice desugar drifted for " (pr-str m))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 8 — definition VALIDATION (rf2-j538f7.18)
+;;
+;; PARITY: `grammar/valid-definition?` (via `definition-defect`) must give the
+;; SAME accept/reject answer as the runtime
+;; `re-frame.machines.lifecycle-fx.validation/validate-machine!` for the
+;; PROJECTABLE structural grammar. If this fails, the viz recursive validator
+;; drifted from the engine — re-sync, do not delete.
+;;
+;; The pre-fix shallow `valid-definition?` blessed every deeply-invalid
+;; definition (nested compound missing `:initial`, dangling target, unknown
+;; bare node key, …). The recursive walker mirrors the engine so a definition
+;; the runtime rejects at `reg-machine` is rejected at EVERY viz ingestion /
+;; export boundary too.
+;;
+;; The corpus below is CURATED to the SHARED structural grammar — it excludes
+;; the documented viz-vs-engine divergences (guard/action ref resolution,
+;; non-parallel root `:after`, viz-stricter root shape), which are pinned
+;; SEPARATELY in `definition-validation-documented-divergences` so a change
+;; that accidentally aligns / diverges them is also caught.
+
+(defn- engine-accepts?
+  "True iff the runtime `validate-machine!` accepts `m` (no thrown error)."
+  [m]
+  (try (validation/validate-machine! m) true
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _e false)))
+
+(defn- viz-accepts? [m] (nil? (g/definition-defect m)))
+
+(def ^:private validation-parity-corpus
+  "Representative definitions spanning the SHARED structural grammar — both the
+  viz validator and the engine must agree on each. Half are projectable (both
+  ACCEPT), half are structurally malformed (both REJECT)."
+  {;; ---- valid (both accept) ----
+   :valid-flat       {:initial :idle :states {:idle {:on {:go :done}} :done {:final? true}}}
+   :valid-compound   {:initial :o :states {:o {:initial :i :states {:i {:on {:up :sib}} :sib {}}} :top {}}}
+   :valid-vec-target {:initial :o :states {:o {:initial :i :states {:i {:on {:esc [:top]}}}} :top {}}}
+   :valid-parallel   {:type :parallel :regions {:r1 {:initial :a :states {:a {:on {:x :b}} :b {}}}
+                                                :r2 {:initial :p :states {:p {}}}}}
+   :valid-history    {:initial :o :states {:o {:initial :s :states {:s {:on {:g :s2}} :s2 {} :h {:type :history :deep? true}}}}}
+   :valid-timeout    {:initial :a :states {:a {:timeout 1000 :on-timeout :b} :b {}}}
+   :valid-choice     {:initial :g :states {:g {:type :choice :choice [{:target :a} {:target :b}]} :a {} :b {}}}
+   :valid-spawn      {:initial :a :states {:a {:spawn {:machine-id :child} :on {:go :b}} :b {}}}
+   :valid-spawn-all  {:initial :a :states {:a {:spawn-all {:children [{:id :c1 :machine-id :m}]
+                                                           :on-child-done :cd :on-child-error :ce
+                                                           :on-all-complete [:done]}
+                                               :on {:go :b}} :b {}}}
+   :valid-namespaced {:initial :a :states {:a {:my.app/note "x"}}}
+   :valid-tags       {:initial :a :states {:a {:tags #{:busy}}}}
+   ;; ---- invalid (both reject) ----
+   :nested-no-init   {:initial :outer :states {:outer {:states {:inner {}}}}}
+   :unresolved-kw    {:initial :idle :states {:idle {:on {:go :missing}}}}
+   :unresolved-vec   {:initial :a :states {:a {:on {:go [:nope]}}}}
+   :bad-target-map   {:initial :a :states {:a {:on {:go {:target 42}}}}}
+   :empty-vec-target {:initial :a :states {:a {:on {:go []}}}}
+   :unknown-node-key {:initial :idle :states {:idle {:on-entry :oops}}}
+   :hist-misplaced   {:initial :a :states {:a {} :hist {:type :history}}}
+   :hist-extra-keys  {:initial :o :states {:o {:initial :s :states {:s {} :h {:type :history :on {:x :s}}}}}}
+   :hist-duplicate   {:initial :o :states {:o {:initial :s :states {:s {} :h1 {:type :history} :h2 {:type :history}}}}}
+   :hist-bad-default {:initial :o :states {:o {:initial :s :states {:s {} :h {:type :history :default-target :nope}}}}}
+   :final-compound   {:initial :a :states {:a {:final? true :states {:b {}}}}}
+   :final-trans      {:initial :a :states {:a {:final? true :on {:x :b}} :b {}}}
+   :output-no-final  {:initial :a :states {:a {:output-key :foo}}}
+   :error-no-final   {:initial :a :states {:a {:error? true}}}
+   :bad-tags         {:initial :a :states {:a {:tags [:x]}}}
+   :bad-after-delay  {:initial :a :states {:a {:after {0 :b}} :b {}}}
+   :spawn-neither    {:initial :a :states {:a {:spawn {}}}}
+   :spawn-both       {:initial :a :states {:a {:spawn {:machine-id :m :definition {:initial :x :states {:x {}}}}}}}
+   :spawn-unknown    {:initial :a :states {:a {:spawn {:machine-id :m :bogus 1}}}}
+   :par-nested       {:type :parallel :regions {:r {:initial :a :states {:a {:type :parallel :regions {:x {:initial :y :states {:y {}}}}}}}}}
+   :par-no-init      {:type :parallel :regions {:r {:states {:a {}}}}}
+   :par-mutex        {:type :parallel :initial :a :regions {:r {:initial :a :states {:a {}}}}}
+   :par-empty        {:type :parallel :regions {}}})
+
+(deftest definition-validation-parity
+  (testing "the viz recursive validator accepts/rejects EXACTLY what the engine
+            validate-machine! does across the shared structural grammar"
+    (doseq [[label m] validation-parity-corpus]
+      (is (= (engine-accepts? m) (viz-accepts? m))
+          (str label ": viz validator drifted from the engine "
+               "(engine-accepts? " (engine-accepts? m)
+               ", viz-accepts? " (viz-accepts? m) ")")))))
+
+(deftest definition-validation-documented-divergences
+  (testing "guard / action keyword REF resolution is a DIVERGENCE — the engine
+            rejects a dangling guard ref (runtime wiring); the viz accepts it
+            (projectable topology, no registry to resolve against)"
+    (let [m {:initial :a :states {:a {:on {:go {:target :b :guard :missing?}}} :b {}}}]
+      (is (false? (engine-accepts? m)) "engine rejects the dangling guard ref")
+      (is (true?  (viz-accepts? m))    "the viz projects it — refs are runtime wiring, not topology")))
+
+  (testing "a NON-parallel root :after is a DIVERGENCE — the engine rejects it
+            (unschedulable at registration); the viz projects it as a
+            machine-root anchor"
+    (let [m {:initial :a :after {1000 :b} :states {:a {} :b {}}}]
+      (is (false? (engine-accepts? m)) "engine rejects a flat-root :after")
+      (is (true?  (viz-accepts? m))    "the viz projects it as a root anchor")))
+
+  (testing "viz-STRICTER root shape is a DIVERGENCE — the engine resolves a
+            missing / late root :initial lazily at runtime; the viz REQUIRES a
+            keyword root :initial + non-empty :states to have an initial-marker
+            to project"
+    (let [m {:states {:idle {}}}]
+      (is (true?  (engine-accepts? m)) "engine accepts a flat machine with no root :initial")
+      (is (false? (viz-accepts? m))    "the viz rejects it (no initial to project)"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
@@ -1,0 +1,291 @@
+(ns day8.re-frame2-machines-viz.grammar-validation-cljs-test
+  "RECURSIVE grammar-validation tests (rf2-j538f7.18).
+
+  `grammar/valid-definition?` / `grammar/definition-defect` recursively enforce
+  the runtime-relevant STRUCTURAL PROJECTABILITY contract — no longer the
+  pre-fix SHALLOW minimum-shape check that validated only the root (or
+  parallel-region roots) and therefore blessed
+  structurally-invalid-but-shallowly-ok definitions.
+
+  These tests pin the recursive walker directly:
+
+    - the three deterministic false positives from the bead report are now
+      REJECTED with the CANONICAL `:rf.error/machine-*` defect category;
+    - recursive coverage over root / nested-compound / parallel-region initial
+      presence + type, empty / non-map state bodies, unknown bare node / spawn
+      keys (namespaced keys pass), malformed / dangling keyword AND vector
+      targets, history / choice / timeout / spawn / final-state structural
+      constraints;
+    - VALID flat / compound / parallel / history / timeout / choice /
+      spawn / spawn-all / namespaced-extension definitions still PROJECT;
+    - the defect diagnostics are VALUE-FREE (never a `:data` slot's live
+      values, an action / guard, or an LLM response).
+
+  Engine-parity (the same accept/reject as `validate-machine!`) is pinned
+  separately in `engine-grammar-parity-test` (which alone `:require`s the
+  test-only engine dep)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.grammar :as g]))
+
+(defn- category [definition]
+  (:category (g/definition-defect definition)))
+
+;; ---------------------------------------------------------------------------
+;; The three deterministic false positives (bead report §DETERMINISTIC
+;; REPRODUCTION). Pre-fix each returned `valid-definition? => true`; each is
+;; now rejected with the SAME `:rf.error/machine-*` id the runtime
+;; `validate-machine!` raises.
+
+(deftest deterministic-false-positives-now-rejected
+  (testing "nested compound missing :initial => machine-compound-state-missing-initial"
+    (let [d {:initial :outer :states {:outer {:states {:inner {}}}}}]
+      (is (false? (g/valid-definition? d)))
+      (is (= :rf.error/machine-compound-state-missing-initial (category d)))
+      (is (= [:outer] (:path (g/definition-defect d))))))
+
+  (testing "dangling transition target => machine-unresolved-target"
+    (let [d {:initial :idle :states {:idle {:on {:go :missing}}}}]
+      (is (false? (g/valid-definition? d)))
+      (is (= :rf.error/machine-unresolved-target (category d)))
+      (is (= [:idle] (:path (g/definition-defect d))))))
+
+  (testing "unknown bare node key => machine-unknown-node-key"
+    (let [d {:initial :idle :states {:idle {:on-entry :oops}}}]
+      (is (false? (g/valid-definition? d)))
+      (is (= :rf.error/machine-unknown-node-key (category d)))
+      (is (= [:idle] (:path (g/definition-defect d))))
+      (is (= [:on-entry] (:keys (g/definition-defect d)))))))
+
+;; ---------------------------------------------------------------------------
+;; Root / nested-compound / parallel-region initial presence + type + resolution
+
+(deftest compound-initial-presence-is-recursive
+  (testing "a DEEPLY-nested compound missing :initial is rejected (the shallow
+            check never descended past the root / region roots)"
+    (is (= :rf.error/machine-compound-state-missing-initial
+           (category {:initial :a
+                      :states  {:a {:initial :b
+                                    :states  {:b {:states {:c {}}}}}}}))))
+  (testing "a compound missing :initial INSIDE a parallel region is rejected"
+    (is (= :rf.error/machine-compound-state-missing-initial
+           (category {:type    :parallel
+                      :regions {:r {:initial :a
+                                    :states  {:a {:states {:b {}}}}}}})))))
+
+(deftest parallel-region-initial-type-and-presence
+  (testing "a region whose :initial is a STRING (not a keyword) is rejected"
+    (is (= :rf.error/machine-parallel-bad-shape
+           (category {:type :parallel :regions {:r {:initial "x" :states {:x {}}}}}))))
+  (testing "a region with no :initial is rejected"
+    (is (= :rf.error/machine-parallel-bad-shape
+           (category {:type :parallel :regions {:r {:states {:x {}}}}}))))
+  (testing ":type :parallel mutually exclusive with :initial / :states"
+    (is (= :rf.error/machine-parallel-bad-shape
+           (category {:type :parallel :initial :a
+                      :regions {:r {:initial :a :states {:a {}}}}})))
+    (is (= :rf.error/machine-parallel-bad-shape
+           (category {:type :parallel :states {:a {}}
+                      :regions {:r {:initial :a :states {:a {}}}}}))))
+  (testing "an empty / non-map :regions is rejected"
+    (is (= :rf.error/machine-parallel-bad-shape (category {:type :parallel :regions {}})))
+    (is (= :rf.error/machine-parallel-bad-shape (category {:type :parallel :regions 5}))))
+  (testing "a nested parallel region is rejected"
+    (is (= :rf.error/machine-parallel-nested-not-supported
+           (category {:type    :parallel
+                      :regions {:r {:initial :a
+                                    :states  {:a {:type    :parallel
+                                                  :regions {:x {:initial :y :states {:y {}}}}}}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; Empty / non-map state bodies
+
+(deftest empty-and-non-map-state-bodies
+  (testing "a non-map definition is rejected"
+    (is (= :rf.error/machine-bad-definition (category 42)))
+    (is (= :rf.error/machine-bad-definition (category "not-a-machine"))))
+  (testing "a flat root with a non-keyword / missing :initial is rejected"
+    (is (= :rf.error/machine-missing-initial (category {:states {:a {}}})))
+    (is (= :rf.error/machine-missing-initial (category {:initial "idle" :states {:idle {}}}))))
+  (testing "a flat root with empty / non-map :states is rejected"
+    (is (= :rf.error/machine-missing-states (category {:initial :a :states {}})))
+    (is (= :rf.error/machine-missing-states (category {:initial :a :states 7})))))
+
+;; ---------------------------------------------------------------------------
+;; Unknown bare keys — with NAMESPACED-extension acceptance
+
+(deftest unknown-bare-keys-vs-namespaced-extension
+  (testing "an unknown BARE node key is rejected (XState's :on-entry / :invoke)"
+    (is (= :rf.error/machine-unknown-node-key (category {:initial :a :states {:a {:on-entry :x}}})))
+    (is (= :rf.error/machine-unknown-node-key (category {:initial :a :states {:a {:invoke {:src :x}}}}))))
+  (testing "an unknown BARE key on the machine ROOT is rejected"
+    (is (= :rf.error/machine-unknown-node-key (category {:initial :a :innitial :a :states {:a {}}}))))
+  (testing "a NAMESPACED key is the open extension carve-out and PASSES"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:my.app/note "meta"}}})))
+    (is (nil? (g/definition-defect {:initial :a :my.tool/x 1 :states {:a {}}}))))
+  (testing ":meta is the sanctioned bare free slot and PASSES"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:meta {:doc "x"}}}}))))
+  (testing "an unknown BARE :spawn key is rejected; namespaced passes"
+    (is (= :rf.error/machine-unknown-spawn-key
+           (category {:initial :a :states {:a {:spawn {:machine-id :m :bogus 1}}}})))
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:spawn {:machine-id :m :my/x 1}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; Malformed / dangling keyword AND vector targets
+
+(deftest transition-target-shape-and-resolution
+  (testing "a dangling KEYWORD target (a top-level state from a nested state
+            needs a vector) is unresolved"
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :o :states {:o {:initial :i :states {:i {:on {:up :top}}}} :top {}}}))))
+  (testing "a dangling VECTOR-PATH target is unresolved"
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:on {:go [:nope]}}}}))))
+  (testing "an EMPTY vector target is a malformed shape"
+    (is (= :rf.error/machine-bad-target (category {:initial :a :states {:a {:on {:go []}}}}))))
+  (testing "a non-keyword / non-vector :target map value is a malformed shape"
+    (is (= :rf.error/machine-bad-target (category {:initial :a :states {:a {:on {:go {:target 42}}}}}))))
+  (testing "the target check covers :after / :always / :on-done / :spawn :on-error, not just :on"
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:after {1000 {:target :nope}}}}})))
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:always [{:target :nope}]}}})))
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:initial :b
+                                               :states {:b {:final? true}}
+                                               :on-done {:target :nope}}}})))
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:spawn {:machine-id :m :on-error {:target :nope}}}}}))))
+  (testing "a VALID vector-path / sibling / :same-state target is accepted"
+    (is (nil? (g/definition-defect {:initial :o :states {:o {:initial :i :states {:i {:on {:up [:top]}}}} :top {}}})))
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:on {:go :b}} :b {}}})))
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:on {:loop :same-state}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; History pseudo-state structural constraints
+
+(deftest history-pseudo-state-constraints
+  (testing "a history node with no owning compound is misplaced"
+    (is (= :rf.error/machine-history-misplaced
+           (category {:initial :a :states {:a {} :hist {:type :history}}}))))
+  (testing "a history node carrying a non-history key is extra-keys"
+    (is (= :rf.error/machine-history-extra-keys
+           (category {:initial :o :states {:o {:initial :s
+                                               :states {:s {} :h {:type :history :on {:x :s}}}}}}))))
+  (testing "two history pseudo-states under one compound is a duplicate"
+    (is (= :rf.error/machine-history-duplicate
+           (category {:initial :o :states {:o {:initial :s
+                                               :states {:s {} :h1 {:type :history} :h2 {:type :history}}}}}))))
+  (testing "a :default-target that resolves is accepted; a dangling one is rejected"
+    (is (nil? (g/definition-defect {:initial :o :states {:o {:initial :s
+                                                             :states {:s {} :h {:type :history :default-target :s}}}}})))
+    (is (= :rf.error/machine-history-bad-default-target
+           (category {:initial :o :states {:o {:initial :s
+                                               :states {:s {} :h {:type :history :default-target :nope}}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; Final-state / tags / after-delay / spawn structural constraints
+
+(deftest final-state-constraints
+  (is (= :rf.error/machine-final-state-compound
+         (category {:initial :a :states {:a {:final? true :states {:b {}}}}})))
+  (is (= :rf.error/machine-final-state-has-transitions
+         (category {:initial :a :states {:a {:final? true :on {:x :b}} :b {}}})))
+  (is (= :rf.error/machine-output-key-without-final
+         (category {:initial :a :states {:a {:output-key :foo}}})))
+  (is (= :rf.error/machine-error-flag-without-final
+         (category {:initial :a :states {:a {:error? true}}})))
+  (testing "a :final? leaf may carry :output-key / :error? / :entry / :exit"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:on {:go :b}}
+                                                          :b {:final? true :output-key :out :error? true}}})))))
+
+(deftest tags-constraint
+  (is (= :rf.error/machine-bad-tags (category {:initial :a :states {:a {:tags [:x]}}})))
+  (is (= :rf.error/machine-bad-tags (category {:initial :a :states {:a {:tags :busy}}})))
+  (is (= :rf.error/machine-bad-tags (category {:initial :a :states {:a {:tags #{:ok "bad"}}}})))
+  (is (nil? (g/definition-defect {:initial :a :states {:a {:tags #{:busy :loading}}}}))))
+
+(deftest after-delay-key-constraint
+  (is (= :rf.error/machine-bad-after-delay (category {:initial :a :states {:a {:after {0 :b}} :b {}}})))
+  (is (= :rf.error/machine-bad-after-delay (category {:initial :a :states {:a {:after {"soon" :b}} :b {}}})))
+  (is (nil? (g/definition-defect {:initial :a :states {:a {:after {1000 :b}} :b {}}}))))
+
+(deftest spawn-xor-constraint
+  (testing "a :spawn declaring NEITHER :machine-id nor :definition is rejected"
+    (is (= :rf.error/machine-spawn-bad-shape (category {:initial :a :states {:a {:spawn {}}}}))))
+  (testing "a :spawn declaring BOTH is rejected"
+    (is (= :rf.error/machine-spawn-bad-shape
+           (category {:initial :a :states {:a {:spawn {:machine-id :m
+                                                       :definition {:initial :x :states {:x {}}}}}}}))))
+  (testing "a :spawn declaring EXACTLY ONE is accepted"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:spawn {:machine-id :m}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; Choice / timeout are validated on their LOWERED (desugared) shape
+
+(deftest choice-and-timeout-validated-on-lowered-shape
+  (testing "a :type :choice whose candidate targets a MISSING state is rejected
+            (validated on the lowered :always form)"
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :g :states {:g {:type :choice :choice [{:target :nope}]} :a {}}}))))
+  (testing "a VALID :type :choice projects"
+    (is (nil? (g/definition-defect {:initial :g :states {:g {:type :choice
+                                                             :choice [{:target :a} {:target :b}]}
+                                                          :a {} :b {}}}))))
+  (testing "a state :timeout whose :on-timeout targets a MISSING state is rejected
+            (validated on the lowered :after form)"
+    (is (= :rf.error/machine-unresolved-target
+           (category {:initial :a :states {:a {:timeout 1000 :on-timeout :nope}}}))))
+  (testing "a VALID state :timeout projects"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:timeout 1000 :on-timeout :b} :b {}}})))))
+
+;; ---------------------------------------------------------------------------
+;; VALID definitions continue to PROJECT (rf2-j538f7.18 acceptance #6)
+
+(def ^:private valid-definitions
+  {:flat       {:initial :idle :states {:idle {:on {:go :done}} :done {:final? true}}}
+   :compound   {:initial :o :states {:o {:initial :i :states {:i {:on {:up :sib}} :sib {}}} :top {}}}
+   :vec-target {:initial :o :states {:o {:initial :i :states {:i {:on {:esc [:top]}}}} :top {}}}
+   :parallel   {:type :parallel :regions {:r1 {:initial :a :states {:a {:on {:x :b}} :b {}}}
+                                          :r2 {:initial :p :states {:p {}}}}}
+   :history    {:initial :o :states {:o {:initial :s :states {:s {:on {:g :s2}} :s2 {} :h {:type :history :deep? true}}}}}
+   :timeout    {:initial :a :states {:a {:timeout 1000 :on-timeout :b} :b {}}}
+   :choice     {:initial :g :states {:g {:type :choice :choice [{:target :a} {:target :b}]} :a {} :b {}}}
+   :spawn      {:initial :a :states {:a {:spawn {:machine-id :child} :on {:go :b}} :b {}}}
+   :spawn-all  {:initial :a :states {:a {:spawn-all {:children [{:id :c1 :machine-id :m}]
+                                                     :on-child-done :cd :on-child-error :ce
+                                                     :on-all-complete [:done]}
+                                         :on {:go :b}} :b {}}}
+   :namespaced {:initial :a :states {:a {:my.app/note "x"}}}})
+
+(deftest valid-definitions-accepted
+  (doseq [[label d] valid-definitions]
+    (is (true? (g/valid-definition? d)) (str label " is accepted"))
+    (is (nil? (g/definition-defect d))  (str label " carries no defect"))))
+
+;; ---------------------------------------------------------------------------
+;; Value-FREE diagnostics (rf2-8nzxib / EP-0015): the defect + summary carry
+;; STRUCTURAL facts only — never a :data slot's live values, an action / guard,
+;; or any raw value.
+
+(deftest defect-diagnostics-are-value-free
+  (let [definition {:initial :a
+                    :data    {:secret "TOP-SECRET-TOKEN" :password "hunter2"}
+                    :states  {:a {:on-entry (fn secret-action [_] :SECRET-RETURN)}}}
+        defect     (g/definition-defect definition)
+        summary    (g/definition-summary definition)]
+    (testing "the definition is rejected (unknown bare :on-entry key)"
+      (is (= :rf.error/machine-unknown-node-key (:category defect))))
+    (testing "the defect carries only structural facts (category / path / keys)"
+      (is (= [:a] (:path defect)))
+      (is (= [:on-entry] (:keys defect))))
+    (testing "no live :data value, password, or action return leaks into the diagnostics"
+      (doseq [needle ["TOP-SECRET-TOKEN" "hunter2" "SECRET-RETURN"]]
+        (is (not (str/includes? (pr-str defect) needle))
+            (str "defect must not leak " needle))
+        (is (not (str/includes? (pr-str summary) needle))
+            (str "summary must not leak " needle))))
+    (testing "definition-summary embeds the canonical defect category so every
+              surface that stashes it carries the same category"
+      (is (= :rf.error/machine-unknown-node-key (get-in summary [:defect :category]))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -672,7 +672,8 @@
                              :states  {:a1 {:on {:go :a2}}
                                        :a2 {:final? true}}}
                          :b {:initial :b1
-                             :states  {:b1 {:on {:go :b2}}}}}}
+                             :states  {:b1 {:on {:go :b2}}
+                                       :b2 {:final? true}}}}}
           out (m/emit m {:fenced? false :header-comment? false})]
       (is (str/includes? out "note right of a")
           "the region's own action-only on-done surfaces as a note on the region root")

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -108,7 +108,7 @@
   {:initial :idle
    :states  {:idle          {:on {:login [:authenticated :browsing]}}
              :authenticated {:initial :browsing
-                             :states  {:browsing {:on {:logout :idle}}
+                             :states  {:browsing {:on {:checkout :paying}}
                                        :paying   {}}}}})
 
 (def vector-path-namespaced-segment-machine
@@ -1090,6 +1090,7 @@
                 :states {:off    {:on {:resume [:player :hist]}}
                          :player {:initial :stopped
                                   :states  {:stopped {:on {:play :playing}}
+                                            :playing {}
                                             :hist    {:type :history}}}}}
           xml  (scxml/spec->scxml spec)
           back (scxml/scxml->spec xml)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -676,6 +676,56 @@
                  "(canonical? " canonical? ", share-ok? " share-ok? ")"))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-j538f7.18 — RECURSIVELY-malformed definitions (structurally invalid
+;; BELOW the root: a nested compound missing :initial, a dangling transition
+;; target, an unknown bare node key) ALSO fail closed at the share boundary. The
+;; pre-fix shallow canonical gate blessed these (their ROOT shape is fine), so a
+;; forged share-URL carrying one decoded :ok and reached MachineChart even though
+;; the definition is rejected everywhere the runtime is consulted. The recursive
+;; gate now rejects them at BOTH encode and decode, exactly like the flat /
+;; parallel shapes rf2-3fc89f.18 covered (which stay green).
+
+(def recursively-malformed-definitions
+  {:nested-compound-no-initial {:initial :outer :states {:outer {:states {:inner {}}}}}
+   :dangling-target            {:initial :idle :states {:idle {:on {:go :missing}}}}
+   :unknown-node-key           {:initial :idle :states {:idle {:on-entry :oops}}}})
+
+(deftest decoded-recursively-malformed-definition-rejected
+  (testing "rf2-j538f7.18 — a forged v2 share-URL carrying a recursively-
+            malformed definition fails closed at decode (:invalid-chart-state),
+            via BOTH the throwing and the safe decode APIs"
+    (doseq [[label definition] recursively-malformed-definitions]
+      (let [d (try (share/decode-share-url (forge-definition-url definition))
+                   (catch :default e (ex-data e)))]
+        (is (= :invalid-chart-state (:reason d))
+            (str "recursively-malformed " label " must fail closed at decode"))
+        (is (= :rf.machines-viz.share/decode-failed (:rf.error/id d))))
+      (let [{:keys [ok error]} (share/decode-share-url-safe (forge-definition-url definition))]
+        (is (nil? ok) (str label " must NOT decode :ok"))
+        (is (= :invalid-chart-state (:reason error)))))))
+
+(deftest encode-rejects-recursively-malformed-definitions
+  (testing "rf2-j538f7.18 — the encoder rejects the same recursively-malformed
+            definitions (encode/decode stay symmetric)"
+    (doseq [[label definition] recursively-malformed-definitions]
+      (let [d (try (share/encode-share-url {:machine-id :demo :definition definition})
+                   (catch :default e (ex-data e)))]
+        (is (= :invalid-chart-state (:reason d))
+            (str "recursively-malformed " label " must be rejected at encode"))
+        (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d)))))))
+
+(deftest share-gate-recursively-malformed-agrees-with-canonical-grammar
+  (testing "rf2-j538f7.18 — the share boundary rejects EXACTLY the recursively-
+            malformed definitions the canonical RECURSIVE grammar gate rejects,
+            and the prior rf2-3fc89f.18 flat/parallel cases remain rejected"
+    (doseq [[label definition] (merge malformed-definitions recursively-malformed-definitions)]
+      (let [canonical? (boolean (grammar/valid-definition? (grammar/desugar-grammar definition)))
+            share-ok?  (some? (:ok (share/decode-share-url-safe (forge-definition-url definition))))]
+        (is (false? canonical?) (str label " is rejected by the canonical recursive grammar gate"))
+        (is (= canonical? share-ok?)
+            (str label ": share boundary agrees with the canonical grammar gate"))))))
+
+;; ---------------------------------------------------------------------------
 ;; rf2-dplwxh — top-level ChartState is CLOSED on decode. The encoder
 ;; allowlists to #{:machine-id :frame-id :definition :snapshot} before
 ;; serialising, but a hand-crafted URL bypasses the encoder entirely. The

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
@@ -80,6 +80,29 @@
       (is (= :invalid-chart-state (:reason vm)))
       (is (nil? (:props vm))))))
 
+(deftest decode-location-rejects-recursively-malformed-definition
+  (testing "rf2-j538f7.18 — a share-URL carrying a RECURSIVELY-malformed machine
+            definition (structurally invalid BELOW the root: a nested compound
+            missing :initial, a dangling transition target, or an unknown bare
+            node key) also fails closed at the viewer boundary — :status :error,
+            :reason :invalid-chart-state, and NO MachineChart props. The pre-fix
+            shallow gate blessed these (root shape OK); the recursive gate now
+            rejects them."
+    (doseq [[label definition]
+            {:nested-compound-no-initial {:initial :outer :states {:outer {:states {:inner {}}}}}
+             :dangling-target            {:initial :idle :states {:idle {:on {:go :missing}}}}
+             :unknown-node-key           {:initial :idle :states {:idle {:on-entry :oops}}}}]
+      (let [url (envelope->url
+                  {:rf.machines-viz.share/v       "2"
+                   :rf.machines-viz.share/chart   {:machine-id :demo :definition definition}
+                   :rf.machines-viz.share/created 0})
+            vm  (viewer/decode-location url)]
+        (is (= :error (:status vm))
+            (str "recursively-malformed " label " must not reach the MachineChart path"))
+        (is (= :invalid-chart-state (:reason vm)) (str label))
+        (is (nil? (:props vm))
+            (str "no MachineChart props are produced for recursively-malformed " label))))))
+
 (deftest viewer-view-dispatches-on-status
   (testing "viewer-view renders the right top-level shape per status"
     ;; The view is hiccup data; assert the data-testid carried by each


### PR DESCRIPTION
## Summary

Fixes rf2-j538f7.18. The shared canonical predicate `grammar/valid-definition?` (delegated to by `share/valid-definition?`) was only a **shallow minimum-shape** check — it validated the root (or parallel-region roots) as a `valid-state-tree?` and nothing deeper. So every boundary that consults it (share encode/decode, AI generation, Mermaid, SCXML, and the chart projector) gave the same **false positive** for structurally-invalid-but-shallowly-ok definitions.

**Premise verified on current main:** the three deterministic false positives from the bead report reproduced exactly — `grammar/valid-definition?` returned `true` for a nested compound missing `:initial`, a dangling transition target, and an unknown bare node key, all of which `validate-machine!` rejects.

## What changed

- **`grammar/definition-defect`** (new) recursively walks the root, every parallel region, and every compound descendant, mirroring the runtime `machines.lifecycle-fx.validation/validate-machine!` for the **projectable structural invariants**: compound-`:initial` presence; transition `:target` shape + resolution for `:on`/`:after`/`:always`/`:on-done`/`:spawn :on-error`; unknown bare node/spawn keys (namespaced keys pass); history placement / closed-keys / at-most-one-per-compound / `:default-target` resolution; `:final?` shape; `:tags`; `:after`-delay keys; mutually-exclusive parallel shape. `:timeout`/`:choice` are validated on their lowered (desugared) shape. Each defect's `:category` **is** the engine's `:rf.error/machine-*` id, so every surface carries the canonical category (via the value-free `definition-summary`) while keeping its own surface-specific error id. `valid-definition?` now delegates here.
- **`chart.layout/project-definition`** routes through the gate **before** graph construction: a malformed direct host prop is rejected (empty graph + value-free `:definition-error`), so nothing reaches ELK and no orphan edges to absent nodes are created. `MachineChart` renders a distinct invalid-definition placeholder.
- **Desugar walkers** made `map?`-safe so a pathological non-map `:states`/`:regions` is rejected, not crashed on (parity-neutral — well-formed inputs unchanged, confirmed by the desugar-parity corpus).
- **Spec** (`tools/machines-viz/spec/API.md`) updated: the AI two-layer contract, the `:scxml/invalid-spec` / `:ai-generate/invalid-spec` / `:invalid-chart-state` rows, and the `MachineChart :definition` prop doc now describe the recursive grammar gate.

### Documented viz-vs-engine divergences (out of scope, pinned in the parity test)
Runtime-wiring not projectable topology, or viz-stricter by necessity: guard/action/`:on-spawn` keyword ref resolution (needs the registry); a non-parallel root `:after` (engine rejects as unschedulable, the viz still projects it as a root anchor); viz-stricter root shape (the viz requires a keyword root `:initial` + non-empty `:states` to have an initial-marker to project). The parallel-root region-qualified target grammar + full `:spawn-all` shape are also not mirrored (a valid spawn-all still projects).

### Test-fixture corrections
Four existing fixtures were structurally invalid — bare-keyword cross-level targets, compounds missing `:initial`, and a stray non-final `:error?` — which the shallow gate let slide and the recursive gate (and `validate-machine!`, verified against the engine) correctly reject. They are corrected to valid forms that preserve each test's intent.

## Quality gates

- **JVM** (`clojure -M:test` from `tools/machines-viz`): **623 tests, 2456 assertions, 0 failures, 0 errors** (baseline was 605 / 2265 / 0 — grew by the parity corpus, recursive-validation, chart-rejection, and cross-surface rejection suites).
- **CLJS** (`npm run test:cljs` — the consolidated `node-test` gate, covering the `.cljs` share/viewer additions): **8509 tests, 39925 assertions, 0 failures, 0 errors**.
- **CLJS browser** (`npm run test:browser` — shadow-cljs `:browser-test`, headless Chromium via Playwright): **257 tests, 866 assertions, 0 failures, 0 errors**. Fixed after landing: two `chart_dom_cljs_test.cljs` `:tags` fixtures were latent-invalid vectors (`[:initial-tag]`, `[:door/open]`) that the new recursive grammar correctly rejects (as `validate-machine!` does); they only surface under the browser gate (node-test short-circuits DOM tests via `(browser?)`), so the gate went red with 4 failures + 5 errors. Corrected to the valid set form (`#{:initial-tag}`, `#{:door/open}`) — grammar unchanged.
- Engine-parity corpus (31 fixtures) asserts the viz validator accepts/rejects **exactly** what `validate-machine!` does; the machines dep stays test-only, bundle isolation unchanged.

## Acceptance criteria
1. The three deterministic false positives are rejected by the canonical validator, share encode/decode, AI, Mermaid, SCXML, and direct chart projection, with stable value-free structured diagnostics. ✅
2. Recursive tests over root / nested-compound / parallel-region initial presence + type; empty/non-map state bodies; unknown bare keys + namespaced acceptance; malformed/dangling keyword & vector targets; history / choice / timeout / spawn / final-state constraints. ✅
3. Table-driven engine-parity corpus; machines dep test-only; bundle isolation unchanged. ✅
4. Forged recursively-malformed v2 share/viewer envelopes → `:invalid-chart-state` + no `MachineChart` props; prior rf2-3fc89f.18 flat/parallel cases remain green. ✅
5. AI no longer returns runtime-rejected specs; Mermaid/SCXML don't emit them; chart projection rejects before ELK with no orphans; each surface carries the canonical defect category. ✅
6. Valid flat/compound/parallel/history/timeout/choice/spawn/spawn-all/namespaced definitions continue to project. ✅
7. JVM + CLJS gates pass; the tool spec now defines "valid" as the runtime-projectable grammar. ✅

