### PR TITLE
fix(examples/nine-states): use injected frame-bound subscribe for consistency (rf2-ltqnoa)

### DIFF
--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -728,7 +728,7 @@
 ;; ============================================================================
 ;;
 ;; The form and control panel grey themselves out once the page is archived,
-;; using `@(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])`. Notice
+;; using `@(subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])`. Notice
 ;; what they DON'T ask: "are we in the :done state of the :mode region?"
 ;; They ask "is this read-only?" and leave it at that. The view states an
 ;; intent and lets the machine decide which state happens to carry it —
@@ -740,7 +740,7 @@
           new-todo-form []
   (let [draft       @(subscribe [:new-todo/draft])
         field-err   @(subscribe [:new-todo/field-error :title])
-        read-only?  @(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
+        read-only?  @(subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
     [:form.new-todo
      {:on-submit (fn [e]
                    (.preventDefault e)
@@ -757,7 +757,7 @@
 (rf/reg-view ^{:doc "Your remote control: one button per state, so you can
                   jump the demo straight to any of the nine."}
           control-panel []
-  (let [read-only? @(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
+  (let [read-only? @(subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
     [:div.control-panel
      [:h3 "Drive the demo"]
      [:button {:on-click #(dispatch [:nine-states.app/initialise])


### PR DESCRIPTION
## What

The `new-todo-form` and `control-panel` reg-views in `examples/patterns/nine_states/core.cljs` read the `:mode/read-only` machine tag via the global `rf/subscribe` facade, while every other subscription in the file — and every other reg-view across all four patterns examples — uses the injected frame-bound `subscribe`. These were the only three `rf/subscribe` occurrences in the entire `examples/patterns` tree (two view bodies at :743 and :760, plus the docstring example at :731).

This changes all three to the injected `subscribe`.

## Why

In a canonical teaching example, mixing `rf/subscribe` with the injected `subscribe` in one view teaches copiers a distinction that does not exist ("global facade for machine subs, injected subscribe for db subs"). The injected `subscribe` is the idiomatic form inside a reg-view.

## Behaviour-neutral (verified)

The `reg-view` macro wraps the body in `(binding [re-frame.frame/*current-frame* <frame-id>] ...)` and the ambient resolver checks `*current-frame*` first, so `rf/subscribe` inside a reg-view already resolves to the same frame as the injected `subscribe`, even under multi-frame mounting. The read-only greying behaviour is identical; this is purely idiomaticity/consistency.

## Quality gates

- `npx shadow-cljs compile examples/nine-states examples/nine-states-with-stories` — 0 warnings on both builds (proves the injected `subscribe` resolves).
- `node examples/scripts/check-examples-assets.cjs` — green (35 pages resolve, `_shared` contract intact).
- `npm run test:cljs` — 8555 tests / 40359 assertions, 0 failures, 0 errors.

No `rf/subscribe` remains inside any reg-view body under `examples/patterns`.