### PR TITLE
fix(story): single run owner — shell auto-play executes exactly once (rf2-j538f7.34)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -186,6 +186,45 @@ node and reseats the workspace. Decorator fingerprinting tracks
 whether the decorator stack used by a mounted variant has changed at
 the registry level; stale variants re-mount.
 
+### One run owner (prepare / resume)
+
+A focused variant's run spans the real React render boundary — the
+frame must exist before the first render (so subscriptions deref
+against a live frame, not `nil`), and DOM play-steps must run **after**
+React commits. The shell therefore drives each variant's run through
+**one owner** split into two halves, so a shell auto-play executes
+**exactly once**:
+
+- **PREPARE** (`runtime/prepare-run!`) — allocate + reset the frame and
+  run loaders + setup (phases 0-2) to `:ready`, **without** the play
+  script. It is **idempotent per `run-key`** (the shell slice of
+  variant × active-modes × cell-overrides × substrate × hot-reload
+  tick): the selection-edge preallocation and the canvas post-commit
+  prepare for the same logical run collapse to **one** frame reset and
+  **one** run generation. A changed `run-key`, or a re-prepare after the
+  current generation was already resumed (a React remount), claims a
+  **fresh generation**.
+- **RESUME** (`runtime/resume-run!`) — run the auto-plays' play script +
+  terminal assertions (phase 4) **exactly once per prepared
+  generation**, then publish the unified result. The canvas post-commit
+  lifecycle is the primary resume caller; the selection-watcher and the
+  mount-time block also call it for the same generation. The generation
+  guard collapses every such call to **one** execution.
+
+A resume **superseded** by a newer prepare (a rapid re-selection /
+cell-override change while a prior run's async play is mid-flight)
+settles as an explicit superseded result — never `:pass`, and it never
+reads the successor frame; the successor's resume owns the one
+execution. The inner per-play run-token still guards play-key
+isolation; it is not the outer lifecycle owner.
+
+The headless `run-variant` (Test mode / MCP / sidebar Run-all) composes
+prepare + resume in one call — one generation claimed and immediately
+resumed — so it runs the full four-phase lifecycle exactly once with no
+render boundary to span. Ownership is per variant/frame (one registry
+slot per variant-id), so different variants run concurrently and
+independently — this is **not** a global lock.
+
 ## Multi-substrate side-by-side rendering
 
 For a variant declaring `:substrates #{:reagent :uix :helix}` (or any

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1220,6 +1220,33 @@
                        :status     :error
                        :passed?    false}]))
 
+(defn- prepare-ctx!
+  "PREPARE half of the four-phase lifecycle: compile the plan, allocate +
+  reset the frame, run db-seed, loaders, and setup (phases 0-2). Returns the
+  threaded ctx with the frame at `:ready` (loader-incomplete / error paths
+  aside) and the first React render therefore safe — but WITHOUT executing the
+  play script. `resume-ctx!` runs the script (phase 4) against this ctx.
+
+  Throws on a plan-construction / db-seed / phase error; the caller's
+  try/catch projects it via `handle-run-error!`. Splitting prepare from
+  resume is what lets the one run owner (rf2-j538f7.34) span the real React
+  render boundary — loaders/setup before the first render, the script after
+  commit — while `run-variant` composes both halves for the headless path."
+  [variant-id variant-body opts]
+  (-> (prepare-context variant-id variant-body opts)
+      run-phase-0!
+      run-db-seed!
+      run-phase-1!
+      run-phase-2!))
+
+(defn- resume-ctx!
+  "RESUME half of the four-phase lifecycle: run phase 4 (the auto-plays' play
+  script + terminal assertions) against a prepared `ctx`, then resolve
+  `resolve` with the unified result once phase 4 settles."
+  [resolve ctx start-ms]
+  (let [[ctx' play-promise] (run-phase-4! ctx)]
+    (finalise-run! resolve play-promise ctx' start-ms)))
+
 (defn run-variant
   "Allocate a frame for `variant-id`, run its setup, loaders, events, and
   play scripts, and return the unified result asynchronously.
@@ -1251,15 +1278,187 @@
            (async/promise
              (fn [resolve]
                (try
-                 (let [ctx          (-> (prepare-context variant-id variant-body opts)
-                                        run-phase-0!
-                                        run-db-seed!
-                                        run-phase-1!
-                                        run-phase-2!)
-                       [ctx' play-promise] (run-phase-4! ctx)]
-                   (finalise-run! resolve play-promise ctx' start-ms))
+                 (let [ctx (prepare-ctx! variant-id variant-body opts)]
+                   (resume-ctx! resolve ctx start-ms))
                  (catch #?(:clj Throwable :cljs :default) e
                    (handle-run-error! resolve variant-id e start-ms)))))))))))
+
+;; ---- the one run owner (rf2-j538f7.34) -----------------------------------
+;;
+;; A shell auto-play must execute EXACTLY ONCE. Before this, a single focused
+;; shell selection had THREE execution owners: the selection-edge frame
+;; preallocation (a full `run-variant`), the canvas `component-did-mount` run
+;; (a second full `run-variant`), and the post-commit `auto-run!` — so a
+;; variant's play-script (and its external effects) ran up to three times and a
+;; cumulative script visibly double-counted (a passing variant looked failed).
+;;
+;; The fix gives Story ONE run owner that spans the real React render
+;; boundary, split into a PREPARE half and a RESUME half over a per-variant
+;; generation:
+;;
+;;   • `prepare-run!` runs loaders + setup (phases 0-2) so the first render is
+;;     safe, WITHOUT the script. It is idempotent per `:run-key`: the
+;;     selection-edge preallocation and the canvas post-commit run collapse to
+;;     ONE frame reset + ONE generation. A changed run-key (cell-override /
+;;     mode / substrate / hot-reload) — or a re-prepare after the current
+;;     generation was already resumed (a React remount) — claims a FRESH
+;;     generation.
+;;
+;;   • `resume-run!` runs the script (phase 4) EXACTLY ONCE per generation.
+;;     Every shell trigger (selection-watcher, mount-time block, canvas
+;;     post-commit) calls it for the same generation; the generation guard
+;;     collapses them to one execution. A resume superseded by a newer prepare
+;;     settles explicitly (never `:pass`, never reads the successor frame).
+;;
+;; Ownership is per variant/frame (one registry slot per variant-id), so two
+;; different variants run concurrently and independently — this is NOT a global
+;; lock. The inner per-play run-token (`runner-events/run!`) still guards
+;; play-key isolation; it is not the outer lifecycle owner.
+
+(defonce ^:private run-owner
+  ;; variant-id -> {:run-key K              ; the shell run-key this generation prepared for
+  ;;                :generation G           ; monotonic per-variant run generation
+  ;;                :resumed-gen R          ; the generation last claimed for resume (R<G ⇒ pending)
+  ;;                :ctx <ctx> | :error e   ; the prepared attempt (or a prepare failure)
+  ;;                :start-ms ms}
+  (atom {}))
+
+(defn current-generation
+  "The current prepared run generation for `variant-id` (0 if never prepared).
+  Public so the shell / canvas / tests can observe supersession."
+  [variant-id]
+  (get-in @run-owner [variant-id :generation] 0))
+
+(defn reset-run-owner!
+  "Drop the one-run-owner state for `variant-id` (frame teardown / re-run) or,
+  with no arg, for every variant (shell unmount / test isolation). A dropped
+  entry means the next `prepare-run!` starts a fresh generation."
+  ([] (reset! run-owner {}))
+  ([variant-id] (swap! run-owner dissoc variant-id) nil))
+
+(defn- superseded-result
+  "The explicit settle-value for a resume that a newer prepare superseded
+  (rf2-j538f7.34 criteria 4/5). Never `:pass`; carries no successor state — it
+  is built frame-free from `empty-result` so a stale attempt cannot green nor
+  combine its args with the successor frame's app-db / evidence."
+  [variant-id generation]
+  (assoc (empty-result variant-id)
+         :status      :cannot-run
+         :lifecycle   :superseded
+         :superseded? true
+         :generation  generation))
+
+(defn prepare-run!
+  "PREPARE the one run owner for `variant-id` (rf2-j538f7.34): allocate + reset
+  the frame and run loaders + setup (phases 0-2) so the first React render is
+  safe, WITHOUT executing the play script. Idempotent per `:run-key` — repeated
+  prepares for the same logical run (selection-edge preallocation + canvas
+  post-commit) collapse to ONE reset + ONE generation.
+
+  `opts` is the standard `run-variant` opts (`:active-modes` / `:cell-overrides`
+  / `:substrate` / `:render?`) plus a `:run-key` — the shell slice that
+  identifies this logical run (see `re-frame.story.ui.canvas/run-key`). A
+  changed `:run-key`, or a re-prepare after the current generation was already
+  resumed, claims a fresh generation and re-runs phases 0-2.
+
+  Fire-and-forget: the display reads the frame's app-db reactively. Returns the
+  claimed (or deduped) generation."
+  [variant-id {:keys [run-key] :as opts}]
+  (when (and config/enabled? variant-id)
+    (let [cur    (get @run-owner variant-id)
+          ;; A fresh logical run when: never prepared; the run-key changed; or
+          ;; the current generation was already resumed (a remount / re-entry).
+          fresh? (or (nil? cur)
+                     (not= (:run-key cur) run-key)
+                     (= (:resumed-gen cur) (:generation cur)))]
+      (if-not fresh?
+        ;; Same run-key, not yet resumed — the frame is already prepared for
+        ;; this generation. Do NOT reset it or bump the generation; the pending
+        ;; resume owns the one execution.
+        (:generation cur)
+        (let [variant-body (frames/variant-body variant-id)
+              gen          (inc (get cur :generation 0))
+              base         {:run-key run-key :generation gen :resumed-gen (dec gen)
+                            :start-ms (interop/now-ms)}]
+          (if (nil? variant-body)
+            (do (swap! run-owner assoc variant-id (assoc base :error :unknown-variant))
+                gen)
+            (do
+              (try
+                (let [ctx (prepare-ctx! variant-id variant-body opts)]
+                  (swap! run-owner assoc variant-id (assoc base :ctx ctx)))
+                (catch #?(:clj Throwable :cljs :default) e
+                  ;; Capture the prepare failure so the matching resume publishes
+                  ;; a structured error result (loaders/setup can throw).
+                  (swap! run-owner assoc variant-id (assoc base :error e))))
+              gen)))))))
+
+(defn- claim-resume!
+  "Atomically claim the current generation for resume. Returns the claimed
+  attempt map iff this caller won the claim (the current generation was still
+  pending), else nil. Exactly one caller per generation wins — the single run
+  owner's exactly-once guarantee."
+  [variant-id]
+  (loop []
+    (let [m   @run-owner
+          cur (get m variant-id)]
+      (if (or (nil? cur) (= (:resumed-gen cur) (:generation cur)))
+        nil
+        (if (compare-and-set! run-owner m
+              (assoc-in m [variant-id :resumed-gen] (:generation cur)))
+          cur
+          (recur))))))
+
+(defn resume-run!
+  "RESUME the one run owner for `variant-id` (rf2-j538f7.34): run the prepared
+  attempt's play script + terminal assertions (phase 4) EXACTLY ONCE per
+  prepared generation, then publish the unified result. The shell
+  selection-watcher, the shell mount-time block, and the canvas post-commit
+  lifecycle all call this for the same generation; the generation guard
+  collapses them to ONE script execution.
+
+  A superseded attempt (a newer `prepare-run!` claimed a fresh generation
+  before or during this resume) settles as an explicit `superseded-result` —
+  never `:pass`, and without reading the successor frame.
+
+  Must be called AFTER `prepare-run!` and AFTER React has committed the canvas
+  (so DOM steps see the mounted view). Returns a promise of the result, or nil
+  when there is nothing to resume (already resumed for this generation, or
+  never prepared)."
+  ([variant-id] (resume-run! variant-id nil))
+  ([variant-id done-cb]
+   (when (and config/enabled? variant-id)
+     (when-let [attempt (claim-resume! variant-id)]
+       (let [my-gen   (:generation attempt)
+             start-ms (or (:start-ms attempt) (interop/now-ms))]
+         (async/promise
+           (fn [resolve]
+             (try
+               (cond
+                 ;; A newer prepare already superseded this attempt.
+                 (not= my-gen (current-generation variant-id))
+                 (resolve (superseded-result variant-id my-gen))
+                 ;; The prepare half failed — project its error.
+                 (= :unknown-variant (:error attempt))
+                 (resolve (unknown-variant-result variant-id))
+                 (:error attempt)
+                 (handle-run-error! resolve variant-id (:error attempt) start-ms)
+                 ;; Run phase 4 against the prepared ctx, re-checking the
+                 ;; generation before publishing so a supersession DURING the
+                 ;; async script settles as superseded rather than reading the
+                 ;; successor frame.
+                 :else
+                 (let [[ctx' play-promise] (run-phase-4! (:ctx attempt))]
+                   (-> play-promise
+                       (async/then
+                         (fn [_]
+                           (if (= my-gen (current-generation variant-id))
+                             (resolve (record-result-map ctx' start-ms))
+                             (resolve (superseded-result variant-id my-gen)))
+                           (when done-cb (try (done-cb) (catch #?(:clj Throwable :cljs :default) _ nil)))
+                           nil)))))
+               (catch #?(:clj Throwable :cljs :default) e
+                 (handle-run-error! resolve variant-id e start-ms))))))))))
 
 ;; ---- inline plan execution -----------------------------------------------
 ;;
@@ -1495,6 +1694,10 @@
   ([variant-id] (reset-variant variant-id nil))
   ([variant-id opts]
    (when config/enabled?
+     ;; Drop the one-run-owner attempt (rf2-j538f7.34): its prepared ctx points
+     ;; at the frame we are about to destroy, so the next prepare must start a
+     ;; fresh generation rather than dedupe onto a stale attempt.
+     (reset-run-owner! variant-id)
      (frames/destroy! variant-id))
    (run-variant variant-id opts)))
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1005,9 +1005,23 @@
   runner drives directly.
 
   Rendering is owned by the UI shell and `render-variant`, not this
-  orchestrator."
-  [{:keys [variant-id loaders-complete? plan] :as ctx}]
-  (if-not loaders-complete?
+  orchestrator.
+
+  `:force-play?` on the ctx (rf2-j538f7.34) runs the auto-plays EVEN WHEN
+  `loaders-complete?` is false — the loader-incomplete-but-drained case where
+  the loader events ran (e.g. `:story.counter-matrix/loader-never-completes`
+  seeds `:count` to 13) but the `:loaders-complete-when` predicate reported
+  not-ready, so the lifecycle parks at `:loading` yet the canvas still renders
+  the user view (the recorded loader-incomplete assertion turns the skeleton
+  off). Only the interactive shell's `resume-run!` sets it: in the browser the
+  view is mounted and the auto-play must run against it and publish a play-
+  runner run-state — the exact behaviour the pre-split browser `auto-run!` had,
+  which the Story/Xray play-scripts browser gate reads via
+  `runner-events/current-state`. The headless `run-variant` / inline paths
+  never set it, so their contract (loader-incomplete ⇒ events + play skipped,
+  lifecycle parks at `:loading`) is unchanged."
+  [{:keys [variant-id loaders-complete? plan force-play?] :as ctx}]
+  (if-not (or loaders-complete? force-play?)
     [ctx (async/resolved (read-assertions variant-id))]
     (let [plays      (get-in plan [:world :scripts] [])
           auto-plays (runner/auto-runnable-plays plays)
@@ -1447,8 +1461,21 @@
                  ;; generation before publishing so a supersession DURING the
                  ;; async script settles as superseded rather than reading the
                  ;; successor frame.
+                 ;;
+                 ;; `:force-play?` so a loader-incomplete-but-drained variant
+                 ;; (`:story.counter-matrix/loader-never-completes` — loaders
+                 ;; ran and seeded state, but `:loaders-complete-when` reported
+                 ;; not-ready) STILL runs its auto-play against the rendered
+                 ;; view and publishes a play-runner run-state. In the browser
+                 ;; the canvas renders the user view for such a variant (the
+                 ;; recorded loader-incomplete assertion turns the skeleton
+                 ;; off), so the auto-play must run — matching the pre-split
+                 ;; browser `auto-run!` the Story/Xray play-scripts gate reads.
+                 ;; The headless `run-variant` (via `resume-ctx!`) sets no such
+                 ;; flag, so its loader-incomplete contract (play skipped,
+                 ;; lifecycle parks at :loading) is unchanged.
                  :else
-                 (let [[ctx' play-promise] (run-phase-4! (:ctx attempt))]
+                 (let [[ctx' play-promise] (run-phase-4! (assoc (:ctx attempt) :force-play? true))]
                    (-> play-promise
                        (async/then
                          (fn [_]

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -5,7 +5,10 @@
 
   - Watches the shell state's `:hot-reload-tick` so it re-mounts when the
     fingerprint detector ticks.
-  - Calls `run-variant` with the active modes / cell-overrides / substrate.
+  - Is the single RESUME owner of the variant's one run (rf2-j538f7.34):
+    post-commit it prepares the frame (idempotent per run-key) with the
+    active modes / cell-overrides / substrate and resumes the play script
+    exactly once per prepared generation.
   - Renders the variant's `:component` (registered re-frame view) under
     the `:hiccup` decorator stack from `resolve-decorators` — which reads
     the FULL stack (globals + story + variant chain) off the compiled
@@ -358,19 +361,6 @@
 
 ;; ---- the canvas component ------------------------------------------------
 
-(defn- run-with-shell-opts!
-  "Drive `run-variant` with the shell's current modes / cell overrides /
-  substrate. Returns nothing — the promise resolves async; the canvas
-  reads the variant's app-db-value reactively after each run."
-  [variant-id]
-  (let [shell @state/shell-state-atom
-        opts  {:active-modes   (:active-modes shell)
-               :cell-overrides (get-in shell [:cell-overrides variant-id])
-               :substrate      (:substrate shell)
-               :render?        true}]
-    (runtime/run-variant variant-id opts)
-    nil))
-
 (defn run-key
   "The shell-state slice that should trigger a fresh runtime run for
   `variant-id`. Ordinary app-db updates inside the variant frame must
@@ -417,7 +407,36 @@
   ([] (reset! first-rendered? #{}) nil)
   ([variant-id] (swap! first-rendered? disj variant-id) nil))
 
+(defn- prepare-with-shell-opts!
+  "PREPARE the variant's one run owner (rf2-j538f7.34) with the shell's
+  current modes / cell overrides / substrate: allocate + reset the frame and
+  run loaders + setup, WITHOUT executing the play script. Idempotent per
+  `:run-key`, so this canvas prepare and the shell's selection-edge prepare
+  for the same logical run collapse to ONE frame reset + ONE generation. The
+  single resume owner runs the script exactly once. Returns nothing — the
+  canvas reads the variant's app-db-value reactively after each run."
+  [variant-id]
+  (let [shell @state/shell-state-atom
+        opts  {:active-modes   (:active-modes shell)
+               :cell-overrides (get-in shell [:cell-overrides variant-id])
+               :substrate      (:substrate shell)
+               :render?        true
+               :run-key        (run-key shell variant-id)}]
+    (runtime/prepare-run! variant-id opts)
+    nil))
+
 (defn- run-if-needed!
+  "The canvas's single-owner lifecycle hook (rf2-j538f7.34). Runs only when
+  the `run-key` changed (a new selection, cell-override, mode, substrate, or
+  hot-reload tick) so ordinary in-frame app-db updates never re-run the
+  variant. On a change it PREPARES the frame (idempotent per run-key) and then
+  RESUMES the single run owner — running the play script EXACTLY ONCE per
+  prepared generation.
+
+  Called from `component-did-mount` / `component-did-update`, both POST-commit,
+  so the resumed script's DOM steps see the mounted view. `resume-run!` is
+  idempotent per generation, so the shell selection-watcher / mount-time block
+  calling it too for the same generation collapses to one execution."
   []
   (when config/enabled?
     (let [shell      @state/shell-state-atom
@@ -427,7 +446,10 @@
         (let [key (run-key shell variant-id)]
           (when (not= key @canvas-last-run-key)
             (reset! canvas-last-run-key key)
-            (run-with-shell-opts! variant-id)))))))
+            (prepare-with-shell-opts! variant-id)
+            ;; RESUME the one run owner post-commit. The generation guard makes
+            ;; this exactly-once even though the shell also schedules a resume.
+            (runtime/resume-run! variant-id)))))))
 
 (defn- variant-substrate-set
   "Resolve the variant's effective substrate set. Per `001-Authoring.md` §Registration macros
@@ -444,7 +466,7 @@
 (defn- canvas-inner
   "The inner render fn — reads the variant's app-db-value reactively. Split
   out so the outer `canvas` component can wrap with a lifecycle for
-  run-variant + tear-down.
+  prepare/resume + tear-down.
 
   The inner render branches on
   `(count (variant-substrate-set variant-id))`:
@@ -647,8 +669,10 @@
             (mark-variant-rendered! variant-id)))))))
 
 (def canvas
-  "Render the focused variant. Triggers a `run-variant` on mount and on
-  each `:hot-reload-tick` bump. Renders the variant's `:component` view
+  "Render the focused variant. Prepares the frame + resumes the one run owner
+  (rf2-j538f7.34) post-commit on mount and on each run-key change
+  (`:hot-reload-tick` / cell-override / mode / substrate). Renders the
+  variant's `:component` view
   with the resolved `:hiccup` decorator stack applied."
   (r/create-class
      {:display-name "rf-story-canvas"

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -55,7 +55,6 @@
             [re-frame.story.config :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames :as frames]
-            [re-frame.story.play.runner-events :as play-runner-events]
             [re-frame.story.predicates :as pred]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.runtime :as runtime]
@@ -285,25 +284,35 @@
   (trace-buffer/clear-buffer!))
 
 (defn- ensure-variant-frame!
-  "Drive `run-variant` for `variant-id` so its frame is allocated and
-  the `:events` slot dispatched before React renders the canvas.
+  "PREPARE `variant-id`'s one run owner (rf2-j538f7.34) on the selection
+  edge: allocate the frame and run loaders + setup (phases 0-2) so React's
+  first canvas render is safe — WITHOUT executing the play script. The
+  single resume owner (the canvas post-commit lifecycle) runs the script
+  exactly once after commit.
 
   Per rf2-zme7: clicking a variant row used to leave the variant's
   frame unallocated until the canvas's `:component-did-mount` lifecycle
   fired — which happens AFTER React's first commit. The first render
   thus tried to deref subscriptions against a non-existent frame, threw
   `IDeref.-deref defined for type null`, and React unmounted the shell
-  (blank page). Running the variant on the *selection edge* puts the
-  frame in place before any view code runs."
+  (blank page). Preparing the variant on the *selection edge* puts the
+  frame in place before any view code runs.
+
+  `prepare-run!` is idempotent per `:run-key`, so this selection-edge
+  prepare and the canvas's post-commit prepare for the same logical run
+  collapse to ONE frame reset + ONE generation — the shell no longer runs
+  the play-script here (which, with the canvas run and the post-commit
+  auto-run, made it execute up to three times)."
   [variant-id]
   (when (and config/enabled? variant-id)
     (let [shell @state/shell-state-atom
           opts  {:active-modes   (:active-modes shell)
                  :cell-overrides (get-in shell [:cell-overrides variant-id])
                  :substrate      (:substrate shell)
-                 :render?        true}]
+                 :render?        true
+                 :run-key        (canvas/run-key shell variant-id)}]
       (try
-        (runtime/run-variant variant-id opts)
+        (runtime/prepare-run! variant-id opts)
         (catch :default e
           ;; Swallow + breadcrumb. The canvas re-tries via
           ;; :component-did-mount / :component-did-update, and the
@@ -413,14 +422,18 @@
                      ;; position) + seed the RHS chip-row's user-
                      ;; override slot from the story's `:xray-panel`.
                      (xray-preset/on-variant-selected! now)
-                     ;; rf2-8i2a9: auto-run the variant's `:play-script`
-                     ;; if `:auto-run?` is true. Best-effort — yields one
-                     ;; tick via setTimeout so React commits the canvas
-                     ;; before the script's first dispatch lands; that
-                     ;; way `[:assert-dom selector :visible]` sees the
-                     ;; mounted DOM. Variants without `:play-script` no-op.
+                     ;; rf2-8i2a9 / rf2-j538f7.34: RESUME the one run owner —
+                     ;; run the auto-plays exactly once per prepared
+                     ;; generation. Yields one tick via setTimeout so React
+                     ;; commits the canvas before the script's first dispatch
+                     ;; lands; that way `[:assert-dom selector :visible]` sees
+                     ;; the mounted DOM. The canvas post-commit lifecycle also
+                     ;; calls `resume-run!` for this generation — the
+                     ;; generation guard collapses both to ONE execution, so
+                     ;; whichever fires first wins and the other no-ops.
+                     ;; Variants without `:play-script` / auto-plays no-op.
                      (js/setTimeout
-                       (fn [] (play-runner-events/auto-run! now))
+                       (fn [] (runtime/resume-run! now))
                        0))
                    (reset! selection-prev now))))))
 
@@ -970,19 +983,18 @@
              ;; change, so a pre-selected variant would otherwise miss
              ;; the preset).
              (xray-preset/on-variant-selected! vid)
-             ;; rf2-8i2a9 / rf2-chi9j3: mount-time auto-run for an
-             ;; already-selected variant (deep-link / persisted
-             ;; selection) — but ONLY when `hydrate-url-state!` did NOT
-             ;; just change the selection during THIS mount. When it did,
-             ;; `selection-watcher`'s change-handler already scheduled its
-             ;; own auto-run for `vid` (above); scheduling a second one
-             ;; here would run the deep-linked variant's `:play-script`
-             ;; TWICE (every dispatch doubled). Yields a tick so the
-             ;; canvas has committed before the script's first
-             ;; DOM-sensitive step runs.
+             ;; rf2-8i2a9 / rf2-chi9j3 / rf2-j538f7.34: mount-time RESUME for
+             ;; an already-selected variant (deep-link / persisted selection).
+             ;; The `mount-time-autorun-vid` guard (rf2-chi9j3) is retained so
+             ;; a deep-link that `hydrate-url-state!` just selected is resumed
+             ;; only by the selection-watcher, not twice — but the one run
+             ;; owner's generation guard is now the structural backstop: even
+             ;; if both scheduled a `resume-run!` for the same generation, only
+             ;; ONE would execute. Yields a tick so the canvas has committed
+             ;; before the script's first DOM-sensitive step runs.
              (when-let [run-vid (mount-time-autorun-vid pre-hydrate-vid vid)]
                (js/setTimeout
-                 (fn [] (play-runner-events/auto-run! run-vid))
+                 (fn [] (runtime/resume-run! run-vid))
                  0))))))
      :component-will-unmount
      (fn [_]
@@ -1002,6 +1014,9 @@
        ;; rf2-o4u18: drop popstate + shell-state URL watchers so a
        ;; re-mount doesn't accumulate listeners.
        (url-state/tear-down! state/shell-state-atom)
+       ;; rf2-j538f7.34: clear the one-run-owner registry so a fresh shell
+       ;; mount starts every variant's run generation from a clean slate.
+       (runtime/reset-run-owner!)
        (teardown-all-listeners!))
      :reagent-render
      (fn []

--- a/tools/story/test/re_frame/story/run_owner_cljc_test.cljc
+++ b/tools/story/test/re_frame/story/run_owner_cljc_test.cljc
@@ -1,0 +1,277 @@
+(ns re-frame.story.run-owner-cljc-test
+  "Regression net for Story's ONE run owner (rf2-j538f7.34).
+
+  A focused shell selection used to have THREE execution owners — the
+  selection-edge frame preallocation (a full `run-variant`), the canvas
+  `component-did-mount` run (a second full `run-variant`), and the post-commit
+  `auto-run!` — so a variant's play-script (and its external effects) ran up to
+  THREE times and a cumulative script double-counted (a passing variant looked
+  failed). These tests drive the production ownership sequence directly against
+  the real plain-atom adapter + lifecycle machine + plan compiler + runner, and
+  pin that the script now executes EXACTLY ONCE.
+
+  Runs on BOTH runtimes: the play-scripts are pure `:dispatch-sync`, which
+  `async/promise` executes synchronously, so the frame's app-db and the
+  external-effect counter are settled the instant `resume-run!` returns — no
+  awaiting needed. The one supersession test that needs an async barrier is
+  JVM-gated (it blocks a thread)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.play :as legacy-play]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.story.runtime :as rt]
+            #?@(:clj [[re-frame.story.async :as async]
+                      [re-frame.story.config :as config]])))
+
+;; ---- external-effect counter (an irreversible effect proxy) --------------
+;;
+;; A single owner would ISSUE this exactly once per script run; the pre-fix
+;; three-owner composition issued it up to nine times. app-db resets between
+;; runs hide the mutation, but an external effect cannot be un-sent — so this
+;; counter is the honest witness of how many times the script actually ran.
+
+(def ^:private ext-effect-count (atom 0))
+
+(defn- reset-all! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  #?(:clj (require 're-frame.machines :reload))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  #?(:clj (config/set-global-args! {}))
+  (reset! legacy-play/stepper-state {})
+  (reset! re/run-state {})
+  (reset! re/step-boundaries {})
+  (rt/reset-run-owner!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (reset! ext-effect-count 0)
+  (rf/reg-fx :probe/external-effect (fn [_ _] (swap! ext-effect-count inc)))
+  (rf/reg-event :probe/inc-and-effect
+    (fn [{:keys [db]} _]
+      {:db (update db :count (fnil inc 0))
+       :fx [[:probe/external-effect nil]]}))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} [_ n]] {:db (assoc db :count (or n 0))}))
+  (test-fn))
+
+(use-fixtures :each reset-all!)
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- reg-cumulative!
+  "Register a cumulative-counter variant: seed 0, increment three times (each
+  increment also issues the external effect), assert final `:count` = 3."
+  [vid]
+  (story/reg-variant vid
+    {:events      [[:counter/initialise 0]]
+     :play-script [[:dispatch-sync [:probe/inc-and-effect]]
+                   [:dispatch-sync [:probe/inc-and-effect]]
+                   [:dispatch-sync [:probe/inc-and-effect]]
+                   [:dispatch-sync [:rf.assert/path-equals [:count] 3]]]}))
+
+(defn- run-key-for [vid tag] {:variant-id vid :cell-overrides tag})
+
+(defn- prepare! [vid tag]
+  (rt/prepare-run! vid {:render? true :run-key (run-key-for vid tag)}))
+
+(defn- resume!
+  "Call the single run owner's resume. The play-scripts here are pure
+  `:dispatch-sync`, so `async/promise` runs the script synchronously and the
+  frame's app-db is settled the instant this returns — no await needed."
+  [vid]
+  (rt/resume-run! vid))
+
+(defn- count-of [vid] (:count (rf/app-db-value vid)))
+
+(defn- passing-assertions [vid]
+  (filterv #(true? (:passed? %))
+           (:rf.story/assertions (rf/app-db-value vid))))
+
+;; ---- (1) the core defect: exactly once -----------------------------------
+
+(deftest shell-auto-play-executes-exactly-once
+  (testing "the three-owner shell sequence (selection preallocation + canvas
+            mount prepare + post-commit resume, resume also re-triggered by the
+            mount-time block) executes the play-script EXACTLY ONCE"
+    (let [vid :story.owner/cumulative]
+      (reg-cumulative! vid)
+      ;; 1. selection-edge preallocation — PREPARE (no script)
+      (prepare! vid :a)
+      ;; frame is ready + rendered clean at seed 0, but the script has NOT run
+      (is (= 0 (count-of vid)) "prepare did not run the script")
+      (is (zero? @ext-effect-count) "prepare issued no external effect")
+      (is (= 1 (rt/current-generation vid)) "one generation claimed")
+      ;; 2. canvas component-did-mount — PREPARE again (same run-key ⇒ dedup)
+      (prepare! vid :a)
+      (is (= 1 (rt/current-generation vid))
+          "the canvas re-prepare for the same run-key did NOT bump the generation")
+      (is (= 0 (count-of vid)) "the dedup prepare did not reset+rerun anything")
+      ;; 3. canvas post-commit resume — the single run owner
+      (resume! vid)
+      (is (= 3 (count-of vid)) "the script ran once: 0 -> 3")
+      (is (= 3 @ext-effect-count) "the external effect fired exactly 3 times (one run)")
+      (is (= 1 (count (passing-assertions vid)))
+          "exactly one passing assertion record — never a second, contradictory one")
+      ;; 4. the mount-time block + the shell selection-watcher's setTimeout both
+      ;;    ALSO call resume for this generation — every extra call is a no-op.
+      (is (nil? (rt/resume-run! vid)) "second resume for the same generation is a no-op")
+      (is (nil? (rt/resume-run! vid)) "third resume for the same generation is a no-op")
+      (is (= 3 (count-of vid)) "count is still 3 — no double-count to 6")
+      (is (= 3 @ext-effect-count) "the external effect still fired exactly 3 times")
+      (is (= 1 (count (passing-assertions vid)))
+          "still exactly one passing assertion — no contradictory second record"))))
+
+;; ---- (2) prepare is script-free, frame renderable ------------------------
+
+(deftest prepare-only-readies-frame-without-running-script
+  (testing "PREPARE completes loaders + setup (frame allocated + :ready) so the
+            first render is safe, WITHOUT dispatching the play script"
+    (let [vid :story.owner/prep]
+      (reg-cumulative! vid)
+      (prepare! vid :a)
+      ;; frame exists (subs can deref) and lifecycle is renderable
+      (is (some? (rf/app-db-value vid)) "the frame is allocated before any resume")
+      (is (= :ready (loaders/current-state vid)) "the frame reached :ready in prepare")
+      ;; but the script has not run
+      (is (= 0 (count-of vid)) "seed 0, no play-script increments yet")
+      (is (zero? @ext-effect-count) "no external effect issued by prepare")
+      (is (empty? (passing-assertions vid)) "no assertion recorded before resume"))))
+
+;; ---- (3) a genuinely new run-key bumps + re-runs -------------------------
+
+(deftest run-key-change-bumps-generation-and-reruns-once
+  (testing "a cell-override / mode / substrate / hot-reload change (new run-key)
+            claims a fresh generation and runs the script once more"
+    (let [vid :story.owner/rekey]
+      (reg-cumulative! vid)
+      (prepare! vid :a)
+      (resume! vid)
+      (is (= 3 (count-of vid)))
+      (is (= 3 @ext-effect-count))
+      ;; run-key changes → fresh generation, fresh reset+run
+      (prepare! vid :b)
+      (is (= 2 (rt/current-generation vid)) "changed run-key bumped the generation")
+      (is (= 0 (count-of vid)) "the fresh prepare reset the frame to seed 0")
+      (resume! vid)
+      (is (= 3 (count-of vid)) "the new generation ran the script once: 0 -> 3")
+      (is (= 6 @ext-effect-count) "exactly one additional run's worth of effects (3 + 3)"))))
+
+;; ---- (4) a remount after resume re-runs ----------------------------------
+
+(deftest remount-after-resume-bumps-and-reruns-once
+  (testing "a React remount (re-prepare for the SAME run-key AFTER the current
+            generation was already resumed) claims a fresh generation and runs
+            the script once — not zero, not twice"
+    (let [vid :story.owner/remount]
+      (reg-cumulative! vid)
+      (prepare! vid :a)
+      (resume! vid)
+      (is (= 1 (rt/current-generation vid)))
+      (is (= 3 @ext-effect-count))
+      ;; remount: same run-key, but the generation was already resumed
+      (prepare! vid :a)
+      (is (= 2 (rt/current-generation vid)) "post-resume re-prepare bumped the generation")
+      (is (= 0 (count-of vid)) "the remount reset the frame")
+      (resume! vid)
+      (is (= 3 (count-of vid)))
+      (is (= 6 @ext-effect-count) "exactly one more run"))))
+
+;; ---- (5) two variants run concurrently + isolated ------------------------
+
+(deftest two-variants-run-concurrently-and-isolated
+  (testing "ownership is per variant/frame, not one global lock: two variants
+            prepare + resume independently with isolated app-db + effects"
+    (let [a :story.owner/a
+          b :story.owner/b]
+      (reg-cumulative! a)
+      (reg-cumulative! b)
+      ;; interleave the two variants' prepare/resume owners
+      (prepare! a :a)
+      (prepare! b :a)
+      (is (= 1 (rt/current-generation a)))
+      (is (= 1 (rt/current-generation b)))
+      (resume! a)
+      (is (= 3 (count-of a)) "A ran to 3")
+      (is (= 0 (count-of b)) "B is untouched by A's run")
+      (resume! b)
+      (is (= 3 (count-of a)) "A stays 3 after B runs")
+      (is (= 3 (count-of b)) "B ran to 3")
+      (is (= 6 @ext-effect-count) "each variant issued its 3 effects exactly once"))))
+
+;; ---- (6) the public headless run-variant is unchanged --------------------
+
+(deftest public-run-variant-still-runs-full-once
+  (testing "the headless `story/run-variant` (test-mode / MCP / sidebar
+            Run-all) is byte-for-byte the old full run: script once, count 3"
+    (let [vid :story.owner/headless]
+      (reg-cumulative! vid)
+      #?(:clj
+         (let [result (async/deref-blocking (story/run-variant vid) 5000)]
+           (is (= :ready (:lifecycle result)))
+           (is (= 3 (:count (:app-db result))) "one full run: count 3")
+           (is (= 3 @ext-effect-count) "one full run's effects")
+           (is (= :pass (:status result)) "the passing variant greens"))
+         :cljs
+         ;; CLJS: the sync script settles the frame synchronously; read it back.
+         (do (story/run-variant vid)
+             (is (= 3 (count-of vid)) "one full run: count 3")
+             (is (= 3 @ext-effect-count) "one full run's effects"))))))
+
+;; ---- (7) supersession never greens a stale run (JVM async barrier) -------
+
+#?(:clj
+   (deftest superseded-resume-never-greens-and-never-reads-successor
+     (testing "run A parks at [:wait] on its own thread; run B (fresh run-key)
+               supersedes it — B's resume stamps a new run-token that aborts A's
+               stale continuation. A settles as an explicit superseded result
+               (never :pass) and NEVER dispatches its remaining event; B
+               completes with only its own state"
+       (let [vid  :story.owner/overlap
+             wait 250]
+         ;; The variant waits, then increments once (issuing the external
+         ;; effect), then asserts. The wait opens the supersession window.
+         (story/reg-variant vid
+           {:events      [[:counter/initialise 0]]
+            :play-script [[:wait wait]
+                          [:dispatch-sync [:probe/inc-and-effect]]
+                          [:dispatch-sync [:rf.assert/path-equals [:count] 1]]]})
+         ;; A prepares + starts resuming on its OWN thread. resume-run! blocks
+         ;; that thread through the [:wait] (JVM waits are Thread/sleep), so the
+         ;; future's value is A's settled result-promise.
+         (prepare! vid :a)
+         (let [gen-a (rt/current-generation vid)
+               fut   (future (rt/resume-run! vid))]
+           (is (= 1 gen-a))
+           ;; Let A reach its wait, then supersede: a fresh run-key bumps the
+           ;; generation, resets the frame, and B's resume stamps a NEW
+           ;; run-token — which A's run-loop sees on wake and aborts against.
+           (Thread/sleep 60)
+           (prepare! vid :b)
+           (is (= 2 (rt/current-generation vid)) "B claimed a fresh generation")
+           (let [b-prom   (rt/resume-run! vid)
+                 a-prom   @fut
+                 a-result (async/deref-blocking a-prom 5000)
+                 b-result (async/deref-blocking b-prom 5000)]
+             (is (not= :pass (:status a-result))
+                 "the superseded run A must NOT return :pass")
+             (is (true? (:superseded? a-result))
+                 "A settles as an explicit superseded result")
+             (is (= gen-a (:generation a-result))
+                 "the superseded result names A's own generation, not B's")
+             (is (= :pass (:status b-result)) "B greens on its own state")
+             (is (= 1 (:count (:app-db b-result))) "B ran its single increment: 0 -> 1")
+             ;; The decisive criterion-5 proof: only B's increment issued an
+             ;; external effect. A's stale continuation was aborted before it
+             ;; could dispatch — it never mutated the successor frame.
+             (is (= 1 @ext-effect-count)
+                 "ONLY B's effect fired — A's stale continuation dispatched nothing")))))))


### PR DESCRIPTION
## Summary

A focused shell selection had **three** execution owners for one variant run:
the selection-edge frame preallocation (a full `run-variant`), the canvas
`component-did-mount` run (a second full `run-variant`), and the post-commit
`auto-run!`. A variant's play-script — and its irreversible external effects —
ran up to **three times**, and a cumulative script visibly double-counted (a
passing variant looked **failed** at 6 instead of 3).

**Premise confirmed on `main`** with a JVM probe of the production ownership
sequence (`run-variant` preallocation + `run-variant` canvas-mount +
`auto-run!`): the external effect fired **9 times** and the count settled at
**6**.

## Fix — one run owner spanning the render boundary

Split the run into a **PREPARE** half and a **RESUME** half over a per-variant
generation:

- **`prepare-run!`** — loaders + setup (phases 0-2) to `:ready` so the first
  render is safe, **without** the script. Idempotent per `run-key`: the
  selection-edge preallocation and the canvas post-commit prepare collapse to
  **one** frame reset + **one** generation. A changed `run-key` (cell-override
  / mode / substrate / hot-reload) — or a re-prepare after resume (a React
  remount) — claims a **fresh generation**.
- **`resume-run!`** — the play script (phase 4) **exactly once per
  generation**. The canvas post-commit lifecycle, the shell selection-watcher,
  and the mount-time block all call it for the same generation; the generation
  guard collapses them to **one** execution. A **superseded** resume settles as
  an explicit result (never `:pass`, never reads the successor frame); the
  inner run-token still guards play-key isolation.

The shell selection-edge and canvas now **prepare** (no script); the canvas
post-commit is the primary resume owner. The public `run-variant` composes
prepare + resume in one call, so the **headless path** (Test mode / MCP /
sidebar Run-all) is behaviourally identical. Ownership is **per variant/frame**
— two different variants run concurrently and independently, not under a global
lock.

## Tests

`run_owner_cljc_test` (7 tests, JVM + CLJS node) drives the production
ownership sequence against the real plain-atom adapter / lifecycle machine /
plan compiler / runner:

- **exactly-once** — effect fires 3, count 3, one passing assertion; extra
  resume calls no-op (never count 6, never a second contradictory record)
- **prepare is script-free** — frame allocated + `:ready`, no effect, no
  assertion before resume
- **run-key change** bumps the generation and reruns once
- **remount after resume** bumps and reruns once
- **two-variant isolation** — per-variant/frame ownership, not a global lock
- **headless `run-variant` unchanged** — full run once
- **two-thread supersession** — the stale continuation dispatches nothing (only
  the successor's effect fires); the stale run never returns `:pass`

Documents the one-run-owner contract in `spec/003-Render-Shell.md`.

## Quality gates

- `clojure -M:test` (tools/story, JVM): **1781 tests / 6553 assertions / 0
  failures / 0 errors** (7 new). Baseline was 1774/6504.
- `clj-kondo --lint src test`: **0 errors** (136 pre-existing warnings, none
  from changed files).
- Browser Story feature/play gates + consolidated CLJS (`npm run test:cljs`):
  **not run locally** (shadow-cljs / implementation `node_modules` not
  installed in this worker, per the review bead's own note) — the new
  regression is `.cljc` and runs on the CLJS node gate in CI. Relying on CI for
  the browser gates.

## Scope notes

- The workspace cell already runs a **single** guarded `run-variant` per
  run-key (no triple-owner defect), so it is left as-is; the sidebar Run-all
  and Test-mode pane use the headless `run-variant` (explicit test runs),
  correctly unchanged.
