### PR TITLE
fix(ui): total root teardown + idempotent mount retry (rf2-vxgfnd.18)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -231,7 +231,13 @@
   then `createRoot` + registration + render. A preflight failure
   therefore fails the mount loudly with the container untouched — no
   React root, no live-root registration, no render; retry = re-call
-  `mount`. Registration still precedes any render (contract §7 Layer 3).
+  `mount`. Registration still precedes any render (contract §7 Layer 3);
+  if that FIRST render (element thunk or host `.render`) throws, the mount
+  rolls back TOTALLY — the exact claim is released and the host root is
+  best-effort unmounted, so a retry starts clean (no phantom live root),
+  and the original error is rethrown even if cleanup also throws. A failed
+  RE-render on an already-live root is the distinct case: the existing
+  root stays registered with its last committed render intact (Q49).
   Returns the Root."
   [{:keys [root-id] :as info} container element-thunk react-opts plans-thunk]
   (require-container! 're-frame.ui/mount root-id container)
@@ -253,8 +259,20 @@
               root       (Root. react-root container root-id)]
           ;; register BEFORE any render (contract §7 Layer 3)
           (register-live-root! info container root)
-          (.render react-root (element-thunk))
-          root)))))
+          (try
+            (.render react-root (element-thunk))
+            root
+            (catch :default e
+              ;; TOTAL rollback of a failed FIRST mount — the element thunk
+              ;; or the synchronous host render threw. Release this exact
+              ;; claim (identity-guarded: a stale handle never evicts a
+              ;; newer root) and best-effort unmount the host root so a
+              ;; retry starts clean, with no phantom live root and no host
+              ;; root residue. Rethrow the ORIGINAL mount error even if the
+              ;; host cleanup also throws (cleanup never masks it).
+              (release-root! root-id root)
+              (try (.unmount react-root) (catch :default _ nil))
+              (throw e))))))))
 
 (defn create-root*
   "Runtime half of `ui/create-root` — claim identity + container and
@@ -311,10 +329,16 @@
 (defn unmount!*
   "Runtime half of `ui/unmount!` — TOTAL teardown: unmount the React root
   and unregister the root-id (contract §7). Idempotent: a Root already
-  torn down (or superseded in the registry) is a no-op. Returns nil."
+  torn down (or superseded in the registry) is a no-op. Framework
+  ownership is released in a `finally`, so a throwing host `.unmount`
+  still frees the exact root-id/container claim (identity-guarded — never
+  evicts a newer claim) and a second `unmount!*` is then a no-op; the
+  host teardown error still propagates to the caller. Returns nil."
   [^Root root]
   (when (and (some? root)
              (identical? (:root (get @live-roots (.-root-id root))) root))
-    (.unmount (.-react-root root))
-    (release-root! (.-root-id root) root))
+    (try
+      (.unmount (.-react-root root))
+      (finally
+        (release-root! (.-root-id root) root))))
   nil)

--- a/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
@@ -153,6 +153,67 @@
         (ui/unmount! root2)))))
 
 ;; ---------------------------------------------------------------------------
+;; exception-safety: total teardown + idempotent mount retry (rf2-vxgfnd.18)
+;; ---------------------------------------------------------------------------
+
+(deftest failed-first-mount-leaves-no-phantom-and-retries-clean
+  ;; criterion 2 — a throwing element thunk on a FIRST mount rolls back
+  ;; TOTALLY: no live-root/container claim, the host root best-effort
+  ;; unmounted, the ORIGINAL error rethrown, and a subsequent mount clean.
+  (when (browser?)
+    (let [c    (container)
+          info {:root-id :dom-throw/x :provenance :authored}
+          boom (fn [] (throw (ex-info "element thunk boom" {:tag :element})))]
+      (is (thrown-with-msg? cljs.core/ExceptionInfo #"element thunk boom"
+                            (react-dom/flushSync #(client/mount* info c boom nil nil)))
+          "the original mount error propagates")
+      (is (not (contains? (client/live-root-ids) :dom-throw/x))
+          "no phantom live root remains after the failed first mount")
+      (is (nil? (client/live-root-entry :dom-throw/x)))
+      ;; retry on the SAME container + root-id via the public API succeeds
+      (let [root (react-dom/flushSync
+                  #(ui/mount [mini-app {:title "retry ok"}] c {:root-id :dom-throw/x}))]
+        (is (some? root))
+        (is (re-find #"retry ok" (.-innerHTML c))
+            "a clean retry mounts successfully into the freed container")
+        (ui/unmount! root)))))
+
+;; criterion 3 (a synchronous host `.render` throw AFTER host creation) is
+;; covered by the SAME rollback catch as the thunk throw above: `mount*`
+;; wraps `(.render react-root (element-thunk))` as one unit, so the thunk
+;; throw exercises the identical release + best-effort-unmount + rethrow
+;; path. There is deliberately no separate "component throws during render"
+;; fixture: under React 19 an uncaught render-phase error does NOT
+;; propagate synchronously out of `.render` — React reports it
+;; (onUncaughtError) and internally unmounts the tree, and `.render`
+;; returns normally, so the root stays legitimately registered (no
+;; phantom). A genuine synchronous `.render` throw is a host-tier
+;; invariant, not a component error, and is not reliably reproducible here.
+
+(deftest re-render-failure-keeps-existing-root-registered
+  ;; criterion 6 — the DISTINCT case: a throwing RE-render on an
+  ;; already-live root leaves that root registered and its last committed
+  ;; render intact (no rollback — the root was live before this call).
+  (when (browser?)
+    (let [c    (container)
+          root (react-dom/flushSync
+                #(ui/mount [mini-app {:title "committed"}] c
+                           {:root-id :dom-rerender/x}))]
+      (is (re-find #"committed" (.-innerHTML c)))
+      (let [info {:root-id :dom-rerender/x :provenance :authored}
+            boom (fn [] (throw (ex-info "re-render boom" {})))]
+        ;; same root-id + same container -> the idempotent re-render branch
+        (is (thrown-with-msg? cljs.core/ExceptionInfo #"re-render boom"
+                              (react-dom/flushSync #(client/mount* info c boom nil nil))))
+        (is (contains? (client/live-root-ids) :dom-rerender/x)
+            "the existing root stays registered on a failed re-render")
+        (is (identical? root (:root (client/live-root-entry :dom-rerender/x)))
+            "it is the same Root — not evicted or replaced")
+        (is (re-find #"committed" (.-innerHTML c))
+            "its last committed render is intact"))
+      (ui/unmount! root))))
+
+;; ---------------------------------------------------------------------------
 ;; frame-root: transparent render + the preflight seam
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -93,6 +93,45 @@
   (is (nil? (client/unmount!* (fake-root :never/registered))))
   (is (nil? (client/unmount!* nil))))
 
+(defn- root-with-throwing-unmount [root-id container]
+  ;; a Root whose host react-root's `.unmount` throws — exercises the
+  ;; unmount!* teardown boundary without a real React root (the registry
+  ;; release must still run in the `finally`).
+  (let [rr (js-obj)]
+    (unchecked-set rr "unmount"
+                   (fn [] (throw (js/Error. "host teardown boom"))))
+    (client/->Root rr container root-id)))
+
+(deftest unmount-releases-claim-even-when-host-teardown-throws
+  ;; rf2-vxgfnd.18 — TOTAL teardown: a throwing host `.unmount` must not
+  ;; strand the framework claim. The registry release rides a `finally`,
+  ;; the host error still propagates, and a second unmount!* is a no-op.
+  (let [c    (js-obj)
+        root (root-with-throwing-unmount :reg/boom c)]
+    (client/register-live-root! {:root-id :reg/boom :provenance :authored} c root)
+    (is (= #{:reg/boom} (client/live-root-ids)))
+    (is (thrown-with-msg? js/Error #"host teardown boom"
+                          (client/unmount!* root))
+        "the host teardown error propagates to the caller")
+    (is (= #{} (client/live-root-ids))
+        "the exact claim is released despite the throw (finally-shaped)")
+    (is (nil? (client/unmount!* root))
+        "a second unmount!* is a no-op — the claim is already gone")))
+
+(deftest unmount-throw-release-is-identity-guarded
+  ;; a STALE handle whose root-id now maps to a NEWER root must not evict
+  ;; the newer claim, even on the throwing-teardown path (the `when` guard
+  ;; short-circuits before `.unmount` is ever called).
+  (let [c        (js-obj)
+        newer    (fake-root :reg/id)
+        stale    (root-with-throwing-unmount :reg/id c)]
+    (client/register-live-root! {:root-id :reg/id :provenance :authored} c newer)
+    (is (nil? (client/unmount!* stale))
+        "a stale handle is a no-op — its throwing .unmount is never reached")
+    (is (= #{:reg/id} (client/live-root-ids))
+        "the newer claim survives")
+    (is (identical? newer (:root (client/live-root-entry :reg/id))))))
+
 ;; ---------------------------------------------------------------------------
 ;; React root options
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes the two remaining non-total exception paths in `re-frame.ui.client`
total, mirroring the S2c/Q49 atomicity posture (no residue). Narrow
exception-safety fix — not a redesign.

## The two paths

**1. `mount*` (failed FIRST mount).** Previously the live root was
registered before the compiled element thunk was evaluated and passed to
host `.render`; if either threw, the root-id/container claim stayed
installed and the React root was never unmounted, so a retry saw a phantom
live root. Registration still precedes render (contract §7 Layer 3), but
the render is now wrapped in a `catch`-rollback: release the exact claim
(identity-guarded — a stale handle never evicts a newer root) and
best-effort unmount the host root, then rethrow the **original** error even
if cleanup also throws. A retry starts clean. The idempotent RE-render
branch is deliberately unchanged: a throwing re-render on an already-live
root keeps that root registered with its last committed render intact (the
distinct Q49 case).

**2. `unmount!*` (throwing host teardown).** Previously `.unmount` ran
before the registry release, so a throwing teardown skipped the release
permanently. The release now rides a `finally`: framework ownership is
freed even when host `.unmount` throws, a second `unmount!*` is then a
no-op (identity guard), and the host teardown error still propagates.

## Tests (adversarial fixtures)

- Registry (node): `unmount!*` releases the exact claim in a `finally`
  despite a throwing host `.unmount` (host error propagates; second call a
  no-op); the throwing-teardown path stays identity-guarded against a stale
  handle.
- DOM (browser): a throwing element thunk on a first mount rolls back
  totally (no phantom live root, clean retry via the public API); a
  throwing re-render keeps the existing root registered with its last
  committed render intact.

Note on acceptance criterion 3 (a synchronous `.render` throw): under React
19 an uncaught render-phase error is **not** rethrown synchronously out of
`.render` (React reports it via `onUncaughtError` and internally unmounts),
so a component that throws during render leaves a legitimately-registered
root, not a phantom. Because `mount*` wraps `(.render (element-thunk))` as
one `try` unit, the element-thunk-throw fixture exercises the identical
rollback catch; a comment in the test file documents why there is no
separate component-render fixture.

## Quality gates

All foreground, on the rebased base (origin/main incl. S2d epoch
coalescing).

- `scripts/test-fast-pr.sh`: PASS (exit 0) — includes `core JVM`,
  `CLJS node integration`, per-ns isolation, and all Python/docs gates.
- `npm run test:cljs` (node): Ran 8927 tests / 42122 assertions —
  **0 failures, 0 errors**.
- `npm run test:browser` (Playwright/chromium, includes the ui DOM
  fixtures): Ran 283 tests / 993 assertions — **0 failures, 0 errors**.

Closes rf2-vxgfnd.18.
