### PR TITLE
fix(xray): drag pointercancel teardown, palette I1-filter source, tool-frame-id reconcile, raw? grain (rf2-65015d, rf2-anbabs, rf2-6yare0, rf2-g7zayk)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -735,6 +735,18 @@ on-box analogue of the off-box redaction call site
 frame-owned, fail-closed `project-egress` boundary, here the on-box render
 default rather than the off-box wire.
 
+> **Status (rf2-g7zayk): the operator reveal act is not yet wired.** The
+> `raw?` **mechanism** exists end-to-end — `local-render-value`'s `raw?`
+> arg resolves to `:rf.egress/local-raw` and is unit-tested
+> (`local_render_cljs_test` §local-raw-opt-in-reveals-sensitive) — but no
+> operator surface (no App-DB panel affordance) flips it today. Every
+> on-box App-DB render therefore currently uses the
+> `:rf.egress/local-redacted` default (`raw?` false), so the panel **fails
+> closed**. Surfacing sensitive on-box values is a **deferred**
+> per-(tool,frame) affordance, not a shipped reveal path; when it lands it
+> is the caller passing `raw? true` at the `local-render-value` call site,
+> not a change to this contract.
+
 ## "Show me when this changed"
 
 The high-leverage right-click affordance. When invoked on any path:

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -534,7 +534,7 @@ rf2-ttnst — Mike 2026-05-19 §0ter.4 walkthrough). Shape mirrors the
              :panel-width-px         480         ; number; clamped [320, 0.9 × viewport-width-px]
              :auto-open-on-error?    false
              :density                :cosy       ; #{:cosy :compact} — no :comfy in v1
-             :show-tool-frames?      false       ; reveal :rf/xray + :rf/pair2 in L1 picker
+             :show-tool-frames?      false       ; reveal :rf/xray + :rf/re-frame2-pair in L1 picker
              :long-keyword-threshold 24}         ; chars; long-keyword elision threshold
  :theme     :dark                                ; :dark | :light
  :diff      {:highlight-fn-ref-changes? false}   ; opt-in fn-ref classification
@@ -549,7 +549,7 @@ The `:general` slot carries three knobs introduced by rf2-ttnst:
   in v1; persisted `:comfy` values from prior schemas are treated as
   `:cosy` by the `:rf.xray/density` convenience sub.
 - `:show-tool-frames?` — boolean. When `true` the L1 frame-picker
-  dropdown reveals `:rf/xray` + `:rf/pair2`. Default `false` per
+  dropdown reveals `:rf/xray` + `:rf/re-frame2-pair`. Default `false` per
   spec/007-UX-IA.md §Frame-observation isolation invariants §I1.
 - `:long-keyword-threshold` — integer (chars). Fully-qualified
   keywords longer than the threshold elide in compact list cells.

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -578,15 +578,25 @@
 ;; named-boundary model matches the per-(tool,frame) `local_render.cljc`
 ;; seam shipped in this tool.
 ;;
-;; This atom holds Xray's local-render egress PROFILE. Xray is a
-;; framework-published trace consumer (its preload listener + the
-;; trace-collector snapshot feed every panel), so every value-bearing slot
-;; it surfaces on a dev surface ships under this profile. The "is a
-;; `:sensitive?` event visible?" decision derives from the profile's
-;; `:rf.size/include-sensitive?` resolution
+;; This atom holds Xray's TRACE-COLLECTOR egress PROFILE. It governs
+;; the trace collector's whole-event `:sensitive?` drop ONLY (spec 013
+;; §Trace-Consumer + spec 015 §Cross-tool visibility grain, rf2-g7zayk):
+;; Xray is a framework-published trace consumer (its preload listener
+;; feeds the trace rings the L2 event list + Trace panel read), and the
+;; profile decides whether a `:sensitive?`-tagged event survives that
+;; feed. The "is a `:sensitive?` event visible?" decision derives from
+;; the profile's `:rf.size/include-sensitive?` resolution
 ;; via the framework projection table (`projection/profile-size-opts`), the
 ;; SAME table `project-egress` consumes — one source of truth, no
 ;; re-implemented redaction policy.
+;;
+;; It does NOT gate the on-box panels that read LIVE frame state.
+;; App-DB (`rf/app-db-value` / epoch records) and Resources (runtime-db)
+;; bypass the trace collector, so they carry their OWN per-(tool,frame)
+;; redaction: `panels/local_render`'s `raw?` grain
+;; (`:rf.egress/local-redacted` by default). Those panels fail closed
+;; independently of this atom — see `panels/local_render.cljc` +
+;; spec/004-App-DB-Diff.md §On-box local-render.
 ;;
 ;; Default is `:rf.egress/local-redacted` — FAIL-CLOSED: sensitive display
 ;; suppressed. An engineer debugging redaction policy on their OWN machine

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -977,7 +977,7 @@
     incrementally.
   - `:show-tool-frames?` (boolean, default `false`) — when true the
     L1 frame picker dropdown reveals tool frames (`:rf/xray`,
-    `:rf/pair2`). OFF by default per spec/007-UX-IA.md §Frame-
+    `:rf/re-frame2-pair`). OFF by default per spec/007-UX-IA.md §Frame-
     observation isolation invariant I1.
   - `:long-keyword-threshold` (integer, default 24) — character count
     above which a fully-qualified keyword is elided in compact list

--- a/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
@@ -145,22 +145,39 @@
          taken)))))
 
 (defn frame-items
-  "Indexed from `frame-ids` (a seq of registered frame ids). The
-  Xray frame itself is excluded — switching focus to `:rf/xray`
-  via the palette is not a meaningful user operation."
-  [frame-ids]
-  (->> frame-ids
-       (remove #(= :rf/xray %))
-       (mapv (fn [fid]
-               {:source :frame
-                :id     fid
-                :label  (str "Switch focus to frame " (pr-str fid))
-                :hint   (str "frame/" (name fid))
-                :icon   (icon-table :frame)
-                :boost  (boost-table :frame)
-                :action [:palette/select-frame fid]
-                :modes  #{:dynamic}
-                :popout? false}))))
+  "Indexed from `frame-ids` (a seq of registered frame ids). Tool
+  frames in `internal-frames` are excluded unless `show-tool-frames?`
+  — the SAME exclusion the ribbon picker applies via
+  `frame-switcher/distinct-frames` (spec/018 §8 I1), rather than a
+  hand-rolled `:rf/xray`-only removal (rf2-anbabs).
+
+  `internal-frames` (the canonical `frame-switcher/internal-frames`
+  set — `#{:rf/xray :rf/re-frame2-pair}`) and `show-tool-frames?` are
+  injected by the `:rf.xray/palette-index` sub (a `.cljs` seam that can
+  reach the frame-switcher contract + the settings toggle), so the
+  palette and the ribbon share ONE exclusion source of truth. Kept
+  pure — the aggregator takes the set as data, never requiring the
+  cljs-only frame-switcher ns.
+
+  The 1-arity is a test / partial-drive convenience defaulting to the
+  historical minimal `#{:rf/xray}` exclusion; production always injects
+  the full set through `build-index`."
+  ([frame-ids] (frame-items frame-ids #{:rf/xray} false))
+  ([frame-ids internal-frames show-tool-frames?]
+   (->> frame-ids
+        (remove (fn [fid]
+                  (and (not show-tool-frames?)
+                       (contains? internal-frames fid))))
+        (mapv (fn [fid]
+                {:source :frame
+                 :id     fid
+                 :label  (str "Switch focus to frame " (pr-str fid))
+                 :hint   (str "frame/" (name fid))
+                 :icon   (icon-table :frame)
+                 :boost  (boost-table :frame)
+                 :action [:palette/select-frame fid]
+                 :modes  #{:dynamic}
+                 :popout? false})))))
 
 (defn handler-items
   "Indexed from a `[{:id k :kind k :doc s :file s :line n} ...]`
@@ -419,14 +436,22 @@
 
   Inputs map shape:
 
-    {:panels        [{:id kw :label str} ...]    ; Dynamic L3 tabs
-     :static-tabs   [{:id kw :label str} ...]    ; Static L3 tabs
-     :trace-buffer  [trace ...]
-     :frame-ids     (keyword?)
-     :handlers      [{:id :kind :doc :file :line} ...]
-     :mode          :dynamic | :static | nil     ; mode filter
-     :recents       [command-id ...]             ; recents boost
+    {:panels           [{:id kw :label str} ...] ; Dynamic L3 tabs
+     :static-tabs      [{:id kw :label str} ...] ; Static L3 tabs
+     :trace-buffer     [trace ...]
+     :frame-ids        (keyword?)
+     :internal-frames  #{kw ...}                 ; tool-frame exclusion set (I1)
+     :show-tool-frames? boolean                  ; re-include tool frames?
+     :handlers         [{:id :kind :doc :file :line} ...]
+     :mode             :dynamic | :static | nil  ; mode filter
+     :recents          [command-id ...]          ; recents boost
     }
+
+  `:internal-frames` + `:show-tool-frames?` (rf2-anbabs) gate the frame
+  source through the SAME exclusion the ribbon picker uses (spec/018 §8
+  I1); the `:rf.xray/palette-index` sub injects the canonical
+  `frame-switcher/internal-frames` set + the settings toggle. Missing →
+  the historical minimal `#{:rf/xray}` / off default.
 
   Missing keys default to empty inputs of that kind — partial drives
   (e.g. recency-rank dragons without a populated buffer) are
@@ -451,11 +476,14 @@
   from the item itself, so the recents bump rides the standard
   scoring pipeline."
   [inputs]
-  (let [{:keys [panels static-tabs trace-buffer frame-ids handlers mode recents]
+  (let [{:keys [panels static-tabs trace-buffer frame-ids internal-frames
+                show-tool-frames? handlers mode recents]
          :or   {panels             []
                 static-tabs        []
                 trace-buffer       []
                 frame-ids          []
+                internal-frames    #{:rf/xray}
+                show-tool-frames?  false
                 handlers           []
                 recents            []
                 mode               nil}} inputs
@@ -474,7 +502,7 @@
                       (static-tab-items static-tabs)
                       (setting-items)
                       (recent-event-items trace-buffer)
-                      (frame-items frame-ids)
+                      (frame-items frame-ids internal-frames show-tool-frames?)
                       (handler-items handlers))
         filtered    (filter (partial in-mode? mode) all)]
     (loop [seen   (transient #{})

--- a/tools/xray/src/day8/re_frame2_xray/palette/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/subs.cljs
@@ -32,6 +32,7 @@
   call in the panel's `install!`; the palette's source aggregator
   picks it up via `palette-panels` / `palette-static-tabs`."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.host-registry :as host-registry]
             [day8.re-frame2-xray.palette.sources :as sources]
             [day8.re-frame2-xray.panel-registry :as panel-registry]))
@@ -126,15 +127,25 @@
     :<- [:rf.xray/trace-buffer]
     :<- [:rf.xray/mode]
     :<- [:rf.xray/palette-recents]
-    (fn [[buffer mode recents] _query]
+    :<- [:rf.xray/show-tool-frames?]
+    (fn [[buffer mode recents show-tool-frames?] _query]
       ;; The sub fn does not receive `db`; we reach into the registrar
       ;; (a process-global atom) + the framework's frame registry
       ;; via the public rf wrappers.
+      ;;
+      ;; rf2-anbabs — inject the canonical `frame-switcher/internal-frames`
+      ;; exclusion set + the `:rf.xray/show-tool-frames?` toggle so the
+      ;; palette's "Switch focus to frame …" source filters the SAME tool
+      ;; frames the ribbon picker hides (spec/018 §8 I1). This is the
+      ;; `.cljs` seam that reaches the cljs-only frame-switcher contract;
+      ;; the pure `.cljc` aggregator takes the set as data.
       (sources/build-index
         {:panels             (palette-panels)
          :static-tabs        (palette-static-tabs)
          :trace-buffer       buffer
          :frame-ids          (rf/frame-ids)
+         :internal-frames    frame-switcher/internal-frames
+         :show-tool-frames?  show-tool-frames?
          :handlers           (handler-entries)
          :mode               mode
          :recents            recents})))

--- a/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
@@ -103,7 +103,7 @@
         (if (#{:cosy :compact} d) d :cosy))))
 
   ;; rf2-ttnst — convenience sub: should the L1 frame-picker dropdown
-  ;; include tool frames (`:rf/xray`, `:rf/pair2`)? OFF by default
+  ;; include tool frames (`:rf/xray`, `:rf/re-frame2-pair`)? OFF by default
   ;; per spec/007-UX-IA.md §Frame-observation isolation invariant I1.
   (rf/reg-sub :rf.xray/show-tool-frames?
     (fn [db _query]

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -582,7 +582,7 @@
      ;;
      ;; Per Mike Q8: the `:show-tool-frames?` toggle lives under a
      ;; `── Power user ──` divider at the bottom of General. Default
-     ;; OFF. Flipping on reveals `:rf/xray` + `:rf/pair2` in the L1
+     ;; OFF. Flipping on reveals `:rf/xray` + `:rf/re-frame2-pair` in the L1
      ;; frame-picker dropdown (per spec/007-UX-IA.md §Frame-observation
      ;; isolation invariant I1).
      [:div {:data-testid "rf-xray-settings-power-user-divider"

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -312,16 +312,59 @@
   (.querySelector grid-el
                   (str "[data-rf-xray-resizable-col='" (name col-id) "']")))
 
-(defn- on-pointer-down
+;; rf2-65015d — hold the active drag's window listeners so an
+;; interrupted drag can always tear them down. Without this the
+;; `pointermove` listener stays bound to `window` whenever `pointerup`
+;; is never delivered (a `pointercancel` from a touch/gesture preempt,
+;; a context menu, or the pointer leaving to another window), and the
+;; next `pointerdown` piles a second listener pair on top — each orphan
+;; re-dispatching `resize-pair-tick` on every subsequent window
+;; pointermove. `defonce` so a shadow-cljs `:after-load` mid-drag
+;; doesn't strand a half-installed listener (the next pointerdown
+;; re-installs cleanly). Mirrors the sibling `resize_handle.cljs`
+;; drag-state + `detach-…!` pattern — `resizable-table` was the lone
+;; drag surface diverging from it.
+(defonce ^:private drag-state
+  ;; {:on-move <fn> :on-up <fn> :on-cancel <fn>} — the bound window
+  ;; handlers for the in-progress drag; nil when no drag is running.
+  (atom nil))
+
+(defn dragging?
+  "Test seam — true iff a column-resize drag is in progress. Pure read
+  of the drag-state atom; the drag lifecycle tests (rf2-65015d) assert
+  the start/teardown transitions through it."
+  []
+  (some? @drag-state))
+
+(defn- detach-window-listeners!
+  "Remove the in-progress drag's window listeners and clear the drag
+  state. Idempotent — a no-op when no drag is running. Runs on
+  pointerup, on pointercancel, and defensively at the head of the next
+  pointerdown so a stranded listener from a failed prior drag never
+  double-fires or piles up. Guards on `js/window` (node-test has none)
+  and swallows per-listener removal errors so teardown always reaches
+  the `reset!`."
+  []
+  (when-let [{:keys [on-move on-up on-cancel]} @drag-state]
+    (when (and (exists? js/window) (.-removeEventListener js/window))
+      (try (.removeEventListener js/window "pointermove" on-move)   (catch :default _ nil))
+      (try (.removeEventListener js/window "pointerup" on-up)       (catch :default _ nil))
+      (try (.removeEventListener js/window "pointercancel" on-cancel) (catch :default _ nil)))
+    (reset! drag-state nil)))
+
+(defn on-pointer-down
   "Begin a drag: capture both adjacent columns' starting widths
   from the live DOM (so the first drag works even when state
-  carries no override), register window-level move/up handlers,
-  dispatch resize-pair events on each move, clean up on up.
+  carries no override), register window-level move/up/cancel handlers,
+  dispatch resize-pair events on each move, clean up on up OR cancel.
+
+  Public for the drag-lifecycle test seam (rf2-65015d) — the shell
+  never calls it except through the `header-gutter` `:on-pointer-down`.
 
   `dispatch-fn` (rf2-r0o63) is the frame-bound `dispatch` the
   surrounding `resizable-table` `reg-view` body injects (the macro
   expands it over a `capture-frame` capturing the render frame). The
-  pointer-move/up handlers run OUTSIDE the React tree (via raw
+  pointer-move/up/cancel handlers run OUTSIDE the React tree (via raw
   `window.addEventListener`), so the dynamic frame
   context has unwound by the time they fire — but the injected
   `dispatch` already bound the instance frame synchronously during
@@ -337,6 +380,11 @@
   [dispatch-fn table-id left-id right-id ev]
   (.preventDefault ev)
   (.stopPropagation ev)
+  ;; rf2-65015d — defensive: tear down any stranded prior drag before
+  ;; attaching a fresh listener set (a missed pointerup / pointercancel
+  ;; from a previous drag would otherwise leave its move listener bound
+  ;; and pile a second pair here).
+  (detach-window-listeners!)
   (when-let [gutter-el (.-currentTarget ev)]
     (let [grid-el  (.-parentElement gutter-el)
           left-el  (find-col-cell grid-el left-id)
@@ -356,12 +404,53 @@
                                           table-id
                                           left-id new-left
                                           right-id new-right])))
-              on-up     (fn on-up [_]
+              ;; rf2-65015d — pointerup AND an interrupted-drag
+              ;; pointercancel both commit the last tick (persisting the
+              ;; widths already painted on screen, so stored never
+              ;; diverges from displayed after a preempted drag) and
+              ;; tear the listeners down. A preempted drag therefore
+              ;; never strands a listener.
+              finish!   (fn []
                           (dispatch-fn [:rf.xray.column-widths/resize-pair-commit])
-                          (.removeEventListener js/window "pointermove" on-move)
-                          (.removeEventListener js/window "pointerup" on-up))]
-          (.addEventListener js/window "pointermove" on-move)
-          (.addEventListener js/window "pointerup" on-up))))))
+                          (detach-window-listeners!))
+              on-up     (fn [_] (finish!))
+              on-cancel (fn [_] (finish!))]
+          (reset! drag-state {:on-move on-move :on-up on-up :on-cancel on-cancel})
+          (when (and (exists? js/window) (.-addEventListener js/window))
+            (try (.addEventListener js/window "pointermove" on-move)     (catch :default _ nil))
+            (try (.addEventListener js/window "pointerup" on-up)         (catch :default _ nil))
+            (try (.addEventListener js/window "pointercancel" on-cancel) (catch :default _ nil))))))))
+
+;; ---- test seams (rf2-65015d) --------------------------------------------
+;; Drive the window-level drag handlers without a real DOM — node-test
+;; has no `js/window`, so `on-pointer-down` sets the drag state but
+;; never attaches real listeners. Mirrors resize_handle.cljs's
+;; simulate-* seams: the drag-state lifecycle is the observable proxy
+;; for the listener lifecycle (detach removes the listeners AND clears
+;; the state in one place).
+
+(defn simulate-move!
+  "Test-only: drive the in-progress drag's pointermove handler with a
+  clientX. No-op when no drag is running."
+  [client-x]
+  (when-let [{:keys [on-move]} @drag-state]
+    (on-move #js {:clientX client-x})))
+
+(defn simulate-up!
+  "Test-only: drive the pointerup handler (commit + teardown). No-op
+  when no drag is running."
+  []
+  (when-let [{:keys [on-up]} @drag-state]
+    (on-up nil)))
+
+(defn simulate-cancel!
+  "Test-only: drive the pointercancel handler (commit + teardown).
+  Covers the system-preempt path — a touch gesture override, a context
+  menu, or the pointer leaving to another window. No-op when no drag is
+  running."
+  []
+  (when-let [{:keys [on-cancel]} @drag-state]
+    (on-cancel nil)))
 
 ;; ---- Header gutter (interactive) ----------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/palette/sources_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/palette/sources_test.cljc
@@ -86,6 +86,47 @@
     (is (not (contains? ids :rf/xray))
         "switching focus to :rf/xray is not a meaningful palette op")))
 
+;; rf2-anbabs — the palette frame source must honour the SAME exclusion
+;; the ribbon picker applies: the FULL internal-frames set (not just
+;; :rf/xray) and the `show-tool-frames?` toggle (spec/018 §8 I1).
+
+(def internal-frames-set #{:rf/xray :rf/re-frame2-pair})
+
+(deftest frame-items-excludes-full-internal-set-by-default
+  (let [frames [:rf/default :rf/xray :app/main :rf/re-frame2-pair]
+        items  (sources/frame-items frames internal-frames-set false)
+        ids    (set (map :id items))]
+    (is (= #{:rf/default :app/main} ids)
+        "both :rf/xray AND :rf/re-frame2-pair are excluded (matches distinct-frames)")))
+
+(deftest frame-items-show-tool-frames-reincludes
+  (let [frames [:rf/default :rf/xray :app/main :rf/re-frame2-pair]
+        items  (sources/frame-items frames internal-frames-set true)
+        ids    (set (map :id items))]
+    (is (= #{:rf/default :rf/xray :app/main :rf/re-frame2-pair} ids)
+        "show-tool-frames? true re-includes the tool frames (ribbon power-user parity)")))
+
+(deftest build-index-frame-source-honours-internal-frames
+  ;; End-to-end through build-index: a registered tool frame is hidden
+  ;; from the palette's frame source with the toggle OFF (the I1 leak
+  ;; this bead fixes) and surfaced with it ON.
+  (let [frames    [:rf/default :app/main :rf/re-frame2-pair]
+        frame-ids (fn [index] (->> index
+                                   (filter #(= :frame (:source %)))
+                                   (map :id) set))
+        off (frame-ids (sources/build-index {:frame-ids         frames
+                                             :internal-frames   internal-frames-set
+                                             :show-tool-frames? false}))
+        on  (frame-ids (sources/build-index {:frame-ids         frames
+                                             :internal-frames   internal-frames-set
+                                             :show-tool-frames? true}))]
+    (is (not (contains? off :rf/re-frame2-pair))
+        "tool frame hidden from the palette frame source with the toggle OFF")
+    (is (contains? off :rf/default)
+        "real user frames still surface")
+    (is (contains? on :rf/re-frame2-pair)
+        "tool frame re-included with the toggle ON")))
+
 (deftest handler-items-include-meta
   (let [items (sources/handler-items sample-handlers)
         login (first (filter #(= :user/login (second (:id %))) items))]

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_drag_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_drag_cljs_test.cljs
@@ -1,0 +1,94 @@
+(ns day8.re-frame2-xray.views.resizable-table-drag-cljs-test
+  "rf2-65015d — column-drag pointer teardown.
+
+  The resizable-table header gutter attaches window-level
+  pointermove/up/cancel listeners on pointerdown. A missed pointerup
+  or a pointercancel (touch gesture preempt, context menu, pointer
+  leaving to another window) MUST tear the listeners down so a drag
+  never strands a listener or piles a second pair on the next
+  pointerdown (each orphan re-dispatching `resize-pair-tick` on every
+  window pointermove).
+
+  Node-test has no `js/window`, so the real addEventListener calls are
+  skipped; these tests drive the drag STATE lifecycle — the observable
+  proxy for the listener lifecycle, since `detach-window-listeners!`
+  removes the listeners AND clears the state in one place. Mirrors
+  `resize_handle_cljs_test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
+
+;; ---- fixture ------------------------------------------------------------
+;; drag-state is a module-level defonce; clear any drag a test left
+;; running so the lifecycle never leaks between tests.
+
+(use-fixtures :each
+  {:after (fn [] (when (rt/dragging?) (rt/simulate-cancel!)))})
+
+;; ---- stubs --------------------------------------------------------------
+
+(defn- stub-cell [width] #js {:offsetWidth width})
+
+(defn- stub-pointer-event
+  "PointerEvent-shaped stub carrying exactly the slots on-pointer-down
+  reads: a currentTarget whose parentElement.querySelector resolves the
+  two adjacent column cells by their `data-rf-xray-resizable-col`
+  selector, plus clientX and no-op prevent/stop."
+  [client-x left-id left-w right-id right-w]
+  (let [by-sel {(str "[data-rf-xray-resizable-col='" (name left-id) "']")  (stub-cell left-w)
+                (str "[data-rf-xray-resizable-col='" (name right-id) "']") (stub-cell right-w)}
+        grid   #js {:querySelector (fn [sel] (get by-sel sel))}
+        gutter #js {:parentElement grid}]
+    #js {:currentTarget   gutter
+         :clientX         client-x
+         :preventDefault  (fn [])
+         :stopPropagation (fn [])}))
+
+;; ---- pointercancel tears down (the core acceptance) ---------------------
+
+(deftest pointercancel-tears-down-drag
+  (testing "a pointercancel mid-drag removes the listeners + clears the
+            drag state (no stuck drag), and commits the last tick so
+            stored widths match what is on screen"
+    (let [d  (atom [])
+          df (fn [ev] (swap! d conj ev))]
+      (is (false? (rt/dragging?)) "no drag in progress at fixture start")
+      (rt/on-pointer-down df :tbl :a :b (stub-pointer-event 100 :a 120 :b 80))
+      (is (true? (rt/dragging?)) "pointerdown started a drag")
+      (rt/simulate-move! 130)   ;; delta +30 → tick
+      (rt/simulate-cancel!)     ;; system preempt
+      (is (false? (rt/dragging?))
+          "pointercancel tore the drag down — no listener/state stranded")
+      (is (some #(= :rf.xray.column-widths/resize-pair-tick (first %)) @d)
+          "the move ticked during the drag")
+      (is (some #(= :rf.xray.column-widths/resize-pair-commit (first %)) @d)
+          "cancel committed the last tick (stored == displayed)"))))
+
+(deftest missed-pointerup-then-new-drag-never-orphans
+  (testing "a missed pointerup leaves the drag state set; the next
+            pointerdown defensively tears it down before attaching a
+            fresh set, so a single up/cancel fully clears the state —
+            no orphaned drag pinned, no listener pile-up"
+    (let [d  (atom [])
+          df (fn [ev] (swap! d conj ev))]
+      ;; First drag — pointerup is NEVER delivered.
+      (rt/on-pointer-down df :tbl :a :b (stub-pointer-event 100 :a 120 :b 80))
+      (is (true? (rt/dragging?)))
+      ;; A new drag begins with the old one still notionally live.
+      (rt/on-pointer-down df :tbl :a :b (stub-pointer-event 200 :a 120 :b 80))
+      (is (true? (rt/dragging?)) "still exactly one drag live")
+      ;; One teardown clears everything — if the defensive detach had
+      ;; NOT run, an orphan would remain after this single up.
+      (rt/simulate-up!)
+      (is (false? (rt/dragging?))
+          "one teardown clears the state — the prior drag left no orphan"))))
+
+(deftest pointerup-commits-and-tears-down
+  (testing "the ordinary pointerup path still commits once + clears"
+    (let [d  (atom [])
+          df (fn [ev] (swap! d conj ev))]
+      (rt/on-pointer-down df :tbl :a :b (stub-pointer-event 100 :a 120 :b 80))
+      (rt/simulate-move! 90)    ;; delta -10
+      (rt/simulate-up!)
+      (is (false? (rt/dragging?)) "pointerup cleared the drag state")
+      (is (= 1 (count (filter #(= :rf.xray.column-widths/resize-pair-commit (first %)) @d)))
+          "exactly one commit per drag (one localStorage write, not one per pixel)"))))


### PR DESCRIPTION
Remaining tools/xray correctness-audit findings (from rf2-057izp). One artefact, four commits ordered by severity.

## rf2-65015d (P3 bug) — resizable-table drag: pointercancel + defensive teardown
The header column-drag attached window-level `pointermove`+`pointerup` but no `pointercancel`, and re-attached without first detaching. A missed `pointerup` (touch gesture preempt, context menu, pointer leaving the window) left the move listener bound and the next `pointerdown` piled a second pair on top — each orphan re-dispatching `resize-pair-tick` on every window pointermove. It was the lone drag surface diverging from the sibling `resize_handle.cljs` pattern.

Fix mirrors `resize_handle.cljs`: a module-level `defonce` drag-state holds the bound handlers; `detach-window-listeners!` removes all three + clears state in one place and runs on pointerup, on the new pointercancel handler, and defensively at the head of the next pointerdown. Both pointerup and pointercancel commit the last tick so stored widths never diverge from what is displayed. Adds `simulate-*` + `dragging?` test seams (node-test has no `js/window`) and a drag-lifecycle test.

## rf2-anbabs (P3 bug) — palette frame source shares the ribbon's I1 exclusion
The Cmd-K "Switch focus to frame …" source removed only `:rf/xray`, ignoring the canonical `frame-switcher/internal-frames` set (also holds `:rf/re-frame2-pair`) and the `show-tool-frames?` toggle — an I1 (frame-observation isolation) leak the ribbon picker does not have. Thread the canonical set + toggle through `build-index` into `frame-items`, injected by the `:rf.xray/palette-index` sub (the `.cljs` seam that can reach the cljs-only frame-switcher contract). `sources.cljc` stays pure — it takes the exclusion set as data, so palette and ribbon share ONE source of truth.

## rf2-6yare0 (P4 bug, spec drift) — tool-frame-id reconciled to `:rf/re-frame2-pair`
The reserved pair frame was spelled two ways: executable exclusion sets + tests use `:rf/re-frame2-pair`; config/settings comments + xray spec/015 said `:rf/pair2` — a latent I1 trap. Aligned every laggard to the executable `:rf/re-frame2-pair` (already the spelling in xray spec/018 §8 I1 + skill docs). One spelling now names the frame across code, tests, xray spec, and config/settings.

> **Deferred:** the bead also asks to catalogue the reserved id in repo-root `spec/Conventions.md`. That file is the spec-doc cluster's hot-zone surface (a concurrent worker owns it), so it is left to that cluster to avoid a collision. The reserved id already appears in the xray-owned `spec/018 §8 I1` frame-isolation contract.

## rf2-g7zayk (P4 task, spec drift) — egress-profile scope + on-box reveal deferred
Two doc-accuracy corrections (no behaviour change — App-DB fails closed):
1. `config.cljc`'s `*egress-profile*` docstring overclaimed the profile "feeds every panel". False for App-DB/Resources, which read LIVE frame state and redact through the SEPARATE per-(tool,frame) `local_render` grain, not the trace collector. Rescoped to the trace collector's whole-event `:sensitive?` drop.
2. `spec/004-App-DB-Diff.md` described the operator reveal act (flip to `:rf.egress/local-raw` via `raw?`) as shipped. The `raw?` mechanism exists + is unit-tested, but no operator surface flips it today. Marked deferred/unimplemented. The `raw?` seam is live + tested (`local_render_cljs_test` local-raw-opt-in-reveals-sensitive), not dead cruft, so it stays — prose accuracy, not removal.

## Quality gates
- **JVM** (`clojure -M:test` from tools/xray): 1248 tests, 5755 assertions, 0 failures/0 errors.
- **CLJS** (`npm run test:cljs` from implementation/ — tools/xray/test compiles in; authoritative for .cljs): 8568 tests, 40436 assertions, 0 failures/0 errors.
- Per-bead regressions: **65015d** drag-lifecycle test (pointercancel tears down; missed-pointerup+new-drag never orphans; one commit per drag) — 3 tests. **anbabs** frame-items full-set exclusion + toggle re-include + build-index end-to-end — 3 tests. **6yare0** verified via `git grep` (no `:rf/pair2` outside `.beads`); executable pin already in `frame_switcher_cljs_test`. **g7zayk** doc-only; `raw?` semantics already pinned by `local_render_cljs_test`.
- **Browser path skip (65015d):** no dedicated resizable-table drag `*.spec.cjs` exists (CLJS-unit-tests-not-Playwright policy). The raw `window.addEventListener/removeEventListener` calls are guarded standard DOM identical in shape to the browser-proven `resize_handle.cljs` sibling (itself only node-unit-tested at the state-lifecycle level); node tests pin the drag-state lifecycle, the observable proxy for listener add/remove.
