### PR TITLE
fix(pair-mcp): stdio-roundtrip harness terminates at roots/list discovery instead of hanging (rf2-6ss40u)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
+++ b/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
@@ -108,6 +108,26 @@ function run() {
         if (!line) continue;
         try {
           const f = JSON.parse(line);
+          // Answer the server's optimistic workspace-roots probe. As
+          // step 3 of its nREPL port-discovery cascade the server sends a
+          // `roots/list` request (see src/re_frame2_pair_mcp/server.cljs
+          // + roots_discovery.cljs); a real MCP client (Claude Code)
+          // answers it, but a minimal client that stays silent leaves the
+          // server blocked on the SDK's 60s roots/list timeout — which
+          // hung this harness (rf2-6ss40u). We reply as a capable client
+          // with no open workspace roots: the empty list yields no shadow
+          // candidates, so discovery falls through to the HTTP-probe / cwd
+          // steps and reaches the degraded :nrepl-port-not-found envelope
+          // the assertions below expect.
+          if (f.method === 'roots/list' && f.id != null) {
+            child.stdin.write(
+              JSON.stringify({ jsonrpc: '2.0', id: f.id, result: { roots: [] } }) + '\n',
+            );
+            continue;
+          }
+          // Ignore any other server-initiated request/notification — none
+          // are issued on this no-nREPL degraded path.
+          if (f.method) continue;
           if (f.id && pending.has(f.id)) {
             pending.get(f.id)(f);
             pending.delete(f.id);
@@ -137,9 +157,12 @@ function run() {
       await waitForStderr(/\bready\b/);
 
       // 1. initialize
+      // Advertise `roots` — this client answers the server's `roots/list`
+      // discovery probe (handled on stdout above), so declaring the
+      // capability keeps the handshake protocol-honest.
       const init = await call('initialize', {
         protocolVersion: '2025-06-18',
-        capabilities: {},
+        capabilities: { roots: {} },
         clientInfo: { name: 'roundtrip', version: '0' },
       });
       if (!init.result?.protocolVersion) throw new Error('initialize failed: ' + JSON.stringify(init));


### PR DESCRIPTION
## What

`tools/re-frame2-pair-mcp/test/stdio-roundtrip.js` hung at its first degraded-mode `eval-cljs` call. The server issues an optimistic `roots/list` request as step 3 of its nREPL port-discovery cascade (`server.cljs` / `roots_discovery.cljs`) and treats a rejection as graceful degradation. The minimal test client declared **no** `roots` capability and silently dropped the request, so the server blocked on the SDK's 60s default `roots/list` timeout — the harness never reached its degraded-envelope assertions.

Pre-existing defect (unmodified harness hangs identically), independent of the rf2-j538f7.32 EOF fix, and not a pair-mcp CI gate.

## Fix (option (a): test client answers the discovery request)

- The client now **answers** the server's `roots/list` request with an empty workspace-roots list (`{ roots: [] }`), modelling a real MCP client (Claude Code) that supports roots but has no relevant workspace open.
- The client advertises the `roots` capability in `initialize` so the handshake is protocol-honest.

Discovery walks the empty roots, finds no shadow candidates, and falls through to the HTTP-probe / cwd steps, reaching the degraded `:nrepl-port-not-found` envelope the assertions already expect. Purely a test-client change — no server source touched.

Chose (a) over (b) (server-side bounded timeout) because (a) is confined to the harness, deterministic/fast (no timeout reliance), models a real capable client, and exercises the roots-walk discovery step. Option (b) would require a server-src change, which is out of scope for this harness fix.

## Terminate-proof

- **Before:** stalls at `tools/call eval-cljs`; killed at 20s (would otherwise unblock only at the SDK's 60s `roots/list` timeout).
- **After:** `SERVER STDIO ROUND-TRIP GREEN`, `node-exit-code=0`, elapsed ~1s. All assertions pass (`initialize`, `tools/list` catalogue, subscribe/unsubscribe/snapshot/get-path descriptors, and the eval-cljs/snapshot/get-path/subscribe/unsubscribe degraded envelopes + unknown-tool recovery hint).