### PR TITLE
fix(core): cold-serialized drain release + nested-sync re-entry, atomic subs cache-miss install (rf2-x76af2.22, rf2-x76af2.23)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1206,7 +1206,29 @@
             ;; free another thread may acquire it and stamp its own holder, so
             ;; clearing after the release could clobber that new owner.
             (reset! holder nil)
-            (reset! drain-lock false)))))
+            ;; Per rf2-x76af2.22 (a): the cold release must mirror the
+            ;; drainer's `try-release-on-empty!`. A `dispatch!` that arrived
+            ;; DURING the hold set `:scheduled?` true and scheduled a
+            ;; `drain-try!` that CAS-lost to us and gave up — and, because we
+            ;; are NOT a drainer, nothing is left to re-check the queue. So a
+            ;; plain `(reset! drain-lock false)` PERMANENTLY STRANDS the queue
+            ;; (`:scheduled?` stuck true no-ops every later
+            ;; `ensure-drain-scheduled!`). Under the same lock submitters take
+            ;; in `ensure-drain-scheduled!`, snapshot the queue (stable — we
+            ;; still hold `:drain-lock`, so no drainer is popping) and release;
+            ;; if non-empty, re-kick a fresh async `drain-try!` (via the
+            ;; `:router/reschedule-drain!` late-bind seam — frame cannot
+            ;; `:require` router) so the stranded events drain. Releasing
+            ;; first lets the re-kicked `drain-try!` CAS-acquire the now-free
+            ;; lock.
+            (let [router  (:router frame-record)
+                  strand? (locking router
+                            (let [pending? (seq (:queue @router))]
+                              (reset! drain-lock false)
+                              (boolean pending?)))]
+              (when strand?
+                (when-let [reschedule! (late-bind/get-fn :router/reschedule-drain!)]
+                  (reschedule! frame-id))))))))
     (f)))
 
 ;; ---- frame presets (Spec 002 §Frame presets) ------------------------------

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -103,6 +103,10 @@
    {:key         :router/dispatch-sync!
     :producer-ns 're-frame.router
     :description "Process an event synchronously, bypassing the drain queue."}
+   {:key         :router/reschedule-drain!
+    :producer-ns 're-frame.router
+    :design-bead "rf2-x76af2.22"
+    :description "Re-kick a fresh async drain for a frame. Called by frame/call-serialized-with-drain!'s cold-section release when the queue is non-empty (a dispatch! that arrived during the hold scheduled a drain-try! that CAS-lost to the cold holder and gave up), so the stranded events drain."}
 
    ;; ---- EP-0023 inline-registration lowering -------------------------------
    ;; `re-frame.image-assembly` lowers an image's inline `:registrations` fn

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -3111,10 +3111,16 @@
   "Release the drain-lock after a `::halt` outcome. The depth-exceeded
   handler has already forcibly cleared the queue and set `:scheduled?`
   false, so we only need to drop the lock. Taken under `locking router`
-  to serialize against `ensure-drain-scheduled!`'s flag-read."
-  [router drain-lock]
+  to serialize against `ensure-drain-scheduled!`'s flag-read.
+
+  Per rf2-x76af2.22 (b): a REENTRANT drain (`hold-lock?` true — driven by
+  `drain-reentrant!` for a thread already holding the frame's cold
+  serialization) does NOT drop the lock; the outer cold section owns it
+  and releases it in its own `finally`."
+  [router drain-lock hold-lock?]
   (locking router
-    (reset! drain-lock false)))
+    (when-not hold-lock?
+      (reset! drain-lock false))))
 
 (defn- try-release-on-empty!
   "Under the same lock that submitters take in `ensure-drain-scheduled!`,
@@ -3128,13 +3134,19 @@
                and now. Leave both flags set and return true so the
                caller recurs into another pass.
 
-  This is the orphan-prevention seam."
-  [router drain-lock]
+  This is the orphan-prevention seam.
+
+  Per rf2-x76af2.22 (b): a REENTRANT drain (`hold-lock?` true) still clears
+  `:scheduled?` on empty but LEAVES `:drain-lock` held — the outer cold
+  `call-serialized-with-drain!` section owns it and drops it in its own
+  `finally`, so its serialized window spans the nested cascade."
+  [router drain-lock hold-lock?]
   (locking router
     (let [{:keys [queue]} @router]
       (if (empty? queue)
         (do (swap! router assoc :scheduled? false)
-            (reset! drain-lock false)
+            (when-not hold-lock?
+              (reset! drain-lock false))
             false)
         true))))
 
@@ -3153,8 +3165,15 @@
   Outer loop re-enters whenever `try-release-on-empty!` reports a
   submitter raced in between the inner empty-check and the lock-protected
   release window. Per-event epoch snapshots (rf2-nj6p7) are taken inside
-  `run-one-pass!` per dequeued event, not here."
-  [frame-id router drain-lock drain-depth]
+  `run-one-pass!` per dequeued event, not here.
+
+  `hold-lock?` (rf2-x76af2.22 (b)): false on the normal async / sync
+  entries (`drain-try!` / `drain-block!`, which acquire the lock and must
+  release it when the queue empties); true on the REENTRANT entry
+  (`drain-reentrant!`), where the calling thread already owns the lock via
+  a cold `frame/call-serialized-with-drain!` section and the release phases
+  must leave it held for that outer section to drop."
+  [frame-id router drain-lock drain-depth hold-lock?]
   (loop []
     (let [outcome (try
                     (mark-drainer! router)
@@ -3162,8 +3181,8 @@
                     (finally
                       (clear-drainer! router)))]
       (case outcome
-        ::halt    (force-release-on-halt! router drain-lock)
-        ::settled (when (try-release-on-empty! router drain-lock)
+        ::halt    (force-release-on-halt! router drain-lock hold-lock?)
+        ::settled (when (try-release-on-empty! router drain-lock hold-lock?)
                     (recur))))))
 
 (defn- drain-emergency-release!
@@ -3191,7 +3210,7 @@
             drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
         (when (compare-and-set! drain-lock false true)
           (try
-            (drain-loop! frame-id router drain-lock drain-depth)
+            (drain-loop! frame-id router drain-lock drain-depth false)
             (catch #?(:clj Throwable :cljs :default) t
               (drain-emergency-release! router drain-lock)
               (throw t))))))))
@@ -3230,9 +3249,39 @@
             (recur)))
         (try
           (under-lock-fn)
-          (drain-loop! frame-id router drain-lock drain-depth)
+          (drain-loop! frame-id router drain-lock drain-depth false)
           (catch #?(:clj Throwable :cljs :default) t
             (drain-emergency-release! router drain-lock)
+            (throw t)))))))
+
+(defn- drain-reentrant!
+  "Reentrant synchronous-drain entry for a thread that ALREADY owns
+  `frame-id`'s drain serialization via a COLD
+  `frame/call-serialized-with-drain!` critical section (a Tool-Pair state
+  write, the `destroy-frame!` liveness flip, or any lifecycle op reached
+  from a serialized thunk). That thread already holds `:drain-lock`, so the
+  normal `drain-block!` spin-CAS-acquire would deadlock against itself
+  (rf2-x76af2.22 (b) — the same-thread self-deadlock).
+
+  Runs `under-lock-fn` (the front-of-queue seed-push) and the drain loop
+  DIRECTLY — no acquire (already held) and no release (`hold-lock?` true):
+  the outer cold section owns the lock and drops it in its own `finally`,
+  so its serialized window spans this nested cascade. On an unhandled
+  throw, clear `:scheduled?` / `:in-drain?` but LEAVE the lock held — the
+  cold section's `finally` releases it — mirroring
+  `drain-emergency-release!` minus the lock reset."
+  [frame-id under-lock-fn]
+  (let [frame-record (frame/frame frame-id)]
+    (when frame-record
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        (try
+          (under-lock-fn)
+          (drain-loop! frame-id router drain-lock drain-depth true)
+          (catch #?(:clj Throwable :cljs :default) t
+            (locking router
+              (swap! router assoc :scheduled? false :in-drain? nil))
             (throw t)))))))
 
 (defn- ensure-drain-scheduled!
@@ -3505,7 +3554,27 @@
                  same-thread-drain?
                  #?(:clj  (identical? (:in-drain? router-state) (Thread/currentThread))
                     :cljs (true? (:in-drain? router-state)))]
-             (or (:in-sync-drain? router-state) same-thread-drain?)))]
+             (or (:in-sync-drain? router-state) same-thread-drain?)))
+         ;; Per rf2-x76af2.22 (b): this thread already OWNS the frame's drain
+         ;; serialization via a COLD `frame/call-serialized-with-drain!`
+         ;; critical section (`:serialized-holder` = this thread) but is NOT
+         ;; the active drainer. A dispatch-sync issued from inside such a thunk
+         ;; (e.g. a Tool-Pair state write, or a lifecycle op reached from a
+         ;; serialized thunk) must RE-ENTER the drain directly — it already
+         ;; holds `:drain-lock`, so routing through `drain-block!`'s spin-CAS-
+         ;; acquire would deadlock against itself. Distinct from `nested-sync?`
+         ;; (a dispatch-sync from inside a running HANDLER, which stays the
+         ;; `:rf.error/dispatch-sync-in-handler` error): the cold holder is not
+         ;; a handler, so its dispatch-sync runs. Mirrors
+         ;; `frame/current-thread-owns-drain-serialization?` for the cold axis;
+         ;; on CLJS the marker is `true`/nil and the same equality
+         ;; discriminates. Checked only when NOT `nested-sync?` so the drainer
+         ;; axis wins if a thread were ever both.
+         reentrant-cold?
+         (when (and frame-record (not nested-sync?))
+           (let [holder @(:serialized-holder frame-record)]
+             #?(:clj  (identical? holder (Thread/currentThread))
+                :cljs (true? holder))))]
      (cond
        (nil? frame-record)
        ;; Per rf2-2hvga (= B + recover-but-emit): dispatch-sync into a
@@ -3555,16 +3624,25 @@
            ;; dispatch-sync from another thread; :scheduled? true
            ;; suppresses async drain scheduling mid-cascade.
            ;; :in-sync-drain? is cleared in the outer finally after
-           ;; drain-block! returns.
-           (drain-block!
-             (:frame envelope)
-             (fn []
-               (swap! router (fn [{:keys [queue] :as r}]
-                               (assoc r
-                                      :queue (into interop/empty-queue
-                                                   (cons envelope queue))
-                                      :scheduled?     true
-                                      :in-sync-drain? true)))))
+           ;; the drain returns.
+           ;;
+           ;; Per rf2-x76af2.22 (b): when this thread already holds the cold
+           ;; serialization (`reentrant-cold?`), route through
+           ;; `drain-reentrant!` instead — it runs the SAME seed-push + drain
+           ;; loop but WITHOUT re-acquiring or releasing `:drain-lock` (this
+           ;; thread already holds it; the outer cold section drops it), so a
+           ;; nested dispatch-sync re-enters rather than spin-CAS-deadlocking
+           ;; on its own lock.
+           (let [seed-push (fn []
+                             (swap! router (fn [{:keys [queue] :as r}]
+                                             (assoc r
+                                                    :queue (into interop/empty-queue
+                                                                 (cons envelope queue))
+                                                    :scheduled?     true
+                                                    :in-sync-drain? true))))]
+             (if reentrant-cold?
+               (drain-reentrant! (:frame envelope) seed-push)
+               (drain-block!     (:frame envelope) seed-push)))
            (finally
              (swap! router assoc :in-sync-drain? false)))))
      nil)))
@@ -3580,3 +3658,18 @@
 
 (late-bind/set-fn! :router/dispatch!       dispatch!)
 (late-bind/set-fn! :router/dispatch-sync!  dispatch-sync!)
+
+;; Per rf2-x76af2.22 (a): re-kick a fresh async drain for `frame-id`.
+;; `frame/call-serialized-with-drain!`'s COLD release calls this — through
+;; the late-bind seam (frame.cljc cannot `:require` router — load cycle) —
+;; when it finds the queue non-empty on release, because a `dispatch!` that
+;; arrived during the cold hold scheduled a `drain-try!` that CAS-lost to the
+;; cold holder and gave up (no drainer left to re-check). Schedules the drain
+;; UNCONDITIONALLY (no `:scheduled?` gate — the point is to re-establish a
+;; live `drain-try!` for the still-true `:scheduled?` flag); a redundant
+;; `drain-try!` merely CAS-loses and returns, so re-kicking when one is
+;; already pending is harmless. Mirrors `ensure-drain-scheduled!`'s scheduling
+;; action.
+(late-bind/set-fn! :router/reschedule-drain!
+                   (fn reschedule-drain! [frame-id]
+                     (interop/next-tick (fn [] (drain-try! frame-id)))))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -944,48 +944,93 @@
     ;; deref to nil (per Spec 009 §Error contract recovery
     ;; :replaced-with-default), but the cache slot stays empty so a later
     ;; registration is observed by the next subscribe.
-    (when (and cache sub-meta)
-      (swap! cache assoc k {:reaction   reaction
-                            :inputs     input-signals
-                            :ref-count  1})
-      (interop/add-on-dispose! reaction
-        (fn []
-          ;; A layer-2+ sub's construction called `subscribe` once per
-          ;; `:<-` input, each incrementing the input's `:ref-count`.
-          ;; The disposal must release those refs symmetrically —
-          ;; without this, input ref-counts leak after Reagent auto-
-          ;; disposes the parent. Decrement inputs BEFORE clearing the
-          ;; parent slot so the cache invariant ("ref-count reflects
-          ;; live refs") holds at every observable moment.
-          ;; Best-effort per-input release: a throw from one input's
-          ;; `unsubscribe` surfaces a dev breadcrumb (rf2-is8ov5) and the
-          ;; loop continues so the remaining inputs still release.
+    (if (and cache sub-meta)
+      ;; Per rf2-x76af2.23: the cache-miss install must be ATOMIC / idempotent.
+      ;; Two threads that both observed a miss for the SAME query-v both reach
+      ;; here and build a reaction; a plain `(swap! cache assoc k …)` lets the
+      ;; second STOMP the first — the first reaction is orphaned (its on-dispose
+      ;; never fires → leaked layer-2 input refs) and `:ref-count` is reset to 1
+      ;; while TWO callers hold refs (a phantom unsubscribe then drives the
+      ;; CACHED reaction 1→0 and disposes it out from under the live holder).
+      ;; Install-if-absent instead, mirroring the subscribe hit path's
+      ;; CAS-after-snapshot discipline: `swap!` installs ONLY when the slot is
+      ;; still empty, so a double-build resolves to ONE cached reaction.
+      ;;
+      ;; Wire the orphan-safe on-dispose closure onto the reaction BEFORE the
+      ;; install attempt so a LOSING racer can dispose its just-built reaction
+      ;; through the same closure (releasing the input refs its build bumped) —
+      ;; the cache-dissoc step is identity-guarded, so firing it on an
+      ;; un-cached orphan is a no-op.
+      (let [entry {:reaction   reaction
+                   :inputs     input-signals
+                   :ref-count  1}]
+        (interop/add-on-dispose! reaction
+          (fn []
+            ;; A layer-2+ sub's construction called `subscribe` once per
+            ;; `:<-` input, each incrementing the input's `:ref-count`.
+            ;; The disposal must release those refs symmetrically —
+            ;; without this, input ref-counts leak after Reagent auto-
+            ;; disposes the parent. Decrement inputs BEFORE clearing the
+            ;; parent slot so the cache invariant ("ref-count reflects
+            ;; live refs") holds at every observable moment.
+            ;; Best-effort per-input release: a throw from one input's
+            ;; `unsubscribe` surfaces a dev breadcrumb (rf2-is8ov5) and the
+            ;; loop continues so the remaining inputs still release.
+            (doseq [input-q input-signals]
+              (release-input-ref! frame-id input-q :on-dispose))
+            (swap! cache (fn [m]
+                           (if (identical? reaction (get-in m [k :reaction]))
+                             (dissoc m k)
+                             m)))))
+        (let [installed (swap! cache (fn [m]
+                                       (if (contains? m k)
+                                         m
+                                         (assoc m k entry))))]
+          (if (identical? entry (get installed k))
+            ;; Uncontended, or we won the install race: our reaction is cached.
+            reaction
+            ;; Collision: a concurrent build already installed for this
+            ;; query-v. Dispose OUR just-built orphan (fires the on-dispose
+            ;; wired above → releases the input refs our build bumped; the
+            ;; cache-dissoc no-ops since our reaction was never cached), then
+            ;; ADOPT the winner as a HIT — bump its ref-count under the same
+            ;; CAS-after-snapshot discipline the `subscribe` hit path uses, so
+            ;; both callers share ONE reaction with a correct ref-count. If the
+            ;; winner was evicted in the race window, fall through to a fresh
+            ;; build (mirroring the hit path's rebuild fall-through).
+            (do
+              (interop/dispose! reaction)
+              (let [winner-reaction (:reaction (get installed k))
+                    [_old post]
+                    (swap-vals! cache
+                                (fn [m]
+                                  (if (identical? winner-reaction
+                                                  (get-in m [k :reaction]))
+                                    (update-in m [k :ref-count] (fnil inc 0))
+                                    m)))]
+                (if (identical? winner-reaction (get-in post [k :reaction]))
+                  winner-reaction
+                  (compute-and-cache! frame-id query-v)))))))
+      ;; Not cached (frame torn down mid-build, or no-such-sub miss).
+      ;; Symmetric input release on the escaped-caching path: a layer-2+ build
+      ;; already subscribed each `:<-` input above (bumping their ref-counts),
+      ;; but the dispose-wiring that releases them lives ONLY inside the cached
+      ;; branch. If the frame was destroyed (or its container torn down)
+      ;; BETWEEN `subscribe`'s frame-record resolution and this re-resolution,
+      ;; `cache` is now nil: the reaction is built and returned but never cached
+      ;; and never dispose-wired, so without this branch nothing would ever call
+      ;; `unsubscribe` for those inputs — a monotonic ref-count leak until
+      ;; `clear-sub-cache!`. Release them here so the input ref-count stays
+      ;; symmetric with the bumps. Layer-1 has no subscribed inputs (its input
+      ;; is the app-db container, not a subscribe), and the no-such-sub miss
+      ;; (`sub-meta` nil) has no `:<-` inputs, so this only fires for a layer-2+
+      ;; reaction that escaped caching.
+      (do
+        (when (and (not layer-1?)
+                   (seq input-signals))
           (doseq [input-q input-signals]
-            (release-input-ref! frame-id input-q :on-dispose))
-          (swap! cache (fn [m]
-                         (if (identical? reaction (get-in m [k :reaction]))
-                           (dissoc m k)
-                           m))))))
-    ;; Symmetric input release on the not-cached path.
-    ;; A layer-2+ build already subscribed each `:<-` input above (bumping
-    ;; their ref-counts), but the dispose-wiring that releases them lives
-    ;; ONLY inside the `(when (and cache sub-meta) …)` branch. If the frame
-    ;; was destroyed (or its container torn down) BETWEEN `subscribe`'s
-    ;; frame-record resolution and this re-resolution, `cache` is now nil:
-    ;; the reaction is built and returned but never cached and never
-    ;; dispose-wired, so without this branch nothing would ever call
-    ;; `unsubscribe` for those inputs — a monotonic ref-count leak until
-    ;; `clear-sub-cache!`. Release them here so the input ref-count stays
-    ;; symmetric with the bumps. Layer-1 has no subscribed inputs (its
-    ;; input is the app-db container, not a subscribe), and the
-    ;; no-such-sub miss (`sub-meta` nil) has no `:<-` inputs, so this
-    ;; only fires for a layer-2+ reaction that escaped caching.
-    (when (and (not (and cache sub-meta))
-               (not layer-1?)
-               (seq input-signals))
-      (doseq [input-q input-signals]
-        (release-input-ref! frame-id input-q :not-cached-release)))
-    reaction))
+            (release-input-ref! frame-id input-q :not-cached-release)))
+        reaction))))
 
 ;; ---- the sub-override subscribe seam (CLJS, dev-only) --------------------
 ;;

--- a/implementation/core/test/re_frame/cold_serialized_drain_test.clj
+++ b/implementation/core/test/re_frame/cold_serialized_drain_test.clj
@@ -1,0 +1,141 @@
+(ns re-frame.cold-serialized-drain-test
+  "JVM-only concurrency tests for the COLD `frame/call-serialized-with-drain!`
+  critical section's interaction with the single-drainer release protocol
+  (rf2-x76af2.22). A cold section (out-of-drain flows lifecycle ops,
+  `destroy-frame!`'s liveness flip, Tool-Pair state writes) takes the SAME
+  per-frame `:drain-lock` as the event drainer but is NOT a drainer, so the
+  drainer's release protocol had two holes:
+
+    (a) PERMANENT QUEUE STRAND. A `dispatch!` arriving during the cold hold
+        set `:scheduled?` true and scheduled a `drain-try!` that CAS-lost to
+        the cold holder and gave up; the cold release did not re-check the
+        queue, so the queue stranded (`:scheduled?` stuck true no-ops every
+        later `ensure-drain-scheduled!`). Fix: the cold release mirrors the
+        drainer's `try-release-on-empty!` — snapshot the queue and, if
+        non-empty, re-kick a fresh async drain.
+
+    (b) SAME-THREAD SELF-DEADLOCK. A `dispatch-sync!` issued from INSIDE a
+        cold serialized thunk on the same thread routed through
+        `drain-block!`, whose spin-CAS-acquire deadlocked on the `:drain-lock`
+        the thread already held. Fix: `dispatch-sync!` detects the cold
+        `:serialized-holder` (reentrant-cold?) and runs the seed-push + drain
+        DIRECTLY via `drain-reentrant!` — no re-acquire, no release.
+
+  Both symptoms are CLJS-immune (single-threaded) but authoritative on the
+  JVM. The interleaving is forced deterministically:
+    - (a) via the single-thread executor's FIFO ordering (a barrier task
+      submitted AFTER the `drain-try!` strictly follows it, so awaiting the
+      barrier proves the `drain-try!` fired-and-CAS-lost) — NOT a wall-clock
+      sleep.
+    - (b) via a bounded thread join that distinguishes 'returned immediately'
+      from 'hung' (the standard deadlock-detector shape).
+
+  Pattern follows `router_drain_race_test.clj` / `sub_cache_concurrency_test.clj`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.interop :as interop]
+            [re-frame.substrate.plain-atom :as plain-atom])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
+
+(use-fixtures :each reset-runtime)
+
+;; A barrier over the runtime executor: submit a countdown task via the SAME
+;; `interop/next-tick` seam the router schedules `drain-try!` through. The JVM
+;; executor is single-threaded FIFO, so this task runs strictly AFTER any
+;; `drain-try!` already submitted — awaiting it deterministically proves the
+;; earlier `drain-try!` completed (no wall-clock sleep). The 5s bound is only a
+;; test-hang guard, never the coordination mechanism.
+(defn- executor-barrier! []
+  (let [latch (CountDownLatch. 1)]
+    (interop/next-tick (fn [] (.countDown latch)))
+    (is (.await latch 5 TimeUnit/SECONDS) "executor barrier task ran")))
+
+;; ---- (a) PERMANENT QUEUE STRAND -------------------------------------------
+
+(deftest cold-serialized-release-rekicks-stranded-queue
+  (testing "a cold call-serialized-with-drain! release re-kicks a queue stranded by a CAS-lost drain-try!"
+    (let [ran      (atom 0)
+          frame-id :rf/default]
+      (rf/reg-event :bump
+        (fn [{:keys [db]} _]
+          (swap! ran inc)
+          {:db (update db :n (fnil inc 0))}))
+      (let [router (:router (frame/frame frame-id))]
+        ;; Cold serialized section on THIS thread. Inside it (holding
+        ;; :drain-lock), dispatch! an event: enqueue + ensure-drain-scheduled!
+        ;; sets :scheduled? true and schedules a drain-try! on the executor,
+        ;; which CAS-loses to us and gives up.
+        (frame/call-serialized-with-drain! frame-id
+          (fn []
+            (rf/dispatch [:bump] {:frame frame-id})
+            ;; Force the scheduled drain-try! to have FIRED and CAS-LOST.
+            (executor-barrier!)
+            ;; The strand precondition now holds deterministically.
+            (is (= 1 (count (:queue @router)))
+                "event queued while the cold section holds the lock")
+            (is (true? (:scheduled? @router)) "a drain was scheduled")
+            (is (zero? @ran)
+                "the handler has NOT run — the cold section holds the lock and the drain-try! CAS-lost")))
+        ;; Cold section released. Post-fix the release re-kicked a fresh
+        ;; drain-try!; await it (FIFO after the re-kick) and assert the
+        ;; stranded event drained. Pre-fix this stays stranded (ran = 0).
+        (executor-barrier!)
+        (is (= 1 @ran) "the cold release re-kicked the drain; the stranded event ran")
+        (is (empty? (:queue @router)) "the queue drained")
+        (is (false? (:scheduled? @router)) ":scheduled? reset after the drain settled")
+        ;; And a FRESH dispatch recovers (pre-fix, :scheduled? stuck true made
+        ;; ensure-drain-scheduled! no-op, so a new dispatch never drained).
+        (rf/dispatch [:bump] {:frame frame-id})
+        (executor-barrier!)
+        (is (= 2 @ran) "a fresh dispatch after the cold section drains normally")))))
+
+;; ---- (b) SAME-THREAD SELF-DEADLOCK ----------------------------------------
+
+(deftest dispatch-sync-inside-cold-serialized-thunk-reenters
+  (testing "dispatch-sync! from inside a cold serialized thunk re-enters instead of self-deadlocking"
+    (let [ran      (atom 0)
+          result   (atom ::unset)
+          frame-id :rf/default]
+      (rf/reg-event :inner
+        (fn [{:keys [db]} _]
+          (swap! ran inc)
+          {:db (assoc db :inner? true)}))
+      ;; Run the cold section on a WORKER thread so a self-deadlock manifests
+      ;; as a JOIN TIMEOUT rather than hanging the whole test JVM.
+      (let [worker (Thread.
+                     ^Runnable
+                     (fn []
+                       (frame/call-serialized-with-drain! frame-id
+                         (fn []
+                           ;; SAME thread already holds :drain-lock via the cold
+                           ;; section. Pre-fix: dispatch-sync! → drain-block! →
+                           ;; spin-CAS on the held lock → hangs forever.
+                           ;; Post-fix: reentrant-cold? routes to drain-reentrant!
+                           ;; which drains without re-acquiring the lock.
+                           (rf/dispatch-sync [:inner] {:frame frame-id})
+                           (reset! result :returned)))))]
+        (.start worker)
+        (.join worker 5000)
+        (is (not (.isAlive worker))
+            "the cold serialized thunk's dispatch-sync returned (no self-deadlock)")
+        (is (= :returned @result) "the thunk completed past the nested dispatch-sync")
+        (is (= 1 @ran) "the nested event actually ran (re-entered the drain)")
+        (is (true? (:inner? (rf/app-db-value frame-id)))
+            "the nested event's :db effect committed")))))

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -37,6 +37,7 @@
   race from the same gun."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.subs :as subs]
             [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
@@ -282,3 +283,61 @@
                  "disposes. Sample: " (vec (take 20 under)))))
       (is (= n-trials (count @per-trial))
           "all trials accounted for"))))
+
+;; ---- 4. Concurrent cache-MISS install resolves to ONE reaction ------------
+
+;; Per rf2-x76af2.23. The HIT path was already CAS-after-snapshot hardened;
+;; the MISS path installed with an unconditional plain `(swap! cache assoc
+;; k …)`. Two threads that both observe a miss for the SAME query-v both call
+;; `compute-and-cache!`, both build a reaction, and the second assoc STOMPS the
+;; first: reaction1 is orphaned (its on-dispose never fires → its layer-2 input
+;; ref-count bumps leak), and `:ref-count` is reset to 1 while TWO callers hold
+;; references — so a phantom holder's unsubscribe drives the CACHED reaction
+;; 1→0 and disposes it while the other caller still uses it.
+;;
+;; The defect IS the unconditional overwrite, so two direct `compute-and-cache!`
+;; calls model two racing misses deterministically (interleaving-injection, not
+;; wall-clock): each call unconditionally rebuilds+installs pre-fix, so the
+;; second call reproduces the exact double-build the CAS-less install could not
+;; prevent. Post-fix, install-if-absent makes the second call adopt the winner.
+(deftest concurrent-miss-install-resolves-to-one-reaction
+  (testing "two racing cache-miss builds for the same query-v resolve to ONE cached reaction"
+    (rf/reg-event :seed (fn [_ _] {:db {:a 1 :b 2}}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    ;; layer-2 sub over two layer-1 inputs, so we can observe input ref-counts.
+    (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:seed] {:frame :rf/default})
+
+    (let [frame-id :rf/default
+          cache    (:sub-cache (frame/frame frame-id))
+          cc!      #'subs/compute-and-cache!   ;; the private build path (cache-key = identity)
+          ;; Two racing misses = two direct build calls.
+          r1       (cc! frame-id [:sum])
+          r2       (cc! frame-id [:sum])]
+
+      (testing "exactly ONE reaction is cached and both builds resolve to it"
+        (is (identical? r1 r2)
+            "the loser adopts the winner — both builds resolve to the SAME reaction")
+        (is (identical? r1 (get-in @cache [[:sum] :reaction]))
+            "the cached slot holds the shared reaction (no stomp)"))
+
+      (testing ":ref-count == subscriber count (2), not reset to 1"
+        (is (= 2 (get-in @cache [[:sum] :ref-count]))
+            "both callers are counted (pre-fix the second overwrite reset it to 1)"))
+
+      (testing "no input-ref leak: each layer-1 input held once by the ONE cached reaction"
+        ;; The loser's build bumped :a / :b then released them on dispose, so
+        ;; each input is held only by the single cached :sum reaction.
+        (is (= 1 (get-in @cache [[:a] :ref-count])) ":a input ref-count is 1, not leaked to 2")
+        (is (= 1 (get-in @cache [[:b] :ref-count])) ":b input ref-count is 1, not leaked to 2"))
+
+      (testing "after N unsubscribes the reaction disposes and all input refs release to zero"
+        ;; ref-count 2 → two unsubscribes → 0 → sync dispose → on-dispose
+        ;; releases the inputs symmetrically.
+        (rf/unsubscribe frame-id [:sum])
+        (is (some? (get @cache [:sum])) "one unsubscribe leaves the reaction live (ref-count 1)")
+        (rf/unsubscribe frame-id [:sum])
+        (is (nil? (get @cache [:sum])) ":sum evicted at ref-count 0")
+        (is (nil? (get @cache [:a])) ":a input released to 0 and evicted — no orphan")
+        (is (nil? (get @cache [:b])) ":b input released to 0 and evicted — no orphan")))))


### PR DESCRIPTION
Fixes two JVM-reproduced concurrency defects from the core audit (both CLJS-immune — the CLJS runtimes are single-threaded). Minimal, provably-correct fixes matching the existing optimistic-CAS / single-drainer idioms; no heavyweight locks.

## rf2-x76af2.22 — cold `call-serialized-with-drain!` broke the single-drainer release protocol

A COLD `frame/call-serialized-with-drain!` section (out-of-drain flows lifecycle ops, `destroy-frame!`'s liveness flip, Tool-Pair state writes) takes the same per-frame `:drain-lock` as the event drainer but is NOT a drainer.

**(a) Permanent queue strand.** A `dispatch!` arriving during the cold hold set `:scheduled?` true and scheduled a `drain-try!` that CAS-lost to the cold holder and gave up; the cold release did not re-check the queue, so the queue stranded (`:scheduled?` stuck true no-ops every later `ensure-drain-scheduled!`). The cold release now mirrors the drainer's `try-release-on-empty!`: under the router lock it snapshots the queue (stable — the lock is still held) and, if non-empty, re-kicks a fresh async drain via the new `:router/reschedule-drain!` late-bind seam (frame cannot `:require` router — load cycle).

**(b) Same-thread self-deadlock.** A `dispatch-sync!` issued from inside a cold serialized thunk on the same thread routed through `drain-block!`, whose spin-CAS-acquire deadlocked on the `:drain-lock` the thread already held. `dispatch-sync!` now detects the cold `:serialized-holder` (`reentrant-cold?`, mirroring `frame/current-thread-owns-drain-serialization?`) and runs the seed-push + drain via the new `drain-reentrant!` — no re-acquire, no release (the outer cold section owns the lock and drops it in its own `finally`). The release phases (`try-release-on-empty!` / `force-release-on-halt!` / `drain-loop!`) take a `hold-lock?` flag so the reentrant drain leaves the lock held; the drainer / sync entries pass `false` (unchanged behaviour).

## rf2-x76af2.23 — subs cache MISS-install was a plain overwrite

The sub-cache HIT path was already CAS-after-snapshot hardened, but the MISS install (`compute-and-cache!`) was an unconditional `(swap! cache assoc k …)`. Two threads that both observe a miss for the same query-v both build a reaction and the second assoc STOMPS the first: reaction1 is orphaned (its on-dispose never fires → its layer-2 input ref-count bumps leak) and `:ref-count` is reset to 1 while two callers hold refs, so a phantom unsubscribe disposes the cached reaction out from under the live holder.

Now **install-if-absent** (`swap!` installs only when the slot is empty). On a collision the losing build disposes its just-built orphan (releasing its input refs via the on-dispose wired before the install attempt) and adopts the winner as a HIT — bumping ref-count under the same CAS-after-snapshot discipline the subscribe hit path uses, falling through to a fresh build if the winner was evicted in the race window. A double-build resolves to ONE reaction with a correct ref-count and no input-ref leak.

## Deterministic regression tests (interleaving-injection, not wall-clock)

- `cold_serialized_drain_test.clj`
  - (a) `cold-serialized-release-rekicks-stranded-queue` — forces the `drain-try!` to have fired-and-CAS-lost via the single-thread executor's FIFO ordering (a barrier task submitted after the `drain-try!` strictly follows it), then asserts the cold release re-kicks and the stranded event drains, and a fresh dispatch recovers.
  - (b) `dispatch-sync-inside-cold-serialized-thunk-reenters` — runs the cold section on a worker thread and asserts a bounded join returns (no self-deadlock), the nested event ran, and its `:db` effect committed.
- `sub_cache_concurrency_test.clj` (4th deftest) `concurrent-miss-install-resolves-to-one-reaction` — two direct `compute-and-cache!` calls model two racing misses; asserts exactly one cached reaction, ref-count == 2, input ref-counts == 1 (no leak), and all refs release to zero after both unsubscribe.

Co-edit: the new `:router/reschedule-drain!` hook is catalogued in `late-bind/directory.cljc` (drift test green). No new `:rf.error/*` id minted.

## Quality gates

- Core JVM suite (`clojure -M:test` from `implementation/core`): **1783 tests, 7862 assertions, 0 failures, 0 errors** (green + grew).
- CLJS node (`npm run test:cljs` from `implementation/`): **8599 tests, 40555 assertions, 0 failures, 0 errors**.
- Both re-run after rebasing onto the merged core-fx cluster (#5645).
