### PR TITLE
fix(machines-viz): exists?-guard ClipboardItem, root-absolute back-edge coords, axis-aware elk hint, font docstrings (rf2-848byi, rf2-qb452y, rf2-0pmi2y, rf2-mx6u22)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -109,8 +109,9 @@ exports:
    encoding version. Roundtrips: `(encode-share-url chart-state)`
    and `(decode-share-url url)`.
 4. **PNG and SVG exporters.** Client-side rasterisers that emit a
-   chart image at 2x DPR (PNG) or as `image/svg+xml` (SVG) with
-   embedded fonts. Both include `<title>` / `<desc>` (SVG) or alt-
+   chart image at 2x DPR (PNG) or as `image/svg+xml` (SVG); fonts are
+   referenced by name (system-monospace fallback), not embedded as glyph
+   data. Both include `<title>` / `<desc>` (SVG) or alt-
    text sidecar (PNG) summarising the machine id, current state,
    and node / transition counts.
 5. **Mermaid `stateDiagram-v2` exporter.** A pure-data emitter

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1883,7 +1883,8 @@ summarises the machine: id, current state, node count, transition count.
 ```clojure
 (export/chart-as-svg chart-element)
 ;; => String — image/svg+xml (a <foreignObject>-embedded viewport
-;;    capture) with embedded fonts
+;;    capture); fonts are referenced BY NAME (system-monospace fallback),
+;;    NOT embedded as glyph data (no @font-face)
 
 (export/copy-svg-to-clipboard! chart-element)
 ;; => Promise; clipboard contains the SVG as image/svg+xml

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -339,8 +339,12 @@
   #js {:id "root"
        :layoutOptions (clj->js (elk-layout-options parsed layout-options
                                                    direction))
+       ;; rf2-0pmi2y — thread the RESOLVED direction so each guarded-fork
+       ;; branch's `elk.position` within-layer hint lands on the cross axis of
+       ;; the ACTUAL layout direction (X for `:tb`, Y for `:lr`). `:auto` routes
+       ;; branchy forks to `:lr`, where the cross axis is Y, not X.
        :children (clj->js (projection/->elk-children parsed measured-dims chart-vc
-                                                     context-rows))
+                                                     context-rows direction))
        ;; Edge-label dims share the `measured-dims` map (it is keyed by
        ;; elk-edge-id for any labelled edge); under events-as-nodes the
        ;; transition text is on the event-node so this is normally a no-op,

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -78,7 +78,12 @@
   ROOT`). The two transposes here respect those frames: the region-interior
   transpose works in the region's LOCAL frame (children are parent-relative);
   the region RE-STACK moves the container's root-relative origin; the
-  back-edge reroute works in the ABSOLUTE frame the edge-points already use.
+  back-edge reroute computes its detour in the shared PARENT frame
+  `node-center` reads (both endpoints share one container) and then REBASES
+  the routed points to root-absolute — by the shared container's origin —
+  before writing them into `:edge-points` (rf2-qb452y: the detour points are
+  parent-relative until rebased, so a nested same-parent back-edge would
+  otherwise land offset by the container origin).
 
   ## What this does NOT own
 
@@ -745,6 +750,28 @@
   [node-parent edge]
   (= (get node-parent (:source edge)) (get node-parent (:target edge))))
 
+(defn- container-origin
+  "rf2-qb452y — the ROOT-ABSOLUTE origin `{:x :y}` of container `pid`: the
+  running sum of every ancestor container's PARENT-RELATIVE position from
+  `pid` up through the root. `elk-result->positions` records every node
+  (containers included) at its position relative to its OWN parent, no
+  re-basing, so a node nested directly in `pid` has root-absolute coords =
+  its parent-relative coords PLUS this origin. A root-level parent (`pid`
+  nil, or absent from `positions`) yields (0,0) — the flat case is
+  unshifted."
+  [positions node-parent pid]
+  (loop [cur pid ox 0 oy 0]
+    (if cur
+      (let [{:keys [x y]} (get positions cur)]
+        (recur (get node-parent cur) (+ ox (or x 0)) (+ oy (or y 0))))
+      {:x ox :y oy})))
+
+(defn- rebase-points
+  "rf2-qb452y — translate a detour point-list by `origin` (parent-relative →
+  root-absolute)."
+  [points {ox :x oy :y}]
+  (mapv (fn [{:keys [x y]}] {:x (+ x ox) :y (+ y oy)}) points))
+
 (defn reroute-back-edges
   "rf2-gnrkke — the back-edge return-route detour pass (§4.3.1 close). Pure:
   `{:positions :edge-points :edge-labels}` + parsed graph + resolved
@@ -761,6 +788,15 @@
   back-edge is simply left untouched (its ELK route stands) rather than
   corrupted.
 
+  rf2-qb452y — the detour `back-edge-detour` returns is in the endpoints'
+  shared-PARENT frame (the frame `node-center` reads). `:edge-points` is
+  ROOT-ABSOLUTE (elk `edgeCoords ROOT`), so the routed `__in`/`__out` points
+  are REBASED to absolute — shifted by the shared container's `container-
+  origin` — before they are written. For a root-level back-edge the origin is
+  (0,0), so a flat machine is byte-identical; a same-parent back-edge nested
+  inside a compound / region (origin ≠ (0,0)) is drawn on its endpoints
+  instead of offset by the container origin.
+
   No back-edge ⇒ the layout is returned unchanged (a non-cyclic / already-
   compact machine is untouched). Only back-edges whose event-node SANK
   (`back-edge?`) are rerouted, so a back-edge ELK already placed compactly
@@ -775,14 +811,26 @@
         (fn [{:keys [positions edge-points] :as acc} edge]
           (if-let [{:keys [event-pos in-points out-points]}
                    (back-edge-detour edge positions direction)]
-            (let [ev-id (projection/event-node-id edge)
-                  ev    (get positions ev-id)]
+            (let [ev-id  (projection/event-node-id edge)
+                  ev     (get positions ev-id)
+                  ;; `back-edge-detour` builds its points in the shared PARENT
+                  ;; frame `node-center` reads (both endpoints share one
+                  ;; container, per `same-parent?`). `:edge-points` is
+                  ;; ROOT-ABSOLUTE (elk `edgeCoords ROOT`), so rebase the
+                  ;; detour to absolute by the shared container's origin before
+                  ;; writing it (rf2-qb452y). `:event-pos` stays parent-relative
+                  ;; — `:positions` records nodes in that frame — so ONLY the
+                  ;; edge-points are shifted.
+                  origin (container-origin positions node-parent
+                                           (get node-parent (:source edge)))
+                  in-abs  (rebase-points in-points origin)
+                  out-abs (rebase-points out-points origin)]
               (assoc acc
                      :positions   (assoc positions ev-id
                                          (merge ev event-pos))
                      :edge-points (assoc edge-points
-                                         (str (:id edge) "__in")  in-points
-                                         (str (:id edge) "__out") out-points)))
+                                         (str (:id edge) "__in")  in-abs
+                                         (str (:id edge) "__out") out-abs)))
             acc))
         (assoc layout :positions positions :edge-points edge-points)
         back-edges))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -843,11 +843,21 @@
   frame's TOP padding only (`context-band-height`), so the first child ELK
   lays out below the title strip clears the painted Context band too. 0 /
   nil ⇒ no band, no extra top reservation — every non-root container is
-  unaffected regardless."
-  ([parsed] (->elk-children parsed nil nil 0))
-  ([parsed measured-dims] (->elk-children parsed measured-dims nil 0))
-  ([parsed measured-dims chart-vc] (->elk-children parsed measured-dims chart-vc 0))
-  ([{:keys [nodes edges] :as parsed} measured-dims chart-vc context-rows]
+  unaffected regardless.
+
+  The optional `direction` (the RESOLVED ELK direction `chart.cljs` feeds
+  ELK — `:tb` DOWN / `:lr` RIGHT, threaded by `->elk-input`) sets the axis of
+  each guarded-fork branch's `elk.position` within-layer hint: the cross axis
+  is X for `:tb` and Y for `:lr`, so the priority index rides the coordinate
+  semiInteractive actually orders by (rf2-0pmi2y). Defaults to `:tb` (the DOWN
+  default) — the non-fork machines never emit the hint, so the default is a
+  no-op for them."
+  ([parsed] (->elk-children parsed nil nil 0 :tb))
+  ([parsed measured-dims] (->elk-children parsed measured-dims nil 0 :tb))
+  ([parsed measured-dims chart-vc] (->elk-children parsed measured-dims chart-vc 0 :tb))
+  ([parsed measured-dims chart-vc context-rows]
+   (->elk-children parsed measured-dims chart-vc context-rows :tb))
+  ([{:keys [nodes edges] :as parsed} measured-dims chart-vc context-rows direction]
   (let [resolved-vc   (or chart-vc vc/chart)
         ;; the default container padding (no initial-marker reservation). A
         ;; container whose own initial substate carries a marker takes the
@@ -907,13 +917,20 @@
                       pos   (get fork-positions ev-id)]
                   (cond-> (elk-event-child e measured-dims)
                     pid (assoc ::event-parent pid)
-                    ;; `elk.position` is a KVector `(x,y)`. With the chart's
-                    ;; DOWN direction the layers stack vertically, so the
-                    ;; WITHIN-LAYER (cross) axis is X — the priority index
-                    ;; goes in x; y is left 0. semiInteractive reads this to
-                    ;; order the branches 1,2,3 left-to-right.
+                    ;; `elk.position` is a KVector `(x,y)` semiInteractive reads
+                    ;; to order the within-layer branches. The WITHIN-LAYER
+                    ;; (cross) axis depends on the RESOLVED ELK `direction`: for
+                    ;; `:tb` (DOWN) layers stack vertically so the cross axis is
+                    ;; X → `(pos,0)`; for `:lr` (RIGHT) layers stack
+                    ;; horizontally so the cross axis is Y → `(0,pos)`. Writing
+                    ;; the index on the off-axis coordinate leaves the branch
+                    ;; order unconstrained for exactly the branchy forks
+                    ;; `post-elk/aspect-direction` routes to `:lr` (rf2-0pmi2y).
                     pos (assoc :layoutOptions
-                               {"elk.position" (str "(" pos ",0)")}))))
+                               {"elk.position"
+                                (if (= direction :lr)
+                                  (str "(0," pos ")")
+                                  (str "(" pos ",0)"))}))))
               edges)
         by-parent (group-by :parent-id nodes)
         events-by-parent (group-by ::event-parent event-children)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -28,8 +28,10 @@
     the edge layer — by embedding the live viewport DOM in a
     `<foreignObject>` (rf2-sr6l3). The node bodies render with inline
     styles, so the foreignObject paints the same visual grammar a
-    sighted user sees, not just the edge `<svg>`. Embedded fonts +
-    `<title>` / `<desc>` summarise the machine for a screen-reader.
+    sighted user sees, not just the edge `<svg>`. Fonts are referenced BY
+    NAME (JetBrains Mono, with a system-monospace fallback) — the glyph
+    files are NOT embedded, so a host lacking the named font renders the
+    fallback. `<title>` / `<desc>` summarise the machine for a screen-reader.
   - **PNG** rasterises that complete SVG to a 2x-DPR `image/png` Blob
     on a transparent background; a `text/plain` alt-text sidecar rides
     the clipboard alongside the image. Because the SVG now carries the
@@ -228,11 +230,13 @@
 ;; so every node body + the current-state highlight were lost.
 ;;
 ;; The fix embeds the live viewport DOM in a `<foreignObject>` inside a
-;; standalone SVG. Two facts make this faithful AND self-contained:
+;; standalone SVG. Two facts make this faithful AND STYLE-self-contained
+;; (the layout + grammar need no external stylesheet; fonts are referenced
+;; BY NAME, not embedded — see `viewport-css`):
 ;;
 ;;   1. Every node component (chart.nodes/*) renders with INLINE styles
 ;;      (`:style {...}` on each div — box geometry, border, header wash,
-;;      box-shadow glow, fonts). Inline styles travel with the cloned
+;;      box-shadow glow, font-family). Inline styles travel with the cloned
 ;;      HTML, so the foreignObject paints the same grammar the operator
 ;;      sees with no external stylesheet to embed.
 ;;   2. xyflow positions each `.react-flow__node` wrapper with an inline
@@ -244,8 +248,11 @@
 
 (def ^:private viewport-css
   "The minimal xyflow positioning rules the cloned viewport needs, plus
-  the embedded font + edge-path defaults — embedded as a `<style>` inside
-  the export SVG so the `<foreignObject>` lays the chart out correctly.
+  the font-family + edge-path defaults — declared BY NAME in a `<style>`
+  inside the export SVG so the `<foreignObject>` lays the chart out
+  correctly. NOTE: the font is NAMED (`'JetBrains Mono',… ,monospace`), not
+  embedded — no `@font-face` with glyph data is emitted, so a host without
+  the named font renders the system-monospace fallback (rf2-mx6u22).
 
   rf2-sr6l3 — xyflow positions the `.react-flow__node` wrappers via its
   EXTERNAL stylesheet (`@xyflow/react/dist/base.css` —
@@ -388,7 +395,8 @@
   "Serialise the FULL rendered chart to an `image/svg+xml` string —
   boxed state nodes, compound/region containers, event chips, final
   rings, labels, the active-state border/glow, AND the edge layer — with
-  embedded fonts + a `<title>` / `<desc>` machine summary.
+  fonts referenced BY NAME (system-monospace fallback, not embedded glyph
+  data) + a `<title>` / `<desc>` machine summary.
 
   rf2-sr6l3 — captures the live `.react-flow__viewport` DOM inside a
   `<foreignObject>` (the visual grammar renders as inline-styled divs

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -445,7 +445,7 @@
   when the clipboard API is unavailable)."
   [chart-element]
   (let [svg-str (chart-as-svg chart-element)]
-    (if (and js/navigator (.-clipboard js/navigator) js/ClipboardItem)
+    (if (and js/navigator (.-clipboard js/navigator) (exists? js/ClipboardItem))
       (let [blob (js/Blob. #js [svg-str] #js {:type "image/svg+xml"})
             item (js/ClipboardItem. #js {"image/svg+xml" blob})]
         (.write (.-clipboard js/navigator) #js [item]))
@@ -533,7 +533,7 @@
     (-> (chart-as-png! chart-element)
         (.then
           (fn [png-blob]
-            (if (and js/navigator (.-clipboard js/navigator) js/ClipboardItem)
+            (if (and js/navigator (.-clipboard js/navigator) (exists? js/ClipboardItem))
               (let [alt-blob (js/Blob. #js [alt] #js {:type "text/plain"})
                     item (js/ClipboardItem. #js {"image/png"  png-blob
                                                  "text/plain" alt-blob})]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -751,6 +751,81 @@
       (is (not (contains? (:edge-points out) (str (:id back-e) "__in"))))
       (is (not (contains? (:edge-points out) (str (:id back-e) "__out")))))))
 
+(def compound-same-parent-back-edge-machine
+  "rf2-qb452y — a compound `:grouped` holding `:a → :b` (forward) and
+  `:b → :a` (a SAME-PARENT back-edge — both leaves parented to `:grouped`).
+  `:grouped` nests under the synthetic root-container, so the shared parent's
+  origin is non-(0,0): the reroute must write the detour in ROOT-ABSOLUTE
+  coords (endpoint centre + container origin), NOT the raw parent-relative
+  values `node-center` reads."
+  {:initial :outer
+   :states  {:outer   {:on {:go :grouped}}
+             :grouped {:initial :a
+                       :states  {:a {:on {:next :b}}
+                                 :b {:on {:back :a}}}}}})
+
+(deftest reroute-back-edges-nested-same-parent-writes-absolute-edge-points
+  ;; rf2-qb452y — a same-parent back-edge whose endpoints are NESTED inside a
+  ;; compound (`:grouped`) whose origin ≠ (0,0). `back-edge-detour` computes in
+  ;; the shared-parent (`:grouped`) frame; `:edge-points` is ROOT-ABSOLUTE, so
+  ;; `reroute-back-edges` must REBASE the written __in/__out by the container
+  ;; origin. Before the fix the parent-relative points were written straight
+  ;; through, floating the detour ~(:grouped origin) away from its endpoints.
+  (let [parsed      (layout/project-definition compound-same-parent-back-edge-machine)
+        node-parent (#'post-elk/node-parent-map (:nodes parsed))
+        grouped-id  (layout/node-id [:grouped])
+        a-id        (layout/node-id [:grouped :a])
+        b-id        (layout/node-id [:grouped :b])
+        back-e      (first (filter (fn [e]
+                                     (and (= (:source e) b-id)
+                                          (= (:target e) a-id)))
+                                   (:edges parsed)))
+        ev-id       (projection/event-node-id back-e)
+        ;; hand-built positions in the REAL frames `elk-result->positions`
+        ;; records: containers + leaves parent-relative to their OWN parent,
+        ;; no re-basing. The root-container sits at a small non-(0,0) origin +
+        ;; `:grouped` is offset FROM it, so the origin exercises the ancestor-
+        ;; chain SUM (grouped + root-container), not just the direct parent.
+        positions   {layout/root-container-id {:x 10  :y 15  :width 800 :height 700}
+                     grouped-id               {:x 600 :y 500 :width 220 :height 320}
+                     a-id                     {:x 40  :y 20  :width 120 :height 50}
+                     b-id                     {:x 40  :y 120 :width 120 :height 50}
+                     ev-id                    {:x 40  :y 260 :width 96  :height 34}}
+        stub        {:positions positions :edge-points {} :edge-labels {}}
+        out         (post-elk/reroute-back-edges stub parsed :tb)
+        origin      (#'post-elk/container-origin positions node-parent grouped-id)
+        ;; parent-relative detour — the pure geometry, unchanged by the fix.
+        {:keys [in-points out-points]} (post-elk/back-edge-detour back-e positions :tb)
+        written-in  (get (:edge-points out) (str (:id back-e) "__in"))
+        written-out (get (:edge-points out) (str (:id back-e) "__out"))]
+
+    (testing "sanity: the fixture is a NESTED same-parent back-edge that sinks"
+      (is (some? back-e) "the b→a back-edge parses")
+      (is (= grouped-id (get node-parent b-id) (get node-parent a-id))
+          "both endpoints share the :grouped parent")
+      (is (true? (#'post-elk/same-parent? node-parent back-e)))
+      (is (true? (post-elk/back-edge? back-e positions :tb))
+          "the event-node sank below both endpoints"))
+
+    (testing "sanity: the shared container origin is non-(0,0) — grouped + root-container"
+      (is (= {:x 610 :y 515} origin)))
+
+    (testing "the written __in / __out are ROOT-ABSOLUTE (parent-relative + origin)"
+      (is (= (#'post-elk/rebase-points in-points origin)  written-in))
+      (is (= (#'post-elk/rebase-points out-points origin) written-out)))
+
+    (testing "the written detour is SHIFTED off the raw parent-relative points
+              (the pre-fix bug wrote the un-rebased values)"
+      (is (not= in-points  written-in))
+      (is (not= out-points written-out)))
+
+    (testing "concretely: the __in arm STARTS at the source's ABSOLUTE centre"
+      (let [b-centre-rel (#'post-elk/node-center positions b-id)]
+        (is (= {:x (+ (:x b-centre-rel) (:x origin))
+                :y (+ (:y b-centre-rel) (:y origin))}
+               (first written-in))
+            "the detour lands on the source box, not offset by the container origin")))))
+
 ;; ====================================================================
 ;; Composing pass
 ;; ====================================================================

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -3708,6 +3708,42 @@
         (is (nil? (opts-of (projection/event-node-id set-edge)))
             "non-fork event-node is unpinned")))))
 
+(deftest elk-children-fork-hint-axis-follows-resolved-direction
+  (testing "rf2-0pmi2y — the guarded-fork `elk.position` within-layer hint
+            rides the CROSS axis of the RESOLVED ELK direction: X for `:tb`
+            (DOWN — layers stack vertically), Y for `:lr` (RIGHT — layers
+            stack horizontally). `post-elk/aspect-direction` routes exactly
+            these branchy forks to `:lr` on the `:auto` path, so the hint must
+            be direction-aware or it lands on the wrong coordinate for the
+            very machines that trigger it."
+    (let [parsed   (layout/project-definition gate-fork-machine)
+          edges    (:edges parsed)
+          checks   (filter #(= :gate/check (:event %)) edges)
+          by-guard (into {} (map (juxt :guard identity) checks))
+          ev       #(projection/event-node-id (get by-guard %))
+          opts-for (fn [direction]
+                     (let [kids (root-children
+                                  (projection/->elk-children parsed nil nil 0 direction))]
+                       (fn [id] (-> (filter #(= id (:id %)) kids) first :layoutOptions))))]
+      (testing ":tb (DOWN) → the index rides X: (order,0)"
+        (let [opts-of (opts-for :tb)]
+          (is (= {"elk.position" "(1,0)"} (opts-of (ev :gate-high?))))
+          (is (= {"elk.position" "(2,0)"} (opts-of (ev :gate-low?))))
+          (is (= {"elk.position" "(3,0)"} (opts-of (ev nil))))))
+      (testing ":lr (RIGHT) → the index rides Y: (0,order) — the cross axis flips"
+        (let [opts-of (opts-for :lr)]
+          (is (= {"elk.position" "(0,1)"} (opts-of (ev :gate-high?)))
+              "branch 1 pinned at cross-axis y=1 under :lr")
+          (is (= {"elk.position" "(0,2)"} (opts-of (ev :gate-low?)))
+              "branch 2 pinned at cross-axis y=2 under :lr")
+          (is (= {"elk.position" "(0,3)"} (opts-of (ev nil)))
+              "branch 3 pinned at cross-axis y=3 under :lr")))
+      (testing "the default (no-direction) arity keeps the :tb X-axis hint (byte-identical)"
+        (let [kids    (root-children (projection/->elk-children parsed))
+              opts-of (fn [id] (-> (filter #(= id (:id %)) kids) first :layoutOptions))]
+          (is (= {"elk.position" "(1,0)"} (opts-of (ev :gate-high?)))
+              "the arity without direction defaults to :tb"))))))
+
 (deftest elk-children-no-fork-no-position-pins
   (testing "rf2-p75kbg — a machine with no guarded fork carries NO
             `elk.position` pins on any child (the ordering machinery is a

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -12,7 +12,7 @@
   - `chart-as-mermaid` delegates to the Mermaid emitter using the
     seam's definition.
   - An element with no seam throws `:no-chart-state`."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [clojure.string :as str]
             [day8.re-frame2-machines-viz.export :as export]
             [day8.re-frame2-machines-viz.share :as share]))
@@ -173,3 +173,89 @@
           "nil :machine-id defaults to :machine")
       (is (str/includes? quoted "&quot;") "\" escaped to &quot;")
       (is (str/includes? quoted "&apos;") "' escaped to &apos;"))))
+
+;; ---- rf2-848byi — clipboard guard tolerates an ABSENT ClipboardItem -----
+;;
+;; `copy-svg-to-clipboard!` / `copy-png-to-clipboard!` guard clipboard
+;; availability with `(exists? js/ClipboardItem)`. On a browser that has
+;; `navigator.clipboard` but NO `ClipboardItem` global (older Firefox that
+;; shipped `clipboard.writeText` before `ClipboardItem`; some non-secure
+;; contexts), the guard must fall through to the typed `:no-clipboard`
+;; REJECTION — not throw a bare-global ReferenceError (the pre-fix bare
+;; `js/ClipboardItem` reference did, SYNCHRONOUSLY for copy-svg).
+;;
+;; The SVG/PNG producers are browser-DOM-only, so we `with-redefs` them to
+;; isolate the GUARD (the unit under test) and drive it under node with a
+;; STUBBED `navigator.clipboard` present + `ClipboardItem` deleted.
+
+(defn- install-clipboard-env!
+  "Install `globalThis.navigator` = a stub carrying a `.clipboard.write`, and
+  DELETE `globalThis.ClipboardItem`. Returns a 0-arg `restore!` thunk, or nil
+  when the runtime pins `navigator` non-configurably (the caller then skips —
+  the browser gate exercises the guard)."
+  []
+  (let [g        js/globalThis
+        nav-desc (js/Object.getOwnPropertyDescriptor g "navigator")
+        ci-desc  (js/Object.getOwnPropertyDescriptor g "ClipboardItem")]
+    (when (or (nil? nav-desc) (.-configurable nav-desc))
+      (js/Object.defineProperty
+        g "navigator"
+        #js {:value #js {:clipboard #js {:write (fn [_] (js/Promise.resolve "ok"))}}
+             :configurable true :writable true})
+      (js/Reflect.deleteProperty g "ClipboardItem")
+      (fn restore! []
+        (if nav-desc
+          (js/Object.defineProperty g "navigator" nav-desc)
+          (js/Reflect.deleteProperty g "navigator"))
+        (when ci-desc
+          (js/Object.defineProperty g "ClipboardItem" ci-desc))))))
+
+(deftest clipboard-guard-tolerates-absent-clipboarditem
+  (testing "rf2-848byi — with navigator.clipboard present but ClipboardItem
+            ABSENT, copy-svg/png-to-clipboard! REJECT with :no-clipboard —
+            never a bare-global ReferenceError, and copy-svg does not throw
+            synchronously (the `.catch` contract holds)."
+    (async done
+      (if-let [restore! (install-clipboard-env!)]
+        (with-redefs [export/chart-as-svg  (fn [_] "<svg/>")
+                      export/chart-as-png! (fn [_] (js/Promise.resolve #js {}))]
+          (let [;; a valid-seam element so copy-png's synchronous
+                ;; chart-state-of / alt-text preamble does not throw — the
+                ;; GUARD (isolated by the with-redefs above) is what's tested.
+                el       (stub-element seam)
+                no-clip? (fn [e]
+                           (= :rf.machines-viz.export/no-clipboard
+                              (:rf.error/id (ex-data e))))
+                ;; Drive one copy fn and assert it REJECTS with :no-clipboard.
+                ;; A two-arg `.then` attaches BOTH the fulfil + reject handlers
+                ;; in ONE call, synchronously on the copy result — so no
+                ;; rejected promise is ever momentarily handler-less (the
+                ;; node-test runner treats a stray unhandled rejection as
+                ;; fatal). The `try` guards the copy-svg SYNCHRONOUS-throw bug:
+                ;; pre-fix the bare `js/ClipboardItem` reference threw right
+                ;; here (before any Promise), which this turns into a
+                ;; :test/sync-throw rejection → a visible assertion failure.
+                run      (fn [thunk label]
+                           (let [p (try (thunk)
+                                        (catch :default e
+                                          (js/Promise.reject
+                                            (ex-info "threw synchronously"
+                                                     {:rf.error/id :test/sync-throw
+                                                      :threw e}))))]
+                             (.then p
+                                    (fn [_]
+                                      (is false (str label " unexpectedly RESOLVED; "
+                                                     "expected a :no-clipboard rejection")))
+                                    (fn [e]
+                                      (is (no-clip? e)
+                                          (str label " rejects with :no-clipboard; got "
+                                               (pr-str (ex-data e))))))))]
+            (-> (js/Promise.all
+                  #js [(run #(export/copy-svg-to-clipboard! el) "copy-svg-to-clipboard!")
+                       (run #(export/copy-png-to-clipboard! el) "copy-png-to-clipboard!")])
+                (.then (fn [_] (restore!) (done))
+                       (fn [_] (restore!) (done))))))
+        (do
+          (is true (str ":node-test: navigator is non-configurable in this runtime "
+                        "— the browser gate exercises the ClipboardItem guard"))
+          (done))))))


### PR DESCRIPTION
Four-bead cluster from the machines-viz correctness-review audit (rf2-w1s4ud). Isolated surface: `tools/machines-viz`. Commits ordered by severity.

## rf2-848byi (P2) — clipboard guard throws ReferenceError
`copy-svg/png-to-clipboard!` guarded with a bare `js/ClipboardItem` reference → compiles to a bare `ClipboardItem` identifier, which throws `ReferenceError` (synchronously for copy-svg) on a browser with `navigator.clipboard` but no `ClipboardItem` global, instead of the typed `:no-clipboard` rejection. Fixed to `(exists? js/ClipboardItem)` (the artefact's own safe-global idiom).

## rf2-qb452y (P2) — back-edge reroute wrote parent-relative coords into root-absolute `:edge-points`
`reroute-back-edges` wrote `back-edge-detour`'s points (parent-relative, from `node-center`) straight into `:edge-points` (root-absolute). A same-parent back-edge nested in a compound/region was drawn offset by the container origin. Added `container-origin` + `rebase-points`; the detour is now rebased to absolute before writing (flat machines byte-identical — origin (0,0)).

## rf2-0pmi2y (P3, VERIFIED) — guarded-fork `elk.position` hint on wrong axis under `:lr`
Verified at code level: `aspect-direction` routes max-out-degree≥3 forks to `:lr`, but `->elk-children` hardcoded the within-layer hint to X (`(pos,0)`). Under `:lr` the cross axis is Y. Threaded the resolved direction through `->elk-input` → `->elk-children`; emits `(0,pos)` for `:lr`, `(pos,0)` for `:tb`. Defaults to `:tb`, so existing call sites are byte-identical. (The coordinate-axis inconsistency is confirmed by inspection + unit-pinned; the end-to-end ELK branch-order magnitude remains browser-gated.)

## rf2-mx6u22 (P3, doc) — export docstrings claimed embedded/self-contained fonts
No `@font-face` with glyph data is emitted anywhere; `viewport-css` names the font only. Corrected the export.cljs docstrings + two spec claims (000-Vision §4, API.md §SVG) to say fonts are referenced by name with a system-monospace fallback. Doc-only — font embedding was deliberately NOT implemented.

## Quality gates
- **JVM (`clojure -M:test`, tools/machines-viz)** — covers qb452y + 0pmi2y (.cljc): **625 tests / 2473 assertions, 0 failures** (baseline 623/2456; +2 tests, +17 assertions).
- **Node-test (`npm run test:cljs`, implementation)** — covers 848byi (.cljs) + full suite: **8602 tests / 40574 assertions, 0 failures**.

Adversarial regressions added: 848byi (absent ClipboardItem → `:no-clipboard`, stubbed under node); qb452y (nested-in-compound back-edge `:edge-points` root-absolute — fails before, passes after); 0pmi2y (hint axis per resolved direction — X for `:tb`, Y for `:lr`); mx6u22 (docstrings match reality).