### PR TITLE
fix(examples/managed-http-counter): emit canonical :rf.reply/cancel-reason (rf2-j538f7.25)

### DIFF
--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -235,16 +235,21 @@
          ;; so we mirror that: the canonical envelope is the appended last arg.
          :abort-fn (fn [reason]
                      (http-registry/clear-in-flight! request-id)
-                     ;; The canonical abort reply uses `:status :cancelled`,
-                     ;; with the `:rf.http/aborted` map under
-                     ;; `:error` (mirrors the live transport's abort path).
+                     ;; The canonical abort reply uses `:status :cancelled`
+                     ;; with `:cancelled? true`, carries the abort reason
+                     ;; under the uniform reply contract's namespaced field
+                     ;; `:rf.reply/cancel-reason`, and rides the
+                     ;; `:rf.http/aborted` map under `:error` — the exact
+                     ;; shape the live transport's abort path emits (see
+                     ;; `re-frame.http.reply/failure-reply`). It passes
+                     ;; `re-frame.reply/validate-reply` unchanged.
                      (rf/dispatch [:http-counter/start-long
-                                   {:status        :cancelled
-                                    :cancelled?    true
-                                    :cancel/reason reason
-                                    :error         {:kind       :rf.http/aborted
-                                                    :request-id request-id
-                                                    :reason     reason}}]
+                                   {:status                 :cancelled
+                                    :cancelled?             true
+                                    :rf.reply/cancel-reason reason
+                                    :error                  {:kind       :rf.http/aborted
+                                                             :request-id request-id
+                                                             :reason     reason}}]
                                   {:frame frame}))}))
     nil))
 

--- a/implementation/core/test/re_frame/managed_http_counter_cljs_test.cljs
+++ b/implementation/core/test/re_frame/managed_http_counter_cljs_test.cljs
@@ -1,0 +1,128 @@
+(ns re-frame.managed-http-counter-cljs-test
+  "Contract regression for the managed-HTTP counter example's synthetic
+  cancellation reply.
+
+  The example's `Start long` / `Cancel` path exercises the production
+  managed-abort registry contract with no network behind it: `Start long`
+  seeds a request-id-keyed handle into the in-flight registry, and `Cancel`
+  fires the live `:rf.http/managed-abort` fx, which resolves the handle and
+  invokes its example-owned `:abort-fn`. That closure HAND-BUILDS the
+  `:rf.http/aborted` reply and dispatches it back to `:http-counter/start-long`.
+
+  Because the reply is hand-built (not lowered through
+  `re-frame.http.reply/failure-reply`), it can drift from the uniform reply
+  contract silently: the example's own handler branches only on `:status`, so
+  a mis-spelled cancellation-reason key still returns the UI to idle and every
+  structural gate (compile, asset-staging, status-only smoke) stays green. The
+  July pre-alpha migration retired the top-level `:cancel/reason` key in favour
+  of the namespaced `:rf.reply/cancel-reason`; this test pins the seeded abort
+  closure to the CURRENT contract so a future drift fails loud. The `teeth`
+  block proves the test cannot false-green on `:status` / `:error` alone —
+  restoring the retired spelling is rejected as
+  `:rf.reply/cancelled-missing-reason`.
+
+  It belongs in the framework test tree, NOT under `examples/` (examples stay
+  test-free per rf2-8cevm). It `:require`s `managed-http-counter.core` (a
+  Reagent-coupled `.cljs`-only entry ns — its ns-load registers the events /
+  subs / fx, and transitively `re-frame.http.managed`, which registers the
+  `:rf.http/managed-abort` fx) so it runs under the consolidated `:node-test`
+  CLJS build, whose source paths include `../examples/core`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.reply :as reply]
+            [re-frame.http.registry :as http-registry]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Requiring the entry ns fires the example's ns-load
+            ;; reg-event / reg-fx / reg-sub / reg-view forms (and,
+            ;; transitively, the managed-HTTP fx family) against the live
+            ;; registrar captured into this ns's fixture baseline.
+            [managed-http-counter.core :as mhc]))
+
+;; `:ambient-frame nil` — these tests create + drive their own anon frames with
+;; an explicit `{:frame f}`; no ambient `:rf/default` scope is wanted.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- start-long-frame!
+  "Boot a fresh anon frame and drive the example's opening
+  `:http-counter/start-long` move — the REAL handler's `:else` branch, which
+  fires `:http-counter/seed-long-request` to record a request-id-keyed handle
+  in the in-flight registry. Returns the frame."
+  []
+  (let [f (frame/make-anon-frame-record! {:doc "managed-http-counter test frame"})]
+    (rf/dispatch-sync [:http-counter/start-long] {:frame f})
+    f))
+
+(deftest cancellation-reply-satisfies-uniform-reply-contract
+  (let [f         (start-long-frame!)
+        delivered (atom [])]
+    (is (some? (http-registry/lookup-in-flight mhc/long-request-id))
+        "Start long seeds the request-id-keyed handle into the in-flight registry")
+
+    ;; Swap in a capturing handler so the reply the example's abort closure
+    ;; DISPATCHES back to :http-counter/start-long is recorded verbatim. The
+    ;; abort reply is delivered synchronously: the async dispatch the closure
+    ;; issues settles to fixed point within the Cancel drain (Spec 002
+    ;; run-to-completion), so no queue flush is needed. The fixture restores
+    ;; the real handler after each test.
+    (rf/reg-event :http-counter/start-long
+      (fn [{:keys [db]} [_ reply]]
+        (swap! delivered conj reply)
+        {:db db}))
+
+    ;; Cancel through the LIVE :rf.http/managed-abort fx — the production
+    ;; abort-by-request-id path (handlers/managed-abort-handler ->
+    ;; registry/abort-in-flight! -> the seeded :abort-fn).
+    (rf/dispatch-sync [:http-counter/cancel] {:frame f})
+
+    (is (= 1 (count @delivered))
+        "exactly one cancellation reply is delivered")
+    (is (nil? (http-registry/lookup-in-flight mhc/long-request-id))
+        "the in-flight registry slot is cleared by the abort closure")
+
+    (let [reply (first @delivered)]
+      (testing "the hand-built reply satisfies the uniform reply contract"
+        (is (reply/valid-reply? reply)
+            (str "re-frame.reply/validate-reply must accept the reply; problems="
+                 (pr-str (reply/validate-reply reply)))))
+      (testing "it carries the canonical cancellation facts"
+        (is (= :cancelled (:status reply)))
+        (is (true? (:cancelled? reply)))
+        (is (= :user (:rf.reply/cancel-reason reply))
+            "the cancellation reason rides the namespaced :rf.reply/cancel-reason key")
+        (is (= :rf.http/aborted (get-in reply [:error :kind])))
+        (is (= :user (get-in reply [:error :reason])))
+        (is (= mhc/long-request-id (get-in reply [:error :request-id]))))
+      (testing "the retired top-level :cancel/reason key is absent"
+        (is (not (contains? reply :cancel/reason))))
+      (testing "teeth — the reply cannot false-green on :status / :error alone"
+        ;; Dropping the namespaced reason, or restoring the retired
+        ;; :cancel/reason spelling (the exact pre-migration defect), is
+        ;; rejected as :rf.reply/cancelled-missing-reason even though
+        ;; :status :cancelled and :error are left untouched.
+        (doseq [broken [(dissoc reply :rf.reply/cancel-reason)
+                        (-> reply
+                            (dissoc :rf.reply/cancel-reason)
+                            (assoc :cancel/reason :user))]]
+          (is (not (reply/valid-reply? broken)))
+          (is (= :rf.reply/cancelled-missing-reason
+                 (:rf.reply/problem (first (reply/validate-reply broken))))))))))
+
+(deftest cancel-restores-idle-and-records-the-aborted-error
+  (testing "the real reply path returns the UI to :idle and records the :rf.http/aborted error"
+    (let [f (start-long-frame!)]
+      (is (= :loading (:http-counter/status (rf/app-db-value f)))
+          "the opening move parks the UI in :loading until the abort resolves")
+
+      (rf/dispatch-sync [:http-counter/cancel] {:frame f})
+      (let [db (rf/app-db-value f)]
+        (is (= :idle (:http-counter/status db))
+            "the abort reply eases the UI back to :idle")
+        (is (= :rf.http/aborted (get-in db [:http-counter/error :kind]))
+            "the classified :rf.http/aborted error is recorded for the view")
+        (is (nil? (http-registry/lookup-in-flight mhc/long-request-id))
+            "the in-flight registry slot is cleared")))))


### PR DESCRIPTION
## What

The managed-HTTP counter example's seeded abort closure hand-built its `:rf.http/aborted` cancellation reply with the **retired** top-level `:cancel/reason` key. Since the July pre-alpha namespace migration the uniform reply contract requires the namespaced `:rf.reply/cancel-reason`, so `re-frame.reply/validate-reply` rejected the payload with `:rf.reply/cancelled-missing-reason`. The example still looked green because `:http-counter/start-long` branches only on `:status`, hiding the contract violation from every structural gate (compile, asset-staging, status-only smoke).

## Changes

- `examples/core/managed_http_counter/core.cljs` — the abort closure now emits the canonical `:rf.reply/cancel-reason` (matching the production `re-frame.http.reply/failure-reply` lowering); the retired `:cancel/reason` is gone. The accompanying comment now teaches the canonical namespaced field.
- `implementation/core/test/re_frame/managed_http_counter_cljs_test.cljs` (new) — a focused CLJS regression in the framework test tree (examples stay test-free per rf2-8cevm), auto-discovered by the `:node-test` build's `cljs-test$` ns-regexp. It drives the **real** Start long -> `:rf.http/managed-abort` -> seeded `:abort-fn` -> `:http-counter/start-long` reply path and asserts:
  - the reply passes `re-frame.reply/valid-reply?`;
  - `:status :cancelled`, `:cancelled? true`, `:rf.reply/cancel-reason :user`, `[:error :kind] :rf.http/aborted` with nested `:reason :user` and `:request-id`;
  - the retired `:cancel/reason` key is absent, the in-flight registry slot is cleared, exactly one reply is delivered;
  - **teeth**: restoring/removing the namespaced reason is rejected as `:rf.reply/cancelled-missing-reason`, so the test cannot false-green on `:status`/`:error` alone.
  - A second deftest confirms the real handler still eases the UI back to `:idle` and records the aborted error (visible behavior unchanged).

## Quality gates

All run in the foreground from `implementation/`.

- **npm install**: PASS (one-time; node_modules/react was absent).
- **Example compile** (`npx shadow-cljs compile examples/managed-http-counter`): PASS — 165 files, **0 warnings**.
- **CLJS regression** (`node-test`): PASS — 8491 tests / 39766 assertions, **0 failures, 0 errors**.
  - Proven to **fail before the fix**: reverting the example to the retired `:cancel/reason` spelling produced 3 failures in this deftest, the first being `validate-reply` reporting `:rf.reply/cancelled-missing-reason` — the exact defect. Restored to green after the fix.
  - Proven to actually execute (sentinel failure attributed to `(cancellation-reply-satisfies-uniform-reply-contract)`; assertion count +1).
  - The 3 node-test compile warnings are pre-existing and in unrelated files (`resources_revalidation_cljs_test.cljc`, `tools/story/.../story_open_in_editor_cljs_test.cljs`); none from the new file.
- **check-examples-assets** (`node examples/scripts/check-examples-assets.cjs`): PASS — all 35 pages resolve, `_shared` tree intact.
- **mkdocs build --strict**: SKIPPED — no committed markdown changed (only a `.cljs` comment tweak + the new test file).

## Risk

Low. The example change is a single reply-key spelling (plus a comment); the production HTTP abort path already emitted `:rf.reply/cancel-reason` and is untouched. No `implementation/reply` source or spec was edited.