### PR TITLE
fix(reagent-slim): stringify nested keyword styles, real fn-component for :f>, lifecycle/hygiene parity (rf2-fdm4rm, rf2-bf4uw2, rf2-mdgt8t)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -699,11 +699,13 @@ as-element
 | `:>` | React component interop | `(apply React.createElement (second hiccup) (convert-props (third hiccup)) children)` |
 | `:<>` | React Fragment | `(apply React.createElement React.Fragment ...)` |
 | `:r>` | raw `React.createElement` | identity passthrough; `make-element` |
-| `:f>` | function-component dispatch | `(apply React.createElement (fn-to-class (second hiccup)) ...)` |
+| `:f>` | function-component dispatch | `React.createElement` on a cached **function-component** wrapper for `(second hiccup)` (via `as-fn-component`) — NOT `fn-to-class`; the wrapper calls the fn with the user args and `as-element`s its hiccup return |
 | user CLJS fn | reagent component | wrapped in a class via `fn-to-class` |
 | reagent class | reagent component | passed through |
 
 The dispatch is small and concrete. Stage 4 references `reagent.impl.template:vec-to-elem` for the canonical shape and re-implements without the compiler-customisation indirection (Stage 1 §2.4 + Stage 2 §2.2).
+
+`:f>` deliberately renders a **real React function component** (rf2-bf4uw2): the head's defining purpose is to let React hooks (`useState`, `useEffect`, …) run inside the fn, which requires a function component — calling a hook during a class render throws `Invalid hook call`. The wrapper is cached on the fn (`.-cljsFnComponent`) so repeated renders reuse one component type (stable reconciliation). Reactivity boundary: a function component does NOT get the class path's bare-RAtom-deref capture; it sources reactive state through `useSyncExternalStore`-shaped subscription hooks (§4.7), the same as the UIx / Helix substrates — `:f>` is the escape hatch to React hooks.
 
 ### §7.2 Target-aware `convert-prop-value`
 

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -60,7 +60,10 @@
   "Flush pending slim renders synchronously. Wraps React's act() —
   intended for test code only. Calls (act (fn [] (batching/flush!)));
   with `f`, runs `f` then the synchronous render drain inside act.
-  Returns nil. No-op when act() is unreachable in the current React build.
+  Returns nil. When act() is unreachable in the current React build it
+  degrades to a plain synchronous flush (still runs `f` and drains the
+  render queue), so a `:node-test` runner with no real React render path
+  still flushes.
   The promise-returning `reagent2.dom.client/flush-views!` remains available
   when callers need deterministic Suspense ordering."
   (:flush-views! spine-fns))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -397,6 +397,14 @@
       (set! (.-componentWillUnmount proto)
             (fn []
               (this-as ^js this
+                ;; Clear the dirty flag on unmount (rf2-mdgt8t (a)). A
+                ;; component queued via batching/queue-render! (which sets
+                ;; cljsIsDirty) and THEN unmounted would otherwise stay
+                ;; dirty, so the next flush-render drain sees (dirty? c)
+                ;; true and calls forceUpdate on the unmounted instance —
+                ;; a React no-op on 18+/19 but a stock-parity gap and free
+                ;; churn (stock clears the flag on unmount).
+                (batching/mark-rendered this)
                 (when-some [rea (.-cljsRenderRea this)]
                   (ratom/dispose! rea)
                   (set! (.-cljsRenderRea this) nil))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -784,20 +784,64 @@
       (set! (.-key js-props) key))
     (make-element argv component js-props 3)))
 
+(defn- as-fn-component
+  "Wrap a plain CLJS render fn `f` as a REAL React FUNCTION component so
+  React hooks called inside `f` (`useState`, `useEffect`, `useRef`, …)
+  run in a valid hooks context — the DEFINING purpose of the `:f>` head,
+  and the whole reason it exists distinct from the class-wrapping user-fn
+  path.
+
+  The reagent argv travels through React props as `__rfArgv`; the wrapper
+  calls `f` with the user args (the argv tail) and converts the returned
+  hiccup (or an already-built React element, which passes through) via
+  `as-element`. The wrapper is a plain JS function, so React treats it as
+  a function component and the hooks dispatcher is installed for `f`'s
+  body.
+
+  Cached on `f` as `.-cljsFnComponent` so repeated renders reuse ONE
+  component type — a fresh wrapper per render would give React a new type
+  identity every time and force a remount (losing hook + DOM state).
+
+  Reactivity boundary (deliberate, per IMPL-SPEC §4.7 + §7.1): unlike the
+  class path (Form-1/2/3, which runs render inside a Reaction that captures
+  bare RAtom derefs), a function component does NOT get bare-deref capture.
+  Function components source reactive state through `useSyncExternalStore`-
+  shaped subscription hooks — `:f>` is the escape hatch TO React hooks, so
+  use a subscription hook for reactivity inside it. This mirrors how the
+  UIx / Helix substrates consume subscriptions."
+  [f]
+  (or (.-cljsFnComponent ^js f)
+      (let [wrapper (fn [^js props]
+                      (as-element (apply f (rest (.-__rfArgv props)))))]
+        (set! (.-displayName wrapper)
+              (or (some-> ^js f .-displayName)
+                  (some-> ^js f .-name)
+                  "reagent-fn-component"))
+        (set! (.-cljsFnComponent ^js f) wrapper)
+        wrapper)))
+
 (defn- function-element
   "Emit `:f>` — function-component dispatch.
-  `[:f> some-fn args...]` wraps `some-fn` via `fn-to-class` so that
-  Reagent-shaped reactivity (deref-capture) wires through. We treat
-  this identically to `react-component-element` because all our user
-  fns reach the renderer via fn-to-class."
+  `[:f> some-fn args...]` renders `some-fn` as a REAL React FUNCTION
+  component (via `as-fn-component`), NOT a class — so React hooks work
+  inside it (rf2-bf4uw2). The prior `fn-to-class` lowering produced a
+  React class, and calling a hook during class render throws
+  'Invalid hook call', silently defeating the head's defining purpose.
+
+  The user args (`[:f> f a b]` → `[a b]`) travel through React props as
+  `__rfArgv` (head-included, matching the class path's convention). The
+  original vector's `:key` meta / props-map `:key` is honoured via
+  `get-react-key` so React keys flow."
   [argv]
-  (let [component (nth argv 1 nil)
-        ;; Reconstruct the argv as if the fn were the head:
-        ;; [head & user-args] becomes [some-fn & user-args].
-        ;; Preserve the original argv's :key meta so React keys flow.
-        synth-argv (with-meta (into [component] (subvec argv 2))
-                              (meta argv))]
-    (react-component-element component synth-argv)))
+  (let [f          (nth argv 1 nil)
+        component  (as-fn-component f)
+        ;; [head & user-args] as [f & user-args] — as-fn-component's
+        ;; wrapper drops the head with (rest __rfArgv) before applying f.
+        synth-argv (with-meta (into [f] (subvec argv 2)) (meta argv))
+        js-props   #js {:__rfArgv synth-argv}]
+    (when-some [key (get-react-key argv)]
+      (set! (.-key js-props) key))
+    (react/createElement component js-props)))
 
 (defn- fragment-element
   "Emit `:<>` — React.Fragment.

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -635,7 +635,23 @@
         void-elem? (and (string? component) (void-tag? component))]
     (cond
       void-elem?
-      (react/createElement component js-props)
+      (do
+        ;; HTML5 void tags (br/hr/img/input/…) take no children — React
+        ;; RAISES "<tag> is a void element tag and must neither have
+        ;; children…" if any are passed. The slim renderer stays LENIENT
+        ;; (it drops the children rather than crashing the render), but
+        ;; that leniency is now INTENTIONAL and NON-SILENT: a DEBUG-gated
+        ;; warning surfaces the app bug instead of masking it
+        ;; (rf2-mdgt8t (c)). Elided under :advanced + goog.DEBUG=false.
+        (when ^boolean js/goog.DEBUG
+          (when (and (pos? n-children) (exists? js/console))
+            (.warn js/console
+                   (str "[reagent-slim] void element <" component
+                        "> was given " n-children
+                        " child element(s); HTML5 void tags cannot have"
+                        " children — the children are dropped. Remove them"
+                        " from the hiccup (rf2-mdgt8t)."))))
+        (react/createElement component js-props))
 
       (== n-children 0)
       (react/createElement component js-props)
@@ -779,10 +795,17 @@
   no prop conversion."
   [argv]
   (let [component (nth argv 1 nil)
-        js-props  (or (nth argv 2 nil) #js {})]
-    (when-some [key (-> (meta argv) :key)]
-      (set! (.-key js-props) key))
-    (make-element argv component js-props 3)))
+        supplied  (nth argv 2 nil)]
+    (if-some [key (-> (meta argv) :key)]
+      ;; Copy the caller's js-props before stamping :key (rf2-mdgt8t (d)).
+      ;; js-props here is the caller-supplied object (nth argv 2); mutating
+      ;; it with (set! (.-key …)) is a user-visible mutation of an input.
+      ;; native-element / react-component-element mint fresh props objects,
+      ;; so only :r> was affected. Shallow-copy so the stamp is ours alone.
+      (let [js-props (js/Object.assign #js {} (or supplied #js {}))]
+        (set! (.-key js-props) key)
+        (make-element argv component js-props 3))
+      (make-element argv component (or supplied #js {}) 3))))
 
 (defn- as-fn-component
   "Wrap a plain CLJS render fn `f` as a REAL React FUNCTION component so

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -299,12 +299,21 @@
   "Reduce-kv step: convert one [k v] pair into the JS props object `o`.
 
   Used for NESTED maps (style objects, custom-component prop sub-maps)
-  reached via `convert-prop-value`'s `map?` branch — there is no
-  native-DOM-tag context at this depth, so per-key conversion uses the
-  2-arg `convert-prop-value` (interop) rule. The TOP-LEVEL prop map is
+  reached via `convert-prop-value`'s `map?` branch. At this depth there
+  is no outer prop-name context — a `:style` sub-map's `:cursor` is the
+  CSS property name, not an HTML attribute — so the per-key VALUE
+  conversion uses the 1-arg `convert-prop-value`, which stringifies
+  EVERY named value (`{:cursor :pointer}` → `cursor \"pointer\"`). This
+  matches stock Reagent AND the pure server serializer
+  (`dom/server.cljs`, whose `named->str` stringifies every style value),
+  so the slim LIVE and SSR style paths agree — no live-vs-SSR hydration
+  mismatch (rf2-fdm4rm). Routing nested values through the 2-arg
+  (interop) form instead left keyword style values (`:cursor :pointer`)
+  reaching React as RAW keywords, silently dropped by the CSSOM. The KEY
+  is still camelCased via `cached-prop-name`. The TOP-LEVEL prop map is
   converted by `convert-props` with the native-aware `top-prop-conv`
-  step instead, which is the seam that makes native-DOM keyword
-  attributes stringify (per rf2-ygknv finding 1).
+  step instead, the seam that makes native-DOM keyword ATTRIBUTES
+  stringify (per rf2-ygknv finding 1).
 
   Per rf2-dwds9 MEDIUM: reserved JS keys (`__proto__`, `prototype`,
   `constructor`) are dropped silently. `aset o \"__proto__\" v` would
@@ -316,7 +325,9 @@
   (let [k' (cached-prop-name k)]
     (if (and (string? k') (reserved-prop-key? k'))
       o
-      (let [v' (convert-prop-value k v)]
+      ;; 1-arg form: nested-map values carry no outer prop-name context,
+      ;; so stringify every named value (rf2-fdm4rm). See the docstring.
+      (let [v' (convert-prop-value v)]
         (aset o k' v')
         o))))
 

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -356,6 +356,24 @@
     (is (= "<div style=\"--gap:8\"></div>"
            (via-rewrite [:div {:style {:--gap 8}}])))))
 
+(deftest parity-style-keyword-value-rf2-fdm4rm
+  (testing "rf2-fdm4rm: keyword-valued style properties stringify on the
+            LIVE React path so react-dom/server and the pure serializer
+            AGREE — {:cursor :pointer} → cursor:pointer on both. This pin
+            FAILS if the live template path passes a raw keyword into React
+            (the pre-fix bug: React string-coerces the CLJS keyword :pointer
+            to \":pointer\", emitting invalid `cursor::pointer`)."
+    (let [[a b] (=parity [:div {:style {:cursor :pointer}}])]
+      (is (= a b)
+          "live React path and pure serializer agree on :cursor :pointer"))
+    (is (= "<div style=\"cursor:pointer\"></div>"
+           (via-rewrite [:div {:style {:cursor :pointer}}])))
+    ;; Mixed keyword values across several properties, one style map.
+    (let [[a b] (=parity [:div {:style {:display :flex :text-align :center}}])]
+      (is (= a b)))
+    (is (= "<div style=\"display:flex;text-align:center\"></div>"
+           (via-rewrite [:div {:style {:display :flex :text-align :center}}])))))
+
 ;; ---------------------------------------------------------------------------
 ;; SVG attribute-name casing parity (rf2-ygknv finding 3)
 ;;

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -28,6 +28,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent2.impl.component :as component]
             [reagent2.impl.template :as template]
+            [reagent2.impl.batching :as batching]
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
@@ -336,6 +337,28 @@
           inst  (new klass #js {:__rfArgv []})]
       (.call (.. klass -prototype -componentWillUnmount) inst)
       (is (identical? inst @fired)))))
+
+(deftest lifecycle-unmount-clears-dirty-flag-rf2-mdgt8t
+  (testing "rf2-mdgt8t (a): componentWillUnmount clears the dirty flag, so a
+            component queued for re-render THEN unmounted is NOT forceUpdate'd
+            on the next flush-render drain (stock-parity: stock clears the
+            flag on unmount)."
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})
+          inst     (new klass #js {:__rfArgv [(fn [_] nil)]})
+          fu-calls (atom 0)]
+      (set! (.-forceUpdate inst) (fn [] (swap! fu-calls inc)))
+      ;; Enqueue for a microtask-turn re-render — sets cljsIsDirty true.
+      (batching/queue-render! inst)
+      (is (true? (.-cljsIsDirty inst)) "queued → dirty")
+      ;; Unmount BEFORE the drain runs — must clear the dirty flag.
+      (.call (.. klass -prototype -componentWillUnmount) inst)
+      (is (false? (.-cljsIsDirty inst))
+          "unmount cleared the dirty flag (the rf2-mdgt8t (a) fix)")
+      ;; Drain: flush-render skips non-dirty components → no forceUpdate on
+      ;; the now-unmounted instance.
+      (batching/flush!)
+      (is (zero? @fu-calls)
+          "unmounted component was NOT forceUpdate'd on the drain"))))
 
 (deftest lifecycle-component-did-update-receives-prev-argv-and-snapshot
   (testing "componentDidUpdate forwards (this, prev-argv, snapshot)"

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -489,6 +489,22 @@
       (is (= Comp (.-type el)))
       (is (= "shaped" (-> el .-props .-already))))))
 
+(deftest as-element-raw-key-does-not-mutate-caller-props-rf2-mdgt8t
+  (testing "rf2-mdgt8t (d): stamping :key on an :r> element COPIES the
+            caller-supplied js-props object instead of mutating it. The
+            caller's object must be unchanged after render."
+    (let [Comp     (fn FakeRaw [_props] nil)
+          js-props #js {:already "shaped"}
+          ^js el   (template/as-element ^{:key "k"} [:r> Comp js-props])]
+      (is (= "k" (.-key el)) "the React key is stamped on the element")
+      (is (= "shaped" (-> el .-props .-already)) "props still flow through")
+      ;; The caller's object must NOT have gained a :key (the pre-fix bug
+      ;; set! (.-key js-props) key directly on this input object).
+      (is (undefined? (.-key js-props))
+          "caller's js-props object was NOT mutated with :key")
+      (is (= 1 (.-length (js/Object.keys js-props)))
+          "caller's js-props gained no extra own keys"))))
+
 (deftest as-element-function-component-is-real-fn-component-rf2-bf4uw2
   (testing "rf2-bf4uw2: [:f> f] renders f as a REAL React FUNCTION
             component — NOT a class. The prior fn-to-class lowering
@@ -732,16 +748,34 @@
       (is (= "img" (.-type el)))
       (is (= "x.png" (-> el .-props .-src))))))
 
-(deftest as-element-void-tag-children-dropped
-  (testing "void tag with child positions: child arg ignored"
-    ;; Per HTML5: br/hr/img/input/etc cannot have children; React would
-    ;; otherwise warn. The renderer drops children for void tags.
-    (let [^js el (template/as-element [:br "should-not-render"])]
-      (is (= "br" (.-type el)))
-      ;; React.createElement(br, props) with no children → undefined
-      ;; or nil children.
-      (is (or (nil? (-> el .-props .-children))
-              (js/Array.isArray (-> el .-props .-children)))))))
+(deftest as-element-void-tag-children-warns-and-drops-rf2-mdgt8t
+  (testing "rf2-mdgt8t (c): a void tag given children still DROPS them
+            (documented leniency — no render crash) but emits a DEBUG dev
+            warning so the app bug is NON-silent, not masked."
+    (let [captured (atom nil)
+          calls    (atom [])]
+      (with-warn-spy calls
+        #(reset! captured (template/as-element [:br "should-not-render"])))
+      (let [^js el @captured]
+        (is (= "br" (.-type el)))
+        ;; children still dropped: React.createElement(br, props) → no children
+        (is (or (nil? (-> el .-props .-children))
+                (js/Array.isArray (-> el .-props .-children)))
+            "children dropped (lenient)"))
+      ;; but NON-silent: exactly one warning naming the void tag
+      (is (= 1 (count @calls)) "one dev warning fired for the dropped children")
+      (is (re-find #"void element" (first @calls)) "warning names the offence")
+      (is (re-find #"<br>" (first @calls)) "warning names the void tag"))))
+
+(deftest as-element-void-tag-no-children-does-not-warn-rf2-mdgt8t
+  (testing "rf2-mdgt8t (c): a void tag WITHOUT children does not warn"
+    (let [calls (atom [])]
+      (with-warn-spy calls
+        #(do (template/as-element [:br])
+             (template/as-element [:input {:type "text"}])
+             (template/as-element [:img {:src "x.png"}])))
+      (is (zero? (count @calls))
+          "no warning when void tags carry no children"))))
 
 ;; ---------------------------------------------------------------------------
 ;; React keys

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -230,11 +230,34 @@
       (is (= 1 (aget out "a")) "key a flows through")
       (is (= 2 (aget out "b")) "key b flows through"))))
 
-(deftest convert-prop-value-1-arg-form-stringifies-named
-  (testing "1-arg form (nested map values) stringifies named values"
-    ;; Used recursively for map values where there's no outer prop-
-    ;; name context (CSS values etc.). Per the impl docstring.
-    (is (= "pointer" (template/convert-prop-value :pointer)))))
+(deftest nested-style-keyword-value-stringifies-on-live-path-rf2-fdm4rm
+  (testing "rf2-fdm4rm: a nested style-map keyword value reaches React as
+            a STRING on the LIVE path (props.style.cursor === \"pointer\"),
+            matching stock Reagent + the SSR serializer — not a raw CLJS
+            keyword. This exercises the real nested-map path through
+            as-element, the path production renders actually take. (The
+            old 1-arg-direct test was VACUOUS: no nested-map render reaches
+            the 1-arg form directly — kv-conv did, but routed values through
+            the 2-arg interop form, leaving the keyword un-stringified.)"
+    (let [^js el (template/as-element [:div {:style {:cursor :pointer}}])
+          style  (-> el .-props .-style)]
+      (is (= "div" (.-type el)))
+      (is (string? (.-cursor style))
+          "nested keyword style value is a JS string, not a raw CLJS keyword")
+      (is (= "pointer" (.-cursor style))
+          "keyword style value stringified to \"pointer\""))
+    ;; A multi-property style map: keyword + keyword + string values all
+    ;; convert, and the camelCase key transform is preserved for each key.
+    (let [^js el (template/as-element
+                   [:div {:style {:display          :flex
+                                  :text-align       :center
+                                  :background-color "red"}}])
+          style  (-> el .-props .-style)]
+      (is (= "flex" (.-display style)) "keyword value :flex → \"flex\"")
+      (is (= "center" (.-textAlign style))
+          "camelCased key :text-align → textAlign, keyword value stringified")
+      (is (= "red" (.-backgroundColor style))
+          "string value passes through under the camelCased key"))))
 
 ;; ---------------------------------------------------------------------------
 ;; warn-once-keyword-prop! — one-shot DEBUG warning contract

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -21,7 +21,11 @@
             [reagent2.impl.template :as template]
             [reagent2.impl.component :as component]
             [goog.object :as gobj]
-            ["react" :as react]))
+            ["react" :as react]
+            ;; rf2-bf4uw2: render an [:f> f] through the server renderer to
+            ;; prove f's React hooks run in a valid function-component
+            ;; context (a class-lowered f would throw 'Invalid hook call').
+            ["react-dom/server" :as rds]))
 
 ;; ---------------------------------------------------------------------------
 ;; Tag parsing — :div.cls#id shorthand
@@ -485,14 +489,50 @@
       (is (= Comp (.-type el)))
       (is (= "shaped" (-> el .-props .-already))))))
 
-(deftest as-element-function-component
-  (testing "[:f> some-fn arg] → wrapped as React class for reactivity"
+(deftest as-element-function-component-is-real-fn-component-rf2-bf4uw2
+  (testing "rf2-bf4uw2: [:f> f] renders f as a REAL React FUNCTION
+            component — NOT a class. The prior fn-to-class lowering
+            produced a React class, defeating the head's defining
+            purpose (hosting React hooks)."
     (let [some-fn (fn [_n] [:div])
           ^js el (template/as-element [:f> some-fn 42])]
-      ;; f> dispatches through fn-to-class so the head is a class.
-      (is (some? (.-type el)))
-      (is (component/reagent-class? (.-type el))
-          "fn-to-class produced a reagent-slim class for the f>'d fn"))))
+      (is (fn? (.-type el)) ":f> head is a function component")
+      (is (not (component/reagent-class? (.-type el)))
+          ":f> is NOT lowered to a reagent-slim class (the rf2-bf4uw2 bug)")
+      (is (not (component/react-class? (.-type el)))
+          ":f> head is not a React class either — a plain function component")
+      ;; Stable identity: the same fn re-wraps to the SAME component type
+      ;; so React reconciles across renders rather than remounting (which
+      ;; would drop hook + DOM state).
+      (let [^js el2 (template/as-element [:f> some-fn 7])]
+        (is (identical? (.-type el) (.-type el2))
+            "wrapper cached per fn for stable reconciliation")))))
+
+(deftest as-element-function-component-passes-args-rf2-bf4uw2
+  (testing "rf2-bf4uw2: [:f> f a b] calls f with the user args (a b),
+            converting its hiccup return to a React element"
+    (let [greet  (fn [who] [:div.greet "hi " who])
+          ^js el (rds/renderToStaticMarkup
+                   (template/as-element [:f> greet "there"]))]
+      (is (= "<div class=\"greet\">hi there</div>" el)
+          "f received its positional arg and its hiccup was rendered"))))
+
+(deftest as-element-function-component-hooks-render-rf2-bf4uw2
+  (testing "rf2-bf4uw2: an [:f> f] whose f calls a React hook renders
+            WITHOUT throwing 'Invalid hook call'. Rendered through
+            react-dom/server, which installs the hooks dispatcher for
+            function components (and an error dispatcher for classes) — the
+            pre-fix class lowering would THROW here; the real function
+            component renders the hook-seeded value."
+    (let [hooked (fn hooked-view [start]
+                   (let [state (react/useState start)
+                         n     (aget state 0)]
+                     [:span "hooked:" n]))
+          markup (rds/renderToStaticMarkup
+                   (template/as-element [:f> hooked 41]))]
+      (is (= "<span>hooked:41</span>" markup)
+          "useState ran in a valid function-component context; state seeded
+           from the arg — no 'Invalid hook call' throw"))))
 
 (deftest as-element-user-fn
   (testing "[my-view 1] — user-fn head wraps via fn-to-class"


### PR DESCRIPTION
Three correctness-review beads on the reagent-slim adapter surface, one commit each, ordered by severity. Each fix REPLACES its vacuous/absent test with a real regression (demonstrated failing before the fix, passing after).

## rf2-fdm4rm (P2 bug) — nested keyword style values reached React as raw keywords
`kv-conv` routed nested map VALUES through the 2-arg (interop) `convert-prop-value`, whose narrowed rule preserves keywords for non-HTML prop names — so `[:div {:style {:cursor :pointer}}]` reached React with `props.style.cursor === :pointer` (a raw CLJS keyword). React string-coerces it to `":pointer"` (invalid CSS, silently dropped by the CSSOM), and the slim LIVE render disagreed with both stock Reagent and the pure SSR serializer, breaking hydration.

Fix: nested map values now convert via the 1-arg `convert-prop-value`, which stringifies every named value — at nested depth there is no outer prop-name context, so a style sub-map's `:cursor` is a CSS property name, not an HTML attribute. Keys are still camelCased.

Tests: replaced the vacuous 1-arg-direct assertion (a form no nested-map render reaches) with one exercising the real nested-map live path through `as-element` (`props.style.cursor === "pointer"`); added an SSR `=parity` pin on a keyword-valued style.

## rf2-bf4uw2 (P3 bug) — `:f>` was lowered to a class, breaking hooks
`[:f> f]` went through `fn-to-class` into a React CLASS, defeating the head's defining purpose (rendering `f` as a real function component so React hooks work). A hook called during class render throws `Invalid hook call`, so any `[:f> f]` using a hook broke at runtime on the published rename-stable adapter ns — a migration trap.

Fix (decision (a) per the bead): `:f>` now renders `f` through `as-fn-component` — a cached function-component wrapper (`React.createElement` on the fn, no `fn-to-class`) that calls `f` with the user args and `as-element`s its hiccup return. Cached on the fn for stable reconciliation. Function components source reactive state through subscription hooks, not the class path's bare-deref capture (documented in the wrapper + IMPL-SPEC §7.1). Decision (a) recorded on the bead.

Tests: replaced the test that pinned the buggy class shape with one asserting a real function component (type is a plain fn, not a reagent/react class) + stable per-fn identity; added a `react-dom/server` render of an `[:f> f]` whose `f` calls `useState`, proving no `Invalid hook call` throw, plus an arg-passing pin.

## rf2-mdgt8t (P4 task) — lifecycle + hygiene parity cluster
- (a) `componentWillUnmount` now clears the dirty flag (`batching/mark-rendered`): a component queued via `queue-render!` then unmounted stayed dirty, so the next drain `forceUpdate`'d the unmounted instance (stock-parity gap + churn).
- (b) `flush-views!` docstring corrected: it degrades to a plain synchronous flush when `act()` is unreachable, not a no-op — now matches the stock twin.
- (c) `make-element` void-tag branch: children handed to a void tag are still dropped (lenient, no render crash) but the drop is now INTENTIONAL and NON-SILENT via a DEBUG-gated dev warning (elided in production).
- (d) `raw-element` (`:r>`) copies the caller-supplied `js-props` object before stamping `:key` instead of mutating the input.

Tests added for (a), (c), (d); (b) is docstring-only.

## Quality gates
- `clojure -M:test` (reagent-slim JVM): 11 tests, 0 failures.
- `npm run test:cljs` (full node-test suite, rebased on main): 8549 tests / 40355 assertions, 0 failures, 0 errors.
- `npm run test:reagent-slim:bundle-isolation`: PASS — 6 contracts, 25 sentinel checks, 0 warnings; slim bundle does NOT pull stock Reagent / react-dom/server (no regression; the only new `react-dom/server` import is in a TEST file).
- reagent-slim headless-Chromium client-runtime smoke: 1 smoke, 0 failures, exit 0.

Fail-before was demonstrated for every regression test by reverting each source hunk and confirming exactly the new tests fail (fdm4rm: 6; bf4uw2: 2 fail + 1 error; mdgt8t: 5 fail + 2 error), all isolated to the new tests with the rest of the suite green.