### PR TITLE
fix(tools): mcp-base marker body-size cap, open-in-editor output drain, skill-drift self-test recipe (rf2-vd1uyn, rf2-j538f7.21, rf2-723lgn)

### DIFF
--- a/scripts/check_skill_re_frame2_drift.py
+++ b/scripts/check_skill_re_frame2_drift.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """No-bead-id + verification-posture + launcher-canonical + machine-handler-
-recipe drift guard for the re-frame2 (authoring) skill.
+recipe + managed-http-recipe drift guard for the re-frame2 (authoring) skill.
 
 `spec/design.md` is the single normative source for the skill's locked
 decisions (L1–L11), file structure, cardinal rules, and verification posture;
@@ -63,6 +63,24 @@ existing automated guards did not catch (the no-bead-id guard was scoped to
      warning that names the shape — so the retained advanced-note mention on
      `reg-machine.md` / `api-cheatsheet.md` stays legal, but a copy-pasteable
      footgun recipe cannot reappear in any user-facing leaf.
+
+  5. **The retired Managed-HTTP reply contract.** The runtime retired the
+     co-located reply default pre-alpha (`rf2-et4c1s` / PR #5449): every
+     `:rf.http/managed` fx-form request must now address its reply with at
+     least one of `:reply-to` / `:on-success` / `:on-failure`, and omitting all
+     three throws `:rf.error/http-no-reply-target` at fx-call time — a
+     targetless canonical recipe cannot even start a request. The skill's
+     primary HTTP example had drifted to teach exactly that removed shape
+     (`rf2-j538f7.35` / PR #5603 repaired the leaf prose). This guard makes the
+     retired teaching a build failure so it cannot re-enter: (5a) a fenced
+     fx-form `[:rf.http/managed …]` recipe that carries a `:request` but no
+     reply target; (5b) reading the removed co-located key `(:rf/reply …)`; and
+     (5c) bare `:work/id` asserted as a TRANSIENT reply field (whose spelling is
+     `:rf.reply/work-id` — bare `:work/id` is the durable ledger / machine-
+     `:data` / correlation identity). The machine-form `:spawn {:machine-id
+     :rf.http/managed …}` (which dispatches back to its parent and needs no
+     `:reply-to`), the `[:rf.http/managed-abort …]` dispatch, and legitimate
+     durable-ledger `:work/id` prose are deliberately allowed.
 
 Scanned leaves (globbed, so a new leaf is covered automatically):
     SKILL.md, README.md, references/**/*.md, patterns/**/*.md,
@@ -203,6 +221,117 @@ def machine_handler_recipe_problems(text: str) -> list[tuple[int, str]]:
     return problems
 
 
+# --- Rule 5: no retired Managed-HTTP reply-contract teaching (rf2-723lgn,
+#     follow-up to rf2-j538f7.35 / PR #5603).
+#
+# 5a — a targetless fx-form `:rf.http/managed` REQUEST recipe. The fx form
+#      `:fx [[:rf.http/managed {:request …}]]` MUST address its reply with at
+#      least one of :reply-to / :on-success / :on-failure; the runtime throws
+#      :rf.error/http-no-reply-target at fx-call time otherwise, so a targetless
+#      canonical recipe cannot even start a request (there is no co-located
+#      default that routes the reply back to the originating event). Scanned
+#      per-FENCED-BLOCK (the tokens span lines). Only the `[:rf.http/managed`
+#      fx invocation head is matched — never `:machine-id :rf.http/managed` (the
+#      machine-form spawn dispatches back to its parent and needs no reply key)
+#      and never `[:rf.http/managed-abort …]` (a dispatch with no :request).
+FX_MANAGED_RE = re.compile(r"\[:rf\.http/managed(?!-)\b")
+HTTP_REQUEST_RE = re.compile(r":request\b")
+HTTP_REPLY_TARGET_RE = re.compile(r":reply-to\b|:on-success\b|:on-failure\b")
+MANAGED_HTTP_TARGETLESS_MSG = (
+    "HTTP-TARGETLESS-RECIPE: this fenced fx-form `:rf.http/managed` recipe "
+    "supplies a `:request` but names NO reply target. The current contract "
+    "REQUIRES at least one of `:reply-to` / `:on-success` / `:on-failure`; "
+    "omitting all three throws :rf.error/http-no-reply-target at fx-call time, "
+    "so the recipe cannot start a request — there is no co-located default that "
+    "routes the reply back to the originating event (retired pre-alpha, "
+    "rf2-et4c1s / PR #5449). Add an explicit reply target. (The machine-form "
+    "`:spawn {:machine-id :rf.http/managed …}` dispatches back to its parent "
+    "and is the allowed exception — it is not matched here.)"
+)
+
+# 5b — reading the RETIRED co-located reply key `(:rf/reply …)`. The current
+#      contract has no implicit reply routed back to the originating event, so a
+#      handler that reads `:rf/reply` teaches the removed recipe. The negative
+#      lookahead excludes the internal descriptor `:rf/reply-to`; the transient
+#      `:rf.reply/work-id` is a different token and never matches.
+RF_REPLY_READ_RE = re.compile(r":rf/reply(?![-\w])")
+
+# 5c — bare `:work/id` asserted as a TRANSIENT reply field. The reply map /
+#      payload / envelope spells the attempt identity `:rf.reply/work-id`; bare
+#      `:work/id` is the durable ledger / machine-`:data` / correlation identity.
+#      Fires only in a reply-map context carrying bare `:work/id` UNLESS the line
+#      also spells `:rf.reply/work-id` or marks the id as the durable / ledger /
+#      machine-`:data` / correlation / verification / abstract identity.
+REPLYMAP_CTX_RE = re.compile(
+    r"reply map|reply payload|reply envelope|transient reply", re.IGNORECASE
+)
+BARE_WORKID_RE = re.compile(r"`:work/id`")
+WORKID_ALLOW_RE = re.compile(
+    r":rf\.reply/work-id|ledger|durab|verification|abstract|:data|correlat",
+    re.IGNORECASE,
+)
+
+
+def reply_contract_problems(line: str) -> list[str]:
+    """Rule 5b/5c — retired Managed-HTTP reply-contract teaching on a single
+    line: reading the removed `:rf/reply` co-located key, or spelling bare
+    `:work/id` on a transient reply map. (5a is a cross-line fenced-block shape,
+    scanned separately in `managed_http_recipe_problems`.)"""
+    problems: list[str] = []
+    if RF_REPLY_READ_RE.search(line):
+        problems.append(
+            "HTTP-REPLY-CO-LOCATED: `:rf/reply` is the RETIRED co-located reply "
+            "key. The current Managed HTTP contract routes replies to an EXPLICIT "
+            "target (`:reply-to` / `:on-success` / `:on-failure`), not back to "
+            "the originating event, and omitting a target throws "
+            ":rf.error/http-no-reply-target. Don't read `:rf/reply` — branch on "
+            "`(:status reply)` in the reply handler (spec/Managed-Effects.md, "
+            "patterns/managed-http.md)."
+        )
+    if (
+        REPLYMAP_CTX_RE.search(line)
+        and BARE_WORKID_RE.search(line)
+        and not WORKID_ALLOW_RE.search(line)
+    ):
+        problems.append(
+            "HTTP-REPLY-WORKID-SPELLING: the TRANSIENT reply map spells the "
+            "attempt identity `:rf.reply/work-id`; bare `:work/id` is the durable "
+            "ledger / machine-`:data` / correlation identity. Don't put bare "
+            "`:work/id` on the reply map (one fact, two spellings across the "
+            "record↔reply boundary — spec/Managed-Effects.md)."
+        )
+    return problems
+
+
+def managed_http_recipe_problems(text: str) -> list[tuple[int, str]]:
+    """Rule 5a — a fenced code block whose fx-form `[:rf.http/managed …]`
+    invocation carries a `:request` args map but names no reply target is the
+    retired targetless canonical recipe. Returns (opening-fence-lineno, message)
+    tuples. Scanned per-FENCED-BLOCK (the tokens span lines of one block); the
+    machine-form `:machine-id :rf.http/managed` spawn and the
+    `[:rf.http/managed-abort …]` dispatch are deliberately not matched."""
+    problems: list[tuple[int, str]] = []
+    in_block = False
+    block_start = 0
+    block_lines: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if FENCE_RE.match(line):
+            if not in_block:
+                in_block, block_start, block_lines = True, lineno, []
+            else:
+                body = "\n".join(block_lines)
+                if (
+                    FX_MANAGED_RE.search(body)
+                    and HTTP_REQUEST_RE.search(body)
+                    and not HTTP_REPLY_TARGET_RE.search(body)
+                ):
+                    problems.append((block_start, MANAGED_HTTP_TARGETLESS_MSG))
+                in_block, block_lines = False, []
+        elif in_block:
+            block_lines.append(line)
+    return problems
+
+
 # --- Rule 3: launcher points at BOTH canonical files, without regrowing the
 #     tree / locks sections. Operates on the whole authoring-prompt.md body
 #     (not the line-by-line leaf scan). `design.md` / `inputs.md` are the
@@ -309,12 +438,16 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
         body = _slurp(path)
         for lineno, line in enumerate(body.splitlines(), start=1):
             lines_checked += 1
-            for label in beadid_problems(line) + posture_problems(line):
+            for label in (beadid_problems(line) + posture_problems(line)
+                          + reply_contract_problems(line)):
                 problems.append(f"{rel}:{lineno}: {label}\n    {line.strip()}")
-        # Rule 4 — the machine-registration footgun is a cross-line shape
-        # (reg-event and make-machine-handler on different lines of one fenced
-        # block), so it is scanned per-block rather than per-line.
+        # Rules 4 & 5a — the machine-registration footgun and the targetless
+        # Managed-HTTP recipe are cross-line shapes (their tokens land on
+        # different lines of one fenced block), so they are scanned per-block
+        # rather than per-line.
         for start_lineno, label in machine_handler_recipe_problems(body):
+            problems.append(f"{rel}:{start_lineno}: {label}")
+        for start_lineno, label in managed_http_recipe_problems(body):
             problems.append(f"{rel}:{start_lineno}: {label}")
 
     # Rule 3 — the launcher (authoring-prompt.md) is checked as a whole body,
@@ -346,9 +479,9 @@ def run(*, verbose: bool, ci: bool) -> int:
     if verbose:
         print(
             "re-frame2 no-bead-id + verify-posture + launcher-canonical + "
-            f"machine-handler-recipe guard: scanned {len(files)} user-facing "
-            f"leaves ({lines_checked} lines) plus the spec/authoring-prompt.md "
-            "launcher."
+            "machine-handler-recipe + managed-http-recipe guard: scanned "
+            f"{len(files)} user-facing leaves ({lines_checked} lines) plus the "
+            "spec/authoring-prompt.md launcher."
         )
 
     if not problems:
@@ -356,8 +489,9 @@ def run(*, verbose: bool, ci: bool) -> int:
             print(
                 "re-frame2-drift: no bead-id leaks, no agent-run verification-"
                 "posture drift, no bare reg-event + make-machine-handler recipe, "
-                "and the launcher points at design.md + inputs.md without "
-                "regrowing the tree / locks."
+                "no retired Managed-HTTP reply-contract teaching, and the "
+                "launcher points at design.md + inputs.md without regrowing the "
+                "tree / locks."
             )
         return 0
 
@@ -369,7 +503,9 @@ def run(*, verbose: bool, ci: bool) -> int:
         "bead ids out of the user-facing leaves (L10), keep the "
         "authoring-only verification posture (Q14 / L3: the author runs the "
         "gates, the skill names them), author machines with reg-machine (not a "
-        "bare reg-event + make-machine-handler recipe), and keep the launcher "
+        "bare reg-event + make-machine-handler recipe), address every Managed-"
+        "HTTP reply with an explicit :reply-to/:on-success/:on-failure (no "
+        "retired co-located `:rf/reply` default), and keep the launcher "
         "pointing at the canonical design.md + inputs.md instead of re-holding "
         "the tree / locks."
     )
@@ -581,6 +717,105 @@ def _self_test() -> int:
     expect(
         machine_handler_recipe_problems, clean_simple,
         dirty=False, label="I3 fenced plain reg-event (no machine handler)",
+    )
+
+    # --- Rule 5a: targetless fx-form :rf.http/managed recipe (rf2-723lgn).
+    #     `managed_http_recipe_problems` takes the WHOLE body (the tokens span
+    #     lines of one fenced block), so these fixtures are multi-line prose
+    #     with fences.
+    dirty_targetless_http = (
+        "Issue the request:\n\n"
+        "```clojure\n"
+        "(rf/reg-event :article/load\n"
+        "  (fn [_ _]\n"
+        "    {:fx [[:rf.http/managed {:request {:url \"/x\"} :decode S}]]}))\n"
+        "```\n"
+    )
+    expect(
+        managed_http_recipe_problems, dirty_targetless_http,
+        dirty=True, label="J1 fx-form :rf.http/managed request with no reply target",
+    )
+    # CLEAN — the corrected fx recipe with an explicit reply target.
+    clean_http_reply_to = (
+        "```clojure\n"
+        "{:fx [[:rf.http/managed {:request {:url \"/x\"} :reply-to [:article/replied]}]]}\n"
+        "```\n"
+    )
+    expect(
+        managed_http_recipe_problems, clean_http_reply_to,
+        dirty=False, label="K1 fx-form request WITH :reply-to (explicit address)",
+    )
+    clean_http_split_sugar = (
+        "```clojure\n"
+        "{:fx [[:rf.http/managed {:request {:url \"/x\"}\n"
+        "                         :on-success [:ok] :on-failure [:err]}]]}\n"
+        "```\n"
+    )
+    expect(
+        managed_http_recipe_problems, clean_http_split_sugar,
+        dirty=False, label="K2 fx-form request WITH :on-success/:on-failure split sugar",
+    )
+    # CLEAN — the machine-form spawn dispatches back to its parent; no :reply-to.
+    clean_http_machine_form = (
+        "```clojure\n"
+        "{:authenticating\n"
+        " {:spawn {:machine-id :rf.http/managed :data {:request {:url \"/login\"}}}}}\n"
+        "```\n"
+    )
+    expect(
+        managed_http_recipe_problems, clean_http_machine_form,
+        dirty=False, label="K3 machine-form :spawn of :rf.http/managed (no reply key needed)",
+    )
+    # CLEAN — the abort dispatch is not a request recipe.
+    clean_http_abort = (
+        "```clojure\n"
+        "(rf/dispatch [:rf.http/managed-abort req-id])\n"
+        "```\n"
+    )
+    expect(
+        managed_http_recipe_problems, clean_http_abort,
+        dirty=False, label="K4 :rf.http/managed-abort dispatch (no request)",
+    )
+
+    # --- Rule 5b: reading the retired co-located `:rf/reply` key. DRIFT fixture.
+    expect(
+        reply_contract_problems,
+        "(rf/reg-event :article/load (fn [_ [_ msg]] (when-let [r (:rf/reply msg)] r)))",
+        dirty=True, label="L1 reads the retired co-located :rf/reply key",
+    )
+    # CLEAN — the current explicit-target contract and the INTERNAL descriptor.
+    expect(
+        reply_contract_problems,
+        "The request names `:reply-to [:article/replied]`; the handler branches on `(:status reply)`.",
+        dirty=False, label="M1 explicit :reply-to target, no :rf/reply read",
+    )
+    expect(
+        reply_contract_problems,
+        "The public `:reply-to` normalizes to the internal `:rf/reply-to` descriptor.",
+        dirty=False, label="M2 internal :rf/reply-to descriptor is not the retired :rf/reply",
+    )
+
+    # --- Rule 5c: bare :work/id on a transient reply map. DRIFT fixture.
+    expect(
+        reply_contract_problems,
+        "The reply map exposes `:status`, `:value`, and `:work/id`.",
+        dirty=True, label="N1 bare :work/id asserted on the transient reply map",
+    )
+    # CLEAN — the transient spelling, and legitimate durable-ledger prose.
+    expect(
+        reply_contract_problems,
+        "The durable ledger row keeps bare `:work/id`; the transient reply map spells `:rf.reply/work-id`.",
+        dirty=False, label="O1 reply map spells :rf.reply/work-id; ledger keeps bare :work/id",
+    )
+    expect(
+        reply_contract_problems,
+        "The reply envelope correlates a late completion by the child's `:work/id` for stale suppression.",
+        dirty=False, label="O2 :work/id as the correlation identity is allowed",
+    )
+    expect(
+        reply_contract_problems,
+        "The durable work-ledger row is keyed by bare `:work/id`.",
+        dirty=False, label="O3 durable-ledger :work/id prose (no reply-map context)",
     )
 
     if failures:

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -44,10 +44,13 @@ Is `text` (the rendered EDN text of a response's first content slot) a wire-boun
 
 Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns the shared recognition logic across hosts.
 
-Two gates, **both required**:
+Three gates, **all required**:
 
 1. A cheap **leading-token pre-filter** — the EXACT marker key must be the first top-level key, not merely a prefix of it (see §Exact-key match below): a lookalike leading key such as `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` is NOT a marker.
-2. A **structural confirmation** — the whole `text` must parse to a closed single-key map whose sole key is a marker key and whose body is a map (see §Closed-wrapper confirmation below).
+2. A **size bound** — the rendered text must estimate within the documented default cap `overflow/default-max-tokens` (see §Size bound below). Closure alone does not bound the marker's SIZE, so a single-key wrapper with an over-budget body is NOT a marker.
+3. A **structural confirmation** — the whole `text` must parse to a closed single-key map whose sole key is a marker key and whose body is a map (see §Closed-wrapper confirmation below).
+
+Together the three gates make the fast-path invariant TRUE: anything `marker-text?` accepts is a closed single-key `:rf.mcp/*` map guaranteed under the default cap.
 
 Nil-safe: a nil / non-string `text` is not a marker.
 
@@ -87,6 +90,18 @@ So after the leading-token pre-filter matches, `marker-text?` **parses the whole
 - a **map** body (additive body fields are permitted where the conformance schema allows them — only the OUTER wrapper must be closed).
 
 The read reuses `cursor.md`'s host-agnostic *one form, EOF-exhausted, tagged-literals-rejected* technique (wrap as `[<text> <eof-sentinel>]`, require the read to yield exactly `[<one-form> <eof-sentinel>]`). This rejects — identically on `clojure.edn` (JVM) and `cljs.reader` (CLJS) — an extra top-level sibling, a trailing EDN form, an injected `]` truncation, any tagged literal (built-in `#inst`/`#uuid` or custom `#js`/`#foo`), and a non-map root/body. Anything that fails the confirmation is ordinary/malformed payload and continues through cap enforcement. The cheap path for genuinely generated markers is preserved: their pre-filter matches and the parse confirms a closed single-key map, with no overflow-of-overflow recursion.
+
+## Size bound
+
+Closure proves the wrapper is closed but NOT small. A **complete, closed, single-key** wrapper whose body is arbitrarily large —
+
+```clojure
+{:rf.mcp/overflow {:limit :reached :blob "<100 KB of x's>"}}
+```
+
+— passes the leading-token and closed-wrapper gates yet renders to ~25 000 tokens, far over the ~5 000-token default cap. Treating it as sub-cap-by-construction would let the fast-path skip egress an over-budget payload un-capped — the BODY dimension of the same reserved-`:rf.mcp/*`-namespace threat the closed-wrapper gate closes for the extra-sibling dimension.
+
+So `marker-text?` also requires the rendered text to estimate within the documented default cap: `(<= (overflow/token-estimate text) overflow/default-max-tokens)`. This expresses "sub-cap by construction" **directly** against the convention cap. The two real markers are tiny fixed-shape maps (a few hundred chars ≈ ~100 tokens), so they pass with vast headroom; only an over-budget reserved-key-shaped payload is caught. Consequently anything `marker-text?` accepts is guaranteed under the default cap, so skipping the cap step on it can never leak an over-default-cap body. The O(1) length check also short-circuits an adversarial 100 KB input before the O(n) closed-wrapper read.
 
 ## Indicator-field parity
 

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -29,6 +29,7 @@
   consumer-side while the prefix-detection logic is shared."
   (:require [clojure.string :as str]
             #?(:clj [clojure.edn :as edn])
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab])
   #?(:cljs (:require [cljs.reader])))
 
@@ -244,10 +245,43 @@
            (and (contains? marker-keys k)
                 (map? body))))))
 
+;; ---------------------------------------------------------------------------
+;; Size bound — the BODY dimension of "sub-cap by construction".
+;;
+;; Closure alone does not bound the marker's SIZE. A COMPLETE, CLOSED,
+;; single-key `{:rf.mcp/overflow {:blob <100 KB>}}` passes both gates above
+;; (leading token + closed single-key map body) yet its rendered text is
+;; arbitrarily large. Classifying it as a marker lets the fast-path skip
+;; egress an over-budget payload un-capped — a reserved-`:rf.mcp/*`-namespace
+;; handler result (the same abnormal precondition rf2-j538f7.20's sibling
+;; case required) bypassing cap enforcement. rf2-vd1uyn.
+;;
+;; The invariant the skip actually relies on is "a marker is sub-cap BY
+;; CONSTRUCTION". We enforce it DIRECTLY against the documented convention
+;; cap (`overflow/default-max-tokens`): a marker candidate whose rendered
+;; text estimates over the default cap is NOT sub-cap by construction, so it
+;; is not a marker and falls through to normal cap enforcement. The two real
+;; markers are tiny fixed-shape maps (a few hundred chars ≈ ~100 tokens), so
+;; they pass with vast headroom; only an over-budget reserved-key-shaped
+;; payload is caught. Anything this fn calls a marker is therefore GUARANTEED
+;; under the default cap — skipping the cap step on it can never leak an
+;; over-default-cap body. The O(1) `count` also short-circuits an adversarial
+;; 100 KB input before the O(n) `closed-marker-envelope?` read.
+;; ---------------------------------------------------------------------------
+
+(defn- marker-sized?
+  "Is `text` small enough to be a genuine, sub-cap-by-construction marker —
+  i.e. does its rendered-text token estimate stay within the documented
+  default cap (`overflow/default-max-tokens`)? A single-key reserved-`:rf.mcp/*`
+  wrapper whose BODY pushes the rendered text over the default cap is NOT a
+  marker (rf2-vd1uyn); it continues through cap enforcement like any payload."
+  [text]
+  (<= (overflow/token-estimate text) overflow/default-max-tokens))
+
 (defn marker-text?
   "Is `text` (the rendered EDN text of a response's first content slot)
   a wire-bounded `:rf.mcp/*` marker envelope — a COMPLETE, CLOSED,
-  single-key marker map?
+  single-key marker map whose BODY is within the default cap?
 
   Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers —
   the two envelopes the cache + cap steps emit themselves. The
@@ -255,18 +289,24 @@
   Clojure map, `j/get :text` from a JS object) and passes the string
   here; this fn owns the shared recognition logic across hosts.
 
-  Two gates, both required:
+  Three gates, all required:
 
     1. A cheap leading-token PRE-FILTER — the EXACT marker key must be
        the first top-level key (not merely a prefix of it): a lookalike
        leading key such as `:rf.mcp/overflowed` or
        `:rf.mcp/cache-hit-extra` is NOT a marker (see §Exact-key match
        in envelope.md).
-    2. A structural CONFIRMATION — the whole `text` must parse to a
+    2. A SIZE bound — the rendered text must estimate within the
+       documented default cap (`marker-sized?`). Closure proves the
+       wrapper is closed but NOT small; a single-key
+       `{:rf.mcp/overflow {…100 KB…}}` is closed yet over-budget.
+       Bounding the body is the BODY dimension of \"sub-cap by
+       construction\": an over-budget single-key marker is NOT a marker
+       and continues through cap enforcement (rf2-vd1uyn).
+    3. A structural CONFIRMATION — the whole `text` must parse to a
        closed single-key map whose sole key is a marker key and whose
        body is a map. The pre-filter proves only the FIRST key; this
-       proves the invariant the fast-path skip relies on: that the
-       marker is sub-cap BY CONSTRUCTION. A mixed wrapper with an
+       proves the OUTER wrapper is closed. A mixed wrapper with an
        unexpected top-level sibling
        (`{:rf.mcp/overflow {...} :unexpected \"<big>\"}`), a trailing
        EDN form, a tagged literal, or a non-map root/body is NOT a
@@ -274,9 +314,14 @@
        Additive fields inside the body remain allowed — only the OUTER
        wrapper must be closed.
 
+  Gates 1-3 together make the invariant the fast-path skip relies on TRUE:
+  anything this fn calls a marker is a closed single-key `:rf.mcp/*` map
+  GUARANTEED under the default cap.
+
   Nil-safe: a nil / non-string `text` is not a marker."
   [text]
   (boolean
     (and (string? text)
+         (marker-sized? text)
          (some #(exact-marker-prefix? text %) marker-prefixes)
          (closed-marker-envelope? text))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -548,6 +548,33 @@
     (is (false? (envelope/marker-text? nil)))))
 
 ;; ---------------------------------------------------------------------------
+;; 7c. marker-text? bounds the marker BODY size on CLJS too (rf2-vd1uyn).
+;;     Closure alone does NOT bound the marker's SIZE: a CLOSED single-key
+;;     {:rf.mcp/overflow {…huge…}} is over-budget by construction, yet the
+;;     pre-fix recogniser returned true and let the pair-mcp fast-path skip
+;;     egress it un-capped. The size gate bounds the rendered text at the
+;;     documented default cap, so an over-default-cap single-key marker is
+;;     NOT skip-eligible and continues through cap enforcement. This runs on
+;;     the CLJS runtime the pair server actually executes (FLAT print form).
+;; ---------------------------------------------------------------------------
+
+(deftest marker-text?-bounds-body-size-cljs
+  (let [over-budget (apply str (repeat (* 8 overflow/default-max-tokens) "x"))] ;; ~2× the default cap
+    (is (> (overflow/token-estimate over-budget) overflow/default-max-tokens)
+        "precondition: the injected body estimates over the default cap")
+    (testing "RED-then-GREEN: an over-budget single-key marker is NOT a marker on CLJS"
+      (is (false? (envelope/marker-text?
+                    (pr-str {vocab/overflow-key {:limit :reached :blob over-budget}})))
+          "an over-default-cap overflow BODY must be capped on CLJS, not skipped")
+      (is (false? (envelope/marker-text?
+                    (pr-str {vocab/cache-hit-key {:tool "x" :blob over-budget}})))
+          "the same hole for cache-hit on CLJS")))
+  (testing "genuine tiny markers stay under the bound and STILL take the fast path"
+    (is (true? (envelope/marker-text?
+                 (pr-str {vocab/overflow-key {:limit :reached :token-count 9000 :cap-tokens 5000}}))))
+    (is (true? (envelope/marker-text? (pr-str {vocab/cache-hit-key {:hash "abc" :tool "snapshot"}}))))))
+
+;; ---------------------------------------------------------------------------
 ;; 8. `sensitive.cljc` CLJS reader-conditional arms.
 ;;
 ;;    `re-frame.mcp-base.sensitive` is the spec/009 §Privacy default-suppress

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -4,6 +4,7 @@
   marker detection."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.envelope :as envelope]
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---------------------------------------------------------------------------
@@ -188,3 +189,35 @@
     (is (true? (envelope/marker-text? (pr-str {vocab/cache-hit-key {:tool "x" :hash "abc"}}))))
     ;; Even under a tiny additive body — additive fields inside the body are fine.
     (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached :extra :ok}}")))))
+
+(deftest marker-text?-bounds-body-size-not-just-closure
+  ;; rf2-vd1uyn. Closure alone does NOT bound the marker BODY size. A
+  ;; COMPLETE, CLOSED, single-key {:rf.mcp/overflow {…huge…}} passes the
+  ;; leading-token + closed-wrapper gates yet its rendered text is
+  ;; arbitrarily large — over-budget by construction. The pre-fix recogniser
+  ;; returned true and let the fast-path skip egress it un-capped (100 KB ≈
+  ;; 25k tokens ≫ the 5k default cap). The size gate makes "a marker is
+  ;; sub-cap BY CONSTRUCTION" TRUE for the recogniser: an over-default-cap
+  ;; single-key marker is NOT skip-eligible and continues through cap
+  ;; enforcement. This is the BODY-SIZE dimension of the same threat the
+  ;; sibling-key test (rf2-j538f7.20) covers for the extra-sibling dimension.
+  (let [over-budget (apply str (repeat (* 8 overflow/default-max-tokens) "x"))] ;; ~2× the default cap
+    (testing "the injected body really is over the default cap (non-vacuous)"
+      (is (> (overflow/token-estimate over-budget) overflow/default-max-tokens)))
+    (testing "RED-then-GREEN: an over-budget-BODY single-key overflow marker is NOT a marker"
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/overflow-key {:limit :reached :blob over-budget}))))
+          "an over-default-cap overflow BODY must be capped, not skipped")
+      (is (false? (envelope/marker-text?
+                    (pr-str (array-map vocab/cache-hit-key {:tool "x" :blob over-budget}))))
+          "the same hole for cache-hit"))
+    (testing "both print forms of the over-budget marker are rejected (host-agnostic)"
+      (is (false? (envelope/marker-text?
+                    (binding [*print-namespace-maps* false]
+                      (pr-str (array-map vocab/overflow-key {:blob over-budget}))))))
+      (is (false? (envelope/marker-text?
+                    (binding [*print-namespace-maps* true]
+                      (pr-str (array-map vocab/overflow-key {:blob over-budget}))))))))
+  (testing "genuine tiny markers stay under the bound and STILL take the fast path"
+    (is (true? (envelope/marker-text? (pr-str (overflow-fixture)))))
+    (is (true? (envelope/marker-text? (pr-str {vocab/cache-hit-key {:tool "x" :hash "abc"}}))))))

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -9,7 +9,8 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.source-coords.editor-uri :as editor-uri])
   (:import [java.net URI]
-           [java.io File]))
+           [java.io File InputStream InputStreamReader]
+           [java.util.concurrent TimeUnit]))
 
 (set! *warn-on-reflection* true)
 
@@ -89,12 +90,67 @@
       line   (str ":" line)
       column (str ":" column))))
 
+(def ^:dynamic *launch-timeout-ms*
+  "Max wall-clock ms to wait for the launch child to exit before terminating
+  it and reporting a timeout. Dynamic so tests can shrink the budget to
+  exercise the timeout branch without a real ten-second stall."
+  10000)
+
+(def ^:private stderr-diagnostic-cap
+  "Max chars of child stderr retained as a launch diagnostic. The stream is
+  ALWAYS drained to EOF (so the child's stderr pipe can never fill and block
+  the child before it exits); only the RETAINED head is bounded, so a runaway
+  dependency cannot trade the pipe deadlock for unbounded parent memory."
+  8192)
+
+(defn ^:private drain-stream
+  "Read `in` to EOF, returning up to `stderr-diagnostic-cap` chars of its head.
+  ALWAYS consumes the whole stream — draining the OS pipe even past the
+  retained cap. Runs on its own thread (a future) concurrently with the timed
+  wait so a child that fills its stderr pipe still makes progress to exit,
+  rather than blocking on a write the parent hasn't read. Never throws."
+  [^InputStream in]
+  (let [sb  (StringBuilder.)
+        buf (char-array 4096)
+        cap (int stderr-diagnostic-cap)]
+    (try
+      (with-open [r (InputStreamReader. in java.nio.charset.StandardCharsets/UTF_8)]
+        (loop []
+          (let [n (.read r buf)]
+            (when-not (neg? n)                       ;; -1 = EOF
+              (let [room (- cap (.length sb))]
+                (when (and (pos? n) (pos? room))
+                  (.append sb buf (int 0) (int (min n room)))))
+              (recur)))))
+      (catch Throwable _ nil))
+    (.toString sb)))
+
+(defn ^:private terminate!
+  "Best-effort stop of a child that overran its budget: destroy, wait briefly,
+  then FORCE-destroy if it is still alive and wait again. Returns true when the
+  child is confirmed dead. Force-termination is the fallback for a child that
+  ignores the graceful destroy signal."
+  [^Process proc]
+  (.destroy proc)
+  (when (and (.isAlive proc)
+             (not (.waitFor proc 500 TimeUnit/MILLISECONDS)))
+    (.destroyForcibly proc)
+    (.waitFor proc 1000 TimeUnit/MILLISECONDS))
+  (not (.isAlive proc)))
+
 (defn launch!
   "Invoke launch-editor from the dev JVM cwd and return `{:ok ...}`.
 
   Missing files are rejected before spawning Node because launch-editor
   otherwise exits successfully without opening anything. Other failures are
-  returned as messages instead of escaping the Ring boundary."
+  returned as messages instead of escaping the Ring boundary.
+
+  The child's pipes are owned before the wait: stdout is DISCARDed (the
+  endpoint never consumes it) and stderr is drained CONCURRENTLY on its own
+  thread. OS pipes are bounded, so a child that fills an undrained pipe blocks
+  on the write and never reaches `process.exit` — the parent would then time
+  out waiting for an exit its own undrained pipe prevents (rf2-j538f7.21). A
+  bounded head of stderr is retained as the failure diagnostic."
   [abs-path line column command]
   (if-not (file-exists? abs-path)
     {:ok false :message "file-not-found"}
@@ -103,21 +159,28 @@
                  command (conj command))]
       (try
         (let [pb (doto (ProcessBuilder. ^java.util.List args)
-                   (.redirectErrorStream false))
-              _  (.directory pb (File. (System/getProperty "user.dir")))
-              proc (.start pb)
-              ;; Bound the wait so Node cannot wedge a dev-server thread.
-              done? (.waitFor proc 10 java.util.concurrent.TimeUnit/SECONDS)
-              exit  (when done? (.exitValue proc))
-              err   (when done?
-                      (slurp (.getErrorStream proc)))]
-          (cond
-            (not done?)  (do (.destroy proc)
-                             {:ok false :message "launch-editor timed out"})
-            (zero? exit) {:ok true}
-            :else        {:ok false
-                          :message (or (when (seq err) (str/trim err))
-                                       (str "launch-editor exited " exit))}))
+                   ;; stdout is unused by the endpoint — discard it so a chatty
+                   ;; child can never fill an undrained stdout pipe and wedge.
+                   (.redirectOutput java.lang.ProcessBuilder$Redirect/DISCARD)
+                   (.redirectErrorStream false)
+                   (.directory (File. (System/getProperty "user.dir"))))
+              proc      (.start pb)
+              ;; Drain stderr CONCURRENTLY with the wait — the whole point: a
+              ;; child that fills its stderr pipe must still reach exit.
+              err-drain (future (drain-stream (.getErrorStream proc)))
+              done?     (.waitFor proc (long *launch-timeout-ms*) TimeUnit/MILLISECONDS)]
+          (if-not done?
+            ;; The child overran its budget: kill it (which EOFs stderr, so the
+            ;; drain future completes on its own) and report the timeout.
+            (do (terminate! proc)
+                {:ok false :message "launch-editor timed out"})
+            (let [exit (.exitValue proc)
+                  err  (deref err-drain 1000 "")]
+              (if (zero? exit)
+                {:ok true}
+                {:ok false
+                 :message (or (when (seq err) (str/trim err))
+                              (str "launch-editor exited " exit))}))))
         (catch Throwable t
           {:ok false :message (.getMessage t)})))))
 

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -465,6 +465,128 @@
     (is (= {:ok false :message "file-not-found"} (oies/launch! nil 1 1 nil)))
     (is (= {:ok false :message "file-not-found"} (oies/launch! "   " 1 1 nil)))))
 
+;; ---------------------------------------------------------------------------
+;; Real-subprocess pipe-drain regressions (rf2-j538f7.21).
+;;
+;; OS pipes are bounded (~64 KiB). The pre-fix `launch!` called `.waitFor`
+;; BEFORE reading either child pipe and never read stdout at all — so a child
+;; that filled either pipe blocked on the write, could not reach `process.exit`,
+;; and the JVM timed out waiting for an exit its own undrained pipe prevented.
+;; These spawn REAL node children (the boundary the unit path never exercised
+;; — every other launch! test stubs launch! or stops at missing-file rejection)
+;; that write MORE than a pipe's worth to stdout / stderr. With the fix (stdout
+;; DISCARDed, stderr drained concurrently) each child exits and `launch!`
+;; classifies it correctly. Each test rebinds a short `*launch-timeout-ms*`
+;; budget so a reintroduced wait-before-drain fails as a BOUNDED timeout result
+;; rather than hanging the suite.
+;; ---------------------------------------------------------------------------
+
+(defn ^:private node-available?
+  "Whether a `node` binary is on PATH — the real-subprocess regressions below
+  need it. Returns false (⇒ the test self-skips with a note) rather than
+  hard-failing on a node-less box."
+  []
+  (try
+    (let [p (.start (ProcessBuilder. ["node" "--version"]))]
+      (and (.waitFor p 10 java.util.concurrent.TimeUnit/SECONDS)
+           (zero? (.exitValue p))))
+    (catch Throwable _ false)))
+
+(def ^:private one-mib-plus
+  "Comfortably more than a plausible OS pipe buffer (~64 KiB)."
+  1200000)
+
+(defn ^:private tmp-existing-file
+  "A real on-disk file whose absolute path `launch!` accepts (file-exists?),
+  so the launch path is reached without opening an editor."
+  []
+  (doto (File/createTempFile "oies-drain-" ".cljs") (.deleteOnExit)))
+
+(defmacro ^:private timed
+  "Eval `body`, returning `[result elapsed-ms]`."
+  [& body]
+  `(let [t0# (System/nanoTime)
+         r#  (do ~@body)]
+     [r# (quot (- (System/nanoTime) t0#) 1000000)]))
+
+(deftest launch-drains-huge-stdout-and-reports-success
+  ;; Criterion 1: a child that floods STDOUT (>1 MiB) and exits 0 is a SUCCESS,
+  ;; reached promptly — never the timeout the undrained-stdout deadlock
+  ;; manufactured. The 8 s budget bounds a reintroduced wait-before-drain to a
+  ;; timeout RESULT at ~8 s (this assertion then goes red) instead of hanging.
+  (if-not (node-available?)
+    (is true "skipped: node not on PATH")
+    (let [f    (tmp-existing-file)
+          shim (str "var b='x'.repeat(" one-mib-plus ");"
+                    "process.stdout.write(b);process.exit(0);")]
+      (with-redefs [oies/launch-shim shim]
+        (binding [oies/*launch-timeout-ms* 8000]
+          (let [[res ms] (timed (oies/launch! (.getAbsolutePath f) nil nil nil))]
+            (is (= {:ok true} res)
+                "a >1 MiB stdout flood + exit 0 is a prompt success, not a timeout")
+            (is (< ms 8000)
+                "returned well within the budget — the child was not wedged by its own pipe")))))))
+
+(deftest launch-drains-huge-stderr-and-reports-bounded-failure
+  ;; Criterion 2: a child that floods STDERR (>1 MiB) and exits nonzero is a
+  ;; FAILURE carrying a BOUNDED diagnostic (never the timeout, never unbounded
+  ;; memory), plus a small-stderr control.
+  (if-not (node-available?)
+    (is true "skipped: node not on PATH")
+    (let [f (tmp-existing-file)]
+      (testing "huge stderr + nonzero exit ⇒ bounded non-timeout diagnostic"
+        (let [shim (str "var b='y'.repeat(" one-mib-plus ");"
+                        "process.stderr.write(b);process.exit(7);")]
+          (with-redefs [oies/launch-shim shim]
+            (binding [oies/*launch-timeout-ms* 8000]
+              (let [[res ms] (timed (oies/launch! (.getAbsolutePath f) nil nil nil))]
+                (is (false? (:ok res)))
+                (is (not= "launch-editor timed out" (:message res))
+                    "a drained stderr flood is a real failure, not the deadlock timeout")
+                (is (<= (count (:message res)) 8192)
+                    "the retained diagnostic is bounded — no unbounded parent memory")
+                (is (< ms 8000) "returned within the budget"))))))
+      (testing "small stderr control still round-trips verbatim"
+        (with-redefs [oies/launch-shim "process.stderr.write('controlled failure');process.exit(7);"]
+          (binding [oies/*launch-timeout-ms* 8000]
+            (is (= {:ok false :message "controlled failure"}
+                   (oies/launch! (.getAbsolutePath f) nil nil nil)))))))))
+
+(deftest launch-genuine-timeout-honours-short-budget
+  ;; Criterion 4 (a): a child that never exits yields the timeout message
+  ;; WITHIN the (short, test-configurable) budget — proving the wait is bounded
+  ;; and the budget is honoured, not the hardcoded 10 s.
+  (if-not (node-available?)
+    (is true "skipped: node not on PATH")
+    (let [f (tmp-existing-file)]
+      (with-redefs [oies/launch-shim "setInterval(function(){},1000);"] ;; never exits
+        (binding [oies/*launch-timeout-ms* 500]
+          (let [[res ms] (timed (oies/launch! (.getAbsolutePath f) nil nil nil))]
+            (is (= {:ok false :message "launch-editor timed out"} res)
+                "a non-exiting child times out")
+            (is (< ms 5000)
+                "the short budget was honoured — nowhere near the old 10 s stall")))))))
+
+(deftest terminate!-force-kills-a-child-that-ignores-graceful-destroy
+  ;; Criterion 4 (b): after cleanup the child is no longer alive, INCLUDING the
+  ;; force-termination fallback when a graceful destroy does not complete (a
+  ;; child that traps SIGTERM — the force path is exercised on POSIX CI; on
+  ;; Windows `.destroy` already terminates forcibly).
+  (if-not (node-available?)
+    (is true "skipped: node not on PATH")
+    (let [pb   (doto (ProcessBuilder. ["node" "-e"
+                                       "process.on('SIGTERM',function(){});setInterval(function(){},1000);"])
+                 (.redirectOutput java.lang.ProcessBuilder$Redirect/DISCARD)
+                 (.redirectErrorStream true))
+          proc (.start pb)]
+      (try
+        (is (.isAlive proc) "the child started and is running")
+        (is (true? (#'oies/terminate! proc))
+            "terminate! confirms the child is dead (force-destroy fallback used if needed)")
+        (is (not (.isAlive proc)) "the child is no longer alive after cleanup")
+        (finally
+          (when (.isAlive proc) (.destroyForcibly proc)))))))
+
 (deftest endpoint-rejects-missing-file-with-422
   (testing "request-level regression: a valid local POST whose `:file`
             resolves to a nonexistent path answers 422 file-not-found (NOT a


### PR DESCRIPTION
Three disjoint tools-plumbing fixes across `tools/` + `scripts/`. One PR, three commits, disjoint files.

## rf2-vd1uyn (P3) — mcp-base: bound marker body size in `marker-text?`
The wire-bounded marker fast-path skip proved a CLOSED single-key `:rf.mcp/*` wrapper but never bounded its BODY size. A single-key `{:rf.mcp/overflow {:blob <100 KB>}}` passed the leading-token and closed-wrapper gates yet rendered to ~25k tokens, so it was treated as sub-cap-by-construction and skipped `apply-cap`, egressing an over-budget payload un-capped — the BODY-SIZE dimension of the same reserved-namespace threat rf2-j538f7.20 closed for the extra-sibling dimension.

Fix: a size gate — a marker candidate whose rendered text estimates over the documented default cap (`overflow/default-max-tokens`) is not sub-cap by construction, so it is not a marker and falls through to normal cap enforcement. Expresses "sub-cap by construction" directly against the convention cap; genuine markers (~100 tokens) pass with vast headroom; anything accepted is guaranteed under the default cap. The O(1) length check also short-circuits an adversarial 100 KB input before the O(n) closed-wrapper read.

- RED-then-GREEN inject-and-check tests on both the JVM `envelope_test` and the CLJS branches suite; `spec/envelope.md` updated to a three-gate recogniser.
- Gate: `clojure -M:test` in `tools/mcp-base` — 272 tests, 924 assertions, 0 failures.

## rf2-j538f7.21 (P3) — testbed-support: drain open-in-editor child output before waiting for exit
`launch!` called `.waitFor` BEFORE reading either child pipe and never read stdout. OS pipes are bounded (~64 KiB), so a child that filled its stdout/stderr pipe blocked on the write, could not reach `process.exit`, and the JVM timed out waiting for an exit its own undrained pipe prevented — turning a verbose Node warning or chatty `launch-editor` into a guaranteed ten-second dev-server stall and a false timeout.

Fix: own every pipe before the wait — DISCARD stdout (never consumed) and drain stderr CONCURRENTLY on its own thread, retaining a bounded head as the failure diagnostic (no unbounded parent memory). On timeout, destroy then force-destroy if the child ignores the graceful signal. The wait budget is a dynamic var so tests can shrink it.

- Real-subprocess regressions spawn node children flooding stdout/stderr with >1 MiB; drained children now exit and `launch!` classifies them correctly, where the pre-fix ordering deadlocked into the timeout. Genuine-timeout and force-termination branches covered. No reflection warnings under `*warn-on-reflection*`.
- Gate: `clojure -M:test` in `tools/testbed-support` — 32 tests, 153 assertions, 0 failures.

## rf2-723lgn (P4) — skill-guard: guard the drift self-test against the retired Managed-HTTP recipe
Follow-up to rf2-j538f7.35 / PR #5603, whose acceptance criterion 6 (drift-guard hardening) lives in repo-root `scripts/check_skill_re_frame2_drift.py`, outside .35's `skills/re-frame2` surface. Adds Rule 5 so the retired co-located reply teaching cannot re-enter:

- **5a** (per-fenced-block): a fx-form `[:rf.http/managed {:request …}]` recipe naming no reply target (throws `:rf.error/http-no-reply-target`). Machine-form `:spawn {:machine-id :rf.http/managed …}` and `[:rf.http/managed-abort …]` are deliberately not matched.
- **5b** (per-line): reading the retired co-located `(:rf/reply …)` key (internal `:rf/reply-to` excluded).
- **5c** (per-line): bare `:work/id` on a transient reply map (spelling is `:rf.reply/work-id`); durable-ledger / machine-`:data` / correlation prose allowed.

Positive + negative self-test fixtures per sub-rule.
- Gate: `python scripts/check_skill_re_frame2_drift.py --self-test` exit 0; full corpus scan exit 0 (50 leaves, no false positives); verified end-to-end that injecting each retired shape into a real leaf flags it.