### PR TITLE
fix(examples/nine-states): reset clears machine-owned domain data (rf2-j538f7.27)

### DIFF
--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -305,7 +305,26 @@
     ;; The demo buttons omit `:now`, so their deterministic sentinel is 0.
     ;; A host that needs a real archive time supplies it on the event.
     (fn action-stamp-archived [{data :data [_ {:keys [now]}] :event}]
-      {:data (assoc data :archived-at (or now 0))})}
+      {:data (assoc data :archived-at (or now 0))})
+
+    :reset-domain
+    ;; The public :reset returns the whole machine to square one — and that
+    ;; has to include the domain data the machine owns, not just its state
+    ;; keywords. Here's the subtlety the whole example turns on: a transition
+    ;; changing :data-region's state from :some back to :nothing does NOT, on
+    ;; its own, touch :data. Machine data is preserved across transitions
+    ;; unless an *action* rewrites it — that's exactly what keeps a bucket's
+    ;; :items alive across a re-render. So without this action the loaded
+    ;; :items (and any recorded :error, and the :archived-at stamp) survive
+    ;; hidden underneath a blank :nothing view, and resurrect the moment the
+    ;; next valid submit conjoins onto them. Clearing owned data is a data
+    ;; change, so it rides a named action. It runs exactly once per reset
+    ;; macrostep — on the :data region's :reset — while the form and mode
+    ;; regions independently walk their own state back to :neutral / :active.
+    ;; Matches Pattern-RemoteData's reset contract: reset clears state AND the
+    ;; durable data that state was about.
+    (fn action-reset-domain [_]
+      {:data {:items [] :error nil :archived-at nil}})}
 
    :regions
    {;; ---- :data region — managed-HTTP lifecycle + cardinality ----
@@ -316,16 +335,20 @@
       ;; State 1 — never fetched. The welcome screen.
       {:tags #{:data/nothing}
        :on   {:fetch-started :loading
-              :reset         :nothing}}
+              :reset         {:target :nothing :action :reset-domain}}}
 
       :loading
       ;; State 2 — a fetch is in flight. The :data/loading tag is what
-      ;; lights up the spinner.
+      ;; lights up the spinner. A user-driven :reset abandons the in-flight
+      ;; fetch: the region drops to :nothing and :reset-domain wipes :data.
+      ;; A late reply from the abandoned load is then inert — :nothing has no
+      ;; :fetch-succeeded handler, so it can't resurrect the reset state.
       {:tags #{:data/loading :data/transient}
        :on   {:fetch-succeeded {:target :resolving
                                 :action :set-items}
               :fetch-failed    {:target :error
-                                :action :set-error}}}
+                                :action :set-error}
+              :reset           {:target :nothing :action :reset-domain}}}
 
       :resolving
       ;; A blink-and-you-miss-it microstep. :set-items has just written the
@@ -340,27 +363,27 @@
       :empty
       {:tags #{:data/empty}
        :on   {:fetch-started :loading
-              :reset         :nothing}}
+              :reset         {:target :nothing :action :reset-domain}}}
 
       :one
       {:tags #{:data/one}
        :on   {:fetch-started :loading
-              :reset         :nothing}}
+              :reset         {:target :nothing :action :reset-domain}}}
 
       :some
       {:tags #{:data/some}
        :on   {:fetch-started :loading
-              :reset         :nothing}}
+              :reset         {:target :nothing :action :reset-domain}}}
 
       :too-many
       {:tags #{:data/too-many}
        :on   {:fetch-started :loading
-              :reset         :nothing}}
+              :reset         {:target :nothing :action :reset-domain}}}
 
       :error
       {:tags #{:data/error}
        :on   {:fetch-started :loading
-              :reset         :nothing}}}}
+              :reset         {:target :nothing :action :reset-domain}}}}}
 
     ;; ---- :form region — form lifecycle ----
     :form
@@ -400,10 +423,18 @@
               :reset   :active}}
 
       :done
-      ;; State 9 — the end of the line. Once archived there's no event out
-      ;; of here. :mode/read-only is the tag the form and control panel
-      ;; read to disable every input.
-      {:tags #{:mode/done :mode/read-only :mode/terminal}}}}}})
+      ;; State 9 — the terminal end of the lifecycle: once archived, no
+      ;; forward event leaves here (no fetch, no submit, no re-archive), and
+      ;; :mode/read-only is the tag the form and control panel read to grey
+      ;; out every input. The lone exception is the whole-machine :reset —
+      ;; "back to square one" is allowed from anywhere, even a frozen list —
+      ;; which thaws :done to :active; the :data region's :reset-domain clears
+      ;; the owned data (including :archived-at) in the same broadcast. The
+      ;; demo disables its reset control while read-only, so in the running
+      ;; app you reach this thaw by reloading — the machine models the full
+      ;; capability, and the headless tests drive it directly.
+      {:tags #{:mode/done :mode/read-only :mode/terminal}
+       :on   {:reset :active}}}}}})
 
 (rf/reg-machine :ui/nine-states nine-states-machine)
 
@@ -420,8 +451,12 @@
 ;; where it doesn't belong.
 
 (rf/reg-event :nine-states.app/initialise
-  {:doc "Back to square one: seed the form slice and reset the machine to
-         its initial state."}
+  {:doc "Back to square one: seed the form slice and broadcast :reset into
+         the machine — returning every region to its initial state AND
+         clearing the machine's owned data (loaded :items, any recorded
+         :error, the :archived-at stamp) through the :data region's
+         :reset-domain action. A genuine blank slate, not a blank view laid
+         over retained data."}
   (fn handler-app-initialise [{:keys [db]} _]
     {:db (assoc db :new-todo new-todo-defaults)
      :fx [[:dispatch [:ui/nine-states [:reset]]]]}))

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -70,6 +70,13 @@
 (defn- render-model [frame]
   (rf/compute-sub [:ui/render] (rf/frame-state-value frame)))
 
+(defn- snapshot
+  "The `:ui/nine-states` machine snapshot from a frame's runtime-db — carries
+   `:state` (the region→state map for a parallel machine) and shared `:data`."
+  [frame]
+  (get-in (rf/frame-state-value frame)
+          [:rf.db/runtime :rf.runtime/machines :snapshots :ui/nine-states]))
+
 (def ^:private demo-overrides
   "Per-test :fx-overrides map that routes `:rf.http/managed` to the in-process
    demo stub so tests run without a backend."
@@ -173,6 +180,107 @@
     (test-state-8-correct))
   (testing "state 9 — done (terminal, read-only)"
     (test-state-9-done)))
+
+;; ----------------------------------------------------------------------------
+;; RESET — whole-machine return to square one clears owned domain data
+;;
+;; The shipped "1. Nothing" control dispatches [:nine-states.app/initialise],
+;; which seeds the form slice and broadcasts [:reset] into the machine. A
+;; region's state keyword flipping back to :nothing does NOT, on its own,
+;; rewrite the machine's :data — machine data is preserved across transitions
+;; unless an action changes it. So reset must run a named :reset-domain action
+;; to clear the loaded :items, any recorded :error, and the :archived-at
+;; stamp. Without it, previously loaded todos survive hidden under a blank
+;; :nothing view and resurrect on the next valid submit. These tests are the
+;; sequence the per-state fixtures never exercise: two states separated by the
+;; reset control. They pin that reset clears state AND owned data, matching
+;; Pattern-RemoteData's reset contract.
+;; ----------------------------------------------------------------------------
+
+(deftest reset-clears-machine-owned-domain-data
+  (testing "initialise after a load returns every region to initial AND wipes :data"
+    (with-new-frame [f (new-frame)]
+      ;; Load four todos → :data region rests at :some with 4 items.
+      (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
+      (is (= 4 (count (get-in (snapshot f) [:data :items])))
+          "precondition: four todos loaded")
+      (is (= :some (render-model f)) "precondition: renders :some")
+
+      ;; The shipped reset control ("1. Nothing").
+      (rf/dispatch-sync [:nine-states.app/initialise] {:frame f})
+
+      ;; Full region map back to initial; :data wiped clean.
+      (is (= {:data :nothing :form :neutral :mode :active}
+             (:state (snapshot f)))
+          "all three regions return to their initial state")
+      (is (= {:items [] :error nil :archived-at nil}
+             (:data (snapshot f)))
+          "the machine's owned :data is wiped — no hidden survivors")
+      (is (= :nothing (render-model f)) "the page renders the blank :nothing slate")
+
+      ;; A valid submit now yields exactly ONE todo (State 4 / :one), not five.
+      ;; The four pre-reset rows must NOT resurrect.
+      (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
+      (rf/dispatch-sync [:new-todo/submit] {:frame f})
+      (let [items (rf/compute-sub [:todos/items] (rf/frame-state-value f))]
+        (is (= 1 (count items))
+            "only the freshly-submitted todo is present")
+        (is (= ["Buy milk"] (mapv :title items))
+            "none of the four pre-reset rows reappear"))
+      ;; :form/success wins the render-priority table over :data/one, so the
+      ;; page shows :correct — but the :data region has genuinely settled at
+      ;; :one beneath it (single item), not :some.
+      (is (= :correct (render-model f)) "the submit acknowledgement wins the priority table")
+      (is       (machine-has-tag? f :data/one) "the :data region rests at :one, not :some")
+      (is (not  (machine-has-tag? f :data/some)) "the pre-reset :some cardinality is gone"))))
+
+(deftest reset-clears-recorded-failure-and-thaws-done
+  (testing "reset wipes a recorded :error and returns an archived :done machine to :active"
+    (with-new-frame [f (new-frame)]
+      ;; Record a failure: the demo's rigged-to-fail load routes the :data
+      ;; region to :error, stamping the failure map at [:data :error].
+      (rf/dispatch-sync [:nine-states.demo/load-with-failure] {:frame f})
+      (is       (machine-has-tag? f :data/error) "precondition: failure recorded")
+      (is (some? (get-in (snapshot f) [:data :error])) "precondition: :error slot populated")
+
+      ;; Archive it: the :mode region freezes at :done, stamping :archived-at.
+      (rf/dispatch-sync [:ui/nine-states [:archive {:now 7}]] {:frame f})
+      (is (= :done (get-in (snapshot f) [:state :mode])) "precondition: archived (:mode :done)")
+      (is (= 7    (get-in (snapshot f) [:data :archived-at])) "precondition: archive stamped")
+
+      ;; Reset the whole machine.
+      (rf/dispatch-sync [:nine-states.app/initialise] {:frame f})
+      (is (= {:data :nothing :form :neutral :mode :active} (:state (snapshot f)))
+          ":mode thaws from :done back to :active; data and form reset too")
+      (is (= {:items [] :error nil :archived-at nil} (:data (snapshot f)))
+          "the recorded failure and the archive stamp are both cleared")
+      (is (= :nothing (render-model f))
+          "renders the blank slate, not the archived or error view"))))
+
+(deftest reset-from-loading-abandons-in-flight-load
+  (testing "reset accepted mid-load lands at :nothing; a late completion cannot mutate it"
+    (with-new-frame [f (new-frame)]
+      ;; Enter :loading without a synchronous reply, as the state-2 fixture
+      ;; does — dispatch :fetch-started directly with no follow-up.
+      (rf/dispatch-sync [:ui/nine-states [:fetch-started]] {:frame f})
+      (is (machine-has-tag? f :data/loading) "precondition: fetch in flight")
+
+      ;; Reset while loading.
+      (rf/dispatch-sync [:nine-states.app/initialise] {:frame f})
+      (is (= :nothing (get-in (snapshot f) [:state :data]))
+          "reset from :loading lands the :data region at :nothing")
+      (is (= [] (get-in (snapshot f) [:data :items])) ":data is clean after the abandon")
+
+      ;; The abandoned load now completes. At :nothing the machine does not
+      ;; listen for :fetch-succeeded, so the stale reply is inert.
+      (rf/dispatch-sync [:ui/nine-states
+                         [:fetch-succeeded {:items [{:id 1 :title "ghost-1" :done? false}
+                                                    {:id 2 :title "ghost-2" :done? false}]}]]
+                        {:frame f})
+      (is (= :nothing (get-in (snapshot f) [:state :data]))
+          "the late completion does not move the region off :nothing")
+      (is (= [] (get-in (snapshot f) [:data :items]))
+          "the abandoned load's items never land"))))
 
 ;; ----------------------------------------------------------------------------
 ;; STORY LIFECYCLE — :error variant

--- a/spec/Pattern-NineStates.md
+++ b/spec/Pattern-NineStates.md
@@ -282,7 +282,7 @@ The transitions the page-level event handler drives, for a `:counter/load`-shape
 | Retry from a bucket | `[:counter/load]` | `:empty | :one | :some | :too-many | :error → :loading` | Same handler; the `:on {:fetch-started :loading}` map on each bucket makes the reload uniform. |
 | Reply success | `[:counter/loaded {:rf/reply {:status :ok :value items …}}]` | `:loading → :resolving → :empty | :one | :some | :too-many` | The `:resolving` `:always`-cascade decides the bucket. |
 | Reply failure | `[:counter/loaded {:rf/reply {:status :error :error failure-map …}}]` | `:loading → :error` | The `:set-error` action stamps the failure map (read from `:error`) at `[:data :error]`. |
-| User-driven reset | `[:counter/reset]` | `* → :nothing` | Optional, per [Pattern-RemoteData](Pattern-RemoteData.md). |
+| User-driven reset | `[:counter/reset]` | `* → :nothing` | Optional, per [Pattern-RemoteData](Pattern-RemoteData.md). The `* → :nothing` transition carries a data-clearing action (`:reset-domain`) so it clears the region's owned `:items` / `:error`, not just the state keyword — a bare `:reset :nothing` leaves stale items to resurrect on the next submit. |
 
 A minimal co-located handler:
 
@@ -334,10 +334,10 @@ The `:data` region's `:loading` state usually has a `:spawn` of `:rf.http/manage
                        :request-id :counter/load}}
  :on    {:succeeded {:target :resolving :action :set-items}
          :failed    {:target :error     :action :set-error}
-         :reset     :nothing}}             ;; user-driven reset cancels the wrapper
+         :reset     {:target :nothing :action :reset-domain}}}  ;; abandon: cancel wrapper + clear data
 ```
 
-`:reset` from a bucket — fired by a navigation handler or an explicit user gesture — exits `:loading`, the wrapper is destroyed, and the in-flight request is aborted. No `:rf.http/managed-abort` call needed; the lifetime binding handles it.
+`:reset` from a bucket — fired by a navigation handler or an explicit user gesture — exits `:loading`, the wrapper is destroyed, and the in-flight request is aborted. No `:rf.http/managed-abort` call needed; the lifetime binding handles it. The transition also carries a `:reset-domain` action — `(fn [_] {:data {:items [] :error nil}})` — because returning a region to `:nothing` does **not**, on its own, rewrite the shared `:data`: machine data is preserved across a transition unless an action changes it. Without that action the just-abandoned `:items` survive under the blank `:nothing` view and resurrect on the next submit. "Reset" therefore means state **and** owned data, matching [Pattern-RemoteData](Pattern-RemoteData.md)'s reset contract.
 
 Pages that issue managed HTTP from an event handler directly (the `:fx [[:rf.http/managed ...]]` form above, not the `:spawn` form) don't get the actor-destroy cascade — per [014 §Direct dispatches from event handlers — NOT covered](014-HTTPRequests.md#direct-dispatches-from-event-handlers--not-covered), only requests issued from inside a spawned actor are subject to actor-destroy cancellation. Apps that want navigation-mid-fetch cancellation in that case have two options: lift the call into the `:spawn` form above, or issue an explicit `[:rf.http/managed-abort :counter/load]` from the navigation handler against the same `:request-id`.
 


### PR DESCRIPTION
## What & why

The canonical Pattern-NineStates / Pattern-RemoteData / Pattern-Forms teaching example had a user-visible **state-resurrection** bug. `[:nine-states.app/initialise]` (the shipped "1. Nothing" control) broadcast `[:reset]` into the `:ui/nine-states` machine, flipping each region's state keyword back toward its initial value — but ran **no action**. Machine transitions preserve `:data` unless an action rewrites it, so the loaded `:items`, any recorded `:error`, and the `:archived-at` stamp survived hidden under a blank `:nothing` view. The next valid submit conjoined onto the retained vector, resurrecting the "cleared" todos (e.g. load 4 → reset → add 1 → **5 rows**, machine renders `:some`).

## The fix (inside the machine ownership boundary)

- **New named action `:reset-domain`** returns `{:items [] :error nil :archived-at nil}`. It runs **exactly once** per reset macrostep, on the `:data` region's `:reset` transition; the `:form` and `:mode` regions independently return to `:neutral` / `:active`. No app handler writes under `:rf.runtime/machines`, no duplicate item store, no destroy/recreate.
- **Every resting/in-flight `:data` state** that can receive the public reset now carries it — **including `:loading`**, which previously ignored `:reset` entirely. Reset from `:loading` abandons the in-flight fetch; a late reply is inert at `:nothing` (no `:fetch-succeeded` handler there).
- **`:mode/:done` handles `:reset` → `:active`**, so `:nine-states.app/initialise` keeps its whole-machine "back to square one" promise from an archived list. The demo greys its reset control out while read-only, so in the running app the thaw is reached by reloading; the machine models the full capability and the headless tests drive it directly.
- **Spec reconciliation** (`spec/Pattern-NineStates.md`): the spawn-cancellation snippet and the worked transition table now show `:reset` carrying the data-clearing action, so "reset" means state **and** owned data, matching Pattern-RemoteData's reset contract. (Pattern-RemoteData / Pattern-Forms already taught this correctly — no change needed there.)

## Tests

Three new `deftest`s in `nine_states_cljs_test.cljs` exercise **two states separated by the shipped reset control** — the sequence the per-state fixtures and Story variants never crossed:

1. `reset-clears-machine-owned-domain-data` — load 4 → initialise → region map `{data :nothing, form :neutral, mode :active}` and data `{:items [] :error nil :archived-at nil}`; a valid submit then yields exactly `:one` (no resurrection).
2. `reset-clears-recorded-failure-and-thaws-done` — reset wipes a recorded `:error` and thaws archived `:done` (with `:archived-at`) back to `:active`.
3. `reset-from-loading-abandons-in-flight-load` — reset mid-load lands at `:nothing`; a late completion cannot mutate the reset state.

All three **fail against the pre-fix machine** (verified by temporarily reverting `core.cljs`) and **pass after**.

## Quality gates

| Gate | Result |
|---|---|
| `npx shadow-cljs compile examples/nine-states examples/nine-states-with-stories` | **PASS** — 0 warnings (nine-states: 225 files; with-stories: 669 files) |
| `npm run test:cljs` (full CLJS suite, incl. new reset tests) | **PASS** — Ran 8491 tests / 39747 assertions, **0 failures, 0 errors** |
| Must-fail-before-fix (reset tests vs reverted `core.cljs`) | **CONFIRMED** — all new assertions fail pre-fix |
| `node examples/scripts/check-examples-assets.cjs` | **PASS** — all 35 host pages resolve, `_shared` intact |
| `mkdocs build --strict` (spec staged per docs.yml) | **PASS** — exit 0, no new warnings |

Skip reasons: none. (3 pre-existing `:undeclared-var` warnings in `late-bind` / `story-open-in-editor-cljs-test` are untouched by this PR.)

## Notes

- `spec/005-StateMachines.md` reset teaching was reviewed and needs **no** change (its `:mode/done` snippet is a generic parallel-regions illustration, not a reset example) — no follow-up bead filed.
- The skill leaf and README carry no incorrect reset teaching (their machine snippets omit reset transitions entirely), so they were left unchanged.