### PR TITLE
fix(tools,examples): machines-viz helix :props docstring; PNG assurance validates raster not just zlib (rf2-177ek6, rf2-j538f7.24)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -129,7 +129,14 @@
  *          CRC-32, at least one IDAT whose zlib stream actually inflates, and a
  *          terminal IEND. A header prefix, a byte-flipped/corrupt chunk, or a
  *          mid-stream truncation fails — not just a missing/renamed file
- *          (rf2-mon7tz + full structural decode rf2-3fc89f.27).
+ *          (rf2-mon7tz + full structural decode rf2-3fc89f.27). The RASTER
+ *          SEMANTICS are validated too, since zlib inflation is not PNG decoding:
+ *          the IHDR colour-type/bit-depth pairing and the compression/filter/
+ *          interlace methods must be legal + supported, and the inflated bytes
+ *          must be EXACTLY the declared image — `height` scanlines of a 1-byte
+ *          filter tag (0..4) + a `ceil(width*channels*bitDepth/8)`-byte pixel row.
+ *          A forbidden colour type, an IDAT that expands to the wrong byte count,
+ *          or an illegal per-row filter byte fails (rf2-j538f7.24).
  *      (d) OG SOURCE-ART PALETTE: og.svg carries no retired / sub-AA colour
  *          literal as a live paint value, so the re-exported card cannot drift
  *          back below the shared palette's accessibility decisions (rf2-y82dk9).
@@ -710,6 +717,25 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 const OG_PNG_WIDTH = 1200;
 const OG_PNG_HEIGHT = 630;
 
+// PNG IHDR semantic tables (PNG spec §11.2.2, Table 11.1) — rf2-j538f7.24. A
+// structurally wrapped chunk stream (bounded chunks + valid CRCs + an IDAT that
+// zlib-inflates) can still declare an ILLEGAL raster: a forbidden colour type,
+// an illegal bit-depth/colour-type pairing, or an unsupported
+// compression/filter/interlace method. No decoder can render such a header, yet
+// a zlib-only check waves it through. These tables pin the legal set so
+// validatePng can reject the header SEMANTICS, not merely the byte envelope.
+// `PNG_CHANNELS_BY_COLOUR_TYPE` also gives the samples-per-pixel the scanline
+// geometry needs (greyscale 1, truecolour 3, indexed 1, greyscale+alpha 2,
+// truecolour+alpha 4).
+const PNG_CHANNELS_BY_COLOUR_TYPE = { 0: 1, 2: 3, 3: 1, 4: 2, 6: 4 };
+const PNG_LEGAL_DEPTHS_BY_COLOUR_TYPE = {
+  0: [1, 2, 4, 8, 16], // greyscale
+  2: [8, 16], // truecolour (RGB)
+  3: [1, 2, 4, 8], // indexed-colour
+  4: [8, 16], // greyscale + alpha
+  6: [8, 16], // truecolour + alpha (RGBA)
+};
+
 // Precomputed CRC-32 lookup table (IEEE 802.3 polynomial, reflected 0xEDB88320)
 // — the checksum every PNG chunk carries over its (type + data) bytes. Built
 // once at module load so validatePng can verify each chunk's CRC in one pass.
@@ -733,22 +759,37 @@ function pngCrc32(buf) {
 }
 
 // Validate that `data` is a STRUCTURALLY COMPLETE, decodable PNG of the expected
-// dimensions — not merely a byte prefix that starts like one. Returns
+// dimensions — not merely a byte prefix that starts like one, and not merely a
+// chunk envelope whose IDAT happens to zlib-inflate. Returns
 // { ok, width, height, reason }.
 //
-// The previous implementation read only the first 24 bytes (signature + IHDR
-// dims), so a 24-byte header prefix, a byte-flipped IDAT, or a mid-stream
-// truncation all reported ok:true — a FALSE-GREEN over a broken raster
-// (rf2-3fc89f.27). This walks the ENTIRE chunk stream and fails on any real
-// corruption:
+// The 24-byte header sniff let a header prefix / byte-flipped IDAT / mid-stream
+// truncation report ok:true (rf2-3fc89f.27); walking the chunk stream fixed that
+// but still called a PNG "decodable" once its IDAT merely INFLATED, so a raster
+// with a forbidden IHDR colour type, an unsupported interlace method, or an IDAT
+// that expands to the wrong number of bytes / carries an illegal per-row filter
+// byte still passed — zlib inflation is not PNG decoding (rf2-j538f7.24).
+//
+// This validates the byte envelope AND the raster semantics, failing on any of:
 //   - the 8-byte PNG signature and an IHDR first chunk (length exactly 13),
 //   - every chunk fully inside the file (a declared length running past EOF is a
 //     truncation), with its stored CRC-32 matching the computed CRC over
 //     type+data (a corrupt/flipped byte fails here),
 //   - at least one IDAT chunk whose concatenated zlib stream actually INFLATES
 //     (a garbled compressed stream fails the real decode), and
-//   - a terminal IEND chunk with no trailing bytes after it.
-// Only then are the IHDR dimensions checked against the expected size.
+//   - a terminal IEND chunk with no trailing bytes after it,
+//   - LEGAL IHDR SEMANTICS: a known colour type (0/2/3/4/6), a bit depth legal
+//     for that colour type, and compression / filter / interlace methods this
+//     gate supports (method 0 each; the social card is non-interlaced, so Adam7
+//     is rejected rather than decoded), and
+//   - RASTER GEOMETRY: the inflated bytes are EXACTLY the declared image —
+//     `height` scanlines, each a 1-byte filter tag (0..4) plus a packed pixel
+//     row of `ceil(width * channels * bitDepth / 8)` bytes. A stream that
+//     expands to too few (the four-byte payload) or too many bytes, or a
+//     scanline whose leading filter byte is not 0..4, is a broken raster.
+// The IHDR dimensions are checked against the expected size before the geometry
+// (a wrong-size card is reported as such, then the geometry confirms the raster
+// is the complete, filter-legal image for those dimensions).
 //
 // Accepts a Buffer or coerces a string fixture to one (latin1 preserves bytes).
 function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG_HEIGHT) {
@@ -824,10 +865,70 @@ function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG
   if (!sawIend) {
     return { ok: false, width, height, reason: 'no terminal IEND chunk (truncated raster)' };
   }
+
+  // IHDR SEMANTIC fields (rf2-j538f7.24). The chunk walk above proved the IHDR
+  // chunk is fully present and CRC-valid, so its 13 data bytes (16..28) are safe
+  // to read here. A structurally wrapped stream can still declare an ILLEGAL
+  // raster no decoder can render — a forbidden colour type, an illegal
+  // bit-depth/colour-type pairing, or an unsupported compression/filter/interlace
+  // method — none of which the CRC or the zlib inflate below catches. Reject the
+  // header semantics before trusting the pixel geometry.
+  const bitDepth = buf[24];
+  const colourType = buf[25];
+  const compressionMethod = buf[26];
+  const filterMethod = buf[27];
+  const interlaceMethod = buf[28];
+  const channels = PNG_CHANNELS_BY_COLOUR_TYPE[colourType];
+  if (channels === undefined) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason: `IHDR declares colour type ${colourType}, not a legal PNG colour type (0, 2, 3, 4 or 6)`,
+    };
+  }
+  if (!PNG_LEGAL_DEPTHS_BY_COLOUR_TYPE[colourType].includes(bitDepth)) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason:
+        `IHDR bit depth ${bitDepth} is illegal for colour type ${colourType} ` +
+        `(allowed: ${PNG_LEGAL_DEPTHS_BY_COLOUR_TYPE[colourType].join('/')})`,
+    };
+  }
+  if (compressionMethod !== 0) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason: `IHDR compression method ${compressionMethod} is unsupported (PNG defines only method 0/deflate)`,
+    };
+  }
+  if (filterMethod !== 0) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason: `IHDR filter method ${filterMethod} is unsupported (PNG defines only method 0)`,
+    };
+  }
+  if (interlaceMethod !== 0) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason:
+        `IHDR interlace method ${interlaceMethod} is unsupported by this gate — the ` +
+        `social card is non-interlaced (method 0); Adam7 (method 1) is rejected, not decoded`,
+    };
+  }
+
   // The compressed image data must actually decode — a garbled zlib stream that
   // still carried a valid CRC would otherwise pass. This is the "real decode".
+  let raster;
   try {
-    zlib.inflateSync(Buffer.concat(idatParts));
+    raster = zlib.inflateSync(Buffer.concat(idatParts));
   } catch (err) {
     return {
       ok: false,
@@ -843,6 +944,42 @@ function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG
       height,
       reason: `dimensions are ${width}x${height}, expected ${expectedWidth}x${expectedHeight}`,
     };
+  }
+
+  // RASTER GEOMETRY (rf2-j538f7.24). Inflating the IDAT proves the zlib stream is
+  // well-formed, NOT that its bytes form the declared image. A non-interlaced PNG
+  // decompresses to EXACTLY `height` scanlines, each `1 + ceil(width * channels *
+  // bitDepth / 8)` bytes: a leading filter-type tag (0..4) followed by the packed
+  // pixel row. An IDAT that inflates to the wrong length (the bead's four-byte
+  // payload, or an over-long one) or a scanline carrying an illegal filter tag is
+  // a structurally-broken raster that zlib-only validation waves through.
+  const bytesPerScanline = Math.ceil((width * channels * bitDepth) / 8);
+  const stride = 1 + bytesPerScanline;
+  const expectedRasterBytes = height * stride;
+  if (raster.length !== expectedRasterBytes) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason:
+        `decompressed image data is ${raster.length} byte(s), expected ` +
+        `${expectedRasterBytes} (${height} scanlines x ${stride} bytes = a 1-byte ` +
+        `filter tag + a ${bytesPerScanline}-byte row for each ${width}px line of ` +
+        `${bitDepth}-bit colour-type-${colourType} pixels). A valid zlib stream ` +
+        `that does not expand to the full declared raster (truncated/oversized ` +
+        `pixel payload) is not a decodable image`,
+    };
+  }
+  for (let row = 0; row < height; row++) {
+    const filterTag = raster[row * stride];
+    if (filterTag > 4) {
+      return {
+        ok: false,
+        width,
+        height,
+        reason: `scanline ${row} begins with filter byte ${filterTag}, not a legal PNG filter type (0..4) — corrupt/mis-encoded raster`,
+      };
+    }
   }
   return { ok: true, width, height };
 }

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -96,23 +96,15 @@ const SYNTHETIC_MANIFEST = [
   },
 ];
 
-// A real, decodable 1200x630 PNG (signature + IHDR + IDAT + IEND), used wherever
-// a fixture's _shared tree must scan clean — the gate now validates the og.png
-// BYTES, so an opaque 'PNGDATA' string no longer passes checkSharedTree
-// (rf2-mon7tz). Stored latin1 so the synthetic io (which returns the stored
-// value verbatim) round-trips the bytes; validatePng coerces it back to a
-// Buffer the same way.
-const VALID_OG_PNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAABLAAAAJ2CAIAAADAIuwLAAAACUlEQVR4nGMAAAABAAFe/335AAAAAElFTkSuQmCC',
-  'base64',
-).toString('latin1');
-
-// Build a STRUCTURALLY COMPLETE PNG (signature + IHDR + IDAT + IEND) at the
-// given dimensions, as a Buffer, for the full-structural-decode teeth
-// (rf2-3fc89f.27). Uses the scanner's own pngCrc32 to write correct chunk CRCs
-// and a real zlib stream for the IDAT, so validatePng's CRC + inflate checks see
-// a genuinely valid raster — the corrupt/truncated fixtures are then derived by
-// mutating this baseline, isolating exactly one defect each.
+// Build a STRUCTURALLY + SEMANTICALLY complete PNG (signature + IHDR + a full
+// raster IDAT + IEND) at the given dimensions, as a Buffer, for the decode teeth
+// (rf2-3fc89f.27 + rf2-j538f7.24). Uses the scanner's own pngCrc32 to write
+// correct chunk CRCs and deflates the WHOLE declared raster — `height` scanlines
+// of a 0/None filter tag + a width*3-byte 8-bit RGB pixel row (matching the
+// shipped og.png's truecolour encoding) — so validatePng's CRC, inflate,
+// IHDR-semantics, exact-scanline-geometry, and filter-byte checks all see a
+// genuinely valid image. The corrupt/truncated/oversized fixtures below are
+// derived by mutating this baseline, isolating exactly one defect each.
 const zlibForTests = require('zlib');
 function pngChunk(type, data) {
   const len = Buffer.alloc(4);
@@ -127,14 +119,30 @@ function buildPng(width = OG_PNG_WIDTH, height = OG_PNG_HEIGHT) {
   ihdr.writeUInt32BE(width, 0);
   ihdr.writeUInt32BE(height, 4);
   ihdr[8] = 8; // bit depth
-  ihdr[9] = 2; // colour type (truecolour)
+  ihdr[9] = 2; // colour type (2 = truecolour RGB → 3 channels)
+  ihdr[10] = 0; // compression method (deflate)
+  ihdr[11] = 0; // filter method
+  ihdr[12] = 0; // interlace method (none)
+  // A FULL raster: height scanlines, each a 1-byte filter tag (0/None, from the
+  // zero-fill) + a width*3-byte RGB pixel row. Buffer.alloc zero-fills, so every
+  // scanline's leading filter byte is 0 (legal) and the pixels are opaque black.
+  const raster = Buffer.alloc(height * (1 + width * 3));
   return Buffer.concat([
     Buffer.from(PNG_SIGNATURE),
     pngChunk('IHDR', ihdr),
-    pngChunk('IDAT', zlibForTests.deflateSync(Buffer.from([0, 0, 0, 0]))),
+    pngChunk('IDAT', zlibForTests.deflateSync(raster)),
     pngChunk('IEND', Buffer.alloc(0)),
   ]);
 }
+
+// A real, decodable 1200x630 PNG used wherever a fixture's _shared tree must scan
+// clean. The gate now validates the og.png BYTES down to the full raster geometry
+// (rf2-mon7tz + rf2-j538f7.24), so the old base64 blob — a 1200x630 header over a
+// 1-byte IDAT payload — no longer passes; buildPng() supplies a genuinely
+// complete raster instead. Stored latin1 so the synthetic io (which returns the
+// stored value verbatim) round-trips the bytes; validatePng coerces it back to a
+// Buffer the same way.
+const VALID_OG_PNG = buildPng().toString('latin1');
 
 // An AA-safe, focus-accessible style.css that satisfies the shared contrast +
 // focus-indicator contracts (rf2-febmqu + rf2-mon7tz), for checkSharedTree
@@ -1954,6 +1962,167 @@ it('TEETH: checkSharedTree rejects a header-only (truncated) og.png', () => {
   assert.ok(
     errors.some((e) => e.includes('og.png') && e.includes('not a valid')),
     `expected checkSharedTree to reject the header-only og.png, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: og.png RASTER SEMANTICS — zlib inflation is not PNG decoding
+// (rf2-j538f7.24) -----------------------------------------------------------
+//
+// The full-structural-decode gate (above) still called a PNG "decodable" once
+// its IDAT merely zlib-INFLATED, so a raster with a forbidden IHDR colour type,
+// an unsupported interlace method, or an IDAT that expands to the wrong number
+// of bytes / carries an illegal per-row filter byte all passed — every social
+// preview would then serve unreadable bytes while the all-35-host gate stayed
+// green. The gate now validates the IHDR SEMANTICS + the exact scanline geometry
+// + the per-row filter tags. Each fixture below keeps a valid signature, bounded
+// chunks, correct CRCs, an inflatable zlib stream, and a terminal IEND —
+// isolating exactly ONE raster-semantic defect the pre-fix zlib-only check waved
+// through.
+
+// Build a PNG with explicit IHDR fields and an explicit (already-inflated) raster
+// payload, so a fixture can hold every envelope invariant while varying exactly
+// one raster-semantic field. `raster` is deflated into the IDAT and all CRCs are
+// recomputed, so the ONLY defect is the one the fixture injects (e.g. a valid
+// IHDR CRC over a forbidden colour type). Defaults to a full 8-bit RGB raster.
+function buildPngWith({
+  width = OG_PNG_WIDTH,
+  height = OG_PNG_HEIGHT,
+  bitDepth = 8,
+  colourType = 2,
+  compression = 0,
+  filter = 0,
+  interlace = 0,
+  raster,
+} = {}) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = bitDepth;
+  ihdr[9] = colourType;
+  ihdr[10] = compression;
+  ihdr[11] = filter;
+  ihdr[12] = interlace;
+  const body = raster !== undefined ? raster : Buffer.alloc(height * (1 + width * 3));
+  return Buffer.concat([
+    Buffer.from(PNG_SIGNATURE),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlibForTests.deflateSync(body)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+it('validatePng accepts buildPngWith defaults (full RGB raster)', () => {
+  const v = validatePng(buildPngWith());
+  assert.ok(v.ok, `expected the default full-raster PNG to validate, got: ${v.reason}`);
+  assert.strictEqual(v.width, OG_PNG_WIDTH);
+  assert.strictEqual(v.height, OG_PNG_HEIGHT);
+});
+
+it('TEETH: a forbidden IHDR colour type (1) is REJECTED with an IHDR-semantic error', () => {
+  // colour type 1 is not a legal PNG colour type (0/2/3/4/6). pngChunk recomputes
+  // the IHDR CRC, so the envelope is valid and this isolates the SEMANTIC defect —
+  // the bead's reproduction (Pillow rejects it; the pre-fix gate returned ok:true).
+  const v = validatePng(buildPngWith({ colourType: 1, raster: Buffer.from([0, 0, 0, 0]) }));
+  assert.ok(!v.ok, 'a forbidden colour type must fail');
+  assert.ok(/colour type 1/.test(v.reason), `expected an IHDR colour-type error, got: ${v.reason}`);
+});
+
+it('TEETH: an illegal bit-depth/colour-type pairing (RGB @ 1-bit) is REJECTED', () => {
+  // Colour type 2 (truecolour) is legal only at bit depth 8 or 16; 1-bit RGB is
+  // forbidden by the PNG spec even though the chunk envelope is intact.
+  const v = validatePng(buildPngWith({ colourType: 2, bitDepth: 1, raster: Buffer.from([0]) }));
+  assert.ok(!v.ok, 'an illegal bit-depth/colour-type pairing must fail');
+  assert.ok(
+    /bit depth 1 is illegal for colour type 2/.test(v.reason),
+    `expected an IHDR bit-depth error, got: ${v.reason}`,
+  );
+});
+
+it('TEETH: a nonzero IHDR compression method is REJECTED', () => {
+  const v = validatePng(buildPngWith({ compression: 1, raster: Buffer.from([0]) }));
+  assert.ok(!v.ok, 'an unsupported compression method must fail');
+  assert.ok(/compression method 1/.test(v.reason), `got: ${v.reason}`);
+});
+
+it('TEETH: a nonzero IHDR filter method is REJECTED', () => {
+  const v = validatePng(buildPngWith({ filter: 1, raster: Buffer.from([0]) }));
+  assert.ok(!v.ok, 'an unsupported filter method must fail');
+  assert.ok(/filter method 1/.test(v.reason), `got: ${v.reason}`);
+});
+
+it('TEETH: an unsupported interlace method (Adam7) is REJECTED explicitly', () => {
+  // Interlace method 1 (Adam7) is a legal PNG but this gate accepts only the
+  // non-interlaced social card (method 0); it must fail explicitly, not decode.
+  const v = validatePng(buildPngWith({ interlace: 1, raster: Buffer.from([0]) }));
+  assert.ok(!v.ok, 'an unsupported interlace method must fail');
+  assert.ok(/interlace method 1/.test(v.reason), `got: ${v.reason}`);
+});
+
+it('TEETH: a valid-zlib IDAT expanding to only 4 bytes over a 1200x630 IHDR is REJECTED (the bead reproduction)', () => {
+  // The exact false-green: a real 1200x630 truecolour IHDR, valid CRCs, a terminal
+  // IEND, and an IDAT that IS a well-formed zlib stream — but one inflating to just
+  // 4 bytes, nowhere near the 630 x (1 + 1200*3) = 2,268,630-byte raster. zlib-only
+  // validation passed this; the scanline-geometry check now rejects it.
+  const v = validatePng(buildPngWith({ raster: Buffer.from([0, 0, 0, 0]) }));
+  assert.ok(!v.ok, 'a 4-byte pixel payload for a 1200x630 raster must fail');
+  assert.ok(
+    /decompressed image data is 4 byte\(s\), expected 2268630/.test(v.reason),
+    `expected an incomplete-payload error, got: ${v.reason}`,
+  );
+});
+
+it('TEETH: an OVER-LONG raster payload (one byte too many) is REJECTED', () => {
+  const oversize = Buffer.alloc(OG_PNG_HEIGHT * (1 + OG_PNG_WIDTH * 3) + 1); // one extra byte
+  const v = validatePng(buildPngWith({ raster: oversize }));
+  assert.ok(!v.ok, 'an oversized pixel payload must fail');
+  assert.ok(/expected 2268630/.test(v.reason), `expected a geometry error, got: ${v.reason}`);
+});
+
+it('TEETH: a scanline with an illegal filter byte (5) is REJECTED', () => {
+  // A COMPLETE 1200x630 raster (correct byte count) whose first scanline's leading
+  // filter tag is 5 — not a legal PNG filter type (0..4). The length check passes;
+  // the per-row filter check catches it.
+  const stride = 1 + OG_PNG_WIDTH * 3;
+  const raster = Buffer.alloc(OG_PNG_HEIGHT * stride);
+  raster[0] = 5; // first scanline filter tag = 5 (illegal)
+  const v = validatePng(buildPngWith({ raster }));
+  assert.ok(!v.ok, 'an illegal filter byte must fail');
+  assert.ok(
+    /scanline 0/.test(v.reason) && /filter byte 5/.test(v.reason),
+    `expected a filter-byte error, got: ${v.reason}`,
+  );
+});
+
+it('a complete raster with legal filter bytes (0..4) still validates', () => {
+  // Guard against over-strict rejection: cycling filter tags 0..4 down the
+  // scanlines is legal and must pass (the real og.png uses tags 1/2/4).
+  const stride = 1 + OG_PNG_WIDTH * 3;
+  const raster = Buffer.alloc(OG_PNG_HEIGHT * stride);
+  for (let r = 0; r < OG_PNG_HEIGHT; r++) raster[r * stride] = r % 5; // 0..4
+  const v = validatePng(buildPngWith({ raster }));
+  assert.ok(v.ok, `a raster with legal filter bytes 0..4 must validate, got: ${v.reason}`);
+});
+
+it('TEETH: checkSharedTree rejects a raster-broken (zlib-valid) og.png (rf2-j538f7.24)', () => {
+  // og.png: valid signature + 1200x630 IHDR + valid-CRC chunks + a valid zlib IDAT
+  // that inflates to 4 bytes + IEND. The pre-fix gate passed this; the raster
+  // geometry check now turns the gate RED end-to-end via checkSharedTree, proving
+  // the wiring has teeth (not just validatePng in isolation).
+  const brokenRaster = buildPngWith({ raster: Buffer.from([0, 0, 0, 0]) }).toString('latin1');
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }\n' +
+      RESPONSIVE_SHELL,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: brokenRaster,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('og.png') && e.includes('not a valid')),
+    `expected checkSharedTree to reject the raster-broken og.png, got: ${errors.join(' | ')}`,
   );
 });
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/helix.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/helix.cljs
@@ -23,10 +23,9 @@
                                 :current-state :idle})
 
   Props are the closed map the Reagent `MachineChart` accepts (see
-  `spec/API.md` §Props). The `:props` Helix-feature is enabled so the
-  component receives the raw props as a single map argument (Helix
-  otherwise spreads named props); the shell forwards them to the
-  bridge unchanged.
+  `spec/API.md` §Props). Helix `defnc` marshals the props object to a
+  single CLJS map by default, so the component receives the whole map
+  as its `props` argument and forwards it to the bridge unchanged.
 
   ## Bundle isolation
 
@@ -38,10 +37,11 @@
 
 (defnc MachineChart
   "Helix component wrapping the xyflow `MachineChart` via the shared
-  React bridge. With the `:props` feature the whole props object
-  arrives as `props`; the shell forwards it to
-  `react-chart/chart-element` which builds the reactified-Reagent
-  React element. Renders the identical chart a Reagent host renders.
+  React bridge. Helix `defnc` marshals the whole props object to a
+  single CLJS map by default, so it arrives as `props`; the shell
+  forwards it to `react-chart/chart-element` which builds the
+  reactified-Reagent React element. Renders the identical chart a
+  Reagent host renders.
 
   `:children` is dropped — the chart manages its own subtree."
   [props]


### PR DESCRIPTION
Two disjoint small fixes from the 2026-07-11 correctness reviews. One PR, two commits, disjoint files.

## rf2-177ek6 (P4) — machines-viz Helix adapter `:props` docstring

`tools/machines-viz/.../adapters/helix.cljs` claimed in both the ns docstring and the `defnc` docstring that "the `:props` Helix-feature is enabled so the component receives the raw props as a single map argument". The feature map only sets `{:check-invalid-hooks-usage false}` — `:props` appears nowhere in the repo. Not a runtime bug (Helix `defnc` already marshals props to a single CLJS map by default, which is why `(dissoc props :children)` works), just a stale/inaccurate docstring. Corrected both docstrings to describe Helix `defnc`'s default marshalling instead of a non-existent enabled feature.

Doc-only. Spec unchanged because this is a docstring-only correction of existing behaviour.

## rf2-j538f7.24 (P4) — PNG assurance validates raster semantics, not just zlib

`examples/scripts/check-examples-assets.cjs` `validatePng` called a PNG "decodable" once its IDAT merely zlib-inflated, so a structurally-wrapped but semantically-invalid raster passed `ok:true` — a forbidden IHDR colour type, an unsupported interlace method, or an IDAT expanding to the wrong byte count / carrying an illegal per-row filter byte — while every social preview would serve unreadable bytes. **zlib inflation is not PNG decoding.**

Strengthened `validatePng` (still dependency-free, hand-parsed chunks) to also validate:
- **IHDR semantics**: a legal colour type (0/2/3/4/6), a bit depth legal for that colour type, and supported compression/filter/interlace methods (0 each; the non-interlaced social card rejects Adam7 explicitly rather than decoding it).
- **Raster geometry**: the inflated bytes are EXACTLY the declared image — `height` scanlines, each a 1-byte filter tag (0..4) + a `ceil(width*channels*bitDepth/8)`-byte pixel row. Too few (the 4-byte payload), too many, or an illegal filter byte all fail.

Replaced the degenerate test oracles (`buildPng`'s 4-byte IDAT; the base64 `VALID_OG_PNG` whose IDAT inflated to 1 byte over a 1200x630 header) with a genuinely full-raster fixture, and added negative tests proving each new rejection path — including the bead's reproduction and an end-to-end `checkSharedTree` teeth test.

### Teeth-proof
The bead's exact reproduction — a real 1200x630 truecolour IHDR + valid CRCs + IEND + an IDAT that IS a valid zlib stream but inflates to only 4 bytes — now fails:

```
validatePng result: {"ok":false,"width":1200,"height":630,"reason":
"decompressed image data is 4 byte(s), expected 2268630 (630 scanlines x 3601 bytes
= a 1-byte filter tag + a 3600-byte row for each 1200px line of 8-bit colour-type-2
pixels). A valid zlib stream that does not expand to the full declared raster
(truncated/oversized pixel payload) is not a decodable image"}
```

The shipped `examples/_shared/img/og.png` (RGB 1200x630, non-interlaced) still fully decodes.

## Quality gates (foreground)
- `node examples/scripts/check-examples-assets.cjs` — **35/35 pages PASS**, `_shared` tree intact.
- `node implementation/scripts/check-examples-assets.test.cjs` — **147 PASS / 0 FAIL** (11 new raster-semantics teeth tests).
- `npm run test:script-policy` — full gate chain **PASS** (exit 0).
- rf2-177ek6: docstring-only correction of a browser-CLJS adapter; not compiled by the machines-viz JVM `:test` runner, so no compiling test (docstring-only-no-test).
