### PR TITLE
docs: test-react transactional-failure teardown + Pair live-browser Story recipe (rf2-a7fodi, rf2-s99lw4)

### DIFF
--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -90,12 +90,35 @@ A render tree may be plain opaque data (`[:div "hi"]` — most tests) *or* decla
 | `:did-mount` | Immediately after the first `:render`. |
 | `:did-update` | Immediately after each subsequent `:render`. |
 | `:will-unmount` | The unmount thunk fires. |
-| `:forced-teardown` | `dispose-adapter!` drained a still-mounted root. |
+| `:forced-teardown` | A mount was torn down bypassing the render-depth unmount guard. Three paths log it: `dispose-adapter!` draining a still-mounted root, a failed **initial** mount rolling back its speculatively-mounted children, or a failed **update** tearing down the whole live root (see *Transactional render failures* below). |
 
 The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is
 called while a render is in flight **anywhere in the tree**. A global counter,
 rather than a per-mount flag, is what catches a parent render unmounting a
 separately tracked sibling root.
+
+### Transactional render failures
+
+A render body that throws is **not** swallowed — the simulator mirrors React
+18+'s uncaught-render semantics, and both failure directions are transactional
+(no half-committed lifecycle state):
+
+- **Failed initial mount (`mount!`).** If the first render throws, any children
+  the render speculatively mounted via `mount-child!` are rolled back —
+  force-torn-down grandchildren-first (each logs a `:forced-teardown`) — and the
+  never-registered parent is discarded. A failed mount registers nothing and
+  leaks nothing; the original exception is rethrown.
+- **Failed update (`trigger-update!`).** If an update render throws, the **whole
+  live root** is unmounted: the mount and its entire child subtree (pre-existing
+  children *and* any this attempt speculatively mounted) are force-evicted
+  grandchildren-first with their render trees cleared (root and each descendant
+  log a `:forced-teardown`), **no** `:did-update` is logged, and the original
+  exception is rethrown. The test double does **not** silently preserve the
+  prior tree, because real React 18+ would tear the root down.
+
+The B.5 layer of `test/re_frame/adapter/test_react_cljs_test.cljc` asserts both
+behaviours; the source docstrings on `trigger-update!` / `run-render!` carry the
+normative contract.
 
 ## What this adapter does NOT cover
 

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -201,7 +201,7 @@ Read the leaf matching the task. Most references are ≤250 lines; the two catal
 | Edit source, then wait for the browser to pick up the new code | [references/ops.md §Hot-reload coordination](references/ops.md#hot-reload-coordination) |
 | Map a v1 (`re-frame-pair`) surface to its v2 equivalent (or know it has none) | [references/ops.md §Dropped from v1](references/ops.md#dropped-from-v1-re-frame-pair--surfaces-with-no-v2-equivalent) |
 | Install/configure the persistent-connection MCP server | [references/mcp-transport.md](references/mcp-transport.md) |
-| Use story-mcp tools during a live re-frame2-pair session — the five live-session tools (`run-variant`, `read-failures`, `snapshot-identity`, `read-a11y-violations`, `record-as-variant`) plus the three read-only enumerations (`list-decorators`, `explain-variant`, `get-docs-markdown`); composition with watch-epochs and dispatch-from-pair | [references/stories.md](references/stories.md) |
+| Drive the **running browser app's own** Story registry via `eval-cljs` (`re-frame.story/ids` / `variants-of` / `run-variant`, await the run-result) — the pair is the live-browser Story host, story-mcp cannot see the browser registry; OR use the story-mcp tools during a live session (the five live-session tools `run-variant` / `read-failures` / `snapshot-identity` / `read-a11y-violations` / `record-as-variant` plus the three read-only enumerations `list-decorators` / `explain-variant` / `get-docs-markdown`; composition with watch-epochs and dispatch-from-pair) | [references/stories.md](references/stories.md) |
 
 Load at most two references for a single task. Wanting three means the request spans concerns and should be broken up.
 

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -328,7 +328,9 @@ Blocks (server polls ~100ms cadence) until the predicate holds — `{:ok? true :
 
 **Why this works:** a Story variant *is* a re-frame2 frame — the variant id is the frame id. Every re-frame2-pair op taking a `frame:` arg works against a variant out of the box. Full pattern: [variant-as-frame.md](variant-as-frame.md).
 
-**Setup.** A Story-enabled build is running (`re-frame.story` loaded; some variants registered). The variant is either already mounted in the canvas or you mount it via story-mcp / `run-variant`.
+> **Two Story hosts — pick the browser one for a live app.** For the **running browser app's own** registered variants, drive `re-frame.story/*` directly through `eval-cljs` — the pair is the live-browser Story host. The `mcp__re-frame2-story-mcp__run-variant` tool used below targets story-mcp's **headless same-JVM** host, which cannot see the browser registry. See [stories.md §Driving Story directly in the browser](stories.md#driving-story-directly-in-the-browser-via-eval-cljs) for the enumerate → run → read recipe against the browser heap.
+
+**Setup.** A Story-enabled build is running (`re-frame.story` loaded; some variants registered). The variant is either already mounted in the canvas or you mount it (browser: `eval-cljs {form: "(re-frame.story/run-variant :story.counter/loaded)", await: true}`; story-mcp's headless host: `run-variant`).
 
 **Procedure:**
 

--- a/skills/re-frame2-pair/references/stories.md
+++ b/skills/re-frame2-pair/references/stories.md
@@ -1,6 +1,6 @@
 # Stories — driving and asserting against Story variants from a re-frame2-pair session
 
-> The five story-mcp tools allow-listed by `re-frame2-pair` (`run-variant`, `read-failures`, `snapshot-identity`, `read-a11y-violations`, `record-as-variant`) and how they compose with the live-runtime surface. Assumes you've read `SKILL.md` (the trace + epoch primitives) and `variant-as-frame.md` (variant-id IS frame-id).
+> Two ways to reach Story from a re-frame2-pair session. **(A) The running app's own stories** — drive `re-frame.story/*` in the live browser heap through `eval-cljs` (this is the live-browser Story host; see [§Driving Story directly in the browser](#driving-story-directly-in-the-browser-via-eval-cljs) first). **(B) story-mcp's own headless host** — the five allow-listed story-mcp tools (`run-variant`, `read-failures`, `snapshot-identity`, `read-a11y-violations`, `record-as-variant`) that drive/assert against a variant in story-mcp's same-JVM registry. Assumes you've read `SKILL.md` (the trace + epoch primitives) and `variant-as-frame.md` (variant-id IS frame-id).
 
 ## When to load this leaf
 
@@ -8,7 +8,73 @@
 - A re-frame2-pair session needs to *assert* against a variant — was the play sequence valid? did the cascade meet `:rf.assert/*` expectations? did axe-core find a regression?
 - The user wants to capture a live cascade back into a `:play-script` snippet to bake the current interaction into a variant body.
 
-Do **not** load this leaf to author variants from scratch (no live runtime in the loop) — that's `skills/re-frame2/references/tooling/stories.md`. Load this leaf for the five live-session tools and the composition patterns with re-frame2-pair's reads/writes/watches.
+Do **not** load this leaf to author variants from scratch (no live runtime in the loop) — that's `skills/re-frame2/references/tooling/stories.md`. Load this leaf for the browser-native `eval-cljs` path below, the five live-session story-mcp tools, and the composition patterns with re-frame2-pair's reads/writes/watches.
+
+## Driving Story directly in the browser via `eval-cljs`
+
+**One live door — reach the running app's stories through the pair, not story-mcp.** The five story-mcp tools below run Story in story-mcp's own **headless, same-JVM** host — a registry story-mcp built in its own process. That host **cannot see a browser tab's Story registry**: variants a `shadow-cljs watch` build registered in the browser heap are unreachable from story-mcp (a capability boundary, not a bug). The re-frame2-pair session **is** the live-browser Story host — its `eval-cljs` channel evaluates ClojureScript in the attached browser heap, so `re-frame.story/*` (the exact API the app's own Story shell calls) is reachable there today, with no extra transport. So when the user wants to enumerate or run the **running app's** stories, drive `re-frame.story/*` through `eval-cljs`; reach for the story-mcp tools only for story-mcp's own headless host.
+
+The Story namespace is loaded in any Story-enabled build, so reference it by its full name in an `eval-cljs` form (there is no `story` alias in the browser unless the app made one).
+
+**1. Enumerate the registry.** `ids` takes a registrar kind — `:story` for the parent stories, `:variant` for every concrete variant; `variants-of` returns one story's variants:
+
+```
+mcp__re-frame2-pair__eval-cljs {form: "(sort (re-frame.story/ids :story))"}
+;; => (:story.login :story.cart …)
+
+mcp__re-frame2-pair__eval-cljs {form: "(sort (re-frame.story/variants-of :story.login))"}
+;; => (:story.login/empty :story.login/filled :story.login/success …)
+```
+
+**2. Run a variant — it returns a Promise, so `await`.** `run-variant` allocates the variant's frame and runs setup → loaders → events → play, resolving to the unified run-result. In the browser it returns a **JS Promise**, so eval it with `await: true` — the server awaits the thenable and returns the resolved value as `:value` (a plain eval would hand back an unresolved Promise). Project down to the verdict in the SAME round-trip so the whole (potentially large) result never crosses the wire — `eval-cljs` is un-elided, so returning only `:status` + failing assertions is both smaller and privacy-safer than shipping the variant's whole `:app-db`:
+
+```
+mcp__re-frame2-pair__eval-cljs {
+  form: "(.then (re-frame.story/run-variant :story.login/success)
+                (fn [res]
+                  {:status   (re-frame.story/result-status res)
+                   :passed?  (re-frame.story/result-passed? res)
+                   :failures (filterv #(not= :pass (:status %))
+                                      (:assertions res))}))",
+  await: true, timeout-ms: 10000
+}
+;; => {:status :pass :passed? true :failures []}
+```
+
+The resolved run-result is the frozen spec/017 §Run-result contract: `:status` (`:pass` | `:fail` | `:cannot-run` | `:error` — read via `re-frame.story/result-status`; `result-passed?` is true only for `:pass`, a `:cannot-run` is NOT a pass), `:assertions` (the unified records, each with `:status` / `:passed?` / `:expected` / `:actual` / `:reason`), `:checks`, plus optional `:app-db` / `:elapsed-ms` / `:narrative` / `:effects` / `:sub-runs` / `:renders`. To inspect the whole result, `await` the bare `(re-frame.story/run-variant …)` form instead of the projection.
+
+**3. Frame-scoped dispatch — the variant id IS the frame id.** Per [variant-as-frame.md](variant-as-frame.md), a running variant is an ordinary isolated frame; poke it with any frame-targeted op by pinning it or passing `frame:` per-call:
+
+```
+set-operating-frame {frame: ":story.login/success"}
+mcp__re-frame2-pair__read-sub {sub: "[:auth.login/status]"}
+mcp__re-frame2-pair__dispatch {event: "[:auth.login/submit]", frame: ":story.login/success"}
+```
+
+A fresh `run-variant` calls `reset-frame!` and wipes anything you injected between runs — bake durable setup into the variant's `:loaders` / `:events`, not a REPL dispatch.
+
+### Verified transcript (condensed)
+
+Against a Story-enabled build with the `:story.login` example loaded (`examples/core/login`), one enumerate → run → read pass:
+
+```
+eval-cljs {form: "(sort (re-frame.story/variants-of :story.login))"}
+;; :value (:story.login/auth-error :story.login/empty :story.login/filled
+;;          :story.login/invalid-credentials :story.login/locked-out
+;;          :story.login/submitting :story.login/success)
+
+eval-cljs {form: "(.then (re-frame.story/run-variant :story.login/success)
+                         (fn [res] [(re-frame.story/result-status res)
+                                    (count (:assertions res))]))",
+           await: true}
+;; :value [:pass 3]
+```
+
+The entry-point names (`ids` / `variants-of` / `run-variant` / `result-status` / `result-passed?`) and the Promise-return + result shape are confirmed against `tools/story/src/re_frame/story.cljc`; substitute your app's own `:story.<name>` ids.
+
+### First-class pair Story tools — a demand-gated future option
+
+`ids` / `variants-of` / `run-variant` are reachable **today** through the generic `eval-cljs` workhorse, so there is deliberately no dedicated pair tool for them. Promoting them to named pair tools (a `list-stories` / `run-variant` on the pair surface, mirroring the story-mcp ones but pointed at the browser) is a **later option held behind a demand bar** — reach for it only if the eval-cljs path proves too noisy in practice. Do not build it pre-emptively.
 
 ## The five live-session tools — drive + assert palette
 


### PR DESCRIPTION
Two disjoint docs fixes, one PR, two commits.

## rf2-a7fodi — test-react README: forced-teardown triggers + failed-update whole-root teardown
`implementation/adapters/test-react/README.md`

The README's `:forced-teardown` lifecycle row documented only the `dispose-adapter!` drain, but `force-teardown-record!` (which logs `:forced-teardown`) actually fires from **three** paths in the source:
1. `dispose-adapter!` draining a still-mounted root (the documented one).
2. Failed **initial** mount rollback — `mount-tree!` -> `roll-back-speculative-children!` (landed 488bf70df).
3. Failed **update** whole-root teardown — `trigger-update!` -> `force-teardown-subtree!` (landed bd14ef705).

The README also nowhere stated that a failed **update** now unmounts the **whole live root** (React 18+ uncaught-render semantics). Fix: extend the row to list all three trigger paths and add a *Transactional render failures* section documenting both directions — failed initial mount rolls back speculative children; failed update tears down the whole root with **no** `:did-update` and the original exception rethrown. Matches the `trigger-update!` / `run-render!` docstrings and the B.5 layer of `test_react_cljs_test.cljc`.

## rf2-s99lw4 — Pair: live-browser Story recipe (drive `re-frame.story/*` via `eval-cljs`)
`skills/re-frame2-pair/references/stories.md` (+ reconciling touches to `references/recipes.md`, `SKILL.md`)

Per the one-live-door ruling, the pair is the live-browser Story host; story-mcp stays the headless same-JVM surface and **cannot see a browser tab's Story registry**. New recipe documents driving the running app's own stories through the pair's `eval-cljs`:
- Enumerate: `(re-frame.story/ids :story)` / `(re-frame.story/variants-of :story.<name>)`.
- Run: `run-variant` returns a **JS Promise** in the browser -> `eval-cljs {await: true}`; project to the verdict in one round-trip.
- Read: `:status` + `:assertions` (accessors `result-status` / `result-passed?`).
- Frame-scoped dispatch: variant-id IS frame-id.

Includes a condensed verified transcript against the real `:story.login` example, states the story-mcp browser-registry capability boundary, and records first-class pair Story tools as a demand-gated future option (not built). Reconciles the pre-ruling recipes.md Story recipe + the SKILL.md loading map with the two-hosts split.

## Verification
- Both docs verified against current code: `force-teardown-record!` call sites (dispose + `roll-back-speculative-children!` + `force-teardown-subtree!`) and the B.5 tests; Story entry points `ids`/`variants-of`/`run-variant`/`result-status`/`result-passed?` on `re-frame.story` + the `eval-cljs` `await` promise path.
- Gates green: `check_skill_mcp_drift`, `check_skill_package_refs`, `check_skill_eval_docs`, `check_skill_redirect_anchors`, `check_doc_slugs`, and the clojure `skills-check` (572 refs in sync). Neither file feeds `mkdocs` (both outside `docs_dir`).