### PR TITLE
fix(ui): semantic/normalize fails loud on bad tree-version + ambiguous/absent discriminators (rf2-vxgfnd.20)

### DIFF
--- a/implementation/ui/src/re_frame/ui/semantic.cljc
+++ b/implementation/ui/src/re_frame/ui/semantic.cljc
@@ -191,24 +191,74 @@
 ;; The walk (steps 1-4, 6, 7)
 ;; ---------------------------------------------------------------------------
 
+(def ^:private node-discriminators
+  "The three PRIMARY structural discriminators of a map tree node
+  (jvm-tree contract §Node schema — the closed five-variant set). A
+  canonical map node carries EXACTLY ONE of these — `:tag` (element),
+  `:view-id` (view boundary), `:html` (trusted markup) — OR none, in
+  which case it is a FRAGMENT, discriminated by its (always-present,
+  possibly empty `[]`) `:children`. `:children` is NOT a co-equal
+  discriminator: element and view-boundary nodes carry it as content, so
+  it is only the fragment signal in the ABSENCE of the three primaries."
+  [:tag :view-id :html])
+
+(defn- malformed-node!
+  "Fail loud with the shared node-malformation id, naming the closed
+  variant set (the escape the emitter/author should honour)."
+  [reason extra]
+  (error/throw-error!
+   :rf.error/ui-tree-malformed 're-frame.ui.semantic/normalize
+   reason {:extra extra}))
+
 (defn- norm-node
-  "-> vector of semantic nodes/strings this tree node contributes."
+  "-> vector of semantic nodes/strings this tree node contributes.
+
+  Discrimination is CLOSED and UNAMBIGUOUS (jvm-tree contract §Node
+  discrimination): a map node carries exactly one of `node-
+  discriminators`, or none plus `:children` (a fragment). Zero
+  discriminators with no `:children`, or two-plus discriminators, is a
+  malformed node — it fails loud rather than being guessed by branch
+  order or silently dropped as `[]`."
   [node]
   (cond
     (string? node) [node]
     (map? node)
-    (cond
-      (contains? node :tag)     [(norm-element node)]
-      (contains? node :html)    [{:html (:html node)}]
-      ;; view boundaries + fragments SPLICE — children replace the node
-      (or (contains? node :view-id) (contains? node :children))
-      (norm-nodes* (:children node))
-      :else [])
+    (let [ds (filterv #(contains? node %) node-discriminators)]
+      (cond
+        (> (count ds) 1)
+        (malformed-node!
+         (str "a tree node carries multiple node discriminators "
+              (pr-str ds) " — every map node is EXACTLY ONE of :tag "
+              "(element), :view-id (view boundary), :html (trusted "
+              "markup), or a fragment (none of these, splicing its "
+              ":children); an ambiguous map must not be interpreted by "
+              "branch order: " (pr-str node))
+         {:value node :got ds})
+
+        (= 1 (count ds))
+        (case (first ds)
+          :tag     [(norm-element node)]
+          :html    [{:html (:html node)}]
+          ;; view boundaries SPLICE — children replace the node
+          :view-id (norm-nodes* (:children node)))
+
+        ;; no primary discriminator: a fragment (splices its children)
+        (contains? node :children)
+        (norm-nodes* (:children node))
+
+        ;; no discriminator AND no :children — not a renderable node; must
+        ;; not silently disappear as [] (a lost fragment / corrupt node)
+        :else
+        (malformed-node!
+         (str "a tree node carries no node discriminator — every map node "
+              "is an element (:tag), a view boundary (:view-id), trusted "
+              "markup (:html), or a fragment (:children); a map with none "
+              "is not a renderable tree node: " (pr-str node))
+         {:value node :got []})))
     :else
-    (error/throw-error!
-     :rf.error/ui-tree-malformed 're-frame.ui.semantic/normalize
+    (malformed-node!
      (str "malformed tree node in normalization N: " (pr-str node))
-     {:extra {:value node}})))
+     {:value node})))
 
 (defn- norm-nodes*
   [children]
@@ -226,8 +276,43 @@
                           [] vs)]
     (into [] (remove #(and (string? %) (= "" %))) coalesced)))
 
+(def ^:private supported-tree-versions
+  "The node-schema versions `normalize` (semantic projection N) accepts.
+  Bumping the tree-version integer (jvm-tree contract §Versioning — any
+  change to the variant set, discrimination, canonical-form rules, or
+  N's behaviour) edits this set DELIBERATELY, in lockstep with the walk
+  above. An unsupported version must never be reinterpreted under v1's
+  rules."
+  #{1})
+
+(defn- validate-tree-version!
+  "Root schema-version gate (jvm-tree contract §Versioning): the root of
+  a structural tree carries `:rf.ui/tree-version` (`re-frame.ui.tree/
+  render` stamps it). A missing, non-integer, or unsupported version is
+  NOT silently coerced to v1 — it fails loud at the N boundary BEFORE any
+  traversal, so a future-version or corrupt tree can never produce a
+  plausible semantic projection / fingerprint. (The S5 SSR serialiser
+  carries its own version-gate sibling
+  `:rf.error/ssr-ui-tree-version-unsupported`; this Tier-1 parity
+  boundary reuses the shared node-malformation id with the same
+  `{:got … :supported …}` ex-data.)"
+  [tree]
+  (let [v (:rf.ui/tree-version tree)]
+    (when-not (and (integer? v) (contains? supported-tree-versions v))
+      (error/throw-error!
+       :rf.error/ui-tree-malformed 're-frame.ui.semantic/normalize
+       (str "normalization N requires a root :rf.ui/tree-version in "
+            (pr-str supported-tree-versions) " — got " (pr-str v)
+            "; an absent or unsupported schema version is never coerced "
+            "to v1 (that would make the version field meaningless and let "
+            "a future-version tree be misread under today's rules)")
+       {:extra {:got v :supported supported-tree-versions}}))))
+
 (defn normalize
   "`N(tree)` — the semantic-node projection of a version-1 structural
-  tree. Returns the VECTOR of semantic roots in document order."
+  tree. Validates the root `:rf.ui/tree-version` FIRST (fail-loud on a
+  missing / non-integer / unsupported version), then returns the VECTOR
+  of semantic roots in document order."
   [tree]
+  (validate-tree-version! tree)
   (norm-nodes [tree]))

--- a/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
@@ -258,7 +258,10 @@
 (defn- jvm-root-semantic [form]
   (let [{:keys [ast]} (analyze-mount-form form)
         tree ((eval `(fn [] ~(emit-jvm/emit-node ast))))]
-    (semantic/normalize tree)))
+    ;; the raw emitted root node bypasses `tree/render`, which is what
+    ;; stamps `:rf.ui/tree-version` in the real path — stamp it here so
+    ;; the semantic-version gate sees a well-formed v1 root (rf2-vxgfnd.20).
+    (semantic/normalize (assoc tree :rf.ui/tree-version tree/tree-version))))
 
 (deftest frame-root-is-transparent-in-the-jvm-tree
   (let [wrapped '[re-frame.ui/frame-root {:id :chat/frame}

--- a/implementation/ui/test/re_frame/ui/semantic_normalize_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/semantic_normalize_cljs_test.cljc
@@ -1,0 +1,193 @@
+(ns re-frame.ui.semantic-normalize-cljs-test
+  "Adversarial coverage for `re-frame.ui.semantic/normalize` (N) — the
+  parity/fingerprint INPUT boundary (rf2-vxgfnd.20).
+
+  Two fail-loud contracts pinned here (jvm-tree contract §Versioning +
+  §Node discrimination):
+
+    1. ROOT VERSION GATE — `normalize` validates `:rf.ui/tree-version`
+       BEFORE any traversal; a missing / non-integer / unsupported
+       version throws `:rf.error/ui-tree-malformed` with ex-data
+       `{:got … :supported #{1}}`. An unknown version is NEVER silently
+       reinterpreted under v1's rules.
+
+    2. NODE DISCRIMINATION — every map node carries EXACTLY ONE of
+       `:tag` / `:view-id` / `:html`, or none plus `:children` (a
+       fragment). Zero discriminators with no `:children`, or two-plus
+       discriminators, throws `:rf.error/ui-tree-malformed` — it is
+       never guessed by branch order nor silently dropped as `[]`.
+
+  Runs on BOTH hosts (`.cljc`): the discrimination + version rules are
+  pure and host-identical."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.semantic :as semantic]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- ex-of
+  "Run `f`; return the thrown ExceptionInfo, or nil when it returns."
+  [f]
+  (try (f) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo
+                 :cljs cljs.core/ExceptionInfo) e e)))
+
+(defn- v1
+  "Stamp a node map as a version-1 tree root."
+  [node]
+  (assoc node :rf.ui/tree-version 1))
+
+;; ---------------------------------------------------------------------------
+;; The five valid variants still normalize (regression floor)
+;; ---------------------------------------------------------------------------
+
+(deftest valid-variants-normalize
+  (testing "element root -> element semantic node"
+    (is (= [{:tag :div :children ["hi"]}]
+           (semantic/normalize (v1 {:tag :div :children ["hi"]})))))
+
+  (testing "trusted-HTML root -> opaque raw-markup leaf"
+    (is (= [{:html "<b>x</b>"}]
+           (semantic/normalize (v1 {:html "<b>x</b>"})))))
+
+  (testing "view-boundary root SPLICES its children (boundary erased in N)"
+    (is (= [{:tag :p :children ["y"]}]
+           (semantic/normalize
+            (v1 {:view-id :app/v :children [{:tag :p :children ["y"]}]})))))
+
+  (testing "fragment root SPLICES its children in document order"
+    (is (= [{:tag :p :children ["a"]} {:tag :p :children ["b"]}]
+           (semantic/normalize
+            (v1 {:children [{:tag :p :children ["a"]}
+                            {:tag :p :children ["b"]}]})))))
+
+  (testing "text is the fifth variant — carried verbatim as a child"
+    (is (= [{:tag :div :children ["hello" {:tag :span :children ["world"]}]}]
+           (semantic/normalize
+            (v1 {:tag :div
+                 :children ["hello" {:tag :span :children ["world"]}]})))))
+
+  (testing "empty valid fragment remains legal -> []"
+    (is (= [] (semantic/normalize (v1 {:children []})))))
+
+  (testing "nil-rooted view boundary (no :children) -> []"
+    (is (= [] (semantic/normalize (v1 {:view-id :app/empty}))))))
+
+;; ---------------------------------------------------------------------------
+;; Version gate — missing / non-integer / unsupported all fail loud
+;; ---------------------------------------------------------------------------
+
+(def ^:private bad-version-trees
+  "[label root expected-:got] — each must throw the typed error with
+  `{:got expected :supported #{1}}` BEFORE any traversal."
+  [["missing version"        {:tag :div :children ["x"]}          nil]
+   ["nil version"            {:rf.ui/tree-version nil :tag :div}   nil]
+   ["string version"        {:rf.ui/tree-version "1" :tag :div}   "1"]
+   ["non-integer version"   {:rf.ui/tree-version 1.5 :tag :div}   1.5]
+   ["keyword version"       {:rf.ui/tree-version :v1 :tag :div}   :v1]
+   ["unsupported version 2" {:rf.ui/tree-version 2 :tag :div}     2]
+   ["unsupported version 0" {:rf.ui/tree-version 0 :tag :div}     0]])
+
+(deftest version-gate-rejects-bad-versions
+  (doseq [[label root got] bad-version-trees]
+    (testing label
+      (let [e    (ex-of #(semantic/normalize root))
+            data (some-> e ex-data)]
+        (is (some? e) (str label " must throw"))
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str label " carries the typed node-malformation id"))
+        (is (= got (:got data)) (str label " reports the offending :got"))
+        (is (= #{1} (:supported data))
+            (str label " reports :supported #{1}"))))))
+
+(deftest version-gate-fires-before-traversal
+  ;; An unsupported version on a root whose BODY is also malformed must
+  ;; surface the VERSION failure (the gate runs first), not a node error.
+  (let [data (-> (ex-of #(semantic/normalize
+                          {:rf.ui/tree-version 2 :tag :div :html "both"}))
+                 ex-data)]
+    (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
+    (is (= 2 (:got data)) "version gate reports the version, not the node")
+    (is (= #{1} (:supported data)))))
+
+;; ---------------------------------------------------------------------------
+;; Discriminator ambiguity — every pair (and the triple) is rejected
+;; ---------------------------------------------------------------------------
+
+(def ^:private ambiguous-nodes
+  "[label extra-node-keys expected-:got] — a v1 root whose single node
+  carries MULTIPLE discriminators is ambiguous and must fail loud
+  instead of being interpreted by branch order."
+  [["tag + html"          {:tag :div :html "trusted"}            [:tag :html]]
+   ["tag + view-id"       {:tag :div :view-id :app/v}            [:tag :view-id]]
+   ["view-id + html"      {:view-id :app/v :html "trusted"}      [:view-id :html]]
+   ["tag + view-id + html" {:tag :div :view-id :app/v :html "h"} [:tag :view-id :html]]])
+
+(deftest ambiguous-discriminators-rejected
+  (doseq [[label node got] ambiguous-nodes]
+    (testing label
+      (let [data (-> (ex-of #(semantic/normalize (v1 node))) ex-data)]
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str label " throws the typed error"))
+        (is (= got (:got data))
+            (str label " enumerates the colliding discriminators in :got"))
+        (is (= (v1 node) (:value data))
+            (str label " carries the offending node as :value"))))))
+
+;; ---------------------------------------------------------------------------
+;; Discriminator-less maps — must NOT silently disappear as []
+;; ---------------------------------------------------------------------------
+
+(deftest discriminatorless-root-rejected
+  (testing "a root with only the version key (no discriminator, no :children)"
+    ;; the bug's case 4: {:rf.ui/tree-version 1} -> [] previously
+    (let [data (-> (ex-of #(semantic/normalize {:rf.ui/tree-version 1}))
+                   ex-data)]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
+      (is (= [] (:got data)) "reports zero discriminators")))
+
+  (testing "an empty map past the version gate still fails as a lost node"
+    (let [data (-> (ex-of #(semantic/normalize
+                            (v1 {:rf.ui/presence {:phase :present}})))
+                   ex-data)]
+      ;; a reserved diagnostic key is NOT a discriminator and does not
+      ;; rescue a node that carries neither a primary nor :children
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
+      (is (= [] (:got data))))))
+
+(deftest nested-malformed-node-rejected
+  (testing "a discriminator-less MAP nested as a child fails loud (AC 6)"
+    (let [data (-> (ex-of #(semantic/normalize
+                            (v1 {:tag :ul
+                                 :children [{:tag :li :children ["ok"]}
+                                            {:unrelated :junk}]})))
+                   ex-data)]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
+      (is (= {:unrelated :junk} (:value data))
+          "the offending nested node is named")))
+
+  (testing "an ambiguous node nested inside a fragment fails loud"
+    (let [data (-> (ex-of #(semantic/normalize
+                            (v1 {:children [{:tag :p :html "x"}]})))
+                   ex-data)]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
+      (is (= [:tag :html] (:got data))))))
+
+;; ---------------------------------------------------------------------------
+;; Forward-compat: unknown reserved :rf.ui/* keys stay ignored (AC 5)
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-reserved-keys-ignored-after-validation
+  (testing "an unknown :rf.ui/* diagnostic key on an element is stripped"
+    (is (= [{:tag :div :children ["hi"]}]
+           (semantic/normalize
+            (v1 {:tag :div :children ["hi"]
+                 :rf.ui/some-future-diag {:whatever true}})))))
+
+  (testing "a fragment's reserved presence/boundary markers are ignored"
+    (is (= [{:tag :p :children ["a"]}]
+           (semantic/normalize
+            (v1 {:rf.ui/presence {:phase :present}
+                 :rf.ui/boundary :client-only
+                 :children [{:tag :p :children ["a"]}]}))))))


### PR DESCRIPTION
## What

`re-frame.ui.semantic/normalize` (the parity/fingerprint input boundary `N`) was ignoring the versioned tree contract:

- It called `norm-nodes` directly **without checking `:rf.ui/tree-version`**, so a missing / non-integer / unsupported version was silently treated as v1.
- `norm-node` discriminated by `cond` precedence (`:tag` wins, then `:html`, then `:view-id`/`:children`), so an **ambiguous** map (multiple discriminators, e.g. `:tag` + `:html`) was resolved by branch order, and a **discriminator-less** map (e.g. `{:rf.ui/tree-version 1}`) silently contributed `[]` (disappeared).

This defeats the version field and makes corrupt/future-version trees produce plausible-but-invalid fingerprints/parity results.

## Fix (`semantic.cljc`)

- **Root version gate** — `normalize` validates `:rf.ui/tree-version` FIRST, before any traversal. A missing / non-integer / unsupported version throws `:rf.error/ui-tree-malformed` with ex-data `{:got … :supported #{1}}`. An unsupported version is never coerced to v1.
- **Closed node discrimination** — `norm-node` now requires EXACTLY ONE of `:tag` / `:view-id` / `:html`, or none plus `:children` (a fragment). Zero discriminators with no `:children`, or two-plus discriminators, fail loud with the same typed id, naming the offending node/discriminators. `:children` is not a co-equal discriminator (element/view carry it as content); empty valid fragments (`{:children []}`) remain legal.
- Unknown reserved `:rf.ui/*` diagnostic keys stay ignored after validation (forward-compatible contract).

## Error-id decision (no spec/009 touch)

Reuses the **already-catalogued** `:rf.error/ui-tree-malformed` (spec/009 row present; "shared by every tree consumer") for both the version gate and the discriminator failures, with the contract's `{:got … :supported #{1}}` ex-data on the version branch. The SSR-namespaced `:rf.error/ssr-ui-tree-version-unsupported` is a poor fit for this Tier-1 non-SSR boundary and remains reserved for the S5 serialiser per the 004B contract. **No spec/009 hot-zone change** — the error-catalogue source-scan gate (which scans `throw-error!` first-args) stays green because the id is already catalogued.

## Tests

New adversarial suite `implementation/ui/test/re_frame/ui/semantic_normalize_cljs_test.cljc` (`.cljc`, runs on both hosts): five valid variants + empty fragment + nil-rooted view still normalize; missing / nil / string / non-integer / unsupported versions all throw with `:got`/`:supported`; version gate fires before node traversal; every discriminator pair + the triple rejected; discriminator-less root/nested maps rejected (not silent `[]`); unknown `:rf.ui/*` keys ignored. The parity-corpus JVM helper `jvm-root-semantic` (which bypasses `tree/render`) now stamps the version to match the real path.

## Quality gates

Run in the foreground (Windows worker):

- ui artefact JVM tests (`clojure -M:test`, `implementation/ui/`): **234 tests, 4401 assertions, 0 failures, 0 errors**.
- Node CLJS suite (`npm run test:cljs`): **8933 tests, 42179 assertions, 0 failures, 0 errors** (includes the new `.cljc` suite via the `cljs-test$` ns-regexp on the `ui/test` classpath).
- Error-catalogue conformance (`re-frame.error-catalogue-channel-conformance-test`): **9 tests, 21 assertions, 0 failures, 0 errors** — confirms the reused id needs no catalogue row.

No spec/009 change. Surface: `semantic.cljc` + two ui test files only.