### PR TITLE
fix(deps): move stock-reagent dep from core to the reagent adapter (rf2-enmvx6)

### DIFF
--- a/implementation/adapters/reagent/deps.edn
+++ b/implementation/adapters/reagent/deps.edn
@@ -4,11 +4,15 @@
 ;; implementation dependencies. This artefact supplies
 ;; re-frame.adapter.reagent and depends on core for the substrate contract.
 ;;
-;; Core itself still carries stock Reagent because the CLJS `reg-view` path is
-;; Reagent-backed. The artefact boundary isolates adapter code; it does not
-;; claim that a UIx or Helix consumer has a Reagent-free core classpath.
+;; This artefact declares the stock `reagent/reagent` dep because it is the
+;; only artefact that requires reagent.core/ratom/dom.client (see
+;; re-frame.adapter.reagent). Core carries no stock-Reagent dep:
+;; re-frame.views late-binds via the `:adapter/current-component` hook and
+;; requires nothing, so a UIx, Helix, or reagent-slim consumer gets a
+;; Reagent-free core classpath.
 {:paths ["src"]
- :deps  {day8/re-frame2 {:local/root "../../core"}}
+ :deps  {day8/re-frame2  {:local/root "../../core"}
+         reagent/reagent {:mvn/version "2.0.1"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -15,10 +15,14 @@
 ;; implementation/ssr/ (`day8/re-frame2-ssr`); the Tool-Pair epoch surface
 ;; lives in implementation/epoch/ (`day8/re-frame2-epoch`).
 ;;
-;; Reagent appears as a dependency here because re-frame.views (CLJS-only
-;; reg-view) is Reagent-coupled per Spec 006 §CLJS reference scope. That
-;; coupling lives at the views.cljs layer; the *substrate* adapter ns
-;; (re-frame.adapter.reagent) lives in the Reagent artefact.
+;; Stock reagent/reagent is intentionally NOT a dep of this artefact: no
+;; core ns requires reagent.* at require time. re-frame.views (the CLJS-only
+;; reg-view path) late-binds the in-flight Reagent component through the
+;; `:adapter/current-component` hook (see views/provider.cljs) rather than
+;; statically requiring reagent.core, so core stays substrate-neutral and
+;; day8/reagent-slim consumers get a Reagent-free core classpath. The stock
+;; Reagent dep lives in the Reagent adapter artefact
+;; (implementation/adapters/reagent), the only artefact that requires it.
 ;;
 ;; metosin/malli is intentionally NOT a dep of this artefact: the schemas
 ;; artefact owns the Malli relationship. The runtime resolves of
@@ -29,8 +33,7 @@
 ;; carries Malli) alongside core.
 {:paths ["src"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.12.145"}
-         reagent/reagent           {:mvn/version "2.0.1"}}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}}
 
  :aliases
  {;; The core artefact's tests exercise schema-aware, machine-aware,

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -34,7 +34,19 @@
          ;; pulls transit through machines-viz — NOT because the dep is
          ;; test-scoped (moving it to :test would break share.cljs at
          ;; runtime).
-         com.cognitect/transit-cljs {:mvn/version "0.8.280"}}
+         com.cognitect/transit-cljs {:mvn/version "0.8.280"}
+
+         ;; The MachineChart component and viewer require stock Reagent
+         ;; directly (`reagent.core` for component-local Ratom state,
+         ;; `reagent.dom.client` in the standalone viewer), so machines-viz
+         ;; declares the stock `reagent/reagent` dep itself. It previously
+         ;; inherited Reagent transitively from core, but core is now
+         ;; Reagent-free (re-frame.views late-binds via the
+         ;; `:adapter/current-component` hook), so every artefact that
+         ;; requires reagent.* must declare it. This is dev-only: the whole
+         ;; machines-viz jar is bundle-isolated, so a consumer's production
+         ;; bundle never pulls Reagent through it.
+         reagent/reagent {:mvn/version "2.0.1"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -15,7 +15,7 @@
   TEMPLATE's own pin, never the impl tree's, so a drift between them would
   otherwise be invisible to every gate:
 
-    - reagent/reagent          ↔ `implementation/core/deps.edn` :deps
+    - reagent/reagent          ↔ `implementation/adapters/reagent/deps.edn` :deps
     - com.pitch/uix.core       ↔ `implementation/adapters/uix/deps.edn` :deps
     - com.pitch/uix.dom        ↔ `implementation/adapters/uix/deps.edn`
                                   :test alias :extra-deps (the shipped
@@ -254,16 +254,20 @@
 
 (deftest substrate-lib-lockstep
   (testing "Template's substrate-lib pins match the implementation adapter tree"
-    ;; reagent/reagent — impl source of truth is core/deps.edn :deps
-    ;; (re-frame.views is Reagent-coupled, so reagent rides core).
-    (let [impl-reagent (read-impl-deps-pin "implementation/core/deps.edn"
+    ;; reagent/reagent — impl source of truth is
+    ;; adapters/reagent/deps.edn :deps. Stock Reagent is a dep of the
+    ;; Reagent adapter artefact only (the sole artefact that requires
+    ;; reagent.core/ratom/dom.client); core stays Reagent-free because
+    ;; re-frame.views late-binds via the `:adapter/current-component`
+    ;; hook. So the pin rides the adapter, alongside uix/helix below.
+    (let [impl-reagent (read-impl-deps-pin "implementation/adapters/reagent/deps.edn"
                                            'reagent/reagent)
           tmp          (tmp-dir "rf2-template-lockstep-reagent-")]
       (try
         (let [tpl-reagent (emit-deps-pin tmp :reagent 'reagent/reagent)]
           (is (= impl-reagent tpl-reagent)
               (str "Template reagent/reagent pin (" tpl-reagent ") must match "
-                   "implementation/core/deps.edn (" impl-reagent ") — P5 "
+                   "implementation/adapters/reagent/deps.edn (" impl-reagent ") — P5 "
                    "lockstep. Bump reagent in the _reagent/deps.edn "
                    "template resource.")))
         (finally (delete-recursively tmp))))

--- a/tools/testbed-support/deps.edn
+++ b/tools/testbed-support/deps.edn
@@ -3,7 +3,16 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
          ;; Supplies the source-coordinate resolver used by the server.
-         day8/re-frame2      {:local/root "../../implementation/core"}}
+         day8/re-frame2      {:local/root "../../implementation/core"}
+
+         ;; The story-host testbed helper requires stock Reagent directly
+         ;; (`re-frame.testbed.story-host` requires `reagent.dom.client`),
+         ;; so testbed-support declares the stock `reagent/reagent` dep
+         ;; itself. It previously inherited Reagent transitively from core,
+         ;; but core is now Reagent-free (re-frame.views late-binds via the
+         ;; `:adapter/current-component` hook), so every artefact that
+         ;; requires reagent.* must declare it. Dev-only test-support tool.
+         reagent/reagent     {:mvn/version "2.0.1"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -50,6 +50,18 @@
          ;; installed by the host still governs the runtime path.
          day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
 
+         ;; Xray's own views require stock Reagent directly — e.g.
+         ;; `day8.re-frame2-xray.views.resizable-table` requires
+         ;; `reagent.core` for its component-local Ratom state — so Xray
+         ;; declares the stock `reagent/reagent` dep itself. It previously
+         ;; inherited Reagent transitively from core, but core is now
+         ;; Reagent-free (re-frame.views late-binds via the
+         ;; `:adapter/current-component` hook), so every artefact that
+         ;; requires reagent.* must declare it. This is dev-only (Xray is a
+         ;; devtools panel excluded from production bundles) and independent
+         ;; of the reagent-slim adapter above, which carries no stock Reagent.
+         reagent/reagent {:mvn/version "2.0.1"}
+
          ;; Editscript is the shared pure-data diff representation for
          ;; the tree inspector, flat diff view, and runtime accessor.
          juji/editscript {:mvn/version "0.6.5"}


### PR DESCRIPTION
## What

Move `reagent/reagent {:mvn/version "2.0.1"}` out of `implementation/core/deps.edn` `:deps` and into `implementation/adapters/reagent/deps.edn` `:deps` — the only artefact that actually requires stock Reagent. Refresh the now-stale justification comments in both files.

Closes rf2-enmvx6.

## Why

Core declared a **production** stock-Reagent dep that **no core namespace requires**. `re-frame.views` (the CLJS-only `reg-view` path) deliberately late-binds the in-flight Reagent component through the `:adapter/current-component` hook (see `views/provider.cljs`, which carries two explicit "does NOT `:require` reagent.core" comments) rather than statically requiring it. The only artefact that requires `reagent.core`/`reagent.ratom`/`reagent.dom.client` is the Reagent adapter — and it declared no reagent dep, silently inheriting core's.

Because core's dep was production, the published `day8/re-frame2` pom carried a hard `reagent/reagent` dependency, which landed transitively on **every `day8/reagent-slim` consumer classpath** — contradicting reagent-slim's "replaces, and does not depend on, stock Reagent" contract. A slim consumer's accidental `(:require [reagent.core])` would then compile fine and silently reintroduce stock Reagent.

## Proof the move is correct

- **Only `core/deps.edn:33` declared `reagent/reagent`**; every real `(:require [reagent.*])` across `implementation/` lives under `adapters/reagent/` (src `reagent.cljs:4-6` + its test suite). Verified by grep.
- **Core production classpath after the move contains no reagent** (`clojure -Spath` from `core/`: grep for reagent exits 1 = absent).
- **Reagent resolves via the adapter's own dep** (`clojure -Spath` from `adapters/reagent/`: `reagent-2.0.1.jar` present).

## Quality gates (all green)

| Gate | Result |
|---|---|
| `clojure -M:test` @ core (no reagent on cp) | **1779 tests / 7833 assertions, 0 failures, 0 errors** — proves core needs nothing from reagent |
| `clojure -M:test` @ adapters/reagent | 0 JVM tests (adapter tests are CLJS), **deps resolved cleanly** |
| `npm run test:cljs` | **8552 tests / 40358 assertions, 0 failures, 0 errors** — includes reagent adapter compiling against its own dep |
| `npm run test:reagent-slim:bundle-isolation` | **PASS** — 6 contracts, 25 sentinel checks; slim=595684 chars |
| `npm run test:bundle-isolation` | **PASS** — 22 artefact entries, 41 internal sentinels absent, 3 budgets ok |
| `npm run test:bundle-isolation` (uix-helix-reagent-free) | **PASS** — UIx/Helix bundles confirmed reagent-free |
| `npm run test:bundle-isolation` (login) | **PASS** — 3 login bundles, 18 sentinel checks |
| `npm run test:adapter-smokes` | **3 specs, 0 failures** — reagent adapter still mounts + dispatches |

Bundle-isolation stayed green (in-repo DCE already stripped reagent since nothing required it, so in-repo bundle sizes are unchanged — the win is the **published pom / consumer transitive tree**, not in-repo bundle size). The `uix-helix-reagent-free` gate confirms UIx/Helix core classpaths remain Reagent-free.

## Surface

- `implementation/core/deps.edn` (hot-zone) — removed the reagent dep + refreshed the stale justification comment
- `implementation/adapters/reagent/deps.edn` — added the reagent dep + refreshed its stale "core still carries stock Reagent" comment

No source, no top-level `deps.edn`/`shadow-cljs.edn` changes (classpath coordination not required — shadow-cljs release builds resolve reagent via the adapter dep, as the passing builds show).
