### PR TITLE
docs(template): correct emitted README reply-map keys + refresh live tailwind-flag comment (rf2-ir4ccb, rf2-re7bt4)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
+++ b/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
@@ -260,7 +260,7 @@ When your app talks to a backend, add `day8/re-frame2-http` and use
 Every managed-async completion delivers the framework's
 [uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
 — one canonical reply map with a single **closed** `:status` (`:ok` / `:error` /
-`:cancelled` / `:stale`), `:value` / `:error`, `:work/id`, and `:completed-at`.
+`:cancelled` / `:stale`), `:value` / `:error`, `:rf.reply/work-id`, and `:completed-at`.
 `:on-success` / `:on-failure` are pure ROUTING sugar over the one direct reply
 target; both receive the identical canonical map. Only the *retryable* subset of
 the `:rf.http/*` failure categories is admissible under `:retry :on`; branch on

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -522,15 +522,15 @@ uses.** Every managed-HTTP completion delivers the framework's
 verbatim (Managed-Effects property 9; the rationale record is
 [EP-0011](https://github.com/day8/re-frame2/blob/main/docs/EP/EP-0011-uniform-async-reply-envelope.md)):
 one canonical reply map with a single **closed** `:status`, `:value` /
-`:error`, `:work/id`, and `:completed-at`. There is no separate
+`:error`, `:rf.reply/work-id`, and `:completed-at`. There is no separate
 `{:kind :success/:failure}` HTTP dialect (rf2-ibksxg — retired). The
 reply `:status` vocabulary:
 
 | Reply `:status` | Meaning | Carries |
 |---|---|---|
-| `:ok` | success | `:value` (decoded body), `:work/id`, `:completed-at` |
-| `:error` | any `:rf.http/*` failure | `:error` map with `:kind`, `:work/status` (`:failed` / `:timed-out`) |
-| `:cancelled` | abort | `:cancelled? true`, `:cancel/reason`, `:rf.http/aborted` under `:error` |
+| `:ok` | success | `:value` (decoded body), `:rf.reply/work-id`, `:completed-at` |
+| `:error` | any `:rf.http/*` failure | `:error` map with `:kind`; top-level `:rf.reply/work-status` (`:failed` / `:timed-out`) |
+| `:cancelled` | abort | `:cancelled? true`, `:rf.reply/cancel-reason`, `:rf.http/aborted` under `:error` |
 | `:stale` | superseded / late | **never delivered to your app target** — stale replies are suppressed before dispatch |
 
 Every `:rf.http/managed` request MUST address its reply. `:reply-to` is

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
@@ -1,8 +1,8 @@
 /* {{name}} — minimal stylesheet.
  *
  * A handful of rules. Plain CSS — no Tailwind, no garden, no spade.
- * Replace or extend as your app grows; or swap to Tailwind via
- * :css :tailwind when that template flag lands. */
+ * Replace or extend as your app grows; or scaffold with
+ * :css :tailwind for the Tailwind v4 variant instead. */
 
 body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
 .rf2-app-shell { display: flex; min-height: 100vh; }


### PR DESCRIPTION
Two DOC/COMMENT-only fixes to emitted `tools/template` scaffold resources, from the template correctness-review audit. The emitted CODE is already correct in both cases — only the prose describing it was wrong. One PR, two commits.

## rf2-ir4ccb — README reply-map keys use the durable-ledger spelling, not the reply-envelope spelling

Both emitted READMEs described the uniform reply MAP as carrying bare `:work/id` / `:work/status` / `:cancel/reason`. Per `spec/Managed-Effects.md` §The reply map (lines 130-142, 151, 167), the reply ENVELOPE single-roots the work identity as `:rf.reply/work-id` / `:rf.reply/work-status` / `:rf.reply/cancel-reason`. The bare `:work/id` spelling is the durable work-LEDGER row — a different layer (spec line 151). The emitted `_shared/events.cljs:123` already documents `:rf.reply/work-id`, so the README prose contradicted its own emitted code and the spec — a consumer reading `(:work/id reply)` off a reply map gets nil.

- `root/README.md` HTTP reply-status table + inline mention → `:rf.reply/work-id` / `:rf.reply/work-status` / `:rf.reply/cancel-reason`. Also lifts `:rf.reply/work-status` out of the `:error` map to a top-level reply field (matches the spec reply map + §Status-taxonomy timeout example at line 175).
- `_shared/README_with_ssr.md` inline reply-map mention → `:rf.reply/work-id`.

## rf2-re7bt4 — plain app.css comment describes the tailwind flag as future work

The default plain-CSS scaffold's `app.css` header said to swap to Tailwind via `:css :tailwind` "when that template flag lands". The flag is LIVE: `hooks.clj` `coerce-css` accepts `:tailwind` (`valid-css #{:tailwind}`) and emits the `_css_tailwind` v4 overlay, exercised by `template_emission_test.clj` and the SSR-tailwind emitted-run tier. Reworded to present-tense.

## Quality gates
- `clojure -M:test` from `tools/template`: **49 tests, 668 assertions, 0 failures, 0 errors**. No test pinned the corrected strings; the README HTTP-section content asserts remain satisfied.
- Grep-confirmed the corrected reply keys match `spec/Managed-Effects.md` §The reply map + the emitted `events.cljs` exactly.
- `mkdocs build --strict`: not applicable — `docs_dir: docs`; the template resources live under `tools/template/resources` (outside `docs_dir`) and no docs page references `re_frame2_template`, so the emitted READMEs do not feed the docs build.

Stance: precise pre-alpha doc corrections, no back-compat shims, no code/engine changes.
