### PR TITLE
docs(implementor,template): three-family gate example, eight-decision-block count, schemas-throws-not-soft-passes comment (rf2-21pdsd, rf2-4h1gnw, rf2-vy8c2e)

### DIFF
--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -101,7 +101,7 @@ The corpus at [`spec/conformance/`](../../spec/conformance) is host-agnostic dat
 ## Reference files (all one level deep)
 
 - [`references/cardinal-rules.md`](references/cardinal-rules.md) — the eleven rules in prose + anti-pattern corollaries.
-- [`references/phase-1-decisions.md`](references/phase-1-decisions.md) — Phase 1 walkthrough, seven decision blocks.
+- [`references/phase-1-decisions.md`](references/phase-1-decisions.md) — Phase 1 walkthrough, eight decision blocks (D1–D7 plus D5b).
 - [`references/decision-record.md`](references/decision-record.md) — fill-in template for the locked-decision record.
 - [`references/phase-2-impl-order.md`](references/phase-2-impl-order.md) — EP-by-EP implementation order.
 - [`references/reference-impl-tour.md`](references/reference-impl-tour.md) — guided tour of the CLJS reference; what's substrate-specific vs pattern-required.

--- a/skills/re-frame2-implementor/references/output-format.md
+++ b/skills/re-frame2-implementor/references/output-format.md
@@ -93,7 +93,9 @@ Produced after acceptance gate 2 passes. This is the final report for the port's
 - **Substrate:** <D2>
 - **Claimed capability tag set:**
   ```
-  :core/*
+  :core/*                 ; always — pattern-required
+  :identity/*             ; always — v1-required (EP-0012 path algebra + CEDN-1 identity)
+  :data-classification/*  ; always — v1-required (Spec 015 egress/redaction)
   <list of optional tags from D7>
   ```
 - **Conformance score:** <claimed-applicable> / <claimed-applicable> on corpus commit <corpus-commit-hash>.

--- a/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
@@ -21,7 +21,8 @@
          ;; Schema attachment — `reg-app-schema` + Malli adapter. The
          ;; starter app's whole-app-db schema (see schema.cljs) needs
          ;; this artefact for validation to actually fire; without it
-         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         ;; the `reg-app-schema` call throws :rf.error/schemas-artefact-missing
+         ;; at boot — a hard requirement for schema registration, not a soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-xray-host] right-side layout host. Wired via

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
@@ -22,7 +22,8 @@
          ;; Schema attachment — `reg-app-schema` + Malli adapter. The
          ;; starter app's whole-app-db schema (see schema.cljs) needs
          ;; this artefact for validation to actually fire; without it
-         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         ;; the `reg-app-schema` call throws :rf.error/schemas-artefact-missing
+         ;; at boot — a hard requirement for schema registration, not a soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-xray-host] right-side layout host. Wired via

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
@@ -39,7 +39,8 @@
          ;; Schema attachment — `reg-app-schema` + Malli adapter. The
          ;; starter app's whole-app-db schema (see core.cljc's CounterDb)
          ;; needs this artefact for validation to actually fire; without it
-         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         ;; the `reg-app-schema` call throws :rf.error/schemas-artefact-missing
+         ;; at boot — a hard requirement for schema registration, not a soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-xray-host] right-side layout host. Wired via

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
@@ -28,7 +28,8 @@
          ;; Schema attachment — `reg-app-schema` + Malli adapter. The
          ;; starter app's whole-app-db schema (see schema.cljs) needs
          ;; this artefact for validation to actually fire; without it
-         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         ;; the `reg-app-schema` call throws :rf.error/schemas-artefact-missing
+         ;; at boot — a hard requirement for schema registration, not a soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-xray-host] right-side layout host. Wired via

--- a/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
@@ -22,7 +22,8 @@
          ;; Schema attachment — `reg-app-schema` + Malli adapter. The
          ;; starter app's whole-app-db schema (see schema.cljs) needs
          ;; this artefact for validation to actually fire; without it
-         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         ;; the `reg-app-schema` call throws :rf.error/schemas-artefact-missing
+         ;; at boot — a hard requirement for schema registration, not a soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-xray-host] right-side layout host. Wired via


### PR DESCRIPTION
Three disjoint small doc/comment corrections from this session's audits. One PR, three commits, one bead each. All doc/comment-only; no code or deps changed.

## rf2-21pdsd (P3) — v1-completion tag-set example omitted two v1-required families
`skills/re-frame2-implementor/references/output-format.md` — the "Claimed capability tag set" example in the v1 completion report listed only `:core/*` + `<list of optional tags from D7>`, burying `:identity/*` (EP-0012 path algebra + CEDN-1) and `:data-classification/*` (Spec 015) under "optional" even though both are always-claimed, v1-required. This was the residual example PR #5608 missed when it fixed every gate description. Corrected to enumerate all three, matching the D7 template at `decision-record.md:200-202`. A port author copying this now publishes a claim consistent with their own D7 record.

## rf2-4h1gnw (P4) — SKILL.md self-contradicted on the Phase-1 block count
`skills/re-frame2-implementor/SKILL.md:104` (reference-files index) said "seven decision blocks", contradicting `:59` ("Eight decision blocks (D1–D7 plus D5b)") and `phase-1-decisions.md`'s Contents (D1, D2, D3, D4, D5, D5b, D6, D7 = eight). Line 104 had dropped D5b (the v1-required data-classification block). Aligned to "eight decision blocks (D1–D7 plus D5b)".

## rf2-vy8c2e (P3) — template deps.edn comment wrongly said a missing schemas artefact "soft-passes"
The emitted `deps.edn` comment claimed that without `day8/re-frame2-schemas` "CLJS soft-passes per Spec 010 §Recommended soft-pass". That is factually wrong: the starter's `schema.cljs` calls `reg-app-schema` at boot, which routes through `re-frame.core-schemas/reg-app-schema` (`:on-absent :throw`) and throws `:rf.error/schemas-artefact-missing` when the artefact is absent — it never reaches a runtime soft-pass. Spec 010 §Recommended soft-pass covers the Malli *validator* being absent while the artefact is present (unreachable on the CLJS default path — `re-frame.schemas` self-wires Malli). Corrected across all five deps variants (`_reagent`/`_uix`/`_helix`/ssr/story) to name the loud throw, matching `deps-versions.md` and the already-correct shipped `schema.cljs`/`events.cljs` comments.

## Quality gates
- `scripts/check_skill_implementor_order.py` — EXIT 0
- `scripts/check_skill_re_frame2_drift.py` — EXIT 0
- `scripts/check_skill_implementor_partition_drift.py` — EXIT 0
- `scripts/check_skill_package_refs.py`, `check_skill_redirect_anchors.py` — EXIT 0
- `tools/template` `clojure -M:test` — 49 tests, 668 assertions, 0 failures, 0 errors
- mkdocs `--strict`: not run — the edited skill-package files (`skills/re-frame2-implementor/*`) and `tools/template/*` are outside `docs_dir` (`docs`); `docs/skills/re-frame2-implementor.md` is a separate landing page that does not mirror the edited text
- grep confirmations: all three `:core/*` + `:identity/*` + `:data-classification/*` present in the example; SKILL.md:104 says "eight" (no "seven"); all 5 deps files name `throws :rf.error/schemas-artefact-missing`, no residual "soft-passes per Spec 010"