### PR TITLE
feat(ui): implementation/ui artefact skeleton + build wiring (rf2-vxgfnd.1)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -33,6 +33,11 @@ Two top-level groupings:
   each plugged into core via the `re-frame.late-bind` hook table per
   [Conventions §Independence rule](../spec/Conventions.md#independence-rule).
 
+The `ui/` artefact (the re-frame.ui compiled-view substrate, epic
+rf2-vxgfnd) sits beside `core/` and — for the duration of the program —
+`adapters/`: it is the substrate slated to replace the adapter trio, not
+another adapter under `adapters/` and not a late-bind feature artefact.
+
 ```
 implementation/
   deps.edn                   Top-level coordinator: :local/root deps for every artefact.
@@ -149,6 +154,16 @@ implementation/
                                    + passive subs, :resource registrar kind, work-ledger.
     test/re_frame/                 CLJS surface/wiring smoke + runtime behaviour tests
                                    (ensure/refetch, work ledger, invalidation/GC, hydration).
+
+  ui/                        day8/re-frame2-ui — the re-frame.ui compiled-view substrate
+                             (epic rf2-vxgfnd; S1a skeleton per rf2-vxgfnd.1 — the
+                             compiler slice lands from S1b).
+    deps.edn                 :local/root dep on ../core; own :test alias (pre-publication,
+                             so no :clein deploy aliases yet).
+    src/re_frame/ui.cljc           Public-surface root stub (defview et al. land S1b+).
+    src/re_frame/ui/compiler.cljc  Compiler entry stub (AST / analyzer / emitters, S1b).
+    src/re_frame/ui/client.cljs    Client-kernel stub (mount surface S1c; reactivity S2).
+    test/re_frame/                 Classpath + build-id probe (npm run test:ui).
 
   ssr-ring/                  day8/re-frame2-ssr-ring — Ring host adapter for the SSR pipeline
                              (rf2-ny6v7).

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -51,7 +51,12 @@
          ;; EP-0003). Managed resource queries: reg-resource, the
          ;; :rf.resource/* events + passive subs, work ledger,
          ;; invalidation/GC, and hydration — runtime landed and tested.
-         day8/re-frame2-resources {:local/root "resources"}}
+         day8/re-frame2-resources {:local/root "resources"}
+         ;; rf2-vxgfnd.1 — the re-frame.ui compiled-view substrate (epic
+         ;; rf2-vxgfnd). Pre-publication: S1a skeleton only
+         ;; (empty-but-loadable compiler .cljc + client-kernel .cljs
+         ;; stubs); the S1b compiler slice lands the real surface.
+         day8/re-frame2-ui        {:local/root "ui"}}
 
  :aliases
  {;; Combined CLJS-test path: convenient for ad-hoc REPL work that wants
@@ -79,6 +84,8 @@
                  "epoch/test"
                  ;; rf2-p10npe — Resources artefact test tree.
                  "resources/test"
+                 ;; rf2-vxgfnd.1 — re-frame.ui artefact test tree.
+                 "ui/test"
                  ;; examples are organised by concept; each bucket is a
                  ;; classpath root so JVM tests can `require` the example
                  ;; source namespaces like `ssr.core` (under

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -28,6 +28,7 @@
     "test:cljs-isolation": "shadow-cljs compile node-test && node scripts/check-per-ns-isolation.cjs",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
     "test:testbed-support": "shadow-cljs compile node-test-testbed-support && node out/node-test-testbed-support.js",
+    "test:ui": "shadow-cljs compile node-test-ui && node out/node-test-ui.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
     "test:browser-schemas-boundary-prod": "shadow-cljs release browser-test-schemas-boundary-prod && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-schemas-boundary-prod --port 8022",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -130,6 +130,16 @@
                 ;; required, and core never :requires re-frame.resources.
                 "resources/src"
                 "resources/test"
+                ;; rf2-vxgfnd.1 — the re-frame.ui compiled-view substrate
+                ;; (epic rf2-vxgfnd), S1a skeleton. src carries the
+                ;; empty-but-loadable compiler (.cljc) + client-kernel
+                ;; (.cljs) stubs; test carries the classpath probe
+                ;; (re-frame.ui.skeleton-cljs-test), which rides the
+                ;; always-on :node-test gate (`cljs-test$` matches) AND
+                ;; the focused :node-test-ui build below. Bundle-isolation
+                ;; holds: no production build :requires re-frame.ui.*.
+                "ui/src"
+                "ui/test"
                 ;; rf2-3cfvt — adversarial-property SECURITY tier. A small
                 ;; cross-artefact test tree probing the three security
                 ;; boundaries the pin-and-assert regime missed: SSR escaping
@@ -662,6 +672,27 @@
   {:target    :node-test
    :output-to "out/node-test-testbed-support.js"
    :ns-regexp "^re-frame\\.testbed\\..+-cljs-test$"
+   :main      re-frame.test-quiet.shadow-node/main
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
+
+  ;; rf2-vxgfnd.1 — FOCUSED node-test build for the re-frame.ui artefact
+  ;; (the compiled-view substrate, epic rf2-vxgfnd).
+  ;;
+  ;; Mirrors :node-test-testbed-support above: the ns-regexp selects only
+  ;; this artefact's own suites (every `re-frame.ui.*` test namespace —
+  ;; nothing else in the repo lives under that prefix), giving the
+  ;; re-frame.ui program a named, cheap gate (`npm run test:ui`) so the
+  ;; long-lived S1b+ compiler-slice workers don't compile + run the full
+  ;; ~3500-test node suite on every iteration. The same namespaces also
+  ;; match the always-on `:node-test` build's broader `cljs-test$` regex,
+  ;; so the artefact is covered on every PR whether or not this focused
+  ;; build is invoked — this is the *named* surface, not an additional
+  ;; required gate.
+  :node-test-ui
+  {:target    :node-test
+   :output-to "out/node-test-ui.js"
+   :ns-regexp "^re-frame\\.ui\\..+-cljs-test$"
    :main      re-frame.test-quiet.shadow-node/main
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}

--- a/implementation/ui/deps.edn
+++ b/implementation/ui/deps.edn
@@ -1,0 +1,26 @@
+;; day8/re-frame2-ui — the compiled-view substrate artefact (epic
+;; rf2-vxgfnd; the ratified re-frame.ui program, 08 §5 R-1..R-6).
+;;
+;; S1a skeleton (rf2-vxgfnd.1): artefact shape + classpath wiring only.
+;; The compiler slice (template AST + analyzer + CLJS emitter + JVM
+;; emitter) lands from S1b (rf2-vxgfnd.2); root identity + mount surface
+;; from S1c; `re-frame.ui.test` (in-artefact, dev/test scope) from S1d.
+;;
+;; Per the program plan the compiler namespaces are `.cljc` — they run
+;; on the JVM during CLJS compilation (and for JVM-tree emission, later
+;; consumed by the ssr artefact) — and the client kernel is `.cljs`.
+;;
+;; NO :clein deploy aliases yet — deliberate, not an omission. The
+;; version-lockstep gate (.github/scripts/verify-version-lockstep.sh)
+;; requires every implementation/*/deps.edn carrying a :clein/build
+;; alias to appear in its ARTEFACTS inventory AND the release.yml deploy
+;; matrix. This artefact is pre-publication (nothing to deploy until the
+;; substrate is real), so the publishing wiring lands with the stage
+;; that first publishes it.
+{:paths ["src"]
+ :deps  {day8/re-frame2 {:local/root "../core"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -1,0 +1,14 @@
+(ns re-frame.ui
+  "Public surface of the re-frame.ui compiled-view substrate
+  (artefact day8/re-frame2-ui; epic rf2-vxgfnd).
+
+  S1a skeleton (rf2-vxgfnd.1): empty-but-loadable. The public grammar
+  (defview, mount, create-root, ...) lands from S1b onward per the
+  blessed surface table; anything not in that table does not exist.")
+
+(def artefact-id
+  "Skeleton classpath probe (rf2-vxgfnd.1). Asserted by
+  `re-frame.ui.skeleton-cljs-test` to prove this artefact's src tree is
+  on the cross-artefact classpath in both runtimes. Free to remove once
+  the S1b compiler slice gives the test suite a real surface."
+  :day8/re-frame2-ui)

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -1,0 +1,7 @@
+(ns re-frame.ui.client
+  "Client kernel of the re-frame.ui substrate — the browser-side runtime
+  the compiled views target (CLJS-only by design).
+
+  S1a skeleton (rf2-vxgfnd.1): empty-but-loadable. Root identity + the
+  mount surface arrive with S1c (rf2-vxgfnd.3); ownership, frames and
+  HMR semantics with S2.")

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -1,0 +1,8 @@
+(ns re-frame.ui.compiler
+  "Compiler entry for the re-frame.ui substrate — .cljc because the
+  compiler runs on the JVM during CLJS compilation (and emits JVM trees
+  for SSR/testing consumers).
+
+  S1a skeleton (rf2-vxgfnd.1): empty-but-loadable. The S1b compiler
+  slice (rf2-vxgfnd.2) lands the template AST, analyzer, CLJS emitter
+  and JVM emitter here (no reactivity in S1).")

--- a/implementation/ui/test/re_frame/ui/skeleton_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/skeleton_cljs_test.cljc
@@ -1,0 +1,21 @@
+(ns re-frame.ui.skeleton-cljs-test
+  "S1a classpath + build-id probe (rf2-vxgfnd.1).
+
+  The :require forms are half the assertion — a missing or unloadable
+  stub fails this namespace at CLJS compile / JVM load time. The deftest
+  pins the marker var so the requires are load-bearing and a green run
+  is non-vacuous.
+
+  Runs under three gates: the focused :node-test-ui build (`npm run
+  test:ui` — the ns matches its `^re-frame\\.ui\\..+-cljs-test$`
+  regexp), the always-on :node-test gate (`cljs-test$` matches), and
+  this artefact's own JVM :test alias (`clojure -M:test` from
+  implementation/ui/)."
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.ui :as ui]
+            [re-frame.ui.compiler]
+            #?(:cljs [re-frame.ui.client])))
+
+(deftest ui-artefact-skeleton-loads
+  (is (= :day8/re-frame2-ui ui/artefact-id)
+      "day8/re-frame2-ui skeleton nses load on the cross-artefact classpath"))

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -27,6 +27,12 @@ artefacts=(
   # resources-only change therefore skipped the JVM tier locally. Added
   # here alongside the matching jvm-resources PR-CI job (test.yml).
   implementation/resources
+  # rf2-vxgfnd.1 — the re-frame.ui compiled-view substrate (epic
+  # rf2-vxgfnd). S1a skeleton: the :test alias runs the classpath probe
+  # (re-frame.ui.skeleton-cljs-test's :clj arm) so the artefact's JVM
+  # side is exercised from day one; the compiler-slice suites (S1b+,
+  # where the .cljc compiler genuinely runs on the JVM) grow here.
+  implementation/ui
   # rf2-gj2ae — the adversarial-property security tier is `.cljc` and
   # advertises a cross-runtime contract (e.g. `re-frame.security.gen`'s
   # JVM `:clj` `long`-multiply vs the CLJS `Math.imul` arm, pinned by


### PR DESCRIPTION
First PR of the re-frame.ui program (epic rf2-vxgfnd). S1a: artefact skeleton + cross-artefact classpath wiring, NO product code. HOT-ZONE SOLO on implementation/deps.edn + shadow-cljs.edn per the bead.

- implementation/ui/ beside core/ and adapters/: deps.edn (:local/root on core, :test alias via test-quiet; deliberately NO :clein deploy aliases yet - the artefact is pre-publication and a :clein/build alias would require touching the version-lockstep inventory + release.yml deploy matrix, both out of this PR''s fence), empty-but-loadable stubs (re-frame.ui + re-frame.ui.compiler .cljc, re-frame.ui.client .cljs), and one classpath/build-id probe (skeleton_cljs_test.cljc, .cljc so it runs in both runtimes).
- Top-level deps.edn: day8/re-frame2-ui :local/root entry + ui/test on the :test alias.
- shadow-cljs.edn: ui/src + ui/test source paths; focused :node-test-ui build (ns-regexp ^re-frame\.ui\..+-cljs-test$, mirrors :node-test-testbed-support). The probe also rides the always-on :node-test gate (cljs-test$ matches).
- package.json: test:ui script.
- implementation/README.md: ui/ layout entry (required by the inventory-ratchet bijection in the fast-PR spine) + a grouping note (ui is the substrate slated to replace the adapter trio, not an adapter or late-bind feature artefact).
- scripts/test-jvm-implementation.sh: implementation/ui added so the artefact''s JVM :test alias runs in the local rigorous sweep. CI gate wiring is S1f (rf2-vxgfnd.6) per the epic.

Gates (all local, foreground): npm run test:ui green (1 test/1 assertion; re-run green post-rebase) - npm run test:bundle-isolation green (new artefact leaks into no production bundle) - npm run test:cljs green (8651 tests / 40752 assertions, probe included) - npm run test:script-policy + test:script-helpers green - scripts/check_readme_inventories.py green - verify-version-lockstep green - clojure -M:test in implementation/ui green.

Closes rf2-vxgfnd.1.