### PR TITLE
fix(spec-015): whole-vector :sensitive example corrected to the shipped payload-rooted form (rf2-i5su5y)

### DIFF
--- a/docs/EP/EP-0025-data-classification.md
+++ b/docs/EP/EP-0025-data-classification.md
@@ -199,7 +199,7 @@ the sensitive/large paths there — the same vocabulary, relative to the payload
 
 (rf/reg-fx :rf.ws/send {:sensitive [[:auth]]} ws-handler)
 
-(rf/reg-event :auth/login {:sensitive [[1 :password]]}
+(rf/reg-event :auth/login {:sensitive [[:password]]}
   (fn [{:keys [db]} [_ {:keys [user password]}]] …))
 
 (rf/reg-cofx :session {:sensitive [[:token]]}

--- a/implementation/core/test/re_frame/redact_event_by_registration_cljs_test.cljc
+++ b/implementation/core/test/re_frame/redact_event_by_registration_cljs_test.cljc
@@ -1,0 +1,74 @@
+(ns re-frame.redact-event-by-registration-cljs-test
+  "rf2-i5su5y — pins the PAYLOAD-ROOTED addressing contract of
+  `re-frame.classification/redact-event-by-registration` (Spec 015
+  §Registration-owned transient classification): a `reg-event` `:sensitive`
+  path indexes into the event PAYLOAD — the SECOND element of the event
+  vector, canonically the arg-map — never the outer event vector. Spec 015's
+  worked example is `{:sensitive [[:password]]}` for
+  `[:auth/login {:password …}]`; the outer-rooted `[[1 :password]]` spelling
+  was documentation drift (it looks up key `1` INSIDE the arg-map and
+  silently no-ops).
+
+  Three legs:
+
+    1. `[[:password]]` redacts the payload's `:password` while the event id
+       and a non-secret sibling payload field ride through.
+    2. `[[]]` (the whole-shape mark) redacts the ENTIRE payload while the
+       event id is preserved — index 0 / the event-id is never addressable.
+    3. A trailing POSITIONAL arg (outer position 2+) rides RAW — the
+       documented positional fail-open (Conventions §Canonical event-vector
+       shape: prefer the map payload form for secrets, then classify the
+       path).
+
+  Seam-level counterparts (same walker, observed through the egress seams):
+  the conformance fixture `data-classification-event-arg-sensitive-path-
+  redacts.edn` and `observability_routing_cljs_test` pin leg 1 end-to-end;
+  this ns pins all three legs at the unit seam.
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
+  (`npm run test:cljs`, `cljs-test$` ns-regexp) AND the JVM `clojure -M:test`
+  runner both run it. Plain CLJC; no DOM dependency."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.classification :as classification]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private eid :rf.i5su5y/login)
+
+(deftest payload-field-path-redacts
+  (testing "a [[:password]] registration path redacts the payload's :password —
+            payload-rooted, not outer-event-rooted"
+    (registrar/register! :event eid {:sensitive [[:password]]})
+    (let [out (classification/redact-event-by-registration
+                [eid {:password "hunter2" :user "ann"}])]
+      (is (= eid (first out)) "the event id is untouched")
+      (is (= privacy/redacted-sentinel (get-in out [1 :password]))
+          "the declared payload path redacts")
+      (is (= "ann" (get-in out [1 :user]))
+          "an undeclared sibling payload field rides raw"))))
+
+(deftest whole-payload-mark-preserves-event-id
+  (testing "the [[]] whole-shape mark redacts the ENTIRE payload while the
+            event id is preserved — index 0 is never addressable"
+    (registrar/register! :event eid {:sensitive [[]]})
+    (let [out (classification/redact-event-by-registration
+                [eid {:password "hunter2" :user "ann"}])]
+      (is (= [eid privacy/redacted-sentinel] out)
+          "the whole payload redacts to the sentinel; the id survives"))))
+
+(deftest trailing-positional-arg-rides-raw
+  (testing "outer positions 2+ pass through RAW — the documented positional
+            fail-open; only the payload (second element) is path-addressable"
+    (registrar/register! :event eid {:sensitive [[:password]]})
+    (let [out (classification/redact-event-by-registration
+                [eid {:password "hunter2"} "positional-secret"])]
+      (is (= privacy/redacted-sentinel (get-in out [1 :password]))
+          "the payload path still redacts")
+      (is (= "positional-secret" (nth out 2))
+          "the trailing positional arg rides raw (fail-open, per Spec 015)"))))

--- a/spec/015-Data-Classification.md
+++ b/spec/015-Data-Classification.md
@@ -92,7 +92,7 @@ The classification lands in the per-frame **elision registry** in runtime-db at 
 A **transient payload** (event args, fx args, cofx values, sub output) is owned by the registration that introduces its shape. Its author declares the sensitive / large paths there — the same vocabulary, relative to the payload's shape:
 
 ```clojure
-(rf/reg-event :auth/login {:sensitive [[1 :password]]}
+(rf/reg-event :auth/login {:sensitive [[:password]]}
   (fn [{:keys [db]} [_ {:keys [user password]}]] …))
 
 (rf/reg-fx :rf.http/managed
@@ -109,7 +109,7 @@ A **transient payload** (event args, fx args, cofx values, sub output) is owned 
   (fn [db _] (get-in db [:tenant :partner-api-key])))
 ```
 
-Paths index into that registration's primary data shape: the event vector (`[1 :password]` reaches the arg-map's `:password`), the fx-input map, the cofx-injected value, the sub output. Empty path `[[]]` marks the whole shape. A mark at a missing slot is a silent no-op (tolerate shape evolution); a malformed path *vector* fails at registration (see [§Failure posture](#failure-posture)).
+Paths index into that registration's primary data shape: the **event payload** (the second element of the event vector, canonically the arg-map per [Conventions §Canonical event-vector shape](Conventions.md#canonical-event-vector-shape-best-practice) — `[:password]` reaches its `:password`), the fx-input map, the cofx-injected value, the sub output. Event paths never index the **outer** event vector: index 0 (the event-id) is not addressable, and outer positions 2+ pass through raw — the documented positional fail-open (a secret in a positional arg is not path-addressable; prefer the map payload form and classify the path). Empty path `[[]]` marks the whole shape. A mark at a missing slot is a silent no-op (tolerate shape evolution); a malformed path *vector* fails at registration (see [§Failure posture](#failure-posture)).
 
 **`:rf.http/managed` is not special, and neither is a websocket effect** — every effect / coeffect / event / sub author declares its own sensitive arg-paths once, at registration. The framework ships sensible defaults for its own effects (e.g. the standard sensitive-header denylist for HTTP — see [§HTTP carriers](#http-carriers)); library authors do it for theirs. There is **no propagation**: a sub's `:sensitive` declaration classifies *that sub's own output paths*, not anything derived from it (see [§No propagation, no taint](#no-propagation-no-taint)).
 


### PR DESCRIPTION
Per the rf2-i5su5y ruling (decision-agent 2026-07-12, Option A): registration `:sensitive`/`:large` paths index into the registration-owned PAYLOAD — for events, the SECOND element of the event vector (canonically the arg-map). The `[[1 :password]]` example in Spec 015 (~line 95) and EP-0025 (~line 202) was documentation drift: under the shipped walker it looks up key `1` INSIDE the arg-map, silently no-ops, and the password egresses raw — a copy-paste privacy trap in the security spec.

## Changes

- **spec/015-Data-Classification.md**: example corrected to `{:sensitive [[:password]]}`; addressing prose reworded payload-rooted ("the event payload — the second element of the event vector, canonically the arg-map — `[:password]` reaches its `:password`"); states explicitly that paths never index the outer event vector (index 0 / event-id not addressable; outer positions 2+ ride raw — the documented positional fail-open), cross-refs Conventions §Canonical event-vector shape (Conventions.md itself untouched).
- **docs/EP/EP-0025-data-classification.md**: same one-line example fix.
- **New dual-runtime unit test** `implementation/core/test/re_frame/redact_event_by_registration_cljs_test.cljc` pinning the three legs at the unit seam: `[[:password]]` redacts a payload field; `[[]]` redacts the whole payload preserving the event id; a trailing positional arg rides raw. (Seam-level leg-1 coverage already existed in the conformance fixture + observability routing test; legs 2 and 3 were not unit-covered for the event registration path.)

NO implementation semantics change; docstrings already read payload-rooted. Machine-context integer paths (`machine_routed_event_classification_cljs_test`) are legitimate — the routed payload IS a vector there — and untouched. The optional docs-CI drift guard (ruling item 5) is deferred (hot-zone workflows; follow-up bead if desired).

## Gates

- `npm run test:cljs` — 8644 tests / 40738 assertions, 0 failures (new ns matches the `cljs-test$` node-build regexp)
- `clojure -M:test` (implementation/core, JVM) — 1808 tests / 7969 assertions, 0 failures; new ns verified directly (3 tests / 6 assertions)
- `python -m mkdocs build --strict` — built clean

Closes rf2-i5su5y.