### PR TITLE
fix(story-mcp): bound lifecycle deadline over synchronous Story work; no false :pass over budget (rf2-j538f7.31)

### DIFF
--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -173,15 +173,27 @@ Given `:variant-id` (plus optional `:substrate`, `:active-modes`,
 and returns the post-pipeline state plus a sharable URL.
 
 `preview-variant` blocks on the SAME `story/run-variant` lifecycle as
-`run-variant`, so it accepts the SAME tunable `:timeout-ms` blocking
-ceiling (rf2-ovmc5e): default 10 s, hard ceiling 30 s (matches
+`run-variant`, so it accepts the SAME tunable `:timeout-ms` end-to-end
+deadline (rf2-ovmc5e): default 10 s, hard ceiling 30 s (matches
 `:rf.http/timeout-ms` per rf2-it1cd), caller values above the ceiling
 clamp DOWN rather than reject. The MCP request loop is single-threaded
-so an unbounded blocking deref would park unrelated calls; both
+so an unbounded lifecycle call would park unrelated calls; both
 lifecycle tools resolve the slot through the shared
 `tools.args/resolve-timeout-ms` helper (advertised via
 `schemas/with-timeout-ms`) so their blocking policy cannot drift by
 copy-paste.
+
+The deadline bounds the SYNCHRONOUS Story work, not just the
+post-return dereference (rf2-j538f7.31). On the JVM `story/run-variant`
+executes synchronously (a `[:wait ms]` step is an inline `Thread/sleep`)
+and returns an already-settled future, so the lifecycle owner runs the
+whole invoke-and-settle on a bounded worker future and waits at most
+`:timeout-ms`. When the deadline elapses the worker is cancelled — its
+`Thread/sleep` interrupts, the scheduled post-wait continuation never
+fires, and the stdio loop is freed at the ceiling — and the call returns
+the canonical `:status :error` run-result. An over-budget run is
+therefore bounded and reports an honest deadline-exceeded outcome, never
+a false `:pass`.
 
 Wire-egress posture: `:app-db` is routed through
 `re-frame.core/elide-wire-value` against the variant frame's

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -47,13 +47,28 @@ agent-onboarding text.
  :include-sensitive boolean (optional, gated — see below)}
 ```
 
-`:timeout-ms` is the JVM blocking ceiling for the lifecycle run.
+`:timeout-ms` is the END-TO-END deadline for the lifecycle run.
 `preview-variant` blocks on the SAME `story/run-variant` lifecycle as
 `run-variant`, so it exposes the SAME tunable knob (rf2-ovmc5e): default
 10 s, hard ceiling 30 s (matches `:rf.http/timeout-ms` per rf2-it1cd),
 caller values above the ceiling clamp DOWN rather than reject. Both
 tools resolve it through the shared `tools.args/resolve-timeout-ms`
 helper so their blocking policy cannot drift.
+
+The deadline covers the SYNCHRONOUS Story work, not just the
+post-return dereference (rf2-j538f7.31). On the JVM `story/run-variant`
+runs synchronously — a `[:wait ms]` play-step is an inline
+`Thread/sleep` — so it returns an already-settled future; a deadline
+that only fenced the dereference of that settled future would be a lie
+(the advertised ceiling would never bound the real work) and a runaway
+variant would monopolise the single-threaded stdio loop while still
+reporting `:pass`. The lifecycle owner therefore runs the whole
+invoke-and-settle on a bounded worker future and waits at most
+`:timeout-ms`; when the deadline elapses the worker is cancelled
+(interrupting its `Thread/sleep` so the scheduled post-wait continuation
+never fires and the stdio loop is freed at the ceiling) and the call
+returns the canonical `:status :error` run-result — an honest
+bounded-deadline-exceeded outcome, NEVER a false `:pass`.
 
 `:include-sensitive` is honoured ONLY when the server was started
 with `--allow-sensitive-reads` (rf2-g9fje); when that boot gate is

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -347,13 +347,19 @@
   10000)
 
 (defn resolve-timeout-ms
-  "Resolve the caller-supplied `:timeout-ms` arg into the JVM blocking
-  deref ceiling for a lifecycle tool. Reads the slot via the cross-MCP
-  `args/parse-positive-int` parser (string-form ints accepted), defaults
-  to `default-timeout-ms` when absent/unparseable, and clamps DOWN to
-  `max-timeout-ms` so one slow request can't park the single-threaded
-  stdio loop. Shared by `tool-run-variant` and `tool-preview-variant` so
-  the two lifecycle tools can never drift in their blocking policy."
+  "Resolve the caller-supplied `:timeout-ms` arg into the END-TO-END
+  lifecycle deadline for a lifecycle tool. Reads the slot via the
+  cross-MCP `args/parse-positive-int` parser (string-form ints accepted),
+  defaults to `default-timeout-ms` when absent/unparseable, and clamps
+  DOWN to `max-timeout-ms` so one slow request can't park the
+  single-threaded stdio loop. Shared by `tool-run-variant` and
+  `tool-preview-variant` so the two lifecycle tools can never drift in
+  their blocking policy.
+
+  The deadline this resolves is enforced by `tools.lifecycle/
+  run-variant-blocking` over the SYNCHRONOUS Story work (a JVM
+  `[:wait]` is an inline `Thread/sleep`), not just the post-return
+  dereference — see that fn's docstring (rf2-j538f7.31)."
   [arguments]
   (min max-timeout-ms
        (args/parse-positive-int (:timeout-ms arguments) default-timeout-ms)))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
@@ -7,8 +7,12 @@
   boundary guarantees settled and error outcomes carry the same evidence
   slots. Each tool still owns its projection, egress scrubbing,
   annotations, indicators, and wire envelope."
-  (:require [re-frame.story       :as story]
-            [re-frame.story.async :as async]))
+  (:require [re-frame.story :as story]
+            ;; JVM-only: `async/deref-blocking` is `#?(:clj …)` and is used
+            ;; solely by the JVM bounded-lifecycle blocker below. story-mcp
+            ;; is a JVM stdio server (deps.edn), so the require is clj-only —
+            ;; the CLJS branch of this ns never blocks.
+            #?(:clj [re-frame.story.async :as async])))
 
 (defn error-outcome
   "Assemble the ONE canonical error run-result for a synchronous throw /
@@ -53,24 +57,24 @@
                   "the single-threaded stdio server loop.")
              {:variant vk :timeout-ms timeout-ms})))
 
-(defn- unwrap-async-cause
-  "Peel the JVM async-plumbing wrappers (`ExecutionException` from the
-  worker future, `CompletionException` from a rejected Story future) off
-  `e` so the canonical error reason is the underlying Story throwable,
-  not the executor's wrapper. Stops at the first non-wrapper cause.
+#?(:clj
+   (defn- unwrap-async-cause
+     "Peel the JVM async-plumbing wrappers (`ExecutionException` from the
+     worker future, `CompletionException` from a rejected Story future) off
+     `e` so the canonical error reason is the underlying Story throwable,
+     not the executor's wrapper. Stops at the first non-wrapper cause.
 
-  JVM-only, like the rest of this blocking-lifecycle owner: `story-mcp`
-  is a JVM-side stdio server (see `deps.edn`) and `async/deref-blocking`
-  is itself `#?(:clj …)`, so this namespace is never compiled for CLJS."
-  [^Throwable e]
-  (loop [t e]
-    (let [c (.getCause t)]
-      (if (and (or (instance? java.util.concurrent.ExecutionException t)
-                   (instance? java.util.concurrent.CompletionException t))
-               (some? c)
-               (not (identical? c t)))
-        (recur c)
-        t))))
+     JVM-only, like the rest of this blocking-lifecycle owner: `story-mcp`
+     is a JVM-side stdio server (see `deps.edn`)."
+     [^Throwable e]
+     (loop [t e]
+       (let [c (.getCause t)]
+         (if (and (or (instance? java.util.concurrent.ExecutionException t)
+                      (instance? java.util.concurrent.CompletionException t))
+                  (some? c)
+                  (not (identical? c t)))
+           (recur c)
+           t)))))
 
 (defn run-variant-blocking
   "Invoke `story/run-variant` for `vk` with `opts` and BLOCK for its
@@ -98,24 +102,34 @@
   `:pass`.
 
   Returns the outcome map (a settled run-result, or the canonical error
-  outcome). The caller projects / scrubs / wire-shapes it."
+  outcome). The caller projects / scrubs / wire-shapes it.
+
+  JVM-only body: `future` + the bounded timed `deref` (`clojure.core/
+  deref`'s 3-arg arity) have no CLJS counterpart — `story-mcp` is a
+  JVM-side stdio server (see `deps.edn`), so the reader conditional keeps
+  the timed-deref off the CLJS surface (`cljs.core/deref` is 1-arg only,
+  which clj-kondo would otherwise flag on the `.cljc`'s cljs branch)."
   [vk opts timeout-ms]
-  (let [worker (future (async/deref-blocking (story/run-variant vk opts)))]
-    (try
-      (let [settled (deref worker timeout-ms ::timeout)]
-        (if (identical? settled ::timeout)
-          (do
-            ;; Abandon the over-budget run: `future-cancel` interrupts the
-            ;; worker so a JVM `[:wait]` (`Thread/sleep`) unblocks and the
-            ;; scheduled post-wait continuation never fires, freeing the
-            ;; single-threaded stdio loop at the ceiling.
-            (future-cancel worker)
-            (deadline-outcome vk timeout-ms))
-          settled))
-      (catch Throwable e
-        ;; A synchronous throw from `story/run-variant`, or a rejected
-        ;; Story future, surfaces here wrapped in the worker future's
-        ;; `ExecutionException`. Unwrap to the underlying Story throwable
-        ;; so the canonical error reason is honest.
-        (future-cancel worker)
-        (error-outcome vk (unwrap-async-cause e))))))
+  #?(:clj
+     (let [worker (future (async/deref-blocking (story/run-variant vk opts)))]
+       (try
+         (let [settled (deref worker timeout-ms ::timeout)]
+           (if (identical? settled ::timeout)
+             (do
+               ;; Abandon the over-budget run: `future-cancel` interrupts the
+               ;; worker so a JVM `[:wait]` (`Thread/sleep`) unblocks and the
+               ;; scheduled post-wait continuation never fires, freeing the
+               ;; single-threaded stdio loop at the ceiling.
+               (future-cancel worker)
+               (deadline-outcome vk timeout-ms))
+             settled))
+         (catch Throwable e
+           ;; A synchronous throw from `story/run-variant`, or a rejected
+           ;; Story future, surfaces here wrapped in the worker future's
+           ;; `ExecutionException`. Unwrap to the underlying Story throwable
+           ;; so the canonical error reason is honest.
+           (future-cancel worker)
+           (error-outcome vk (unwrap-async-cause e)))))
+     :cljs
+     (throw (ex-info "run-variant-blocking is JVM-only (story-mcp is a JVM stdio server)"
+                     {:vk vk :opts opts :timeout-ms timeout-ms}))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/lifecycle.cljc
@@ -37,19 +37,85 @@
          :lifecycle :error
          :frame     vk))
 
+(defn deadline-outcome
+  "The ONE canonical outcome for a lifecycle `:timeout-ms` deadline that
+  elapsed before the Story run settled. Routes a self-describing timeout
+  through the SAME `error-outcome` boundary a synchronous throw uses, so
+  an over-budget run reports the canonical `:status :error` verdict —
+  NEVER a false `:pass` (spec/017 §Run result). Pure given `vk` +
+  `timeout-ms`."
+  [vk timeout-ms]
+  (error-outcome
+    vk
+    (ex-info (str "Story lifecycle deadline exceeded: variant " (pr-str vk)
+                  " did not settle within the " timeout-ms " ms ceiling. "
+                  "The over-budget run was abandoned so it cannot monopolise "
+                  "the single-threaded stdio server loop.")
+             {:variant vk :timeout-ms timeout-ms})))
+
+(defn- unwrap-async-cause
+  "Peel the JVM async-plumbing wrappers (`ExecutionException` from the
+  worker future, `CompletionException` from a rejected Story future) off
+  `e` so the canonical error reason is the underlying Story throwable,
+  not the executor's wrapper. Stops at the first non-wrapper cause.
+
+  JVM-only, like the rest of this blocking-lifecycle owner: `story-mcp`
+  is a JVM-side stdio server (see `deps.edn`) and `async/deref-blocking`
+  is itself `#?(:clj …)`, so this namespace is never compiled for CLJS."
+  [^Throwable e]
+  (loop [t e]
+    (let [c (.getCause t)]
+      (if (and (or (instance? java.util.concurrent.ExecutionException t)
+                   (instance? java.util.concurrent.CompletionException t))
+               (some? c)
+               (not (identical? c t)))
+        (recur c)
+        t))))
+
 (defn run-variant-blocking
   "Invoke `story/run-variant` for `vk` with `opts` and BLOCK for its
   unified run-result, capped at `timeout-ms` (the single-threaded-stdio
   ceiling both lifecycle tools share via `targs/resolve-timeout-ms`). A
-  synchronous throw or a timeout-elapsed deref is normalized into the ONE
-  canonical `error-outcome` — so `run-variant` and `preview-variant`
-  return the SAME settled-or-error vocabulary and can never drift in their
-  blocking / failure policy.
+  synchronous throw, or a deadline that elapses before the run settles, is
+  normalized into the ONE canonical `error-outcome` — so `run-variant`
+  and `preview-variant` return the SAME settled-or-error vocabulary and
+  can never drift in their blocking / failure policy.
+
+  ## The deadline covers the SYNCHRONOUS work (rf2-j538f7.31)
+
+  On the JVM `story/run-variant` runs SYNCHRONOUSLY (a `[:wait ms]` step
+  is an inline `Thread/sleep`), so it returns an ALREADY-settled future.
+  Deref'ing that settled future under `timeout-ms` is a no-op — the
+  advertised ceiling never bounds the real work, an over-budget run
+  reports a false `:pass`, and it monopolises the single-threaded stdio
+  loop for the full duration. To make the advertised bound REAL, the whole
+  invoke-and-settle runs on a bounded worker `future` conveyed with this
+  thread's dynamic bindings; the caller waits at most `timeout-ms`. When
+  the deadline elapses the worker is CANCELLED (interrupting its
+  `Thread/sleep`, so the scheduled post-wait continuation never runs and
+  the stdio loop is freed) and the canonical `deadline-outcome` is
+  returned — an honest bounded-deadline-exceeded `:error`, not a false
+  `:pass`.
 
   Returns the outcome map (a settled run-result, or the canonical error
   outcome). The caller projects / scrubs / wire-shapes it."
   [vk opts timeout-ms]
-  (try
-    (async/deref-blocking (story/run-variant vk opts) timeout-ms)
-    (catch Throwable e
-      (error-outcome vk e))))
+  (let [worker (future (async/deref-blocking (story/run-variant vk opts)))]
+    (try
+      (let [settled (deref worker timeout-ms ::timeout)]
+        (if (identical? settled ::timeout)
+          (do
+            ;; Abandon the over-budget run: `future-cancel` interrupts the
+            ;; worker so a JVM `[:wait]` (`Thread/sleep`) unblocks and the
+            ;; scheduled post-wait continuation never fires, freeing the
+            ;; single-threaded stdio loop at the ceiling.
+            (future-cancel worker)
+            (deadline-outcome vk timeout-ms))
+          settled))
+      (catch Throwable e
+        ;; A synchronous throw from `story/run-variant`, or a rejected
+        ;; Story future, surfaces here wrapped in the worker future's
+        ;; `ExecutionException`. Unwrap to the underlying Story throwable
+        ;; so the canonical error reason is honest.
+        (future-cancel worker)
+        (error-outcome vk (unwrap-async-cause e))))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -3635,6 +3635,144 @@
             (is (= [] (get s k)) (str k " defaults to [] rather than nil"))))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-j538f7.31 — the lifecycle :timeout-ms ceiling must bound the
+;; SYNCHRONOUS Story work, not just the post-return deref window.
+;;
+;; On the JVM `story/run-variant` executes synchronously (a `[:wait ms]`
+;; step is an inline `Thread/sleep`), so it returns an ALREADY-settled
+;; future. The old `run-variant-blocking` deref'd that already-settled
+;; future under `:timeout-ms` — a no-op — so a variant whose synchronous
+;; work blew past the advertised ceiling still reported `:pass` (false
+;; green) AND monopolised the single-threaded stdio loop for the full
+;; wait. The regressions below use a REAL registered variant with a REAL
+;; `[:wait]` (not a `with-redefs` never-settling future) so they exercise
+;; the synchronous-constructor path this bug lives on. The advertised
+;; bound must be real: an over-budget synchronous run is BOUNDED near the
+;; ceiling and reports the canonical `:error` verdict, never a false
+;; `:pass`.
+;; ---------------------------------------------------------------------------
+
+(deftest run-variant-synchronous-wait-is-bounded-and-honest
+  (testing "an over-budget SYNCHRONOUS `[:wait]` is bounded near :timeout-ms and reports :error, never a false :pass"
+    (config/set-allow-writes! true)
+    ;; A variant whose play-script sleeps far past the deadline. On the JVM
+    ;; the `[:wait 3000]` is a synchronous `Thread/sleep` inside
+    ;; `story/run-variant` — the exact synchronous-work path the advertised
+    ;; ceiling must cover.
+    (story/reg-variant :story.button/slow-wait
+      {:doc    "Play-script sleeps far past the deadline."
+       :args   {:label "Slow"}
+       :tags   #{:dev}
+       :script [[:wait 3000]]})
+    (with-clean-frame [vid :story.button/slow-wait]
+      (let [t0      (System/nanoTime)
+            r       (invoke "run-variant" {:variant-id "story.button/slow-wait"
+                                           :timeout-ms 100})
+            elapsed (/ (double (- (System/nanoTime) t0)) 1e6)
+            s       (:structuredContent r)]
+        (is (success? r)
+            "the tool call itself succeeds — the deadline outcome rides IN the run-result")
+        (is (not= :pass (:status s))
+            "an over-budget synchronous run must NOT report a false :pass")
+        (is (= :error (:status s))
+            "the bounded-deadline-exceeded run reports the canonical :error verdict")
+        (is (story/valid-run-result? s)
+            (str "the deadline outcome conforms to the frozen RunResult schema; "
+                 (story/explain-run-result s)))
+        (doseq [k [:schema-violations :warnings :effects :sub-runs :renders :narrative]]
+          (is (= [] (get s k)) (str k " defaults to [] rather than nil")))
+        (is (< elapsed 2000.0)
+            (str "the run must be BOUNDED near the 100ms :timeout-ms ceiling, "
+                 "not the 3000ms wait — synchronous work is under the deadline. "
+                 "elapsed=" elapsed "ms"))))))
+
+(deftest preview-variant-synchronous-wait-is-bounded-and-honest
+  (testing "preview-variant shares the same bounded-deadline policy over synchronous `[:wait]`"
+    (config/set-allow-writes! true)
+    (story/reg-variant :story.button/slow-preview
+      {:doc    "Play-script sleeps far past the deadline."
+       :args   {:label "Slow"}
+       :tags   #{:dev}
+       :script [[:wait 3000]]})
+    (with-clean-frame [vid :story.button/slow-preview]
+      (let [t0      (System/nanoTime)
+            r       (invoke "preview-variant" {:variant-id "story.button/slow-preview"
+                                               :timeout-ms 100})
+            elapsed (/ (double (- (System/nanoTime) t0)) 1e6)
+            s       (:structuredContent r)]
+        (is (success? r))
+        (is (not= :pass (:status s))
+            "preview must not report a false :pass over budget either")
+        (is (= :error (:status s)))
+        (is (= :error (:lifecycle s))
+            "preview keeps the :lifecycle :error loader-state on the deadline outcome")
+        (is (< elapsed 2000.0)
+            (str "preview is BOUNDED near the 100ms ceiling, not the 3000ms wait. "
+                 "elapsed=" elapsed "ms"))))))
+
+(deftest run-variant-short-wait-within-timeout-still-passes
+  (testing "a fast `[:wait]` well within :timeout-ms still settles :pass — the fix doesn't break the happy path"
+    (config/set-allow-writes! true)
+    (story/reg-variant :story.button/quick-wait
+      {:doc    "Short wait, comfortably inside the timeout."
+       :args   {:label "Quick"}
+       :tags   #{:dev}
+       :script [[:wait 20]]})
+    (with-clean-frame [vid :story.button/quick-wait]
+      (let [r (invoke "run-variant" {:variant-id "story.button/quick-wait"
+                                     :timeout-ms 5000})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= :pass (:status s))
+            "a fast variant within a generous timeout still settles :pass")
+        (is (story/valid-run-result? s))))))
+
+(deftest stdio-loop-freed-after-lifecycle-deadline
+  (testing "a timed-out run-variant does NOT monopolise the single-threaded
+            stdio loop — a following `ping` is answered bounded near the
+            ceiling, not held for the full Story wait (rf2-j538f7.31)"
+    (story/reg-variant :story.button/slow-loop
+      {:doc    "Runaway wait that would park the whole stdio loop pre-fix."
+       :args   {:label "Slow"}
+       :tags   #{:dev}
+       :script [[:wait 3000]]})
+    (with-clean-frame [vid :story.button/slow-loop]
+      (let [frames   [{:jsonrpc "2.0" :id 1 :method "initialize"
+                       :params  {:protocolVersion "2025-06-18"
+                                 :capabilities    {}
+                                 :clientInfo      {:name "test" :version "0"}}}
+                      {:jsonrpc "2.0" :id 2 :method "tools/call"
+                       :params  {:name      "run-variant"
+                                 :arguments {:variant-id "story.button/slow-loop"
+                                             :timeout-ms 100
+                                             :dedup      false}}}
+                      ;; The liveness probe RIGHT BEHIND the runaway call. In
+                      ;; the single-threaded loop it is only READ after
+                      ;; run-variant returns — so its answer is held for
+                      ;; however long run-variant blocks.
+                      {:jsonrpc "2.0" :id 3 :method "ping"}]
+            input    (apply str (map #(str (cheshire/generate-string %) "\n") frames))
+            reader   (java.io.BufferedReader. (java.io.StringReader. input))
+            writer   (java.io.StringWriter.)
+            t0       (System/nanoTime)
+            _        (server/run-loop! reader writer)
+            elapsed  (/ (double (- (System/nanoTime) t0)) 1e6)
+            by-id    (into {}
+                           (comp (remove #(zero? (count ^String %)))
+                                 (map #(cheshire/parse-string % true))
+                                 (map (juxt :id identity)))
+                           (seq (.split ^String (str writer) "\n")))]
+        ;; The whole loop — the runaway run-variant AND the trailing ping —
+        ;; completes bounded near the 100ms ceiling, NOT the 3000ms wait.
+        (is (< elapsed 2000.0)
+            (str "the stdio loop is freed at the ceiling, not held for the "
+                 "full 3000ms wait. elapsed=" elapsed "ms"))
+        (is (= "error" (get-in by-id [2 :result :structuredContent :status]))
+            "the over-budget run reports :error over the wire, never a false :pass")
+        (is (= {} (get-in by-id [3 :result]))
+            "the following ping IS answered — the loop was not monopolised past the deadline")))))
+
+;; ---------------------------------------------------------------------------
 ;; rf2-iapjh7: ONE lifecycle execution owner for both consumers
 ;;
 ;; `run-variant` (tools.testing) + `preview-variant` (tools.dev) share the


### PR DESCRIPTION
## What

Story-MCP advertised `:timeout-ms` as a bounded lifecycle deadline (default 10s, hard max 30s), but the deadline began only **after** `story/run-variant` / `story/preview-variant` returned. On the JVM the real Story work runs **synchronously** before that return (a `[:wait ms]` play-step is an inline `Thread/sleep`), so `run-variant` returned an already-settled future and the timed deref (`.get(timeout)`) was a no-op. Result: a variant whose synchronous work blew past the ceiling still reported `:status :pass` (false green) **and** monopolised the single-threaded stdio loop for the full duration (a `[:wait 60000]` overran the documented 30s ceiling and blocked every following MCP request, a local DoS vector).

## Fix

`tools.lifecycle/run-variant-blocking` now runs the whole invoke-and-settle on a bounded worker `future` (this thread's dynamic bindings conveyed) and waits at most `:timeout-ms`. When the deadline elapses the worker is cancelled, interrupting its `Thread/sleep` so the scheduled post-wait continuation never fires and the stdio loop is freed at the ceiling, and the call returns the canonical `:status :error` run-result through the **same** `error-outcome` boundary a synchronous throw uses. An over-budget run is bounded and reports an honest deadline-exceeded `:error`, **never** a false `:pass`. No schema/descriptor/timeout-value change (descriptor manifest unchanged); the existing `:rf.error/run-failed` canonical outcome is reused, so no new error id.

## Teeth (fail-before / pass-after)

New regressions use a **real** registered variant with a **real** `[:wait]` (not a `with-redefs` never-settling future, the arm the prior test missed):

- `run-variant-synchronous-wait-is-bounded-and-honest` — `[:wait 3000]` under `:timeout-ms 100`. **Before:** `:status :pass`, elapsed ~3015ms. **After:** `:status :error`, schema-valid, elapsed bounded <2000ms.
- `preview-variant-synchronous-wait-is-bounded-and-honest` — same policy for preview; keeps `:lifecycle :error`.
- `run-variant-short-wait-within-timeout-still-passes` — a `[:wait 20]` under `:timeout-ms 5000` still settles `:pass` (happy path preserved).
- `stdio-loop-freed-after-lifecycle-deadline` — drives the real `run-loop!`: a runaway `run-variant` followed by `ping`; the ping is answered bounded near the ceiling, not held for the whole 3000ms wait.

## Scope

story-mcp-only. The deeper JVM/CLJS scheduler parity + run-token/clear-state cancellation seam (tools/story `runner_events` DESIGN direction) is owned by **rf2-j538f7.34** and sequenced separately; this PR makes the advertised bound real from the lifecycle owner without touching tools/story. Story-MCP API/registry prose updated to describe the end-to-end deadline + cleanup.

## Gates

- `clojure -M:test` (story-mcp): **290 tests, 1516 assertions, 0 failures, 0 errors**
- `clojure -M:gen --check`: descriptors in sync (20 tools)
