### PR TITLE
fix(xray): chrome.md pulse + SKILL frame-picker scope + auto-open-on-error surface-preserving reopen (rf2-wjl2qo, rf2-tet4wy, rf2-kggzi4)

### DIFF
--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -319,8 +319,12 @@ redaction contract, the rewind detail) when the question needs more than
 the one-liner.
 
 - **L1 frame picker.** The Frame control on the L1 ribbon chooses *which
- frame* Xray observes — every tab and the spine rebind to it
- (mode-independent: it scopes both Dynamic and Static). It **always
+ frame* Xray observes — it moves the per-frame *live* projections and the
+ spine's observed frame; the process-global catalogues (Graph Declared,
+ Frames, the Static definition catalogues) read the same in every frame and
+ do **not** follow the picker (see the scope matrix above). It is
+ mode-independent: the frame-observation axis moves in both Dynamic and
+ Static. It **always
  renders**; on a single-frame app it is a working one-entry dropdown (only a
  zero-frame state disables it). The button face shows the currently-selected
  frame id live (e.g. `:rf/default ▾`). The pin is a **transient view

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -59,8 +59,10 @@ Spec [`007-UX-IA.md` §Frame slot contract](../../../tools/xray/spec/007-UX-IA.m
 
 The L2 spine live-tails new events at the head (**LIVE**) until you pick a
 historical event or pause, which drops to **RETRO** (inspecting a past
-epoch). `Space` pauses/resumes LIVE; `L` snaps back to LIVE; the head row
-pulses while live. Spec
+epoch). `Space` pauses/resumes LIVE; `L` snaps back to LIVE. There is **no
+mode pill and no animated head-row cue** — LIVE vs RETRO is conveyed by the
+`[◀ ▶ ⏭]` nav cluster plus the focused-row state (a background wash + a
+leading `>` caret on the focused row, which in LIVE tracks the head). Spec
 [`007-UX-IA.md` §L1](../../../tools/xray/spec/007-UX-IA.md).
 
 ## Time-travel: passive inspect vs explicit rewind

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -312,8 +312,10 @@ overlays, or fixed-position chrome as part of the default developer
 experience. `Ctrl+Shift+C` shows the existing shell again; no React
 remount is required.
 
-The global show/hide route — the `Ctrl+Shift+C` toggle and the command
-palette's "show the shell first" step — is surface-**preserving**: it
+The global show/hide route — the `Ctrl+Shift+C` toggle, the command
+palette's "show the shell first" step, and the auto-open-on-error
+watcher's reopen (see [`016-Auxiliary-Panels.md` §Auto-open-on-error
+semantics](./016-Auxiliary-Panels.md)) — is surface-**preserving**: it
 reopens whatever physical surface the shell was last realized on. A
 hidden overlay reopens as the overlay (a CSS-only show under
 `document.body`); a hidden inline shell reopens inline; the first-ever

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -657,8 +657,16 @@ density at `:cosy`.
 When `:auto-open-on-error?` flips ON, a sub-watcher is installed
 against the existing `:rf.xray/issues-ribbon` sub. On the **first
 empty → non-empty** transition (and only when Xray is not already
-visible) the watcher dispatches the late-bound `mount/open!` browser
-API export. Two install triggers (both idempotent): (1) on toggle
+visible) the watcher drives the late-bound **surface-preserving**
+reopen `mount/toggle!` browser API export — **not** `mount/open!`.
+Auto-open is a *reopen*, not an explicit surface request: the
+"not already visible" guard proves the shell is hidden, so `toggle!`
+shows whatever physical surface the shell was last realized on
+(a hidden overlay reopens as the overlay, not silently re-parented
+back inline). This is the same generic-reopen contract the
+`Ctrl+Shift+C` toggle and the command palette's "show the shell
+first" step honour — see [`011-Launch-Modes.md` §Closed
+state](./011-Launch-Modes.md). Two install triggers (both idempotent): (1) on toggle
 flip-on inside `:rf.xray/settings-update`, and (2) on first Xray
 open via `mount/ensure-xray-frame!` when the persisted toggle is
 already on. The install is a **defensive no-op pre-mount** — if the

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -108,6 +108,20 @@
       (boolean (:visible? (js->clj (status-fn) :keywordize-keys true))))
     (catch :default _ false)))
 
+(defn- reopen-preserving-surface!
+  "Show a hidden shell again via the mode-aware generic reopen
+  `mount/toggle!` — NOT the surface-CHANGING `mount/open!`. A reopen must
+  not re-parent a hidden overlay back inline: `toggle!` shows whatever
+  physical surface the shell was last realized on, so a hidden overlay
+  reopens as the overlay (and, with no layout host, is never stranded
+  hidden). This is the rf2-j538f7.41 surface-preserving contract; the
+  auto-open-on-error watcher (rf2-kggzi4) routes its reopen through here
+  — it is the THIRD reopen route, joining the `Ctrl+Shift+C` toggle and
+  the Cmd/Ctrl+K palette. Spec: 011-Launch-Modes §Closed state +
+  016-Auxiliary-Panels §Auto-open-on-error."
+  []
+  (call-mount-fn! "toggle_BANG_"))
+
 ;; ---- DOM helpers ---------------------------------------------------------
 
 (defn- shell-root-element
@@ -509,8 +523,11 @@
 ;;
 ;; The auto-open-on-error wiring is a sub-watcher: we subscribe to the
 ;; `:rf.xray/issues-ribbon` composite (registered in `registry.cljs`)
-;; and dispatch `mount/open!` on the first transition from empty →
-;; non-empty IFF the toggle is on AND Xray is not already visible. Two
+;; and drive the surface-preserving generic reopen `mount/toggle!` on
+;; the first transition from empty → non-empty IFF the toggle is on AND
+;; Xray is not already visible. (`toggle!` not `open!`: a reopen must
+;; not re-parent a hidden overlay back inline — rf2-kggzi4, mirroring
+;; the rf2-j538f7.41 fix on the palette + Ctrl+Shift+C routes.) Two
 ;; install triggers, both idempotent: (1) `mount/ensure-xray-frame!`
 ;; on first Xray open when the persisted toggle is on, (2)
 ;; `:rf.xray/settings-update` on toggle flip-on. Detached on flip-off.
@@ -553,9 +570,11 @@
 
 (defn install-auto-open-watcher!
   "Subscribe to `:rf.xray/issues-ribbon` and arrange for the watcher
-  to dispatch the late-bound `mount/open!` on the first transition
-  from empty → non-empty issue list IFF `:auto-open-on-error?` is on
-  AND Xray is not already visible.
+  to drive the late-bound surface-preserving reopen `mount/toggle!` on
+  the first transition from empty → non-empty issue list IFF
+  `:auto-open-on-error?` is on AND Xray is not already visible.
+  (`toggle!` reopens on the last-realized surface — rf2-kggzi4 —
+  rather than `open!`, which would revert a hidden overlay to inline.)
 
   The sub is created via a `(rf/capture-frame :rf/xray)` `:subscribe`
   so the watcher reads the Xray frame's app-db (where the issues feed
@@ -590,7 +609,14 @@
                                     (pos? n)
                                     (zero? prev)
                                     (not (visible-shell?)))
-                           (call-mount-fn! "open_BANG_"))))]
+                           ;; Surface-preserving reopen (rf2-kggzi4): the
+                           ;; `(not (visible-shell?))` guard above proves the
+                           ;; shell is hidden, so route through the mode-aware
+                           ;; `toggle!` (which reopens on the last-realized
+                           ;; surface) — NOT the surface-CHANGING `open!` that
+                           ;; would revert a hidden overlay to inline. See
+                           ;; `reopen-preserving-surface!`'s docstring.
+                           (reopen-preserving-surface!))))]
         ;; Seed the baseline from the reaction's CURRENT value before
         ;; `add-watch` — a reagent/re-frame reaction is already live the
         ;; instant `subscribe` returns (it may have run against issues

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -205,6 +205,61 @@
   (is (false? (config/get-setting :general :auto-open-on-error?))
       "config carries the flipped value"))
 
+;; ---- auto-open reopen preserves the realized surface (rf2-kggzi4) -------
+;;
+;; rf2-j538f7.41 made the two GLOBAL reopen routes (Ctrl+Shift+C toggle +
+;; Cmd/Ctrl+K palette) preserve the last-realized mount surface via
+;; `mount/toggle!`. The auto-open-on-error watcher was the THIRD reopen
+;; route and still hard-coded `mount/open!` — a surface CHANGE that would
+;; revert a hidden overlay to inline on auto-open. rf2-kggzi4 routes it
+;; through the shared `reopen-preserving-surface!` helper (→ `toggle!`).
+;;
+;; We unit-test that helper's routing directly (mirroring how
+;; mount_cljs_test's `toggle!-*` suite unit-tests the mount layer's own
+;; surface preservation): the auto-open GATE — the empty→non-empty edge +
+;; toggle-on + hidden — is covered by the watcher tests above. Note the
+;; full `install-auto-open-watcher!` `add-watch` path can't be driven
+;; under this suite's headless plain-atom adapter (its derived
+;; subscriptions reify `IDeref`/`IDisposable` only, not `IWatchable`);
+;; that reactive glue is exercised in the browser suites.
+
+(defn- with-recording-mount-exports
+  "Install a stub `window.day8.re_frame2_xray` whose mount exports each
+  record their own export name when invoked. Calls `(f invoked-atom)`,
+  then tears the stub window (and `day8`) back down."
+  [f]
+  (let [invoked     (atom [])
+        had-window? (exists? js/globalThis.window)
+        record      (fn [nm] (fn [] (swap! invoked conj nm) nil))]
+    (when-not had-window?
+      (set! (.-window js/globalThis) #js {}))
+    (let [win js/globalThis.window]
+      (set! (.-day8 win)
+            #js {"re_frame2_xray"
+                 #js {"open_BANG_"         (record "open_BANG_")
+                      "open_overlay_BANG_" (record "open_overlay_BANG_")
+                      "toggle_BANG_"       (record "toggle_BANG_")}})
+      (try
+        (f invoked)
+        (finally
+          (js-delete win "day8")
+          (when-not had-window?
+            (js-delete js/globalThis "window")))))))
+
+(deftest reopen-preserving-surface-routes-through-toggle-not-open
+  (testing "rf2-kggzi4 — the auto-open-on-error reopen route
+            (`reopen-preserving-surface!`) invokes the surface-preserving
+            `mount/toggle!` export, never the surface-changing `mount/open!`
+            (which would revert a hidden overlay to inline). Mirrors the
+            rf2-j538f7.41 fix on the Ctrl+Shift+C + palette routes."
+    (with-recording-mount-exports
+      (fn [invoked]
+        (#'effects/reopen-preserving-surface!)
+        (is (= ["toggle_BANG_"] @invoked)
+            "reopen invoked the surface-preserving toggle! export, and only it")
+        (is (not-any? #{"open_BANG_"} @invoked)
+            "reopen did NOT call the surface-changing open!")))))
+
 ;; ---- apply-all! ---------------------------------------------------------
 
 (deftest apply-all-restores-text-size-and-theme


### PR DESCRIPTION
Three disjoint Xray-domain correctness fixes, one commit each.

## rf2-wjl2qo — chrome.md drops the unshipped "head row pulses while live"
`skills/re-frame2-xray/references/chrome.md` §LIVE vs RETRO taught a head-row LIVE pulse that is not implemented in the shipped L2 spine (no head/focused-row animation; the only keyframes are `rf-xray-diff-flash` / `rf-xray-fade-in` / `dashdraw`; the mode pill was dropped in rf2-g9pee). Replaced with the actual live-state chrome: LIVE vs RETRO is conveyed by the `[◀ ▶ ⏭]` nav cluster plus the focused-row wash + leading `>` caret (which tracks the head in LIVE). The `grep pulse` acceptance now returns only the panels.md machine-pulse *retirement* lines (rf2-wct1s8), which are left untouched.

## rf2-tet4wy — SKILL.md frame-picker scope matches the scope matrix
The one-liner "every tab and the spine rebind to it" overstated scope, contradicting the package's own scope matrix (SKILL.md §Scope matrix), chrome.md §L1 frame picker, and panels.md §Scope model. Reworded to the mixed-scope model: the picker moves the per-frame *live* projections and the spine's observed frame; the process-global catalogues (Graph Declared, Frames, the Static definition catalogues) read the same in every frame and do not follow the picker. The mode-independent note is kept (the frame-observation axis moves in both Dynamic and Static).

## rf2-kggzi4 — auto-open-on-error reopen preserves the realized surface
The auto-open-on-error watcher (`settings/effects.cljs`) was the third generic-reopen route (after the `Ctrl+Shift+C` toggle + Cmd/Ctrl+K palette fixed in rf2-j538f7.41) that still hard-coded `mount/open!` — a surface CHANGE that reverts a hidden overlay mount back inline on auto-open. Routed through a new shared `reopen-preserving-surface!` helper (→ `mount/toggle!`), which reopens on the shell's last-realized surface.

- **Spec (same PR):** 016-Auxiliary-Panels §Auto-open-on-error now names `mount/toggle!` with the surface-preserving rationale; 011-Launch-Modes §Closed state enumerates the watcher as the third surface-preserving reopen route.
- **Regression:** `reopen-preserving-surface-routes-through-toggle-not-open` asserts the route invokes `toggle_BANG_` and never `open_BANG_`. (The full `install-auto-open-watcher!` `add-watch` path can't be driven under the node suite's headless plain-atom adapter — its derived subscriptions reify `IDeref`/`IDisposable` only, not `IWatchable`; that reactive glue is exercised in the browser suites.)

## Quality gates
- CLJS node-test suite (`npm run test:cljs`): **8600 tests / 40557 assertions, 0 failures, 0 errors** (exit 0).
- skill↔MCP allow-list drift: pass (0)
- docs corpus anchor validator (doc-slugs): pass (0)
- Xray tab-inventory drift: pass (0, 9 Dynamic tabs verified)
- skill eval-docs: pass (0)
- mkdocs: N/A — edited files (skills/re-frame2-xray/*, tools/xray/spec/*) are outside `docs_dir` and not snippet-included; `docs/skills/re-frame2-xray.md` only links to them.