### PR TITLE
fix(http): close abort-vs-retry double-reply/re-issue race + identity-conditional clear-in-flight (rf2-6nczv9, rf2-ous9e5)

### DIFF
--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -103,7 +103,20 @@
   `maybe-retry!`) call this directly; the abort sites
   (`managed-abort-handler`, `abort-on-actor-destroy`) rely on the
   abort-fn → `finalise-failure!` cascade to reach here. Idempotent
-  against already-gone state — the swap!s no-op on absent slots."
+  against already-gone state — the swap!s no-op on absent slots.
+
+  rf2-ous9e5 — the 2-arg request-id dissoc is IDENTITY-CONDITIONAL,
+  mirroring `remove-from-actor-index!`: it drops the request-id slot
+  ONLY while that slot still holds THIS `handle`. A completing OLD
+  attempt whose slot has already been taken over by a same-id SUCCESSOR
+  (a fresh request superseded it, or a retry re-registered a backoff
+  handle under the id) therefore no-ops on the request-id index and
+  leaves the live successor's handle in place. The earlier unconditional
+  `(dissoc request-id)` evicted the successor, making two effectively-
+  live requests share one id — the out-of-order-reply pattern
+  supersession exists to prevent. Single-request cleanup is unchanged:
+  when the slot still holds `handle`, the identity check passes and the
+  dissoc runs exactly as before."
   ([request-id]
    (when request-id
      (let [handle (get @in-flight request-id)]
@@ -113,7 +126,18 @@
    nil)
   ([request-id handle]
    (when request-id
-     (swap! in-flight dissoc request-id))
+     (swap! in-flight
+            (fn [m]
+              ;; rf2-ous9e5 — drop the slot ONLY while it still holds THIS
+              ;; handle, so a same-id successor is never evicted. A nil `handle`
+              ;; (an abort that fired before the handle was published to
+              ;; `@handle-cell` / `@handle-holder`) falls back to the
+              ;; unconditional dissoc — that pre-publication window precedes any
+              ;; successor, so there is nothing to protect and the slot must
+              ;; still be cleared.
+              (if (or (nil? handle) (identical? (get m request-id) handle))
+                (dissoc m request-id)
+                m))))
    (when handle
      (remove-from-actor-index! (:actor-id handle) handle))
    nil))

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -44,6 +44,37 @@
 (declare finalise-failure!)
 (declare schedule-backoff-handle!)
 
+;; ---- test-only interleaving seam (rf2-6nczv9) ------------------------------
+;;
+;; The abort-vs-retry race lives in the TRANSITIONAL window between
+;; `maybe-retry!`'s abort-snapshot and the backoff handle taking over the
+;; request-id slot. On the JVM the completion runs on a ForkJoinPool thread and
+;; the abort dispatch on the event thread, so the window is only reachable by
+;; wall-clock timing — non-deterministic. This seam lets a JVM concurrency test
+;; DETERMINISTICALLY inject an abort at a named point in that window (the audit
+;; noted deterministic repro needs interleaving injection, not timing). It is a
+;; single atom-holder deref at each call site; nil in production (never set),
+;; so the cost is one volatile read on the retry path and nothing else.
+
+(defonce ^:private test-interleave-hook
+  ;; A fn `(fn [point ctx])` invoked at named lifecycle points, or nil.
+  (atom nil))
+
+(defn set-test-interleave-hook!
+  "Test-only (rf2-6nczv9): install a `(fn [point ctx])` interleaving hook, or
+  clear it with nil. Not part of the user-facing API."
+  [f]
+  (reset! test-interleave-hook f)
+  nil)
+
+(defn- interleave!
+  "Invoke the test interleaving hook for `point` if one is installed. A no-op
+  (single atom deref) in production."
+  [point ctx]
+  (when-let [f @test-interleave-hook]
+    (f point ctx))
+  nil)
+
 (def ^:private reply-suppressing-abort-reasons
   "Abort reasons whose `:rf.http/aborted` failure is NOT dispatched to the app
   `:on-failure` reply target — the cancellation replaces the original outcome,
@@ -808,7 +839,7 @@
   "rf2-wj8vv — arm the retry backoff timer AND keep the request
   registered (and therefore cancellable) for the whole backoff window.
 
-  Two cells coordinate the timer-fires-vs-cancel race:
+  Cells coordinating the transition:
    - `fired?` is a once-only CAS owned jointly by the timer callback and
      the abort-fn. Whoever wins it owns the transition out of the
      backoff state; the loser is a no-op. This is the source of truth —
@@ -820,6 +851,19 @@
      which is constructed before the handle exists. The abort-fn reads
      it lazily and calls `interop/clear-timeout!` (a best-effort fast
      cancel layered over the authoritative `fired?` CAS).
+   - `finalised?` / `aborted?` are the just-completed live-fetch attempt's
+     REQUEST-LEVEL cells, REUSED here (rf2-6nczv9) rather than minted fresh.
+     `finalised?` is the once-only reply guard; `aborted?` is the abort-
+     precedence cell. Reusing the prior handle's cells makes the prior
+     live-fetch handle and this backoff handle act as ONE reply-guarded,
+     one-abort unit across the transition, so (a) an abort that resolves
+     the prior handle mid-transition and delivers the terminal reply is
+     visible here (the post-arm re-check reads `aborted?`), and (b) two
+     abort-fns firing for the same request (e.g. actor-destroy walking both
+     handles while both are transiently in the actor index) dispatch AT
+     MOST ONE reply (both CAS the shared `finalised?`). See Spec 014
+     §486-492 (abort always wins / a cancelled request MUST NOT issue a
+     fresh attempt / an abort during the backoff MUST cancel the retry).
 
   The backoff handle carries the same `:request-id` / `:actor-id` /
   `:url` / `:sensitive?` shape every cancellation path expects, so
@@ -833,12 +877,33 @@
   correct carried work-id (issuance/attempt preserved) rather than a
   default first-attempt id.
 
+  `prev-handle` is the just-completed live-fetch attempt's handle. This
+  registers the backoff handle FIRST (taking over the request-id slot),
+  THEN clears `prev-handle` — CONTINUOUS REGISTRATION (rf2-6nczv9): the
+  request is never absent from the registry for an instant, so an abort
+  landing anywhere in the transition always resolves SOME live handle
+  (the narrower-sibling window where an abort resolved no handle is
+  closed). The prior early clear-then-arm left that gap.
+
   `interop/set-timeout!` / `interop/clear-timeout!` are defined on both
   platforms (CLJS: `js/setTimeout` / `js/clearTimeout`; JVM:
   `ScheduledExecutorService` + `ScheduledFuture.cancel`), so the backoff
   scheduling and its cancellation are uniform across hosts."
-  [ctx delay-ms]
+  [ctx delay-ms prev-handle]
+  ;; rf2-6nczv9 — test-only interleaving seam: an abort injected HERE resolves
+  ;; the prior live-fetch handle (still registered — the backoff has not yet
+  ;; taken over the slot), reproducing the transitional / narrower-sibling
+  ;; window deterministically. No-op in production.
+  (interleave! :backoff/before-register ctx)
   (let [{:keys [request-id actor-id]} ctx
+        ;; rf2-6nczv9 — REUSE the just-completed attempt's request-level cells
+        ;; (see docstring). The prior live-fetch handle always carries them
+        ;; (stamped in `run-attempt!`) on the production retry path. Synthetic /
+        ;; test-path callers may pass a nil `prev-handle` (no prior phase); fall
+        ;; back to fresh cells so the abort-fn's `reset!` / `compare-and-set!`
+        ;; always operate on a real atom.
+        finalised? (or (:finalised? prev-handle) (atom false))
+        aborted?   (or (:aborted? prev-handle) (atom nil))
         fired?     (atom false)
         timer-cell (atom nil)
         ;; rf2-meq28 — forward-reference cell for the stamped handle, the
@@ -849,6 +914,11 @@
         ;; fire time (always after registration completes).
         handle-cell (atom nil)
         abort-fn   (fn [reason]
+                     ;; rf2-6nczv9 — abort always wins: flip the shared
+                     ;; precedence cell FIRST (before racing `fired?`), so a
+                     ;; concurrent timer-fire (its `run-attempt!` guard) and the
+                     ;; post-arm re-check both observe the cancellation.
+                     (reset! aborted? {:reason reason :actor-id actor-id})
                      ;; Win the once-only transition; a concurrent timer
                      ;; fire that loses here bails without retrying.
                      (when (compare-and-set! fired? false true)
@@ -862,24 +932,18 @@
                        ;; This mirrors the rf2-lz7se fix at the live-fetch
                        ;; abort-fn in `run-attempt!` and the by-identity
                        ;; clear the timer-fires path below already uses.
-                       ;; The earlier 1-arg form resolved by request-id and
-                       ;; no-op'd on a nil id — correct only under the
-                       ;; implicit, load-bearing invariant that an anonymous
-                       ;; (request-id-less, issued-from-actor) request can be
-                       ;; aborted SOLELY via actor-destroy (which eager-
-                       ;; dissocs the actor slot first). An anonymous request
-                       ;; can carry a `:retry` config and sit in this backoff
-                       ;; window with `actor-id` set / `request-id` nil; any
-                       ;; future non-pre-clearing trigger (frame-level
-                       ;; abort-all, timeout-driven abort of a sleeping retry)
-                       ;; would strand the handle. Passing the handle drops
-                       ;; that fragility: the 2-arg `remove-from-actor-index!`
-                       ;; is an identity-based vector remove that no-ops
-                       ;; against an already-cleared (or absent) slot, so it
-                       ;; is a safe idempotent no-op on the actor-destroy path
-                       ;; while closing the gap for any future trigger.
                        (registry/clear-in-flight! request-id @handle-cell)
-                       (dispatch-aborted! ctx reason)))
+                       ;; rf2-6nczv9 — dispatch guarded by the SHARED once-only
+                       ;; reply guard so a prior-phase abort-fn (the just-
+                       ;; completed live-fetch handle, resolvable during the
+                       ;; transition) that already delivered the terminal reply
+                       ;; is not doubled. In steady state (an abort during the
+                       ;; settled backoff window) `finalised?` is still false —
+                       ;; the retry path never consumed it — so this CAS wins
+                       ;; and the canonical aborted reply is dispatched exactly
+                       ;; as before.
+                       (when (compare-and-set! finalised? false true)
+                         (dispatch-aborted! ctx reason))))
         handle     (registry/record-in-flight!
                      request-id actor-id
                      {:abort-fn   abort-fn
@@ -908,12 +972,29 @@
                       :origin-event (:origin-event ctx)
                       :issuance     (:issuance ctx)
                       :attempt      (:attempt ctx)})
+        ;; rf2-6nczv9 — the shared `finalised?` / `aborted?` cells are NOT
+        ;; stamped onto the backoff handle: the abort-fn closes over them
+        ;; lexically, and the re-check / timer-guard read the same lexical
+        ;; bindings, so a handle copy would be dead weight. The backoff handle
+        ;; deliberately carries NO `:finalised?` — that absence is the
+        ;; documented invariant distinguishing a sleeping-backoff handle from a
+        ;; live-fetch handle (the fetch handle carries `:finalised?`).
         ;; rf2-meq28 — publish the stamped handle so the abort-fn closure
         ;; (defined above, before `handle` was bound) can pass it to the
         ;; 2-arg `clear-in-flight!` via `@handle-cell`. The reset! happens
         ;; synchronously here, before the timer is armed, so the cell is
         ;; always populated by the time any abort can fire.
         _          (reset! handle-cell handle)
+        ;; rf2-6nczv9 — CONTINUOUS REGISTRATION. The backoff handle now owns the
+        ;; request-id slot (`record-in-flight!` overwrote it). Clear the PRIOR
+        ;; live-fetch handle only NOW — AFTER the backoff is registered — so the
+        ;; request is never absent from the registry for an instant. The 2-arg
+        ;; clear is identity-conditional (rf2-ous9e5): the request-id slot holds
+        ;; the backoff handle (not `prev-handle`) so it no-ops on the request-id
+        ;; index and only drops the prior handle from the actor index (rf2-wvkn
+        ;; — no stale accumulation across retries).
+        _          (when prev-handle
+                     (registry/clear-in-flight! request-id prev-handle))
         ;; rf2-3fc89f.9 — ownership transfer: rebind the external
         ;; `:abort-signal` from the just-completed live-fetch handle onto THIS
         ;; sleeping-backoff handle's canonical abort-fn, so a signal that fires
@@ -922,11 +1003,15 @@
         ;; the next attempt starts. `bind-external-abort!` detaches the prior
         ;; live-fetch listener first. An already-aborted signal fires the
         ;; backoff abort-fn synchronously (winning `fired?`); the trailing
-        ;; `(when @fired? clear-timeout!)` below then disarms the armed timer.
+        ;; re-check below then disarms the armed timer.
         #?@(:cljs
             [_     (transport-cljs/bind-external-abort!
                      (:external-abort ctx)
                      (fn [] ((:abort-fn handle) :user)))])
+        ;; rf2-6nczv9 — test-only interleaving seam: an abort injected HERE
+        ;; resolves the BACKOFF handle (now registered), the settled-window
+        ;; path. No-op in production.
+        _          (interleave! :backoff/after-register ctx)
         ;; Schedule AFTER registering so the request is cancellable the
         ;; instant the timer is armed. The callback wins/loses the same
         ;; `fired?` CAS: on a win it clears its own handle and proceeds;
@@ -935,18 +1020,42 @@
                      (fn []
                        (when (compare-and-set! fired? false true)
                          (registry/clear-in-flight! request-id handle)
-                         (run-attempt! (-> ctx
-                                           (dissoc :handle)
-                                           (update :attempt inc)))))
+                         ;; rf2-6nczv9 — never re-issue a fresh attempt for a
+                         ;; request the caller already cancelled. If the shared
+                         ;; `:aborted?` cell was flipped during the backoff
+                         ;; window, the terminal aborted reply already went out;
+                         ;; issuing attempt N+1 would re-send a cancelled
+                         ;; (possibly non-idempotent) request (Spec 014
+                         ;; §486-492). This is load-bearing for the interleaving
+                         ;; where the prior handle's abort-fn EXECUTES after the
+                         ;; post-arm re-check ran — the re-check missed the flip
+                         ;; but the fresh attempt is still suppressed here.
+                         (when-not (some? @aborted?)
+                           (run-attempt! (-> ctx
+                                             (dissoc :handle)
+                                             (update :attempt inc))))))
                      delay-ms)]
     (reset! timer-cell timer)
-    ;; rf2-wj8vv — a cancel that arrived between `record-in-flight!` and
-    ;; this `reset!` already won `fired?` (so the timer callback will
-    ;; no-op) but may have read `timer-cell` as nil and skipped
-    ;; `clear-timeout!`. Re-check and cancel the now-known timer so the
-    ;; scheduler doesn't carry a doomed task for the full backoff.
-    (when @fired?
-      (interop/clear-timeout! timer))
+    (cond
+      ;; rf2-wj8vv — the backoff handle's own abort-fn already fired (won
+      ;; `fired?`): it cleared the registry + guarded-dispatched. It may have
+      ;; read `timer-cell` as nil and skipped `clear-timeout!`; re-check and
+      ;; disarm the now-known timer so the scheduler carries no doomed task.
+      @fired?
+      (interop/clear-timeout! timer)
+
+      ;; rf2-6nczv9 — the SHARED abort cell is flipped but this backoff's own
+      ;; abort-fn never ran: an abort resolved the PRIOR live-fetch handle
+      ;; during the transition into this backoff and already delivered the
+      ;; single terminal reply through the shared once-only guard. Win the
+      ;; transition, disarm the timer, and DROP the freshly-registered backoff
+      ;; handle so NO fresh network attempt fires for the cancelled request. Do
+      ;; NOT re-dispatch — the prior handle's abort-fn already replied.
+      (and (some? @aborted?)
+           (compare-and-set! fired? false true))
+      (do
+        (interop/clear-timeout! timer)
+        (registry/clear-in-flight! request-id handle)))
     nil))
 
 (defn- maybe-retry!
@@ -1012,13 +1121,25 @@
                          (or (contains? failure :body)
                              (contains? failure :body-text))
                          (assoc :rf.http/off-box-body :omit))))
-        ;; Clear the prior attempt's live-fetch handle from both indexes;
-        ;; `schedule-backoff-handle!` immediately re-registers a fresh
-        ;; backoff handle so the request is never invisible to a
-        ;; cancellation path. Without the clear the actor-in-flight index
-        ;; would accumulate stale handles across retries (rf2-wvkn).
-        (registry/clear-in-flight! request-id (:handle ctx))
-        (schedule-backoff-handle! ctx delay-ms))
+        ;; rf2-6nczv9 — test-only interleaving seam: an abort injected HERE
+        ;; (after `aborted?` was already sampled `false`, so `can-retry?` is
+        ;; committed) resolves the PRIOR live-fetch handle, still registered
+        ;; because the clear is now deferred into `schedule-backoff-handle!`.
+        ;; No-op in production.
+        (interleave! :maybe-retry/before-schedule ctx)
+        ;; rf2-6nczv9 — hand the prior attempt's live-fetch handle to
+        ;; `schedule-backoff-handle!`, which registers the backoff handle FIRST
+        ;; and only THEN clears the prior handle (continuous registration). The
+        ;; earlier shape cleared the prior handle HERE, before arming, which (a)
+        ;; opened a window where an abort resolved no handle and was lost, and
+        ;; (b) sampled the abort cell only once (`aborted?` above) so an abort
+        ;; landing during the arm re-issued a cancelled request. Deferring the
+        ;; clear closes both: the prior handle stays resolvable through the
+        ;; transition, and `schedule-backoff-handle!` re-checks the shared abort
+        ;; cell after arming (Spec 014 §486-492). The actor-in-flight
+        ;; accumulation the clear prevents (rf2-wvkn) still happens — just after
+        ;; registration, by identity.
+        (schedule-backoff-handle! ctx delay-ms (:handle ctx)))
       (do
         ;; rf2-upexd.3 — terminal failure: emit the final `:rf.http/retry-
         ;; attempt` trace (with `:next-backoff-ms nil`) ONLY when retries

--- a/implementation/http/test/re_frame/http_abort_retry_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_retry_race_test.clj
@@ -1,0 +1,201 @@
+(ns re-frame.http-abort-retry-race-test
+  "JVM concurrency regression for the abort-vs-retry-vs-successor race
+  (rf2-6nczv9 + rf2-ous9e5, http correctness audit rf2-k0pa70).
+
+  These are JVM-only races (CLJS is single-threaded and immune): on the JVM
+  the request completion runs on a `CompletableFuture` ForkJoinPool thread
+  while the abort dispatch runs on the event thread, so they can interleave
+  mid-`maybe-retry!`.
+
+  The transitional window is the instant between `maybe-retry!` sampling the
+  abort cell (deciding the failure is retry-eligible) and the backoff handle
+  taking over the request-id slot. An abort that lands there used to:
+   - DOUBLE-REPLY (the prior handle's abort-fn replied, then the freshly-armed
+     retry replied again), and
+   - RE-ISSUE a fresh network attempt for a request the caller cancelled
+     (Spec 014 §486-492).
+  The narrower sibling — an abort between the prior clear and the backoff
+  re-register — resolved NO handle and was silently lost, and the retry fired
+  anyway.
+
+  Deterministic repro needs INTERLEAVING INJECTION, not wall-clock timing (the
+  existing `http_backoff_cancellation_test` fires 150ms into the settled
+  backoff, which correctly cancels the steady-state handle — not this window).
+  We drive the interleaving through `transport/set-test-interleave-hook!`, a
+  test-only seam that fires the abort SYNCHRONOUSLY at a named point inside the
+  transition (on the completion thread, while the prior handle is still
+  registered), reproducing the exact ordering the audit described.
+
+  Spec references:
+   - Spec 014 §Abort precedence (abort always wins), §486-492
+   - Spec 014 §Retry and backoff / §Aborts
+
+  Coverage:
+   1. abort injected in `maybe-retry!` (post-abort-snapshot, pre-schedule)
+      → exactly one :rf.http/aborted reply, ZERO extra server hits.
+   2. abort injected at the START of `schedule-backoff-handle!`
+      (the narrower-sibling window) → same: one aborted reply, no retry.
+   3. rf2-ous9e5 unit: `clear-in-flight!` (2-arg) is identity-conditional —
+      a completing OLD attempt does NOT evict a same-id SUCCESSOR's handle."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as registry]
+            [re-frame.http.transport :as transport]
+            [re-frame.machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
+           [java.net InetSocketAddress]
+           [java.util.concurrent.atomic AtomicInteger]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- hit-counting always-500 server ---------------------------------------
+
+(defn- start-counting-500-server!
+  []
+  (let [hits   (AtomicInteger. 0)
+        server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/"
+                    (reify HttpHandler
+                      (handle [_ ex]
+                        (.incrementAndGet hits)
+                        (let [^HttpExchange ex ex
+                              bs (.getBytes "boom" "UTF-8")]
+                          (try
+                            (.sendResponseHeaders ex 500 (long (count bs)))
+                            (with-open [os (.getResponseBody ex)]
+                              (.write os bs))
+                            (catch Throwable _ nil))))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server
+     :port   (.getPort (.getAddress server))
+     :hits   hits}))
+
+(defn- stop-server! [{:keys [^HttpServer server]}]
+  (.stop server 0))
+
+;; A long-enough backoff that a re-issue (if the bug were live) would land
+;; well inside the observation window.
+(def ^:private backoff-ms 2000)
+
+(def ^:private retry-config
+  {:on           #{:rf.http/http-5xx}
+   :max-attempts 5
+   :backoff      {:base-ms backoff-ms :factor 1 :max-ms backoff-ms}})
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-abort-retry-race condition"})
+   true))
+
+;; ---- shared driver ---------------------------------------------------------
+
+(defn- run-injected-abort-case!
+  "Issue a retrying request against an always-500 server; install the
+  interleaving hook so the abort fires (once) at `inject-point`, squarely in
+  the transitional window. Assert: exactly ONE :rf.http/aborted reply, the
+  server was hit exactly ONCE (no re-issue), and the registry is clean."
+  [inject-point]
+  (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-500-server!)
+        replies (atom [])
+        fired?  (atom false)]
+    (try
+      (rf/reg-event :reply/recorder
+        (fn [_ [_ payload]] (swap! replies conj payload) {}))
+      (rf/reg-event :issue
+        (fn [_ _]
+          {:fx [[:rf.http/managed
+                 {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}
+                  :decode     :json
+                  :retry      retry-config
+                  :request-id :race
+                  :on-failure [:reply/recorder]
+                  :on-success [:reply/recorder]}]]}))
+      ;; The seam: fire the abort exactly once, when the retry lifecycle
+      ;; reaches `inject-point`, resolving the still-registered prior handle.
+      (transport/set-test-interleave-hook!
+        (fn [point ctx]
+          (when (and (= point inject-point)
+                     (= :race (:request-id ctx))
+                     (compare-and-set! fired? false true))
+            ;; Same seam the `:rf.http/managed-abort` fx routes through.
+            (registry/abort-in-flight! (:request-id ctx) :user))))
+      (rf/dispatch-sync [:issue])
+      ;; The abort's reply must arrive.
+      (await-condition! #(seq @replies))
+      (is (true? @fired?) "the interleaving hook fired the abort in-window")
+      ;; Wait past the FULL backoff window — proving the ABSENCE of a re-issue,
+      ;; which has no positive signal to poll on.
+      (Thread/sleep (long (+ backoff-ms 600)))
+      (is (= 1 (.get hits))
+          "ZERO extra server hits — the cancelled request was NEVER re-issued")
+      (is (= 1 (count @replies))
+          "EXACTLY ONE terminal reply — no double-reply")
+      (let [reply (first @replies)]
+        (is (= :cancelled (:status reply))
+            "the single reply is the cancellation")
+        (is (= :rf.http/aborted (get-in reply [:error :kind]))
+            "the single reply is the canonical :rf.http/aborted")
+        (is (= :user (get-in reply [:error :reason]))))
+      (is (empty? (registry/in-flight-snapshot))
+          "the request-id registry is clean after the cancelled transition")
+      (is (empty? (registry/actor-in-flight-snapshot))
+          "the actor registry is clean")
+      (finally
+        (transport/set-test-interleave-hook! nil)
+        (stop-server! srv)))))
+
+;; ---- (1) abort in maybe-retry!'s transitional window -----------------------
+
+(deftest abort-injected-in-maybe-retry-window-no-double-reply-no-reissue
+  (testing "rf2-6nczv9 — an abort landing after maybe-retry!'s abort-snapshot but before the backoff registers yields exactly one :rf.http/aborted reply and no fresh network attempt"
+    (run-injected-abort-case! :maybe-retry/before-schedule)))
+
+;; ---- (2) narrower-sibling window (start of schedule-backoff-handle!) --------
+
+(deftest abort-injected-at-backoff-registration-boundary-no-reissue
+  (testing "rf2-6nczv9 (narrower sibling) — an abort landing at the backoff registration boundary (prior clear now deferred, so the prior handle is still resolvable) yields one aborted reply and no retry"
+    (run-injected-abort-case! :backoff/before-register)))
+
+;; ---- (3) rf2-ous9e5 — identity-conditional clear-in-flight! ----------------
+
+(deftest clear-in-flight-2arg-is-identity-conditional
+  (testing "rf2-ous9e5 — clear-in-flight! (2-arg) does NOT evict a same-id successor's live handle; a completing OLD attempt clearing by its own handle leaves the successor in place"
+    (registry/clear-all-in-flight!)
+    (let [h-a (registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "a"})
+          h-b (registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "b"})]
+      ;; H_B (the successor) took over the request-id slot.
+      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+          "the successor H_B is the live occupant under :R")
+      ;; The OLD attempt (H_A) completes and clears BY ITS OWN handle.
+      (registry/clear-in-flight! :R h-a)
+      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+          "the successor H_B SURVIVES — a stale completion must not evict it (the pre-fix unconditional dissoc did)")
+      ;; Single-request cleanup is unchanged: clearing by the LIVE handle removes it.
+      (registry/clear-in-flight! :R h-b)
+      (is (not (contains? (registry/in-flight-snapshot) :R))
+          "clearing by the live handle removes the slot exactly as before"))
+    (registry/clear-all-in-flight!)))
+
+;; ---- (4) actor-index identity clear survives a successor -------------------
+
+(deftest clear-in-flight-2arg-preserves-successor-actor-index
+  (testing "rf2-ous9e5 — an OLD attempt's identity-conditional clear does not evict a same-id successor even when actor-indexed (mirrors remove-from-actor-index!)"
+    (registry/clear-all-in-flight!)
+    (let [h-a (registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "a"})
+          h-b (registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "b"})]
+      (is (identical? h-b (get (registry/in-flight-snapshot) :R)))
+      (registry/clear-in-flight! :R h-a)
+      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+          "successor survives in the request-id index")
+      ;; H_A is removed from the actor vector (by identity); H_B remains.
+      (let [v (get (registry/actor-in-flight-snapshot) :actor)]
+        (is (some #(identical? % h-b) v) "H_B still actor-indexed")
+        (is (not (some #(identical? % h-a) v)) "H_A dropped from the actor index by identity")))
+    (registry/clear-all-in-flight!)))

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -518,7 +518,11 @@
           ;; test — the abort-fn wins the once-only `fired?` CAS and the
           ;; timer callback (which would otherwise also reach the registry)
           ;; bails on its lost CAS.
-          _        (schedule-backoff-handle! ctx 600000)
+          ;; rf2-6nczv9 — the 3rd arg is the prior live-fetch handle whose
+          ;; request-level cells the backoff reuses; this synthetic ctx has no
+          ;; prior phase, so pass nil (schedule-backoff-handle! mints fresh
+          ;; cells in that case).
+          _        (schedule-backoff-handle! ctx 600000 nil)
           slot     (get (http-managed/actor-in-flight-snapshot) actor-id)
           handle   (first slot)]
       (is (= 1 (count slot))


### PR DESCRIPTION
## What

Two tightly-coupled JVM-only concurrency fixes in the `:rf.http/managed` abort/retry path (http correctness audit rf2-k0pa70). CLJS is single-threaded and immune; the JVM suite is the load-bearing gate. These are **one coherent race fix** — rf2-ous9e5 is half of rf2-6nczv9's fix.

### rf2-6nczv9 — abort-vs-retry double-reply + re-issue (P2)
`maybe-retry!` sampled the per-phase abort cell **once**, then cleared the live-fetch handle and armed a fresh backoff whose new cells knew nothing of a concurrent abort. An abort landing in that transitional window **double-replied AND re-issued a fresh network attempt for a cancelled request** (a non-idempotent POST got re-sent) — Spec 014 §486-492. The narrower sibling — an abort between the clear and the backoff re-register — resolved no handle, was silently **lost**, and the timer fired anyway.

### rf2-ous9e5 — `clear-in-flight!` unconditional eviction (P3)
The 2-arity `clear-in-flight!` `dissoc`ed by request-id **unconditionally**, so a completing OLD attempt could evict a same-id SUCCESSOR's live handle (unlike the actor index, which is identity-based).

## Fix

- **`schedule-backoff-handle!` reuses the prior live-fetch attempt's request-level `:finalised?` / `:aborted?` cells** (passed as `prev-handle`) instead of minting fresh ones — the prior handle and the backoff handle become ONE reply-guarded, one-abort unit. The backoff abort-fn's dispatch is guarded by the shared `:finalised?` CAS (no double-reply), and the shared `:aborted?` cell is visible across the phase boundary.
- **Continuous registration**: register the backoff handle first, then clear the prior handle (identity-conditional) — the request is never absent from the registry, closing the narrower-sibling lost-abort window.
- **Post-arm re-check** of the shared `:aborted?` cell (mirrors the existing `fired?` re-check idiom) disarms a freshly-armed retry when an abort resolved the prior handle mid-transition; a timer-callback guard suppresses the fresh attempt if the cell flipped after the re-check. No re-dispatch — the prior handle already delivered the single terminal reply.
- **`clear-in-flight!` (2-arg) is now identity-conditional**, mirroring `remove-from-actor-index!` — drops the request-id slot only while it still holds THIS handle (a nil handle falls back to unconditional dissoc; single-request cleanup unchanged). This is what makes the reorder safe.

Matches the blessed optimistic identity-token idiom (no new locks). Pre-alpha: no back-compat shims.

## Tests

New `implementation/http/test/re_frame/http_abort_retry_race_test.clj`:
- A deterministic **thread-interleaving injection** (a test-only seam, `set-test-interleave-hook!`) that lands the abort in the **transitional** and **narrower-sibling** windows, asserting exactly one `:rf.http/aborted` reply, ZERO extra server hits, and a clean registry.
- Direct unit tests for the identity-conditional `clear-in-flight!` (request-id + actor-index).

Verified **fail-before / pass-after**: with the fix logic reverted (seam kept), the interleaving tests fail with `hits=2` (re-issue) and a stranded backoff handle.

## Gates

- `implementation/http` JVM (`clojure -M:test`): **480 tests / 3724 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs`: **8555 tests / 40359 assertions, 0 failures, 0 errors**

Closes rf2-6nczv9, rf2-ous9e5.