### PR TITLE
fix(scripts,test-quiet): preserve browser-server bind host + restore JVM summary reporter (rf2-j538f7.12, rf2-j538f7.17)

### DIFF
--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -11,6 +11,7 @@ const path = require('path');
 const {
   TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  deriveProbeHost,
   fetchToken,
   findFreePort,
   isPortFree,
@@ -29,6 +30,33 @@ const tests = [];
 
 function test(name, fn) {
   tests.push({ name, fn });
+}
+
+// The IPv6-loopback owned-readiness tests need a `::1` that both binds AND
+// accepts a client connection. Most modern Windows/macOS/Linux hosts have it,
+// but minimal CI containers occasionally disable IPv6, so those tests SKIP
+// (rather than fail) where it is unavailable — the deriveProbeHost mapping
+// unit test plus the wildcard/default functional coverage still pin the fix
+// on every platform. (Per the repo's cross-platform maintainer discipline: a
+// script must not hard-require a feature a maintainer's box may lack.)
+function testIpv6(name, fn) {
+  tests.push({ name, fn, needsIpv6: true });
+}
+
+function ipv6LoopbackAvailable() {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen(0, '::1', () => {
+      const { port } = srv.address();
+      // Bindable — now confirm a client can actually reach it over ::1.
+      const client = net.connect({ host: '::1', port }, () => {
+        client.destroy();
+        srv.close(() => resolve(true));
+      });
+      client.once('error', () => { srv.close(() => resolve(false)); });
+    });
+  });
 }
 
 function listenOnLoopback(server) {
@@ -1052,9 +1080,150 @@ test('startLocalHttpServer cleanup unlinks its own ownership token in the non-ov
   }
 });
 
+// rf2-j538f7.12 — startLocalHttpServer must PROVE owned readiness against the
+// interface the server actually bound to, not a hard-coded 127.0.0.1 default.
+// It advertises a configurable `host` (passed to http-server as `-a <host>`)
+// but previously dropped it when waiting for owned readiness: the readiness
+// call passed only `{isAborted}`, so probeHttp/fetchToken defaulted to
+// 127.0.0.1. A server bound `::1` (IPv6 loopback only) was therefore probed on
+// IPv4 loopback and falsely reported timeout — a false-red gate against a
+// healthy server, plus a cleanup that kills it. The fix threads a `probeHost`
+// (derived from `host`) through the single options object both the liveness
+// probe and the ownership-token fetch read, so they cannot diverge.
+
+test('deriveProbeHost keeps concrete binds and maps wildcards to loopback (rf2-j538f7.12)', () => {
+  // Concrete binds probe THEMSELVES — the readiness check must address the
+  // same interface the server listens on (an ::1 server is unreachable via
+  // 127.0.0.1, and vice versa).
+  assert.equal(deriveProbeHost('127.0.0.1'), '127.0.0.1');
+  assert.equal(deriveProbeHost('::1'), '::1');
+  assert.equal(deriveProbeHost('localhost'), 'localhost');
+  assert.equal(deriveProbeHost('staging.internal'), 'staging.internal');
+  // Wildcard binds are "every interface" bind targets, never portable client
+  // destinations — map each to the matching, reachable loopback.
+  assert.equal(deriveProbeHost('0.0.0.0'), '127.0.0.1');
+  assert.equal(deriveProbeHost('::'), '::1');
+  assert.equal(deriveProbeHost('[::]'), '::1');
+});
+
+testIpv6('startLocalHttpServer proves owned readiness over a non-default IPv6-loopback bind (rf2-j538f7.12)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const tokenPath = path.join(dir, TOKEN_FILE_BASENAME);
+  try {
+    const { server, ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      host: '::1', // bind IPv6 loopback ONLY
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {},
+    });
+    // THE regression: readiness is proven over the configured ::1 bind. On the
+    // pre-fix code the prove defaulted to 127.0.0.1 and TIMED OUT against this
+    // healthy IPv6-only server, so `ready` would be false here.
+    assert.equal(ready, true, 'owned readiness must be proven over the configured ::1 bind host');
+    // The `-a <host>` bind host propagated to spawn (recorded argv).
+    const argv = JSON.parse(fs.readFileSync(path.join(dir, '.fake-argv.json'), 'utf8'));
+    assert.deepEqual(argv, [dir, '-a', '::1', '-p', String(port), '-s', '-c-1']);
+    // The exact ownership token was fetched over ::1.
+    assert.equal(
+      await fetchToken(port, { host: '::1' }),
+      fs.readFileSync(tokenPath, 'utf8'),
+      'the ownership token must be fetchable over ::1',
+    );
+    // TEETH: the same server is NOT reachable through 127.0.0.1 — so the
+    // success above came from host propagation, not dual-stack behaviour in
+    // the fake. A 127.0.0.1 fetch must find nothing.
+    assert.equal(
+      await fetchToken(port, { host: '127.0.0.1', timeout: 500 }),
+      null,
+      'the IPv6-only server must be unreachable via 127.0.0.1 (proves host propagation, not dual-stack)',
+    );
+    // Cleanup terminates the child and removes this run's ownership token.
+    const exited = waitForExit(server, 30000);
+    await cleanup.cleanup();
+    await exited;
+    assert.equal(
+      fs.existsSync(tokenPath),
+      false,
+      'cleanup must remove this run\'s ownership token',
+    );
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
+testIpv6('startLocalHttpServer readiness follows probeHost, not the bind host (rf2-j538f7.12)', async () => {
+  // Bind IPv6 loopback but OVERRIDE the probe to IPv4 loopback. The server is
+  // healthy and serving its token over ::1, yet readiness must FAIL — proving
+  // the owned-readiness prove connects to `probeHost` for BOTH the liveness
+  // probe and the token fetch, never a hard-coded/derived default that could
+  // diverge from where the caller pointed it.
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  try {
+    const { ready, isDown } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      host: '::1',
+      probeHost: '127.0.0.1', // deliberately mismatched with the bind
+      cwd: dir,
+      readyTimeoutMs: 800,
+      log: () => {},
+    });
+    assert.equal(ready, false, 'probing 127.0.0.1 against an ::1-only server must not prove ready');
+    assert.equal(isDown(), false, 'the server is healthy — it was simply not probed on its interface');
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
+test('startLocalHttpServer proves readiness against loopback for a wildcard 0.0.0.0 bind (rf2-j538f7.12)', async () => {
+  const { dir, binPath } = mkFakeBin(FAKE_HTTP_SERVER, 'fake-http-server.cjs');
+  const port = await findFreePort();
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  try {
+    const { ready } = await startLocalHttpServer({
+      cleanup,
+      httpServerBin: binPath,
+      root: dir,
+      port,
+      host: '0.0.0.0', // wildcard bind — a bind target, not a client address
+      cwd: dir,
+      readyTimeoutMs: 5000,
+      log: () => {},
+    });
+    // deriveProbeHost maps 0.0.0.0 -> 127.0.0.1, a concrete reachable loopback
+    // the wildcard-bound server answers on; the prove must never connect to
+    // the unspecified 0.0.0.0 itself.
+    assert.equal(ready, true, 'a wildcard-bound server must be proven ready via 127.0.0.1');
+    const argv = JSON.parse(fs.readFileSync(path.join(dir, '.fake-argv.json'), 'utf8'));
+    assert.deepEqual(argv, [dir, '-a', '0.0.0.0', '-p', String(port), '-s', '-c-1']);
+  } finally {
+    await cleanup.cleanup();
+    rmTmp(dir);
+  }
+});
+
 (async () => {
+  const hasIpv6 = await ipv6LoopbackAvailable();
   let failed = 0;
-  for (const { name, fn } of tests) {
+  let skipped = 0;
+  for (const { name, fn, needsIpv6 } of tests) {
+    if (needsIpv6 && !hasIpv6) {
+      skipped += 1;
+      console.log(`SKIP ${name} (no IPv6 loopback available)`);
+      continue;
+    }
     try {
       await fn();
     } catch (err) {
@@ -1069,7 +1238,10 @@ test('startLocalHttpServer cleanup unlinks its own ownership token in the non-ov
     process.exit(1);
   }
 
-  console.log(`local-browser-harness tests: ${tests.length} passed.`);
+  console.log(
+    `local-browser-harness tests: ${tests.length - skipped} passed` +
+      (skipped ? `, ${skipped} skipped (no IPv6 loopback).` : '.'),
+  );
 })().catch((err) => {
   console.error(err && err.stack ? err.stack : err);
   process.exit(1);

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -246,6 +246,34 @@ function probeTargetFromBaseUrl(baseUrl, opts = {}) {
   return { host: parsed.hostname, port, path, protocol: parsed.protocol };
 }
 
+// The address a server BINDS to is not always an address a client can
+// CONNECT to, so a readiness prove must derive its probe host from the bind
+// host rather than defaulting to loopback. A readiness check MUST address the
+// same interface the server actually listens on: an IPv6-loopback-only bind
+// (`::1`) is unreachable via IPv4 `127.0.0.1` (and vice versa), so probing the
+// wrong loopback times out against a perfectly healthy server. Every CONCRETE
+// bind host — a loopback literal, `localhost`, or a hostname — is therefore
+// threaded through to the probe unchanged.
+//
+// The exception is a WILDCARD bind. `0.0.0.0` / `::` mean "listen on every
+// interface"; they are bind targets, never portable client destinations, and
+// connecting to an unspecified address is not reliable. Each maps to its
+// matching loopback — a concrete, reachable address a wildcard-bound server
+// necessarily answers on: `0.0.0.0` -> `127.0.0.1`, `::` -> `::1`. This never
+// broadens a server's bind surface; it only picks a client-usable address for
+// the liveness/ownership handshake.
+function deriveProbeHost(bindHost) {
+  switch (bindHost) {
+    case '0.0.0.0':
+      return '127.0.0.1';
+    case '::':
+    case '[::]':
+      return '::1';
+    default:
+      return bindHost;
+  }
+}
+
 async function waitForHttpReady(port, deadline, opts = {}) {
   const pollMs = opts.pollMs || 200;
   const isAborted = opts.isAborted || (() => false);
@@ -525,6 +553,14 @@ function ownedReadinessFailureDiagnostic(result, port, timeoutMs) {
 //                 asset tree is never valid.
 //   - port       (required) — the resolved, already-free port to bind.
 //   - host       — bind address (default '127.0.0.1').
+//   - probeHost  — the address the owned-readiness handshake CONNECTS to.
+//                 Defaults to a client-usable derivation of `host`
+//                 (deriveProbeHost): a concrete bind (`::1`, `localhost`, a
+//                 hostname) probes itself; a wildcard bind (`0.0.0.0`/`::`)
+//                 probes the matching loopback. Both the liveness probe and
+//                 the ownership-token fetch use this SAME host, so they can
+//                 never diverge onto different interfaces (a server bound to
+//                 `::1` must be proven ready over `::1`, not IPv4 loopback).
 //   - cwd        — spawn cwd (where node_modules / http-server resolves).
 //   - execPath   — node binary to run http-server under (default
 //                 process.execPath, shell-free).
@@ -568,6 +604,7 @@ async function startLocalHttpServer(opts = {}) {
     root,
     port,
     host = '127.0.0.1',
+    probeHost = deriveProbeHost(host),
     cwd,
     execPath = process.execPath,
     readyTimeoutMs = 30000,
@@ -666,11 +703,16 @@ async function startLocalHttpServer(opts = {}) {
   // Accept ready:true ONLY when the responder serves this run's token; return
   // ready:false for every other structured outcome, with a reason-specific
   // diagnostic.
+  // Prove owned readiness against the SAME interface the server bound to.
+  // `probeHost` is threaded through the single options object both probeHttp
+  // and fetchToken read, so the liveness probe and the ownership-token fetch
+  // address one host — never loopback-by-default while the server listens on
+  // a non-default bind (e.g. `::1`), which would time out a healthy server.
   const result = await waitForOwnedHttpReady(
     port,
     token,
     Date.now() + readyTimeoutMs,
-    { isAborted: aborted },
+    { isAborted: aborted, host: probeHost },
   );
   if (!result.ok) {
     log(ownedReadinessFailureDiagnostic(result, port, readyTimeoutMs));
@@ -683,6 +725,7 @@ async function startLocalHttpServer(opts = {}) {
 module.exports = {
   TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  deriveProbeHost,
   fetchToken,
   findFreePort,
   isPortFree,

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -428,7 +428,7 @@
   written to it (trimming `sb` to the newest `stderr-buffer-cap`
   characters) and forwards NOTHING to the real stderr.  The runner reads
   `sb` back at `:summary` time and replays it only on red
-  (`install-summary-replay-hook!`); on green the buffer is dropped."
+  (`make-summary-replay-method`); on green the buffer is dropped."
   ^java.io.Writer [^StringBuilder sb]
   (let [append! (fn [^String s]
                   ;; Serialize the WHOLE append-plus-front-trim transaction on
@@ -443,7 +443,7 @@
                   ;; otherwise-valid test. StringBuilder (unlike StringBuffer) has
                   ;; no synchronized methods, so nothing else contends for this
                   ;; monitor; the summary snapshot in
-                  ;; `install-summary-replay-hook!` locks on the SAME `sb`, so a
+                  ;; `make-summary-replay-method` locks on the SAME `sb`, so a
                   ;; red replay never reads a half-applied mutation.
                   (locking sb
                     (.append sb s)
@@ -470,70 +470,101 @@
       (flush [])
       (close []))))
 
-(defn- install-summary-replay-hook!
-  "Install a `clojure.test/report :summary` override that replays the
-  buffered stderr (`sb`) to `real-err` when the run is red, then delegates
-  to whatever `:summary` method was installed before us so the canonical
-  summary line still prints.
+(defn- install-summary-method!
+  "Install `f` as `clojure.test/report`'s `:summary` method, or — when `f`
+  is nil — remove any installed method so the multimethod falls back to its
+  default. Centralises the `MultiFn` mutation (and its type hint) that
+  `-main` uses to install this invocation's replay method and to restore the
+  prior one."
+  [f]
+  (if f
+    (.addMethod ^clojure.lang.MultiFn clojure.test/report :summary f)
+    (remove-method clojure.test/report :summary)))
+
+(defn- make-summary-replay-method
+  "Build the `clojure.test/report :summary` method for ONE `-main`
+  invocation.  On a RED run it replays the buffered stderr ring `sb` to
+  `real-err`, then delegates to `prior` (the `:summary` method installed
+  before this invocation) so the canonical summary line still prints.
 
   `:summary` is the JVM-side counterpart to the CLJS `:end-run-tests`
   reporter: it fires once at the end of `run-tests` from the same
   fail/error counts cognitect reads to compute the exit code, and it runs
-  on the test-driver thread inside the `binding` that rebinds `*err*`,
-  so it runs before cognitect's `System/exit` and can flush the captured
-  context. A run is red iff `(pos? (+ fail error))`, matching cognitect's
+  on the test-driver thread inside the `binding` that rebinds `*err*`, so it
+  runs before cognitect's `System/exit` and can flush the captured context.
+  A run is red iff `(pos? (+ fail error))`, matching cognitect's
   `(zero? (+ fail error))` green test.
 
-  The replay is bounded to the test-run red path. cognitect only
-  fires `:summary` once it has reached `run-tests`, so the buffered stderr
-  is replayed only for a red run that actually executed tests.  The
-  non-test exit-1 path — a CLI parse error
-  (`cognitect.test-runner/-main` prints the parse diagnostics + usage and
-  `System/exit`s 1 BEFORE ever calling `run-tests`) — never fires
-  `:summary`, so its buffer is dropped, not replayed.  That is sound here:
-  on the parse-error path the diagnostics cognitect emits go to `*out*`
-  (the banner-filtering writer), NOT `*err*`, so nothing diagnostic is
-  lost — the only thing dropped is whatever incidental `*err*`/`System.err`
-  noise was written before the parse failed (in practice none; arg parsing
-  does not log to stderr).  A `finally`-flush in `-main` cannot widen the
-  scope: cognitect `System/exit`s straight from the parse-error branch, so
-  `-main`'s `finally` never runs on that path; it runs on returning paths
-  such as `-H` help.
+  This method is INVOCATION-SCOPED, not a permanent global override: `-main`
+  installs it via `install-summary-method!` before the delegated run and
+  RESTORES `prior` on every returning/throwing path (its `finally`). A
+  returning `-main` — notably `-H` help, or an embedded/REPL/in-process
+  call — therefore leaves no global closure over this run's ring/`real-err`
+  installed for a later, unrelated `clojure.test` run to trip over, and
+  repeated invocations never chain wrapper-over-wrapper.
 
-  The replay goes to the original stderr writer. The `*err*` ring is still
-  bound at this point, so using `*err*`/`println` here would feed the replay
-  straight back into the buffer. Each captured chunk is
-  written verbatim; a header marks it as a red-run replay so it is
-  distinguishable from the reporter's own stdout, mirroring the CLJS
-  replay's `[test-quiet]` prefix.  On green the buffer is simply dropped
-  (never written)."
-  [^StringBuilder sb ^java.io.Writer real-err]
-  (let [prior-summary (get-method clojure.test/report :summary)]
-    (defmethod clojure.test/report :summary [m]
-      (let [{:keys [fail error]} m]
-        (when (pos? (+ (or fail 0) (or error 0)))
-          ;; Snapshot the ring under `sb`'s monitor — the SAME lock every
-          ;; writer in `buffering-stderr-writer` takes — so the `.length`
-          ;; guard and the `.toString` copy observe a consistent ring rather
-          ;; than a mutation half-applied by a still-live background writer.
-          ;; Copy out under the lock, then do the (unbounded) real-err replay
-          ;; I/O OUTSIDE it so a writer is never blocked on the replay. An
-          ;; empty ring yields `nil` and replays nothing, exactly as the prior
-          ;; `(pos? (.length sb))` guard did.
-          (let [captured (locking sb
-                           (when (pos? (.length sb))
-                             (.toString sb)))]
-            (when captured
-              (.write real-err
-                      (str "\n[test-quiet] buffered stderr replayed"
-                           " because the run was RED:\n"))
-              (.write real-err captured)
-              (when-not (.endsWith captured "\n")
-                (.write real-err "\n"))
-              (.flush real-err)))))
-      ;; Delegate to the prior :summary so the canonical
-      ;; "Ran N tests…/K failures, J errors." line still prints.
-      (when prior-summary (prior-summary m)))))
+  The replay is bounded to the test-run red path. cognitect only fires
+  `:summary` once it has reached `run-tests`, so the buffered stderr is
+  replayed only for a red run that actually executed tests.  The non-test
+  exit-1 path — a CLI parse error (`cognitect.test-runner/-main` prints the
+  parse diagnostics + usage and `System/exit`s 1 BEFORE ever calling
+  `run-tests`) — never fires `:summary`, so its buffer is dropped, not
+  replayed.  That is sound: on the parse-error path the diagnostics cognitect
+  emits go to `*out*` (the banner-filtering writer), NOT `*err*`, so nothing
+  diagnostic is lost — the only thing dropped is whatever incidental
+  `*err*`/`System.err` noise preceded the parse failure (in practice none;
+  arg parsing does not log to stderr).
+
+  The replay goes to `real-err` — the ORIGINAL stderr writer captured before
+  the `*err*` ring was bound — so it is never fed back into the buffer. Each
+  captured chunk is written verbatim under a red-run header, mirroring the
+  CLJS replay's `[test-quiet]` prefix.  On green the buffer is dropped."
+  [^StringBuilder sb ^java.io.Writer real-err prior]
+  (fn summary-replay [m]
+    (let [{:keys [fail error]} m]
+      (when (pos? (+ (or fail 0) (or error 0)))
+        ;; Snapshot the ring under `sb`'s monitor — the SAME lock every
+        ;; writer in `buffering-stderr-writer` takes — so the `.length`
+        ;; guard and the `.toString` copy observe a consistent ring rather
+        ;; than a mutation half-applied by a still-live background writer.
+        ;; Copy out under the lock, then do the (unbounded) real-err replay
+        ;; I/O OUTSIDE it so a writer is never blocked on the replay. An
+        ;; empty ring yields `nil` and replays nothing, exactly as the prior
+        ;; `(pos? (.length sb))` guard did.
+        (let [captured (locking sb
+                         (when (pos? (.length sb))
+                           (.toString sb)))]
+          (when captured
+            (.write real-err
+                    (str "\n[test-quiet] buffered stderr replayed"
+                         " because the run was RED:\n"))
+            (.write real-err captured)
+            (when-not (.endsWith captured "\n")
+              (.write real-err "\n"))
+            (.flush real-err)))))
+    ;; Delegate to the prior :summary so the canonical
+    ;; "Ran N tests…/K failures, J errors." line still prints.
+    (when prior (prior m))))
+
+(def ^:dynamic *register-flush-hook!*
+  "Test seam over the JVM shutdown-hook registry for `-main`'s stdout
+  flush-on-exit hook.  Called with the hook `Thread`; it must register the
+  hook and RETURN a 0-arg deregister fn that `-main` invokes on every
+  returning/throwing path.  Deregistering matters because a returning `-main`
+  (help, or an embedded/in-process call) does NOT terminate the JVM: without
+  removal, each such invocation would leave its filtering-writer hook
+  registered until shutdown, accumulating one per call.
+
+  Defaults to the real `Runtime` registry.  Tests rebind it to observe the
+  add/remove lifecycle in-process without mutating the test JVM's own
+  shutdown-hook set."
+  (fn [^Thread hook]
+    (.addShutdownHook (Runtime/getRuntime) hook)
+    (fn deregister-flush-hook []
+      ;; `removeShutdownHook` throws only while the JVM is already shutting
+      ;; down; a returning `-main` never is, so this is safe. It returns
+      ;; false (harmless) if the hook already ran or was removed.
+      (.removeShutdownHook (Runtime/getRuntime) hook))))
 
 (defn -main [& args]
   ;; Bind `*out*` to a line-filtering writer over the real stdout that
@@ -570,17 +601,29 @@
   ;; parse error) drops its buffer rather than replaying it — sound because
   ;; cognitect's parse diagnostics go to `*out*` (the filter), not `*err*`,
   ;; and that path `System/exit`s before `-main`'s `finally` can run (see
-  ;; `install-summary-replay-hook!`).
+  ;; `make-summary-replay-method`).
   (let [real-out   *out*
         real-err   *err*
         sys-err    System/err
         filtering  (java.io.PrintWriter. (banner-filtering-writer real-out))
         stderr-sb  (StringBuilder.)
         buffered-w (buffering-stderr-writer stderr-sb)
-        buffered-e (java.io.PrintWriter. buffered-w)]
-    (.addShutdownHook (Runtime/getRuntime)
-                      (Thread. ^Runnable #(.flush filtering)))
-    (install-summary-replay-hook! stderr-sb real-err)
+        buffered-e (java.io.PrintWriter. buffered-w)
+        ;; The flush-on-`System/exit` hook for the stdout filtering writer,
+        ;; registered through the `*register-flush-hook!*` seam. Its
+        ;; `deregister-flush-hook!` is called on every returning/throwing path
+        ;; so repeated in-process/help invocations don't accumulate a
+        ;; filtering-writer hook apiece.
+        flush-hook (Thread. ^Runnable #(.flush filtering))
+        deregister-flush-hook! (*register-flush-hook!* flush-hook)
+        ;; Capture the `:summary` method installed before us, then install
+        ;; THIS invocation's replay method. The override is invocation-scoped:
+        ;; we DELEGATE to `prior-summary` during the run and RESTORE it on exit
+        ;; (see the `finally`), never leaving a global closure over this run's
+        ;; ring/`real-err` behind.
+        prior-summary (get-method clojure.test/report :summary)
+        summary-fn    (make-summary-replay-method stderr-sb real-err prior-summary)]
+    (install-summary-method! summary-fn)
     ;; Route raw `System/err` bytes into the same ring as `*err*` so a
     ;; library that writes `System.err` directly is buffered too. Each chunk
     ;; is decoded to a `String` and appended to the ring (this buffer is the
@@ -620,6 +663,16 @@
         (apply cognitect.test-runner/-main args)
         (finally
           (.flush filtering)
-          ;; Returning paths (notably help) restore System/err. `System/exit`
-          ;; paths terminate without running this `finally`.
-          (System/setErr sys-err))))))
+          ;; Returning paths (notably help) restore System/err + the prior
+          ;; `:summary` reporter and deregister the flush hook. `System/exit`
+          ;; paths terminate WITHOUT running this `finally`, which is correct:
+          ;; the summary replay already fired during the run, and the flush
+          ;; hook must survive to flush stdout at shutdown.
+          (System/setErr sys-err)
+          ;; Restore the prior `:summary` method — but ONLY if ours is still
+          ;; the installed one. If an unrelated run replaced it during this
+          ;; invocation, that run now owns the method and must not be
+          ;; clobbered by a blind restore.
+          (when (identical? summary-fn (get-method clojure.test/report :summary))
+            (install-summary-method! prior-summary))
+          (deregister-flush-hook!))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_lifecycle_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_lifecycle_test.clj
@@ -1,0 +1,280 @@
+(ns re-frame.test-quiet-runner-lifecycle-test
+  "Lifecycle pins for `re-frame.test-quiet.runner/-main`'s reporter + shutdown-
+  hook restoration on RETURNING and THROWING invocations (rf2-j538f7.17).
+
+  `-main` installs an invocation-scoped `clojure.test/report :summary` method
+  (the red-run stderr replay), swaps `System.err` to a bounded ring, and
+  registers a stdout flush-on-exit shutdown hook.  On the standalone test path
+  `cognitect.test-runner` `System/exit`s, so none of that needs unwinding — the
+  process dies.  But `-H`/help intentionally RETURNS, and embedded/REPL/in-
+  process callers can return OR throw.  On those paths every one of those
+  global mutations must be undone, or an unrelated later `clojure.test` run
+  inherits this run's ring/writer, repeated calls chain wrapper-over-wrapper,
+  and flush hooks accumulate until JVM shutdown.
+
+  These can only be observed by RUNNING `-main` and then inspecting the JVM's
+  reporter/`System.err`/hook state AFTER it returns.  A standalone
+  `System/exit` erases that state across a process boundary, and running the
+  probe in THIS test JVM (itself driven by the quiet runner) would be
+  re-entrant, so each pin is a self-checking Clojure program run in a fresh
+  JVM (`clojure.main <file>`) that exits 0 iff its lifecycle invariant holds.
+  Each program stubs `cognitect.test-runner/-main` so it RETURNS/THROWS
+  instead of exiting, reproducing the returning lifecycle deterministically."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+;; ----------------------------------------------------------------------
+;; Fresh-JVM program harness.
+
+(defn- drain
+  "Drain `proc`'s stdout + stderr concurrently, then `waitFor` under a
+  timeout.  Returns {:exit :out :err :timed-out?}.  Concurrent drain avoids a
+  pipe deadlock; the timeout force-kills a wedged child so a regression fails
+  fast instead of hanging the suite."
+  [^Process proc timeout-ms]
+  (let [out-f (future (slurp (.getInputStream proc)))
+        err-f (future (slurp (.getErrorStream proc)))
+        done? (.waitFor proc timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
+    (if done?
+      {:exit (.exitValue proc) :out @out-f :err @err-f :timed-out? false}
+      (do
+        (.destroyForcibly proc)
+        (.waitFor proc 5000 java.util.concurrent.TimeUnit/MILLISECONDS)
+        (future-cancel out-f)
+        (future-cancel err-f)
+        {:exit -1
+         :out (try @out-f (catch Throwable _ ""))
+         :err (try @err-f (catch Throwable _ ""))
+         :timed-out? true}))))
+
+(defn- run-program
+  "Spawn a fresh JVM on THIS test's classpath running `clojure.main` over
+  `src` (spat to a temp file).  Reusing `java.class.path` keeps the child on
+  the same classpath (runner src + cognitect + clojure) without re-resolving
+  deps or shelling the `clojure` launcher (dodging Windows `-Sdeps` escaping)."
+  [src]
+  (let [tmp (java.io.File/createTempFile "tq-lifecycle" ".clj")
+        os-win (str/includes? (str/lower-case (System/getProperty "os.name")) "win")
+        java-bin (str (io/file (System/getProperty "java.home") "bin"
+                               (if os-win "java.exe" "java")))
+        cmd [java-bin "-cp" (System/getProperty "java.class.path")
+             "clojure.main" (.getAbsolutePath tmp)]]
+    (spit tmp src)
+    (try
+      (drain (-> (ProcessBuilder. ^java.util.List cmd)
+                 (.redirectErrorStream false)
+                 (.start))
+             60000)
+      (finally (.delete tmp)))))
+
+(def ^:private program-preamble
+  (str "(require '[re-frame.test-quiet.runner :as r]\n"
+       "         '[clojure.test :as t]\n"
+       "         '[clojure.string :as s]\n"
+       "         '[cognitect.test-runner :as ctr])\n"))
+
+;; ----------------------------------------------------------------------
+;; A returning invocation restores the summary reporter, and a later run
+;; still emits its summary (criteria 1, 2).
+;;
+;; The core defect: `install-summary-replay-hook!` installed a global
+;; `:summary` defmethod closing over this run's ring + real-err and NEVER
+;; restored it.  After a returning `-main` (help/embedded), an unrelated
+;; `clojure.test` summary saw the stale ring and replayed a previous run's
+;; stderr, and the reporter method was permanently the wrapper.  The fix makes
+;; the method invocation-scoped, restored in `-main`'s `finally`.
+
+(def ^:private returning-restores-summary-program
+  (str program-preamble
+       "(let [stderr (java.io.StringWriter.)\n"
+       "      testout (java.io.StringWriter.)\n"
+       "      initial (get-method t/report :summary)]\n"
+       "  (binding [*err* (java.io.PrintWriter. stderr)\n"
+       "            t/*test-out* (java.io.PrintWriter. testout)]\n"
+       "    (with-redefs [ctr/-main (fn [& _]\n"
+       "                              (.println ^java.io.PrintWriter *err* \"STALE-FROM-RETURNED-RUN\"))]\n"
+       "      (r/-main \"-H\"))\n"
+       "    (let [restored? (identical? initial (get-method t/report :summary))]\n"
+       "      (t/report {:type :summary :test 1 :pass 0 :fail 1 :error 0})\n"
+       "      (.flush ^java.io.PrintWriter *err*)\n"
+       "      (let [summary-out (str testout)\n"
+       "            later-err (str stderr)\n"
+       "            stale? (s/includes? later-err \"STALE-FROM-RETURNED-RUN\")\n"
+       "            replay? (s/includes? later-err \"buffered stderr replayed\")\n"
+       "            emitted? (s/includes? summary-out \"1 failures\")]\n"
+       "        (println \"RESTORED?\" restored?)\n"
+       "        (println \"STALE-LEAKED?\" stale?)\n"
+       "        (println \"REPLAY-LEAKED?\" replay?)\n"
+       "        (println \"SUMMARY-EMITTED?\" emitted?)\n"
+       "        (flush)\n"
+       "        (if (and restored? (not stale?) (not replay?) emitted?)\n"
+       "          (do (println \"LIFECYCLE-OK\") (flush) (System/exit 0))\n"
+       "          (do (println \"LIFECYCLE-FAIL\") (flush) (System/exit 1)))))))\n"))
+
+(deftest returning-invocation-restores-summary-reporter
+  (testing "a returning -main restores the prior :summary; a later run still emits its summary with no stale replay"
+    (let [{:keys [exit out err timed-out?]} (run-program returning-restores-summary-program)]
+      (is (not timed-out?) "the probe must terminate, not hang")
+      (is (zero? exit)
+          (str "the returning invocation must restore the reporter (RESTORED? true),"
+               " leak no earlier stderr into a later summary (STALE/REPLAY false),"
+               " and the later summary must still print (SUMMARY-EMITTED? true)."
+               "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+      (is (str/includes? out "LIFECYCLE-OK")
+          (str "expected the LIFECYCLE-OK marker; got:\n" out)))))
+
+;; ----------------------------------------------------------------------
+;; Two returning invocations do not chain summary methods (criterion 3).
+;;
+;; The pre-fix code wrapped the already-wrapped method on each call, so a
+;; later red summary walked the whole chain and replayed EVERY invocation's
+;; ring (two returning runs -> two replay blocks).  Invocation scoping means
+;; each run restores the prior method, so no chain accumulates.
+
+(def ^:private no-chain-program
+  (str program-preamble
+       "(let [stderr (java.io.StringWriter.)\n"
+       "      testout (java.io.StringWriter.)\n"
+       "      initial (get-method t/report :summary)]\n"
+       "  (binding [*err* (java.io.PrintWriter. stderr)\n"
+       "            t/*test-out* (java.io.PrintWriter. testout)]\n"
+       "    (with-redefs [ctr/-main (fn [& _]\n"
+       "                              (.println ^java.io.PrintWriter *err* \"STALE-RUN\"))]\n"
+       "      (r/-main \"-H\")\n"
+       "      (r/-main \"-H\"))\n"
+       "    (let [restored? (identical? initial (get-method t/report :summary))]\n"
+       "      (t/report {:type :summary :test 1 :pass 0 :fail 1 :error 0})\n"
+       "      (.flush ^java.io.PrintWriter *err*)\n"
+       "      (let [later-err (str stderr)\n"
+       "            replay-blocks (count (re-seq #\"buffered stderr replayed\" later-err))]\n"
+       "        (println \"RESTORED?\" restored?)\n"
+       "        (println \"REPLAY-BLOCKS\" replay-blocks)\n"
+       "        (flush)\n"
+       "        (if (and restored? (zero? replay-blocks))\n"
+       "          (do (println \"NO-CHAIN-OK\") (flush) (System/exit 0))\n"
+       "          (do (println \"NO-CHAIN-FAIL\") (flush) (System/exit 1)))))))\n"))
+
+(deftest two-returning-invocations-do-not-chain-summary-methods
+  (testing "sequential returning invocations restore the reporter each time — no wrapper chain, no accumulated replay"
+    (let [{:keys [exit out err timed-out?]} (run-program no-chain-program)]
+      (is (not timed-out?) "the probe must terminate, not hang")
+      (is (zero? exit)
+          (str "two returning invocations must not chain reporters (RESTORED? true,"
+               " REPLAY-BLOCKS 0); the pre-fix code accumulated one replay block per"
+               " invocation.\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+      (is (str/includes? out "NO-CHAIN-OK")
+          (str "expected the NO-CHAIN-OK marker; got:\n" out)))))
+
+;; ----------------------------------------------------------------------
+;; A throwing delegate restores state and propagates (criterion 4).
+;;
+;; `-main`'s `finally` fires on the throwing path too: `System.err` and the
+;; prior `:summary` method are restored, and the original exception propagates
+;; unchanged.
+
+(def ^:private throwing-restores-program
+  (str program-preamble
+       "(let [initial (get-method t/report :summary)\n"
+       "      sys-err System/err\n"
+       "      threw? (atom false)]\n"
+       "  (with-redefs [ctr/-main (fn [& _]\n"
+       "                            (.println ^java.io.PrintWriter *err* \"ERR-CHANNEL\")\n"
+       "                            (.println System/err \"RAW-CHANNEL\")\n"
+       "                            (throw (ex-info \"BOOM-DELEGATE\" {})))]\n"
+       "    (try\n"
+       "      (r/-main)\n"
+       "      (catch Throwable e\n"
+       "        (when (s/includes? (str (.getMessage e)) \"BOOM-DELEGATE\")\n"
+       "          (reset! threw? true)))))\n"
+       "  (let [restored? (identical? initial (get-method t/report :summary))\n"
+       "        syserr-back? (identical? sys-err System/err)]\n"
+       "    (println \"PROPAGATED?\" @threw?)\n"
+       "    (println \"RESTORED?\" restored?)\n"
+       "    (println \"SYSERR-RESTORED?\" syserr-back?)\n"
+       "    (flush)\n"
+       "    (if (and @threw? restored? syserr-back?)\n"
+       "      (do (println \"THROW-OK\") (flush) (System/exit 0))\n"
+       "      (do (println \"THROW-FAIL\") (flush) (System/exit 1)))))\n"))
+
+(deftest throwing-invocation-restores-state-and-propagates
+  (testing "a throwing delegate restores System.err + the prior :summary in finally, and the exception propagates"
+    (let [{:keys [exit out err timed-out?]} (run-program throwing-restores-program)]
+      (is (not timed-out?) "the probe must terminate, not hang")
+      (is (zero? exit)
+          (str "a throwing delegate must propagate (PROPAGATED? true) AND restore"
+               " both the reporter (RESTORED? true) and System.err (SYSERR-RESTORED?"
+               " true) in finally.\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+      (is (str/includes? out "THROW-OK")
+          (str "expected the THROW-OK marker; got:\n" out)))))
+
+;; ----------------------------------------------------------------------
+;; A pre-existing custom :summary method is preserved (criterion 5).
+;;
+;; A third party may install its own `:summary` reporter before invoking the
+;; runner.  `-main` must DELEGATE to it during the run (exactly once per
+;; summary) and RESTORE it on return — never leave its own wrapper installed
+;; in its place.
+
+(def ^:private custom-summary-preserved-program
+  (str program-preamble
+       "(let [calls (atom 0)\n"
+       "      custom (fn [_m] (swap! calls inc))]\n"
+       "  (.addMethod ^clojure.lang.MultiFn clojure.test/report :summary custom)\n"
+       "  (with-redefs [ctr/-main (fn [& _]\n"
+       "                            (t/report {:type :summary :test 1 :pass 1 :fail 0 :error 0}))]\n"
+       "    (r/-main \"-H\"))\n"
+       "  (let [installed-after (get-method t/report :summary)\n"
+       "        restored? (identical? custom installed-after)]\n"
+       "    (println \"CUSTOM-CALLS\" @calls)\n"
+       "    (println \"CUSTOM-RESTORED?\" restored?)\n"
+       "    (flush)\n"
+       "    (if (and (= 1 @calls) restored?)\n"
+       "      (do (println \"CUSTOM-OK\") (flush) (System/exit 0))\n"
+       "      (do (println \"CUSTOM-FAIL\") (flush) (System/exit 1)))))\n"))
+
+(deftest returning-invocation-preserves-custom-summary-method
+  (testing "a pre-existing custom :summary is delegated exactly once during the run and re-installed afterward"
+    (let [{:keys [exit out err timed-out?]} (run-program custom-summary-preserved-program)]
+      (is (not timed-out?) "the probe must terminate, not hang")
+      (is (zero? exit)
+          (str "a pre-existing custom :summary must be delegated exactly once"
+               " (CUSTOM-CALLS 1) and re-installed after the returning invocation"
+               " (CUSTOM-RESTORED? true).\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+      (is (str/includes? out "CUSTOM-OK")
+          (str "expected the CUSTOM-OK marker; got:\n" out)))))
+
+;; ----------------------------------------------------------------------
+;; Returning invocations do not accumulate shutdown hooks (criterion 6).
+;;
+;; `-main` registers a stdout flush-on-exit hook through the
+;; `*register-flush-hook!*` seam and deregisters it on every returning/throwing
+;; path.  Binding the seam to a counter proves repeated help invocations net
+;; zero registered hooks — without the removal, each returning call would leave
+;; a filtering-writer hook registered until JVM shutdown.
+
+(def ^:private hook-lifecycle-program
+  (str program-preamble
+       "(let [registered (atom 0)]\n"
+       "  (binding [r/*register-flush-hook!*\n"
+       "            (fn [_hook]\n"
+       "              (swap! registered inc)\n"
+       "              (fn [] (swap! registered dec)))]\n"
+       "    (with-redefs [ctr/-main (fn [& _] nil)]\n"
+       "      (dotimes [_ 5] (r/-main \"-H\"))))\n"
+       "  (println \"NET-HOOKS\" @registered)\n"
+       "  (flush)\n"
+       "  (if (zero? @registered)\n"
+       "    (do (println \"HOOK-OK\") (flush) (System/exit 0))\n"
+       "    (do (println \"HOOK-FAIL\") (flush) (System/exit 1))))\n"))
+
+(deftest returning-invocations-do-not-accumulate-shutdown-hooks
+  (testing "each returning -main deregisters its flush hook — five help calls net zero registered hooks"
+    (let [{:keys [exit out err timed-out?]} (run-program hook-lifecycle-program)]
+      (is (not timed-out?) "the probe must terminate, not hang")
+      (is (zero? exit)
+          (str "repeated returning invocations must net zero registered flush hooks"
+               " (NET-HOOKS 0) — the hook must be removed on every returning path."
+               "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+      (is (str/includes? out "HOOK-OK")
+          (str "expected the HOOK-OK marker; got:\n" out)))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_stderr_ring_concurrency_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_stderr_ring_concurrency_test.clj
@@ -11,7 +11,7 @@
   `buffering-stderr-writer`'s append-plus-front-trim transaction and tear
   the StringBuilder's internal count/array, throwing
   `ArrayIndexOutOfBoundsException` from an otherwise-valid test (a reporter
-  bug reddening a passing suite). `install-summary-replay-hook!` also read
+  bug reddening a passing suite). `make-summary-replay-method` also read
   the ring (`.length`/`.toString`) with no coordination, so a red replay
   could snapshot a half-applied mutation.
 
@@ -22,7 +22,7 @@
   channel throws, the ring stays at or below `stderr-buffer-cap`, each
   channel's newest tail write survives, and a `locking`-coordinated
   snapshot taken CONCURRENTLY with the writers (the shape
-  `install-summary-replay-hook!` uses) never observes a torn ring. The
+  `make-summary-replay-method` uses) never observes a torn ring. The
   real `:summary` hook is covered end-to-end by the subprocess red fixture
   in `re-frame.test-quiet-runner-contract-test`.
 
@@ -127,7 +127,7 @@
           f-sys (future @gate
                         (try (dotimes [_ writes-each] (.println sys-channel big-line))
                              (catch Throwable e (swap! writer-errs conj (.getMessage e)))))
-          ;; The snapshotter mirrors EXACTLY what `install-summary-replay-hook!`
+          ;; The snapshotter mirrors EXACTLY what `make-summary-replay-method`
           ;; does: read the ring under `sb`'s monitor. It must never observe a
           ;; half-applied append+trim, so every snapshot is a valid String
           ;; bounded by the cap.


### PR DESCRIPTION
Two isolated P3 test/build-infra correctness bugs on different artefacts, from the wave-2 review cluster rf2-j538f7. One commit per bead.

## rf2-j538f7.12 — `implementation/scripts`: preserve the bind host when proving owned readiness

`startLocalHttpServer` advertises a configurable `host` (passed to http-server as `-a <host>`) but dropped it when waiting for owned readiness — the `waitForOwnedHttpReady` call passed only `{isAborted}`, so both `probeHttp` and `fetchToken` defaulted their host to `127.0.0.1`. A server bound to a non-default interface (e.g. `::1`, IPv6 loopback only) was probed on IPv4 loopback and falsely reported timeout: a false-red gate against a healthy server whose child cleanup then kills it.

Fix: a new `deriveProbeHost` separates bind addressing from connect addressing — concrete binds (`::1`, `localhost`, a hostname) probe themselves; wildcard binds map to the matching loopback (`0.0.0.0` -> `127.0.0.1`, `::` -> `::1`), because an unspecified bind is a bind target, never a portable client destination. `startLocalHttpServer` derives a `probeHost` from `host` (overridable) and threads it through the single options object both the liveness probe and the ownership-token fetch read, so they can never diverge. The default stays `127.0.0.1`; no launcher broadens its bind surface.

Regression coverage: the `deriveProbeHost` mapping; a functional `::1`-only bind proven ready over `::1` with the token fetched over `::1` (teeth: the same server is unreachable via `127.0.0.1`, proving host propagation not dual-stack); readiness following an explicit mismatched `probeHost`; and a wildcard `0.0.0.0` bind proven ready via `127.0.0.1`. IPv6 tests skip gracefully where `::1` is unavailable.

## rf2-j538f7.17 — `implementation/test-quiet`: restore the JVM summary reporter after returning invocations

`runner/-main` installed a global `clojure.test/report :summary` defmethod (the red-run stderr replay) closing over this run's ring + real-err, but never restored it. On the standalone path cognitect `System/exit`s, so nothing needs unwinding — but `-H`/help RETURNS, and embedded/REPL/in-process callers can return or throw. After a returning invocation the reporter stayed the wrapper: an unrelated later `clojure.test` summary saw the stale ring and replayed a previous run's stderr, repeated calls chained wrapper-over-wrapper, and the stdout flush hook accumulated one filtering writer per call.

Fix: the reporter override is now invocation-scoped. `make-summary-replay-method` builds a `:summary` fn delegating to the method installed before it; `-main` installs it and, in its `finally`, restores the prior method — but only if ours is still installed (never clobbering a run that replaced it). The stdout flush hook is registered through a `*register-flush-hook!*` seam and deregistered on every returning/throwing path. The `System/exit` path intentionally keeps both the already-fired summary and the flush hook.

Regression coverage (fresh-JVM self-checking probes, since returning-lifecycle state can't be observed across a `System/exit`): reporter restored + later run still emits its summary with no stale replay; two returning invocations don't chain; a throwing delegate restores state and propagates; a pre-existing custom `:summary` is delegated once and re-installed; repeated help calls net zero registered flush hooks.

## Quality gates (all foreground, green)

- `.12`: `npm run test:script-helpers` (local-browser-harness 44 passed, all helper suites green) + `npm run test:script-policy` (all policy suites green). `node --check` on the changed lib.
- `.17`: `clojure -M:test` from `implementation/test-quiet` — 38 tests / 226 assertions, 0 failures (was 33; +5 lifecycle probes). `clj-kondo --lint src test` — 0 errors / 0 warnings. `git diff --check` clean.
- CLJS no-regression (JVM-only change): consolidated `npm run test:cljs` — 8496 tests / 39787 assertions, 0 failures (includes the test-quiet CLJS runner-contract suite).

Both defects were reproduced on pre-fix code and confirmed fixed: `.12` `{dropped:{ok:false,timeout}}` vs `{threaded:{ok:true}}` on an `::1` server; `.17` `RESTORED? false` + stale replay leak on pre-fix vs `LIFECYCLE-OK` on the fix.