### PR TITLE
feat(ui/S2d): epoch coalescing + flush! (rf2-vxgfnd.10)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -47,7 +47,68 @@
   `rf=`-stable read does not repaint downstream. Stabilization here is
   keyed by target identity `(frame, stabilized query)`; per-site query-
   object reuse (the parametric-args case) needs compile-site identity and
-  lands with the HMR site-identity slice (S2e)."
+  lands with the HMR site-identity slice (S2e).
+
+  ## Epoch coalescing + `flush!` scope (S2d — 03 §3 invariant 6; Spec 006
+  §Epoch finalization)
+
+  The sixth frozen invariant: EPOCH CLOSE NOTIFIES EACH DIRTY CELL ONCE.
+  Sub deltas mark their cell dirty through constant-work `on-change`
+  (never compute — I-5); the cell enters a module-level DIRTY REGISTRY
+  exactly once (a set, deduped by cell identity) and one coalesced flush
+  is scheduled per microtask (`interop/next-tick` — drain→React is
+  microtask-aligned) ON CLJS; the JVM headless host has no async render
+  loop, so it auto-schedules NOTHING and drains via the EXPLICIT `flush!`
+  (07 §2's only flush idiom; SSR is one-shot) — one honest option per
+  host. N sub deltas within one epoch therefore advance the cell's
+  revision ONCE. Coalescing is per-cell-per-flush-boundary; the
+  cross-epoch SEPARATION the push-economics bench asserts (8 epochs ⇒ 8
+  renders — G-5/G-13) rides the async drain boundaries and is wired with
+  the bench in S2f, not here.
+
+  `flush!` — the SYNCHRONOUS forcing of pending notifications — is SCOPED
+  over that registry. The Q51 scope ruling, PINNED here:
+
+    - `flush!` is PER-ROOT at the public boundary: it flushes the CALLING
+      root's pending commit work. The substrate primitive is a scoped
+      drain (`flush-scope!`), and the natural scope the substrate owns is
+      the FRAME — a dirty cell's pending work belongs to the frame(s) its
+      committed sites observe. Root scope COMPOSES over frame scope (a
+      root scopes ≥1 frame); the root→frames resolution lives in the
+      client root registry (where roots live — off this artefact's
+      surface), so the ROOT-spelled public `ui/flush!` / `flush-render!`
+      wires there (S2f). The substrate mechanism + the frame-scoped and
+      global spellings land HERE.
+    - `(flush-frame! frame-id)` — the frame arity — flushes every root
+      observing that frame (each dirty cell whose committed deps include
+      the frame).
+    - the GLOBAL all-roots flush is the TEST-ONLY `ui.test/flush!`
+      spelling (`flush-pending!` here). There is no app-facing global
+      flush — an app forces its own root, never every root.
+
+  A scoped flush leaves out-of-scope cells pending — no epoch work leaks
+  across roots. Flush is reentrancy-SAFE BY CONSTRUCTION: `flush-scope!`
+  atomically drains-then-notifies (`swap-vals!`), so a notify-triggered
+  re-entrant flush finds the registry already drained and cannot
+  double-advance a cell. The DEV-tier `:rf.error/flush-in-open-epoch`
+  signal — the DX guard naming a re-entrant flushSync-into-an-open-epoch
+  misuse (03 §11; Spec 006 §Epoch finalization) — is REFERENCED, not
+  emitted, here: its typed throw lands with its Spec 009 catalogue row in
+  the S2f 009 batch (the catalogue↔throw co-edit ratchet couples them,
+  and the reentrancy it guards is only reachable once mounted Tier-3
+  roots land).
+
+  ## The slice-scoped probe memo (S2d item 3 — 03 §3; Spec 006 §The
+  slice-scoped probe memo)
+
+  `sub-read` threads a SLICE-SCOPED pure memo (`obs/make-slice-memo`)
+  into every `probe`, so N sibling rows probing one query compute shared
+  derivation parents once per synchronous execution slice, not once per
+  row (the first-mount fan-out mitigation). The handle is created lazily
+  on the first probe of a slice and cleared on the next microtask
+  (`interop/next-tick`), so an abandoned slice's table is unreachable
+  garbage. The memo is an ECONOMY, never an authority — the commit
+  evidence comparison (step 5) corrects any staleness before paint."
   (:require [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.substrate.observation :as obs]
@@ -115,6 +176,41 @@
         (assoc-in [:by-key tk] {:target target :evidence ev :value value}))))
 
 ;; ---------------------------------------------------------------------------
+;; The slice-scoped probe memo (S2d item 3; 03 §3)
+;;
+;; ONE memo handle per synchronous execution slice, shared by every probe
+;; in the slice so sibling rows compute shared derivation parents once
+;; (the first-mount fan-out mitigation). Created lazily on the first probe
+;; of a slice; cleared on the next microtask so an abandoned slice's table
+;; is unreachable garbage. The memo is an ECONOMY only — commit step 5
+;; corrects any staleness before paint — so a single module holder (probes
+;; never nest across slices synchronously) is sufficient.
+;; ---------------------------------------------------------------------------
+
+(def ^:private slice-memo* (atom nil))
+
+(defn- current-slice-memo
+  "The current slice's probe memo handle — reused across every probe of
+  this synchronous slice, created lazily. On CLJS a fresh slice mints a
+  fresh handle and the old one is released on the next microtask (a true
+  `goog.async.nextTick` boundary firing AFTER the synchronous render pass).
+  On the JVM `next-tick` is a concurrent executor, not a microtask, so a
+  timer-driven clear would race a synchronous render; there the handle is
+  invalidated by the memo's own `(frame, frame-epoch, registry-epoch)` tag
+  on the next epoch (`slice-memo-table!`) and cleared between fixtures by
+  `reset-scheduler!`. The memo is an ECONOMY — commit step 5 corrects any
+  staleness before paint — so the coarser JVM lifetime is harmless."
+  []
+  (or @slice-memo*
+      (let [h (obs/make-slice-memo)]
+        (reset! slice-memo* h)
+        ;; Release OUR handle at slice end; a later slice may already have
+        ;; installed a newer one, so clear only while ours is still current.
+        #?(:cljs
+           (interop/next-tick (fn [] (compare-and-set! slice-memo* h nil))))
+        h)))
+
+;; ---------------------------------------------------------------------------
 ;; The ViewCell
 ;; ---------------------------------------------------------------------------
 
@@ -130,7 +226,8 @@
   ;;    :values    {tk -> value} ; last published site values (stabilization
   ;;                             ;   + the revision snapshot's evidence)
   ;;    :revision  int           ; get-snapshot returns this (useSyncExternalStore)
-  ;;    :dirty?    bool          ; coalescing flag for the async notify path
+  ;;    :dirty?    bool          ; pending-notification flag (epoch coalescing)
+  ;;    :dirty-epoch epoch|nil   ; the epoch the pending notification tags
   ;;    :latest-capture cap|nil  ; last finished render capture (commit input)
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]}   ; lifecycle facts (dev/tool; 03 §4)
@@ -157,6 +254,7 @@
             :values         {}
             :revision       0
             :dirty?         false
+            :dirty-epoch    nil
             :latest-capture nil
             :listeners      {}
             :intervals      []}))))
@@ -182,7 +280,7 @@
         site-ctx (cond-> {:query-v query}
                    (some? override) (assoc :override override))
         target   (obs/resolve-target site-ctx)
-        ev       (obs/probe target)
+        ev       (obs/probe target (current-slice-memo))
         v        (:value ev)
         {:keys [cell capture]} @ambient]
     (if (some? cell)
@@ -241,39 +339,153 @@
   (swap! (state cell) update :revision inc)
   (notify-listeners! cell))
 
-;; ---- the async dirty path (value-movement on watchable hosts) ---------------
+;; ---- epoch coalescing + the notification scheduler (S2d) --------------------
 ;;
-;; `on-change` is constant-work (mark-dirty; never compute — I-5). Multiple
-;; movements coalesce to one revision advance per microtask. (Exact
-;; once-per-epoch coalescing at the transaction boundary is S2d; per-tick
-;; coalescing here already satisfies the useSyncExternalStore contract.)
+;; `on-change` is constant-work (mark-dirty; never compute — I-5). A cell
+;; enters the module DIRTY REGISTRY exactly once per flush boundary (the
+;; set dedups by identity); N sub deltas in one epoch therefore advance
+;; the cell ONCE at flush. One coalesced async flush is scheduled per
+;; microtask (drain→React is microtask-aligned — 03 §3); `flush!` is the
+;; synchronous forcing, SCOPED so no epoch work leaks across roots. The
+;; Q51 scope ruling and the reentrancy contract live in the ns docstring.
 
-(defn flush-dirty!
-  "Run any pending coalesced notification synchronously (test seam + the
-  scheduled-flush body): if the cell is dirty, clear the flag and advance
-  the revision once."
+(defonce ^:private dirty-cells
+  ;; The set of ViewCells with a pending (unflushed) notification — the
+  ;; input to every scoped flush. `defonce` (module-lived); tests clear it
+  ;; via `reset-scheduler!`.
+  (atom #{}))
+
+(defonce ^:private flush-scheduled? (atom false))
+
+(declare flush-pending!)
+
+(defn- schedule-flush!
+  "Arm ONE coalesced microtask that drains the whole registry — the CLJS
+  host's realization of the microtask-aligned epoch close (03 §3). Re-marks
+  before it runs fold into the same flush; a synchronous `flush!` beforehand
+  just leaves it an empty drain.
+
+  CLJS-only: `interop/next-tick` there is a true `goog.async.nextTick`
+  microtask that fires AFTER the synchronous render pass. The JVM headless
+  host has NO async render loop to align to — its epoch close is the
+  EXPLICIT `flush!` (07 §2 'the only flush idiom'; SSR renders one-shot) —
+  and `next-tick` there is a CONCURRENT executor, not a microtask, so a
+  background auto-drain would race synchronous callers. One honest option
+  per host, not a pretended same mechanism (03 §3)."
+  []
+  #?(:cljs
+     (when (compare-and-set! flush-scheduled? false true)
+       (interop/next-tick
+         (fn []
+           (reset! flush-scheduled? false)
+           (flush-pending!))))
+     :clj nil))
+
+(defn mark-dirty!
+  "The `on-change` body: mark `cell` dirty for `epoch` and enrol it in the
+  dirty registry (once — a re-mark while already dirty coalesces), then
+  arm one microtask flush. Never acquires/releases (no reentrant-graph-op)
+  and never computes (I-5) — it flags a revision advance the scheduled
+  render re-probes. `epoch` (the moving frame's commit epoch, from the
+  `on-change` payload) tags the pending notification; nil when driven
+  without epoch evidence."
+  ([^ViewCell cell] (mark-dirty! cell nil))
+  ([^ViewCell cell epoch]
+   (let [st (state cell)]
+     (when-not (:dirty? @st)
+       (swap! st assoc :dirty? true :dirty-epoch epoch)
+       (swap! dirty-cells conj cell)
+       (schedule-flush!)))))
+
+(defn- flush-one!
+  "Clear `cell`'s pending flag and advance its revision once (the caller
+  has already removed it from the registry). No-op when not dirty —
+  idempotent under a concurrent drain."
   [^ViewCell cell]
   (let [st (state cell)]
     (when (:dirty? @st)
-      (swap! st assoc :dirty? false)
+      (swap! st assoc :dirty? false :dirty-epoch nil)
       (advance-revision! cell))))
 
-(defn mark-dirty!
-  "The `on-change` body (also the notification seam S2d refines to exact
-  once-per-epoch coalescing): mark the cell dirty and schedule one
-  coalesced flush. Never acquires/releases (no reentrant-graph-op) and
-  never computes (I-5) — it advances the revision, and the render it
-  schedules re-probes. Multiple marks before the scheduled flush coalesce
-  to one revision advance."
+(defn flush-scope!
+  "The scoped-flush PRIMITIVE: synchronously flush every pending cell for
+  which `(scope-pred cell)` is truthy, advancing each once; cells outside
+  the scope stay pending (no epoch work leaks across scopes). Reentrancy-
+  SAFE by construction — the matching cells are removed from the registry
+  ATOMICALLY (`swap-vals!`) before any notify, so a notify-triggered
+  re-entrant flush sees an already-drained set. Returns the count flushed."
+  [scope-pred]
+  (let [[old _] (swap-vals! dirty-cells
+                            (fn [cells] (into #{} (remove scope-pred) cells)))
+        flushed (filterv scope-pred old)]
+    (doseq [cell flushed]
+      (flush-one! cell))
+    (count flushed)))
+
+(defn flush-pending!
+  "GLOBAL drain — flush EVERY pending cell once (the test-only all-roots
+  spelling `ui.test/flush!` rides this). Returns the count flushed."
+  []
+  (flush-scope! (constantly true)))
+
+(defn- cell-frames
+  "The set of frame-ids `cell`'s committed subscription sites observe."
   [^ViewCell cell]
-  (let [st (state cell)]
-    (when-not (:dirty? @st)
-      (swap! st assoc :dirty? true)
-      (interop/next-tick #(flush-dirty! cell)))))
+  (into #{}
+        (keep (fn [tk] (when (= :sub (nth tk 0)) (nth tk 1))))
+        (keys (:committed @(state cell)))))
+
+(defn cell-observes-frame?
+  "True when `cell`'s committed dependency set includes a site in frame
+  `frame-id` (the frame-scope membership test)."
+  [^ViewCell cell frame-id]
+  (contains? (cell-frames cell) frame-id))
+
+(defn flush-frame!
+  "The FRAME arity of `flush!` — flush every pending cell observing frame
+  `frame-id` (every root that observes that frame). Cells scoped to other
+  frames stay pending. Returns the count flushed."
+  [frame-id]
+  (flush-scope! #(cell-observes-frame? % frame-id)))
+
+(defn flush-dirty!
+  "Synchronously flush THIS cell's pending notification, if any (test seam
+  + the per-cell forcing door). Returns nil."
+  [^ViewCell cell]
+  (flush-scope! #(identical? % cell))
+  nil)
+
+(defn- discard-pending!
+  "Drop `cell`'s pending notification WITHOUT advancing its revision —
+  used at disconnect/teardown so an unmounted or dead cell never lingers
+  in the registry or fires a stale flush. Returns nil."
+  [^ViewCell cell]
+  (swap! dirty-cells disj cell)
+  (swap! (state cell) assoc :dirty? false :dirty-epoch nil)
+  nil)
+
+(defn dirty?
+  "True when `cell` has a pending (unflushed) notification (tool/test read)."
+  [^ViewCell cell]
+  (boolean (:dirty? @(state cell))))
+
+(defn pending-cell-count
+  "The number of cells with a pending notification (tool/test read)."
+  []
+  (count @dirty-cells))
+
+(defn reset-scheduler!
+  "Test support: drop every pending notification and the slice memo without
+  advancing any revision — a clean slate between fixtures. Returns nil."
+  []
+  (reset! dirty-cells #{})
+  (reset! flush-scheduled? false)
+  (reset! slice-memo* nil)
+  nil)
 
 (defn- on-change-fn
   [^ViewCell cell]
-  (fn [_payload] (mark-dirty! cell)))
+  (fn [payload] (mark-dirty! cell (:frame-epoch payload))))
 
 ;; ---- lifecycle (03 §4) ------------------------------------------------------
 ;;
@@ -337,6 +549,7 @@
   (let [st (state cell)]
     (when (contains? #{:fresh :connected} (:lifecycle @st))
       (release-committed! cell)
+      (discard-pending! cell)
       (swap! st (fn [m]
                   (-> m
                       (assoc :lifecycle :disconnected)
@@ -358,6 +571,7 @@
         (swap! st update :intervals conj
                {:state :unmounted :reason :unmounted :proof :host-teardown}))
       (release-committed! cell)
+      (discard-pending! cell)
       (swap! st assoc :lifecycle :dead))
     cell))
 

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -39,8 +39,10 @@
   above. Handing a CSS string to `find`, a structural tree to `query`,
   or a DOM element to `attrs`/`text` is a typed error
   (`:rf.error/ui-test-tier-mismatch`) pointing at the other tier.
-  Tier-3 mounting (`with-root` / `flush!` / `simulate!`) lands with the
-  mount/reactivity slices (S1c/S2) — `query` has no live behaviour yet.
+  Tier-3 mounting (`with-root` / `simulate!`, and `flush!`'s React-`act`
+  half) lands with the mount/reactivity slices (S1c/S2) — `query` has no
+  live behaviour yet; `flush!`'s host-agnostic epoch-drain half is landed
+  (S2d, the global spelling of the Q51 flush scope ruling).
 
   ## JVM semantics under test (06 §1 subset)
 
@@ -464,6 +466,32 @@
   events, re-render, assert on the new tree."
   [frame-target event]
   (router/dispatch-sync! event {:frame frame-target})
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; flush! — the epoch drain (07 §2 "act + epoch drain + commit — the only
+;; flush idiom")
+;; ---------------------------------------------------------------------------
+
+(defn flush!
+  "`(flush!)` — the TEST-ONLY GLOBAL all-roots flush (07 §2's single flush
+  idiom): synchronously drain EVERY pending ViewCell notification, closing
+  the framework epoch so pending sub deltas advance their cells' revisions
+  before the test's next assertion.
+
+  This is the GLOBAL spelling of the Q51 scope ruling (03 §3; recorded in
+  `re-frame.ui.reactive`): app code forces PER-ROOT (`ui/flush!`, S2f) or
+  per-frame (`reactive/flush-frame!`); only the test surface flushes every
+  root at once. Returns nil.
+
+  Scope note — the epoch-drain half is host-agnostic and lands here; the
+  `act()`/`flushSync` wrapping that also settles React's own commit for a
+  MOUNTED Tier-3 root (`with-root`) rides the mount slice, since no mounted
+  root exists to settle until then. On the JVM Tier-1 surface renders are
+  one-shot (no mounted cells), so a `flush!` there drains an empty registry
+  — honest, not a stub."
+  []
+  (reactive/flush-pending!)
   nil)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -21,7 +21,23 @@
       idempotent (kept-check retains unchanged leases untouched); the
       lifecycle layout effect (empty deps) owns connect/disconnect, so
       React unmount / Activity hide releases owners and reveal reacquires
-      and corrects before paint."
+      and corrects before paint.
+
+  ## Epoch close → React (S2d)
+
+  Sub deltas do NOT re-render synchronously. A moving site's `on-change`
+  (registered at commit) marks the cell dirty in `reactive`'s epoch-scoped
+  registry (constant-work, coalesced once per cell per epoch); one
+  microtask-aligned flush advances the cell's revision, `getSnapshot`
+  moves, and this component re-renders. React BATCHING is inherited, not
+  hand-rolled: `useSyncExternalStore` routes every revision advance
+  through React's own scheduler, so N cells flushed in one drain settle in
+  ONE render pass, and adding an explicit batch wrapper here would only
+  fight React's ownership of the schedule. The synchronous forcing door is
+  `reactive/flush-frame!` / `ui.test/flush!` (the Q51 scope ruling —
+  03 §3); the commit reconciler's own step-8 advance already runs inside
+  this layout effect (React's commit phase), correcting moved evidence
+  before paint without any flush call."
   (:require ["react" :as react]
             [re-frame.ui.reactive :as reactive]))
 

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -1,0 +1,223 @@
+(ns re-frame.ui.reactive-epoch-cljs-test
+  "rf2-vxgfnd.10 (S2d) — epoch coalescing + `flush!` scope over the ViewCell
+  notification scheduler (03 §3 invariant 6 'epoch close notifies each dirty
+  cell once'; Spec 006 §Epoch finalization). Headless fixtures on the REAL
+  observation port + plain-atom sub-cache — the value-movement `on-change`
+  watch channel is a reactive-host surface, so these fixtures drive the
+  notification seam DIRECTLY (`mark-dirty!` with an epoch tag) exactly the
+  way the reactive spine's watch fan-out would, then force with `flush!`.
+
+  The rows:
+
+    - EPOCH COALESCING — N sub deltas within one epoch advance a cell's
+      revision ONCE (the sixth frozen invariant); a fresh epoch after the
+      flush notifies again;
+    - flush! SCOPE (the Q51 ruling) — the frame arity `flush-frame!` flushes
+      only cells observing that frame; a scoped `flush-scope!` leaves
+      out-of-scope cells pending; the global `flush-pending!` /
+      `ui.test/flush!` drains every root;
+    - NO EPOCH WORK LEAKS ACROSS ROOTS — a per-frame / per-scope flush never
+      advances a cell outside its scope;
+    - REENTRANCY-SAFE BY CONSTRUCTION — a notify-triggered re-entrant flush
+      finds the registry already drained and cannot double-advance (the
+      safety the dev-tier `:rf.error/flush-in-open-epoch` signal, whose
+      typed throw + Spec 009 catalogue row ride the S2f 009 batch, sits atop);
+    - DISCARD ON DISCONNECT/TEARDOWN — an unmounted cell leaves the registry
+      without a stale flush;
+    - THE SLICE-SCOPED PROBE MEMO — `sub-read` threads one memo per slice, so
+      sibling probes compute shared derivation parents once.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` / `test:ui` (node)
+  AND `clojure -M:test` (JVM), so the scheduler is graft-checked on both."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]
+            [re-frame.ui.test              :as uit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- sub-cache [] (:sub-cache (frame/frame fid)))
+(defn- entry [q] (get @(sub-cache) q))
+(defn- seed! [id db] (frame/replace-app-db! id db))
+(defn- tk [id q] [:sub id q])
+
+(defn- rc!
+  "Render (probe) `queries` under frame `id`, then commit — the cell ends
+  observing `id`."
+  [cell id queries]
+  (rf/with-frame id
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  (reactive/commit! cell)
+  cell)
+
+;; ===========================================================================
+;; Epoch coalescing — N deltas within one epoch → ONE notification
+;; ===========================================================================
+
+(deftest n-deltas-in-one-epoch-notify-once
+  (let [cell (reactive/make-cell ::v)
+        hits (atom 0)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (testing "N sub deltas in ONE epoch (same epoch tag) coalesce to one advance"
+      (dotimes [_ 5] (reactive/mark-dirty! cell 7))
+      (is (reactive/dirty? cell) "the cell is pending")
+      (is (= 1 (reactive/pending-cell-count)) "enrolled ONCE despite 5 deltas")
+      (reactive/flush-pending!)
+      (is (= 1 (reactive/revision cell)) "N deltas → ONE revision advance")
+      (is (= 1 @hits) "N deltas → ONE notification")
+      (is (not (reactive/dirty? cell)))
+      (is (= 0 (reactive/pending-cell-count))))
+    (testing "a fresh epoch after the flush notifies again (not swallowed)"
+      (reactive/mark-dirty! cell 8)
+      (reactive/flush-pending!)
+      (is (= 2 (reactive/revision cell)))
+      (is (= 2 @hits)))))
+
+(deftest coalescing-is-independent-of-the-epoch-tag-while-pending
+  ;; while already pending, ANY further delta folds in — the coalescing
+  ;; gate is the pending flag; the epoch tag is evidence, not a second key.
+  (let [cell (reactive/make-cell ::v)
+        hits (atom 0)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/mark-dirty! cell 1)
+    (reactive/mark-dirty! cell 2)          ;; different tag, still pending
+    (reactive/mark-dirty! cell 2)
+    (reactive/flush-pending!)
+    (is (= 1 (reactive/revision cell)))
+    (is (= 1 @hits) "still one notification across the flush boundary")))
+
+;; ===========================================================================
+;; flush! scope (the Q51 ruling) + no epoch work leaks across roots
+;; ===========================================================================
+
+(deftest scoped-flush-leaves-out-of-scope-cells-pending
+  (let [c1 (reactive/make-cell ::c1)
+        c2 (reactive/make-cell ::c2)]
+    (reactive/mark-dirty! c1 1)
+    (reactive/mark-dirty! c2 1)
+    (is (= 2 (reactive/pending-cell-count)))
+    (testing "a scoped flush advances only the matching cell"
+      (is (= 1 (reactive/flush-scope! #(identical? % c1))) "one cell flushed")
+      (is (= 1 (reactive/revision c1)))
+      (is (= 0 (reactive/revision c2)) "the out-of-scope cell stays put — no leak")
+      (is (reactive/dirty? c2))
+      (is (= 1 (reactive/pending-cell-count))))
+    (testing "the remaining scope flushes independently"
+      (reactive/flush-scope! #(identical? % c2))
+      (is (= 1 (reactive/revision c2)))
+      (is (= 0 (reactive/pending-cell-count))))))
+
+(deftest flush-frame-flushes-only-that-frames-cells
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/make-frame {:id ::f2})
+  (seed! fid  {:a 1})
+  (seed! ::f2 {:a 2})
+  (let [c1 (rc! (reactive/make-cell ::c1) fid   [[:r/a]])
+        c2 (rc! (reactive/make-cell ::c2) ::f2  [[:r/a]])]
+    (is (= #{(tk fid  [:r/a])} (reactive/committed-target-keys c1)))
+    (is (= #{(tk ::f2 [:r/a])} (reactive/committed-target-keys c2)))
+    (is (reactive/cell-observes-frame? c1 fid))
+    (is (reactive/cell-observes-frame? c2 ::f2))
+    (is (not (reactive/cell-observes-frame? c1 ::f2)) "frames are isolated scopes")
+    (reactive/mark-dirty! c1 (frame/frame-commit-epoch fid))
+    (reactive/mark-dirty! c2 (frame/frame-commit-epoch ::f2))
+    (testing "flush-frame! flushes only the cells observing that frame"
+      (is (= 1 (reactive/flush-frame! fid)) "only the :rf/default cell")
+      (is (= 1 (reactive/revision c1)))
+      (is (= 0 (reactive/revision c2)) "the ::f2 cell's epoch work did not leak across roots")
+      (is (reactive/dirty? c2)))
+    (testing "the other frame flushes on its own scope"
+      (is (= 1 (reactive/flush-frame! ::f2)))
+      (is (= 1 (reactive/revision c2)))
+      (is (= 0 (reactive/pending-cell-count))))))
+
+(deftest global-flush-drains-every-root
+  (let [c1 (reactive/make-cell ::c1)
+        c2 (reactive/make-cell ::c2)
+        c3 (reactive/make-cell ::c3)]
+    (doseq [c [c1 c2 c3]] (reactive/mark-dirty! c 1))
+    (is (= 3 (reactive/pending-cell-count)))
+    (testing "ui.test/flush! is the test-only GLOBAL all-roots spelling"
+      (uit/flush!)
+      (is (= 1 (reactive/revision c1)))
+      (is (= 1 (reactive/revision c2)))
+      (is (= 1 (reactive/revision c3)))
+      (is (= 0 (reactive/pending-cell-count))))))
+
+;; ===========================================================================
+;; Reentrancy — safe by construction (the flush-in-open-epoch safety net)
+;; ===========================================================================
+
+(deftest reentrant-flush-during-notify-does-not-double-advance
+  (let [cell (reactive/make-cell ::v)
+        hits (atom 0)]
+    ;; a listener that re-enters the GLOBAL flush from inside its own notify
+    (reactive/subscribe cell (fn []
+                               (swap! hits inc)
+                               (reactive/flush-pending!)))  ;; re-entrant
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (is (= 1 (reactive/revision cell))
+        "the atomic drain-then-notify means the re-entrant flush sees an
+         empty registry — one advance, never two")
+    (is (= 1 @hits))))
+
+;; ===========================================================================
+;; Discard on disconnect / teardown — no stale flush of an unmounted cell
+;; ===========================================================================
+
+(deftest disconnect-discards-pending-notification
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! fid {:a 1})
+  (let [cell (rc! (reactive/make-cell ::v) fid [[:r/a]])]
+    (reactive/mark-dirty! cell 1)
+    (is (= 1 (reactive/pending-cell-count)))
+    (reactive/disconnect! cell)
+    (is (= :disconnected (reactive/lifecycle cell)))
+    (is (not (reactive/dirty? cell)) "a disconnected cell holds no pending flush")
+    (is (= 0 (reactive/pending-cell-count)) "and leaves the registry")
+    (testing "a later global flush does not advance the unmounted cell"
+      (reactive/flush-pending!)
+      (is (= 0 (reactive/revision cell))))))
+
+(deftest teardown-discards-pending-notification
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! fid {:a 1})
+  (let [cell (rc! (reactive/make-cell ::v) fid [[:r/a]])]
+    (reactive/mark-dirty! cell 1)
+    (reactive/teardown! cell)
+    (is (= :dead (reactive/lifecycle cell)))
+    (is (= 0 (reactive/pending-cell-count)) "teardown drops the pending flush")))
+
+;; ===========================================================================
+;; The slice-scoped probe memo — sibling probes share derivation parents
+;; ===========================================================================
+
+(deftest slice-memo-shares-derivation-parents-within-one-render
+  (let [parent-runs (atom 0)]
+    (rf/reg-sub :s/parent (fn [db _] (swap! parent-runs inc) (:n db)))
+    (rf/reg-sub :s/a :<- [:s/parent] (fn [n _] [:a n]))
+    (rf/reg-sub :s/b :<- [:s/parent] (fn [n _] [:b n]))
+    (seed! fid {:n 5})
+    (reactive/reset-scheduler!)          ;; a clean slice
+    (reset! parent-runs 0)
+    (let [cell (reactive/make-cell ::v)
+          out  (rf/with-frame fid
+                 (reactive/with-capture cell
+                   (fn [] [(reactive/sub-read [:s/a])
+                           (reactive/sub-read [:s/b])])))]
+      (is (= [[:a 5] [:b 5]] out))
+      (is (= 1 @parent-runs)
+          "sibling cold probes in ONE render compute the shared parent ONCE
+           via the slice-scoped memo threaded through sub-read")
+      (is (nil? (entry [:s/parent])) "probes stayed ownership-free — no cache node"))))


### PR DESCRIPTION
Lands the sixth frozen invariant — **epoch close notifies each dirty cell once** — and the scoped `flush!` surface, over the just-merged S2b ViewCell. Surface: `reactive.cljc` + `viewcell.cljs` + `ui/test.cljc` + a new dual-host test. Closes rf2-vxgfnd.10.

## What landed

**1. Epoch coalescing.** A moving site's `on-change` marks its cell dirty in a module-level dirty registry (deduped by cell identity, tagged with the payload's `frame-epoch`). N sub deltas within one epoch advance the cell's revision **once**. On CLJS one coalesced flush is scheduled per microtask (`interop/next-tick` — drain→React microtask-aligned, 03 §3); the JVM headless host auto-schedules nothing and drains via the explicit `flush!` (one honest option per host — there is no async React render loop to align a microtask drain to). The committed push-economics bench (G-13/G-5, 8 epochs ⇒ 8 renders) rides S2f, per the bead.

**2. `flush!` + the Q51 scope ruling** (see below).

**3. Slice-scoped probe memo.** `sub-read` threads one `obs/make-slice-memo` per synchronous slice into `probe`, so sibling rows compute shared derivation parents once (the first-mount fan-out mitigation). CLJS clears the handle on the next microtask; JVM by the memo's own `(frame, frame-epoch, registry-epoch)` tag. React batching is inherited from `useSyncExternalStore` (not hand-rolled). Unmounted/dead cells are discarded from the registry at disconnect/teardown so no stale flush fires.

## Q51 — flush! scope (PINNED)

`flush!` is **PER-ROOT** at the public boundary: it flushes the *calling root's* pending commit work. The substrate primitive is a scoped drain (`flush-scope!`) and the natural scope the substrate owns is the **FRAME** — a dirty cell's pending work belongs to the frame(s) its committed sites observe. The three spellings compose over the one primitive:

- **Root** (`ui/flush!` / `flush-render!`) — the app-facing sync door; root→frames resolution lives in the client root registry (where roots live — off this artefact's surface), so the root-spelled public wiring lands in **S2f**. The substrate mechanism + the two spellings below land here.
- **Frame** (`reactive/flush-frame!`) — flushes every root observing that frame.
- **Global all-roots** — the **test-only** `ui.test/flush!` spelling (`reactive/flush-pending!`). No app-facing global flush exists.

A scoped flush leaves out-of-scope cells pending — **no epoch work leaks across roots** — and is **reentrancy-safe by construction** (atomic drain-then-notify via `swap-vals!`, so a notify-triggered re-entrant flush finds the registry already drained). The ruling is recorded in the `re-frame.ui.reactive` ns docstring, the `ui.test/flush!` docstring (with the 07 §2 alignment note), and the tests.

**Reentrancy / `:rf.error/flush-in-open-epoch`.** Checked spec/009 first: the row is **not** catalogued (only referenced in spec/006 §Epoch finalization + 03 §11). Per the bead it is **referenced, not emitted** here — its typed throw + Spec 009 catalogue row ride the S2f 009 batch (the catalogue↔throw co-edit ratchet in `error_catalogue_channel_conformance` couples them; shipping the throw now would fail that gate). The implementation is already reentrancy-safe without it; the dev signal is a DX guard reachable only once mounted Tier-3 roots land.

## Quality gates

Foreground, 0-fail on the ui transitive surface:

- `npm run test:cljs` (full node suite, incl. core + ui + all artefacts): **8922 tests, 42107 assertions — 0 failures, 0 errors**
- `implementation/ui` JVM (`clojure -M:test`, dual-host graft of the `.cljc` fixtures): **205 tests, 4273 assertions — 0 failures, 0 errors**
- `implementation/core` JVM (`clojure -M:test`, incl. the catalogue-conformance SOURCE-SCAN that validates the deferred throw): **1852 tests, 8234 assertions — 0 failures, 0 errors**
- `scripts/test-fast-pr.sh`: **PASS** (all python gates, per-ns isolation, markdown gates green; mkdocs soft-skipped on Windows)

Rebased cleanly onto `origin/main` after the S2c merge (which changed `observation.cljc` / `ui.cljc`); re-ran node + ui-JVM post-rebase — both green.

## Surface discipline

Confined to `reactive.cljc`, `viewcell.cljs`, `ui/test.cljc`, and the new `reactive_epoch_cljs_test.cljc`. No edits to `spec/009`, `compiler/*`, `client.cljs`, or `frames.cljc` (S2c-owned).
