### PR TITLE
fix(resources): refetch empty hydrated infinite feed, classification-lower mutations, stamp cancelled-work completed-at (rf2-x76af2.11, rf2-x76af2.13, rf2-x76af2.14, rf2-x76af2.15)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -440,12 +440,18 @@
                      framework-authority-meta
                      (resource-events/with-classification-lowering
                        resource-events/release-owner-handler))
+;; rf2-x76af2.14 — clear-scope / remove settle in-flight work rows terminal
+;; `:cancelled`, and a cancellation is a COMPLETION: its terminal outcome carries
+;; the event's causal `:completed-at` (from the declared-flat `:rf/time-ms`),
+;; symmetric with every reply-driven cancellation (rf2-rl27r2). Declare
+;; `time-meta` (framework-authority + the `:rf/time-ms` cofx) so the causal time
+;; is delivered flat and the handler can stamp it onto the cancelled work row.
 (events/reg-event :rf.resource/clear-scope
-                     framework-authority-meta
+                     time-meta
                      (resource-events/with-classification-lowering
                        resource-events/clear-scope-handler))
 (events/reg-event :rf.resource/remove
-                     framework-authority-meta
+                     time-meta
                      (resource-events/with-classification-lowering
                        resource-events/remove-handler))
 

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -542,9 +542,23 @@
 ;; replay for free. The internal replies carry the verification payload
 ;; (instance id + work-id + generation). User code MUST NOT dispatch the
 ;; internal replies.
+;;
+;; The ENTRY-mutating mutation handlers (`execute` optimistic apply / seed;
+;; `succeeded` `:patches` / `:populates` / `:removes`; `failed` conflict-aware
+;; rollback restore / remove / invalidate) are wrapped in
+;; `resource-events/with-classification-lowering` exactly like the resource
+;; reply/lifecycle handlers — a `:populates` can CREATE a brand-new registered-
+;; resource entry the elision registry never lowered a declaration for, so
+;; without the reconcile the per-frame registry drifts out of step with
+;; `:entries` and a fine-grained-classified field would ride egress verbatim
+;; (rf2-x76af2.13). The reconcile is idempotent + value-independent, so it is
+;; safe to add and rides unchanged when a handler makes no durable write.
+;; `:rf.mutation/clear` is a causal INSTANCE reset (no resource-entry write), so
+;; it stays unwrapped.
 (events/reg-event :rf.mutation/execute
                      generation-meta
-                     mutation-events/execute-handler)
+                     (resource-events/with-classification-lowering
+                       mutation-events/execute-handler))
 (events/reg-event :rf.mutation/clear
                      framework-authority-meta
                      mutation-events/clear-handler)
@@ -554,10 +568,12 @@
 ;; the time cofx (success + failure both, symmetric).
 (events/reg-event :rf.mutation.internal/succeeded
                      time-meta
-                     mutation-events/succeeded-handler)
+                     (resource-events/with-classification-lowering
+                       mutation-events/succeeded-handler))
 (events/reg-event :rf.mutation.internal/failed
                      time-meta
-                     mutation-events/failed-handler)
+                     (resource-events/with-classification-lowering
+                       mutation-events/failed-handler))
 
 ;; Passive mutation subs. Per Spec 016 §Mutations.
 (mutation-subs/register-subs!)

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1867,8 +1867,14 @@
   scope, or a `{:from-db …}` reference already resolved against app-db). Routes
   the concrete scope through the shared `state/canonicalize-scope` validation
   path, then removes the in-scope entries, settles their in-flight work rows
-  `:cancelled`, recomputes indexes, and emits the explaining trace + fx."
-  [runtime-db frame-id scope cause]
+  `:cancelled`, recomputes indexes, and emits the explaining trace + fx.
+
+  rf2-x76af2.14 — a cancellation is a COMPLETION: each terminal `:cancelled`
+  work row carries the event's causal `:completed-at` (`time-ms`, the declared-
+  flat `:rf/time-ms`), symmetric with every reply-driven cancellation
+  (rf2-rl27r2), so epoch / tooling correlation of a logout / tenant-switch
+  cancellation is intact."
+  [runtime-db frame-id scope cause time-ms]
   (let [cscope     (state/canonicalize-scope scope 'rf.resource/clear-scope nil)
         entries    (get-in runtime-db (state/entries-path))
         ;; rf2-9e0tyq — `entries` is keyed on the byte `key-id`; the scope to
@@ -1901,14 +1907,18 @@
                        (as-> db (reduce (fn [d [wid _]]
                                           (work-ledger/update-record
                                             d wid work-ledger/mark-terminal
-                                            :cancelled {:reason :clear-scope}))
+                                            ;; rf2-x76af2.14 — carry the causal
+                                            ;; `:completed-at` onto the cancelled
+                                            ;; work row (a cancellation completes).
+                                            :cancelled {:reason :clear-scope
+                                                        :completed-at time-ms}))
                                         db in-flight))
                        (update state/resources-key state/reindex-keys
                                entries in-scope-ids))]
     (trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :scope cscope :cause cause
                   :removed (vec in-scope) :reason :clear-scope
-                  :aborted (mapv first in-flight)})
+                  :aborted (mapv first in-flight) :completed-at time-ms})
     {:rf.db/runtime rdb'
      ;; best-effort abort of each in-scope in-flight attempt PLUS cancel the
      ;; cleared entries' advisory stale / GC timers (their durable facts are
@@ -1952,7 +1962,8 @@
   which keys nothing — would be the silent no-op the spec prohibits). The
   resolved concrete scope is then routed through `state/canonicalize-scope`
   exactly as a literal scope is. Per Spec 016 §clear-scope is causal."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db} [_event-id {:keys [scope cause]}]]
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db, time-ms :rf/time-ms}
+   [_event-id {:keys [scope cause]}]]
   (let [runtime-db (or rt {})
         ;; EP-0016 D3 / rf2-mfnc5i: resolve a `{:from-db …}` reference at use
         ;; time against the handler's app-db coeffect. A reference that resolves
@@ -1990,15 +2001,21 @@
                                         "logged-in user at logout). Per Spec 016 "
                                         "§clear-scope is causal.")})
         {})
-      (clear-scope-handler* runtime-db frame-id resolved cause))))
+      (clear-scope-handler* runtime-db frame-id resolved cause time-ms))))
 
 ;; ---- remove — single-instance cache removal --------------------------------
 
 (defn remove-handler
   "`:rf.resource/remove` — remove a single resource instance from the cache
   by its scoped key, and drop its owner/tag-index rows. Per Spec 016
-  §Events. Payload: `{:resource :scope :params}`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db} [_event-id {:keys [resource] :as payload}]]
+  §Events. Payload: `{:resource :scope :params}`.
+
+  rf2-x76af2.14 — when the removed instance has an in-flight attempt, its
+  terminal `:cancelled` work row carries the event's causal `:completed-at`
+  (`time-ms`, the declared-flat `:rf/time-ms`), symmetric with clear-scope and
+  every reply-driven cancellation (rf2-rl27r2)."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db, time-ms :rf/time-ms}
+   [_event-id {:keys [resource] :as payload}]]
   (let [runtime-db (or rt {})
         spec       (registry/require-resource-spec! resource 'rf.resource/remove)
         ;; EP-0016 D3 slice 3: resolve a `{:from-db …}` scope against app-db.
@@ -2024,12 +2041,15 @@
                        (update-in (state/entries-path) dissoc (state/key-id scoped-key))
                        (cond-> wid (work-ledger/update-record
                                      wid work-ledger/mark-terminal
-                                     :cancelled {:reason :remove}))
+                                     ;; rf2-x76af2.14 — carry the causal
+                                     ;; `:completed-at` onto the cancelled work
+                                     ;; row (a cancellation completes).
+                                     :cancelled {:reason :remove :completed-at time-ms}))
                        (update state/resources-key state/reindex-keys
                                old-entries [(state/key-id scoped-key)]))]
     (trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :resource/key scoped-key :reason :remove
-                  :aborted (when wid [wid])})
+                  :aborted (when wid [wid]) :completed-at time-ms})
     {:rf.db/runtime rdb'
      ;; best-effort abort of the removed instance's in-flight attempt
      ;; (opportunistic; stale suppression protects correctness) PLUS cancel

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -1549,17 +1549,25 @@
 
 (defn hydrated-data-usable?
   "True iff a HYDRATED `entry` carries USABLE last-known-good `:data` — i.e.
-  `:data` is present AND is NOT the redaction sentinel
-  (`privacy/redacted-sentinel`). A `:sensitive?` resource projects its data
-  as the sentinel (`project-entry` `:redact`), so on the wire the entry's
-  `:data` is `:rf/redacted` — metadata only, never usable. An `:large?`
-  resource OMITS the `:data` key entirely (nil — also not usable). This is the
-  hydration-side counterpart of `state/has-data?`, which does NOT know about
-  the wire sentinel because it only ever sees live durable data. Per Spec 016
-  §SSR and hydration (redacted entries hydrate as metadata only)."
+  `:data` is NOT the redaction sentinel (`privacy/redacted-sentinel`) AND the
+  durable `state/has-data?` predicate reports usable data. A `:sensitive?`
+  resource projects its data as the sentinel (`project-entry` `:redact`), so on
+  the wire the entry's `:data` is `:rf/redacted` — metadata only, never usable.
+  An `:large?` resource OMITS the `:data` key entirely (nil — also not usable).
+
+  This DELEGATES the 'is there usable last-known-good data?' question to
+  `state/has-data?` so the two never drift: crucially, an INFINITE feed's
+  `:data` is the ordered PAGE VECTOR (seeded `[]`), and an EMPTY page vector is
+  NO usable data (EP-0021 R1) — a naive `(some? :data)` would treat `[]` as
+  present and strand an empty hydrated feed fresh-forever (rf2-x76af2.11). The
+  sentinel exclusion is checked FIRST (short-circuit): a redacted infinite
+  entry keeps `:infinite?`, and `has-data?` would `(seq sentinel)` — the
+  sentinel is a keyword, so it must be ruled out before `has-data?` runs. Per
+  Spec 016 §SSR and hydration (redacted entries hydrate as metadata only)."
   [entry]
   (let [d (:data entry)]
-    (and (some? d) (not= privacy/redacted-sentinel d))))
+    (and (not= privacy/redacted-sentinel d)
+         (state/has-data? entry))))
 
 (defn entry-needs-refetch?
   "Decide whether a hydrated `entry` needs a client refetch against
@@ -1630,7 +1638,13 @@
                                                  ;; sensitive-redaction refetch from a
                                                  ;; large-omission one (rf2-fopuj9).
                                                  (= privacy/redacted-sentinel (:data entry)) :metadata-only
-                                                 (nil? (:data entry))         :no-data
+                                                 ;; no usable last-known-good data — a nil
+                                                 ;; scalar (omitted `:large?`) OR an EMPTY
+                                                 ;; infinite page vector `[]` (EP-0021 R1;
+                                                 ;; rf2-x76af2.11). `state/has-data?` is the
+                                                 ;; single home for the infinite-empty branch,
+                                                 ;; reached only after the sentinel is ruled out.
+                                                 (not (state/has-data? entry))       :no-data
                                                  (state/entry-stale? entry clock-ms) :stale
                                                  :else                         :metadata-only)})))
                        entries)]

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -116,27 +116,35 @@
 
 ;; ---- per-entry sensitivity / size classification (Spec 016 clause 4) ------
 ;;
-;; EP-0015 §6 reconciliation (rf2-5pld34). Params, scopes, and data carry
-;; `:sensitive?` / `:large?` classification OWNED by the resource definition
-;; (Spec 015 §Resource and mutation durable classification). The owner
-;; surface, per EP-0015 issue 11 (ruled):
+;; EP-0015 §6 / EP-0025 reconciliation (rf2-5pld34, rf2-71dr8t). Params,
+;; scopes, and data carry `:sensitive` / `:large` classification OWNED by the
+;; resource definition (Spec 015 §Resource and mutation durable
+;; classification). The owner surface splits in two:
 ;;
 ;;   - the coarse whole-entry `:sensitive?` / `:large?` claims on the
 ;;     resource spec are the degenerate ROOT-PROP case (the whole resource is
 ;;     the classification unit) — they gate the metadata-only redact / omit
 ;;     shape (`whole-entry-disposition`);
-;;   - per-slot `:sensitive?` / `:large?` props on the `:data-schema` /
-;;     `:params-schema` are the canonical FINE-GRAINED surface (the same
-;;     EP-0005 mechanism the machine `:data-schema` uses) — there is NO new
-;;     resource path-map vocabulary.
+;;   - the canonical FINE-GRAINED surface is the projection-relative
+;;     `:sensitive` / `:large` PATH declarations on the resource spec (EP-0025).
+;;     They are LOWERED per instance into the per-frame elision registry
+;;     (`classification/reconcile-registry`, `:source :resource`) at the entry's
+;;     absolute runtime-db path, and the SSR egress READS that registry back
+;;     (`project-entry-data` / `project-entry-params`). The per-slot
+;;     `:sensitive?` / `:large?` props on a co-present `:data-schema` /
+;;     `:params-schema` do NOT drive durable egress classification — the schema
+;;     VALIDATES, it does not classify (rf2-fuqcob); a schema mark serves only
+;;     validation-failure-trace redaction (EP-0025).
 ;;
 ;; A `:sensitive?` (or `:large?`) resource must NOT ship its data verbatim
 ;; onto the wire — every visitor of every SSR page would otherwise receive
 ;; it. The whole-entry coarse claim drives redact / omit; a `:serialize`
-;; entry's data slice still rides through the merged frame-owned
-;; `re-frame.projection/project-egress` (over the SHARED `rf/elide-wire-value`
-;; walker) under the SSR boundary profile, so any per-slot `:data-schema`
-;; mark the frame classification carries composes as defense-in-depth. The
+;; entry's data slice still rides through the registry-driven
+;; `classification/project-entry-data` (over the SHARED `rf/elide-wire-value`
+;; walker) under the SSR boundary profile, so the resource's OWN lowered
+;; projection-relative `:sensitive` / `:large` path declarations redact / elide
+;; their slots, and any path the FRAME ALSO classifies composes as
+;; defense-in-depth (the same registry, all sources unioned at lookup). The
 ;; classification + projection live in `re-frame.resources.classification`
 ;; (the owner-classification seam); this slice consults it — never a
 ;; family-private elider.

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -30,8 +30,15 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
    [re-frame.core :as rf]
+   [re-frame.elision :as elision]
+   [re-frame.privacy :as privacy]
    [re-frame.reply :as reply]
+   ;; rf2-x76af2.13 — the mutation classification-lowering regression reads the
+   ;; per-frame elision registry the succeeded-handler lowers into, then projects
+   ;; the populated entry's data through the registry-driven egress projector.
+   [re-frame.resources.classification :as classification]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
@@ -461,6 +468,60 @@
         (is (= :loaded (:status e)))
         (is (= {:slug "w" :title "Fresh"} (:data e)))
         (is (= #{[:article "w"]} (:tags e)))))))
+
+(deftest populate-lowers-sensitive-classification-without-manual-reconcile
+  ;; rf2-x76af2.13 — the entry-mutating mutation handlers are wrapped in
+  ;; resource-events/with-classification-lowering (like the resource reply
+  ;; handlers), so the per-frame elision registry stays in step with :entries
+  ;; after a mutation. A :populates can CREATE a brand-new registered-resource
+  ;; entry the registry never lowered a declaration for; without the reconcile
+  ;; the registry drifts and project-entry-data's registry-classifies-under?
+  ;; gate rides a fine-grained-classified field VERBATIM.
+  ;;
+  ;; NON-VACUOUS: this dispatches a REAL mutation and NEVER calls
+  ;; reconcile-registry (unlike the classification suites, which manually
+  ;; reconcile before asserting). Pre-fix — succeeded-handler unwrapped — the
+  ;; registry has no :acct/profile declaration, so project-entry-data rides the
+  ;; :ssn verbatim and the redaction assertion FAILS.
+  (rf/reg-resource :acct/profile
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :sensitive [[:data :ssn]]
+                    :tags (fn [{:keys [slug]} _] #{[:acct slug]})}
+                   (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
+  (rf/reg-mutation :m/save-profile
+                   {:params-schema [:map [:slug :string]]
+                    :populates (fn [_params result]
+                                 {{:resource :acct/profile :params {:slug "w"}
+                                   :scope :rf.scope/global} result})}
+                   (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
+  ;; NO prior ensure — the populate SEEDS a brand-new entry (the un-reconciled
+  ;; path: no wrapped resource event ever ran for this key).
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-profile :params {:slug "w"} :instance :sp1}])
+  (reply-success! @last-managed-args {:ssn "123-45-6789" :name "Alice"})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :acct/profile {:slug "w"})
+        k-id (state/key-id rkey)
+        e    (entry rkey)]
+    (testing "the populate seeded the entry — raw data lives in the durable cache
+              (redaction is an egress concern, not a durable one)"
+      (is (= :loaded (:status e)))
+      (is (= {:ssn "123-45-6789" :name "Alice"} (:data e))))
+    (testing "rf2-x76af2.13 — the succeeded-handler LOWERED the resource's
+              :data :ssn declaration into the frame registry (under :source
+              :resource), WITHOUT the test reconciling"
+      (is (= #{{:source :resource}}
+             (get (elision/sensitive-declarations :rf/default)
+                  [:rf.runtime/resources :entries k-id :data :ssn]))
+          "the mutation handler kept the elision registry in step with :entries"))
+    (testing "rf2-x76af2.13 — SSR project-entry-data redacts the field via the
+              registry the handler lowered (the drift is closed)"
+      (let [projected (classification/project-entry-data
+                        (:data e) k-id :rf/default :rf.egress/ssr-hydration)]
+        (is (= privacy/redacted-sentinel (:ssn projected))
+            "the populated entry's :ssn is redacted at egress")
+        (is (= "Alice" (:name projected)) "the undeclared sibling rides verbatim")
+        (is (not (str/includes? (pr-str projected) "123-45-6789"))
+            "no raw sensitive value rides")))))
 
 (deftest success-populate-arms-stale-and-gc-timers
   ;; rf2-h4cv5e — a mutation :populates seeds a fresh, OWNERLESS :loaded entry

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -884,6 +884,84 @@
         "no-data (metadata-only) → refetch")))
 
 ;; ===========================================================================
+;; 4a-bis. Empty infinite feed hydrates into a REFETCH, not fresh-forever
+;;         (rf2-x76af2.11)
+;; ===========================================================================
+;;
+;; An infinite feed's `:data` is the ordered PAGE VECTOR seeded `[]` (EP-0021
+;; R1). An SSR-serialized infinite feed that was ensured but never drained rides
+;; the wire with `:data []`, `:infinite? true`, `:stale-at nil`. The pre-fix
+;; `hydrated-data-usable?` used `(some? :data)`, so `[]` read as fresh-with-data
+;; → EXCLUDED from the refetch plan → the feed rendered permanently empty with no
+;; error and no recovery (a terminal no-op `load-more`). The fix delegates the
+;; usable-data question to `state/has-data?` (whose infinite branch is
+;; `(seq data)`), so an empty page vector is correctly refetched on hydration.
+
+(def ^:private fkey
+  ;; a global-scope INFINITE feed key
+  (state/scoped-resource-key :rf.scope/global :feed/timeline {}))
+
+(defn- infinite-entry* [m]
+  (assoc (entry m) :infinite? true))
+
+(deftest empty-infinite-feed-is-not-usable-data
+  (testing "rf2-x76af2.11 — hydrated-data-usable? mirrors state/has-data?'s
+            infinite empty-page-vector branch (an empty feed is NOT usable)"
+    (is (false? (ssr/hydrated-data-usable?
+                  (infinite-entry* {:resource-id :feed/timeline :data [] :status :idle})))
+        "empty infinite :data [] is NOT usable last-known-good data")
+    (is (true? (ssr/hydrated-data-usable?
+                 (infinite-entry* {:resource-id :feed/timeline :data [{:items [1]}]
+                                   :status :loaded :loaded-at 1000 :stale-at 9.0e15})))
+        "an infinite feed with at least one accumulated page IS usable")
+    (is (false? (ssr/hydrated-data-usable?
+                  (infinite-entry* {:resource-id :feed/timeline :data privacy/redacted-sentinel
+                                    :status :loaded})))
+        "a redacted infinite entry is still metadata-only (sentinel ruled out before has-data?)")))
+
+(deftest empty-infinite-feed-refetches-not-stranded-fresh-forever
+  (testing "rf2-x76af2.11 ADVERSARIAL — an SSR-serialized empty infinite feed
+            (:data [], never drained, :stale-at nil) appears in the refetch plan
+            with :reason :no-data; pre-fix it was treated as fresh-with-data and
+            stranded rendering permanently empty"
+    (let [empty-feed (infinite-entry* {:resource-id :feed/timeline :status :idle
+                                       :data [] :stale-at nil})]
+      (is (true? (ssr/entry-needs-refetch? empty-feed 5000))
+          "an empty infinite feed needs a client refetch — never fresh-forever")
+      (let [plan (->> (ssr/hydrate-refetch-plan (runtime-db-with {fkey empty-feed}) 5000)
+                      (into {} (map (juxt :resource/key identity))))]
+        (is (contains? plan fkey) "the empty infinite feed IS in the refetch plan")
+        (is (= :no-data (:reason (plan fkey)))
+            "reason is :no-data (no usable last-known-good page)")
+        (is (= :feed/timeline (:resource-id (plan fkey))))))))
+
+(deftest loaded-infinite-feed-with-page-not-double-fetched
+  (testing "rf2-x76af2.11 — the fix must not over-refetch: a FRESH infinite feed
+            WITH a page stays ABSENT from the plan (the SSR win, no double-fetch)"
+    (let [loaded-feed (infinite-entry* {:resource-id :feed/timeline :status :loaded
+                                        :data [{:items [1 2 3]}] :loaded-at 1000 :stale-at 9.0e15})]
+      (is (false? (ssr/entry-needs-refetch? loaded-feed 5000)))
+      (let [plan (->> (ssr/hydrate-refetch-plan (runtime-db-with {fkey loaded-feed}) 5000)
+                      (into {} (map (juxt :resource/key identity))))]
+        (is (not (contains? plan fkey))
+            "a fresh infinite feed WITH a page is NOT double-fetched")))))
+
+(deftest hydrate-settles-empty-infinite-loading-then-refetches
+  (testing "rf2-x76af2.11 END-TO-END repro — a server-side :loading empty infinite
+            feed settles to :idle (has-data? false) on hydration and the plan then
+            refetches it :no-data (the actual stranded-fresh-forever path)"
+    (let [e   (infinite-entry* {:resource-id :feed/timeline :status :loading
+                                :data [] :stale-at nil})
+          out (ssr/hydrate-runtime-db (runtime-db-with {fkey e}) :app/main)
+          se  (get-in out [state/resources-key :entries (state/key-id fkey)])]
+      (is (= :idle (:status se)) "empty infinite :loading → :idle (never dangling :loading)")
+      (is (= [] (:data se)) "the empty page vector is preserved")
+      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+                      (into {} (map (juxt :resource/key identity))))]
+        (is (contains? plan fkey) "the settled empty infinite feed IS refetched")
+        (is (= :no-data (:reason (plan fkey))))))))
+
+;; ===========================================================================
 ;; 4b. Hydration refetch: redacted sentinel is metadata-only (rf2-fopuj9)
 ;; ===========================================================================
 ;;

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -499,6 +499,45 @@
         (is (= :cancelled (:status (record wid))))
         (is (contains? (set @aborts) (req wid)))))))
 
+(deftest clear-scope-cancelled-row-carries-causal-completed-at
+  ;; rf2-x76af2.14 — a clear-scope cancellation is a COMPLETION: the terminal
+  ;; :cancelled work row carries the event's causal :completed-at (from the
+  ;; declared-flat :rf/time-ms), symmetric with the reply-driven aborted /
+  ;; failed rows (rf2-rl27r2). Pre-fix, clear-scope was registered
+  ;; framework-authority-meta (no :rf/time-ms cofx) so the row had NO
+  ;; :completed-at — an epoch / tooling correlation gap for logout / tenant
+  ;; switch cancellations.
+  (rf/reg-resource :cst/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
+  (let [scope-a      {:user "a"}
+        ka           (state/scoped-resource-key scope-a :cst/article {:slug "w"})
+        completed-at 1781649764222]
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :cst/article :scope scope-a
+                                            :params {:slug "w"} :owner [:lease :a 1]}])
+    (let [wid (:current-work (entry ka))]
+      (rf/dispatch-sync [:rf.resource/clear-scope {:scope scope-a :cause :logout}]
+                        {:rf.cofx {:rf/time-ms completed-at}})
+      (testing "the cancelled work row carries the causal :completed-at"
+        (is (= :cancelled (:status (record wid))))
+        (is (= {:reason :clear-scope :completed-at completed-at}
+               (:outcome (record wid))))))))
+
+(deftest remove-cancelled-row-carries-causal-completed-at
+  ;; rf2-x76af2.14 — remove has the identical gap clear-scope had: its terminal
+  ;; :cancelled row now carries the event's causal :completed-at.
+  (rf/reg-resource :rmt/article (article-spec) article-spec-request)
+  (let [scoped-key   (state/scoped-resource-key :rf.scope/global :rmt/article {:slug "w"})
+        completed-at 1781649764333]
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :rmt/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :rm 1]}])
+    (let [wid (:current-work (entry scoped-key))]
+      (rf/dispatch-sync [:rf.resource/remove {:resource :rmt/article :scope :rf.scope/global
+                                              :params {:slug "w"}}]
+                        {:rf.cofx {:rf/time-ms completed-at}})
+      (testing "the cancelled work row carries the causal :completed-at"
+        (is (= :cancelled (:status (record wid))))
+        (is (= {:reason :remove :completed-at completed-at}
+               (:outcome (record wid))))))))
+
 ;; ===========================================================================
 ;; 9. frame destroy cleans the side tables (durable records may persist)
 ;; ===========================================================================


### PR DESCRIPTION
Four fixes from the resources correctness audit (rf2-x76af2 epic), one P2 + three P3, ordered by severity. Surface: `implementation/resources` only.

## rf2-x76af2.11 (P2 bug) — empty infinite feed strands fresh-forever on hydration
`hydrated-data-usable?` (ssr.cljc) used `(some? d)`, so an SSR-serialized infinite feed with `:data []` (ensured but never drained) read as fresh-with-data: it was EXCLUDED from `hydrate-refetch-plan` and rendered permanently empty with no error and no recovery. Now it delegates the usable-data question to `state/has-data?` (whose infinite branch is `(seq data)`), with the redaction-sentinel exclusion short-circuited first (a redacted infinite entry keeps `:infinite?` and `has-data?` would `(seq sentinel)` on a keyword). The refetch-plan `:reason` cond likewise moves from `(nil? :data)` to `(not (has-data? entry))`, so an empty infinite feed classifies `:no-data`.
Tests: empty infinite feed not usable / in plan `:no-data` / fresh feed WITH a page not double-fetched / end-to-end `:loading`→settle→`:idle`→refetch.

## rf2-x76af2.13 (P3 bug) — mutation handlers omit `with-classification-lowering`
The entry-mutating mutation handlers (`:rf.mutation/execute`, `.internal/succeeded`, `.internal/failed`) were not wrapped in `with-classification-lowering` like the resource reply handlers, so a `:populates` that CREATES a brand-new registered-resource entry left the per-frame elision registry out of step with `:entries` — `project-entry-data`'s `registry-classifies-under?` gate would ride a fine-grained-classified field verbatim. Wrapped all three (idempotent, value-independent; `:rf.mutation/clear` stays unwrapped — no resource-entry write).
Test: a NON-vacuous regression — a `:populates` seeding a fresh entry of a resource declaring `:sensitive [[:data :ssn]]` keeps the registry in step; `project-entry-data` redacts the field WITHOUT the test calling `reconcile-registry` (verified to fail with the handler unwrapped).

## rf2-x76af2.14 (P3 bug) — clear-scope AND remove cancelled rows omit causal `:completed-at`
`clear-scope-handler*` and `remove-handler` settle in-flight work rows terminal `:cancelled` but were registered `framework-authority-meta` (no `:rf/time-ms` cofx), so the outcome carried no `:completed-at` — asymmetric with every reply-driven cancellation (rf2-rl27r2). Declared `time-meta` on both events and threaded the causal `:rf/time-ms` onto the `:cancelled` work-row outcome and the `:rf.resource/removed` trace.
Tests: a clear-scope and a remove that cancel an in-flight row each produce a `:cancelled` outcome carrying the scripted causal `:completed-at`.

## rf2-x76af2.15 (P3 task) — stale ssr.cljc comment contradicts EP-0025
The per-entry classification comment claimed schema `:sensitive?`/`:large?` marks were "the canonical FINE-GRAINED surface". Corrected to describe the projection-relative `:sensitive`/`:large` path declarations lowered into the elision registry (`reconcile-registry` → `project-entry-data`/`params`) as the fine-grained surface, and that schema marks serve only validation-failure-trace redaction. Doc-only.

## Quality gates
- `clojure -M:test` (implementation/resources): 640 tests, 6291 assertions, 0 failures (baseline 633/6268). Per bead: .11 +4 deftests (ssr test); .13 +1 deftest (mutation test); .14 +2 deftests (work-ledger test); .15 comment-only.
- `npm run test:cljs` (implementation/): 8586 tests, 40517 assertions, 0 failures.
- No new `:rf.error/*` / `:rf.warning/*` id → no spec/009 row.