### PR TITLE
docs: pair-retro mutator count + transport, tools/README namespaces+deps, implementation/README tenant-switcher port row (rf2-l67uxu, rf2-tx4pqa, rf2-dajpq6, rf2-fci2z9)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -357,6 +357,7 @@ preserving first-seen order.
 | `:examples/counter-with-stories` | http://localhost:8042/ · `/#/stories` |
 | `:examples/login-form` | http://localhost:8043/ · `/#/stories` |
 | `:examples/linearlite` | http://localhost:8044/ |
+| `:testbeds/tenant-switcher` | http://localhost:8060/ |
 
 The build→port table mirrors the `:dev-http` map in `shadow-cljs.edn`.
 

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -638,9 +638,10 @@
   ;;
   ;; tools/testbed-support is a tiny but cross-platform-load-bearing helper
   ;; library (the open-in-editor project-root resolver + the live-app ↔
-  ;; Story-shell hash host). It has no `deps.edn` (it is consumed purely as
-  ;; an extra source path), so its only executable home was the full
-  ;; consolidated `npm run test:cljs` build — which compiles + runs the whole
+  ;; Story-shell hash host). Its `deps.edn` exists only for the JVM endpoint
+  ;; tests (not a packaging surface — the library is consumed as an extra
+  ;; source path), so the node-runnable CLJS suites' only executable home was
+  ;; the full consolidated `npm run test:cljs` build — which compiles + runs the whole
   ;; ~3500-test node suite and, in a fresh worker worktree, may not even start
   ;; without a local shadow-cljs binary. That made this small slice expensive
   ;; to verify in worktrees and in targeted CI (the bead's finding #3).

--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -39,7 +39,7 @@ It is intentionally diagnosis-first: the default outcome is a better understandi
 - [`re-frame2`](https://github.com/day8/re-frame2) — the framework. When friction is caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings), GitHub issues route here, not to `re-frame2-pair`.
 - [`re-frame-pair-improver`](https://github.com/day8/re-frame-pair-improver) — the v1 sibling that targets v1 `re-frame-pair`.
 
-This skill does **not** depend on or reference `re-frame-10x`. re-frame2's Tool-Pair surfaces replace the v1 reliance on the 10x dev tool — the current surface-family enumeration (trace stream, registrar query API, epoch-history / restore, the four state-injection mutators, schema reflection, source-coord annotation, direct reads, render-driving / dispatch-settle, view-plane reads, the signal recorder, the operating-frame trio) lives in [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md), the single source an upstream finding names a surface from.
+This skill does **not** depend on or reference `re-frame-10x`. re-frame2's Tool-Pair surfaces replace the v1 reliance on the 10x dev tool — the current surface-family enumeration (trace stream, registrar query API, epoch-history / restore, state injection (`replace-frame-state!`), schema reflection, source-coord annotation, direct reads, render-driving / dispatch-settle, view-plane reads, the signal recorder, the operating-frame trio) lives in [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md), the single source an upstream finding names a surface from.
 
 ## Typical output
 

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -23,7 +23,7 @@ These are not up for re-litigation. A future authoring pass MUST preserve them u
 
 ### L1 — No re-frame-10x routing
 
-Per the parent `re-frame2-pair` skill's L2: re-frame2's pair tooling does not depend on re-frame-10x. This skill MUST NOT propose fixes that route through 10x — time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces. The authoritative, current surface-family enumeration lives in [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (trace stream, registrar query API, epoch-history / restore, the four state-injection mutators, schema reflection, source-coord annotation, direct reads, render-driving / dispatch-settle, view-plane reads, the signal recorder, the operating-frame trio) — name the matching family from there rather than re-spelling an abbreviated subset here. This is a cardinal "What to avoid" rule.
+Per the parent `re-frame2-pair` skill's L2: re-frame2's pair tooling does not depend on re-frame-10x. This skill MUST NOT propose fixes that route through 10x — time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces. The authoritative, current surface-family enumeration lives in [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (trace stream, registrar query API, epoch-history / restore, state injection (`replace-frame-state!`), schema reflection, source-coord annotation, direct reads, render-driving / dispatch-settle, view-plane reads, the signal recorder, the operating-frame trio) — name the matching family from there rather than re-spelling an abbreviated subset here. This is a cardinal "What to avoid" rule.
 
 ### L2 — Never file a GitHub issue without explicit user approval
 

--- a/skills/re-frame2-pair-retro/spec/inputs.md
+++ b/skills/re-frame2-pair-retro/spec/inputs.md
@@ -23,7 +23,7 @@ The sibling skill the user just exercised. This skill reads the parent skill's:
 - **`references/ops.md` + `references/recipes.md`** — the catalogue the user navigated. Missing ops or missing recipes are first-class findings.
 - **`references/errors.md`** — the error-recovery catalogue. Misleading recovery suggestions are findings.
 - **`references/ops.md` §Hot-reload coordination** — the strict source-edit protocol (folded into the op catalogue, not a standalone leaf). Friction here is high-leverage (every source edit triggers it).
-- **`scripts/`** + **MCP server** — the transport surface. Brittleness here breaks every session.
+- **`preload/`** (runtime preload) + **MCP server** (`references/mcp-transport.md`) — the transport surface. Brittleness here breaks every session.
 - **`spec/design.md`** (this skill's neighbour) — the locked decisions. This skill respects locks; doesn't propose changes that contradict them.
 
 ## 3. Tertiary input — `references/analysis-lenses.md`
@@ -82,7 +82,7 @@ These shape the skill's voice and structure but aren't quoted directly.
 When the pair tool changes:
 
 1. **A new structured op ships in `re-frame2-pair`** → check whether known-frictions has a "missing op" pattern that this resolves; update `known-frictions.md` if so.
-2. **A bash shim is retired / migrated to MCP** → `known-frictions.md` may have entries about shim brittleness; update to reflect.
+2. **The MCP transport changes** (the bash-shim → MCP migration is already complete — MCP is the one transport) → `known-frictions.md` may retain entries about the old shim's brittleness; update them to reflect the MCP transport.
 3. **A cardinal rule changes in `re-frame2-pair` SKILL.md** → re-read the parent's `spec/design.md`; verify this skill's lens-routing still respects the new lock.
 4. **A new common friction pattern emerges** (3+ retros surface it) → add a row to `known-frictions.md` with the pattern shape and the typical resolution.
 5. **A new analysis lens is named** → add to `analysis-lenses.md` with the canonical question and improvement shape.

--- a/tools/README.md
+++ b/tools/README.md
@@ -70,8 +70,9 @@ Two tools are deliberate exceptions to the Clojars publish model:
   template repo, invoked via `clojure -Tnew create`. See the `template`
   entry under "Shipped" below.
 - **`tools/testbed-support/`** is **not a published jar at all** — it
-  has no `deps.edn`/Clojars coord and is consumed only as an extra
-  source path wired into the testbed builds. See its entry under
+  has no Clojars/publish coord (its local `deps.edn` exists only for the
+  JVM endpoint tests, not as a packaging surface) and is consumed only as
+  an extra source path wired into the testbed builds. See its entry under
   "Shipped" below.
 
 A top-level `tools/deps.edn` and `tools/shadow-cljs.edn` (rf2-nuuk3) act
@@ -134,8 +135,10 @@ wired into the build, and consumers can use it today.
   [`tools/machines-viz/README.md`](./machines-viz/README.md).
 
 - **`tools/testbed-support/`** — a small dev-only support library
-  (two namespaces: `re-frame.testbed.config` and
-  `re-frame.testbed.story-host`) the Xray / Story browser testbeds share.
+  (three namespaces: `re-frame.testbed.config`,
+  `re-frame.testbed.story-host`, and the security-sensitive
+  `re-frame.testbed.open-in-editor-server`) the Xray / Story browser
+  testbeds share.
   `config/resolve-source-root` derives the on-disk source root for
   "open in editor" from a build-env `checkout-root` `goog-define` (seeded
   per build via `#shadow/env`, so it's cross-platform with no hardcoded


### PR DESCRIPTION
Four disjoint small doc/comment corrections from this session's read-only correctness audits. One commit per bead; all premises verified against current source before editing.

## Commits

- **rf2-l67uxu** (P3) — `skills/re-frame2-pair-retro/README.md:42` + `spec/design.md:26` enumerated "the four state-injection mutators", a retired count. API-shrink #3 (rf2-t3lftq) consolidated the former four-mutator family into the ONE partial-map mutator `replace-frame-state!`. Both leaves cite `../shared/tool-pair-surfaces.md` as their single source, which names "the one partial-map mutator" — so they contradicted the source they point at. Corrected both to `state injection (replace-frame-state!)`.

- **rf2-tx4pqa** (P4) — `spec/inputs.md:26` named the retired `scripts/` bash transport as the pair skill's transport surface; the pair skill has no `scripts/` dir (removed by rf2-dduetj). Its transport is `preload/` (runtime preload) + the MCP server (`references/mcp-transport.md`). `inputs.md:85` also framed the shim→MCP migration as a pending trigger; reworded as the historical fact it is.

- **rf2-dajpq6** (P4) — `tools/README.md:137` named only two testbed-support namespaces (omitting the security-sensitive `re-frame.testbed.open-in-editor-server`); `:72-73` falsely asserted "no `deps.edn`" (one exists for the JVM endpoint tests). Corrected to three namespaces + "no Clojars/publish coord (local deps.edn for JVM endpoint tests)". The `shadow-cljs.edn:641` `:node-test-testbed-support` **comment** repeated the same "no deps.edn" inaccuracy — corrected the comment only (no build-config change). Now consistent with `tools/testbed-support/README.md`.

- **rf2-fci2z9** (P4) — `implementation/README.md:361` claims its build→port table mirrors the `:dev-http` map, but the table listed only 12 of the 13 ports. Added the missing `:testbeds/tenant-switcher` (8060) row (verified against `shadow-cljs.edn:524` + `dev-testbed.cjs` DEV_HTTP). Table is now a full 13-port mirror.

## Gates

- `mkdocs build --strict` — pass (exit 0). None of the edited files feed the docs build (all outside `docs/`, no snippet includes), so this is a no-breakage confirmation.
- `python scripts/check_doc_slugs.py` — pass (exit 0).
- grep-confirmed each corrected count/name/row against the source of truth.