### PR TITLE
fix(examples): asset inventory ignores HTML comments; sweep stale Xray accent #7C5CFF→#539bf5 (rf2-j538f7.28, rf2-x76af2.28)

### DIFF
--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -212,7 +212,7 @@ hr {
  */
 
 :root {
-  --rf-xray-accent: #7C5CFF;
+  --rf-xray-accent: #539bf5;
 }
 
 .rf2-testbed-shell {

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -461,6 +461,18 @@ function stripCssComments(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+// Strip HTML comment spans `<!-- … -->` from a source before scanning it for
+// live tags. A tag inside a comment is inert — the browser never fetches it nor
+// exposes it as document metadata — so a commented link/meta/script/img must
+// not satisfy a required-asset contract, trip the direct-network policy, or
+// enter on-disk resolution (rf2-j538f7.28). An UNTERMINATED `<!--` (no closing
+// `-->`) comments out the remainder of the document, so it is stripped through
+// end-of-input too. Mirrors the stripCssComments posture: one lexical pass feeds
+// the single inventory walk, no general HTML parser.
+function stripHtmlComments(html) {
+  return html.replace(/<!--[\s\S]*?-->/g, '').replace(/<!--[\s\S]*/, '');
+}
+
 // Build the page's complete HTML reference inventory in ONE pass over its tags
 // (rf2-6a3rgx). Every supported reference shape — a quoted OR unquoted attribute
 // (rf2-3dzb6h), each srcset/imagesrcset candidate + a <video> poster
@@ -528,7 +540,10 @@ function extractHtmlReferenceInventory(html) {
   };
   const mediaEls = new Set(['img', 'source', 'video', 'audio', 'track']);
 
-  for (const m of html.matchAll(/<([a-zA-Z][a-zA-Z0-9:-]*)[^>]*>/g)) {
+  // Remove inert comment markup FIRST so a commented tag contributes zero
+  // references to any of the three views below (rf2-j538f7.28), mirroring the
+  // stripCssComments strip the CSS extractors already perform.
+  for (const m of stripHtmlComments(html).matchAll(/<([a-zA-Z][a-zA-Z0-9:-]*)[^>]*>/g)) {
     const tag = m[0];
     const el = m[1].toLowerCase();
 

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -651,6 +651,58 @@ const INVENTORY_CASES = [
     // both survive; the duplicate og meta collapses.
     assetSourceSet: { '_shared/img/og.png': ['<link rel="icon" href>', 'og:image'] },
   },
+  {
+    // Inert markup: a link/meta/script/img that lives ONLY inside a closed HTML
+    // comment is never fetched nor exposed as metadata by the browser, so it
+    // contributes ZERO references to any of the three views (rf2-j538f7.28).
+    name: 'inert HTML comment — commented link/meta/script/img contribute no references (rf2-j538f7.28)',
+    html: [
+      '<script src="main.js"></script>',
+      '<!--',
+      '  <link rel="icon" href="_shared/img/favicon.svg">',
+      '  <meta property="og:image" content="_shared/img/og.png">',
+      '  <link rel="stylesheet" href="_shared/css/style.css">',
+      '  <img src="commented.png">',
+      '-->',
+    ].join('\n'),
+    localExact: ['main.js'],
+    ogExact: [],
+    assetExcludes: [
+      '_shared/img/favicon.svg',
+      '_shared/img/og.png',
+      '_shared/css/style.css',
+      'commented.png',
+    ],
+  },
+  {
+    // Live references immediately before and after a comment retain their order
+    // and classification, and a tag following a CLOSED comment is still
+    // discovered — the strip removes only the inert span (rf2-j538f7.28).
+    name: 'inert HTML comment — live refs before/after keep order; post-comment tag still seen (rf2-j538f7.28)',
+    html: [
+      '<link rel="stylesheet" href="before.css">',
+      '<!-- <link rel="icon" href="commented.svg"> -->',
+      '<script src="after.js"></script>',
+    ].join('\n'),
+    localExact: ['before.css', 'after.js'],
+    assetSourceIncludes: { 'before.css': 'link', 'after.js': 'script' },
+    assetExcludes: ['commented.svg'],
+  },
+  {
+    // An UNTERMINATED `<!--` comments out the remainder of the document, so the
+    // would-be tags after it are inert rather than satisfying the gate
+    // (rf2-j538f7.28).
+    name: 'inert HTML comment — an unterminated <!-- makes the rest of the document inert (rf2-j538f7.28)',
+    html: [
+      '<script src="live.js"></script>',
+      '<!-- unterminated comment swallows the rest',
+      '<link rel="stylesheet" href="never.css">',
+      '<meta property="og:image" content="never-og.png">',
+    ].join('\n'),
+    localExact: ['live.js'],
+    ogExact: [],
+    assetExcludes: ['never.css', 'never-og.png'],
+  },
 ];
 
 for (const c of INVENTORY_CASES) {
@@ -689,6 +741,56 @@ for (const c of INVENTORY_CASES) {
     }
   });
 }
+
+it('TEETH: required shared refs that exist ONLY inside an HTML comment are reported missing (rf2-j538f7.28)', () => {
+  // The false-GREEN case this bead closes: a maintainer comments out the three
+  // required refs while debugging. The files still exist on disk (fullIo), but
+  // the live page ships without its stylesheet, favicon, and social-preview —
+  // so the gate must report all three missing. A commented tag is inert.
+  const html = [
+    '<!doctype html><html><head>',
+    '<!--',
+    '<meta property="og:image" content="_shared/img/og.png">',
+    '<link rel="icon" href="_shared/img/favicon.svg">',
+    '<link rel="stylesheet" href="_shared/css/style.css">',
+    '-->',
+    '</head><body><script src="main.js"></script></body></html>',
+  ].join('\n');
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  for (const need of [
+    '_shared/img/og.png',
+    '_shared/img/favicon.svg',
+    '_shared/css/style.css',
+  ]) {
+    assert.ok(
+      errors.some((e) =>
+        e.includes(`missing required shared asset reference '${need}'`),
+      ),
+      `commented-out required ref '${need}' must be reported missing, got: ${errors.join(' | ')}`,
+    );
+  }
+});
+
+it('TEETH: a commented remote ref does not trip the network policy and a commented missing local ref is not resolved (rf2-j538f7.28)', () => {
+  // The false-FAIL polarity: inert markup must be absent from BOTH verdicts. A
+  // commented remote <script> is not a direct-network violation, and a
+  // commented missing local <link> is not a disk-resolution failure. goodHtml
+  // keeps the three required refs live, so the page is otherwise clean.
+  const html = goodHtml().replace(
+    '</head>',
+    '<!-- <script src="https://cdn.evil/x.js"></script>' +
+      '<link rel="stylesheet" href="missing-local.css"> -->\n</head>',
+  );
+  const { errors } = scanPage(fullIo({ [PAGE]: html }), PAGE);
+  assert.ok(
+    !errors.some((e) => e.includes('cdn.evil')),
+    `a commented remote ref must not trip the network policy, got: ${errors.join(' | ')}`,
+  );
+  assert.ok(
+    !errors.some((e) => e.includes('missing-local.css')),
+    `a commented missing local ref must not be resolved on disk, got: ${errors.join(' | ')}`,
+  );
+});
 
 it('TEETH: a missing LOCAL srcset candidate is reported (rf2-arkvq8)', () => {
   // The page references two responsive candidates; the 640w one is absent on

--- a/tools/xray/testbeds/edn_inspector/index.html
+++ b/tools/xray/testbeds/edn_inspector/index.html
@@ -17,7 +17,7 @@
        `day8.re-frame2-xray.core/init!` + `open!` (the manual alternative
        to the :preloads wiring) so the Epoch + App-db panels read the
        single default frame here — the inspector's primary use case. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>

--- a/tools/xray/testbeds/machine_epochs/index.html
+++ b/tools/xray/testbeds/machine_epochs/index.html
@@ -13,7 +13,7 @@
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
        affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>

--- a/tools/xray/testbeds/managed_http/index.html
+++ b/tools/xray/testbeds/managed_http/index.html
@@ -13,7 +13,7 @@
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
        affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>

--- a/tools/xray/testbeds/routes_epochs/index.html
+++ b/tools/xray/testbeds/routes_epochs/index.html
@@ -13,7 +13,7 @@
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
        affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>

--- a/tools/xray/testbeds/standard_epochs/index.html
+++ b/tools/xray/testbeds/standard_epochs/index.html
@@ -13,7 +13,7 @@
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
        affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>

--- a/tools/xray/testbeds/two_frame_isolation/index.html
+++ b/tools/xray/testbeds/two_frame_isolation/index.html
@@ -13,7 +13,7 @@
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
        affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-xray-accent: #7C5CFF; }
+    :root { --rf-xray-accent: #539bf5; }
     [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>


### PR DESCRIPTION
Two example-asset correctness fixes. One PR, two commits (ordered j538f7.28 → x76af2.28).

## rf2-j538f7.28 (P3 bug) — asset inventory ignores inert HTML comments
`extractHtmlReferenceInventory` scanned the raw HTML, so `link/meta/script/img` tags inside `<!-- … -->` were indistinguishable from live tags. Consequences:
- **False-green (serious):** a commented-out required ref could make the required-shared-asset check pass while the staged page ships without its stylesheet / favicon / OG metadata.
- **False-fail:** a commented remote or missing ref could trip the network policy / disk-resolution on an otherwise-clean page.

Fix: added `stripHtmlComments` (mirrors the existing `stripCssComments` posture) and strip comment spans — including an unterminated `<!--` through end-of-input — before the single inventory walk. Inert markup now contributes zero references to `localRefs`, `assets`, and `ogImages`; live tags before/after a comment keep their order and classification.

Tests (`implementation/scripts/check-examples-assets.test.cjs`): three inert-markup cases in the table-driven inventory suite + two `scanPage` teeth tests (required-asset false-green closed; a commented remote ref does not trip the network policy and a commented missing local ref is not resolved on disk).

## rf2-x76af2.28 (P4) — sweep stale Xray accent #7C5CFF → #539bf5 in host CSS
`examples/_shared/css/structure.css` published `--rf-xray-accent: #7C5CFF` (Xray's pre-migration accent-violet). Under rf2-ad7zx.13 Xray collapsed to a single GitHub-blue accent `#539bf5`, and the recommended host snippet now publishes `:root { --rf-xray-accent: #539bf5 }`. Runtime-inert but stale/contract-contradicting in the canonical shared example stylesheet.

Swept the same copy-propagated `--rf-xray-accent: #7C5CFF` host-var declaration across all host/example CSS:
- `examples/_shared/css/structure.css`
- 6 Xray testbed hosts: `tools/xray/testbeds/{edn_inspector,machine_epochs,managed_http,routes_epochs,standard_epochs,two_frame_isolation}/index.html`

`git grep -i 7C5CFF` under `examples/` is now zero; no host/example CSS carries the old value. **Intentionally left as historical artefacts / out-of-scope surfaces:** the retired-accent note in `021-Dynamic-Panel-Designs.md`, the theme test fixtures asserting the old `:accent-violet` value, testbed `core.cljs` decorative chrome, and docs/spec/skills/Story design-rationale prose referencing Xray's brand violet (some of that prose — docs/xray, spec/Tool-Pair.md, skills — is stale too but out of this bead's host-CSS scope; flag for a docs follow-up).

## Quality gates
- `node examples/scripts/check-examples-assets.cjs` — **35/35 pages green**, `_shared` tree intact.
- `npm run test:script-policy` — **all suites green** (incl. the new inert-markup + false-green teeth tests).
- `git grep -i 7C5CFF -- 'examples/'` — **zero**; no `#7C5CFF` in any host/example CSS.
- mkdocs: N/A — no edited file is under `docs_dir: docs`.