### PR TITLE
fix(pair): dry-run rollback failure reports isError, not silent success (rf2-glg4uo)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2472,12 +2472,21 @@
                                           the rejected event).
      - `:reason :rollback-failed`       — the would-be epoch assembled
                                           but restore-epoch returned
-                                          false. The recorded would-be
-                                          db IS the live db; the caller
-                                          needs to re-restore manually.
-                                          Should not occur in practice
-                                          (the id we just produced is
-                                          at the head of the ring).
+                                          false, so the recorded would-be
+                                          db IS the live db and a spurious
+                                          epoch is left at the ring head.
+                                          A SAFETY failure — a dry-run
+                                          that mutated the live app must
+                                          NOT read as success — so it
+                                          rides back `:ok? false`
+                                          (isError at the MCP boundary),
+                                          carrying `:before-epoch-id` so
+                                          the caller can re-restore
+                                          manually. Rare but reachable: a
+                                          nil `before-id` on a frame's
+                                          first epoch-recording event, or
+                                          a tiny epoch-history ring
+                                          evicting the rollback target.
 
    This primitive is the framework-side surface; the MCP
    tool `dispatch-dry-run` wraps it. Production builds elide the entire
@@ -2552,27 +2561,39 @@
                    ;; to the target (the assembled would-be epoch is
                    ;; removed from history).
                    rolled-back? (boolean (rf/restore-epoch! frame-id before-id))
-                   base {:ok?                       true
-                         :dry-run?                  true
-                         :rolled-back?              rolled-back?
-                         :event                     event-v
-                         :frame                     frame-id
-                         :before-epoch-id           before-id
-                         ;; Project the would-be epoch into the same
-                         ;; cascade-summary shape dispatch /
-                         ;; replace-app-db / restore-epoch use.
-                         ;; Operators read one vocabulary across all four.
-                         :cascade-summary           (cascade-summary target-epoch)
-                         :would-fire-effects        recorded
-                         :db-state-after-simulation (:db-after target-epoch)}]
+                   ;; The informational payload is shared across both arms —
+                   ;; a caller wanting to re-restore after a FAILED rollback
+                   ;; still needs :before-epoch-id + the would-be state.
+                   shared {:dry-run?                  true
+                           :rolled-back?              rolled-back?
+                           :event                     event-v
+                           :frame                     frame-id
+                           :before-epoch-id           before-id
+                           ;; Project the would-be epoch into the same
+                           ;; cascade-summary shape dispatch /
+                           ;; replace-app-db / restore-epoch use.
+                           ;; Operators read one vocabulary across all four.
+                           :cascade-summary           (cascade-summary target-epoch)
+                           :would-fire-effects        recorded
+                           :db-state-after-simulation (:db-after target-epoch)}]
                (if rolled-back?
-                 base
-                 (assoc base :rollback-hint
-                        (str "restore-epoch returned false; the would-be db "
-                             "IS the live db. Re-restore manually via "
-                             "(rf/restore-epoch! <frame> <before-epoch-id>)."
-                             " Should not occur — the id we just produced "
-                             "is at the head of the ring.")))))))))))
+                 (assoc shared :ok? true)
+                 ;; SAFETY (rf2-glg4uo): the rollback FAILED, so the would-be
+                 ;; epoch's db IS now the live app-db and a spurious epoch is
+                 ;; left at the ring head. A dry-run that mutated the live app
+                 ;; MUST NOT read as success — return the documented
+                 ;; `:ok? false :reason :rollback-failed` shape (see the
+                 ;; "Failure paths" docstring) so the MCP tool's
+                 ;; `(false? (:ok? result))` routing surfaces isError:true
+                 ;; instead of a green envelope over a mutated db.
+                 (assoc shared
+                        :ok?    false
+                        :reason :rollback-failed
+                        :hint   (str "restore-epoch returned false; the would-be db "
+                                     "IS the live db and a spurious epoch remains at "
+                                     "the ring head. Re-restore manually via "
+                                     "(rf/restore-epoch! <frame> <before-epoch-id>) "
+                                     "using :before-epoch-id from this envelope.")))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Time-travel — first-class via re-frame2

--- a/skills/re-frame2-pair/tests/runtime/dry_run_rollback_failure_pin_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dry_run_rollback_failure_pin_test.clj
@@ -1,0 +1,131 @@
+;;;; tests/runtime/dry_run_rollback_failure_pin_test.clj
+;;;;
+;;;; Babashka-runnable STRUCTURAL PIN for the dry-run rollback-failure
+;;;; SAFETY contract in `preload/re_frame2_pair/runtime.cljs` (rf2-glg4uo).
+;;;;
+;;;; The defect: `dispatch-dry-run`'s `:else` branch used to return
+;;;; `:ok? true :rolled-back? false` + a human-readable `:rollback-hint`
+;;;; when `restore-epoch!` returned false — CONTRADICTING its own
+;;;; docstring (which lists `:reason :rollback-failed` as an `:ok? false`
+;;;; failure). Because the MCP tool routes isError purely on
+;;;; `(false? (:ok? result))`, that read GREEN over a MUTATED live app-db
+;;;; (the would-be epoch's db IS now the live db + a spurious epoch left
+;;;; in the ring). A dry-run whose whole contract is "no observable
+;;;; effect" must NOT report success when it in fact mutated the app.
+;;;;
+;;;; Why a structural pin rather than a live runtime test:
+;;;;
+;;;; `preload/re_frame2_pair/runtime.cljs` is CLJS-only (loaded via
+;;;; shadow-cljs `:devtools :preloads`) so it does not run under bb, and
+;;;; `dispatch-dry-run` needs a LIVE re-frame2 frame (`rf/dispatch-sync`,
+;;;; `rf/restore-epoch!`, `rf/epoch-history`). We therefore pin the
+;;;; SOURCE-level contract: the not-rolled-back arm returns the documented
+;;;; `:ok? false :reason :rollback-failed` shape and the old silent-green
+;;;; `:rollback-hint` key is GONE. The MCP-boundary routing (isError on
+;;;; :ok? false AND the belt-and-braces :rolled-back? false guard) is
+;;;; covered by the real cljs.test unit + conformance suites at
+;;;; tools/re-frame2-pair-mcp/test/.
+;;;;
+;;;; Run: bb tests/runtime/dry_run_rollback_failure_pin_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
+(ns dry-run-rollback-failure-pin-test
+  (:require [clojure.string :as str]
+            [clojure.walk :as walk]
+            [clojure.test :refer [deftest is run-tests]]
+            [runtime-support :as rt]))
+
+(def ^:private ddr-form (rt/defn-named 'dispatch-dry-run))
+
+(defn- if-rolled-back-form
+  "The `(if rolled-back? <success-arm> <failure-arm>)` node inside
+   `dispatch-dry-run` — the branch that decides success vs the
+   rollback-failure shape."
+  []
+  (let [found (atom nil)]
+    (walk/postwalk
+      (fn [node]
+        (when (and (seq? node)
+                   (= 'if (first node))
+                   (= 'rolled-back? (second node)))
+          (reset! found node))
+        node)
+      ddr-form)
+    @found))
+
+(defn- assoc-pairs
+  "For an `(assoc m :k1 v1 :k2 v2 ...)` form, the `{:k1 v1 ...}` map. nil
+   when `form` isn't an assoc call."
+  [form]
+  (when (and (seq? form) (= 'assoc (first form)))
+    (apply hash-map (drop 2 form))))
+
+(defn- docstring []
+  ;; The defn's direct docstring is the only string among the top-level
+  ;; children (arity bodies are seqs, not bare strings).
+  (first (filter string? ddr-form)))
+
+;; ---------------------------------------------------------------------------
+;; The runtime must ATTEMPT a rollback, and the two arms of that attempt
+;; must carry the documented shapes: success -> :ok? true, failure ->
+;; :ok? false :reason :rollback-failed. This is the core of rf2-glg4uo.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-dry-run-is-defined
+  (is (some? ddr-form) "dispatch-dry-run must be defined in the preload runtime"))
+
+(deftest attempts-rollback-via-restore-epoch
+  (is (rt/form-contains? #(= % 'rf/restore-epoch!) ddr-form)
+      "dispatch-dry-run must attempt the rollback via rf/restore-epoch!")
+  (is (rt/form-contains? #(= % 'rolled-back?) ddr-form)
+      "it must bind the rollback outcome to `rolled-back?` and branch on it"))
+
+(deftest not-rolled-back-arm-returns-ok-false-rollback-failed
+  (let [if-form (if-rolled-back-form)]
+    (is (some? if-form)
+        "dispatch-dry-run must branch on (if rolled-back? <success> <failure>)")
+    (let [[_if _cond then else] if-form
+          then-kv (assoc-pairs then)
+          else-kv (assoc-pairs else)]
+      (is (= true (:ok? then-kv))
+          "the rolled-back? TRUE arm returns :ok? true (the success shape)")
+      (is (= false (:ok? else-kv))
+          (str "the NOT-rolled-back arm MUST return :ok? false — a dry-run "
+               "whose rollback failed left the live app MUTATED and must not "
+               "read as success (rf2-glg4uo). It returned "
+               (pr-str (:ok? else-kv))))
+      (is (= :rollback-failed (:reason else-kv))
+          "the failed-rollback arm carries the documented :reason :rollback-failed")
+      (is (contains? else-kv :hint)
+          "the failed-rollback arm carries a :hint for manual re-restore"))))
+
+;; ---------------------------------------------------------------------------
+;; The old silent-green shape must be DELETED. If `:rollback-hint` (the
+;; :ok? true + human-string signal that read GREEN over a mutated db)
+;; reappears, dry-run has regressed to reporting success on a failed
+;; rollback — the exact defect rf2-glg4uo closed.
+;; ---------------------------------------------------------------------------
+
+(deftest silent-green-rollback-hint-is-gone
+  (is (not (rt/form-contains? #(= % :rollback-hint) ddr-form))
+      (str "the old :rollback-hint key (an :ok? true + string signal that "
+           "read GREEN over a mutated live db) MUST be deleted — a failed "
+           "rollback is an :ok? false :reason :rollback-failed failure now")))
+
+;; ---------------------------------------------------------------------------
+;; The docstring already documented :rollback-failed as an :ok? false
+;; failure path; pin that the code now honours it (docstring + code agree).
+;; ---------------------------------------------------------------------------
+
+(deftest docstring-documents-rollback-failed-as-failure
+  (let [ds (docstring)]
+    (is (some? ds) "dispatch-dry-run must carry a docstring")
+    (is (str/includes? ds "rollback-failed")
+        "the docstring must document the :rollback-failed reason")
+    (is (str/includes? ds ":ok? false")
+        "the docstring must frame :rollback-failed as an :ok? false failure")))
+
+(let [{:keys [fail error]} (run-tests 'dry-run-rollback-failure-pin-test)]
+  (System/exit (if (pos? (+ fail error)) 1 0)))

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -1576,18 +1576,49 @@ redacted unless the operator opted in. The `:elision` slot echoes the
 effective walker state; `:elided-large` reports the marker count when
 non-zero.
 
-**Returns** (failure — all `isError: true`, the dry-run did NOT land,
-rf2-wdxyx3 finding 2):
+**Returns** (failure — all `isError: true`, rf2-wdxyx3 finding 2):
 
 - `:reason :no-epoch-recorded` — epoch-history empty / frame
-  unregistered / `interop/debug-enabled?` false. No rollback needed.
+  unregistered / `interop/debug-enabled?` false. The dry-run did NOT
+  land; no rollback needed.
 - `:reason :no-new-epoch` — `dispatch-sync` returned but the head did
   not advance (the reducer rejected the event or an interceptor
-  early-returned). No rollback needed.
+  early-returned). The dry-run did NOT land; no rollback needed.
+- `:reason :rollback-failed` (rf2-glg4uo) — the simulation LANDED and a
+  would-be epoch assembled, but `restore-epoch` returned `false`, so the
+  rollback did NOT complete: the would-be db IS now the live app-db and
+  a spurious epoch remains at the ring head. This is the one failure
+  where the dry-run left the live app **mutated**, so it is the most
+  important to surface — a dry-run that silently mutated the live app
+  and reported green would defeat the tool's entire "no observable
+  effect" contract. The envelope carries `:rolled-back? false`,
+  `:before-epoch-id`, and a `:hint` for manual re-restore
+  (`(rf/restore-epoch! <frame> <before-epoch-id>)`). Rare but reachable:
+  a nil `before-id` on a frame's first epoch-recording event, or a tiny
+  `:epoch-history` ring (e.g. `:depth 1`) that evicts the rollback
+  target. The MCP tool routes it to `isError: true` on BOTH `:ok?
+  false` AND a belt-and-braces `(false? (:rolled-back? result))`
+  boundary check — defence-in-depth so that even a degraded/older
+  runtime that mis-reported `:ok? true` cannot ride green over a
+  `:rolled-back? false` envelope.
 
 The arg-parse failure modes (`:missing-event`, `:invalid-event-edn`,
 `:not-an-event-vector`) mirror `dispatch` exactly — the EDN-data
 posture (rf2-vflrg) is the same security gate.
+
+**Annotation honesty (rf2-glg4uo)**: the descriptor keeps
+`readOnlyHint` + `idempotentHint`. Those hints describe the tool's
+CONTRACT — a read-only simulation — and a host uses them to auto-approve
+the call. The `:rollback-failed` edge is the one path where the tool
+does mutate, but it is now surfaced LOUDLY as `isError: true` rather
+than as a silent green envelope, so the host is not misled: it
+auto-approves the probe (correct for the ~always read-only case) and, on
+the should-not-occur rollback failure, receives a RED result that names
+the mutation and how to undo it. Flipping the hints to `destructiveHint`
+would gate every genuinely-read-only dry-run behind the same approval
+ceremony as `dispatch` — a real usability regression to signal an edge
+that is already loud — so the honest, proportionate posture is: advisory
+hints unchanged, failure loud.
 
 ## restore-epoch
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -373,14 +373,31 @@
                                         {:ok? false :reason :unexpected-shape :value env})]
                        ;; A known-tool runtime failure (`:ok? false`, e.g.
                        ;; the reducer rejected the event / an interceptor
-                       ;; early-returned → `:no-new-epoch`, or a degraded
-                       ;; runtime → `:unexpected-shape`) rides back as an
-                       ;; `isError` envelope, matching the dispatch /
-                       ;; read-sub no-silent-success parity model and the
-                       ;; published wire contract — a non-landed dry-run
-                       ;; must not read as green. The structured
-                       ;; `:reason`/`:hint` rides through verbatim so the
-                       ;; caller still sees why.
-                       (if (false? (:ok? result))
+                       ;; early-returned → `:no-new-epoch`, a FAILED
+                       ;; rollback → `:rollback-failed` (rf2-glg4uo), or a
+                       ;; degraded runtime → `:unexpected-shape`) rides
+                       ;; back as an `isError` envelope, matching the
+                       ;; dispatch / read-sub no-silent-success parity
+                       ;; model and the published wire contract — a
+                       ;; non-landed / non-rolled-back dry-run must not
+                       ;; read as green. The structured `:reason`/`:hint`
+                       ;; rides through verbatim so the caller still sees
+                       ;; why.
+                       ;;
+                       ;; SAFETY (rf2-glg4uo): route to isError when
+                       ;; `:ok?` is false OR the rollback did not complete.
+                       ;; The runtime now reports a failed rollback as
+                       ;; `:ok? false`, so the `:ok?` arm already catches
+                       ;; it; the extra `(false? (:rolled-back? result))`
+                       ;; guard is defence-in-depth AT THE MCP BOUNDARY —
+                       ;; a degraded or older runtime that still returned
+                       ;; `:ok? true` alongside `:rolled-back? false` (the
+                       ;; would-be db IS the live db) must NOT read green
+                       ;; either. A successful dry-run always rolls back
+                       ;; (`:rolled-back? true`); a non-`:else` failure
+                       ;; omits the key entirely (nil, so `false?` is
+                       ;; false), so neither is affected.
+                       (if (or (false? (:ok? result))
+                               (false? (:rolled-back? result)))
                          (wire/err-text result)
                          (wire/ok-text result)))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -928,6 +928,31 @@
     {:isError? true
      :edn-submap {:ok? false :reason :no-new-epoch}}}
 
+   ;; rf2-glg4uo (P2 SAFETY): the simulation LANDED but restore-epoch
+   ;; returned false, so the would-be db IS the live app-db and a spurious
+   ;; epoch is left at the ring head. The runtime reports the documented
+   ;; {:ok? false :reason :rollback-failed :rolled-back? false} shape (NOT
+   ;; the old :ok? true + :rollback-hint that read GREEN over a mutated
+   ;; db). A dry-run that silently mutated the live app must ride as
+   ;; isError — the tool routes it red on :ok? false AND on the
+   ;; belt-and-braces :rolled-back? false boundary guard.
+   {:fixture/id    :dispatch-dry-run/rollback-failed
+    :fixture/doc   "dispatch-dry-run surfaces the runtime's {:ok? false :reason :rollback-failed :rolled-back? false} as an isError envelope (rf2-glg4uo — a failed rollback left the live db MUTATED; it must never read as a silent green success)."
+    :fixture/tool  "dispatch-dry-run"
+    :fixture/args  {:event "[:cart/checkout]"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["dispatch-dry-run"          {:value {:ok? false :reason :rollback-failed
+                                           :rolled-back? false
+                                           :event [:cart/checkout] :frame :rf/default
+                                           :before-epoch-id nil}
+                                   :elided-count 0}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :rollback-failed :rolled-back? false}}}
+
    ;; ---------- restore-epoch (gated write) -------------------------------
    ;; The --allow-writes gate ships DEFAULT-OFF. The disabled fixture pins
    ;; the gate-closed envelope (no nREPL round-trip); the happy fixture

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
@@ -631,6 +631,94 @@
                      (is (= :no-new-epoch (:reason edn))))
                    (done)))))))
 
+(deftest rollback-failed-rides-as-iserror
+  ;; rf2-glg4uo (P2 SAFETY). The simulation LANDED but the rollback FAILED
+  ;; (`restore-epoch` returned false: nil before-id on a frame's first
+  ;; epoch, or a tiny epoch-history ring evicted the target). The would-be
+  ;; db IS now the LIVE app-db and a spurious epoch is left at the ring
+  ;; head. The runtime now reports this as the documented
+  ;; `:ok? false :reason :rollback-failed :rolled-back? false` shape (NOT
+  ;; the old `:ok? true` + `:rollback-hint` that read GREEN over a mutated
+  ;; db). The tool's `(false? (:ok? result))` routing MUST surface it as
+  ;; an isError envelope so a dry-run that silently mutated the live app
+  ;; can never read as success. The structured :reason/:hint +
+  ;; :before-epoch-id ride through verbatim so the caller can re-restore.
+  (async done
+    (let [hint (str "restore-epoch returned false; the would-be db IS the live db "
+                    "and a spurious epoch remains at the ring head. Re-restore "
+                    "manually via (rf/restore-epoch! <frame> <before-epoch-id>) "
+                    "using :before-epoch-id from this envelope.")
+          env {:ok?             false
+               :reason          :rollback-failed
+               :dry-run?        true
+               :rolled-back?    false
+               :event           [:cart/checkout]
+               :frame           :rf/default
+               :before-epoch-id nil
+               :hint            hint}]
+      (-> (with-captured-eval! (atom []) (wrap env 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "[:cart/checkout]"})))
+          (.then (fn [r]
+                   (is (err? r)
+                       ":rollback-failed dry-run rides as isError, not a silent green over a mutated db")
+                   (let [edn (read-result-text r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :rollback-failed (:reason edn)))
+                     (is (false? (:rolled-back? edn))
+                         "the mutated-state signal (rolled-back? false) rides through")
+                     (is (= hint (:hint edn))
+                         "the re-restore hint rides through verbatim for manual recovery"))
+                   (done)))))))
+
+(deftest rolled-back-false-still-iserror-even-if-runtime-claims-ok
+  ;; rf2-glg4uo belt-and-braces (defence-in-depth AT THE MCP BOUNDARY). A
+  ;; DEGRADED or OLDER runtime could still return the pre-fix shape —
+  ;; `:ok? true` alongside `:rolled-back? false` (the would-be db IS the
+  ;; live db). The MCP tool is the safety boundary the host trusts, so it
+  ;; must NOT green-light a non-rolled-back dry-run regardless of what the
+  ;; runtime claims for `:ok?`. The `(false? (:rolled-back? result))`
+  ;; guard catches exactly that — an `:ok? true :rolled-back? false`
+  ;; envelope routes to isError.
+  (async done
+    (let [env {:ok?          true
+               :dry-run?     true
+               :rolled-back? false
+               :event        [:cart/checkout]
+               :frame        :rf/default}]
+      (-> (with-captured-eval! (atom []) (wrap env 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "[:cart/checkout]"})))
+          (.then (fn [r]
+                   (is (err? r)
+                       "an :ok? true :rolled-back? false envelope must NOT read green — the boundary guard fires")
+                   (let [edn (read-result-text r)]
+                     (is (false? (:rolled-back? edn))
+                         "the non-rolled-back signal rides through to the caller"))
+                   (done)))))))
+
+(deftest happy-rolled-back-true-stays-green
+  ;; Guard the boundary check does not over-fire: a genuine success
+  ;; (`:ok? true :rolled-back? true`) MUST still ride green — the
+  ;; belt-and-braces `(false? (:rolled-back? result))` guard only fires on
+  ;; an explicit false, never on the true happy path.
+  (async done
+    (let [env {:ok?          true
+               :dry-run?     true
+               :rolled-back? true
+               :event        [:cart/checkout]
+               :frame        :rf/default}]
+      (-> (with-captured-eval! (atom []) (wrap env 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "[:cart/checkout]"})))
+          (.then (fn [r]
+                   (is (not (err? r))
+                       "a rolled-back? true success still reads green")
+                   (let [edn (read-result-text r)]
+                     (is (true? (:ok? edn)))
+                     (is (true? (:rolled-back? edn))))
+                   (done)))))))
+
 (deftest non-map-runtime-result-surfaced-as-unexpected-shape
   ;; A runtime without `dispatch-dry-run` returns something other than
   ;; the wrapped map. The tool surfaces that as a structured


### PR DESCRIPTION
## Summary

Closes **rf2-glg4uo** (P2 SAFETY). A failed rollback in `dispatch-dry-run`
read as an `isError:false` (green) MCP envelope even though the simulated
epoch's db IS now the live app-db. Because the tool is annotated
`readOnlyHint` + `idempotentHint`, hosts auto-approve it and read the result
as "no modification" — so the net effect was **silent live-app mutation +
green envelope + read-only annotation**, with only a human-readable hint
string as signal.

## Root cause

The runtime primitive (`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`)
`dispatch-dry-run` `:else` branch returned `:ok? true :rolled-back? false` +
a `:rollback-hint` string when `restore-epoch!` returned `false` — directly
**contradicting its own docstring**, which lists `:reason :rollback-failed`
as an `:ok? false` failure path. The MCP tool
(`tools/re-frame2-pair-mcp/.../dispatch_dry_run.cljs`) routes isError purely
on `(false? (:ok? result))`, so `:ok? true` rode green over a mutated db and
a spurious epoch left in the ring.

Reachability: `restore-epoch!` returns false when `before-id` isn't an `:ok`
record in the ring — a nil `before-id` on a frame's first epoch-recording
event, or a tiny `:epoch-history` ring (`{:depth 1}`) evicting the target.
Rare, but whenever it happens the false-green is guaranteed.

## Safety rationale

A dry-run's entire contract is "no observable effect." The one path where
that contract is violated — the rollback failing and leaving the live app
mutated — is precisely the path that must NOT report success. This change
makes that failure **loud** (`isError:true`) instead of silent green, so the
host and operator see a red result naming the mutation and how to undo it,
rather than caching a false success over a corrupted app-db.

## Fix (align the runtime with its own documented contract)

- **Runtime**: the not-rolled-back arm now returns the documented
  `:ok? false :reason :rollback-failed :rolled-back? false` shape, carrying
  `:before-epoch-id` and a re-restore `:hint`, never `:ok? true`. The
  existing `(false? (:ok? result))` MCP routing then surfaces `isError:true`
  with no other change required.
- **MCP tool (belt-and-braces)**: defence-in-depth at the safety boundary —
  route to isError on `(false? (:rolled-back? result))` as well, so even a
  degraded/older runtime that mis-reported `:ok? true` alongside
  `:rolled-back? false` cannot ride green. A successful dry-run always sets
  `:rolled-back? true`; a non-`:else` failure omits the key (nil, so `false?`
  is false), so neither the happy path nor the other failure paths are
  affected.
- **spec/003-Tool-Catalogue**: documents the `:rollback-failed` outcome in
  the dispatch-dry-run failure enumeration.

## Descriptor honesty (readOnlyHint / idempotentHint)

**Kept, and the rationale is documented in spec/003.** The hints describe the
tool's contract — a read-only simulation — which a host uses to auto-approve.
The rollback-failure edge is the one path where the tool mutates, but it is
now surfaced loudly as `isError:true` rather than as a silent green envelope,
so the host is not misled. Flipping to `destructiveHint` would gate every
genuinely-read-only dry-run behind the same approval ceremony as `dispatch` —
a real usability regression to signal an edge that is already loud. The
mcp-conformance classification ratchet (`dispatch-dry-run: read-only`) stays
consistent, so no descriptor change was needed.

## Tests (fail before / pass after — no test previously covered `:rolled-back? false`)

- **Skills structural pin** (babashka, auto-discovered by CI): new
  `tests/runtime/dry_run_rollback_failure_pin_test.clj` pins that the
  not-rolled-back arm returns `:ok? false :reason :rollback-failed`, that the
  old silent-green `:rollback-hint` key is deleted, and that code + docstring
  agree.
- **MCP unit** (`npm test`): a `:rollback-failed` env rides as `isError`; the
  belt-and-braces boundary guard fires on `:ok? true` + `:rolled-back? false`
  (degraded-runtime case); and a genuine `:rolled-back? true` success still
  reads green (guards against over-fire).
- **MCP conformance fixture**: `:dispatch-dry-run/rollback-failed` →
  `isError:true`.

## Quality gates (foreground)

- Skills structural loop (`bb tests/runtime/*_test.clj` + prompts): 11 files,
  all green — new pin 5 tests / 12 assertions; prompts 27 tests / 144
  assertions. (Caught and fixed a one-paren imbalance mid-work.)
- pair-mcp `npm test` (`server-test`): **1206 tests / 4155 assertions, 0
  failures, 0 errors** (was 1 pre-existing count before this change; +5 new
  assertions across 3 new deftests + 1 conformance fixture).
- `npm run check:descriptors`: in sync (30 tools) — no descriptor change.

Live-nREPL note: the runtime primitive needs a live shadow-cljs frame, so its
behaviour is proven by the structural pin (source contract) + the MCP unit /
conformance suites (boundary routing), per the established preload test
posture — no live end-to-end required for this reporting fix.
