### PR TITLE
fix(subs): retain subscribe-once (advanced tier); drift-fix machine-action docstrings + 2 misuse call sites (rf2-ihkk6l)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -971,9 +971,20 @@
 ;; a keyword target both route correctly.
 
 (def ^{:doc "One-shot read of a sub's current value — subscribes, derefs,
-  then unsubscribes. Does NOT retain a cache reference. Use in handler
-  bodies, machine actions, REPL — anywhere you need a value without a
-  reactive subscription. Per spec/API.md §Dispatch and subscribe.
+  then unsubscribes. Does NOT retain a cache reference. The **advanced**
+  live one-shot read for non-reactive consumers — REPL sessions, SSR
+  builders, tools, and integration tests that want what the running frame
+  sees right now; for reactive consumers (Reagent views, tools holding
+  the reaction) use `subscribe`. NOT the default write-side idiom:
+  ordinary event/effect design derives from the handler's declared
+  coeffects (`:rf.cofx/requires`, EP-0017) and pure helpers, so the read
+  rides the causal record rather than an ambient side-effect. And **never
+  from inside a machine callback** (`:guard` / `:action` / `:entry` /
+  `:exit`): an in-callback ambient read is unrecorded, so replay could
+  select a different transition — a machine takes external facts by
+  payload threading or a declared recordable coeffect (machines-only
+  `{:rf/sub query-v :as fact-id}`). Per Spec 006 §subscribe-once and
+  Cross-Spec-Interactions §2.
 
   Call shapes, mirroring `subscribe`:
 

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1548,12 +1548,18 @@
   unsubscribes — does NOT retain a reference on the cache entry and
   does NOT register the caller for reactive re-render.
 
-  Use in tests, REPL sessions, machine-action bodies, SSR builders,
-  or any non-reactive consumer that wants the value right now. For
-  reactive consumers (Reagent views, tools holding the reaction) use
-  `subscribe`. For event handlers prefer declaring a sub-reading cofx via
-  `:rf.cofx/requires` (EP-0017) so the read is part of the cofx contract
-  rather than a side-effect inside the handler body.
+  The **advanced** live one-shot read: use in tests, REPL sessions, SSR
+  builders, tools, or any non-reactive consumer that wants the value
+  right now. For reactive consumers (Reagent views, tools holding the
+  reaction) use `subscribe`. For event handlers prefer declaring a
+  sub-reading cofx via `:rf.cofx/requires` (EP-0017) so the read is part
+  of the cofx contract rather than a side-effect inside the handler body.
+  **Never from inside a machine callback** (`:guard` / `:action` /
+  `:entry` / `:exit`): an in-callback ambient read is unrecorded and
+  breaks 005's token-grain replay contract — a machine takes external
+  facts by payload threading or a declared recordable coeffect
+  (machines-only `{:rf/sub query-v :as fact-id}`). Per
+  Cross-Spec-Interactions §2 / Spec 006 §subscribe-once.
 
   Per Spec 006 §Reference counting and disposal: the
   teardown `unsubscribe` runs synchronously on the 1 → 0 transition,

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2112,7 +2112,12 @@
         (is (some #(= :rf.frame/destroyed (:operation %)) @traces) ":rf.frame/destroyed fires after the per-machine traces")))))
 
 (defn assert-xspec-machine-microstep-subscribe
-  "#2 Sub-cache hit inside a machine microstep."
+  "#2 Sub-cache hit inside a machine microstep — the SUPPORTED shape.
+  The action reads the sub value off its recorded `:rf.cofx` (a declared
+  `{:rf/sub … :as …}` recordable source, evaluated once against the
+  committed pre-cascade frame-state), NOT via an in-callback
+  `subscribe-once` — an in-callback ambient read is unrecorded and breaks
+  005's replay contract (Cross-Spec-Interactions §2, rf2-h6ggnt)."
   [{:keys [name]}]
   (testing (str name " — #2 sub-cache hit inside a machine microstep")
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user/role :admin}}))
@@ -2123,11 +2128,14 @@
                    :states  {:idle   {:on {:go {:target :acting :action :record-role}}}
                              :acting {}}
                    :actions {:record-role
-                             (fn [_] (reset! observed-by-action (rf/subscribe-once [:user-role])) nil)}}]
+                             {:rf.cofx/requires [{:rf/sub [:user-role] :as :auth/role}]
+                              :fn (fn [{cofx :rf.cofx}]
+                                    (reset! observed-by-action (:auth/role cofx))
+                                    nil)}}}]
       (rf/reg-machine :auth/check machine)
       (rf/dispatch-sync [:auth/check [:go]])
       (is (= :admin @observed-by-action)
-          "the sub returns the committed app-db value visible to the action body"))))
+          "the action read the recorded (pre-cascade) sub value off its :rf.cofx"))))
 
 (defn assert-xspec-boot-order-adapter-ready
   "#3 Machine spawn at boot before substrate adapter ready."

--- a/testbeds/ssr_multi_frame/core.cljs
+++ b/testbeds/ssr_multi_frame/core.cljs
@@ -125,13 +125,14 @@
 
 (reg-view hydration-summary []
   ;; Cross-frame readout — proves each frame's :rf/hydration metadata
-  ;; was written independently. We use the frame-explicit
-  ;; subscribe-once opts form (`[query-v {:frame f}]`) so each call
-  ;; resolves against the named frame's app-db, not the surrounding
-  ;; `frame-provider`'s default.
-  (let [hyd-a (rf/subscribe-once [:hydration] {:frame frame-a})
-        hyd-b (rf/subscribe-once [:hydration] {:frame frame-b})
-        hyd-l (rf/subscribe-once [:hydration] {:frame frame-log})]
+  ;; was written independently. Reactive `subscribe` with the frame-explicit
+  ;; opts form (`[query-v {:frame f}]`) so each reaction resolves against the
+  ;; named frame's app-db (this view renders OUTSIDE any `frame-provider`),
+  ;; and the summary re-renders when a frame's hydration metadata changes.
+  ;; (Render-time reads are reactive `subscribe`, never `subscribe-once`.)
+  (let [hyd-a @(rf/subscribe [:hydration] {:frame frame-a})
+        hyd-b @(rf/subscribe [:hydration] {:frame frame-b})
+        hyd-l @(rf/subscribe [:hydration] {:frame frame-log})]
     [:div {:data-testid "hydration-summary"
            :style {:border  "1px solid #aaa"
                    :padding "0.5em"


### PR DESCRIPTION
## Ruling: Option C — RETAIN (rf2-ihkk6l, Mike→Fable 2026-07-11)

`subscribe-once` stays the public **advanced-tier** operation — name and both call shapes unchanged. It is a distinct **lifetime** contract (acquire one ref, deref through the live graph, release synchronously), not read-sugar; `compute-sub` compositions cannot replace it (they cannot evaluate runtime-db/mixed subs, and bypass the per-frame cache, Story overrides, and live error attribution). Its implementation, signature, manifest row, and API.md row are **untouched** — the manifest already classifies it `:advanced` / `"v1 (preserved + extended)"` and API.md already says *"never inside a machine callback"* (confirmed no drift).

This PR is the three targeted **drift fixes** the ruling dispatched, aligning source with Spec 006 / Cross-Spec-Interactions §2 / the rf2-h6ggnt machine carve-out.

### Changes
- **Docstrings (`re-frame.core` + `re-frame.subs`)** no longer bless `subscribe-once` inside machine actions. They now frame it as the advanced *live one-shot* escape for non-reactive consumers (REPL / SSR / tools / integration tests), keep ordinary event/effect design on declared coeffects + pure helpers, and state the hard machine-callback prohibition (facts arrive via payload threading or a declared recordable `{:rf/sub … :as …}` coeffect).
- **`react_shared_suite.cljs`** — `assert-xspec-machine-microstep-subscribe` migrated off the in-callback `subscribe-once` to the recorded `{:rf/sub [:user-role] :as :auth/role}` coeffect, read off `:rf.cofx` (the supported machine shape; mirrors the proven JVM `machine_cofx_sub_source_test`).
- **`testbeds/ssr_multi_frame`** — `hydration-summary`'s render-time `subscribe-once` reads become reactive `subscribe` (render-safe; re-renders on change).

### Quality gates (all green)
- `npm run test:cljs` (node-test): **8617 tests / 40627 assertions / 0 failures / 0 errors** — includes the migrated `xspec-machine-microstep-subscribe` deftest (emitted per adapter under node-test).
- `shadow-cljs compile browser-test`: 845 files, 0 warnings (react_shared_suite migration compiles).
- `shadow-cljs compile :testbeds/ssr-multi-frame`: 535 files, 0 warnings.
- `mkdocs build --strict`: pass.
- api-manifest `gen --check`: OK (457 public vars in sync). `api-md-check`: OK (183 rows in sync).
- `subscribe-once` retained (not deleted); its existing tests remain green (implementation unchanged).