### PR TITLE
fix(examples/capabilities): hydrate baked resource-SSR payload into the live cache (rf2-j538f7.26)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/README.md
+++ b/examples/capabilities/ssr/resources_ssr/README.md
@@ -125,11 +125,19 @@ projection (redaction / omission / scoped-key privacy / index omission),
 and the client hydration reconcile + refetch plan all run end-to-end.
 
 The `index.html` next to this file carries a **pre-baked** hydration
-payload — a `:loaded` `:articles/list` entry under
-`[:rf.scope/global :articles/list {}]` — so the browser-side `run` runs
-without a Clojure server in the box. It's an **illustrative** stand-in
-for what `handle-request` emits behind a real server, not a byte-exact
-capture. One visible difference is the frame-id. This hand-written
+payload — a `:loaded` `:articles/list` entry — so the browser-side `run`
+runs without a Clojure server in the box. Like the live runtime, the entry
+is **map-keyed by its CEDN-1 byte `key-id`** (the storage identity public
+reads look up under) and carries the canonical scoped key
+`[:rf.scope/global :articles/list {}]` as its own **`:resource/key`** (the
+scoped resource fact the reverse indexes and refetch plan re-key from) —
+*not* under the scoped-key vector as a map key. It's an **illustrative**
+stand-in for what `handle-request` emits behind a real server, not a
+byte-exact capture. Because `:articles/list` declares no time-based
+staleness policy, the baked entry carries `:stale-at nil` and stays
+deterministically fresh — no rotting absolute deadline — so on hydration
+it renders immediately and the client does **not** refetch. One visible
+difference is the frame-id. This hand-written
 payload pins `:rf/frame-id :rf/default` — present *and equal* to the
 client's fixed target, a valid no-conflict shape a static file can
 hand-pick. `handle-request` instead *drops* `:rf/frame-id`, because its

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -99,11 +99,21 @@
 ;; global claim is the explicit, checkable statement that this handoff is safe.
 ;; See docs/resources/glossary.md#scope.
 
+;; This list declares NO time-based staleness policy (`:stale-after-ms` is
+;; deliberately absent), so an entry never ages out on a wall-clock timer — its
+;; `:stale-at` is nil and it stays fresh until something explicitly invalidates
+;; its `[:article-list]` tag. That is the right freshness shape for THIS demo:
+;; the point is the SSR cache handoff, not TTL behaviour, and it lets the
+;; offline `index.html` bake a `:stale-at nil` entry that stays deterministically
+;; fresh forever — no rotting absolute deadline a static file would have to
+;; rebase. A resource that genuinely ages would add `:stale-after-ms <ms>`;
+;; explicit invalidation is the freshness authority either way. See
+;; docs/resources/glossary.md#invalidate.
+
 (rf/reg-resource :articles/list
-  {:doc            "Recent articles (public, SSR-preloaded)."
+  {:doc            "Recent articles (public, SSR-preloaded, invalidation-only freshness)."
    :params-schema  [:map]
    :scope          :rf.scope/global
-   :stale-after-ms 60000
    :tags           (fn [_params _data] #{[:article-list]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/articles"}

--- a/examples/capabilities/ssr/resources_ssr/index.html
+++ b/examples/capabilities/ssr/resources_ssr/index.html
@@ -24,16 +24,29 @@
 
     The load-bearing detail vs the plain `ssr/` example: the page's
     server-state rides `:rf/runtime-db` as a RESOURCE projection under
-    `:rf.runtime/resources :entries`, keyed by the scoped resource key
-    `[<scope> <resource-id> <canonical-params>]` — NOT as an app-db value.
-    This is exactly what `payload-policy/project-runtime-db` emits in
-    `handle-request`: only the durable `:entries` are serialized; the
-    `:tag-index` / `:owner-index` are EXCLUDED (recomputed from `:entries` on
-    install — Spec 016 §SSR / §Restore part 5), `:current-work` is stripped on
-    the wire, and host handles never serialize. On hydration the framework
-    `:rf/hydrate` installs this projection into the client frame's runtime
-    partition; the reconcile orphans the SSR owner + recomputes the indexes; a
-    fresh entry renders immediately and does NOT immediately re-fetch.
+    `:rf.runtime/resources :entries`. Each entry is MAP-KEYED by its CEDN-1
+    byte `key-id` — `(state/key-id [<scope> <resource-id> <canonical-params>])`,
+    the string `"v[k::rf.scope/global k::articles/list m{}]"` below — and
+    carries the canonical scoped key vector `[<scope> <resource-id>
+    <canonical-params>]` as its own `:resource/key`. Byte key-id = storage
+    identity (what public reads look up under); `:resource/key` = the scoped
+    resource fact (what the reverse indexes and refetch plan re-key from). It
+    is NOT an app-db value. This is exactly the shape
+    `payload-policy/project-runtime-db` emits in `handle-request`: only the
+    durable `:entries` are serialized; the `:tag-index` / `:owner-index` are
+    EXCLUDED (recomputed from `:entries` on install — Spec 016 §SSR / §Restore
+    part 5), `:current-work` is stripped on the wire, and host handles never
+    serialize. On hydration the framework `:rf/hydrate` installs this projection
+    into the client frame's runtime partition; the reconcile orphans the
+    `[:ssr …]` SSR owner + recomputes the indexes; a fresh entry renders
+    immediately and does NOT immediately re-fetch.
+
+    Freshness: this article list declares NO time-based staleness policy
+    (`:articles/list` omits `:stale-after-ms`), so its entry never ages out on
+    a timer and the baked `:stale-at` is nil. That keeps this offline fixture
+    deterministically fresh indefinitely — no rebased clock, no rotting
+    absolute deadline — with explicit invalidation as the real freshness
+    authority. So the hydrated entry is fresh, and the client does NOT refetch.
   -->
   <div id="app">
     <div class="page">
@@ -51,16 +64,19 @@
  :rf/runtime-db
  {:rf.runtime/resources
   {:entries
-   {[:rf.scope/global :articles/list {}]
-    {:resource/id :articles/list
-     :status      :loaded
-     :data        [{:slug "welcome"   :title "Welcome to re-frame2"}
-                   {:slug "resources" :title "Server-state as resources"}]
-     :error       nil
-     :loaded-at   1780752000000
-     :stale-at    1780752060000
-     :generation  1
-     :tags        #{[:article-list]}}}}}
+   {"v[k::rf.scope/global k::articles/list m{}]"
+    {:resource/key   [:rf.scope/global :articles/list {}]
+     :resource/id    :articles/list
+     :status         :loaded
+     :data           [{:slug "welcome"   :title "Welcome to re-frame2"}
+                      {:slug "resources" :title "Server-state as resources"}]
+     :error          nil
+     :loaded-at      1780752000000
+     :stale-at       nil
+     :invalidated-at nil
+     :generation     1
+     :active-owners  #{[:ssr :ssr/req-1 :ssr/nav-1]}
+     :tags           #{[:article-list]}}}}}
  :rf/render-hash nil}
   </script>
   <script src="main.js"></script>

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -20,6 +20,7 @@
   (:require [clojure.set]
             [clojure.string]
             [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
@@ -34,6 +35,12 @@
             ;; and the late-bound SSR runtime-db projection + hydration
             ;; reconcile hooks the `resources-ssr` example drives.
             [re-frame.resources]
+            ;; Byte `key-id` + client refetch-plan helpers — the
+            ;; `resources-ssr` static-payload hydration regression asserts the
+            ;; baked `:entries` are keyed on `state/key-id` and that a fresh
+            ;; hydrated entry issues no client refetch.
+            [re-frame.resources.state :as res-state]
+            [re-frame.resources.ssr :as res-ssr]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.error-listener :as ssr-error-listener]
             [re-frame.ssr.request :as ssr-request]
@@ -726,6 +733,94 @@
               "the hydrated resource entry installed into the client frame")
           (is (= :loaded (-> client-entries vals first :status))
               "the hydrated entry is :loaded (renders immediately, no refetch)"))))))
+
+(deftest resources-ssr-example-static-index-payload-hydrates-into-live-cache
+  (testing "examples/capabilities/ssr/resources_ssr — the ACTUAL checked-in
+            `index.html` `__rf_payload` (the offline stand-in a reader opens
+            without a Clojure server) hydrates into the LIVE resource cache:
+            after `ssr/hydrate!` the public `rf/resource-state` /
+            `[:rf/resource …]` view reads the two baked articles on the FIRST
+            client render, the baked `:entries` are keyed on the CEDN byte
+            `key-id` (each entry carrying the scoped vector as `:resource/key`,
+            no legacy vector-map-key row), and the fresh entry issues NO client
+            refetch (rf2-j538f7.26). Reads the file itself — NOT a hand-built
+            payload — so a future drift back to the pre-EP-0012 vector-keyed /
+            rotting-absolute-`:stale-at` shape fails here."
+    (require 'resources-ssr.core :reload)
+    (rf/init! ssr/adapter)
+    ;; Read the SHIPPED static host page off the classpath (the
+    ;; `../../examples/capabilities/ssr` source root is a `:test` classpath
+    ;; entry, so `resources_ssr/index.html` resolves next to `core.cljc`) and
+    ;; extract the same `__rf_payload` EDN the browser reader parses.
+    (let [index-html (some-> (io/resource "resources_ssr/index.html") slurp)
+          payload    (some-> index-html
+                             (->> (re-find #"(?s)id=\"__rf_payload\" type=\"application/edn\">(.*?)</script>"))
+                             second
+                             edn/read-string)]
+      (is (some? index-html)
+          "the checked-in resources_ssr/index.html is on the test classpath")
+      (is (some? payload)
+          "the __rf_payload EDN parsed out of the static index.html body")
+      ;; ── The baked payload is the CURRENT projector shape ─────────────────
+      ;; `:entries` are map-keyed on the CEDN-1 byte `key-id` (rf2-9e0tyq), each
+      ;; entry carrying the scoped `[scope resource-id params]` vector as its own
+      ;; `:resource/key`. A legacy vector-map-key row would key by the vector and
+      ;; leave `:resource/key` nil — unreachable through the byte-key lookup.
+      (let [baked-entries (get-in payload [:rf/runtime-db :rf.runtime/resources :entries])
+            scoped-key    [:rf.scope/global :articles/list {}]
+            expected-kid  (res-state/key-id scoped-key)]
+        (is (= 1 (count baked-entries)) "one resource entry rides the static payload")
+        (is (= #{expected-kid} (set (keys baked-entries)))
+            "the baked entry is map-keyed by (state/key-id scoped-key), NOT the scoped vector")
+        (is (every? string? (keys baked-entries))
+            "no legacy vector-keyed :entries row survives (byte key-id is a string)")
+        (let [entry (first (vals baked-entries))]
+          (is (= scoped-key (:resource/key entry))
+              "the entry carries the canonical scoped vector as :resource/key")
+          (is (= expected-kid (res-state/key-id (:resource/key entry)))
+              "the map key equals the byte key-id of the entry's own :resource/key")
+          (is (nil? (:stale-at entry))
+              "the baked entry declares no rotting absolute :stale-at (never-stale policy)")))
+      ;; ── Hydrate the example's OWN :rf/default client frame ───────────────
+      (let [client-frame @(resolve 'resources-ssr.core/app-frame)
+            _            (rf/reg-frame client-frame
+                           {:doc "resources-ssr static-payload client frame"
+                            :platform :client})
+            returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+        (is (= payload returned)
+            "hydrate! applied the static payload (frame-id present-and-equal, no conflict)")
+        ;; The live cache serves the baked entry through the PUBLIC read — the
+        ;; property that regressed: before the fix this returned nil.
+        (let [state (rf/resource-state {:resource :articles/list
+                                        :scope    :rf.scope/global
+                                        :params   {}
+                                        :frame    client-frame})]
+          (is (= :loaded (:status state))
+              "rf/resource-state reads the baked entry :loaded from the live cache")
+          (is (= [{:slug "welcome"   :title "Welcome to re-frame2"}
+                  {:slug "resources" :title "Server-state as resources"}]
+                 (:data state))
+              "both baked articles are reachable through the live resource read"))
+        ;; The example's OWN view renders both titles on the first client render
+        ;; (no skeleton, no empty <ul>) — the pre-rendered static rows stay put.
+        (let [html (rf/with-frame client-frame
+                     (rf/render-to-string ((rf/view :app/root)) {}))]
+          (is (clojure.string/includes? html "Welcome to re-frame2")
+              "first client render shows the first article title")
+          (is (clojure.string/includes? html "Server-state as resources")
+              "first client render shows the second article title"))
+        ;; No double-fetch: a fresh hydrated entry is ABSENT from the refetch
+        ;; plan, so the route-free client boot issues no transport request.
+        (let [rdb  (:rf.db/runtime (rf/frame-state-value client-frame))
+              plan (res-ssr/hydrate-refetch-plan rdb)]
+          (is (empty? plan)
+              "the fresh baked entry issues NO client refetch (no double-fetch)")
+          ;; And the entry installed under the SAME byte key-id, with the SSR
+          ;; owner reconciled away (never trusted from the wire).
+          (let [client-entries (get-in rdb [:rf.runtime/resources :entries])]
+            (is (= #{(res-state/key-id [:rf.scope/global :articles/list {}])}
+                   (set (keys client-entries)))
+                "the client cache keys the installed entry on the byte key-id")))))))
 
 ;; ============================================================================
 ;; state-machine-walkthrough — chapter §Headless testing. Two flavours:


### PR DESCRIPTION
## What

The canonical browser-runnable **resource-SSR** example
(`examples/capabilities/ssr/resources_ssr/`) baked a stale hydration payload
into `index.html`. Its `:entries` were keyed by the scoped-key **vector**
`[:rf.scope/global :articles/list {}]` with no `:resource/key` and a fixed
60-second absolute `:stale-at`. Since the rf2-9e0tyq / PR #4043 re-key, the live
runtime keys `:entries` on the CEDN-1 byte `key-id` (`state/key-id`) and stores
the scoped vector as each entry's `:resource/key`.

Result: the baked row was **unreachable**. After `ssr/hydrate!` the client
`rf/resource-state` / `[:rf/resource …]` read returned `nil`, and the first
client render produced `<ul data-testid="articles-list"></ul>` — erasing the two
pre-rendered `<li>` rows the static HTML shipped. The example's headline
property (server-rendered resource data becoming a live client cache with no
flicker / no double-fetch) was not demonstrated. Independently, the absolute
`:stale-at` (2026-06-06T13:21Z) had expired over a month ago, so the fixture
could no longer show "fresh, no second fetch" even after re-keying.

This is a stale **example** payload; the framework projector/reconciler were
already correct (Spec 016:78 already states the byte-key model). No framework
change.

## Changes

- **`index.html` payload** re-keyed on the byte `key-id`
  (`"v[k::rf.scope/global k::articles/list m{}]"`), with the scoped vector stored
  as `:resource/key` and the `[:ssr …]` owner baked so the client reconcile has
  one to orphan — the exact shape `payload-policy/project-runtime-db` emits.
- **Never-stale freshness**: dropped `:stale-after-ms` from `:articles/list`
  (`core.cljc`) and baked `:stale-at nil`. The offline fixture is now
  deterministically fresh indefinitely — no rebased clock, no far-future
  timestamp — with explicit invalidation as the freshness authority.
- **Prose** in `index.html` and `README.md` reconciled to the byte-keyed-storage
  + in-entry-`:resource/key` model (byte key-id = storage identity;
  `:resource/key` = the scoped fact). Spec 016:78 already states this, so no spec
  edit was needed.
- **Regression** (`implementation/core/test/re_frame/examples_test.clj`): reads
  the ACTUAL checked-in `index.html` `__rf_payload` off the classpath (not a
  hand-built payload), hydrates it through `ssr/hydrate!` against the example's
  `:rf/default` client frame, and asserts the live cache serves both articles
  through `rf/resource-state` and the rendered view on the first client render,
  the entries are byte-key-keyed with in-entry `:resource/key`, and the fresh
  entry issues **no** client refetch. Fails on the old payload (nil read, empty
  `<ul>`, vector key, stale plan); passes now.

## Acceptance criteria (bead)

All seven met: (1) regression reads the real `index.html`; (2) `:loaded` with
both articles reachable via `rf/resource-state` + view on first render;
(3) byte-`key-id`-keyed, in-entry `:resource/key`, no vector-map-key row;
(4) `hydrate-refetch-plan` omits the entry, no boot transport request, no rotting
deadline; (5) dynamic `handle-request` path unchanged, single doctype
(rf2-3fc89f.30 regression still green); (6) prose accurate, no vector-map-key
claim; (7) example tests, resource-SSR/hydration CLJS tests, `:examples/resources-ssr`
compile, and the asset gate all pass. No legacy hydration compatibility shim.

## Quality gates

- **shadow-cljs compile `:examples/resources-ssr`** — PASS (218 files, **0 warnings**).
- **JVM example suite** `re-frame.examples-test` — PASS (15 tests / 89 assertions, 0 failures). New regression **fails before / passes after** the payload fix (verified by temporarily restoring the old payload: nil `resource-state`, empty `<ul>`, vector key, stale plan).
- **Resource SSR/hydration CLJS suite** `re-frame.resources-ssr-cljs-test` (run on JVM) — PASS (44 tests / 167 assertions, 0 failures); confirms the framework is untouched.
- **`node examples/scripts/check-examples-assets.cjs`** — PASS (35 host pages + `_shared` tree).
- **`mkdocs build --strict`** — PASS (exit 0). (Example READMEs live under `examples/`, outside `docs_dir: docs`, so they are not in the site; run anyway since committed markdown changed.)
- **Full `npm run test:cljs` node suite** — SKIPPED (heavy; the change is example + JVM-test only, framework untouched — the targeted `.cljc` resource-SSR/hydration namespace was run on JVM instead, and the example compiles clean).

## Surface / scope notes

- Diff confined to `examples/capabilities/ssr/resources_ssr/*` plus the mandated
  regression in `implementation/core/test/re_frame/examples_test.clj` (examples
  are test-free by convention, so the JVM example suite is the only home for an
  example regression). No shared `examples/README.md` or asset-walker change; no
  spec change; no `.beads` commit.
