### PR TITLE
fix(machines): desugar region-cache body, raised-event parallel-root fallback, region-root after consistency (rf2-x76af2.7, rf2-x76af2.8, rf2-x76af2.10)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -464,29 +464,69 @@
 ;; `timeout/desugar-timeouts`), so a root `:timeout` — which lowers onto
 ;; `:after` — is caught via its lowered form in the SAME check as a
 ;; directly-authored root `:after`.
+;;
+;; A parallel machine's REGION-ROOT `:after` (rf2-x76af2.10) has the SAME
+;; unscheduled shape: it sits on the region body itself (decl-path `[]` WITHIN
+;; the region), not on an entered leaf. `bootstrap-step` schedules only the
+;; region's entered initial LEAVES; `schedule-root-after-fx` schedules only the
+;; MACHINE root's own `:after` — neither reaches the region container's own
+;; `:after`, so it too registers-but-never-fires. A region body is structurally
+;; a flat/compound mini-machine, so its root `:after` is the exact analog of a
+;; flat machine-root `:after` and is rejected with the SAME category — keeping
+;; the runtime honest (no accept-but-inert path) and consistent with the
+;; machine-root rejection. (The machine's OWN parallel-root `:after` remains
+;; the one supported, scheduled root-`:after` form.) Reject-vs-schedule is a
+;; genuine design call; REJECT was chosen for consistency with the existing
+;; machine-root rejection + fail-loud (a per-region root scheduler would be a
+;; feature expansion), so a region-root deadline moves onto the region's
+;; `:initial` state's own `:after` / `:timeout` instead.
 
 (defn- validate-non-parallel-root-after!
-  "Reject a non-parallel (flat / compound) machine root's `:after` map —
-  whether hand-authored or lowered from a root `:timeout` / `:on-timeout`
-  — with `:rf.error/machine-non-parallel-root-after-not-supported`. A
-  `:type :parallel` root's `:after` is unaffected (that IS the supported,
-  scheduled, resolved feature per Spec 005). Absent / empty root `:after`
-  is fine on either machine shape."
+  "Reject an UNSCHEDULED root-level `:after` — whether hand-authored or lowered
+  from a `:timeout` / `:on-timeout` — with
+  `:rf.error/machine-non-parallel-root-after-not-supported`. Two shapes are
+  rejected:
+
+    - a non-parallel (flat / compound) MACHINE root's `:after`; and
+    - a parallel machine's REGION-ROOT `:after` (on a region body itself).
+
+  A `:type :parallel` machine's OWN root `:after` is unaffected — that IS the
+  supported, scheduled, resolved feature per Spec 005. Absent / empty `:after`
+  is fine everywhere."
   [machine]
-  (when (and (not (parallel/parallel? machine))
-             (seq (:after machine)))
-    (throw (validation-error
-             :rf.error/machine-non-parallel-root-after-not-supported
-             (str "a non-parallel (flat/compound) machine root declares "
-                  ":after " (pr-str (:after machine)) " — either "
-                  "hand-authored or lowered from a root :timeout / "
-                  ":on-timeout. Root-level :after scheduling + resolution "
-                  "is supported ONLY for a :type :parallel machine root "
-                  "(Per Spec 005 §Root-level :after). On a flat/compound "
-                  "root the timer would register but NEVER schedule or "
-                  "fire. Move the deadline onto the machine's :initial "
-                  "state's own :after / :timeout instead.")
-             {:after (:after machine)}))))
+  (if (parallel/parallel? machine)
+    ;; The machine's own parallel-root `:after` is supported; only a
+    ;; REGION-ROOT `:after` is the unscheduled shape.
+    (doseq [[rn region-body] (:regions machine)]
+      (when (seq (:after region-body))
+        (throw (validation-error
+                 :rf.error/machine-non-parallel-root-after-not-supported
+                 (str "region " (pr-str rn) " of a :type :parallel machine "
+                      "declares a REGION-ROOT :after " (pr-str (:after region-body))
+                      " on the region body itself — either hand-authored or "
+                      "lowered from a region-root :timeout / :on-timeout. "
+                      "Root-level :after scheduling + resolution is supported "
+                      "ONLY for the :type :parallel MACHINE root (Per Spec 005 "
+                      "§Root-level :after); a region body is structurally a "
+                      "flat/compound mini-machine, so its OWN root :after would "
+                      "register but NEVER schedule or fire (bootstrap-step "
+                      "schedules only the region's entered leaves). Move the "
+                      "deadline onto the region's :initial state's own :after / "
+                      ":timeout instead.")
+                 {:region rn :after (:after region-body)}))))
+    (when (seq (:after machine))
+      (throw (validation-error
+               :rf.error/machine-non-parallel-root-after-not-supported
+               (str "a non-parallel (flat/compound) machine root declares "
+                    ":after " (pr-str (:after machine)) " — either "
+                    "hand-authored or lowered from a root :timeout / "
+                    ":on-timeout. Root-level :after scheduling + resolution "
+                    "is supported ONLY for a :type :parallel machine root "
+                    "(Per Spec 005 §Root-level :after). On a flat/compound "
+                    "root the timer would register but NEVER schedule or "
+                    "fire. Move the deadline onto the machine's :initial "
+                    "state's own :after / :timeout instead.")
+               {:after (:after machine)})))))
 
 (defn- walk-state-nodes
   "Yield `[state-key state-node]` pairs for every node under `:states`,

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -237,9 +237,30 @@
 (defn- build-region-machine
   "Construct a synthetic single-machine spec for one region of
   `parent-machine`. See `region-machine` for the contract — this is the
-  uncached compute path."
+  uncached compute path.
+
+  The region body is DESUGARED here — `:timeout` / `:on-timeout` lowered onto
+  `:after`, `:type :choice` / `:choice` onto `:always` — so the synthetic
+  region-spec is ALWAYS in the lowered form the engine drives, regardless of
+  whether `parent-machine` was desugared. This is the single choke-point where
+  region-specs are born (`region-machine` memoises the result), so the cache
+  holds the desugared form and BOTH the birth paths that call
+  `apply-transition-once` directly (`bootstrap-step`, `apply-root-region-target`
+  — which BYPASS the per-dispatch `machine-transition` desugar seam) and the
+  event path see identically-lowered region bodies. Without this, a
+  region-initial `:timeout` never armed at birth and a region-initial
+  `:type :choice` stayed stuck at its transient node (rf2-x76af2.7): the raw
+  region body was faulted into the cache during `build-initial-snapshot`'s tag
+  computation, then served — still raw — on those direct-apply paths. Both
+  desugars are idempotent and short-circuit for the common timeout/choice-free
+  region, so this costs one structural scan on the once-per-region cache miss.
+  A region-ROOT `:after` / `:timeout` is rejected at registration
+  (`validate-non-parallel-root-after!`, rf2-x76af2.10), so only region STATE
+  nodes carry lowerable `:timeout` / `:choice` by the time a body reaches here."
   [parent-machine region-name]
-  (let [region-body (get-in parent-machine [:regions region-name])]
+  (let [region-body (choice/desugar-choices
+                      (timeout/desugar-timeouts
+                       (get-in parent-machine [:regions region-name])))]
     (-> region-body
         (assoc :guards            (:guards parent-machine))
         (assoc :actions           (:actions parent-machine))

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -792,6 +792,10 @@
     (bootstrap-step machine initial-snapshot)))
 
 (declare machine-transition)
+;; `drain-parent-queue` consults the parallel root `:on` ancestor fallback for a
+;; re-broadcast raise declined by every region (rf2-x76af2.8); `root-fallback-
+;; seed` is defined below it (alongside the external-seed path it mirrors).
+(declare root-fallback-seed)
 
 ;; ---- parallel macrostep internal-event queue ------------------------------
 ;;
@@ -1115,8 +1119,28 @@
                     ;; augmented `:rf/cofx` overlays onto each region spec via
                     ;; `region-spec-overlaid`, and threads forward so a later
                     ;; re-broadcast re-presents the generated value.
-                    m'   (transition/ensure-raised-cofx m cur-snap ev)
-                    step (broadcast-once m' cur-snap ev)]
+                    m'    (transition/ensure-raised-cofx m cur-snap ev)
+                    bstep (broadcast-once m' cur-snap ev)
+                    ;; A raised internal event declined by EVERY region consults
+                    ;; the parallel root's own `:on` as the ancestor fallback —
+                    ;; mirroring the EXTERNAL-seed path (`root-fallback-seed` in
+                    ;; `parallel-machine-transition`), the flat/compound drain
+                    ;; (each dequeued raise selects against the machine-root `:on`
+                    ;; fallback), and XState v6 / SCXML (a raised event selects
+                    ;; against the FULL configuration incl. the parallel
+                    ;; ancestor). Selection is against `cur-snap` — the config as
+                    ;; of this microstep's start — the frozen view a raise sees.
+                    ;; `root-fallback-seed` returns `bstep` UNCHANGED when a
+                    ;; region handled it (atomic ancestor suppression), when the
+                    ;; root declares no matching `:on`, or for reserved `:rf/*`
+                    ;; framework traffic; when the root fires it applies the
+                    ;; transition, settles the moved region(s)' `:always`, and
+                    ;; defers any surfaced raises back through `split-raises`
+                    ;; below — so they drain FIFO through this same queue
+                    ;; (rf2-x76af2.8). A `result/fail` short-circuits.
+                    step  (if (result/fail? bstep)
+                            bstep
+                            (root-fallback-seed m' cur-snap ev bstep))]
                 (if (result/fail? step)
                   step
                   (result/with-ok [snap2 fx2] step

--- a/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
+++ b/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
@@ -15,6 +15,11 @@
   internal-event queue and re-broadcasts each surfaced raise across every
   region.
 
+  A raised event DECLINED by every region consults the parallel root's own
+  `:on` as the ancestor fallback — identically to an external event (XState v6
+  / SCXML: a raised event selects against the FULL configuration incl. the
+  parallel ancestor; rf2-x76af2.8).
+
   Pure-engine tests — call `machine-transition` directly and read the merged
   post-macrostep snapshot. Order is recorded in `:data :log` (shared `:data`
   threads sequentially through regions in declaration order, so the log is
@@ -246,3 +251,76 @@
       (is (= :done (get-in snap [:state :flow]))
           "re-broadcast raise drove a→b, [:advance]→c, then region :always c→done")
       (is (= [:arm :step :auto] (:log (:data snap)))))))
+
+;; ---- 7. a raised event declined by EVERY region consults the root :on ------
+;;
+;; rf2-x76af2.8: a re-broadcast raise that no region handles must consult the
+;; parallel ROOT's own `:on` ancestor fallback — exactly as an EXTERNAL event
+;; does (`root-fallback-seed`). Pre-fix, `drain-parent-queue` re-broadcast to
+;; the regions only and silently DROPPED the raise when all declined, diverging
+;; from the flat-machine drain and XState v6 / SCXML (a raised event selects
+;; against the full configuration incl. the parallel ancestor).
+
+(deftest raised-event-declined-by-regions-consults-root-on
+  (let [spec
+        {:type    :parallel
+         :data    {}
+         :actions {;; :left's :trigger raises [:reset]; NO region handles [:reset].
+                   :raise-reset (fn [{:keys [data]}]
+                                  {:data (log! data :raise-reset)
+                                   :fx   [[:raise [:reset]]]})
+                   :root-reset  (fn [{:keys [data]}]
+                                  {:data (-> data (assoc :root-fired true)
+                                             (log! :root-reset))})}
+         ;; root :on — the ancestor fallback for [:reset].
+         :on      {:reset {:target [:left :done] :action :root-reset}}
+         :regions {:left {:initial :idle
+                         :states  {:idle {:on {:trigger {:target :fired
+                                                          :action :raise-reset}}}
+                                   :fired {}
+                                   :done  {}}}}}
+        initial {:state {:left :idle} :data {}}]
+    (testing "control: an EXTERNAL [:reset] fires the root :on"
+      (let [{snap ::result/snap} (machines/machine-transition spec initial [:reset])]
+        (is (= :done (get-in snap [:state :left])) "root :on moved :left to :done")
+        (is (true? (get-in snap [:data :root-fired])) "root :root-reset action ran")))
+    (testing "a RAISED [:reset] declined by every region ALSO fires the root :on"
+      (let [{snap ::result/snap} (machines/machine-transition spec initial [:trigger])]
+        (is (= :done (get-in snap [:state :left]))
+            "the raised [:reset] consulted the root :on (pre-fix: stuck at :fired)")
+        (is (true? (get-in snap [:data :root-fired]))
+            "the root :root-reset action fired for the RAISED event too")
+        (is (= [:raise-reset :root-reset] (:log (:data snap)))
+            "the region trigger ran, then the root fallback fired for the raise")))))
+
+;; ---- 8. a region handling the raise SUPPRESSES the root (atomic fallback) --
+;;
+;; The ancestor fallback is atomic: if ANY region handles the raised event, the
+;; root `:on` is suppressed ENTIRELY (same as the external-event semantic).
+
+(deftest region-handling-raise-suppresses-root
+  (let [spec
+        {:type    :parallel
+         :data    {}
+         :actions {:raise-reset (fn [{:keys [data]}]
+                                  {:data (log! data :raise-reset)
+                                   :fx   [[:raise [:reset]]]})
+                   :region-reset (fn [{:keys [data]}] {:data (log! data :region-reset)})
+                   :root-reset   (fn [{:keys [data]}]
+                                   {:data (-> data (assoc :root-fired true)
+                                              (log! :root-reset))})}
+         :on      {:reset {:target [:left :root-done] :action :root-reset}}
+         :regions {:left {:initial :idle
+                         ;; :left handles [:reset] LOCALLY — so the root is suppressed.
+                         :states  {:idle {:on {:trigger {:target :fired :action :raise-reset}}}
+                                   :fired {:on {:reset {:target :region-done
+                                                        :action :region-reset}}}
+                                   :region-done {}
+                                   :root-done   {}}}}}
+        initial {:state {:left :idle} :data {}}
+        {snap ::result/snap} (machines/machine-transition spec initial [:trigger])]
+    (is (= :region-done (get-in snap [:state :left]))
+        "the region handled the raised [:reset] locally — root suppressed")
+    (is (nil? (get-in snap [:data :root-fired]))
+        "the root :on was NOT consulted (atomic ancestor suppression)")
+    (is (= [:raise-reset :region-reset] (:log (:data snap))))))

--- a/implementation/machines/test/re_frame/region_initial_desugar_test.clj
+++ b/implementation/machines/test/re_frame/region_initial_desugar_test.clj
@@ -1,0 +1,119 @@
+(ns re-frame.region-initial-desugar-test
+  "rf2-x76af2.7: the synthetic region-spec must be DESUGARED —
+  `:timeout` / `:on-timeout` lowered onto `:after`, `:type :choice` / `:choice`
+  onto `:always` — on EVERY path, including the birth / root-target paths that
+  call `apply-transition-once` directly (`bootstrap-step`,
+  `apply-root-region-target`) and therefore BYPASS the per-dispatch
+  `machine-transition` desugar seam.
+
+  The fix desugars the region body at `build-region-machine` — the single
+  choke-point where synthetic region-specs are born and memoised in the
+  `::region-cache` — so the cache holds the lowered form and both the direct-
+  apply birth paths and the event path (which re-desugars per dispatch) see
+  identically-lowered region bodies.
+
+  Pre-fix, the raw region body was faulted into the cache during
+  `build-initial-snapshot`'s tag computation, then served — still raw — on
+  the direct-apply paths, so:
+    (a) a region-initial `:timeout` never armed its `:after` at birth;
+    (b) a region-initial `:type :choice` stayed stuck at its transient node;
+    (c) a root `:on` target INTO a `:timeout` state never lowered.
+  All three are exercised end-to-end through registration + live dispatch
+  (the JVM plain-atom substrate the audit reproduced on)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private snapshot mtest/snapshot)
+
+(defn- scheduled-delays
+  "The set of `:delay`s across all `:rf.machine.timer/scheduled` traces."
+  [traces]
+  (into #{}
+        (comp (filter #(= :rf.machine.timer/scheduled (:operation %)))
+              (map #(:delay (:tags %))))
+        traces))
+
+;; ---- (a) region-initial :timeout arms its :after at birth ------------------
+
+(deftest region-initial-timeout-arms-at-birth
+  (testing "a region-initial state's :timeout schedules its :after (5000) at birth"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left {:initial :waiting
+                             :states  {:waiting {:timeout    "PT5S"
+                                                 :on-timeout {:target :done}}
+                                       :done    {}}}}}
+          traces (atom [])]
+      (rf/reg-machine :rf.region-desugar/timeout m)
+      (rf/register-listener! :trace ::t (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.region-desugar/timeout [:rf.machine/start]])
+      (rf/unregister-listener! :trace ::t)
+      (is (contains? (scheduled-delays @traces) 5000)
+          "the region-initial :timeout lowered onto :after and armed at birth
+           (pre-fix: SCHEDULED was #{} — the raw region body served from the cache)"))))
+
+;; ---- (b) region-initial :type :choice resolves past the transient node -----
+
+(deftest region-initial-choice-resolves-at-birth
+  (testing "a region-initial :type :choice resolves to its guarded branch on start"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left {:initial :pick
+                             :states  {:pick {:type   :choice
+                                              :choice [{:target :yes}]}
+                                       :yes  {}}}}}]
+      (rf/reg-machine :rf.region-desugar/choice m)
+      (rf/dispatch-sync [:rf.region-desugar/choice [:rf.machine/start]])
+      (is (= :yes (get-in (snapshot :rf.region-desugar/choice) [:state :left]))
+          "the transient :type :choice node settled past to :yes at birth
+           (pre-fix: stuck at :pick — externally observed transient node)"))))
+
+;; ---- (c) a root :on target INTO a :timeout state lowers --------------------
+
+(deftest root-on-target-into-timeout-state-lowers
+  (testing "a root :on landing a region on a :timeout state arms that state's :after"
+    (let [m {:type    :parallel
+             :data    {}
+             :on      {:jump {:target [:left :waiting]}}
+             :regions {:left {:initial :idle
+                             :states  {:idle    {}
+                                       :waiting {:timeout    "PT5S"
+                                                 :on-timeout {:target :done}}
+                                       :done    {}}}}}
+          traces (atom [])]
+      (rf/reg-machine :rf.region-desugar/root-target m)
+      (rf/dispatch-sync [:rf.region-desugar/root-target [:rf.machine/start]])
+      ;; capture only the :jump macrostep's traces
+      (rf/register-listener! :trace ::t (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.region-desugar/root-target [:jump]])
+      (rf/unregister-listener! :trace ::t)
+      (is (= :waiting (get-in (snapshot :rf.region-desugar/root-target) [:state :left]))
+          "the root :on moved :left into :waiting")
+      (is (contains? (scheduled-delays @traces) 5000)
+          "entering :waiting via the root target armed its lowered :after
+           (pre-fix: the un-desugared :timeout on the cached region body never armed)"))))
+
+;; ---- sanity: an EXPLICIT (already-lowered) :after arms identically ---------
+;;
+;; Control proving the birth/root scheduling path itself is sound — the bug was
+;; purely the un-lowered :timeout, not the scheduler.
+
+(deftest region-initial-explicit-after-arms-at-birth
+  (testing "a region-initial state with an explicit :after arms at birth"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left {:initial :waiting
+                             :states  {:waiting {:after {5000 {:target :done}}}
+                                       :done    {}}}}}
+          traces (atom [])]
+      (rf/reg-machine :rf.region-desugar/explicit-after m)
+      (rf/register-listener! :trace ::t (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.region-desugar/explicit-after [:rf.machine/start]])
+      (rf/unregister-listener! :trace ::t)
+      (is (contains? (scheduled-delays @traces) 5000)
+          "the explicit region-initial :after arms at birth (control for the :timeout case)"))))

--- a/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
+++ b/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
@@ -8,6 +8,13 @@
   §Root-level `:after` scopes the feature to a `:type :parallel` root only,
   so `validate-non-parallel-root-after!` enforces the supported scope.
 
+  A parallel machine's REGION-ROOT `:after` (rf2-x76af2.10) has the SAME
+  unscheduled shape — it sits on the region body itself, not on an entered
+  leaf, and `bootstrap-step` / `schedule-root-after-fx` never reach it — so it
+  is rejected with the SAME category, keeping the runtime honest (no
+  accept-but-inert path) and consistent with the flat machine-root rejection.
+  The machine's OWN parallel-root `:after` stays the one supported form.
+
   This suite pins:
    1. a hand-authored root `:after` on a flat machine is rejected;
    2. a hand-authored root `:after` on a COMPOUND machine (nested `:states`)
@@ -16,7 +23,10 @@
       onto `:after` — is rejected via the SAME error category;
    4. a flat machine with NO root `:after` / `:timeout` is unaffected;
    5. a `:type :parallel` root's `:after` is UNAFFECTED (still the
-      supported, scheduled, resolved feature)."
+      supported, scheduled, resolved feature);
+   6. a parallel machine's REGION-ROOT `:after` is rejected (rf2-x76af2.10);
+   7. a region-root `:timeout` / `:on-timeout` (lowered onto `:after`) is
+      rejected via the SAME error category too."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
@@ -101,3 +111,63 @@
                  :regions {:a {:initial :one :states {:one {} :two {}}}
                            :b {:initial :one :states {:one {} :two {}}}}}))
         "a parallel root's :after validates cleanly — unaffected by the non-parallel rejection")))
+
+;; ---- (6) region-root :after on a :type :parallel machine — rejected --------
+;;
+;; rf2-x76af2.10: a REGION-ROOT :after (on the region body itself, decl-path []
+;; WITHIN the region) has the same unscheduled shape as a flat machine-root
+;; :after — bootstrap-step schedules only the region's entered leaves, and
+;; schedule-root-after-fx schedules only the MACHINE root's own :after — so it
+;; registered-but-never-fired. Reject it for consistency with the flat-root
+;; rule (a region body is structurally a flat/compound mini-machine). Pins the
+;; ALREADY-DESUGARED :after shape (distinct root cause from rf2-x76af2.7's
+;; desugar-cache miss).
+
+(deftest region-root-after-rejected
+  (testing "a parallel machine's region-root :after fails registration"
+    (let [m {:type    :parallel
+             :regions {:left {:initial :a
+                             :after   {5000 {:target :b}}
+                             :states  {:a {} :b {}}}
+                       :right {:initial :x
+                              :states  {:x {}}}}}
+          thrown (registration-throws? :rf.root-after-np/region m)]
+      (is (some? thrown) "a region-root :after SHOULD fail registration")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))
+          "the SAME error category catches the region-root :after")
+      (is (= :left (:region (ex-data thrown)))
+          "ex-data names the offending region")
+      (is (= {5000 {:target :b}} (:after (ex-data thrown)))
+          "ex-data carries the offending region-root :after map"))))
+
+;; ---- (7) region-root :timeout / :on-timeout (lowers onto :after) — rejected
+
+(deftest region-root-timeout-rejected-via-lowered-after
+  (testing "a region-root :timeout / :on-timeout is rejected via its lowered :after form"
+    (let [m {:type    :parallel
+             :regions {:left {:initial    :a
+                             :timeout    "PT5S"
+                             :on-timeout {:target :b}
+                             :states     {:a {} :b {}}}}}
+          thrown (registration-throws? :rf.root-after-np/region-timeout m)]
+      (is (some? thrown) "a well-formed region-root :timeout SHOULD still fail registration")
+      (is (= :rf.error/machine-non-parallel-root-after-not-supported
+             (:rf.error/id (ex-data thrown)))
+          "the SAME category catches both hand-authored region-root :after and lowered :timeout")
+      (is (= {5000 {:target :b}} (:after (ex-data thrown)))
+          "ex-data carries the LOWERED region-root :after map (the desugared form)"))))
+
+;; ---- (8) sanity: a region STATE-level :after is UNAFFECTED -----------------
+;;
+;; The rejection is scoped to the region ROOT only — an :after on a region's
+;; STATE node (entered leaf) is scheduled normally and MUST still register.
+
+(deftest region-state-after-still-registers
+  (testing "an :after on a region STATE (not the region root) is unaffected"
+    (is (nil? (machines/validate-machine!
+                {:type    :parallel
+                 :regions {:left {:initial :a
+                                 :states  {:a {:after {5000 {:target :b}}}
+                                           :b {}}}}}))
+        "a region STATE-level :after validates cleanly — only the region ROOT is rejected")))


### PR DESCRIPTION
Three region/parallel-root transition-semantics bugs from the machines
correctness audit (rf2-x76af2), all reproduced empirically on the JVM
plain-atom substrate before fixing. One PR, commits ordered by severity.

## rf2-x76af2.7 (P2) — region-cache served the PRE-desugar region body
The `::region-cache` faulted the RAW region body during
`build-initial-snapshot`'s tag computation, then served it — still raw — on the
birth / root-target paths that call `apply-transition-once` directly
(`bootstrap-step`, `apply-root-region-target`), which BYPASS the per-dispatch
`machine-transition` desugar seam. On a registered `:type :parallel` machine a
region-initial `:timeout` never armed at birth, a region-initial `:type :choice`
stayed stuck at its transient node, and a root `:on` target into a `:timeout`
state never lowered.

**Fix:** desugar the region body at `build-region-machine` — the single
choke-point where synthetic region-specs are born and memoised — so the cache
holds the lowered form and both the direct-apply birth paths and the event path
see identically-lowered region bodies. Idempotent + short-circuiting, so it
costs one scan on the once-per-region cache miss.

## rf2-x76af2.8 (P3) — raised event declined by all regions dropped the root :on
`drain-parent-queue` re-broadcast each dequeued raise to the regions only and,
when every region declined it, silently dropped it — it never consulted the
parallel root's own `:on` ancestor fallback (that was applied only to the
external seed). Diverged from spec/005, the flat/compound drain, and XState v6 /
SCXML (a raised event selects against the full configuration incl. the parallel
ancestor).

**Fix:** in the drain's re-broadcast step, when the broadcast is declined by
every region, consult `root-fallback-seed` for the raised event (against the
current microstep snapshot) — mirroring the external-seed path. Region-match
suppression, no-root, reserved-traffic pass-through, `:always` settle, FIFO
raise deferral, and depth-limit/atomic-rollback semantics are all preserved.

## rf2-x76af2.10 (P3) — region-root :after/:timeout accepted but scheduled on no path
A region-root `:after` (on the region body itself) registered but never fired —
`bootstrap-step` schedules only entered leaves and `schedule-root-after-fx`
only the machine's own root. `validate-non-parallel-root-after!` only walked
non-parallel machine roots. Reproduces with an explicit already-desugared
`:after` too (distinct root cause from .7).

**Fix (design call: REJECT):** extend `validate-non-parallel-root-after!` to
reject a region-root `:after` with the same category
(`:rf.error/machine-non-parallel-root-after-not-supported`) — a region body is
structurally a flat/compound mini-machine, so its root `:after` is the exact
analog of a flat machine-root `:after`. Chosen for consistency with the existing
machine-root rejection + fail-loud (a per-region root scheduler would be a
feature expansion). Runs on the desugared machine, so a region-root `:timeout`
is caught via its lowered form. Reuses the existing Spec 009 error id — no new
catalogue row. The machine's OWN parallel-root `:after` and region STATE-level
`:after` are unaffected.

## Quality gates (foreground)
- `clojure -M:test` (implementation/machines): **954 tests / 3017 assertions, 0 failures** (baseline 945 + 9 new)
  - +4 region_initial_desugar_test (.7), +2 parallel_raise_broadcast_test (.8), +3 root_after_non_parallel_test (.10)
- `clojure -M:slow-test` (machines): 1 test / 35 assertions, 0 failures
- `npm run test:cljs` (implementation): **8560 tests / 40397 assertions, 0 failures** (the .cljc engine changes run here too)

Each fix adds an adversarial regression matching the audit repro; all six repros
confirmed failing on main pre-fix, green post-fix.
