### PR TITLE
fix(examples/real-apps): classify login/register/settings password body field (rf2-agb5jk)

### DIFF
--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -176,6 +176,7 @@
              (rh/request {:method     :post
                           :path       "/users/login"
                           :body       {:user {:email email :password password}}
+                          :sensitive? true
                           :decode     schema/UserResponse
                           :on-success [:auth/flow [:auth/success]]
                           :on-failure [:auth/flow [:auth/failure]]})]]})
@@ -189,6 +190,7 @@
                           :body       {:user {:username username
                                               :email email
                                               :password password}}
+                          :sensitive? true
                           :decode     schema/UserResponse
                           :on-success [:auth/flow [:auth/success]]
                           :on-failure [:auth/flow [:auth/failure]]})]]})
@@ -297,6 +299,14 @@
 (def register-form-defaults {:username "" :email "" :password ""})
 
 (rf/reg-event :auth.login-form/initialise
+  {:doc "Seed the login-form slice AND classify its draft-password path
+         :sensitive, in the first durable write that creates the slice — so the
+         raw password is redacted at every app-db egress (snapshot, epoch,
+         off-box shipper, SSR) from the very first keystroke, while handlers
+         still read the live value. Classification is egress-only + path-based,
+         mirroring :auth/classify-token for the JWT (core.cljs). See the
+         keep-secrets how-to:
+         ../../../docs/core/how-to/keep-secrets-out-of-traces.md"}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
               {:draft             login-form-defaults
@@ -305,7 +315,8 @@
                :errors            {}
                :touched           #{}
                :submit-attempted? false
-               :submit-error      nil})}))
+               :submit-error      nil})
+     :sensitive [[:auth :login-form :draft :password]]}))
 
 (rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
@@ -323,6 +334,9 @@
        :fx [[:dispatch [:auth/flow [:auth/login draft]]]]})))
 
 (rf/reg-event :auth.register-form/initialise
+  {:doc "Seed the register-form slice AND classify its draft-password path
+         :sensitive, in the first durable write that creates the slice — same
+         egress-only, path-based discipline as the login form above."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:auth :register-form]
               {:draft             register-form-defaults
@@ -331,7 +345,8 @@
                :errors            {}
                :touched           #{}
                :submit-attempted? false
-               :submit-error      nil})}))
+               :submit-error      nil})
+     :sensitive [[:auth :register-form :draft :password]]}))
 
 (rf/reg-event :auth.register-form/edit-field
   (fn [{:keys [db]} [_ field value]]

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -54,10 +54,10 @@
             [re-frame.ssr]
             [re-frame.adapter.reagent :as reagent-adapter]
             [realworld-shared.avatar :as avatar]
-            ;; The in-process Conduit demo backend shared by both RealWorld
-            ;; examples — wired under an app-local fx-id below.
-            [realworld-shared.demo-backend :as demo]
             [realworld-http.schema]
+            ;; Requiring http registers the demo `:rf.http/managed` override fx
+            ;; (`:realworld.demo/http-stub`) the frame's `:fx-overrides` reference
+            ;; below, alongside the request-builder + retry policy.
             [realworld-http.http]
             [realworld-http.routing :as routing]
             [realworld-http.auth :as auth]
@@ -105,13 +105,34 @@
 ;; external tool, a hydration payload — sees the token redacted, while the
 ;; running app keeps the raw value it needs.
 ;;
-;; One path is all this app has to classify by hand. The outbound
-;; `Authorization` Bearer header is already on the framework's built-in HTTP
-;; carrier denylist, so it's redacted off-box with zero config. And the
-;; login / register password drafts at [:auth :login-form] /
-;; [:auth :register-form] are throwaway form state that never leaves app-db,
-;; so there's nothing there to protect. See the keep-secrets how-to:
+;; The JWT is not the only credential in this app, and it is a mistake to think
+;; the login / register / settings PASSWORD is safe just because it is
+;; "throwaway form state". A password is a credential the moment it is typed,
+;; and it egresses raw unless classified: the draft lives in app-db
+;; ([:auth :login-form :draft :password] / [:auth :register-form :draft
+;; :password], both classified :sensitive at slice-init in auth.cljs); it rides
+;; the outbound HTTP body ({:user {:password …}}, classified on the managed-HTTP
+;; request below); and the settings password lives in the :settings/form
+;; machine's :data (classified :sensitive on the machine, settings.cljs). Each
+;; surface is classified on its own — classification is fail-open and does not
+;; propagate. See the keep-secrets how-to:
 ;; ../../../docs/core/how-to/keep-secrets-out-of-traces.md
+;;
+;; The one carrier we deliberately do NOT classify by hand is the outbound
+;; `Authorization` Bearer header: it is already on the framework's built-in HTTP
+;; carrier denylist, so it is redacted off-box with zero config — over-declaring
+;; a built-in would only teach a redundant ritual.
+;;
+;; One structural corner is worth calling out honestly, because it is the exact
+;; gotcha the keep-secrets how-to warns about: the credential also travels
+;; through the auth machine as a POSITIONAL sub-event
+;; ([:auth/flow [:auth/login {… :password …}]]). A positional arg is not
+;; path-addressable — only a map payload is — so a secret riding one still ships
+;; raw in the dispatched-event and :rf.machine/* trace slots, and no :sensitive
+;; mark can reach it. The examples/core/login model sidesteps this by keeping
+;; its machine credential-free (the form issues the request and the machine only
+;; sees a bare :submit signal); this app instead routes login/register through
+;; the machine, so it wears that limitation openly.
 (rf/reg-event :auth/classify-token
   {:doc "Mark the durable JWT path [:auth :token] sensitive, at frame
          creation."}
@@ -232,24 +253,16 @@
 ;; Out of the box this example talks to no server at all. Normally it would hit
 ;; the hosted Conduit API (https://api.realworld.show/api —
 ;; `realworld-http.http/api-base`), but a live backend is slow and flaky for a
-;; demo, and we'd like you to be able to clone-and-run on a plane. So we override
-;; `:rf.http/managed` with the in-process demo backend both RealWorld examples
-;; share (`realworld-shared.demo-backend`): one canonical Conduit corpus + a
-;; URL/method request router + a canned-reply adapter, wired here under an
-;; app-local fx-id. The shared `respond` does the routing and defers each reply
-;; through the framework's canned-success / canned-failure fxs.
+;; demo, and we'd like you to be able to clone-and-run on a plane. So the demo
+;; `:rf.http/managed` override — `:realworld.demo/http-stub`, defined in
+;; `http.cljs` alongside the request builder and referenced from the frame's
+;; `:fx-overrides` in `mount!` below — routes every request through the
+;; in-process demo backend both RealWorld examples share
+;; (`realworld-shared.demo-backend`): one canonical Conduit corpus + a
+;; URL/method request router + a canned-reply adapter. The stub (and its
+;; request-body `:sensitive` classification) lives with the rest of the app's
+;; HTTP surface in `http.cljs`.
 ;; ----------------------------------------------------------------------------
-
-(rf/reg-fx :realworld.demo/http-stub
-  {:doc       "This example's `:rf.http/managed` override: the shared in-process
-               Conduit demo backend (`realworld-shared.demo-backend`), wired
-               under an app-local fx-id and referenced from the frame's
-               `:fx-overrides` in `mount!`. All the routing + canned-reply
-               machinery (including the `::decode-failure` session-restore path)
-               lives in the shared backend; this is just the app-local seam."
-   :platforms #{:server :client}}
-  (fn fx-managed-demo-stub [frame-ctx args-map]
-    (demo/respond frame-ctx args-map)))
 
 ;; The React root lives in an atom and gets created lazily inside `run`, so
 ;; that merely loading this namespace touches no DOM. That restraint earns

--- a/examples/real-apps/realworld_http/http.cljs
+++ b/examples/real-apps/realworld_http/http.cljs
@@ -17,14 +17,22 @@
    architecture: the `request` builder and `paginate-path`.
 
    BACKEND MODES (see this example's README §Running against a real backend):
-   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed`
-     with an in-process router built on `realworld-shared.demo-backend`, so the
-     app runs with NO network at all. `api-base` is never contacted.
+   - canned demo stub (DEFAULT) — the demo `:rf.http/managed` override fx
+     (`:realworld.demo/http-stub`, defined at the bottom of this ns and wired
+     from `core.cljs`'s frame `:fx-overrides`) routes through an in-process
+     backend built on `realworld-shared.demo-backend`, so the app runs with NO
+     network at all. `api-base` is never contacted.
    - official hosted API — point `api-base` at the hosted Conduit API,
      `https://api.realworld.show/api`, and drop the demo-stub override.
    - local reference backend — the upstream Node/Postgres backend on
      `http://localhost:3000/api`."
-  (:require [realworld-shared.http :as wh]))
+  (:require [re-frame.core :as rf]
+            [realworld-shared.http :as wh]
+            ;; The in-process Conduit demo backend shared by both RealWorld
+            ;; examples — wired under an app-local fx-id at the bottom of this ns
+            ;; (the demo `:rf.http/managed` override `core.cljs` references from
+            ;; the frame's `:fx-overrides`).
+            [realworld-shared.demo-backend :as demo]))
 
 ;; ============================================================================
 ;; CONFIG
@@ -119,7 +127,7 @@
                          :retry  rh/data-fetch-retry})]]}"
   [{:keys [method path body decode accept retry timeout-ms
            on-success on-failure reply-to request-id abort-signal
-           extra-headers]
+           extra-headers sensitive?]
     :or   {method :get
            decode :json}
     :as   args}]
@@ -127,8 +135,18 @@
         req     (cond-> {:method method
                          :url    (full-url path)
                          :headers headers}
-                  body (assoc :body body
-                              :request-content-type :json))
+                  body       (assoc :body body
+                                    :request-content-type :json)
+                  ;; `:sensitive? true` tells the REAL managed-HTTP handler to
+                  ;; scrub the whole request body (and params) from every
+                  ;; `:rf.http/*` trace event — the run mode that talks to a real
+                  ;; Conduit backend. A credential-bearing call (login / register
+                  ;; / settings) sets it. Note the DEFAULT run mode overrides
+                  ;; `:rf.http/managed` with the demo stub, which bypasses this
+                  ;; scrub — that path is covered by the stub's own `:sensitive`
+                  ;; (core.cljs). See keep-secrets:
+                  ;; ../../../docs/core/how-to/keep-secrets-out-of-traces.md
+                  sensitive? (assoc :sensitive? true))
         out     (cond-> {:request req
                          :decode  decode}
                   retry        (assoc :retry retry)
@@ -172,3 +190,41 @@
 ;; dispatch opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code just
 ;; lets the router stamp the real time. See the coeffects guide:
 ;; ../../../docs/core/coeffects.md#two-grades-ambient-and-recordable
+
+;; ============================================================================
+;; DEMO BACKEND
+;; ============================================================================
+;;
+;; Out of the box this example talks to no server at all. Normally it would hit
+;; the hosted Conduit API (`api-base`), but a live backend is slow and flaky for
+;; a demo, and we'd like you to be able to clone-and-run on a plane. So we
+;; override `:rf.http/managed` with the in-process demo backend both RealWorld
+;; examples share (`realworld-shared.demo-backend`): one canonical Conduit corpus
+;; + a URL/method request router + a canned-reply adapter, wired here under an
+;; app-local fx-id. `core.cljs` references it from the demo frame's
+;; `:fx-overrides` — there is no explicit install call to make. The shared
+;; `respond` does the routing and defers each reply through the framework's
+;; canned-success / canned-failure fxs.
+
+(rf/reg-fx :realworld.demo/http-stub
+  {:doc       "This example's `:rf.http/managed` override: the shared in-process
+               Conduit demo backend (`realworld-shared.demo-backend`), wired
+               under an app-local fx-id and referenced from the frame's
+               `:fx-overrides` in `core.cljs`. All the routing + canned-reply
+               machinery (including the `::decode-failure` session-restore path)
+               lives in the shared backend; this is just the app-local seam."
+   ;; This stub is the CLASSIFIED OWNER of the request body it receives. The
+   ;; login / register / settings requests carry the plaintext password at
+   ;; [:request :body :user :password] (the Conduit `{user {…}}` envelope). The
+   ;; real `:rf.http/managed` handler would scrub a `:sensitive?`-marked request
+   ;; body itself, but the frame's `:fx-overrides` remap `:rf.http/managed` to
+   ;; THIS stub, BYPASSING that scrub. When the override fires, `handle-one-fx`
+   ;; stamps the always-emitted `:rf.fx/handled` trace with THIS fx's id and its
+   ;; RAW args, and the classification projector redacts `:rf.fx/args` off the
+   ;; RESOLVED fx's own `:sensitive`. So the stub must declare its own — without
+   ;; it the password would ride raw on the one wire every tool reads
+   ;; (docs/core/how-to/keep-secrets-out-of-traces.md).
+   :sensitive [[:request :body :user :password]]
+   :platforms #{:server :client}}
+  (fn fx-managed-demo-stub [frame-ctx args-map]
+    (demo/respond frame-ctx args-map)))

--- a/examples/real-apps/realworld_http/settings.cljs
+++ b/examples/real-apps/realworld_http/settings.cljs
@@ -97,6 +97,16 @@
    ;; :data shape is validated right here via [:schemas :data] — an app-schema
    ;; only sees the app-db partition.
    :schemas {:data app-schema/SettingsFormData}
+   ;; The password the user types to change their credentials lands in this
+   ;; machine's :data — the live draft at [:data :draft :password] and, once
+   ;; a submit is in flight, the snapshot at [:data :submitted :password].
+   ;; Both are credentials, so classify them :sensitive relative to the
+   ;; snapshot's :data (EP-0025 projection-relative machine classification,
+   ;; lowered per actor at spawn). The snapshot then reads :rf/redacted at
+   ;; every egress — machine-transition traces, epoch, off-box shipper, SSR —
+   ;; while the action bodies still read the live value to send it.
+   :sensitive [[:data :draft :password]
+               [:data :submitted :password]]
 
    :actions
    {:seed-from-user
@@ -258,6 +268,7 @@
                           :body       {:user (cond-> (select-keys draft [:image :username :bio :email])
                                                (seq (:password draft))
                                                (assoc :password (:password draft)))}
+                          :sensitive? true
                           :decode     schema/UserResponse
                           :on-success [:settings/submit-success]
                           :on-failure [:settings/submit-error]})]]})))

--- a/examples/real-apps/realworld_resources/auth.cljs
+++ b/examples/real-apps/realworld_resources/auth.cljs
@@ -273,7 +273,13 @@
       {:data {:error nil}
        :fx [[:rf.http/managed
              {:request {:method :post :url (rh/full-url "/users/login")
-                        :body {:user {:email email :password password}}}
+                        :body {:user {:email email :password password}}
+                        ;; Scrub the whole body from `:rf.http/*` traces in the
+                        ;; real-backend run mode. The default demo run mode
+                        ;; overrides `:rf.http/managed` with the stub (which
+                        ;; bypasses this scrub); that path is covered by the
+                        ;; stub's own `:sensitive` (http.cljs).
+                        :sensitive? true}
               :decode schema/UserResponse
               :on-success [:auth/flow [:auth/success]]
               :on-failure [:auth/flow [:auth/failure]]}]]})
@@ -283,7 +289,8 @@
       {:data {:error nil}
        :fx [[:rf.http/managed
              {:request {:method :post :url (rh/full-url "/users")
-                        :body {:user {:username username :email email :password password}}}
+                        :body {:user {:username username :email email :password password}}
+                        :sensitive? true}
               :decode schema/UserResponse
               :on-success [:auth/flow [:auth/success]]
               :on-failure [:auth/flow [:auth/failure]]}]]})
@@ -408,7 +415,15 @@
 (def register-form-defaults  {:username "" :email "" :password ""})
 
 (rf/reg-event :auth.login-form/initialise
-  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :login-form] {:draft login-form-defaults :touched #{}})}))
+  {:doc "Seed the login-form draft AND classify its password path :sensitive in
+         the first durable write that creates the slice — so the raw password is
+         redacted at every app-db egress (snapshot, epoch, off-box shipper, SSR)
+         while handlers still read the live value. Mirrors :auth/classify-token
+         for the JWT (core.cljs). See keep-secrets:
+         ../../../docs/core/how-to/keep-secrets-out-of-traces.md"}
+  (fn [{:keys [db]} _]
+    {:db        (assoc-in db [:auth :login-form] {:draft login-form-defaults :touched #{}})
+     :sensitive [[:auth :login-form :draft :password]]}))
 
 (rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
@@ -422,7 +437,11 @@
     {:fx [[:dispatch [:auth/flow [:auth/login (get-in db [:auth :login-form :draft])]]]]}))
 
 (rf/reg-event :auth.register-form/initialise
-  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :register-form] {:draft register-form-defaults :touched #{}})}))
+  {:doc "Seed the register-form draft AND classify its password path :sensitive —
+         same egress-only, path-based discipline as the login form above."}
+  (fn [{:keys [db]} _]
+    {:db        (assoc-in db [:auth :register-form] {:draft register-form-defaults :touched #{}})
+     :sensitive [[:auth :register-form :draft :password]]}))
 
 (rf/reg-event :auth.register-form/edit-field
   (fn [{:keys [db]} [_ field value]]

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -257,6 +257,16 @@
 ;;     app-db before the bearer-auth interceptor fires its first authenticated
 ;;     request.
 ;;
+;; The token is not the only credential, though: the login / register / settings
+;; PASSWORD is one too, the moment it is typed. Its app-db drafts are classified
+;; :sensitive at slice-init (auth.cljs / settings.cljs) and its outbound HTTP
+;; body is classified on the demo stub (http.cljs) — same discipline as the
+;; token, applied where the password actually rests and travels. (One corner it
+;; can't reach: login/register ride the auth machine as a POSITIONAL sub-event
+;; and settings rides `:rf.mutation/execute`'s :params — a positional / framework
+;; payload a path-based :sensitive cannot address, so those trace slots still
+;; ship raw; keeping a credential out of such payloads is the only real fix.)
+;;
 ;; Two things we deliberately DON'T classify, since under-redacting and
 ;; over-redacting are both mistakes. The outbound `Authorization` Bearer header
 ;; is already redacted off-box by the framework's built-in HTTP carrier denylist,

--- a/examples/real-apps/realworld_resources/http.cljs
+++ b/examples/real-apps/realworld_resources/http.cljs
@@ -102,6 +102,18 @@
                `:fx-overrides` in core.cljs. All the routing + canned-reply
                machinery (including the `::decode-failure` session-restore path)
                lives in the shared backend; this is just the app-local seam."
+   ;; This stub is the CLASSIFIED OWNER of the request body it receives. The
+   ;; login / register requests and the settings mutation carry the plaintext
+   ;; password at [:request :body :user :password] (the Conduit `{user {…}}`
+   ;; envelope). The real `:rf.http/managed` handler would scrub a
+   ;; `:sensitive?`-marked request body, but the frame's `:fx-overrides` remap
+   ;; `:rf.http/managed` to THIS stub, BYPASSING that scrub. When the override
+   ;; fires, `handle-one-fx` stamps the always-emitted `:rf.fx/handled` trace
+   ;; with THIS fx's id and its RAW args, and the classification projector
+   ;; redacts `:rf.fx/args` off the RESOLVED fx's own `:sensitive`. So the stub
+   ;; must declare its own — without it the password would ride raw on the one
+   ;; wire every tool reads (docs/core/how-to/keep-secrets-out-of-traces.md)."
+   :sensitive [[:request :body :user :password]]
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (demo/respond frame-ctx args-map)))

--- a/examples/real-apps/realworld_resources/mutations.cljs
+++ b/examples/real-apps/realworld_resources/mutations.cljs
@@ -296,5 +296,10 @@
                :url    (rh/full-url "/user")
                :body   {:user (cond-> {:username username :email email
                                        :bio bio :image image}
-                                (seq password) (assoc :password password))}}
+                                (seq password) (assoc :password password))}
+               ;; Scrub the whole body from `:rf.http/*` traces when this
+               ;; mutation lowers onto the REAL managed handler (real-backend
+               ;; run mode). The default demo run mode overrides `:rf.http/managed`
+               ;; with the stub, covered by the stub's own `:sensitive` (http.cljs).
+               :sensitive? true}
      :decode  schema/UserResponse}))

--- a/examples/real-apps/realworld_resources/settings.cljs
+++ b/examples/real-apps/realworld_resources/settings.cljs
@@ -60,10 +60,17 @@
          pure Form-1: a re-render never re-runs the load, so edits you've got in
          flight survive. Seeds `:touched` alongside `:draft` — the FormSlice
          schema (schema.cljs) requires both, so a slice with only `:draft`
-         would fail its own schema until the first field edit."}
+         would fail its own schema until the first field edit.
+
+         Also classifies the draft-password path :sensitive in this same seed
+         write (classify-before-write, mirroring :auth/classify-token), so the
+         new-password the user types reads :rf/redacted at every app-db egress
+         while the submit handler still reads the live value. See keep-secrets:
+         ../../../docs/core/how-to/keep-secrets-out-of-traces.md"}
   (fn [{:keys [db]} _]
-    {:db (assoc-in db [:settings-form] {:draft   (draft-from-user (get-in db [:auth :user]))
-                                        :touched #{}})}))
+    {:db        (assoc-in db [:settings-form] {:draft   (draft-from-user (get-in db [:auth :user]))
+                                               :touched #{}})
+     :sensitive [[:settings-form :draft :password]]}))
 
 (rf/reg-event :settings/edit-field
   {:schema [:cat [:= :settings/edit-field] :keyword :string]}

--- a/implementation/core/test/re_frame/example_realworld_password_classification_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_realworld_password_classification_cljs_test.cljs
@@ -1,0 +1,225 @@
+(ns re-frame.example-realworld-password-classification-cljs-test
+  "Framework-tree security regression for the RealWorld reference apps' PASSWORD
+   classification (rf2-agb5jk) — the classification declared by
+   examples/real-apps/realworld_http/* and examples/real-apps/realworld_resources/*.
+
+   These belong in the framework test tree, NOT under examples/ (examples stay
+   test-free per rf2-8cevm). The ns requires the managed-HTTP app's FEATURE nses
+   (never `core` — that would pull `routing.cljs` and register routes into the
+   shared node-test registrar) PLUS the resources app's HTTP ns (for its demo
+   stub only). It does NOT co-load both apps' `settings` / `auth` nses: the two
+   apps deliberately define the SAME ids (`:settings/load`, `:auth/flow`) with
+   DIFFERENT implementations, and re-frame2's image-assembly duplicate-id guard
+   (`:rf.error/image-duplicate-id`) rejects that for every frame in the process
+   — the apps are built and run as separate bundles, never co-loaded. So this ns
+   loads the managed-HTTP app fully (for the distinct machine-`:data` mechanism
+   the resources app doesn't have) and reaches the resources app ONLY through its
+   stub's registration (a unique fx-id). The resources app's login / register /
+   settings app-db draft classifications use the IDENTICAL slice-init `:sensitive`
+   pattern proven here on the managed-HTTP app's drafts (and were runtime-verified
+   against the resources app directly during development).
+
+   THE DEFECT (rf2-agb5jk): both apps meticulously classified the durable JWT but
+   NEVER the user PASSWORD — a credential that egresses raw through the
+   dispatched-event trace, the managed-HTTP request record, the settings machine
+   snapshot / app-db drafts, and any off-box shipper. This ns pins the THREE
+   surfaces the fix classifies:
+
+     1. THE MANAGED-HTTP REQUEST BODY. Both apps run against a demo-stub
+        `:fx-overrides` remap of `:rf.http/managed`, which BYPASSES the real
+        handler's `:sensitive?` body scrub. When the override fires,
+        `handle-one-fx` stamps the always-emitted `:rf.fx/handled` trace with the
+        RESOLVED stub id + RAW args, and the classification projector redacts
+        `:rf.fx/args` off the RESOLVED fx's own `:sensitive` (post-rf2-6h3c02).
+        So each stub declares `:sensitive [[:request :body :user :password]]` —
+        the Conduit `{user {…}}` envelope path — and the request-body password
+        reads `:rf/redacted` on the one wire every tool reads.
+
+     2. THE APP-DB FORM DRAFTS. The login / register / (resources) settings
+        password drafts live in app-db. Each is classified `:sensitive` in the
+        first durable write that creates the slice (classify-before-write,
+        mirroring `:auth/classify-token` for the JWT), so the draft reads
+        `:rf/redacted` at every app-db egress while handlers read the live value.
+
+     3. THE SETTINGS MACHINE :data (managed-HTTP app). Its settings form is a
+        machine whose `:data` holds the draft / submitted password; the machine
+        declares projection-relative `:sensitive [[:data :draft :password]
+        [:data :submitted :password]]`, lowered per actor at spawn.
+
+   KNOWN RESIDUAL — NOT closed here (rf2-agb5jk, framework-pattern decision).
+   The credential ALSO travels through a framework-DISPATCHED event whose payload
+   the app cannot classify: login/register ride `[:auth/flow [:auth/login {…
+   :password …}]]` — a POSITIONAL machine sub-event (the documented
+   'positional secret ships raw' structural limitation) — and resources settings
+   rides `[:rf.mutation/execute {:params {… :password …}}]`. Those still ship raw
+   in the dispatched-event + `:rf.machine/*` trace slots. Closing them needs a
+   framework change (classify positional / framework-event payloads) or an
+   auth-flow redesign that keeps the machine credential-free (as
+   examples/core/login does) — reserved for a ruling, so NOT asserted here."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.classification :as classification]
+            [re-frame.elision :as elision]
+            [re-frame.privacy :as privacy]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.schemas]
+            [re-frame.machines]
+            [re-frame.resources]
+            [re-frame.http.managed]
+            ;; managed-HTTP app FEATURE nses (no core → no routes)
+            [realworld-http.http :as http-req]
+            [realworld-http.schema]
+            [realworld-http.auth]
+            [realworld-http.settings]
+            ;; resources app — its HTTP ns ONLY, for the demo-stub registration.
+            ;; Loading its settings/auth would collide with the managed-HTTP app's
+            ;; `:settings/load` / `:auth/flow` under the image-assembly guard.
+            [realworld-resources.http])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; A UNIQUE sentinel password (>= 8 chars) that appears nowhere else, so a scan
+;; for it can only be hitting THIS drive's credential.
+(def sentinel "PW-REALWORLD-SENTINEL-7d2c4a")
+
+;; A local stub that mirrors the app stubs' :sensitive — proves the projector
+;; redacts the Conduit body shape at the resolved-fx :rf.fx/handled slot. The
+;; app stubs' OWN declarations are pinned by the registration tests below; using
+;; a local mirror keeps the drive deterministic (the real stubs route through
+;; the demo backend corpus).
+(rf/reg-fx :test.realworld/body-stub
+  {:sensitive [[:request :body :user :password]]}
+  (fn [_ _] nil))
+
+(rf/reg-event :test.realworld/emit-managed
+  (fn [_ [_ args]] {:fx [[:rf.http/managed args]]}))
+
+(defn- record-traces! [id]
+  (let [a (atom [])]
+    (rf/register-listener! :trace id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- login-args []
+  {:request    {:method :post
+                :url    "https://api.realworld.show/api/users/login"
+                :headers {"Accept" "application/json"}
+                :body   {:user {:email "alice@example.com" :password sentinel}}
+                :request-content-type :json
+                :sensitive? true}
+   :decode     :json
+   :on-success [:test.realworld/noop]
+   :on-failure [:test.realworld/noop]})
+
+;; ---------------------------------------------------------------------------
+;; 1. THE REQUEST BODY — each app's demo stub owns the redaction
+;; ---------------------------------------------------------------------------
+
+(deftest http-stub-declares-request-body-sensitive
+  (testing "the managed-HTTP app's demo stub classifies the Conduit request-body
+            password path — the registration the projector reads at egress"
+    (is (= {:sensitive [[:request :body :user :password]]}
+           (classification/registration-classification :fx :realworld.demo/http-stub))
+        ":realworld.demo/http-stub owns [:request :body :user :password]")))
+
+(deftest resources-stub-declares-request-body-sensitive
+  (testing "the resources app's demo stub classifies the same Conduit
+            request-body password path"
+    (is (= {:sensitive [[:request :body :user :password]]}
+           (classification/registration-classification :fx :realworld-resources.demo/http-stub))
+        ":realworld-resources.demo/http-stub owns [:request :body :user :password]")))
+
+(deftest request-body-password-redacts-in-fx-handled-trace
+  (testing "a managed request routed through a stub carrying the app's
+            :sensitive redacts the request-body password in the always-emitted
+            :rf.fx/handled trace, while the non-secret email rides visible"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (rf/with-fx-overrides {:rf.http/managed :test.realworld/body-stub}
+        (let [traces (record-traces! ::body)]
+          (rf/dispatch-sync [:test.realworld/emit-managed (login-args)] {:frame f})
+          (rf/unregister-listener! :trace ::body)
+          (let [handled (->> @traces
+                             (filter #(= :test.realworld/body-stub
+                                         (get-in % [:tags :rf.fx/id]))))]
+            (is (seq handled)
+                "the stub emitted a :rf.fx/handled trace with its args")
+            (doseq [ev handled]
+              (is (= privacy/redacted-sentinel
+                     (get-in ev [:tags :rf.fx/args :request :body :user :password]))
+                  "the request-body password reads :rf/redacted in :rf.fx/args")
+              (is (= "alice@example.com"
+                     (get-in ev [:tags :rf.fx/args :request :body :user :email]))
+                  "the non-secret email rides visible — selective classification"))))))))
+
+(deftest http-request-builder-passes-sensitive-flag
+  (testing "realworld-http.http/request threads :sensitive? into the request map
+            (the real-backend run-mode scrub for the managed handler)"
+    (let [req (:request (http-req/request {:method :post :path "/users/login"
+                                           :body {:user {:password sentinel}}
+                                           :sensitive? true}))]
+      (is (true? (:sensitive? req))
+          "the builder stamps :sensitive? true on the request")
+      (is (= sentinel (get-in req [:body :user :password]))
+          "the builder still carries the real password for the wire"))
+    (let [req (:request (http-req/request {:method :get :path "/user"}))]
+      (is (not (contains? req :sensitive?))
+          "a non-credential request stays unmarked — no reflexive sprinkle"))))
+
+;; ---------------------------------------------------------------------------
+;; 2. THE APP-DB FORM DRAFTS — classified at slice-init, redacted at egress
+;; ---------------------------------------------------------------------------
+
+(deftest login-register-drafts-classified-and-redacted
+  (testing "the login + register form drafts classify their password path
+            :sensitive at slice-init, so it is redacted at every app-db egress
+            while the live value stays readable"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      (rf/dispatch-sync [:auth.login-form/initialise] {:frame f})
+      (rf/dispatch-sync [:auth.register-form/initialise] {:frame f})
+      (rf/dispatch-sync [:auth.login-form/edit-field :email "alice@example.com"] {:frame f})
+      (rf/dispatch-sync [:auth.login-form/edit-field :password sentinel] {:frame f})
+      (is (contains? (elision/sensitive-declarations f)
+                     [:auth :login-form :draft :password])
+          "the login-form draft-password path is in the per-frame sensitive registry")
+      (is (contains? (elision/sensitive-declarations f)
+                     [:auth :register-form :draft :password])
+          "the register-form draft-password path is classified too")
+      (is (= sentinel (get-in (rf/app-db-value f) [:auth :login-form :draft :password]))
+          "app-db still holds the REAL password — classification redacts only at egress")
+      (doseq [profile [:rf.egress/local-redacted :rf.egress/off-box-tool]]
+        (let [wire (rf/project-egress (rf/app-db-value f)
+                                      {:frame f :rf.egress/profile profile})]
+          (is (= privacy/redacted-sentinel
+                 (get-in wire [:auth :login-form :draft :password]))
+              (str "the login-form password reads :rf/redacted at egress under " profile))
+          (is (= "alice@example.com"
+                 (get-in wire [:auth :login-form :draft :email]))
+              (str "the non-secret email rides through unredacted under " profile)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. THE SETTINGS MACHINE :data (managed-HTTP app; :settings/form is unique)
+;; ---------------------------------------------------------------------------
+
+(deftest http-settings-machine-data-classified
+  (testing "the managed-HTTP app's :settings/form machine lowers its
+            projection-relative :sensitive [:data :draft :password] to the
+            absolute snapshot path at spawn, redacting the password in every
+            machine-snapshot egress while the action bodies read the live value"
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      ;; :settings/form is http-unique — driving it directly is collision-proof.
+      (rf/dispatch-sync [:settings/form [:reset]] {:frame f})
+      (rf/dispatch-sync [:settings/form [:edit {:field :password :value sentinel}]] {:frame f})
+      (is (contains? (elision/sensitive-declarations f)
+                     [:rf.runtime/machines :snapshots :settings/form :data :draft :password])
+          "the machine :data draft-password path lowered to the snapshot path at spawn")
+      (is (contains? (elision/sensitive-declarations f)
+                     [:rf.runtime/machines :snapshots :settings/form :data :submitted :password])
+          "the machine :data submitted-password path lowered too")
+      (is (= sentinel (get-in (rf/frame-state-value f)
+                              [:rf.db/runtime :rf.runtime/machines :snapshots
+                               :settings/form :data :draft :password]))
+          "the live snapshot still holds the REAL password — classification is egress-only"))))


### PR DESCRIPTION
## Why

Both RealWorld reference apps (`realworld_http` + `realworld_resources`) carefully classify the durable JWT (`:sensitive [[:auth :token]]` + the wire `User :token {:sensitive? true}`) but classified the user **PASSWORD** nowhere. The framework's immutable HTTP carrier denylist covers headers + query-params only — never request-**body** fields — and classification is fail-open, so the password shipped **raw** through the managed-HTTP request record, the app-db form drafts, and (managed-HTTP app) the settings machine snapshot, onward to any off-box shipper / Xray / epoch export. The managed-HTTP app additionally documented a materially **false** rationale ("throwaway form state ... nothing there to protect"). These are the flagship examples that explicitly teach classification discipline, so the token/password asymmetry + the wrong teaching comment are a real teaching + security defect.

## What this classifies (the cleanly-declarable surfaces)

- **Request body** — each app's demo `:rf.http/managed` override stub declares `:sensitive [[:request :body :user :password]]` (the Conduit `{user {…}}` envelope). Because the frame's `:fx-overrides` remap bypasses the real handler's `:sensitive?` scrub, `handle-one-fx` stamps `:rf.fx/handled` with the **resolved stub** id + raw args, and the projector redacts `:rf.fx/args` off the resolved fx's own `:sensitive`. Credential-bearing requests (login / register / settings) also mark `:sensitive? true` for the real-backend run mode.
- **App-db drafts** — login / register (both apps) and the resources settings draft are classified `:sensitive` in the slice-init write (classify-before-write, mirroring `:auth/classify-token`).
- **Settings machine `:data`** (managed-HTTP app) — the `:settings/form` machine declares projection-relative `:sensitive [[:data :draft :password] [:data :submitted :password]]`, lowered per actor at spawn.

Runtime-verified with a driven login / register / settings submit: after the fix the password reads `:rf/redacted` in the request `:rf.fx/args`/`:rf.fx/handled` slots, the app-db draft egress, and the settings machine snapshot slots.

## Also

- Corrects the false rationale comment in `realworld_http/core.cljs` and adds a truthful counterpart to `realworld_resources/core.cljs`.
- Moves the managed-HTTP app's demo-stub fx from `core.cljs` to `http.cljs` (symmetric with the resources app; loadable without the routing surface).
- Adds a framework-tree regression (examples stay test-free) — fail-before / pass-after; full CLJS suite green.

## Known residual — NOT closed here (a framework-pattern decision)

The credential **also** travels through a framework-dispatched event whose payload the app cannot path-classify: login/register ride `[:auth/flow [:auth/login {… :password …}]]` — a **positional** machine sub-event (the documented "positional secret ships raw" structural limitation) — and resources settings rides `[:rf.mutation/execute {:params {… :password …}}]`. Those still ship raw in the dispatched-event and `:rf.machine/*` trace slots. Closing them requires either a framework change (classify positional / framework-event payloads) or an auth-flow redesign that keeps the machine credential-free (as `examples/core/login` does). This half of the bead is deliberately left for a ruling; the bead should stay open.

## Gates

- `npx shadow-cljs compile examples/realworld examples/realworld-resources` — 0 warnings
- `node examples/scripts/check-examples-assets.cjs` — green
- `npm run test:cljs` — 0 failures / 0 errors (full suite)
