### PR TITLE
docs(resources): stop promising {:from-db} scope on :rf.mutation/execute (rf2-jok6kz)

### DIFF
--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -403,7 +403,7 @@ Invalidation timing is explicit via **`:invalidate-timing`** — `:after-success
 
 !!! warning "Gotcha — match the scope or the invalidation silently misses"
 
-    A mutation's `:invalidates` matches only entries *in the mutation's resolved scope*. If a `:rf.scope/global`-defaulted mutation invalidates a tag owned by a session-scoped read (or the reverse), no entry matches, nothing refreshes, and **no error is raised** — it's a legitimate "no match in this scope." When a write affects session- or tenant-scoped reads, name the matching scope on the execute payload, or — cleaner — use the **per-target descriptor form**, where each descriptor carries its own scope:
+    A mutation's `:invalidates` matches only entries *in the mutation's resolved scope*. If a `:rf.scope/global`-defaulted mutation invalidates a tag owned by a session-scoped read (or the reverse), no entry matches, nothing refreshes, and **no error is raised** — it's a legitimate "no match in this scope." When a write affects session- or tenant-scoped reads, use the **per-target descriptor form**, where each descriptor carries its own scope, resolving a `{:from-db …}` reference against app-db:
 
     ```clojure
     :invalidates
@@ -426,7 +426,6 @@ Invalidation timing is explicit via **`:invalidate-timing`** — `:after-success
  {:mutation :realworld/favorite
   :params   {:slug slug}
   :instance [:favorite slug]            ;; caller-supplied (or generated) instance id
-  :scope    {:from-db :realworld/session}
   :cause    [:click :article/favorite]
   :reply-to [:favorite/replied slug]}]  ;; optional continuation (below)
 ```
@@ -442,7 +441,6 @@ A view reads the instance's progress through `:rf/mutation` (or the narrower `:r
                                     {:mutation :realworld/favorite
                                      :params   {:slug slug}
                                      :instance [:favorite slug]
-                                     :scope    {:from-db :realworld/session}
                                      :cause    [:click :article/favorite]}])}
      (cond
        (:pending? m) "Saving…"


### PR DESCRIPTION
Fixes rf2-jok6kz (docs-only). The mutation execute payload :scope is canonicalized literally (fail-open to :rf.scope/global) at mutation_registry/resolve-scope (implementation/resources/src/re_frame/resources/mutation_registry.cljc:395-421) — it is NOT resolved against app-db the way an ensure / route / sub / clear-scope {:from-db} reference is. docs/resources/concepts.md showed :scope {:from-db :realworld/session} on the execute payload in two examples (~lines 429, 445), which the runtime would treat as a literal map scope matching nothing (a silent zero-match). The real favorite mutation (examples/real-apps/realworld_resources/views.cljs :ui/favorite) passes no execute-payload :scope at all; it reaches the viewer and session scopes via its per-target :invalidates / :optimistic-tags descriptors, each carrying its own {:from-db ...} scope resolved against app-db. This PR removes the non-resolving :scope from both execute examples and corrects the gotcha prose to point at the per-target descriptor form. Docs-only; no runtime or skills changes. Confirmed against oo8cv7 ruling FOLLOW-UP item 7. Gate: python -m mkdocs build --strict passes.