### PR TITLE
docs(spec-schemas): tighten :rf/public-error to 400..599 + closed four-key set, matching shipped SSR validator (rf2-vikt89)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3536,15 +3536,16 @@ The sanitised, client-safe projection of an internal error trace event. Per [011
 
 ```clojure
 (def PublicError
-  [:map {:closed true}                                                     ;; closed in prod — extra keys are a leak risk
-   [:status     :int]
+  [:map {:closed true}                                                     ;; closed to EXACTLY the four keys below — a 5th key (incl. a projector-supplied :details) fails conformance
+   [:status     [:int {:min 400 :max 599}]]                                ;; HTTP error status; 400..499 client-fault arm, 500..599 server-fault arm
    [:code       :keyword]                                                  ;; stable category (:not-found :bad-request :unauthorised :internal-error ...)
    [:message    :string]                                                   ;; one-sentence human-facing
-   [:retryable? :boolean]
-   [:details    {:optional true} :any]])                                   ;; dev-only; the full trace event for developer view
+   [:retryable? :boolean]])
 ```
 
-The map is **closed** — production must not silently leak unknown keys. The `:details` key is dev-only (gated by `:dev-error-detail?`); production builds elide it.
+This is the exact shape the runtime validator `public-error-shape?` enforces (per [011 §Server error projection](011-SSR.md#server-error-projection)): the map is **closed to exactly these four keys**, and `:status` is an HTTP **error** status in **400..599**. A projector that returns any extra key — including its own `:details` — or an out-of-range `:status` (a `200`/`302`, a negative, a `>599`) fails conformance, and the runtime substitutes the locked generic-500 fallback (`{:status 500 :code :internal-error :message "Something went wrong" :retryable? false}`).
+
+In **dev** builds (gated by the frame's `:ssr {:dev-error-detail? true}`), the runtime appends a `:details` key carrying the raw trace event **after** this validation — it is a runtime augmentation, not part of the projector-returned contract, and production builds omit it.
 
 ### Standard fx args schemas
 


### PR DESCRIPTION
## What

Tightens the `:rf/public-error` schema entry in `spec/Spec-Schemas.md` to match the shipped SSR error-projector validator, closing a doc/impl gap left open by rf2-oytx7j (PR #5672).

## Why

rf2-oytx7j tightened the runtime validator `public-error-shape?` (`implementation/ssr/src/re_frame/ssr/error_projector.cljc`) to enforce a **closed four-key set** and a **400..599** status range. The `:rf/public-error` schema doc was owned by a concurrent worker at the time and left looser than the shipped code. This is the doc-side follow-up: the schema doc should describe exactly what the runtime validates.

## Change

The `PublicError` malli schema now matches `public-error-shape?` on all five axes:

| Validator (`public-error-shape?`)                          | Schema (`PublicError`)               |
|------------------------------------------------------------|--------------------------------------|
| `(= public-error-keys (set (keys x)))` — exactly 4 keys    | `[:map {:closed true}]`, four entries|
| `(integer? …)` + `(<= 400 (:status x) 599)`                | `[:status [:int {:min 400 :max 599}]]`|
| `(keyword? (:code x))`                                      | `[:code :keyword]`                   |
| `(string? (:message x))`                                   | `[:message :string]`                 |
| `(boolean? (:retryable? x))`                               | `[:retryable? :boolean]`             |

The prior schema listed `:status :int` (unbounded) and an optional `:details` 5th key inside a `{:closed true}` map — but the validator rejects a projector-supplied `:details` (exactly four keys) and requires `:status` in 400..599. `:details` is now described in prose as a dev-only runtime augmentation appended **after** validation, not part of the projector-returned contract.

Doc-only; single `:rf/public-error` entry; no impl change.

## Gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_keyword_catalogue_drift.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (built clean)

rf2-vikt89