### PR TITLE
fix(core): release earlier input refs on sub-cycle unwind for multi-input subs (rf2-t3cpn3)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -742,9 +742,11 @@
   the gap is observability, not recovery). `:recovery :ignored` — the input
   release is best-effort, exactly as the parent dispose walk continues.
 
-  `where` distinguishes the two release sites (`:on-dispose` for the cached
+  `where` distinguishes the release sites (`:on-dispose` for the cached
   reaction's on-dispose callback, `:not-cached-release` for the symmetric
-  release on the escaped-caching path). Returns nil."
+  release on the escaped-caching path, `:sub-cycle-unwind` for the earlier
+  inputs released when a `:<-` cycle in a non-first input abandons the build —
+  rf2-t3cpn3). Returns nil."
   [frame-id input-q where]
   (try
     (unsubscribe frame-id input-q)
@@ -973,7 +975,40 @@
                         :else        (binding [*subs-under-construction*
                                                (conj *subs-under-construction*
                                                      [frame-id (cache-key query-v)])]
-                                       (mapv (fn [input-q] (subscribe-in-frame frame-id input-q)) input-qs)))
+                                       ;; Track the inputs successfully subscribed
+                                       ;; so far so a `:<-` cycle detected in a
+                                       ;; NON-FIRST input can release the earlier
+                                       ;; inputs it already ref-bumped
+                                       ;; (rf2-t3cpn3). On a cycle, `subscribe-
+                                       ;; in-frame` for input N throws the
+                                       ;; sub-cycle sentinel and the WHOLE partial
+                                       ;; build unwinds to the outermost
+                                       ;; `compute-and-cache!` recovery WITHOUT
+                                       ;; ever wiring this reaction's on-dispose —
+                                       ;; so nothing else would release inputs
+                                       ;; 1..N-1 (a bounded dev-only ref-count
+                                       ;; leak). `subscribe-in-frame` bumps the
+                                       ;; input's ref-count before it returns, so
+                                       ;; `acquired` holds exactly the inputs
+                                       ;; whose ref must be undone; the cyclic
+                                       ;; input threw before its own bump, so it
+                                       ;; is (correctly) absent. Release is
+                                       ;; scoped to the sub-cycle sentinel only —
+                                       ;; the minimal precise fix; any other
+                                       ;; (theoretical) throw re-propagates
+                                       ;; unchanged.
+                                       (let [acquired (volatile! [])]
+                                         (try
+                                           (mapv (fn [input-q]
+                                                   (let [r (subscribe-in-frame frame-id input-q)]
+                                                     (vswap! acquired conj input-q)
+                                                     r))
+                                                 input-qs)
+                                           (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+                                             (when (= :rf.error/sub-cycle (:rf.error/id (ex-data e)))
+                                               (doseq [input-q @acquired]
+                                                 (release-input-ref! frame-id input-q :sub-cycle-unwind)))
+                                             (throw e))))))
         parametric?   (= :parametric input-kind)
         memoised-body (cond
                         input-error?

--- a/implementation/core/test/re_frame/sub_cycle_cljs_test.cljc
+++ b/implementation/core/test/re_frame/sub_cycle_cljs_test.cljc
@@ -18,6 +18,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core           :as rf]
+            [re-frame.frame          :as frame]
             [re-frame.subs           :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support   :as test-support]))
@@ -89,6 +90,40 @@
                          (subs/subscribe [:a] {:frame fid})))]
       (is (= 2 (count events))
           "each subscribe of the uncached cyclic sub re-emits the structured error"))))
+
+(deftest reactive-multi-input-cycle-releases-earlier-input-refs
+  (testing "a >=2-input sub whose NON-FIRST input cycles releases the
+            already-acquired earlier input ref on the cycle-unwind path — the
+            earlier input's cache ref-count returns to baseline after recovery,
+            with no bounded leak (rf2-t3cpn3). Before the fix the first input
+            (:leaf) was subscribed (ref bumped) then the abandoned :multi build
+            unwound to the outermost recovery WITHOUT ever wiring its on-dispose,
+            so nothing released :leaf — a monotonic +1 leak."
+    ;; :leaf — a layer-1 (`:db`) sub: cacheable + ref-countable, no `:<-` inputs.
+    (rf/reg-sub :leaf (fn [db _] (:leaf db 7)))
+    ;; :cyc — closes the cycle back to :multi.
+    (rf/reg-sub :cyc :<- [:multi] (fn [m _] m))
+    ;; :multi — TWO inputs; the FIRST (:leaf) resolves cleanly, the SECOND
+    ;; (:cyc) cycles back to :multi. This is the multi-input edge .24 left.
+    (rf/reg-sub :multi :<- [:leaf] :<- [:cyc] (fn [[l c] _] [l c]))
+    (let [cache (:sub-cache (frame/frame fid))]
+      ;; Baseline: :leaf is not yet in the cache.
+      (is (nil? (get @cache [:leaf]))
+          "precondition: :leaf has no cache entry before the cyclic subscribe")
+      (let [[reaction events] (capture-sub-cycles #(subs/subscribe [:multi] {:frame fid}))]
+        (is (nil? (deref reaction))
+            "the cyclic multi-input subscription recovered to a nil-yielding reaction")
+        (is (= 1 (count events))
+            "exactly one structured :rf.error/sub-cycle was emitted")
+        (is (= [:multi :cyc :multi] (:cycle (:tags (first events))))
+            "the cycle path is the closing-repeat sub-id chain through the non-first input")
+        ;; TEETH (rf2-t3cpn3): :leaf was subscribed (ref bumped) BEFORE :cyc
+        ;; cycled. On the cycle-unwind path it must be released so its ref-count
+        ;; returns to baseline (entry dropped on the 1→0 transition). Before the
+        ;; fix this asserts the leak: the entry lingers with :ref-count 1.
+        (is (or (nil? (get @cache [:leaf]))
+                (zero? (or (get-in @cache [[:leaf] :ref-count]) 0)))
+            "the earlier input :leaf's ref-count returned to baseline (released on the cycle unwind) — no bounded leak")))))
 
 ;; ===========================================================================
 ;; Pure `compute-sub` path (per-call memo doubles as the under-construction set)


### PR DESCRIPTION
## What

Follow-up to rf2-x76af2.24 (PR #5658). The `:rf.error/sub-cycle` guard unwinds the partial build and recovers to nil, but on a sub with **>=2 inputs where a NON-FIRST input cycles**, the already-subscribed earlier input reaction's ref-count leaked (never released on the cycle-unwind path). The .24 acceptance cases each have a single input, so the leak was invisible there — this is the multi-input edge.

## Root cause

In `build-and-cache!*`, layer-2+ input resolution `mapv`s `subscribe-in-frame` over each input, bumping each input's ref-count. When input N throws the `:rf.error/sub-cycle` sentinel, the whole partial build unwinds to the outermost `compute-and-cache!` recovery **without ever wiring the abandoned reaction's on-dispose** — so inputs 1..N-1 (subscribed before the cycle) are never released. A bounded dev-only ref-count leak on a fail-loud path.

## Fix

Track the successfully-subscribed inputs in the build frame (`acquired`) and, when the sub-cycle sentinel is caught during input resolution, `release-input-ref!` each acquired input before re-throwing. Scoped to the sub-cycle sentinel only — minimal and precise, no build-path refactor. Reuses the existing `:rf.error/sub-cycle` id; no error-catalogue change (a new `:sub-cycle-unwind` `where` tag on the existing best-effort release breadcrumb is not an error id).

## Teeth (fail-before / pass-after)

New test `reactive-multi-input-cycle-releases-earlier-input-refs`: `:multi :<- [:leaf] :<- [:cyc]` where `:leaf` resolves and `:cyc` cycles back to `:multi`. Before the fix `:leaf`'s cache entry lingered with `:ref-count` 1 after recovery; after the fix its ref-count returns to baseline (entry dropped on the 1→0 transition).

- Fail-before: `expected … actual: false` (leak: `:leaf` entry with ref-count 1)
- Pass-after: green

## Quality gates

- Core JVM `clojure -M:test` (implementation/core): **1798 tests / 7930 assertions, 0 failures**
- CLJS node `npm run test:cljs` (implementation): **8615 tests / 40619 assertions, 0 failures**
- `error-catalogue-channel-conformance` (`every-emitted-category-is-catalogued`): **9 tests / 21 assertions, 0 failures** (no new id)
- Existing x76af2.24 sub-cycle tests: green

Closes rf2-t3cpn3.