### PR TITLE
fix(core/classification): apply fx :sensitive to all fx-arg trace slots, not just :rf.fx/handled (rf2-6h3c02)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -355,14 +355,62 @@
         (assoc tags slot redacted)))))
 
 (defn- project-fx-tags
-  "Walk `:rf.fx/handled` tag shape: `:rf.fx/id` carries the fx keyword and
-  `:rf.fx/args` carries the args value."
+  "Redact the fx args carried by ANY trace slot that stamps the `[:rf.fx/id
+  :rf.fx/args]` pair, against the fx REGISTRATION's declared `:sensitive` /
+  `:large`.
+
+  Covers the per-effect `:rf.fx/handled` success trace AND the always-on fx
+  ERROR traces (`:rf.error/fx-handler-exception` + its siblings) AND
+  `:rf.fx/skipped-on-platform` — every one stamps the SAME `:rf.fx/id` +
+  `:rf.fx/args`, so every one gets the SAME registration-owned redaction
+  (rf2-6h3c02). Keying off the SLOT SHAPE (both keys present) rather than op
+  `:rf.fx/handled` is what closes the error-trace `:rf.fx/args` leak — the
+  production-survivable `:rf.error/fx-handler-exception` fans out through the
+  always-on error-emit listener, not just the dev trace, so an fx that persists
+  / sends a classified value (a session token to localStorage, an auth header)
+  must NOT egress it raw when the fx throws.
+
+  A no-op when the fx declared no classification — which INCLUDES an
+  UNREGISTERED fx-id on `:rf.error/no-such-fx` (there is no registration to
+  read a `:sensitive` off, and an unaddressable arg is the known EP-0025
+  fail-open, not a bug this closes)."
   [tags]
   (let [fx-id (:rf.fx/id tags)
         class (classification-when :fx fx-id)]
-    (if-not class
+    (if (and class (contains? tags :rf.fx/args))
+      (assoc tags :rf.fx/args (redact-by-classification (:rf.fx/args tags) class))
+      tags)))
+
+(defn- project-event-fx-entry
+  "Redact ONE `[fx-id args …]` effect-vector entry against `fx-id`'s
+  registration classification. The args value is the SECOND element (Spec 002
+  §The effect vector); replace it IN PLACE so the fx-id + any trailing elements
+  survive. A no-op when the entry is not a `[fx-id args …]` vector (a nil /
+  empty conditional-fx no-op, or a reserved fx whose args carry no declarable
+  path — e.g. `:dispatch`, which declares no fx classification) or the fx
+  declared none."
+  [entry]
+  (if (and (vector? entry) (>= (count entry) 2))
+    (if-let [class (classification-when :fx (first entry))]
+      (assoc entry 1 (redact-by-classification (second entry) class))
+      entry)
+    entry))
+
+(defn- project-event-fx-tags
+  "Walk the `:rf.event/fx` slot carried by the `:rf.fx/do-fx` trace — the
+  handler's WHOLE returned effect vector (`[[fx-id args] …]`, stamped raw by
+  `re-frame.fx/do-fx`). Redact each entry's args through THAT fx-id's
+  registration classification, mirroring how `project-db-tags` covers the
+  sibling `:rf.event/db` slot (the two share posture — Spec 009 §Canonical
+  per-event trace sequence). This closes the aggregate-slot leak the per-effect
+  `:rf.fx/handled` redaction alone left open: a classified fx's args survived
+  RAW on this always-stamped `:rf.event/fx` vector even though `:rf.fx/handled`
+  redacted them (rf2-6h3c02)."
+  [tags]
+  (let [fx-vec (:rf.event/fx tags)]
+    (if-not (vector? fx-vec)
       tags
-      (assoc tags :rf.fx/args (redact-by-classification (:rf.fx/args tags) class)))))
+      (assoc tags :rf.event/fx (mapv project-event-fx-entry fx-vec)))))
 
 (defn- project-cofx-map-slot
   "Walk a `{cofx-id value}` map carried under `slot` in `tags`, redacting each
@@ -835,7 +883,20 @@
                         (contains? tags :event)
                         (project-event-tags :event)
 
-                        (= :rf.fx/handled operation)
+                        ;; `:rf.event/fx` — the WHOLE returned effect vector on
+                        ;; `:rf.fx/do-fx`; redact each entry's args through its
+                        ;; fx registration (sibling of the `:rf.event/db` walk).
+                        (contains? tags :rf.event/fx)
+                        (project-event-fx-tags)
+
+                        ;; ANY slot carrying the `[:rf.fx/id :rf.fx/args]` pair —
+                        ;; `:rf.fx/handled` AND the always-on fx error traces
+                        ;; (`:rf.error/fx-handler-exception` + siblings) +
+                        ;; `:rf.fx/skipped-on-platform`. Keyed off slot SHAPE,
+                        ;; not op `:rf.fx/handled`, so the production-survivable
+                        ;; error-trace args redact too (rf2-6h3c02).
+                        (and (contains? tags :rf.fx/id)
+                             (contains? tags :rf.fx/args))
                         (project-fx-tags)
 
                         (contains? tags :rf.event/coeffects)

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -33,24 +33,25 @@
         `[:auth.login/flow [:auth.login/success]]` signal, so the flow reaches
         `:authed` without ever seeing the token.
 
-   KNOWN FRAMEWORK-GATED RESIDUAL (deliberately NOT asserted clean here). Two
-   trace slots still carry the raw token, and NEITHER is reachable by app-side
-   classification — they are central classification-projector gaps
-   (`re-frame.classification/project-trace-event` applies an fx registration's
-   `:sensitive` only to the `:rf.fx/handled` slot):
+   FRAMEWORK-GATED SLOTS — NOW CLOSED (rf2-6h3c02). Two trace slots used to carry
+   the raw token, neither reachable by app-side classification — central
+   classification-projector gaps where `project-trace-event` applied the fx
+   registration's `:sensitive` only to the `:rf.fx/handled` slot. rf2-6h3c02
+   taught the projector to apply the fx registration's `:sensitive` to EVERY
+   fx-arg-bearing slot, so both now redact off the SAME `:auth.session/store`
+   `:sensitive [[:token]]` this example already declares:
 
      - `:rf.event/fx` on `:rf.fx/do-fx` — the handler's WHOLE returned effect
-       vector is stamped raw; the projector walks the sibling `:rf.event/db` slot
-       but not `:rf.event/fx` (Spec 009 §Canonical per-event trace sequence notes
-       they share posture).
-     - `:rf.fx/args` on the always-on `:rf.error/fx-handler-exception` (and
-       sibling fx error traces) — fx-args redaction is keyed on op
-       `:rf.fx/handled` only.
+       vector; each entry's args now walk through its fx registration (sibling of
+       the `:rf.event/db` walk — Spec 009 §Canonical per-event trace sequence
+       notes they share posture). Asserted clean by the whole-stream sweep below.
+     - `:rf.fx/args` on the always-on (production-survivable)
+       `:rf.error/fx-handler-exception` — fx-args redaction is now keyed on the
+       slot shape, not op `:rf.fx/handled`. Asserted clean by the error-arm test.
 
-   Both are tracked as a framework bead; see the sweep exclusions below. This ns
-   asserts everything the EXAMPLE owns is redacted, and pins the two registration
-   declarations that the framework projector will consume once it covers those
-   slots."
+   This ns asserts everything the example owns is redacted, pins the two
+   registration declarations the projector consumes, and — post-rf2-6h3c02 — the
+   two formerly-residual framework slots."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
             [re-frame.classification :as classification]
@@ -174,16 +175,15 @@
             (is (= privacy/redacted-sentinel (get-in ev [:tags :rf.fx/args :token]))
                 "the store fx :token arg reads :rf/redacted in :rf.fx/handled")))
 
-        ;; --- the whole-stream sweep: the sentinel appears in NO trace tag,
-        ;;     save the two framework-gated slots (see ns docstring). Excluded:
-        ;;     :rf.event/fx (the :rf.fx/do-fx aggregate) — the projector has no
-        ;;     branch for it. (The error-arm :rf.fx/args gap only fires when the
-        ;;     fx THROWS, exercised in the error-arm test below; it does not
-        ;;     appear on this success sweep.)
+        ;; --- the whole-stream sweep: the sentinel appears in NO trace tag.
+        ;;     Post-rf2-6h3c02 this includes :rf.event/fx (the :rf.fx/do-fx
+        ;;     aggregate) — the projector now walks each fx entry's args through
+        ;;     its registration, so the store fx's [:token] redacts there too.
+        ;;     (The error-arm :rf.fx/args gap — also closed by rf2-6h3c02 — only
+        ;;     fires when the fx THROWS, exercised in the error-arm test below.)
         (let [checked (atom 0)]
           (doseq [ev @traces
-                  [k v] (:tags ev)
-                  :when (not= :rf.event/fx k)]
+                  [k v] (:tags ev)]
             (swap! checked inc)
             (is (not (contains-sentinel? v))
                 (str "the session token must not appear raw in " (:operation ev)
@@ -195,11 +195,11 @@
 ;; the error arm — the origin event on the fx-exception trace is redacted
 ;; ---------------------------------------------------------------------------
 
-(deftest error-arm-origin-event-redacted-on-fx-exception
-  (testing "when the localStorage fx throws, the origin event carried on the
-            always-on :rf.error/fx-handler-exception trace redacts the token
-            (the example-owned :event slot); the fx-args redaction on error
-            traces is the framework-gated residual and is NOT asserted here"
+(deftest error-arm-origin-event-and-fx-args-redacted-on-fx-exception
+  (testing "when the localStorage fx throws, BOTH the origin event (:event slot,
+            example-owned) AND the fx args (:rf.fx/args slot, framework-gated
+            until rf2-6h3c02) on the always-on :rf.error/fx-handler-exception
+            trace redact the token"
     (with-new-frame [f (frame/make-anon-frame-record! {})]
       (submit! f)
       (let [traces (record-traces!)]
@@ -216,7 +216,13 @@
           (doseq [ev errs]
             (is (not (contains-sentinel? (get-in ev [:tags :event])))
                 "the origin event on the error trace redacts the token — the
-                 :auth.login/succeeded registration classifies it")))))))
+                 :auth.login/succeeded registration classifies it")
+            ;; rf2-6h3c02: the fx args on the production-survivable error trace
+            ;; now redact off :auth.session/store's own :sensitive [[:token]].
+            (is (= privacy/redacted-sentinel (get-in ev [:tags :rf.fx/args :token]))
+                "the store fx :token arg reads :rf/redacted in :rf.fx/args")
+            (is (not (contains-sentinel? (:tags ev)))
+                "the token appears nowhere raw across the error trace tags")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; the two registrations own their classification (what the projector consumes)

--- a/implementation/core/test/re_frame/fx_args_trace_egress_cljs_test.cljc
+++ b/implementation/core/test/re_frame/fx_args_trace_egress_cljs_test.cljc
@@ -1,0 +1,172 @@
+(ns re-frame.fx-args-trace-egress-cljs-test
+  "rf2-6h3c02 — an fx registration's `:sensitive` classification must reach
+  EVERY trace slot that carries the fx's args, not only the per-effect
+  `:rf.fx/handled` slot.
+
+  Before this fix `re-frame.classification/project-trace-event` applied the fx
+  registration's `:sensitive` only inside `project-fx-tags`, gated on op
+  `:rf.fx/handled`. Two OTHER slots carried the SAME fx args RAW, unreachable by
+  any app-side classification:
+
+    1. `:rf.event/fx` on the `:rf.fx/do-fx` trace — the handler's WHOLE returned
+       effect vector, stamped raw. (The projector walked the sibling
+       `:rf.event/db` slot but not this one.)
+    2. `:rf.fx/args` on the ALWAYS-ON fx error traces
+       (`:rf.error/fx-handler-exception` + siblings). The more serious of the
+       two: that trace is production-survivable — it fans out through the
+       always-on error-emit listener, not just the dev trace.
+
+  This suite is the adversarial regression: it drives a `reg-fx` declaring
+  `{:sensitive [[:token]]}` through a SUCCESS arm and an ERROR arm and pins the
+  sentinel token absent from every fx-arg-bearing slot, PLUS a non-sensitive
+  control fx that must ride RAW (no over-redaction). Each sensitive assertion
+  FAILS before the fix and PASSES after.
+
+  Dual-runtime `.cljc` (`*-cljs-test` ns): the shadow-cljs `:node-test` build
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up —
+  traces fire in both runtimes (`goog.DEBUG` / JVM `debug-enabled?` default on)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.classification :as classification]
+            [re-frame.privacy :as privacy]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; A UNIQUE sentinel — appears nowhere else, so a whole-stream scan that finds
+;; it can only be hitting THIS fx's token arg.
+(def ^:private sentinel "FX-ARGS-EGRESS-SENTINEL-6h3c02")
+
+(def ^:private frame-id :fx-args-egress/frame)
+
+(defn- register! []
+  (rf/reg-frame frame-id {})
+  ;; A CLASSIFIED fx — its own registration declares [:token] sensitive.
+  (rf/reg-fx :fx-args/store {:sensitive [[:token]]}
+    (fn [_ _] nil))
+  ;; A CLASSIFIED fx that THROWS — to exercise the error-arm :rf.fx/args slot
+  ;; carried by :rf.error/fx-handler-exception (production-survivable).
+  (rf/reg-fx :fx-args/store-throwing {:sensitive [[:token]]}
+    (fn [_ _] (throw (ex-info "fx blew up" {}))))
+  ;; A NON-sensitive control fx — its args must ride RAW (guard against
+  ;; over-redaction of unclassified fx).
+  (rf/reg-fx :fx-args/audit
+    (fn [_ _] nil))
+  ;; SUCCESS event: returns both the classified store fx and the control fx.
+  (rf/reg-event :fx-args/succeed
+    (fn [_ _]
+      {:fx [[:fx-args/store {:token sentinel}]
+            [:fx-args/audit {:msg "a benign audit line"}]]}))
+  ;; ERROR event: returns the throwing classified fx.
+  (rf/reg-event :fx-args/fail
+    (fn [_ _]
+      {:fx [[:fx-args/store-throwing {:token sentinel}]]})))
+
+(defn- collect-traces! [id]
+  (let [acc (atom [])]
+    (rf/register-listener! :trace id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+(defn- contains-sentinel?
+  "True when the sentinel string appears ANYWHERE in a nested data structure —
+  the recursive scan an off-box shipper / dev tool applies."
+  [x]
+  (cond
+    (string? x) #?(:clj (.contains ^String x sentinel)
+                   :cljs (not= -1 (.indexOf x sentinel)))
+    (map? x)    (boolean (some contains-sentinel? (concat (keys x) (vals x))))
+    (coll? x)   (boolean (some contains-sentinel? x))
+    :else       false))
+
+;; ---------------------------------------------------------------------------
+;; SUCCESS arm — :rf.event/fx (on :rf.fx/do-fx) + :rf.fx/handled both redact;
+;; the control fx rides raw.
+;; ---------------------------------------------------------------------------
+
+(deftest success-arm-redacts-classified-fx-args-in-every-slot
+  (testing "a classified fx's token is redacted in BOTH the :rf.event/fx
+            aggregate (on :rf.fx/do-fx) AND the per-effect :rf.fx/handled slot,
+            while the non-sensitive control fx rides raw"
+    (register!)
+    (let [acc (collect-traces! ::success)]
+      (rf/dispatch-sync [:fx-args/succeed] {:frame frame-id})
+      (rf/unregister-listener! :trace ::success)
+
+      ;; --- :rf.event/fx on :rf.fx/do-fx: the classified entry redacts ---
+      (let [do-fx (->> @acc (filterv #(= :rf.fx/do-fx (:operation %))))]
+        (is (seq do-fx) ":rf.fx/do-fx was emitted with the effect vector")
+        (doseq [ev do-fx]
+          (let [fx-vec (get-in ev [:tags :rf.event/fx])
+                store  (first (filter #(= :fx-args/store (first %)) fx-vec))
+                audit  (first (filter #(= :fx-args/audit (first %)) fx-vec))]
+            (is (= privacy/redacted-sentinel (get-in store [1 :token]))
+                "the classified fx's :token reads :rf/redacted in :rf.event/fx")
+            (is (= :fx-args/store (first store))
+                "shape retained — the fx-id survives")
+            (is (= {:msg "a benign audit line"} (second audit))
+                "the NON-sensitive control fx rides RAW (no over-redaction)"))))
+
+      ;; --- per-effect :rf.fx/handled: unchanged redaction (control) ---
+      (let [handled (->> @acc
+                         (filterv #(= :fx-args/store (get-in % [:tags :rf.fx/id]))))]
+        (is (seq handled) "the classified fx emitted a :rf.fx/handled trace")
+        (doseq [ev handled]
+          (is (= privacy/redacted-sentinel (get-in ev [:tags :rf.fx/args :token]))
+              "the :token arg reads :rf/redacted in :rf.fx/handled (unchanged)")))
+
+      (let [audit-handled (->> @acc
+                               (filterv #(= :fx-args/audit (get-in % [:tags :rf.fx/id]))))]
+        (is (seq audit-handled) "the control fx also emitted a :rf.fx/handled trace")
+        (doseq [ev audit-handled]
+          (is (= {:msg "a benign audit line"} (get-in ev [:tags :rf.fx/args]))
+              "the control fx's args ride RAW in :rf.fx/handled (no over-redaction)")))
+
+      ;; --- whole-stream sweep: the sentinel appears in NO trace tag ---
+      (let [checked (atom 0)]
+        (doseq [ev @acc
+                [_ v] (:tags ev)]
+          (swap! checked inc)
+          (is (not (contains-sentinel? v))
+              (str "the token must not appear raw in " (:operation ev))))
+        (is (pos? @checked) "the sweep actually inspected trace tags")))))
+
+;; ---------------------------------------------------------------------------
+;; ERROR arm — the production-survivable :rf.error/fx-handler-exception carries
+;; :rf.fx/args; it must redact the classified token.
+;; ---------------------------------------------------------------------------
+
+(deftest error-arm-redacts-fx-args-on-fx-handler-exception
+  (testing "when a classified fx throws, :rf.error/fx-handler-exception redacts
+            its :rf.fx/args :token (the always-on, production-survivable slot)"
+    (register!)
+    (let [acc (collect-traces! ::error)]
+      (rf/dispatch-sync [:fx-args/fail] {:frame frame-id})
+      (rf/unregister-listener! :trace ::error)
+
+      (let [errs (->> @acc
+                      (filterv #(= :rf.error/fx-handler-exception (:operation %))))]
+        (is (seq errs)
+            "the throwing classified fx emitted an :rf.error/fx-handler-exception trace")
+        (doseq [ev errs]
+          (is (= privacy/redacted-sentinel (get-in ev [:tags :rf.fx/args :token]))
+              "the :rf.fx/args :token reads :rf/redacted on the error trace")
+          (is (= :fx-args/store-throwing (get-in ev [:tags :rf.fx/id]))
+              "shape retained — the fx-id survives")
+          (is (not (contains-sentinel? (:tags ev)))
+              "the token appears nowhere raw in the error trace tags"))))))
+
+;; ---------------------------------------------------------------------------
+;; The registration owns its classification (what the projector consumes).
+;; ---------------------------------------------------------------------------
+
+(deftest classified-fx-registration-declares-its-path
+  (testing "the fx registration owns the [:token] sensitive path the projector
+            reads at egress"
+    (register!)
+    (is (= {:sensitive [[:token]]}
+           (classification/registration-classification :fx :fx-args/store))
+        ":fx-args/store owns [:token]")))


### PR DESCRIPTION
## Security rationale

**P2 SECURITY — sensitive-value leak in trace slots.** An fx registration's `:sensitive` classification reached only the per-effect `:rf.fx/handled` trace slot. Two OTHER slots carried the SAME fx args RAW, and **no app-side classification could reach them** — they are framework-owned trace stamps redacted by framework-owned projection:

1. **`:rf.event/fx` on `:rf.fx/do-fx`** — `re-frame.fx/do-fx` stamps the handler's WHOLE returned effect vector here. The projector walked the sibling `:rf.event/db` slot but never this one, so a classified fx's args (e.g. `[:auth.session/store {:token "…"}]`) shipped raw on this aggregate even though `:rf.fx/handled` redacted them.
2. **`:rf.fx/args` on the always-on fx error traces** (`:rf.error/fx-handler-exception` + siblings). The more serious leak: this trace is **production-survivable** — it fans out through the always-on error-emit listener, not just the dev trace (which DCE-elides in prod). So an fx that persists/sends a classified value (session token → localStorage, auth header, WS payload) leaked it whenever the fx threw, in production observability.

No app can classify its way out of either; the fix must live in the single egress chokepoint.

## Change

`re-frame.classification/project-trace-event` now:

- **`project-event-fx-tags`** — walks each `[fx-id args]` entry under `:rf.event/fx` through that fx-id's registration classification, mirroring how `project-db-tags` covers the sibling `:rf.event/db` slot (Spec 009 §Canonical per-event trace sequence notes they share posture).
- **`project-fx-tags`** — keyed off the SLOT SHAPE (`:rf.fx/id` + `:rf.fx/args` both present) rather than op `:rf.fx/handled`, so the error-trace and `:rf.fx/skipped-on-platform` args redact off the same fx registration. Unregistered fx-ids (`:rf.error/no-such-fx`) stay a no-op — no registration to read, the known EP-0025 positional/unaddressable fail-open.

General fix — also closes the login example's `:auth.session/store {:token …}` and the RealWorld `:auth.session/persist {:token …}` residual.

## Tests

- **`fx_args_trace_egress_cljs_test`** (new, dual-runtime `.cljc`) — drives a `reg-fx {:sensitive [[:token]]}` through a SUCCESS arm and an ERROR arm, asserting the sentinel token absent from `:rf.event/fx`, `:rf.fx/handled`, and error-arm `:rf.fx/args`, plus a **non-sensitive control fx** that must ride raw (no over-redaction). Confirmed RED before the fix (4 failures on exactly the two sensitive slots), GREEN after.
- **`example_login_success_token_cljs_test`** extended (AC5): the whole-stream sweep now includes `:rf.event/fx` (exclusion removed), and the error-arm test asserts `:rf.fx/args :token` clean. Stale "known residual" docstring refreshed.

## Quality gates

- `clojure -M:test` (core JVM): **1779 tests, 7833 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **8543 tests, 40331 assertions, 0 failures, 0 errors**
- `npm run test:elision`: **PASS** (production 47/47 absent; control 47/47 present)

## Follow-up

Spec 015 + Spec 009 doc updates (AC4) and the stale `examples/core/login/model.cljs` comment are deferred to **rf2-1yfskz** — spec/009 is owned by an in-flight spec-doc worker and the login example source is another worker's surface.

Closes rf2-6h3c02.