### PR TITLE
fix(reagent-slim): framework-internal argv-equality sCU on every class; narrow FORM-3 contract (rf2-5al9d7)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -150,24 +150,42 @@ in a Form-2 component:
       [:div precomputed (str props)])))
 ```
 
-### `:should-component-update` → React.memo at the user's call site, or accept the re-render
+### `:should-component-update` → the framework installs one for you
 
-`shouldComponentUpdate` returned `false` to skip a re-render. The React-blessed
-replacement is `React.memo` (for function components) or `React.PureComponent`
-(for class components). reagent-slim ships neither as a Form-3 cap key, but
-users can apply `React.memo` at the call site by reactifying their component:
+`shouldComponentUpdate` returned `false` to skip a re-render. reagent-slim does
+**not** accept `:should-component-update` as a user cap key — and you almost
+never need it, because the framework installs its own.
 
-```clojure
-(def memoised-thing
-  (js/React.memo (reagent2.core/reactify-component thing)))
-```
+**The framework default.** Every reagent-slim class carries an internal,
+framework-owned `shouldComponentUpdate` that compares the component's hiccup
+argv with `=`. A child whose argv is `=` to its previous argv is **not**
+re-rendered just because its parent re-rendered — the fine-grained-re-render
+property, matching stock Reagent. This is a framework invariant, not a user
+surface: you cannot override it through the cap (a `:should-component-update`
+key is still rejected at registration time, per §1), and you do not need to —
+it is always on.
 
-In re-frame2's idiom, the more common answer is **accept the re-render**:
-re-frame2's reactive substrate already gates render at the subscription level
-(views only re-render when their subscribed values change), so most
-`:should-component-update` use cases are subsumed by sub graph design. If a
-component is re-rendering too often, the diagnosis is usually "your sub is
-firing too often," not "this component needs a manual gate."
+**What still triggers a render.** The argv gate skips *only* equal-argv parent
+propagation. A view still re-renders when:
+
+- its argv **changes** — a parent passed a value that is `not=` the previous one;
+- a **subscription it deref's is invalidated** — the reactive substrate targets
+  that view directly (the update drains as a `forceUpdate`, which React
+  specifies bypasses `shouldComponentUpdate`), so a view's *own* data changes
+  always commit;
+- its **local reactive state** (a Form-2 `reagent2.core/atom`) changes;
+- an ancestor **React context** it consumes changes;
+- something calls **force-update** on it.
+
+So the accurate contract is two-sided: the reactive substrate gates a view's
+*subscription-driven* re-renders to the moment its subscribed values change, and
+the argv gate additionally spares it from its *parent's* unrelated re-renders.
+It does **not** mean "a view only ever re-renders when a subscribed value
+changes" — the causes above still apply. If a component re-renders more than you
+expect, the usual diagnosis is "your sub is firing too often" or "the value you
+pass down is `not=` every render" (an inline `(fn …)` closure — never `=` to
+another — or a freshly-built collection whose contents differ), not "this
+component needs a manual gate."
 
 ### `:get-initial-state` → outer-fn Form-2 closure, or `:initial-events`
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -530,6 +530,70 @@
                        (._run cached-rea false))]
           (->react-element hiccup))))))
 
+;; ---------------------------------------------------------------------------
+;; Framework-default shouldComponentUpdate — argv-equality gate (rf2-5al9d7)
+;;
+;; Stock Reagent installs a default `shouldComponentUpdate` that compares a
+;; component's argv with `=`: a child whose args did not change does NOT
+;; re-render just because its parent did (the signature "fine-grained
+;; re-render" property). reagent-slim shipped without it, so React took its
+;; always-render default and every slim class re-rendered on every parent
+;; re-render — an observable lifecycle-frequency divergence from stock
+;; (`:component-did-update` / `:get-snapshot-before-update` firing on
+;; value-identical argvs) plus wasted work down Reagent-shaped subtrees. This
+;; restores the invariant.
+;;
+;; This is a FRAMEWORK-INTERNAL default, NOT a user surface. `:should-
+;; component-update` stays OUT of the 7-key `create-class` cap — a user
+;; override is still rejected at registration time (see `cap-keys`). The
+;; framework merely restores its own invariant.
+;;
+;; It does NOT suppress subscription- or local-state-driven updates. Every
+;; reactive update in reagent-slim (a subscription invalidation or a Form-2
+;; RAtom change) drains through `reagent2.impl.batching` as a `forceUpdate`,
+;; and React specifies that `forceUpdate` re-renders WITHOUT consulting
+;; `shouldComponentUpdate`. Parent propagation and reactive invalidation are
+;; therefore separate causes: this gate skips equal-argv PARENT re-renders
+;; while a subscription change still commits its own view. Context changes
+;; (React forces `contextType` consumers to re-render regardless of sCU) and
+;; error-boundary state transitions (`getDerivedStateFromError`) are likewise
+;; not gated away — they are non-prop causes React drives independently.
+;;
+;; Fail-open: `=` over an app-owned argv can throw (a value with a throwing
+;; `-equiv`, a same-reference foreign object mutated in place). Stock Reagent
+;; fails CLOSED (skips); we fail OPEN (render) with a dev warning — skipping
+;; on a comparison failure risks a stale UI, and a class component is always
+;; correct WITH a render. The extra render is the safe branch (rf2-5al9d7).
+;; ---------------------------------------------------------------------------
+
+(defn- argv-should-update?
+  "Framework-default `shouldComponentUpdate` body. `this` is the mounted
+  instance (current props under `.-props`); `next-props` is React's incoming
+  props. Returns `true` to render, `false` to skip.
+
+  Renders when either argv is missing (nothing to compare — fall back to
+  React's always-render default) or the argvs are NOT `=`. Skips only when
+  both argvs are present and `=`. Fails OPEN (renders + dev-warns) if the
+  `=` comparison itself throws."
+  [^js this ^js next-props]
+  (let [prev-argv (some-> (.-props this) .-__rfArgv)
+        next-argv (some-> next-props .-__rfArgv)]
+    (if (or (nil? prev-argv) (nil? next-argv))
+      true
+      (try
+        (not= prev-argv next-argv)
+        (catch :default _e
+          (when ^boolean js/goog.DEBUG
+            (when (exists? js/console)
+              (.warn js/console
+                     (str "[reagent-slim] shouldComponentUpdate argv `=` "
+                          "comparison threw; rendering this component "
+                          "(fail-open). Argv shapes — prev: "
+                          (pr-str (diag/value-summary prev-argv))
+                          ", next: "
+                          (pr-str (diag/value-summary next-argv)) "."))))
+          true)))))
+
 (defn create-class*
   "Build a React component class from a Form-3 spec map. Validates
   the spec against the 7-key cap (per IMPL-SPEC §6.1) — any
@@ -579,6 +643,16 @@
     ;; make-render-method's body re-stashes argv from props at render
     ;; entry, so a single install is sufficient.
     (set! (.. klass -prototype -render) (make-render-method render-fn))
+
+    ;; Framework-default shouldComponentUpdate: restore stock Reagent's
+    ;; argv-equality gate on every slim class (rf2-5al9d7). Internal — NOT a
+    ;; user cap key. React skips sCU on the initial render and for forceUpdate
+    ;; (the reactive-update drain in reagent2.impl.batching), so this gates
+    ;; only parent-propagated re-renders: an equal-argv child is skipped.
+    (set! (.. klass -prototype -shouldComponentUpdate)
+          (fn [next-props _next-state]
+            (this-as this
+              (argv-should-update? this next-props))))
 
     (install-lifecycle! klass spec)
     klass))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
@@ -1,0 +1,145 @@
+(ns re-frame.adapter.reagent-slim-scu-argv-gate-dom-cljs-test
+  "rf2-5al9d7 — the reagent-slim framework-default `shouldComponentUpdate`
+  DOM regression proof, under a React 19 `createRoot`.
+
+  WHAT IT PROVES. Every reagent-slim class carries a framework-INTERNAL
+  argv-equality `shouldComponentUpdate` (restored from stock Reagent). When a
+  parent re-renders but a child's argv is `=`, the child's render fn AND its
+  `:component-did-update` lifecycle do NOT run — the signature fine-grained
+  re-render property. When the child's argv CHANGES, they DO run. This is the
+  real-React proof that the gate governs parent propagation: the unit tests in
+  `component_cljs_test` call prototype methods directly and cannot observe
+  React's reconciliation bailout, so this DOM-level test is the load-bearing
+  regression.
+
+  It also proves the gate does NOT globally suppress work: the child in the
+  changed-argv case commits through ordinary reconciliation. The complementary
+  guarantee — that same-argv SUBSCRIPTION invalidation still commits (because
+  the reactive drain uses `forceUpdate`, which React specifies bypasses
+  `shouldComponentUpdate`) — is proven by the sibling
+  `reagent_slim_flush_render_dom_cljs_test`, which stays green alongside this
+  file.
+
+  WHY A reagent-slim-SPECIFIC DOM FILE. The gate is a class-prototype
+  `shouldComponentUpdate` React only consults during real reconciliation. It
+  cannot be exercised by invoking prototype methods directly (no reconciler in
+  the loop); only a `react-dom/client createRoot` mount + a genuine parent
+  re-render surfaces the bailout. So the probe mounts through the substrate's
+  own root (`reagent2.dom.client/create-root` + hiccup), exactly the path a
+  slim app runs.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` discovers it
+  for the real-DOM assertion; the `:node-test` runner also loads it, where the
+  body gates on `(browser?)` and no-ops cleanly (no DOM)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent2.dom.client :as rdc]
+            [reagent2.core :as r]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's
+;; default ambient `*current-frame*` :rf/default scope so the probe's
+;; subscribes resolve their frame from the enclosing `frame-provider` via the
+;; React-context tier (mirrors the flush-render DOM twin).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(deftest scu-argv-gate-skips-equal-argv-child-renders-changed-argv
+  (testing "reagent-slim — the framework-default sCU gates parent-propagated child re-renders by argv `=` (rf2-5al9d7)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [frame-kw     :rf.reagent-slim-scu/probe-frame
+            flush!       (:flush-render! reagent-slim-adapter/adapter)
+            render-count (atom 0)
+            update-count (atom 0)
+            ;; The child's ONLY input is the arg its parent passes down — it
+            ;; subscribes to nothing, so the only cause that can re-render it
+            ;; is parent propagation, which the sCU gates. `:reagent-render`
+            ;; receives the user-args slice of the argv (NOT `this`), so it
+            ;; takes the passed value directly; it counts renders.
+            ;; `:component-did-update` counts commits AFTER the first.
+            child (r/create-class
+                    {:display-name "scu-probe-child"
+                     :reagent-render
+                     (fn [v]
+                       (swap! render-count inc)
+                       [:span "child-v=" v])
+                     :component-did-update
+                     (fn [_this _prev-argv _snapshot]
+                       (swap! update-count inc))})]
+        (rf/reg-frame frame-kw {:doc "sCU argv-gate probe frame"})
+        (rf/reg-event ::seed       (fn [_ _] {:db {:tick 0 :child-v 1}}))
+        (rf/reg-event ::bump-tick  (fn [{:keys [db]} _] {:db (update db :tick inc)}))
+        (rf/reg-event ::bump-child (fn [{:keys [db]} _] {:db (update db :child-v inc)}))
+        (rf/dispatch-sync [::seed] {:frame frame-kw})
+        (rf/reg-sub ::tick    (fn [db _] (:tick db)))
+        (rf/reg-sub ::child-v (fn [db _] (:child-v db)))
+        ;; The parent subscribes to BOTH :tick and :child-v so it re-renders
+        ;; on either — but it only passes :child-v down to the child. Bumping
+        ;; :tick re-renders the parent WITHOUT changing the child's argv;
+        ;; bumping :child-v re-renders the parent AND changes the child's argv.
+        (rf/reg-view* :rf.reagent-slim-scu/parent
+                      (fn parent []
+                        (let [tick @(rf/subscribe [::tick])
+                              cv   @(rf/subscribe [::child-v])]
+                          [:div
+                           [child cv]
+                           [:span "tick=" tick]])))
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; Initial mount wrapped in flushSync so the first pass commits
+            ;; before render returns (React 19 root.render is otherwise async).
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [rf/frame-provider {:frame frame-kw}
+                                  [(rf/view :rf.reagent-slim-scu/parent)]])))
+            ;; Initial mount: child rendered once; no update lifecycle yet
+            ;; (React never calls sCU or componentDidUpdate on the first pass).
+            (is (= 1 @render-count) "child render fn ran once on initial mount")
+            (is (= 0 @update-count) "no :component-did-update on the initial mount")
+            (is (= "child-v=1tick=0" (.-textContent mount-node))
+                "committed DOM shows the seeded child-v=1 tick=0")
+
+            ;; ── EQUAL ARGV. Bump :tick: the parent re-renders (its :tick sub
+            ;; fired), producing a fresh child element whose argv is `=` to the
+            ;; live one. The sCU returns false → the child's render fn AND
+            ;; :component-did-update MUST NOT run. The parent's own "tick="
+            ;; text still updates (the parent re-renders via forceUpdate, which
+            ;; bypasses ITS sCU).
+            (rf/dispatch-sync [::bump-tick] {:frame frame-kw})
+            (flush!)
+            (is (= 1 @render-count)
+                "EQUAL-ARGV parent re-render: child render fn did NOT run (sCU skipped it)")
+            (is (= 0 @update-count)
+                "EQUAL-ARGV parent re-render: child :component-did-update did NOT run (sCU skipped it)")
+            (is (= "child-v=1tick=1" (.-textContent mount-node))
+                "parent's own text advanced to tick=1 while the child DOM stayed child-v=1")
+
+            ;; ── CHANGED ARGV. Bump :child-v: the parent re-renders (its
+            ;; :child-v sub fired) and the child's argv CHANGES. The sCU
+            ;; returns true → the child's render fn AND :component-did-update
+            ;; DO run.
+            (rf/dispatch-sync [::bump-child] {:frame frame-kw})
+            (flush!)
+            (is (= 2 @render-count)
+                "CHANGED-ARGV parent re-render: child render fn ran (sCU allowed the render)")
+            (is (= 1 @update-count)
+                "CHANGED-ARGV parent re-render: child :component-did-update ran (sCU allowed the render)")
+            (is (= "child-v=2tick=1" (.-textContent mount-node))
+                "child DOM reflects the changed arg child-v=2")
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -780,3 +780,70 @@
               ":recovery is :no-recovery — there is no fallback path")
           (is (string? (:reason thrown))
               ":reason carries an actionable message"))))))
+
+;; ---------------------------------------------------------------------------
+;; Framework-default shouldComponentUpdate — argv-equality gate (rf2-5al9d7)
+;;
+;; Prototype-level unit coverage: the install is present on every class, and
+;; the predicate exercises all four branches — equal argv skips, changed argv
+;; renders, missing argv renders, and a THROWING comparison fails OPEN
+;; (renders), tightening stock Reagent's fail-CLOSED default. The real-React
+;; reconciliation-bailout proof (equal argv → the child's render + update
+;; lifecycles do NOT run) lives in the DOM twin
+;; reagent_slim_scu_argv_gate_dom_cljs_test: sCU is only consulted by a live
+;; reconciler, so these direct-invocation tests assert the predicate contract,
+;; not React's use of it.
+;; ---------------------------------------------------------------------------
+
+(defn- scu-call
+  "Invoke `klass`'s shouldComponentUpdate with `this` bound to a synthesised
+  instance carrying `prev-argv` under `.props.__rfArgv`, and React's incoming
+  props carrying `next-argv`. Returns the boolean the gate produced."
+  [^js klass prev-argv next-argv]
+  (let [scu  (.. klass -prototype -shouldComponentUpdate)
+        inst #js {:props #js {:__rfArgv prev-argv}}]
+    (.call scu inst #js {:__rfArgv next-argv})))
+
+(deftest scu-installed-on-every-class
+  (testing "create-class* installs a framework-default shouldComponentUpdate"
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})]
+      (is (fn? (.. klass -prototype -shouldComponentUpdate))
+          "shouldComponentUpdate is present on the class prototype")))
+  (testing "fn-to-class (Form-1/2) classes also carry the default sCU"
+    (let [^js klass (component/fn-to-class (fn [_] [:div]))]
+      (is (fn? (.. klass -prototype -shouldComponentUpdate))
+          "the sCU rides through fn-to-class → create-class*"))))
+
+(deftest scu-skips-equal-argv
+  (testing "structurally-= argv → false (skip the parent-propagated re-render)"
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})]
+      ;; Fresh vectors, equal contents — the slim per-render argv shape.
+      (is (false? (scu-call klass [:head {:a 1} [1 2 3]] [:head {:a 1} [1 2 3]]))
+          "= argv (distinct vectors, equal contents) skips"))))
+
+(deftest scu-renders-changed-argv
+  (testing "not= argv → true (render)"
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})]
+      (is (true? (scu-call klass [:head {:a 1}] [:head {:a 2}]))
+          "a changed arg renders"))))
+
+(deftest scu-renders-when-argv-missing
+  (testing "either argv missing → true (fall back to React's always-render)"
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})
+          scu       (.. klass -prototype -shouldComponentUpdate)]
+      (is (true? (scu-call klass nil [:head]))
+          "missing prev argv renders")
+      (is (true? (scu-call klass [:head] nil))
+          "missing next argv renders")
+      (is (true? (.call scu #js {:props #js {}} #js {}))
+          "undefined __rfArgv on both sides renders"))))
+
+(deftest scu-fails-open-on-throwing-comparison
+  (testing "a comparison that THROWS → true (fail OPEN, tightening stock's fail-closed)"
+    ;; Distinct values whose `=` throws (a throwing -equiv) force the
+    ;; comparison to throw. The gate must render rather than risk a stale UI.
+    (let [^js klass (component/create-class* {:reagent-render (fn [_] [:div])})
+          boom1 (reify IEquiv (-equiv [_ _] (throw (js/Error. "equiv boom"))))
+          boom2 (reify IEquiv (-equiv [_ _] (throw (js/Error. "equiv boom"))))]
+      (is (true? (scu-call klass [boom1] [boom2]))
+          "throwing `=` fails open (renders)"))))


### PR DESCRIPTION
## What & why (rf2-5al9d7, RULED Option A tightened)

reagent-slim installed **no** default `shouldComponentUpdate`, so React took its always-render default: every slim class re-rendered whenever its parent did, regardless of whether its argv changed. That lost stock Reagent's signature fine-grained re-render property and fired `:component-did-update` / `:get-snapshot-before-update` on value-identical argvs — an observable lifecycle-frequency divergence from stock plus wasted work down Reagent-shaped subtrees. FORM-3.md also *promised* the absent behaviour ("views only re-render when their subscribed values change"), so this was a doc-vs-behaviour contradiction, not just a perf nit.

## Change

- **Framework-internal argv-equality sCU** on every class produced by `create-class*` (`fn-to-class` routes through it, so Form-1/2 are covered). Compares prev/next `__rfArgv` with `=`; renders when either argv is missing; **fails OPEN** (renders + dev warns) if the comparison throws — tightening stock's fail-*closed* default, since skipping on a comparison failure risks a stale UI.
- **Not a user surface.** `:should-component-update` stays OUT of the public 7-key cap; a user override is still rejected at registration. The framework merely restores its own invariant.
- **Reactive updates unaffected.** The reactive drain (`reagent2.impl.batching`) commits via `forceUpdate`, which React specifies bypasses `shouldComponentUpdate`. Parent propagation and subscription invalidation stay separate causes; context changes and error-boundary state transitions are non-prop causes React drives independently.
- **FORM-3.md narrowed** to the accurate two-sided contract (subscription invalidation targets its own view; equal-argv parent propagation skipped; argv change / local reactive state / context / force-update still render). Removed the impossible `reactify-component` escape prose (unshipped fn).

## DOM teeth-proof

New real React-19 `createRoot` regression (`reagent_slim_scu_argv_gate_dom_cljs_test`): an equal-argv parent re-render runs **neither** the child's render fn **nor** its `:component-did-update`; a changed-argv re-render runs **both**. Verified it discriminates: with the sCU neutered (always-render) the browser gate produces exactly **4 failures**; with the real gate, **0**.

## Quality gates (all green)

| Gate | Result |
|---|---|
| `npm run test:cljs` (node-test) | Ran 8623 tests / 40636 assertions — 0 failures, 0 errors |
| `npm run test:browser` (Playwright DOM) | Ran 264 tests / 918 assertions — 0 failures (incl. new sCU regression + existing subscription/`forceUpdate` flush-render coverage) |
| `npm run test:adapter-smokes` | Ran 3 adapter-smoke specs — 0 failures |
| `npm run test:reagent-slim:bundle-isolation` | PASS — 6 contracts, 25 sentinel checks (slim does not pull stock Reagent) |
| `mkdocs build --strict` | Built successfully |
