### PR TITLE
fix(examples/login): keep the session token classified through reply + effect traces (rf2-j538f7.30)

### DIFF
--- a/examples/core/login/model.cljs
+++ b/examples/core/login/model.cljs
@@ -185,6 +185,15 @@
   {:doc       "Stash the session token in localStorage so the login
                 survives a refresh. Client-only — localStorage is a
                 browser thing, so `:platforms` keeps it off the server."
+   ;; The token is a credential, and fx args are a transient payload with their
+   ;; OWN egress owner — separate from the event that produced them. So this
+   ;; registration classifies its `:token` arg `:sensitive`: the per-effect
+   ;; `:rf.fx/handled` trace redacts `[:token]` to `:rf/redacted` while the
+   ;; handler body still receives the real token to write. (Classification is
+   ;; egress-only; the value stays live for the side effect.) See owner 2 of
+   ;; the success-token note above `:auth.login/succeeded`, and
+   ;; docs/core/how-to/keep-secrets-out-of-traces.md.
+   :sensitive [[:token]]
    :platforms #{:client}}
   (fn fx-auth-session-store [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
@@ -207,9 +216,10 @@
                stays on the tape and survives time-travel. Those 50 ms are
                a courtesy to the reader: just long enough to actually see
                the `:submitting` state before it resolves. The reply then
-               travels home to the `:auth.login/success` /
-               `:auth.login/failure` sub-events via `:on-success` /
-               `:on-failure`."
+               travels home via `:on-success` / `:on-failure` — success to the
+               classified `:auth.login/succeeded` event (which owns the session
+               token), failure to the machine's `:auth.login/failure`
+               sub-event."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -293,12 +303,15 @@
       {:fx [[:rf.http/managed
              {:request    {:method :post :url "/api/auth/lock"}
               :on-success nil
-              :on-failure nil}]]})
-
-    :store-session
-    ;; Login worked — squirrel away the token the server handed back.
-    (fn [{[_ {:keys [value]}] :event}]
-      {:fx [[:auth.session/store {:token (:token value)}]]})}
+              :on-failure nil}]]})}
+   ;; No `:store-session` action here — and that absence is the point. The
+   ;; success reply carries the session TOKEN (a credential), and the machine
+   ;; must never see a credential (same rule the password follows on the way
+   ;; IN). So the token-bearing reply lands on `:auth.login/succeeded` — the
+   ;; classified owner of the response credential — which persists the token and
+   ;; then nudges the machine with a bare, credential-free `:success` signal. The
+   ;; machine's `:success` transition below therefore takes NO action: it only
+   ;; flips the flow to `:authed`. See `:auth.login/succeeded` below.
 
    :states
    {:idle
@@ -320,8 +333,7 @@
      ;; retry limit? Show the error and let them try again. Out of tries (the
      ;; second entry has no guard, so it's the fallthrough)? Lock the account.
      ;; The entire retry-then-lockout policy lives in these four lines.
-     :on    {:auth.login/success {:target :authed
-                                  :action :store-session}
+     :on    {:auth.login/success {:target :authed}
              :auth.login/failure [{:target :error-shown
                                    :guard  :under-retry-limit
                                    :action :record-error}
@@ -522,8 +534,19 @@
               ;; classified owner that sends the credential. The request body
               ;; carries the real password; `:sensitive? true` scrubs it (and
               ;; every param) from every `:rf.http/*` trace event, so the wire
-              ;; never sees it. The reply comes home to the machine's
-              ;; :success / :failure sub-events.
+              ;; never sees it.
+              ;;
+              ;; The reply comes home NOT to the machine, but to
+              ;; `:auth.login/succeeded` — a classified, map-payload event that
+              ;; owns the response credential (the session token). Why not
+              ;; straight to the machine? Because a managed-HTTP reply is
+              ;; appended as the LAST positional arg of `:on-success`, and a
+              ;; positional arg ships raw (redaction is path-based, only a map
+              ;; payload is addressable). Routing the reply to the machine would
+              ;; make the token an unclassifiable positional arg on the machine
+              ;; event; routing it to a one-element event makes the reply the
+              ;; addressable arg-map instead. The failure reply still rides the
+              ;; machine (it carries an error message, not a credential).
               [:rf.http/managed
                {:request    {:method :post
                              :url    "/api/login"
@@ -531,9 +554,62 @@
                              :request-content-type :json
                              :sensitive? true}
                 :decode     :json
-                :on-success [:auth.login/flow [:auth.login/success]]
+                :on-success [:auth.login/succeeded]
                 :on-failure [:auth.login/flow [:auth.login/failure]]}]]}
         {:db (assoc-in db' [:auth :login-form :errors] errors)}))))
+
+;; The success reply comes home here — and this event exists FOR the session
+;; token's egress hygiene, exactly the way `:auth.login/edit-password` exists for
+;; the password's. On the way IN, the password crosses three boundaries and each
+;; gets its own classified owner; on the way BACK, the token the server hands us
+;; is a credential too, and it crosses two transient boundaries — so it gets two
+;; owners here.
+;;
+;;   OWNER 1 — THE REPLY EVENT (this registration). Managed HTTP appends its
+;;   canonical reply as the LAST positional arg of the `:on-success` event. Point
+;;   it at a one-element `[:auth.login/succeeded]` and the reply lands in the
+;;   SECOND slot — the arg-map — which IS path-addressable, so
+;;   `:sensitive [[:value :token]]` redacts the token to `:rf/redacted` in the
+;;   dispatched-event trace (and any error record carrying this event) while the
+;;   handler still reads the real token. (Had we appended it to the two-element
+;;   machine event `[:auth.login/flow [:auth.login/success]]`, the reply would be
+;;   a THIRD positional arg — unaddressable, shipping raw. That's the whole
+;;   reason this event exists rather than routing success straight to the
+;;   machine.)
+;;
+;;   OWNER 2 — THE STORAGE FX. `:auth.session/store` declares `:sensitive
+;;   [[:token]]` on its own registration, because fx args are a separate
+;;   transient owner from the event that produced them (see its reg-fx above).
+;;
+;; The handler then nudges the machine with a bare, credential-free
+;; `[:auth.login/flow [:auth.login/success]]` — the machine flips to `:authed`
+;; and never sees the token. One credential, two egress owners, and a machine
+;; kept credential-free end to end. See
+;; docs/core/how-to/keep-secrets-out-of-traces.md.
+;;
+;; KNOWN GAP (not this example's to fix): the `:rf.event/fx` slot on the
+;; `:rf.fx/do-fx` trace stamps this handler's WHOLE returned effect vector, and
+;; the central classification projector does not yet walk it through each fx's
+;; registration (it walks the sibling `:rf.event/db` slot, but not `:rf.event/fx`
+;; — Spec 009 §Canonical per-event trace sequence). Until the projector covers
+;; it, `:auth.session/store`'s `:sensitive [[:token]]` redacts the per-effect
+;; `:rf.fx/handled` copy but not the `:rf.event/fx` aggregate. That is a
+;; framework projector gap, tracked separately; no app-side classification can
+;; reach the `:rf.event/fx` stamp.
+(rf/reg-event :auth.login/succeeded
+  {:doc       "Managed-HTTP login succeeded: the reply carries the session
+               token. Persist it (via the classified :auth.session/store fx) and
+               nudge the :auth.login/flow machine with a credential-free :success
+               signal. The reply rides a map payload classified :sensitive so the
+               token is redacted at event egress."
+   :sensitive [[:value :token]]
+   :schema    [:cat [:= :auth.login/succeeded] [:map [:value [:map [:token :string]]]]]}
+  (fn handler-login-succeeded [_ [_ {:keys [value]}]]
+    {:fx [;; Owner 2 persists the real token; its reg-fx classification redacts
+          ;; the per-effect trace.
+          [:auth.session/store {:token (:token value)}]
+          ;; The machine gets a bare success fact — no credential.
+          [:dispatch [:auth.login/flow [:auth.login/success]]]]}))
 
 ;; Wipe the slate — slice back to empty, status back to `:idle`.
 (rf/reg-event :auth.login/reset-form

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -1,0 +1,234 @@
+(ns re-frame.example-login-success-token-cljs-test
+  "Framework-tree regression for the login feature's SUCCESS-TOKEN privacy — the
+   `:auth.login/succeeded` reply event and the `:auth.session/store` persistence
+   fx owned by examples/core/login/model.cljs, the substrate-free model shared
+   across the Reagent/UIx/Helix login examples (rf2-ppbvav / rf2-j538f7.30).
+
+   These belong in the framework test tree, NOT under examples/ (examples stay
+   test-free per rf2-8cevm). The ns requires the login model owner
+   (`login.model`) so its events / subs / machine / schemas register at ns-load,
+   then drives the success continuation directly. Sibling of
+   `re-frame.example-login-form-slice-cljs-test` (the PASSWORD-egress half); this
+   ns pins the RETURN half — the session token the server hands back.
+
+   THE SUCCESS TOKEN IS A CREDENTIAL, so — exactly like the password on the way
+   in — it is classified at every TRANSIENT boundary it crosses on the way back
+   (docs/core/how-to/keep-secrets-out-of-traces.md):
+
+     1. THE REPLY EVENT. Managed HTTP appends its reply as the LAST positional
+        arg of `:on-success`. Routed at a one-element `[:auth.login/succeeded]`,
+        the reply lands in the addressable arg-map slot, and the registration's
+        `:sensitive [[:value :token]]` redacts `[:value :token]` in the
+        dispatched-event trace (and any error record carrying the event) while
+        the handler still reads the real token. (Routing it at the two-element
+        machine event would make the reply a THIRD positional arg — unaddressable
+        — which is the leak this fix closes.)
+
+     2. THE STORAGE FX. `:auth.session/store` declares `:sensitive [[:token]]`
+        on its own registration, so the per-effect `:rf.fx/handled` trace redacts
+        `[:token]`. fx args are a transient owner distinct from the event.
+
+     3. THE MACHINE IS KEPT CREDENTIAL-FREE. The reply never reaches the machine
+        — `:auth.login/succeeded` nudges it with a bare, credential-free
+        `[:auth.login/flow [:auth.login/success]]` signal, so the flow reaches
+        `:authed` without ever seeing the token.
+
+   KNOWN FRAMEWORK-GATED RESIDUAL (deliberately NOT asserted clean here). Two
+   trace slots still carry the raw token, and NEITHER is reachable by app-side
+   classification — they are central classification-projector gaps
+   (`re-frame.classification/project-trace-event` applies an fx registration's
+   `:sensitive` only to the `:rf.fx/handled` slot):
+
+     - `:rf.event/fx` on `:rf.fx/do-fx` — the handler's WHOLE returned effect
+       vector is stamped raw; the projector walks the sibling `:rf.event/db` slot
+       but not `:rf.event/fx` (Spec 009 §Canonical per-event trace sequence notes
+       they share posture).
+     - `:rf.fx/args` on the always-on `:rf.error/fx-handler-exception` (and
+       sibling fx error traces) — fx-args redaction is keyed on op
+       `:rf.fx/handled` only.
+
+   Both are tracked as a framework bead; see the sweep exclusions below. This ns
+   asserts everything the EXAMPLE owns is redacted, and pins the two registration
+   declarations that the framework projector will consume once it covers those
+   slots."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.classification :as classification]
+            [re-frame.privacy :as privacy]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; login.model pulls these transitively; require here so the ns is
+            ;; self-sufficient (mirrors the sibling login test namespaces).
+            [re-frame.schemas]
+            [re-frame.machines]
+            [login.model])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+;; A UNIQUE sentinel token — a string that appears nowhere else in the source or
+;; the framework, so a recursive scan for it across the trace stream can only be
+;; hitting THIS reply's token.
+(def sentinel "SESSION-TOKEN-SENTINEL-8b71e0")
+
+(def success-reply
+  "The canonical managed-HTTP success envelope for the login request, carrying a
+   uniquely-tagged session token — exactly what the demo stub conjures and what
+   managed HTTP appends to `[:auth.login/succeeded]`."
+  {:status :ok
+   :value  {:user  {:id "u1" :email "alice@example.com"}
+            :token sentinel}})
+
+(defn- machine-state [f]
+  (get-in (rf/frame-state-value f)
+          [:rf.db/runtime :rf.runtime/machines :snapshots :auth.login/flow :state]))
+
+(defn- contains-sentinel?
+  "True when `x` contains the sentinel token string ANYWHERE in a nested data
+   structure — the recursive scan an off-box shipper / dev tool would apply."
+  [x]
+  (cond
+    (string? x) (not= -1 (.indexOf x sentinel))
+    (map? x)    (boolean (some contains-sentinel? (concat (keys x) (vals x))))
+    (coll? x)   (boolean (some contains-sentinel? x))
+    :else       false))
+
+(defn- record-traces! []
+  (let [a (atom [])]
+    (rf/register-listener! :trace ::probe (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- submit! [f]
+  (rf/dispatch-sync [:auth.login/flow [:auth.login/submit]] {:frame f}))
+
+;; ---------------------------------------------------------------------------
+;; (positive control) the real token IS usable end to end
+;; ---------------------------------------------------------------------------
+
+(deftest succeeded-persists-real-token-and-drives-machine-to-authed
+  (testing "the success handler hands the REAL token to the persistence fx and
+            drives the machine to :authed with a credential-free signal"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (submit! f)
+      (is (= :submitting (machine-state f))
+          "the submit signal put the flow in :submitting")
+      (let [stored (atom nil)]
+        ;; Capture the persistence fx's args (positive control) but let the
+        ;; credential-free machine :dispatch run, so the flow reaches :authed.
+        (rf/dispatch-sync [:auth.login/succeeded success-reply]
+                          {:frame        f
+                           :fx-overrides {:auth.session/store
+                                          (fn [_ args] (reset! stored args))}})
+        (is (= {:token sentinel} @stored)
+            "the persistence fx received the REAL token — it is fully usable by
+             the app logic (this is what gets written to localStorage)")
+        (is (= :authed (machine-state f))
+            "the bare, credential-free :success signal drove the flow to :authed
+             — the machine reached the happy ending without seeing the token")))))
+
+;; ---------------------------------------------------------------------------
+;; the token is redacted across every EXAMPLE-OWNED trace slot
+;; ---------------------------------------------------------------------------
+
+(deftest success-token-redacted-across-trace-egress
+  (testing "on a successful login, the session token does NOT appear raw in any
+            reply-event or per-effect trace slot the example owns; the reply
+            event redacts [:value :token] and the store fx redacts [:token]"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (submit! f)
+      (let [traces (record-traces!)]
+        (rf/dispatch-sync [:auth.login/succeeded success-reply] {:frame f})
+        (rf/unregister-listener! :trace ::probe)
+
+        (is (= :authed (machine-state f))
+            "sanity: the drive reached :authed (so the full cascade was traced)")
+
+        ;; --- the reply event trace redacts the token, shape retained ---
+        (let [succeeded-vs (->> @traces
+                                (keep #(get-in % [:tags :rf.event/v]))
+                                (filter #(and (vector? %)
+                                              (= :auth.login/succeeded (first %)))))]
+          (is (seq succeeded-vs)
+              "the :auth.login/succeeded event surfaced on the trace with its payload")
+          (doseq [v succeeded-vs]
+            (is (= privacy/redacted-sentinel (get-in v [1 :value :token]))
+                "the token reads :rf/redacted in the succeeded event trace")
+            (is (= :ok (get-in v [1 :status]))
+                "shape retained — the envelope :status is still visible")
+            (is (contains? (get-in v [1 :value]) :user)
+                "shape retained — the :user sibling is still present")))
+
+        ;; --- the store fx's per-effect trace redacts its :token arg ---
+        (let [handled (->> @traces
+                           (filter #(= :auth.session/store (get-in % [:tags :rf.fx/id]))))]
+          (is (seq handled)
+              "the :auth.session/store fx emitted a :rf.fx/handled trace")
+          (doseq [ev handled]
+            (is (= privacy/redacted-sentinel (get-in ev [:tags :rf.fx/args :token]))
+                "the store fx :token arg reads :rf/redacted in :rf.fx/handled")))
+
+        ;; --- the whole-stream sweep: the sentinel appears in NO trace tag,
+        ;;     save the two framework-gated slots (see ns docstring). Excluded:
+        ;;     :rf.event/fx (the :rf.fx/do-fx aggregate) — the projector has no
+        ;;     branch for it. (The error-arm :rf.fx/args gap only fires when the
+        ;;     fx THROWS, exercised in the error-arm test below; it does not
+        ;;     appear on this success sweep.)
+        (let [checked (atom 0)]
+          (doseq [ev @traces
+                  [k v] (:tags ev)
+                  :when (not= :rf.event/fx k)]
+            (swap! checked inc)
+            (is (not (contains-sentinel? v))
+                (str "the session token must not appear raw in " (:operation ev)
+                     " / " k)))
+          (is (pos? @checked)
+              "the sweep actually inspected trace tags (guard against a no-op)"))))))
+
+;; ---------------------------------------------------------------------------
+;; the error arm — the origin event on the fx-exception trace is redacted
+;; ---------------------------------------------------------------------------
+
+(deftest error-arm-origin-event-redacted-on-fx-exception
+  (testing "when the localStorage fx throws, the origin event carried on the
+            always-on :rf.error/fx-handler-exception trace redacts the token
+            (the example-owned :event slot); the fx-args redaction on error
+            traces is the framework-gated residual and is NOT asserted here"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (submit! f)
+      (let [traces (record-traces!)]
+        (rf/dispatch-sync
+          [:auth.login/succeeded success-reply]
+          {:frame        f
+           :fx-overrides {:auth.session/store
+                          (fn [_ _] (throw (js/Error. "localStorage unavailable")))}})
+        (rf/unregister-listener! :trace ::probe)
+        (let [errs (->> @traces
+                        (filter #(= :rf.error/fx-handler-exception (:operation %))))]
+          (is (seq errs)
+              "the throwing store fx emitted an :rf.error/fx-handler-exception trace")
+          (doseq [ev errs]
+            (is (not (contains-sentinel? (get-in ev [:tags :event])))
+                "the origin event on the error trace redacts the token — the
+                 :auth.login/succeeded registration classifies it")))))))
+
+;; ---------------------------------------------------------------------------
+;; the two registrations own their classification (what the projector consumes)
+;; ---------------------------------------------------------------------------
+
+(deftest owners-declare-their-classification
+  (testing "the reply event and the persistence fx each declare their own
+            :sensitive path — the registration-owned classification the trace
+            projector reads at egress"
+    (is (= {:sensitive [[:value :token]]}
+           (classification/registration-classification :event :auth.login/succeeded))
+        ":auth.login/succeeded owns [:value :token] — the reply's token slot")
+    (is (= {:sensitive [[:token]]}
+           (classification/registration-classification :fx :auth.session/store))
+        ":auth.session/store owns [:token] — its own transient fx arg")))


### PR DESCRIPTION
## What

On a successful login the demo backend returns a session token in the reply. Even though the originating request is coarse-`:sensitive? true` (so the `:rf.http/*` traces redact it), classification does not propagate once the app receives the live reply, so the token was re-keyed **raw** into two unclassified transient carriers after HTTP ownership ended:

1. the **machine reply event** — `:on-success [:auth.login/flow [:auth.login/success]]` made the appended reply an unaddressable **3rd positional arg**, leaking the token across `:rf.event/dispatched` / `:rf.event/run-start`/`-end` / `:rf.machine/*` / `:rf.event/frame-state-changed`;
2. the **`:auth.session/store` fx args** — unclassified, leaking across `:rf.machine/action-ran`, `:rf.fx/handled`, and `:rf.fx/do-fx`.

Premise reproduced on this branch's model: a `:submitting → :authed` success leaked the token in **10 trace slots**.

## Fix (example-side — classify the app-owned carriers)

Mirrors the password's owner-per-boundary shape, but for the token on the way back:

- **New `:auth.login/succeeded` event** (`:sensitive [[:value :token]]`). Routing `:on-success` at a **one-element** event makes the appended reply the addressable **arg-map**, so the registration redacts `[:value :token]` at event egress. The handler persists the token and nudges the machine with a bare `[:auth.login/flow [:auth.login/success]]` signal.
- **`:auth.session/store` fx** gains `:sensitive [[:token]]` — its per-effect `:rf.fx/handled` trace now redacts `[:token]`.
- **Machine is credential-free** — `:store-session` removed; `:success → :authed` takes no action. The machine never sees the token.

Result: **8 of the 10** leaking slots close; the flow still reaches `:authed` and the real token still reaches localStorage.

## Regression

`implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs` (examples stay test-free per rf2-8cevm):

- **positive control** — the persistence fx receives the real token and the credential-free signal drives the machine to `:authed`;
- **redaction** — `:auth.login/succeeded` `:rf.event/v` redacts `[:value :token]` (shape retained), `:auth.session/store` `:rf.fx/handled` redacts `[:token]`, a whole-stream sweep finds the token in no other app-owned slot, and the error arm proves the origin `:event` on `:rf.error/fx-handler-exception` redacts;
- **owners** — pins the two registration declarations the projector consumes.

## Framework residual (not fixable app-side) — filed as **rf2-6h3c02**

Two slots still carry the token raw, and no app-side classification can reach them — the central projector (`re-frame.classification/project-trace-event`) applies an fx registration's `:sensitive` only to `:rf.fx/handled`:

- `:rf.event/fx` on `:rf.fx/do-fx` (the whole returned effect vector — the sibling `:rf.event/db` slot IS walked, this one is not);
- `:rf.fx/args` on the always-on `:rf.error/fx-handler-exception`.

Closing these app-side would need an unidiomatic fx-reads-db/origin-event contortion that misteaches in the canonical login example, so they're left to the framework projector fix (rf2-j538f7.30 DESIGN item 3, option a).

## Quality gates

- `npx shadow-cljs compile examples/login examples/login-uix examples/login-helix` — **0 warnings** each.
- Regression `re-frame.example-login-success-token-cljs-test` — **4 tests / 115 assertions green**.
- Full CLJS suite (`node out/node-test.js`) — **8528 tests / 40183 assertions, 0 failures** (shared model change breaks nothing).
- Sibling login suites (form-slice, machine data, http-managed-machine) — **13 tests / 73 assertions green**.
- `node examples/scripts/check-examples-assets.cjs` — **green** (35 pages).
- `npm run test:bundle-isolation` — **green** (login bundles isolated).
- `mkdocs build --strict` — **skipped** (no markdown changed).
