### PR TITLE
test(mcp-conformance): give indicator-splice, vocab-pin, realm-slot gates real teeth (rf2-qyfy1m, rf2-njudn8, rf2-txgs76)

### DIFF
--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -97,8 +97,14 @@
 (deftest every-tree-walking-tool-routes-through-the-helper
   (doseq [[tool rel] tree-walking-tool-sources]
     (testing (str "tool " tool " — wire/with-indicators call-site in " rel)
-      (let [src (fx/read-source rel)]
-        (is (str/includes? src "wire/with-indicators")
+      ;; Match against `fx/strip-comments-and-strings`-neutered source so a
+      ;; docstring / comment MENTION of `wire/with-indicators` can't satisfy
+      ;; the routing pin — only a real CODE reference counts (rf2-qyfy1m).
+      ;; subscribe.cljs names the helper in two docstrings; without the
+      ;; strip, deleting its real splices would leave the pin green.
+      (let [src      (fx/read-source rel)
+            stripped (fx/strip-comments-and-strings src)]
+        (is (str/includes? stripped "wire/with-indicators")
             (str "Tool " tool " at " rel
                  " does not route its envelope through `wire/with-indicators`. "
                  "The centralised emit-path is the structural contract — a "
@@ -113,9 +119,17 @@
   ;; splice would silently ship per-tick payloads without indicator
   ;; counts on the streaming path while still showing them on the
   ;; final summary — invisible to single-payload conformance.
-  (let [rel "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs"
-        src (fx/read-source rel)
-        n   (count (re-seq #"wire/with-indicators" src))]
+  ;; Count over `fx/strip-comments-and-strings`-neutered source (rf2-qyfy1m):
+  ;; subscribe.cljs mentions `wire/with-indicators` in TWO docstrings
+  ;; (terminal-summary + streaming) on top of the two REAL splices. A raw
+  ;; `re-seq` counts all four, so deleting BOTH real splices — the exact
+  ;; regression this pin names — still counts the two docstrings and stays
+  ;; `>= 2` green. Stripping drops the prose to spaces, so the count reflects
+  ;; only the two genuine call-sites and falls to 0 when they are removed.
+  (let [rel      "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs"
+        src      (fx/read-source rel)
+        stripped (fx/strip-comments-and-strings src)
+        n        (count (re-seq #"wire/with-indicators" stripped))]
     (is (>= n 2)
         (str "Expected `subscribe-emit` to call `wire/with-indicators` "
              "at least twice (once on the per-tick progress payload, "

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/operating_frame_address_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/operating_frame_address_test.clj
@@ -67,6 +67,25 @@
 ;; FAILURE shape, dispatched on `:ok?`. Both are co-located here.
 ;; ---------------------------------------------------------------------------
 
+(defn- realm-shaped-key?
+  "A map key whose namespace OR name mentions `realm` — the coordinate
+  EP-0023/rf2-udl74a removed from the operating-frame wire shape. Matched
+  case-insensitively over the keyword's full string form so `:realms`,
+  `:operating-realm`, `:frame-realms`, and a namespaced `:rf.realm/id`
+  all trip."
+  [k]
+  (and (keyword? k)
+       (boolean (re-find #"(?i)realm" (subs (str k) 1)))))
+
+(defn- no-realm-slots?
+  "True when `m` carries no realm-shaped key. This is the closed-key
+  NEGATIVE that gives the deliberately-OPEN `OperatingFrameSuccess`
+  schema real teeth against a re-introduced realm slot (rf2-txgs76): the
+  envelope stays open to legitimate non-realm additive decorations
+  (source-uri / freshness) while ANY realm-shaped key is rejected."
+  [m]
+  (not (some realm-shaped-key? (keys m))))
+
 (def OperatingFrameSuccess
   "The `{:ok? true ...}` operating-frame envelope per the Tool-Pair
   §Tool-surface-obligations contract as collapsed by EP-0023 (q8whbb).
@@ -85,19 +104,29 @@
                   AMBIGUOUS: two-plus app frames, no pin). A frame-id or nil.
 
   There are NO realm slots — the re-frame.realm substrate was removed
-  (rf2-udl74a); the wire shape is frame-only.
+  (rf2-udl74a); the wire shape is frame-only. This is enforced with
+  teeth by the `[:fn no-realm-slots?]` arm below — NOT by `:closed`,
+  which would also reject the legitimate additive decorations.
 
   Open map `{:closed false}` — additive envelope slots (the
   source-uri/freshness decorations the wire-pipeline layers on) compose
   without a schema bump. The LOAD-BEARING claim is that the public
-  addressing slots are present and correctly typed."
-  [:map
-   {:closed false}
-   [:ok?        [:= true]]
-   [:frames     [:sequential :keyword]]
-   [:app-frames [:sequential :keyword]]
-   [:selected   [:maybe :keyword]]
-   [:operating  [:maybe :keyword]]])
+  addressing slots are present and correctly typed AND that no
+  realm-shaped slot rides the envelope (rf2-txgs76): the closed-key
+  negative catches a real emitter re-introducing a realm coordinate,
+  which the open map alone would silently accept."
+  [:and
+   [:map
+    {:closed false}
+    [:ok?        [:= true]]
+    [:frames     [:sequential :keyword]]
+    [:app-frames [:sequential :keyword]]
+    [:selected   [:maybe :keyword]]
+    [:operating  [:maybe :keyword]]]
+   [:fn {:error/message (str "operating-frame envelope carries a realm-shaped slot — "
+                             "EP-0023/rf2-udl74a made the wire shape frame-only "
+                             "(no realm coordinate, public or internal)")}
+    no-realm-slots?]])
 
 (def OperatingFrameFailure
   "The `{:ok? false :reason <kw> ...}` operating-frame failure envelope.
@@ -230,13 +259,39 @@
 (deftest no-realm-slots-on-the-envelope
   ;; rf2-udl74a: the re-frame.realm substrate was removed atomically. The
   ;; operating-frame envelope is frame-only — no realm coordinate, public or
-  ;; internal. A regression that re-introduced a realm slot would surface here.
-  (doseq [[fixture-name fixture-value] success-fixtures]
-    (testing (str "fixture " fixture-name " carries no realm slots")
-      (is (not (contains? fixture-value :realms)))
-      (is (not (contains? fixture-value :operating-realm)))
-      (is (not (contains? fixture-value :selected-realm)))
-      (is (not (contains? fixture-value :frame-realms))))))
+  ;; internal.
+  ;;
+  ;; The teeth (rf2-txgs76): the guarantee is enforced by the SCHEMA's
+  ;; closed-key negative (`[:fn no-realm-slots?]` on `OperatingFrameSuccess`),
+  ;; NOT by iterating the author's own fixtures. A fixture-only absence check
+  ;; is self-referential — the schema is `{:closed false}`, so a real emitter
+  ;; re-introducing a `:realms` slot would validate against every
+  ;; schema-conformance gate AND never flow through a fixture `contains?`
+  ;; check. Asserting the SCHEMA rejects the slot catches the emitter
+  ;; regression the docstring names.
+  (testing "the local success-fixtures carry no realm slots (sanity on the fixtures themselves)"
+    (doseq [[fixture-name fixture-value] success-fixtures]
+      (testing (str "fixture " fixture-name)
+        (is (not (contains? fixture-value :realms)))
+        (is (not (contains? fixture-value :operating-realm)))
+        (is (not (contains? fixture-value :selected-realm)))
+        (is (not (contains? fixture-value :frame-realms))))))
+  (testing "the SCHEMA rejects a re-introduced realm slot (the emitter-regression guard)"
+    (let [base (:multi-frame-pinned success-fixtures)]
+      (doseq [realm-slot [:realms :operating-realm :selected-realm :frame-realms
+                          :frame-realm :rf.realm/id]]
+        (testing (str "a success envelope carrying " realm-slot " fails validation")
+          (is (not (m/validate OperatingFrameSuccess (assoc base realm-slot :whatever)))
+              (str "OperatingFrameSuccess MUST reject a re-introduced " realm-slot
+                   " slot — EP-0023/rf2-udl74a made the wire shape frame-only. "
+                   "The schema stays OPEN for non-realm additive decorations but "
+                   "the [:fn no-realm-slots?] arm rejects any realm-shaped key."))))
+      (testing "a non-realm additive decoration still validates (the schema stays open)"
+        (is (m/validate OperatingFrameSuccess
+                        (assoc base :rf.source/uri "app://x" :fresh? true))
+            (str "OperatingFrameSuccess MUST remain OPEN to legitimate additive "
+                 "wire decorations (source-uri / freshness) — the realm negative "
+                 "must not become a general closed-map rejection."))))))
 
 (deftest multi-frame-independent-resolution
   ;; Bead rf2-f0isjs finding 2: two distinct frame ids resolve

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -169,19 +169,26 @@
   "tools/mcp-base/src/re_frame/mcp_base/vocab.cljc")
 
 (def ^:private mcp-base-vocab-literals
-  "The canonical slot keywords that MUST appear verbatim in the vocab
-  ns. The vocab ns is the cross-MCP single source of truth; a rename
-  here breaks every server in lockstep — which is the right
-  invariant. The slot keys in this set are the NAMESPACED framework
-  forms (`:rf.size/include-large?` /
-  `:rf.size/include-sensitive?` — the walker opts; these are internal
-  framework keys, NOT wire keys, so they retain the predicate `?`)
-  PLUS the unqualified MCP-surface form (`:include-sensitive` — no
-  `?` because the wire-key MUST omit `?` per Anthropic's tool input
-  schema regex `^[a-zA-Z0-9_.-]{1,64}$`)."
+  "The canonical slot keywords that MUST appear verbatim — as CODE
+  constants — in the vocab ns. The vocab ns is the cross-MCP single
+  source of truth; a rename here breaks every server in lockstep —
+  which is the right invariant. These are the NAMESPACED framework
+  walker-opt forms (`:rf.size/include-large?` /
+  `:rf.size/include-sensitive?`) — internal framework keys, NOT wire
+  keys, so they retain the predicate `?` and are DEF'd here
+  (`include-large-opt` / `include-sensitive-opt`).
+
+  The unqualified MCP-surface wire-key `:include-sensitive` (no `?`
+  per Anthropic's tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$`) is
+  DELIBERATELY NOT in this set (rf2-njudn8): it is a per-server wire
+  surface key, not an mcp-base constant — its only appearance in
+  vocab.cljc is a docstring MENTION, so pinning it here asserted a
+  source-of-truth constant that does not exist and could only ever be
+  satisfied by prose. Its cross-server wire parity is enforced with
+  teeth by Gate 1 (`canonical-slot-literal-appears-in-every-contracted-server`,
+  token-boundary matched)."
   #{":rf.size/include-large?"
-    ":rf.size/include-sensitive?"
-    ":include-sensitive"})
+    ":rf.size/include-sensitive?"})
 
 ;; ---------------------------------------------------------------------------
 ;; Argument-role schema gate. Each role pins a Malli shape — a
@@ -390,16 +397,24 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest mcp-base-vocab-pins-the-canonical-slot-keywords
-  (let [src (fx/read-source mcp-base-vocab-source)]
+  ;; Match against `fx/strip-comments-and-strings`-neutered source
+  ;; (rf2-njudn8): each namespaced walker-opt keyword is named in a
+  ;; docstring AS WELL AS being DEF'd, so a raw `str/includes?` stays
+  ;; green when the real `(def ...)` constant is removed but its prose
+  ;; mention survives — no teeth against a constant removal. Stripping
+  ;; drops docstrings/comments to spaces, so only the genuine CODE
+  ;; constant satisfies the pin.
+  (let [src      (fx/read-source mcp-base-vocab-source)
+        stripped (fx/strip-comments-and-strings src)]
     (doseq [literal mcp-base-vocab-literals]
-      (testing (str "mcp-base/vocab.cljc pins literal " literal)
-        (is (str/includes? src literal)
-            (str "Literal " literal " missing from " mcp-base-vocab-source
-                 ".\nThe vocab ns is the cross-MCP single source of "
-                 "truth for slot keywords (Conventions §Reserved "
-                 "namespaces). A rename here breaks every consumer "
-                 "in lockstep — which is the right invariant; restore "
-                 "the literal or update this test."))))))
+      (testing (str "mcp-base/vocab.cljc pins literal " literal " as a code constant")
+        (is (str/includes? stripped literal)
+            (str "Literal " literal " missing from the CODE of " mcp-base-vocab-source
+                 " (present only in a docstring does not count).\nThe vocab ns "
+                 "is the cross-MCP single source of truth for slot keywords "
+                 "(Conventions §Reserved namespaces). A rename here breaks "
+                 "every consumer in lockstep — which is the right invariant; "
+                 "restore the constant or update this test."))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Gate 6 — server-coverage sanity. Every server referenced in


### PR DESCRIPTION
Three VACUOUS / fail-open gate fixes from the mcp-conformance audit (the "green gate, no teeth" class, rf2-lo28u lineage). Each gate previously passed on its own named injected defect; each is now proven to go RED on the exact regression it names. Test-only — no source change to subscribe.cljs / vocab.cljc / the envelope schema.

## rf2-qyfy1m (P2) — subscribe indicator-splice pins
`indicator_field_test.clj`. Both dedicated gates grepped RAW source, so `subscribe.cljs`'s TWO docstring mentions of `wire/with-indicators` satisfied them even with the real splices gone. `subscribe-emit-carries-both-streaming-and-final-splice` (`re-seq` count `>= 2`) and the subscribe row of `every-tree-walking-tool-routes-through-the-helper` (`str/includes?`) now match against `fx/strip-comments-and-strings`-neutered source, so only genuine CODE references count.

## rf2-njudn8 (P3) — mcp-base vocab-pin
`slot_name_test.clj`. The bare `:include-sensitive` row was satisfied ONLY by a docstring (no such code constant exists — it is a per-server wire-arg, backstopped with teeth by Gate 1). Dropped that row. The two namespaced walker-opt rows are DEF'd AND named in docstrings, so a raw `str/includes?` had no teeth against a constant removal; the pin now matches against stripped (code-only) source.

## rf2-txgs76 (P3) — realm-slot-absence gate
`operating_frame_address_test.clj`. `no-realm-slots-on-the-envelope` only iterated the author's own local fixtures, and `OperatingFrameSuccess` is `{:closed false}` (open) — so a real emitter re-introducing a `:realms` slot validated against every schema gate and never flowed through the fixture `contains?` check. Added a closed-key negative `[:fn no-realm-slots?]` arm to the schema (rejects any realm-shaped key while staying OPEN to legitimate non-realm additive decorations); the deftest now asserts the SCHEMA rejects a spread of realm slots.

## Quality gates

Gate: `tools/mcp-conformance/wire-vocab` JVM suite — `clojure -M:test`.
Result with all three fixes: **100 tests, 1062 assertions, 0 failures, 0 errors** (was 1056 assertions pre-fix; +6 from the txgs76 schema-rejection assertions).

Teeth proofs (reproduced the false-green on `origin/main`, confirmed RED after the fix):

| Bead | Named regression | Pre-fix (main) | Post-fix |
|------|------------------|----------------|----------|
| rf2-qyfy1m | delete BOTH real `wire/with-indicators` splices in subscribe.cljs (docstrings kept) | GREEN (0 failures) | RED — `subscribe-emit-carries-both-streaming-and-final-splice` + `every-tree-walking-tool-routes-through-the-helper` both fail |
| rf2-njudn8 | remove the real `:rf.size/include-sensitive?` code constant (docstring kept) | GREEN (vocab-pin row; only unrelated egress tests failed) | RED — `mcp-base-vocab-pins-the-canonical-slot-keywords` fails ("present only in a docstring does not count") |
| rf2-njudn8 (acceptance) | remove ONLY the bare `:include-sensitive` docstring | RED (row tracked prose) | GREEN (row removed — no longer tracks prose) |
| rf2-txgs76 | add a `:realms` slot to a success emission | GREEN (`success-fixtures-conform-to-schema`; open schema accepts it) | RED — schema rejects the realm slot |

## Risks
- Low. Test-only; no product source touched. The `realm-shaped-key?` predicate matches `(?i)realm` over the keyword's full string form — no legitimate operating-frame envelope key contains "realm", verified against all fixtures + the open-schema positive (`:rf.source/uri` / `:fresh?` still validate).
