### PR TITLE
fix(core): acquire! fails loud on never-cached recovery reactions (rf2-vxgfnd.27)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -625,6 +625,40 @@
 
 (declare subscribe subscribe-in-frame unsubscribe compute-and-cache!)
 
+;; ---- observation-port acquire recovery channel (rf2-vxgfnd.27) -----------
+;;
+;; The observation port's `acquire!` is the cache's ref-count ATTACH (Spec 006
+;; §The internal observation port). Three build outcomes hand back a NON-NIL but
+;; NEVER-CACHED, zero-ref recovery reaction instead of a canonical node: a
+;; cyclic entry sub (`compute-and-cache!`'s outermost catch), a parametric
+;; `input-fn` failure (`build-and-cache!*`'s `input-error?` escaped-caching
+;; branch), and a frame destroyed mid-build (the same branch with `cache` nil).
+;; There is no cache node to attach to, so the port must NOT lease a lying
+;; `owned?`-true zero-ref reaction — it re-derives WHICH recovery happened and
+;; throws the matching typed error. This out-channel carries that classification
+;; from the build sites up to `acquire-cache-reaction!`. It is bound ONLY by the
+;; port's acquire path; on the public `subscribe` / `compute-sub` paths it is
+;; nil and every recorder call short-circuits, so those paths are byte-identical.
+
+(def ^:dynamic ^:no-doc *acquire-recovery*
+  "Port-internal recovery out-channel (rf2-vxgfnd.27) — a `volatile!` bound by
+  `acquire-cache-reaction!` around the reactive build, or nil on the public
+  subscribe / compute-sub paths. The never-cached recovery sites record their
+  classification into it via [[record-acquire-recovery!]]; the port reads it to
+  throw the matching typed error rather than lease a zero-ref recovery reaction."
+  nil)
+
+(defn- record-acquire-recovery!
+  "Record a never-cached recovery classification for the observation-port
+  acquire path — `kind` ∈ `:cycle` / `:input-fn-exception` /
+  `:input-fn-bad-return`; `data` carries the typed error id + context the port
+  re-throws with. A no-op (channel nil-bound) on the public subscribe /
+  compute-sub paths, so this is invisible there. rf2-vxgfnd.27."
+  [kind data]
+  (when-some [sink *acquire-recovery*]
+    (vreset! sink (assoc data :recovery kind)))
+  nil)
+
 ;; The memo wrappers (`make-layer-1-memoised-body`,
 ;; `make-layer-n-single-input-memoised-body`, `make-layer-n-memoised-body`) and
 ;; the trace/perf/validate/recover bracket (`validate-and-trace`,
@@ -718,11 +752,27 @@
     [(produce-input-queries sub-meta query-v) false]
     (catch #?(:clj Throwable :cljs :default) e
       (let [bad-return? (= :rf.error/sub-input-fn-bad-return
-                           (:rf.error/id (ex-data e)))]
-        (emit-sub-input-fn-error! (if bad-return?
-                                    :rf.error/sub-input-fn-bad-return
-                                    :rf.error/sub-input-fn-exception)
-                                  query-id query-v frame-id e where)
+                           (:rf.error/id (ex-data e)))
+            error-kw    (if bad-return?
+                          :rf.error/sub-input-fn-bad-return
+                          :rf.error/sub-input-fn-exception)]
+        (emit-sub-input-fn-error! error-kw query-id query-v frame-id e where)
+        ;; Observation-port acquire path only (rf2-vxgfnd.27): record the
+        ;; parametric-failure classification so `acquire!` throws the matching
+        ;; typed error instead of leasing this never-cached recovery reaction.
+        ;; `emit-sub-input-fn-error!` ALREADY fanned the always-on record above,
+        ;; so the port re-throws the same id WITHOUT a second fan (one record,
+        ;; one throw). No-op on the subscribe / compute-sub paths.
+        (record-acquire-recovery!
+          (if bad-return? :input-fn-bad-return :input-fn-exception)
+          {:error-kw error-kw
+           :query-v  query-v
+           :reason   (str "parametric subscription " (pr-str query-id)
+                          " input-fn "
+                          (if bad-return?
+                            "returned a value outside the input grammar"
+                            "threw")
+                          " while materializing.")})
         [recovery-qs true]))))
 
 (defn- release-input-ref!
@@ -1195,6 +1245,14 @@
           (if (= :rf.error/sub-cycle (:rf.error/id (ex-data e)))
             (do
               (emit-sub-cycle! frame-id query-v (:cycle (ex-data e)) :subscribe)
+              ;; Observation-port acquire path only (rf2-vxgfnd.27): record the
+              ;; cycle so `acquire!` throws typed `:rf.error/sub-cycle`
+              ;; (fail-loud → the ViewCell error boundary) rather than lease
+              ;; this never-cached nil reaction. sub-cycle stays DIAGNOSTIC (009
+              ;; catalogue) — the port throws the typed carrier but does NOT
+              ;; promote it to the always-on axis. No-op on the subscribe path.
+              (record-acquire-recovery! :cycle {:cycle   (:cycle (ex-data e))
+                                                :query-v query-v})
               (adapter/make-derived-value [] (constantly nil)))
             (throw e))))
       (build-and-cache!* frame-id query-v))))
@@ -1925,6 +1983,55 @@
   [query-v db memo]
   (compute-sub* query-v db memo))
 
+(defn- canonical-cache-reaction?
+  "True when `reaction` is still exactly the frame's live cache entry for `k`
+  — an identical cached node, so a real ref-count attach happened. False for a
+  never-cached recovery reaction (nothing at `k`, or a different node), and for
+  the single-thread-unreachable case of a node evicted in the build→check
+  window. rf2-vxgfnd.27."
+  [frame-id k reaction]
+  (boolean
+    (when-let [cache (:sub-cache (frame/frame frame-id))]
+      (identical? reaction (:reaction (get @cache k))))))
+
+(defn- build-and-classify!
+  "Drive `compute-and-cache!` for the observation-port acquire path and
+  DISCRIMINATE its result (rf2-vxgfnd.27). Returns `{:reaction r}` for a
+  CANONICAL cached node (a real ref-count attach) or `{:recovery kind …}` for a
+  never-cached, zero-ref recovery reaction:
+
+    - `:frame-destroyed` — the frame's cache vanished DURING the build (the race
+      that used to slip through the caller's nil→guard).
+    - `:cycle` / `:input-fn-exception` / `:input-fn-bad-return` — the entry
+      node's OWN build recovered, recording its classification through
+      `*acquire-recovery*`.
+
+  The canonical check is AUTHORITATIVE: a real cached node is owned even when a
+  mid-graph INPUT recovered (the graph's own recover-to-nil), so a nested
+  recovery recorded on the channel is IGNORED once the entry node itself cached."
+  [frame-id query-v k]
+  (let [sink     (volatile! nil)
+        reaction (binding [*acquire-recovery* sink]
+                   (compute-and-cache! frame-id query-v))]
+    (cond
+      ;; Frame torn down during the build — the reaction escaped caching (the
+      ;; `build-and-cache!*` else-branch). Map it to the typed
+      ;; `:rf.error/frame-destroyed`, closing the nil→guard bypass the race used.
+      (nil? (:sub-cache (frame/frame frame-id)))
+      {:recovery :frame-destroyed}
+
+      ;; A real cached node — the build installed or adopted it and took a +1
+      ;; reference. Own it (ignore any nested-input recovery on the channel).
+      (canonical-cache-reaction? frame-id k reaction)
+      {:reaction reaction}
+
+      ;; Non-canonical: the entry node's OWN build produced a never-cached
+      ;; recovery reaction. Use the recorded classification; fall back to
+      ;; `:frame-destroyed` for the (single-thread-unreachable) evicted-in-window
+      ;; case where nothing recorded.
+      :else
+      (or @sink {:recovery :frame-destroyed}))))
+
 (defn ^:no-doc acquire-cache-reaction!
   "INTERNAL (observation port). Resolve-or-build the canonical sub-cache
   node for `query-v` in `frame-id` and take ONE reference on it — the
@@ -1938,15 +2045,30 @@
   seam so an image-loaded frame's build resolves the sub through its own
   generation, byte-identical to `subscribe`.
 
-  Returns the cache node's reaction, or nil when the frame's cache is gone
-  (destroyed in the race window — the caller maps nil to its typed
-  `:rf.error/frame-destroyed`). Callers release via the identity-guarded
-  decrement they own (the lease `release!`), or `unsubscribe`."
+  Returns a DISCRIMINATED result (rf2-vxgfnd.27):
+
+    {:reaction <r>}          — a CANONICAL cached node holding a real +1
+                               reference: the ONLY result the caller wraps in an
+                               owning lease.
+    {:recovery <kind> …}     — the build produced a NON-NIL but NEVER-CACHED,
+                               zero-ref recovery reaction instead of a canonical
+                               node. `<kind>` is `:cycle` (cyclic entry sub),
+                               `:input-fn-exception` / `:input-fn-bad-return`
+                               (parametric `input-fn` failure), or
+                               `:frame-destroyed` (the frame's cache vanished
+                               before or during the build). `acquire` IS the
+                               ref-count attach — there is no node to own — so
+                               the caller (the fail-loud observation port) throws
+                               the matching typed error rather than lease a
+                               lying `owned?`-true zero-ref reaction.
+
+  Callers release via the identity-guarded decrement they own (the lease
+  `release!`), or `unsubscribe`."
   [frame-id query-v]
   (live-frame/call-with-frame-resolution
     (live-frame/frame-resolution-target frame-id)
     (fn []
-      (when-let [cache (:sub-cache (frame/frame frame-id))]
+      (if-let [cache (:sub-cache (frame/frame frame-id))]
         (let [k (cache-key query-v)]
           (if-let [entry (get @cache k)]
             ;; Hit — bump ref-count under the same CAS-after-snapshot
@@ -1962,9 +2084,11 @@
                                   (update-in m [k :ref-count] (fnil inc 0))
                                   m)))]
               (if (identical? reaction (get-in new [k :reaction]))
-                reaction
-                (compute-and-cache! frame-id query-v)))
-            (compute-and-cache! frame-id query-v)))))))
+                {:reaction reaction}
+                (build-and-classify! frame-id query-v k)))
+            (build-and-classify! frame-id query-v k)))
+        ;; The frame's cache is gone (destroyed before the build began).
+        {:recovery :frame-destroyed}))))
 
 (defn unsubscribe
   "Decrement the ref-count on the cached subscription for query-v.

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -305,6 +305,62 @@
     {:unresolved-input query-v
      :resolved-inputs  []}))
 
+(defn- throw-acquire-recovery!
+  "rf2-vxgfnd.27 — the ENTRY node's OWN build produced a NEVER-CACHED, zero-ref
+  recovery reaction instead of a canonical cache node: a cyclic entry sub, a
+  parametric `input-fn` failure, or a frame destroyed mid-build. `acquire!` IS
+  the cache's ref-count attach; there is no node to own, so the port is
+  fail-loud and throws the typed error mirroring the recovery taxonomy rather
+  than lease a lying `owned?`-true zero-ref reaction that re-churns every
+  commit. `result` is the `{:recovery kind …}` map from
+  `subs/acquire-cache-reaction!`. Never returns.
+
+  Emit discipline — exactly one always-on record, no duplicate:
+    - `:frame-destroyed` → fan the always-on record + throw via
+      `throw-frame-destroyed!` (the 009 frame-destroyed row already carries the
+      port's throwing surface; the build emitted nothing for the race). Also the
+      catch-all for any unexpected classification (safe fail-loud).
+    - `:input-fn-exception` / `:input-fn-bad-return` → throw the matching id;
+      the build ALREADY fanned the always-on `:rf.error/sub-input-fn-*` record,
+      so the port does NOT re-fan (one record, one throw).
+    - `:cycle` → throw the typed `:rf.error/sub-cycle` to the ViewCell error
+      boundary; it stays DIAGNOSTIC (009 catalogue) — already emitted on the
+      trace channel by the build — so the port does NOT promote it to the
+      always-on axis."
+  [frame-id query-v result]
+  (case (:recovery result)
+    :cycle
+    (error/throw-error!
+      :rf.error/sub-cycle
+      're-frame.substrate.observation/acquire!
+      (str "acquire! targeted subscription " (pr-str (first query-v))
+           " which sits on a :<- dependency cycle " (pr-str (:cycle result))
+           "; a cyclic sub has no cacheable node, so the observation port is "
+           "fail-loud (the public subscribe surface keeps its recover-to-nil "
+           "semantics). Break the cycle so no sub transitively lists itself "
+           "among its inputs.")
+      {:recovery :no-recovery
+       :extra    {:frame          frame-id
+                  :rf.sub/query-v query-v
+                  :cycle          (:cycle result)}})
+
+    (:input-fn-exception :input-fn-bad-return)
+    (error/throw-error!
+      (:error-kw result)
+      're-frame.substrate.observation/acquire!
+      (str "acquire! targeted parametric subscription " (pr-str (first query-v))
+           " whose input-fn failed at materialization, so there is no cacheable "
+           "node to own; the observation port is fail-loud (the public "
+           "subscribe surface keeps its recover-to-nil semantics). "
+           (:reason result))
+      {:recovery :no-recovery
+       :extra    {:frame          frame-id
+                  :rf.sub/query-v query-v}})
+
+    ;; :frame-destroyed and any unexpected classification — fan + throw typed.
+    (throw-frame-destroyed! 're-frame.substrate.observation/acquire!
+                            frame-id query-v)))
+
 ;; ---- the lease ---------------------------------------------------------------
 
 (deftype ObservationLease [state]
@@ -723,7 +779,15 @@
   retargets through the normal staged commit path.
 
   Fail-loud: `:rf.error/frame-destroyed`, `:rf.error/no-such-sub` (entry),
-  `:rf.error/reentrant-graph-op` (dev — called from inside the fan-out)."
+  `:rf.error/reentrant-graph-op` (dev — called from inside the fan-out). When
+  the entry node's OWN build cannot produce a canonical cache node — a cyclic
+  entry sub, a parametric `input-fn` failure, or a frame destroyed mid-build —
+  `acquire!` throws the matching typed error (`:rf.error/sub-cycle`,
+  `:rf.error/sub-input-fn-exception` / `:rf.error/sub-input-fn-bad-return`,
+  `:rf.error/frame-destroyed`) rather than lease a zero-ref recovery reaction
+  (rf2-vxgfnd.27): a lease MUST NOT report `owned?` without a real cache ref +
+  attach. The static override lease and the public subscribe surface keep their
+  recover-to-nil semantics."
   [target on-change]
   (assert-not-in-fan-out! 're-frame.substrate.observation/acquire!)
   (case (:kind target)
@@ -743,39 +807,45 @@
           (when (nil? (registrar/lookup :sub (first query)))
             (throw-no-such-sub! 're-frame.substrate.observation/acquire!
                                 frame-id query))))
-      (let [reaction (subs/acquire-cache-reaction! frame-id query)]
-        (when (nil? reaction)
-          ;; The frame's cache vanished in the check→acquire window.
-          (throw-frame-destroyed! 're-frame.substrate.observation/acquire!
-                                  frame-id query))
-        (let [state (atom {:lease-kind :node
-                           :target     target
-                           :frame-id   frame-id
-                           :query-v    query
-                           :reaction   reaction
-                           :on-change  on-change
-                           :status     :live})
-              lease (->ObservationLease state)]
-          ;; Watch BEFORE the baseline observe: a watched reaction is live
-          ;; on the reactive hosts, so the observe below reads through the
-          ;; activated node. `add-watch` never fires synchronously.
-          (when (watchable? reaction)
-            (let [wk (gensym "rf-obs-lease")]
-              (add-watch reaction wk (make-watch-handler state))
-              (swap! state assoc :watch-key wk)))
-          (let [[rec v] (observe-node! reaction)]
-            (swap! state assoc :last {:value    v
-                                      :version  (:version rec)
-                                      :node-key (:node-key rec)}))
-          ;; Node-disposed notification. Enrol this lease as an active owner
-          ;; and — only for the FIRST owner — install the node's single
-          ;; disposal hook (delivery is queued; see the ns docstring's HMR
-          ;; section). `release!` de-enrols the lease, so a released lease is no
-          ;; longer reachable from the live reaction: disposal work stays
-          ;; O(current owners), never O(all owners ever acquired) (rf2-vxgfnd.15).
-          (when (register-owner! reaction lease)
-            (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
-          lease)))))
+      (let [result (subs/acquire-cache-reaction! frame-id query)]
+        (if-some [reaction (:reaction result)]
+          ;; Canonical cached node — the real ref-count attach. Take ownership.
+          (let [state (atom {:lease-kind :node
+                             :target     target
+                             :frame-id   frame-id
+                             :query-v    query
+                             :reaction   reaction
+                             :on-change  on-change
+                             :status     :live})
+                lease (->ObservationLease state)]
+            ;; Watch BEFORE the baseline observe: a watched reaction is live
+            ;; on the reactive hosts, so the observe below reads through the
+            ;; activated node. `add-watch` never fires synchronously.
+            (when (watchable? reaction)
+              (let [wk (gensym "rf-obs-lease")]
+                (add-watch reaction wk (make-watch-handler state))
+                (swap! state assoc :watch-key wk)))
+            (let [[rec v] (observe-node! reaction)]
+              (swap! state assoc :last {:value    v
+                                        :version  (:version rec)
+                                        :node-key (:node-key rec)}))
+            ;; Node-disposed notification. Enrol this lease as an active owner
+            ;; and — only for the FIRST owner — install the node's single
+            ;; disposal hook (delivery is queued; see the ns docstring's HMR
+            ;; section). `release!` de-enrols the lease, so a released lease is no
+            ;; longer reachable from the live reaction: disposal work stays
+            ;; O(current owners), never O(all owners ever acquired) (rf2-vxgfnd.15).
+            (when (register-owner! reaction lease)
+              (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
+            lease)
+          ;; NEVER-CACHED, zero-ref RECOVERY reaction (rf2-vxgfnd.27): a cyclic
+          ;; entry sub, a parametric input-fn failure, or a frame destroyed
+          ;; mid-build. There is no cache node to attach to — `acquire!` is the
+          ;; ref-count attach — so the port is fail-loud and throws the matching
+          ;; typed error rather than lease an owned?-true reaction that owns
+          ;; nothing (no entry, no ref) and re-churns a fresh orphan + node
+          ;; record + disposal hook + re-emit on EVERY commit.
+          (throw-acquire-recovery! frame-id query result))))))
 
 ;; ---- current? -------------------------------------------------------------------
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -232,6 +232,99 @@
           "always-on record fanned before the throw"))))
 
 ;; ===========================================================================
+;; acquire! on never-cached recovery reactions — rf2-vxgfnd.27
+;;
+;; `acquire!` IS the cache's ref-count attach. When the ENTRY node's OWN build
+;; cannot produce a canonical cache node — a cyclic entry sub, a parametric
+;; input-fn failure, or a frame destroyed mid-build — the build hands back a
+;; NON-NIL but NEVER-CACHED, zero-ref recovery reaction. The port MUST NOT lease
+;; it: a lying `owned?`-true lease is `current? false` from birth, so every
+;; commit retargets and rebuilds a fresh orphan + node record + disposal hook
+;; and re-emits — structural churn. The fix: the port classifies the recovery
+;; and throws the matching typed error (fail-loud → the ViewCell error boundary;
+;; the public subscribe surface keeps its recover-to-nil semantics).
+
+(defn- dispose-trace-counter
+  "Register a `:rf.sub/dispose` trace counter; returns `[count-atom unreg-fn]`."
+  []
+  (let [n (atom 0)]
+    (rf/register-listener! :trace ::vxgfnd27-dispose
+      (fn [ev] (when (= :rf.sub/dispose (:operation ev)) (swap! n inc))))
+    [n #(rf/unregister-listener! :trace ::vxgfnd27-dispose)]))
+
+(deftest acquire-on-cyclic-entry-sub-throws-sub-cycle-no-false-ownership
+  (rf/reg-sub :obs/cyc1 :<- [:obs/cyc2] (fn [v _] v))
+  (rf/reg-sub :obs/cyc2 :<- [:obs/cyc1] (fn [v _] v))
+  (let [target             (obs/resolve-target {:frame fid :query-v [:obs/cyc1]})
+        [disposals unreg]  (dispose-trace-counter)]
+    (try
+      (testing "acquire! fails loud with typed :rf.error/sub-cycle carrying the cycle path"
+        (let [[[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
+          (is (= :threw outcome) "acquire! did NOT return a (lying) lease")
+          (is (= :rf.error/sub-cycle (error-id e)))
+          (is (= [:obs/cyc1 :obs/cyc2 :obs/cyc1] (:cycle (ex-data e)))
+              "the throw carries the closing-repeat cycle path")
+          (is (empty? (filter #(= :rf.error/sub-cycle (:error %)) records))
+              "sub-cycle stays DIAGNOSTIC — the port throws the typed carrier but
+               does NOT promote it to the always-on axis")))
+      (testing "NO false ownership was taken: no cache entry, no orphan node built+disposed"
+        (is (nil? (entry [:obs/cyc1])) "the cyclic sub is NOT cached")
+        (is (nil? (entry [:obs/cyc2])))
+        (is (zero? @disposals) "no orphan node/hook was built and disposed"))
+      (testing "repeated acquires each throw once and NEVER accrete ownership churn"
+        (dotimes [_ 5]
+          (is (= :rf.error/sub-cycle
+                 (error-id (try (obs/acquire! target (fn [_]))
+                                (catch #?(:clj Throwable :cljs :default) e e))))))
+        (is (nil? (entry [:obs/cyc1])) "still no cache entry after repeated acquires")
+        (is (zero? @disposals) "still zero disposals — no orphan churn accrued"))
+      (finally (unreg)))))
+
+(deftest acquire-on-parametric-input-fn-failure-throws-typed-no-false-ownership
+  (testing "input-fn THROWS → :rf.error/sub-input-fn-exception; not cached; ONE always-on record"
+    (rf/reg-sub :obs/pthrow
+                (fn [_] (throw (ex-info "boom-input-fn" {})))
+                (fn [_v _] :unreachable))
+    (let [target (obs/resolve-target {:frame fid :query-v [:obs/pthrow]})
+          [[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
+      (is (= :threw outcome))
+      (is (= :rf.error/sub-input-fn-exception (error-id e)))
+      (is (nil? (entry [:obs/pthrow])) "the failed parametric node is NOT cached")
+      (is (= 1 (count (filter #(= :rf.error/sub-input-fn-exception (:error %)) records)))
+          "exactly ONE always-on record — the build's; the port re-throws the
+           same id WITHOUT a second fan (no duplicate)")))
+  (testing "input-fn RETURNS a bad shape → :rf.error/sub-input-fn-bad-return; not cached; ONE record"
+    (rf/reg-sub :obs/pbad
+                (fn [_] :not-a-vector-of-query-vectors)
+                (fn [_v _] :unreachable))
+    (let [target (obs/resolve-target {:frame fid :query-v [:obs/pbad]})
+          [[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
+      (is (= :threw outcome))
+      (is (= :rf.error/sub-input-fn-bad-return (error-id e)))
+      (is (nil? (entry [:obs/pbad])))
+      (is (= 1 (count (filter #(= :rf.error/sub-input-fn-bad-return (:error %)) records)))
+          "one always-on record, no duplicate fan from the port"))))
+
+(deftest acquire-on-frame-destroyed-mid-build-throws-frame-destroyed
+  ;; The JVM race: the frame's cache vanishes DURING the build (here an impure
+  ;; input-fn destroys the frame), so build-and-cache!* returns a never-cached
+  ;; reaction that used to bypass the caller's nil→frame-destroyed guard and be
+  ;; leased as canonical. The port now classifies it and throws typed.
+  (let [race-fid :obs/race-frame]
+    (rf/make-frame {:id race-fid :adapter plain-atom/adapter})
+    (rf/reg-sub :obs/race
+                (fn [_] (frame/destroy-frame! race-fid) [])  ;; kills the frame mid-materialize
+                (fn [_v _] :unreachable))
+    (let [target (obs/resolve-target {:frame race-fid :query-v [:obs/race]})
+          [[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
+      (is (= :threw outcome) "the mid-build destroy no longer slips through as a lease")
+      (is (= :rf.error/frame-destroyed (error-id e)))
+      (is (some #(= :rf.error/frame-destroyed (:error %)) records)
+          "the port fanned the always-on frame-destroyed record before throwing")
+      (is (nil? (:sub-cache (frame/frame race-fid)))
+          "the destroyed frame's cache is gone — nothing was cached under it"))))
+
+;; ===========================================================================
 ;; movement evidence — node version, frame epoch, registry epoch
 ;; ===========================================================================
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1154,6 +1154,47 @@ The port and the public read API split deliberately ⟨09 codex2 F1 — binding�
   propagating only on cold probes would make probe temperature observable — cold probes
   are first-class, so both temperatures recover identically. Port-entry conditions
   remain fail-loud.)*
+- **`acquire!` fails loud when the ENTRY node's own build cannot cache.** `acquire!` IS
+  the ref-count **attach** ([§The port operations](#the-port-operations-final)) — it must return a lease over a REAL cached node holding a
+  real reference. Three build outcomes hand back a **non-nil but never-cached, zero-ref
+  recovery reaction** instead of a canonical node: a **cyclic entry sub** (the target's
+  own query sits on a `:<-` cycle, so the build recovers to a nil-yielding reaction that
+  is deliberately NOT cached — [§Subscription cache](#subscription-cache--contract-and-operational-semantics)), a **parametric `input-fn` failure** (the entry sub's
+  `input-fn` threw or returned a value outside the input grammar — [§Subscription input
+  producers](#subscription-input-producers--app-db-reader-static-parametric-input-fn)), and a **frame destroyed mid-build** (the frame's cache vanished between the
+  port's liveness check and the build's cache-install step — the JVM race). In every
+  case there is **no node to own**, so `acquire!` is **fail-loud** and throws the typed
+  error mirroring the condition rather than lease a reaction that owns nothing:
+  `:rf.error/sub-cycle` (cyclic entry sub), `:rf.error/sub-input-fn-exception` /
+  `:rf.error/sub-input-fn-bad-return` (parametric failure), `:rf.error/frame-destroyed`
+  (mid-build destroy race — the same catalogue id and throwing surface a
+  destroyed-frame entry already uses). **The invariant is binding: a lease MUST NOT
+  report `owned?` true without a real cache ref + attach** — a lease that claims
+  ownership of an uncached zero-ref reaction is `current? false` from birth, so every
+  commit retargets and rebuilds a fresh orphan + node record + disposal hook and
+  re-emits — structural churn instead of one honest typed throw. (rf2-vxgfnd.27.)
+  - **Emit discipline — one always-on record, never a duplicate.** The parametric
+    categories already fan their always-on record from the build ([009 §Error event
+    catalogue](009-Instrumentation.md#error-event-catalogue)), so the port re-throws the same id **without** a second fan.
+    `:rf.error/frame-destroyed` fans + throws through the port's existing throwing
+    surface (the build emits nothing for the race). `:rf.error/sub-cycle` **stays
+    diagnostic** (its 009 channel is unchanged — it is emitted on the dev trace channel
+    by the build); the port throws the typed carrier to the ViewCell error boundary but
+    does **not** promote sub-cycle to the always-on axis.
+  - **This is the entry-node line, not the mid-graph line.** The bullet above governs a
+    sub **body's** `:<-` reference to a failing/cyclic INPUT: that recovers to nil and
+    the ENTRY node still caches normally, so `acquire!` takes ownership of the real
+    entry node (a nested recovery never blocks the attach). The fail-loud rule here
+    governs only the case where the **entry node itself** cannot be cached.
+  - **`acquire!` and `probe` diverge here by design, exactly as they do for a
+    destroyed frame.** `probe` recovers a cyclic / parametric-failed entry query to a
+    pure evidence `nil` (a legitimate value to render, identical cold and live — the
+    bullet above), because a probe produces a *value*. `acquire!` must attach a
+    *reference to a node that structurally cannot exist*, so it cannot recover — it
+    fails loud, and the ViewCell maps the throw to the view error boundary
+    (loud-at-the-seam; the public `subscribe` surface keeps its recover-to-nil
+    semantics unchanged). This is the same probe-recovers / acquire-throws split the
+    port already draws for `:rf.error/frame-destroyed`.
 
 ### The slice-scoped probe memo
 


### PR DESCRIPTION
Fixes **rf2-vxgfnd.27** (P1 MAJOR correctness/contract).

## The bug

The observation port's `acquire!` treated **any** non-nil return from `subs/acquire-cache-reaction!` as a canonical cached, ref-attached node. But three `subs.cljc` build outcomes hand back a non-nil but **never-cached, zero-ref** recovery reaction:

1. **Cycle recovery** — a cyclic entry sub recovers to a nil-yielding reaction that is deliberately not cached (`compute-and-cache!` outermost catch).
2. **Parametric input-fn failure** — the entry sub's `input-fn` throws or returns a bad shape → nil reaction, escaped caching (`build-and-cache!*` `input-error?` branch).
3. **Frame destroyed mid-build** — the frame's cache vanished between the port's liveness check and the build's install step; the reaction escaped caching and **bypassed** the caller's `nil → :rf.error/frame-destroyed` guard (it was non-nil).

Leasing any of these was a **lie**: `owned? true` with no cache entry and no ref, `current? false` from birth → **every commit retargets** and rebuilds a fresh orphan + node record + disposal hook and re-emits `:rf.error/sub-cycle` — structural churn instead of one stable recovery or one typed throw.

## Ruling — the acquire-time recovery contract (was UNSPECIFIED in Spec 006)

**`acquire!` throws the typed error mirroring the recovery taxonomy** rather than lease a zero-ref reaction. Chosen over the "unowned recovery lease" alternative:

- The port is **defined** as the fail-loud surface. It already throws `:rf.error/no-such-sub` (entry) and `:rf.error/frame-destroyed` exactly where public `subscribe` recovers to nil, and Spec 006 endorses "loud-at-the-seam plus recover-at-the-public-surface … the ViewCell maps port throws to the view error boundary." A cyclic / parametric-failed / race entry node is the same class; leasing an unowned nil would create an inconsistent split (fail-loud for a missing registration, silent-nil for a cycle).
- `acquire!` **is** the ref-count attach. For these three cases there is **no node to own** — the contract is structurally unfulfillable, so fail-loud is the honest response. `probe` (which produces a *value*) legitimately recovers a cyclic/parametric entry to `nil`; `acquire!` (which must attach a *reference*) cannot, so the probe-recovers / acquire-throws split is by design — the same one already drawn for `:rf.error/frame-destroyed`.
- **Simplicity** — reuses existing throw machinery; no new lease kind, no registry-epoch-keyed `current?` for a recovery lease.
- **No-churn** — a throw aborts the site's commit to the view error boundary (which does not auto-retry), eliminating the per-commit retarget → re-acquire → re-build → re-emit loop entirely.

**Key invariant honored:** a lease MUST NOT report `owned?` without a real cache ref + attach.

Typed throws: `:rf.error/sub-cycle` (cycle), `:rf.error/sub-input-fn-exception` / `:rf.error/sub-input-fn-bad-return` (parametric), `:rf.error/frame-destroyed` (race).

**Emit discipline — exactly one always-on record, no duplicate:** the parametric build already fans its always-on `:rf.error/sub-input-fn-*` record, so the port re-throws the same id **without** a second fan; `:rf.error/frame-destroyed` fans + throws (build emits nothing for the race); `:rf.error/sub-cycle` **stays diagnostic** (009 channel unchanged) — the port throws the typed carrier to the ViewCell boundary but does **not** promote it to the always-on axis. **No new error-id and no channel-classification change**, so the error-catalogue / always-on conformance surface is untouched.

## ⚠️ Spec/006 amendment — NORMATIVE, HOT-ZONE — please review before merge

`spec/006-ReactiveSubstrate.md` §Error contract gains a new bullet **"`acquire!` fails loud when the ENTRY node's own build cannot cache"** specifying the acquire-time contract for recovery reactions (closes the bead's "UNSPECIFIED" gap). It states the three conditions + typed throws, the binding `owned?`-requires-a-real-attach invariant, the one-record emit discipline (incl. sub-cycle staying diagnostic), the entry-node-vs-mid-graph line, and the deliberate probe-recovers / acquire-throws asymmetry. I am the sole toucher of 006 on this branch; the rebase onto `origin/main` was conflict-free.

## Surface

`subs.cljc` (`acquire-cache-reaction!` now returns a discriminated `{:reaction r}` / `{:recovery kind …}`; a port-only `*acquire-recovery*` out-channel — nil-bound and byte-identical on subscribe/compute-sub — carries the cycle/parametric classification; the canonical check is authoritative so a mid-graph input recovery still yields an owned entry node) + `observation.cljc` (`acquire!` owns only `{:reaction r}`, else `throw-acquire-recovery!`) + `spec/006` + the test file. No edits to `reactive.cljc` / `viewcell.cljs` / `compiler/*` / `client.cljs` / `frames.cljc`.

## Quality gates

All foreground, 0-fail:

| Gate | Result |
|------|--------|
| `clojure -M:test` (core, JVM) | **1856 tests, 8268 assertions, 0 failures, 0 errors** |
| `clojure -M:test` (ui artefact, JVM — the ViewCell/commit reconciler consuming the port) | **235 tests, 4360 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node runtime; the `.cljc` fixtures ride both hosts) | **8937 tests, 42172 assertions, 0 failures, 0 errors** |
| observation-port namespace (focused) | **26 tests, 138 assertions, 0 failures** |

The always-on-axis + error-catalogue conformance tests are within the core/CLJS suites above (green); no new error-id or channel change was introduced.

Three new fixtures (`.cljc`, both hosts): `acquire-on-cyclic-entry-sub-throws-sub-cycle-no-false-ownership` (typed throw + cycle path, no cache entry, zero orphan disposals across repeated acquires, sub-cycle NOT on the always-on axis), `acquire-on-parametric-input-fn-failure-throws-typed-no-false-ownership` (throw + bad-return, not cached, exactly one always-on record each), `acquire-on-frame-destroyed-mid-build-throws-frame-destroyed` (impure input-fn destroys the frame mid-materialize → typed frame-destroyed, always-on record fanned).

Do not merge until the 006 normative amendment is reviewed.
