### PR TITLE
fix(core,epoch): don't strand a foreign-dispatch-id frame-created marker in a sibling frame buffer (rf2-7eel71)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -387,6 +387,28 @@
     (assoc base-tags :rf.trace/dispatch-id dispatch-id)
     base-tags))
 
+(def ^:private uncorrelated-op-types
+  "Op-type classes whose emits are STRUCTURAL — not part of any cascade's
+  causal event chain — so they must never inherit the in-scope cascade's
+  `:rf.trace/dispatch-id`, even when they fire while a cascade is on the
+  stack. Per Spec 009 §Dispatch correlation, frame-lifecycle emits (op-type
+  `:rf.frame`: `:rf.frame/created` / `:rf.frame/re-registered` /
+  `:rf.frame/destroyed` / `:rf.frame/drain-interrupted`) stay UNCORRELATED.
+
+  The load-bearing case (rf2-7eel71): when `reg-frame` runs inside frame A's
+  handler / fx scope — e.g. an fx that dynamically creates a modal / panel
+  frame B — its `:rf.frame/created` emit is tagged `{:frame B}` but the
+  scope carries A's cascade dispatch-id. Stamping A's id onto B's marker
+  makes the epoch capture seam bypass its orphan-drop arm (the marker's id
+  is non-nil) and buffer it into B; B never runs an event carrying A's id,
+  so the marker strands in B's buffer for the frame's whole lifetime and is
+  swept into any later halt record. Leaving frame-lifecycle emits
+  uncorrelated (nil dispatch-id) is precisely what lets that orphan-drop arm
+  keep the cross-frame marker out of the sibling frame's harvested record.
+  `:rf.frame/destroyed` / `:rf.frame/drain-interrupted` already self-heal,
+  but the rule is single-sourced here for the whole op-type class."
+  #{:rf.frame})
+
 (defn- build-event
   "Assemble the trace envelope (pure construction; reads
   `*handler-scope*`). `op-type` discriminates the success vs error
@@ -422,7 +444,14 @@
         base-tags   (cond-> (dissoc tags :recovery :sensitive?)
                       (not error?) (dissoc :source)
                       error?       (->> (merge {:category operation})))
-        tags+       (stamp-dispatch-id base-tags dispatch-id)]
+        ;; Structural (frame-lifecycle) emits stay UNCORRELATED — they never
+        ;; inherit the in-scope cascade's dispatch-id, so the epoch capture
+        ;; seam's orphan-drop arm keeps a cross-frame `:rf.frame/created` /
+        ;; `:rf.frame/re-registered` marker out of a SIBLING frame's harvested
+        ;; record (rf2-7eel71). See `uncorrelated-op-types`.
+        tags+       (if (contains? uncorrelated-op-types op-type)
+                      base-tags
+                      (stamp-dispatch-id base-tags dispatch-id))]
     (cond-> {:operation operation
              :op-type   op-type
              :id        (next-event-id)

--- a/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
+++ b/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
@@ -182,3 +182,30 @@
           "every emit in the second cascade shares one :rf.trace/dispatch-id")
       (is (empty? (clojure.set/intersection ids1 ids2))
           "the two cascades' :dispatch-ids are disjoint"))))
+
+;; ---- frame-lifecycle emits stay uncorrelated ------------------------------
+
+(deftest frame-lifecycle-emits-stay-uncorrelated-under-a-cascade-scope
+  (testing "rf2-7eel71 — a frame-lifecycle emit (op-type :rf.frame) fired while a
+            cascade's *handler-scope* is bound (e.g. reg-frame re-registering a
+            SIBLING frame from inside a handler / fx) must NOT inherit the
+            cascade's :rf.trace/dispatch-id. Stamping a foreign id there makes the
+            epoch capture seam strand the marker in the sibling frame's buffer for
+            the frame's whole lifetime. An ordinary in-cascade emit under the same
+            scope DOES still carry the id (control)."
+    (let [evs   (record-traces
+                  (fn []
+                    (trace/with-dispatch-id+call-site 4242 nil
+                      ;; Frame-lifecycle markers tagged with a DIFFERENT (sibling) frame.
+                      (trace/emit! :rf.frame :rf.frame/re-registered {:frame :test/sibling})
+                      (trace/emit! :rf.frame :rf.frame/created        {:frame :test/other})
+                      ;; Control: an ordinary cascade emit inherits the dispatch-id.
+                      (trace/emit! :rf.sub   :rf.sub/run              {:frame :test/sibling
+                                                                       :rf.sub/id :x}))))
+          by-op (fn [op] (some #(when (= op (:operation %)) %) evs))]
+      (is (nil? (dispatch-id (by-op :rf.frame/re-registered)))
+          ":rf.frame/re-registered stays uncorrelated — no cascade dispatch-id")
+      (is (nil? (dispatch-id (by-op :rf.frame/created)))
+          ":rf.frame/created stays uncorrelated — no cascade dispatch-id")
+      (is (= 4242 (dispatch-id (by-op :rf.sub/run)))
+          "control: an ordinary cascade emit still rides the cascade's dispatch-id"))))

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -1097,6 +1097,75 @@
             "C's claimed marker still names parent A (parent-child causality kept)"))
       (state/drop-frame-buffer! frame))))
 
+;; ---------------------------------------------------------------------------
+;; inv-6d — a frame-LIFECYCLE emit for a SIBLING frame, fired while frame A's
+;;          cascade scope is bound (dynamic frame management from inside a
+;;          handler / fx), must NOT strand a foreign-dispatch-id marker in the
+;;          sibling frame's capture buffer (rf2-7eel71).
+;; ---------------------------------------------------------------------------
+;;
+;; The live vector is RE-REGISTRATION: EP-0027 forbids handler-time frame
+;; CREATION (reg-frame throws when `*handler-scope*` is bound), but a handler /
+;; fx re-registering an ALREADY-EXISTING sibling frame B is unguarded and DOES
+;; emit `:rf.frame/re-registered {:frame B}` while A's `:rf.trace/dispatch-id`
+;; is in scope. Pre-fix, `build-event` stamped A's id onto that marker; at the
+;; capture seam frame-id resolved to B, the marker's dispatch-id was NON-nil so
+;; the orphan-drop arm was bypassed, and it buffered into B forever — B never
+;; runs an event carrying A's id, so every `harvest-buffer-for-event!` on B
+;; retained it as 'theirs', and a later depth-halt swept the phantom into B's
+;; halt record. The fix keeps frame-lifecycle emits UNCORRELATED (op-type
+;; `:rf.frame` never inherits the cascade dispatch-id), so the marker arrives
+;; with nil id and the existing orphan-drop arm keeps it out of B's buffer.
+
+(deftest inv-6d-nested-re-registration-does-not-strand-marker-in-sibling
+  (testing "rf2-7eel71 — re-registering a SIBLING frame from inside another
+            frame's fx must not strand a `:rf.frame/re-registered` marker in the
+            sibling frame's capture buffer."
+    (rf/reg-frame :test/main {})
+    ;; B exists (top-level creation — uncorrelated, drops cleanly).
+    (rf/reg-frame :test/modal {})
+    ;; An fx that re-registers the (existing) sibling frame B, run from inside
+    ;; frame A's cascade — so A's dispatch-id is in scope at the emit.
+    (rf/reg-fx :test/re-reg-modal (fn [_ frame-id] (rf/reg-frame frame-id {:extra :v})))
+    (rf/reg-event :app/reopen (fn [_ _] {:fx [[:test/re-reg-modal :test/modal]]}))
+
+    (rf/dispatch-sync [:app/reopen] {:frame :test/main})
+
+    (is (not-any? #(= :rf.frame (:op-type %)) (state/buffer-for :test/modal))
+        "no frame-lifecycle marker is stranded in the sibling frame's buffer")
+    (is (not-any? #(= :rf.frame/re-registered (:operation %))
+                  (state/buffer-for :test/modal))
+        "specifically, the cross-frame :rf.frame/re-registered marker is absent")))
+
+(deftest inv-6d-nested-re-registration-strand-not-swept-into-later-halt-record
+  (testing "rf2-7eel71 — a later depth-halt of the sibling frame B produces no
+            phantom `:rf.frame/re-registered` in its :halted-depth record. Pre-fix
+            the stranded marker (foreign dispatch-id) survived every :loop settle
+            as 'theirs' and `commit-halt-record!`'s full harvest swept it into the
+            halt record's :trace-events."
+    (rf/reg-frame :test/main {})
+    (rf/reg-frame :test/modal {:drain-depth 5})
+    (rf/reg-fx :test/re-reg-modal (fn [_ frame-id] (rf/reg-frame frame-id {:drain-depth 5})))
+    (rf/reg-event :app/reopen (fn [_ _] {:fx [[:test/re-reg-modal :test/modal]]}))
+    (rf/reg-event :loop
+      (fn [{:keys [db]} _]
+        {:db (update (or db {}) :n (fnil inc 0))
+         :fx [[:dispatch [:loop]]]}))
+
+    ;; Re-register B mid-cascade (strands the marker in B's buffer, pre-fix).
+    (rf/dispatch-sync [:app/reopen] {:frame :test/main})
+    ;; Drive B to a depth-halt; the trailing :halted-depth record full-harvests
+    ;; B's buffer.
+    (rf/dispatch-sync [:loop] {:frame :test/modal})
+
+    (let [halt (last (rf/epoch-history :test/modal))]
+      (is (= :halted-depth (:outcome halt))
+          "sanity: B's drain tripped the depth limit and committed a halt record")
+      (is (not-any? #(= :rf.frame (:op-type %)) (:trace-events halt))
+          "the depth-halt record carries no foreign frame-lifecycle marker")
+      (is (not-any? #(= :rf.frame/re-registered (:operation %)) (:trace-events halt))
+          "specifically, no phantom :rf.frame/re-registered in the halt record"))))
+
 ;; ===========================================================================
 ;; INVARIANT 7 — a tool / inspector frame's OWN render never pollutes the
 ;;                INSPECTED app frame's epoch :renders (rf2-tqlmq — the


### PR DESCRIPTION
## Problem

When `reg-frame` runs inside frame A's handler/fx scope (dynamic frame management — e.g. an fx that re-registers a modal/panel frame B), the frame-lifecycle emit is tagged `{:frame B}` but the in-scope `*handler-scope*` carries A's cascade dispatch-id. `build-event`'s `stamp-dispatch-id` blindly merged that foreign id onto the marker (trace.cljc). At the epoch capture seam, frame-id resolved to B and the **non-nil** dispatch-id bypassed the orphan-drop arm (capture.cljc), so the marker buffered into B forever. B never runs an event carrying A's id, so every `harvest-buffer-for-event!` on B classified it as 'theirs' and retained it for the frame lifetime; a later depth-halt of B swept the phantom into its `:halted-depth` record (`commit-halt-record!`).

Note: EP-0027 forbids handler-time frame **creation** (`reg-frame` throws when `*handler-scope*` is bound), so the live reproduction vector is **re-registration** of an existing sibling frame, which is unguarded. `:rf.frame/re-registered` strands exactly as the bead's `:rf.frame/created` analysis describes.

## Fix

Frame-lifecycle emits are, per Spec 009 §Dispatch correlation and the capture orphan-drop contract, **uncorrelated** — they are not part of any cascade's causal event chain. `build-event` now never inherits the in-scope cascade dispatch-id for op-type `:rf.frame` emits (`created` / `re-registered` / `destroyed` / `drain-interrupted`). The marker arrives with a nil dispatch-id and the **existing** orphan-drop arm keeps it out of the sibling frame's harvested record — no capture-side special-case skip needed.

This is the root-cause fix (not-stamping-foreign-id), and it matches what consumers already expect: a `:rf.frame/created` carrying a dispatch-id is the documented "pre-fix corruption shape" (xray L2 test), and `projection` groups frame-lifecycle emits under `:ungrouped`.

## Tests (all fail before / pass after — verified by revert-and-rerun)

- **core** `cascade-dispatch-id`: a frame-lifecycle emit fired under a bound cascade scope stays uncorrelated (no dispatch-id); an ordinary `:rf.sub/run` under the same scope still rides the id (control).
- **epoch** `epoch-attribution` inv-6d: nested re-registration of a sibling frame strands no marker in the sibling's capture buffer, and a later depth-halt of the sibling produces no phantom `:rf.frame/re-registered` in its `:halted-depth` record.

## Gates

- core JVM `clojure -M:test`: 1780 tests / 7836 assertions — 0 failures, 0 errors
- epoch JVM `clojure -M:test`: 388 tests / 2413 assertions — 0 failures, 0 errors (includes `:rf.frame/destroyed` self-heal + halted-destroy suites — no regression)
- `npm run test:cljs`: 8544 tests / 40332 assertions — 0 failures, 0 errors

Files: `implementation/core/src/re_frame/trace.cljc` (fix), `implementation/core/test/re_frame/cascade_dispatch_id_test.clj`, `implementation/epoch/test/re_frame/epoch_attribution_test.clj`.
