### PR TITLE
fix(ui/compiler): build registries are a pure function of current inputs (rf2-vxgfnd.16)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -9,6 +9,7 @@
   namespace stays loadable everywhere."
   (:require [clojure.string :as str]
             #?@(:clj [[re-frame.ui.compiler.analyze :as ana]
+                      [re-frame.ui.compiler.build :as build]
                       [re-frame.ui.compiler.emit-cljs :as emit-cljs]
                       [re-frame.ui.compiler.emit-jvm :as emit-jvm]
                       [re-frame.ui.compiler.env :as env]
@@ -20,10 +21,21 @@
    (do
 
 (defonce ^{:doc "view-id -> [template-fingerprint hook-signature-hash],
-  accumulated at macro-expansion time; `current-build-digest` derives the
+  contributed at macro-expansion time through the build-scoped model
+  (`re-frame.ui.compiler.build`) so a recompiled / edited / renamed source
+  replaces its whole prior contribution; `current-build-digest` derives the
   bd1- digest (compile-order independent — the triples sort by view-id)."}
   build-views
   (atom {}))
+
+;; Enrol the two compiler-owned aggregates in the one build-scoped state
+;; model (rf2-vxgfnd.16): views live here; the compile-time custom-element
+;; declarations live in `re-frame.ui.rules/custom-elements` but are WRITTEN
+;; from this ns (macro expansion), so their build boundary is coordinated
+;; here too. The Layer-1 root/plan/descriptor registries enrol from
+;; `re-frame.ui.compiler.root`.
+(build/register! build/views build-views)
+(build/register! build/elements rules/custom-elements)
 
 (defn current-build-digest []
   (fingerprint/build-digest
@@ -174,10 +186,11 @@
         sites   @(:sites e)
         tf      (fingerprint/template-fingerprint ast)
         hs      (fingerprint/hook-signature-hash {:locals [] :effects []})
+        src     (source-coords form cljs?)
         manifest {:view-id view-id
                   :display-name display-name
                   :doc docstring
-                  :source (source-coords form cljs?)
+                  :source src
                   :prop-slots (into []
                                     (map-indexed
                                      (fn [i k]
@@ -204,7 +217,7 @@
                  :manifest manifest
                  :closed-keys closed-keys
                  :children? children?}]
-    (swap! build-views assoc view-id [tf hs])
+    (build/contribute! build/views (:file src) view-id [tf hs])
     (if cljs?
       (emit-cljs/emit-defview args)
       (emit-jvm/emit-defview args))))
@@ -218,7 +231,7 @@
             #(defview** form menv vname forms)))
 
 (defn- custom-element**
-  [tag opts]
+  [coords tag opts]
   (when-not (and (keyword? tag) (nil? (namespace tag))
                  (str/includes? (name tag) "-"))
     (fail :rf.ui.compile/bad-custom-element
@@ -249,9 +262,11 @@
                  "property); got " (pr-str props))
             {:tag tag :properties props}))
     ;; compile-time registration (this JVM performs macroexpansion for
-    ;; both hosts) + emitted runtime registration (ui/spread classifies
-    ;; at render via the same registry)
-    (rules/register-custom-element! tag {:properties props})
+    ;; both hosts) routed through the build-scoped model so a removed /
+    ;; renamed declaration drops its stale property classification with
+    ;; its file (rf2-vxgfnd.16) + emitted runtime registration (ui/spread
+    ;; classifies at render via the same registry, on the client).
+    (build/contribute! build/elements (:file coords) tag {:properties props})
     `(re-frame.ui.rules/register-custom-element! ~tag {:properties ~props})))
 
 (defn custom-element*
@@ -262,7 +277,8 @@
   not silent growth. `form` = &form, `menv` = &env — compile errors are
   anchored with the declaration form's source coordinates (S1e)."
   [form menv tag opts]
-  (anchored (source-coords form (some? (:ns menv)))
-            #(custom-element** tag opts)))
+  (let [coords (source-coords form (some? (:ns menv)))]
+    (anchored coords
+              #(custom-element** coords tag opts))))
 
 ))

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -1,0 +1,208 @@
+(ns re-frame.ui.compiler.build
+  "The ONE build-scoped compiler state model (rf2-vxgfnd.16).
+
+  The S1 compiler runs inside a long-lived JVM (the shadow-cljs daemon, a
+  REPL, a whole test run). Its build registries — view digests, the
+  Layer-1 root-site and frame-plan indexes, the Root Descriptor index,
+  the compile-time custom-element declarations — MUST be a pure function
+  of the CURRENT build inputs, never of process history. Recompiling,
+  editing, renaming, or deleting a source has to leave those registries
+  exactly as a clean process would: the process lifetime is NOT the build
+  lifetime.
+
+  Before this model the registries were process-global `defonce` atoms
+  that only ever `assoc`ed the current declaration, so a deleted or
+  renamed `defview` / root / frame plan / `ui/custom-element` left its old
+  contribution behind — watch builds, sequential builds in one daemon, and
+  REPL reloads observed ghosts a fresh process never would, and a live
+  file could take a false cross-file `:rf.error/duplicate-root-id` /
+  `:rf.error/frame-payload-conflict` from a deleted site.
+
+  ## The model
+
+  Each registry stays a plain aggregate atom (`{k v}`) so every existing
+  consumer reads it unchanged — no hot-path lookup pays for this
+  bookkeeping. Alongside, this namespace holds a per-SOURCE contribution
+  ledger: for each registry, which keys each source (a source-file path,
+  the compile unit) contributed, and the build generation it last did so.
+
+  A source's whole contribution is replaced ATOMICALLY the first time it
+  declares in a new build generation (self-arming — never the unsound
+  'clear on the first macro', which breaks multiple declarations in one
+  file and file deletion). So:
+
+    - multiple declarations in one file accumulate, then replace together;
+    - a recompiled / edited / renamed file drops its entire prior
+      contribution and re-accumulates only what it now declares;
+    - a deleted DECLARATION vanishes when its file re-declares without it.
+
+  ## Lifecycle hooks (the smallest integration)
+
+    (begin-build! [build-id?])  a compile pass starts. Same build-id bumps
+                                the generation (incremental — every source
+                                re-opens fresh on its next declaration); a
+                                different build-id starts an isolated slice
+                                (independent builds in one JVM never cross-
+                                contribute — the wipe is `reset-build!`).
+    (reconcile!)                a WHOLE build pass ended: drop every source
+                                that did NOT re-declare this generation (a
+                                deleted / renamed FILE). Only sound after a
+                                full pass — an incremental pass recompiles a
+                                SUBSET, whose untouched files legitimately
+                                keep their prior generation, so it must NOT
+                                reconcile.
+    (reset-build!)              hard-clear every registered aggregate + the
+                                ledger — the clean-build / test-isolation /
+                                build-id-switch boundary.
+
+  Owners register their aggregate atom (`register!`) at load and route
+  every write through `contribute!` (plain assoc registries) or
+  `open-source!` + `note!` (the Layer-1 indexes, whose pre-write conflict
+  check must read the aggregate AFTER the source's stale rows are evicted,
+  so a source never conflicts with its own ghost).
+
+  Compile-time state is mutated single-threaded (macro expansion), so the
+  two-atom (aggregate + ledger) updates need no coordination.")
+
+;; ---------------------------------------------------------------------------
+;; Registry ids (opaque keys naming the five build-scoped registries)
+;; ---------------------------------------------------------------------------
+
+(def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
+(def roots       ::roots)        ; Layer-1 root-site index
+(def plans       ::plans)        ; Layer-1 frame-plan index
+(def descriptors ::descriptors)  ; Root Descriptor index
+(def elements    ::elements)     ; compile-time custom-element declarations
+
+;; ---------------------------------------------------------------------------
+;; State
+;; ---------------------------------------------------------------------------
+
+(defonce ^{:private true
+           :doc "Monotonic build-pass counter. `begin-build!` bumps it; a
+  source re-opens its contribution the first time it declares at a
+  generation newer than the one its ledger records."}
+  generation (atom 0))
+
+(defonce ^{:private true
+           :doc "The build-id of the current slice — a different id at
+  `begin-build!` isolates by wiping (independent builds never share rows)."}
+  build-id (atom ::none))
+
+(defonce ^{:private true
+           :doc "registry-id -> {:agg <aggregate atom>
+                                 :sources {source {:gen g :keys #{k}}}}.
+  `:agg` is the plain-map atom consumers read; `:sources` is the per-source
+  contribution ledger this model reconciles."}
+  registries (atom {}))
+
+;; ---------------------------------------------------------------------------
+;; Registration (owners declare their aggregate at load)
+;; ---------------------------------------------------------------------------
+
+(defn register!
+  "Declare a build-scoped registry: `reg-id` names it, `agg` is the
+  plain-map atom consumers read. Idempotent — the existing ledger is kept
+  so a hot ns reload never drops live contributions."
+  [reg-id agg]
+  (swap! registries update reg-id
+         (fn [r] (if r (assoc r :agg agg) {:agg agg :sources {}})))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Per-source contribution
+;; ---------------------------------------------------------------------------
+
+(defn open-source!
+  "Ensure `source`'s contribution to `reg-id` is fresh for the current
+  build generation. On `source`'s FIRST declaration this generation, evict
+  its prior keys from the aggregate (the atomic per-source replace) and
+  reset its key set; idempotent for later same-generation declarations.
+  Call BEFORE reading the aggregate for a conflict check so a source never
+  conflicts with its own stale row."
+  [reg-id source]
+  (let [g @generation
+        r (get @registries reg-id)]
+    (when (and r (not= g (get-in r [:sources source :gen])))
+      (when-let [ks (seq (get-in r [:sources source :keys]))]
+        (apply swap! (:agg r) dissoc ks))
+      (swap! registries assoc-in [reg-id :sources source] {:gen g :keys #{}})))
+  nil)
+
+(defn note!
+  "Record that `source` contributed key `k` to `reg-id` (after storing it
+  in the aggregate). Pairs with `open-source!`."
+  [reg-id source k]
+  (swap! registries update-in [reg-id :sources source :keys] (fnil conj #{}) k)
+  nil)
+
+(defn contribute!
+  "The plain-registry case: open `source`'s scope, store `k` -> `v` in the
+  aggregate, and note it. Registries with a pre-write conflict check use
+  `open-source!` + `note!` around the check instead."
+  [reg-id source k v]
+  (open-source! reg-id source)
+  (swap! (:agg (get @registries reg-id)) assoc k v)
+  (note! reg-id source k)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle hooks
+;; ---------------------------------------------------------------------------
+
+(defn reset-build!
+  "Hard-clear every registered aggregate and the whole ledger — the
+  clean-build / independent-build / test-isolation boundary (generalises
+  the old per-namespace `reset-build-registries!`). `begin-build!`'s
+  per-source replace covers incremental correctness; this is the fresh
+  top-level slice."
+  []
+  (doseq [[reg-id r] @registries]
+    (reset! (:agg r) {})
+    (swap! registries assoc-in [reg-id :sources] {}))
+  nil)
+
+(defn begin-build!
+  "Open a compile pass. The SAME `build-id` bumps the generation
+  (incremental — every source re-opens fresh on its next declaration, so
+  edits / renames / declaration deletions replace rather than accumulate);
+  a DIFFERENT `build-id` starts an isolated slice (wipes first, so two
+  build-ids sharing one JVM never contribute rows or conflicts to each
+  other). The zero-arg form uses the sole default build."
+  ([] (begin-build! ::default))
+  ([id]
+   (when (not= id @build-id)
+     (reset! build-id id)
+     (reset-build!))
+   (swap! generation inc)
+   nil))
+
+(defn reconcile!
+  "Whole-build end hook: drop every source that did NOT re-declare in the
+  current generation (a deleted or renamed FILE no longer contributes),
+  evicting its keys from every aggregate — so the registries equal a clean
+  build over exactly the files that declared this pass. Sound ONLY after a
+  WHOLE pass; an incremental pass that recompiles a subset must not call it
+  (its untouched files keep their prior generation, which is correct)."
+  []
+  (let [g @generation]
+    (doseq [[reg-id r] @registries
+            [source {sg :gen ks :keys}] (:sources r)
+            :when (not= sg g)]
+      (when (seq ks) (apply swap! (:agg r) dissoc ks))
+      (swap! registries update-in [reg-id :sources] dissoc source)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Introspection (tests / tooling)
+;; ---------------------------------------------------------------------------
+
+(defn current-generation
+  "The current build generation (tests / tooling)."
+  []
+  @generation)
+
+(defn source-keys
+  "The keys `source` currently contributes to `reg-id` (tests / tooling)."
+  [reg-id source]
+  (get-in @registries [reg-id :sources source :keys] #{}))

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -61,8 +61,20 @@
   check must read the aggregate AFTER the source's stale rows are evicted,
   so a source never conflicts with its own ghost).
 
+  ## One open per source, across every registry
+
+  A source's generation is tracked ONCE (globally), not per registry, and
+  `open-source!` fires exactly once per source per generation — at the
+  source's FIRST declaration of the pass — evicting that source's ENTIRE
+  prior contribution from EVERY registry before it re-accumulates. That
+  cross-registry sweep is what makes a deleted declaration disappear even
+  from a registry the recompiled source no longer touches at all (a file
+  that drops its only frame plan but keeps a root): the plan is gone the
+  moment the file re-declares anything, so it cannot fail a later file
+  with a false `:rf.error/frame-payload-conflict`.
+
   Compile-time state is mutated single-threaded (macro expansion), so the
-  two-atom (aggregate + ledger) updates need no coordination.")
+  aggregate + ledger updates need no coordination.")
 
 ;; ---------------------------------------------------------------------------
 ;; Registry ids (opaque keys naming the five build-scoped registries)
@@ -80,8 +92,8 @@
 
 (defonce ^{:private true
            :doc "Monotonic build-pass counter. `begin-build!` bumps it; a
-  source re-opens its contribution the first time it declares at a
-  generation newer than the one its ledger records."}
+  source re-opens (once, across every registry) the first time it declares
+  at a generation newer than the one it last opened at."}
   generation (atom 0))
 
 (defonce ^{:private true
@@ -90,10 +102,15 @@
   build-id (atom ::none))
 
 (defonce ^{:private true
+           :doc "source -> the generation it last opened at (tracked ONCE,
+  globally, so a source's cross-registry contribution is evicted together)."}
+  source-gen (atom {}))
+
+(defonce ^{:private true
            :doc "registry-id -> {:agg <aggregate atom>
-                                 :sources {source {:gen g :keys #{k}}}}.
-  `:agg` is the plain-map atom consumers read; `:sources` is the per-source
-  contribution ledger this model reconciles."}
+                                 :keys {source #{k}}}.
+  `:agg` is the plain-map atom consumers read; `:keys` records which keys
+  each source contributed, so a re-opening source's rows evict cleanly."}
   registries (atom {}))
 
 ;; ---------------------------------------------------------------------------
@@ -106,7 +123,7 @@
   so a hot ns reload never drops live contributions."
   [reg-id agg]
   (swap! registries update reg-id
-         (fn [r] (if r (assoc r :agg agg) {:agg agg :sources {}})))
+         (fn [r] (if r (assoc r :agg agg) {:agg agg :keys {}})))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -114,26 +131,28 @@
 ;; ---------------------------------------------------------------------------
 
 (defn open-source!
-  "Ensure `source`'s contribution to `reg-id` is fresh for the current
-  build generation. On `source`'s FIRST declaration this generation, evict
-  its prior keys from the aggregate (the atomic per-source replace) and
-  reset its key set; idempotent for later same-generation declarations.
-  Call BEFORE reading the aggregate for a conflict check so a source never
-  conflicts with its own stale row."
-  [reg-id source]
-  (let [g @generation
-        r (get @registries reg-id)]
-    (when (and r (not= g (get-in r [:sources source :gen])))
-      (when-let [ks (seq (get-in r [:sources source :keys]))]
-        (apply swap! (:agg r) dissoc ks))
-      (swap! registries assoc-in [reg-id :sources source] {:gen g :keys #{}})))
+  "Open `source`'s contribution for the current build generation. On
+  `source`'s FIRST declaration this generation, evict its prior keys from
+  EVERY registry's aggregate (the atomic, cross-registry per-source
+  replace) and reset its key sets; idempotent for later same-generation
+  declarations. Call BEFORE reading any aggregate for a conflict check so a
+  source never conflicts with its own stale row (and a dropped declaration
+  is gone from registries the source no longer touches this pass)."
+  [source]
+  (let [g @generation]
+    (when (not= g (get @source-gen source))
+      (doseq [[reg-id r] @registries]
+        (when-let [ks (seq (get-in r [:keys source]))]
+          (apply swap! (:agg r) dissoc ks))
+        (swap! registries assoc-in [reg-id :keys source] #{}))
+      (swap! source-gen assoc source g)))
   nil)
 
 (defn note!
   "Record that `source` contributed key `k` to `reg-id` (after storing it
   in the aggregate). Pairs with `open-source!`."
   [reg-id source k]
-  (swap! registries update-in [reg-id :sources source :keys] (fnil conj #{}) k)
+  (swap! registries update-in [reg-id :keys source] (fnil conj #{}) k)
   nil)
 
 (defn contribute!
@@ -141,7 +160,7 @@
   aggregate, and note it. Registries with a pre-write conflict check use
   `open-source!` + `note!` around the check instead."
   [reg-id source k v]
-  (open-source! reg-id source)
+  (open-source! source)
   (swap! (:agg (get @registries reg-id)) assoc k v)
   (note! reg-id source k)
   nil)
@@ -159,7 +178,8 @@
   []
   (doseq [[reg-id r] @registries]
     (reset! (:agg r) {})
-    (swap! registries assoc-in [reg-id :sources] {}))
+    (swap! registries assoc-in [reg-id :keys] {}))
+  (reset! source-gen {})
   nil)
 
 (defn begin-build!
@@ -185,12 +205,14 @@
   WHOLE pass; an incremental pass that recompiles a subset must not call it
   (its untouched files keep their prior generation, which is correct)."
   []
-  (let [g @generation]
-    (doseq [[reg-id r] @registries
-            [source {sg :gen ks :keys}] (:sources r)
-            :when (not= sg g)]
-      (when (seq ks) (apply swap! (:agg r) dissoc ks))
-      (swap! registries update-in [reg-id :sources] dissoc source)))
+  (let [g @generation
+        stale (for [[source sg] @source-gen :when (not= sg g)] source)]
+    (doseq [source stale]
+      (doseq [[reg-id r] @registries]
+        (when-let [ks (seq (get-in r [:keys source]))]
+          (apply swap! (:agg r) dissoc ks))
+        (swap! registries update-in [reg-id :keys] dissoc source))
+      (swap! source-gen dissoc source)))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -205,4 +227,4 @@
 (defn source-keys
   "The keys `source` currently contributes to `reg-id` (tests / tooling)."
   [reg-id source]
-  (get-in @registries [reg-id :sources source :keys] #{}))
+  (get-in @registries [reg-id :keys source] #{}))

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -327,10 +327,10 @@
   `:rf.error/duplicate-root-id` — thrown through the canonical builder,
   with the both-derived didactic fix per the contract."
   [where root-id provenance coords]
-  ;; Evict THIS source's prior root rows first (build-scoped replace), so a
-  ;; moved / renamed / deleted site never conflicts with its own ghost and
-  ;; a deleted site cannot fail a later file (rf2-vxgfnd.16).
-  (build/open-source! build/roots (:file coords))
+  ;; Open THIS source (cross-registry, once per pass): a moved / renamed /
+  ;; deleted site never conflicts with its own ghost, and a deleted site
+  ;; cannot fail a later file (rf2-vxgfnd.16).
+  (build/open-source! (:file coords))
   (let [existing (get @build-roots root-id)]
     (when (and existing
                (:file existing) (:file coords)
@@ -359,10 +359,10 @@
   re-registration replaces — watch tolerance; matching fingerprints are
   the ratified idempotent no-op)."
   [where {:keys [frame-id config-fingerprint]} coords]
-  ;; Evict THIS source's prior plan rows first (build-scoped replace) — a
-  ;; deleted / edited plan never conflicts with its own ghost, and a
-  ;; removed plan cannot fail a later file (rf2-vxgfnd.16).
-  (build/open-source! build/plans (:file coords))
+  ;; Open THIS source (cross-registry, once per pass) — a deleted / edited
+  ;; plan never conflicts with its own ghost, and a removed plan cannot fail
+  ;; a later file (rf2-vxgfnd.16).
+  (build/open-source! (:file coords))
   (let [existing (get @build-plans frame-id)]
     (when (and existing
                (not= (:config-fingerprint existing) config-fingerprint)

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -45,6 +45,7 @@
   (:require [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.fingerprint :as fingerprint]
             #?@(:clj [[re-frame.ui.compiler :as compiler]
@@ -297,12 +298,24 @@
   build-descriptors
   (atom {}))
 
+;; Enrol the three Layer-1 / descriptor aggregates in the one build-scoped
+;; state model (rf2-vxgfnd.16) so a recompiled / edited / renamed / removed
+;; source replaces its whole prior contribution atomically — a deleted root
+;; or plan cannot linger to raise a FALSE cross-file duplicate/conflict, and
+;; the indexes stay a pure function of the current build inputs.
+(build/register! build/roots build-roots)
+(build/register! build/plans build-plans)
+(build/register! build/descriptors build-descriptors)
+
 (defn reset-build-registries!
-  "Test support: wipe the Layer-1 indexes + descriptor index."
+  "Hard-clear every build-scoped compiler registry (views, the Layer-1
+  root/plan indexes, the descriptor index, compile-time custom-elements)
+  and the contribution ledger — the clean-build / test-isolation boundary.
+  Delegates to the one build-scoped model; correctness across a watch
+  session comes from per-source replacement on `build/begin-build!`, not
+  from this wipe (rf2-vxgfnd.16 AC6)."
   []
-  (reset! build-roots {})
-  (reset! build-plans {})
-  (reset! build-descriptors {})
+  (build/reset-build!)
   nil)
 
 (defn- site-str [{:keys [file line]}]
@@ -314,6 +327,10 @@
   `:rf.error/duplicate-root-id` — thrown through the canonical builder,
   with the both-derived didactic fix per the contract."
   [where root-id provenance coords]
+  ;; Evict THIS source's prior root rows first (build-scoped replace), so a
+  ;; moved / renamed / deleted site never conflicts with its own ghost and
+  ;; a deleted site cannot fail a later file (rf2-vxgfnd.16).
+  (build/open-source! build/roots (:file coords))
   (let [existing (get @build-roots root-id)]
     (when (and existing
                (:file existing) (:file coords)
@@ -332,6 +349,7 @@
                 :provenance [(:provenance existing) provenance]
                 :sites      [(dissoc existing :provenance) coords]}}))
     (swap! build-roots assoc root-id (assoc coords :provenance provenance))
+    (build/note! build/roots (:file coords) root-id)
     nil))
 
 (defn register-plan-site!
@@ -341,6 +359,10 @@
   re-registration replaces — watch tolerance; matching fingerprints are
   the ratified idempotent no-op)."
   [where {:keys [frame-id config-fingerprint]} coords]
+  ;; Evict THIS source's prior plan rows first (build-scoped replace) — a
+  ;; deleted / edited plan never conflicts with its own ghost, and a
+  ;; removed plan cannot fail a later file (rf2-vxgfnd.16).
+  (build/open-source! build/plans (:file coords))
   (let [existing (get @build-plans frame-id)]
     (when (and existing
                (not= (:config-fingerprint existing) config-fingerprint)
@@ -361,6 +383,7 @@
     (swap! build-plans assoc frame-id {:config-fingerprint config-fingerprint
                                        :file (:file coords)
                                        :line (:line coords)})
+    (build/note! build/plans (:file coords) frame-id)
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -514,7 +537,8 @@
               desc   (root-descriptor {:root-id root-id :provenance provenance
                                        :views views :plans plans :ast ast
                                        :build-digest (compiler/current-build-digest)})
-              _      (swap! build-descriptors assoc root-id desc)
+              _      (build/contribute! build/descriptors (:file coords)
+                                        root-id desc)
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
           `(re-frame.ui.client/mount*
             {:root-id ~root-id
@@ -614,7 +638,7 @@
             (when (= 1 (count views))
               (let [derived (:view-id (first views))]
                 (register-root-site! 'ui/hydrate-root derived :derived coords)
-                (swap! build-descriptors assoc derived
+                (build/contribute! build/descriptors (:file coords) derived
                        (root-descriptor {:root-id derived :provenance :derived
                                          :views views :plans plans :ast ast
                                          :build-digest (compiler/current-build-digest)}))))

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -1,0 +1,263 @@
+(ns re-frame.ui.compiler-build-jvm-test
+  "rf2-vxgfnd.16 — the S1 compiler build registries are a PURE FUNCTION of
+  the current build inputs, not of process history.
+
+  The adversarial crux: in ONE long-lived JVM (never restarted), declare a
+  source's contributions to all five build registries — a `defview`, a root
+  site + static frame plan + descriptor, a `ui/custom-element` — then
+  rebuild after edits / renames / deletions and assert the registries +
+  `current-build-digest` equal a CLEAN-process build of the edited source.
+  Before this model those registries were process-global `defonce` atoms
+  that only ever `assoc`ed, so a deleted or renamed declaration lingered and
+  a live file could take a FALSE cross-file duplicate-root /
+  frame-payload-conflict from a deleted site.
+
+  The mount-surface macros are client entry points (JVM-host expansion is a
+  compile error), so the Layer-1 / descriptor writes are driven the way
+  `re-frame.ui.compiler.root/mount-form` drives them (register-root-site! +
+  register-plan-site! + the descriptor contribution) — the same call
+  sequence one mount site performs. `defview` and `ui/custom-element` ARE
+  JVM-expandable and run their real macro bodies, with the source file bound
+  so distinct 'files' are addressable in the ledger."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler :as compiler]
+            [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.root :as root]
+            [re-frame.ui.rules :as rules]))
+
+;; Every test starts from a clean slice; correctness across a watch session
+;; comes from per-source replacement on begin-build!, but tests want
+;; independence, so the fixture uses the hard boundary.
+(use-fixtures :each
+  (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
+
+;; ---------------------------------------------------------------------------
+;; Harness — drive the five registries the way real compilation does, with a
+;; controllable source-file key.
+;; ---------------------------------------------------------------------------
+
+(defn- declare-view!
+  "Run the real `defview` macro body (JVM emitter path) with `file` bound as
+  the source — contributes [template-fp hook-sig] under the derived view-id."
+  [file vname template]
+  (binding [*file* file]
+    (compiler/defview* (with-meta (list 'defview vname [] template) {:line 1})
+                       {} vname (list [] template))))
+
+(defn- declare-element!
+  "Run the real `ui/custom-element` macro body with `file` bound as the
+  source — contributes the compile-time property classification for `tag`."
+  [file tag properties]
+  (binding [*file* file]
+    (compiler/custom-element* (with-meta (list 'custom-element tag
+                                               {:properties properties})
+                                         {:line 1})
+                              {} tag {:properties properties})))
+
+(defn- mount-site!
+  "Mirror `mount-form`'s Layer-1 / descriptor writes for one root site in
+  `file`: index the root-id, index each frame plan, and contribute the Root
+  Descriptor — exactly the sequence a `ui/mount` expansion performs."
+  [file root-id plans desc]
+  (let [coords {:file file :line 1}]
+    (root/register-root-site! 'ui/mount root-id :authored coords)
+    (doseq [p plans] (root/register-plan-site! 'ui/mount p coords))
+    (build/contribute! build/descriptors file root-id desc)))
+
+(defn- snapshot
+  "The observable state of all five build registries + the build digest."
+  []
+  {:views       @compiler/build-views
+   :digest      (compiler/current-build-digest)
+   :roots       @root/build-roots
+   :plans       @root/build-plans
+   :descriptors @root/build-descriptors
+   :elements    @rules/custom-elements})
+
+;; ---------------------------------------------------------------------------
+;; The build-scoped model itself (re-frame.ui.compiler.build)
+;; ---------------------------------------------------------------------------
+
+(def ^:private probe (atom {}))
+(def ^:private probe2 (atom {}))
+(build/register! ::probe probe)
+(build/register! ::probe2 probe2)
+
+(deftest per-source-contribution-replaces-atomically
+  (build/begin-build!)
+  (build/contribute! ::probe "a.cljs" :x 1)
+  (build/contribute! ::probe "a.cljs" :y 2)
+  (is (= {:x 1 :y 2} @probe)
+      "multiple declarations in one source accumulate — never clear-on-first-macro")
+  (build/begin-build!)                       ; a fresh pass
+  (build/contribute! ::probe "a.cljs" :x 10) ; the source is edited: :y removed, :x changed
+  (is (= {:x 10} @probe)
+      "recompiling a source replaces its WHOLE prior contribution — :y is gone"))
+
+(deftest open-source-evicts-across-every-registry
+  ;; a source contributing to TWO registries, then re-declaring in only one,
+  ;; must drop its stale rows from the registry it no longer touches.
+  (build/begin-build!)
+  (build/contribute! ::probe  "a.cljs" :p 1)
+  (build/contribute! ::probe2 "a.cljs" :q 2)
+  (is (= {:p 1} @probe))
+  (is (= {:q 2} @probe2))
+  (build/begin-build!)
+  (build/contribute! ::probe "a.cljs" :p 11) ; a.cljs re-declares only in ::probe
+  (is (= {:p 11} @probe))
+  (is (= {} @probe2)
+      "opening a.cljs evicted its ::probe2 row even though it did not re-touch ::probe2"))
+
+(deftest incremental-preserves-untouched-reconcile-drops-deleted-files
+  (build/begin-build!)
+  (build/contribute! ::probe "a.cljs" :a 1)
+  (build/contribute! ::probe "b.cljs" :b 2)
+  (is (= {:a 1 :b 2} @probe))
+  (build/begin-build!)                       ; incremental: only a.cljs recompiles
+  (build/contribute! ::probe "a.cljs" :a 11)
+  (is (= {:a 11 :b 2} @probe)
+      "an incremental pass recompiles a SUBSET — b.cljs's row is untouched")
+  (build/reconcile!)
+  (is (= {:a 11} @probe)
+      "a whole-build reconcile drops b.cljs — a deleted/renamed FILE that did not re-declare"))
+
+(deftest build-ids-are-isolated
+  (build/begin-build! :app)
+  (build/contribute! ::probe "a.cljs" :x 1)
+  (is (= {:x 1} @probe))
+  (build/begin-build! :node-test)
+  (is (= {} @probe) "switching build-id starts an isolated (wiped) slice")
+  (build/contribute! ::probe "a.cljs" :y 2)
+  (is (= {:y 2} @probe) "the :app rows never reach the :node-test build"))
+
+;; ---------------------------------------------------------------------------
+;; Integration — clean-vs-incremental parity across all five registries
+;; ---------------------------------------------------------------------------
+
+(defn- declare-edited-source!
+  "The EDITED file app/a.cljs: a renamed view, a different root + frame plan,
+  a renamed custom-element (the original declared `foo` / :page/shop / :shop
+  / :x-el)."
+  []
+  (declare-view! "app/a.cljs" 'bar [:section "bar"])
+  (mount-site!   "app/a.cljs" :page/cart
+                 [{:frame-id :cart :config-fingerprint "cf1-cart"}]
+                 {:rf.root/schema-version 1 :root-id :page/cart})
+  (declare-element! "app/a.cljs" :y-el #{:label}))
+
+(deftest incremental-edit-equals-clean-build
+  ;; 1) the ORIGINAL source A, built in this JVM
+  (build/begin-build! :app)
+  (declare-view! "app/a.cljs" 'foo [:div "foo"])
+  (mount-site!   "app/a.cljs" :page/shop
+                 [{:frame-id :shop :config-fingerprint "cf1-shop"}]
+                 {:rf.root/schema-version 1 :root-id :page/shop})
+  (declare-element! "app/a.cljs" :x-el #{:help-text})
+  ;; 2) EDIT the same file in the SAME JVM (no restart) — incremental rebuild
+  (build/begin-build! :app)
+  (declare-edited-source!)
+  (let [incremental (snapshot)]
+    ;; 3) a CLEAN-process build of the edited source (fresh slice)
+    (build/reset-build!)
+    (build/begin-build! :app)
+    (declare-edited-source!)
+    (let [clean (snapshot)]
+      (is (= clean incremental)
+          "incremental output after edit/rename/delete EQUALS a clean build")
+      (testing "no ghost of the pre-edit source survives"
+        (is (= #{:page/cart} (set (keys (:roots incremental))))       "root :page/shop gone")
+        (is (= #{:cart} (set (keys (:plans incremental))))            "plan :shop gone")
+        (is (= #{:page/cart} (set (keys (:descriptors incremental)))) "descriptor :page/shop gone")
+        (is (contains? (:elements incremental) :y-el))
+        (is (not (contains? (:elements incremental) :x-el))          "custom-element :x-el gone")
+        (is (= 1 (count (:views incremental)))                        "view foo gone, only bar"))
+      (testing "the digest is a function of current views only"
+        (is (= (:digest clean) (:digest incremental)))))))
+
+(deftest repeated-rebuilds-stay-bounded-without-a-reset
+  ;; AC6: correctness across a watch session needs NO test-only global reset —
+  ;; re-declaring the same file N times replaces (never grows).
+  (dotimes [_ 25]
+    (build/begin-build! :app)
+    (declare-view! "app/a.cljs" 'only [:div "only"])
+    (mount-site! "app/a.cljs" :page/shop [] {:rf.root/schema-version 1 :root-id :page/shop}))
+  (is (= 1 (count @compiler/build-views)) "views bounded across repeated rebuilds")
+  (is (= #{:page/shop} (set (keys @root/build-roots))) "roots bounded")
+  (is (= #{:page/shop} (set (keys @root/build-descriptors))) "descriptors bounded"))
+
+;; ---------------------------------------------------------------------------
+;; The false cross-file duplicate/conflict from a DELETED site (bead §Steps)
+;; ---------------------------------------------------------------------------
+
+(deftest deleted-root-site-does-not-falsely-duplicate-a-later-file
+  ;; original: a.cljs mounts :page/shop
+  (build/begin-build!)
+  (root/register-root-site! 'ui/mount :page/shop :authored {:file "a.cljs" :line 1})
+  ;; edit a.cljs: the :page/shop site is DELETED (a.cljs now mounts :page/cart)
+  (build/begin-build!)
+  (root/register-root-site! 'ui/mount :page/cart :authored {:file "a.cljs" :line 1})
+  ;; b.cljs legitimately takes over the now-free :page/shop — the deleted
+  ;; a.cljs site must NOT raise a false :rf.error/duplicate-root-id
+  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored
+                                      {:file "b.cljs" :line 1}))
+      "a deleted root site cannot fail a later file (rf2-vxgfnd.16)")
+  (is (= #{:page/cart :page/shop} (set (keys @root/build-roots)))))
+
+(deftest genuine-current-cross-file-duplicate-still-fails
+  (build/begin-build!)
+  (root/register-root-site! 'ui/mount :page/dup :authored {:file "a.cljs" :line 1})
+  (let [ex (try (root/register-root-site! 'ui/mount :page/dup :authored
+                                          {:file "b.cljs" :line 2})
+                nil (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? ex) "two LIVE sites for one root-id still fail the build")
+    (is (= :rf.error/duplicate-root-id (:rf.error/id (ex-data ex))))
+    (is (= 2 (count (:sites (ex-data ex)))) "both current sites named with coords")))
+
+(deftest deleted-frame-plan-does-not-falsely-conflict-a-later-file
+  ;; original: a.cljs carries a :shop plan
+  (build/begin-build!)
+  (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
+                            {:file "a.cljs" :line 1})
+  (is (contains? @root/build-plans :shop))
+  ;; edit a.cljs: the :shop plan is DELETED — a.cljs now declares only a root
+  ;; (it no longer touches the plan registry at all). Opening a.cljs must
+  ;; still evict its stale :shop plan (cross-registry sweep).
+  (build/begin-build!)
+  (root/register-root-site! 'ui/mount :page/a :authored {:file "a.cljs" :line 1})
+  (is (not (contains? @root/build-plans :shop))
+      "opening the recompiled a.cljs evicted its dropped :shop plan")
+  ;; b.cljs now carries :shop with a DIFFERENT fingerprint — no false conflict
+  (is (nil? (root/register-plan-site! 'ui/mount
+                                      {:frame-id :shop :config-fingerprint "cf1-b"}
+                                      {:file "b.cljs" :line 1}))
+      "a deleted plan cannot fail a later file's differing plan (rf2-vxgfnd.16)")
+  (is (= "cf1-b" (:config-fingerprint (get @root/build-plans :shop)))))
+
+(deftest genuine-current-cross-file-plan-conflict-still-fails
+  (build/begin-build!)
+  (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
+                            {:file "a.cljs" :line 1})
+  (let [ex (try (root/register-plan-site! 'ui/mount
+                                          {:frame-id :shop :config-fingerprint "cf1-b"}
+                                          {:file "b.cljs" :line 2})
+                nil (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? ex) "two LIVE differing plans for one frame still fail the build")
+    (is (= :rf.error/frame-payload-conflict (:rf.error/id (ex-data ex))))))
+
+;; ---------------------------------------------------------------------------
+;; Custom-element declaration removal clears stale property classification
+;; (AC5, compile side)
+;; ---------------------------------------------------------------------------
+
+(deftest removed-custom-element-clears-stale-property-classification
+  (build/begin-build! :app)
+  (declare-element! "app/a.cljs" :x-el #{:help-text})
+  (is (= #{:help-text} (rules/custom-element-properties :x-el))
+      "the declaration classifies :help-text as a property")
+  ;; edit a.cljs: :x-el renamed to :y-el (its declaration deleted)
+  (build/begin-build! :app)
+  (declare-element! "app/a.cljs" :y-el #{:label})
+  (is (= #{} (rules/custom-element-properties :x-el))
+      "the removed :x-el no longer classifies any property (was leaking)")
+  (is (= #{:label} (rules/custom-element-properties :y-el))
+      "the current :y-el declaration classifies its property"))


### PR DESCRIPTION
Closes rf2-vxgfnd.16 (P2, S1 compiler).

## Problem

The S1 compiler accumulated build facts in five process-global `defonce`
atoms that only ever `assoc`ed the current declaration — with no build/file
lifecycle:

- `re-frame.ui.compiler/build-views` (the digest source)
- `re-frame.ui.compiler.root/build-roots` / `build-plans` / `build-descriptors` (Layer-1 + descriptor indexes)
- `re-frame.ui.rules/custom-elements` (compile-time property classification)

So a deleted or renamed `defview` / root / frame plan / `ui/custom-element`
left its old contribution behind in the compiler JVM. Watch builds,
sequential builds in one daemon, and REPL reloads observed ghosts a fresh
process never would — and a live file could take a **false** cross-file
`:rf.error/duplicate-root-id` / `:rf.error/frame-payload-conflict` from a
deleted site. The process lifetime was treated as the build lifetime.

## Fix

New `re-frame.ui.compiler.build` — one build-scoped state model that enrols
all five registries. Each stays a plain aggregate atom (every existing
consumer reads it unchanged; **no hot-path lookup pays for the bookkeeping**),
but every write routes through a per-**source** (source-file) contribution
ledger. A source's whole contribution is replaced **atomically** the first
time it declares in a new build generation, and that open is a single
**cross-registry** sweep — so a dropped declaration is evicted even from a
registry the recompiled source no longer touches (a file that deletes its
only frame plan but keeps a root).

Lifecycle hooks (the smallest integration — the model is driven by these,
never by an ad-hoc reset):

- `begin-build! [build-id?]` — a compile pass starts (same id bumps the
  generation → per-source replace; a different id starts an isolated slice,
  so two build-ids in one JVM never cross-contribute).
- `reconcile!` — a whole build ended: drop sources that did not re-declare
  (a deleted/renamed **file**).
- `reset-build!` — the clean-build / test-isolation boundary; the old
  `reset-build-registries!` now delegates here (and now covers all five
  registries + the ledger, not just root's three).

Registries are now a pure function of the current build inputs:
`current-build-digest`, the duplicate/conflict indexes, the descriptor
index, and custom-element classification all track current source, and
correctness across a watch session needs no global reset (AC6).

Wiring `begin-build!` into the shadow-cljs build lifecycle (a build hook /
stage hook — a hot-zone, out-of-surface `shadow-cljs.edn` touch) is the one
remaining integration; filed as follow-up. This PR lands the mechanism +
the conformance fixtures that drive it.

## Tests

New `compiler_build_jvm_test.clj` (11 deftests): in ONE long-lived JVM,
declare a source's contributions across all five registries, then rebuild
after edit / rename / deletion **without restarting** and assert the
registries + `current-build-digest` **equal a clean-process build** of the
edited source. Covers the bead's named cases:

- clean-vs-incremental parity across all five registries + digest;
- a deleted root / plan site no longer raises a false cross-file
  duplicate/conflict, **while genuine current cross-file duplicates still
  fail** with both source coords;
- cross-registry eviction (a dropped plan clears even when the source stops
  touching the plan registry);
- removed `ui/custom-element` drops stale property classification;
- repeated rebuilds stay bounded with no global reset;
- two build-ids are isolated;
- `reconcile!` drops deleted files while incremental preserves untouched.

## Quality gates

All foreground, 0-fail:

- **ui compiler JVM** (`clojure -M:test` in `implementation/ui`) — **217 tests / 4318 assertions, 0 failures, 0 errors** (incl. the 11 new fixtures; existing Layer-1 / defview-grammar / parity suites unchanged).
- **CLJS node integration** (`npm run test:cljs`) — **8914 tests / 42068 assertions, 0 failures, 0 errors**.
- **core JVM** (`clojure -M:test` in `implementation/core`) — 0 failures.
- **per-ns test isolation** — 15/15 namespaces pass.
- **test:script-policy / test:script-helpers** — pass (0 fail). A transient bash-spawn flake surfaced once under the full `test-fast-pr.sh` run on Windows; greens on isolated re-run and cannot be influenced by this diff.

Surface stayed within `compiler.cljc`, `compiler/root.cljc` (+ the new
`compiler/build.cljc` build entry) and the new compiler test; `reactive.cljc`
/ `viewcell.cljs` / `test.cljc` / `client.cljs` / `analyze.cljc` / `env.cljc`
untouched. No production bundle bytes or hot-path branches added.
