### PR TITLE
fix(examples/core): render unknown-op cell error, drop dead login :status slice, consistent subscribe, redact demo-stub password (rf2-3xn8qr, rf2-fai6a8, rf2-88qc0k, rf2-a6zmmu)

### DIFF
--- a/examples/core/login/README.md
+++ b/examples/core/login/README.md
@@ -36,7 +36,7 @@ The whole flow is one transition table, registered with `reg-machine` under the 
 
 - **The form's draft is application state, not view state.** This is the Pattern-Forms *machine + slice* split. The **slice** at `[:auth :login-form]` owns the **draft**, projected via subscriptions and changed via the standard form events (`initialise-form` / `edit-field` / `edit-password` / `submit-form` / `reset-form`). The **machine** owns submit/auth status. On submit, the draft is validated against `Credentials`, the login request is issued, and the machine is nudged with a credential-free signal. The slice, events, and subscriptions live once in `login.model` and drive the Reagent, UIx, and Helix views unchanged; only the view syntax differs.
 
-- **Tags, not boolean subs.** Three states carry tags — `:auth/busy` on `:submitting`, `:auth/authenticated` on `:authed`, `:auth/locked` on `:locked-out`. Views ask the question by tag — `@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])` to disable inputs while a request is in flight — instead of listing exact state names. *Ask, don't tell*: add a second busy state later, and the views don't change.
+- **Tags, not boolean subs.** Three states carry tags — `:auth/busy` on `:submitting`, `:auth/authenticated` on `:authed`, `:auth/locked` on `:locked-out`. Views ask the question by tag — `@(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])` (the frame-injected `subscribe`, no `rf/` prefix inside a `reg-view`) to disable inputs while a request is in flight — instead of listing exact state names. *Ask, don't tell*: add a second busy state later, and the views don't change.
 
 - **Open maps everywhere.** Every shape on the wire is an open map.
 

--- a/examples/core/login/README.md
+++ b/examples/core/login/README.md
@@ -46,7 +46,7 @@ One detail worth noticing, about the password. A password is a secret, and re-fr
 2. **The edit event** — the password's keystrokes ride `:auth.login/edit-password`, a *map-payload* event whose registration declares `:sensitive [[:value]]`, so the dispatched-event trace redacts it. (A positional arg can't be classified — redaction is path-based — which is why the secret field gets its own map-shaped event while the non-secret email keeps the plain positional `:auth.login/edit-field`.)
 3. **The HTTP request** — `:submit-form` issues the managed-HTTP call with `:sensitive? true`, scrubbing the request body from every `:rf.http/*` trace event.
 
-The password **never enters the machine** — `:submit-form` sends the request and hands the machine a credential-free signal — and it never touches `:submitted`. It is also blanked from the draft on submit, to keep its *live* lifetime short: classification covers the observable shadow, blanking retires the live value.
+The password **never enters the machine** — `:submit-form` sends the request and hands the machine a credential-free signal. It is also blanked from the draft on submit, to keep its *live* lifetime short: classification covers the observable shadow, blanking retires the live value.
 
 ## Why this shape
 

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -54,7 +54,7 @@
 (rf/reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
   (let [draft     @(subscribe [:auth.login/draft])
-        busy?     @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
+        busy?     @(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
         err       @(subscribe [:auth.login/error])
         email-err @(subscribe [:auth.login/field-error :email])
         pw-err    @(subscribe [:auth.login/field-error :password])]
@@ -97,8 +97,8 @@
 ;; form the rest of the time.
 (rf/reg-view ^{:doc "Picks what to show by login state: welcome / locked panel / the form."}
           login-banner []
-  (let [authed? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/authenticated])
-        locked? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/locked])]
+  (let [authed? @(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/authenticated])
+        locked? @(subscribe [:rf.machine/has-tag? :auth.login/flow :auth/locked])]
     [:div.banner {:data-testid "login-banner"}
      (cond
        authed? [:span "Welcome!"]

--- a/examples/core/login/model.cljs
+++ b/examples/core/login/model.cljs
@@ -220,6 +220,17 @@
                classified `:auth.login/succeeded` event (which owns the session
                token), failure to the machine's `:auth.login/failure`
                sub-event."
+   ;; This stub is the CLASSIFIED OWNER of the request body it receives. The
+   ;; login request carries the plaintext password at [:request :body :password],
+   ;; and `submit-form` marks the request `:sensitive? true` — but that scrub
+   ;; lives inside the REAL `:rf.http/managed` handler, which the `:fx-overrides`
+   ;; remap to this stub BYPASSES. When the override fires, `handle-one-fx`
+   ;; stamps the always-emitted `:rf.fx/handled` trace with THIS fx's id and its
+   ;; RAW args, and the classification projector redacts `:rf.fx/args` off the
+   ;; RESOLVED fx's own `:sensitive`. So the stub must declare its own — without
+   ;; it the password would ride raw on the one wire every tool reads
+   ;; (docs/core/how-to/keep-secrets-out-of-traces.md).
+   :sensitive [[:request :body :password]]
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)

--- a/examples/core/login/model.cljs
+++ b/examples/core/login/model.cljs
@@ -411,10 +411,16 @@
   [schema value]
   (or (some-> (m/explain schema value) me/humanize) {}))
 
-;; Lay down the slice in its standard form-recipe shape — empty draft, `:idle`
-;; status, all the bookkeeping fields blank. Dispatched once at boot (from each
-;; substrate mount's `:initial-events`) so the very first render reads a real
-;; draft.
+;; Lay down the slice in its shape for this MACHINE-DRIVEN variant: the draft
+;; plus the validation bookkeeping the form recipe needs (`:submit-attempted?`,
+;; `:errors`, `:touched`). Notice what is ABSENT — no `:status` / `:submitted` /
+;; `:submit-error` mirror. The generic form recipe carries those to track the
+;; submit/auth lifecycle (docs/core/how-to/build-a-form.md), but here the
+;; `:auth.login/flow` machine and its state tags ARE that lifecycle, so a
+;; parallel slice mirror would be a second source of truth no view reads —
+;; write-only state that could only drift out of step with the machine.
+;; Dispatched once at boot (from each substrate mount's `:initial-events`) so the
+;; very first render reads a real draft.
 ;;
 ;; This is also OWNER 1 of the password's three egress boundaries (see the
 ;; `Credentials` note above). Alongside the `:db` write we return a `:sensitive`
@@ -427,18 +433,17 @@
 ;; (docs/core/how-to/keep-secrets-out-of-traces.md, "Classify a durable secret
 ;; in app-db").
 (rf/reg-event :auth.login/initialise-form
-  {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         form-recipe shape (empty draft, :idle status), and classify the
-         draft-password path :sensitive so it is redacted at every egress."}
+  {:doc "Seed the login-form slice at [:auth :login-form] for this machine-driven
+         variant (empty draft + validation bookkeeping; the machine owns the
+         submit/auth lifecycle, so the slice carries no :status mirror), and
+         classify the draft-password path :sensitive so it is redacted at every
+         egress."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
-                    :submitted         nil
                     :submit-attempted? false
-                    :status            :idle
                     :errors            {}
-                    :touched           #{}
-                    :submit-error      nil})
+                    :touched           #{}})
      :sensitive [[:auth :login-form :draft :password]]}))
 
 ;; A keystroke landed on a NON-SECRET field (the email). Write the new value into
@@ -490,11 +495,11 @@
 ;; the user first presses submit, every invalid field is allowed to speak
 ;; (docs/core/how-to/build-a-form.md, step 3).
 ;;
-;; If the draft is clean, this is the handoff point. It flips the slice `:status`
-;; to `:submitting`, clears any stale field errors, issues the login request
-;; itself, and nudges the machine with a credential-free `:submit` signal. From
-;; here on the *machine* owns the in-flight / authed / error / locked story; the
-;; slice `:status` is just a mirror.
+;; If the draft is clean, this is the handoff point. It clears any stale field
+;; errors, issues the login request itself, and nudges the machine with a
+;; credential-free `:submit` signal. From here on the *machine* owns the whole
+;; in-flight / authed / error / locked story — read through its state tags — so
+;; the slice keeps no parallel `:status` of its own to fall out of step.
 ;;
 ;; If the draft is *invalid*, we stop right here: the field errors land in
 ;; `:errors` (rendered under each input) and nothing is dispatched. Handing a bad
@@ -509,8 +514,8 @@
 ;; lives in app-db — but a password is transient, so once the request is in
 ;; flight we also blank `[:draft :password]` to keep its *live* lifetime short.
 ;; Classification covers the observable shadow; blanking retires the live value.
-;; The password never touches `:submitted` or the machine — only the HTTP body
-;; carries it off-box, scrubbed by `:sensitive? true`. See
+;; The password never touches the machine — only the HTTP body carries it
+;; off-box, scrubbed by `:sensitive? true`. See
 ;; docs/core/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: validate the draft against Credentials. If
@@ -524,7 +529,6 @@
           db'    (assoc-in db [:auth :login-form :submit-attempted?] true)]
       (if (empty? errors)
         {:db (-> db'
-                 (assoc-in [:auth :login-form :status] :submitting)
                  (assoc-in [:auth :login-form :errors] {})
                  (assoc-in [:auth :login-form :draft :password] ""))
          :fx [;; Advance the machine — a credential-free signal. The machine
@@ -612,18 +616,15 @@
           ;; The machine gets a bare success fact — no credential.
           [:dispatch [:auth.login/flow [:auth.login/success]]]]}))
 
-;; Wipe the slate — slice back to empty, status back to `:idle`.
+;; Wipe the slate — slice back to empty defaults.
 (rf/reg-event :auth.login/reset-form
-  {:doc "Clear the login-form slice back to empty defaults / :idle."}
+  {:doc "Clear the login-form slice back to empty defaults."}
   (fn handler-login-form-reset [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
-                    :submitted         nil
                     :submit-attempted? false
-                    :status            :idle
                     :errors            {}
-                    :touched           #{}
-                    :submit-error      nil})}))
+                    :touched           #{}})}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -401,6 +401,29 @@
 ;; VIEW
 ;; ============================================================================
 
+;; The typed error markers the evaluator emits, each mapped to the familiar
+;; spreadsheet hash-code a user expects to see. EVERY marker `evaluate-ast` /
+;; `evaluate-cell` can produce needs an entry here — a marker with no mapping
+;; falls through to `(str value)` in `value->display` and leaks its raw
+;; `:error/…` keyword into the grid.
+(def error-marker->hash
+  {:error/cycle       "#CYCLE"
+   :error/eval        "#EVAL"
+   :error/type        "#TYPE"
+   :error/div-by-zero "#DIV/0"
+   :error/unknown-op  "#OP?"})   ;; a list whose head isn't + - * / (e.g. =(1 2))
+
+(defn value->display
+  "Turn a computed cell value into the text the grid shows. A parse error arrives
+   as an `[:error/parse msg]` pair and shows as #PARSE; every other typed error
+   marker maps through `error-marker->hash` to its spreadsheet hash-code; anything
+   else is just the value, stringified. Pure — it takes no view state — so the
+   marker→hash mapping is unit-testable away from the DOM."
+  [value]
+  (or (when (parse-error? value) "#PARSE")
+      (error-marker->hash value)
+      (str value)))
+
 ;; One cell. It has two faces: while you're editing it shows an <input> holding
 ;; the raw text; otherwise it shows the computed value. Which face we wear comes
 ;; straight from subscriptions, so any edit anywhere just flows back in.
@@ -412,17 +435,10 @@
         ;; A parse error arrives as `[:error/parse msg]`; pull the message out so
         ;; we can show it on hover.
         parse-err  (parse-error-text value)
-        ;; Pick what the cell shows. The error markers map to the familiar
-        ;; spreadsheet hash-codes (#CYCLE, #DIV/0, …); anything else is just the
-        ;; value, stringified.
-        display    (cond
-                     editing?                  raw
-                     parse-err                 "#PARSE"
-                     (= value :error/cycle)    "#CYCLE"
-                     (= value :error/eval)     "#EVAL"
-                     (= value :error/type)     "#TYPE"
-                     (= value :error/div-by-zero) "#DIV/0"
-                     :else                     (str value))]
+        ;; While editing, show the raw text; otherwise show the computed value
+        ;; mapped through `value->display` — error markers become spreadsheet
+        ;; hash-codes (#CYCLE, #DIV/0, …), never a raw keyword.
+        display    (if editing? raw (value->display value))]
     ;; The `data-*` attributes are hooks for tests and tooling: `data-cell`
     ;; tags the coordinate, and `data-testid` follows the same naming the other
     ;; seven-GUIs examples use, so one selector convention covers them all. When

--- a/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
@@ -106,8 +106,8 @@
   (testing "rf2-3fc89f.33 — a clean submit issues the (sensitive) managed-HTTP
             request carrying the REAL password, nudges the machine with a
             CREDENTIAL-FREE :submit signal (no password anywhere in the machine
-            event), blanks [:draft :password], flips :status to :submitting,
-            clears :errors, latches :submit-attempted?, and leaves the email"
+            event), blanks [:draft :password], clears :errors, latches
+            :submit-attempted?, and leaves the email"
     (with-new-frame [f (frame/make-anon-frame-record! {})]
       (seed-draft! f "alice@example.com" "hunter2pw")
       (let [dispatched (atom [])
@@ -119,8 +119,17 @@
               "the password is blanked in the app-db slice draft after submit")
           (is (= "alice@example.com" (get-in s [:draft :email]))
               "only the SECRET is cleared — the email draft is left intact")
-          (is (= :submitting (:status s))
-              "the slice :status advanced to :submitting on the clean branch")
+          ;; rf2-fai6a8 — this machine-driven variant carries NO :status /
+          ;; :submitted / :submit-error mirror: the :auth.login/flow machine and
+          ;; its state tags own the submit/auth lifecycle, so the slice keeps no
+          ;; parallel status a view could read stale. Assert the mirror is gone
+          ;; on the clean branch (it used to advance :status to :submitting here).
+          (is (not (contains? s :status))
+              "no :status mirror — the machine + its state tags own the lifecycle")
+          (is (not (contains? s :submitted))
+              "the vestigial :submitted field is gone from the slice")
+          (is (not (contains? s :submit-error))
+              "the vestigial :submit-error field is gone from the slice")
           (is (= {} (:errors s))
               "stale field errors were cleared on the clean branch")
           (is (true? (:submit-attempted? s))
@@ -221,9 +230,9 @@
 (deftest invalid-submit-issues-nothing-and-retains-password
   (testing "rf2-t83ail — an invalid draft (bad email + short password) fails the
             pre-submit Credentials validation: :errors is populated per field,
-            :submit-attempted? latches, :status stays :idle, and NOTHING is
-            issued (no machine signal, no HTTP). The password is RETAINED for the
-            fix-up — nothing left the box, so this is not the leak the fix guards."
+            :submit-attempted? latches, and NOTHING is issued (no machine signal,
+            no HTTP). The password is RETAINED for the fix-up — nothing left the
+            box, so this is not the leak the fix guards."
     (with-new-frame [f (frame/make-anon-frame-record! {})]
       (seed-draft! f "not-an-email" "short")
       (let [dispatched (atom [])
@@ -236,8 +245,9 @@
               "the bad email produced a field error")
           (is (contains? (:errors s) :password)
               "the short password produced a field error")
-          (is (= :idle (:status s))
-              ":status did NOT advance to :submitting on an invalid submit")
+          (is (not (contains? s :status))
+              "rf2-fai6a8 — the slice carries no :status mirror on any branch;
+               the machine owns the lifecycle, not a parallel slice field")
           (is (zero? (count @dispatched))
               "no machine signal — the invalid draft was not handed off")
           (is (zero? (count @http))

--- a/implementation/core/test/re_frame/example_login_stub_fx_args_redaction_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_stub_fx_args_redaction_cljs_test.cljs
@@ -1,0 +1,129 @@
+(ns re-frame.example-login-stub-fx-args-redaction-cljs-test
+  "Framework-tree security regression for the login example's DEMO HTTP STUB —
+   the `:auth.login.demo/managed-stub` reg-fx owned by
+   examples/core/login/model.cljs (rf2-a6zmmu).
+
+   These belong in the framework test tree, NOT under examples/ (examples stay
+   test-free per rf2-8cevm). The ns requires the login model owner
+   (`login.model`) so its events / subs / machine / schemas / demo-stub register
+   at ns-load, then drives a real submit through the stub. Sibling of
+   `re-frame.example-login-success-token-cljs-test` (the RETURN-token half) and
+   `re-frame.example-login-form-slice-cljs-test` (the password-egress half); this
+   ns pins the DEMO-STUB fx-args egress.
+
+   THE LEAK THIS PINS. The three login examples run against a demo backend by
+   REMAPPING `:rf.http/managed` → `:auth.login.demo/managed-stub` through the
+   shared `frame-config` `:fx-overrides`. When the override fires, `handle-one-fx`
+   stamps the always-emitted `:rf.fx/handled` trace with the RESOLVED stub id and
+   the RAW fx args — and the classification projector redacts `:rf.fx/args` off
+   the RESOLVED fx's OWN registration `:sensitive` (post-rf2-6h3c02). The real
+   `:rf.http/managed` handler's `:sensitive? true` request-body scrub is
+   BYPASSED by the override, so unless the stub declares its own `:sensitive`,
+   the plaintext password in the request body rides RAW in the stub's
+   `:rf.fx/handled` trace — a credential leaking onto the one wire every tool
+   reads. The fix is the stub reg-fx declaring `:sensitive [[:request :body
+   :password]]`, so the projector redacts it there too.
+
+   Distinct from rf2-j538f7.30 (the reply/effect token leak) and rf2-6h3c02 (the
+   projector walking every fx-arg slot): this is the demo stub missing its OWN
+   `:sensitive` declaration — the registration the projector consumes."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.classification :as classification]
+            [re-frame.privacy :as privacy]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; login.model pulls these transitively; require here so the ns is
+            ;; self-sufficient (mirrors the sibling login test namespaces).
+            [re-frame.schemas]
+            [re-frame.machines]
+            [re-frame.http.managed]
+            [re-frame.http.test-support]
+            [login.model])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; A UNIQUE sentinel password — a valid Credentials password (>= 8 chars) that
+;; appears nowhere else in the source or the framework, so a recursive scan for
+;; it across the trace stream can only be hitting THIS submit's credential.
+(def sentinel "PW-STUB-ARGS-SENTINEL-4c1f9e")
+
+(defn- contains-sentinel?
+  "True when `x` contains the sentinel password ANYWHERE in a nested data
+   structure — the recursive scan an off-box shipper / dev tool would apply."
+  [x]
+  (cond
+    (string? x) (not= -1 (.indexOf x sentinel))
+    (map? x)    (boolean (some contains-sentinel? (concat (keys x) (vals x))))
+    (coll? x)   (boolean (some contains-sentinel? x))
+    :else       false))
+
+(defn- record-traces! [id]
+  (let [a (atom [])]
+    (rf/register-listener! :trace id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- seed+submit!
+  "Boot the slice, type a valid draft carrying the sentinel password, then submit
+   through the frame's demo-stub override — the SAME `:fx-overrides` remap the
+   shared `frame-config` installs, so `:rf.http/managed` resolves to
+   `:auth.login.demo/managed-stub` and the stub actually fires."
+  [f]
+  (rf/dispatch-sync [:auth.login/initialise-form] {:frame f})
+  (rf/dispatch-sync [:auth.login/edit-field :email "alice@example.com"] {:frame f})
+  (rf/dispatch-sync [:auth.login/edit-password {:value sentinel}] {:frame f})
+  (rf/dispatch-sync [:auth.login/submit-form]
+                    {:frame        f
+                     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}))
+
+;; ---------------------------------------------------------------------------
+;; the stub owns its classification (what the projector consumes)
+;; ---------------------------------------------------------------------------
+
+(deftest stub-declares-its-own-sensitive-request-body-password
+  (testing "the demo stub reg-fx declares :sensitive [[:request :body :password]]
+            — the registration-owned classification the trace projector reads to
+            redact the RESOLVED fx's args when the override bypasses the real
+            managed-HTTP handler's :sensitive? scrub"
+    (is (= {:sensitive [[:request :body :password]]}
+           (classification/registration-classification :fx :auth.login.demo/managed-stub))
+        ":auth.login.demo/managed-stub owns [:request :body :password]")))
+
+;; ---------------------------------------------------------------------------
+;; the stub's :rf.fx/handled trace redacts the request-body password
+;; ---------------------------------------------------------------------------
+
+(deftest stub-fx-handled-trace-redacts-request-body-password
+  (testing "on a real submit routed through the demo stub, the plaintext password
+            in the request body is NOT raw in the stub's :rf.fx/handled trace —
+            it reads :rf/redacted off the stub's own :sensitive declaration
+            (rf2-a6zmmu)"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (let [traces (record-traces! ::probe)]
+        (seed+submit! f)
+        (rf/unregister-listener! :trace ::probe)
+        (let [handled (->> @traces
+                           (filter #(= :auth.login.demo/managed-stub
+                                       (get-in % [:tags :rf.fx/id]))))]
+          (is (seq handled)
+              "the demo stub emitted a :rf.fx/handled trace (the override fired
+               and the fx actually ran)")
+          (doseq [ev handled]
+            (is (= privacy/redacted-sentinel
+                   (get-in ev [:tags :rf.fx/args :request :body :password]))
+                "the request-body password reads :rf/redacted in the stub's
+                 :rf.fx/handled :rf.fx/args slot")
+            ;; shape retained — the non-secret sibling and the url are still there
+            (is (= "alice@example.com"
+                   (get-in ev [:tags :rf.fx/args :request :body :email]))
+                "shape retained — the non-secret email rides through unredacted")
+            (is (= "/api/login"
+                   (get-in ev [:tags :rf.fx/args :request :url]))
+                "shape retained — the request url is still visible")
+            (is (not (contains-sentinel? (:tags ev)))
+                "the plaintext password appears NOWHERE raw in the stub's
+                 :rf.fx/handled trace tags")))))))

--- a/implementation/core/test/re_frame/seven_guis_cells_parser_cljs_test.cljs
+++ b/implementation/core/test/re_frame/seven_guis_cells_parser_cljs_test.cljs
@@ -180,6 +180,46 @@
     (is (= :error/eval (cells/evaluate-ast true {} #{})))))
 
 ;; ===========================================================================
+;; value->display — the marker→hash display mapping (rf2-3xn8qr)
+;; ===========================================================================
+;;
+;; The evaluator emits typed keyword markers; the grid's `value->display` must
+;; translate EVERY one to a spreadsheet hash-code. A marker with no mapping falls
+;; through to `(str value)` and leaks its raw `:error/…` keyword into the cell —
+;; which is exactly what used to happen to `:error/unknown-op` (a list whose head
+;; is not + - * /, reachable from real user input like `=(1 2)`): the display
+;; cond had no branch for it, so the cell rendered the literal ":error/unknown-op".
+
+(deftest value->display-maps-every-error-marker-to-a-hash-code
+  (testing "each typed error marker shows its spreadsheet hash-code, never a raw
+            keyword"
+    (doseq [[marker hash] {:error/cycle       "#CYCLE"
+                           :error/eval        "#EVAL"
+                           :error/type        "#TYPE"
+                           :error/div-by-zero "#DIV/0"
+                           :error/unknown-op  "#OP?"}]
+      (is (= hash (cells/value->display marker))
+          (str marker " must display as " hash))
+      (is (not (re-find #":error/" (cells/value->display marker)))
+          (str marker " must not leak its raw keyword to the grid"))))
+  (testing "a parse-error pair shows #PARSE, and a plain value is stringified"
+    (is (= "#PARSE" (cells/value->display [:error/parse "boom"])))
+    (is (= "42" (cells/value->display 42)))
+    (is (= "hi" (cells/value->display "hi")))))
+
+(deftest unknown-op-formula-renders-hash-not-raw-keyword
+  (testing "=(1 2) — a list whose head is a number, not an operator — reaches the
+            evaluator as :error/unknown-op, and the grid maps it to a hash-code
+            rather than leaking the raw ':error/unknown-op' keyword (rf2-3xn8qr)"
+    (let [v (cells/evaluate-cell "A1" {"A1" (cell-entry "=(1 2)")} #{})]
+      (is (= :error/unknown-op v)
+          "the evaluator emits the typed marker for a non-operator-headed list")
+      (is (= "#OP?" (cells/value->display v))
+          "the grid maps :error/unknown-op to its hash-code")
+      (is (not (re-find #":error/" (cells/value->display v)))
+          "no raw keyword leaks to the grid — the bug was the missing display branch"))))
+
+;; ===========================================================================
 ;; evaluate-cell / evaluate-ast — arithmetic + empty-cell semantics
 ;; ===========================================================================
 


### PR DESCRIPTION
Four findings from the examples/core correctness/security audit, same surface (examples/core: cells + login), one PR / four commits. Examples stay test-free — all regressions land in the framework test tree (`implementation/core/test`).

## rf2-3xn8qr (P3 bug) — cells: raw `:error/unknown-op` keyword leaked to the grid
`evaluate-ast` emits `:error/unknown-op` when a parenthesised list's head is not one of `+ - * /` (reachable from real input like `=(1 2)` or `=(A1 2)`), but `cell-view`'s display `cond` had no branch for it, so the cell rendered the literal `:error/unknown-op` instead of a spreadsheet hash-code.

Extracted the marker→hash mapping into a pure, testable `value->display` fn backed by a total `error-marker->hash` table (the missing marker now maps to `#OP?`). Regression over the display mapping added to `seven_guis_cells_parser_cljs_test`.

## rf2-fai6a8 (P3 dead-slice) — login: dropped the write-only `:status` mirror
The login form slice wrote `[:auth :login-form :status]` forward to `:submitting` on submit and never reconciled it, and seeded `:submitted` / `:submit-error` that were never written or read — write-only state in a machine-driven variant where the `:auth.login/flow` machine and its state tags already own the submit/auth lifecycle. No view read `:status`, but it leaked through the public `:auth.login/form-slice` sub as a stuck-at-`:submitting` lie-in-waiting.

Per Mike's rf2-01rgg7 precedent for this exact pattern: dropped `:status` / `:submitted` / `:submit-error` from both initialisers and the submit-form clean-branch write; aligned model + README prose (the machine is the single source of lifecycle truth). Updated the form-slice test to assert the mirror is gone on both branches.

## rf2-88qc0k (P4 idiom) — login: consistent injected `subscribe`
`login/core.cljs` mixed the frame-injected `subscribe` with the bare facade `rf/subscribe` for the three `:rf.machine/has-tag?` reads — contradicting the file's own lesson (and every sibling example). Verified same-frame resolution (not a wrong-frame bug), so purely cosmetic. Switched the three machine-tag reads to the injected `subscribe` and aligned the README prose.

## rf2-a6zmmu (P2 security) — login: redact the demo-stub request-body password
The examples run against a demo backend by remapping `:rf.http/managed` → `:auth.login.demo/managed-stub` via the shared `frame-config` `:fx-overrides`. When the override fires, `handle-one-fx` stamps the always-emitted `:rf.fx/handled` trace with the resolved stub id and the RAW fx args, and the classification projector redacts `:rf.fx/args` off the resolved fx's OWN registration `:sensitive`. The real managed-HTTP handler's `:sensitive? true` body scrub is bypassed by the override, so with no `:sensitive` on the stub the plaintext password rode raw in the stub's `:rf.fx/handled` trace — a credential on the one wire every tool reads. **Runtime-confirmed** via a real submit before the fix (password present raw; after: `:rf/redacted`).

Declared `:sensitive [[:request :body :password]]` on the demo stub reg-fx; added a framework-tree regression driving a real submit through the stub (fails before, passes after). Distinct from rf2-j538f7.30 / rf2-6h3c02 — this is the stub missing its own declaration.

## Quality gates
- `shadow-cljs compile :examples/cells` — 0 warnings
- `shadow-cljs compile :examples/login` — 0 warnings
- `npm run test:cljs` (node-test) — 8564 tests / 40421 assertions / 0 failures
- `node examples/scripts/check-examples-assets.cjs` — green (35 pages)
- Regressions (framework tree): 3xn8qr (display mapping + `=(1 2)` renders `#OP?`); fai6a8 (form-slice mirror gone both branches); a6zmmu (stub `:rf.fx/handled` password redacted, runtime-verified fail-before/pass-after)