### PR TITLE
fix(epoch): bound post-restore render attribution to the restore anchor (rf2-arzb9o)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -439,11 +439,27 @@
                (:sub-runs record)))))
 
 (defn- value-changed-epoch-for
-  "Scan `frame-id`'s ring (most-recent first) for the newest epoch in
-  which the view named by `render-key` had a value-changed `:sub/run` —
-  i.e. the cascade that genuinely re-rendered the view. Returns that
-  epoch-id, or nil when no retained epoch shows a value-change for the
+  "Scan `frame-id`'s ring (from the last-settled anchor, newest-first) for
+  the newest epoch AT OR BEFORE the anchor in which the view named by
+  `render-key` had a value-changed `:sub/run` — i.e. the cascade that
+  genuinely re-rendered the view. Returns that epoch-id, or nil when no
+  retained epoch at or before the anchor shows a value-change for the
   view (a mount / mount-burst tail).
+
+  The scan starts at `anchor-epoch-id` (the most-recently-settled epoch —
+  `resolve-render-epoch`'s `default`), so records NEWER than the anchor are
+  NEVER considered. In normal operation the anchor IS the ring-newest record,
+  so the start index is `(dec n)` and the bound is a no-op. After a time-travel
+  restore `perform-restore!` re-anchors last-settled to an OLDER epoch WITHOUT
+  truncating the ring (rf2-arzb9o), so the newer pre-restore epochs remain —
+  and they still carry value-changed sub-run evidence for a repainted view. An
+  UNBOUNDED newest-first scan would return one of those STALE newer epochs,
+  attributing a POST-restore repaint to a PRE-restore cascade and silently
+  defeating the restore re-anchor (the render-path sibling of the rf2-w4q9gt
+  back-fill re-anchor). Bounding the scan at the anchor index confines
+  attribution to the restored timeline. When the anchor is nil or evicted the
+  bound degrades to the ring-newest index (`(dec n)`) — there is no bound to
+  apply.
 
   A view's subs are matched (see `epoch-value-changed-for-view?`): by the
   `:reader-render-key` stamp (synchronous in-render deref, raw-trace only) and
@@ -477,13 +493,16 @@
   `:sub-runs` fallback. Under keep-0 the scan is O(depth) to a
   miss; that is the necessary cost of attribution when no trace window exists,
   and it still short-circuits on the first (newest) value-change for the common
-  genuine-re-render case. One pass newest-first; short-circuits at the first
-  matching epoch."
-  [frame-id render-key]
+  genuine-re-render case. One pass newest-first from the anchor;
+  short-circuits at the first matching epoch."
+  [frame-id render-key anchor-epoch-id]
   (let [history (history-for frame-id)
         deps    (render-deps-for frame-id render-key)
-        n       (count history)]
-    (loop [i (dec n)]
+        n       (count history)
+        ;; Records newer than the anchor exist only after a restore rewind;
+        ;; start the newest-first scan at the anchor so they are excluded.
+        start   (or (epoch-index history anchor-epoch-id) (dec n))]
+    (loop [i start]
       (when (>= i 0)
         (let [record (nth history i)]
           (if (epoch-value-changed-for-view? record render-key deps)
@@ -496,9 +515,12 @@
   recently settled epoch, when no better anchor is found.
 
   Resolution order:
-    1. The newest epoch in which the view's OWN inputs changed
-       (`value-changed-epoch-for`) — a genuine reactive re-render rides
-       its causing cascade.
+    1. The newest epoch AT OR BEFORE the anchor in which the view's OWN
+       inputs changed (`value-changed-epoch-for`, bounded at
+       `default-epoch-id`) — a genuine reactive re-render rides its causing
+       cascade. The anchor bound keeps a post-restore repaint on the restored
+       timeline rather than attributing it to a stale newer pre-restore epoch
+       (rf2-arzb9o).
     2. Otherwise the view's MOUNT epoch (`mount-epoch-for`) — a mount
        render, or a mount-burst tail that re-deref'd unchanged subs, is
        anchored to where the instance first rendered rather than leaking
@@ -508,7 +530,7 @@
        value-change scan hit): treat the settling cascade as its mount,
        which `record-mount-epoch!` then anchors."
   [frame-id render-key default-epoch-id]
-  (or (when render-key (value-changed-epoch-for frame-id render-key))
+  (or (when render-key (value-changed-epoch-for frame-id render-key default-epoch-id))
       (when render-key (mount-epoch-for frame-id render-key))
       default-epoch-id))
 

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -1782,6 +1782,127 @@
             "post-failure render attributes to the unchanged last-settled
              epoch — the re-anchor is success-only")))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-arzb9o — a post-restore repaint whose STALE (newer) pre-restore epoch
+;;               carries value-changed sub-run evidence must still attribute to
+;;               the RESTORED-TARGET epoch, not the stale newer one.
+;; ---------------------------------------------------------------------------
+;;
+;; The RENDER-PATH sibling of inv-9. inv-9's re-anchor (`perform-restore!` sets
+;; last-settled to the restored target) is correct, but the render path routes
+;; through `resolve-render-epoch` → `value-changed-epoch-for`, which scans the
+;; ring newest-first for an epoch that shows a value-change for the repainted
+;; view. `perform-restore!` re-anchors WITHOUT truncating the ring, so the NEWER
+;; pre-restore epochs survive — and in a real substrate they carry the
+;; value-changed sub-run evidence for the very view now being repainted. An
+;; UNBOUNDED scan returns that stale newer epoch, OVERRIDING the re-anchor:
+;;   (b) stale has no prior `:renders` row for the view → the render is
+;;       back-filled INTO the stale epoch (the corruption inv-9 claims fixed);
+;;   (a) stale already has a `:renders` row for the view → the de-dup arm SKIPS
+;;       the back-fill → the repaint is silently absorbed (target gets nothing).
+;;
+;; The inv-9 tests above MISS this: their headless cascades seed NO value-change
+;; evidence in the stale epoch, so the scan misses everywhere and falls through
+;; to the re-anchored default — the anchor "works" only because the scan never
+;; fires. These two tests seed the stale evidence a real substrate produces and
+;; pin the anchor bound (`value-changed-epoch-for` starts at the last-settled
+;; anchor index, so records newer than the restored target are excluded). Both
+;; FAIL on the pre-fix unbounded scan; both PASS after the anchor bound.
+
+(deftest inv-9-post-restore-render-not-backfilled-into-stale-value-change-epoch
+  (testing "rf2-arzb9o (case b) — a post-restore repaint whose STALE newer epoch
+            carries value-changed sub-run evidence for the view (but no prior
+            render row) must NOT be back-filled into that stale epoch; it
+            attributes to the restored-target epoch."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
+
+    (let [render-key [:counter-view 0]]
+      (rf/dispatch-sync [:seed]        {:frame :test/main})   ;; counter 0
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})   ;; counter 1 — restore target
+      (let [target-epoch (last-epoch :test/main)]
+        ;; Seed value-changed sub-run evidence into the TARGET and LEARN the
+        ;; view's read-set ({:counter}) via the reader-render-key stamp.
+        (emit-mount-sub-run! :test/main :counter render-key 0 1)
+
+        (rf/dispatch-sync [:counter-inc] {:frame :test/main}) ;; counter 2 — stale
+        (let [stale-epoch (last-epoch :test/main)]
+          ;; Seed value-changed sub-run evidence into the STALE (newer) epoch —
+          ;; the evidence a real substrate's post-settle reactive recompute
+          ;; leaves; this is exactly what the inv-9 headless cascades omit.
+          (emit-sub-run! :test/main :counter 1 2)
+
+          ;; PREMISE — the trap is armed: stale is last-settled, the read-set is
+          ;; learned, and the stale epoch genuinely carries value-change evidence
+          ;; for the view (so an unbounded scan WOULD return it).
+          (is (= (:epoch-id stale-epoch) (state/last-settled-epoch-id :test/main)))
+          (is (contains? (state/render-deps-for :test/main render-key) :counter)
+              "the view's read-set is learned — the deps-match arm can fire")
+          (is (contains? (sub-run-ids (epoch-by-id :test/main stale-epoch)) :counter)
+              "the STALE newer epoch carries the value-change evidence the scan
+               would match (the premise inv-9's tests lack)")
+
+          ;; Rewind to the OLDER target epoch.
+          (is (true? (rf/restore-epoch! :test/main (:epoch-id target-epoch))))
+
+          ;; The restore-induced repaint fires post-settle.
+          (emit-render! :test/main render-key)
+
+          (let [stale  (epoch-by-id :test/main stale-epoch)
+                target (epoch-by-id :test/main target-epoch)]
+            (is (not (contains? (rendered-view-ids stale) :counter-view))
+                "rf2-arzb9o — the repaint did NOT back-fill into the stale newer
+                 epoch, even though that epoch carries value-change evidence")
+            (is (contains? (rendered-view-ids target) :counter-view)
+                "the repaint attributes to the restored-target epoch — the
+                 anchor-bounded scan hits the target, not the stale newer
+                 epoch")))))))
+
+(deftest inv-9-post-restore-render-not-absorbed-by-stale-dedup
+  (testing "rf2-arzb9o (case a) — when the STALE newer epoch ALSO already holds a
+            render row for the view, the pre-fix scan resolves the post-restore
+            repaint to the stale epoch and the de-dup arm SILENTLY ABSORBS it
+            (target gets nothing). The anchor bound must resolve to the target
+            so the repaint is recorded there."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
+
+    (let [render-key [:counter-view 0]]
+      (rf/dispatch-sync [:seed]        {:frame :test/main})
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})   ;; counter 1 — target
+      (let [target-epoch (last-epoch :test/main)]
+        ;; value-change evidence + learned read-set into the TARGET, so the
+        ;; anchor-bounded scan hits the target directly (never falling through to
+        ;; the mount-epoch, which the pre-restore render below pins to stale).
+        (emit-mount-sub-run! :test/main :counter render-key 0 1)
+
+        (rf/dispatch-sync [:counter-inc] {:frame :test/main}) ;; counter 2 — stale
+        (let [stale-epoch (last-epoch :test/main)]
+          (emit-sub-run! :test/main :counter 1 2)             ;; value-change into stale
+          ;; A pre-restore repaint lands in the stale (then-newest) epoch, seeding
+          ;; a :renders row there — so the POST-restore repaint hits the de-dup
+          ;; arm (`render-key-already-in-epoch?` on the stale epoch).
+          (emit-render! :test/main render-key)
+
+          (is (contains? (rendered-view-ids (epoch-by-id :test/main stale-epoch))
+                         :counter-view)
+              "premise — the stale epoch already carries a render row for the
+               view (arms the de-dup absorb path)")
+
+          (is (true? (rf/restore-epoch! :test/main (:epoch-id target-epoch))))
+
+          ;; The restore-induced repaint fires post-settle.
+          (emit-render! :test/main render-key)
+
+          (let [target (epoch-by-id :test/main target-epoch)]
+            (is (contains? (rendered-view-ids target) :counter-view)
+                "rf2-arzb9o — the repaint attributes to the restored-target
+                 epoch; pre-fix the scan resolved to the stale newer epoch and
+                 the de-dup arm silently absorbed the repaint (target got
+                 nothing)")))))))
+
 ;; ===========================================================================
 ;; rf2-qh13yf — back-fill splice is SNAPSHOT-CONSISTENT under interleaved
 ;;               eviction at ring cap

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2492,7 +2492,9 @@
       ;; new-keep = 3 → the index bound would be lo = (- 8 3) = 5, skipping
       ;; idx 2 even though it still carries :trace-events.
       (reset! @#'state/config {:depth 50 :trace-events-keep 3 :redact-fn nil})
-      (is (= :e2 (@#'state/value-changed-epoch-for frame-id render-key))
+      ;; Anchor at the ring-newest epoch (:e7) so the scan runs the full
+      ;; newest-first walk — the anchor bound (rf2-arzb9o) is a no-op here.
+      (is (= :e2 (@#'state/value-changed-epoch-for frame-id render-key :e7))
           "the scan reaches the still-trace-bearing value-change at idx 2,
            below (- n new-keep) = 5 — the post-reduction transient gap"))))
 
@@ -2514,7 +2516,8 @@
           ]
       (reset! @#'state/histories {frame-id history})
       (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-      (is (nil? (@#'state/value-changed-epoch-for frame-id render-key))
+      ;; Anchor at the ring-newest epoch (:e4) — full newest-first scan.
+      (is (nil? (@#'state/value-changed-epoch-for frame-id render-key :e4))
           "the elided record carries no evidence the attribution scan can match"))))
 
 ;; ---- restore-epoch! reactive surfaces -------------------------------------


### PR DESCRIPTION
## What

`perform-restore!` re-anchors `last-settled-epoch` at the restored (older) epoch but does **not** truncate the ring, so newer pre-restore epochs survive a rewind. `value-changed-epoch-for` scanned the **whole** ring newest-first with no anchor bound, matching by the view's learned read-set / render-key against retained `:sub-runs`. In a real substrate the stale newer epochs carry value-changed sub-run evidence for a repainted view, so the scan returned a **stale newer epoch** instead of the restored target — overriding the rf2-w4q9gt re-anchor:

- **case (b)** stale epoch has no prior `:renders` row for the view → the repaint is back-filled **into** the stale epoch (the exact corruption inv-9 claims fixed);
- **case (a)** stale epoch already holds a `:renders` row → the de-dup arm **skips** the back-fill → the repaint is silently absorbed (restored target gets nothing).

## Fix

Bound the value-changed scan at the last-settled anchor index (`resolve-render-epoch` passes `default-epoch-id` through). Records newer than the anchor exist **only** after a restore rewind. In normal operation the anchor **is** the ring-newest record, so the start index is `(dec n)` and behaviour is unchanged; a nil / evicted anchor degrades to the ring-newest index (no bound to apply).

## Tests

Adds two adversarial regressions under inv-9 that seed value-changed sub-run evidence into the **stale** newer epoch — the premise the existing inv-9 tests lacked (which is why they passed vacuously on this path). Both **fail** on the pre-fix unbounded scan and **pass** after the bound. The two direct `value-changed-epoch-for` unit tests are updated for the new 3-arg signature (anchor = ring-newest epoch, preserving their full-scan intent).

## Quality gates

- `clojure -M:test` (implementation/epoch): **386 tests, 2408 assertions, 0 failures, 0 errors** — inv-9 + restore suites green.
- `npm run test:cljs` (implementation): **8540 tests, 40272 assertions, 0 failures, 0 errors**.
- Premise check: with the bound disabled, both new tests fail (case b: render corrupted into stale + target empty; case a: target empty via silent de-dup absorb) while the existing `inv-9-restore-induced-render-does-not-backfill-into-stale-epoch` stayed green — confirming the vacuity gap.