### PR TITLE
fix(story): verdict-authority in assertions-passing?, recorder flush isolation, decorator teardown stack, real dialog-snapshot test (rf2-x76af2.16, rf2-x76af2.18, rf2-x76af2.19, rf2-x76af2.20)

### DIFF
--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -316,12 +316,27 @@ Stage 5 ships the `story/assertions-passing?` predicate as the canonical
 ```
 
 `assertions-passing?` accepts either the `run-variant` result map or its
-`:assertions` vector and returns true iff every record has `:passed?
-true` (an empty vector is vacuously passing — the
-[spec/007 §Story-as-test duality](../../../implementation/...) contract:
-a variant with no `:play-script` still "passes"). The result map's
-`:assertions` slot now carries EVERY assertion outcome — both the
-`:rf.assert/*` dispatch-step records AND the rich-DSL `:assert-db` /
+`:assertions` vector, but the two shapes have two DIFFERENT authorities:
+
+- **Result map → the run VERDICT (`:status`).** For a result map,
+  `assertions-passing?` is `true` iff `(= :pass (:status result))` — the
+  SAME authority as `result-passed?`, NOT a fold over `:assertions`. This
+  consults the agreement floor and the run-level `:cannot-run` slot, so a
+  floor-escalated `:fail` (an unconsumed schema violation / failing epoch
+  outcome) or a run-level `:cannot-run` returns FALSE even when every
+  `:assertions` record is `:passed? true`. A verdict and the assertions
+  slot can never disagree (the `result.cljc` core invariant); folding
+  `:assertions` on a result map would be a floor-blind SECOND verdict path
+  — the false-GREEN class (rf2-x76af2.16). A zero-assertion `:pass` run
+  stays green (its `:status` is `:pass`).
+- **Bare `:assertions` vector → the vacuous-green fold.** For a bare
+  vector, it returns true iff every record has `:passed? true` (an empty
+  vector is vacuously passing — the
+  [spec/007 §Story-as-test duality](../../../implementation/...) contract:
+  a variant with no `:play-script` still "passes").
+
+The result map's `:assertions` slot carries EVERY assertion outcome — both
+the `:rf.assert/*` dispatch-step records AND the rich-DSL `:assert-db` /
 `:assert-dom` step records (rf2-ee38b.3 closed the false-green gap where
 rich-DSL assert failures landed only in the runner's `run-state` atom).
 
@@ -369,8 +384,10 @@ reports); the pure CLJS projection by
 
 `story/assertions-passing?` remains the one-line boolean predicate for the
 `(is (story/assertions-passing? result))` pattern above; `story/is` is the
-richer per-assertion surface. Both consume the same unified `:assertions`
-vector.
+richer per-assertion surface. On a result map both agree with the run
+verdict (`:status`) — `assertions-passing?` reads it directly, `story/is`
+projects a run-level report when the verdict exceeds any single assertion —
+so neither can report a floor-blind false GREEN.
 
 ## Cross-references
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1378,16 +1378,23 @@
 
 (defn assertions-passing?
   "Per `004-Assertions.md` §Test-runner integration + /spec/007-Stories.md
-  §Story-as-test duality — true iff
-  every entry in the assertions list has `:passed? true`. Accepts
-  either an assertions vector or a `run-variant` result map.
-
-  This is the canonical predicate for the cljs.test / clojure.test
-  adapter pattern from /spec/007-Stories.md §Portable into tests:
+  §Story-as-test duality — the canonical predicate for the cljs.test /
+  clojure.test adapter pattern:
 
       (deftest counter-empty-state
         (let [result @(story/run-variant :story.counter/empty {})]
-          (is (story/assertions-passing? result))))"
+          (is (story/assertions-passing? result))))
+
+  Given a `run-variant` RESULT MAP, this reflects the run VERDICT
+  (`:status`) — the SAME authority as `result-passed?` — so a
+  floor-escalated `:fail` (an unconsumed schema violation / failing epoch
+  outcome) or a run-level `:cannot-run` returns FALSE even when every
+  assertion is `:passed? true` (no floor-blind false GREEN, rf2-x76af2.16).
+  A zero-assertion `:pass` run stays green (the §Story-as-test duality).
+
+  Given a bare ASSERTIONS VECTOR (e.g. `read-assertions`), it is the
+  vacuous-green fold: true iff every record has `:passed? true` (an empty
+  vector passes). See `re-frame.story.assertions/passing?`."
   [assertions-or-result]
   (assertions/passing? assertions-or-result))
 

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -258,20 +258,41 @@
   (or (:rf.story/assertions (rf/app-db-value frame-id)) []))
 
 (defn passing?
-  "Per `004-Assertions.md` §Canonical assertion vocabulary + Phase-2 §5.1 #9:
-  true iff every entry in
-  `assertions` has `:passed? true`. An assertions vector with zero
-  entries is vacuously passing — this is the /spec/007-Stories.md §Story-as-test
-  duality contract: a variant with no `:play-script` (and therefore no
-  assertions) still 'passes', and shows up as green in test reports.
+  "True iff `assertions-or-result` is passing. Two input shapes, two
+  authorities:
 
-  Accepts either an assertions vector or a `run-variant` result map."
+  - A `run-variant` RESULT MAP — the authority is the run VERDICT
+    (`:status`), NOT the assertion fold. `passing?` is `true` iff
+    `(= :pass (:status result))`, mirroring `re-frame.story.result/passed?`
+    (the verdict authority). Reading `:status` consults the agreement
+    floor AND the run-level `:cannot-run` slot, so a floor-escalated
+    `:fail` (an unconsumed schema violation / failing epoch outcome / error
+    effect that `result/run-result` escalated `:status` to `:fail`) or a
+    run-level `:cannot-run` returns FALSE even when every `:assertions`
+    entry is `:passed? true`. `result.cljc`'s core invariant is that a
+    verdict and the assertions slot can never disagree — folding
+    `:assertions` here (the old behaviour) was a floor-blind SECOND verdict
+    path, the false-GREEN class (rf2-x76af2.16). A zero-assertion `:pass`
+    run is still green (its `:status` is `:pass`), so the
+    /spec/007-Stories.md §Story-as-test duality still holds.
+
+  - A bare ASSERTIONS VECTOR (render-only / live-introspection path, e.g.
+    `read-assertions`) — true iff every entry has `:passed? true`. A vector
+    with zero entries is vacuously passing (the same §Story-as-test
+    duality: a variant with no `:play-script` shows green).
+
+  `re-frame.story.result` cannot be `:require`d here (it already requires
+  this ns — cycle), so the one-line verdict check is inlined rather than
+  delegated to `result/passed?`."
   [assertions-or-result]
-  (let [items (cond
-                (map? assertions-or-result)    (:assertions assertions-or-result)
-                (sequential? assertions-or-result) assertions-or-result
-                :else                          [])]
-    (every? :passed? items)))
+  (if (map? assertions-or-result)
+    ;; Run-result map → the run VERDICT is authoritative (mirror
+    ;; `result/passed?`), NOT the floor-blind `:assertions` fold.
+    (= :pass (:status assertions-or-result))
+    ;; Bare assertions vector → the vacuous-green fold (render-only duality).
+    (every? :passed? (if (sequential? assertions-or-result)
+                       assertions-or-result
+                       []))))
 
 ;; ---------------------------------------------------------------------------
 ;; Assertion-evaluation helpers

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -126,6 +126,22 @@
   (swap! stub-call-log dissoc frame-id)
   nil)
 
+;; Per-frame ALLOCATE-TIME decorator stack. `allocate!` resolves the
+;; decorator stack upstream and runs each `:frame-setup` decorator's `:init`
+;; against it; we stash the SAME stack here so `run-teardown-walks!` runs the
+;; matching `:teardown` set — even when a hot-reload changed the variant's
+;; `:decorators` between allocate! and teardown. Re-resolving at teardown (the
+;; prior behaviour) ran a DIFFERENT set than `:init` did, leaking a resource
+;; the old `:init` opened and tearing down one the new set never opened
+;; (rf2-x76af2.19). Mirrors `destroy-inline!`, which already uses its
+;; caller-supplied captured stack. Evicted by `run-teardown-walks!`.
+(defonce
+  ^{:doc "frame-id → the `decorators/resolve-decorators` result CAPTURED at
+         `allocate!` time. Read (and evicted) by `run-teardown-walks!` so
+         teardown mirrors the allocate-time `:frame-setup` set."}
+  allocated-decorator-stacks
+  (atom {}))
+
 (defn- ensure-stub-event!
   "Register a `reg-fx` handler under `stub-id` that handles a
   redirected fx call. Idempotent — re-registration replaces the slot
@@ -820,6 +836,12 @@
        ;; decorators (that's part of the events-only? predicate), so this
        ;; is a no-op on the fast-path branch.
        (apply-frame-setup! variant-id (:frame-setup decorator-stack))
+       ;; Stash the ALLOCATE-TIME stack so teardown runs the SAME
+       ;; :frame-setup set whose :init just ran, even if a hot-reload changes
+       ;; the variant's :decorators before teardown (rf2-x76af2.19). In the
+       ;; re-run path (run-phase-0!) reset-state!'s teardown reads the PRIOR
+       ;; stash BEFORE this line overwrites it with the current stack.
+       (swap! allocated-decorator-stacks assoc variant-id decorator-stack)
        variant-id))))
 
 ;; ---- inline-plan allocation ----------------------------------------------
@@ -991,11 +1013,20 @@
       (when (seq evs)
         (apply-loaders-teardown! variant-id evs)))
     (catch #?(:clj Throwable :cljs :default) _ nil))
-  ;; Step 4 — :frame-setup decorator :teardown events. Resolve the
-  ;; decorator stack here (rather than carrying it through the caller
-  ;; signature) so the caller surface stays unchanged.
+  ;; Step 4 — :frame-setup decorator :teardown events. Use the decorator
+  ;; stack CAPTURED at allocate! time (stashed in `allocated-decorator-stacks`)
+  ;; rather than re-resolving here, so a hot-reload that changed the variant's
+  ;; :decorators between allocate! and teardown still tears down the SAME
+  ;; :frame-setup set whose :init ran — mirroring `destroy-inline!`, which
+  ;; uses its caller-supplied captured stack (rf2-x76af2.19). Falls back to a
+  ;; fresh resolve when nothing was stashed (a frame torn down without going
+  ;; through allocate!'s stash path). Evicted so the side-table never outlives
+  ;; the frame; in the re-run path (run-phase-0!) this read happens BEFORE the
+  ;; following allocate! re-stashes the new stack.
   (try
-    (let [stack (decorators/resolve-decorators variant-id)]
+    (let [stack (or (get @allocated-decorator-stacks variant-id)
+                    (decorators/resolve-decorators variant-id))]
+      (swap! allocated-decorator-stacks dissoc variant-id)
       (apply-frame-teardown! variant-id (:frame-setup stack)))
     (catch #?(:clj Throwable :cljs :default) _ nil))
   nil)

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -52,6 +52,26 @@
                                      teardown call routes through this hook.
                                      Signature: `(f frame-id) → nil`.
 
+  - `:recorder/reset-dom-buffer`   — dom-capture → recorder. Called by
+                                     `recorder/start-recording!` and
+                                     `recorder/clear!` to cancel every
+                                     pending DOM type-debounce flush timer
+                                     and drop the per-selector type-buffer.
+                                     Without it a keystroke buffered under a
+                                     PRIOR recording (its `setTimeout` flush
+                                     still pending) would fire after a new
+                                     recording started / the recorder was
+                                     cleared and — via the `:recording?`-
+                                     agnostic buffered append — bleed into
+                                     the CURRENT recording's `:entries`
+                                     (rf2-x76af2.18). `recorder` (cljc)
+                                     cannot `:require` `dom-capture` (cljs;
+                                     cycle: dom-capture → recorder), so the
+                                     drain routes through this hook. Absent
+                                     on hosts with no DOM capture (bare
+                                     JVM), where there is no buffer to drain.
+                                     Signature: `(f) → nil`.
+
   - `:render-host`                 — story (via the canonical
                                      `install-render-host!`) → render. The
                                      CLJS host's view-render seam, consumed

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -122,6 +122,7 @@
   - `insert-assertion!`       — impure entrypoint for the picker UI."
   (:require [clojure.string :as str]
             [re-frame.story.config :as config]
+            [re-frame.story.late-bind :as late-bind]
             [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]
             ;; The listener surface lives in `re-frame.trace.tooling`
@@ -788,6 +789,16 @@
 ;; production CLJS build's call sites elide cleanly.
 ;; ---------------------------------------------------------------------------
 
+(defn- reset-dom-buffer!
+  "Cancel + drop any pending DOM type-debounce buffer via the late-bound
+  `:recorder/reset-dom-buffer` seam the CLJS `dom-capture` layer registers.
+  No-op on hosts where DOM capture isn't loaded (bare JVM — no buffer
+  exists). Called at recording start/clear so a keystroke buffered under a
+  PRIOR recording cannot bleed into the next one (rf2-x76af2.18)."
+  []
+  (when-let [f (late-bind/get-fn :recorder/reset-dom-buffer)]
+    (f)))
+
 (defn start-recording!
   "Begin recording events dispatched against `variant-id`'s frame.
   Returns the new state. Stops any in-flight recording first. Under
@@ -798,6 +809,10 @@
   frame-scoped (`{:frame variant-id}`) so it lands in the frame's own running
   environment by construction — the recorder stamps no separate realm key.
 
+  Drains the DOM type-debounce buffer (cancels pending flush timers) so a
+  keystroke still buffered from a prior recording cannot bleed into this one
+  (rf2-x76af2.18).
+
   The two-arity `(start-recording! variant-id now-ms)` lets a test pin the
   wall-clock start time."
   ([variant-id]
@@ -805,7 +820,8 @@
                                    :cljs (.now js/Date))))
   ([variant-id now-ms]
    (if config/enabled?
-     (swap! state start variant-id now-ms)
+     (do (reset-dom-buffer!)
+         (swap! state start variant-id now-ms))
      initial-state)))
 
 (defn stop-recording!
@@ -819,10 +835,15 @@
 
 (defn clear!
   "Drop the captured events and return to idle. Under elision returns
-  `initial-state` without touching the atom."
+  `initial-state` without touching the atom.
+
+  Also drains the DOM type-debounce buffer (cancels pending flush timers) so
+  a discarded recording leaves no phantom keystroke to land in a subsequent
+  recording (rf2-x76af2.18)."
   []
   (if config/enabled?
-    (reset! state initial-state)
+    (do (reset-dom-buffer!)
+        (reset! state initial-state))
     initial-state))
 
 (defn toggle!

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -77,6 +77,7 @@
   (:require [clojure.set                     :as set]
             [clojure.string                  :as str]
             [re-frame.story.config           :as config]
+            [re-frame.story.late-bind        :as late-bind]
             [re-frame.story.recorder         :as recorder]
             [re-frame.story.recorder.selector :as selector]
             [re-frame.story.ui.canvas-listeners :as canvas-listeners]))
@@ -219,6 +220,34 @@
                                        :t     (recording-now-ms)
                                        :timer nil})
     (schedule-type-flush! selector)))
+
+(defn cancel-pending-flushes!
+  "Cancel every pending debounce timer and DROP the type-buffer WITHOUT
+  flushing. Unties the buffer + its live `setTimeout` timers from the
+  recording boundary: called at `start-recording!` / `clear!` so a keystroke
+  buffered under a PRIOR recording can never bleed into the next one
+  (rf2-x76af2.18).
+
+  This is deliberately NOT a flush — a keystroke pending when a NEW
+  recording starts (or the recorder is cleared) belongs to the recording
+  that ended, and dropping it is correct: the stop-into-SAME-recording final
+  keystroke survival (rf2-eztym.3) relies on the pending timer firing while
+  the buffer is still intact (stop-recording! does NOT drain the buffer), and
+  is unaffected — only start/clear drain here.
+
+  Registered as the `:recorder/reset-dom-buffer` late-bind hook (below) so
+  the cljc recorder — which cannot `:require` this cljs ns — can invoke it."
+  []
+  (doseq [entry (vals @type-buffer)]
+    (clear-buffer-timer! entry))
+  (reset! type-buffer {})
+  nil)
+
+;; Register the buffer-drain seam so `recorder/start-recording!` + `clear!`
+;; can cancel + drop pending keystrokes at the recording boundary. Runs at
+;; ns load (dom-capture requires recorder, so recorder is loaded first and
+;; the runtime lookup resolves this at call time). rf2-x76af2.18.
+(late-bind/set-fn! :recorder/reset-dom-buffer cancel-pending-flushes!)
 
 ;; ---- predicates ---------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
@@ -153,3 +153,86 @@
           (is (= 1 (count type-entries))
               "rapid typing still folds to a single in-session entry")
           (is (= "ali" (:text (first type-entries)))))))))
+
+;; ---- cross-recording bleed regression (rf2-x76af2.18) --------------------
+;;
+;; rf2-eztym.3 made `flush-type-buffer!` bypass the `:recording?` re-check so
+;; the FINAL keystroke survives a flush firing after stop (stop-into-SAME-
+;; recording). But it left the DOM type-buffer + its live `setTimeout` timers
+;; untied to the recorder start/clear boundary: a keystroke buffered under
+;; recording A, whose pending flush fired AFTER a fresh `start-recording!` B
+;; (or `clear!`), appended UNCONDITIONALLY into the CURRENT recorder atom —
+;; bleeding an A-relative `:dom/type` step into B (or a phantom into the next
+;; recording). The fix: `start-recording!` / `clear!` drain + cancel the
+;; pending buffer via the `:recorder/reset-dom-buffer` late-bind seam.
+
+(deftest stop-then-restart-does-not-bleed-across-recordings
+  (when (dom-available?)
+    (testing "a keystroke buffered under recording A, then a NON-flushing
+              stop + start-recording! B within the debounce window, does NOT
+              land in B's :entries — start-recording! drains + cancels the
+              pending DOM type-buffer (rf2-x76af2.18)"
+      (recorder/start-recording! :story.a/rec)
+      (dom/set-debounce-ms! 5000)          ; hold the buffer open (no sync flush)
+      (let [input (.createElement js/document "input")]
+        (.setAttribute input "id" "note")
+        (.appendChild @test-root input)
+        (set! (.-value input) "aaa")
+        (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
+        ;; STOP via the non-flushing facade path; the debounce timer T is
+        ;; still pending, the buffered "aaa" still held.
+        (recorder/stop-recording!)
+        ;; A FRESH recording B starts before T fires. This must DRAIN A's
+        ;; pending buffer (cancel T + drop the entry), not carry it into B.
+        (recorder/start-recording! :story.b/rec)
+        (is (recorder/recording?) "B is recording")
+        (is (empty? (recorder/recorded-entries)) "B starts with no entries")
+        ;; Force any surviving timer to fire. Under the bug A's "aaa" appends
+        ;; here into B (append-dom-buffered ignores :recording?); under the
+        ;; fix the buffer was cancelled + emptied, so this is a no-op.
+        (dom/flush-type-buffer!)
+        (let [type-entries (filterv #(= :dom/type (:kind %))
+                                    (recorder/recorded-entries))]
+          (is (= [] type-entries)
+              "A's buffered keystroke did NOT bleed into recording B"))))))
+
+(deftest clear-while-typing-leaves-no-phantom-in-next-recording
+  (when (dom-available?)
+    (testing "clear! while a keystroke is buffered cancels the pending flush,
+              so a subsequent recording sees no phantom entry (rf2-x76af2.18)"
+      (recorder/start-recording! :story.a/rec)
+      (dom/set-debounce-ms! 5000)
+      (let [input (.createElement js/document "input")]
+        (.setAttribute input "id" "note")
+        (.appendChild @test-root input)
+        (set! (.-value input) "bbb")
+        (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
+        ;; Discard the recording mid-type.
+        (recorder/clear!)
+        ;; Start a fresh recording; the cancelled buffer must not resurface.
+        (recorder/start-recording! :story.c/rec)
+        (dom/flush-type-buffer!)
+        (is (empty? (filterv #(= :dom/type (:kind %))
+                             (recorder/recorded-entries)))
+            "clear! cancelled the pending flush — no phantom entry in C")))))
+
+(deftest stop-into-same-recording-final-keystroke-still-survives
+  (when (dom-available?)
+    (testing "rf2-eztym.3 guard still holds under the rf2-x76af2.18 fix:
+              stop-recording! does NOT drain the buffer, so a flush firing
+              after stop (with NO intervening start/clear) still captures the
+              final keystroke into the stopped recording"
+      (recorder/start-recording! :story.x/same)
+      (dom/set-debounce-ms! 5000)
+      (let [input (.createElement js/document "input")]
+        (.setAttribute input "id" "note")
+        (.appendChild @test-root input)
+        (set! (.-value input) "keep")
+        (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
+        (recorder/stop-recording!)          ; no start/clear after → buffer intact
+        (dom/flush-type-buffer!)            ; the pending timer's late fire
+        (let [type-entries (filterv #(= :dom/type (:kind %))
+                                    (recorder/recorded-entries))]
+          (is (= 1 (count type-entries))
+              "the final keystroke survived the post-stop flush (rf2-eztym.3)")
+          (is (= "keep" (:text (first type-entries)))))))))

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -18,6 +18,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core               :as m]
             [re-frame.epoch.capture   :as capture]
+            [re-frame.story.assertions :as assertions]
             [re-frame.story.result   :as result]
             [re-frame.story.play.evidence :as evidence]
             [re-frame.story.requirements  :as requirements]))
@@ -256,6 +257,59 @@
            top-level :status escalated past it — the two are separate
            result slots")
       (is (= 1 (count (:schema-violations r))) "the violation is still projected"))))
+
+;; ---- rf2-x76af2.16: assertions-passing? consults the VERDICT, not the ----
+;; ---- floor-blind assertion fold (no false GREEN) -------------------------
+
+(deftest assertions-passing?-consults-the-run-verdict
+  (testing "the public cljs.test-adapter predicate `assertions/passing?`
+            (also `story/assertions-passing?`) reads the run VERDICT
+            (`:status`) for a RESULT MAP — NOT a fold over `:assertions` —
+            so a floor-escalated `:fail` or a run-level `:cannot-run` with
+            an all-green assertion set returns FALSE, agreeing with
+            `result/passed?`. Before rf2-x76af2.16 it folded only
+            `(every? :passed? (:assertions result))` and reported a false
+            GREEN on both shapes."
+    (testing "floor-escalated :fail (red tape + a single passing assertion)"
+      (let [tape [(epoch {:trace-events
+                          [{:operation :rf.error/schema-validation-failure
+                            :tags {:where :event :failing-id :checkout/submit}}]})]
+            r    (result/run-result
+                   {:epoch-tape tape
+                    :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
+        (is (= :fail (:status r)) "sanity: the agreement floor escalated to :fail")
+        (is (every? :passed? (:assertions r))
+            "sanity: the assertion fold alone is all-green (the false-GREEN trap)")
+        (is (false? (result/passed? r)) "the verdict authority says NOT passing")
+        (is (false? (assertions/passing? r))
+            "assertions/passing? MUST agree with the verdict — no false GREEN")))
+    (testing "run-level :cannot-run (unmet requirement) + a passing assertion"
+      (let [refusal (requirements/requirement-refusal
+                      #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
+                      :runner-lacks-capability :headless)
+            r       (result/run-result
+                      {:epoch-tape [(epoch {})]
+                       :assertions [{:assertion :rf.assert/path-equals :passed? true}]
+                       :unmet      [refusal]})]
+        (is (= :cannot-run (:status r)) "sanity: run refused → :cannot-run")
+        (is (false? (assertions/passing? r))
+            "a :cannot-run run proved nothing — assertions/passing? is FALSE")))
+    (testing "the vacuous-green duality still holds — a zero-assertion :pass"
+      (let [r (result/run-result {:assertions []})]
+        (is (= :pass (:status r)))
+        (is (true? (assertions/passing? r))
+            "a zero-assertion :pass run is still green (Story-as-test duality)")))
+    (testing "a genuinely-passing run with passing assertions is still green"
+      (let [r (result/run-result
+                {:epoch-tape [(epoch {})]
+                 :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
+        (is (= :pass (:status r)))
+        (is (true? (assertions/passing? r)))))
+    (testing "the bare-assertions-VECTOR arity is unchanged (the fold path)"
+      (is (true?  (assertions/passing? []))            "empty vector vacuously passes")
+      (is (true?  (assertions/passing? [{:passed? true}])))
+      (is (false? (assertions/passing? [{:passed? true} {:passed? false}]))
+          "any :passed? false in the vector fails the fold"))))
 
 ;; ===========================================================================
 ;; SCHEMA-ERROR EXACT CONSUMPTION  (spec/017 §Schema rule, rf2-5x1wt.21)

--- a/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
@@ -15,6 +15,7 @@
     replay / close buttons all surface)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.recorder                    :as recorder]
             [re-frame.story.recorder.play-export        :as export]
             [re-frame.story.recorder.play-export-events :as export-events]
             #?(:cljs [re-frame.story.ui.recorder-export-dialog :as export-dialog])))
@@ -135,25 +136,50 @@
 
 #?(:cljs
    (deftest dialog-survives-fresh-recording
-     (testing "starting a fresh recording while the export dialog is open does
-              NOT mutate the in-flight export — the snapshot is taken at open
-              time, NOT read live off the recorder atom"
-       (export-dialog/open-dialog!
-         {:source-id :story.a/source
-          :events    [[:auth/login] [:counter/inc]]})
-       (let [before (str (export-dialog/export-dialog))]
-         (is (str/includes? before ":auth/login"))
-         ;; A fresh recording starts (recorder reset, new events) — this
-         ;; would be the same race the parent save-dialog dodges via
-         ;; rf2-8x9nb. The export dialog inherits the safety because it
-         ;; carries its own snapshot.
-         (reset! export-dialog/ui-dialog
-                 (assoc @export-dialog/ui-dialog :events []))
-         ;; The dialog state was directly poked → render reflects the poke.
-         ;; This test merely demonstrates the snapshot is on the ratom we
-         ;; own. The integration guarantee against recorder-atom mutation
-         ;; is by construction: open-dialog! deref'd events at call time.
-         (is true)))))
+     (testing "the export dialog holds its OWN snapshot of the captured
+              events, taken when the export-open handler runs; mutating the
+              recorder afterwards (a fresh recording + a new keystroke, then
+              a discard) does NOT change the in-flight export. Drives the REAL
+              call-site (open-from-recorder-dialog!) with the recorder's live
+              capture, then churns the recorder — exercising the
+              snapshot-independence the test name promises, NOT a self-poke of
+              the dialog's own ratom (rf2-x76af2.20)."
+       ;; Seed the recorder with a completed capture.
+       (recorder/clear!)
+       (recorder/start-recording! :story.a/source)
+       (recorder/record-event! [:auth/login])
+       (recorder/record-event! [:counter/inc])
+       (is (seq (recorder/recorded-events))
+           "sanity: the recorder captured the seeded events")
+       ;; Drive the export-open handler EXACTLY as the toolbar :on-export
+       ;; closure does — deref the recorder AT click time and pass the
+       ;; snapshot. :source-id nil keeps the frame-db snapshot out of scope.
+       (export-dialog/open-from-recorder-dialog!
+         {:events    (recorder/recorded-events)
+          :entries   (recorder/recorded-entries)
+          :source-id nil})
+       (let [snap-events  (:events  @export-dialog/ui-dialog)
+             snap-entries (:entries @export-dialog/ui-dialog)]
+         (is (str/includes? (str (export-dialog/export-dialog)) ":auth/login")
+             "the export dialog snapshotted the captured events at open time")
+         ;; MUTATE THE RECORDER: a fresh recording resets the atom, a new
+         ;; keystroke lands, then a discard — the exact churn the snapshot
+         ;; must survive. Were any link reading the recorder live, the
+         ;; already-open export would change.
+         (recorder/start-recording! :story.b/other)
+         (recorder/record-event! [:counter/dec])
+         (recorder/clear!)
+         (is (= snap-events (:events @export-dialog/ui-dialog))
+             "recorder churn did not change the export dialog :events snapshot")
+         (is (= snap-entries (:entries @export-dialog/ui-dialog))
+             "recorder churn did not change the export dialog :entries snapshot")
+         (let [after (str (export-dialog/export-dialog))]
+           (is (str/includes? after ":auth/login")
+               "the rendered export still carries the originally-captured events")
+           (is (not (str/includes? after ":counter/dec"))
+               "the post-open recorder keystroke never leaked into the export")))
+       ;; Leave the recorder idle for the next test.
+       (recorder/clear!))))
 
 #?(:cljs
    (deftest dialog-auto-assert-includes-assertions-in-snippet

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -59,6 +59,7 @@
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (reset! frames/stub-call-log {})
+  (reset! frames/allocated-decorator-stacks {})
   (runner-events/clear-all-runs!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
@@ -203,6 +204,54 @@
       (story/destroy-variant! :story.teardown.same-level/v)
       (is (= [:b :a] @fired)
           "later-declared :dec-b tears down before earlier-declared :dec-a"))))
+
+;; ===========================================================================
+;; HOT-RELOAD ASYMMETRY — teardown uses the ALLOCATE-TIME decorator stack
+;; (rf2-x76af2.19)
+;;
+;; `allocate!` runs each :frame-setup decorator's :init against the stack it
+;; resolved at ALLOCATE time. The registered teardown path previously
+;; RE-RESOLVED the stack at TEARDOWN time — so if a hot-reload changed the
+;; variant's :decorators between allocate! and destroy!, teardown ran a
+;; DIFFERENT :frame-setup set than :init did: a resource opened by the old
+;; :init was never closed, and the new set's :teardown ran against a resource
+;; it never opened. The inline twin `destroy-inline!` already used its
+;; captured stack; the fix carries the allocate-time stack to the registered
+;; teardown walk the same way.
+;; ===========================================================================
+
+(deftest teardown-uses-allocate-time-decorator-stack-after-hot-reload
+  (testing "when a hot-reload changes a variant's :decorators between
+            allocate! and destroy!, teardown runs the :frame-setup :teardown
+            of the stack CAPTURED at allocate! time — NOT the re-resolved
+            current stack (rf2-x76af2.19)"
+    (let [fired (atom [])]
+      (rf/reg-event :d1/init    (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :d2/init    (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :d1/cleanup (fn [{:keys [db]} _] (swap! fired conj :d1) {:db db}))
+      (rf/reg-event :d2/cleanup (fn [{:keys [db]} _] (swap! fired conj :d2) {:db db}))
+      (story/reg-decorator :hot/d1
+        {:kind :frame-setup :init [[:d1/init]] :teardown [[:d1/cleanup]]})
+      (story/reg-decorator :hot/d2
+        {:kind :frame-setup :init [[:d2/init]] :teardown [[:d2/cleanup]]})
+      ;; Allocate with D1 — its :init ran; the allocate-time stack is captured.
+      (story/reg-variant :story.hotdec/v
+        {:decorators [[:hot/d1]] :events []})
+      (async/deref-blocking (story/run-variant :story.hotdec/v) 5000)
+      ;; HOT-RELOAD: the variant body now declares D2 instead of D1. The live
+      ;; frame still carries D1's :init; only the registered body changed.
+      (story/reg-variant :story.hotdec/v
+        {:decorators [[:hot/d2]] :events []})
+      ;; Sanity: the CURRENT resolution IS D2 — exactly what the buggy
+      ;; re-resolve-at-teardown would read (so this test is not vacuous).
+      (is (= [:hot/d2]
+             (mapv :id (:frame-setup (story/resolve-decorators :story.hotdec/v))))
+          "post-hot-reload resolve-decorators returns D2")
+      ;; Destroy — teardown MUST use the allocate-time stack (D1), not D2.
+      (story/destroy-variant! :story.hotdec/v)
+      (is (= [:d1] @fired)
+          "teardown ran D1's :cleanup (the allocate-time :frame-setup set
+           whose :init actually ran), NOT the re-resolved D2's"))))
 
 ;; ===========================================================================
 ;; EXCEPTION HANDLING — throwing teardown caught; record projected


### PR DESCRIPTION
Story correctness-audit cluster (epic rf2-x76af2). One P1 false-green in the testing tool + three P3s. Commits ordered by severity.

## rf2-x76af2.16 — P1 BUG, FALSE GREEN (headline; severe)

`story/assertions-passing?` / `assertions/passing?` — the spec-documented cljs.test adapter predicate `(is (story/assertions-passing? result))` — folded ONLY `(every? :passed? (:assertions result))` on a run-RESULT map and **ignored `:status`**. So a floor-escalated `:fail` (an unconsumed schema violation / failing epoch outcome) or a run-level `:cannot-run` with an all-green/empty assertion set reported **GREEN**. This is a floor-blind SECOND verdict path that directly contradicts `result.cljc`'s core invariant ("a verdict and the assertions slot can never disagree — the false-GREEN class"). Since Story's entire value is trustworthy verdicts, a false-green **in the testing tool** is the severe class: a consumer's green test silently hides a floor-failed / cannot-run run.

**Fix:** for a result MAP, `passing?` now mirrors `result/passed?` — `(= :pass (:status result))` — so a `:fail`/`:cannot-run` returns FALSE even when the assertion fold is green. `result.cljc` cannot be required from `assertions.cljc` (cycle), so the one-line verdict check is inlined. The bare-assertions-VECTOR arity (render-only vacuous-green fold) and the zero-assertion `:pass` duality are preserved. spec/004-Assertions.md §Test-runner integration updated so spec and code agree.

## rf2-x76af2.18 — P3 BUG, cross-recording state bleed

The recorder DOM type-buffer + its `setTimeout` flush timers survived `start-recording!`/`clear!`. A keystroke buffered under recording A, whose pending flush fired after a non-flushing stop + `start-recording!` B (or `clear!`) within the debounce window, appended unconditionally into B's `:entries` (a regression surface from rf2-eztym.3, which made the flush `:recording?`-agnostic). **Fix:** `start-recording!`/`clear!` cancel pending timers + drop the buffer via a new `:recorder/reset-dom-buffer` late-bind seam (cljc recorder ↔ cljs dom-capture). `stop-recording!` deliberately does NOT drain, so the rf2-eztym.3 stop-into-same-recording final-keystroke survival still holds.

## rf2-x76af2.19 — P3 BUG, lifecycle asymmetry

`run-teardown-walks!` re-resolved the decorator stack at TEARDOWN time while `allocate!` ran `:init` against the ALLOCATE-time stack — so a hot-reload that changed `:decorators` between allocate and teardown ran a different `:frame-setup` set than `:init` did (leak + mis-teardown). **Fix:** allocate! stashes the resolved stack; run-teardown-walks! reads (and evicts) it, mirroring `destroy-inline!`. In the re-run path, reset-state!'s teardown reads the prior stash before allocate! re-stashes.

## rf2-x76af2.20 — P3 TASK, test vacuity

`dialog-survives-fresh-recording` asserted `(is true)` after poking its own ratom — the named snapshot-independence invariant was untested. **Fix:** drive the real export-open call-site (`open-from-recorder-dialog!`) with the recorder's click-time snapshot, then churn the recorder and assert the already-open export is unchanged. Coverage-only; no product bug surfaced.

## Quality gates

Both foreground gates green (no upstream tools/story changes since base):

- `clojure -M:test` (tools/story JVM): **1783 tests / 6568 assertions, 0 failures** (baseline 1781). +2 tests: rf2-x76af2.16 verdict-authority regression (result_test.cljc, 13 assertions across both false-GREEN classes + vacuous-green duality + vector arity), rf2-x76af2.19 hot-reload teardown-stack regression (story_teardown_test.clj).
- `npm run test:cljs` (node CLJS): **8582 tests / 40498 assertions, 0 failures** — compiles dom_capture.cljs + recorder.cljc + the browser test; runs rf2-x76af2.20's real node test.
- rf2-x76af2.18's DOM regressions (stop→restart bleed, clear→restart phantom, + an rf2-eztym.3 survival guard) live in the browser-gated `*_dom_cljs_test.cljs` (where rf2-eztym.3 lives); compile-verified locally, assertions run in CI's `:browser-test` gate. On JVM the seam resolves to nil (no-op), verified by the JVM gate.

No new `:rf.error/*` / `:rf.warning/*` ids minted (no spec/009 row needed).