### PR TITLE
fix(resources): mutation egress derives execute/trace/instance/continuation projections from owner :sensitive declaration (rf2-825mzj)

### DIFF
--- a/examples/real-apps/realworld_resources/mutations.cljs
+++ b/examples/real-apps/realworld_resources/mutations.cljs
@@ -289,6 +289,14 @@
                    [:bio      [:maybe :string]]
                    [:image    [:maybe :string]]
                    [:password {:optional true} [:maybe :string]]]
+   ;; The new-password rides the mutation envelope as a param, so the mutation
+   ;; OWNER classifies it :sensitive projection-relative to its instance (Spec
+   ;; 016 clause 4 / EP-0025). The runtime lowers this per-instance into the
+   ;; frame elision registry, so the password redacts across the durable
+   ;; instance's egress projection AND the completion continuation echo, while
+   ;; the `:request` handler below still receives the raw value. The HTTP body
+   ;; is scrubbed separately by `:sensitive?` on the `:request` (below).
+   :sensitive     [[:params :password]]
    :invalidates   (fn [{:keys [username]} _result]
                     [{:scope {:from-db :realworld/viewer} :tags #{[:profile username]}}])}
   (fn [{:keys [username email bio image password]} _ctx]

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -49,6 +49,7 @@
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            [re-frame.resources.classification :as classification]
             [re-frame.resources.events :as resource-events]
             [re-frame.resources.mutation-events :as mutation-events]
             [re-frame.resources.mutation-registry :as mutation-registry]
@@ -559,15 +560,41 @@
 ;; `:entries` and a fine-grained-classified field would ride egress verbatim
 ;; (rf2-x76af2.13). The reconcile is idempotent + value-independent, so it is
 ;; safe to add and rides unchanged when a handler makes no durable write.
-;; `:rf.mutation/clear` is a causal INSTANCE reset (no resource-entry write), so
-;; it stays unwrapped.
+;; rf2-825mzj — the mutation INSTANCE-mutating handlers ALSO lower each live
+;; instance's owner-declared projection-relative `:sensitive` / `:large`
+;; classification into the per-frame elision registry (under `:source :mutation`,
+;; via `with-mutation-classification-lowering`), so a `:sensitive [[:params
+;; :password]]` mutation's durable instance `:params` redacts at every registry-
+;; reading egress boundary (epoch export, off-box tool, MCP) while the raw value
+;; stays on the instance for the success-path `:invalidates` / `:patches`. This
+;; is the mutation peer of the resource-entry `with-classification-lowering`
+;; fold. `:rf.mutation/clear` DROPS an instance, so it is wrapped too (the
+;; self-dropping reconcile removes the cleared instance's lowered declaration).
+(defn- with-mutation-classification-lowering
+  "Wrap a mutation event handler `f` so the `:rf.db/runtime` value of its returned
+  effects map is reconciled through `classification/reconcile-mutation-registry`
+  (resolver = `mutation-registry/mutation-meta`) — lowering each live mutation
+  instance's projection-relative classification into the per-frame elision
+  registry under `:source :mutation`. Composes with the resource-entry
+  `resource-events/with-classification-lowering` (each reconcile touches only its
+  own registry owner, so order is immaterial). A returned map with no
+  `:rf.db/runtime` key rides unchanged."
+  [f]
+  (fn [& args]
+    (let [effects (apply f args)]
+      (if (and (map? effects) (contains? effects :rf.db/runtime))
+        (update effects :rf.db/runtime
+                classification/reconcile-mutation-registry mutation-registry/mutation-meta)
+        effects))))
 (events/reg-event :rf.mutation/execute
                      generation-meta
                      (resource-events/with-classification-lowering
-                       mutation-events/execute-handler))
+                       (with-mutation-classification-lowering
+                         mutation-events/execute-handler)))
 (events/reg-event :rf.mutation/clear
                      framework-authority-meta
-                     mutation-events/clear-handler)
+                     (with-mutation-classification-lowering
+                       mutation-events/clear-handler))
 ;; The mutation reply handlers consume the reply token's
 ;; causal `:rf/time-ms` for the canonical reply's `:completed-at` → the durable
 ;; instance `:settled-at` + any patch / populate `:loaded-at`, so they declare
@@ -575,11 +602,13 @@
 (events/reg-event :rf.mutation.internal/succeeded
                      time-meta
                      (resource-events/with-classification-lowering
-                       mutation-events/succeeded-handler))
+                       (with-mutation-classification-lowering
+                         mutation-events/succeeded-handler)))
 (events/reg-event :rf.mutation.internal/failed
                      time-meta
                      (resource-events/with-classification-lowering
-                       mutation-events/failed-handler))
+                       (with-mutation-classification-lowering
+                         mutation-events/failed-handler)))
 
 ;; Passive mutation subs. Per Spec 016 §Mutations.
 (mutation-subs/register-subs!)

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -60,6 +60,7 @@
             [re-frame.elision :as elision]
             [re-frame.path :as path]
             [re-frame.projection :as projection]
+            [re-frame.resources.mutation-runtime :as mutation-runtime]
             [re-frame.resources.state :as state]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -217,6 +218,51 @@
         ->decl (fn [paths] (into {} (map (fn [p] [p {:source :owner-declaration}])) paths))]
     {:data   {:sensitive (->decl (:data s))   :large (->decl (:data l))}
      :params {:sensitive (->decl (:params s)) :large (->decl (:params l))}}))
+
+;; ---------------------------------------------------------------------------
+;; Mutation continuation-reply projection (rf2-825mzj / EP-0025 §subsystems).
+;;
+;; A `:reply-to` mutation continuation dispatches a canonical reply map carrying
+;; the accepted attempt's `:params` + resolved `:scope` (Spec 016 §Mutation
+;; completion continuations). Those are the SAME owner-classified facts the
+;; durable instance stores, so an owner that declared `:sensitive [[:params
+;; :password]]` must not repeat the raw value on the continuation reply (which
+;; rides the trace bus AND is dispatched into app workflow). The mutation OWNER
+;; declaration is the single source — this redacts the reply IN THE SAME
+;; construction step resources builds it, deriving the paths from the spec (never
+;; a second classification language). The mutation `:request` handler already ran
+;; on the RAW params before the instance was minted, so the causal write is
+;; unaffected; only the completion echo is projected.
+;; ---------------------------------------------------------------------------
+
+(defn redact-continuation-reply
+  "Redact the owner-declared `:sensitive` / `:large` param + scope subpaths of a
+  mutation continuation REPLY map, deriving the paths from the mutation `spec`'s
+  projection-relative declaration (`split-projection-paths`). The reply carries
+  `:params` + `:scope` as siblings and the decoded result under `:value`, so a
+  `:params`-rooted decl `[:password]` redacts reply `[:params :password]`, a
+  `:scope`-rooted decl redacts reply `[:scope …]`, and a `:data`-rooted decl
+  redacts the reply's `:value` (the mutation-result projection). Sensitive wins
+  over large at a shared path (the shared elision walker's ordering). A `spec`
+  that declares neither axis — or a nil spec (unregistered owner) — rides the
+  reply UNCHANGED. Pure / value-independent."
+  [reply spec]
+  (let [s       (split-projection-paths spec :sensitive)
+        l       (split-projection-paths spec :large)
+        ;; reply-relative re-rooting: the `:params` bucket holds params-rooted
+        ;; paths (head stripped) AND `:scope`-rooted paths (kept WITH their
+        ;; `[:scope …]` head), so a scope entry indexes the reply's sibling
+        ;; `:scope` verbatim while a params entry re-roots under `[:params …]`.
+        ;; The `:data` bucket re-roots under the reply's `:value` result slot.
+        ->reply (fn [{:keys [data params]}]
+                  (into (mapv #(into [:value] %) data)
+                        (mapv (fn [p] (if (= :scope (first p)) p (into [:params] p)))
+                              params)))
+        sens    (->reply s)
+        large   (->reply l)]
+    (if (or (seq sens) (seq large))
+      (classification/redact-with-paths reply sens large)
+      reply)))
 
 ;; ---------------------------------------------------------------------------
 ;; Schemas validate; they do NOT classify durably.
@@ -620,4 +666,122 @@
       (assoc base elision-registry-key {})
 
       ;; nothing ever classified → leave the key absent (no stray sub-tree).
+      :else base)))
+
+;; ---------------------------------------------------------------------------
+;; Per-instance MUTATION lowering into the per-frame elision registry
+;; (rf2-825mzj — the mutation peer of the resource-entry lowering above).
+;;
+;; A mutation INSTANCE lives at `[:rf.runtime/mutations <key-id>]` and stores the
+;; canonical `:params`, resolved `:scope`, and decoded `:result` (Spec 016
+;; §Cache home). The owner `reg-mutation` spec declares its sensitive slots
+;; PROJECTION-RELATIVE to that instance projection (`:sensitive [[:params
+;; :password]]`), and the runtime LOWERS the declaration into the SAME per-frame
+;; elision registry PER INSTANCE, re-rooting each projection-relative path to the
+;; instance's ABSOLUTE runtime-db path under `:source :mutation` — exactly as
+;; resource entries lower under `:source :resource`. The durable instance keeps
+;; the RAW value (the success-path `:invalidates` / `:patches` / `:populates`
+;; read it, and the request handler already consumed it); only the egress
+;; boundaries that read this registry (epoch export, off-box tool, MCP) redact.
+;;
+;; Re-rooting (per instance, keyed on the instance id's byte `key-id`):
+;;   - a `:params`-rooted path → `[:rf.runtime/mutations <key-id> :params …]`;
+;;   - a `:scope`-rooted path  → `[:rf.runtime/mutations <key-id> :scope …]`;
+;;   - a `:data`-rooted / bare path → `[:rf.runtime/mutations <key-id> :result …]`
+;;     (the mutation's decoded result is its data projection).
+;; ---------------------------------------------------------------------------
+
+(defn- mutation-instance-declaration-paths
+  "The ABSOLUTE `{:sensitive [paths] :large [paths]}` runtime-db paths a single
+  mutation instance contributes, re-rooting `spec`'s projection-relative
+  declarations under the instance's byte `key-id`. `:params`-rooted paths
+  re-root under the instance `:params`; `:scope`-rooted paths under `:scope`;
+  `:data`-rooted / bare paths under `:result`. Pure; returns `{:sensitive []
+  :large []}` when the spec declares neither axis."
+  [key-id spec]
+  (let [s            (split-projection-paths spec :sensitive)
+        l            (split-projection-paths spec :large)
+        inst-prefix  (conj (mutation-runtime/instances-path) key-id)
+        result-pre   (conj inst-prefix :result)
+        params-pre   (conj inst-prefix :params)
+        scope-pre    (conj inst-prefix :scope)
+        ;; a `:params`-bucket path is either a params-rooted path (head stripped)
+        ;; or a `:scope`-rooted path (kept WITH its `[:scope …]` head); re-root
+        ;; each to the matching instance slot.
+        ->key-abs    (fn [p]
+                       (if (= :scope (first p))
+                         (into scope-pre (subvec (vec p) 1))
+                         (into params-pre p)))
+        ->abs        (fn [axis]
+                       (into (mapv #(into result-pre %) (:data axis))
+                             (mapv ->key-abs (:params axis))))]
+    {:sensitive (->abs s)
+     :large     (->abs l)}))
+
+(def ^:private mutation-source
+  "The elision-registry `:source` tag a mutation-lowered declaration carries —
+  the mutation peer of `:source :resource`. Source-scoped so reconciliation /
+  clear touch only mutation-sourced entries (an evicted instance self-drops)."
+  :mutation)
+
+(def ^:private mutation-owner
+  "The multi-owner elision-registry owner identity a mutation instance lowering
+  claims under. The reconcile rebuilds the full mutation-owned claim set from the
+  live instances each commit (self-dropping), so `replace-owner-claims` drops a
+  cleared instance's claims and installs current ones in one step."
+  {:source mutation-source})
+
+(defn reconcile-mutation-registry
+  "PURE per-instance MUTATION lowering: given a base `runtime-db` value and a
+  `spec-of` resolver `(fn [mutation-id] -> spec|nil)`, return the runtime-db with
+  the `[:rf.runtime/elision …]` registry's `:source :mutation` claims REPLACED by
+  the declarations of EVERY current mutation instance (re-rooted absolute per the
+  instance's byte `key-id`), delegating to `re-frame.elision/replace-owner-claims`.
+  The mutation peer of `reconcile-registry` — the standard EP-0025 lowering.
+
+  Operates on a VALUE so a mutation handler's durable `:rf.db/runtime` transition
+  folds the registry update into the SAME atomic commit that mints / settles /
+  clears the instance. IDEMPOTENT + SELF-DROPPING: the full mutation-owned claim
+  set is rebuilt from the current `:rf.runtime/mutations` instances, so a cleared
+  instance's declarations vanish and a newly-minted instance's appear, with no
+  separate drop hook. Value-INDEPENDENT. A path ALSO claimed by another owner
+  (`:source :resource` / `:effect` / …) rides untouched and unions at
+  egress-lookup time.
+
+  `spec-of` is injected (the mutation registry requires this ns, so a static
+  back-require would cycle) — the caller passes `mutation-registry/mutation-meta`.
+  A mutation id with no registered spec, or a spec that declares no
+  classification, contributes nothing.
+
+  Reconcile-aware (mirrors `reconcile-registry`): when the lowering emptied a
+  base that carried a registry, it emits an EXPLICIT (possibly cleared)
+  `:rf.runtime/elision` key so a whole-value runtime-db commit honours a clear's
+  drop verbatim; the never-classified case emits no key."
+  [runtime-db spec-of]
+  (let [base      (or runtime-db {})
+        instances (get-in base (mutation-runtime/instances-path))
+        reg       (get base elision-registry-key)
+        {:keys [sensitive large]}
+        (reduce-kv
+          (fn [acc key-id inst]
+            (let [mid  (:mutation/id inst)
+                  spec (when mid (spec-of mid))]
+              (if-not spec
+                acc
+                (let [{:keys [sensitive large]} (mutation-instance-declaration-paths key-id spec)]
+                  (-> acc
+                      (update :sensitive into sensitive)
+                      (update :large into large))))))
+          {:sensitive [] :large []}
+          (or instances {}))
+        new-reg   (-> (or reg {})
+                      (elision/replace-owner-claims :sensitive-declarations mutation-owner sensitive)
+                      (elision/replace-owner-claims :declarations mutation-owner large))]
+    (cond
+      (seq new-reg)
+      (assoc base elision-registry-key new-reg)
+
+      (contains? base elision-registry-key)
+      (assoc base elision-registry-key {})
+
       :else base)))

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -62,6 +62,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.reply :as reply]
+            [re-frame.resources.classification :as rclass]
             [re-frame.resources.events :as events]
             [re-frame.resources.mutation-registry :as mreg]
             [re-frame.resources.mutation-runtime :as mstate]
@@ -1805,13 +1806,23 @@
             ;; `:rf.mutation/succeeded` (rf2-ru73k6 F2).
             cont-fx     (continuation-fx
                           reply-to
-                          (continuation-reply
-                            reply {:mutation-id mutation-id :params params
-                                   :instance-id instance-id :scope scope
-                                   ;; rf2-fi6tda.2 + .3: the full affected set
-                                   ;; (populated + patched + removed + stale),
-                                   ;; not just patch/populate.
-                                   :affected-keys affected}))
+                          ;; rf2-825mzj — redact the owner-declared sensitive
+                          ;; param / scope subpaths on the continuation echo
+                          ;; (derived from the mutation spec's projection-relative
+                          ;; declaration), so a `:sensitive`-declared param does
+                          ;; not repeat RAW on the reply that rides the trace bus
+                          ;; and dispatches into app workflow. The durable
+                          ;; instance keeps the raw value (the success-path
+                          ;; `:invalidates` / `:patches` above already read it).
+                          (rclass/redact-continuation-reply
+                            (continuation-reply
+                              reply {:mutation-id mutation-id :params params
+                                     :instance-id instance-id :scope scope
+                                     ;; rf2-fi6tda.2 + .3: the full affected set
+                                     ;; (populated + patched + removed + stale),
+                                     ;; not just patch/populate.
+                                     :affected-keys affected})
+                            spec))
             ;; best-effort abort of each REMOVED entry's in-flight attempt +
             ;; cancel its advisory timers (its durable facts are gone) —
             ;; mirroring `:rf.resource/remove`. Stale suppression by work-id +
@@ -2051,10 +2062,16 @@
             ;; `:rf.mutation/failed` (rf2-ru73k6 F2).
             cont-fx  (continuation-fx
                        reply-to
-                       (continuation-reply
-                         reply {:mutation-id mutation-id :params params
-                                :instance-id instance-id :scope scope
-                                :affected-keys affected}))]
+                       ;; rf2-825mzj — redact the owner-declared sensitive param /
+                       ;; scope subpaths on the failure continuation echo too
+                       ;; (an accepted `:error` / `:cancelled` reply dispatches
+                       ;; `:reply-to`). Derived from the mutation spec.
+                       (rclass/redact-continuation-reply
+                         (continuation-reply
+                           reply {:mutation-id mutation-id :params params
+                                  :instance-id instance-id :scope scope
+                                  :affected-keys affected})
+                         spec))]
         (work-ledger/clear-handle! frame-id work-id)
         ;; EP-0019 — the optimistic rollback trace (phase 4, error/cancel).
         ;; Carries the snapshot id, per-key restored-vs-conflict disposition (the

--- a/implementation/resources/test/re_frame/resources_mutation_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_classification_cljs_test.cljc
@@ -1,0 +1,253 @@
+(ns re-frame.resources-mutation-classification-cljs-test
+  "rf2-825mzj (agb5jk item 3) — a mutation OWNER's projection-relative
+  `:sensitive` / `:large` declaration governs the mutation ENVELOPE's egress, so
+  a `:sensitive [[:params :password]]` param does NOT ship raw in the durable
+  instance's egress projection nor on the completion CONTINUATION echo, while the
+  causal write (the `:request` handler) and the success-path `:invalidates` /
+  `:patches` still read the RAW value.
+
+  The gap this closes (verified by probe on the pre-fix tree): the mutation
+  registry SUPPORTED the owner declaration, but the mutation projections IGNORED
+  it — the durable instance `:params`, the continuation reply `:params`, and the
+  `elide-wire-value` egress walk over `:rf.runtime/mutations` all rode the raw
+  value. The fix lowers each live instance's declaration into the per-frame
+  elision registry under `:source :mutation` (the resource-entry lowering peer)
+  and redacts the resources-constructed continuation reply from the same owner
+  declaration.
+
+  CLJC so the JVM run (`clojure -M:test`, the load-bearing gate) exercises it
+  and the CLJS node run does too; the schemas artefact is a test-only dep so the
+  shared walker hooks are bound."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
+   [re-frame.core :as rf]
+   [re-frame.elision :as elision]
+   [re-frame.privacy :as privacy]
+   [re-frame.resources.classification :as classification]
+   [re-frame.resources.mutation-registry :as mreg]
+   [re-frame.resources.mutation-runtime :as mstate]
+   ;; load-bearing side-effecting requires: register the :rf.mutation/* events +
+   ;; subs + the generation cofx/fx + bind the shared walker hooks.
+   [re-frame.resources]
+   [re-frame.http.managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport (records the lowered request args) ----------------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- capturing-transport-fixture [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-transport-fixture)
+
+;; A UNIQUE sentinel so a leak anywhere in the projected surface is unambiguous.
+(def ^:private PW "PW-SENTINEL-7f3a91")
+
+(defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
+
+(defn- reg-secret-mutation!
+  "Register `:m/secret` — a mutation classifying its `:password` param
+  :sensitive projection-relative to the instance."
+  ([] (reg-secret-mutation! {}))
+  ([overrides]
+   (rf/clear-mutation :m/secret)
+   (rf/reg-mutation :m/secret
+     (merge {:params-schema [:map [:slug :string] [:password {:optional true} [:maybe :string]]]
+             :sensitive     [[:params :password]]}
+            overrides)
+     (fn [{:keys [slug password]} _]
+       {:request {:method :put :url (str "/x/" slug) :body {:slug slug :password password}}}))))
+
+;; A runtime-db carrying ONE mutation instance under its byte key-id, mirroring
+;; the durable `:rf.runtime/mutations` shape the runtime mints.
+(defn- runtime-db-with-instance [instance-id inst]
+  {mstate/mutations-key {(mstate/instance-key-id instance-id) inst}})
+
+;; ===========================================================================
+;; 1. reconcile-mutation-registry — lowers a live instance's owner declaration
+;;    into the per-frame elision registry at the ABSOLUTE instance path.
+;; ===========================================================================
+
+(deftest reconcile-lowers-instance-params-declaration
+  (reg-secret-mutation!)
+  (testing "a live mutation instance's owner :params-rooted :sensitive
+            declaration is LOWERED into the elision registry under
+            :source :mutation, rooted at the instance's absolute runtime-db path"
+    (let [k-id (mstate/instance-key-id :i1)
+          rdb  (runtime-db-with-instance
+                 :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          out  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
+          sens (get-in out [:rf.runtime/elision :sensitive-declarations])]
+      (is (= #{{:source :mutation}}
+             (get sens [:rf.runtime/mutations k-id :params :password]))
+          "the :params :password decl is lowered at the absolute instance path"))))
+
+(deftest reconcile-mutation-is-idempotent
+  (reg-secret-mutation!)
+  (testing "re-running the mutation reconcile over its own output is a no-op"
+    (let [rdb   (runtime-db-with-instance
+                  :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          once  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
+          twice (classification/reconcile-mutation-registry once mreg/mutation-meta)]
+      (is (= once twice) "mutation reconciliation is idempotent"))))
+
+(deftest reconcile-mutation-self-drops-cleared-instance
+  (reg-secret-mutation!)
+  (testing "a cleared instance's :source :mutation declaration vanishes on the
+            next reconcile (the per-instance teardown — no separate drop hook)"
+    (let [rdb   (runtime-db-with-instance
+                  :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          live  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
+          ;; drop the instance, keep the carried registry, reconcile again.
+          cleared (-> live
+                      (assoc mstate/mutations-key {})
+                      (classification/reconcile-mutation-registry mreg/mutation-meta))]
+      (is (seq (get-in live [:rf.runtime/elision :sensitive-declarations]))
+          "the live instance lowered a declaration")
+      (is (empty? (get-in cleared [:rf.runtime/elision :sensitive-declarations]))
+          "the cleared instance's declaration is dropped"))))
+
+(deftest reconcile-mutation-preserves-foreign-owner
+  (reg-secret-mutation!)
+  (testing "a non-mutation-sourced registry entry (:source :resource / :effect)
+            rides untouched through the mutation reconcile (multi-owner union)"
+    (let [rdb (-> (runtime-db-with-instance
+                    :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+                  (assoc-in [:rf.runtime/elision :sensitive-declarations [:app :token]]
+                            #{{:source :effect}}))
+          out (classification/reconcile-mutation-registry rdb mreg/mutation-meta)]
+      (is (= #{{:source :effect}}
+             (get-in out [:rf.runtime/elision :sensitive-declarations [:app :token]]))
+          "the :source :effect entry survives the mutation reconcile"))))
+
+(deftest reconcile-mutation-no-classification-no-registry
+  (rf/clear-mutation :m/plain)
+  (rf/reg-mutation :m/plain {:params-schema [:map [:slug :string]]}
+    (fn [_ _] {:request {:method :get :url "/x"}}))
+  (testing "a mutation that declares no classification lowers nothing"
+    (let [rdb (runtime-db-with-instance
+                :i1 (mstate/empty-instance :m/plain :i1 {:params {:slug "w"}}))
+          out (classification/reconcile-mutation-registry rdb mreg/mutation-meta)]
+      (is (not (contains? out :rf.runtime/elision))
+          "no :rf.runtime/elision key when nothing classifies"))))
+
+;; ===========================================================================
+;; 2. redact-continuation-reply — derives the reply redaction from the owner.
+;; ===========================================================================
+
+(deftest redact-continuation-reply-redacts-owner-param
+  (reg-secret-mutation!)
+  (testing "the owner-declared :params :password is redacted on the continuation
+            reply map; the non-sensitive sibling rides verbatim"
+    (let [reply {:status :ok :value {:ok true}
+                 :params {:slug "w" :password PW} :scope :rf.scope/global}
+          out   (classification/redact-continuation-reply reply (mreg/mutation-meta :m/secret))]
+      (is (= privacy/redacted-sentinel (get-in out [:params :password]))
+          "the sensitive param is redacted on the reply")
+      (is (= "w" (get-in out [:params :slug])) "the non-sensitive param rides verbatim")
+      (is (= {:ok true} (:value out)) "the result value rides verbatim")
+      (is (not (str/includes? (pr-str out) PW)) "no raw sentinel rides on the reply"))))
+
+(deftest redact-continuation-reply-unclassified-rides-verbatim
+  (rf/clear-mutation :m/plain)
+  (rf/reg-mutation :m/plain {:params-schema [:map [:slug :string]]}
+    (fn [_ _] {:request {:method :get :url "/x"}}))
+  (testing "a mutation that declares no classification rides the reply UNCHANGED"
+    (let [reply {:status :ok :params {:slug "w" :password PW}}]
+      (is (= reply (classification/redact-continuation-reply reply (mreg/mutation-meta :m/plain)))
+          "no declaration → the reply is unchanged"))))
+
+;; ===========================================================================
+;; 3. END-TO-END — drive a real classified mutation through execute + reply.
+;; ===========================================================================
+
+(deftest execute-lowers-instance-and-redacts-egress-and-continuation
+  (reg-secret-mutation!)
+  (let [replied (atom nil)
+        traces  (atom [])]
+    (rf/reg-event :m/replied (fn [_ [_ reply]] (reset! replied reply) {}))
+    (trace-tooling/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/secret
+                        :params   {:slug "w" :password PW}
+                        :instance :i1
+                        :reply-to [:m/replied]}])
+    ;; the causal write handler runs on the RAW params BEFORE the instance mints.
+    (testing "the :request handler received the RAW password (causal write intact)"
+      (is (= PW (get-in @last-managed-args [:request :body :password]))))
+    ;; reply success to settle the instance + fire the continuation.
+    (rf/dispatch-sync (conj (:on-success @last-managed-args) {:status :ok :value {:ok true}}))
+    (trace-tooling/unregister-listener! ::rec)
+
+    (let [rdb  (runtime-db)
+          k-id (mstate/instance-key-id :i1)
+          inst (get-in rdb (mstate/instance-path :i1))]
+      (testing "the durable instance keeps the RAW params (success-path fns read them)"
+        (is (= PW (get-in inst [:params :password]))
+            "the durable instance :password is NOT destroyed"))
+      (testing "the owner declaration is LOWERED into the frame elision registry"
+        (is (= #{{:source :mutation}}
+               (get (elision/sensitive-declarations :rf/default)
+                    [:rf.runtime/mutations k-id :params :password]))
+            "the instance :params :password decl is in the per-frame registry"))
+      (testing "the off-box egress walk over the instance REDACTS :password"
+        (let [proj (rf/elide-wire-value inst {:frame :rf/default
+                                              :path [:rf.runtime/mutations k-id]
+                                              :rf.egress/profile :rf.egress/off-box-tool})]
+          (is (= privacy/redacted-sentinel (get-in proj [:params :password]))
+              "the instance :password is redacted at egress")
+          (is (= "w" (get-in proj [:params :slug])) "the non-sensitive :slug rides verbatim")
+          (is (not (str/includes? (pr-str proj) PW))
+              "no raw sentinel rides anywhere on the projected instance"))))
+
+    (testing "the continuation reply redacts :password but keeps the result + slug"
+      (is (= privacy/redacted-sentinel (get-in @replied [:params :password]))
+          "the continuation reply :password is redacted")
+      (is (= "w" (get-in @replied [:params :slug])) "the reply :slug rides verbatim")
+      (is (= {:ok true} (:value @replied)) "the reply :value (result) rides verbatim")
+      (is (not (str/includes? (pr-str @replied) PW)) "no raw sentinel rides on the reply"))
+
+    (testing "no :rf.mutation/* trace row carries the raw sentinel (params never
+              ride the mutation trace family)"
+      (doseq [ev @traces]
+        (when (and (keyword? (:operation ev))
+                   (= "rf.mutation" (namespace (:operation ev))))
+          (is (not (str/includes? (pr-str (:tags ev)) PW))
+              (str (:operation ev) " must not carry the raw sentinel")))))
+
+    (testing "the FAILURE continuation echo redacts :password too (an accepted
+              :error reply also dispatches :reply-to)"
+      (reset! last-managed-args nil)
+      (reset! replied nil)
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/secret
+                          :params   {:slug "w" :password PW}
+                          :instance :i2
+                          :reply-to [:m/replied]}])
+      (rf/dispatch-sync (conj (:on-failure @last-managed-args)
+                              {:status :error :error {:status 422 :body "nope"}}))
+      (is (= privacy/redacted-sentinel (get-in @replied [:params :password]))
+          "the failure continuation reply :password is redacted")
+      (is (= "w" (get-in @replied [:params :slug])) "the failure reply :slug rides verbatim")
+      (is (not (str/includes? (pr-str @replied) PW))
+          "no raw sentinel rides on the failure reply"))
+
+    (testing "clear DROPS the lowered instance declaration (self-dropping)"
+      (rf/dispatch-sync [:rf.mutation/clear {:instance :i1}])
+      (is (empty? (get (elision/sensitive-declarations :rf/default)
+                       [:rf.runtime/mutations (mstate/instance-key-id :i1) :params :password]))
+          "the cleared instance's declaration is gone from the registry"))))


### PR DESCRIPTION
## What

agb5jk item 3 (Mike/Fable ruling, 2026-07-11). A mutation that classifies a param `:sensitive` (e.g. `[[:params :password]]`) leaked the raw value across the mutation **envelope's** egress: the durable instance's off-box projection and the completion **continuation** echo both shipped it raw. The `reg-mutation` registry already *supported* the owner declaration, but the projections **ignored** it (reproduced by a probe on `main` before the fix — the durable instance `:params`, the `elide-wire-value` walk over `:rf.runtime/mutations`, and the dispatched continuation reply all rode the raw sentinel).

The fix makes **resources egress derive the projections from the mutation OWNER declaration** — no new classification machinery, the resource-entry lowering pattern applied to mutation instances.

## How

- **Instance projection** — `resources.classification/reconcile-mutation-registry` lowers each live mutation instance's projection-relative `:sensitive`/`:large` paths into the per-frame elision registry under `:source :mutation` (the peer of the resource-entry `:source :resource` lowering), re-rooted at `[:rf.runtime/mutations <key-id> :params|:scope|:result …]`. The four instance-mutating handlers (`execute` / `succeeded` / `failed` / `clear`) fold it into their `:rf.db/runtime` commit via a new `with-mutation-classification-lowering` wrapper (composes with the existing resource-entry `with-classification-lowering` — each reconcile touches only its own registry owner). Every registry-reading egress boundary (epoch export, off-box tool, MCP) then redacts the param, while the **durable instance keeps the RAW value** for the success-path `:invalidates`/`:patches` and the `:request` handler.
- **Continuation projection** — `resources.classification/redact-continuation-reply` redacts the owner-declared sensitive param/scope subpaths on the resources-constructed continuation reply (success **and** accepted-error), derived from the same spec.
- **Trace projection** — the `:rf.mutation/*` trace rows carry no `:params` (their scoped keys are already projected by the family trace-egress projector), so no param rides the trace family.
- **App** — `:realworld/update-settings` declares `:sensitive [[:params :password]]` (its param leaked; the `:request` body was already scrubbed via `:sensitive?`).

## Quality gates

- resources JVM suite (`clojure -M:test`): **651 tests / 6335 assertions, 0 failures, 0 errors**
- new regression `resources-mutation-classification-cljs-test`: **8 tests / 28 assertions, 0 failures** (pure `reconcile-mutation-registry` lower/idempotent/self-drop/multi-owner/no-op; pure `redact-continuation-reply`; end-to-end drive)
- CLJS node suite (`npm run test:cljs`): **8629 tests / 40680 assertions, 0 failures, 0 errors**
- error/trace catalogue conformance gate (`every-emitted-category-is-catalogued`, core): **9 tests / 21 assertions, 0 failures** — **no new trace category or error id**

### Sentinel teeth-proof (unique sentinel `PW-SENTINEL-7f3a91`)

Drive a real classified mutation `execute → success/failure` and assert absence of the sentinel across the four egress surfaces, presence where the causal write needs it:

| surface | pre-fix | post-fix |
|---|---|---|
| `:request` handler body (causal write) | raw | **raw** (write intact) |
| durable instance `:params :password` | raw | **raw** (success-path fns read it) |
| off-box `elide-wire-value` over the instance | raw | **`:rf/redacted`** (`:slug` verbatim) |
| success continuation reply `:params :password` | raw | **`:rf/redacted`** (`:value`/`:slug` verbatim) |
| failure continuation reply `:params :password` | raw | **`:rf/redacted`** |
| `:rf.mutation/*` trace rows | (no `:params`) | (no `:params`) |

`clear` drops the lowered instance declaration (self-dropping reconcile).

## Scope note

The `:rf.mutation/execute` **dispatched-event trace** (`:rf.event/v`) is projected by the **core** event-registration chokepoint (`redact-event-by-registration`), not a resources egress boundary — it is default-redacted off-box by `omit-off-box-event-args` (all event args stripped) and only rides raw under the trusted-local `:include-event-args?` opt-in. Closing that per-owner needs a core event-projection change (parallel to the routing `project-route-sub-egress` late-bind precedent and the sibling machine-projector work); left untouched here per the core-collision boundary.