### PR TITLE
fix(flows): reject self-referential/cyclic flow dependencies at registration (rf2-j538f7.6)

### DIFF
--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -103,21 +103,27 @@
 (defn topo-sort
   "Return flow ids in Kahn topological order.
 
-  Throws `:rf.error/flow-cycle` with a closing-repeat `:cycle` path. This is
-  intentionally unmemoized: frame flow maps are small and lifecycle changes
-  would require explicit cache invalidation."
+  Throws `:rf.error/flow-cycle` with a closing-repeat `:cycle` path. A flow
+  whose own :inputs overlap its own :output-path depends on itself; that is a
+  single-node cycle reported as `[id id]`. A flow is a pure derivation of
+  independently-owned facts, never a recurrence over its own prior output
+  (Spec 013 §Dependency rule), so the dependency graph RETAINS the `id -> id`
+  self-edge and Kahn rejects it exactly like a multi-node cycle — there is no
+  separate self-edge case and no singleton fast path that could smuggle one in.
+  This is intentionally unmemoized: frame flow maps are small and lifecycle
+  changes would require explicit cache invalidation."
   [flow-map]
   (let [ids (vec (keys flow-map))]
-    ;; Avoid the quadratic graph build for the trivial cases.
-    (case (count ids)
-      0 []
-      1 ids
+    (if (empty? ids)
+      []
+      ;; Build the full dependency graph — INCLUDING any `id -> id` self-edge —
+      ;; even for a singleton. A one-flow registry whose input overlaps its own
+      ;; output is a self-cycle and must be rejected, not fast-pathed to `[id]`.
       (let [graph (into {}
                         (map (fn [id]
                                (let [flow (flow-map id)]
                                  [id (into #{}
-                                           (filter #(and (not= id %)
-                                                         (depends-on? flow (flow-map %))))
+                                           (filter #(depends-on? flow (flow-map %)))
                                            ids)])))
                         ids)]
         (loop [ready     (filterv #(empty? (graph %)) ids)
@@ -126,7 +132,9 @@
           (if-let [node-id (peek ready)]
             ;; Peel `node-id` from the remaining graph: drop its row, then
             ;; walk every other node, dropping the edge into `node-id` from
-            ;; its dep-set. A dep-set that empties out is newly-ready.
+            ;; its dep-set. A dep-set that empties out is newly-ready. A
+            ;; self-edged node never becomes ready (its own row is skipped by
+            ;; `remaining-without-node`), so it stays stuck → cycle.
             (let [remaining-without-node (dissoc remaining node-id)
                   [remaining' ready']
                   (reduce-kv (fn [[acc-remaining acc-ready] dep-id dep-set]
@@ -143,7 +151,7 @@
               ;; so callers can correct the graph and retry.
               (error/throw-error!
                 :rf.error/flow-cycle 'rf/reg-flow
-                "Cyclic flow dependency — at least one pair of flows' :output-path / :inputs overlap mutually (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain."
+                "Cyclic flow dependency — either two-or-more flows' :output-path / :inputs overlap mutually, or one flow's :inputs overlap its own :output-path (a self-cycle) (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain; a self-cycle repeats one id, e.g. [id id]."
                 {:recovery :fix-registration
                  :extra    {:cycle (extract-cycle-path graph
                                                        (set (keys remaining)))}})

--- a/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
@@ -57,6 +57,96 @@
     (is (false? (topo/output-paths-overlap? [:a] [:b]))       "unrelated are disjoint")))
 
 ;; ===========================================================================
+;; 1b. topo-sort self-cycle rejection (pure data, host-portable) — rf2-j538f7.6
+;;
+;; A flow whose own :inputs overlap its own :output-path depends on itself:
+;; that is a single-node dependency cycle and MUST be rejected at registration
+;; (a flow is a pure derivation of independently-owned facts, not a recurrence
+;; over its own prior output — Spec 013 §Dependency rule). `topo-sort` retains
+;; the `id -> id` self-edge and rejects it exactly like a multi-node cycle,
+;; producing a closing-repeat `[id id]`. Driven directly (pure, no runtime) so
+;; JVM and CLJS agree on the topology/error behaviour.
+;; ===========================================================================
+
+(defn- topo-throws
+  "Run `topo/topo-sort` and return the thrown ExceptionInfo (or nil)."
+  [flow-map]
+  (try
+    (topo/topo-sort flow-map)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e)))
+
+(deftest topo-sort-rejects-self-cycle-on-this-host
+  (testing "a singleton flow whose bare input EQUALS its own :output-path is a
+            self-cycle → :rf.error/flow-cycle with closing-repeat [:a :a]"
+    (let [ex (topo-throws {:a {:id :a :inputs [[:x]] :derive identity :output-path [:x]}})]
+      (is (some? ex) "the self-cyclic singleton is rejected, not fast-pathed to [:a]")
+      (is (= :rf.error/flow-cycle (error-id ex)) "structured :rf.error/flow-cycle")
+      (is (= [:a :a] (:cycle (ex-data ex)))
+          ":cycle is the closing-repeat single-node path [:a :a]")))
+
+  (testing "prefix self-overlap in BOTH directions is a self-cycle (Spec 013
+            'prefix in either direction')"
+    ;; input PARENT / output CHILD: input [:x] overlaps output [:x :y].
+    (let [ex (topo-throws {:a {:id :a :inputs [[:x]] :derive identity :output-path [:x :y]}})]
+      (is (= :rf.error/flow-cycle (error-id ex))
+          "input [:x] is a prefix of output [:x :y] → self-cycle")
+      (is (= [:a :a] (:cycle (ex-data ex)))))
+    ;; input CHILD / output PARENT: input [:x :y] overlaps output [:x].
+    (let [ex (topo-throws {:a {:id :a :inputs [[:x :y]] :derive identity :output-path [:x]}})]
+      (is (= :rf.error/flow-cycle (error-id ex))
+          "output [:x] is a prefix of input [:x :y] → self-cycle")
+      (is (= [:a :a] (:cycle (ex-data ex))))))
+
+  (testing "a self-edge is NOT discarded from a multi-node graph — a self-cyclic
+            flow alongside other acyclic flows is still rejected"
+    (let [ex (topo-throws {:a {:id :a :inputs [[:x]]         :derive identity :output-path [:x]}
+                           :b {:id :b :inputs [[:unrelated]] :derive identity :output-path [:b]}})]
+      (is (= :rf.error/flow-cycle (error-id ex))
+          "the :a self-cycle is detected even with acyclic sibling :b present")
+      (is (= [:a :a] (:cycle (ex-data ex)))
+          ":cycle names the offending self-cyclic id"))))
+
+(deftest topo-sort-accepts-acyclic-diamond-on-this-host
+  (testing "a valid acyclic diamond (D reads B and C; B and C read A) topo-sorts
+            with A first and D last — no false-positive self/cycle rejection"
+    ;; A: source, writes [:a]. B,C: read [:a], write [:b]/[:c]. D: reads [:b]
+    ;; and [:c], writes [:d]. No self-overlap anywhere.
+    (let [order (topo/topo-sort
+                  {:a {:id :a :inputs [[:src]]      :derive identity :output-path [:a]}
+                   :b {:id :b :inputs [[:a]]        :derive identity :output-path [:b]}
+                   :c {:id :c :inputs [[:a]]        :derive identity :output-path [:c]}
+                   :d {:id :d :inputs [[:b] [:c]]   :derive identity :output-path [:d]}})
+          pos   (into {} (map-indexed (fn [i id] [id i]) order))]
+      (is (= #{:a :b :c :d} (set order)) "every diamond node appears exactly once")
+      (is (< (pos :a) (pos :b)) "A precedes B")
+      (is (< (pos :a) (pos :c)) "A precedes C")
+      (is (< (pos :b) (pos :d)) "B precedes D")
+      (is (< (pos :c) (pos :d)) "C precedes D"))))
+
+;; ===========================================================================
+;; 1c. integrated reg-flow self-cycle rejection + runtime-input non-overlap
+;; ===========================================================================
+
+(deftest reg-flow-rejects-self-cycle-on-this-host
+  (testing "reg-flow rejects a self-referential flow at registration with
+            :rf.error/flow-cycle and installs nothing (rf2-j538f7.6)"
+    (let [ex (reg-flow-throws {:id :probe/self :inputs [[:x]] :derive inc :output-path [:x]})]
+      (is (some? ex) "the self-cyclic registration throws")
+      (is (= :rf.error/flow-cycle (error-id ex)) "structured :rf.error/flow-cycle")
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+          "the rejected self-cyclic flow is absent from the registry"))))
+
+(deftest reg-flow-runtime-input-overlapping-app-db-output-is-not-a-self-cycle-on-this-host
+  (testing "a runtime-qualified input [:rf.db/runtime :x] whose partition-relative
+            suffix matches the app-db :output-path [:x] is a DIFFERENT partition,
+            not a self-cycle — it registers cleanly (rf2-j538f7.6, Spec 013)"
+    (is (some? (rf/reg-flow :probe/runtime {:inputs [[:rf.db/runtime :x]] :output-path [:x]} identity))
+        "the runtime-input flow registers (its input reads runtime-db, its output writes app-db)")
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :probe/runtime)
+        "the flow row is present after clean registration")))
+
+;; ===========================================================================
 ;; 2. reg-flow accepts the SHARED concrete-segment domain (CLJS host)
 ;; ===========================================================================
 

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -801,10 +801,11 @@
   ;; that the prior registration survives.
   (testing "a cyclic reg-flow REPLACEMENT must not silently delete the prior registration"
     ;; Set up a non-cyclic two-flow graph where REPLACING :b is what
-    ;; closes the cycle. Cannot use a self-cycle on :b (topo-sort skips
-    ;; the `id = other` self-edge via `(not= id other)`), so we set
-    ;; :a's :inputs to point at :b's :output-path. After replacement of :b's
-    ;; inputs to point at :a's :output-path, the cycle :a → :b → :a closes.
+    ;; closes the cycle. This specifically exercises the REPLACEMENT-introduced
+    ;; MULTI-node cycle path (single-node self-cycles are covered separately in
+    ;; the self-cycle tests, rf2-j538f7.6), so we set :a's :inputs to point at
+    ;; :b's :output-path. After replacement of :b's inputs to point at :a's
+    ;; :output-path, the cycle :a → :b → :a closes.
     ;;
     ;; 1. :a reads [:b], writes [:a]. Currently no cycle because :b is
     ;;    not yet registered.
@@ -849,6 +850,130 @@
       ;; must still resolve the prior :b for this frame.
       (is (some? (flows/flow-meta-at :b {:frame :rf/default}))
           "the per-frame flow store for :b is still populated"))))
+
+;; ---------------------------------------------------------------------------
+;; 1c. Self-referential (single-node) dependency cycles — rf2-j538f7.6
+;;
+;; A flow whose own :inputs overlap its own :output-path depends on itself.
+;; A flow is a pure derivation of independently-owned facts, NOT a recurrence
+;; over its own prior output (Spec 013 §Dependency rule), so a self-overlap is
+;; a single-node cycle and must be rejected at registration — with the same
+;; canonical `:rf.error/flow-cycle` used for multi-node cycles, closing-repeat
+;; `[id id]`. Without this, the flow silently becomes a stateful oscillator/
+;; reducer that every UNRELATED event advances (1 → 2 → 3 …).
+;; ---------------------------------------------------------------------------
+
+(defn- flow-cycle? [^Throwable t]
+  (= :rf.error/flow-cycle (:rf.error/id (ex-data t))))
+
+(deftest reg-flow-rejects-self-referential-cycle-at-registration
+  (testing "a singleton flow whose bare input EQUALS its own :output-path is a
+            self-cycle → :rf.error/flow-cycle, closing-repeat [id id], nothing
+            registered"
+    (let [before (flows/flows-snapshot)
+          ex     (reg-flow-throwing {:id :probe/self :inputs [[:x]] :derive inc :output-path [:x]})]
+      (is (some? ex) "the self-cyclic registration throws")
+      (is (flow-cycle? ex) "structured :rf.error/flow-cycle")
+      (is (= [:probe/self :probe/self] (:cycle (ex-data ex)))
+          ":cycle is the closing-repeat single-node path [id id]")
+      (is (= :fix-registration (:recovery (ex-data ex)))
+          ":recovery :fix-registration — the cycle is caller-fixable")
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+          "the rejected flow is absent from the registry")
+      (is (= before (flows/flows-snapshot))
+          "registration mutated no flow state (rejected before commit)")))
+
+  (testing "prefix self-overlap in BOTH directions is also a self-cycle"
+    ;; input PARENT / output CHILD.
+    (is (flow-cycle? (reg-flow-throwing {:id :self/parent-child :inputs [[:x]] :derive identity :output-path [:x :y]}))
+        "input [:x] is a prefix of output [:x :y] → self-cycle")
+    ;; input CHILD / output PARENT.
+    (is (flow-cycle? (reg-flow-throwing {:id :self/child-parent :inputs [[:x :y]] :derive identity :output-path [:x]}))
+        "output [:x] is a prefix of input [:x :y] → self-cycle")))
+
+(deftest reg-flow-rejects-self-cycle-even-with-other-flows-registered
+  (testing "a self-edge is not discarded from a multi-node graph — registering
+            a self-cyclic flow while unrelated acyclic flows already exist is
+            still rejected, and the prior flows survive"
+    (rf/reg-flow :keep/a {:inputs [[:src-a]] :output-path [:a]} identity)
+    (rf/reg-flow :keep/b {:inputs [[:src-b]] :output-path [:b]} identity)
+    (let [ex (reg-flow-throwing {:id :probe/self :inputs [[:c]] :derive inc :output-path [:c]})]
+      (is (flow-cycle? ex) "the self-cycle is detected alongside acyclic siblings")
+      (is (= [:probe/self :probe/self] (:cycle (ex-data ex)))
+          ":cycle names only the offending self-cyclic id"))
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :keep/a)
+        "the prior acyclic :keep/a survives the rejected registration")
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :keep/b)
+        "the prior acyclic :keep/b survives the rejected registration")
+    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+        "the rejected self-cyclic flow is absent")))
+
+(deftest reg-flow-self-cycle-replacement-preserves-prior-registration-and-output
+  (testing "a hot-reload REPLACEMENT that introduces self-dependency is rejected
+            and preserves the prior working flow, its dirty-check row, and its
+            materialized output (rf2-j538f7.6 AC-4)"
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :tick (fn [{:keys [db]} _] {:db (update db :tick (fnil inc 0))}))
+    (let [original-derive (fn [n] (* 2 n))]
+      ;; A valid flow: reads [:n], writes [:derived :doubled]. Drain it so it
+      ;; materializes an output AND seeds a dirty-check row.
+      (rf/reg-flow :double {:inputs [[:n]] :output-path [:derived :doubled]} original-derive)
+      (rf/dispatch-sync [:init])
+      (is (= 10 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
+          "the valid flow materialized its output")
+      (is (some? (registry/get-frame-flow-last-inputs :rf/default :double))
+          "the valid flow seeded a dirty-check row")
+      ;; Re-register :double so its INPUT now overlaps its OWN output — a
+      ;; self-cycle. The replacement must be rejected.
+      (let [ex (reg-flow-throwing {:id     :double
+                                   :inputs [[:derived :doubled]]
+                                   :derive (fn [d] (inc d))
+                                   :output-path [:derived :doubled]})]
+        (is (flow-cycle? ex) "the self-cyclic replacement is rejected"))
+      ;; The prior working definition, its dirty-check row, and its output
+      ;; must all survive — the rejection happened before any mutation.
+      (let [after (get-in (flows/flows-snapshot) [:rf/default :double])]
+        (is (= [[:n]] (:inputs after))
+            "prior :double's :inputs are intact ([[:n]], not the rejected self-input)")
+        (is (identical? original-derive (:derive after))
+            "prior :double's :derive fn has the SAME identity"))
+      (is (some? (registry/get-frame-flow-last-inputs :rf/default :double))
+          "the prior dirty-check row is preserved")
+      (is (= 10 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
+          "the prior materialized output is untouched"))))
+
+(deftest reg-flow-self-cycle-blocks-recurrence-before-first-dispatch
+  (testing "because registration fails BEFORE the first dispatch, unrelated
+            events can no longer drive the 1 → 2 → 3 recurrence the accepted
+            self-cycle produced (rf2-j538f7.6 AC-6)"
+    (rf/reg-event :seed (fn [{:keys [db]} [_ v]] {:db (assoc db :x v)}))
+    (rf/reg-event :tick (fn [{:keys [db]} _] {:db (update db :other (fnil inc 0))}))
+    ;; The reproduction flow: reads [:x], writes [:x], (inc). Registration must
+    ;; throw before it can ever run.
+    (is (thrown? Throwable
+                 (rf/reg-flow :probe/self {:inputs [[:x]] :output-path [:x]} inc))
+        "the oscillator flow is rejected at registration")
+    (rf/dispatch-sync [:seed 0])
+    (rf/dispatch-sync [:tick])
+    (rf/dispatch-sync [:tick])
+    (is (= 0 (:x (rf/app-db-value :rf/default)))
+        ":x is exactly the independently-owned seeded fact (0); unrelated ticks
+         did NOT advance it — no self-feedback loop was ever installed")))
+
+(deftest flow-acyclic-diamond-registers-and-drains-correctly
+  (testing "a valid acyclic diamond (B,C read A; D reads B and C) registers and
+            settles in one drain — the self-cycle fix introduces no
+            false-positive rejection of legitimate multi-node graphs"
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2}}))
+    ;; B reads [:a] → [:b]; C reads [:a] → [:c]; D reads [:b] and [:c] → [:d].
+    (rf/reg-flow :flow/b {:inputs [[:a]]      :output-path [:b]} (fn [a] (+ a 1)))
+    (rf/reg-flow :flow/c {:inputs [[:a]]      :output-path [:c]} (fn [a] (* a 10)))
+    (rf/reg-flow :flow/d {:inputs [[:b] [:c]] :output-path [:d]} (fn [b c] (+ b c)))
+    (rf/dispatch-sync [:init])
+    (let [db (rf/app-db-value :rf/default)]
+      (is (= 3  (:b db)) "B = a + 1 = 3")
+      (is (= 20 (:c db)) "C = a * 10 = 20")
+      (is (= 23 (:d db)) "D = B + C = 23, settled in one drain after B and C"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. Dirty-check / re-evaluation

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -154,16 +154,16 @@
           "A writes [:foo] which is a prefix of B's input [:foo :bar :baz]"))))
 
 (deftest depends-on?-self-edge-via-overlapping-path
-  (testing "rf2-m05md — depends-on? returns true for a self-edge if a
-            flow's own :inputs share a prefix with its own :output-path. The
-            consumer (topo-sort) explicitly filters self-edges out via
-            `(not= id %)` so this only matters at the helper boundary
-            — pinning the truth of the helper's prefix rule
-            independent of its caller's self-edge guard."
+  (testing "rf2-m05md / rf2-j538f7.6 — depends-on? returns true for a self-edge
+            when a flow's own :inputs share a prefix with its own :output-path.
+            The consumer (topo-sort) RETAINS this `id -> id` self-edge and
+            rejects the flow as a single-node cycle (a flow is a pure
+            derivation of independently-owned facts, not a recurrence over its
+            own prior output — Spec 013 §Dependency rule)."
     (let [a {:id :a :output-path [:foo] :inputs [[:foo]]}]
       (is (true? (topo/depends-on? a a))
           "A's own :inputs include A's own :output-path → depends-on? returns
-           true; topo-sort filters this self-edge separately"))))
+           true; topo-sort retains this self-edge to reject the self-cycle"))))
 
 (deftest depends-on?-false-when-no-overlap
   (testing "rf2-m05md — depends-on? returns false when no input shares

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -187,6 +187,31 @@
     (is (= 1 (count (by-op :rf.flow/registered)))
         "only :a's register trace; :b's was rolled back")))
 
+(deftest reg-flow-self-cycle-does-NOT-emit-registered-or-replaced
+  (testing "a rejected self-referential flow emits NO success trace — neither a
+            first-time :rf.flow/registered nor a hot-reload
+            :rf.registry/handler-replaced (rf2-j538f7.6 AC-4)"
+    ;; First-time self-cycle: throws, no :rf.flow/registered.
+    (is (thrown? Throwable
+                 (rf/reg-flow :probe/self {:inputs [[:x]] :output-path [:x]} inc)))
+    (is (zero? (count (by-op :rf.flow/registered)))
+        "no :rf.flow/registered fired for the rejected self-cyclic flow")
+    ;; A valid flow first (its own success traces are irrelevant here) …
+    (rf/reg-flow :double {:inputs [[:n]] :output-path [:derived :doubled]} (fn [n] (* 2 n)))
+    ;; … then a REPLACEMENT that introduces a self-cycle. `handler-replaced`
+    ;; is op-type :rf.registry (not :flow), so capture the FULL trace stream
+    ;; for this rejected call and assert the replaced signal never fired.
+    (let [all (record-all-traces
+                (fn []
+                  (is (thrown? Throwable
+                               (rf/reg-flow :double {:inputs      [[:derived :doubled]]
+                                                     :output-path [:derived :doubled]}
+                                            inc)))))]
+      (is (empty? (filterv #(= :rf.registry/handler-replaced (:operation %)) all))
+          "the rejected self-cyclic REPLACEMENT emitted no :rf.registry/handler-replaced")
+      (is (empty? (filterv #(= :rf.flow/registered (:operation %)) all))
+          "and no :rf.flow/registered for the rejected replacement"))))
+
 ;; ---------------------------------------------------------------------------
 ;; 2. :rf.flow/computed fires when a flow recomputes
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A flow whose own `:inputs` overlap its own `:output-path` depends on itself. A flow is a pure derivation of independently-owned facts, **not** a recurrence over its own prior output (Spec 013 §Dependency rule), so a self-overlap is a single-node dependency **cycle** and must be rejected at registration — with the same canonical `:rf.error/flow-cycle` used for multi-node cycles, closing-repeat `[id id]`.

**Defect (confirmed on `origin/main`):** `topo-sort` fast-pathed a singleton to `[id]` and filtered `(not= id %)` self-edges out of the multi-node graph. A self-cyclic flow (e.g. input `[:x]` / output `[:x]`) registered silently and then behaved as a stateful oscillator/reducer that **every unrelated event advanced** (`1 → 2 → 3 …`), bypassing the documented registration-time cycle diagnostic.

Reproduction before the fix: `topo-sort` returned `[:probe/self]` for the singleton self-cycle and `[:b :a]` for a multi-node map containing a self-cyclic node — both accepted.

## Fix

`re_frame/flows/topo.cljc` — `topo-sort` now builds the full dependency graph **including any `id → id` self-edge** for every non-empty flow-map (no singleton fast path). Kahn finds no ready node and the existing cycle extractor naturally produces `[id id]`. No separate self-edge case; registration's existing prospective-map validation (inside the drain CAS) rejects the cycle **before any mutation**, so a prior hot-reloaded definition is preserved. A runtime-qualified input (`[:rf.db/runtime …]`) stays a different partition from an app-db output and is never misclassified as a self-cycle.

Production diff is topo.cljc only; the registry, drain path, and error id are unchanged.

## Tests

- **Portable CLJC** (`flows_path_cljs_test.cljc`, runs JVM **and** CLJS): singleton exact self-overlap → `:rf.error/flow-cycle` `:cycle [:a :a]`; prefix self-overlap in **both** directions; self-edge retained in a multi-node graph; acyclic-diamond topo-sorts with no false-positive; runtime-input non-overlap registers cleanly; integrated `reg-flow` self-cycle rejection.
- **JVM integration** (`flows_test.clj`): self-referential rejection installs nothing; rejection still fires with other acyclic flows registered (self-edge not discarded); a rejected self-cycle **replacement** preserves the prior definition, dirty-check row, and materialized output; the `1 → 2 → 3` recurrence is blocked because registration fails before first dispatch; acyclic diamond registers and drains to correct values.
- **Trace** (`flows_trace_test.clj`): a rejected self-cycle emits no `:rf.flow/registered` and a rejected self-cycle replacement emits no `:rf.registry/handler-replaced`.
- Updated the stale comment/test that described self-edge filtering as intentional (`flows_topo_test.clj`, `flows_test.clj`).

## Quality gates

| Gate | Result |
|------|--------|
| `clojure -M:test` (implementation/flows) | **PASS** — 212 tests / 5872 assertions, 0 failures/0 errors (baseline was 202 / 5823; +10 tests, +49 assertions) |
| `npm run test:cljs` (implementation/) | **PASS** — 8493 tests / 39748 assertions, 0 failures/0 errors |
| `clj-kondo --lint src/re_frame/flows/topo.cljc` | **PASS** — 0 errors, 0 warnings |

No deferred Spec 009 catalogue row was required: this fix reuses the existing `:rf.error/flow-cycle` id and its already-catalogued thrown-error shape (only the human `:reason` sentence was broadened to name the self-cycle case). No new error id was introduced.

Closes rf2-j538f7.6.