### PR TITLE
docs(spec): 004C injective-slug re-derivation + 009 route-keyword catalogue row (rf2-jl1tvt, rf2-ahjbsi)

### DIFF
--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -41,11 +41,20 @@ so the single-root common case stays one-liner clean:
    ids derived from `:shop/app` — add `:disambiguator` or author `:root-id`"*. Stripped
    from shipped manifests.
 
-**Root-id slug** (one deterministic function, used by the identifier-prefix default and
-synthesised locators): keyword → `namespace "-" name` (namespace absent → name);
-vector → element slugs joined by `"--"`; any character outside `[A-Za-z0-9_-]`
-normalised to `-`. `:page/shop` → `"page-shop"`; `[:shop/app :left]` →
-`"shop-app--left"`.
+**Root-id slug** (one deterministic, **injective** function, used by the
+identifier-prefix default and synthesised locators — distinct valid root-ids ALWAYS
+yield distinct slugs). It is a decodable canonical form over the DOM-safe alphabet
+`[A-Za-z0-9_-]`: `_` is the sole metacharacter — every character outside `[A-Za-z0-9-]`
+(**including `_` itself**) is reversibly escaped `_<lowercase-hex-code-unit>_`, and each
+structural boundary carries an uppercase `_`-tag the escape never emits (`_S` keyword
+namespace/name separator; `_V` vector lead-in; `_K`/`_T`/`_I` a vector element's
+keyword/string/integer type). A keyword root encodes to `enc(namespace) _S enc(name)`
+(namespace absent → `enc(name)`); a vector root to `_V` followed by its type-tagged,
+escaped elements. `:page/shop` → `"page_Sshop"`; `[:shop/app :left]` →
+`"_V_Kshop_Sapp_Kleft"`. Because every boundary is *marked* rather than inferred from a
+data character, the mapping is losslessly decodable and thus injective — no two distinct
+root-ids can alias to one slug (the earlier lossy "normalise every disallowed char to
+`-`" transform could: `:a/b-c` and `:a-b/c` both flattened to `a-b-c`).
 
 ## 2. The Root Descriptor v1 — the named, versioned S1 subset
 
@@ -125,7 +134,7 @@ id" is closed here:
 |---|---|---|
 | `:root-id` | identity | authored root-id (§1.1); immutable for the root's lifetime |
 | `:disambiguator` | identity | scalar; only meaningful when `:root-id` is absent (§1.2) |
-| `:identifier-prefix` | rendering | string fed to React's `identifierPrefix` (`use-id`). Default: `"rf2-" + root-id-slug + "-"` (§1) — `:page/shop` → `"rf2-page-shop-"`. (06 §2's `"rf2-shop-"` example is an authored value, not the derived default.) |
+| `:identifier-prefix` | rendering | string fed to React's `identifierPrefix` (`use-id`). Default: `"rf2-" + root-id-slug + "-"` (§1) — `:page/shop` → `"rf2-page_Sshop-"`. (06 §2's `"rf2-shop-"` example is an authored value, not the derived default.) |
 | `:on-uncaught-error` `:on-caught-error` `:on-recoverable-error` | host | plain CLJS fns passed to the React root options. Host-tier option maps are **not** template positions — the §02 §3 handler boundary law does not apply here. Invoked by React outside the re-frame2 commit path; to dispatch they must go through a live frame handle. |
 
 Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) must be **compile-time
@@ -180,7 +189,9 @@ positional locators — an id is stable under fragment reordering, which is the 
   synthesised locator on a host-owned element.
 - **SSR, emitter-synthesised container** (the server emitter is asked to produce the
   container itself): id is generated deterministically as
-  `"rf2-root-" + root-id-slug` — unique because root-ids are unique per page (§7).
+  `"rf2-root-" + root-id-slug` — unique per page because the slug is **injective** (§1),
+  so distinct root-ids yield distinct slugs, and root-ids are unique per page (§7): two
+  synthesised locators can therefore never collide.
 - **Manifest placement:** the manifest rides a script element **adjacent** (immediately
   following sibling) to the root's container, EDN-safe-encoded per Spec 011.
   `hydrate-root` discovers the manifest *positionally* (adjacent to its `dom-node`) and
@@ -270,7 +281,10 @@ per Spec 011). This is the layer that catches **independently rendered page
 fragments** composed into one response — the case Layer 1 cannot see. The same
 registry asserts **identifier-prefix uniqueness** across the page's roots
 (`:rf.error/root-manifest-invalid`, data `{:conflict :identifier-prefix}`) — two roots
-sharing a prefix would collide `use-id` output.
+sharing a prefix would collide `use-id` output. The **default** prefix
+`"rf2-" + root-id-slug + "-"` is already collision-free for distinct root-ids because the
+slug is injective (§1); this check therefore backstops **authored** `:identifier-prefix`
+opts, which can still collide.
 
 **Layer 3 — client runtime (S1).** A per-document live-root registry: `create-root`,
 `hydrate-root`, and `mount` register their root-id before any render; `unmount!`


### PR DESCRIPTION
Two tiny, additive hot-zone spec follow-ups on disjoint files — one PR, two commits.

## rf2-jl1tvt — spec/004C root-identity contract refresh

rf2-vxgfnd.17 (#5725) made `root-id-slug` an injective/decodable encoding (`_` metacharacter; `_S`/`_V`/`_K`/`_T`/`_I` structural markers; reversible `_<hex>_` escapes). This refreshes the doc to match the shipped code:

- **§1 slug definition + examples** rewritten to the injective encoding. Corrected examples (re-derived from `re_frame/ui/compiler/root.cljc`):
  - `:page/shop` → `"page_Sshop"` (was the lossy `"page-shop"`)
  - `[:shop/app :left]` → `"_V_Kshop_Sapp_Kleft"` (was the lossy `"shop-app--left"`)
- **§3** default `:identifier-prefix` example: `:page/shop` → `"rf2-page_Sshop-"` (was `"rf2-page-shop-"`).
- **§4** synthesised-locator uniqueness and **§7** identifier-prefix uniqueness are now **re-derived from the injective slug** (distinct valid root-ids → distinct slugs → distinct prefixes/locators) instead of the old lossy transform they implicitly relied on. The §7 default-prefix uniqueness is now a consequence of injectivity; the runtime registry check backstops *authored* prefixes.

The `:rf.error/root-not-live` roster row (#5724) was left untouched.

## rf2-ahjbsi — spec/009 catalogue row

rf2-qot6ii (#5723) added a `reg-route` fail-loud throw `:rf.error/route-keyword-unbounded-unsupported` (rejecting bare/unbounded `:keyword` route slots). Adds the Spec 009 catalogue row for it, **mirroring the existing `:rf.error/route-decimal-unsupported` row** (same section, column shape, and wording pattern; same `:route-id`/`:slot`/`:param`/`:type-form` data keys). Additive — no other rows altered. Catalogue-completeness only (the source-scan under-reports routing errors, which flow through the `route-error` helper's variable error-kw arg, so CI was already green without it).

## Quality gates

Ran in the foreground (the full `test-fast-pr.sh` spine was intentionally not run):

- **error-catalogue-channel-conformance** (`clojure -M:test -n re-frame.error-catalogue-channel-conformance-test`): **9 tests, 21 assertions, 0 failures, 0 errors** — the new 009 row parses, carries a valid `diagnostic` channel, no duplicate id, and the always-on coupling is intact.
- **`python scripts/check_doc_slugs.py`**: exit 0 (no broken anchors).
- **`python scripts/check_readme_links.py --ci`**: exit 0.
- **mkdocs**: not on PATH locally → soft-skipped; CI runs `mkdocs build --strict`.