### PR TITLE
fix(routing): fragment-only navigate short-circuit — no re-match, token/loaders preserved, scroll+history via effects (rf2-k4exp1)

### DIFF
--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -112,6 +112,83 @@
     (assoc tags :error privacy/redacted-sentinel :sensitive? true)
     tags))
 
+(defn- fragment-only-nav-fx
+  "Spec 012 §Fragments rules 3-4 / §Programmatic navigation with fragments
+  (rf2-k4exp1): a resolved `:rf.route/navigate` whose target differs from the
+  CURRENT slice ONLY in its `#fragment` (same `:route-id`/`:params`/`:query`)
+  is an in-page anchor change, not a route (re)activation. Mirrors the
+  URL-driven `url_change.cljc` fragment-only short-circuit so the SAME logical
+  operation behaves identically whichever door — programmatic
+  `:rf.route/navigate`, forward-nav `:rf.route/transitioned`, or popstate
+  `:rf.route/handle-url-change` — it enters.
+
+  Classified only AFTER target resolution / fragment-normalisation / query
+  shaping / URL build / validation AND after the `:can-leave`/`:can-enter`
+  gate passes (both upstream in `navigate-handler`). On this branch the
+  handler:
+
+    1. assocs ONLY `[:rf.runtime/routing :current :fragment]` — `:route-id`,
+       `:params`, `:query`, `:transition`, `:error`, `:nav-token`, and every
+       routing sibling (pending-nav, resource-blocking bookkeeping) are
+       preserved BYTE-FOR-BYTE. It does NOT call `commit-navigation`: no
+       `:on-match` re-fire, no settle event, no resource ensure/release plan,
+       and no nav-token counter bump — the standing token stays current, so an
+       already-running loader for the unchanged route remains eligible to
+       complete.
+    2. emits exactly one `:rf.route/fragment-changed` op carrying
+       `{:route-id :prev-fragment :next-fragment :frame}` — and NO
+       `:rf.route.nav-token/allocated`, NO route activated/deactivated pair,
+       NO resource route-plan trace.
+    3. drives programmatic history + scroll via REGISTERED effects, in order:
+       capture the LEAVING url's scroll position, then push (default) /
+       replace (`{:replace? true}`) the new URL via `:rf.nav/push-url` /
+       `:rf.nav/replace-url` (never `window.location.hash`), then the resolved
+       `:rf.nav/scroll` unless `:scroll false` suppresses it (via
+       `plan/scroll-plan`). Default `:top` scrolls to the new fragment (or top
+       when the fragment is cleared/missing); `:restore`/`:preserve`/map-form
+       retain today's meanings. `pushState`/`replaceState` do NOT scroll to a
+       fragment natively, so `:rf.nav/scroll` IS required — this makes NO focus
+       / `:target` pseudo-class parity claim (a separate a11y decision).
+
+  State-first: the runtime-db `:fragment` write commits before the ordered
+  history/scroll effects, exactly like every other route effect; a rejected
+  history projection surfaces the existing `:rf.fx/push-url-failed` /
+  `:rf.fx/replace-url-failed` diagnostic and leaves the slice + trace
+  committed. NB this must NOT copy `url_change.cljc`'s `fragment-only-fx`
+  verbatim — that helper carries scroll CAPTURE only; the programmatic path
+  also drives the URL and the resolved scroll."
+  [{:keys [rdb current fragment url opts route-meta route-id params query frame]}]
+  (trace/emit! :rf.event :rf.route/fragment-changed
+               {:route-id      (:route-id current)
+                :prev-fragment (:fragment current)
+                :next-fragment fragment
+                :frame         frame})
+  (let [push-fx (if (:replace? opts)
+                  [:rf.nav/replace-url url]
+                  [:rf.nav/push-url    url])
+        {:keys [capture-fx scroll-fx]}
+        (plan/scroll-plan {:rdb              rdb
+                           ;; rf2-1hncp2: saved scroll positions are a
+                           ;; host-side transient cache — thread the active
+                           ;; frame's cache in explicitly so the planner stays
+                           ;; pure (same shape the full commit branch passes).
+                           :scroll-cache     (scroll/frame-scroll-cache frame)
+                           :route-meta       route-meta
+                           :opts             opts
+                           :default-strategy :top
+                           :route-id         route-id
+                           :params           params
+                           :query            query
+                           :fragment         fragment
+                           :url              url})]
+    ;; EP-0001 (rf2-vzld77): the route slice is durable framework runtime-db
+    ;; state — write ONLY the `:fragment` field of `:current`; every other
+    ;; slice field and routing sibling is preserved.
+    {:rf.db/runtime (assoc-in rdb [:rf.runtime/routing :current :fragment] fragment)
+     :fx (vec (concat (when capture-fx [capture-fx])
+                      [push-fx]
+                      (when scroll-fx [scroll-fx])))}))
+
 (defn navigate-handler
   "`:rf.route/navigate` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar.
@@ -429,7 +506,24 @@
           ;; unchanged data.
           identical-nav? (plan/identical-route-target?
                            (get-in rdb [:rf.runtime/routing :current])
-                           route-id path-params query-params fragment)]
+                           route-id path-params query-params fragment)
+          ;; Spec 012 §Fragments rules 3-4 / §Programmatic navigation with
+          ;; fragments (rf2-k4exp1): the SIBLING short-circuit to
+          ;; `identical-nav?` — same `:route-id`/`:params`/`:query` as the
+          ;; current slice but a DIFFERENT `:fragment` (a same-page anchor
+          ;; change). Classified through the SAME shared `plan/fragment-only?`
+          ;; predicate the URL-driven doors use, so the one logical operation
+          ;; behaves identically whichever entry point it arrives on. Guarded
+          ;; by `(not unmatched-url)` so a `{:url ...}` route-MISS fallback
+          ;; keeps its full not-found path (mirrors `url_change.cljc`'s
+          ;; `(and match …)`); the `::reject` and `external-url-target?`
+          ;; targets short-circuit in earlier cond arms and never reach here.
+          ;; Mutually exclusive with `identical-nav?` (which requires the
+          ;; fragment to be equal too).
+          fragment-only? (and (not unmatched-url)
+                              (plan/fragment-only?
+                                (get-in rdb [:rf.runtime/routing :current])
+                                route-id path-params query-params fragment))]
       (cond
         ;; rf2-1os1c: params/opts positional swap. An opts-only key
         ;; (`:replace?` / `:scroll` / `:fragment` / `:bypass-guards?`)
@@ -491,11 +585,36 @@
                            (:bypass-guards? opts)
                            pending-nav-allocation)]
           blocked
-          (if identical-nav?
+          (cond
             ;; Spec 012 §Per-route data loading rule 3: nothing relevant
             ;; changed — leave the slice and the standing nav-token as-is;
-            ;; emit no allocation, fire no loaders, push no URL.
+            ;; emit no allocation, fire no loaders, push no URL. An exactly
+            ;; identical target is the complete no-op even when `:replace?`
+            ;; was supplied (wins over the fragment-only branch below, which
+            ;; requires the fragment to DIFFER).
+            identical-nav?
             {}
+
+            ;; Spec 012 §Fragments rules 3-4 / §Programmatic navigation with
+            ;; fragments (rf2-k4exp1): same route-id/params/query, only the
+            ;; `#fragment` differs — update `:fragment`, emit
+            ;; `:rf.route/fragment-changed`, and drive history + scroll via
+            ;; effects. NO `commit-navigation`: no nav-token bump, no
+            ;; `:on-match` re-fire, no resource re-plan. The SAME short-circuit
+            ;; `url_change.cljc` applies on the URL-driven doors.
+            fragment-only?
+            (fragment-only-nav-fx {:rdb        rdb
+                                   :current    current
+                                   :fragment   fragment
+                                   :url        url
+                                   :opts       opts
+                                   :route-meta route-meta
+                                   :route-id   route-id
+                                   :params     path-params
+                                   :query      query-params
+                                   :frame      frame})
+
+            :else
             (let [push-fx    (if (:replace? opts)
                                [:rf.nav/replace-url url]
                                [:rf.nav/push-url    url])

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -1448,3 +1448,74 @@
             "the trace carries the attempted :url")
         (is (= "boom-push" (:error tags))
             "the trace carries the browser error message")))))
+
+;; =========================================================================
+;; rf2-k4exp1: programmatic fragment-only navigate drives real history
+;; =========================================================================
+;;
+;; Spec 012 §Fragments / §Programmatic navigation with fragments. A
+;; `:rf.route/navigate` differing from the current slice ONLY in its
+;; `#fragment` takes the short-circuit — no :on-match re-fire, no new
+;; :nav-token — while still driving the browser history: PUSH by default
+;; (adds an entry), REPLACE with {:replace? true} (mutates the active entry
+;; in place), and clearing the fragment pushes the fragment-less URL. This is
+;; the CLJS counterpart of the JVM `navigate-fragment-only-*` tests, exercised
+;; against the real pushState/replaceState history stub.
+
+(defn- k4exp1-slice []
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+          [:rf.runtime/routing :current]))
+
+(deftest programmatic-fragment-only-navigate-drives-history-cljs-rf2-k4exp1
+  (testing "rf2-k4exp1: programmatic fragment-only navigate pushes / replaces /
+            clears the browser history without re-firing :on-match or allocating
+            a new nav-token"
+    ;; Register the routes BEFORE binding the URL owner, so the `:url-bound?`
+    ;; frame's create-time initial-URL sync (rf2-9vgyp7) matches a real route
+    ;; rather than falling to not-found. (That sync also allocates a token, so
+    ;; the teeth below capture the token AFTER the first explicit nav and assert
+    ;; it is UNCHANGED — never a hardcoded "nav-1" — which is the real invariant:
+    ;; a fragment-only nav allocates NO new token.)
+    (rf/reg-route :hist/home {} "/")
+    (let [loads (atom 0)]
+      (rf/reg-event :docs/load (fn [{:keys [db]} _] (swap! loads inc) {:db db}))
+      (rf/reg-route :hist/docs {:on-match [[:docs/load]]} "/docs/:page")
+      (rf/reg-frame :rf/default {:url-bound? true})
+
+      ;; --- Full nav: loader fires once, pushes /docs/guide#a. ---
+      (rf/dispatch-sync [:rf.route/navigate :hist/docs {:page "guide"} {:fragment "a"}])
+      (is (= "/docs/guide#a" (current-url *history-state*))
+          "full nav pushed /docs/guide#a onto the history stack")
+      (is (= 1 @loads) ":on-match fired once on the full nav")
+      (let [token (:nav-token (k4exp1-slice))
+            entries-after-full (:entries @*history-state*)]
+        (is (some? token) "the full nav allocated a nav-token")
+
+        ;; --- Fragment-only PUSH: #a → #b adds a new entry, no re-fire, same token. ---
+        (rf/dispatch-sync [:rf.route/navigate :hist/docs {:page "guide"} {:fragment "b"}])
+        (is (= (conj entries-after-full "/docs/guide#b") (:entries @*history-state*))
+            "fragment-only push added a NEW history entry for #b")
+        (is (= 1 @loads) "fragment-only push did NOT re-fire :on-match")
+        (is (= token (:nav-token (k4exp1-slice)))
+            "fragment-only push did NOT allocate a new nav-token")
+        (is (= "b" (:fragment (k4exp1-slice))) "the slice fragment updated to #b")
+
+        ;; --- Fragment-only REPLACE: #b → #c mutates the ACTIVE entry in place. ---
+        (let [entry-count-before (count (:entries @*history-state*))]
+          (rf/dispatch-sync [:rf.route/navigate :hist/docs {:page "guide"}
+                             {:fragment "c" :replace? true}])
+          (is (= "/docs/guide#c" (current-url *history-state*))
+              "{:replace? true} moved the active entry to #c")
+          (is (= entry-count-before (count (:entries @*history-state*)))
+              "replace did NOT grow the history stack (no new entry)")
+          (is (= 1 @loads) "fragment-only replace did NOT re-fire :on-match")
+          (is (= token (:nav-token (k4exp1-slice))) "replace did NOT allocate a new token"))
+
+        ;; --- Clear the fragment: pushes the fragment-less URL, still no re-fire. ---
+        (rf/dispatch-sync [:rf.route/navigate :hist/docs {:page "guide"}])
+        (is (= "/docs/guide" (current-url *history-state*))
+            "clearing the fragment pushed the fragment-less URL")
+        (is (nil? (:fragment (k4exp1-slice))) "the slice fragment cleared to nil")
+        (is (= 1 @loads) "clearing the fragment did NOT re-fire :on-match")
+        (is (= token (:nav-token (k4exp1-slice)))
+            "clearing the fragment is still a fragment-only short-circuit — no new token")))))

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -7,6 +7,7 @@
   from routing_test.clj per rf2-u8qe7y finding 3."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
 
@@ -1552,3 +1553,220 @@
             "a self-nav to the identical query pushes no URL (rule-3 no-op)")
         (is (= token-before (:nav-token (nav-slice)))
             "the nav-token is unchanged (no fresh epoch)")))))
+
+;; ============================================================================
+;; rf2-k4exp1 — programmatic fragment-only navigate short-circuit
+;; ============================================================================
+;;
+;; Spec 012 §Fragments rules 3-4 / §Programmatic navigation with fragments.
+;; A `:rf.route/navigate` whose resolved target differs from the current slice
+;; ONLY in its `#fragment` (same route-id/params/query) must take the SAME
+;; short-circuit the URL-driven doors take: update `:fragment`, emit ONE
+;; `:rf.route/fragment-changed`, drive history+scroll via effects, and do NOT
+;; call `commit-navigation` — no fresh nav-token, no `:on-match` re-fire, no
+;; resource re-plan. Before the fix the programmatic door took the full commit
+;; path (fresh token, every loader re-fired, stale-suppressing in-flight work
+;; for the route you were already on).
+
+(defn- reg-nav-fxs-capturing!
+  "Register the four routing history/scroll fxs (`:platforms #{:server
+  :client}` so they route on the JVM) with capturing handlers. Returns a map
+  of atoms: `:push` / `:replace` (URL vectors), `:scroll` (args vectors), and
+  `:order` (an ordered `[fx-id args]` log across all four)."
+  []
+  (let [pushed   (atom [])
+        replaced (atom [])
+        scrolled (atom [])
+        order    (atom [])]
+    (rf/reg-fx :rf.nav/push-url {:platforms #{:server :client}}
+               (fn [_ url]  (swap! pushed conj url)   (swap! order conj [:rf.nav/push-url url])))
+    (rf/reg-fx :rf.nav/replace-url {:platforms #{:server :client}}
+               (fn [_ url]  (swap! replaced conj url) (swap! order conj [:rf.nav/replace-url url])))
+    (rf/reg-fx :rf.nav/scroll {:platforms #{:server :client}}
+               (fn [_ args] (swap! scrolled conj args) (swap! order conj [:rf.nav/scroll args])))
+    (rf/reg-fx :rf.nav/capture-scroll {:platforms #{:server :client}}
+               (fn [_ args] (swap! order conj [:rf.nav/capture-scroll args])))
+    {:push pushed :replace replaced :scroll scrolled :order order}))
+
+(deftest navigate-fragment-only-short-circuits-no-refire-no-token-rf2-k4exp1
+  (testing "rf2-k4exp1: a programmatic `:rf.route/navigate` changing ONLY the
+            fragment updates `:fragment`, emits one `:rf.route/fragment-changed`,
+            preserves the slice byte-for-byte except `:fragment`, does NOT
+            re-fire `:on-match`, and does NOT allocate a new `:nav-token`"
+    (let [on-match-calls (atom 0)]
+      (rf/reg-event :docs/load (fn [{:keys [db]} _] (swap! on-match-calls inc) {:db db}))
+      (rf/reg-route :route/docs {:on-match [[:docs/load]]} "/docs/:page")
+      (let [fxs (reg-nav-fxs-capturing!)]
+        ;; Full nav → loader fires once, nav-1, pushes /docs/routing#a.
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+        (is (= 1 @on-match-calls) ":on-match fired once on the full nav")
+        (let [slice-before (nav-slice)]
+          (is (= "nav-1"  (:nav-token slice-before)) "first nav allocated nav-1")
+          (is (= "a"      (:fragment slice-before)) "fragment is #a after the full nav")
+          (is (= ["/docs/routing#a"] @(:push fxs)) "full nav pushed /docs/routing#a")
+
+          (let [traces (atom [])]
+            (rf/register-listener! :trace ::k4exp1-frag (fn [ev] (swap! traces conj ev)))
+            ;; Fragment-only nav: same route/params/query, #a → #b.
+            (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "b"}])
+            (rf/unregister-listener! :trace ::k4exp1-frag)
+
+            (let [slice-after (nav-slice)]
+              ;; TEETH 1 — no re-fire.
+              (is (= 1 @on-match-calls)
+                  "rule 4: :on-match did NOT re-fire on the fragment-only nav")
+              ;; TEETH 2 — token unchanged (no new allocation).
+              (is (= "nav-1" (:nav-token slice-after))
+                  "rule 3: no NEW nav-token on the fragment-only nav (still nav-1)")
+              ;; TEETH 3 — only :fragment changed; everything else byte-for-byte.
+              (is (= "b" (:fragment slice-after)) ":fragment updated to #b")
+              (is (= (assoc slice-before :fragment "b") slice-after)
+                  "the slice is byte-for-byte identical except :fragment — :transition
+                   / :error / :nav-token / :route-id / :params / :query preserved")
+              ;; TEETH 4 — one fragment-changed, no allocation trace.
+              (let [frag (filter #(= :rf.route/fragment-changed (:operation %)) @traces)
+                    tags (-> frag first :tags)]
+                (is (= 1 (count frag))
+                    "exactly one :rf.route/fragment-changed emitted")
+                (is (= :route/docs (:route-id tags))      "fragment-changed carries :route-id")
+                (is (= "a" (:prev-fragment tags))         "fragment-changed carries :prev-fragment")
+                (is (= "b" (:next-fragment tags))         "fragment-changed carries :next-fragment")
+                (is (= :rf/default (:frame tags))         "fragment-changed carries :frame (rf2-n0851k parity)"))
+              (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
+                  "NO :rf.route.nav-token/allocated on the fragment-only nav")
+              (is (not-any? #(= :rf.route/activated (:operation %)) @traces)
+                  "NO :rf.route/activated on the fragment-only nav (route stays active)")
+              ;; History: a push for the new fragment URL.
+              (is (= ["/docs/routing#a" "/docs/routing#b"] @(:push fxs))
+                  "the fragment-only nav pushed /docs/routing#b via :rf.nav/push-url")
+              (is (empty? @(:replace fxs))
+                  "no :rf.nav/replace-url on the default (push) door"))))))))
+
+(deftest navigate-fragment-only-effect-ordering-rf2-k4exp1
+  (testing "rf2-k4exp1: the fragment-only nav's effects are ordered
+            capture-scroll → push-url → scroll (state-first: the :fragment
+            write commits before the ordered history/scroll effects)"
+    (rf/reg-route :route/docs {} "/docs/:page")
+    (let [fxs (reg-nav-fxs-capturing!)]
+      (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+      (reset! (:order fxs) [])
+      (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "b"}])
+      (let [ids (mapv first @(:order fxs))]
+        (is (= [:rf.nav/capture-scroll :rf.nav/push-url :rf.nav/scroll] ids)
+            "ordered: capture the leaving scroll, push the new URL, then scroll")
+        ;; The scroll fx targets the NEW fragment with the default :top strategy.
+        (let [scroll-args (-> @(:scroll fxs) last)]
+          (is (= :top (:strategy scroll-args)) "default forward strategy is :top")
+          (is (= "b"  (:fragment scroll-args)) "scroll targets the new #b fragment"))
+        ;; capture-scroll keyed on the LEAVING url (/docs/routing#a).
+        (is (= {:url "/docs/routing#a"}
+               (-> (filter #(= :rf.nav/capture-scroll (first %)) @(:order fxs)) first second))
+            "capture-scroll saves the position of the route being left (#a)")))))
+
+(deftest navigate-fragment-only-replace-uses-replace-url-rf2-k4exp1
+  (testing "rf2-k4exp1: `{:replace? true}` routes the fragment-only nav through
+            :rf.nav/replace-url (NOT push) — still no re-fire, still nav-1"
+    (let [on-match-calls (atom 0)]
+      (rf/reg-event :docs/load (fn [{:keys [db]} _] (swap! on-match-calls inc) {:db db}))
+      (rf/reg-route :route/docs {:on-match [[:docs/load]]} "/docs/:page")
+      (let [fxs (reg-nav-fxs-capturing!)]
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+        (reset! (:push fxs) [])
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"}
+                           {:fragment "b" :replace? true}])
+        (is (= "b"    (:fragment (nav-slice))) "fragment updated to #b")
+        (is (= "nav-1" (:nav-token (nav-slice))) "no new nav-token")
+        (is (= 1 @on-match-calls) ":on-match did NOT re-fire")
+        (is (= ["/docs/routing#b"] @(:replace fxs))
+            "{:replace? true} routed :rf.nav/replace-url with the new fragment URL")
+        (is (empty? @(:push fxs))
+            "no :rf.nav/push-url on the replace door")))))
+
+(deftest navigate-fragment-only-scroll-false-suppresses-scroll-rf2-k4exp1
+  (testing "rf2-k4exp1: `{:scroll false}` on a fragment-only nav suppresses the
+            :rf.nav/scroll effect but still updates :fragment and pushes the URL"
+    (rf/reg-route :route/docs {} "/docs/:page")
+    (let [fxs (reg-nav-fxs-capturing!)]
+      (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+      (reset! (:scroll fxs) [])
+      (reset! (:push fxs) [])
+      (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"}
+                         {:fragment "b" :scroll false}])
+      (is (= "b" (:fragment (nav-slice))) ":fragment still updates with :scroll false")
+      (is (= ["/docs/routing#b"] @(:push fxs)) "the URL is still pushed")
+      (is (empty? @(:scroll fxs))
+          ":scroll false suppressed the :rf.nav/scroll effect"))))
+
+(deftest navigate-fragment-only-clearing-fragment-rf2-k4exp1
+  (testing "rf2-k4exp1: navigating with NO fragment from a fragment'd route
+            CLEARS the fragment (writes nil, pushes the fragment-less URL) and
+            is still a fragment-only short-circuit (no re-fire, no new token)"
+    (let [on-match-calls (atom 0)]
+      (rf/reg-event :docs/load (fn [{:keys [db]} _] (swap! on-match-calls inc) {:db db}))
+      (rf/reg-route :route/docs {:on-match [[:docs/load]]} "/docs/:page")
+      (let [fxs (reg-nav-fxs-capturing!)]
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+        (reset! (:push fxs) [])
+        ;; No :fragment opt → normalises to nil; #a → nil differs → fragment-only.
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"}])
+        (is (nil? (:fragment (nav-slice))) "fragment cleared to nil")
+        (is (= "nav-1" (:nav-token (nav-slice))) "clearing a fragment is fragment-only — no new token")
+        (is (= 1 @on-match-calls) "clearing a fragment does NOT re-fire :on-match")
+        (is (= ["/docs/routing"] @(:push fxs))
+            "the fragment-less URL is pushed")))))
+
+(deftest navigate-identical-target-with-replace-stays-noop-rf2-k4exp1
+  (testing "rf2-k4exp1: an EXACTLY identical target (same fragment too) stays the
+            complete no-op even with {:replace? true} — no history rewrite, no
+            fragment-changed, no token change (identical wins over fragment-only)"
+    (rf/reg-route :route/docs {} "/docs/:page")
+    (let [fxs (reg-nav-fxs-capturing!)]
+      (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+      (let [token-before (:nav-token (nav-slice))
+            traces       (atom [])]
+        (reset! (:push fxs) [])
+        (reset! (:replace fxs) [])
+        (rf/register-listener! :trace ::k4exp1-identical (fn [ev] (swap! traces conj ev)))
+        ;; Same route/params/query AND same fragment #a, with :replace? true.
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"}
+                           {:fragment "a" :replace? true}])
+        (rf/unregister-listener! :trace ::k4exp1-identical)
+        (is (= token-before (:nav-token (nav-slice))) "identical target: token unchanged")
+        (is (empty? @(:push fxs))    "identical target: no push")
+        (is (empty? @(:replace fxs)) "identical target: no replace even with :replace? true")
+        (is (not-any? #(= :rf.route/fragment-changed (:operation %)) @traces)
+            "identical target emits NO :rf.route/fragment-changed (it is a complete no-op)")))))
+
+(deftest navigate-fragment-only-does-not-replan-resources-rf2-k4exp1
+  (testing "rf2-k4exp1: a fragment-only nav does NOT invoke the route-entry
+            resource plan (no ensure / release / re-plan) and leaves the owner
+            nav-token unchanged — proven via the shared `:routing/on-route-entry`
+            late-bind hook `commit-navigation` calls (the fragment-only branch
+            never enters `commit-navigation`)"
+    (rf/reg-route :route/docs {:on-match [[:docs/load]]} "/docs/:page")
+    (rf/reg-event :docs/load (fn [{:keys [db]} _] {:db db}))
+    (let [fxs        (reg-nav-fxs-capturing!)
+          plan-calls (atom [])
+          prior      (late-bind/get-fn :routing/on-route-entry)]
+      ;; Spy the route-entry hook the Resources artefact publishes; return an
+      ;; empty plan (no blocking, no fx, no error) so commit-navigation proceeds.
+      (late-bind/set-fn! :routing/on-route-entry
+                         (fn [ctx] (swap! plan-calls conj ctx) {}))
+      (try
+        ;; Full nav → the route-entry plan runs once.
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}])
+        (is (= 1 (count @plan-calls))
+            "the route-entry resource plan ran once on the full nav")
+        (let [token-after-full (:nav-token (nav-slice))]
+          ;; Fragment-only nav → the plan is NOT invoked again; owner token stays.
+          (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "routing"} {:fragment "b"}])
+          (is (= 1 (count @plan-calls))
+              "the fragment-only nav did NOT re-run the route-entry plan — no
+               ensure/release/re-plan")
+          (is (= token-after-full (:nav-token (nav-slice)))
+              "the owner nav-token is unchanged, so an in-flight resource lease
+               keyed on it stays valid"))
+        (finally
+          ;; Restore the prior hook binding (nil in the resources-free routing
+          ;; suite) so this spy never leaks into a sibling test.
+          (late-bind/set-fn! :routing/on-route-entry prior))))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -819,6 +819,8 @@ When a route is loading and the user navigates away before the load completes, t
 
 1. **Allocation.** When a navigation drain commits the slice — the programmatic `:rf.route/navigate` handler (which writes the slice inline; see [§Navigation is an event](#navigation-is-an-event)), or a URL-change handler `:rf.route/transitioned` (forward nav driven by a `route-link` click via `:rf.route/url-requested`) or `:rf.route/handle-url-change` (popstate / initial / SSR) — it allocates a fresh `:nav-token` (a gensym or monotonic counter) and writes it to the `:rf/route` slice alongside the new id/params/query/fragment.
 
+   > **Two commits do NOT allocate: the identical and fragment-only short-circuits.** "Commits the slice" above means a *route (re)activation* — a change to `:route-id`, `:params`, or `:query`. Two resolved targets skip allocation entirely and keep the standing token: an **identical** re-navigation (nothing changed — [§Per-route data loading](#per-route-data-loading) rule 3) and a **fragment-only** change (same route-id/params/query, different `#fragment` — [§Fragments](#fragment-only-changes-do-not-re-fire-on-match)). Both hold the current `:nav-token` so a still-in-flight loader for the unchanged route stays eligible; neither is a new epoch. This holds whichever door the navigation entered.
+
    > **The allocation counter is monotone and unbounded.** A nav-token need only be *unique within the lifetime of any in-flight async continuation*; equality against the current slice token is the only operation performed on it (step 4). A per-frame monotonic counter satisfies uniqueness without ever needing to wrap or reset. It does NOT carry the bounded-structure treatment applied to other *retained* collections (the host-side scroll-position LRU cache, the route-registry decoded-key cap): those bound collections that would otherwise accumulate entries, whereas the counter is a single scalar that retains nothing — it is GC'd whole when the frame is destroyed. Practical overflow is a non-concern: on CLJS the counter is an IEEE-754 double (exact integers to 2^53, far beyond any real navigation count); on the JVM it is a `long` that would overflow only after 2^63 navigations. No id collision is possible because each token is a fresh string. Implementations MUST NOT wrap or recycle the counter — doing so would risk colliding a freshly-allocated token with one still carried by a slow in-flight continuation, silently re-validating a stale result.
 
    > **Storage: the counter is host-side transient, NOT `runtime-db`.** The *active* `:nav-token` is a durable fact on the route slice (`[:rf.runtime/routing :current :nav-token]`) and restores coherently with the rest of the slice. The *allocator* (the `:nav-token-counter` / `:pending-nav-counter` monotonic high-water marks) is held in a host-side per-frame transient cache (a module-private atom, mirroring the scroll-position cache). The two are separated: an epoch restore replaces the `runtime-db` partition **wholesale**, which would rewind a runtime-db-resident counter to its value at the restored epoch — and a pre-restore in-flight async continuation (a request already on the wire, uncancellable) returning afterward could then carry a token the post-restore timeline has *re-allocated*, the exact recycle the rule above forbids. Held host-side, the counter is untouched by restore, so every post-restore allocation strictly exceeds any pre-restore in-flight token and a collision is structurally impossible. Conflating the allocator (whose property is *never rewind*) with the active token (which *should* restore) in one restorable partition is a category error.
@@ -1108,16 +1110,20 @@ Read it via the `:rf.route/fragment` sub. Fragment is **populated by `match-url`
 
 ### Fragment-only changes do NOT re-fire `:on-match`
 
-When the new URL differs from the current URL **only** in its fragment (same `:route-id`, same `:params`, same `:query`, but different `:fragment`), the runtime:
+When a navigation's resolved target differs from the current slice **only** in its fragment (same `:route-id`, same `:params`, same `:query`, but different `:fragment`), the runtime treats it as an in-page anchor change — one logical operation with **the same behaviour whichever of the three commit doors it enters** (programmatic `:rf.route/navigate`, forward-nav `:rf.route/transitioned`, or popstate `:rf.route/handle-url-change`). The runtime:
 
-1. Updates `:fragment` in the `:rf/route` slice.
-2. Emits a `:rf.route/fragment-changed` trace event with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s>}`.
-3. Does **NOT** allocate a new `:nav-token`.
-4. Does **NOT** re-fire `:on-match`.
+1. Updates **only** `:fragment` in the `:rf/route` slice. `:route-id`, `:params`, `:query`, `:transition`, `:error`, and `:nav-token` are preserved **byte-for-byte**, as are the routing siblings (pending-navigation, resource-blocking bookkeeping).
+2. Emits **exactly one** `:rf.route/fragment-changed` trace event with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s> :frame <navigating-frame>}`. It emits **no** `:rf.route.nav-token/allocated`, **no** route `:rf.route/activated`/`:rf.route/deactivated` lifecycle pair, and **no** route-resource plan trace.
+3. Does **NOT** allocate or bump the `:nav-token` counter. The standing token stays current, so an already-running `:on-match` loader (or route `:resources` fetch) for the unchanged route remains eligible to complete — a fragment jump must not stale-suppress in-flight work for the route you are already on.
+4. Does **NOT** re-fire `:on-match`, run the route's `:resources` re-plan, or release/re-`ensure` any resource lease (the route-entry hook is not invoked — the fragment-only branch never calls the shared navigation-commit assembler).
 
-The reason: `:on-match` exists to re-load route-scoped data when path or query changes. A fragment-only change does not change loaded data — only the in-page anchor target. Re-firing the loaders would re-fetch unchanged data on every `#section` jump, which is exactly the kind of thrash users complain about.
+**Guard ordering.** Classification happens **after** target resolution / fragment-normalisation / query-shaping / URL build / validation **and** after the shared leave-then-enter gate (`:can-leave` on the current route, then `:can-enter` on the target). A blocked guard wins over the fragment-only short-circuit and produces the normal pending-nav protocol (no fragment update, no history mutation, no `:rf.route/fragment-changed`); a `:rf.route/continue` re-runs the gate and takes the short-circuit only after it passes. A malformed / route-miss / rejected / external target keeps its existing path and is **not** newly classified as fragment-only.
 
-Views that need to react to fragment changes subscribe to `:rf.route/fragment` (or to `:rf/route` for the whole slice). Whichever URL-change event fires — `:rf.route/transitioned` on forward nav, `:rf.route/handle-url-change` on popstate — the shared slice-rewrite logic distinguishes a fragment-only change from a full transition, so both honour the no-re-fire rule above.
+**History (programmatic door).** `:rf.route/navigate` drives the browser URL: a fragment-only nav pushes the new fragment URL via `:rf.nav/push-url` by default, or replaces the active entry via `:rf.nav/replace-url` when `{:replace? true}` is supplied. Clearing a fragment (navigating with no `:fragment`) pushes/replaces the fragment-less URL and writes `:fragment nil`. The URL is driven through those registered effects (never a direct `window.location.hash` write), so URL-owner and URL-strategy enforcement stay intact. The URL-driven doors emit no push — the browser URL already changed (popstate / link-click).
+
+The reason for rules 3-4: `:on-match` (and route `:resources`) exist to re-load route-scoped data when path or query changes. A fragment-only change does not change loaded data — only the in-page anchor target. Re-firing the loaders would re-fetch unchanged data on every `#section` jump, which is exactly the kind of thrash users complain about — and, worse, the token bump would stale-suppress a still-in-flight loader for the route you never left. (An explicit force-reload is a *separate*, named contract, not an overload of `#fragment`; route data must therefore never depend on the fragment — data-bearing tabs/filters belong in path/query, fragments are presentation / in-page-location state.)
+
+Views that need to react to fragment changes subscribe to `:rf.route/fragment` (or to `:rf/route` for the whole slice). The fragment-only classification lives in the shared navigation-planning seam (`plan/fragment-only?`) that all three doors consult, so they cannot drift.
 
 ### `:rf.nav/scroll` integration
 
@@ -1151,6 +1157,10 @@ Hosts that ship a custom map-form scroll strategy may interpret `:fragment` per 
 
 Either form ends up in the `:rf/route` slice's `:fragment`.
 
+**Fragment-only programmatic navs take the short-circuit too.** A `:rf.route/navigate` whose resolved target differs from the current slice **only** in its fragment is a fragment-only change and honours [§Fragment-only changes do NOT re-fire `:on-match`](#fragment-only-changes-do-not-re-fire-on-match) in full: `:fragment` updates, one `:rf.route/fragment-changed` fires, and the `:nav-token` / `:on-match` / route-`:resources` are left untouched — identical to the same anchor jump arriving via a `route-link` click or Back/Forward. This is the regularity contract: the same logical operation cannot behave differently just because it entered through the programmatic door. (Before this was wired, a programmatic fragment nav took the full commit path — re-firing every loader and bumping the token, stale-suppressing in-flight work for the route you were already on.)
+
+**Scroll.** A fragment-only programmatic nav still emits the resolved `:rf.nav/scroll` effect (default strategy `:top` — scroll to the new fragment element, or to the top when the fragment is cleared/absent), ordered after the leaving-scroll capture and the history push/replace. `pushState`/`replaceState` do **not** scroll to a fragment natively (they are neither navigation nor traversal per the WHATWG URL-and-history-update steps), so the `:rf.nav/scroll` effect is what performs the visual scroll; `{:scroll false}` suppresses it, and `:restore`/`:preserve`/map-form strategies retain their usual meanings. The runtime makes **no** focus-movement or `:target` pseudo-class parity claim for the fragment-only path — `:rf.nav/scroll` supplies visual scrolling only; focus/`:target` parity is a separate accessibility decision.
+
 ### SSR
 
 Browsers do **not** send `#fragment` to the server — `window.location.hash` is client-only. For browser-initiated SSR requests, the server-side `:fragment` is therefore typically `nil`, regardless of what the user typed in the address bar. The exceptions are static-site generators, server-side test harnesses, and crawlers that synthesise URLs with explicit fragments (e.g., for anchored documentation pages); when the host's request abstraction exposes a `#fragment`, SSR includes it in the seeded `:rf/route` slice. See [011 §Fragments under SSR](011-SSR.md#fragments-under-ssr) for the full SSR-side contract.
@@ -1159,10 +1169,15 @@ The server does NOT scroll (no DOM); `:rf.nav/scroll` is `:platforms #{:client}`
 
 ### Conformance
 
-Fixture `route-fragment-change.edn` exercises:
+Fixture `route-fragment-change.edn` exercises the **URL-driven** door (`:rf.route/transitioned`):
 1. Navigate to `/docs/routing#scroll-restoration`. Verify the slice's `:fragment` is `"scroll-restoration"`.
 2. Navigate to `/docs/routing#caching` (same path/query, different fragment). Verify `:on-match` does NOT re-fire and `:rf.route/fragment-changed` trace event fires.
 3. Navigate to `/docs/instrumentation#scroll-restoration` (different path, same fragment). Verify `:on-match` DOES re-fire (path changed; fragment-only rule does not apply).
+
+Fixture `routing-fragment-navigate.edn` exercises the **programmatic** door (`:rf.route/navigate`):
+1. Navigate `[:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}]` — a full commit: `:on-match` fires once, a fresh `:nav-token` is allocated, `:rf.nav/push-url` pushes `/docs/routing#a`.
+2. Navigate `[:rf.route/navigate :route/docs {:page "routing"} {:fragment "b"}]` (same route-id/params/query, different fragment). Verify `:on-match` does NOT re-fire (loader count unchanged), the `:nav-token` is **unchanged** (no new allocation), `:rf.route/fragment-changed` fires, and `:rf.nav/push-url` pushes `/docs/routing#b`.
+3. Navigate `[:rf.route/navigate :route/docs {:page "routing"} {:fragment "c" :replace? true}]`. Verify the same fragment-only short-circuit routes through `:rf.nav/replace-url` (not push) and still does not re-fire `:on-match` or allocate a token.
 
 ## Nested layouts
 

--- a/spec/conformance/fixtures/routing-fragment-navigate.edn
+++ b/spec/conformance/fixtures/routing-fragment-navigate.edn
@@ -1,0 +1,107 @@
+;; Conformance fixture: routing/fragment-navigate  (rf2-k4exp1)
+;;
+;; The PROGRAMMATIC door (`:rf.route/navigate`) honours the fragment-only
+;; short-circuit identically to the URL-driven door (`route-fragment-change.edn`
+;; drives `:rf.route/transitioned`). A programmatic navigation whose resolved
+;; target differs from the current slice ONLY in its `#fragment` (same
+;; :route-id / :params / :query) updates :fragment and emits
+;; :rf.route/fragment-changed WITHOUT re-firing :on-match, allocating a new
+;; :nav-token, or re-planning route resources. The `{:replace? true}` variant
+;; routes through :rf.nav/replace-url instead of :rf.nav/push-url but is the
+;; same short-circuit.
+;;
+;; This pins the cross-implementation contract the bead (rf2-k4exp1) fixes:
+;; before the fix a programmatic fragment nav took the FULL commit path
+;; (fresh token, every :on-match re-fired, stale-suppressing in-flight loaders
+;; for the route you were already on).
+;;
+;; Per [012 §Fragments](../../012-Routing.md#fragment-only-changes-do-not-re-fire-on-match)
+;; and [012 §Programmatic navigation with fragments](../../012-Routing.md#programmatic-navigation-with-fragments).
+
+{:fixture/id           :routing/fragment-navigate
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :routing/fragment :routing/nav-token
+                         :core/event-handler :core/fx :core/trace}
+ :fixture/doc          "Programmatic :rf.route/navigate honours the fragment-only short-circuit: same route-id/params/query with a different #fragment updates :fragment and emits :rf.route/fragment-changed WITHOUT re-firing :on-match or allocating a new nav-token. The default door pushes (:rf.nav/push-url); {:replace? true} replaces (:rf.nav/replace-url). The loader count and standing nav-token are the teeth: both are unchanged across the two fragment-only navs."
+
+ :fixture/registry
+ {:event {:docs/load-page {:doc "Increments a counter so the fixture can detect :on-match re-fires."}}
+  ;; No :rf/route sub override — the framework route-sub-fn projects the slice
+  ;; exactly (route-id/params/query/fragment/transition/error/nav-token), which
+  ;; is what consumers see; a fixture-DSL body would leak the internal container.
+  :sub   {:rf/route {:doc "Current route slice."}}
+  :route {:route/docs {:path     "/docs/:page"
+                       :params   [:map [:page :string]]
+                       :on-match [[:docs/load-page]]}}
+  :fx    {:rf.nav/push-url       {:platforms #{:client}}
+          :rf.nav/replace-url    {:platforms #{:client}}
+          :rf.nav/scroll         {:platforms #{:client}}
+          :rf.nav/capture-scroll {:platforms #{:client}}}}
+
+ :fixture/handlers
+ {:event {:docs/load-page [[:update [:load-count] [:fn :inc]]]}
+  :fx    {:rf.nav/push-url       [[:noop]]
+          :rf.nav/replace-url    [[:noop]]
+          :rf.nav/scroll         [[:noop]]
+          :rf.nav/capture-scroll [[:noop]]}}
+
+ ;; :platform :client so the history / scroll fxs (all :platforms #{:client})
+ ;; actually route (per Spec 002 §`:platforms` gating on reg-fx).
+ :fixture/frame-config {:platform :client}
+
+ :fixture/dispatches
+ [;; Step 1: full commit. :on-match fires once (load-count → 1); nav-1 allocated;
+  ;; :rf.nav/push-url pushes /docs/routing#a.
+  [:rf.route/navigate :route/docs {:page "routing"} {:fragment "a"}]
+
+  ;; Step 2: same route-id/params/query, DIFFERENT fragment → fragment-only.
+  ;; :on-match does NOT re-fire (load-count stays 1); nav-token stays nav-1;
+  ;; :rf.route/fragment-changed fires; :rf.nav/push-url pushes /docs/routing#b.
+  [:rf.route/navigate :route/docs {:page "routing"} {:fragment "b"}]
+
+  ;; Step 3: fragment-only with {:replace? true} → :rf.nav/replace-url (NOT push).
+  ;; Still no re-fire, still nav-1; pushes /docs/routing#c via replaceState.
+  [:rf.route/navigate :route/docs {:page "routing"} {:fragment "c" :replace? true}]]
+
+ :fixture/expect
+ {;; TEETH: the loader ran exactly once — the two fragment-only navs did NOT
+  ;; re-fire :on-match.
+  :final-app-db {:load-count 1}
+
+  :final-runtime-db {:rf.runtime/routing {:current {:route-id :route/docs
+                                                    :params   {:page "routing"}
+                                                    :fragment "c"}}}
+
+  ;; TEETH: nav-token is STILL nav-1 — neither fragment-only nav allocated a
+  ;; new token (a full commit would advance it to nav-2 / nav-3).
+  :sub-values {[:rf/route] {:route-id   :route/docs
+                            :params     {:page "routing"}
+                            :query      {}
+                            :fragment   "c"
+                            :transition :idle
+                            :error      nil
+                            :nav-token  "nav-1"}}
+
+  ;; History contract: push for the default door, replace for {:replace? true};
+  ;; order-preserving subset tolerates the interleaved capture/scroll effects.
+  :effects-routed
+  [{:fx-id :rf.nav/push-url    :args "/docs/routing#a"}
+   {:fx-id :rf.nav/push-url    :args "/docs/routing#b"}
+   {:fx-id :rf.nav/replace-url :args "/docs/routing#c"}]
+
+  :trace-emissions
+  [;; Step 1: full nav — nav-token allocated (the only allocation in the run).
+   {:operation :rf.route.nav-token/allocated
+    :tags      {:route-id :route/docs}}
+
+   ;; Step 2: fragment-only push — :rf.route/fragment-changed a → b.
+   {:operation :rf.route/fragment-changed
+    :tags      {:route-id      :route/docs
+                :prev-fragment "a"
+                :next-fragment "b"}}
+
+   ;; Step 3: fragment-only replace — :rf.route/fragment-changed b → c.
+   {:operation :rf.route/fragment-changed
+    :tags      {:route-id      :route/docs
+                :prev-fragment "b"
+                :next-fragment "c"}}]}}


### PR DESCRIPTION
## What

Programmatic `:rf.route/navigate` classified `identical-nav?` (id+params+query+**fragment** all equal → no-op) but never `fragment-only?` (id+params+query equal, fragment differs). A programmatic nav changing **only** the `#fragment` therefore took the **full commit path**: fresh nav-token, every `:on-match` loader re-fired, and the token bump **stale-suppressed any in-flight loader** for the route you were already on — the exact thrash Spec 012 §Fragments rules 3-4 forbid. The two URL-driven doors (`:rf.route/transitioned` / `:rf.route/handle-url-change`) already short-circuit via the shared `plan/fragment-only?`; the programmatic door did not. Ruled **Option A** (Mike→Fable, 2026-07-11) with the Codex implementation contract.

## The fix

A `fragment-only?` branch on `navigate-handler`, classified **after** target resolution/normalisation/validation **and** after the `:can-leave`/`:can-enter` gate passes. On that branch (`fragment-only-nav-fx`):

1. assoc **only** `[:rf.runtime/routing :current :fragment]` — `:route-id`/`:params`/`:query`/`:transition`/`:error`/`:nav-token` preserved **byte-for-byte**;
2. emit **exactly one** `:rf.route/fragment-changed` (no token-alloc trace, no activated/deactivated pair, no resource route-plan trace);
3. do **not** call `commit-navigation` — no `:on-match`, no settle, no resource ensure/release, no token counter bump; the standing token stays current so an in-flight loader for the unchanged route remains eligible;
4. history via **registered effects**: default `:rf.nav/push-url`, `{:replace? true}` → `:rf.nav/replace-url` (never `window.location.hash`);
5. scroll: capture the leaving position, push/replace, then the resolved `:rf.nav/scroll` unless `:scroll false` (`pushState`/`replaceState` do not scroll to a fragment natively, so the scroll fx is required). **No** focus/`:target` parity claim.

An exactly identical target (fragment equal too) stays the existing complete no-op, even with `:replace? true`.

## Spec 012

- §Fragments rules + §Programmatic-navigation amended to cover all three commit doors (guard ordering, history push/replace, preserved token/transition/error, no resource re-plan, resolved scroll);
- §Navigation tokens "each commit allocates" wording qualified with the identical + fragment-only exceptions;
- §Conformance lists the new `routing-fragment-navigate.edn` fixture.

## Tests / teeth

- **`routing-fragment-navigate.edn`** conformance fixture (both hosts): programmatic full nav then two fragment-only navs — loader count **unchanged (1)**, standing `:nav-token` **unchanged (nav-1)**, one `:rf.route/fragment-changed` per fragment step, `push`/`push`/`replace` effects routed.
- **JVM `navigate-handler` integration**: byte-for-byte slice preservation except `:fragment`; one `:rf.route/fragment-changed` with frame stamp; no nav-token/allocated + no activated; replace variant; `:scroll false` suppression; fragment clearing; identical-with-replace no-op; effect ordering (capture → push → scroll).
- **Resources no-replan proof**: the `:routing/on-route-entry` route-entry plan runs once on the full nav and is **not** re-invoked on the fragment-only nav; owner token unchanged.
- **CLJS history**: real push (new entry) / replace (in-place) / clear stack semantics with token preserved.

## Gates (foreground)

- routing CLJ: 406 tests / 1836 assertions — 0 failures
- CLJS node suite: 8618 tests / 40642 assertions — 0 failures
- `mkdocs build --strict`: clean

## Scope

Programmatic door only. The **adjacent** URL-driven fragment-only path that computes a scroll plan but drops its `scroll-fx` is **not** folded in here — filed separately as rf2-p1aipi.

Closes rf2-k4exp1.