### PR TITLE
test(ssr,security): fix framed-hydrate test key, drop vestigial exact? knob + dead gen-status (rf2-di627l, rf2-rqwx76, rf2-65iu5k)

### DIFF
--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -39,7 +39,7 @@
 (defn- contains-sentinel?
   "True when the sentinel survives anywhere in `x`, including stringified data."
   [x]
-  (gen/contains-string? x sentinel false))
+  (gen/contains-string? x sentinel))
 
 (def ^:private sensitive-machine-id :sec/sensitive-machine)
 (def ^:private plain-machine-id     :sec/plain-machine)

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -201,7 +201,7 @@
   (let [out (atom nil)
         traces (capture
                  #(reset! out (hydrate/hydrate-event-handler
-                                {:db existing-db :frame :rf/default}
+                                {:db existing-db :rf.frame/id :rf/default}
                                 [:rf/hydrate payload])))]
     {:result @out :traces traces}))
 
@@ -253,7 +253,15 @@
                  " must fire no compatibility-check fxs"))
         (is (pos? (count (ops traces :rf.error/malformed-hydration-payload)))
             (str "payload " (pr-str payload)
-                 " must emit :rf.error/malformed-hydration-payload"))))))
+                 " must emit :rf.error/malformed-hydration-payload"))
+        ;; Fidelity: the rejection diagnostic carries the DISPATCH frame
+        ;; (:rf/default), proving this test drove the FRAMED handler path
+        ;; via the :rf.frame/id coeffect the handler destructures — not the
+        ;; frameless frame=nil path a mis-keyed coeffect silently produced.
+        (is (every? #(= :rf/default (:frame (:tags %)))
+                    (ops traces :rf.error/malformed-hydration-payload))
+            (str "payload " (pr-str payload)
+                 " — rejection diagnostic must carry :frame :rf/default"))))))
 
 (deftest wellformed-hydration-payload-still-installs
   (testing "the guard is precise: a well-formed payload (a map

--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -177,32 +177,27 @@
 ;; one copy gaining a leak-class fix the siblings silently miss.
 ;;
 ;; Each surface keeps its OWN per-file sentinel string local and calls
-;; `(contains-string? x sentinel exact?)`, passing `exact?` to preserve that
-;; surface's per-node matching: some surfaces match the sentinel as an EXACT
-;; string equality on each walked leaf (`exact? true`), others as a SUBSTRING
-;; (`exact? false`, the `re-find` form - catches a sentinel embedded inside a
-;; larger leaf). Either way the `pr-str` fallback always uses a SUBSTRING scan,
-;; so a sentinel surviving inside a non-string leaf (a keyword/symbol form
-;; built from it, or a stringified collection) is still caught.
+;; `(contains-string? x sentinel)`. Every surface matches the sentinel as a
+;; SUBSTRING - both the per-leaf walker (`re-find`) and the `pr-str` fallback
+;; scan for it - so a sentinel surviving inside a larger leaf, OR inside a
+;; non-string leaf (a keyword/symbol form built from it, or a stringified
+;; collection), is still caught.
 ;; ---------------------------------------------------------------------------
 
 (defn contains-string?
-  "Deep-walk `x`; true when `needle` appears anywhere - as a value, inside a
-  collection, or inside a stringified form. When `exact?` is truthy, a walked
-  STRING leaf matches only on exact `=` equality with `needle`; otherwise a
-  leaf matches when `needle` REGEX-matches it (`re-find` over `(re-pattern
-  needle)`). The `pr-str` fallback always uses the same regex search, so
-  `needle` surviving inside a non-string leaf (e.g. a keyword/symbol form
-  built from it) is also caught. `needle` MUST therefore be a regex-safe
-  literal (no unescaped regex metacharacters); the current sentinels are."
-  [x needle exact?]
+  "Deep-walk `x`; true when `needle` appears anywhere - as a string leaf, inside
+  a collection, or inside a stringified form. A walked STRING leaf matches when
+  `needle` REGEX-matches it (`re-find` over `(re-pattern needle)`), and the
+  `pr-str` fallback runs the same regex search over the rendered value, so
+  `needle` surviving inside a non-string leaf (e.g. a keyword/symbol form built
+  from it) is also caught. `needle` MUST therefore be a regex-safe literal (no
+  unescaped regex metacharacters); the current sentinels are."
+  [x needle]
   (let [hit (volatile! false)]
     (walk/postwalk
       (fn [node]
         (when (and (string? node)
-                   (if exact?
-                     (= needle node)
-                     (re-find (re-pattern needle) node)))
+                   (re-find (re-pattern needle) node))
           (vreset! hit true))
         node)
       x)

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -21,10 +21,10 @@
 
 (defn- contains-sentinel?
   "True when the sentinel survives anywhere in `x`, including secondary or
-  stringified slots. The exact-leaf match prevents unrelated substrings from
-  satisfying the check."
+  stringified slots. The sentinel is a unique long literal, so a substring
+  scan cannot be satisfied by an unrelated value."
   [x]
-  (gen/contains-string? x sentinel true))
+  (gen/contains-string? x sentinel))
 
 (def ^:private gen-clean-event
   "A non-sensitive trace event - no :sensitive? stamp (or explicit false)."

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -28,9 +28,9 @@
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-PUBLIC-PROFILE-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
-  "True when the exact sentinel survives anywhere in `x`."
+  "True when the sentinel survives anywhere in `x` (substring scan)."
   [x]
-  (gen/contains-string? x sentinel true))
+  (gen/contains-string? x sentinel))
 
 (def ^:private big-string (apply str (repeat 40000 \x)))
 

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -128,8 +128,6 @@
         (is (= sentinel (get-in out [:value :token]))
             "explicit include-sensitive? true is the deliberate frameless opt-out")))))
 
-(def ^:private gen-status (gen/gen-elem (vec reply/statuses)))
-
 (def ^:private gen-reply
   "A status-correct reply map carrying the sentinel in its wire slots. The
   status drives which value/error slots are present (so the corpus stays

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -26,9 +26,9 @@
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-REPLY-EGRESS-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
-  "True when the exact sentinel survives anywhere in `x`."
+  "True when the sentinel survives anywhere in `x` (substring scan)."
   [x]
-  (gen/contains-string? x sentinel true))
+  (gen/contains-string? x sentinel))
 
 ;; `trace-summary` elides each wire slot rooted at its OWN value (not at the
 ;; reply-map root), so classification paths are relative to each slot value:

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -81,10 +81,10 @@
   "Deep-walk `x`; true when the sentinel string appears anywhere (as a
   value - matched as a SUBSTRING - inside a collection, or inside a
   stringified form, e.g. a keyword or symbol form built from it). Thin
-  wrapper over the shared `gen/contains-string?` (rf2-n5bkm7); the sentinel
-  is matched as a substring (`exact? false`)."
+  wrapper over the shared `gen/contains-string?` (rf2-n5bkm7), which
+  matches the sentinel as a substring."
   [x]
-  (gen/contains-string? x sentinel false))
+  (gen/contains-string? x sentinel))
 
 ;; ---------------------------------------------------------------------------
 ;; Recursive generator - build [schema db] where a :sensitive? scalar slot

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -105,9 +105,9 @@
   "Deep-walk `x`; true when the sentinel string appears anywhere (as a
   value - matched as a SUBSTRING - inside a collection, or inside a
   stringified form). Thin wrapper over the shared `gen/contains-string?`
-  (rf2-n5bkm7); the sentinel is matched as a substring (`exact? false`)."
+  (rf2-n5bkm7), which matches the sentinel as a substring."
   [x]
-  (gen/contains-string? x sentinel false))
+  (gen/contains-string? x sentinel))
 
 ;; ---------------------------------------------------------------------------
 ;; Trace capture — register a listener, run `f`, return the single


### PR DESCRIPTION
Three TEST-ONLY correctness-audit cleanups from rf2-iizjau (implementation/security correctness review). No production behaviour change.

## rf2-di627l (P3 bug) — framed-hydrate test key
`hydrate-with` built the coeffect map with `:frame :rf/default`, but `hydrate-event-handler` (ssr/hydrate.cljc:254) destructures the frame from `:rf.frame/id` (sibling `hydrate-with-runtime` already uses the correct key). `:frame` was never read, so `frame` bound `nil` and the three tests using `hydrate-with` (`malformed-hydration-payload-never-installs`, `wellformed-hydration-payload-still-installs`, `non-map-hydration-inputs-always-fail-closed`) silently ran the FRAMELESS path — a test-fidelity gap. The guard is frame-independent, so the suite stayed green while the framed path went untested.

- Pass `:rf.frame/id :rf/default` (matching `hydrate-with-runtime`) — the TEST is fixed to match the handler's real key; the handler is untouched.
- Added a fidelity assertion: the rejection diagnostic carries `:frame :rf/default`, observing the dispatch frame the framed path now threads through `emit-rejected-hydration!`. Verified it FAILS under the old mis-keyed coeffect (diagnostic `:frame nil`) and passes with the fix.

## rf2-rqwx76 (P3 task) — vestigial `exact?` knob
`gen/contains-string?` ended with an unconditional `pr-str` substring scan `(or @hit (re-find needle (pr-str x)))`. Any walker hit (exact-leaf `=` OR substring `re-find`) implies a `pr-str` substring hit (pr-str renders a string leaf verbatim; print-length/level unbounded in the runners), so `result(exact? true) == result(exact? false)` for all inputs. The `exact?` knob never changed the return value; three callers' docstrings claimed exact-leaf false-positive protection they did not get.

Option (a): dropped the `exact?` parameter (always substring-scan, keeping the walker's belt-and-braces arm), collapsed all six call sites to the 2-arity form, and corrected the misleading docstrings + the shared consolidation comment. Sentinels are unique long literals, so the substring scan cannot false-positive.

## rf2-65iu5k (P4 task) — dead code
Removed unused `gen-status` in `reply_envelope_egress_security_cljs_test.cljc`; `gen-reply` draws the status directly via `gen/rand-nth` over `reply/statuses`.

## Quality gates
- `clojure -M:test` (implementation/security): **92 tests / 698 assertions, 0 failures, 0 errors** (green after each commit; +18 assertions vs the pre-change 680 = the new di627l fidelity assertion, one per malformed payload).
- di627l fidelity proof: temporarily reverting the coeffect key to the buggy `:frame` made the new assertion FAIL for every malformed payload (trace `:frame nil`); restoring `:rf.frame/id` returns it to green.
- `npm run test:cljs` (implementation/, node build — these namespaces compile in): **8530 tests / 40137 assertions, 0 failures, 0 errors**.