### PR TITLE
fix(spec-schemas): DispatchLaterFxArgs uses :event key (rf2-guzg2w)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3564,12 +3564,12 @@ The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (t
 (def DispatchLaterFxArgs
   [:or
    [:map
-    [:ms       :int]                                                        ;; non-negative
-    [:dispatch [:vector :any]]]
+    [:ms    :int]                                                           ;; non-negative
+    [:event [:vector :any]]]
    [:vector
     [:map
-     [:ms       :int]
-     [:dispatch [:vector :any]]]]])
+     [:ms    :int]
+     [:event [:vector :any]]]]])
 
 ;; :http — pattern-level HTTP fx (per Pattern-RemoteData). Args are user-supplied;
 ;; the framework treats them opaquely. Schema is recommendation, not contract.


### PR DESCRIPTION
Fixes rf2-guzg2w (P3 bug).

`DispatchLaterFxArgs` in `spec/Spec-Schemas.md` declared the delayed-dispatch event key as `:dispatch`, but that is the sole outlier — the shipped runtime, docs, and examples all use `:event`:

- **Runtime**: `implementation/core/src/re_frame/fx.cljc` — the `:dispatch-later` fx body-fn destructures `(fn [frame-id parent-envelope {:keys [ms event]}] ...)` and passes `event` to `arm-dispatch-later!`.
- **Examples**: `examples/substrates/helix/process_monitor/core.cljs` — `[[:dispatch-later {:ms 1800 :event [:process-monitor/tick ...]}]]`.
- **Docs**: reference `:event`.

Corrected the schema (both the map and vector-of-maps arms) to `:event`. (The `:dispatch` occurrence in `migration/from-re-frame-v1/README.md` is intentional — it shows the re-frame v1 shape being migrated *from* — and is out of scope.)

Gates: `python -m mkdocs build --strict` passes. No CLJS test imports this doc-level Malli schema; no conformance fixture references dispatch-later.