### PR TITLE
fix(xray): redact on-box resources egress, implement error-override filter guard, mount-gate after-rings rAF (rf2-9zix0u, rf2-jqqsh9, rf2-e64drj)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1668,7 +1668,11 @@ per-machine in localStorage).
   do not re-layout — they just update node highlights.
 - **`:after` countdown rings** update at 60Hz only when the panel is
   visible; backgrounded panels pause the countdown render (the timer
-  itself runs at framework-time).
+  itself runs at framework-time). The rAF tick loop is MOUNT-gated: it
+  stops within one frame when the rings overlay UNMOUNTS (e.g. switching
+  to another L3 tab) even while an `:after` timer stays armed, so it can
+  never outlive its panel dispatching in the background (rf2-e64drj); a
+  remount re-arms it.
 - **Transition history** virtualises past 200 entries; older entries
   scroll into view but are not retained in DOM.
 

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -899,7 +899,10 @@ All forthcoming keys follow the `:rf.xray/*` convention.
   patterns to auto-hide (e.g. `["my-app.noisy" "re-com.box"]`).
 - `:rf.xray/filters-auto-hide-error-overrides? <bool>` — when an
   auto-hidden event raises an exception, surface it anyway (default
-  `true`). Errors override filters.
+  `true`). Errors override filters. **Implemented (rf2-jqqsh9)** —
+  wired through `configure!` + the `:rf.xray/filtered-event-bundles`
+  data-layer chain (`filters.error-override`); see
+  [`018-Event-Spine.md`](./018-Event-Spine.md) §7 Error overrides.
 - `:rf.xray/buffer-retained-epochs <int>` — exposed retainer-N depth
   control (re-frame-10x's `retained-epochs`). Floor 25; ceiling 5000.
 - Theme — already wired in v1 via `:rf.xray/settings`. Future:

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1033,7 +1033,7 @@ The category table below is retained as the canonical **"what counts as an issue
 | Subscription design advisories | Views tab → per-sub advisory chip on sub-row |
 | Framework-internal `console.warn` | Dev console (where they originate) |
 | Recoverable HTTP retries (recovered = not an issue) | Trace tab (visible when `fx` chip ON) |
-| Filtered-OUT events that errored (already surfaced via row error-override) | Event list with `⚠` + `▽` filter-bypass gutter |
+| Filtered-OUT events that errored (already surfaced via row error-override) | Event list — re-added by `filters.error-override`, painted with the pink issue-wash + tagged `data-rf-xray-filter-bypassed` |
 
 ### §5.5 Machines tab — see [`003-Machine-Inspector.md`](003-Machine-Inspector.md)
 
@@ -1381,7 +1381,11 @@ Full per-pill management lives in the ribbon strip + per-pill edit popup + mute 
 
 ### Error overrides
 
-When a filtered event raises an exception, surface it anyway (`:rf.xray/filters-auto-hide-error-overrides?` config key, default `true`). The row appears with both `⚠` and `▽` (filter-bypass) gutter; user knows "this would normally be hidden, but it errored."
+When a filtered event raises an exception, surface it anyway (`:rf.xray/filters-auto-hide-error-overrides?` config key, default `true`) — hiding an error behind a filter is the silent-failure footgun this feature prevents (`error` is *never filtered out*, §5.4). Implemented in the DATA layer (`filters.error-override/apply-error-overrides`, wired into `:rf.xray/filtered-event-bundles`): an errored event-bundle a filter dropped — an OUT-pill match, a failure to match an active IN pill, or a mute — is re-added in its original position and tagged `:rf.xray/filter-bypassed? true`.
+
+**Frame is a VIEW SCOPE, not a filter** (§7 Frame dropdown): the override operates on the frame-SCOPED list, so an errored event from *another* frame is never dragged into the current frame's view — only pill/mute drops within the observed frame's scope are re-added.
+
+**Row treatment.** The re-added errored row already carries the L2 pink issue-wash (errored ⇒ `event-bundle-has-issue?` ⇒ rose wash, §5.4) so it reads as an error at a glance. The `:rf.xray/filter-bypassed?` tag additionally surfaces as a machine-readable `data-rf-xray-filter-bypassed="true"` row attribute + a hover-tooltip line ("shown because it errored — a filter would normally hide it"), so the user knows *"this would normally be hidden, but it errored."* (The earlier `⚠` + `▽` leading-gutter glyphs were superseded by the rf2-pjjwh clean-mock row + the pink issue-wash error signal.)
 
 ### Data-layer filtering
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1533,6 +1533,50 @@
   []
   @filters-storage-key)
 
+;; ---- error-override filter bypass (rf2-jqqsh9) --------------------------
+;;
+;; spec/018-Event-Spine.md §7 Error overrides + §5.4 (`error` never filtered
+;; out) + spec/015-Configuration.md §Must-haves: an errored event that a
+;; filter (an OUT-pill match, a failure to match an active IN pill, or a mute)
+;; would hide is surfaced ANYWAY — hiding an error behind a filter is the
+;; silent-failure footgun the feature exists to prevent. DEFAULT `true`.
+;; The frame picker is a VIEW SCOPE, not a filter (spec/018 §7), so this
+;; override never re-adds an errored event from ANOTHER frame — only ones the
+;; pill/mute filters dropped WITHIN the observed frame's scope.
+
+(def default-filters-auto-hide-error-overrides?
+  "The default for `:rf.xray/filters-auto-hide-error-overrides?` — `true`.
+  Errors override filters (spec/018 §7 + spec/015 §Must-haves)."
+  true)
+
+(defonce
+  ^{:doc "Atom holding whether an errored event a filter would hide is
+         surfaced anyway (spec/018 §7 Error overrides). Default `true`
+         (`default-filters-auto-hide-error-overrides?`). Set `false` via
+         `(xray-config/configure!
+         {:rf.xray/filters-auto-hide-error-overrides? false})` to let filters
+         hide errored events too (opt OUT of the bypass). Read by the
+         `:rf.xray/filters-auto-hide-error-overrides?` sub the filtered-
+         event-bundle chain consults."}
+  filters-auto-hide-error-overrides?
+  (atom default-filters-auto-hide-error-overrides?))
+
+(defn set-filters-auto-hide-error-overrides!
+  "Replace the error-override bypass flag (spec/018 §7). `nil` resets to the
+  default (`true` — errors override filters). Any other value coerces to a
+  boolean."
+  [v]
+  (reset! filters-auto-hide-error-overrides?
+          (if (nil? v) default-filters-auto-hide-error-overrides? (boolean v)))
+  nil)
+
+(defn error-override-bypass-enabled?
+  "Return true when an errored event a filter would hide should be surfaced
+  anyway (the `:rf.xray/filters-auto-hide-error-overrides?` posture). The
+  filtered-event-bundle sub consults this via its own convenience sub."
+  []
+  @filters-auto-hide-error-overrides?)
+
 ;; ---- configure! convenience ---------------------------------------------
 
 (defn configure!
@@ -1615,6 +1659,12 @@
        the filter persistence layer reads / writes. Default
        `\"re-frame2.xray.filters.v1\"`. Hosts that run multiple
        Xray instances (Story testbeds) override for isolation.
+    `{:rf.xray/filters-auto-hide-error-overrides? <bool>}` — when an
+       errored event would be hidden by a filter (an OUT-pill match, a
+       failure to match an active IN pill, or a mute), surface it anyway
+       (spec/018 §7 Error overrides — the silent-failure footgun the
+       feature prevents). Default `true`; set `false` to let filters hide
+       errored events too. `nil` resets to the default.
 
   Future phases extend this with theme / buffer / placement keys.
 
@@ -1643,6 +1693,7 @@
     egress-profile-opt  :rf.xray/egress-profile
     filters-opt         :rf.xray/filters
     filters-key-opt     :rf.xray/filters-storage-key
+    error-overrides-opt :rf.xray/filters-auto-hide-error-overrides?
     :as opts}]
   ;; Gate on key PRESENCE, not value `some?`. `set-editor!` treats `nil`
   ;; as the reset-to-default + clear-the-explicit-flag case (the per-key
@@ -1713,6 +1764,11 @@
     (set-filters-storage-key! filters-key-opt))
   (when (contains? opts :rf.xray/filters)
     (set-filter-seed! filters-opt))
+  ;; Error-override bypass (rf2-jqqsh9). `contains?`-gated so an explicit
+  ;; `nil` resets to the default (`true`) and an ABSENT key leaves the atom
+  ;; untouched — matching every other key above.
+  (when (contains? opts :rf.xray/filters-auto-hide-error-overrides?)
+    (set-filters-auto-hide-error-overrides! error-overrides-opt))
   nil)
 
 ;; ---- pass-through: editor-uri --------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -27,6 +27,7 @@
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
+            [day8.re-frame2-xray.filters.error-override :as error-override]
             [day8.re-frame2-xray.filters.hidden :as hidden]
             [day8.re-frame2-xray.filters.matcher :as matcher]
             [day8.re-frame2-xray.filters.persistence :as persistence]
@@ -207,19 +208,41 @@
   ;; off the strict frame filter drops it, matching the default
   ;; silent-by-default L2 list (no frameless bucket leaks into the data
   ;; layer when nobody asked for it).
+  ;; rf2-jqqsh9 — the error-override bypass posture
+  ;; (`:rf.xray/filters-auto-hide-error-overrides?`, default true). A
+  ;; boot-time `configure!` slot, not a per-event-bundle reactive Settings
+  ;; key, so it reads the config atom directly (mirrors
+  ;; `:rf.xray/editor-host-default`) — no app-db mirror needed.
+  (rf/reg-sub :rf.xray/filters-auto-hide-error-overrides?
+    (fn [_db _query]
+      (config/error-override-bypass-enabled?)))
+
+  ;; rf2-jqqsh9 — ERROR OVERRIDES (spec/018 §7). An errored event a FILTER
+  ;; would hide is surfaced anyway (§5.4: `error` is never filtered out) — the
+  ;; silent-failure footgun the feature prevents. The frame is a VIEW SCOPE,
+  ;; not a filter, so the override operates on the frame-SCOPED list: an
+  ;; errored event from another frame is never dragged into the current
+  ;; frame's view (frames are isolated contexts). `scoped` is the list after
+  ;; the view scope; `filtered` is `scoped` after the pill + mute filters;
+  ;; `apply-error-overrides` re-adds any errored bundle the filters dropped,
+  ;; tagged `:rf.xray/filter-bypassed?` for the row's filter-bypass cue. Gated
+  ;; on `:rf.xray/filters-auto-hide-error-overrides?` (default true).
   (rf/reg-sub :rf.xray/filtered-event-bundles
     :<- [:rf.xray/event-bundles]
     :<- [:rf.xray/active-filters]
     :<- [:rf.xray/view-scope-frame]
     :<- [:rf.xray/muted-event-ids]
     :<- [:rf.xray/show-ungrouped?]
-    (fn [[event-bundles filters view-scope-frame muted show-ungrouped?] _query]
-      (-> event-bundles
-          (cond->
-            show-ungrouped?       (matcher/filter-event-bundles-by-view-scope view-scope-frame)
-            (not show-ungrouped?) (matcher/filter-event-bundles-by-frame view-scope-frame))
-          (typed/filter-event-bundles filters)
-          (spine-filters/filter-event-bundles muted))))
+    :<- [:rf.xray/filters-auto-hide-error-overrides?]
+    (fn [[event-bundles filters view-scope-frame muted show-ungrouped?
+          error-overrides?] _query]
+      (let [scoped   (cond-> event-bundles
+                       show-ungrouped?       (matcher/filter-event-bundles-by-view-scope view-scope-frame)
+                       (not show-ungrouped?) (matcher/filter-event-bundles-by-frame view-scope-frame))
+            filtered (-> scoped
+                         (typed/filter-event-bundles filters)
+                         (spine-filters/filter-event-bundles muted))]
+        (error-override/apply-error-overrides scoped filtered error-overrides?))))
 
   ;; The 'N events hidden by filters' message model. Composes the raw +
   ;; filtered event-bundle lists and the active filter state into the pure

--- a/tools/xray/src/day8/re_frame2_xray/filters/error_override.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/filters/error_override.cljc
@@ -1,0 +1,78 @@
+(ns day8.re-frame2-xray.filters.error-override
+  "Error-override filter bypass for the L2 event list (rf2-jqqsh9).
+
+  ## What this is
+
+  spec/018-Event-Spine.md §7 Error overrides: *\"When a filtered event raises
+  an exception, surface it anyway.\"* An errored event that a FILTER (an
+  OUT-pill match, a failure to match an active IN pill, or a mute) would hide
+  is the silent-failure footgun the feature exists to prevent (§5.4:
+  `error` is *never filtered out*). So the filter chain re-adds any errored
+  event-bundle the pill/mute filters dropped, tagging it `:rf.xray/filter-
+  bypassed? true` so the row can carry the *\"would normally be hidden, but it
+  errored\"* cue.
+
+  ## Frame is a VIEW SCOPE, not a filter
+
+  spec/018 §7: the frame picker is a view scope, *not counted as hidden*. So
+  the override operates on the frame-SCOPED list — an errored event from
+  ANOTHER frame is never dragged back into the current frame's view (Xray
+  observes ONE frame; frames are isolated contexts). The `scoped` arg is the
+  view-scope-filtered list; `filtered` is `scoped` AFTER the pill + mute
+  filters. Only bundles the pill/mute filters removed FROM `scoped` are
+  candidates for re-adding.
+
+  ## Pure data, JVM-portable
+
+  `.cljc` so the bypass contract is pinned by the JVM test corpus without a
+  CLJS runtime. The error classification delegates to the already-pure
+  `event-status-colour/event-bundle-outcome` — the SAME `:error` classifier
+  the Epoch outcome banner + L2 row colouring key off — so the bypass can
+  never disagree with the rest of Xray about what counts as errored."
+  (:require [day8.re-frame2-xray.panels.event.event-status-colour
+             :as event-status-colour]))
+
+(def filter-bypassed-key
+  "The tag key stamped on an event-bundle the pill/mute filters would have
+  hidden but that surfaces anyway because it errored (spec/018 §7). The row
+  reads this to render the filter-bypass cue. Namespaced under `:rf.xray/` so
+  it never collides with a projected event-bundle field."
+  :rf.xray/filter-bypassed?)
+
+(defn errored?
+  "True iff `event-bundle` carries an error trace (its lifecycle outcome is
+  `:error`, per `event-status-colour/event-bundle-outcome`). Pure predicate;
+  JVM-runnable."
+  [event-bundle]
+  (= :error (:outcome (event-status-colour/event-bundle-outcome event-bundle))))
+
+(defn apply-error-overrides
+  "Re-add any errored event-bundle the pill/mute filters dropped, so an error a
+  filter would hide still surfaces (spec/018 §7 Error overrides).
+
+  - `scoped`   — the view-scope-filtered event-bundle list (frame is a view
+                 scope, NOT a filter; an errored event outside the current
+                 frame is already absent here and stays absent).
+  - `filtered` — `scoped` AFTER the pill + mute filters.
+  - `enabled?` — the `:rf.xray/filters-auto-hide-error-overrides?` posture
+                 (default `true`). When false this is a no-op returning
+                 `filtered` unchanged.
+
+  Returns a `scoped`-ORDERED vector: every bundle the filters kept, plus every
+  errored bundle they dropped (re-inserted at its original position and tagged
+  `filter-bypassed-key` → `true`). A bundle the filters kept is returned
+  as-is (never tagged). Pure data → data; JVM-runnable."
+  [scoped filtered enabled?]
+  (if-not enabled?
+    (vec filtered)
+    (let [kept (set filtered)]
+      (reduce (fn [acc b]
+                (cond
+                  ;; survived the filters — keep verbatim (untagged).
+                  (contains? kept b)   (conj acc b)
+                  ;; dropped by a filter but errored — surface it anyway.
+                  (errored? b)         (conj acc (assoc b filter-bypassed-key true))
+                  ;; dropped by a filter and clean — stays hidden.
+                  :else                acc))
+              []
+              scoped))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -202,3 +202,26 @@
   ([v frame-id] (local-render-value v frame-id false))
   ([v frame-id raw?]
    (rf/project-egress v (local-render-opts frame-id raw?))))
+
+(defn local-render-value-at
+  "Like `local-render-value`, but for a value that sits at absolute app-db /
+  runtime-db `path` (a SLICE egress'd in isolation, not the whole walked
+  root). Threading `:path` lets `rf/project-egress` match the path-keyed
+  `:sensitive` / `:large` declarations a bare-value walk (path `[]`) would
+  miss — e.g. the per-instance resource declarations the resources registry
+  LOWERS onto absolute runtime-db slot paths rooted at the entry's byte
+  key-id (`[:rf.runtime/resources :entries <key-id> :data …]`, rf2-aw9cfs).
+  This is the Resources tab's on-box per-slot egress seam (rf2-9zix0u), the
+  path-aware sibling of `local-render-value` the App-DB tab uses.
+
+  Same fail-closed + per-frame guarantees as `local-render-value` — they
+  share `local-render-opts`, so an unreachable `frame-id` (nil / destroyed /
+  never registered) stamps the dead-frame sentinel and redacts the whole
+  slice rather than borrow the ambient frame's policy, and the projection
+  applies the OBSERVED frame's own `:sensitive` / `:large` classification. The
+  explicit `:path` composes with (never overrides) the profile floor + the
+  `include-large?` overlay `local-render-opts` sets."
+  ([v frame-id path] (local-render-value-at v frame-id path false))
+  ([v frame-id path raw?]
+   (rf/project-egress v (assoc (local-render-opts frame-id raw?)
+                               :path (vec path)))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -203,25 +203,39 @@
 ;;
 ;;   - all timers are cancelled / fired
 ;;   - the scrubber leaves `:present`
-;;   - the panel un-mounts (no callers means the next dispatched
-;;     `:rings/now-ms` isn't read; the next render's `kick-tick!`
-;;     call won't fire because the panel isn't on screen)
+;;   - the `AfterRingsOverlay` UNMOUNTS (rf2-e64drj) — the loop is
+;;     MOUNT-gated, not only DATA-gated. Pre-fix the only stop conditions
+;;     were `needs-ticking?` false or an exception, so an ALREADY-RUNNING
+;;     loop was self-sustaining on app-db data: switching away from the
+;;     Machine Inspector while an `:after` timer stayed armed + the scrubber
+;;     sat at `:present` left the loop dispatching `:rf.xray/timer-tick`
+;;     ~60×/s in the background, outliving its panel (unbounded CPU / battery
+;;     drain). The overlay now owns a `:mounted?` liveness flag (set true on
+;;     render via `kick-tick!`, cleared on unmount via the `overlay-ref!`
+;;     React ref callback); `tick-loop!` requires it before dispatching /
+;;     re-scheduling, so unmount stops the loop within one frame. Remount
+;;     re-arms via `kick-tick!`.
 ;;
 ;; Per the bead's divergence allowances the throttle knob lives in
 ;; `*tick-min-delta-ms*`. v1 sets it to 0 (no skip-frame); a follow-on
 ;; can tune up if many-timer scenarios show jank.
 
 (defonce ^:private tick-state
-  ;; `{:running? bool :last-now-ms long :frame <frame-id>}`
+  ;; `{:running? bool :last-now-ms long :frame <frame-id> :mounted? bool}`
   ;;   :running? — true while a rAF is queued and undrained.
   ;;   :last-now-ms — last bumped value; the next tick can skip-frame
   ;;     if (- now last) < *tick-min-delta-ms*.
   ;;   :frame — rf2-nesy9: the surrounding instance frame captured by
   ;;     the overlay reg-view at `kick-tick!` time, so the off-render
   ;;     rAF tick dispatch lands on it (defaults to default-frame-id).
+  ;;   :mounted? — rf2-e64drj: the overlay's liveness. `kick-tick!` sets it
+  ;;     true (called only from the mounted overlay's render); the
+  ;;     `overlay-ref!` React ref callback clears it on unmount. `tick-loop!`
+  ;;     requires it, so the loop can never outlive the panel.
   (atom {:running?    false
          :last-now-ms 0
-         :frame       defaults/default-frame-id}))
+         :frame       defaults/default-frame-id
+         :mounted?    false}))
 
 (def ^:dynamic *tick-min-delta-ms*
   "Minimum gap (ms) between consecutive `:rf.xray/timer-tick`
@@ -245,7 +259,16 @@
 (defn- tick-loop!
   "One iteration of the rAF tick loop. Reads the active-timers sub +
   scrubber sub; bumps `now-ms` when ticking is warranted; re-schedules
-  itself iff still needed.
+  itself iff still needed AND the overlay is still mounted.
+
+  rf2-e64drj — MOUNT gate. The loop is gated on the overlay's
+  `:mounted?` liveness, not only on app-db data (`needs-ticking?`). An
+  UNMOUNTED overlay stops the loop IMMEDIATELY — no dispatch, no reschedule
+  — even if an `:after` timer stays armed + the scrubber sits at `:present`.
+  Pre-fix the data-gated loop was self-sustaining on app-db state and kept
+  dispatching `:rf.xray/timer-tick` ~60×/s in the background after the panel
+  unmounted (switch to another L3 tab). The overlay owns `:mounted?` via
+  `kick-tick!` (sets true on render) + `overlay-ref!` (clears on unmount).
 
   rf2-nms77h — the loop runs as a rAF/next-tick callback, OFF-render:
   there is no established frame scope (no `with-frame`, no enclosing
@@ -260,26 +283,33 @@
   dispatch below already correctly targets."
   []
   (try
-    (let [frame    (:frame @tick-state)
-          timers   @(rf/subscribe [:rf.xray/active-timers-for-focused-machine]
-                                  {:frame frame})
-          scrub    @(rf/subscribe [:rf.xray/machine-scrubber-position]
-                                  {:frame frame})
-          now      (now-ms)
-          last-now (:last-now-ms @tick-state)
-          due?     (or (zero? *tick-min-delta-ms*)
-                       (>= (- now last-now) *tick-min-delta-ms*))]
-      (when due?
-        ;; rf2-nesy9 — the rAF tick loop runs outside the render scope;
-        ;; dispatch into the frame captured at `kick-tick!` (the
-        ;; surrounding instance frame at the time the overlay armed the
-        ;; clock), not a `{:frame :rf/xray}` literal.
-        (rf/dispatch [:rf.xray/timer-tick now]
-                     {:frame frame})
-        (swap! tick-state assoc :last-now-ms now))
-      (if (rings-h/needs-ticking? timers scrub)
-        (raf! tick-loop!)
-        (swap! tick-state assoc :running? false)))
+    (if-not (:mounted? @tick-state)
+      ;; rf2-e64drj — the overlay unmounted (e.g. the user switched L3 tab).
+      ;; Stop the loop with NO dispatch + NO reschedule even while an :after
+      ;; timer stays armed + the scrubber sits at :present, so the loop can
+      ;; never outlive its panel. A remount re-arms via `kick-tick!`.
+      (swap! tick-state assoc :running? false)
+      (let [frame    (:frame @tick-state)
+            timers   @(rf/subscribe [:rf.xray/active-timers-for-focused-machine]
+                                    {:frame frame})
+            scrub    @(rf/subscribe [:rf.xray/machine-scrubber-position]
+                                    {:frame frame})
+            now      (now-ms)
+            last-now (:last-now-ms @tick-state)
+            due?     (or (zero? *tick-min-delta-ms*)
+                         (>= (- now last-now) *tick-min-delta-ms*))]
+        (when due?
+          ;; rf2-nesy9 — the rAF tick loop runs outside the render scope;
+          ;; dispatch into the frame captured at `kick-tick!` (the
+          ;; surrounding instance frame at the time the overlay armed the
+          ;; clock), not a `{:frame :rf/xray}` literal.
+          (rf/dispatch [:rf.xray/timer-tick now]
+                       {:frame frame})
+          (swap! tick-state assoc :last-now-ms now))
+        ;; Re-schedule only while STILL mounted AND still data-warranted.
+        (if (and (:mounted? @tick-state) (rings-h/needs-ticking? timers scrub))
+          (raf! tick-loop!)
+          (swap! tick-state assoc :running? false))))
     (catch :default _e
       ;; Defensive: a frame error must not strand the loop in
       ;; `:running? true` (would block future kicks).
@@ -290,24 +320,43 @@
   callers (the rings overlay component, mounted per render) call this
   on every render; the `:running?` sentinel prevents duplicate loops.
 
+  rf2-e64drj — `kick-tick!` is only ever called from the MOUNTED overlay's
+  active render, so it stamps `:mounted? true` (the overlay is live). This
+  also closes the boot race: on the first render the `overlay-ref!` callback
+  fires only after React commits, so `:mounted? true` is set here BEFORE the
+  first off-render `tick-loop!` iteration runs. The `overlay-ref!` callback
+  clears `:mounted?` on unmount.
+
   `frame` (rf2-nesy9) is the surrounding instance frame the overlay
   reg-view captured at render; stashed so the off-render tick dispatch
   lands on it. Defaults to `defaults/default-frame-id` for the test
   seam / direct callers."
   ([] (kick-tick! defaults/default-frame-id))
   ([frame]
-   ;; Record the captured frame before arming so `tick-loop!` reads it.
-   (swap! tick-state assoc :frame frame)
+   ;; Record the captured frame + live liveness before arming so `tick-loop!`
+   ;; reads them (rf2-e64drj: a render IS a mount signal).
+   (swap! tick-state assoc :frame frame :mounted? true)
    (when (compare-and-set!
            tick-state
            (assoc @tick-state :running? false)
            (assoc @tick-state :running? true))
      (raf! tick-loop!))))
 
+(defn- overlay-ref!
+  "React ref callback owning the overlay's `:mounted?` liveness in
+  `tick-state` (rf2-e64drj). React invokes it with the DOM node on MOUNT and
+  `nil` on UNMOUNT. A stable top-level fn identity means React calls it ONLY on
+  mount / unmount (never on a re-render), so it is a clean lifecycle signal.
+  Clearing `:mounted?` on unmount is what lets `tick-loop!` stop the rAF loop
+  within one frame even while an `:after` timer stays armed — the loop can
+  never outlive the panel."
+  [el]
+  (swap! tick-state assoc :mounted? (some? el)))
+
 (defn stop-tick!
   "Force-stop the rAF tick loop. Tests use this to reset between
   fixtures; production code never calls this directly (the loop
-  self-gates on `needs-ticking?`)."
+  self-gates on `needs-ticking?` + the overlay's `:mounted?` liveness)."
   []
   (swap! tick-state assoc :running? false))
 
@@ -417,6 +466,12 @@
                  timers chart-layout/highlight-id now)]
     (when (seq specs)
       [:div {:data-rf-xray-after-rings-host ""
+             ;; rf2-e64drj — the React ref that clears `:mounted?` on unmount
+             ;; so the off-render rAF tick loop stops when this overlay leaves
+             ;; the screen (switch away from the Machine Inspector) even while
+             ;; an `:after` timer stays armed. Stable fn identity ⇒ React fires
+             ;; it only on mount (node) / unmount (nil), never per re-render.
+             :ref overlay-ref!
              :style {:display "contents"}}
        [mv-after-rings/AfterRingsOverlay
         {:ring-specs specs

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -56,6 +56,7 @@
             [day8.re-frame2-xray.host-registry :as host-registry]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.resources-helpers :as h]
+            [day8.re-frame2-xray.panels.local-render :as local-render]
             [day8.re-frame2-xray.panels.reply-envelope :as reply]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -1114,6 +1115,47 @@
   (when (map? target-runtime-db)
     (get target-runtime-db h/routing-key)))
 
+;; ---- on-box payload egress (rf2-9zix0u) ----------------------------------
+;;
+;; PRIVACY: the on-box Resources render must redact frame-`:sensitive` resource
+;; payloads exactly as the App-DB tab's `local-render` seam does, and exactly
+;; as the OFF-BOX MCP accessors (`runtime/list-resource-instances` /
+;; `get-resource-state`) already do via `runtime/resource-egress-fn`. Before
+;; rf2-9zix0u the on-box `:rf.xray/resources-tab-data` sub called
+;; `project-instances` with NO egress-fn, so `instance-row` defaulted to
+;; identity and `summarize` `pr-str`-previewed the RAW scope / params / data /
+;; error to the DOM — catching only literal `:rf/redacted` sentinels the
+;; runtime had already elided. A LIVE `:sensitive?`-declared entry holds the
+;; real fetched value, so up to 120 chars of it rendered on-box
+;; (screen-share / recorded-session exposure). The on-box render path was the
+;; LONE `project-instances` caller omitting the egress-fn.
+
+(defn- on-box-resource-egress-fn
+  "The ON-BOX Resources payload-egress fn (rf2-9zix0u) — the resources-panel
+  analog of the App-DB tab's `local-render`. Redacts each frame-declared
+  `:sensitive` payload slot (scope / params / data / error / refresh-error)
+  under the OBSERVED frame's classification BEFORE `summarize`, so a sensitive
+  resource renders `[redacted]` on the on-box render path instead of a raw
+  `pr-str` preview — while the local operator still sees large values +
+  non-sensitive runtime-db payloads (the EP-0015 `:rf.egress/local-redacted`
+  on-box posture, via `local-render`'s `include-large?` overlay).
+
+  Structurally MIRRORS the off-box `runtime/resource-egress-fn`: each slot
+  egresses at its ABSOLUTE runtime-db path (`[:rf.runtime/resources :entries
+  <key-id> …]`, re-rooted by `h/resource-payload-path-suffix`) so the
+  resources registry's per-instance lowered `:sensitive?` declarations match
+  (rf2-aw9cfs). The ONLY difference from the off-box path is the on-box
+  redacted-but-locally-visible posture vs the off-box partition-default
+  posture. `key-id` is the entry's `:entries` map key (`instance-row` passes it
+  as the 3rd arg); `instance-row`'s own `some?` guard means this fn never sees
+  a nil slot value."
+  [observed-frame]
+  (fn [value slot-key key-id]
+    (local-render/local-render-value-at
+      value observed-frame
+      (into (conj (vec h/entries-rel-path) key-id)
+            (h/resource-payload-path-suffix slot-key)))))
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
@@ -1207,12 +1249,24 @@
     :<- [:rf.xray/resource-sub-reads]
     :<- [:rf.xray/resource-routing-slice]
     :<- [:rf.xray/registered-scope-resolvers]
+    ;; rf2-9zix0u — the OBSERVED frame whose `:sensitive` / `:large`
+    ;; classification governs the on-box payload egress below (the frame Xray
+    ;; is inspecting). Already an upstream dep transitively (via
+    ;; `:rf.xray/resource-entries` → `:rf.xray/target-frame-runtime-db`); named
+    ;; directly here so the egress projects the entries under THEIR frame.
+    :<- [:rf.xray/observed-frame]
     (fn [[registrations entries ledger trace-buffer sub-reads routing-slice
-          scope-resolvers] _]
+          scope-resolvers observed-frame] _]
       (let [now-ms        (.now js/Date)
             routes-map    (host-registry/registrations :route)
             registry-rows (h/project-registry registrations routes-map)
-            instance-rows (h/project-instances entries now-ms)
+            ;; rf2-9zix0u — thread the on-box egress-fn so a frame-`:sensitive`
+            ;; resource payload redacts to `[redacted]` on the on-box render
+            ;; path (screen-share safe), structurally matching the off-box MCP
+            ;; accessors. The prior no-egress call leaked raw values.
+            instance-rows (h/project-instances
+                            entries now-ms
+                            (on-box-resource-egress-fn observed-frame))
             work-rows     (h/project-work-ledger ledger)
             resolver-rows (h/project-scope-resolvers scope-resolvers)]
         {:silent?       (and (empty? registry-rows) (empty? instance-rows)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -74,6 +74,31 @@
   "Runtime-db-relative path to the cache entries map. Per Spec 016."
   [resources-key :entries])
 
+(defn resource-payload-path-suffix
+  "The lowered-declaration path SUFFIX, relative to an entry's `key-id`, a
+  payload `slot-key` re-roots under (rf2-aw9cfs) — mirrors
+  `re-frame.resources.classification/instance-declaration-paths`'s re-rooting:
+  a `:data`-rooted declaration lands directly under the entry (`[key-id
+  :data]`); a `:scope`- / `:params`-rooted one lands under the scoped-key
+  `:resource/key` carrier at index 0 / 2 (the scoped key is `[scope
+  resource-id params]`). `:error` / `:refresh-error` are not currently lowered
+  by the resources registry but live at the entry's own key, so they re-root
+  there too — a harmless no-match today that is correct the day the registry
+  starts classifying them.
+
+  The absolute egress `:path` for a slot is
+  `(into (conj (vec entries-rel-path) key-id) (resource-payload-path-suffix
+  slot-key))`. Canonical home for the pure path logic so BOTH the off-box
+  accessors (`runtime/resource-egress-fn`) and the on-box Resources-panel
+  egress (`resources/on-box-resource-egress-fn`, rf2-9zix0u) re-root each slot
+  to the SAME absolute coordinate the resources artefact lowers its per-instance
+  `:sensitive?` / `:large?` declarations to — one source of truth, no drift."
+  [slot-key]
+  (case slot-key
+    :scope  [:resource/key 0]
+    :params [:resource/key 2]
+    [slot-key]))
+
 (def tag-index-rel-path
   "Runtime-db-relative path to the reverse tag index."
   [resources-key :tag-index])

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -435,22 +435,11 @@
 ;; entry's `key-id` (its literal `:entries` map key, per rf2-9e0tyq) into the
 ;; path, re-rooting each slot exactly where the lowering wrote it.
 
-(defn- resource-payload-path-suffix
-  "The lowered-declaration path SUFFIX, relative to an entry's `key-id`, a
-  payload `slot-key` re-roots under (rf2-aw9cfs) — mirrors
-  `re-frame.resources.classification/instance-declaration-paths`'s re-rooting:
-  a `:data`-rooted declaration lands directly under the entry (`[key-id
-  :data]`); a `:scope`- / `:params`-rooted one lands under the scoped-key
-  `:resource/key` carrier at index 0 / 2 (the scoped key is `[scope
-  resource-id params]`). `:error` / `:refresh-error` are not currently
-  lowered by the resources registry but live at the entry's own key, so they
-  re-root there too — a harmless no-match today that is correct the day the
-  registry starts classifying them."
-  [slot-key]
-  (case slot-key
-    :scope  [:resource/key 0]
-    :params [:resource/key 2]
-    [slot-key]))
+;; The lowered-declaration path SUFFIX a payload slot re-roots under
+;; (rf2-aw9cfs) is the pure `resources-helpers/resource-payload-path-suffix`
+;; — the SAME re-rooting the on-box Resources-panel egress uses (rf2-9zix0u),
+;; so the off-box and on-box paths can never drift on where a slot's
+;; declaration lives.
 
 (defn- resource-egress-fn
   "Return the `(fn [value slot-key key-id] -> egressed)` payload-egress
@@ -469,7 +458,7 @@
       value
       (assoc egress-opts
              :path (into (conj (vec resources-helpers/entries-rel-path) key-id)
-                         (resource-payload-path-suffix slot-key))))))
+                         (resources-helpers/resource-payload-path-suffix slot-key))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Event-level default-suppress gate (rf2-to36uj)

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -292,12 +292,18 @@
         handler       (:handler event-bundle)
         handler-ms    (or (:elapsed-ms handler)
                           (get-in handler [:tags :elapsed-ms]))
+        ;; rf2-jqqsh9 — the filter-bypass cue. An errored event a filter would
+        ;; hide is surfaced anyway (spec/018 §7 Error overrides); the tooltip
+        ;; tells the operator WHY it is visible so a bypassed row never reads
+        ;; as an escaped filter.
+        bypassed?     (:rf.xray/filter-bypassed? event-bundle)
         lines (cond-> []
                 (vector? event-vec) (conj (pr-str event-vec))
                 (some? dispatch-id) (conj (str "#" dispatch-id))
                 (some? frame-id)    (conj (str "frame: " frame-id))
                 (some? coord-str)   (conj (str "source: " coord-str))
                 (some? handler-ms)  (conj (str "handler: " handler-ms "ms"))
+                bypassed?           (conj "⚠ shown because it errored — a filter would normally hide it")
                 true                (conj "Click → open Event detail"))]
     (str/join "\n" lines)))
 
@@ -1581,6 +1587,14 @@
                   ;; test (issue epoch → "true"; clean row → absent) without
                   ;; parsing the inline gradient string.
                   :data-rf-xray-issue-row (when has-issue? "true")
+                  ;; rf2-jqqsh9 — machine-readable filter-bypass flag. An
+                  ;; errored event a filter would hide is surfaced anyway
+                  ;; (spec/018 §7 Error overrides), tagged in the data layer
+                  ;; by `filters.error-override`; the errored row already
+                  ;; carries the pink issue-wash above, and this flag makes
+                  ;; the "shown despite a filter" reason pinnable from a unit
+                  ;; test + queryable by tooling.
+                  :data-rf-xray-filter-bypassed (when (:rf.xray/filter-bypassed? event-bundle) "true")
                   :role        "button"
                   :tab-index   "0"
                   :aria-label  (if ev-id

--- a/tools/xray/test/day8/re_frame2_xray/filters/error_override_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/filters/error_override_test.cljc
@@ -1,0 +1,94 @@
+(ns day8.re-frame2-xray.filters.error-override-test
+  "Pure-data contract for the error-override filter bypass (rf2-jqqsh9).
+
+  spec/018-Event-Spine.md §7 Error overrides + §5.4 (`error` never filtered
+  out): an errored event a FILTER would hide is surfaced anyway. This is the
+  JVM-runnable regression for `filters.error-override/apply-error-overrides` —
+  the data-layer half of the fix, exercised without a CLJS runtime."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.filters.error-override :as eo]))
+
+;; ---- fixtures -----------------------------------------------------------
+;;
+;; An event-bundle is errored iff its `:other` bucket carries an error trace
+;; (`:op-type :error` / `:rf.error/*`), per
+;; `event-status-colour/event-bundle-outcome`.
+
+(def ^:private errored-out
+  {:event [:auth/login {}] :dispatch-id 1 :other [{:op-type :error}]})
+
+(def ^:private clean-kept
+  {:event [:cart/add {}] :dispatch-id 2 :other []})
+
+(def ^:private clean-dropped
+  {:event [:mouse/move {}] :dispatch-id 3 :other []})
+
+(def ^:private errored-in-non-match
+  {:event [:order/retry {}] :dispatch-id 4 :other [{:operation :rf.error/handler-threw}]})
+
+;; ---- errored? classifier ------------------------------------------------
+
+(deftest errored?-keys-off-the-shared-outcome-classifier
+  (is (true?  (eo/errored? errored-out)))
+  (is (true?  (eo/errored? errored-in-non-match))
+      "the :rf.error/* namespace fallback also classifies as errored")
+  (is (false? (eo/errored? clean-kept)))
+  (is (false? (eo/errored? clean-dropped))))
+
+;; ---- apply-error-overrides ----------------------------------------------
+
+(deftest re-adds-an-errored-bundle-an-OUT-pill-dropped
+  (testing "an errored event an OUT filter removed is surfaced anyway, tagged
+            :rf.xray/filter-bypassed?, in its original scoped position"
+    (let [scoped   [errored-out clean-kept clean-dropped]
+          filtered [clean-kept]                     ; pills dropped errored + clean-dropped
+          result   (eo/apply-error-overrides scoped filtered true)]
+      (is (= 2 (count result)) "the errored drop is re-added; the clean drop stays hidden")
+      (is (= [1 2] (mapv :dispatch-id result))
+          "scoped order is preserved — errored bundle re-inserted ahead of the kept one")
+      (is (true? (:rf.xray/filter-bypassed? (first result)))
+          "the re-added errored bundle is tagged for the filter-bypass cue")
+      (is (nil? (:rf.xray/filter-bypassed? (second result)))
+          "a bundle the filters KEPT is never tagged"))))
+
+(deftest re-adds-an-errored-bundle-that-fails-to-match-an-IN-pill
+  (testing "an errored event dropped because it failed to match an active IN
+            pill is ALSO surfaced (§7: any filter drop, not just OUT matches)"
+    (let [scoped   [clean-kept errored-in-non-match]
+          filtered [clean-kept]                     ; IN pill kept clean-kept, dropped the errored non-match
+          result   (eo/apply-error-overrides scoped filtered true)]
+      (is (= #{2 4} (set (mapv :dispatch-id result))))
+      (is (true? (:rf.xray/filter-bypassed?
+                   (first (filter #(= 4 (:dispatch-id %)) result))))))))
+
+(deftest disabled-is-a-passthrough-noop
+  (testing "with the bypass disabled the filtered list passes through unchanged
+            — errored drops stay hidden (opt-out honoured)"
+    (let [scoped   [errored-out clean-kept]
+          filtered [clean-kept]
+          result   (eo/apply-error-overrides scoped filtered false)]
+      (is (= [2] (mapv :dispatch-id result)))
+      (is (not-any? :rf.xray/filter-bypassed? result)
+          "nothing is tagged when the override is off"))))
+
+(deftest frame-scope-drops-are-never-re-added
+  (testing "the override operates on the frame-SCOPED list — an errored event
+            already excluded by the VIEW SCOPE (absent from `scoped`) is never
+            dragged back in (frame is a view scope, not a filter)"
+    ;; `scoped` is post-view-scope, so a cross-frame errored bundle simply is
+    ;; NOT a member of scoped and cannot be re-added.
+    (let [scoped   [clean-kept]
+          filtered [clean-kept]
+          result   (eo/apply-error-overrides scoped filtered true)]
+      (is (= [2] (mapv :dispatch-id result))
+          "no cross-frame errored bundle appears — only scoped members qualify"))))
+
+(deftest all-kept-is-identity-in-value
+  (testing "when the filters dropped nothing, every bundle is returned as-is,
+            untagged"
+    (let [scoped   [errored-out clean-kept]
+          filtered [errored-out clean-kept]         ; no filter active
+          result   (eo/apply-error-overrides scoped filtered true)]
+      (is (= [1 2] (mapv :dispatch-id result)))
+      (is (not-any? :rf.xray/filter-bypassed? result)
+          "an errored bundle the filters KEPT is not tagged (it was never bypassed)"))))

--- a/tools/xray/test/day8/re_frame2_xray/filters/error_override_wiring_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/error_override_wiring_cljs_test.cljs
@@ -1,0 +1,106 @@
+(ns day8.re-frame2-xray.filters.error-override-wiring-cljs-test
+  "Sub-level wiring for the error-override filter bypass (rf2-jqqsh9).
+
+  The pure algebra lives in `error_override_test.cljc`; this drives the
+  PRODUCTION `:rf.xray/filtered-event-bundles` sub end-to-end so the
+  integration is proven: the config plumbs through `configure!` → the
+  `:rf.xray/filters-auto-hide-error-overrides?` sub → the filtered-event-bundle
+  chain, and the error classifier reaches the bundle through `group-by-event`
+  (the errored trace lands in the bundle's `:other` bucket).
+
+  spec/018-Event-Spine.md §7 Error overrides: an errored event a filter would
+  hide is surfaced anyway (default `true`); with the bypass off, filters hide
+  it too."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(use-fixtures :each
+  ;; `:post-reset` runs during fixture setup (before each test body), so it
+  ;; restores the error-override config to its default (`true`) — a prior
+  ;; test that flipped it off can't leak.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (config/set-filters-auto-hide-error-overrides! nil))}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (frame/reg-frame :rf/xray {})
+  (frame/reg-frame :rf/default {})
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])))
+
+(defn- dispatch-trace-ev
+  "A minimal `:rf.event/dispatched` trace event → one focusable bundle."
+  [id event-v]
+  {:id        id
+   :op-type   :rf.event
+   :operation :rf.event/dispatched
+   :tags      {:rf.trace/dispatch-id id
+               :frame                :rf/default
+               :rf.event/v           event-v}})
+
+(defn- error-trace-ev
+  "An `:rf.error/*` trace event (`:op-type :error`) carrying the SAME
+  dispatch-id so `group-by-event` buckets it into that cascade's `:other`
+  slot — the canonical 'this event errored' signal (mirrors
+  `shell_cljs_test/error-trace-ev`)."
+  [id]
+  {:id        (+ id 2000)
+   :op-type   :error
+   :operation :rf.error/handler-exception
+   :tags      {:frame :rf/default :rf.trace/dispatch-id id}})
+
+(defn- out-pill! [& event-ids]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/hydrate-filters
+                       {:in [] :out (mapv (fn [id] {:pattern id}) event-ids)}])))
+
+(defn- filtered-bundles []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/filtered-event-bundles])))
+
+(deftest errored-event-survives-an-out-pill-that-would-hide-it
+  (testing "rf2-jqqsh9 — with the default bypass ON, an errored event an OUT
+            pill would hide is surfaced anyway (spec/018 §7); a CLEAN event the
+            same pill matches IS hidden (the pill still works)"
+    (setup!)
+    ;; cascade 1 — clean :cart/add; cascade 2 — errored :auth/login.
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:auth/login]))
+    (trace-collector/seed-trace-for-test! (error-trace-ev 2))
+    (is (= #{1 2} (set (map :dispatch-id (filtered-bundles))))
+        "sanity: both cascades visible with no filter")
+    ;; OUT-pill BOTH event-ids. The clean one drops; the errored one survives.
+    (out-pill! :cart/add :auth/login)
+    (let [bundles (filtered-bundles)]
+      (is (= [2] (mapv :dispatch-id bundles))
+          "the clean OUT-matched cascade is hidden; the errored OUT-matched
+           cascade is surfaced anyway")
+      (is (true? (:rf.xray/filter-bypassed? (first bundles)))
+          "the surfaced errored bundle is tagged for the filter-bypass cue"))))
+
+(deftest disabled-config-lets-filters-hide-errored-events
+  (testing "rf2-jqqsh9 — with the bypass explicitly OFF
+            (:rf.xray/filters-auto-hide-error-overrides? false) an OUT pill
+            hides the errored event too (opt-out honoured through the sub)"
+    ;; Set BEFORE the first sub read so the config sub computes against false.
+    (config/set-filters-auto-hide-error-overrides! false)
+    (setup!)
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:auth/login]))
+    (trace-collector/seed-trace-for-test! (error-trace-ev 2))
+    (out-pill! :auth/login)
+    (is (empty? (filtered-bundles))
+        "the errored event is hidden when the bypass is disabled")))
+
+(deftest configure-plumbs-the-error-override-flag
+  (testing "rf2-jqqsh9 — configure! round-trips the config key + resets on nil"
+    (config/configure! {:rf.xray/filters-auto-hide-error-overrides? false})
+    (is (false? (config/error-override-bypass-enabled?)))
+    (config/configure! {:rf.xray/filters-auto-hide-error-overrides? nil})
+    (is (true? (config/error-override-bypass-enabled?))
+        "nil resets to the default (true)")))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
@@ -95,6 +95,9 @@
             :delay-source :literal
             :epoch epoch}}))
 
+(defn- pin-now-ms! [ms]
+  (rf/dispatch-sync [:rf.xray/set-now-ms-override-for-test ms]))
+
 ;; ---- rf2-nms77h — off-render tick-loop! dispatches with no ambient frame --
 
 (deftest tick-loop-runs-off-render-without-ambient-frame-context
@@ -129,3 +132,53 @@
                       (str "tick-loop! never dispatched :rf.xray/timer-tick "
                            "onto :rf/xray — " (.-message e)))
                   (done))))))
+
+;; ---- rf2-e64drj — the rAF loop is MOUNT-gated, not only DATA-gated --------
+;;
+;; Pre-fix `tick-loop!` re-scheduled itself whenever `needs-ticking?` was true
+;; (an armed `:after` timer + a `:present` scrubber), regardless of whether the
+;; `AfterRingsOverlay` was still mounted — so switching to another L3 tab left
+;; the loop dispatching `:rf.xray/timer-tick` ~60×/s in the background,
+;; outliving its panel. The overlay now owns a `:mounted?` liveness flag
+;; (`kick-tick!` sets it, the `overlay-ref!` React ref callback clears it on
+;; unmount); `tick-loop!` requires it before dispatching / re-scheduling.
+
+(deftest tick-loop-mount-gate-stops-loop-after-unmount
+  ;; Stub `js/requestAnimationFrame` to a no-op capture so a reschedule is a
+  ;; deterministic drop (no async next-tick racing the synchronous
+  ;; assertions); we assert on `tick-state`, not the real rAF queue.
+  (let [had? (exists? js/requestAnimationFrame)
+        orig (when had? js/requestAnimationFrame)
+        ts   @#'day8.re-frame2-xray.panels.machine-after-rings/tick-state]
+    (set! js/requestAnimationFrame (fn [_f] 0))
+    (try
+      (rf/with-frame :rf/xray
+        (override-machines!    [:auth/login])
+        (override-definitions! {:auth/login fixture-definition})
+        (pin-now-ms! 2000)                          ; now (2000) < fires-at (6000) ⇒ armed
+        (push-scheduled! 1000 :auth/login :idle 5000 0)
+        (rf/dispatch-sync [:rf.xray/set-scrubber-position :present])
+        ;; the mounted overlay's render arms the loop.
+        (after-rings/kick-tick! :rf/xray))
+      (is (true? (:running? @ts)) "sanity: kick-tick! armed the loop")
+      (is (true? (:mounted? @ts)) "sanity: kick-tick! stamped the overlay live")
+      ;; `needs-ticking?` is TRUE here (armed timer + :present scrubber), so
+      ;; PRE-FIX `tick-loop!` would re-arm regardless of mount. Simulate the
+      ;; overlay UNMOUNTING — React fires the ref with nil.
+      (#'day8.re-frame2-xray.panels.machine-after-rings/overlay-ref! nil)
+      (is (false? (:mounted? @ts)) "the ref-callback recorded the unmount")
+      (#'day8.re-frame2-xray.panels.machine-after-rings/tick-loop!)
+      (is (false? (:running? @ts))
+          "rf2-e64drj: unmounting AfterRingsOverlay stops the rAF loop within
+           one frame even though the :after timer is still armed + the scrubber
+           sits at :present (pre-fix the data-gated loop kept re-arming)")
+      (is (nil? (:rings/now-ms (frame/frame-app-db-value :rf/xray)))
+          "the unmounted iteration dispatched NO :rf.xray/timer-tick")
+      ;; A remount (the overlay's next render) re-arms the loop.
+      (rf/with-frame :rf/xray (after-rings/kick-tick! :rf/xray))
+      (is (true? (:mounted? @ts)) "remount re-stamps the overlay live")
+      (is (true? (:running? @ts)) "remount re-arms the loop via kick-tick!")
+      (finally
+        (set! js/requestAnimationFrame (if had? orig js/undefined))
+        (after-rings/stop-tick!)
+        (swap! ts assoc :mounted? false)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -19,7 +19,9 @@
     7. **Decoupled** — the panel reads the registry + the runtime-db
        slice via override hooks; no `re-frame.resources` require."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [day8.re-frame2-xray.registry :as registry]
@@ -523,6 +525,98 @@
         (is (some? scope))
         (is (re-find #"\[redacted\]" (node-text scope))
             "a redacted scope (PII) renders [redacted] — same elision as data")))))
+
+;; ---- (4b) PRIVACY: on-box render redacts a RAW :sensitive value (rf2-9zix0u)
+;;
+;; The `privacy-redacted-data-never-raw` test above proves the panel renders an
+;; ALREADY-`:rf/redacted` sentinel (the runtime elided it BEFORE Xray saw it).
+;; It does NOT prove the on-box render path redacts a RAW frame-`:sensitive`
+;; resource value — which is the actual rf2-9zix0u leak: the production sub
+;; called `project-instances` with NO egress-fn, so a LIVE `:sensitive?` entry
+;; (holding the real fetched value) `pr-str`-previewed raw to the DOM. This
+;; test drives the PRODUCTION sub `:rf.xray/resources-tab-data` end-to-end
+;; against an OBSERVED frame that declares its resource payload paths
+;; `:sensitive`, and asserts the rendered rows redact. FAILS before the fix
+;; (raw token previews), PASSES after.
+
+(def ^:private zix-secret "secret-session-jwt-zzz-9zix0u")
+(def ^:private zix-observed-frame :app/secure-observed)
+;; The `:entries` map key is the opaque byte key-id STRING (rf2-9e0tyq); the
+;; kind-preserving scoped-key rides on the entry as `:resource/key`.
+(def ^:private zix-key-id "kid-9zix0u-secret-1")
+(def ^:private zix-scoped-key
+  [[:rf.scope/session {:secret zix-secret :tenant "t-1"}]
+   :article/by-slug
+   {:secret zix-secret :slug "welcome"}])
+(def ^:private zix-entries
+  {zix-key-id
+   {:resource/id   :article/by-slug
+    :resource/key  zix-scoped-key
+    :status        :loaded
+    :data          {:secret zix-secret :title "Welcome"}
+    :generation    7
+    :active-owners #{[:route :route/article "nav-1"]}
+    :tags          #{[:article "welcome"]}
+    :request-id    [:w 7]}})
+
+(defn- install-zix-observed-frame! []
+  ;; Declare the three payload SLOTS `:sensitive` at the ABSOLUTE runtime-db
+  ;; paths the resources registry lowers per-instance declarations to
+  ;; (rf2-aw9cfs) — data at `[…entries <key-id> :data]`, scope at
+  ;; `[…entries <key-id> :resource/key 0]`, params at `[… :resource/key 2]`.
+  ;; The on-box egress re-roots each slot to exactly these coordinates.
+  (frame/reg-frame zix-observed-frame {})
+  (frame/swap-runtime-db! zix-observed-frame
+    (fn [rt]
+      (elision/apply-classification-effects rt
+        {:sensitive [[:rf.runtime/resources :entries zix-key-id :data]
+                     [:rf.runtime/resources :entries zix-key-id :resource/key 0]
+                     [:rf.runtime/resources :entries zix-key-id :resource/key 2]]}))))
+
+(defn- zix-instance-row []
+  (let [data (:instances @(rf/subscribe [:rf.xray/resources-tab-data]))]
+    (first data)))
+
+(deftest on-box-render-redacts-raw-sensitive-payload
+  (testing "rf2-9zix0u — the production :rf.xray/resources-tab-data sub redacts
+            a RAW frame-`:sensitive` resource payload on the ON-BOX render path
+            (screen-share safe), not just an already-`:rf/redacted` sentinel"
+    (setup-xray-frame!)
+    (install-zix-observed-frame!)
+    (rf/with-frame :rf/xray
+      ;; Point Xray's observed frame at the classified frame + seed the raw
+      ;; sensitive entries the on-box render projects.
+      (rf/dispatch-sync [:rf.xray/set-target-frame zix-observed-frame]
+                        {:frame :rf/xray})
+      (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
+                        {:frame :rf/xray})
+      (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test zix-entries]
+                        {:frame :rf/xray})
+      (is (= zix-observed-frame @(rf/subscribe [:rf.xray/observed-frame]))
+          "sanity: Xray is observing the classified frame")
+      (let [row (zix-instance-row)]
+        (is (some? row) "the sub projected the seeded live instance")
+        (testing "each :sensitive payload slot renders [redacted], never the raw token"
+          (doseq [slot [:data :scope :params]]
+            (is (= "[redacted]" (:preview (get row slot)))
+                (str slot " redacts to [redacted] on the on-box render path"))
+            (is (true? (:redacted? (get row slot)))
+                (str slot " carries the :redacted? sentinel flag"))))
+        (testing "no raw secret leaks into ANY string display field of any slot"
+          (doseq [slot [:data :scope :params]]
+            (is (not-any? #(and (string? %) (str/includes? % zix-secret))
+                          (vals (get row slot)))
+                (str "the raw session token never appears in the " slot " summary"))))
+        (testing "metadata + derived facts survive the redaction (project from the
+                  RAW entry, never through egress)"
+          (is (= :loaded (:status row)))
+          (is (= 7 (:generation row)))
+          (is (= :article/by-slug (:resource-id row)))
+          (is (true? (:has-data? row))
+              "redacting the payload must not flip the derived :has-data? fact")
+          (is (= 1 (:owner-count row)))
+          (is (= zix-scoped-key (:scoped-key row))
+              "the RAW scoped-key survives as the identity/react key"))))))
 
 ;; ---- (6) silent state ---------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -213,6 +213,9 @@
    ;; to the behaviour name `:rf.xray/focused-event-bundle-detail`.
    :rf.xray/focused-event-bundle-detail
    :rf.xray/filtered-event-bundles
+   ;; rf2-jqqsh9 — the error-override bypass posture consulted by the
+   ;; filtered-event-bundle chain (spec/018 §7 Error overrides).
+   :rf.xray/filters-auto-hide-error-overrides?
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
    ;; (raw vs filtered visible counts + the active filter cause).
    :rf.xray/hidden-by-filters


### PR DESCRIPTION
Three P2 bugs from the tools/xray correctness audit (rf2-057izp), same artefact, distinct sub-areas. Commits ordered by severity/independence.

## rf2-9zix0u — PRIVACY LEAK: on-box resources render leaked `:sensitive` payloads
The production sub `:rf.xray/resources-tab-data` called `project-instances` with **no egress-fn**, so `summarize` pr-str-previewed **raw** scope/params/data/error to the DOM — catching only literal `:rf/redacted` sentinels the runtime had already elided. A **live** frame-`:sensitive`-declared resource entry holds the real fetched value, so up to 120 chars of it rendered on-box: **screen-share / recorded-session exposure**. The off-box MCP accessors (`list-resource-instances`, `get-resource-state`) already redact via `resource-egress-fn`; the on-box render path was the lone `project-instances` caller omitting it.

**Fix** makes on-box egress structurally match off-box: threads `on-box-resource-egress-fn` (keyed on `:rf.xray/observed-frame`) into the sub, each payload slot egressing at its **absolute runtime-db coordinate** under the EP-0015 `:rf.egress/local-redacted` posture (suppress sensitive; keep large + runtime-db for the local operator). Adds `local-render/local-render-value-at` (path-aware sibling), and DRYs the per-slot path re-rooting into `resources-helpers/resource-payload-path-suffix` (shared by both paths so they can't drift). Regression drives the **production sub** end-to-end (the prior helper-level test was vacuous w.r.t. production).

## rf2-jqqsh9 — error-override filter bypass was unimplemented
The spec-mandated `:rf.xray/filters-auto-hide-error-overrides?` (spec/018 §7, default `true`) was **absent from src** — the filter chain never consulted error status, so an errored event a filter would exclude was silently dropped (the silent-failure footgun the feature prevents). Implemented in the data layer: `filters.error-override/apply-error-overrides` re-adds any errored bundle the pill/mute filters dropped (tagged `:rf.xray/filter-bypassed?`), wired into `:rf.xray/filtered-event-bundles`, gated on the config key (plumbed through `configure!` + a sub). Frame is a **view scope, not a filter**, so cross-frame errors are never dragged in.

## rf2-e64drj — after-rings rAF loop outlived its panel
The tick loop was DATA-gated (`needs-ticking?`), not MOUNT-gated, so it kept dispatching `:rf.xray/timer-tick` ~60x/s after `AfterRingsOverlay` unmounted while a timer stayed armed (background CPU/battery drain). Fix: the overlay owns a `:mounted?` flag (`kick-tick!` sets it; an `overlay-ref!` React ref clears it on unmount); `tick-loop!` requires it before dispatching/re-scheduling. Unmount stops the loop within one frame; remount re-arms.

## Quality gates
- **JVM** (`clojure -M:test`, tools/xray): **1245 tests / 5750 assertions, 0 failures** (baseline ~1239; +6 from the pure `error_override_test.cljc`).
- **Node** (`npm run test:cljs`, implementation/): **8557 tests / 40396 assertions, 0 failures** (includes the new on-box-render, error-override wiring, and mount-gate regressions; registry sub-snapshot updated for the new config sub).
- Per-bead adversarial regressions all fail-before / pass-after. Browser gate not run — every new assertion is unit-testable at the data/sub layer (the on-box redaction, the filter-chain union, and the mount-gate all assert on subs/pure fns, not DOM); the tick-loop test drives the private `tick-loop!` deterministically with a stubbed rAF.

Specs updated in-PR: spec/018 §7 + §5.4, spec/015 (filters cluster), spec/003 §Performance.
