### PR TITLE
refactor(resources): collapse dead declassify branch + single-eval scope :inputs (rf2-2dmtyl)

### DIFF
--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -484,48 +484,48 @@
 ;; the raw evidence (the row is dev observability — the leak is at off-box /
 ;; epoch / MCP egress, not the local listener).
 
-(defn scope-resolver-egress-sensitive?
-  "FAIL-CLOSED off-box egress classification for a `:rf.resource/scope-resolved`
-  row's resolver `scope-id` (rf2-84l82t). A db-reading resolver MAY read a
-  frame-sensitive path the off-box walk cannot prove safe (the row carries the
-  resolved VALUES, not the path provenance), so the resolved `:input-values` /
-  `:scope` are UNCONDITIONALLY egress-sensitive: a resolver derives a tenant /
-  user / impersonation identity that must not ride an off-box wire raw.
-  EP-0025 (rf2-71dr8t) removed the `:rf.egress/output-sensitivity :rf.egress/
-  public` declassification escape hatch (it was the propagation enum), so the
-  off-box redaction is now always-on for any resolved-scope row — the trusted-
-  local `:include-sensitive?` opt-in at the epoch consumer is the only lift.
-  The `scope-id` arg is retained for the row-attribution signature the epoch
-  projector calls with; the result is constant `true`. Pure."
-  [_scope-id]
-  true)
-
 (defn project-scope-resolved-egress
   "Project a `:rf.resource/scope-resolved` trace row's `tags` for OFF-BOX
-  egress (rf2-84l82t). When the row's resolver
-  (`scope-resolver-egress-sensitive?`) is egress-sensitive (the fail-closed
-  default for any db-reading resolver not explicitly declassified), the
-  resolved `:input-values` (the raw db reads) and `:scope` (the derived
-  identity tuple, which embeds those reads) are replaced by the `:rf/redacted`
-  sentinel and the row is stamped `:sensitive? true`. The STRUCTURAL slots —
-  `:resource-id` (the resolver id), `:kind`, the declared input NAMES
-  (`:inputs`), `:whole-db?`, `:resolved-nil?` — ride verbatim (they carry no
-  user value and a tool needs them to attribute the resolution). An explicitly
-  declassified (`:rf.egress/public`) resolver rides verbatim. Idempotent
-  (`:rf/redacted` re-redacts to itself); a non-map `tags` rides unchanged.
-  Pure. The on-box listener path never calls this — the raw evidence stays for
-  dev tooling; this is the OFF-BOX egress projector."
+  egress (rf2-84l82t). The resolved `:input-values` (the raw db reads) and
+  `:scope` (the derived identity tuple, which embeds those reads) are
+  UNCONDITIONALLY replaced by the `:rf/redacted` sentinel and the row is
+  stamped `:sensitive? true`. The redaction is FAIL-CLOSED: a db-reading
+  resolver MAY read a frame-sensitive path the off-box value-path walk cannot
+  prove safe (the row carries the resolved VALUES, not the path provenance),
+  so a resolved tenant / user / impersonation identity must never ride an
+  off-box wire raw. EP-0025 (rf2-71dr8t) removed the
+  `:rf.egress/output-sensitivity :rf.egress/public` declassification escape
+  hatch, so the redaction is now always-on for every resolved-scope row — the
+  trusted-local `:include-sensitive?` opt-in at the epoch consumer is the only
+  lift. The STRUCTURAL slots — `:resource-id` (the resolver id), `:kind`, the
+  declared input NAMES (`:inputs`), `:whole-db?`, `:resolved-nil?` — ride
+  verbatim (they carry no user value and a tool needs them to attribute the
+  resolution). Idempotent (`:rf/redacted` re-redacts to itself); a non-map
+  `tags` rides unchanged. Pure. The on-box listener path never calls this —
+  the raw evidence stays for dev tooling; this is the OFF-BOX egress
+  projector."
   [tags]
   (if-not (map? tags)
     tags
-    (if (scope-resolver-egress-sensitive? (:resource-id tags))
-      (-> tags
-          (assoc :input-values :rf/redacted
-                 :scope        :rf/redacted
-                 :sensitive?   true))
-      tags)))
+    (-> tags
+        (assoc :input-values :rf/redacted
+               :scope        :rf/redacted
+               :sensitive?   true))))
 
 ;; ---- the pure resolve helper (Spec 016 §`clear-scope` … coeffect db) ------
+
+(defn- resolve-scope-from-inputs
+  "PURE core of resolver evaluation: given the ALREADY-EVALUATED resolver
+  `in-vals`, call `:resolve` with `(in-vals nil)` (the `ctx` arg is reserved,
+  literal nil in this slice), then route a non-nil result through the SHARED
+  concrete-scope canonicalization path (`state/canonicalize-scope`). A nil
+  result passes through as nil (the fail-closed unresolved condition). Shared
+  by `resolve-scope*-pure` and the traced `resolve-scope*` wrapper so a single
+  causal resolution evaluates its declared `:inputs` exactly ONCE."
+  [scope-id spec in-vals where]
+  (let [raw ((:resolve spec) in-vals nil)]
+    (when (some? raw)
+      (state/canonicalize-scope raw where scope-id))))
 
 (defn resolve-scope*-pure
   "PURE: resolve resolver `spec` against `db`, returning a canonical scope
@@ -545,10 +545,7 @@
   `resolve-scope*` wrapper layers the `:rf.resource/scope-resolved` evidence
   on for CAUSAL boundaries (events / routes / mutations)."
   [scope-id spec db where]
-  (let [in-vals (eval-inputs (:inputs spec) db)
-        raw     ((:resolve spec) in-vals nil)]
-    (when (some? raw)
-      (state/canonicalize-scope raw where scope-id))))
+  (resolve-scope-from-inputs scope-id spec (eval-inputs (:inputs spec) db) where))
 
 (defn resolve-scope*
   "Resolve resolver `spec` against `db` AND emit the dev-time
@@ -564,8 +561,8 @@
   cannot classify, so the resource family owns their OFF-BOX egress projector
   (`project-scope-resolved-egress`, published as
   `:resources/project-scope-resolved-egress` and consulted by the epoch
-  tool-pair): fail-closed redaction for any db-reading resolver not explicitly
-  declassified (rf2-84l82t / EP-0015). The on-box listener keeps the raw
+  tool-pair): unconditional fail-closed redaction for every db-reading
+  resolver (rf2-84l82t / EP-0015). The on-box listener keeps the raw
   evidence (the leak is at off-box / epoch / MCP egress, not the local
   listener). Tooling reads the declared inputs to avoid unnecessary whole-db
   re-resolution and to mark the whole-db-sugar cost (EP-0015 disposition 8).
@@ -576,7 +573,7 @@
   [scope-id spec db where]
   (let [inputs   (:inputs spec)
         in-vals  (eval-inputs inputs db)
-        resolved (resolve-scope*-pure scope-id spec db where)]
+        resolved (resolve-scope-from-inputs scope-id spec in-vals where)]
     (trace/emit! :rf.event :rf.resource/scope-resolved
                  {:resource-id   scope-id
                   :kind          :resource-scope

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -506,21 +506,6 @@
       (is (:sensitive? proj) "the row is stamped sensitive")
       (is (= [:locale] (:inputs proj)) "the structural input NAMES ride verbatim"))))
 
-(deftest scope-resolver-egress-sensitive-always-fail-closed
-  ;; EP-0025: off-box resolved-scope egress is unconditionally sensitive — the
-  ;; declassify escape hatch is gone (rf2-71dr8t).
-  (testing "the predicate is sensitive for an unregistered resolver"
-    (is (true? (scope-registry/scope-resolver-egress-sensitive? :t/never-registered))))
-  (testing "the predicate is sensitive for a db-reading resolver"
-    (is (true? (scope-registry/scope-resolver-egress-sensitive? :t/session))))
-  (testing "a resolver that once declared :rf.egress/public is STILL sensitive
-            (the declassify hatch was removed)"
-    (rf/reg-resource-scope :t/public2
-      {:inputs {:locale [:db [:i18n :locale]]}
-       :rf.egress/output-sensitivity :rf.egress/public}
-      (fn [{:keys [locale]} _] (when locale [:rf.scope/locale {:locale locale}])))
-    (is (true? (scope-registry/scope-resolver-egress-sensitive? :t/public2)))))
-
 ;; ===========================================================================
 ;; rf2-oo8cv7 — the DIRECT :rf.resource/invalidate-tags event resolves a
 ;; `{:from-db <id>}` :scope SYMMETRICALLY with ensure / clear-scope (Spec 016


### PR DESCRIPTION
P3 elegance/clarity cleanup in `implementation/resources/src/re_frame/resources/scope_registry.cljc`, surfaced by EP-0025's declassification removal (rf2-2dmtyl). No runtime behaviour change.

## Fix 1 — collapse the dead declassify branch + stale docs

`scope-resolver-egress-sensitive?` had become `(constantly true)` after EP-0025 (rf2-71dr8t) removed the `:rf.egress/output-sensitivity :rf.egress/public` declassification enum, so `project-scope-resolved-egress` carried an **unreachable** `tags`-verbatim else-branch (`(if (scope-resolver-egress-sensitive? …) <redact> tags)`).

- Delete the constant predicate and its only production call.
- Collapse `project-scope-resolved-egress` to an **unconditional** fail-closed redaction (keeping the non-map `tags` guard), folding the fail-closed rationale into its docstring.
- Delete the stale "An explicitly declassified (`:rf.egress/public`) resolver rides verbatim" docstring sentence, and tighten the sibling "not explicitly declassified" qualifier in `resolve-scope*`'s docstring to "unconditional … for every db-reading resolver".
- Remove the now self-referential `scope-resolver-egress-sensitive-always-fail-closed` test (it only asserted the deleted `(constantly true)` predicate). The observable redaction contract stays covered by the two `project-scope-resolved-egress` tests (`…redacts-resolver-values` + `…no-declassify-escape-hatch`).

## Fix 2 — single-eval the scope `:inputs`

`resolve-scope*` evaluated the declared `:inputs` via `eval-inputs` for the trace `:input-values`, then `resolve-scope*-pure` evaluated the *same* `(:inputs spec)`/`db` **again** (the declared `:db` paths were `get-in`'d twice per causal resolution). Extract a private `resolve-scope-from-inputs` that takes the already-evaluated `in-vals`; both `resolve-scope*-pure` and the traced `resolve-scope*` route through it, so a causal resolution evaluates its `:inputs` **exactly once**. `eval-inputs` is pure, so behaviour is equivalent.

## Quality gates

All run in the foreground on the worktree, 0-fail:

- `scripts/test-fast-pr.sh` → `PASS fast PR spine`; 8922 tests / 42112 assertions, 0 failures, 0 errors; per-ns isolation all 15 namespaces pass standalone; markdown gates skipped (no `.md` changes). Exit 0.
- resources artefact tests (`clojure -M:test` in `implementation/resources`) → 670 tests / 6402 assertions, 0 failures, 0 errors.
- `npm run test:cljs` → 8922 tests / 42112 assertions, 0 failures, 0 errors.

Closes rf2-2dmtyl.
