### PR TITLE
fix(core/spine): use-subscribe serves the new target on query-v/frame change (rf2-naz09e)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -52,6 +52,14 @@
 (def ^:private probe-frame-provider-observed (atom []))
 (def ^:private refcount-target               (atom nil))
 (def ^:private stable-deps-set-tick          (atom nil))
+;; rf2-naz09e key-change probe side-channels: the child reads its (frame,
+;; query-v) from these atoms (2-arg explicit-pin use-subscribe) and records
+;; every use-subscribe return; the parent stashes its set-tick here so the
+;; suite can swap the target on the MOUNTED child and force a re-render.
+(def ^:private key-change-set-tick           (atom nil))
+(def ^:private key-change-frame              (atom nil))
+(def ^:private key-change-query              (atom nil))
+(def ^:private key-change-observed           (atom []))
 
 (defnc Probe []
   (let [target @refcount-target
@@ -165,6 +173,28 @@
     (d/div {:data-tick tick}
            ($ ProbeStableDepsChild))))
 
+;; ---- key-change probes (rf2-naz09e) ---------------------------------------
+;; A child that reads its (frame, query-v) from side-channel atoms via the
+;; 2-arg explicit-pin use-subscribe and records every observed value, under a
+;; parent that owns a tick + stashes its set-tick. The suite swaps the atoms
+;; and bumps the tick to change the subscription target on the MOUNTED child.
+
+(defnc ProbeKeyChangeChild []
+  (let [fr @key-change-frame
+        qv @key-change-query
+        v  (helix-adapter/use-subscribe fr qv)]
+    (swap! key-change-observed conj v)
+    (d/div (str "v=" v))))
+
+(defnc ProbeKeyChangeParent []
+  (let [[tick set-tick] (helix-hooks/use-state 0)]
+    (helix-hooks/use-effect
+      []
+      (reset! key-change-set-tick set-tick)
+      (fn cleanup [] nil))
+    (d/div {:data-tick tick}
+           ($ ProbeKeyChangeChild))))
+
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
 (def ^:private cfg
@@ -221,6 +251,16 @@
    :stable-deps-set-tick  stable-deps-set-tick
    :stable-deps-frame     :rf.helix-stable-deps/probe-frame
    :stable-deps-query     :rf.helix-stable-deps/p
+   ;; rf2-naz09e — key-change serves the NEW target
+   :probe-key-change-element (fn [] ($ ProbeKeyChangeParent))
+   :key-change-set-tick   key-change-set-tick
+   :key-change-frame      key-change-frame
+   :key-change-query      key-change-query
+   :key-change-observed   key-change-observed
+   :kc-frame              :rf.helix-key-change/frame-a
+   :kc-frame2             :rf.helix-key-change/frame-b
+   :kc-query-a            :rf.helix-key-change/qa
+   :kc-query-b            :rf.helix-key-change/qb
    ;; rf2-40a84 — flush-render! synchronous-commit proof. Reuses the Probe
    ;; (reads :refcount-target for its frame, queries :rf.helix-use-subscribe-test/n)
    ;; under a fresh isolated frame so it can't collide with the use-subscribe
@@ -288,6 +328,13 @@
 ;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
 (deftest use-subscribe-getsnapshot-tracks-committed-reaction
   (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+
+;; rf2-naz09e — a query-v / frame change on a MOUNTED component must render the
+;; NEW target's value on the change-commit (parity with Reagent's in-render
+;; recompute), never the previous target's. Value + object-identity proof, plus
+;; a stable-key control (no over-invalidation).
+(deftest use-subscribe-key-change-serves-new-target
+  (suite/assert-use-subscribe-key-change-serves-new-target cfg))
 
 ;; rf2-40a84 — flush-render! synchronously commits a pending render (the
 ;; proof the pair-MCP headless dispatch→render loop depends on).

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -49,6 +49,14 @@
 (def ^:private probe-frame-provider-observed (atom []))
 (def ^:private refcount-target               (atom nil))
 (def ^:private stable-deps-set-tick          (atom nil))
+;; rf2-naz09e key-change probe side-channels: the child reads its (frame,
+;; query-v) from these atoms (2-arg explicit-pin use-subscribe) and records
+;; every use-subscribe return; the parent stashes its set-tick here so the
+;; suite can swap the target on the MOUNTED child and force a re-render.
+(def ^:private key-change-set-tick           (atom nil))
+(def ^:private key-change-frame              (atom nil))
+(def ^:private key-change-query              (atom nil))
+(def ^:private key-change-observed           (atom []))
 
 (defui Probe []
   (let [target @refcount-target
@@ -163,6 +171,27 @@
     ($ :div {:data-tick tick}
        ($ ProbeStableDepsChild))))
 
+;; ---- key-change probes (rf2-naz09e) ---------------------------------------
+;; A child that reads its (frame, query-v) from side-channel atoms via the
+;; 2-arg explicit-pin use-subscribe and records every observed value, under a
+;; parent that owns a tick + stashes its set-tick. The suite swaps the atoms
+;; and bumps the tick to change the subscription target on the MOUNTED child.
+
+(defui ProbeKeyChangeChild []
+  (let [fr @key-change-frame
+        qv @key-change-query
+        v  (uix-adapter/use-subscribe fr qv)]
+    (swap! key-change-observed conj v)
+    ($ :div (str "v=" v))))
+
+(defui ProbeKeyChangeParent []
+  (let [[tick set-tick] (uix/use-state 0)]
+    (uix/use-effect
+      (fn [] (reset! key-change-set-tick set-tick) js/undefined)
+      [])
+    ($ :div {:data-tick tick}
+       ($ ProbeKeyChangeChild))))
+
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
 (def ^:private cfg
@@ -219,6 +248,16 @@
    :stable-deps-set-tick  stable-deps-set-tick
    :stable-deps-frame     :rf.uix-stable-deps/probe-frame
    :stable-deps-query     :rf.uix-stable-deps/p
+   ;; rf2-naz09e — key-change serves the NEW target
+   :probe-key-change-element (fn [] (uix/$ ProbeKeyChangeParent))
+   :key-change-set-tick   key-change-set-tick
+   :key-change-frame      key-change-frame
+   :key-change-query      key-change-query
+   :key-change-observed   key-change-observed
+   :kc-frame              :rf.uix-key-change/frame-a
+   :kc-frame2             :rf.uix-key-change/frame-b
+   :kc-query-a            :rf.uix-key-change/qa
+   :kc-query-b            :rf.uix-key-change/qb
    ;; rf2-40a84 — flush-render! synchronous-commit proof. Reuses the Probe
    ;; (reads :refcount-target for its frame, queries :rf.uix-use-subscribe-test/n)
    ;; under a fresh isolated frame so it can't collide with the use-subscribe
@@ -286,6 +325,13 @@
 ;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
 (deftest use-subscribe-getsnapshot-tracks-committed-reaction
   (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+
+;; rf2-naz09e — a query-v / frame change on a MOUNTED component must render the
+;; NEW target's value on the change-commit (parity with Reagent's in-render
+;; recompute), never the previous target's. Value + object-identity proof, plus
+;; a stable-key control (no over-invalidation).
+(deftest use-subscribe-key-change-serves-new-target
+  (suite/assert-use-subscribe-key-change-serves-new-target cfg))
 
 ;; rf2-40a84 — flush-render! synchronously commits a pending render (the
 ;; proof the pair-MCP headless dispatch→render loop depends on).

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1657,6 +1657,13 @@
                 ;; committed reaction stored here once `subscribe-fn` has run
                 ;; (post-commit), falling back to the render-phase handle only
                 ;; for the very first pre-commit snapshot.
+                ;;
+                ;; rf2-naz09e: the ref stores the committed reaction KEY-TAGGED
+                ;; as `#js [stable-key committed]` (see `subscribe-fn` and
+                ;; `get-snap` below) so a query-v/frame change on a mounted
+                ;; component can't serve the PREVIOUS target's value for the
+                ;; change-commit — `get-snap` reads the tag only while it
+                ;; matches the current render's key.
                 committed-ref (React/useRef nil)
                 stable-key
                 (let [prev (.-current key-ref)
@@ -1745,15 +1752,42 @@
                 ;; value `=` the render-phase one (rf2-cmfln), so the source
                 ;; swap is tear-free.
                 ;;
-                ;; Deps include `reaction` so the pre-commit fallback never
-                ;; closes over a stale (perf-discarded) render-phase handle;
-                ;; once `committed-ref` is populated post-commit, `get-snap`'s
-                ;; identity is irrelevant to correctness — React drives tear
-                ;; detection off the returned VALUE, and the committed source
-                ;; is read through the ref on every call.
+                ;; rf2-naz09e — the committed reaction is stored KEY-TAGGED as
+                ;; `#js [stable-key committed]`, and `get-snap` reads it ONLY
+                ;; when the stored key is `identical?` the CURRENT render's
+                ;; `stable-key`; otherwise it falls back to the render-phase
+                ;; handle. This closes the KEY-CHANGE window. When query-v /
+                ;; frame change on a mounted component, `committed-ref`
+                ;; transiently still holds the PREVIOUS target's reaction — the
+                ;; old `subscribe-fn`'s ref-clearing cleanup is a passive effect
+                ;; that runs AFTER this render commits, and the NEW
+                ;; `subscribe-fn` that repopulates the ref also runs
+                ;; post-commit. Without the key guard `get-snap` would serve the
+                ;; OLD target's value for the change-commit — a torn commit (old
+                ;; data under the new query args) that any same-commit
+                ;; layout-effect / ref read deterministically observes and which
+                ;; under a transition lane can paint before the passive-phase
+                ;; store-consistency check forces a corrective re-render. The
+                ;; render-phase `reaction` memo is keyed on `#js [stable-key]`,
+                ;; so on a key change it already holds the NEW target: the
+                ;; fallback serves the NEW value for that very commit, matching
+                ;; the Reagent substrate's in-render recompute (no tear). The
+                ;; earlier claim — "once committed-ref is populated post-commit,
+                ;; get-snap's identity is irrelevant to correctness" — was
+                ;; UNTRUE across a key change: committed-ref points at the WRONG
+                ;; (old) reaction until the passive cleanup runs.
+                ;;
+                ;; Deps include `reaction` so the fallback path always closes
+                ;; over the CURRENT render's handle — both the pre-commit first
+                ;; snapshot AND the key-change render — never a stale
+                ;; perf-discarded one.
                 get-snap
                 (use-callback (fn []
-                                (let [r (or (.-current committed-ref) reaction)]
+                                (let [stored (.-current committed-ref)
+                                      r (if (and stored
+                                                 (identical? (aget stored 0) stable-key))
+                                          (aget stored 1)
+                                          reaction)]
                                   (when r @r)))
                               #js [stable-key reaction])
                 ;; The store-subscribe fn — React's COMMIT-OWNED acquire/release
@@ -1787,11 +1821,17 @@
                     ;; reaction is the live cached one and `=` (often identical)
                     ;; to the render-phase handle `reaction`.
                     (let [committed (subs/subscribe stable-query-v {:frame stable-frame-kw})]
-                      ;; rf2-sqhjtu: publish the durable committed reaction so
-                      ;; `get-snap` derefs THIS live handle (source watches +
+                      ;; rf2-sqhjtu / rf2-naz09e: publish the durable committed
+                      ;; reaction KEY-TAGGED with this invocation's `stable-key`
+                      ;; so `get-snap` derefs THIS live handle (source watches +
                       ;; current sub body) rather than the disposed render-phase
-                      ;; one. Set post-commit (here), cleared on teardown below.
-                      (set! (.-current committed-ref) committed)
+                      ;; one — but ONLY while the current render's key matches
+                      ;; the tag. Set post-commit (here), cleared on teardown
+                      ;; below. The key tag is what lets `get-snap` reject a
+                      ;; stale committed reaction across a query-v / frame
+                      ;; change (the change-commit reads the render-phase handle
+                      ;; for the NEW target instead).
+                      (set! (.-current committed-ref) #js [stable-key committed])
                       ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
                       ;; closed over by the returned cleanup. The key MUST
                       ;; NOT derive from `(hash reaction)`: subscriptions are
@@ -1813,15 +1853,18 @@
                           (add-watch committed k (fn [_ _ _ _] (on-change))))
                         (fn unsubscribe []
                           (when committed (remove-watch committed k))
-                          ;; rf2-sqhjtu: clear the published committed reaction,
-                          ;; but ONLY if it still points at THIS invocation's
-                          ;; handle. A later `subscribe-fn` re-acquire (e.g. a
-                          ;; subscribe-identity change) may have already
-                          ;; overwritten `committed-ref` with the NEW committed
-                          ;; reaction before this older cleanup runs; clobbering
-                          ;; it to nil would strand `get-snap` on the fallback.
-                          (when (identical? (.-current committed-ref) committed)
-                            (set! (.-current committed-ref) nil))
+                          ;; rf2-sqhjtu / rf2-naz09e: clear the published
+                          ;; committed reaction, but ONLY if it still holds THIS
+                          ;; invocation's handle (compare the tagged reaction at
+                          ;; index 1). A later `subscribe-fn` re-acquire (e.g. a
+                          ;; subscribe-identity / key change) may have already
+                          ;; overwritten `committed-ref` with the NEW tagged
+                          ;; committed reaction before this older cleanup runs;
+                          ;; clobbering it to nil would strand `get-snap` on the
+                          ;; fallback.
+                          (let [stored (.-current committed-ref)]
+                            (when (and stored (identical? (aget stored 1) committed))
+                              (set! (.-current committed-ref) nil)))
                           ;; Release the durable committed ref — symmetric with
                           ;; the `subs/subscribe` above. Runs on unmount /
                           ;; key change / teardown.

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -4108,6 +4108,184 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+;; ---- key-change serves the NEW target (rf2-naz09e) ------------------------
+;;
+;; THE BUG (UIx + Helix shared spine only — Reagent recomputes in-render and
+;; never tears; a cross-substrate correctness divergence). When query-v (or the
+;; resolved frame) changes to a DIFFERENT subscription target on a MOUNTED
+;; use-subscribe component, the pre-fix spine served the PREVIOUS target's value
+;; for the change-commit:
+;;
+;;   • render — stable-key recomputes to a fresh #js object; the
+;;     `[stable-key]`-keyed reaction memo re-runs to the NEW target; get-snap +
+;;     subscribe-fn take new identities.
+;;   • but committed-ref.current STILL holds the OLD committed reaction — the old
+;;     subscribe-fn's ref-clearing cleanup AND the new subscribe-fn that
+;;     repopulates the ref are BOTH post-commit effects.
+;;   • the pre-fix get-snap `(or committed-ref reaction)` therefore returned the
+;;     OLD reaction's value; useSyncExternalStore committed it (it equals the
+;;     prior snapshot, so nothing flags a tear) → ONE commit renders the OLD
+;;     target's value under the NEW query args. The passive-phase store-
+;;     consistency check then forces a corrective re-render — so the tear self-
+;;     heals, but the torn commit is real (a same-commit layout-effect / ref read
+;;     observes it; a transition lane can paint it).
+;;
+;; The fix key-tags committed-ref as `#js [stable-key committed]` and has
+;; get-snap read it ONLY while the tag matches the current render's key — so the
+;; change-commit falls back to the render-phase handle (the NEW target),
+;; matching Reagent's in-render recompute.
+;;
+;; TWO PROOFS (both FAIL on the pre-fix spine, PASS after) + a control:
+;;   (1) VALUE — the child records use-subscribe's return every render; the FIRST
+;;       render after the key change already shows the NEW value and the OLD value
+;;       never reappears. (Deterministic here: the two targets hold DISTINCT
+;;       values, unlike rf2-sqhjtu where both handles deref the same value.)
+;;   (2) OBJECT IDENTITY — a subs/subscribe spy tags reactions by generation (the
+;;       rf2-sqhjtu deref-recording proxy); no get-snap deref after the change
+;;       hits the OLD target's committed generation.
+;;   CONTROL — a re-render with an UNCHANGED query-v keeps serving the committed
+;;   reaction (value stable, ref-count still 1: no over-invalidation / no churn).
+
+(defn assert-use-subscribe-key-change-serves-new-target
+  "rf2-naz09e: a query-v / frame change on a mounted use-subscribe probe must
+  render the NEW target's value on the change-commit (parity with Reagent's
+  in-render recompute), never the previous target's. Value proof + object-
+  identity deref proof; plus a stable-key control (no over-invalidation).
+
+  cfg keys:
+    :probe-key-change-element  thunk -> parent element. The parent owns a
+                               use-state tick and stashes its set-tick into
+                               :key-change-set-tick; the child reads the
+                               :key-change-frame / :key-change-query atoms (2-arg
+                               explicit-pin use-subscribe) and records each
+                               use-subscribe return into :key-change-observed.
+    :key-change-set-tick :key-change-frame :key-change-query :key-change-observed
+    :kc-frame :kc-frame2 :kc-query-a :kc-query-b"
+  [{:keys [name probe-key-change-element key-change-set-tick
+           key-change-frame key-change-query key-change-observed
+           kc-frame kc-frame2 kc-query-a kc-query-b]}]
+  (testing (str name " — use-subscribe serves the NEW target on a query-v / frame change (rf2-naz09e)")
+    (with-browser-act
+     (fn [act-fn]
+      ;; Two frames; kc-query-a / kc-query-b read DISTINCT db keys so every
+      ;; (frame, query) target carries a distinct value.
+      (rf/reg-frame kc-frame  {:doc "rf2-naz09e key-change probe frame A"})
+      (rf/reg-frame kc-frame2 {:doc "rf2-naz09e key-change probe frame B"})
+      (rf/reg-event ::kc-seed-a (fn [_ _] {:db {:va "A"   :vb "B"}}))
+      (rf/reg-event ::kc-seed-b (fn [_ _] {:db {:va "FA2" :vb "FB2"}}))
+      (rf/dispatch-sync [::kc-seed-a] {:frame kc-frame})
+      (rf/dispatch-sync [::kc-seed-b] {:frame kc-frame2})
+      (rf/reg-sub kc-query-a (fn [db _] (:va db)))
+      (rf/reg-sub kc-query-b (fn [db _] (:vb db)))
+      ;; ---- deref-recording subscribe spy (object-identity proof) -----------
+      (let [real-subscribe subs/subscribe
+            gen-counter    (atom 0)
+            real->gen      (atom {})
+            deref-log      (atom [])
+            gen-of         (fn [real]
+                             (or (get @real->gen real)
+                                 (let [g (swap! gen-counter inc)]
+                                   (swap! real->gen assoc real g)
+                                   g)))
+            wrap           (fn [real]
+                             (let [g (gen-of real)]
+                               (reify
+                                 IDeref
+                                 (-deref [_] (swap! deref-log conj g) @real)
+                                 IWatchable
+                                 (-add-watch [this k f]
+                                   (add-watch real k (fn [_ _ old nu] (f k this old nu)))
+                                   this)
+                                 (-remove-watch [_ k] (remove-watch real k) nil)
+                                 (-notify-watches [_ _o _n] nil))))]
+        (with-redefs [subs/subscribe
+                      (fn spy-subscribe
+                        ([query-v]      (wrap (real-subscribe query-v {:frame (frame/resolve-current-frame)})))
+                        ([query-v opts] (wrap (real-subscribe query-v opts))))]
+          ;; ============ PHASE 1 — QUERY-V change (frame fixed) =============
+          (reset! key-change-frame kc-frame)
+          (reset! key-change-query [kc-query-a])
+          (reset! key-change-observed [])
+          (let [cache      (:sub-cache (frame/frame kc-frame))
+                mount-node (make-mount-node!)
+                root       (react-dom-client/createRoot mount-node)]
+            (try
+              (act-fn (fn [] (.render root (probe-key-change-element))))
+              (is (= "A" (last @key-change-observed))
+                  "precondition: mounted probe shows target-A's value")
+              (is (= "v=A" (.-textContent mount-node))
+                  "precondition: DOM shows target-A")
+              (let [committed-a     (get-in @cache [[kc-query-a] :reaction])
+                    committed-a-gen (get @real->gen committed-a)]
+                (is (some? committed-a-gen)
+                    "the committed target-A reaction was seen through the subscribe spy")
+                ;; ---- drive the QUERY-V change on the MOUNTED child ---------
+                (reset! deref-log [])
+                (reset! key-change-observed [])
+                (act-fn (fn []
+                          (reset! key-change-query [kc-query-b])
+                          (@key-change-set-tick inc)))
+                ;; VALUE proof.
+                (is (seq @key-change-observed)
+                    "the query-v change re-rendered the child")
+                (is (= "B" (first @key-change-observed))
+                    (str "the FIRST render after the query-v change already shows the "
+                         "NEW target (kc-query-b => \"B\"), not the previous target's "
+                         "\"A\". Observed " @key-change-observed))
+                (is (not (some #{"A"} @key-change-observed))
+                    (str "the OLD target's value \"A\" never appears after the query-v "
+                         "change. Observed " @key-change-observed))
+                (is (= "v=B" (.-textContent mount-node))
+                    "post-change DOM settles on target-B")
+                ;; OBJECT-IDENTITY proof: no get-snap deref after the change hit
+                ;; the OLD (target-A) committed reaction's generation.
+                (is (not (some #{committed-a-gen} @deref-log))
+                    (str "no get-snap deref after the query-v change hit the OLD "
+                         "target-A committed reaction (gen " committed-a-gen "). "
+                         "Observed gens " @deref-log)))
+              ;; ---- CONTROL: an UNCHANGED query-v keeps serving correctly ----
+              (reset! key-change-observed [])
+              (reset! deref-log [])
+              (act-fn (fn [] (@key-change-set-tick inc)))
+              (is (seq @key-change-observed)
+                  "the control re-render ran the child")
+              (is (every? #{"B"} @key-change-observed)
+                  (str "a re-render with an UNCHANGED query-v keeps serving the "
+                       "committed target-B value — no over-invalidation. Observed "
+                       @key-change-observed))
+              (is (= 1 (or (get-in @cache [[kc-query-b] :ref-count]) 0))
+                  "stable-key control holds exactly one durable ref (no re-subscribe churn)")
+              (finally
+                (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))
+          ;; ============ PHASE 2 — FRAME change (query-v fixed) =============
+          (reset! deref-log [])
+          (reset! key-change-frame kc-frame)
+          (reset! key-change-query [kc-query-a])
+          (reset! key-change-observed [])
+          (let [mount-node (make-mount-node!)
+                root       (react-dom-client/createRoot mount-node)]
+            (try
+              (act-fn (fn [] (.render root (probe-key-change-element))))
+              (is (= "A" (last @key-change-observed))
+                  "precondition: mounted probe shows frame-A's value")
+              (reset! key-change-observed [])
+              (act-fn (fn []
+                        (reset! key-change-frame kc-frame2)
+                        (@key-change-set-tick inc)))
+              (is (seq @key-change-observed)
+                  "the frame change re-rendered the child")
+              (is (= "FA2" (first @key-change-observed))
+                  (str "the FIRST render after the FRAME change already shows the NEW "
+                       "frame's value (frame-B => \"FA2\"), not frame-A's \"A\". "
+                       "Observed " @key-change-observed))
+              (is (not (some #{"A"} @key-change-observed))
+                  (str "frame-A's value \"A\" never appears after the frame change. "
+                       "Observed " @key-change-observed))
+              (is (= "v=FA2" (.-textContent mount-node))
+                  "post-change DOM settles on frame-B")
+              (finally
+                (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))))))))
+
 ;; ---- unsubscribe arity contract (rf2-gizlj) -------------------------------
 ;;
 ;; The shared spine's `use-subscribe` useEffect cleanup calls


### PR DESCRIPTION
## What

Closes **rf2-naz09e** (P2 correctness bug; cross-substrate divergence).

When `query-v` — or the resolved frame — changed to a **different** subscription target on a **mounted** `use-subscribe` component, the shared React-hook spine (UIx + Helix) served the **previous** target's value for that change-commit: a torn commit (old data under the new query args). The Reagent substrate has no such tear (it recomputes in-render), so this was a cross-substrate correctness divergence.

## Root cause

`implementation/core/src/re_frame/substrate/spine.cljs`, `use-subscribe-2`:

- On a key change, `stable-key` recomputes, the `#js [stable-key]`-keyed `reaction` memo re-runs to the NEW target, and `get-snap` / `subscribe-fn` take new identities.
- But `committed-ref.current` still holds the **OLD** committed reaction — the old `subscribe-fn`'s ref-clearing cleanup, and the new `subscribe-fn` that repopulates the ref, are **both post-commit effects**.
- The pre-fix `get-snap` `(or (.-current committed-ref) reaction)` therefore returned the OLD reaction's value. `useSyncExternalStore` committed it (it equalled the prior snapshot, so nothing flagged a tear) → one commit rendered the OLD target's value under the NEW query args. The passive-phase store-consistency check then forced a corrective re-render, so it self-heals — but the torn commit is real (a same-commit layout-effect / ref read observes it; a transition lane can paint it).

The prior `rf2-sqhjtu` docstring claim — "once `committed-ref` is populated post-commit, `get-snap`'s identity is irrelevant to correctness" — was untrue across a key change. Corrected in-place.

## Fix

Make `committed-ref` **key-aware**: store it as `#js [stable-key committed]`, and have `get-snap` read the tagged reaction **only while its key is `identical?` to the current render's `stable-key`**; otherwise it falls back to the render-phase `reaction` memo, which already holds the NEW target. The change-commit now serves the NEW value, matching Reagent's in-render recompute. The `subscribe-fn` cleanup guard now compares the tagged reaction (index 1). No new render-phase ref writes.

## Regression

`assert-use-subscribe-key-change-serves-new-target` in the shared React-adapter suite (wired into the UIx + Helix DOM twins) swaps `query-v` (and separately the frame) on a mounted probe and asserts the change-commit renders the NEW target's value:

- **Value proof** — the child records `use-subscribe`'s return every render; the first render after the change already shows the NEW value, and the OLD value never reappears.
- **Object-identity proof** — a `subs/subscribe` spy tags reactions by generation (rf2-sqhjtu style); no `get-snap` deref after the change hits the OLD target's committed generation.
- **Control** — a re-render with an unchanged `query-v` keeps serving the committed reaction (value stable, ref-count still 1: no over-invalidation). The control passes on both the buggy and fixed spine, confirming it is a proper control.

Verified fail-before / pass-after on the browser runner (headless Chromium):
- Pre-fix: both twins FAIL — query-v `Observed ["A" "B"]` (torn "A" then corrective "B"); frame `Observed ["A" "FA2"]`; deref-log hit the old committed gen.
- Post-fix: **259 tests / 898 assertions, 0 failures**.

## Gates

- `clojure -M:test` (implementation/core): 1776 tests / 7778 assertions, 0/0.
- `npm run test:cljs`: 8542 tests / 40274 assertions, 0/0.
- `npm run test:browser` (with fix): 259 tests / 898 assertions, 0/0.