### PR TITLE
fix(xray): fail-soft filter <-edn, keybinding repeat/focus guards, view-scope select reconcile (rf2-oa1va6, rf2-llecpa, rf2-d716o9, rf2-v8bule)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1200,6 +1200,12 @@ contract for this section — trim any spec drift back to it):
   stealing keystrokes from the host app, from text fields, and from a
   modal's own inner mnemonics (per spec/018 §3 + §6 and rf2-ttnst).
 
+Every binding fires **once per physical key press**: OS key-repeat
+(`event.repeat`) is ignored for the toggle chords and the toggle-style
+spine keys so a held chord does not flap the surface open↔closed. The
+sole exemption is the `j` / `k` step keys, where held-key auto-repeat
+deliberately walks the event feed (rf2-llecpa).
+
 ### Global chords
 
 | Key | Action | Predicate |

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1195,10 +1195,13 @@ contract for this section — trim any spec drift back to it):
 - **Shell spine keys** are bare unmodified keys that fire **only** when
   the Xray shell is visible AND the keydown target is inside the shell
   DOM tree AND the target is not an editable element (`<input>` /
-  `<textarea>` / `<select>` / contenteditable) AND not inside a modal
-  (Settings / palette). Those guards keep the bare letters from
-  stealing keystrokes from the host app, from text fields, and from a
-  modal's own inner mnemonics (per spec/018 §3 + §6 and rf2-ttnst).
+  `<textarea>` / `<select>` / contenteditable) AND not an activatable
+  control (`<button>` / `<summary>` / `[role=button]`, which own
+  `Space` / `Enter` for their own activation — rf2-d716o9) AND not
+  inside a modal (Settings / palette). Those guards keep the bare
+  letters from stealing keystrokes from the host app, from text fields,
+  from a focused control's native activation, and from a modal's own
+  inner mnemonics (per spec/018 §3 + §6, rf2-ttnst, rf2-d716o9).
 
 Every binding fires **once per physical key press**: OS key-repeat
 (`event.repeat`) is ignored for the toggle chords and the toggle-style
@@ -1218,8 +1221,8 @@ deliberately walks the event feed (rf2-llecpa).
 ### Shell spine keys
 
 Bare, unmodified keys — only inside the visible shell, never on an
-editable or modal target (see the scope guards above). Per spec/018 §3
-+ §6.
+editable, activatable, or modal target (see the scope guards above).
+Per spec/018 §3 + §6.
 
 | Key | Action | Event dispatched |
 |---|---|---|

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1364,6 +1364,15 @@ frame composed into `filtered-event-bundles`" framing in §6):
 - **Default = head-epoch frame.** On a fresh load the L2 list scopes to
   whichever frame produced the most-recent pickable event
   (`frame-switcher/head-frame`), rather than merging every frame.
+- **Empty-scope-safe picker.** The view scope INTENTIONALLY survives a
+  pinned frame that has no events (an "empty scope" — the L2 list shows
+  0 rows, not "hidden by filters"), so it is never silently retargeted.
+  The ribbon therefore surfaces the pinned frame as its OWN `<option>`
+  whenever it is not in `:rf.xray/available-frames`, so the controlled
+  `<select>`'s value always has a matching option — no React "value not
+  in options" warning and no blank render when the pinned frame has no
+  events yet or has left the stream (buffer cleared, frame destroyed /
+  stopped emitting). rf2-v8bule.
 - **Single dedicated slot.** The picker writes `:view-scope-frame` (via
   the canonical event-fx `:rf.xray/select-frame`); the L2 list scopes by
   it through `matcher/filter-event-bundles-by-view-scope`, which is a NO-OP

--- a/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
@@ -111,13 +111,19 @@
 (defn <-edn
   "Parse a stored EDN string. Returns the parsed map on success, or
   `{:in [] :out []}` on parse failure / unrecognised shape — the
-  load path never throws into init."
+  load path never throws into init.
+
+  Each of `:in` / `:out` is coerced fail-soft: a non-sequential value
+  (a corrupt / hand-edited scalar like `{:in 5}` or `{:in :oops}`)
+  degrades to `[]` rather than throwing `(vec 5)` (\"not ISeqable\")
+  out of init. Per-field, so a good `:in` survives a scalar `:out`."
   [s]
   (let [parsed (try (reader/read-string s)
-                    (catch :default _ nil))]
+                    (catch :default _ nil))
+        as-vec (fn [v] (if (sequential? v) (vec v) []))]
     (if (map? parsed)
-      {:in  (vec (get parsed :in []))
-       :out (vec (get parsed :out []))}
+      {:in  (as-vec (:in parsed))
+       :out (as-vec (:out parsed))}
       {:in [] :out []})))
 
 ;; ---- public API ----------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -337,6 +337,20 @@
   (let [selected-frame  @(rf/subscribe [:rf.xray/current-frame])
         frames          @(rf/subscribe [:rf.xray/available-frames])
         active          (or selected-frame (first frames))
+        ;; rf2-v8bule — the controlled `<select>`'s value is `(str active)`,
+        ;; so it MUST have a matching `<option>` or React warns "value not
+        ;; in options" and renders blank. `active` can be a frame that is
+        ;; NOT in `available-frames`: a view scope pinned to a frame with no
+        ;; events yet, or a picked frame that left the stream (buffer
+        ;; cleared / frame destroyed / stopped emitting). rf2-4vp5j keeps
+        ;; that empty scope intact (the L2 list scopes to it, 0 rows) rather
+        ;; than silently retargeting, so we surface the pinned frame as its
+        ;; own option — the control stays consistent AND the pin is re-
+        ;; selectable. In the normal case (`active` already available) the
+        ;; option set is unchanged.
+        option-frames   (if (and active (not (some #{active} frames)))
+                          (conj (vec frames) active)
+                          (vec frames))
         ;; rf2-ad7zx.14 — interactive whenever there is >=1 frame. A native
         ;; <select> with one option opens + shows it (not inert), which is
         ;; what Mike expects in the step-deck (a single :step-deck frame).
@@ -405,7 +419,10 @@
       ;; Flat option list — the frame is the EP-0023 public addressing unit.
       ;; The former realm `<optgroup>` grouping was removed (rf2-70owfr): with
       ;; a single default realm there was never more than one group.
-      (for [f frames]
+      ;; `option-frames` always includes `active` so the controlled select's
+      ;; value has a matching option even when the pinned frame has no
+      ;; events (rf2-v8bule).
+      (for [f option-frames]
         ^{:key (str f)}
         [:option {:value (str f)}
          (str (if (= f active) "✓ " "  ") f)])]]))
@@ -480,6 +497,13 @@
   ;;      frame produced the most recent event.
   ;; Composes off `:rf.xray/event-bundles` so the head default re-resolves
   ;; as the stream grows; once the user explicitly picks, slot #1 wins.
+  ;;
+  ;; The scope INTENTIONALLY survives a frame that has no events (rf2-4vp5j
+  ;; "empty scope" — the L2 list shows 0 rows, not "hidden by filters").
+  ;; So a pinned frame is NOT reconciled away when it leaves the stream;
+  ;; the controlled `<select>` mismatch that a now-event-less pin causes is
+  ;; fixed at the VIEW layer instead (rf2-v8bule — see `frame-switcher-view`
+  ;; where the pinned frame is surfaced as its own `<option>`).
   (rf/reg-sub :rf.xray/view-scope-frame
     :<- [:rf.xray/view-scope-frame-slot]
     :<- [:rf.xray/target-frame-slot]

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -227,6 +227,27 @@
           ;; one coerced read carries the same truth value.
           (boolean (.-isContentEditable target))))))
 
+(defn- target-activatable?
+  "True when `event.target` is an activatable control that natively
+  consumes Space (and Enter) for its OWN activation — a `<button>`,
+  `<summary>`, or `[role=button]`. Even inside Xray's shell, Space
+  belongs to the focused control (activating it), NOT to the spine's
+  `Space` → live-pause toggle. Without this exemption the spine branch
+  hijacks Space from a focused ribbon `<button>` / `<summary>` and
+  `.preventDefault`s it, blocking the control's native activation
+  (rf2-d716o9). Mirrors `target-editable?` for text surfaces: when a
+  native control owns the keystroke, the spine yields.
+
+  (`<a href>` links activate on Enter, which is not a spine key, so
+  they are unaffected — the concrete victims are `<button>` /
+  `<summary>` / `[role=button]`.)"
+  [^js event]
+  (when-let [^js target (.-target event)]
+    (let [tag (some-> target .-tagName .toUpperCase)]
+      (or (= tag "BUTTON")
+          (= tag "SUMMARY")
+          (= "button" (some-> target (.getAttribute "role")))))))
+
 (defn- target-inside-modal?
   "True when `event.target` is a DOM node inside one of Xray's modal
   surfaces (Settings popup, command palette) — identified by the
@@ -384,6 +405,10 @@
     (when (and (mount/visible?)
                (target-inside-xray? event)
                (not (target-editable? event))
+               ;; rf2-d716o9 — yield to a focused activatable control
+               ;; (button / summary / [role=button]) so Space activates
+               ;; the control instead of being hijacked as live-pause.
+               (not (target-activatable? event))
                (not (target-inside-modal? event)))
       (when-let [event-id (spine-key-id event)]
         (.preventDefault event)

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -288,8 +288,37 @@
         (and (not shift?) (or (= "s" k) (= "KeyS" code)))
         :rf.xray/settings-toggle))))
 
+(defn- step-key?
+  "True when `event` is one of the repeat-friendly spine STEP bindings —
+  unmodified `j` / `k` (spec/018 §3 event-feed stepping). Held-key OS
+  auto-repeat is DESIRABLE here: you hold `j` / `k` to walk the feed.
+  These are therefore the sole exemption from the `handle-keydown`
+  repeat guard that suppresses held toggle chords (rf2-llecpa). Mirrors
+  the no-modifier / no-shift shape of `spine-key-id`'s j / k arms so the
+  exemption tracks exactly the keys that want repeat."
+  [^js event]
+  (and (not (.-ctrlKey event))
+       (not (.-metaKey event))
+       (not (.-altKey event))
+       (not (.-shiftKey event))
+       (let [k    (.-key event)
+             code (.-code event)]
+         (or (= "j" k) (= "KeyJ" code)
+             (= "k" k) (= "KeyK" code)))))
+
 (defn- handle-keydown [^js event]
   (cond
+    ;; rf2-llecpa — ignore OS key-repeat for every binding EXCEPT the
+    ;; j / k step keys. Holding a toggle chord (Ctrl+Shift+C shell,
+    ;; Cmd/Ctrl+K palette, Cmd/Ctrl+Shift+M mode, Space live-pause,
+    ;; `,`/`s` settings) would otherwise re-fire the toggle at the OS
+    ;; key-repeat rate and flap the surface open↔closed. `.repeat` is set
+    ;; on every keydown the OS emits while a key is held; swallow those
+    ;; here so a held toggle fires once per physical press, while held
+    ;; j / k still walk the feed.
+    (and (.-repeat event) (not (step-key? event)))
+    nil
+
     (xray-toggle-key? event)
     (do (.preventDefault event)
         (.stopPropagation event)

--- a/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
@@ -67,6 +67,28 @@
          (persistence/<-edn "[1 2 3]"))
       "non-map parsed value collapses to default"))
 
+(deftest from-edn-scalar-in-out-degrades-not-throws
+  ;; rf2-oa1va6 — a parseable, map-shaped, but corrupt / hand-edited
+  ;; payload whose :in / :out value is a NON-seqable scalar must NOT
+  ;; throw `(vec 5)` ("5 is not ISeqable") out of `<-edn`, escaping the
+  ;; load path into init. The prior guard only rejected non-map / non-
+  ;; parseable payloads; a scalar :in / :out slipped past the `map?`
+  ;; check and blew up on the `(vec …)` coercion. Each field now
+  ;; degrades fail-soft to [] — the documented never-throws-into-init
+  ;; contract.
+  (is (= {:in [] :out []}
+         (persistence/<-edn "{:in 5 :out []}"))
+      "scalar :in (a number) degrades to [] instead of throwing ISeqable")
+  (is (= {:in [] :out []}
+         (persistence/<-edn "{:in :oops :out []}"))
+      "scalar :in (a keyword) degrades to []")
+  (is (= {:in [] :out []}
+         (persistence/<-edn "{:in [] :out true}"))
+      "scalar :out (a boolean) degrades to []")
+  (is (= {:in [{:pattern :auth/*}] :out []}
+         (persistence/<-edn "{:in [{:pattern :auth/*}] :out 9}"))
+      "per-field: a good :in survives while a scalar :out degrades to []"))
+
 ;; -------------------------------------------------------------------------
 ;; (2) save! / load round-trip (depends on localStorage being available)
 ;; -------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
@@ -362,3 +362,111 @@
 ;; produced more than one group, so the grouping never branched away from the
 ;; flat option list. The picker renders the flat list directly; the public
 ;; partition is image -> frame (EP-0023).
+
+;; -------------------------------------------------------------------------
+;; (8) rf2-v8bule — stale view-scope frame reconciles to an available frame
+;; -------------------------------------------------------------------------
+;;
+;; An explicitly-picked (or host-seeded) view-scope frame used to win
+;; forever, with no membership check against `:rf.xray/available-frames`.
+;; Once that frame left the stream (buffer cleared / frame destroyed) the
+;; controlled `<select>` carried a value with NO matching `<option>`
+;; (React "value not in options" warning + blank render + an unpickable
+;; label). `:rf.xray/view-scope-frame` now clamps to availability.
+
+(defn- current-frame []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/current-frame])))
+
+(defn- available-frames []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/available-frames])))
+
+(defn- picker-value+options
+  "Render the ribbon frame-switcher view and return the controlled
+  `<select>`'s `:value` plus the set of its `<option>` values, so a test
+  can assert the value always matches a rendered option (the controlled-
+  input invariant)."
+  []
+  (rf/with-frame :rf/xray
+    (let [tree    (frame-switcher/frame-switcher-view {})
+          picker  (th/find-by-testid tree "rf-xray-ribbon-frame-picker")
+          options (filter (fn [n] (and (vector? n) (= :option (first n))))
+                          (hiccup-seq tree))]
+      {:value         (:value (second picker))
+       :option-values (set (map (fn [o] (:value (second o))) options))})))
+
+(deftest stale-pin-still-has-a-matching-select-option
+  (testing "rf2-v8bule — when the pinned view-scope frame leaves the stream
+            (buffer cleared / frame destroyed) the controlled <select>'s
+            value STILL matches a rendered <option>: the pinned frame is
+            surfaced as its own option, so there is no React 'value not in
+            options' mismatch. The scope itself is preserved (rf2-4vp5j
+            empty-scope), so current-frame keeps the pin — it is NOT
+            silently retargeted."
+    ;; Two frames in the stream; the user pins the OLDER one (:app/admin).
+    (dispatch-trace 1 :app/main)
+    (dispatch-trace 2 :app/admin)
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-frame :app/admin]))
+    (is (= :app/admin (current-frame)) "precondition — the pin is live")
+    ;; The pinned frame leaves the stream; only :app/main remains available.
+    (trace-collector/reset-for-test!)
+    (dispatch-trace 3 :app/main)
+    (is (= [:app/main] (available-frames))
+        ":app/admin is gone from the available (pickable) set")
+    (is (= :app/admin (current-frame))
+        "the empty scope survives — the pin is NOT retargeted (rf2-4vp5j)")
+    (let [{:keys [value option-values]} (picker-value+options)]
+      (is (contains? option-values value)
+          "the controlled <select> value matches a rendered option — no mismatch")
+      (is (= ":app/admin" value) "the value is the pinned frame")
+      (is (contains? option-values ":app/main")
+          "the still-available frame is offered so the user can re-scope"))))
+
+(deftest pinned-frame-with-empty-stream-has-matching-option
+  (testing "rf2-v8bule — with the pinned frame gone AND no frames left, the
+            disabled control still carries a value that matches its sole
+            (pinned) option — no orphan value, no React warning"
+    (dispatch-trace 1 :app/admin)
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-frame :app/admin]))
+    (is (= :app/admin (current-frame)))
+    ;; Every frame leaves the stream (buffer cleared).
+    (trace-collector/reset-for-test!)
+    (trace-collector/refresh-trace-rings!)
+    (is (= [] (available-frames)) "no frames remain in the pickable set")
+    (is (= :app/admin (current-frame)) "the empty scope survives")
+    (let [{:keys [value option-values]} (picker-value+options)]
+      (is (contains? option-values value)
+          "the value still matches an option (the pinned frame is surfaced)")
+      (is (= #{":app/admin"} option-values)
+          "the pinned frame is the sole option"))))
+
+(deftest no-pick-empty-stream-renders-clean-empty-select
+  (testing "rf2-v8bule — with no pick and no frames, the select carries the
+            empty value and renders no options (value \"\" with zero
+            options is React's clean 'nothing selected' — no mismatch)"
+    (setup!)  ;; no cascades seeded
+    (is (nil? (current-frame)) "no frame to scope to")
+    (let [{:keys [value option-values]} (picker-value+options)]
+      (is (= "" value) "empty value")
+      (is (empty? option-values) "no options"))))
+
+(deftest available-pick-adds-no-synthetic-option
+  (testing "rf2-v8bule — the surfaced option is added ONLY when the active
+            frame is not available; in the normal case (the pick IS
+            available) the option set is exactly the available frames — no
+            synthetic duplicate"
+    (dispatch-trace 1 :app/main)
+    (dispatch-trace 2 :app/admin)
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-frame :app/main]))
+    (is (= :app/main (current-frame)))
+    (let [{:keys [value option-values]} (picker-value+options)]
+      (is (= #{":app/main" ":app/admin"} option-values)
+          "exactly the available frames — no synthetic duplicate")
+      (is (contains? option-values value)))))

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -40,6 +40,7 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.keybinding :as keybinding]
+            [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -828,3 +829,104 @@
       (handle-keydown event)
       (is (false? @prevented) "repeat Escape is ignored — not consumed")
       (is (false? @stopped)))))
+
+;; ---- (9) rf2-d716o9 — Space not hijacked from focused button/summary -----
+;;
+;; `target-editable?` only exempted INPUT/TEXTAREA/SELECT/contenteditable,
+;; so a focused shell `<button>` / `<summary>` / `[role=button]` fell into
+;; the spine branch: Space dispatched `:rf.xray/toggle-live-pause` and
+;; `.preventDefault`d, blocking the control's native Space activation. The
+;; new `target-activatable?` predicate yields the spine to those controls.
+
+(defn- mk-target-event
+  "Synthetic keydown whose `.target` is a fake element with the given
+  `tag` (tagName) and optional `role` attribute — enough to drive the
+  target-* predicates without a real DOM."
+  [{:keys [tag role]}]
+  (js-obj "target"
+          (js-obj "tagName"      tag
+                  "getAttribute" (fn [attr] (when (= attr "role") role)))))
+
+(defn- mk-shell-space-event
+  "Synthetic bare Space keydown whose `.target` is a fake element INSIDE
+  the Xray shell: `.closest` resolves the shell testid (so
+  `target-inside-xray?` is true) but carries no modal marker. `tag` /
+  `role` drive the activatable check; preventDefault / stopPropagation
+  are spied so a test can see whether the spine consumed Space."
+  [{:keys [tag role]}]
+  (let [prevented  (atom false)
+        stopped    (atom false)
+        shell-node (js-obj "id" "fake-shell")
+        target     (js-obj "tagName"      tag
+                           "getAttribute" (fn [attr] (when (= attr "role") role))
+                           "closest"      (fn [sel]
+                                            (when (re-find #"rf-xray-shell" sel)
+                                              shell-node)))
+        event      (js-obj "key"             " "
+                           "code"            "Space"
+                           "target"          target
+                           "ctrlKey"  false  "metaKey" false
+                           "altKey"   false  "shiftKey" false
+                           "repeat"          false
+                           "preventDefault"  (fn [] (reset! prevented true))
+                           "stopPropagation" (fn [] (reset! stopped true)))]
+    {:event event :prevented prevented :stopped stopped}))
+
+(deftest target-activatable-matches-buttons-summary-role
+  (testing "rf2-d716o9 — a focused <button> / <summary> / [role=button]
+            natively consumes Space; target-activatable? flags them so the
+            spine yields"
+    (is (true? (boolean (#'keybinding/target-activatable?
+                          (mk-target-event {:tag "BUTTON"})))))
+    (is (true? (boolean (#'keybinding/target-activatable?
+                          (mk-target-event {:tag "SUMMARY"})))))
+    (is (true? (boolean (#'keybinding/target-activatable?
+                          (mk-target-event {:tag "DIV" :role "button"}))))
+        "[role=button] is an ARIA button — also activatable")
+    (is (true? (boolean (#'keybinding/target-activatable?
+                          (mk-target-event {:tag "button"}))))
+        "tagName compared case-insensitively (lower-case host quirk)")))
+
+(deftest target-activatable-rejects-non-activatable
+  (testing "rf2-d716o9 — ordinary shell nodes are NOT activatable, so the
+            spine keys still fire on them"
+    (is (false? (boolean (#'keybinding/target-activatable?
+                           (mk-target-event {:tag "DIV"})))))
+    (is (false? (boolean (#'keybinding/target-activatable?
+                           (mk-target-event {:tag "SPAN"})))))
+    (is (false? (boolean (#'keybinding/target-activatable?
+                           (mk-target-event {:tag "A"}))))
+        "<a href> activates on Enter (not a spine key) — not activatable")
+    (is (false? (boolean (#'keybinding/target-activatable?
+                           (mk-target-event {:tag "DIV" :role "listbox"}))))
+        "a non-button role is not activatable")
+    (is (nil? (#'keybinding/target-activatable? (js-obj)))
+        "an event with no target must not throw")))
+
+(deftest space-on-focused-button-is-not-hijacked
+  (testing "rf2-d716o9 — a focused shell <button> / <summary> / [role=
+            button] keeps Space for its native activation: the spine
+            branch yields (no preventDefault, no live-pause dispatch)."
+    (setup-xray-runtime!)
+    (with-redefs [mount/visible? (constantly true)]
+      (doseq [spec [{:tag "BUTTON"}
+                    {:tag "SUMMARY"}
+                    {:tag "DIV" :role "button"}]]
+        (let [{:keys [event prevented stopped]} (mk-shell-space-event spec)]
+          (handle-keydown event)
+          (is (false? @prevented)
+              (str "Space on a focused " spec " must NOT be hijacked"))
+          (is (false? @stopped)
+              (str "Space on a focused " spec " must not stopPropagation")))))))
+
+(deftest space-on-non-activatable-shell-target-still-pauses
+  (testing "rf2-d716o9 — the guard is surgical: Space on a NON-activatable
+            focused shell node still fires the LIVE-pause binding
+            (preventDefault called), so the spine keeps working normally
+            when focus is not on an activatable control."
+    (setup-xray-runtime!)
+    (with-redefs [mount/visible? (constantly true)]
+      (let [{:keys [event prevented]} (mk-shell-space-event {:tag "DIV"})]
+        (handle-keydown event)
+        (is (true? @prevented)
+            "Space consumed — the spine live-pause binding fired on a plain node")))))

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -731,3 +731,100 @@
     (reset! frame/frames {})
     (is (false? (#'keybinding/editor-hint-open?))
         "false when the :rf/xray frame is absent — Esc falls through")))
+
+;; ---- (8) rf2-llecpa — held toggle chords must not flap (repeat guard) ----
+;;
+;; No `event.repeat` guard meant HOLDING a toggle chord fired it at the
+;; OS key-repeat rate — the shell / palette / mode / live-pause flapped
+;; open↔closed. `handle-keydown` now swallows `.repeat` keydowns for
+;; every binding EXCEPT the j / k step keys (which WANT auto-repeat so a
+;; held key walks the feed). `step-key?` is the exemption predicate.
+
+(defn- step-key?
+  "Reach the private step-exemption predicate via var access."
+  [event]
+  (#'keybinding/step-key? event))
+
+(defn- mk-spy-event
+  "KeyboardEvent-shaped object with preventDefault / stopPropagation
+  spies plus arbitrary modifier + `.repeat` fields, so a test can assert
+  whether `handle-keydown` consumed (acted on) a synthetic keydown."
+  [opts]
+  (let [{:keys [key code ctrl? shift? meta? alt? repeat?]
+         :or   {ctrl? false shift? false meta? false alt? false repeat? false}} opts
+        prevented (atom false)
+        stopped   (atom false)]
+    {:event     (js-obj "key"             key
+                        "code"            code
+                        "ctrlKey"         ctrl?
+                        "shiftKey"        shift?
+                        "metaKey"         meta?
+                        "altKey"          alt?
+                        "repeat"          repeat?
+                        "preventDefault"  (fn [] (reset! prevented true))
+                        "stopPropagation" (fn [] (reset! stopped true)))
+     :prevented prevented
+     :stopped   stopped}))
+
+(deftest step-key-exempts-only-unmodified-j-and-k
+  (testing "rf2-llecpa — step-key? is the SOLE repeat exemption: the
+            feed-stepping keys j / k (which want held-key auto-repeat)"
+    (is (true? (boolean (step-key? (mk-event {:key "j"})))))
+    (is (true? (boolean (step-key? (mk-event {:key "k"})))))
+    (is (true? (boolean (step-key? (mk-event {:code "KeyJ"})))))
+    (is (true? (boolean (step-key? (mk-event {:code "KeyK"}))))))
+  (testing "toggles + idempotent snaps are NOT step keys — they get
+            repeat-guarded so a held press fires once per physical press"
+    (is (false? (boolean (step-key? (mk-event {:key " "})))) "Space")
+    (is (false? (boolean (step-key? (mk-event {:key "l"})))) "snap-LIVE")
+    (is (false? (boolean (step-key? (mk-event {:key "G" :shift? true})))) "go-to-head")
+    (is (false? (boolean (step-key? (mk-event {:key "s"})))) "settings")
+    (is (false? (boolean (step-key? (mk-event {:key ","})))) "settings"))
+  (testing "MODIFIED j / k are not the bare step binding (Ctrl+j etc.) —
+            those never matched the spine anyway, so no exemption applies"
+    (is (false? (boolean (step-key? (mk-event {:key "j" :ctrl? true})))))
+    (is (false? (boolean (step-key? (mk-event {:key "k" :meta? true})))))
+    (is (false? (boolean (step-key? (mk-event {:key "j" :shift? true})))))))
+
+(deftest held-toggle-chords-are-ignored
+  (testing "rf2-llecpa — a repeat keydown for a toggle chord is swallowed:
+            handle-keydown bails at the first cond arm before the action,
+            so it never preventDefaults / stopPropagations / toggles.
+            Proves shell (Ctrl+Shift+C), palette (Cmd/Ctrl+K), and mode
+            (Cmd/Ctrl+Shift+M) toggles fire once per PHYSICAL press, not
+            once per OS repeat tick."
+    (doseq [chord [{:key "C" :ctrl? true :shift? true :repeat? true}    ;; shell
+                   {:key "k" :meta? true :repeat? true}                 ;; palette (mac)
+                   {:key "k" :ctrl? true :repeat? true}                 ;; palette (win/linux)
+                   {:key "M" :ctrl? true :shift? true :repeat? true}]]  ;; mode
+      (let [{:keys [event prevented stopped]} (mk-spy-event chord)]
+        (handle-keydown event)
+        (is (false? @prevented)
+            (str "repeat chord " chord " must be ignored — not consumed"))
+        (is (false? @stopped)
+            (str "repeat chord " chord " must not stopPropagation"))))))
+
+(deftest held-space-does-not-toggle-live-pause
+  (testing "rf2-llecpa — a HELD Space (auto-repeat) inside the shell does
+            not re-fire the LIVE pause toggle. The runtime + shell-visible
+            plumbing that a genuine Space press needs is the browser lane;
+            here we assert the repeat is swallowed at the guard (no
+            preventDefault) — the spine branch is never reached."
+    (let [{:keys [event prevented stopped]} (mk-spy-event {:key " " :repeat? true})]
+      (handle-keydown event)
+      (is (false? @prevented) "repeat Space is ignored — not consumed")
+      (is (false? @stopped)))))
+
+(deftest held-escape-does-not-redismiss-hint
+  (testing "rf2-llecpa — a HELD Escape (auto-repeat) does not re-fire the
+            editor-hint dismiss; the first physical press already acted.
+            The non-repeat Escape path stays live (see
+            esc-dismisses-open-editor-hint), so this also proves a plain
+            keydown is NOT over-blocked by the guard."
+    (setup-xray-runtime!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-show]))
+    (let [{:keys [event prevented stopped]} (mk-spy-event {:key "Escape" :repeat? true})]
+      (handle-keydown event)
+      (is (false? @prevented) "repeat Escape is ignored — not consumed")
+      (is (false? @stopped)))))


### PR DESCRIPTION
Four P3 correctness-review fixes from the tools/xray audit (rf2-057izp), same artefact, different sub-areas. Commits ordered by area: filters/persistence -> keybinding -> view-scope. All premises reproduced on current main.

## rf2-oa1va6 - fail-soft filter `<-edn` on scalar `:in`/`:out`
A parseable, map-shaped, but corrupt/hand-edited persisted filter payload whose `:in`/`:out` value is a non-seqable scalar (e.g. `{:in 5}`) slipped past the `map?` guard and threw `(vec 5)` ("not ISeqable") out of `<-edn`, escaping the load path into xray init - violating the documented never-throws-into-init contract. Each of `:in`/`:out` is now coerced fail-soft (non-sequential -> `[]`, per-field). Regression covers scalar `:in`/`:out` payloads.

## rf2-llecpa - `event.repeat` guard so held toggle chords fire once
The global keydown handler had no `event.repeat` guard, so HOLDING a toggle chord fired it at the OS key-repeat rate - shell (Ctrl+Shift+C), palette (Cmd/Ctrl+K), mode (Cmd/Ctrl+Shift+M), live-pause (Space), settings (`,`/`s`) all flapped open<->closed. `handle-keydown` now swallows `.repeat` keydowns as its first `cond` arm for every binding EXCEPT the `j`/`k` step keys (which want held-key auto-repeat to walk the event feed). New `step-key?` predicate marks that exemption.

## rf2-d716o9 - yield spine `Space` to focused activatable controls
`target-editable?` only exempted INPUT/TEXTAREA/SELECT/contenteditable, so a focused shell `<button>`/`<summary>`/`[role=button]` fell into the spine branch - `Space` dispatched `:rf.xray/toggle-live-pause` and `preventDefault`'d, blocking the control's native activation. New `target-activatable?` predicate flags those controls; the spine `:else` guard bails on them so `Space` activates the control. (`<a href>` activates on Enter, not a spine key, so links are unaffected.)

## rf2-v8bule - pinned view-scope frame always has a matching `<select>` option
A view-scope frame pinned via the picker/palette rendered as the controlled `<select>`'s value while the option list carried only `:rf.xray/available-frames`; once the pinned frame had no events, the value matched no `<option>` -> React "value not in options" warning + blank render + unpickable label.

**Premise check found the bead's clamp fix-sketch collides with rf2-4vp5j.** Clamping `:rf.xray/view-scope-frame` to availability broke two existing rf2-4vp5j "empty-scope is valid" tests (`current-frame-sub-resolves-the-spine-slot`, `frame-scope-to-empty-frame-is-not-hidden-by-filters`) - it silently retargets the scope, reverting a prior design decision. The defect is a **render-layer** bug, so it is fixed there: the picker surfaces the pinned frame as its own `<option>` whenever it is not already available. The controlled select always has a matching option; the scope is never retargeted (empty scope preserved, L2 list shows 0 rows).

## Quality gates
- **`clojure -M:test` from tools/xray** (JVM `.clj`/`.cljc` via cognitect runner): **1245 tests, 0 failures** - green. Note: this runner does not execute `.cljs` files, so it does not exercise these fixes (all `.cljs`); it confirms no `.cljc`/`.clj` regression.
- **`npm run test:cljs` from implementation/** (shadow-cljs `:node-test`, which includes `tools/xray/test`): **8573 tests, 0 failures, 0 errors** - green. Authoritative gate for these `.cljs` changes; grew from an 8560 baseline with 13 new tests: oa1va6 +1, llecpa +8, d716o9 +8 (incl. behavioural `mount/visible?`-stubbed Space-on-button tests), v8bule +4.
- **Browser lane:** the keybinding + select fixes' full DOM integration lives in the Playwright/xray-feature-gate lane. The node gate covers them via pure predicates plus `with-redefs`-stubbed `handle-keydown` behavioural tests (repeat swallow; Space-on-button not hijacked / Space-on-plain-node still pauses) and rendered-view assertions (select value in option-values), so no browser run was required for regression coverage.

Spec updated in the same PR: spec/007-UX-IA.md (repeat once-per-press contract + activatable-control scope guard) and spec/018-Event-Spine.md (empty-scope-safe picker).
