### PR TITLE
fix(story-mcp): make a11y-provider / substrate-provider CLJS seams consistent — no silent asymmetry (rf2-jyjadg)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
@@ -24,12 +24,36 @@
 
   This boundary represents AVAILABILITY separately from the returned
   collection. Each browser-only surface has a PROVIDER SEAM: a zero-arg fn
-  held in a dynamic var. `nil` means 'no provider reachable' (the JVM
-  stdio default). A bound provider's `[]`/`#{}`/`{}` means 'reached and
-  empty', which is DISTINCT from the var being nil. A future browser
-  bridge (or a test) supplies a provider by binding the seam; the
-  transport itself is OUT OF SCOPE here (a later bead owns it — this ns
-  only distinguishes 'reached + empty' from 'cannot answer').
+  held in a dynamic var. `nil` means 'no provider reachable' — the default
+  on EVERY platform (see the next section). A bound provider's
+  `[]`/`#{}`/`{}` means 'reached and empty', which is DISTINCT from the var
+  being nil. A future browser bridge (or a test) supplies a provider by
+  binding the seam; the transport itself is OUT OF SCOPE here (a later bead
+  owns it — this ns only distinguishes 'reached + empty' from 'cannot
+  answer').
+
+  ## Neither seam auto-wires — the browser bridge binds BOTH (rf2-jyjadg)
+
+  BOTH provider seams default to `nil` on EVERY platform, JVM and CLJS
+  alike. Neither `*substrate-provider*` nor `*a11y-provider*` is
+  auto-wired: a future browser-local host (or a test) MUST bind BOTH for
+  either browser-only read to answer. `substrate-provider-available?` and
+  `a11y-provider-available?` therefore report the SAME posture out of the
+  box (both false), and `list-substrates` / `read-a11y-violations` both
+  degrade to `capability-unavailable` until their seam is bound.
+
+  This symmetry is deliberate. The substrate registry
+  (`re-frame.story/registered-substrates`) lives in the already-loaded
+  Story CORE ns, so a CLJS default COULD cheaply dereference it in-process
+  — but the a11y violations atom (`re-frame.story.ui.a11y/
+  violations-by-frame`) lives in the Story UI ns, which this helper must
+  NOT require (bundle isolation — the MCP classpath may not drag in the
+  Story UI; see `deps.edn`). Auto-wiring ONLY the reachable seam would
+  leave a HALF-WORKING default: `list-substrates` answering out of the box
+  while `read-a11y-violations` silently reports capability-unavailable in
+  the SAME live process — and would invite a bridge author to assume a11y
+  'just works' because substrate does. So the seams are held CONSISTENT:
+  the bridge wires both, together, and there is no silent asymmetry.
 
   The two browser-only read handlers (`dev/tool-list-substrates`,
   `testing/tool-read-a11y-violations`) and the `:substrate` validation in
@@ -40,9 +64,15 @@
   ## The low-level resolver
 
   `resolve-cljs-var` probes for a CLJS-only `def` via `clojure.core/
-  resolve` on the JVM (nil on miss); it is the mechanism the two
-  platform-default providers are wired from."
-  (:require [re-frame.story :as story]))
+  resolve` on the JVM (nil on miss); it is the mechanism the two JVM-side
+  default probes attempt — both resolve nil on the stdio host, since the
+  substrate registry and the a11y atom are CLJS-only."
+  ;; `re-frame.story` is required (loaded) so the JVM `resolve-cljs-var`
+  ;; can reach its CLJC vars; it is no longer aliased, because both
+  ;; provider-seam defaults are now nil symmetrically (rf2-jyjadg) and no
+  ;; branch dereferences it — the resolver reaches it by fully-qualified
+  ;; symbol below.
+  (:require [re-frame.story]))
 
 (defn resolve-cljs-var
   "Resolve a fully-qualified symbol (`fully.qualified.ns/sym`) to the
@@ -59,12 +89,14 @@
   (try (resolve sym) (catch Throwable _ nil)))
 
 ;; ---------------------------------------------------------------------------
-;; Resolved CLJS-only vars — the platform-default provider sources.
+;; Resolved CLJS-only vars — the JVM-side default probe sources.
 ;;
 ;; Each is probed ONCE at ns-load. On a JVM host the CLJS-only Var does not
 ;; exist, so the probe is nil and the surface is UNAVAILABLE (NOT empty).
-;; The `:cljs` accessor branches below read the live surface directly when
-;; these namespaces are hosted in a CLJS runtime.
+;; The CLJS defaults do NOT read these surfaces directly either: both seams
+;; default nil on every platform (rf2-jyjadg — see the ns docstring), so a
+;; browser-local host binds BOTH providers rather than inheriting a
+;; half-working default.
 ;; ---------------------------------------------------------------------------
 
 #?(:clj
@@ -87,13 +119,19 @@
 (def ^:dynamic *substrate-provider*
   "Provider seam for the substrate-REGISTRY browser-only read. A provider
   is a zero-arg fn returning the registered-substrate id collection;
-  `nil` means NO provider is reachable — the JVM stdio default (no bridge
-  to the CLJS `register-substrate!` registry). A bound provider's `[]`
-  means 'reached and empty', DISTINCT from this var being nil ('cannot
-  answer'). Rebind in tests / a future browser bridge to supply one."
+  `nil` means NO provider is reachable — the default on EVERY platform
+  (JVM stdio AND CLJS), no auto-wire. A bound provider's `[]` means
+  'reached and empty', DISTINCT from this var being nil ('cannot answer').
+  Rebind in tests / a future browser bridge to supply one.
+
+  NOTE (rf2-jyjadg): the CLJS default is nil even though the registry
+  (`re-frame.story/registered-substrates`) is reachable in-process — it is
+  held nil to stay SYMMETRIC with `*a11y-provider*`, whose UI-ns source is
+  bundle-isolated out of this helper and so CANNOT auto-wire. A browser
+  bridge binds BOTH seams together; see the ns docstring."
   #?(:clj  (when registered-substrates-var
              (fn [] (registered-substrates-var)))
-     :cljs (fn [] (story/registered-substrates))))
+     :cljs nil))
 
 (defn substrate-provider-available?
   "True iff a substrate-registry provider is reachable. The availability
@@ -134,10 +172,17 @@
   "Provider seam for the a11y-panel VIOLATIONS browser-only read. A
   provider is a zero-arg fn returning the by-frame violations map
   (`{variant-kw [violation …]}`); `nil` means NO provider is reachable —
-  the JVM stdio default (no bridge to the CLJS `violations-by-frame`
-  atom). A bound provider that returns `{}` (or lacks an entry for a
-  frame) means 'reached and empty', DISTINCT from this var being nil.
-  Rebind in tests / a future browser bridge to supply one.
+  the default on EVERY platform (JVM stdio AND CLJS). A bound provider
+  that returns `{}` (or lacks an entry for a frame) means 'reached and
+  empty', DISTINCT from this var being nil. Rebind in tests / a future
+  browser bridge to supply one.
+
+  The CLJS default is nil because the source atom
+  (`re-frame.story.ui.a11y/violations-by-frame`) lives in the Story UI ns
+  this helper must NOT require (bundle isolation). It is held SYMMETRIC
+  with `*substrate-provider*` (also nil on CLJS) so the browser bridge
+  wires BOTH seams together — no silent half-working default (rf2-jyjadg;
+  see the ns docstring).
 
   The `:clj` default derefs the resolved var-of-atom (`@var` → the atom,
   `(deref …)` → the by-frame map), matching the shape a browser-local

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -658,6 +658,33 @@
       (is (= [:reagent] (cljs-resolve/registered-substrates)))
       (is (= #{:reagent} (cljs-resolve/registered-substrates-set))))))
 
+(deftest provider-seams-are-symmetric-no-silent-asymmetry
+  ;; rf2-jyjadg — the substrate + a11y provider seams default to the SAME
+  ;; posture: NEITHER auto-wires, so out of the box BOTH report unavailable
+  ;; and a browser-local host binds BOTH. This locks the both-consistent
+  ;; contract against a re-introduced asymmetry (the old bug: a CLJS
+  ;; substrate default that auto-wired while a11y stayed nil, leaving
+  ;; `read-a11y-violations` falsely capability-unavailable in a process
+  ;; where the panel was live). NOTE: the `#?(:cljs …)` reader-conditional
+  ;; defaults cannot be exercised from this JVM suite (no CLJS build hosts
+  ;; story-mcp); this guards the symmetry the source now documents, plus
+  ;; the seam INDEPENDENCE binding one must not imply the other.
+  (testing "no binding ⇒ BOTH seams unavailable (the symmetric default)"
+    (is (false? (cljs-resolve/substrate-provider-available?)))
+    (is (false? (cljs-resolve/a11y-provider-available?)))
+    (is (= [] (cljs-resolve/registered-substrates)))
+    (is (= #{} (cljs-resolve/registered-substrates-set)))
+    (is (nil? (cljs-resolve/a11y-violations-by-frame))))
+  (testing "binding EITHER seam flips ONLY its own availability — independent seams"
+    (binding [cljs-resolve/*substrate-provider* (fn [] [:reagent])]
+      (is (true? (cljs-resolve/substrate-provider-available?)))
+      (is (false? (cljs-resolve/a11y-provider-available?))
+          "binding substrate must NOT imply a11y is available"))
+    (binding [cljs-resolve/*a11y-provider* (fn [] {:story.button/primary []})]
+      (is (true? (cljs-resolve/a11y-provider-available?)))
+      (is (false? (cljs-resolve/substrate-provider-available?))
+          "binding a11y must NOT imply substrate is available"))))
+
 ;; ---------------------------------------------------------------------------
 ;; Docs tools
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes **rf2-jyjadg** (correctness-review wave, story-mcp source-consistency; from the yo6kxo audit, F1). LOW/latent — no CLJS build compiles story-mcp today, so no runtime impact, but a real asymmetry a future browser-bridge author would trip over. Fails **closed** (not a false-green).

## The defect

In `tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc`, the CLJS default for `*substrate-provider*` was auto-wired to `(fn [] (story/registered-substrates))`, but `*a11y-provider*` was hardcoded `nil`. So in a browser-local CLJS Story host, `list-substrates` worked out of the box while `read-a11y-violations` **always** returned capability-unavailable — even though `re-frame.story.ui.a11y/violations-by-frame` was live in the same process. The `nil` is forced by bundle isolation (cljs-resolve deliberately does NOT require the Story UI ns). The defect was the silent **asymmetry**: nothing flagged that a browser host must rebind `*a11y-provider*`, and the substrate precedent invited a bridge author to assume a11y "just works".

## The fix — option (a): symmetric nil + loud contract

- `*substrate-provider*` CLJS default `(fn [] (story/registered-substrates))` → **`nil`**. Both seams now default `nil` on **every** platform (JVM and CLJS); a future browser bridge (or a test) binds **both**, together — no half-working default.
- The ns docstring gains a loud `## Neither seam auto-wires — the browser bridge binds BOTH` section; the JVM-probe comment block and both var docstrings are aligned to the same both-consistent posture.
- Satisfies the bead's acceptance clause 2: the required rebind is documented at ns level **and** substrate now matches a11y's posture.

This is the least-invasive option that removes the silent asymmetry (chosen over (b) a new bundle-included wiring ns — heavier, unwarranted). cljs-resolve stays UI-free.

## Bundle isolation stays intact

The only `:require` in `cljs_resolve.cljc` is the core `re-frame.story` ns (isolation-safe). `re-frame.story.ui.a11y` appears **only** as a quoted resolver symbol and in prose — never as a `:require`. The now-unused `:as story` alias was dropped; `re-frame.story` stays required (loaded) so the JVM `resolve-cljs-var` can reach its CLJC vars.

## Test

Adds `provider-seams-are-symmetric-no-silent-asymmetry` (JVM): asserts both seams default unavailable and are **independent** (binding one must not imply the other). Note: the `#?(:cljs …)` reader-conditional defaults can't be exercised from the JVM suite (no CLJS build hosts story-mcp); the test guards the symmetry the source now documents.

No new `:rf.error/*` id (reuses `:rf.error/story-mcp-capability-unavailable`) → no Spec 009 touch.

## Quality gates

- `clojure -M:test` (story-mcp): **291 tests, 1525 assertions, 0 failures, 0 errors**
- `clojure -M:gen --check`: **OK — tool-descriptors.edn in sync (20 tools)**
- `clj-kondo` on changed files: **0 errors** (only the pre-existing single-file `Throwable` artifact in `resolve-cljs-var`'s catch, which resolves under CI's full-classpath config)