### PR TITLE
fix(ui): wire viewcell teardown! from frame-destroy so cells go :dead not throw (rf2-vxgfnd.42)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2580,6 +2580,16 @@
                                       Falls back to minimal HTTP-abort +
                                       trace when the machines artefact is
                                       absent.
+    2b. :ui/on-frame-destroyed!     — detach the compiled-view
+                                      (day8/re-frame2-ui) observers: every
+                                      currently-connected ViewCell observing
+                                      this frame transitions to :dead (03 §4)
+                                      and releases its leases against the
+                                      still-live sub-cache, so a later
+                                      read/probe follows the dead-cell
+                                      lifecycle rather than throwing
+                                      :rf.error/frame-destroyed. No-op when
+                                      the artefact is absent (rf2-vxgfnd.42).
     3. mark-frame-destroyed!        — flip :lifecycle :destroyed?.
     4. tear-down-sub-cache!         — dispose every cached reaction
                                       via the sub-cache-owned
@@ -2699,6 +2709,15 @@
         (try
         (fire-on-destroy-event! id f)
         (notify-machine-destruction! id)
+        ;; Detach the compiled-view (day8/re-frame2-ui) observers BEFORE the
+        ;; liveness flip / sub-cache teardown, so every currently-connected
+        ;; ViewCell observing this frame transitions to :dead (03 §4 dead-cell
+        ;; lifecycle) and releases its leases against the still-live sub-cache —
+        ;; instead of being left live to throw :rf.error/frame-destroyed off the
+        ;; observation port on its next read. Symmetric with the machine cascade
+        ;; above (observers torn down against a live container). No-op when the
+        ;; re-frame2-ui artefact is absent (the hook is unbound) — rf2-vxgfnd.42.
+        (safe-call-hook! :ui/on-frame-destroyed! id)
         ;; Flip the liveness bit under the frame's OWN `:drain-lock` (the ONE
         ;; frame-owned lifecycle gate, via the same `call-serialized-with-drain!`
         ;; the flows lifecycle ops use) so a concurrent cold `reg-flow` / flow

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1109,6 +1109,12 @@
     :design-bead "rf2-931pm"
     :description "Restore the no-op default focus predicate (no epoch focused). Withdraw counterpart of `:trace.cascade/set-focus-predicate!`; same no-Xray-consumer status — only the core `trace_cascade_captured_test` calls `re-frame.trace.cascade/clear-focus-predicate!` directly."}
 
+   ;; ---- re-frame.ui (compiled-view substrate; day8/re-frame2-ui) -----------
+   {:key         :ui/on-frame-destroyed!
+    :producer-ns 're-frame.ui.frames
+    :design-bead "rf2-vxgfnd.42"
+    :description "Transition every currently-connected ViewCell observing the destroyed frame to :dead (re-frame.ui.reactive/teardown-frame!) so a subsequent read/probe follows the 03 §4 dead-cell lifecycle instead of throwing :rf.error/frame-destroyed off the observation port. Consumed by frame/destroy-frame! (fired before the liveness flip, against the still-live sub-cache); no-op when the day8/re-frame2-ui artefact is absent from the classpath."}
+
    ;; NOTE: `:subs/resolve-sub-override` — the SUBSTITUTIVE
    ;; dev-only sub-override seam consulted by `re-frame.subs/subscribe`
    ;; inside its `interop/debug-enabled?` gate — is PUBLISHED from the

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -109,7 +109,9 @@
   (`jvm-provider-scope`)."
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.live-frame :as live-frame]
+            [re-frame.ui.reactive :as reactive]
             #?@(:cljs [[re-frame.adapter.context :as adapter-context]])))
 
 ;; ---------------------------------------------------------------------------
@@ -329,3 +331,19 @@
   (binding [frame/*current-frame*
             (require-scope-frame! target 're-frame.ui/frame-provider)]
     (body-thunk)))
+
+;; ---------------------------------------------------------------------------
+;; Frame-destroy → ViewCell teardown wiring (03 §4; rf2-vxgfnd.42)
+;; ---------------------------------------------------------------------------
+;;
+;; core's `frame/destroy-frame!` fires the named cleanup hook
+;; `:ui/on-frame-destroyed!` — exactly like `:machines/on-frame-destroyed!`,
+;; `:schemas/on-frame-destroyed!`, `:routing/on-frame-destroyed!`, … — one
+;; per optional artefact that owns frame-scoped teardown. The compiled-view
+;; substrate answers it by transitioning every currently-connected ViewCell
+;; observing the destroyed frame to `:dead` (`reactive/teardown-frame!`), so a
+;; subsequent read/probe follows the 03 §4 dead-cell lifecycle instead of
+;; throwing `:rf.error/frame-destroyed` off the observation port. Late-bound so
+;; core never statically requires this artefact — the hook is simply unbound
+;; (a no-op) when day8/re-frame2-ui is absent from the classpath.
+(late-bind/set-fn! :ui/on-frame-destroyed! reactive/teardown-frame!)

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -424,6 +424,20 @@
 
 (defonce ^:private flush-scheduled? (atom false))
 
+(defonce ^:private live-cells
+  ;; The set of currently-CONNECTED ViewCells — the input to a frame-destroy
+  ;; sweep (`teardown-frame!`). A cell enrols on `connect!` (its first commit,
+  ;; when it starts observing a frame) and leaves on `disconnect!` (React
+  ;; unmount / Activity hide, when it releases its committed dependency set) or
+  ;; `teardown!` (it goes :dead). Membership therefore tracks EXACTLY the cells
+  ;; carrying a live committed dependency set, so a destroyed frame can find the
+  ;; cells observing it and transition them to :dead (03 §4) rather than leave
+  ;; them live to throw `:rf.error/frame-destroyed` on their next read. Because
+  ;; a disconnected cell leaves the set, an unmounted cell never lingers here
+  ;; (no retention leak). `defonce` (module-lived); tests clear it via
+  ;; `reset-scheduler!`.
+  (atom #{}))
+
 (declare flush-pending!)
 
 (defn- schedule-flush!
@@ -548,6 +562,7 @@
   (reset! dirty-cells #{})
   (reset! flush-scheduled? false)
   (reset! slice-memo* nil)
+  (reset! live-cells #{})
   nil)
 
 (defn- on-change-fn
@@ -604,7 +619,10 @@
   (let [st @(state cell)]
     (when (= :disconnected (:lifecycle st))
       (annotate-open-disconnect! cell :activity-hidden :reconnect))
-    (swap! (state cell) assoc :lifecycle :connected)))
+    (swap! (state cell) assoc :lifecycle :connected)
+    ;; Enrol in the live-cell registry (idempotent — a set) so a frame-destroy
+    ;; sweep can find this cell while it observes a live committed dep set.
+    (swap! live-cells conj cell)))
 
 (defn disconnect!
   "Effects-cleanup transition (React unmount OR Activity hide —
@@ -617,6 +635,9 @@
     (when (contains? #{:fresh :connected} (:lifecycle @st))
       (release-committed! cell)
       (discard-pending! cell)
+      ;; Leave the live-cell registry: a disconnected cell holds no committed
+      ;; deps, so it observes no frame — and an unmounted cell must not linger.
+      (swap! live-cells disj cell)
       (swap! st (fn [m]
                   (-> m
                       (assoc :lifecycle :disconnected)
@@ -627,9 +648,10 @@
   "Explicit host/root teardown (root unmount, parent teardown, frame
   destroy): the frame/adapter/root is destroyed under this cell's handle —
   the retained interval is proven an unmount. Detaches leases, marks the
-  cell `:dead` (no resume), and annotates. Wired by the frame/root
-  teardown path (S2c/core) for a frame-scoped destroy; here it is the
-  substrate contract + its fixtures. Idempotent. Returns the cell."
+  cell `:dead` (no resume), annotates, and de-enrols it from the live-cell
+  registry. Wired from core's frame-destroy path via `teardown-frame!` (the
+  `:ui/on-frame-destroyed!` late-bind hook `re-frame.ui.frames` registers).
+  Idempotent. Returns the cell."
   [^ViewCell cell]
   (let [st (state cell)]
     (when-not (= :dead (:lifecycle @st))
@@ -639,8 +661,30 @@
                {:state :unmounted :reason :unmounted :proof :host-teardown}))
       (release-committed! cell)
       (discard-pending! cell)
-      (swap! st assoc :lifecycle :dead))
+      (swap! st assoc :lifecycle :dead)
+      (swap! live-cells disj cell))
     cell))
+
+(defn teardown-frame!
+  "Frame-destroy sweep: transition every currently-connected ViewCell
+  observing frame `frame-id` to `:dead` (03 §4 dead-cell lifecycle). Each
+  matched cell's leases are detached, its pending notification dropped, and
+  its retained interval proven an unmount (`:unmounted {:proof
+  :host-teardown}`) — so a subsequent read/probe on such a cell follows the
+  dead-cell lifecycle instead of throwing `:rf.error/frame-destroyed` off the
+  observation port. Fired from core's `frame/destroy-frame!` through the
+  `:ui/on-frame-destroyed!` late-bind hook wired in `re-frame.ui.frames`;
+  the sweep runs while the frame is still live, so each cell releases its
+  leases against the live sub-cache (symmetric with `disconnect!`). The
+  membership test rides the cell's committed dependency set
+  (`cell-observes-frame?`); a disconnected cell holds none and is therefore
+  never a target. Iterates a snapshot, so the per-cell `teardown!` de-enrol
+  is safe. Returns the count torn down."
+  [frame-id]
+  (let [victims (filterv #(cell-observes-frame? % frame-id) @live-cells)]
+    (doseq [cell victims]
+      (teardown! cell))
+    (count victims)))
 
 ;; ---------------------------------------------------------------------------
 ;; The 8-step layout-commit reconciler (03 §3)

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -1,0 +1,160 @@
+(ns re-frame.ui.reactive-frame-teardown-cljs-test
+  "rf2-vxgfnd.42 — frame-destroy → ViewCell teardown wiring.
+
+  core's `frame/destroy-frame!` fires the named cleanup hook
+  `:ui/on-frame-destroyed!` (registered in `re-frame.ui.frames`), which sweeps
+  every currently-connected ViewCell observing the destroyed frame to `:dead`
+  (03 §4 dead-cell lifecycle): leases detached, pending notification dropped,
+  the retained interval proven an unmount (`:unmounted {:proof :host-teardown}`).
+
+  Before this wiring `teardown!` had ZERO callers: a destroyed frame left its
+  mounted cells LIVE, so the sub-cache teardown's disposal notification marked
+  them dirty and the next flush re-rendered them straight into a
+  `:rf.error/frame-destroyed` port throw — the bug this fixture pins closed.
+
+  `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
+  (`clojure -M:test`), so the wiring is graft-checked on both hosts against the
+  REAL observation port + sub-cache (plain-atom adapter). The
+  `re-frame.ui.frames` require is load-bearing: its `set-fn!` publishes the
+  hook `frame/destroy-frame!` reaches."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.late-bind             :as late-bind]
+            [re-frame.live-frame            :as live-frame]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            ;; Load-bearing: registers the :ui/on-frame-destroyed! hook.
+            [re-frame.ui.frames]
+            [re-frame.ui.reactive           :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- ref-count [fid q]
+  (:ref-count (get @(:sub-cache (frame/frame fid)) q)))
+
+(defn- render+commit! [cell fid queries]
+  (rf/with-frame fid
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  (reactive/commit! cell)
+  cell)
+
+(defn- throws-id [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+;; ===========================================================================
+;; The hook is actually published (the wiring, not just the logic)
+;; ===========================================================================
+
+(deftest destroy-hook-is-registered
+  (is (some? (late-bind/get-fn :ui/on-frame-destroyed!))
+      "re-frame.ui.frames must publish :ui/on-frame-destroyed! at load — the
+       seam frame/destroy-frame! reaches the compiled-view substrate through")
+  (is (identical? reactive/teardown-frame!
+                  (late-bind/get-fn :ui/on-frame-destroyed!))
+      "the hook resolves to the substrate's frame-destroy sweep"))
+
+;; ===========================================================================
+;; The core contract: a destroyed frame transitions its cells to :dead
+;; ===========================================================================
+
+(deftest frame-destroy-transitions-connected-cell-to-dead
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :td/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:td/a]])]
+    (testing "precondition — the cell is connected and observes the frame"
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (reactive/cell-observes-frame? cell fid))
+      (is (= 1 (ref-count fid [:td/a])) "one owner installed at commit"))
+
+    (testing "destroying the frame completes cleanly and marks the cell :dead"
+      ;; The destroy itself must not throw — the port throw the bug produced
+      ;; came LATER, on a spurious re-render of a still-live cell.
+      (is (nil? (frame/destroy-frame! fid)) "destroy-frame! is a clean nil")
+      (is (= :dead (reactive/lifecycle cell))
+          "the destroyed frame's cell followed the dead-cell lifecycle (03 §4)
+           — NOT left live to throw :rf.error/frame-destroyed on next read"))))
+
+(deftest frame-destroy-emits-the-unmount-fact
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :td/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:td/a]])]
+    (frame/destroy-frame! fid)
+    (is (= {:state :unmounted :reason :unmounted :proof :host-teardown}
+           (peek (reactive/intervals cell)))
+        "a frame-destroy under a mounted cell proves the interval an unmount
+         (03 §4 — :unmounted {:proof :host-teardown})")))
+
+(deftest frame-destroy-detaches-leases-and-drops-pending
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :td/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:td/a]])
+        rev0 (reactive/revision cell)]
+    (frame/destroy-frame! fid)
+    (testing "the dead cell holds no leases and no pending notification"
+      (is (empty? (reactive/committed-target-keys cell))
+          "teardown detached every committed lease")
+      (is (false? (reactive/dirty? cell))
+          "no stale pending notification lingers in the dirty registry"))
+    (testing "a flush cannot re-render the dead cell into a port throw"
+      (reactive/flush-pending!)
+      (is (= rev0 (reactive/revision cell))
+          "the dead cell's revision does not advance — nothing schedules a
+           re-render that would probe the destroyed frame"))))
+
+(deftest frame-really-destroyed-but-cell-took-the-lifecycle-path
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :td/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:td/a]])]
+    (frame/destroy-frame! fid)
+    (testing "the observation port DOES throw frame-destroyed against the gone
+              frame — proving it is truly destroyed"
+      (is (= :rf.error/frame-destroyed
+             (throws-id #(obs/probe {:kind :subscription :frame-id fid
+                                     :query [:td/a]}
+                                    nil)))))
+    (testing "…yet the cell reached :dead through the lifecycle sweep, not by
+              being caught in that throw"
+      (is (= :dead (reactive/lifecycle cell))))
+    (testing "a :dead cell still fails loudly on re-commit — no resume (03 §4)"
+      (rf/with-frame fid
+        (reactive/with-capture cell (fn [] nil)))
+      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))))))
+
+;; ===========================================================================
+;; The sweep is frame-scoped — a sibling frame's cells are untouched
+;; ===========================================================================
+
+(deftest frame-destroy-leaves-sibling-frames-cells-alive
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fa     (make-frame! :td/frame-a {:a 1})
+        fb     (make-frame! :td/frame-b {:a 2})
+        cell-a (render+commit! (reactive/make-cell ::va) fa [[:td/a]])
+        cell-b (render+commit! (reactive/make-cell ::vb) fb [[:td/a]])]
+    (is (= :connected (reactive/lifecycle cell-a)))
+    (is (= :connected (reactive/lifecycle cell-b)))
+    (frame/destroy-frame! fa)
+    (testing "only the destroyed frame's observers die"
+      (is (= :dead (reactive/lifecycle cell-a)) "cell under the destroyed frame")
+      (is (= :connected (reactive/lifecycle cell-b))
+          "a cell observing a DIFFERENT live frame is untouched")
+      (is (= 1 (ref-count fb [:td/a]))
+          "the sibling frame's lease is neither released nor churned")
+      (is (reactive/cell-observes-frame? cell-b fb)))
+    (testing "the sibling frame still reads live"
+      (is (= 2 (rf/with-frame fb
+                 (reactive/with-capture cell-b
+                   (fn [] (reactive/sub-read [:td/a])))))))))


### PR DESCRIPTION
## What & why

`teardown!` (in `implementation/ui/src/re_frame/ui/reactive.cljc`) had **zero callers**. Its docstring scoped wiring to "the frame/root teardown path (S2c/core)", but S2c merged without wiring it — so `frame/destroy-frame!` left mounted ViewCells **live**. The sub-cache teardown's disposal notification then marked those cells dirty, and the next flush re-rendered them straight into a `:rf.error/frame-destroyed` port throw — instead of the 03 §4 dead-cell lifecycle (a destroyed frame's cells should transition to `:dead`, not throw).

## The fix

Wire `teardown!` through a **named cleanup hook** mirroring the six existing `*/on-frame-destroyed!` seams (machines / schemas / routing / resources / http / fx) — the established pattern for an optional artefact that owns frame-scoped teardown:

- **`reactive.cljc`** — a module-level `live-cells` registry (cells enrol on `connect!`, leave on `disconnect!` / `teardown!`, so membership is exactly the connected cells carrying a live committed dependency set — no retention leak) + `teardown-frame!`, which sweeps every cell observing the destroyed frame to `:dead` (leases detached, pending notification dropped, `:unmounted {:proof :host-teardown}` fact emitted).
- **`frames.cljc`** — publishes the `:ui/on-frame-destroyed!` late-bind hook → `reactive/teardown-frame!` (no-op when the artefact is absent).
- **`core/frame.cljc`** — one `(safe-call-hook! :ui/on-frame-destroyed! id)` line, fired **before** the liveness flip so cells release their leases against the still-live sub-cache (symmetric with the machine cascade). *(core edit — flagged)*
- **`core/late_bind/directory.cljc`** — the required directory entry for the new hook key (keeps the late-bind drift gate green). *(core edit — flagged)*

## Where `teardown!` is hooked

Prefer-ui-layer was honored for the logic (all of it lives in `reactive.cljc` + `frames.cljc`); the frame-destroy path itself lives only in core's `destroy-frame!`, so the minimal seam is one `safe-call-hook!` line there plus its directory row — exactly the pattern the other six subsystems use. Both core edits are pure wiring, flagged here per the brief.

## Test

New fixture `implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc` (`.cljc`, runs node + JVM): mount a cell under a frame, destroy the frame, assert the cell is `:dead` with the `:unmounted {:proof :host-teardown}` fact, leases detached, no stale flush advances its revision, the observation port genuinely throws `frame-destroyed` (proving the frame is gone) while the cell reached `:dead` via the lifecycle path, and a sibling frame's cells stay `:connected`.

## Quality gates

Run in the foreground (no full spine per the brief):

- ui artefact JVM tests — `clojure -M:test` (from `implementation/ui`): **241 tests / 4381 assertions, 0 failures, 0 errors** (includes the 6 new tests / 21 assertions).
- `npm run test:cljs` (node CLJS gate): **8941 tests / 42181 assertions, 0 failures, 0 errors**.
- late-bind drift gate (core JVM, touched by the directory entry): `re-frame.late-bind-drift-test` — **6 tests / 632 assertions, 0 failures, 0 errors**.