### PR TITLE
test(uix): add use-resource-lease StrictMode double-mount balance twin (rf2-k32p16)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_resource_lease_dom_cljs_test.cljs
@@ -142,3 +142,70 @@
                       (fn []
                         (is (= 1 (count @releases)) "release fired on unmount")
                         (done)))))))))))))
+
+;; ---- StrictMode double-mount (rf2-ui5ahy) ---------------------------------
+;;
+;; use-resource-lease is an EFFECT-driven mount-lifecycle hook (ensure on
+;; setup, release on cleanup) — the seam React's dev double-invoke stresses
+;; most. React 18/19's default dev scaffold wraps the tree in
+;; `React.StrictMode`, which double-invokes the mount effect
+;; (setup → cleanup → setup). The lease token is minted ONCE per instance via
+;; `useRef` (re-frame.adapter.resource-lease), so it must be STABLE across the
+;; double-invoke: the mount cycle emits ensure(T) → release(T) → ensure(T)
+;; (net one held lease T), and unmount emits release(T) (net zero) — ALL under
+;; the SAME lease token. A per-invoke token (the regression this pins) would
+;; leak a second, never-released lease: two distinct tokens and an unbalanced
+;; ledger. Mirrors the use-subscribe StrictMode refcount-balance gate
+;; (rf2-nymuy); use-resource-lease is at least as effect-centric.
+
+(deftest use-resource-lease-strictmode-double-mount-balances
+  (testing "UIx — use-resource-lease under React.StrictMode: ONE stable lease token across the dev double-invoke; balanced ensure/release ledger (rf2-ui5ahy)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (install-spies!)
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                ;; Mount ProbeLease wrapped in React.StrictMode — the mount
+                ;; effect double-invokes setup → cleanup → setup.
+                (act-fn
+                  (fn []
+                    (.render root
+                      (React/createElement
+                        (.-StrictMode React) nil
+                        ($ uix-adapter/frame-provider {:frame lease-frame}
+                           ($ ProbeLease))))))
+                (after-drain
+                  (fn []
+                    ;; StrictMode double-invoked the mount effect: the setup
+                    ;; ran on mount AND again after the dev cleanup.
+                    (is (<= 2 (count @ensures))
+                        (str "StrictMode double-invoked the mount effect (ensure on mount + remount) — got "
+                             (count @ensures) " ensures"))
+                    ;; The crux: the useRef-minted lease token is STABLE across
+                    ;; the double-invoke — exactly ONE distinct lease owner.
+                    ;; A per-invoke token would show two distinct owners here.
+                    (is (= 1 (count (distinct (map :owner @ensures))))
+                        (str "exactly ONE distinct lease token across all ensures — the useRef token survived StrictMode's mount→cleanup→mount; owners="
+                             (pr-str (distinct (map :owner @ensures)))))
+                    ;; net one held lease after the mount cycle settles
+                    ;; (ensure → release → ensure).
+                    (is (= 1 (- (count @ensures) (count @releases)))
+                        (str "net one held lease after the mount double-invoke settles — ensures="
+                             (count @ensures) " releases=" (count @releases)))
+                    (act-fn (fn [] (.unmount root)))
+                    (after-drain
+                      (fn []
+                        ;; Fully balanced after unmount — no leaked lease.
+                        (is (= (count @ensures) (count @releases))
+                            (str "ensure/release ledger balanced after unmount (no leaked lease) — ensures="
+                                 (count @ensures) " releases=" (count @releases)))
+                        (is (= (set (map :owner @ensures))
+                               (set (map :owner @releases)))
+                            "every ensured lease token was released — the SAME stable token acquired was dropped")
+                        (done)))))))))))))


### PR DESCRIPTION
## What

Adds the missing UIx twin of the `use-resource-lease` StrictMode double-mount balance test. The test landed Helix-only (rf2-ui5ahy / PR #5383); a deftest-count sweep across all seven uix/helix twin pairs found this the ONLY asymmetry (use_resource_lease uix=2 helix=3; every other pair symmetric).

## Why

Both adapters re-export the ONE shared hook `re-frame.adapter.resource-lease/use-resource-lease` (raw React `useRef` + `useEffect`, no substrate-specific effect wrappers). So today the StrictMode-stable-token failure path is exercised once through the Helix twin only; residual exposure is a future UIx-side wrapper change regressing the StrictMode lease balance unobserved. rf2-ui5ahy's text noted the fix ideally lands twinned. This closes the twin drift so both adapters pin the same invariant.

## What the test pins

Under `React.StrictMode` the mount effect double-invokes (setup -> cleanup -> setup). The lease token is minted ONCE per instance via `useRef`, so it must be STABLE across the double-invoke:
- exactly ONE distinct lease owner across all ensures (a per-invoke token regression would leak a second, never-released lease),
- net one held lease after the mount cycle settles (ensure -> release -> ensure),
- a fully balanced ensure/release ledger after unmount (no leaked lease), with the same owner set on both sides.

Byte-parallel to the Helix twin modulo substrate naming (`uix-adapter/frame-provider`, `UIx —` testing label). Browser-only; self-gates on `(browser?)` under `:node-test`.

## Test only

No production source touched.

## Quality gates

- `clojure -M:test` (implementation/adapters/uix classpath probe): 0 tests, 0 failures, 0 errors — CLJS-only artefact, JVM probe confirms classpath resolves.
- `npm run test:cljs` (node): 8541 tests, 40273 assertions, 0 failures, 0 errors — new test compiles into the node build and no-ops under `:node-test` (no DOM).
- `npm run test:browser` (Playwright): 258 tests, 871 assertions, 0 failures, 0 errors — the new deftest is compiled into `uix_use_resource_lease_dom_cljs_test.js` and executes in-browser where `(browser?)` is true, so the StrictMode balance assertions genuinely run (not vacuous).

Closes rf2-k32p16.