### PR TITLE
fix(pair-mcp): exit and close nREPL socket on stdin EOF (rf2-j538f7.32)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2726,6 +2726,22 @@ jobs:
       - name: Assert tool-descriptors.edn matches the registry
         run: npm run check:descriptors
 
+      # stdin-EOF lifecycle regression (rf2-j538f7.32). Compiles the SHIPPED
+      # `:server` bundle and drives it over real stdio against a self-contained
+      # fake bencode nREPL: a completed app-facing tool opens an idle nREPL
+      # socket, then closing stdin must close that socket AND exit the process
+      # 0 — with NO out-of-band kill. This is the canonical CI grader for the
+      # documented `stdin EOF -> nREPL close -> process exit` contract
+      # (spec/001-Wire-Protocol.md, server.cljs lifecycle step 6); the pre-fix
+      # server left an orphan process + a live nREPL socket here. The harness
+      # is hermetic (no live shadow-cljs), so it runs on both Ubuntu and
+      # Windows runners without extra infra.
+      - name: Compile re-frame2-pair-mcp server bundle (shadow-cljs :server)
+        run: npm run build
+
+      - name: Run stdin-EOF shutdown regression (tools/re-frame2-pair-mcp artefact)
+        run: npm run test:stdin-eof-shutdown
+
   node-test-tools-story-mcp:
     name: Node tools/story-mcp (stdio roundtrip, rf2-h8z5l)
     needs: detect_changed_surfaces

--- a/tools/re-frame2-pair-mcp/package.json
+++ b/tools/re-frame2-pair-mcp/package.json
@@ -19,6 +19,7 @@
     "test": "shadow-cljs compile server-test && node out/server-test.js",
     "start": "node out/server.js",
     "stdio-roundtrip": "node test/stdio-roundtrip.js",
+    "test:stdin-eof-shutdown": "node test/stdin-eof-shutdown.cjs",
     "test:post-merge-hook": "node test/post-merge-hook-test.cjs",
     "test:roots-discovery-live": "node test/roots-discovery-live.js",
     "test:live-e2e-fixture": "node test/live-e2e-fixture.cjs"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -35,7 +35,13 @@
      and cwd-only discovery have no stable file to re-read and keep the
      active endpoint until connection state is explicitly invalidated.
 
-  6. stdin EOF: shut down cleanly.
+  6. stdin EOF: the MCP host owns process lifecycle — when it closes
+     stdin, Node reaches EOF and `shutdown!` retires the session: it
+     closes the persistent nREPL socket (via `nrepl/close!`), closes the
+     SDK server + stdio transport, and exits 0. The SDK 1.29
+     `StdioServerTransport` registers only `data`/`error` on stdin — it
+     does NOT convert EOF into a transport close — so `connect-transport!`
+     owns the stdin `end` signal directly.
 
   ## Why low-level Server, not McpServer
 
@@ -176,6 +182,13 @@
 ;; so the discovery flow can reach `listRoots()` and `elicitInput()`
 ;; without threading the server through every handler signature.
 (def ^:private server-instance (atom nil))
+
+(defn set-server-instance-for-tests!
+  "Set (or clear, with nil) the captured Server instance. Exposed so the
+  `shutdown!` teardown contract can be exercised against a stub server —
+  or a nil server (pre-first-tool EOF) — without a live SDK transport."
+  [server]
+  (reset! server-instance server))
 
 (defn- list-roots-fn
   "Closure over the captured Server instance that calls SDK
@@ -606,10 +619,86 @@
     (reset! server-instance server)
     server))
 
+(def ^:private shutdown-fallback-ms
+  "Upper bound on how long `shutdown!` waits for the SDK `server.close()`
+  to settle before forcing exit. The nREPL socket + transport close
+  synchronously (or resolve on the next microtask); this only guards
+  against a stalled SDK close so process teardown never hangs on it."
+  250)
+
+(defonce ^:private shutdown-claimed?
+  ;; `defonce` (not `def`) so a dev hot-reload can't reset the latch
+  ;; mid-teardown and admit a second shutdown.
+  (atom false))
+
+(defn reset-shutdown-latch-for-tests!
+  "Clear the one-shot shutdown latch so the idempotency contract can be
+  re-exercised from a known slate."
+  []
+  (reset! shutdown-claimed? false))
+
+(defn shutdown!
+  "Retire the Pair session on stdio EOF (the client closed stdin — the
+  documented shutdown signal; see the ns `Lifecycle` docstring step 6).
+
+  Idempotent: the FIRST terminal event claims shutdown; any duplicate (a
+  stdin `end` followed by `close`, a double `stdin.end()`) is a no-op and
+  cannot double-close the socket, republish a conn, throw an unhandled
+  rejection, or change the exit status.
+
+  Teardown, in order: close the persistent nREPL socket via the existing
+  idempotent `nrepl/close!` (which bumps the conn generation so a late /
+  in-flight connect candidate can't publish behind us), drop the session
+  conn reference, then close the SDK server + its stdio transport so no
+  further frames are accepted. Exit 0 once those settle. A bounded,
+  `unref`-ed fallback timer forces exit if the SDK close stalls — it is a
+  fail-safe, never the process-liveness policy.
+
+  Diagnostics stay on stderr; teardown emits nothing on stdout (reserved
+  for MCP frames).
+
+  `exit-fn` (default `js/process.exit`) is injected so the teardown /
+  idempotency contract can be graded without exiting the test runner.
+  Returns a Promise that resolves once teardown has settled."
+  ([reason] (shutdown! reason (fn [code] (js/process.exit code))))
+  ([reason exit-fn]
+   (if-not (compare-and-set! shutdown-claimed? false true)
+     (js/Promise.resolve :already-shutting-down)
+     (do
+       (log! "stdin EOF —" reason "— closing nREPL socket and exiting")
+       (when-let [conn (:conn @session-state)]
+         (try (nrepl/close! conn) (catch :default _ nil)))
+       (swap! session-state assoc :conn nil)
+       (let [close-p (if-let [^js server @server-instance]
+                       (-> (js/Promise.resolve (try (j/call server :close)
+                                                    (catch :default _ nil)))
+                           (.catch (fn [_] nil)))
+                       (js/Promise.resolve nil))
+             timer   (js/setTimeout (fn [] (exit-fn 0)) shutdown-fallback-ms)]
+         ;; `.unref` keeps the fallback timer from being the sole event-loop
+         ;; handle holding the process open (Node exposes it; guard for
+         ;; runtimes/fakes that don't).
+         (when (fn? (some-> timer .-unref))
+           (.unref timer))
+         (-> close-p
+             (.then (fn [_]
+                      (js/clearTimeout timer)
+                      (exit-fn 0)))))))))
+
 (defn- connect-transport!
   "Connect `server` to a fresh stdio transport. Logs `ready-msg` on
-  success; logs and exits on transport-connect failure."
+  success; logs and exits on transport-connect failure.
+
+  Installs the stdin EOF handlers here — the stdio boundary is the one
+  owner of the Pair session's resources, so loss of stdio deterministically
+  retires its nREPL connection (`shutdown!`). The SDK 1.29
+  `StdioServerTransport` never converts EOF into a transport close, so we
+  observe `process.stdin`'s `end` directly; `close` is a belt-and-braces
+  backstop for a host that drops the pipe without a clean FIN. `shutdown!`
+  is idempotent, so a double fire is harmless."
   [server ready-msg]
+  (.on js/process.stdin "end" (fn [] (shutdown! "client closed stdin")))
+  (.on js/process.stdin "close" (fn [] (shutdown! "stdin closed")))
   (let [StdioTransport (j/get mcp-stdio :StdioServerTransport)]
     (-> (j/call server :connect (StdioTransport.))
         (.then (fn [_] (log! ready-msg)))

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -14,6 +14,7 @@ integration scripts.
 | Does the compiled `out/server.js` complete an MCP handshake and surface the documented tool descriptors? | **JS** — `stdio-roundtrip.js` |
 | Does the persistent nREPL socket survive multiple ops on one server process without leaking / hanging? | **JS** — `live-nrepl.js` |
 | Do connect / dispatch / trace / hot-reload work end-to-end against a live browser-hosted fixture, through the real MCP boundary? | **JS** — `live-e2e-fixture.cjs` |
+| Does closing stdin (EOF) retire the session — close the persistent nREPL socket and exit 0 — with no out-of-band kill? | **JS** — `stdin-eof-shutdown.cjs` |
 
 If a regression would only be visible **after** the CLJS compiles to
 JS, write a JS test. If it would be visible in the CLJS source, write a
@@ -143,6 +144,34 @@ Run with: `npm run test:live-e2e-fixture` (after `npm run build` and booting
 the fixture; `RE_FRAME2_PAIR_FIXTURE_URL` / `SHADOW_CLJS_NREPL_PORT`
 override discovery).
 
+#### `stdin-eof-shutdown.cjs` — EOF lifecycle contract (rf2-j538f7.32)
+
+The self-contained lifecycle grader. Spawns `out/server.js` and drives it
+over real stdio against a **fake bencode nREPL** the script itself boots —
+no live shadow-cljs, so it runs anywhere (Ubuntu + Windows CI). It pins the
+documented `stdin EOF -> nREPL close -> process exit` contract
+(`spec/001-Wire-Protocol.md`, `server.cljs` lifecycle step 6): the MCP host
+owns process lifecycle, so closing stdin must retire the session. Three
+cases:
+
+- **with nREPL** — a completed `eval-cljs` call opens an idle nREPL socket;
+  `child.stdin.end()` must close that socket (the fake peer observes its
+  connection close) AND exit the process `0` within a short bound. The
+  success path never calls `child.kill()` — force-kill lives only in the
+  cleanup `finally`, so a leaked/hung process surfaces as a red instead of
+  being masked. Before the fix the child stayed alive indefinitely.
+- **no nREPL** — a closed-world session (discovery never resolves a port)
+  still exits `0` promptly on EOF.
+- **early EOF** — EOF before the first tool call (no socket ever opened) is
+  harmless, and a duplicate terminal event does not change the exit status
+  (idempotency).
+
+Every case also asserts stdout purity — teardown emits nothing but MCP
+frames on stdout. The `shutdown!` teardown logic has hermetic CLJS unit
+counterparts in `re_frame2_pair_mcp/shutdown_test.cljs`.
+
+Run with: `npm run test:stdin-eof-shutdown` (after `npm run build`).
+
 #### `post-merge-hook-test.cjs` — stale-binary post-merge hook (rf2-6jj3r)
 
 Unit + smoke tests for the repo's `post-merge` git hook (source lives
@@ -178,6 +207,7 @@ Is the regression visible in CLJS source?
   │
   └── no → JS integration test
             ├── concerns the stdio handshake / tool catalogue?   → stdio-roundtrip.js
+            ├── concerns the stdin-EOF shutdown lifecycle?        → stdin-eof-shutdown.cjs
             ├── concerns the live nREPL socket?                   → live-nrepl.js
             └── concerns an end-to-end flow against a live app?   → live-e2e-fixture.cjs
 ```

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shutdown_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shutdown_test.cljs
@@ -1,0 +1,90 @@
+(ns re-frame2-pair-mcp.shutdown-test
+  "stdin-EOF session teardown (rf2-j538f7.32).
+
+  The MCP host owns process lifecycle: when it closes stdin, Node reaches
+  EOF and the server must retire the session — close the persistent nREPL
+  socket and exit 0. Before the fix no `process.stdin` `end` listener was
+  installed, so a completed tool's idle nREPL socket kept the event loop
+  alive indefinitely.
+
+  These are the hermetic unit counterparts to the real-boundary subprocess
+  regression (`test/stdin-eof-shutdown.cjs`): they grade `shutdown!`'s
+  teardown ordering and one-shot idempotency directly, with an injected
+  `exit-fn` so no process actually exits and no npm SDK / live shadow is
+  required."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.server :as server]))
+
+(use-fixtures :each
+  {:before (fn []
+             (server/reset-session-state-for-tests!)
+             (server/reset-shutdown-latch-for-tests!)
+             ;; No SDK server captured — teardown's `server.close()` is a
+             ;; Promise.resolve nil, so the exit path settles immediately.
+             (server/set-server-instance-for-tests! nil))
+   :after  (fn []
+             (server/reset-session-state-for-tests!)
+             (server/reset-shutdown-latch-for-tests!)
+             (server/set-server-instance-for-tests! nil))})
+
+(defn- conn-with-recording-socket
+  "A discovered conn whose socket records `.end` invocations, so the test
+  can assert `nrepl/close!` fired exactly once on EOF."
+  [end-count]
+  (let [conn (nrepl/make-conn 6543 "127.0.0.1")]
+    (swap! conn assoc
+           :socket  (j/lit {:end (fn [] (swap! end-count inc) nil)})
+           :closed? false)
+    conn))
+
+(deftest eof-closes-socket-drops-conn-and-exits-zero
+  (testing "shutdown! closes the nREPL socket, clears :conn, and exits 0 exactly once"
+    (async done
+      (let [end-count (atom 0)
+            exit-args (atom [])
+            conn      (conn-with-recording-socket end-count)]
+        (server/mark-discovered-for-tests! conn)
+        (-> (server/shutdown! "unit-test EOF" (fn [code] (swap! exit-args conj code)))
+            (.then (fn [_]
+                     (is (= 1 @end-count) "the persistent nREPL socket was closed exactly once")
+                     (is (nil? (:conn (server/session-state-snapshot)))
+                         "the session conn reference was dropped")
+                     (is (= [0] @exit-args) "exited exactly once with code 0")
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+
+(deftest duplicate-terminal-event-is-a-no-op
+  (testing "a second shutdown! (end then close) does not double-close or re-exit"
+    (async done
+      (let [end-count (atom 0)
+            exit-args (atom [])
+            conn      (conn-with-recording-socket end-count)
+            exit-fn   (fn [code] (swap! exit-args conj code))]
+        (server/mark-discovered-for-tests! conn)
+        (-> (server/shutdown! "first EOF" exit-fn)
+            (.then (fn [_]
+                     ;; The duplicate terminal signal — must claim nothing.
+                     (-> (server/shutdown! "duplicate close" exit-fn)
+                         (.then (fn [r]
+                                  (is (= :already-shutting-down r)
+                                      "the duplicate shutdown short-circuits")
+                                  (is (= 1 @end-count)
+                                      "the socket was NOT closed a second time")
+                                  (is (= [0] @exit-args)
+                                      "exit fired exactly once across both calls")
+                                  (done))))))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+
+(deftest eof-before-first-tool-exits-cleanly
+  (testing "EOF with no discovered conn (no socket ever opened) still exits 0"
+    (async done
+      (let [exit-args (atom [])]
+        ;; Pristine session — :conn is nil (discovery never ran).
+        (is (nil? (:conn (server/session-state-snapshot))))
+        (-> (server/shutdown! "early EOF" (fn [code] (swap! exit-args conj code)))
+            (.then (fn [_]
+                     (is (= [0] @exit-args) "exited 0 with nothing to close")
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))

--- a/tools/re-frame2-pair-mcp/test/stdin-eof-shutdown.cjs
+++ b/tools/re-frame2-pair-mcp/test/stdin-eof-shutdown.cjs
@@ -1,0 +1,382 @@
+// stdin-eof-shutdown.cjs — adversarial regression for the documented
+// stdin-EOF lifecycle contract (rf2-j538f7.32).
+//
+// Contract (spec/001-Wire-Protocol.md:16-25, spec/API.md:245-257,
+// server.cljs lifecycle step 6): when the MCP stdio client closes stdin,
+// the Node process reaches EOF, closes its persistent nREPL socket, and
+// exits 0 — WITHOUT relying on an out-of-band kill.
+//
+// Before the fix the server installed no `process.stdin` `end` listener,
+// so a completed app-facing tool left an idle nREPL TCP socket as a live
+// event-loop handle: closing stdin neither closed the socket nor exited
+// the process. This harness reproduces that leak and grades the fix.
+//
+// It is fully self-contained — a minimal fake bencode nREPL stands in for
+// shadow-cljs, so no live runtime is required. Run with:
+//   node test/stdin-eof-shutdown.cjs   (after `npm run build`)
+// Exits 0 on success, non-zero on any failure.
+//
+// CRITICAL (acceptance criteria 1-2): the SUCCESS path never calls
+// `child.kill()`. Force-kill lives only in the failure/cleanup finally so
+// the oracle cannot mask a lingering process by killing it.
+
+'use strict';
+
+const { spawn } = require('node:child_process');
+const net = require('node:net');
+const path = require('node:path');
+
+const SERVER = path.join(__dirname, '..', 'out', 'server.js');
+
+// The bound within which a healthy server must retire itself after EOF.
+// Generous enough for a slow CI runner; short enough that the pre-fix
+// hang (which never exits) is caught deterministically.
+const EXIT_BOUND_MS = 4000;
+
+// --------------------------------------------------------------------------
+// Minimal bencode — self-contained so the harness has no decode-API
+// coupling. `encode` builds nREPL response dicts; `parseOne` is an
+// INCREMENTAL decoder that returns null on a partial (chunk-split) value
+// so the fake server can reassemble streamed ops.
+// --------------------------------------------------------------------------
+function encode(v) {
+  if (Buffer.isBuffer(v)) return Buffer.concat([Buffer.from(v.length + ':'), v]);
+  if (typeof v === 'string') {
+    const b = Buffer.from(v, 'utf8');
+    return Buffer.concat([Buffer.from(b.length + ':'), b]);
+  }
+  if (typeof v === 'number') return Buffer.from('i' + Math.trunc(v) + 'e');
+  if (Array.isArray(v)) {
+    return Buffer.concat([Buffer.from('l'), ...v.map(encode), Buffer.from('e')]);
+  }
+  if (v && typeof v === 'object') {
+    const parts = [Buffer.from('d')];
+    for (const k of Object.keys(v).sort()) {
+      parts.push(encode(k), encode(v[k]));
+    }
+    parts.push(Buffer.from('e'));
+    return Buffer.concat(parts);
+  }
+  throw new Error('cannot bencode: ' + String(v));
+}
+
+// Returns { value, next } for the value at byte offset `i`, or null when
+// the buffer holds only a partial value (needs more bytes).
+function parseOne(buf, i) {
+  if (i >= buf.length) return null;
+  const c = buf[i];
+  if (c === 0x69) {
+    // i<int>e
+    const e = buf.indexOf(0x65, i + 1);
+    if (e < 0) return null;
+    return { value: parseInt(buf.slice(i + 1, e).toString('ascii'), 10), next: e + 1 };
+  }
+  if (c === 0x6c || c === 0x64) {
+    // l...e (list) / d...e (dict)
+    let j = i + 1;
+    const items = [];
+    for (;;) {
+      if (j >= buf.length) return null;
+      if (buf[j] === 0x65) { j += 1; break; }
+      const r = parseOne(buf, j);
+      if (!r) return null;
+      items.push(r.value);
+      j = r.next;
+    }
+    if (c === 0x6c) return { value: items, next: j };
+    const obj = {};
+    for (let k = 0; k + 1 < items.length; k += 2) obj[String(items[k])] = items[k + 1];
+    return { value: obj, next: j };
+  }
+  // <len>:<bytes> string
+  const colon = buf.indexOf(0x3a, i);
+  if (colon < 0) return null;
+  const len = parseInt(buf.slice(i, colon).toString('ascii'), 10);
+  if (Number.isNaN(len)) throw new Error('malformed bencode string length at ' + i);
+  const start = colon + 1;
+  const end = start + len;
+  if (end > buf.length) return null;
+  return { value: buf.slice(start, end).toString('utf8'), next: end };
+}
+
+// --------------------------------------------------------------------------
+// Fake bencode nREPL — accepts TCP connections, answers every op with a
+// `["done"]` status frame echoing the request id, and records socket
+// lifecycle so the test can assert the server closes its connection on EOF.
+// --------------------------------------------------------------------------
+function startFakeNrepl() {
+  let live = 0;
+  let closed = 0;
+  const server = net.createServer((sock) => {
+    live += 1;
+    let buf = Buffer.alloc(0);
+    sock.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      for (;;) {
+        let r;
+        try { r = parseOne(buf, 0); } catch { buf = Buffer.alloc(0); break; }
+        if (!r) break;
+        buf = buf.slice(r.next);
+        const msg = r.value || {};
+        const id = msg.id;
+        if (id == null) continue;
+        // A `["done"]` frame is all send-op! needs to resolve. A `value`
+        // keeps the eval-cljs probe ladder from hanging; its exact shape
+        // is irrelevant — the socket stays persistently open regardless of
+        // whether the probe concludes a runtime is present.
+        sock.write(encode({ id: String(id), status: ['done'], value: '1', ns: 'user' }));
+      }
+    });
+    sock.on('close', () => { live -= 1; closed += 1; });
+    sock.on('error', () => { /* client teardown races are expected */ });
+  });
+  return {
+    server,
+    listen: () =>
+      new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+      }),
+    liveConnections: () => live,
+    closedConnections: () => closed,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+// --------------------------------------------------------------------------
+// MCP stdio client — spawn the compiled server, drive line-delimited
+// JSON-RPC, and expose EOF + exit primitives. Records EVERY stdout line so
+// the harness can assert stdout purity (no non-JSON noise on teardown).
+// --------------------------------------------------------------------------
+function spawnServer(extraEnv, extraArgs) {
+  const env = { ...process.env, ...extraEnv };
+  const child = spawn(process.execPath, [SERVER, ...(extraArgs || [])], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+  });
+
+  let stderrBuf = '';
+  child.stderr.on('data', (d) => {
+    const s = d.toString();
+    stderrBuf += s;
+    process.stderr.write('[server] ' + s);
+  });
+
+  const stdoutLines = [];
+  const nonJsonStdout = [];
+  let next = 1;
+  const pending = new Map();
+  let buf = '';
+  child.stdout.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    let i;
+    while ((i = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, i).trim();
+      buf = buf.slice(i + 1);
+      if (!line) continue;
+      stdoutLines.push(line);
+      let frame;
+      try {
+        frame = JSON.parse(line);
+      } catch {
+        // stdout is reserved for MCP frames — anything else is a purity
+        // violation the harness must fail on.
+        nonJsonStdout.push(line);
+        continue;
+      }
+      if (frame.id && pending.has(frame.id)) {
+        pending.get(frame.id)(frame);
+        pending.delete(frame.id);
+      }
+    }
+  });
+
+  const waitForStderr = (pattern, { timeoutMs = 8000, intervalMs = 25 } = {}) =>
+    new Promise((res, rej) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = () => {
+        if (pattern.test(stderrBuf)) return res();
+        if (child.exitCode !== null) {
+          return rej(new Error('server exited (code=' + child.exitCode + ') before matching ' + pattern));
+        }
+        if (Date.now() >= deadline) {
+          return rej(new Error('timed out waiting for ' + pattern + ' on stderr; saw:\n' + stderrBuf));
+        }
+        setTimeout(tick, intervalMs);
+      };
+      tick();
+    });
+
+  const call = (m, p) => {
+    const id = next++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error('MCP call ' + m + ' (id ' + id + ') timed out'));
+      }, 15000);
+      pending.set(id, (frame) => { clearTimeout(timer); resolve(frame); });
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method: m, params: p }) + '\n');
+    });
+  };
+  const notify = (m, p) =>
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: m, params: p }) + '\n');
+
+  // Resolves { code, signal } when the child exits; rejects if it stays
+  // alive past `ms` (the pre-fix behaviour this regression is designed to
+  // catch). Deliberately does NOT kill on timeout — the caller's finally
+  // owns force-kill so a hung child surfaces as a red, not a masked pass.
+  const waitForExit = (ms) =>
+    new Promise((resolve, reject) => {
+      if (child.exitCode !== null) return resolve({ code: child.exitCode, signal: null });
+      const timer = setTimeout(() => {
+        reject(new Error('child did not exit within ' + ms + 'ms of stdin EOF (still alive) — leak reproduced'));
+      }, ms);
+      child.once('exit', (code, signal) => { clearTimeout(timer); resolve({ code, signal }); });
+    });
+
+  return {
+    child,
+    call,
+    notify,
+    waitForStderr,
+    waitForExit,
+    endStdin: () => child.stdin.end(),
+    nonJsonStdout: () => nonJsonStdout.slice(),
+    forceKill: () => { try { child.kill('SIGKILL'); } catch { /* best effort */ } },
+  };
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+async function handshake(client, name) {
+  await client.waitForStderr(/\bready\b/);
+  const init = await client.call('initialize', {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name, version: '0' },
+  });
+  assert(init.result?.protocolVersion, 'initialize failed: ' + JSON.stringify(init));
+  client.notify('notifications/initialized', {});
+}
+
+// Case A — the core regression: a completed app-facing tool leaves an idle
+// nREPL socket; stdin EOF must close it AND exit 0.
+async function caseWithNrepl() {
+  const fake = startFakeNrepl();
+  const port = await fake.listen();
+  const client = spawnServer({ SHADOW_CLJS_NREPL_PORT: String(port) });
+  try {
+    await handshake(client, 'stdin-eof-with-nrepl');
+
+    // Complete one app-facing tool so the persistent TCP socket opens and
+    // goes idle. eval-cljs drives the nREPL round-trip unconditionally; its
+    // result envelope is irrelevant here — we only need the socket open.
+    const resp = await client.call('tools/call', { name: 'eval-cljs', arguments: { form: '(+ 1 2)' } });
+    assert(resp.result, 'eval-cljs returned no result: ' + JSON.stringify(resp));
+    assert(
+      fake.liveConnections() >= 1,
+      'expected an open nREPL socket after the tool completed, saw ' + fake.liveConnections(),
+    );
+    console.log('OK   eval-cljs opened an idle nREPL socket (' + fake.liveConnections() + ' live)');
+
+    // The documented shutdown signal: close stdin, nothing else.
+    client.endStdin();
+    const { code, signal } = await client.waitForExit(EXIT_BOUND_MS);
+    assert(code === 0, 'expected clean exit 0 on stdin EOF, got code=' + code + ' signal=' + signal);
+    console.log('OK   stdin EOF -> process exited 0 within ' + EXIT_BOUND_MS + 'ms (no kill)');
+
+    // The fake nREPL peer must observe its socket close — the leak's other half.
+    const deadline = Date.now() + 1000;
+    while (fake.liveConnections() > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    assert(
+      fake.liveConnections() === 0 && fake.closedConnections() >= 1,
+      'nREPL socket was not closed on EOF: live=' + fake.liveConnections() + ' closed=' + fake.closedConnections(),
+    );
+    console.log('OK   nREPL peer observed socket close on EOF');
+
+    assert(
+      client.nonJsonStdout().length === 0,
+      'stdout purity violated — non-MCP lines on stdout: ' + JSON.stringify(client.nonJsonStdout()),
+    );
+    console.log('OK   stdout stayed pure (no non-MCP output on teardown)');
+  } finally {
+    client.forceKill();
+    await fake.close();
+  }
+}
+
+// Case B — no-nREPL counterpart (acceptance criterion 3): a closed-world
+// session (discovery never resolves a port) must still exit promptly on EOF.
+async function caseNoNrepl() {
+  // Empty SHADOW_CLJS_NREPL_PORT + a closed --http-port forces the degraded
+  // (no-nREPL) boot deterministically.
+  const env = { ...process.env };
+  delete env.SHADOW_CLJS_NREPL_PORT;
+  const client = spawnServer({ ...env, SHADOW_CLJS_NREPL_PORT: '' }, ['--http-port', '1']);
+  try {
+    await handshake(client, 'stdin-eof-no-nrepl');
+    const list = await client.call('tools/list', {});
+    assert(Array.isArray(list.result?.tools), 'tools/list failed: ' + JSON.stringify(list));
+
+    client.endStdin();
+    const { code, signal } = await client.waitForExit(EXIT_BOUND_MS);
+    assert(code === 0, 'no-nREPL: expected clean exit 0 on stdin EOF, got code=' + code + ' signal=' + signal);
+    assert(
+      client.nonJsonStdout().length === 0,
+      'no-nREPL: stdout purity violated: ' + JSON.stringify(client.nonJsonStdout()),
+    );
+    console.log('OK   no-nREPL session exited 0 on stdin EOF within ' + EXIT_BOUND_MS + 'ms');
+  } finally {
+    client.forceKill();
+  }
+}
+
+// Case C — EOF before the first tool call (no socket ever opened) must be
+// harmless, and a duplicate terminal event (end after already-ended stdin)
+// must not change the exit status (idempotency, acceptance criteria 4-5).
+async function caseEofBeforeFirstTool() {
+  const fake = startFakeNrepl();
+  const port = await fake.listen();
+  const client = spawnServer({ SHADOW_CLJS_NREPL_PORT: String(port) });
+  try {
+    await handshake(client, 'stdin-eof-early');
+    // No tool call — discovery never ran, no nREPL socket exists.
+    assert(fake.liveConnections() === 0, 'unexpected early nREPL socket');
+    client.endStdin();
+    // A duplicate terminal nudge must be a no-op, never a double-close crash.
+    try { client.child.stdin.end(); } catch { /* already ended */ }
+    const { code, signal } = await client.waitForExit(EXIT_BOUND_MS);
+    assert(code === 0, 'early-EOF: expected clean exit 0, got code=' + code + ' signal=' + signal);
+    assert(
+      client.nonJsonStdout().length === 0,
+      'early-EOF: stdout purity violated: ' + JSON.stringify(client.nonJsonStdout()),
+    );
+    console.log('OK   EOF before first tool exited 0 (idempotent, no socket to leak)');
+  } finally {
+    client.forceKill();
+    await fake.close();
+  }
+}
+
+async function main() {
+  const fs = require('node:fs');
+  if (!fs.existsSync(SERVER)) {
+    console.error('FAIL: server bundle missing at ' + SERVER + ' — run `npm run build` first');
+    process.exit(1);
+  }
+  await caseWithNrepl();
+  await caseNoNrepl();
+  await caseEofBeforeFirstTool();
+  console.log('\nSTDIN-EOF SHUTDOWN GREEN');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('FAIL:', err && err.message ? err.message : err);
+    if (err && err.stack) console.error(err.stack);
+    process.exit(1);
+  });


### PR DESCRIPTION
## What

The MCP host owns Pair's process lifecycle: closing stdin (EOF) must retire the session. Previously the server installed no `process.stdin` `end` listener, so after a completed app-facing tool opened the persistent nREPL socket, closing stdin left **both** the Node process and the nREPL TCP connection alive indefinitely — an orphan process + leaked socket that only an out-of-band kill reaped.

The SDK 1.29 `StdioServerTransport` registers only `data`/`error` on stdin and never converts EOF into a transport close, so the assumption that the SDK owned this was false.

## Fix

- Install stdin `end`/`close` handlers at the stdio boundary (`connect-transport!`) — the one owner of the session's resources.
- Add an idempotent `shutdown!` that closes the persistent nREPL socket via the existing `nrepl/close!` (which bumps the conn generation so a late/in-flight connect candidate can't publish behind us), closes the SDK server + transport, and exits 0. A bounded, `unref`-ed fallback timer forces exit if the SDK close stalls — a fail-safe, never the liveness policy.
- Teardown diagnostics stay on stderr; stdout remains reserved for MCP frames.

Scope is strictly transport/lifecycle — no tool descriptor / annotation changes, no `mcp-base` or `implementation/*` edits.

## Premise verified (fail-before / pass-after)

Against the **unfixed** build the new subprocess regression reproduces the leak exactly as the bead describes: `eval-cljs` opens an idle nREPL socket, then `child.stdin.end()` leaves the child alive past 4000 ms. After the fix the child exits 0 and the fake nREPL peer observes its socket close.

## Regression coverage

- **`test/stdin-eof-shutdown.cjs`** — self-contained subprocess grader against a fake bencode nREPL (no live shadow). Three cases: (1) completed tool → idle socket → EOF closes socket **and** exits 0 with **no** `child.kill()` on the success path (force-kill only in cleanup `finally`); (2) no-nREPL closed-world session exits 0 on EOF; (3) early-EOF/idempotent (EOF before first tool + duplicate terminal event). Every case asserts stdout purity. Wired into the `node-test-tools-re-frame2-pair-mcp` CI job so the `stdin EOF → nREPL close → process exit` contract is continuously graded on Ubuntu + Windows.
- **`test/re_frame2_pair_mcp/shutdown_test.cljs`** — hermetic CLJS unit counterparts (teardown ordering + one-shot idempotency) in the fast `npm test` gate.

## Quality gates (local)

- `npm test` (CLJS `:server-test`): **1204 tests / 4148 assertions, 0 failures, 0 errors**, 0 warnings.
- `npm run build` (`:server` bundle): 0 warnings.
- `npm run check:descriptors`: in sync (30 tools).
- `npm run test:stdin-eof-shutdown`: **GREEN** (fails against the pre-fix build, passes after).

Closes rf2-j538f7.32.