### PR TITLE
fix(core): default image path fails loud on app/standard collision; cascade truncated? flags only when exceeding cap (rf2-x76af2.29, rf2-x76af2.31)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -889,14 +889,26 @@
   `:rf/set-db`, EP-0027) into the regular registrar/source store too, so the
   registrar-direct (non-generation) resolution path can find them. Those
   source-store shadows are NOT ordinary app registrations — they are the
-  framework standard's own copy. The default image's WHOLE-STORE selection must
-  drop any descriptor whose `[kind id]` is a framework standard: the standard is
-  unioned in separately (and protected), so projecting its registrar-shadow as
-  an app descriptor would make the default frame fail
-  `check-standard-collision!` against the very standard it shadows. An EXPLICIT
-  `:select-ns` image is unaffected — it selects by provenance namespace, and a
-  standard's registrar shadow carries no `:rf.provenance/ns`, so it is never
-  glob-selectable anyway."
+  framework standard's own copy, recorded with NO `:rf.provenance/ns` (a
+  nil-provenance registrar slot). The default image's WHOLE-STORE selection
+  drops ONLY that framework-own copy — a descriptor whose `[kind id]` is a
+  framework standard AND whose `:rf.provenance/ns` is nil: the standard is
+  unioned in separately (and protected), so projecting its own registrar-shadow
+  as an app descriptor would make the default frame fail
+  `check-standard-collision!` against the very standard it shadows.
+
+  The filter is deliberately NOT a blanket `[kind id]` match (rf2-x76af2.29): a
+  PROVENANCED app descriptor colliding with a framework standard MUST survive
+  selection so it reaches `check-standard-collision!` and FAILS LOUD with
+  `:rf.error/image-standard-replacement-forbidden` — exactly as an explicit
+  image's collision does — rather than being silently dropped by the filter and
+  letting the standard resolve unnoticed. A blanket match would bypass the
+  standard-collision gate on the default path only, breaking the documented
+  guarantee that the default path fails loud exactly as the explicit path.
+
+  An EXPLICIT `:select-ns` image is unaffected — it selects by provenance
+  namespace, and a standard's registrar shadow carries no `:rf.provenance/ns`,
+  so it is never glob-selectable anyway."
   [image descriptors]
   (lower-inline-descriptors
     (if (default-image? image)
@@ -904,7 +916,13 @@
                                 (map descriptor-kind+id)
                                 (standard-descriptors))]
         (into []
-              (remove #(contains? standard-keys (descriptor-kind+id %)))
+              ;; Drop ONLY the framework's OWN no-provenance registrar shadow of
+              ;; a standard (rf2-x76af2.29). A PROVENANCED app descriptor
+              ;; colliding with a standard must SURVIVE so it reaches
+              ;; `check-standard-collision!` and fails loud — symmetric with the
+              ;; explicit path — instead of being silently dropped here.
+              (remove #(and (contains? standard-keys (descriptor-kind+id %))
+                            (nil? (:rf.provenance/ns %))))
               descriptors))
       (image/select-descriptors image descriptors))))
 

--- a/implementation/core/src/re_frame/trace/cascade.cljc
+++ b/implementation/core/src/re_frame/trace/cascade.cljc
@@ -101,6 +101,23 @@
     (conj! tv entry)
     tv))
 
+(defn- accumulate-bounded
+  "Conj `entry` onto the transient vector under `vec-key` in the transient
+  accumulator `acc`, bounded at `cap` (via `conj-bounded`). When that vector is
+  ALREADY at `cap` — so `entry` is DROPPED — stamp `flag-key` true.
+
+  The truncation flag therefore fires ONLY when an entry is genuinely elided: a
+  cascade with EXACTLY `cap` entries retains all of them and is NOT truncated
+  (rf2-x76af2.31); only cap+1 sets the flag — matching this namespace's
+  docstring (`Cascades exceeding either cap …`) and Spec 009's `:rf.cascade/
+  captured` wording (`cascades exceeding the cap stamp :sub-cap-truncated?
+  true`). The `full?` guard is read BEFORE the conj so it never observes the
+  post-mutation count of the in-place transient vector."
+  [acc vec-key entry cap flag-key]
+  (let [full? (>= (count (get acc vec-key)) cap)]
+    (cond-> (assoc! acc vec-key (conj-bounded (get acc vec-key) entry cap))
+      full? (assoc! flag-key true))))
+
 (defn aggregate-cascade
   "Pure: walk `events` (the raw trace events harvested for one cascade)
   ONCE and produce the structured cascade-DAG map shape documented in
@@ -121,57 +138,42 @@
                       t  (:tags ev)]
                   (cond
                     (= :rf.sub/run op)
-                    (-> acc
-                        ;; Per rf2-l1jz8 — thread the reactive recompute's
-                        ;; value-change + cascade attribution onto the
-                        ;; aggregated record so the `:rf.cascade/captured`
-                        ;; projection carries the same fields as the epoch
-                        ;; record's `:sub-runs`. Slots are nil for the
-                        ;; `compute-sub` base-shape emit (which omits them).
-                        (assoc! :subs-recomputed
-                                (conj-bounded (get acc :subs-recomputed)
-                                              {:sub-id         (:rf.sub/id t)
-                                               :query-v        (:rf.sub/query-v t)
-                                               :value-changed? (:rf.sub/value-changed? t)
-                                               :prev-value     (:rf.sub/prev-value t)
-                                               :value          (:rf.sub/value t)
-                                               :cascade?       (:rf.sub/cascade? t)
-                                               :cause-sub      (:rf.sub/cause-sub t)
-                                               ;; rf2-okz1u — `:cause-event-id` names
-                                               ;; the dispatching cascade's event-id
-                                               ;; (the head of the event vector that
-                                               ;; kicked off the in-flight drain).
-                                               ;; Threaded from `:rf.sub/cause-event-id`
-                                               ;; on the recompute trace tag (sourced
-                                               ;; via the `:epoch/run-cause` late-
-                                               ;; bind hook at emit time). nil when the
-                                               ;; sub ran outside any run or the
-                                               ;; epoch artefact is absent — consumers
-                                               ;; (Xray's Epoch panel SUBSCRIPTIONS
-                                               ;; section) read it to credit each
-                                               ;; sub-run to the right epoch row even
-                                               ;; when the physical reactive flush
-                                               ;; deferred into a chained sibling
-                                               ;; event's drain.
-                                               :cause-event-id (:rf.sub/cause-event-id t)}
-                                              sub-cap))
-                        (cond->
-                          (>= (count (get acc :subs-recomputed)) sub-cap)
-                          (assoc! :sub-cap-truncated? true)))
+                    ;; Per rf2-l1jz8 — thread the reactive recompute's value-
+                    ;; change + cascade attribution onto the aggregated record so
+                    ;; the `:rf.cascade/captured` projection carries the same
+                    ;; fields as the epoch record's `:sub-runs`. Slots are nil for
+                    ;; the `compute-sub` base-shape emit (which omits them).
+                    (accumulate-bounded
+                      acc :subs-recomputed
+                      {:sub-id         (:rf.sub/id t)
+                       :query-v        (:rf.sub/query-v t)
+                       :value-changed? (:rf.sub/value-changed? t)
+                       :prev-value     (:rf.sub/prev-value t)
+                       :value          (:rf.sub/value t)
+                       :cascade?       (:rf.sub/cascade? t)
+                       :cause-sub      (:rf.sub/cause-sub t)
+                       ;; rf2-okz1u — `:cause-event-id` names the dispatching
+                       ;; cascade's event-id (the head of the event vector that
+                       ;; kicked off the in-flight drain). Threaded from
+                       ;; `:rf.sub/cause-event-id` on the recompute trace tag
+                       ;; (sourced via the `:epoch/run-cause` late-bind hook at
+                       ;; emit time). nil when the sub ran outside any run or the
+                       ;; epoch artefact is absent — consumers (Xray's Epoch panel
+                       ;; SUBSCRIPTIONS section) read it to credit each sub-run to
+                       ;; the right epoch row even when the physical reactive flush
+                       ;; deferred into a chained sibling event's drain.
+                       :cause-event-id (:rf.sub/cause-event-id t)}
+                      sub-cap :sub-cap-truncated?)
 
                     (= :rf.sub/skip op)
-                    (-> acc
-                        (assoc! :subs-skipped
-                                (conj-bounded (get acc :subs-skipped)
-                                              {:sub-id  (:rf.sub/id t)
-                                               :query-v (:rf.sub/query-v t)
-                                               :reason  (:rf.sub/reason t)
-                                               :input-paths-unchanged
-                                               (:rf.sub/input-paths-unchanged t)}
-                                              sub-cap))
-                        (cond->
-                          (>= (count (get acc :subs-skipped)) sub-cap)
-                          (assoc! :sub-cap-truncated? true)))
+                    (accumulate-bounded
+                      acc :subs-skipped
+                      {:sub-id  (:rf.sub/id t)
+                       :query-v (:rf.sub/query-v t)
+                       :reason  (:rf.sub/reason t)
+                       :input-paths-unchanged
+                       (:rf.sub/input-paths-unchanged t)}
+                      sub-cap :sub-cap-truncated?)
 
                     (= :rf.flow/computed op)
                     (assoc! acc :flows-computed
@@ -187,15 +189,11 @@
                                     (:input-paths-unchanged t)}))
 
                     (= :rf.view/render op)
-                    (-> acc
-                        (assoc! :views-rendered
-                                (conj-bounded (get acc :views-rendered)
-                                              {:render-key   (:rf.view/render-key t)
-                                               :triggered-by (:triggered-by t)}
-                                              view-cap))
-                        (cond->
-                          (>= (count (get acc :views-rendered)) view-cap)
-                          (assoc! :view-cap-truncated? true)))
+                    (accumulate-bounded
+                      acc :views-rendered
+                      {:render-key   (:rf.view/render-key t)
+                       :triggered-by (:triggered-by t)}
+                      view-cap :view-cap-truncated?)
 
                     :else acc)))
               (transient {:subs-recomputed     (transient [])

--- a/implementation/core/test/re_frame/image_assembly_default_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_default_cljs_test.cljc
@@ -35,6 +35,7 @@
   `clojure -M:test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image          :as image]
             [re-frame.image-assembly :as asm]
             [re-frame.source-store   :as ss]))
 
@@ -282,3 +283,65 @@
     (is (true? (:rf.image/default? asm/default-image)))
     (is (not (asm/default-image? {:rf.image/include-ns ["a.b"]})))
     (is (not (asm/default-image? {})))))
+
+;; ===========================================================================
+;; 7. A PROVENANCED app descriptor colliding with a framework STANDARD FAILS
+;;    LOUD on the DEFAULT path too — symmetric with the explicit path
+;;    (rf2-x76af2.29). The default-image standard-shadow filter drops ONLY the
+;;    framework's OWN no-provenance registrar shadow; a provenanced app
+;;    descriptor must survive selection so it reaches check-standard-collision!.
+;; ===========================================================================
+
+(deftest default-projection-provenanced-app-colliding-with-standard-fails-loud
+  (testing "a PROVENANCED app descriptor in the default pool whose (kind, id)
+            collides with a registered framework standard FAILS LOUD on the
+            DEFAULT path with :rf.error/image-standard-replacement-forbidden —
+            the standard is protected and the app registration is NOT silently
+            dropped (rf2-x76af2.29)"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [pool [(reg-desc "shop.nav"  :fx    :rf.nav/push-url ::app-nav)
+                (reg-desc "shop.cart" :event :cart/add        ::cart-add)]]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (assembly-error-id #(asm/assemble-default pool)))
+          "the default path throws the SAME error the explicit path throws")
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (assembly-error-id #(asm/assemble [] pool)))
+          "the empty-:images default route throws it too"))))
+
+(deftest default-and-explicit-paths-fail-loud-symmetrically-on-standard-collision
+  (testing "the SAME misconfiguration — a provenanced app descriptor colliding
+            with a standard — yields the SAME
+            :rf.error/image-standard-replacement-forbidden on BOTH the default
+            and the explicit path. Before rf2-x76af2.29 the default path
+            silently dropped the app descriptor and resolved to the standard
+            (the documented fail-loud asymmetry)"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [pool     [(reg-desc "shop.nav" :fx :rf.nav/push-url ::app-nav)]
+          explicit (image/image {:id :shop/nav :select-ns {:include ["shop.nav"]}})]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (assembly-error-id #(asm/assemble-default pool))))
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (assembly-error-id #(asm/assemble [explicit] pool))))
+      (is (= (assembly-error-id #(asm/assemble-default pool))
+             (assembly-error-id #(asm/assemble [explicit] pool)))
+          "same error id on both paths — the default path is no longer the odd one out"))))
+
+(deftest default-projection-drops-framework-own-no-provenance-standard-shadow
+  (testing "the framework's OWN no-provenance registrar shadow of a standard
+            (nil :rf.provenance/ns) is STILL filtered out of the default
+            selection — it is the standard's own copy, unioned in separately, so
+            it must NOT reach check-standard-collision! and must NOT throw. The
+            standard still resolves and ordinary app descriptors still project
+            (rf2-x76af2.29 NARROWED the filter, it did not remove it)"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [own-shadow {:rf.provenance/ns nil :kind :fx :id :rf.nav/push-url
+                      :handler-fn ::std-nav}
+          pool       [own-shadow
+                      (reg-desc "shop.cart" :event :cart/add ::cart-add)]
+          gen        (asm/assemble-default pool)]
+      (is (contains? (:rf.gen/resolver gen) [:fx :rf.nav/push-url])
+          "the standard is still present (unioned in)")
+      (is (= ::std-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))
+          "resolves to the standard's own copy; the no-provenance shadow was dropped")
+      (is (contains? (:rf.gen/resolver gen) [:event :cart/add])
+          "ordinary app descriptors still project into the default generation"))))

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -203,6 +203,49 @@
       (is (true? (:view-cap-truncated? dag)))
       (is (false? (:sub-cap-truncated? dag))))))
 
+(deftest aggregate-cascade-truncated-flag-only-when-exceeding-cap
+  (testing "rf2-x76af2.31 — the truncation flag fires ONLY when an entry is
+            genuinely elided. `conj-bounded` already caps growth, so the prior
+            `>=` post-conj check over-flagged at EXACTLY the cap (nothing
+            dropped). EXACTLY the cap retains all entries and is NOT truncated;
+            one MORE elides one and sets the flag."
+    (let [run (fn [i] {:operation :rf.sub/run
+                       :tags {:rf.sub/id      (keyword (str "s" i))
+                              :rf.sub/query-v [(keyword (str "s" i))]}})]
+      (testing "exactly sub-cap subs recomputed → not truncated (none elided)"
+        (let [dag (cascade/aggregate-cascade (map run (range cascade/sub-cap)))]
+          (is (= cascade/sub-cap (count (:subs-recomputed dag))))
+          (is (false? (:sub-cap-truncated? dag))
+              "a cascade with EXACTLY sub-cap subs elides nothing")))
+      (testing "one OVER sub-cap → truncated (the cap+1-th sub is dropped)"
+        (let [dag (cascade/aggregate-cascade (map run (range (inc cascade/sub-cap))))]
+          (is (= cascade/sub-cap (count (:subs-recomputed dag))))
+          (is (true? (:sub-cap-truncated? dag)))))))
+
+  (testing "the boundary holds for :rf.sub/skip too (shares :sub-cap-truncated?)"
+    (let [skip (fn [i] {:operation :rf.sub/skip
+                        :tags {:rf.sub/id                    (keyword (str "k" i))
+                               :rf.sub/query-v               [(keyword (str "k" i))]
+                               :rf.sub/reason                :input-value-equal
+                               :rf.sub/input-paths-unchanged []}})]
+      (is (false? (:sub-cap-truncated?
+                    (cascade/aggregate-cascade (map skip (range cascade/sub-cap))))))
+      (is (true? (:sub-cap-truncated?
+                   (cascade/aggregate-cascade (map skip (range (inc cascade/sub-cap)))))))))
+
+  (testing "the boundary holds for :rf.view/render (:view-cap-truncated?)"
+    (let [view (fn [i] {:operation :rf.view/render
+                        :tags {:rf.view/render-key [:v (str "v" i)]
+                               :triggered-by       :db-change}})
+          at   (cascade/aggregate-cascade (map view (range cascade/view-cap)))
+          over (cascade/aggregate-cascade (map view (range (inc cascade/view-cap))))]
+      (is (= cascade/view-cap (count (:views-rendered at))))
+      (is (false? (:view-cap-truncated? at))
+          "exactly view-cap views elides nothing")
+      (is (= cascade/view-cap (count (:views-rendered over))))
+      (is (true? (:view-cap-truncated? over))
+          "the view-cap+1-th view is dropped → truncated"))))
+
 ;; ---- :rf.sub/run value-change + cascade attribution (rf2-l1jz8) --------------
 ;;
 ;; The reactive recompute path (subs.memo/validate-and-trace) enriches the


### PR DESCRIPTION
Two core second-pass audit findings on disjoint files. One PR, two ordered commits. Both JVM-reproduced on the pre-fix base; neither mints a new error id, so `spec/009-Instrumentation.md` is untouched.

## rf2-x76af2.29 (P3 — fail-loud asymmetry, headline)

`image_assembly.cljc` `select-and-lower-image`: the default-image standard-shadow filter dropped descriptors by a blanket `[kind id]` match against the framework standards. That correctly drops the framework's OWN no-provenance registrar shadow of a dual-registered standard, but it also dropped a **provenanced app descriptor** colliding with a standard — so it never reached `check-standard-collision!`, the app registration was silently ignored, and the standard resolved. The DEFAULT path returned no-throw while the EXPLICIT path (which selects by provenance ns) threw `:rf.error/image-standard-replacement-forbidden` for the same misconfiguration — violating the documented guarantee that the default path fails loud exactly as the explicit path.

Fix: narrow the filter to drop only the framework's own no-provenance shadow (`:rf.provenance/ns` nil). A provenanced app descriptor colliding with a standard now survives selection, reaches `check-standard-collision!`, and fails loud with the **same existing** `:rf.error/image-standard-replacement-forbidden` — no new error id.

Repro (pre-fix): DEFAULT threw? false, `:fx` resolved to `:std` (app descriptor silently dropped); EXPLICIT threw `image-standard-replacement-forbidden`. Post-fix: both paths throw the same error.

## rf2-x76af2.31 (P4 — off-by-one flag)

`trace/cascade.cljc` `aggregate-cascade`: `:sub-cap-truncated?` / `:view-cap-truncated?` were stamped via a `>=` check on the count AFTER `conj-bounded`. Since `conj-bounded` already caps growth at the cap, the check fired on the entry that brings the count to exactly the cap — before anything was elided — so a cascade with exactly `sub-cap` subs (or `view-cap` views) was flagged truncated while all entries were retained. Off-by-one vs the documented "cascades exceeding either cap … stamp `:truncated? true`" (also Spec 009 §`:rf.cascade/captured`).

Fix: extract `accumulate-bounded`, which reads the pre-conj count and sets the flag only when the vector is already at cap (entry genuinely dropped). Exactly cap -> false; cap+1 -> true. Dev-only cosmetic; no error id.

Repro (pre-fix), sub-cap 50: 50 events -> captured 50, truncated? true, dropped 0. Post-fix: 50 -> false/0; 51 -> true/1.

## Quality gates

- Core JVM `clojure -M:test` (implementation/core): **1789 tests, 7900 assertions, 0 failures, 0 errors**.
- CLJS node `npm run test:cljs` (implementation): **8605 tests, 40582 assertions, 0 failures, 0 errors**.
- `every-emitted-category-is-catalogued` (error-catalogue conformance): **9 tests, 21 assertions, 0 failures** — confirms no new error id.
- Regressions added: `.29` default/empty-:images app/standard collision throws `image-standard-replacement-forbidden` symmetric with explicit path + framework's own no-provenance shadow still filtered; `.31` exactly-cap -> false, cap+1 -> true across subs-recomputed / subs-skipped / views-rendered.

`spec/009-Instrumentation.md` is NOT touched (disjoint from the concurrent core-2 worker).