### PR TITLE
fix(core): machine trace projector redacts echoed :event + [:input :event] slots for sensitive routed events (rf2-ghgbqi)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -684,7 +684,19 @@
   Machine `:data` surfaces in several differently-shaped trace slots, and EVERY
   one is redacted: `:before` / `:after` / `:snapshot` (full snapshot maps),
   `:data` (bare `:data` map, one level shallower), `:input` (`{:data … :event
-  …}`), and `:cascade` (step vector each with a `:data-delta`)."
+  …}`), and `:cascade` (step vector each with a `:data-delta`).
+
+  The trace ALSO ECHOES the ROUTED inner event into two slots — top-level
+  `:event` and `[:input :event]` (per Spec 005 §Trace events; the router copies
+  `(second outer-event)` there). A `:sensitive` payload carried THROUGH the
+  machine as that routed event would otherwise ship RAW in these echo slots —
+  the generic `project-event-tags` keys off the INNER event-id, which is
+  typically unregistered (rf2-ghgbqi, rf2-agb5jk item 2). So the machine's own
+  EVENT-rooted classification paths redact these echo slots too. That is safe to
+  union with the `:data` snapshot paths on the SAME declaration because the two
+  roots are disjoint: an integer event index never matches a `:data`-prefixed
+  snapshot key, and a `:data`-prefixed key never matches a vector index — each
+  path bites only the surface it is rooted at."
   [tags frame-id]
   ;; The CHILD-OWNED synthetic on-error payload and the `:start` payload are
   ;; summarized UNCONDITIONALLY (independent of the parent/spawn machine's
@@ -708,8 +720,15 @@
             project    (fn [v] (when v (redact-with-paths v sens large)))
             project-data (fn [v] (when v (redact-with-paths v data-sens data-large)))
             project-input (fn [input]
-                            (if (and (map? input) (contains? input :data))
-                              (assoc input :data (project-data (:data input)))
+                            (if (map? input)
+                              (cond-> input
+                                ;; `:data` is snapshot-relative (one level
+                                ;; shallower than a full snapshot map).
+                                (contains? input :data)  (update :data project-data)
+                                ;; `:event` echoes the routed inner event —
+                                ;; redacted by the machine's EVENT-rooted paths
+                                ;; (rf2-ghgbqi), mirroring the top-level `:event`.
+                                (contains? input :event) (update :event project))
                               input))
             project-cascade (fn [cascade]
                               (when (vector? cascade)
@@ -724,6 +743,11 @@
           (contains? tags :after)    (assoc :after    (project (:after    tags)))
           (contains? tags :snapshot) (assoc :snapshot (project (:snapshot tags)))
           (contains? tags :data)     (assoc :data     (project-data (:data tags)))
+          ;; The routed inner event echoed at the top level — redacted by the
+          ;; machine's EVENT-rooted classification (rf2-ghgbqi). `project` is
+          ;; a whole-value path walk; only the machine's event-rooted paths
+          ;; bite here (the disjoint-root reasoning in the docstring).
+          (contains? tags :event)    (assoc :event    (project (:event    tags)))
           (contains? tags :input)    (assoc :input    (project-input (:input tags)))
           (contains? tags :cascade)  (assoc :cascade  (project-cascade (:cascade tags))))))))
 

--- a/implementation/core/test/re_frame/machine_routed_event_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/machine_routed_event_classification_cljs_test.cljc
@@ -1,0 +1,230 @@
+(ns re-frame.machine-routed-event-classification-cljs-test
+  "rf2-ghgbqi (agb5jk item 2) — the machine trace projector redacts the
+  ROUTED inner event echoed into the machine trace slots, not only the
+  durable `:data` snapshot.
+
+  Spec 005 §Trace events: when an event is ROUTED THROUGH a machine
+  (`[:machine-id <inner-event>]`), the trace echoes the routed inner event
+  into two slots — top-level `:event` (`:rf.machine/transition`,
+  `:rf.machine/event-received`) and `[:input :event]`
+  (`:rf.machine/guard-evaluated`, `:rf.machine/action-ran`). Before this
+  fix, `re-frame.classification/project-machine-tags` projected only the
+  `:data` snapshot slots, so a `:sensitive`-classified payload carried
+  THROUGH the machine shipped RAW in those echo slots (the generic
+  event projector keys off the INNER event-id, which is typically
+  unregistered).
+
+  Two SEPARATE classification channels, kept disjoint by rooting:
+
+    - the machine SPEC's `:sensitive` (`{:data …}`-rooted) classifies the
+      DURABLE snapshot `:data` — validated `:data`-rooted at `reg-machine`,
+      lowered per actor to the frame elision registry (`:source :machine`).
+    - the `reg-machine` OPTS metadata `:sensitive` (event-vector-rooted,
+      e.g. `[[1 :password]]`) is the machine's `:event` REGISTRATION
+      classification — the TRANSIENT event classification this fix projects
+      onto the echoed `:event` / `[:input :event]` slots.
+
+  An event-rooted path (integer index) never matches a `:data`-prefixed
+  snapshot key and vice versa, so both path sets ride the same union and
+  each bites only the surface it is rooted at.
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
+  (`npm run test:cljs`, `cljs-test$` ns-regexp) AND the JVM `clojure -M:test`
+  runner both run it."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.string :as str]
+            [re-frame.classification :as classification]
+            [re-frame.core :as rf]
+            ;; Boot the optional machines artefact so `rf/reg-machine`
+            ;; resolves through the spec-005 implementation (the late-bind
+            ;; hooks install on load — see machine_handler_meta_test.clj).
+            [re-frame.machines]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+;; The reset fixture auto-registers + scope-pins a default frame (the ambient
+;; scope a bare `dispatch-sync` cascades into), so the live round-trip below
+;; runs with a frame context.
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; A UNIQUE sentinel that must never appear in any projected trace echo slot.
+(def ^:private pw-sentinel "rf2-ghgbqi-PW-4f3a91")
+(def ^:private token-sentinel "rf2-ghgbqi-JWT-8c17be")
+(def ^:private email "user@example.test")
+
+(defn- leaks? [sentinel x] (str/includes? (pr-str x) sentinel))
+
+;; The machine's OPTS metadata `:sensitive` — the routed-event (transient)
+;; classification. `[1 :password]` is rooted at the SECOND element of the
+;; routed inner event vector `[:auth/login {…}]` (index 1 = the arg-map),
+;; exactly as the generic event projector roots a dispatched-event payload.
+;; `[:data :token]` is a durable snapshot path — inert against an event vector.
+(def ^:private mid :rf.ghgbqi/auth)
+
+(defn- register-machine-event-classification! []
+  (registrar/register! :event mid
+                       {:sensitive [[1 :password] [:data :token]]}))
+
+(defn- inner-event [] [:auth/login {:email email :password pw-sentinel}])
+
+(defn- project [ev] (:tags (classification/project-trace-event ev)))
+
+;; =====================================================================
+;; A. Deterministic projector teeth — hand-built machine trace shapes
+;;    (mirrors machine_spawn_trace_egress_test.clj's methodology).
+;; =====================================================================
+
+(deftest transition-echoed-event-slots-redacted
+  (testing "rf2-ghgbqi: a :rf.machine/transition echoing a :sensitive routed
+            event redacts the password in BOTH echo slots (top-level :event and
+            [:input :event]) while the durable :data (token) still redacts and
+            the non-secret :email survives"
+    (register-machine-event-classification!)
+    (let [raw (inner-event)
+          ev  {:operation :rf.machine/transition
+               :tags {:actor-id mid
+                      :frame    :rf/default
+                      :event    raw
+                      :input    {:data {:token token-sentinel} :event raw}
+                      :before   {:state :idle :data {:token token-sentinel}}
+                      :after    {:state :done :data {:token token-sentinel}}}}
+          t   (project ev)]
+      ;; --- the fix: routed-event echo slots redact the password ---
+      (is (= privacy/redacted-sentinel (get-in t [:event 1 :password]))
+          "top-level :event password redacted by the machine's event classification")
+      (is (= privacy/redacted-sentinel (get-in t [:input :event 1 :password]))
+          "[:input :event] password redacted too")
+      (is (not (leaks? pw-sentinel t))
+          "the password sentinel appears NOWHERE in the projected transition trace")
+      ;; --- precision: the non-secret field survives ---
+      (is (= email (get-in t [:event 1 :email]))
+          "non-secret :email is NOT redacted (path-precise, not whole-event)")
+      ;; --- durable :data still redacts (unchanged pre-existing behaviour) ---
+      (is (not (leaks? token-sentinel t))
+          "durable :data token still redacted in :before / :after / [:input :data]")
+      (is (= privacy/redacted-sentinel (get-in t [:before :data :token]))
+          ":before snapshot data token redacted")
+      ;; --- non-destructive: the RAW routed event the machine control flow
+      ;;     read locally is untouched (projection is trace-EGRESS only) ---
+      (is (= pw-sentinel (get-in raw [1 :password]))
+          "projection did not mutate the raw routed event — handlers see the raw value"))))
+
+(deftest event-received-echoed-event-redacted
+  (testing "rf2-ghgbqi: :rf.machine/event-received carries the routed event under
+            top-level :event; the password redacts"
+    (register-machine-event-classification!)
+    (let [ev {:operation :rf.machine/event-received
+              :tags {:machine-id mid
+                     :frame      :rf/default
+                     :event      (inner-event)}}
+          t  (project ev)]
+      (is (= privacy/redacted-sentinel (get-in t [:event 1 :password])))
+      (is (= email (get-in t [:event 1 :email])))
+      (is (not (leaks? pw-sentinel t))))))
+
+(deftest guard-and-action-input-event-redacted
+  (testing "rf2-ghgbqi: :rf.machine/guard-evaluated and :rf.machine/action-ran
+            carry the routed event under [:input :event]; the password redacts"
+    (register-machine-event-classification!)
+    (doseq [op [:rf.machine/guard-evaluated :rf.machine/action-ran]]
+      (let [ev {:operation op
+                :tags {:actor-id mid
+                       :frame    :rf/default
+                       :input    {:data {:token token-sentinel} :event (inner-event)}}}
+            t  (project ev)]
+        (is (= privacy/redacted-sentinel (get-in t [:input :event 1 :password]))
+            (str op " [:input :event] password redacted"))
+        (is (not (leaks? pw-sentinel t)) (str op " leaks no password"))
+        (is (not (leaks? token-sentinel t)) (str op " leaks no [:input :data] token"))))))
+
+(deftest disjoint-roots-and-noop-precision
+  (testing "rf2-ghgbqi precision: the two path roots are disjoint, and an
+            unclassified machine leaves the echoed event untouched"
+    ;; (1) A machine that declares ONLY a durable :data path does NOT touch
+    ;;     the echoed event vector (a :data-prefixed key never indexes a vector).
+    (registrar/register! :event mid {:sensitive [[:data :token]]})
+    (let [t (project {:operation :rf.machine/transition
+                      :tags {:actor-id mid :frame :rf/default
+                             :event    (inner-event)
+                             :before   {:state :idle :data {:token token-sentinel}}}})]
+      (is (leaks? pw-sentinel (:event t))
+          "a :data-only machine does not redact the event (event path undeclared — fail-open)")
+      (is (not (leaks? token-sentinel t))
+          "…but the durable :data token still redacts"))
+    ;; (2) A machine that declares ONLY an event path does NOT touch the
+    ;;     durable snapshot (an integer index never matches a snapshot key).
+    (registrar/register! :event mid {:sensitive [[1 :password]]})
+    (let [t (project {:operation :rf.machine/transition
+                      :tags {:actor-id mid :frame :rf/default
+                             :event    (inner-event)
+                             :before   {:state :idle :data {:token token-sentinel}}}})]
+      (is (= privacy/redacted-sentinel (get-in t [:event 1 :password]))
+          "the event-path machine redacts the echoed event password")
+      (is (leaks? token-sentinel (:before t))
+          "…and leaves the durable snapshot untouched (no cross-root bleed)"))
+    ;; (3) An UNCLASSIFIED machine (no :event registration) is a clean no-op.
+    (registrar/clear-all!)
+    (let [raw (inner-event)
+          t   (project {:operation :rf.machine/transition
+                        :tags {:actor-id :rf.ghgbqi/unclassified
+                               :frame    :rf/default
+                               :event    raw}})]
+      (is (= raw (:event t))
+          "an unclassified machine's echoed event rides through untouched"))))
+
+;; =====================================================================
+;; B. Real round-trip — reg-machine + dispatch. Proves the machine
+;;    ACTION receives the RAW routed payload while the emitted trace
+;;    redacts every echo slot at egress.
+;; =====================================================================
+
+(deftest routed-sensitive-event-redacts-in-live-machine-trace
+  (testing "rf2-ghgbqi acceptance: routing a :sensitive event THROUGH a live
+            machine — the action reads the RAW password, but every emitted
+            machine trace echo slot ships it redacted"
+    (let [captured (atom ::none)
+          seen     (atom [])]
+      ;; OPTS (middle slot) :sensitive = the routed-event classification.
+      (rf/reg-machine mid
+        {:sensitive [[1 :password]]}
+        {:initial :idle
+         :actions {:capture!
+                   ;; Spec 005 §Actions — ctx is {:data :event :state :meta};
+                   ;; :event is the routed inner event [:auth/login {…}].
+                   (fn [{:keys [event]}]
+                     (reset! captured (get-in event [1 :password]))
+                     nil)}
+         :states  {:idle {:on {:auth/login {:target :done :action :capture!}}}
+                   :done {}}})
+      (rf/dispatch-sync [mid [:rf.machine/start]])
+      (rf/register-listener! :trace ::ghgbqi (fn [ev] (swap! seen conj ev)))
+      (rf/dispatch-sync [mid [:auth/login {:email email :password pw-sentinel}]])
+
+      ;; 1. The machine ACTION received the RAW password (control flow is
+      ;;    untouched by egress projection).
+      (is (= pw-sentinel @captured)
+          "the machine action read the RAW routed password locally")
+
+      ;; 2. A machine transition trace actually fired (teeth — the echo
+      ;;    surface exists to protect).
+      (let [ops (into #{} (map :operation) @seen)]
+        (is (contains? ops :rf.machine/transition)
+            "a :rf.machine/transition trace was emitted for the routed event"))
+
+      ;; 3. EVERY emitted trace ships the password redacted (the transition
+      ;;    echo slots, the action-ran [:input :event], AND the outer
+      ;;    :rf.event/dispatched vector — all keyed off the same
+      ;;    registration classification).
+      (is (not (some #(leaks? pw-sentinel %) @seen))
+          "no emitted trace event leaks the routed password sentinel")
+
+      ;; 4. Precision — the non-secret :email is still observable somewhere in
+      ;;    the trace stream (redaction is path-precise, not whole-event).
+      (is (some #(leaks? email %) @seen)
+          "the non-secret :email survives in the trace stream")
+
+      (rf/unregister-listener! :trace ::ghgbqi))))


### PR DESCRIPTION
## What

Item 2 of the RULED rf2-agb5jk decision (Mike -> Fable, 2026-07-11) — a framework projector completion.

When a `:sensitive`-classified event is routed **through** a machine (`[:machine-id <inner-event>]`), the machine trace **echoes the routed inner event** into two slots:

- top-level `:event` — `:rf.machine/transition`, `:rf.machine/event-received`
- `[:input :event]` — `:rf.machine/guard-evaluated`, `:rf.machine/action-ran`

`project-machine-tags` projected only the durable `:data` snapshot slots (`:before` / `:after` / `:snapshot` / `:data` / `[:input :data]` / `:cascade`), so the routed sensitive payload shipped **RAW** in the echo slots. The generic `project-event-tags` keys off the *inner* event-id (e.g. `:auth/login`), which is typically unregistered, so it never redacted them.

### Probe (current main, before fix)

A machine registered `:sensitive [[1 :password] [:data :token]]`, routing `[:auth/login {:password :PW}]`:

```
:event slot            => [:auth/login {:email :e, :password :PW}]   ; leaks
[:input :event] slot   => [:auth/login {:email :e, :password :PW}]   ; leaks
:before slot           => {:state :idle, :data {:token :rf/redacted}} ; already redacted
```

After the fix both echo slots redact `:password` (sentinel absent), while the non-secret `:email` and the durable `:data` behaviour are unchanged.

## How

Extend `project-machine-tags` to redact the top-level `:event` and `[:input :event]` echo slots with the machine's **event-rooted** classification (the `reg-machine` OPTS metadata `:sensitive`, e.g. `[[1 :password]]`). This is a whole-value path walk with the machine's declared paths.

The durable machine `:data` classification (the machine **SPEC**'s `:data`-rooted `:sensitive`) stays separate: the two path roots are **disjoint** — an integer event index never matches a `:data`-prefixed snapshot key and vice versa — so each path bites only the surface it is rooted at, and the same union rides both surfaces safely. No new positional-classification language (Option A rejected in the ruling); no new error id; no spec/009 touch.

## Tests

New dual-runtime regression `machine_routed_event_classification_cljs_test.cljc`:

- **Deterministic projector teeth** over all four echo-bearing machine trace ops (`transition`, `event-received`, `guard-evaluated`, `action-ran`) — password redacted in the echo slots, durable `:data` still redacted, non-secret field survives, raw routed event untouched (projection is trace-egress only), plus disjoint-root precision (data-only decl leaves the event untouched; event-only decl leaves the snapshot untouched; unclassified machine is a clean no-op).
- **Live `reg-machine` round-trip** — the machine action reads the **RAW** routed password locally while every emitted trace echo slot (and the outer dispatched-event vector) ships it redacted.

## Quality gates

- Core JVM `clojure -M:test`: **1805 tests / 7963 assertions, 0 failures, 0 errors** (was 1800 / 7938 on main — +5 tests / +25 assertions).
- CLJS node `npm run test:cljs`: **8622 tests / 40652 assertions, 0 failures, 0 errors**.
- `every-emitted-category-is-catalogued` green in both — no new error id.

Unblocks part of the agb5jk app-redesign (alongside the mutation-projector bead rf2-825mzj).
