### PR TITLE
fix(ui): validate + elide Story sub-overrides on the compiled path (rf2-vxgfnd.21)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -44,6 +44,12 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.subs.cache :as subs-cache]
             [re-frame.subs.memo :as subs-memo]
+            ;; The ONE shared Story-override schema-validation primitive
+            ;; (rf2-vxgfnd.21) — reused verbatim by the compiled-view path
+            ;; (`re-frame.ui.reactive`) so both tiers reject a schema-invalid
+            ;; override identically. Reached ONLY inside the CLJS
+            ;; `interop/debug-enabled?` gate below, so it DCEs in production.
+            [re-frame.subs.override-schema :as override-schema]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
             ;; JVM autoload: the tooling sibling has zero
@@ -1195,83 +1201,21 @@
 
 ;; ---- the sub-override subscribe seam (CLJS, dev-only) --------------------
 ;;
-;; See the block comment inside `subscribe` for the full rationale. These
-;; two helpers are CLJS-only and consulted ONLY inside the
+;; See the block comment inside `subscribe` for the full rationale. This
+;; helper is CLJS-only and consulted ONLY inside the
 ;; `interop/debug-enabled?` gate, so the whole seam DCEs under `:advanced`
 ;; + `goog.DEBUG=false`. The resolver fn + the React-context reader are
 ;; published from Story / the CLJS-only carriage ns
 ;; (`re-frame.adapter.sub-override-context`) via the
 ;; `:subs/resolve-sub-override` late-bind hook, so core never `:require`s
 ;; a tools ns (bundle-isolation holds).
-
-#?(:cljs
-   (defn- maybe-validate-sub-override!
-     "When a `:sub-overrides` HIT targets a sub that
-     declares an output `:schema`, validate the pinned `value` against it
-     the SAME way Spec 010 §step 6 validates a `:sub-return` — through the
-     registered validator reached via the `:schemas/validate-with-registered-fn`
-     late-bind hook (NOT a second validation mechanism). On a mismatch,
-     emit `:rf.error/schema-validation-failure` with a NEW `:where
-     :sub-override` discriminator and return nil, mirroring `:sub-return`'s
-     `:replaced-with-default` recovery (observational, dev-only — the
-     failure is surfaced, the violating value is replaced with the
-     default). On a pass / no `:schema` / no registered validator, returns
-     `value` unchanged.
-
-     Rationale: an override that violates the sub's own output contract is
-     exactly the 'pin a state the real derivation could never produce'
-     anti-pattern; schema-validating it closes that honesty gap. Reuses
-     the registered validator so a substituted (non-Malli) validator
-     covers this surface identically to `:sub-return`.
-
-     `frame-id` is the subscribing frame — stamped onto the
-     failure trace so `re-frame.epoch.capture/capture-event!` (which
-     buffers only frame-tagged traces) attributes the override-validation
-     failure to that frame's epoch, mirroring `:sub-return`'s `:frame`
-     stamp (validate.cljc `validate-sub!` 5-arity). Without it the trace
-     is invisible to the per-frame epoch / Xray Schema-timeline lens."
-     [value query-v sub-meta frame-id]
-     (let [schema (:schema sub-meta)]
-       (if (and schema (some? sub-meta))
-         (if-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
-           (if (try (validate schema value)
-                    ;; A throwing validator must not crash the render; treat
-                    ;; it as a pass (mirrors `subs.memo/maybe-validate-sub!`).
-                    (catch :default _ true))
-             value
-             (let [sub-id  (first query-v)
-                   explain (when-let [exp (late-bind/get-fn-cached
-                                            :schemas/explain-with-registered-fn)]
-                             (try (exp schema value) (catch :default _ nil)))
-                   ;; Route the value-bearing slots (`:value` /
-                   ;; `:received` / `:explain` / `:rf.sub/query-v`) through the
-                   ;; SHARED schema-aware redaction seam so a `:sub-override`
-                   ;; on a `:sensitive?`-marked sub schema scrubs identically
-                   ;; to the regular `:sub-return` path (which redacts via
-                   ;; `validate-sub!`). This override path bypasses
-                   ;; `validate-sub!`, so the seam is what keeps the failing
-                   ;; value from leaking verbatim on the `:sub-override`
-                   ;; surface.
-                   redact  (late-bind/get-fn-cached :schemas/redact-validation-tags)
-                   tags    (cond-> {:where          :sub-override
-                                    :rf.sub/id      sub-id
-                                    :failing-id     sub-id
-                                    :schema-id      sub-id
-                                    :rf.sub/query-v query-v
-                                    :received       value
-                                    :value          value
-                                    :explain        explain
-                                    :reason         (str "Subscription " sub-id
-                                                         " :sub-override value failed schema "
-                                                         (pr-str schema) ".")
-                                    :recovery       :replaced-with-default}
-                             frame-id (assoc :frame frame-id))]
-               (trace/emit-error! :rf.error/schema-validation-failure
-                                  (cond-> tags
-                                    redact (->> (redact schema))))
-               nil))
-           value)
-         value))))
+;;
+;; The schema-validation fold-in (`:where :sub-override` — an override
+;; that violates the sub's own declared `:schema` is the 'pin a state the
+;; real derivation could never produce' anti-pattern) lives in the ONE
+;; shared `re-frame.subs.override-schema/validate-sub-override!` primitive
+;; (rf2-vxgfnd.21) so the compiled-view path applies byte-identical
+;; validation + `:replaced-with-default` recovery.
 
 #?(:cljs
    (defn- resolve-sub-override
@@ -1281,12 +1225,12 @@
      returns `[value]` on a hit (a one-element vector so a nil-valued
      override is honoured) or nil on a miss / unbound.
 
-     On a HIT, schema-validate the pinned value (see
-     `maybe-validate-sub-override!`) and return a CONSTANT reaction
-     `(adapter/make-derived-value [] (constantly v))` — no inputs, never
-     recomputes, never cached, never touches app-db / `compute-sub`. On a
-     miss / unbound / unpublished hook, return nil so `subscribe` falls
-     through to the normal build-and-cache path.
+     On a HIT, schema-validate the pinned value (the shared
+     `override-schema/validate-sub-override!` primitive) and return a
+     CONSTANT reaction `(adapter/make-derived-value [] (constantly v))` —
+     no inputs, never recomputes, never cached, never touches app-db /
+     `compute-sub`. On a miss / unbound / unpublished hook, return nil so
+     `subscribe` falls through to the normal build-and-cache path.
 
      CLJS-only and called ONLY inside `subscribe`'s `interop/debug-enabled?`
      gate, so this DCEs in production."
@@ -1295,7 +1239,7 @@
        (when-let [hit (resolve-override query-v)]
          (let [v        (first hit)
                sub-meta (registrar/lookup :sub (first query-v))
-               v*       (maybe-validate-sub-override! v query-v sub-meta frame-id)]
+               v*       (override-schema/validate-sub-override! v query-v sub-meta frame-id)]
            (adapter/make-derived-value [] (constantly v*)))))))
 
 (defn- subscribe-in-frame

--- a/implementation/core/src/re_frame/subs/override_schema.cljc
+++ b/implementation/core/src/re_frame/subs/override_schema.cljc
@@ -1,0 +1,86 @@
+(ns re-frame.subs.override-schema
+  "The ONE Story `:sub-overrides` schema-validation primitive, shared by
+  BOTH override tiers (rf2-vxgfnd.21).
+
+  A Story render's lowest-fidelity rung pins a view into an
+  `:error`/`:loading`/`:empty` state by naming subscription query-vectors
+  and the values they should surface (`tools/story/spec/017-Testing-Story.md`
+  §View-state subscription overrides). An override whose value VIOLATES the
+  target sub's own declared output `:schema` is exactly the 'pin a state the
+  real derivation could never produce' anti-pattern — so BOTH the
+  Reagent-family `subscribe` path (`re-frame.subs`) and the compiled-view
+  path (`re-frame.ui.reactive`) validate a HIT the SAME way Spec 010 §step 6
+  validates a `:sub-return`: through the registered validator reached via the
+  `:schemas/validate-with-registered-fn` late-bind hook (NOT a second
+  validation mechanism, NO tools dependency), emit
+  `:rf.error/schema-validation-failure` with the `:where :sub-override`
+  discriminator, and recover-to-nil (mirroring `:sub-return`'s
+  `:replaced-with-default`). Both tiers thus reject an impossible override
+  identically — the honesty gap the compiled path used to leave open.
+
+  This primitive is HOST-AGNOSTIC (`.cljc`): the compiled path's explicit
+  JVM `ui.test/render {:sub-overrides …}` door runs it headlessly on the JVM
+  (`interop/debug-enabled?` is true there), while both tiers gate the whole
+  consult behind `interop/debug-enabled?` so it DCEs under `:advanced` +
+  `goog.DEBUG=false`. It is reached ONLY from those gated consults, so no
+  production build retains it (its containing `(when interop/debug-enabled?
+  …)` blocks fold away, dropping the last reference)."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn validate-sub-override!
+  "Validate a resolved Story override HIT and RECOVER to nil on a violation.
+
+  When `sub-meta` declares an output `:schema`, validate `value` against it
+  via the registered validator (`:schemas/validate-with-registered-fn`). On
+  a mismatch, emit `:rf.error/schema-validation-failure` tagged `:where
+  :sub-override` (value-bearing slots routed through the shared
+  `:schemas/redact-validation-tags` seam so a `:sensitive?`-marked sub
+  scrubs identically to the `:sub-return` path) and return nil. On a pass /
+  no `:schema` / no registered validator, return `value` unchanged. A
+  throwing validator is treated as a pass (mirrors
+  `subs.memo/maybe-validate-sub!`) so a bad validator never crashes the
+  render.
+
+  `query-v` is the overridden query (its head is the sub-id); `frame-id` is
+  the subscribing frame, stamped onto the failure trace so
+  `re-frame.epoch.capture/capture-event!` (which buffers only frame-tagged
+  traces) attributes the failure to that frame's epoch — pass nil when
+  frameless. Callers resolve `sub-meta` through the target frame's IMAGE
+  generation (a multi-image frame validates against its own image's schema);
+  this primitive takes the already-resolved metadata."
+  [value query-v sub-meta frame-id]
+  (let [schema (:schema sub-meta)]
+    (if (and schema (some? sub-meta))
+      (if-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
+        (if (try (validate schema value)
+                 (catch #?(:clj Throwable :cljs :default) _ true))
+          value
+          (let [sub-id  (first query-v)
+                explain (when-let [exp (late-bind/get-fn-cached
+                                         :schemas/explain-with-registered-fn)]
+                          (try (exp schema value)
+                               (catch #?(:clj Throwable :cljs :default) _ nil)))
+                redact  (late-bind/get-fn-cached :schemas/redact-validation-tags)
+                tags    (cond-> {:where          :sub-override
+                                 :rf.sub/id      sub-id
+                                 :failing-id     sub-id
+                                 :schema-id      sub-id
+                                 :rf.sub/query-v query-v
+                                 :received       value
+                                 :value          value
+                                 :explain        explain
+                                 :reason         (str "Subscription " sub-id
+                                                      " :sub-override value failed schema "
+                                                      (pr-str schema) ".")
+                                 :recovery       :replaced-with-default}
+                          frame-id (assoc :frame frame-id))]
+            (trace/emit-error! :rf.error/schema-validation-failure
+                               (cond-> tags
+                                 redact (->> (redact schema))))
+            nil))
+        value)
+      value)))

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -460,8 +460,23 @@
                                         ;; (:rf.error/no-frame-context when
                                         ;; no scope is established)
      :override {:value v                ;; optional — the consumer's
-                :override-id o          ;; already-read Story override
-                :version n}}            ;; context HIT for this query
+                :override-id o          ;; already-read + already-VALIDATED
+                :version n}}            ;; Story HIT for this query
+
+  ## The override change token (OPAQUE to this port)
+
+  `:override-id` and `:version` are OPAQUE change tokens SUPPLIED by the
+  consumer (the compiled-view artefact's `re-frame.ui.reactive`). This port
+  never interprets them — it compares each by `=` only: `:override-id` is
+  the slot-identity token (the kept-check's `= :override-id`), `:version`
+  is the movement token (the kept-check's `= :version`, so a moved value
+  retargets). The consumer's LOWERING (which app-level value becomes the id
+  vs. the version) is recorded on the consumer side
+  (`re-frame.ui.reactive/*sub-overrides*`), NOT here — so the query-as-id /
+  value-as-version choice never leaks into this port's contract, and the
+  port stays correct whatever opaque tokens the consumer mints. Schema
+  validation + recover-to-nil happen ON the consumer side BEFORE the HIT
+  reaches here: `:value` is the ALREADY-VALIDATED value.
 
   An `:override` HIT resolves to `{:kind :story-override …}` — the pinned
   value rides the target because the value IS the resolution; there is no
@@ -778,7 +793,12 @@
   query. An unchanged live lease is retained untouched by the caller; a
   disposed node (HMR), a destroyed/swapped frame, a restabilized query, or a
   moved/removed override fails the check and classifies the site as
-  retargeted. Pure read; never throws."
+  retargeted. Pure read; never throws.
+
+  Static (override) leases compare the consumer's OPAQUE change token by
+  `=` only — `:override-id` (slot identity) and `:version` (movement) — so
+  an equal-value provider replacement retains and any value/schema move
+  retargets, without this port interpreting either token."
   [lease target]
   (let [st @(lease-state lease)]
     (case (:lease-kind st)

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -88,7 +88,16 @@
             ;; contains the prose and the production build (DEBUG=false) DCEs it —
             ;; the methodology now has teeth for the direct-call elision path.
             [re-frame.routing.classification :as routing-classification]
-            [re-frame.machines.lifecycle-fx.traces :as machines-traces]))
+            [re-frame.machines.lifecycle-fx.traces :as machines-traces]
+            ;; rf2-vxgfnd.21 — root the compiled-view Story `:sub-overrides`
+            ;; consult so its `interop/debug-enabled?`-gated body (the
+            ;; `*sub-overrides*` dynamic-var read, the schema validation, the
+            ;; opaque-token lowering) sits in the :advanced DCE reachability
+            ;; graph. Under goog.DEBUG=false the whole consult must fold away —
+            ;; the shared validator's " :sub-override value failed schema "
+            ;; reason string (reachable ONLY from the two gated override
+            ;; consults) must NOT survive.
+            [re-frame.ui.reactive :as ui-reactive]))
 
 ;; ---- trace listener API ---------------------------------------------------
 
@@ -770,9 +779,36 @@
     (fn [_ _] {:fx [[:dispatch [:rf.probe/loop-forever]]]}))
   (rf/dispatch-sync [:rf.probe/loop-forever] {:frame :rf.probe/drain-depth}))
 
+;; ---- rf2-vxgfnd.21: compiled-view Story `:sub-overrides` consult ----------
+;;
+;; The compiled-view substrate consults `:sub-overrides` for a Story render
+;; via `re-frame.ui.reactive/resolve-override` (reached from every `sub-read`).
+;; The WHOLE consult — the `*sub-overrides*` dynamic-var read, the schema
+;; validation via the shared `re-frame.subs.override-schema/validate-sub-override!`
+;; primitive, and the opaque-token lowering — sits inside
+;; `(when interop/debug-enabled? ...)`, so under :advanced + goog.DEBUG=false it
+;; DCEs: a production build carries ZERO per-sub branch, no dynamic-var read,
+;; and none of these bytes on the subscription render path.
+;;
+;; This touch roots `sub-read` (→ `resolve-override` → the shared validator) so
+;; the gated body is in the reachability graph: under DEBUG=true the shared
+;; validator's " :sub-override value failed schema " reason string is reachable
+;; through the UI consult; under DEBUG=false the gate folds and it must DCE.
+;; The `check-elision.cjs` sentinel pins that absence. Reachability only — the
+;; grep never runs this; the try/catch keeps a bundle-LOAD (which would run it)
+;; from throwing on the frameless probe read.
+
+(defn ^:export touch-ui-sub-overrides! []
+  (rf/reg-sub :rf.probe/ui-override (fn [db _q] (:ui-override db)))
+  (try
+    (binding [ui-reactive/*sub-overrides* {[:rf.probe/ui-override] :rf.probe/override-value}]
+      (ui-reactive/sub-read [:rf.probe/ui-override]))
+    (catch :default _ nil)))
+
 (defn ^:export run []
   (touch-direct-emit-diagnostics!)
   (touch-drain-depth!)
+  (touch-ui-sub-overrides!)
   (touch-trace!)
   (touch-schemas!)
   (touch-registrar!)

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -587,7 +587,23 @@ const DEV_ONLY_SENTINELS = [
   // `touch-drain-depth!` triggers a real halt so the control build (DEBUG=true)
   // contains this prose and the production build (DEBUG=false) must elide it.
   { source: 're-frame.router/handle-depth-exceeded! (drain-depth :reason prose, always-on-promoted)',
-    sentinel: 'likely a dispatch loop. Cycle (last settled ids)' }
+    sentinel: 'likely a dispatch loop. Cycle (last settled ids)' },
+  // re-frame.subs.override-schema/validate-sub-override! — the Story
+  // `:sub-overrides` schema-failure reason string (rf2-vxgfnd.21). The ONE
+  // shared override validator is reached ONLY from the two override consults,
+  // and BOTH gate the whole consult on `interop/debug-enabled?`: the
+  // Reagent-family `re-frame.subs/resolve-sub-override` (inside subscribe's
+  // gate) and the compiled-view `re-frame.ui.reactive/resolve-override` (its
+  // whole body is `(when interop/debug-enabled? ...)`). Under :advanced +
+  // goog.DEBUG=false BOTH call sites DCE, dropping the validator's last
+  // referent so its reason-string literal must NOT survive. The elision-probe's
+  // `touch-ui-sub-overrides!` roots the COMPILED-VIEW consult (sub-read →
+  // resolve-override → validate-sub-override!) so a UI-side un-gating
+  // regression surfaces this string in production; the control build
+  // (DEBUG=true) contains it via that consult. The fragment is the distinctive
+  // middle of the reason string, unambiguous under a global grep.
+  { source: 're-frame.subs.override-schema/validate-sub-override! (:sub-override schema-failure reason)',
+    sentinel: ' :sub-override value failed schema ' }
   // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
   // once warning + its emit helper were RETIRED (EP-0002; superseded by
   // the always-on :rf.error/no-frame-context). There is no longer any

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -110,8 +110,12 @@
   garbage. The memo is an ECONOMY, never an authority — the commit
   evidence comparison (step 5) corrects any staleness before paint."
   (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.observation :as obs]
+            [re-frame.subs.override-schema :as override-schema]
             [re-frame.ui.eq :as eq]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -131,18 +135,81 @@
 (def ^:dynamic *sub-overrides*
   "Override door: a map of query-vector → pinned value, or nil. A HIT
   resolves the site to a `:story-override` target — the pinned value IS the
-  resolution (no node), and commit acquires a STATIC lease. `:override-id`
-  is the query (the override's stable slot identity); `:version` is the
-  pinned value itself, so `current?` (a `=` on version) retargets exactly
-  when the pinned value moves."
+  resolution (no node), and commit acquires a STATIC lease
+  (`:owned? false`, callback-free). Seeded by the JVM `ui.test/render`
+  door (an explicit `binding`) and, on CLJS, by the Story skeleton off the
+  public override context (that React-context→var seeding is S2f).
+
+  ## The change token (opaque to the observation port — the target ABI)
+
+  `resolve-override` LOWERS a HIT to the port's opaque
+  `{:override-id :version}` change token (see
+  `re-frame.substrate.observation`, which compares both by `=` only and
+  never interprets them). This artefact's private lowering:
+
+    - `:override-id` ← the QUERY — the override's stable slot identity, so
+      two overrides never collide and a site dedups by its slot.
+    - `:version`     ← the VALIDATED value — the movement token, so
+      `current?` (a `=` on version) retargets EXACTLY when the surfaced
+      value moves.
+
+  Because `resolve-override` re-runs (and re-validates) every render, the
+  semantics fall out of the token:
+
+    - equal-value provider replacement → same validated value → version
+      unchanged → the kept-check retains the static lease (no retarget).
+    - nested providers → the CLOSEST enclosing override wins (the innermost
+      `*sub-overrides*` binding / React-context map) → its value is the token.
+    - value change → version differs → the site retargets to a fresh
+      static lease carrying the new value.
+    - HMR / schema change → the override is re-validated against the
+      CURRENT registration each render; a schema that now rejects a
+      previously-valid value flips the surfaced value to nil, moving the
+      version and retargeting the site to nil."
   nil)
 
+(defn- override-sub-meta
+  "The target sub's registration metadata for override-value validation,
+  resolved through the CURRENT frame's IMAGE generation when a scope is in
+  effect (so a multi-image frame validates against its own image's schema —
+  parity with the subscription resolution `re-frame.substrate.observation`
+  performs), else the global registrar (absence-is-default). Non-throwing;
+  nil when the entry sub is unregistered (validation then no-ops)."
+  [query-v]
+  (if-some [frame-id (frame/resolve-current-frame)]
+    (live-frame/call-with-frame-resolution
+      (live-frame/frame-resolution-target frame-id)
+      (fn [] [(registrar/lookup :sub (first query-v)) frame-id]))
+    [(registrar/lookup :sub (first query-v)) nil]))
+
 (defn- resolve-override
+  "Resolve a Story `:sub-overrides` HIT for `query`, or nil on a miss.
+
+  The ENTIRE consult — the `*sub-overrides*` dynamic-var read, the schema
+  validation, and the token lowering — sits behind `interop/debug-enabled?`
+  so a PRODUCTION build (Story absent) carries ZERO per-sub branch, no
+  dynamic-var read, and none of these bytes on the subscription render
+  path: the whole body DCEs under `:advanced` + `goog.DEBUG=false`, and
+  `sub-read`'s `(some? override)` folds to false (rf2-vxgfnd.21).
+
+  On a HIT the pinned value is schema-validated against the target sub's
+  declared output `:schema` through the SHARED
+  `override-schema/validate-sub-override!` primitive — the SAME registered
+  validator + `:rf.error/schema-validation-failure {:where :sub-override}`
+  emission + recover-to-nil the Reagent-family `subscribe` path applies, so
+  the compiled view can never surface a state the sub's own schema says is
+  impossible. A nil-valued (or validation-failed) HIT stays a HIT (distinct
+  from a miss). The returned map is the port's opaque change token (see
+  `*sub-overrides*`)."
   [query]
-  (when-some [m *sub-overrides*]
-    (when (contains? m query)
-      (let [v (get m query)]
-        {:value v :override-id query :version v}))))
+  (when interop/debug-enabled?
+    (when-some [m *sub-overrides*]
+      (when (contains? m query)
+        (let [raw            (get m query)
+              [sub-meta fid] (override-sub-meta query)
+              v              (override-schema/validate-sub-override!
+                               raw query sub-meta fid)]
+          {:value v :override-id query :version v})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Ambient render capture

--- a/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
@@ -1,0 +1,139 @@
+(ns re-frame.ui.reactive-sub-override-schema-cljs-test
+  "rf2-vxgfnd.21 — the compiled-view Story `:sub-overrides` path applies the
+  SAME schema validator + recover-to-nil as the Reagent-family `subscribe`
+  path, and resolves the override ONCE at render.
+
+  The Reagent leg of this parity is pinned by
+  `re-frame.subs-override-seam-cljs-test` (the honesty fold-in) and
+  `re-frame.security.*` (the redaction leg); BOTH now route through the ONE
+  shared `re-frame.subs.override-schema/validate-sub-override!` primitive, so
+  this file only has to prove the compiled-view door (`re-frame.ui.reactive`)
+  invokes it identically — a schema-invalid override emits
+  `:rf.error/schema-validation-failure {:where :sub-override}` and surfaces
+  nil, a conforming or schemaless override surfaces unchanged, a nil-valued
+  override stays a HIT (distinct from a miss), and a miss reads the real sub.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` (node) AND
+  `clojure -M:test` (JVM), so the override validation is graft-checked on
+  BOTH tiers against the REAL observation port + sub-cache (plain-atom)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.late-bind            :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace.tooling        :as trace-tooling]
+            [re-frame.ui.reactive          :as reactive]))
+
+(def ^:private fid :rf/default)
+
+(defn- with-stub-validator
+  "Install a minimal REGISTERED validator (the same late-bind hook the Malli
+  adapter and Spec 010 §step-6 use) so the override schema check runs without
+  pulling the schemas artefact onto the ui test classpath — the point under
+  test is that the compiled path reuses whatever validator is registered.
+  Saves + restores the prior hook so the consolidated node-test bundle's real
+  Malli validator is untouched for sibling tests."
+  [test-fn]
+  (let [prior (late-bind/get-fn :schemas/validate-with-registered-fn)]
+    (late-bind/set-fn! :schemas/validate-with-registered-fn
+      (fn [schema value] (if (= schema :int) (int? value) true)))
+    (try (test-fn)
+         (finally (late-bind/set-fn! :schemas/validate-with-registered-fn prior)))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-stub-validator)
+
+(defn- read-override
+  "Read `query` as a compiled-view site with `overrides` bound (the explicit
+  override door). Outside a ViewCell, `sub-read` returns the freshly resolved
+  value — for a HIT, the schema-validated pinned value."
+  [overrides query]
+  (rf/with-frame fid
+    (binding [reactive/*sub-overrides* overrides]
+      (reactive/sub-read query))))
+
+(defn- collect-errors
+  "Run `thunk` capturing every `:rf.error/*` trace event. Returns the vector
+  of captured events."
+  [thunk]
+  (let [seen (atom [])
+        lid  ::override-schema-errors]
+    (trace-tooling/register-listener! lid
+      (fn [ev] (when (= :error (:op-type ev)) (swap! seen conj ev))))
+    (try (thunk) (finally (trace-tooling/unregister-listener! lid)))
+    @seen))
+
+;; ---- the schema-validation fold-in (parity with the Reagent path) --------
+
+(deftest invalid-override-emits-and-surfaces-nil
+  (testing "an override violating the sub's :schema emits :where :sub-override
+            (frame-stamped) and surfaces nil through the compiled-view door"
+    (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
+    (let [result (atom ::unset)
+          errors (collect-errors
+                   (fn []
+                     (reset! result
+                             (read-override {[:count/value] "not-an-int"}
+                                            [:count/value]))))]
+      (is (nil? @result)
+          "the violating override is replaced-with-default (nil)")
+      (let [failure (first (filter #(= :rf.error/schema-validation-failure
+                                       (:operation %))
+                                   errors))]
+        (is (some? failure)
+            "a schema-validation-failure was emitted for the violating override")
+        (is (= :sub-override (-> failure :tags :where))
+            "the :where discriminator is :sub-override")
+        (is (= fid (-> failure :tags :frame))
+            "the failure trace is stamped with the subscribing frame")))))
+
+(deftest conforming-override-surfaces-unchanged-no-failure
+  (testing "an override that conforms to the sub's :schema surfaces unchanged
+            with no failure trace"
+    (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
+    (let [result (atom ::unset)
+          errors (collect-errors
+                   (fn []
+                     (reset! result
+                             (read-override {[:count/value] 42} [:count/value]))))]
+      (is (= 42 @result) "the conforming override surfaces unchanged")
+      (is (not-any? #(= :rf.error/schema-validation-failure (:operation %)) errors)
+          "no schema-validation-failure for a conforming override"))))
+
+(deftest schemaless-sub-skips-validation
+  (testing "a sub with no :schema → any override value surfaces, no validation"
+    (rf/reg-sub :free/value (fn [db _] (get db :v)))
+    (let [result (atom ::unset)
+          errors (collect-errors
+                   (fn []
+                     (reset! result
+                             (read-override {[:free/value] {:any "shape"}}
+                                            [:free/value]))))]
+      (is (= {:any "shape"} @result)
+          "any value surfaces when the sub declares no schema")
+      (is (not-any? #(= :rf.error/schema-validation-failure (:operation %)) errors)
+          "no validation runs when the sub has no :schema"))))
+
+;; ---- HIT vs MISS distinction ---------------------------------------------
+
+(deftest nil-valued-override-is-a-hit-distinct-from-a-miss
+  (testing "a nil-valued override is a HIT (surfaces nil), distinct from a
+            miss (surfaces the real subscription)"
+    (rf/reg-sub :x/value (fn [db _] (get db :x ::real)))
+    (rf/dispatch-sync [:rf/set-db {}] {:frame fid})
+    (is (nil? (read-override {[:x/value] nil} [:x/value]))
+        "nil override surfaces as nil, NOT the real ::real value")
+    (is (= ::real (read-override {[:other/q] :pinned} [:x/value]))
+        "a MISS falls through to the real subscription")))
+
+(deftest miss-reads-the-real-subscription
+  (testing "a non-overridden query is unaffected even with other overrides bound"
+    (rf/reg-sub :a/sub (fn [_db _] :real-a))
+    (rf/reg-sub :b/sub (fn [_db _] :real-b))
+    (rf/dispatch-sync [:rf/set-db {}] {:frame fid})
+    (is (= :pinned-a (read-override {[:a/sub] :pinned-a} [:a/sub]))
+        "overridden query → pinned")
+    (is (= :real-b (read-override {[:a/sub] :pinned-a} [:b/sub]))
+        "non-overridden query → real")))

--- a/implementation/ui/test/re_frame/ui/test_render_sub_override_schema_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_sub_override_schema_jvm_test.clj
@@ -1,0 +1,106 @@
+(ns re-frame.ui.test-render-sub-override-schema-jvm-test
+  "rf2-vxgfnd.21 — `ui.test/render {:sub-overrides …}` (the explicit JVM
+  Story-override door) applies the SAME schema validator + recover-to-nil as
+  the Reagent-family `subscribe` path.
+
+  End-to-end on the Tier-1 JVM structural render: a compiled view reads a sub
+  declaring an output `:schema`; a `:sub-overrides` HIT that VIOLATES it emits
+  `:rf.error/schema-validation-failure {:where :sub-override}` and the view
+  surfaces nil (the impossible state never reaches the tree), while a
+  conforming override renders unchanged with no failure. This is the door
+  `re-frame.ui.reactive/*sub-overrides*` binding that
+  `re-frame.ui.test/render` establishes — the compiled-path counterpart of
+  the `re-frame.subs-override-seam-cljs-test` Reagent parity."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.test :as uit]))
+
+(defn- with-stub-validator
+  "Install a minimal REGISTERED validator (the same late-bind hook the Malli
+  adapter and Spec 010 §step-6 use) so the override schema check runs without
+  pulling the schemas artefact onto the ui test classpath. Saves + restores
+  the prior hook."
+  [test-fn]
+  (let [prior (late-bind/get-fn :schemas/validate-with-registered-fn)]
+    (late-bind/set-fn! :schemas/validate-with-registered-fn
+      (fn [schema value] (if (= schema :int) (int? value) true)))
+    (try (test-fn)
+         (finally (late-bind/set-fn! :schemas/validate-with-registered-fn prior)))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-stub-validator)
+
+(defview counter
+  "Reads a schema-bearing sub — the headless read the override door intercepts."
+  []
+  [:span.count "n=" (ui/sub [:count/value])])
+
+(defn- collect-errors
+  "Run `thunk` capturing every `:rf.error/*` trace event; return the events."
+  [thunk]
+  (let [seen (atom [])
+        lid  ::override-render-errors]
+    (trace-tooling/register-listener! lid
+      (fn [ev] (when (= :error (:op-type ev)) (swap! seen conj ev))))
+    (try (thunk) (finally (trace-tooling/unregister-listener! lid)))
+    @seen))
+
+(deftest override-violating-schema-renders-nil-and-emits
+  (testing "a :sub-overrides HIT that violates the sub's :schema emits
+            :where :sub-override and the compiled view surfaces nil"
+    (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
+    (let [f      (uit/frame {:app-db {:n 7}})
+          tree   (atom nil)
+          errors (collect-errors
+                   (fn []
+                     (reset! tree
+                             (uit/render counter
+                                         {:frame f
+                                          :sub-overrides {[:count/value] "not-an-int"}}))))]
+      (is (= "n=" (uit/text (uit/find @tree :span)))
+          "the violating override is replaced-with-default (nil), so only the
+           literal prefix renders — the impossible value never reaches the tree")
+      (let [failure (first (filter #(= :rf.error/schema-validation-failure
+                                       (:operation %))
+                                   errors))]
+        (is (some? failure) "a schema-validation-failure was emitted")
+        (is (= :sub-override (-> failure :tags :where))
+            "the :where discriminator is :sub-override")))))
+
+(deftest override-conforming-schema-renders-and-no-failure
+  (testing "a :sub-overrides HIT that conforms surfaces unchanged, no failure"
+    (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
+    (let [f      (uit/frame {:app-db {:n 7}})
+          tree   (atom nil)
+          errors (collect-errors
+                   (fn []
+                     (reset! tree
+                             (uit/render counter
+                                         {:frame f
+                                          :sub-overrides {[:count/value] 42}}))))]
+      (is (= "n=42" (uit/text (uit/find @tree :span)))
+          "the conforming override renders unchanged")
+      (is (not-any? #(= :rf.error/schema-validation-failure (:operation %)) errors)
+          "no schema-validation-failure for a conforming override"))))
+
+(deftest override-on-schemaless-sub-renders-any-value
+  (testing "a sub with no :schema → the override renders with no validation"
+    (rf/reg-sub :count/value (fn [db _] (get db :n 0)))
+    (let [f      (uit/frame {:app-db {:n 7}})
+          tree   (atom nil)
+          errors (collect-errors
+                   (fn []
+                     (reset! tree
+                             (uit/render counter
+                                         {:frame f
+                                          :sub-overrides {[:count/value] 99}}))))]
+      (is (= "n=99" (uit/text (uit/find @tree :span)))
+          "any override value renders when the sub declares no schema")
+      (is (not-any? #(= :rf.error/schema-validation-failure (:operation %)) errors)
+          "no validation runs when the sub has no :schema"))))


### PR DESCRIPTION
## What

The compiled-view (`re-frame.ui`) Story `:sub-overrides` path bypassed the sub's output-`:schema` validation that the Reagent-family `subscribe` path applies — it could display a state the sub's own schema declares impossible — and kept an **ungated per-sub `*sub-overrides*` dynamic-var read + branch on the production subscription render path**. Fixes rf2-vxgfnd.21 (P1 correctness + production-elision).

### 1. Validation parity (correctness)
Extracted the ONE shared override-schema primitive `re-frame.subs.override-schema/validate-sub-override!` from the Reagent path. Both tiers now emit the same `:rf.error/schema-validation-failure {:where :sub-override}` and recover-to-nil through the SAME registered validator (`:schemas/validate-with-registered-fn`) — no duplicate schema engine, no tools dependency. `re-frame.ui.reactive` resolves sub metadata through the current frame's image (parity with the subscription resolution), else the global registrar. A nil-valued / validation-failed HIT stays a HIT (distinct from a miss). `re-frame.subs` now delegates to the shared primitive (behaviour unchanged — the existing seam/security tests stay green).

### 2. Elision (production cost)
The whole compiled-view override consult — the `*sub-overrides*` dynamic-var read, the schema validation, and the token lowering — now sits behind `interop/debug-enabled?`, so a production build DCEs it: **zero per-sub branch, zero dynamic-var read, zero Story-override bytes** on the subscription render path. Pinned by a new `check-elision.cjs` sentinel (` :sub-override value failed schema `) rooted through the elision-probe's compiled-view consult (`touch-ui-sub-overrides!`).

### 3. Opaque change token (ABI)
The observation-port ABI now records `:override-id`/`:version` as OPAQUE consumer-supplied change tokens (compared by `=` only, never interpreted); the query-as-id / value-as-version lowering is documented on the `re-frame.ui.reactive` consumer side, not leaked into the port. Override resolution happens ONCE at render; commit acquires the captured static target and never re-consults context. Static leases stay `:owned? false` + callback-free.

## Surface
`implementation/ui/src/re_frame/ui/reactive.cljc`, `implementation/core/src/re_frame/substrate/observation.cljc` (docs-only ABI), plus the shared `re-frame.subs.override-schema` primitive + a minimal delegation edit in `re-frame.subs` (directed by the bead DESIGN: "extract/reuse one internal override-validation primitive from the current re-frame.subs path"). Elision-probe + sentinel + tests. No edits to `compiler/*`, `client.cljs`, or `ui/test.cljc`.

## Quality gates (foreground, 0-fail)
- **`npm run test:elision`** (required — the "zero Story-override bytes in prod" claim): **PASS** — production **48/48 absent** (new sentinel included; 785,423 chars), control **48/48 present** (916,537 chars), EP-0023 1/1 provenance-survives + 2/2 assembly-DCE.
- **`npm run test:cljs`** (node): **PASS** — 8928 tests, 42127 assertions, **0 failures, 0 errors** (includes the new reactive `.cljc` fixture on CLJS + the Reagent seam/security tests now routed through the shared primitive).
- **ui-artefact JVM** (`clojure -M:test`): **PASS** — 214 tests, 4300 assertions, **0 failures, 0 errors** (includes the new `.cljc` reactive fixture on the JVM + the JVM `ui.test/render` door fixture).
- G-1/G-13 bundle budgets retained by construction — all new code is dev-gated and DCEs in production.

## Coverage notes
Cross-tier fixtures: reactive-level `.cljc` (runs JVM + node) covers the compiled-path validation on both hosts; the JVM `ui.test/render {:sub-overrides …}` door fixture covers the explicit test door; the Reagent leg rides the existing `subs-override-seam` + security-redaction tests (now through the shared primitive). The **Tier-3 mounted Story-context fixture is deferred** — it depends on the S2f React-context→`*sub-overrides*` seeding + the CLJS mount path (not landed; out of this slice's surface).

Closes rf2-vxgfnd.21.