### PR TITLE
fix(ui): ENSURE adoption of a live plan-less frame is a config/generation no-op (rf2-vxgfnd.26)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -17,10 +17,23 @@
 
   Per-plan disposition (document order; conflicts validated FIRST):
 
-    - NO live install       -> INSTALL: `make-frame` (create-if-absent;
-      an already-live plan-less frame is ADOPTED via the engine's
-      idempotent refresh — durable state preserved, no re-seed), then
-      record `{:config-fingerprint :installed-by}`.
+    - NO live frame         -> INSTALL: `make-frame` creates it
+      (create-if-absent), then record `{:config-fingerprint
+      :installed-by}`.
+    - LIVE frame, NO install
+      record (a boot `rf/make-frame`
+      the plan registry never saw) -> ADOPT: create-if-absent means
+      create NOTHING (03 §8 / 004C §6 — later roots find it live and do
+      not re-seed). The boot frame's OWN config + image generation are
+      AUTHORITATIVE and left UNTOUCHED — no `make-frame`, so no
+      config/generation clobber, no `:images` discard, no re-seed. Only
+      the plan's `{:config-fingerprint :installed-by}` is recorded, so a
+      later cross-root arrival is conflict-scoped against it. This is the
+      shared-frame case: an app boots the frame with its images /
+      `:fx-overrides` and a root then declares `[frame-root {:id …}]`
+      merely to SCOPE it. (rf2-vxgfnd.26: adopting via a config-carrying
+      `make-frame` used to swap the generation to the default and wipe
+      the boot config — the durable app-db survived, masking the clobber.)
     - SAME fingerprint      -> found live: PURE NO-OP (the ratified
       idempotent install — no re-seed, no config churn, no trace noise).
       This is the HMR / remount / shared-frame non-reseed guarantee.
@@ -153,38 +166,66 @@
 
   Phase 1 VALIDATES every plan (pure — cross-root fingerprint conflicts
   throw `:rf.error/frame-payload-conflict` before ANY install). Phase 2
-  installs/refreshes in document order: `make-frame` creates the frame
-  if absent and drains `:initial-events` synchronously before returning
-  (EP-0027); a found-live same-fingerprint plan is a pure no-op (no
-  re-seed — the HMR guarantee). Returns nil."
+  installs/adopts/refreshes in document order: `make-frame` creates the
+  frame if absent and drains `:initial-events` synchronously before
+  returning (EP-0027); a found-live same-fingerprint plan is a pure no-op
+  (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
+  is ADOPTED — its config/generation untouched, only the fingerprint
+  recorded (rf2-vxgfnd.26). Returns nil."
   [root-id plans]
   (let [decided
         (mapv (fn [{:keys [frame-id config-fingerprint] :as plan}]
                 (let [installed (installed-plan-entry frame-id)]
                   (cond
-                    (nil? installed)
-                    (assoc plan ::action :install)
+                    (some? installed)
+                    ;; a recorded plan already governs this LIVE frame
+                    (cond
+                      (= (:config-fingerprint installed) config-fingerprint)
+                      (assoc plan ::action :found-live)
 
-                    (= (:config-fingerprint installed) config-fingerprint)
-                    (assoc plan ::action :found-live)
+                      (= (:installed-by installed) root-id)
+                      (assoc plan ::action :refresh)
 
-                    (= (:installed-by installed) root-id)
-                    (assoc plan ::action :refresh)
+                      :else
+                      (throw-plan-conflict! root-id plan installed))
+
+                    ;; No install record. Either the id is genuinely absent
+                    ;; (INSTALL) or a frame is already LIVE under it but was
+                    ;; created OUTSIDE the plan registry — a boot
+                    ;; `rf/make-frame`. ENSURE is create-if-absent (03 §8):
+                    ;; a live frame is ADOPTED, never re-created, so its
+                    ;; boot config + image generation stay authoritative.
+                    (some? (frame/frame frame-id))
+                    (assoc plan ::action :adopt)
 
                     :else
-                    (throw-plan-conflict! root-id plan installed))))
+                    (assoc plan ::action :install))))
               plans)]
     (doseq [{:keys [frame-id config config-fingerprint] :as plan} decided]
-      (when (not= :found-live (::action plan))
-        ;; create-if-absent / surgical refresh; :initial-events drain
-        ;; synchronously inside the engine, in document order across
-        ;; plans. The record lands only AFTER a successful install, so a
-        ;; throwing plan leaves no install record (and the engine leaves
-        ;; no frame residue).
-        (live-frame/make-frame (assoc (or config {}) :id frame-id))
-        (swap! installed-plans assoc frame-id
-               {:config-fingerprint config-fingerprint
-                :installed-by root-id})))
+      (case (::action plan)
+        ;; the ratified idempotent no-op: no re-seed, no record churn.
+        :found-live nil
+
+        ;; a live plan-less (boot-created) frame: create-if-absent means
+        ;; create NOTHING. Record only the plan's fingerprint so a later
+        ;; cross-root arrival is conflict-scoped — the boot frame's
+        ;; config/generation/`:images` are left entirely untouched
+        ;; (rf2-vxgfnd.26: a config-carrying `make-frame` here clobbered
+        ;; them, masked by the durable app-db surviving).
+        :adopt (swap! installed-plans assoc frame-id
+                      {:config-fingerprint config-fingerprint
+                       :installed-by root-id})
+
+        ;; :install / :refresh — create-if-absent / surgical refresh;
+        ;; :initial-events drain synchronously inside the engine, in
+        ;; document order across plans. The record lands only AFTER a
+        ;; successful install, so a throwing plan leaves no install record
+        ;; (and the engine leaves no frame residue).
+        (do
+          (live-frame/make-frame (assoc (or config {}) :id frame-id))
+          (swap! installed-plans assoc frame-id
+                 {:config-fingerprint config-fingerprint
+                  :installed-by root-id}))))
     nil))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -160,6 +160,85 @@
     (is (= 1 (:n (rf/app-db-value :frame/session)))
         "new lifetime re-seeds from :initial-events")))
 
+;; ---- ADOPT — a live plan-less (boot-created) frame (rf2-vxgfnd.26) --------
+;; ENSURE is create-if-absent (03 §8 / 004C §6): when a plan meets a frame that
+;; is already LIVE but was never plan-installed (a boot `rf/make-frame`), the
+;; frame is ADOPTED — its config + image generation are AUTHORITATIVE and left
+;; untouched. Only the plan's fingerprint is recorded (for cross-root conflict
+;; scoping). Regression: a config-carrying `make-frame` used to run here, swapping
+;; the generation to the default (discarding the boot `:images`) and wiping the
+;; boot config (`:fx-overrides` / `:doc` / …); the durable app-db survived, which
+;; masked the clobber.
+
+(deftest adoption-of-a-live-plan-less-frame-preserves-config-and-generation
+  ;; boot an app frame with a real image generation + rich config, OUTSIDE the
+  ;; plan registry (the app's own rf/make-frame at boot).
+  (rf/make-frame {:id :app/session
+                  :images       [(rf/image {:id :app/img})]
+                  :fx-overrides {:app/save :app/mock-save}
+                  :doc          "boot-authored config"})
+  (let [gen0 (frame/frame-generation :app/session)]
+    (is (some? gen0) "sanity: the boot frame resolved an image generation")
+    (is (nil? (frames/installed-plan-entry :app/session))
+        "sanity: the boot frame is LIVE but PLAN-LESS (no install record)")
+    ;; a root declares [frame-root {:id :app/session}] purely to SHARE it — a
+    ;; plain, config-less plan.
+    (frames/execute-frame-plans!
+     :page/app [(plan :app/session {} "cf1-adopt-aaaaaaaaa")])
+    (is (identical? gen0 (frame/frame-generation :app/session))
+        "the boot generation is the SAME object — NOT re-resolved to the default")
+    (is (= [:app/img]
+           (mapv :rf.image/id (:rf.gen/images (frame/frame-generation :app/session))))
+        "the boot frame's :images are preserved (not discarded for the default)")
+    (is (= {:app/save :app/mock-save}
+           (:fx-overrides (frame/frame-meta :app/session)))
+        ":fx-overrides survive adoption (the boot config is not replaced wholesale)")
+    (is (= "boot-authored config" (:doc (frame/frame-meta :app/session)))
+        "the boot :doc config survives adoption")
+    (is (= {:config-fingerprint "cf1-adopt-aaaaaaaaa" :installed-by :page/app}
+           (frames/installed-plan-entry :app/session))
+        "adoption records the plan fingerprint (for conflict scoping) and NOTHING else")))
+
+(deftest adoption-then-same-fingerprint-second-root-is-a-found-live-no-op
+  (rf/make-frame {:id :app/session :images [(rf/image {:id :app/img})]})
+  (let [gen0 (frame/frame-generation :app/session)
+        p    (plan :app/session {} "cf1-adopt-bbbbbbbbb")]
+    (frames/execute-frame-plans! :page/one [p])
+    (is (= :page/one (:installed-by (frames/installed-plan-entry :app/session)))
+        "the first adopter is recorded")
+    ;; a second root sharing the same frame with the same (config-less) plan
+    (frames/execute-frame-plans! :page/two [p])
+    (is (identical? gen0 (frame/frame-generation :app/session))
+        "the second-root found-live pass leaves the generation untouched too")
+    (is (= :page/one (:installed-by (frames/installed-plan-entry :app/session)))
+        "found-live writes nothing — the first adopter is retained")))
+
+(deftest adoption-coexists-with-a-fresh-install-in-the-same-root
+  ;; both ways in one run: adopt a live boot frame AND install a genuinely-new
+  ;; one — the new-frame INSTALL path still creates + seeds correctly.
+  (reg-events!)
+  (rf/make-frame {:id :app/session
+                  :images       [(rf/image {:id :app/img})]
+                  :fx-overrides {:app/save :app/mock-save}})
+  (let [gen0 (frame/frame-generation :app/session)]
+    (frames/execute-frame-plans!
+     :page/app
+     [(plan :app/session {} "cf1-adopt-ccccccccc")
+      (plan :app/fresh {:initial-events [[:test/set-db {:n 5}]]} "cf1-fresh-ddddddddd")])
+    ;; adopt arm — untouched
+    (is (identical? gen0 (frame/frame-generation :app/session))
+        "the adopted boot frame's generation is untouched")
+    (is (= {:app/save :app/mock-save}
+           (:fx-overrides (frame/frame-meta :app/session)))
+        "the adopted boot frame keeps its :fx-overrides")
+    ;; install arm — the genuinely-new frame is created + seeded
+    (is (some? (frame/frame :app/fresh)) "the absent frame is created (install)")
+    (is (= 5 (:n (rf/app-db-value :app/fresh)))
+        ":initial-events drain synchronously for the newly-installed frame")
+    (is (= {:config-fingerprint "cf1-fresh-ddddddddd" :installed-by :page/app}
+           (frames/installed-plan-entry :app/fresh))
+        "the new install is recorded with its fingerprint + installing root")))
+
 ;; ===========================================================================
 ;; G-6 — the ambient frame chain + scope
 ;; ===========================================================================


### PR DESCRIPTION
## Summary

`rf2-vxgfnd.26` (MAJOR-CONFIRMED P2 correctness bug). The preflight ENSURE executor (`re-frame.ui.frames/execute-frame-plans!`) silently clobbered a live, boot-created frame's config and image generation when a root declared `[frame-root {:id …}]` to *share* it.

**Root cause.** Phase-1 decided `:install` whenever the plan-install record was `nil` — which includes the case *frame is LIVE but boot-created (never plan-installed)*, because `installed-plan-entry` returns `nil` for a live frame with no registry record. Phase-2 then ran `(make-frame (assoc (or config {}) :id frame-id))` unconditionally. Downstream (`live_frame.cljc`) always re-resolves a generation (the **default** store when the plan carries no `:images`), and `frame.cljc`'s re-registration replaces `:config` + `:generation` **wholesale**. So an app that boots `(rf/make-frame {:id :app/session :images [...] :fx-overrides {...}})` and then declares `[frame-root {:id :app/session}]` to share it had its generation swapped to the default (images discarded), its `:fx-overrides`/`:preset`/`:url-strategy` wiped, and its generation-pool provenance rewritten. The durable app-db survived, **masking** the clobber.

**Contract.** ENSURE is *create-if-absent* (03 §8 / 004C §6 — "later roots find it live and do not re-seed"). If the frame is already present/live, ENSURE must create **nothing**.

## Fix

Guard is entirely in `frames.cljc` phase-1 (no core `make-frame` change):

- Phase-1 now splits the `nil`-record case: **frame absent → `:install`**; **frame live but plan-less → `:adopt`**.
- Phase-2 `:adopt` records **only** the plan's `{:config-fingerprint :installed-by}` for cross-root conflict scoping — it does **not** call `make-frame`, so the boot frame's `:config` / `:generation` / `:images` are left entirely untouched.
- `:found-live`, `:refresh`, `:install`, and the cross-root conflict paths are unchanged. A destroyed frame still routes to `:install` (new lifetime, `:initial-events` replayed).

## Ruling — no-op vs. hard-conflict

I chose the bead's **primary option: adoption is a no-op on config/generation**, not the "config-carrying plan meets live plan-less frame → hard conflict" alternative.

Rationale: the contract language is unambiguous create-if-absent — "later roots find it live and do not re-seed." The canonical, idiomatic case is an app that boot-creates its frame (`rf/make-frame` with its images/overrides) and then writes a plain `[frame-root {:id :x}]` purely to **scope** that frame in a root form; the bead states this "must succeed as a no-op." A hard-conflict rule would break that intended shared-frame pattern. The boot `make-frame` is authoritative because it ran first and holds the durable state; the sharing root asserts existence, not configuration. The recorded fingerprint still governs genuine cross-*root* config conflicts (two roots asserting differing plans for the same id), so the loud-on-real-conflict guarantee is retained. No contract reason to prefer conflict was found.

Refresh semantics are deliberately unchanged: if the *owning* root later re-declares its own frame-root with a differing fingerprint, that remains the documented HMR `:refresh` path — out of scope for this bug.

## Quality gates

Foreground, on this branch (rebased clean on `origin/main`):

- `npm run test:cljs` (node CLJS integration, includes the new adoption fixtures): **8930 tests / 42137 assertions — 0 failures, 0 errors**
- `implementation/ui` JVM (`clojure -M:test`): **206 tests / 4281 assertions — 0 failures, 0 errors**

These two suites are the coverage for the `frames.cljc` (+ ui tests) surface; the full `test-fast-pr.sh` spine is left to CI (Linux).

## Tests added (`preflight_frame_wiring_cljs_test.cljs`, G-4)

1. `adoption-of-a-live-plan-less-frame-preserves-config-and-generation` — boot a frame with `:images` + `:fx-overrides` + `:doc`, then share it via a config-less plan → asserts the generation object is **identical** (not re-resolved), `:rf.gen/images` preserved, `:fx-overrides`/`:doc` preserved, and the fingerprint is recorded (and nothing else).
2. `adoption-then-same-fingerprint-second-root-is-a-found-live-no-op` — a second root sharing the same frame is a pure no-op; first adopter retained.
3. `adoption-coexists-with-a-fresh-install-in-the-same-root` — both ways in one run: adopt the boot frame **and** still install + seed a genuinely-new frame.
