### PR TITLE
refactor(core): rename frame engine to private upsert-frame! + routing off registrar :frame (rf2-h1vqa4 slice 1/3)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -75,7 +75,7 @@
             [re-frame.classification]
             ;; EP-0015 §3 (rf2-ueg1tn): required for its ns-load side-effect
             ;; only — it publishes the `:frame-classification/*` late-bind
-            ;; hooks `re-frame.frame/reg-frame` consults to validate + install
+            ;; hooks `re-frame.frame/upsert-frame!` consults to validate + install
             ;; frame-owned durable classification. No symbols are referenced
             ;; here; the require exists so the hooks are bound at boot before
             ;; any runtime `reg-frame` call.
@@ -248,9 +248,11 @@
   differing only in source-coord capture). Atomically create + register a
   frame under `id` with the given metadata — an unregistered id creates; an
   already-registered id is IDEMPOTENT REPLACEMENT (EP-0024 §Duplicate id
-  policy), not a sibling constructor with its own duplicate-id story. See
-  `re-frame.frame/reg-frame` and spec/API.md §Registration."}
-       reg-frame       frame/reg-frame)
+  policy), not a sibling constructor with its own duplicate-id story.
+  TEMPORARY delegation to the private engine `re-frame.frame/upsert-frame!`
+  (rf2-h1vqa4 scaffolding — the reg-frame spelling is being removed; prefer
+  `make-frame`). See spec/API.md §Registration."}
+       reg-frame       frame/upsert-frame!)
      (def ^{:doc "Fn-alias of the `reg-route` macro for HoF / programmatic
   registration (no source-coord capture). Register a route: `(reg-route id
   metadata path)` — `metadata` is the MIDDLE registration-metadata map
@@ -444,14 +446,15 @@
        for the full signature."
        {:arglists '([id descriptor] [id metadata descriptor])})
 
-     (rm/defreg-macro reg-frame frame/reg-frame
+     (rm/defreg-macro reg-frame frame/upsert-frame!
        "Register a frame — the macro spelling of `make-frame` (rf2-lxwpob,
        Option B: documented sugar, ONE semantics — `(reg-frame id metadata)`
        ≡ `(make-frame (assoc metadata :id id))`, differing only in
        source-coord capture; NOT a sibling constructor with its own
        duplicate-id story). Captures source-coords (Spec 001) at this
-       call site. See `re-frame.frame/reg-frame` for the full
-       signature."
+       call site. TEMPORARY delegation to the private engine
+       `re-frame.frame/upsert-frame!` (rf2-h1vqa4 scaffolding — the
+       reg-frame spelling is being removed; prefer `make-frame`)."
        {:arglists '([id metadata])})
 
      (rm/defreg-macro reg-flow rf-flows/reg-flow

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -19,7 +19,6 @@
     :rf.frame/<gensym>       — anonymous instances from make-anon-frame-record!"
   (:require [clojure.string]
             [re-frame.error :as error]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -1800,20 +1799,20 @@
   hook (rf2-g8pbwg), by key. No-op when `re-frame.routing` is not loaded (the
   artefact is optional).
 
-  Called at the END of BOTH `reg-frame` branches below — first registration
-  (after `:initial-events` ran and `:rf.frame/created` emitted) and
-  re-registration (after the surgical config update and
+  Called at the END of BOTH `upsert-frame!` branches below — first
+  registration (after `:initial-events` ran and `:rf.frame/created` emitted)
+  and re-registration (after the surgical config update and
   `:rf.frame/re-registered` emitted) — so the frame container is always
-  guaranteed live by the time the hook fires. This is deliberately NOT the
-  registrar's `:frame` registration hook (`registrar/add-registration-hook!`,
-  which `re-frame.routing.url-bound` also consults): that hook fires INSIDE
-  `registrar/register!` above, BEFORE the frame container exists on first
-  registration, so an install from there would target a not-yet-live frame.
+  guaranteed live by the time the hook fires. This is THE frame
+  (re-)registration lifecycle extension point: frames do not flow through
+  `registrar/register!` (rf2-h1vqa4 — the frames registry is the one store),
+  so there is no registrar registration hook for frames.
 
-  Currently consumed by routing's `:url-bound?` listener wiring
-  (`:routing/on-frame-registered!` — installs/rewires the URL-change listener
-  when the (re-)registered frame is the resolved URL owner; a losing
-  duplicate `:url-bound? true` registration is a no-op). Not wrapped in
+  Currently consumed by routing (`:routing/on-frame-registered!` — maintains
+  the `:url-bound?` exclusivity check + URL-ownership claim order on BOTH
+  hosts, then installs/rewires the CLJS URL-change listener when the
+  (re-)registered frame is the resolved URL owner; a losing duplicate
+  `:url-bound? true` registration is a no-op). Not wrapped in
   `safe-call-hook!` (the teardown-specific accumulator/diagnostic pairing) —
   an extension hook here runs OUTSIDE any teardown, so a genuine failure
   propagates loudly rather than being swallowed."
@@ -1821,27 +1820,39 @@
   (when-let [on-registered! (late-bind/get-fn :routing/on-frame-registered!)]
     (on-registered! id)))
 
-(defn reg-frame
-  "Atomic create-and-register — the ENGINE `re-frame.live-frame/make-frame`
-  (the public `rf/make-frame`) delegates to, and the macro spelling `rf/reg-frame`
-  documents itself as sugar for (rf2-lxwpob, Option B: `(reg-frame id metadata)`
-  ≡ `(make-frame (assoc metadata :id id))`, differing only in source-coord
-  capture — ONE semantics, not a sibling constructor with its own duplicate-id
-  story). Per Spec 002 §Frame lifecycle:
+(defn ^:no-doc upsert-frame!
+  "PRIVATE frame ENGINE — atomic create-or-REFRESH (upsert) of the frame
+  record for `id` (rf2-h1vqa4). Called by `re-frame.live-frame/make-frame`
+  (the public constructor `rf/make-frame`) and tightly-scoped engine tests
+  ONLY; the public `rf/reg-frame` facade TEMPORARILY delegates here as
+  scaffolding while the reg-frame spelling is removed (rf2-h1vqa4 slices
+  2–3 — not a stable entry point).
+
+  The name pins the REFRESH semantics — this engine upserts SEATED ids too.
+  Per Spec 002 §Frame lifecycle:
   - If the id is unregistered, create the frame container, run the
     :initial-events setup steps synchronously (EP-0027), return the keyword.
-  - If the id is already registered, perform a SURGICAL UPDATE / IDEMPOTENT
+  - If the id is already SEATED, perform a SURGICAL UPDATE / IDEMPOTENT
     REPLACEMENT (EP-0024 §Duplicate id policy): existing runtime state
     (app-db, sub-cache, queue) is preserved; only the metadata/config is
-    replaced (the recorded :initial-events is REPLACED, not replayed —
-    idempotent re-registration). Hot-reload Just Works. This IS re-construction
-    — the Clojure re-def model: re-declaring the same id refreshes config
-    (+ generation, when the caller threads `:rf.frame/generation`) while
-    durable state survives."
+    replaced (+ the `:generation` slot, when the caller threads
+    `:rf.frame/generation`), and the recorded :initial-events is RE-RECORDED,
+    never REPLAYED. Hot-reload Just Works. This IS re-construction — the
+    Clojure re-def model: re-declaring the same id refreshes config while
+    durable state survives. `:initial-events` replay is ONLY the opt-in
+    full-replace composition (`destroy-frame!` then re-seat, rf2-lxwpob).
+
+  SUBSTRATE OWNERSHIP (rf2-h1vqa4): the `frames` registry is the ONE store a
+  seated frame lives in. Seating a frame writes NO registrar row and NO
+  source-store descriptor — a frame is a LIVE runtime object, not a program
+  member, so seating/reseating must never bump the registration source-store
+  generation (which would invalidate the resolved-image-generation cache,
+  EP-0023) nor surface in image assembly. Frame introspection is
+  `frame-meta` / `frame-ids`, not the registrar query API."
   [id metadata]
   (let [;; The registry is keyed by the bare frame-id.
         config (source-coords/merge-coords (expand-preset metadata))
-        ;; EP-0027 PREFLIGHT (BEFORE the registrar write / any container): reject
+        ;; EP-0027 PREFLIGHT (BEFORE any container / process-global write): reject
         ;; the retired `:on-create` / `:initial-db` keys fail-loud, and normalize
         ;; + validate `:initial-events` into a vector of setup steps. Both run
         ;; here so a bad construction declaration throws BEFORE any frame is
@@ -1853,8 +1864,8 @@
         ;; EP-0015 §9: validate the surviving frame-owned policy key
         ;; (`:observability` sink policy) EARLY — pure, container-independent,
         ;; fail-loud. A retired `:sensitive` / `:large` frame key, an unknown
-        ;; observability key, or a malformed sink entry throws here, BEFORE the
-        ;; registrar write and BEFORE any container exists, so a bad
+        ;; observability key, or a malformed sink entry throws here, BEFORE
+        ;; any container exists or process-global write runs, so a bad
         ;; declaration leaves no half-registered frame and never reaches
         ;; `:initial-events`. Reached via late-bind: `re-frame.frame-classification`
         ;; requires this ns, so a static require would cycle; `re-frame.core`
@@ -1879,7 +1890,7 @@
         ;; COMMIT chokepoint. The routing artefact validates an explicitly-
         ;; declared `:url-strategy` (shape + host-required callable legs) against
         ;; the FINAL expanded config — here, alongside the other pure preflights,
-        ;; BEFORE the record build, `registrar/register!`, the trace-policy
+        ;; BEFORE the record build, the trace-policy
         ;; writes, the `frames` swap, the `:initial-events` setup dispatch, and
         ;; any trace emit. So a malformed declaration fails with ZERO residue on
         ;; a first registration, and a failed RE-registration preserves every
@@ -1910,20 +1921,29 @@
                              {:extra {:frame id}})))
         existing       (get @frames id)
         ;; rf2-hhlzky: construct the frame record BEFORE any process-global
-        ;; write (the registrar row + the trace-suppression flags below).
+        ;; write (the trace-suppression flags below).
         ;; `new-frame-record` calls `adapter/make-state-container`, which THROWS
         ;; (`:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed`) when
         ;; no adapter is installed — a `reg-frame` issued before `rf/init!` or
         ;; after `destroy-adapter!`. Building the record here means such a
-        ;; construction failure escapes this `let` BEFORE `registrar/register!`
-        ;; and `trace/set-frame-no-emit!` run, so a frame that never came into
-        ;; existence leaves NO registrar row and NO trace-disabled residue (which
+        ;; construction failure escapes this `let` BEFORE
+        ;; `trace/set-frame-no-emit!` runs, so a frame that never came into
+        ;; existence leaves NO trace-disabled residue (which
         ;; would otherwise persist with no destroy path to clear it). This is the
         ;; DEFER form of the rollback the bead calls for — there is nothing to
         ;; unwind because nothing was written. Re-registration is a surgical
         ;; update (no container is built), so `new-record` is nil there.
         new-record     (when (nil? existing) (new-frame-record id config))]
-    (registrar/register! :frame id config)
+    ;; SUBSTRATE OWNERSHIP (rf2-h1vqa4): deliberately NO `registrar/register!`
+    ;; here. A seated frame lives in the `frames` registry alone. The former
+    ;; `:frame` registrar row leaked into the registration SOURCE STORE
+    ;; (`registrar/register!` → `source-store/record-descriptor!`), bumping the
+    ;; source-store generation on every seat/reseat — invalidating the
+    ;; resolved-image-generation cache (EP-0023) and marking the live-frame
+    ;; reprojection dirty for a change that is NOT a registration-pool change.
+    ;; Routing (the one former consumer) reads frame config via
+    ;; `frame-meta` / `frame-ids`; the registrar `:frame` kind is reserved with
+    ;; an intentionally EMPTY slot (the `:flow` precedent, rf2-en00bk).
     ;; Frame-level trace-emission gate: a frame registered
     ;; with `:rf.trace/frame-no-emit? true` is a tool / inspector frame
     ;; (e.g. Xray's `:rf/xray`) whose own reactive substrate must NOT
@@ -2063,6 +2083,15 @@
           (fire-frame-registered-hook! id)
           id))))
 
+(def ^{:no-doc true
+       :doc "TEMPORARY SCAFFOLDING (rf2-h1vqa4 slice 1): the engine's former
+  name, kept ONLY so un-migrated in-tree `frame/reg-frame` call sites compile
+  while consumers converge on the public `rf/make-frame` (slice 2). New code
+  must not call this — the engine is `upsert-frame!`; this alias and the
+  public `rf/reg-frame` facade are deleted in slice 3."}
+  reg-frame
+  upsert-frame!)
+
 (defn make-anon-frame-record!
   "INTERNAL anonymous-instance creation (EP-0024): generate a
   gensym'd id under `:rf.frame/`, register a configured record under it, and
@@ -2078,7 +2107,7 @@
   `re-frame.live-frame/make-frame` (the frame-VALUE constructor) at a call site."
   [config]
   (let [id (keyword "rf.frame" (str (gensym "")))]
-    (reg-frame id config)
+    (upsert-frame! id config)
     id))
 
 (defn make-frame-value
@@ -2464,12 +2493,6 @@
   [id]
   (swap! frames dissoc id))
 
-(defn- unregister-frame!
-  ;; The `:frame` registrar slot lives in the process-global registrar, so the
-  ;; unregister is a plain registrar call.
-  [id]
-  (registrar/unregister! :frame id))
-
 (defn- notify-epoch-listeners!
   "Fire the epoch destroy hook, threading the two frame-state snapshots the
   `:halted-destroy` epoch record carries per Spec-Schemas §`:rf/epoch-record`
@@ -2559,9 +2582,11 @@
                                               suppressed.
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
                                       machine cascade.
-    6. dissoc-frame!                — remove from the `frames` atom.
-    7. unregister-frame!            — drop from the registrar.
-    8. notify-epoch-listeners!      — fire the epoch hook so tools see
+    6. dissoc-frame!                — remove from the `frames` atom. This IS
+                                      the whole forget: the `frames` registry
+                                      is the ONE store a seated frame lives in
+                                      (rf2-h1vqa4 — no registrar row exists).
+    7. notify-epoch-listeners!      — fire the epoch hook so tools see
                                       :rf.epoch.cb/silenced-on-frame-destroy,
                                       threading the pre-run
                                       (`*run-frame-state-before*`) and
@@ -2603,8 +2628,8 @@
   ;; Silent no-op (idempotent destroy is a no-op pattern; no new trace event
   ;; needed).
   ;; The registry is keyed by the bare frame-id, so every keyed teardown step
-  ;; (the in-flight guard, `mark-frame-destroyed!`, `dissoc-frame!`, the
-  ;; registrar unregister) targets the frame-id-keyed record directly.
+  ;; (the in-flight guard, `mark-frame-destroyed!`, `dissoc-frame!`)
+  ;; targets the frame-id-keyed record directly.
   (when-let [f (frame id)]
       (when-not (contains? @destroying-frames id)
       (swap! destroying-frames conj id)
@@ -2616,7 +2641,7 @@
       ;; requested — the `:frame-state-after` slot the `:halted-destroy`
       ;; epoch record carries. The pre-run `:frame-state-before` rides the
       ;; router-bound `*run-frame-state-before*` dynamic var (nil outside a
-      ;; drain). Both are passed to `notify-epoch-listeners!` (step 8): the
+      ;; drain). Both are passed to `notify-epoch-listeners!` (step 7): the
       ;; whole frame-state, both partitions.
       (let [run-fs-before *run-frame-state-before*
             ;; The destroying event's causal `:time-ms`, bound by
@@ -2770,7 +2795,6 @@
         ;; `:generation` slot, so dropping the record drops it too — no separate
         ;; forget hook is needed.
         (dissoc-frame! id)
-        (unregister-frame! id)
         (notify-epoch-listeners! id run-fs-before fs-at-destroy run-time-ms)
         nil
         (finally
@@ -2872,4 +2896,4 @@
   app frame registers it explicitly via `(rf/reg-frame :rf/default {…})`."
   []
   (when-not (get @frames :rf/default)
-    (reg-frame :rf/default {:doc "Test-fixture default frame (ordinary id; not a runtime floor)."})))
+    (upsert-frame! :rf/default {:doc "Test-fixture default frame (ordinary id; not a runtime floor)."})))

--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -311,10 +311,10 @@
     (validate-observability! frame-id (:observability config)))
   nil)
 
-;; Published so the frame-registration path (`re-frame.frame/reg-frame`)
+;; Published so the frame-registration path (`re-frame.frame/upsert-frame!`)
 ;; can reach validation without a static require (frame.cljc sits below this
 ;; ns in the load order). `re-frame.core` requires this ns at boot, so the
-;; hook is always published before any runtime `reg-frame` call.
+;; hook is always published before any runtime frame registration.
 ;;
 ;; EP-0025: there is no `install!` / `install-from-config!` / `validate+extract`
 ;; hook anymore — durable app-db classification moved off the frame annotation

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -228,7 +228,7 @@
     :description "ALWAYS-ON (NOT a DCE seam, rf2-eq7m0x — the registration classification is populated in production too; only the emit-time TRACE projection is dev-gated): apply an event handler's REGISTRATION-OWNED :sensitive / :large classification to a [event-id arg-map] vector (EP-0015 — event args are registration-owned transient payloads). Consumed by re-frame.projection for the :rf.observe/error / handled-event :event slot."}
 
    ;; ---- re-frame.frame-classification (EP-0015 §9 observability) ----
-   ;; `re-frame.frame/reg-frame` consults this to validate the surviving
+   ;; The frame engine (`re-frame.frame/upsert-frame!`) consults this to validate the surviving
    ;; frame-owned :observability sink policy. Reached via late-bind because
    ;; frame-classification requires frame, so a static require would cycle.
    ;;
@@ -515,11 +515,11 @@
    {:key         :routing/preflight-frame-config!
     :producer-ns 're-frame.routing
     :design-bead "rf2-ktmto9"
-    :description "Registration-time frame-config PREFLIGHT `(fn [frame-id config])` — PURE validation of routing-owned frame-config keys, invoked by frame/reg-frame (the one frame-config commit chokepoint) with the FINAL expanded config (after preset expansion + source-coordinate merging) BEFORE any candidate-derived write: the frame-record build, the registrar row, the trace-policy flags, the frames swap, the :initial-events setup dispatch, and any trace emit. Validates an explicitly-declared :url-strategy for host-required shape/callability (validate-url-strategy!, fail-loud :rf.error/invalid-url-strategy with {:frame frame-id} ex-data); PRESENCE semantics — a config with NO :url-strategy key is a no-op (omission alone selects the default history strategy), while a PRESENT key INCLUDING explicit nil is an explicit declaration and fails loud when malformed. Published on BOTH hosts. When the hook is UNPUBLISHED (routing not loaded) and a config declares :url-strategy, core fails loud with :rf.error/routing-artefact-missing rather than storing a strategy nobody can validate or execute; the :url-bound?-only late-load case is unchanged. Routing owns the meaning; core owns the timing — the fail-loud + failure-atomicity completion of PR #5633's consult-seam validation. Per Spec 012 §URL strategies / Spec 002 §reg-frame construction failure-atomicity."}
+    :description "Registration-time frame-config PREFLIGHT `(fn [frame-id config])` — PURE validation of routing-owned frame-config keys, invoked by the frame engine (frame/upsert-frame!, the one frame-config commit chokepoint) with the FINAL expanded config (after preset expansion + source-coordinate merging) BEFORE any candidate-derived write: the frame-record build, the trace-policy flags, the frames swap, the :initial-events setup dispatch, and any trace emit. Validates an explicitly-declared :url-strategy for host-required shape/callability (validate-url-strategy!, fail-loud :rf.error/invalid-url-strategy with {:frame frame-id} ex-data); PRESENCE semantics — a config with NO :url-strategy key is a no-op (omission alone selects the default history strategy), while a PRESENT key INCLUDING explicit nil is an explicit declaration and fails loud when malformed. Published on BOTH hosts. When the hook is UNPUBLISHED (routing not loaded) and a config declares :url-strategy, core fails loud with :rf.error/routing-artefact-missing rather than storing a strategy nobody can validate or execute; the :url-bound?-only late-load case is unchanged. Routing owns the meaning; core owns the timing — the fail-loud + failure-atomicity completion of PR #5633's consult-seam validation. Per Spec 012 §URL strategies / Spec 002 §reg-frame construction failure-atomicity."}
    {:key         :routing/on-frame-registered!
     :producer-ns 're-frame.routing
     :design-bead "rf2-g8pbwg"
-    :description "Fired by frame/reg-frame AFTER the frame container exists (first registration: after :initial-events ran; re-registration: after the surgical config update) — the registrar's OWN :frame registration hook fires too early (before the container exists) for an install. When the just-(re)registered frame is the resolved URL owner, (re)installs its :url-strategy browser listener (popstate or hashchange); a losing duplicate :url-bound? true registration is a no-op (never installs). Folds the retired install-url-listener! / install-history-listener! imperative exports into the :url-bound? frame lifecycle. CLJS-only."}
+    :description "Fired by the frame engine (frame/upsert-frame!) AFTER the frame container exists (first registration: after :initial-events ran; re-registration: after the surgical config update) — THE frame (re-)registration lifecycle extension point (rf2-h1vqa4: frames do not flow through registrar/register!, so there is no registrar registration hook for frames). Published on BOTH hosts; the facade body is ORDERED: (1) url-bound exclusivity + URL-ownership claim maintenance (re-frame.routing.url-bound, reading config via frame/frame-meta — both hosts), then (2) CLJS-only strategy-aware browser-listener reconcile: when the just-(re)registered frame is the resolved URL owner, (re)installs its :url-strategy browser listener (popstate or hashchange); a losing duplicate :url-bound? true registration is a no-op (never installs). Folds the retired install-url-listener! / install-history-listener! imperative exports into the :url-bound? frame lifecycle."}
    {:key         :routing/reset-url-listener!
     :producer-ns 're-frame.routing
     :design-bead "rf2-g8pbwg"
@@ -1045,7 +1045,7 @@
    ;;
    ;; The four hooks below carry the per-frame ring + B4 dedup machinery.
    ;; They're consulted from
-   ;; `re-frame.frame/reg-frame` + `destroy-frame!` (lifecycle) and
+   ;; `re-frame.frame/upsert-frame!` + `destroy-frame!` (lifecycle) and
    ;; `re-frame.registrar/register!` / `unregister!` / `clear-kind!`
    ;; (B4 dedup). All routed via late-bind so production CLJS bundles
    ;; that never load `re-frame.trace.tooling` short-circuit cleanly
@@ -1065,7 +1065,7 @@
    {:key         :trace.tooling/set-frame-events-retained!
     :producer-ns 're-frame.trace.tooling
     :design-bead "rf2-g1b2m"
-    :description "Apply a per-frame `:rf.trace/events-retained` override. `re-frame.frame/reg-frame` invokes this when the config carries the key; raises / lowers the ring's slot cap (one slot per event / pipeline run), trimming evictions in-place when lowering."}
+    :description "Apply a per-frame `:rf.trace/events-retained` override. The frame engine (`re-frame.frame/upsert-frame!`) invokes this when the config carries the key; raises / lowers the ring's slot cap (one slot per event / pipeline run), trimming evictions in-place when lowering."}
    {:key         :frame/current-frame-id
     :producer-ns 're-frame.frame
     :design-bead "rf2-g1b2m"

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -14,7 +14,7 @@
 
     * `make-frame` — the ONE public constructor (EP-0024 §One constructor).
       Resolves `:images` into a sealed generation, threads it + `:initial-events`
-      through `frame/reg-frame` (the seed steps run AT construction, in order,
+      through the frame engine `frame/upsert-frame!` (the seed steps run AT construction, in order,
       draining before the call returns), and returns the frame VALUE. A duplicate `:id` is IDEMPOTENT REPLACEMENT (config +
       generation refresh, durable state preserved — EP-0024 §Duplicate id policy);
       it does NOT fail loud. Record-config keys are honoured in the same call
@@ -37,7 +37,7 @@
       REPLACING reload (rf2-lxwpob folded the dedicated `reload-images!` verb
       into this — one grammar, not two). Calling `make-frame` again with the
       SAME `:id` and a NEW `:images` vector re-assembles the new composition
-      into a fresh sealed generation and installs it via `reg-frame`'s
+      into a fresh sealed generation and installs it via `upsert-frame!`'s
       surgical-update path WHILE PRESERVING FRAME MEMORY — app-db, runtime-db,
       caches, lifecycle, and every other frame-owned slot continue unchanged;
       only `:rf.frame/generation` moves (EP-0023 §Hot Reload — \"Hot reload
@@ -437,10 +437,10 @@
 ;; EP-0024 (rf2-tu2vr7) replaced the old fail-loud-on-every-live-id refusal with
 ;; hot-reload-friendly IDEMPOTENT REPLACEMENT: re-`make-frame`-ing the same id
 ;; updates the frame's record-config + resolved generation WITHOUT destroying
-;; durable state. That is exactly `frame/reg-frame`'s existing surgical-update
+;; durable state. That is exactly `frame/upsert-frame!`'s surgical-update
 ;; contract (app-db / sub-cache / queue preserved, config replaced), so the
 ;; unified constructor inherits it — no separate fail-loud registry. The
-;; irreconcilable-conflict fail-loud path is the `reg-frame` install-time
+;; irreconcilable-conflict fail-loud path is the engine's install-time
 ;; validators (classification / schema), which still throw; a benign same-shape
 ;; re-mount just refreshes.
 
@@ -453,24 +453,24 @@
 ;; fail-loud redirect). The image-selection opts the constructor consumes
 ;; directly (`:images` → generation; `:id` / `:adapter` → the frame
 ;; value); EVERY OTHER opt is record-config
-;; passed verbatim to `frame/reg-frame` (`:initial-events` / `:fx-overrides` /
+;; passed verbatim to `frame/upsert-frame!` (`:initial-events` / `:fx-overrides` /
 ;; `:platform` / `:ssr` / `:doc` / `:preset` / `:tags` / classification keys /
 ;; …). So `(rf/make-frame {:id … :images [...] :fx-overrides {...}})` works in
 ;; one call — no record-only-key fail-loud redirect.
 
 (def ^:private image-selection-opt-keys
   "The `make-frame` opts the unified constructor consumes directly (EP-0024) —
-  resolved into the generation + the frame value, NOT passed to `reg-frame` as
+  resolved into the generation + the frame value, NOT passed to the engine as
   record config. Everything else in the opts map is record-config.
 
   EP-0027 retired `:initial-db`: it is NO LONGER an image-selection key. A
-  supplied `:initial-db` now flows through to `reg-frame` as record-config and is
+  supplied `:initial-db` now flows through to the engine as record-config and is
   rejected fail-loud there (`:rf.error/initial-db-retired`) — seeding app-db is
   itself an event (`{:initial-events [[:rf/set-db {…}]]}`).
 
   EP-0026 (rf2-dlvmpc) retired `:capabilities`: image-declared host capabilities
   are removed end-to-end, so `make-frame :capabilities` is no longer a recognized
-  key. A supplied `:capabilities` now flows through to `reg-frame` as
+  key. A supplied `:capabilities` now flows through to the engine as
   record-config (an ordinary config key)."
   #{:images :id :adapter})
 
@@ -558,7 +558,7 @@
   resolved against: nil for the live source store, a real descriptors value
   for an explicit pool (`make-frame`'s 2-arity). Recorded by `make-frame` on
   every SUCCESSFUL call (creation + hot-reload re-construction), AFTER the
-  `reg-frame` engine commit returns (rf2-ktmto9 — a failed creation records
+  `upsert-frame!` engine commit returns (rf2-ktmto9 — a failed creation records
   nothing; a failed re-construction preserves the old row), so reprojection
   re-resolves against the SAME provenance (rf2-rf3zgt) instead of silently
   defaulting to the live store for a frame that was never resolved against
@@ -622,7 +622,8 @@
   image-declared host capabilities are removed end-to-end. A `:capabilities` key
   is no longer special-cased — it flows through as ordinary record-config.
 
-  EVERY OTHER key is RECORD-CONFIG passed verbatim to `re-frame.frame/reg-frame`
+  EVERY OTHER key is RECORD-CONFIG passed verbatim to the frame engine
+  (`re-frame.frame/upsert-frame!`)
   — `:initial-events` (a vector of event vectors dispatch-sync'd into the new
   frame at construction, in order, draining before the call returns — seed a
   literal app-db with `[[:rf/set-db {…}]]`; EP-0027), `:fx-overrides`,
@@ -649,8 +650,8 @@
   The frame's runnable interior — app-db / runtime-db container, projection
   reactions, router queue, drain-lock, sub-cache, lifecycle, AND the resolved
   generation — is ONE `frames`-registry record (EP-0024 §One live frame
-  registry): created/updated here via `frame/reg-frame` (idempotent), with the
-  generation written onto it via `frame/set-generation!`.
+  registry): created/updated here via `frame/upsert-frame!` (idempotent), with
+  the generation written onto it via `frame/set-generation!`.
 
   Two arities:
     (make-frame opts)            — resolve `:images` against the LIVE source store.
@@ -699,14 +700,15 @@
                          (asm/assemble-default)
                          (asm/assemble-default descriptors)))
          ;; Everything outside the image-selection/value keys is record-config
-         ;; passed verbatim to `reg-frame` — `:initial-events` / `:fx-overrides` /
+         ;; passed verbatim to the engine (`upsert-frame!`) — `:initial-events` /
+         ;; `:fx-overrides` /
          ;; `:platform` / `:ssr` / `:doc` / `:preset` / `:tags` / classification.
          ;; EP-0024 option-(a): the unified constructor honours these, no
          ;; fail-loud record-only-key redirect. EP-0027: `:initial-events` is one
-         ;; of these record-config keys — it flows verbatim to `reg-frame`, which
+         ;; of these record-config keys — it flows verbatim to the engine, which
          ;; PREFLIGHT-validates it and runs the setup steps synchronously at
          ;; construction (and a retired `:initial-db` / `:on-create` likewise flows
-         ;; through to reg-frame's fail-loud guard). We thread two reserved
+         ;; through to the engine's fail-loud guard). We thread two reserved
          ;; construction inputs through the config:
          ;;   :rf.frame/generation   — the resolved generation. ALWAYS present now
          ;;                            (EP-0026 §Default Image): a PRESENT `:images`
@@ -716,7 +718,7 @@
          ;;                            every frame carries a generation and resolves
          ;;                            through it — the absence-is-default
          ;;                            registrar-atom fall-through no longer fires
-         ;;                            on the make-frame path. reg-frame seats it
+         ;;                            on the make-frame path. The engine seats it
          ;;                            into the `:generation` slot and strips it
          ;;                            from the stored config. Installed BEFORE the
          ;;                            `:initial-events` setup runs, so a setup
@@ -731,20 +733,20 @@
                          true            (assoc :rf.frame/generation generation)
                          (some? adapter) (assoc :rf.frame/adapter adapter))]
      ;; Create (or idempotently update) the ONE `frames`-registry record under
-     ;; the id. `reg-frame` is idempotent on an existing id (surgical update
+     ;; the id. `upsert-frame!` is idempotent on an existing id (surgical update
      ;; preserving runtime state — EP-0024 §Duplicate id policy), installs the
      ;; generation BEFORE running the `:initial-events` setup steps, and applies
      ;; the record-config (presets, classification, fx-overrides, …). Default-realm
      ;; (the collapse supersedes the public realm dimension), so the record is
      ;; keyed by the bare id.
-     (frame/reg-frame runnable-id record-config)
+     (frame/upsert-frame! runnable-id record-config)
      ;; Record which pool this generation was resolved against AFTER the engine
      ;; commit returns successfully — see §Generation PROVENANCE above
      ;; (rf2-rf3zgt): a later reprojection reads this back so it re-resolves
      ;; against the SAME pool (explicit or live) rather than always falling
      ;; through to the live store. Recorded on every SUCCESSFUL call (creation +
      ;; hot-reload re-construction), so a re-`make-frame` that changes arity
-     ;; keeps the record current — and ordered after `reg-frame` (rf2-ktmto9,
+     ;; keeps the record current — and ordered after `upsert-frame!` (rf2-ktmto9,
      ;; the failure-atomicity completion) so a FAILED creation records nothing
      ;; and a FAILED re-construction preserves the OLD provenance row, matching
      ;; the engine's own no-residue-on-failure contract.
@@ -776,7 +778,7 @@
 ;; rf2-lxwpob (API-shrink #5, frame-lifecycle collapse): the dedicated
 ;; `reload-images!` verb is RETIRED — `make-frame` re-called against an
 ;; EXISTING `:id` with a new `:images` vector already resolves a fresh
-;; generation and installs it via `reg-frame`'s surgical-update / idempotent-
+;; generation and installs it via `upsert-frame!`'s surgical-update / idempotent-
 ;; replacement path (EP-0024 §Duplicate id policy), PRESERVING frame memory
 ;; exactly as reload did. That IS image hot-reload via re-construction, one
 ;; grammar instead of two. The AUTOMATIC `reg-*` re-eval reprojection path
@@ -824,7 +826,7 @@
 ;; public reload verb (`reload-images!`) that used to call this too was
 ;; RETIRED in rf2-lxwpob — folded into `make-frame` re-construction (an
 ;; `:id`-bearing `make-frame` call already installs a fresh generation via
-;; `reg-frame`'s surgical-update path, preserving frame memory identically).
+;; `upsert-frame!`'s surgical-update path, preserving frame memory identically).
 
 (defn- swap-frame-generation!
   "Swap `new-generation` onto frame `id`'s record IN PLACE via
@@ -1163,8 +1165,9 @@
   (`reproject-live-frames!` enumerates `live-frame-ids` = the `frames` records
   carrying a `:generation`). With none the flush would be a guaranteed no-op, so
   there is nothing to mark dirty or schedule. This is the dominant case: every
-  `reg-event` / `reg-sub` / `reg-fx` — and the `reg-frame` of EVERY frame's
-  record — funnels through `register!` and so fires this hook, but the
+  `reg-event` / `reg-sub` / `reg-fx` funnels through `register!` and so fires
+  this hook (frame seating does NOT — rf2-h1vqa4: `frame/upsert-frame!` writes
+  no registrar row, so seating a frame is not a registration-pool change), but the
   overwhelming majority run while NO image-loaded frame exists (app boot, every
   handler-only test). Marking + scheduling on each would flood
   `interop/next-tick` with one no-op flush per registration; skipping when

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -40,6 +40,17 @@
   `handlers :flow` / `handler-meta :flow` — matching the `:app-schema`
   precedent (rf2-0frdi).
 
+  Per rf2-h1vqa4 the `:frame` kind is likewise RESERVED with an intentionally
+  **empty** registrar slot — the frame engine (`re-frame.frame/upsert-frame!`)
+  writes only to the frames registry (`re-frame.frame/frames`), the single
+  source of truth for seated frames. A frame is a LIVE runtime object, not an
+  image-resolved program member: routing a `:frame` row through `register!`
+  leaked it into the provenance source store, bumping the source-store
+  generation (invalidating the resolved-image-generation cache, EP-0023) and
+  firing the live-frame reprojection hook on every seat/reseat. Frame
+  introspection goes through `rf/frame-meta` / `rf/frame-ids` (Spec 002 §The
+  public registrar query API), never `registrations :frame`.
+
   ## Production elision
 
   The :rf.registry/* trace emit sites in this namespace are gated on
@@ -86,6 +97,11 @@
 
 (def kinds
   "The closed set of registry kinds for v1. Adding a new kind is a Spec change.
+
+  `:frame` is RESERVED with an intentionally EMPTY slot (rf2-h1vqa4) — seated
+  frames live in the frames registry (`re-frame.frame/frames`), introspected
+  via `rf/frame-meta` / `rf/frame-ids`; nothing writes `:frame` rows here
+  (the `:flow` precedent below).
 
   Machine guards/actions are NOT registrar kinds — the runtime resolves
   them through the machine spec's `:guards` / `:actions` maps, and their
@@ -594,7 +610,7 @@
                (catch #?(:clj Throwable :cljs :default) _ nil)))
         ;; Per Spec 001 §Hot-reload trace surface: emit
         ;; `:rf.registry/handler-replaced` on EVERY re-registration —
-        ;; not only when the handler-fn changes. Kinds like `:frame`
+        ;; not only when the handler-fn changes. Kinds like `:route`
         ;; replace the slot without rotating `:handler-fn`, so gating the
         ;; emit on `different?` would drop legitimate re-registration
         ;; events on the floor. The `:different-fn?` tag is preserved
@@ -621,7 +637,7 @@
           ;; shape, and carries its OWN per-(kind, id) suppression
           ;; (`collision-warned`). It must run independently of the
           ;; `dedup-allow?` (handler-replaced) gate: a kind with no rotating
-          ;; `:handler-fn` — `:frame`, `:route`, `:head` — can be deduped-away
+          ;; `:handler-fn` — `:route`, `:head` — can be deduped-away
           ;; by shape, so nesting the collision check inside that gate would
           ;; let a GENUINE cross-source clash for those kinds go unwarned.
           ;; Called here independently (still under `interop/debug-enabled?`

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -683,7 +683,8 @@
     ;; DETERMINISM (rf2-ssokdr): the auto-reprojection wiring
     ;; (`live-frame/reproject-on-registration-change!`, installed once as a
     ;; process-`defonce` `registrar/add-registration-hook!`) fires on EVERY
-    ;; `register!` — including the `reg-frame` inside each `make-frame` below.
+    ;; `register!` — the `reg-event` re-evals below (frame seating no longer
+    ;; routes through `register!`, rf2-h1vqa4).
     ;; Once a live image-loaded frame exists, that hook MARKS the shared
     ;; process-wide `pending-reprojection?` flag dirty and schedules a REAL
     ;; deferred `interop/next-tick` flush (on the JVM: an async single-thread

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -10,12 +10,12 @@
   `dispose!` throws mid-sub-cache-walk, what happens when a frame's
   `:on-destroy` event dispatch-syncs across to a sibling. These are the
   rare cases most likely to leave sub-cache, epoch buffers, flow
-  registries, or registrar slots alive after destroy.
+  registries, or frames-store records alive after destroy.
 
   Acceptance per rf2-gh1mj:
     - At least four composed lifecycle interleavings (this file: five).
     - Assertions prove no leaked sub-cache, epoch buffer, flow
-      registration, or registrar slot for the destroyed frame.
+      registration, or frames-store record for the destroyed frame.
     - Listener-throw and late-bound-hook-throw paths pinned.
     - JVM coverage suffices — every assertion is pure runtime semantics
       with no host-specific divergence (the destroy step list is host-
@@ -131,15 +131,15 @@
                               @survivor)))
           "survivor saw both per-machine destroyed events (one per snapshot)")
 
-      ;; The frame is fully gone from BOTH the frames atom AND the
-      ;; registrar — proves no destroy step was skipped by the
-      ;; listener throw.
+      ;; The frame is fully gone from the frames store (the ONE store a
+      ;; seated frame lives in, rf2-h1vqa4) — proves no destroy step was
+      ;; skipped by the listener throw.
       (is (nil? (frame/frame :composed/scoped))
           "frame is dissoc'd from the frames atom")
       (is (nil? (get @frame/frames :composed/scoped))
           "frame entry is gone from the underlying atom (no soft-destroy)")
-      (is (nil? (registrar/lookup :frame :composed/scoped))
-          "frame is unregistered from the registrar")
+      (is (nil? (frame/frame-meta :composed/scoped))
+          "frame is invisible to the frame-meta introspection surface")
 
       (rf/unregister-listener! :trace ::thrower)
       (rf/unregister-listener! :trace ::survivor))))
@@ -199,8 +199,8 @@
         ;; The frame is fully gone.
         (is (nil? (frame/frame :composed/hook-throw))
             "frame is dissoc'd from the frames atom despite the hook throw")
-        (is (nil? (registrar/lookup :frame :composed/hook-throw))
-            "frame is unregistered from the registrar despite the hook throw")
+        (is (nil? (frame/frame-meta :composed/hook-throw))
+            "frame is invisible to frame-meta despite the hook throw")
 
         (finally
           ;; Restore the original hook fns so subsequent tests are not
@@ -259,8 +259,8 @@
       ;; Frame is fully gone.
       (is (nil? (frame/frame :composed/sub-throw))
           "frame is dissoc'd")
-      (is (nil? (registrar/lookup :frame :composed/sub-throw))
-          "frame is unregistered"))))
+      (is (nil? (frame/frame-meta :composed/sub-throw))
+          "frame is invisible to frame-meta"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3b. Frame-destroy sub-cache eviction emits :rf.sub/dispose (rf2-x3m8c f2)
@@ -480,8 +480,8 @@
       ;; the dissoc.
       (is (nil? (frame/frame :composed/child))
           "child frame is dissoc'd after the cross-frame :on-destroy")
-      (is (nil? (registrar/lookup :frame :composed/child))
-          "child frame is unregistered after the cross-frame :on-destroy")
+      (is (nil? (frame/frame-meta :composed/child))
+          "child frame is invisible to frame-meta after the cross-frame :on-destroy")
 
       ;; The parent is untouched.
       (is (some? (frame/frame :composed/parent))
@@ -494,7 +494,7 @@
 ;; teardown hook: schemas (per-frame schema registry), flows (per-frame
 ;; flows registry + last-inputs cache), epoch (per-frame ring buffer
 ;; + observed-frames-by-cb entry), sub-cache (pinned reactions),
-;; registrar. Destroy. Pin that ALL of them are cleared in a single
+;; the frames store. Destroy. Pin that ALL of them are cleared in a single
 ;; composed assertion — guards against a future regression that fixes
 ;; each leak in isolation while breaking the destroy step list's
 ;; ordering.
@@ -502,7 +502,7 @@
 
 (deftest composed-destroy-leak-audit
   (testing "after destroy: sub-cache empty, epoch buffer cleared, flow rows
-            cleared, schema rows cleared, frame absent, registrar dropped"
+            cleared, schema rows cleared, frame absent from the frames store"
     (rf/reg-frame :composed/leak-audit {:doc "leak-audit"})
 
     ;; --- schemas: register a schema rooted at the frame -------------------
@@ -545,9 +545,12 @@
       (is (pos? (count @cache))
           "precondition: sub-cache pinned at least one entry"))
 
-    ;; --- registrar: precondition --------------------------------------
-    (is (some? (registrar/lookup :frame :composed/leak-audit))
-        "precondition: frame is registered in the registrar")
+    ;; --- frames store: precondition -----------------------------------
+    (is (some? (frame/frame-meta :composed/leak-audit))
+        "precondition: frame is seated in the frames store (frame-meta reads it)")
+    ;; rf2-h1vqa4 substrate ownership: seating writes NO registrar row.
+    (is (nil? (registrar/lookup :frame :composed/leak-audit))
+        "precondition: no :frame registrar row exists for a seated frame")
 
     ;; --- destroy ---------------------------------------------------------
     (frame/destroy-frame! :composed/leak-audit)
@@ -557,8 +560,8 @@
         "post: frame is dissoc'd from frames atom")
     (is (nil? (get @frame/frames :composed/leak-audit))
         "post: frame entry is gone from the underlying atom")
-    (is (nil? (registrar/lookup :frame :composed/leak-audit))
-        "post: frame is unregistered from the registrar")
+    (is (nil? (frame/frame-meta :composed/leak-audit))
+        "post: frame is invisible to frame-meta")
     (is (not (contains? (schemas/snapshot-schemas-by-frame) :composed/leak-audit))
         "post: schema row dropped (per rf2-wkxng / rf2-6m0se)")
     (is (not (contains? (flows/flows-snapshot) :composed/leak-audit))

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -11,6 +11,7 @@
             [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
+            [re-frame.source-store :as source-store]
             [re-frame.flows :as flows]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -596,9 +597,9 @@
 
 (deftest reg-frame-construction-failure-leaves-no-registrar-or-trace-residue
   (testing "rf2-hhlzky — a reg-frame whose frame CONSTRUCTION fails (no adapter
-            installed: reg-frame before rf/init!) leaves NO registrar row and NO
-            trace-disabled residue. `new-frame-record` (which calls
-            make-state-container) is built BEFORE the registrar / trace-
+            installed: reg-frame before rf/init!) leaves NO frames-store record
+            and NO trace-disabled residue. `new-frame-record` (which calls
+            make-state-container) is built BEFORE the trace-
             suppression writes, so a construction throw escapes before any
             process-global metadata is written — nothing to roll back."
     (let [fid :test/no-adapter-frame]
@@ -615,14 +616,53 @@
         (is (= :rf.error/no-adapter-installed thrown-id)
             "construction fails loud with the no-adapter throw (frame never built)"))
       ;; No half-registered process-global state survives the failed build:
-      (is (nil? (registrar/lookup :frame fid))
-          "no :frame registrar row was written for the frame that failed to build")
       (is (nil? (frame/frame fid))
           "no frame record landed in the frames atom")
+      (is (nil? (frame/frame-meta fid))
+          "the failed frame is invisible to the frame-meta introspection surface")
       (is (false? (trace/frame-trace-disabled? fid))
           "no trace-disabled residue — set-frame-no-emit! never ran for the failed frame")
       ;; Restore a working adapter so the fixture teardown / next test are clean.
       (rf/init! plain-atom/adapter))))
+
+;; ---- rf2-h1vqa4 — substrate ownership: frames never touch the registrar /
+;;      source store ---------------------------------------------------------
+;;
+;; A frame is a LIVE runtime object, not an image-resolved program member.
+;; Before the fix, the engine routed every seat/reseat through
+;; `registrar/register! :frame`, which ALSO recorded a `:frame` descriptor in
+;; the provenance source store and bumped the source-store GENERATION — the
+;; key leg of the resolved-image-generation cache (EP-0023). So merely seating
+;; or hot-reseating a frame invalidated the default-generation cache and fired
+;; the live-frame reprojection hook, for a change that is NOT a
+;; registration-pool change. This test pins the ownership fix end-to-end.
+
+(deftest frame-seating-writes-no-registrar-row-and-no-source-store-descriptor
+  (testing "rf2-h1vqa4 — seating + reseating a frame writes NO :frame registrar
+            row, records NO :frame source-store descriptor, and does NOT bump
+            the source-store generation (no resolved-image-generation cache
+            invalidation, no image-descriptor churn); frame introspection rides
+            frame-meta"
+    (let [gen-before (source-store/store-generation)]
+      ;; First seat + hot reseat (surgical update) + a make-frame reseat.
+      (rf/reg-frame :h1vqa4/owned {:doc "v1"})
+      (rf/reg-frame :h1vqa4/owned {:doc "v2 (reseat refreshes config)"})
+      (is (= "v2 (reseat refreshes config)" (:doc (rf/frame-meta :h1vqa4/owned)))
+          "the reseat refreshed the stored config (upsert semantics) via frame-meta")
+      (is (nil? (registrar/lookup :frame :h1vqa4/owned))
+          "no :frame registrar row exists for the seated frame")
+      (is (not (contains? (registrar/registrations :frame) :h1vqa4/owned))
+          "the (reserved, intentionally empty) :frame registrar slot stays empty")
+      (is (empty? (source-store/descriptors-for :frame :h1vqa4/owned))
+          "no :frame descriptor was recorded in the provenance source store")
+      (is (= gen-before (source-store/store-generation))
+          "the source-store generation did NOT move — seating/reseating a frame
+           cannot invalidate the resolved-image-generation cache")
+      ;; Destroy leaves the world exactly as before (frames store only).
+      (rf/destroy-frame! :h1vqa4/owned)
+      (is (nil? (rf/frame-meta :h1vqa4/owned)) "destroyed frame is gone")
+      (is (= gen-before (source-store/store-generation))
+          "destroy does not move the source-store generation either"))))
 
 (deftest top-level-reg-frame-initial-events-runs-synchronously
   (testing "Top-level reg-frame (NOT inside a handler) runs :initial-events

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -351,7 +351,7 @@
 ;; F3 — collision warning is DECOUPLED from the handler-replaced dedup gate
 ;;      (rf2-3az1vn P2)
 ;;
-;; A kind with NO `:handler-fn` — `:frame` / `:route` / `:head` — replaces its
+;; A kind with NO `:handler-fn` — `:route` / `:head` — replaces its
 ;; slot WITHOUT rotating a handler fn. The B4 hot-reload dedup-by-shape table
 ;; (`trace.tooling/dedup-allow?`) strips source-coords (`:ns`/`:file`/`:line`/
 ;; `:column`) from the shape, so two cross-source registrations of such a kind
@@ -364,7 +364,7 @@
 ;; =============================================================================
 
 (defn- reg-no-handler-fn!
-  "Register a `kind` id carrying NO `:handler-fn` (a `:frame` / `:route` /
+  "Register a `kind` id carrying NO `:handler-fn` (a `:route` /
   `:head`-shaped slot) with an explicit source-coord `provenance` envelope. The
   residual metadata is identical across calls except for provenance, so the B4
   shape table sees the SAME shape on re-register — exactly the case the old
@@ -373,15 +373,15 @@
   (registrar/register! kind id (merge (or provenance {}) {:doc "slot"})))
 
 (deftest collision-fires-for-no-handler-fn-kind-despite-shape-dedup
-  (testing "a :frame-kind cross-source reassignment WARNS even though its shape
+  (testing "a :route-kind cross-source reassignment WARNS even though its shape
             is dedup-identical (no rotating :handler-fn) — collision is decoupled
             from the handler-replaced dedup gate (rf2-3az1vn P2)"
     (let [recorded (record-traces! ::no-fn-collision)]
-      ;; Two DIFFERENT authoring sites register the SAME :frame id. No handler-fn
+      ;; Two DIFFERENT authoring sites register the SAME :route id. No handler-fn
       ;; on either, identical residual metadata → identical dedup shape.
-      (reg-no-handler-fn! :frame :surface/main
+      (reg-no-handler-fn! :route :surface/main
                           {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1})
-      (reg-no-handler-fn! :frame :surface/main
+      (reg-no-handler-fn! :route :surface/main
                           {:ns 'feature.b :file "feature/b.cljc" :line 20 :column 1})
       (let [replaced (filterv (fn [ev]
                                 (and (= :rf.registry (:op-type ev))
@@ -394,7 +394,7 @@
         (is (= 1 (count collisions))
             "the collision warning STILL fires — it is decoupled from the dedup gate")
         (let [t (:tags (first collisions))]
-          (is (= :frame (:kind t)))
+          (is (= :route (:kind t)))
           (is (= :surface/main (:id t)))
           (is (= 'feature.b (:ns (:source-coords t))))
           (is (= 'feature.a (:ns (:previous-coords t)))))))))
@@ -404,8 +404,8 @@
             decoupled collision check still keys on provenance, not shape"
     (let [recorded (record-traces! ::no-fn-same-source)
           coords   {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1}]
-      (reg-no-handler-fn! :frame :surface/hot coords)
-      (reg-no-handler-fn! :frame :surface/hot coords)
+      (reg-no-handler-fn! :route :surface/hot coords)
+      (reg-no-handler-fn! :route :surface/hot coords)
       (is (empty? (warnings-of recorded :rf.warning/registration-collision))
           "same (ns,file,line) re-eval is a hot reload — no collision even though
            the collision check now runs unconditionally"))))

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -146,9 +146,11 @@
                    :cofx :rf2-k84s/reg-cofx-sample)))
 
 (deftest source-coords-on-reg-frame
-  (testing "reg-frame stamps :ns / :line / :file"
+  (testing "reg-frame stamps :ns / :line / :file — read through `rf/frame-meta`
+            (rf2-h1vqa4: frames live in the frames store, not the registrar; the
+            macro-captured coords land on the stored frame config)"
     (rf/reg-frame :rf2-k84s/reg-frame-sample {:doc "smoke"})
-    (assert-coords (rf/handler-meta :frame :rf2-k84s/reg-frame-sample)
+    (assert-coords (rf/frame-meta :rf2-k84s/reg-frame-sample)
                    :frame :rf2-k84s/reg-frame-sample)))
 
 (deftest source-coords-on-reg-view

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -126,6 +126,20 @@
       ;; Re-register :inc with a different fn body to fire
       ;; :rf.registry/handler-replaced.
       (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+      ;; Re-register the SAME fx fn with changed metadata — fires
+      ;; :rf.registry/handler-replaced with :different-fn? false (a
+      ;; metadata-only replacement; no handler-fn rotation, but the changed
+      ;; :doc changes the B4 dedup shape so the emit is not suppressed).
+      ;; Frames no longer ride the registrar (rf2-h1vqa4), so an fx supplies
+      ;; the idempotent-fn replacement case here.
+      (let [same-fx (fn [_ _] :same)]
+        (rf/reg-fx :test/same-fx same-fx)
+        (rf/reg-fx :test/same-fx {:doc "same fn, new doc (rev 2)"} same-fx))
+      ;; Explicitly unregister an event so :rf.registry/handler-cleared has an
+      ;; emit source in the flow — destroying a frame no longer clears a
+      ;; registrar row (rf2-h1vqa4: frames have no registrar rows).
+      (rf/reg-event :short-lived (fn [_ _] {}))
+      (registrar/unregister! :event :short-lived)
 
       ;; Subs (used to demonstrate the absence of :sub/run / :sub/create
       ;; emit — see rf2-hyxg).
@@ -366,14 +380,14 @@
         (testing ":rf.registry :rf.registry/handler-replaced fires on EVERY re-registration (rf2-6w7zn)"
           ;; Per Spec 001 §Hot-reload trace surface the emit is
           ;; unconditional on re-registration — the prior `different-fn?`
-          ;; gate dropped events for kinds like `:frame` whose slot
+          ;; gate dropped events for kinds like `:route` whose slot
           ;; replacement need not rotate `:handler-fn`. Tools branch on
           ;; the `:different-fn?` tag (preserved below) to suppress
           ;; idempotent reload noise on their side.
           (is (has-op? events :rf.registry :rf.registry/handler-replaced)
               "expected :rf.registry :rf.registry/handler-replaced")
-          ;; The flow re-registers BOTH `:test/main` (a frame, same
-          ;; handler-fn) and `:inc` (an event, different fn body) so
+          ;; The flow re-registers BOTH `:test/same-fx` (same handler-fn,
+          ;; changed :doc) and `:inc` (an event, different fn body) so
           ;; both events fire. Find the `:inc` event explicitly so the
           ;; `:different-fn?` assertion targets the real fn-change case.
           (let [different-events (filterv (fn [ev]
@@ -391,7 +405,7 @@
             (is (seq different-events)
                 "expected at least one handler-replaced with :different-fn? true")
             (is (seq idempotent-events)
-                "expected at least one handler-replaced with :different-fn? false (frame re-reg)")
+                "expected at least one handler-replaced with :different-fn? false (same-fn fx re-reg)")
             (let [t (:tags (first different-events))]
               (is (keyword? (:kind t)))
               (is (some?    (:id t)))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -10,7 +10,7 @@
   artefact: apps load it with `(:require [re-frame.routing])`. Doing so
   transitively loads every runtime concern under `re-frame.routing.*` (each owns
   one cohesive concern, see below) and runs the registrations
-  (`reg-event` / `reg-fx` / `reg-sub` / `add-registration-hook!` /
+  (`reg-event` / `reg-fx` / `reg-sub` / the late-bind lifecycle hooks /
   `register-error-listener!` / `reg-view*`) at the bottom of this file.
 
   Registrations live here rather than in the concern namespaces so a
@@ -33,7 +33,7 @@
   - `re-frame.routing.navigate`       — :rf.route/navigate event
   - `re-frame.routing.url-change`     — :rf.route/transitioned + :rf.route/handle-url-change
   - `re-frame.routing.nav-fx`         — :rf.nav/push-url + :rf.nav/replace-url + url-owner-frame-id
-  - `re-frame.routing.url-bound`      — :url-bound? exclusivity registration hook
+  - `re-frame.routing.url-bound`      — :url-bound? exclusivity + claim-order maintenance
   - `re-frame.routing.history`        — strategy listener lifecycle + current-url
   - `re-frame.routing.subs`           — framework-shipped subs over the slice
   - `re-frame.routing.link`           — :route/link registered view"
@@ -293,13 +293,25 @@
 (fx/reg-fx :rf.nav/capture-scroll scroll/capture-scroll-meta scroll/capture-scroll-handler)
 (fx/reg-fx :rf.nav/scroll         scroll/scroll-fx-meta      scroll/scroll-fx-handler)
 
-;; The registration-hook collection survives reload, so install this hook
-;; once. Registration hooks observe only future registrations; reconcile the
-;; current frame registry on every facade load to seed an unambiguous existing
+;; Frame (re-)registration lifecycle hook (rf2-h1vqa4: frames do not flow
+;; through `registrar/register!`, so the former registrar registration hook is
+;; gone — the frame engine's `:routing/on-frame-registered!` late-bind hook is
+;; THE lifecycle point, fired AFTER the frame container exists and, on first
+;; registration, after `:initial-events` ran). The body is ORDERED: url-bound
+;; exclusivity + claim maintenance FIRST (both hosts — JVM routing tests
+;; resolve URL ownership too), THEN the CLJS browser-listener reconcile, so
+;; the owner resolution the reconcile performs sees current claims. Published
+;; via `late-bind/set-fn!` (key-idempotent — a facade `:reload` re-publishes,
+;; never stacks). The hook observes only future registrations; reconcile the
+;; current frames store on every facade load to seed an unambiguous existing
 ;; owner. Reconciliation is idempotent and fails closed when multiple
 ;; pre-existing bindings have no recoverable claim order.
-(defonce ^:private _url-bound-exclusivity-hook
-  (registrar/add-registration-hook! url-bound/check-url-bound-exclusivity!))
+(defn- on-frame-registered!
+  [frame-id]
+  (url-bound/check-url-bound-exclusivity! frame-id)
+  #?(:cljs (history/reconcile-url-listener!))
+  nil)
+(late-bind/set-fn! :routing/on-frame-registered! on-frame-registered!)
 (url-bound/reconcile-existing-url-bindings!)
 
 ;; Framework-shipped subs over routing runtime-db state. The derived
@@ -371,7 +383,8 @@
 
 ;; Registration-time frame-config preflight (rf2-ktmto9): routing owns the
 ;; MEANING of `:url-strategy` (presence semantics + host-required legs), core
-;; owns the TIMING — `re-frame.frame/reg-frame` invokes this hook with the
+;; owns the TIMING — the frame engine (`re-frame.frame/upsert-frame!`) invokes
+;; this hook with the
 ;; final expanded config BEFORE any candidate-derived write, so a malformed
 ;; declaration fails with zero residue (first registration) / preserves the
 ;; previous frame untouched (re-registration). Published on BOTH hosts — the
@@ -400,9 +413,10 @@
   ;; strategy when a live claimant remains (the ownership-transfer fix), tears
   ;; the listener down when no successor remains, and leaves the incumbent
   ;; instance untouched when a non-owner frame is destroyed. `frame-id` is passed
-  ;; as the EXCLUDED owner: this hook runs BEFORE core's `unregister-frame!`, so
-  ;; the destroyed frame's `:url-bound? true` registry entry still lingers and
-  ;; must not resolve as the owner via the claim-free fallback.
+  ;; as the EXCLUDED owner as defence in depth: by hook time the destroyed
+  ;; frame's `:destroyed?` flag is already flipped so `frame-meta` reads it as
+  ;; absent, but the exclusion keeps the must-not-resolve-as-owner contract
+  ;; explicit rather than timing-derived.
   (nav-fx/drop-url-claim! frame-id)
   #?(:cljs (history/reconcile-url-listener! frame-id))
   nil)
@@ -411,15 +425,15 @@
 
 ;; Browser URL-change wiring is strategy-aware and follows the URL-owning
 ;; frame's lifecycle. It is CLJS-only; SSR feeds request URLs through
-;; `:rf.route/handle-url-change`.
-;;
-;; Registration runs after the frame container exists, so the listener's
-;; synchronous initial URL dispatch has a valid target. Only the resolved URL
-;; owner installs; a losing duplicate does not replace the incumbent listener.
+;; `:rf.route/handle-url-change`. The listener reconcile rides the composed
+;; `:routing/on-frame-registered!` hook published above (after the url-bound
+;; claim maintenance) — it runs after the frame container exists, so the
+;; listener's synchronous initial URL dispatch has a valid target; only the
+;; resolved URL owner installs, and a losing duplicate does not replace the
+;; incumbent listener.
 ;;
 ;; The reset hook covers test fixtures that reset frame containers without
 ;; executing `destroy-frame!`.
-#?(:cljs (late-bind/set-fn! :routing/on-frame-registered! history/on-frame-registered!))
 #?(:cljs (late-bind/set-fn! :routing/reset-url-listener!  history/remove-url-listener!))
 
 ;; route-link is exposed on both platforms so .cljc render trees

--- a/implementation/routing/src/re_frame/routing/history.cljc
+++ b/implementation/routing/src/re_frame/routing/history.cljc
@@ -41,22 +41,23 @@
 
   Reconciliation runs from TWO lifecycle points:
 
-    - `on-frame-registered!` — `re-frame.frame/reg-frame`'s POST-CREATE hook
-      (`:routing/on-frame-registered!`, fired AFTER the frame container exists
-      and, on first registration, after `:initial-events` ran — the registrar's
-      OWN `:frame` registration hook,
-      `re-frame.routing.url-bound/check-url-bound-exclusivity!`, fires too
-      early: `registrar/register!` runs BEFORE the frame container is created,
-      so an install from there would dispatch the initial sync into a
-      not-yet-live frame). It reconciles after every (re-)registration, so a
+    - `re-frame.routing`'s `:routing/on-frame-registered!` hook body — the
+      frame engine (`re-frame.frame/upsert-frame!`) POST-CREATE hook, fired
+      AFTER the frame container exists (and, on first registration, after
+      `:initial-events` ran), so the listener's synchronous initial URL sync
+      always targets a live frame. The facade body runs the url-bound
+      exclusivity/claim maintenance FIRST (`re-frame.routing.url-bound`), then
+      calls `reconcile-url-listener!` — claims are current when the owner is
+      resolved. It reconciles after every (re-)registration, so a
       post-registration claim change (an owner opting out with `:url-bound?
       false` while a successor is live) rebinds to the successor's strategy.
     - `re-frame.routing/release-routing-host-caches!` —
       `frame/destroy-frame!`'s teardown hook. It drops the destroyed frame's
       URL claim and then reconciles, passing the destroyed id as the EXCLUDED
-      owner (the frame is still in the registrar here — `unregister-frame!`
-      runs after this hook — so its lingering `:url-bound? true` entry must not
-      resolve as the owner). A destroyed owner with a live successor rebinds to
+      owner (defence in depth: the destroyed frame is already invisible to
+      `frame-meta` reads by hook time — `:destroyed?` flipped earlier in the
+      teardown — but the exclusion keeps the contract explicit rather than
+      timing-derived). A destroyed owner with a live successor rebinds to
       it; a destroyed owner with no successor leaves no listener.
 
   A losing duplicate `:url-bound? true` registration (`id` is NOT the resolved
@@ -176,12 +177,12 @@
                                                           listener + initial
                                                           sync.
 
-     `excluded-id` (destroy path) is a frame whose registry entry still lingers
-     mid-teardown (`re-frame.frame/destroy-frame!` runs this hook BEFORE
-     `unregister-frame!`): its stale `:url-bound? true` entry could otherwise be
-     resolved as the sole owner by the claim-free fallback even though its claim
-     was just dropped, so a resolved owner equal to `excluded-id` is treated as
-     no owner.
+     `excluded-id` (destroy path) is the frame being torn down. By the time
+     `:routing/on-frame-destroyed!` fires, the destroyed frame's `:destroyed?`
+     flag is already flipped, so `frame-meta` reads it as absent and the
+     claim-free fallback cannot resolve it — the exclusion is defence in
+     depth (an explicit contract rather than a timing-derived one): a
+     resolved owner equal to `excluded-id` is treated as no owner.
 
      Ownership-driven, so ONE op serves both lifecycle points: it installs the
      successor when the incumbent relinquishes/is destroyed while a live
@@ -227,25 +228,16 @@
      []
      (teardown-current!)))
 
-#?(:cljs
-   (defn on-frame-registered!
-     "Post-(re-)registration frame-lifecycle hook: reconcile the browser URL
-     listener (`reconcile-url-listener!`). Ownership-driven, so it does the
-     right thing on every registration path — first URL owner installs; a frame
-     newly opting into `:url-bound? true` installs; an owner re-registering with
-     a changed `:url-strategy` rewires once; an owner opting OUT with
-     `:url-bound? false` while a successor is live rebinds to the successor's
-     strategy; and a losing-duplicate `:url-bound? true` registration (the
-     resolved owner is unchanged — `re-frame.routing.url-bound` already emitted
-     `:rf.error/duplicate-url-binding`) or an ordinary non-url-bound frame is a
-     no-op, leaving the incumbent listener instance untouched.
-
-     Published as the `:routing/on-frame-registered!` late-bind hook, invoked by
-     `re-frame.frame/reg-frame` AFTER the frame container exists (and, on first
-     registration, after `:initial-events` ran) — the registrar's OWN `:frame`
-     registration hook (`re-frame.routing.url-bound/check-url-bound-
-     exclusivity!`) fires too early for an install: `registrar/register!` runs
-     BEFORE the frame container is created, so a listener installed from there
-     would dispatch its initial sync into a not-yet-live frame."
-     [_id]
-     (reconcile-url-listener!)))
+;; The post-(re-)registration listener reconcile is composed into the facade's
+;; `:routing/on-frame-registered!` hook body (`re-frame.routing`), ORDERED
+;; AFTER the url-bound exclusivity/claim maintenance so `url-owner-frame-id`
+;; resolves against current claims. The facade calls
+;; `reconcile-url-listener!` directly — ownership-driven, so it does the right
+;; thing on every registration path: first URL owner installs; a frame newly
+;; opting into `:url-bound? true` installs; an owner re-registering with a
+;; changed `:url-strategy` rewires once; an owner opting OUT with
+;; `:url-bound? false` while a successor is live rebinds to the successor's
+;; strategy; and a losing-duplicate `:url-bound? true` registration (the
+;; resolved owner is unchanged — `re-frame.routing.url-bound` already emitted
+;; `:rf.error/duplicate-url-binding`) or an ordinary non-url-bound frame is a
+;; no-op, leaving the incumbent listener instance untouched.

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -16,7 +16,7 @@
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
   a fresh registrar."
-  (:require [re-frame.registrar :as registrar]
+  (:require [re-frame.frame :as frame]
             [re-frame.routing.strategy :as strategy]
             [re-frame.trace :as trace]))
 
@@ -36,13 +36,15 @@
 ;; must resolve to the frame that claimed `:url-bound? true` FIRST — the
 ;; incumbent — never to whichever id happens to sort earlier.
 ;;
-;; The registrar's `kind->id->metadata` is unordered, so registration order is
+;; The frames store (`re-frame.frame/frames`) is an unordered map, so
+;; registration order is
 ;; not recoverable from it. A separate claim-order vector is required; sorting
 ;; frame ids would allow a later duplicate to displace the incumbent.
 ;;
 ;; The fix records claim ORDER in this process-global vector. The url-bound
-;; exclusivity registration hook (`re-frame.routing.url-bound`, which already
-;; runs on every `:frame` registration) calls `record-url-claim!` / `drop-
+;; exclusivity check (`re-frame.routing.url-bound`, run from the
+;; `:routing/on-frame-registered!` lifecycle hook on every frame
+;; (re-)registration) calls `record-url-claim!` / `drop-
 ;; url-claim!` so the vector tracks, in claim order, which frames currently
 ;; carry `:url-bound? true`. Process-global like routing's other
 ;; intentionally-cross-frame slots (the route `reg-counter`, the
@@ -51,8 +53,8 @@
 ;; resolved across all frames, not per-frame.
 ;;
 ;; `url-owner-frame-id` returns the FIRST still-valid claimant — validated
-;; against the LIVE registry so the resolver self-heals if the incumbent later
-;; drops its binding (re-registers `:url-bound? false`) or is unregistered:
+;; against the LIVE frames store so the resolver self-heals if the incumbent
+;; later drops its binding (re-registers `:url-bound? false`) or is destroyed:
 ;; ownership then falls to the next-claimed frame that still carries
 ;; `:url-bound? true`, in claim order. Fail-closed: a frame never owns the URL
 ;; unless it is the first-claimed live `:url-bound? true` frame.
@@ -127,8 +129,8 @@
   `url-claim-order` (recorded by the
   url-bound exclusivity hook); this resolver walks it in claim order and
   returns the first id that STILL carries a live `:url-bound? true` binding in
-  the registry — so the incumbent always wins, and ownership self-heals to the
-  next claimant if the incumbent later drops its binding or is unregistered.
+  the frames store — so the incumbent always wins, and ownership self-heals to
+  the next claimant if the incumbent later drops its binding or is destroyed.
 
   When no claim is recorded yet (frames registered before the
   hook installed AND before the façade's `reconcile-existing-url-bindings!`
@@ -136,26 +138,29 @@
   (order is trivially known), but TWO OR MORE bound frames with unknowable
   claim order fails closed to nil rather than id-sorting.
 
+  Frame config is read from the frames store (`frame/frame-meta` — nil for a
+  destroyed / absent frame, so a dead claim reads as not-bound; rf2-h1vqa4:
+  frames have no registrar rows).
+
   Public (rather than `defn-`) so the ownership-resolution contract is
   directly assertable — the single declared-owner case the step-deck
   testbed relies on. A reimplemented gate cannot catch a
   regression in THIS resolution; the test must reach the real fn."
   []
-  (let [frames (registrar/registrations :frame)
-        bound? (fn [frame-id]
-                 (true? (url-bound?-from-config (get frames frame-id))))]
+  (let [bound? (fn [frame-id]
+                 (true? (url-bound?-from-config (frame/frame-meta frame-id))))]
     ;; Walk the claim order; the first frame whose binding is still live owns
     ;; the URL. A claimed-but-since-relinquished/destroyed frame is skipped
     ;; (self-healing).
     ;;
     ;; When no claim is recorded yet but `:url-bound? true` frame(s) exist in
-    ;; the registry (frames registered before the hook was
+    ;; the frames store (frames registered before the hook was
     ;; installed and before the façade's `reconcile-existing-url-bindings!`
     ;; seeded them, or a raw programmatic path), fall back to claim-free
     ;; resolution that NEVER steals:
     ;;   - exactly ONE bound frame → it owns (order is trivially known);
     ;;   - TWO OR MORE bound frames → claim order is genuinely unknowable
-    ;;     (the registrar map is unordered), so FAIL CLOSED to nil rather than
+    ;;     (the frames store is unordered), so FAIL CLOSED to nil rather than
     ;;     picking by id sort. nil here means 'no deterministic owner
     ;;     for this ambiguous load-order' — outbound pushes no-op and popstate
     ;;     skips until one binding is re-registered/removed through the live
@@ -165,10 +170,7 @@
     ;; in `url-claim-order`, so the first `some` branch resolves the incumbent.
     (or (some (fn [frame-id] (when (bound? frame-id) frame-id))
               @url-claim-order)
-        (let [bound (->> frames
-                         (filter (fn [[_id meta]]
-                                   (true? (url-bound?-from-config meta))))
-                         (map first))]
+        (let [bound (filterv bound? (frame/frame-ids))]
           (when (= 1 (count bound))
             (first bound))))))
 

--- a/implementation/routing/src/re_frame/routing/strategy.cljc
+++ b/implementation/routing/src/re_frame/routing/strategy.cljc
@@ -60,7 +60,7 @@
   Internal namespace; the public facade is `re-frame.routing`, which
   re-exports the two shipped strategies."
   (:require [re-frame.error :as error]
-            [re-frame.registrar :as registrar]))
+            [re-frame.frame :as frame]))
 
 ;; ---- history strategy (default) ------------------------------------------
 ;; Path-form. `:encode` / `:decode` are identity over the app-relative URL —
@@ -413,9 +413,10 @@
   the offending frame.
 
   Published as the `:routing/preflight-frame-config!` late-bind hook on
-  BOTH hosts; `re-frame.frame/reg-frame` (the one frame-config commit
+  BOTH hosts; the frame engine `re-frame.frame/upsert-frame!` (the one
+  frame-config commit
   chokepoint) invokes it with the final expanded config BEFORE any
-  candidate-derived write — the frame-record build, the registrar row, the
+  candidate-derived write — the frame-record build, the
   trace-policy flags, the frames swap, the `:initial-events` setup
   dispatch, and any trace emit — so a malformed declaration leaves NO
   residue on a first registration and preserves every previously committed
@@ -445,11 +446,13 @@
     history-url-strategy))
 
 (defn url-strategy-for-frame-id
-  "Resolve the `:url-strategy` for `frame-id` by reading its stored
-  `reg-frame` config, defaulting to `history-url-strategy`. `nil` frame-id
-  (or an unregistered frame) resolves to the history default. Used by the
+  "Resolve the `:url-strategy` for `frame-id` by reading its stored frame
+  config off the frames store (`frame/frame-meta` — rf2-h1vqa4: frames have
+  no registrar rows), defaulting to `history-url-strategy`. `nil` frame-id
+  (or an unregistered / destroyed frame — `frame-meta` returns nil) resolves
+  to the history default. Used by the
   `route-link` href render, which captures the render-time frame id."
   [frame-id]
   (if (nil? frame-id)
     history-url-strategy
-    (url-strategy-from-config (get (registrar/registrations :frame) frame-id))))
+    (url-strategy-from-config (frame/frame-meta frame-id))))

--- a/implementation/routing/src/re_frame/routing/url_bound.cljc
+++ b/implementation/routing/src/re_frame/routing/url_bound.cljc
@@ -1,15 +1,20 @@
 (ns re-frame.routing.url-bound
-  "`:url-bound?` exclusivity check + registration-hook install for
+  "`:url-bound?` exclusivity check + claim-order maintenance for
   re-frame2 routing.
 
   Per Spec 012 §Multi-frame routing — 'Only one frame can own the URL at
   a time': registering a second `:url-bound? true` frame emits
   `:rf.error/duplicate-url-binding` per Spec 009 §error event catalogue.
-  The check runs from a registrar registration hook so it
-  fires on BOTH first-time and re-registration paths.
+  The check runs from the frame (re-)registration lifecycle hook
+  (`:routing/on-frame-registered!`, fired by the frame engine
+  `re-frame.frame/upsert-frame!` on BOTH first-time registration and
+  re-registration — rf2-h1vqa4: frames do not flow through
+  `registrar/register!`, so there is no registrar registration hook for
+  frames; frame config is read from the frames store via
+  `frame/frame-meta`).
 
-  The recovery is `:no-recovery` per Spec 009. The registry remains
-  inspectable as-written, but `url-owner-frame-id` (in
+  The recovery is `:no-recovery` per Spec 009. The frame metadata remains
+  inspectable as-written (`rf/frame-meta`), but `url-owner-frame-id` (in
   `re-frame.routing.nav-fx`) enforces one active owner at fx time:
   non-owner `:rf.nav/push-url` / `:rf.nav/replace-url` calls no-op. The
   error surfaces the conflict; resolving it is the app's concern.
@@ -20,25 +25,25 @@
   incumbent and a later duplicate cannot steal the browser URL even if its id
   sorts before the incumbent.
 
-  `add-registration-hook!` observes only future registrations; it
-  does not replay existing registrations. So frames that claimed `:url-bound?
-  true` BEFORE `(require 're-frame.routing)` never recorded a claim, and the
-  claim order cannot be inferred from the registry map. The facade calls
-  `reconcile-existing-url-bindings!` after installing the hook to seed the
+  The lifecycle hook observes only registrations issued AFTER routing loads.
+  So frames that claimed `:url-bound? true` BEFORE `(require
+  're-frame.routing)` never recorded a claim, and the claim order cannot be
+  inferred from the frames store (an unordered map). The facade calls
+  `reconcile-existing-url-bindings!` after publishing the hook to seed the
   unambiguous incumbent (and fail closed on an unrecoverable multi-binding
   load-order), so first-claim-wins holds regardless of frame-vs-routing load
   order.
 
   Internal namespace; the public facade is `re-frame.routing`. The
-  facade owns the `registrar/add-registration-hook!` call. The hook is
-  process-lifetime state and survives reload; facade loads rerun the
-  idempotent reconciliation."
-  (:require [re-frame.registrar :as registrar]
+  facade owns the `:routing/on-frame-registered!` publication. Late-bind
+  publication is key-idempotent, so facade reloads simply re-publish;
+  facade loads rerun the idempotent reconciliation."
+  (:require [re-frame.frame :as frame]
             [re-frame.routing.nav-fx :as nav-fx]
             [re-frame.trace :as trace]))
 
 (defn- frame-id-of-existing-url-binding
-  "Scan the registrar's `:frame` map for any frame OTHER than `exclude-id`
+  "Scan the frames store for any live frame OTHER than `exclude-id`
   that currently carries an explicit `:url-bound? true`. Returns the
   offending frame-id or nil.
 
@@ -47,21 +52,24 @@
   when it carries an explicit `:url-bound? true` like any other frame; an
   un-annotated `:rf/default` is NOT an implicit owner."
   [exclude-id]
-  (some (fn [[other-id other-meta]]
+  (some (fn [other-id]
           (when (and (not= other-id exclude-id)
-                     (true? (nav-fx/url-bound?-from-config other-meta)))
+                     (true? (nav-fx/url-bound?-from-config
+                              (frame/frame-meta other-id))))
             other-id))
-        (registrar/registrations :frame)))
+        (frame/frame-ids)))
 
 (defn check-url-bound-exclusivity!
-  "Registration-hook fn. When a `:frame` registration carries
-  `:url-bound? true` AND another frame already owns the URL, emit
-  `:rf.error/duplicate-url-binding`. Per Spec 012 §Multi-frame routing
-  and Spec 009 §error event catalogue.
+  "Frame (re-)registration lifecycle body. When the just-(re)registered
+  frame's config carries `:url-bound? true` AND another frame already owns
+  the URL, emit `:rf.error/duplicate-url-binding`. Per Spec 012 §Multi-frame
+  routing and Spec 009 §error event catalogue. The frame's effective config
+  is read from the frames store (`frame/frame-meta`) — the engine fires the
+  hook AFTER the container + config are seated, so the read is always live.
 
-  Recovery per Spec 009 is `:no-recovery` — the offending registration's
-  storage has already been written by `registrar/register!`, but the
-  navigation fx (`:rf.nav/push-url` / `:rf.nav/replace-url`) consults
+  Recovery per Spec 009 is `:no-recovery` — the offending frame's config is
+  already seated in the frames store, but the navigation fx
+  (`:rf.nav/push-url` / `:rf.nav/replace-url`) consults
   `url-owner-frame-id`, so only the single active owner can mutate
   browser history. The app resolves the conflict by removing one of the
   bindings.
@@ -77,43 +85,42 @@
   incumbent can no longer steal the browser URL (Spec 012 §Multi-frame routing:
   the existing owner is unchanged, the duplicate's history-mutation fxs no-op).
 
-  Public so the façade can wire it via `registrar/add-registration-hook!`."
-  [{:keys [kind id now]}]
-  (when (= :frame kind)
-    (if (true? (nav-fx/url-bound?-from-config now))
-      (do
-        ;; Record the claim FIRST so the incumbent keeps its claim position; a
-        ;; duplicate appends after it and never steals ownership.
-        (nav-fx/record-url-claim! id)
-        (when-let [other (frame-id-of-existing-url-binding id)]
-          (trace/emit-error! :rf.error/duplicate-url-binding
-                             {:existing-frame  other
-                              :offending-frame id
-                              :reason          "Two frames carry :url-bound? true; only one frame may own the URL at a time."
-                              :recovery        :no-recovery})))
-      ;; A `:frame` registration that does NOT carry `:url-bound? true`
-      ;; relinquished any prior URL claim (e.g. `:rf/default {:url-bound?
-      ;; false}` opting out): drop it so a stale claim cannot keep a now-unbound
-      ;; frame at the head of the claim order. Idempotent.
-      (nav-fx/drop-url-claim! id))))
+  Public so the façade can compose it into its
+  `:routing/on-frame-registered!` hook body (both hosts)."
+  [id]
+  (if (true? (nav-fx/url-bound?-from-config (frame/frame-meta id)))
+    (do
+      ;; Record the claim FIRST so the incumbent keeps its claim position; a
+      ;; duplicate appends after it and never steals ownership.
+      (nav-fx/record-url-claim! id)
+      (when-let [other (frame-id-of-existing-url-binding id)]
+        (trace/emit-error! :rf.error/duplicate-url-binding
+                           {:existing-frame  other
+                            :offending-frame id
+                            :reason          "Two frames carry :url-bound? true; only one frame may own the URL at a time."
+                            :recovery        :no-recovery})))
+    ;; A frame registration that does NOT carry `:url-bound? true`
+    ;; relinquished any prior URL claim (e.g. `:rf/default {:url-bound?
+    ;; false}` opting out): drop it so a stale claim cannot keep a now-unbound
+    ;; frame at the head of the claim order. Idempotent.
+    (nav-fx/drop-url-claim! id)))
 
 (defn reconcile-existing-url-bindings!
-  "Reconcile `:url-bound? true` frames ALREADY in the registry when the
-  url-bound exclusivity hook is installed. Called by the facade after
-  `add-registration-hook!` and on reload, so frames registered
-  BEFORE `(require 're-frame.routing)` are not silently invisible to URL-
-  ownership resolution.
+  "Reconcile `:url-bound? true` frames ALREADY seated when the
+  url-bound exclusivity hook is published. Called by the facade after
+  publishing `:routing/on-frame-registered!` and on reload, so frames
+  registered BEFORE `(require 're-frame.routing)` are not silently invisible
+  to URL-ownership resolution.
 
-  `add-registration-hook!` observes only future registrations; it does not
-  replay existing registrations (re-frame.registrar
-  §registration-hooks). So a frame that claimed `:url-bound? true` before
+  The lifecycle hook observes only future registrations; it does not
+  replay existing ones. So a frame that claimed `:url-bound? true` before
   routing loaded never recorded a claim in `url-claim-order`, leaving the
   resolver without claim order. Choosing by frame id would violate Spec 012's
   rule that the existing owner remains unchanged.
 
-  Why this can't simply replay in true claim order: the registrar's
-  `(kind, id) → metadata` table is UNORDERED (re-frame.registrar), so the
-  registration order of frames registered before the hook existed is NOT
+  Why this can't simply replay in true claim order: the frames store is an
+  UNORDERED `{frame-id record}` map (`re-frame.frame/frames`), so the
+  registration order of frames seated before the hook existed is NOT
   recoverable. We therefore reconcile conservatively, preserving first-claim-
   wins where order is knowable and FAILING CLOSED where it is not:
 
@@ -132,10 +139,10 @@
   second call (e.g. a façade `:reload`) is a no-op. Public so the façade can
   invoke it and the load-order test can drive it directly."
   []
-  (let [bound-ids (->> (registrar/registrations :frame)
-                       (keep (fn [[id meta]]
-                               (when (true? (nav-fx/url-bound?-from-config meta))
-                                 id)))
+  (let [bound-ids (->> (frame/frame-ids)
+                       (filter (fn [id]
+                                 (true? (nav-fx/url-bound?-from-config
+                                          (frame/frame-meta id)))))
                        vec)]
     (cond
       (empty? bound-ids)

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -747,7 +747,7 @@
             fails LOUD with :rf.error/invalid-url-strategy at the
             registration-time PREFLIGHT — BEFORE any write — so EVERY previously
             committed value survives: the frames-registry record (config +
-            generation, the same object), the registrar row, the URL claim, and
+            generation, the same object), the URL claim, and
             the incumbent working listener instance; and no
             :rf.frame/re-registered trace fires. (#5633 proved only listener
             survival; the preflight makes the whole re-registration
@@ -758,7 +758,7 @@
     (let [incumbent       (first (get-in @*history-state* [:listeners "popstate"]))
           ;; SNAPSHOT the committed state before the malformed attempt.
           record-before   (get @frame/frames :owner/a)
-          registrar-before (get (rf/registrations :frame) :owner/a)
+          meta-before     (rf/frame-meta :owner/a)
           captured        (atom [])
           cb-key          (keyword (gensym "ktmto9-rereg-trace-"))]
       (is (some? incumbent) "A's popstate listener is installed")
@@ -785,8 +785,8 @@
         (is (identical? record-before (get @frame/frames :owner/a))
             "the frames-registry record (config + generation + containers) is
              the SAME object — the frames swap never ran")
-        (is (= registrar-before (get (rf/registrations :frame) :owner/a))
-            "the registrar row is unchanged — registrar/register! never ran")
+        (is (= meta-before (rf/frame-meta :owner/a))
+            "the frame-meta introspection surface is unchanged — no config commit")
         (is (= :owner/a (routing/url-owner-frame-id))
             "A still owns the URL — the claim order is unchanged")
         (is (empty? (filter #(= :rf.frame/re-registered (:operation %)) @captured))
@@ -812,11 +812,11 @@
 ;;
 ;; Pre-fix, a URL owner's FIRST registration with a malformed custom
 ;; :url-strategy threw only in the POST-create hook: the frame container was
-;; already built, the registrar row + trace-policy flags written, and the
+;; already built, the trace-policy flags written, and the
 ;; :initial-events setup had already RUN before validation fired. The
 ;; registration-time preflight (through :routing/preflight-frame-config!)
 ;; validates the FINAL expanded config BEFORE any candidate-derived write, so
-;; a failed first registration leaves NO frame record, NO registrar row, NO
+;; a failed first registration leaves NO frame record, NO
 ;; URL claim or listener, NO trace-policy residue, NO trace event, and NO
 ;; :initial-events effect — via BOTH constructor spellings.
 
@@ -840,8 +840,8 @@
           "the :initial-events setup step never ran — no probe increment")
       (is (not (contains? (set (rf/frame-ids)) frame-id))
           "no frame record was created")
-      (is (not (contains? (rf/registrations :frame) frame-id))
-          "no registrar row was written")
+      (is (nil? (rf/frame-meta frame-id))
+          "no frame config was seated (rf2-h1vqa4 — frames have no registrar rows)")
       (is (nil? (routing/url-owner-frame-id))
           "no URL claim was recorded")
       (is (empty? (get-in @*history-state* [:listeners "popstate"]))

--- a/implementation/routing/test/re_frame/routing_jvm_facade_noop_test.clj
+++ b/implementation/routing/test/re_frame/routing_jvm_facade_noop_test.clj
@@ -7,11 +7,12 @@
   `install-url-listener!` / `remove-url-listener!` facade wrappers were FOLDED
   into the `:url-bound?` frame lifecycle (rf2-g8pbwg) — a `:url-bound? true`
   frame installs its strategy listener on CREATE (CLJS) and removes it on
-  DESTROY, and the cross-feature hooks the core frame lifecycle consults
-  (`:routing/on-frame-registered!`, `:routing/reset-url-listener!`) are
-  published CLJS-only, so on the JVM `re-frame.frame`'s `fire-frame-registered-
-  hook!` finds no hook and skips (a graceful `when-let` no-op — never
-  `:rf.error/routing-artefact-missing`). The one remaining query-shaped export,
+  DESTROY. Per rf2-h1vqa4 `:routing/on-frame-registered!` is published on BOTH
+  hosts (its url-bound exclusivity / claim-order leg is host-agnostic); the
+  BROWSER-LISTENER leg inside its body is CLJS-only, so on the JVM the hook
+  runs the claim maintenance and skips the listener work (a graceful no-op —
+  never `:rf.error/routing-artefact-missing`). `:routing/reset-url-listener!`
+  stays CLJS-only. The one remaining query-shaped export,
   `current-url`, is published on BOTH hosts and returns `\"/\"` server-side.
 
   These tests pin, with routing PRESENT (required + reloaded by the suite
@@ -62,15 +63,16 @@
 
 (deftest url-bound-frame-lifecycle-is-a-noop-on-jvm-rf2-j1p1fv
   (testing "registering AND destroying a :url-bound? true frame on the JVM does
-            not throw — the browser listener install/teardown is CLJS-only, so
-            the :routing/on-frame-registered! / :routing/on-frame-destroyed!
-            frame-lifecycle hooks are a graceful no-op server-side (Spec 012 SSR
+            not throw — the browser listener install/teardown legs inside the
+            :routing/on-frame-registered! / :routing/on-frame-destroyed!
+            frame-lifecycle hooks are CLJS-only and skipped server-side, while
+            the host-agnostic claim maintenance still runs (Spec 012 SSR
             listener install is a no-op). A losing duplicate url-binding (the
             suite fixture already binds :rf/default) is REPORTED via a diagnostic
             but must never throw."
     (is (= :ok (outcome #(rf/reg-frame :zz/jvm-url-owner {:url-bound? true})))
         "reg-frame of a url-bound frame returns normally on the JVM — the
-         listener-install lifecycle hook is unpublished server-side and skipped")
+         listener-install leg is CLJS-only and skipped server-side")
     (is (= "/" (routing/current-url))
         "current-url still reads the SSR root while a url-bound frame is live")
     (is (= :ok (outcome #(frame/destroy-frame! :zz/jvm-url-owner)))

--- a/implementation/routing/test/re_frame/routing_test_support.clj
+++ b/implementation/routing/test/re_frame/routing_test_support.clj
@@ -67,8 +67,8 @@
   (routing/reset-nav-counters!)
   ;; rf2-3l7xxz: the URL-ownership claim-order vector is process-global state
   ;; (re-frame.routing.nav-fx/url-claim-order) that `clear-all!` / the `frames`
-  ;; reset above does NOT touch (the registrar's registration-hooks vector is
-  ;; `defonce` and survives `clear-all!`, so the `:rf/default` reg at the top
+  ;; reset above does NOT touch (the late-bind `:routing/on-frame-registered!`
+  ;; publication survives `clear-all!`, so the `:rf/default` reg at the top
   ;; DID record a claim through the still-live hook — but a PRIOR test's claims
   ;; also accumulated). Reset the vector here so the incumbent is deterministic
   ;; per test, then re-seat `:rf/default`'s claim so it is the first-claimed

--- a/implementation/routing/test/re_frame/routing_url_bound_test.clj
+++ b/implementation/routing/test/re_frame/routing_url_bound_test.clj
@@ -5,6 +5,7 @@
   Split from routing_test.clj per rf2-u8qe7y finding 3."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]
@@ -132,39 +133,39 @@
           ":rf/default opted out of URL ownership, so its push is suppressed"))))
 
 ;; ============================================================================
-;; rf2-25i7r7 — finding 1: reload idempotence of the url-bound registration hook
+;; rf2-25i7r7 — finding 1: reload idempotence of the url-bound lifecycle hook
 ;; ============================================================================
 ;;
-;; The registrar's `add-registration-hook!` appends to a process-`defonce`
-;; vector with no dedupe, and `clear-all!` does NOT clear it. Before the
-;; fix the facade called `add-registration-hook!` unconditionally at the
-;; top level, so every `(require 're-frame.routing :reload)` — the
-;; long-established `clear-all!` test-fixture recovery pattern, run on
-;; EVERY test by `reset-runtime` above, and any REPL hot-reload — stacked
-;; one more identical copy of `check-url-bound-exclusivity!`. N copies
-;; meant a single duplicate URL binding emitted N
-;; `:rf.error/duplicate-url-binding` diagnostics. The fix wraps the
-;; install in a `defonce` guard so it fires exactly once per process and
-;; survives reload (the registrar hooks vector is itself `defonce` and
-;; survives `clear-all!`).
+;; Historically the exclusivity check was a REGISTRAR registration hook
+;; (`add-registration-hook!` appends to a process-`defonce` vector with no
+;; dedupe), so an unguarded facade reload stacked one more identical copy per
+;; `(require 're-frame.routing :reload)` — a single duplicate URL binding then
+;; emitted N `:rf.error/duplicate-url-binding` diagnostics. Per rf2-h1vqa4 the
+;; check moved to the frame (re-)registration lifecycle hook
+;; (`:routing/on-frame-registered!`, fired by the frame engine — frames no
+;; longer flow through `registrar/register!`), published via
+;; `late-bind/set-fn!`, which is KEY-IDEMPOTENT: a reload re-publishes the one
+;; hook fn rather than stacking. The one-conflict → one-diagnostic invariant
+;; below is the behavioral pin; this test pins the ownership move itself.
 
-(deftest url-bound-hook-installed-exactly-once-across-reloads
-  (testing "rf2-25i7r7 finding 1: re-requiring re-frame.routing with
-            :reload does NOT stack additional copies of
-            check-url-bound-exclusivity! in the registrar's
-            registration-hooks vector — the defonce guard keeps it at one"
+(deftest url-bound-hook-is-not-a-registrar-hook
+  (testing "rf2-h1vqa4: the url-bound exclusivity check no longer rides the
+            registrar's registration-hooks vector (frames don't flow through
+            registrar/register!), and repeated facade reloads leave no copies
+            there — the lifecycle hook is the late-bind
+            :routing/on-frame-registered! publication, which is key-idempotent"
     ;; reset-runtime already did clear-all! + one :reload before this test.
     ;; Reload twice more to simulate repeated REPL/test recovery cycles.
     (require 're-frame.routing :reload)
     (require 're-frame.routing :reload)
-    (let [hooks @(deref #'registrar/registration-hooks)
-          ;; The url-bound hook is `check-url-bound-exclusivity!`; identify
-          ;; copies by fn identity (defonce keeps a single var binding, so
-          ;; idempotent installs share identity).
+    (let [hooks  @(deref #'registrar/registration-hooks)
           target url-bound/check-url-bound-exclusivity!
           copies (count (filter #(identical? target %) hooks))]
-      (is (= 1 copies)
-          "exactly one copy of the url-bound exclusivity hook after repeated reloads"))))
+      (is (zero? copies)
+          "the url-bound exclusivity check is absent from the registrar's
+           registration-hooks vector — it rides the frame lifecycle hook"))
+    (is (some? (late-bind/get-fn :routing/on-frame-registered!))
+        "the :routing/on-frame-registered! lifecycle hook is published")))
 
 (deftest one-conflict-emits-one-duplicate-binding-after-repeated-reloads
   (testing "rf2-25i7r7 finding 1: after reinstalling the routing facade
@@ -195,8 +196,8 @@
 ;; ============================================================================
 ;;
 ;; Spec 009's recovery text formerly said "the second binding is rejected;
-;; the existing URL-owning frame is unchanged." The registrar hook runs
-;; AFTER the slot is written, so the implementation cannot reject — it
+;; the existing URL-owning frame is unchanged." The lifecycle hook runs
+;; AFTER the frame config is seated, so the implementation cannot reject — it
 ;; stores both bindings and `url-owner-frame-id` resolves a single owner.
 ;; These tests pin the corrected (option-b) semantics: both bindings are
 ;; visible in frame metadata, the existing owner is unchanged, and only
@@ -339,9 +340,10 @@
 ;;              later, earlier-sorting duplicate STEAL the URL by id sort
 ;; ============================================================================
 ;;
-;; `registrar/add-registration-hook!` is an append-only FUTURE observer — it
-;; does NOT replay existing registrations. So a frame that claimed `:url-bound?
-;; true` BEFORE `(require 're-frame.routing)` never recorded a claim in
+;; The frame lifecycle hook (`:routing/on-frame-registered!`) is a FUTURE
+;; observer — it does NOT replay existing registrations. So a frame that
+;; claimed `:url-bound? true` BEFORE `(require 're-frame.routing)` never
+;; recorded a claim in
 ;; `url-claim-order`. The resolver's OLD claim-free fallback then sorted all
 ;; bound frames by `(str id)` and took the first — letting a later duplicate
 ;; whose id sorts BEFORE the true first-claimant WIN the alphabetical tiebreak

--- a/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_url_strategy_cljs_test.cljs
@@ -407,7 +407,7 @@
   (testing "rf2-ktmto9: a custom strategy carrying only the two host-agnostic
             legs (JVM-shaped) is rejected at FIRST registration on CLJS — the
             browser legs :push! / :replace! / :install-listener! are
-            host-required here; no registrar row / frame record is left"
+            host-required here; no frame record is left"
     (let [ex (try (rf/reg-frame :ktmto9/cljs-legs
                                 {:url-bound?   true
                                  :url-strategy {:encode identity
@@ -420,8 +420,8 @@
           "the ex-data names the offending frame")
       (is (contains? (set (:missing (ex-data ex))) :install-listener!)
           "the missing browser leg is named")
-      (is (not (contains? (rf/registrations :frame) :ktmto9/cljs-legs))
-          "no registrar row was written")
+      (is (nil? (rf/frame-meta :ktmto9/cljs-legs))
+          "no frame config was seated (rf2-h1vqa4 — frames have no registrar rows)")
       (is (not (contains? (set (rf/frame-ids)) :ktmto9/cljs-legs))
           "no frame record was created"))))
 
@@ -436,7 +436,8 @@
       (is (some? ex) "an explicit nil :url-strategy throws")
       (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
       (is (= :ktmto9/nil-strat (:frame (ex-data ex))))
-      (is (not (contains? (rf/registrations :frame) :ktmto9/nil-strat))))))
+      (is (nil? (rf/frame-meta :ktmto9/nil-strat))
+          "no frame config was seated"))))
 
 (deftest reg-frame-missing-routing-artefact-fails-loud-ktmto9-cljs
   (testing "rf2-ktmto9: declaring :url-strategy while the
@@ -453,8 +454,8 @@
         (is (some? ex) "declaring :url-strategy without the hook throws")
         (is (= :rf.error/routing-artefact-missing (:rf.error/id (ex-data ex))))
         (is (= :ktmto9/no-artefact (:frame (ex-data ex))))
-        (is (not (contains? (rf/registrations :frame) :ktmto9/no-artefact))
-            "no registrar row was written"))
+        (is (nil? (rf/frame-meta :ktmto9/no-artefact))
+            "no frame config was seated"))
       (finally
         (late-bind/set-fn! :routing/preflight-frame-config!
                            strategy/preflight-frame-config!)))))

--- a/implementation/routing/test/re_frame/routing_url_strategy_test.clj
+++ b/implementation/routing/test/re_frame/routing_url_strategy_test.clj
@@ -14,11 +14,12 @@
   `url-strategy-from-config` / `url-strategy-for-frame-id`. Per Spec 012
   §URL strategies."
   (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
             [re-frame.routing :as routing]
-            [re-frame.routing.strategy :as strategy]))
+            [re-frame.routing.strategy :as strategy]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ---- shipped-strategy shape ----------------------------------------------
 
@@ -367,24 +368,24 @@
                                          :decode (constantly "/")}})))))
 
 (deftest reg-frame-engine-rejects-malformed-strategy-before-any-write
-  (testing "rf2-ktmto9: the core engine (frame/reg-frame) preflights the
+  (testing "rf2-ktmto9: the core engine (frame/upsert-frame!) preflights the
             declared :url-strategy BEFORE any write — a malformed first
             registration throws :rf.error/invalid-url-strategy and leaves NO
-            registrar row and NO frame record (the fail-loud + no-residue
+            frame record (the fail-loud + no-residue
             invariant; pre-fix the throw came from the post-create hook, after
             the container + :initial-events already ran)"
-    (let [ex (try (frame/reg-frame :ktmto9/bad-jvm
-                                   {:url-bound?   true
-                                    :url-strategy {:decode (constantly "/")}})
+    (let [ex (try (frame/upsert-frame! :ktmto9/bad-jvm
+                                       {:url-bound?   true
+                                        :url-strategy {:decode (constantly "/")}})
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "the malformed first registration throws")
       (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
       (is (= :ktmto9/bad-jvm (:frame (ex-data ex))))
-      (is (not (contains? (registrar/registrations :frame) :ktmto9/bad-jvm))
-          "no registrar row was written")
       (is (not (contains? (set (frame/frame-ids)) :ktmto9/bad-jvm))
-          "no frame record was created"))))
+          "no frame record was created")
+      (is (nil? (frame/frame-meta :ktmto9/bad-jvm))
+          "the failed frame is invisible to frame-meta"))))
 
 (deftest reg-frame-missing-routing-artefact-fails-loud
   (testing "rf2-ktmto9: a config declaring :url-strategy while the
@@ -394,28 +395,32 @@
             validate or execute is worse than a dependency error"
     (try
       (late-bind/set-fn! :routing/preflight-frame-config! nil)
-      (let [ex (try (frame/reg-frame :ktmto9/no-artefact
-                                     {:url-bound?   true
-                                      :url-strategy strategy/history-url-strategy})
+      (let [ex (try (frame/upsert-frame! :ktmto9/no-artefact
+                                         {:url-bound?   true
+                                          :url-strategy strategy/history-url-strategy})
                     nil
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex) "declaring :url-strategy without the routing artefact throws")
         (is (= :rf.error/routing-artefact-missing (:rf.error/id (ex-data ex))))
         (is (= :ktmto9/no-artefact (:frame (ex-data ex))))
-        (is (not (contains? (registrar/registrations :frame) :ktmto9/no-artefact))
-            "no registrar row was written"))
+        (is (nil? (frame/frame-meta :ktmto9/no-artefact))
+            "no frame record was seated"))
       (finally
         (late-bind/set-fn! :routing/preflight-frame-config!
                            strategy/preflight-frame-config!)))))
 
-(deftest url-strategy-for-frame-id-reads-registry
-  (testing "url-strategy-for-frame-id reads the frame's stored config, defaulting
-            to history for an unregistered / nil frame"
+(deftest url-strategy-for-frame-id-reads-frames-store
+  (testing "url-strategy-for-frame-id reads the frame's stored config off the
+            frames store (rf2-h1vqa4 — frames have no registrar rows),
+            defaulting to history for an unregistered / nil frame"
+    ;; Real seated frames — the resolver reads `frame/frame-meta`, so the test
+    ;; must go through the engine (container creation needs an adapter).
+    (rf/init! plain-atom/adapter)
     (try
       ;; A hash-bound frame resolves to the hash strategy.
-      (registrar/register! :frame :test/hash-owner
+      (frame/upsert-frame! :test/hash-owner
                            {:url-bound? true :url-strategy strategy/hash-url-strategy})
-      (registrar/register! :frame :test/plain {:url-bound? true})
+      (frame/upsert-frame! :test/plain {:url-bound? true})
       (is (identical? strategy/hash-url-strategy
                       (strategy/url-strategy-for-frame-id :test/hash-owner)))
       (is (identical? strategy/history-url-strategy
@@ -428,5 +433,5 @@
                       (strategy/url-strategy-for-frame-id nil))
           "a nil frame-id resolves to the history default")
       (finally
-        (registrar/unregister! :frame :test/hash-owner)
-        (registrar/unregister! :frame :test/plain)))))
+        (frame/destroy-frame! :test/hash-owner)
+        (frame/destroy-frame! :test/plain)))))


### PR DESCRIPTION
## rf2-h1vqa4 — slice 1 of 3 (per the 2026-07-11 22:17 STRENGTHENED OPTION A ruling)

Slice 1 only: engine rename + the substrate ownership fix. Slices 2 (consumer migration by behavior) and 3 (facade/manifest/spec deletion) are later dispatches; the bead stays open.

### Engine rename
- `frame/reg-frame` → private `^:no-doc frame/upsert-frame!` — the name pins the refresh semantics (it refreshes SEATED ids too: surgical update, durable state preserved, `:initial-events` re-recorded never replayed; deliberately NOT install-frame!/ensure-frame!).
- `make-frame` (live_frame.cljc) and internal engine callers (`make-anon-frame-record!`, `ensure-default-frame!`) now call `upsert-frame!` directly.
- The PUBLIC `rf/reg-frame` facade exports (core.cljc fn alias + source-coord macro) TEMPORARILY delegate to `upsert-frame!` — scaffolding, not final; they die in slice 3. A thin `frame/reg-frame` alias def remains so the ~200 un-migrated in-tree `frame/reg-frame` call sites compile until slice 2 migrates consumers to public `rf/make-frame`. Public surface unchanged (reg-frame still exported, delegating); no spec/API.md or manifest changes in this slice per the ruling's fences.

### Substrate ownership fix (landed, not fenced)
`:frame` was a registrar kind: every seat/reseat ran `registrar/register! :frame`, which **recorded a `:frame` descriptor into the provenance source store and bumped the source-store generation** — invalidating the resolved-image-generation cache (EP-0023) and firing the live-frame reprojection hook for a change that is not a registration-pool change. A frame is a live runtime object, not a program member.

- The engine no longer writes/unregisters registrar `:frame` rows; the frames registry is the ONE store (`:frame` stays a reserved kind with an intentionally EMPTY slot — the `:flow` rf2-en00bk precedent; no Spec-001 grammar change needed this slice).
- Routing migrated off `registrar/registrations :frame` onto the frames store (`frame/frame-meta` / `frame/frame-ids`): `nav-fx/url-owner-frame-id`, `strategy/url-strategy-for-frame-id`, `url-bound` exclusivity + reconcile.
- The url-bound exclusivity/claim maintenance moved from the registrar registration hook to the frame lifecycle hook: `:routing/on-frame-registered!` is now published on BOTH hosts with an ordered body — (1) claim/exclusivity maintenance (host-agnostic), (2) CLJS-only strategy-aware listener reconcile. Late-bind publication is key-idempotent, so the old defonce-guarded hook-stacking concern (rf2-25i7r7) dissolves; the reload test now pins the ownership move + the one-conflict → one-diagnostic invariant.
- The #5688 (rf2-ktmto9) url-strategy preflight carries unchanged against the renamed engine; its tests (JVM + CLJS) migrated off direct `registrar/register! :frame` writes onto real seated frames / frame-meta assertions and stay green.
- New pin test (`frame-seating-writes-no-registrar-row-and-no-source-store-descriptor`): seat + reseat + destroy writes no registrar row, records no `:frame` source-store descriptor, and does NOT move `source-store/store-generation` — no image-descriptor churn, no default-generation cache invalidation.

### Validation matrix (ruling §Codex)
- reseat preserves state / no initial-event replay; destroy–recreate replays — existing lifecycle/EP-0024/EP-0027 suites green.
- no image-descriptor churn — new pin test above.
- routing green (JVM 418 tests / CLJS suites); SSR/Story surfaces ride the CLJS node suite.
- generation-cache regression watch — the pin test asserts the generation leg directly.

### Gates (foreground, post-rebase onto origin/main)
- core JVM: 1825 tests / 8082 assertions, 0 failures
- routing JVM: 418 tests / 2057 assertions, 0 failures
- CLJS node: 8691 tests / 41244 assertions, 0 failures
- bundle-isolation: PASS (all three checks)

Bead rf2-h1vqa4 stays OPEN — slices 2–3 remain.