### PR TITLE
fix(story): causal assertions resolve to :cannot-run when truncation can change the verdict (rf2-4u5zl4)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1511,8 +1511,35 @@ the key is a no-cascade opt-out ONLY and is rejected on `:rf.assert/caused`
 (whose positive-claim semantics are unchanged — `:observed-cause-count` rides
 its record as a diagnostic only). The verdict precedence for a causal record
 is: no `:event` → `:fail`; no `:reactive-counts` evidence → `:cannot-run`;
-(no-cascade only) `c = 0` without the opt-out → `:cannot-run`; else the
-existing `min ≤ n ≤ max` bounds.
+(no-cascade only) `c = 0` without the opt-out → `:cannot-run`; a TRUNCATED run
+whose in-bounds `:pass` has a finite upper bound → `:cannot-run` (below); else
+the existing `min ≤ n ≤ max` bounds.
+
+##### Truncation honesty: a bounded ring cannot prove an upper bound (rf2-4u5zl4)
+
+The effect count `n` is projected off the run-sliced `:epoch-tape`, itself a
+bounded per-frame ring (`epoch-history`, default depth 50, **front-eviction**).
+A run that commits more epochs than the ring holds loses its EARLIEST epochs —
+they are evicted and gone. Because eviction only ever LOWERS `n` (dropped effect
+rows are never counted), truncation can turn a would-be over-render into a false
+GREEN: an upper-bounded assertion (`:rf.assert/no-cascade-rerender`'s `[0,0]`, a
+`:rf.assert/caused {:max N}`) reads in-bounds only because the failing evidence
+was truncated away, not because the over-effect did not happen. This is the
+truncation sibling of the unobserved-cause honesty fix above.
+
+So a **per-run truncation signal** (`re-frame.story.play.evidence/run-tape-truncated?`
+→ the `:epoch-truncated?` matcher input) gates the verdict: when the ring evicted
+the run's earliest epochs, an otherwise in-bounds causal `:pass` **against a finite
+upper bound** resolves **`:cannot-run`** — the retained tape cannot PROVE the bound
+held. A **min-only** expectation (no `:max`, e.g. `:rf.assert/caused`'s default
+`{:min 1}`) is NOT affected: the true count is `≥` the retained one, so an in-bounds
+min-only pass stays honest under truncation. A run whose ring was NOT overflowed
+(the common case — no eviction of the run's own epochs) keeps the exact bounds
+logic. The signal is DEPTH-FREE — it observes that the ring no longer covers the
+run's baseline record (the baseline was evicted), which proves at least `depth`
+newer run epochs displaced it — so it needs no configured ring depth. A fresh
+inline frame (zero baseline, empty starting ring) carries no baseline record to
+evict and is not flagged.
 
 These are PURE expectations, **not** agreement-floor signals — an over-render
 is a `:fail` of a declared `:rf.assert/no-cascade-rerender`, not a tape-floor

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -936,3 +936,59 @@
               :renders           render-rows
               :narrative         (narrative script narr-tape)}
        (some? rc) (assoc :reactive-counts rc)))))
+
+;; ===========================================================================
+;; RUN-TAPE TRUNCATION  (rf2-4u5zl4 — the causal-assertion honesty floor)
+;; ===========================================================================
+;;
+;; The retained epoch tape is a bounded per-frame ring (`epoch-history`,
+;; default depth 50, front-eviction). A run that commits MORE epochs than the
+;; ring holds loses its EARLIEST epochs — they are evicted from the front and
+;; gone from the tape. A causal assertion's effect COUNT is projected off that
+;; tape, so an evicted effect epoch UNDER-counts the true effects: a would-be
+;; over-render an evicted epoch carried never reaches the count, so an
+;; upper-bounded assertion (`:rf.assert/no-cascade-rerender`'s `[0,0]`, a
+;; `:rf.assert/caused {:max N}`) can read a false GREEN — it passed its bounds
+;; only because the failing evidence was truncated away, NOT because the
+;; effect did not happen. This is the truncation sibling of rf2-x76af2.17's
+;; unobserved-cause honesty fix: `run-tape-truncated?` is the per-run signal
+;; the causal matcher (`result/match-causal-expectations`) reads to refuse
+;; such a verdict — an in-bounds causal `:pass` with a finite upper bound
+;; resolves `:cannot-run` (honest) when the run overflowed the ring, because
+;; the retained evidence cannot PROVE the bound held.
+
+(defn run-tape-truncated?
+  "True iff the bounded `epoch-history` ring evicted the run's baseline
+  record — i.e. the run committed at least `depth` epochs to the frame and
+  its EARLIEST run epochs were dropped from the ring's front (rf2-4u5zl4).
+  Pure data → data.
+
+  `full-ring` is the frame's COMPLETE retained ring (oldest-first — the raw
+  `re-frame.core/epoch-history`, NOT the baseline-filtered run tape);
+  `baseline` is the last-committed `:epoch-id` at run start
+  (`record-result-map`'s `:epoch-baseline`), which is the ring-newest record
+  at that moment.
+
+  Detection is DEPTH-FREE: front-eviction is monotonic, so the baseline
+  record — present in the ring at run start — survives iff fewer than `depth`
+  newer records were appended after it. Every record newer than the baseline
+  is a RUN record, so if NO retained record still has `:epoch-id <= baseline`
+  the baseline (and the run's earliest epochs) were evicted → the run tape is
+  TRUNCATED. If any record at/older-than the baseline survives, the ring
+  still holds every run record (all newer than the baseline) → the tape is
+  COMPLETE. The ring is per-frame, so epochs another frame committed never
+  evict THIS frame's baseline — the signal is not perturbed by concurrent
+  frames (the global `:epoch-id` counter is shared, but each frame's ring
+  holds only its own records).
+
+  Only a POSITIVE baseline (a same-frame rerun inheriting a populated ring)
+  carries a baseline record to evict; a zero/absent baseline (a fresh inline
+  frame whose ring started empty) has none, so this returns false — a
+  fresh-frame overflow is not distinguishable from an exact fill without the
+  ring depth (which no facade exposes), and this fn does not over-claim."
+  [full-ring baseline]
+  (boolean
+    (and (some? baseline)
+         (pos? baseline)
+         (seq full-ring)
+         (not-any? #(<= (or (:epoch-id %) 0) baseline) full-ring))))

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -578,8 +578,9 @@
   `n` is the measured effect count (`causal-count`); `c` is the
   `:observed-cause-count` — how many run-owned epoch records named the
   cause (`observed-cause-count`); `reactive?` is whether the run carried
-  ANY reactive evidence (a `:reactive-counts` slot). The verdict, in
-  precedence:
+  ANY reactive evidence (a `:reactive-counts` slot); `truncated?` is whether
+  the bounded `epoch-history` ring evicted the run's EARLIEST epochs
+  (`evidence/run-tape-truncated?`, rf2-4u5zl4). The verdict, in precedence:
 
   - a degenerate atom that names no `:event` → `:fail` (it asserts nothing
     measurable);
@@ -598,19 +599,32 @@
     explicit opt-out: it lets `c = 0` proceed to the normal bounds, so a
     legitimately-optional interaction's `[0,0]` may pass with a reason that
     states the vacuity was explicitly enabled;
+  - a TRUNCATED run whose bounds would otherwise `:pass` AND whose
+    expectation carries a finite upper bound (`:max`) → `:cannot-run`
+    (rf2-4u5zl4) — the ring evicted the run's earliest epochs, and the
+    dropped effect evidence could carry additional effects that would push
+    the true count ABOVE `:max` (a false GREEN: the assertion read in-bounds
+    only because the failing evidence was truncated away, not because the
+    over-effect did not happen). A min-only expectation (no `:max`, e.g.
+    `:rf.assert/caused`'s `{:min 1}`) is NOT affected — dropped effects can
+    only LOWER the count, so an in-bounds min-only `:pass` stays honest under
+    truncation (the true count is `≥` the retained one, still `≥ :min`);
   - else the expectation passes iff `n` is within the `[:min :max]` bounds.
 
   A cause observed ONCE with zero matching renders (`c = 1`, `n = 0`) stays
   `:pass` — the premise held and the guard was honoured. `:rf.assert/caused`
-  is unchanged: `c` rides its `:actual` as a diagnostic only; its
-  positive-claim `{:min 1}` still fails closed on `n = 0`.
+  is unchanged for its default (min-only) shape: `c` rides its `:actual` as a
+  diagnostic only; its positive-claim `{:min 1}` still fails closed on
+  `n = 0` and is not truncation-gated. An explicit `:rf.assert/caused
+  {:max N}` DOES gain the truncation guard (a finite upper bound).
 
   The record carries the declared spec as `:expected` and the measured
-  count + observed-cause-count + bounds as `:actual` so a failing / refused
-  expectation reads diagnostically. `:count` stays the EFFECT count `n`;
-  `:observed-cause-count` is the additive premise diagnostic `c`."
+  count + observed-cause-count + bounds + `:truncated?` as `:actual` so a
+  failing / refused expectation reads diagnostically. `:count` stays the
+  EFFECT count `n`; `:observed-cause-count` is the additive premise
+  diagnostic `c`."
   [{:keys [atom id event surface min max require-cause?] :as expectation}
-   n c reactive?]
+   n c reactive? truncated?]
   (let [degenerate?    (nil? event)
         ;; The no-cascade premise gate: active unless the author explicitly
         ;; opted out with `{:require-cause? false}`. `:rf.assert/caused`
@@ -625,12 +639,21 @@
                             (false? require-cause?)
                             (zero? c))
         in-bounds?     (causal-in-bounds? expectation n)
+        ;; The truncation honesty guard (rf2-4u5zl4): a would-be `:pass`
+        ;; against a finite upper bound cannot be TRUSTED when the ring
+        ;; evicted the run's earliest epochs — the dropped effect evidence
+        ;; could push the true count above `:max`. Only an in-bounds pass
+        ;; with a finite `:max` is affected (a min-only claim is safe: lost
+        ;; effects only lower the count). Ordered after `unobserved?` so a
+        ;; c=0 no-cascade keeps its more-specific 'not observed' refusal.
+        truncation-unsafe? (and truncated? in-bounds? (some? max))
         status         (cond
-                         degenerate?     :fail
-                         (not reactive?) :cannot-run
-                         unobserved?     :cannot-run
-                         in-bounds?      :pass
-                         :else           :fail)]
+                         degenerate?        :fail
+                         (not reactive?)    :cannot-run
+                         unobserved?        :cannot-run
+                         truncation-unsafe? :cannot-run
+                         in-bounds?         :pass
+                         :else              :fail)]
     {:assertion   id
      :payload     (vec (rest atom))
      :passed?     (= :pass status)
@@ -638,7 +661,8 @@
      :cannot-run? (= :cannot-run status)
      :expected    (:spec expectation)
      :actual      {:event event :surface surface :count n
-                   :observed-cause-count c :min min :max max}
+                   :observed-cause-count c :min min :max max
+                   :truncated? (boolean truncated?)}
      :reason      (cond
                     degenerate?
                     (str (name id) " names no :event — a causal assertion MUST "
@@ -652,6 +676,14 @@
                          "retained run tape; " (name id) " cannot establish "
                          "its required cause premise (pass :require-cause? "
                          "false to allow vacuous evaluation)")
+                    truncation-unsafe?
+                    (str "event " (pr-str event) " caused " n " "
+                         (pr-str surface) " effect(s) within bounds "
+                         "[" min " " (or max "∞") "], but the epoch-history "
+                         "ring evicted earlier run epochs; the dropped "
+                         "evidence could carry additional effects exceeding "
+                         "the upper bound, so " (name id) " cannot be proven "
+                         "from the retained run tape — :cannot-run")
                     vacuity-opt?
                     (str "event " (pr-str event) " was not observed in the "
                          "retained run tape, but :require-cause? false "
@@ -696,17 +728,29 @@
   `:rf.assert/no-cascade-rerender` that count is the required-premise signal:
   an unobserved cause (0) resolves `:cannot-run` rather than passing the
   `[0,0]` default vacuously (unless the author opted out with
-  `{:require-cause? false}`)."
-  [causal-atoms evidence]
-  (let [reactive? (contains? evidence :reactive-counts)
-        tape      (:epoch-tape evidence)]
-    {:records (mapv (fn [a]
-                      (let [exp (assertions/causal-expectation a)]
-                        (causal-record exp
-                                       (causal-count exp evidence)
-                                       (observed-cause-count (:event exp) tape)
-                                       reactive?)))
-                    (or causal-atoms []))}))
+  `{:require-cause? false}`).
+
+  `truncated?` (rf2-4u5zl4) is the per-run epoch-tape truncation signal
+  (`evidence/run-tape-truncated?`): true when the bounded `epoch-history`
+  ring evicted the run's earliest epochs. When true, an otherwise in-bounds
+  causal `:pass` against a finite upper bound resolves `:cannot-run` — the
+  dropped effect evidence could carry effects exceeding the bound, so the
+  retained tape cannot PROVE the bound held (fail closed, never a truncation
+  false-green). The 2-arity defaults `truncated?` to false (a complete tape —
+  the common case, existing bounds logic stands)."
+  ([causal-atoms evidence]
+   (match-causal-expectations causal-atoms evidence false))
+  ([causal-atoms evidence truncated?]
+   (let [reactive? (contains? evidence :reactive-counts)
+         tape      (:epoch-tape evidence)]
+     {:records (mapv (fn [a]
+                       (let [exp (assertions/causal-expectation a)]
+                         (causal-record exp
+                                        (causal-count exp evidence)
+                                        (observed-cause-count (:event exp) tape)
+                                        reactive?
+                                        truncated?)))
+                     (or causal-atoms []))})))
 
 ;; ===========================================================================
 ;; THE UNIFIED RUN RESULT  (spec/017 §Run result)
@@ -758,6 +802,16 @@
                           failure); a run with no reactive rows is caught
                           upstream by the `:reactive-counts` fail-closed
                           evidence-slot check (`:cannot-run`).
+  - `:epoch-truncated?` — the per-run epoch-tape truncation signal
+                          (`evidence/run-tape-truncated?`, rf2-4u5zl4): true
+                          when the bounded `epoch-history` ring evicted the
+                          run's earliest epochs. When true, an otherwise
+                          in-bounds causal `:pass` against a finite upper
+                          bound resolves `:cannot-run` (the dropped effect
+                          evidence could exceed the bound — a truncation
+                          false-green). Defaults to false (a complete tape).
+                          NOT surfaced on the result — an internal input to
+                          the causal matcher only.
   - `:consumed-selectors` — additional schema-violation selectors to excuse
                           from the agreement floor (§Schema rule), unioned
                           with whatever `:schema-expectations` consumed. A
@@ -785,7 +839,8 @@
   green while the tape is red, and the verdict is computed from the
   PROJECTED evidence, not a sibling accumulator."
   [{:keys [epoch-tape assertions script check->atoms consumed-selectors
-           schema-expectations causal-expectations unmet app-db attribution]
+           schema-expectations causal-expectations unmet app-db attribution
+           epoch-truncated?]
     :as   parts}]
   (let [tape           (vec (or epoch-tape []))
         ;; `:attribution` (the runner / replay-recorded
@@ -821,7 +876,11 @@
         ;; the minted records join `:assertions` and the verdict reads them
         ;; through `aggregate-status`. A run with no reactive rows is caught
         ;; upstream by the `:reactive-counts` fail-closed evidence-slot check.
-        causal-match   (match-causal-expectations causal-expectations evidence-slots)
+        ;; `epoch-truncated?` (rf2-4u5zl4) refuses an in-bounds finite-upper-bound
+        ;; `:pass` when the ring evicted the run's earliest epochs (a truncation
+        ;; false-green) — the retained tape cannot prove the upper bound held.
+        causal-match   (match-causal-expectations
+                         causal-expectations evidence-slots (boolean epoch-truncated?))
         records        (-> (assertion-records assertions)
                            (into (:records schema-match))
                            (into (:records causal-match)))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -600,8 +600,19 @@
         ;; rather than dropping a count, remains correct when the bounded ring
         ;; evicts records from its front. Inline runs use a fresh frame and a
         ;; zero baseline, so the same filter covers both paths.
+        ;; The FULL retained ring (oldest-first, before the baseline filter).
+        ;; rf2-4u5zl4: reading it whole is what lets the truncation signal see
+        ;; whether the ring evicted the baseline record itself — the
+        ;; baseline-filtered `tape` alone cannot witness its own truncation.
+        full-ring (rf/epoch-history variant-id)
+        ;; The per-run epoch-tape truncation signal (rf2-4u5zl4): true when
+        ;; the bounded ring evicted the run's earliest epochs (the baseline is
+        ;; no longer covered). Threaded to `result/run-result` so an in-bounds
+        ;; causal `:pass` against a finite upper bound resolves `:cannot-run`
+        ;; rather than a truncation false-green.
+        truncated? (evidence/run-tape-truncated? full-ring epoch-baseline)
         tape     (vec (filter #(> (or (:epoch-id %) 0) (or epoch-baseline 0))
-                              (rf/epoch-history variant-id)))
+                              full-ring))
         ;; The runner-recorded per-dispatch-step settle boundaries light
         ;; up the EXACT narrative attribution
         ;; (`evidence/spans-from-stamps`). The
@@ -673,6 +684,12 @@
                     ;; dispatched — collected from the plan.
                     :causal-expectations (plan-causal-expectations
                                            plan executed-script)
+                    ;; rf2-4u5zl4: whether the bounded ring truncated the run
+                    ;; tape (evicted the earliest run epochs). An in-bounds
+                    ;; causal `:pass` against a finite upper bound resolves
+                    ;; `:cannot-run` under truncation — the dropped effects
+                    ;; could exceed the bound (a truncation false-green).
+                    :epoch-truncated?    truncated?
                     ;; The per-requirement `:cannot-run` refusals
                     ;; the runner could not even attempt (above). Folded into
                     ;; the verdict + surfaced on `:cannot-run` by

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -581,3 +581,45 @@
       (is (not (and (= :pass (:status sibling-says-ok))
                     (not tape-red?)))
           "cannot be both sibling-green and tape-clean"))))
+
+;; ===========================================================================
+;; RUN-TAPE TRUNCATION SIGNAL  (rf2-4u5zl4)
+;; ===========================================================================
+;;
+;; `run-tape-truncated?` observes whether the bounded per-frame ring evicted
+;; the run's baseline record (front-eviction): if NO retained record still
+;; sits at/before the baseline, the ring overflowed with run epochs and the
+;; earliest run evidence is GONE. Depth-free — it needs only the full ring +
+;; the baseline id.
+
+(deftest run-tape-truncated-detects-evicted-baseline
+  (testing "baseline still covered (a record ≤ baseline survives) → NOT truncated"
+    ;; baseline 100; the ring still holds record 100 (the baseline itself) and
+    ;; newer run records — nothing evicted.
+    (let [full-ring [(epoch 100 {}) (epoch 103 {}) (epoch 107 {})]]
+      (is (false? (evidence/run-tape-truncated? full-ring 100))
+          "the baseline record survives → the ring holds every run record")))
+
+  (testing "baseline evicted (every retained record > baseline) → TRUNCATED"
+    ;; baseline 100 but the oldest surviving record is 142 — the baseline
+    ;; (and the run's earliest epochs) were pushed off the ring's front.
+    (let [full-ring [(epoch 142 {}) (epoch 150 {}) (epoch 159 {})]]
+      (is (true? (evidence/run-tape-truncated? full-ring 100))
+          "no record ≤ baseline survives → the run overflowed the ring")))
+
+  (testing "a pre-baseline record older than the baseline also counts as covered"
+    ;; The ring may hold records OLDER than the baseline (a same-id rerun
+    ;; inherits pre-run history); any record ≤ baseline proves no run epoch
+    ;; was evicted.
+    (let [full-ring [(epoch 88 {}) (epoch 100 {}) (epoch 140 {})]]
+      (is (false? (evidence/run-tape-truncated? full-ring 100)))))
+
+  (testing "a fresh inline frame (zero / nil baseline) is never flagged"
+    ;; No baseline record exists to evict, and depth-free detection cannot
+    ;; tell overflow from an exact fill without the ring depth — so it does
+    ;; not over-claim.
+    (is (false? (evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] 0)))
+    (is (false? (evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] nil))))
+
+  (testing "an empty ring is not truncated"
+    (is (false? (evidence/run-tape-truncated? [] 100)))))

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -955,6 +955,106 @@
       (is (= :fail (:status rec)))
       (is (= 0 (get-in rec [:actual :observed-cause-count]))))))
 
+;; ===========================================================================
+;; CAUSAL TRUNCATION HONESTY (rf2-4u5zl4)
+;; ===========================================================================
+;;
+;; The effect count is projected off the bounded epoch-history ring; a run
+;; that overflows the ring loses its EARLIEST epochs (front-eviction). Because
+;; eviction only LOWERS the count, an upper-bounded causal assertion can read
+;; a false GREEN — it passed its bounds only because the failing evidence was
+;; truncated away. The `:epoch-truncated?` matcher input refuses such a
+;; verdict: an in-bounds `:pass` with a finite `:max` resolves :cannot-run.
+;; A min-only expectation is UNAFFECTED (lost effects only lower the count, so
+;; an in-bounds min-only pass stays honest). These tests drive the PURE
+;; result assembly directly with `:epoch-truncated?` — the runtime computes
+;; the flag from the real ring (`evidence/run-tape-truncated?`, unit-tested in
+;; evidence_test).
+
+(deftest no-cascade-truncation-in-bounds-is-cannot-run
+  (testing "TEETH: an over-render whose epoch was EVICTED reads in-bounds [0,0]
+            in the retained tape, but the truncation flag refuses the false
+            GREEN → :cannot-run (NOT :pass)"
+    ;; :counter/inc IS observed (c=1) and rendered :counter once, but produced
+    ;; ZERO retained :results renders (n=0 ∈ [0,0]). WITHOUT truncation this is
+    ;; a genuine :pass. WITH truncation, an evicted epoch could have carried a
+    ;; :results over-render for :counter/inc, so the retained tape cannot prove
+    ;; the [0,0] guard held.
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
+          decl [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :results}]]
+          ;; fully-retained window (control): the existing bounds :pass stands.
+          r-complete  (result/run-result
+                        {:epoch-tape tape :causal-expectations decl})
+          ;; truncated window (teeth): the same in-bounds count → :cannot-run.
+          r-truncated (result/run-result
+                        {:variant/id :story.counter/badge
+                         :epoch-tape tape :causal-expectations decl
+                         :epoch-truncated? true})
+          rec-complete  (no-cascade-rec r-complete)
+          rec-truncated (no-cascade-rec r-truncated)]
+      ;; --- control: no truncation → the bounds logic is UNCHANGED ---
+      (is (= :pass (:status rec-complete))
+          "a fully-retained in-bounds window still passes — existing logic stands")
+      (is (false? (get-in rec-complete [:actual :truncated?])))
+      ;; --- teeth: truncation → the would-be pass becomes :cannot-run ---
+      (is (= :cannot-run (:status rec-truncated))
+          "an evicted over-render epoch → :cannot-run, never a truncation false-green")
+      (is (true?  (:cannot-run? rec-truncated)))
+      (is (false? (:passed? rec-truncated)))
+      (is (true?  (get-in rec-truncated [:actual :truncated?])))
+      (is (= 1 (get-in rec-truncated [:actual :observed-cause-count]))
+          "the cause WAS observed — this is a truncation refusal, not an unobserved-cause one")
+      (is (re-find #"evicted earlier run epochs" (:reason rec-truncated)))
+      (is (nil? (re-find #"not observed" (:reason rec-truncated)))
+          "distinct from the unobserved-cause reason (the cause here was observed)")
+      ;; --- run aggregation + frozen contract + host bridge ---
+      (is (= :cannot-run (:status r-truncated)) "the run aggregates to :cannot-run")
+      (is (result/valid-run-result? r-truncated))
+      (is (some #(= :fail (:type %)) (result/result->reports r-truncated))
+          "a :cannot-run assertion reports a host :fail, never a silent pass"))))
+
+(deftest caused-explicit-max-truncation-is-cannot-run
+  (testing ":rf.assert/caused {:max N} gains the truncation guard (a finite
+            upper bound): an in-bounds pass under truncation → :cannot-run"
+    (let [tape [(reactive-epoch :counter/inc :total 0 :badge 2)]   ; 2 :badge renders
+          decl [[:rf.assert/caused {:event :counter/inc :view :badge :max 3}]]
+          rec  (fn [r] (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r))))
+          r-complete  (rec (result/run-result {:epoch-tape tape :causal-expectations decl}))
+          r-truncated (rec (result/run-result
+                             {:epoch-tape tape :causal-expectations decl
+                              :epoch-truncated? true}))]
+      (is (= :pass (:status r-complete)) "n=2 ∈ [1,3] passes on a complete tape")
+      (is (= 2 (get-in r-complete [:actual :count])))
+      (is (= :cannot-run (:status r-truncated))
+          "under truncation the finite :max cannot be proven → :cannot-run")
+      (is (re-find #"exceeding the upper bound" (:reason r-truncated))))))
+
+(deftest caused-min-only-truncation-still-passes
+  (testing ":rf.assert/caused's default min-only {:min 1} is NOT truncation-gated:
+            lost effects only LOWER the count, so an in-bounds pass stays honest"
+    (let [tape [(reactive-epoch :counter/inc :total 3 :counter 0)]  ; 3 :total recomputes
+          decl [[:rf.assert/caused {:event :counter/inc :sub :total}]]
+          rec  (fn [r] (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r))))
+          r-truncated (rec (result/run-result
+                             {:epoch-tape tape :causal-expectations decl
+                              :epoch-truncated? true}))]
+      (is (= :pass (:status r-truncated))
+          "min-only (no :max) → truncation cannot create a false green; stays :pass")
+      (is (= 3 (get-in r-truncated [:actual :count])))
+      (is (true? (get-in r-truncated [:actual :truncated?])) "the flag still rides the diagnostic"))))
+
+(deftest truncation-does-not-rescue-a-genuine-over-render-fail
+  (testing "a real over-render (n > max) under truncation stays :fail — the
+            guard only refuses a would-be PASS, it never masks a failure"
+    (let [tape [(reactive-epoch :counter/inc :total 0 :results 3)]  ; 3 :results renders
+          decl [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :results}]]
+          rec  (no-cascade-rec
+                 (result/run-result {:epoch-tape tape :causal-expectations decl
+                                     :epoch-truncated? true}))]
+      (is (= :fail (:status rec))
+          "n=3 > [0,0] is a genuine over-render — truncation does not convert it to :cannot-run")
+      (is (= 3 (get-in rec [:actual :count]))))))
+
 ;; ---- projections AGREE with the tape (§B5) -------------------------------
 
 (deftest result-projections-agree-with-the-tape


### PR DESCRIPTION
## What

Follow-up to **rf2-x76af2.17** (PR #5673). That fix made an *unobserved* required cause resolve to `:cannot-run` (honest) instead of a vacuous `:pass`. This closes the **broader truncation gap** it explicitly left open.

**The defect (false-green):** a causal assertion's effect count is projected off the bounded `epoch-history` ring (default depth 50, **front-eviction**). A run that overflows the ring loses its EARLIEST epochs. Because eviction only ever *lowers* the count, an upper-bounded assertion — `:rf.assert/no-cascade-rerender`'s `[0,0]`, or a `:rf.assert/caused {:max N}` — can read a **false GREEN**: it passed its bounds only because the failing (over-render) evidence was truncated away, not because the over-effect did not happen.

## The fix

A per-run truncation signal, `evidence/run-tape-truncated?` (pure, depth-free): the bounded ring evicted the run's earliest epochs iff **no retained record still covers the run baseline** (the baseline record was pushed off the front — proving ≥ `depth` newer run epochs displaced it). Threaded as `:epoch-truncated?` through `record-result-map` → `result/run-result` → `match-causal-expectations` → `causal-record`.

New verdict precedence branch (after the x76af2.17 unobserved-cause branch): a **truncated** run whose in-bounds `:pass` has a **finite upper bound** → `:cannot-run` (the retained tape cannot *prove* the bound held).

- **Min-only** expectations (`:caused`'s default `{:min 1}`, no `:max`) are **unaffected** — lost effects only lower the count, so an in-bounds min-only pass stays honest.
- A **fully-retained** window keeps the exact bounds logic unchanged.
- A **genuine** over-render (`n > max`) under truncation stays `:fail` — the guard only refuses a would-be *pass*, never masks a failure.
- Honest reason wording ("evicted earlier run epochs … cannot be proven from the retained run tape") mirrors x76af2.17's discipline — no overclaiming.

Fresh inline frames (zero baseline, empty starting ring) carry no baseline record to evict and are not flagged — a known depth-free residual (no facade exposes the ring depth); the dominant same-id-rerun Story path is covered precisely.

## IDs

No new `:rf.error/story-*` id minted — reuses x76af2.17's `:cannot-run` outcome vocabulary. (`:rf.error/story-*` ids are not in Spec 009, confirmed by x76af2.17 — no catalogue row.)

## Surface

`tools/story` only: `result.cljc` / `play/evidence.cljc` / `runtime.cljc` + `spec/017` causal section + tests. No `spec/009`, no `tools/story-mcp` descriptors, no `implementation/` changes. `:epoch-truncated?` is an internal matcher input — NOT surfaced on the `RunResult` (schema unchanged).

## Quality gates

- `tools/story` `clojure -M:test`: **1802 tests, 6645 assertions, 0 failures, 0 errors** (focused result-test + evidence-test: 77 tests / 372 assertions, 0 failures).
- `mkdocs build --strict`: clean.
- **Teeth-proof** (`no-cascade-truncation-in-bounds-is-cannot-run`): an over-render whose epoch is EVICTED reads in-bounds `[0,0]` in the retained tape → with `:epoch-truncated? true` resolves **`:cannot-run`** (not a false `:pass`), reports a host `:fail`, aggregates the run to `:cannot-run`; the *same* window with `:epoch-truncated? false` stays **`:pass`** (existing bounds logic unchanged). Companion teeth: `:caused {:max 3}` in-bounds → `:cannot-run` under truncation; min-only `:caused` → stays `:pass`; genuine over-render → stays `:fail`. Pure detection unit-tested in `evidence_test` (baseline evicted → true; baseline covered / zero / nil / empty → false).