### PR TITLE
fix(ui): drain queued writes before one render batch; epochs are evidence not render boundaries (rf2-vxgfnd.45)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -23,7 +23,9 @@
 
   Every lexical `(sub …)` in a view is a compile-indexed site; all of a
   view's sites share ONE ViewCell — one `useSyncExternalStore`, one scalar
-  revision snapshot, one notification per epoch. Render probes WITHOUT
+  revision snapshot, one coalesced notification per render batch (the
+  drain-quiescence boundary, NOT per epoch — see §Drain coalescing below).
+  Render probes WITHOUT
   ownership (resolve-target + probe, no ref-count / watch / cache node);
   the layout commit acquires the CAPTURED targets. Abandoned renders
   (StrictMode double-render, time-sliced tear-off) retain NOTHING because
@@ -49,22 +51,41 @@
   object reuse (the parametric-args case) needs compile-site identity and
   lands with the HMR site-identity slice (S2e).
 
-  ## Epoch coalescing + `flush!` scope (S2d — 03 §3 invariant 6; Spec 006
+  ## Drain coalescing + `flush!` scope (S2d — 03 §3 invariant 6; Spec 006
   §Epoch finalization)
 
-  The sixth frozen invariant: EPOCH CLOSE NOTIFIES EACH DIRTY CELL ONCE.
-  Sub deltas mark their cell dirty through constant-work `on-change`
-  (never compute — I-5); the cell enters a module-level DIRTY REGISTRY
-  exactly once (a set, deduped by cell identity) and one coalesced flush
-  is scheduled per microtask (`interop/next-tick` — drain→React is
-  microtask-aligned) ON CLJS; the JVM headless host has no async render
-  loop, so it auto-schedules NOTHING and drains via the EXPLICIT `flush!`
-  (07 §2's only flush idiom; SSR is one-shot) — one honest option per
-  host. N sub deltas within one epoch therefore advance the cell's
-  revision ONCE. Coalescing is per-cell-per-flush-boundary; the
-  cross-epoch SEPARATION the push-economics bench asserts (8 epochs ⇒ 8
-  renders — G-5/G-13) rides the async drain boundaries and is wired with
-  the bench in S2f, not here.
+  The sixth frozen invariant, stated correctly: THE RENDER BATCH BOUNDARY
+  IS DRAIN QUIESCENCE, NOT EPOCH CLOSE. An event/frame EPOCH is a
+  write-side commit + diagnostic-evidence unit (one per dequeued event —
+  Spec 002 §Drain versus event); it is NOT a React render boundary. A
+  single run-to-completion drain may settle SEVERAL queued events, each
+  committing its OWN epoch record, before the host regains control — and
+  every one of those epochs coalesces into ONE render batch.
+
+  The mechanism: sub deltas mark their cell dirty through constant-work
+  `on-change` (never compute — I-5), carrying the moving frame's epoch as
+  CAUSE EVIDENCE only. The cell enters a module-level DIRTY REGISTRY
+  exactly once (a set, deduped by cell identity); a re-mark while already
+  pending FOLDS IN regardless of its epoch tag — the pending flag is the
+  coalescing key, the epoch tag is NEVER a second key. On CLJS one
+  coalesced flush is armed per drain (`interop/next-tick` — a
+  `goog.async.nextTick` MICROTASK that cannot run until the synchronous
+  run-to-completion drain unwinds, so it fires strictly AFTER drain
+  quiescence, never between two queued events of the same drain); the JVM
+  headless host has no async render loop, so it auto-schedules NOTHING and
+  drains via the EXPLICIT `flush!` (07 §2's only flush idiom; SSR is
+  one-shot) — one honest option per host. Either way, N epochs committed
+  in one drain advance each dirty cell's revision ONCE and let React
+  perform ONE read/render batch.
+
+  Render SEPARATION is therefore per DRAIN, not per epoch: two epochs
+  settled in one drain share one render batch; two epochs settled in
+  SEPARATE drains (distinct external events, the host regaining control
+  between them) render separately — NO render count may be inferred from
+  the number of event/frame epochs. The push-economics bench's queued-
+  cascade gate (a parent event that queues further events, proving one
+  ViewCell notification and one React render for the whole batch —
+  G-5/G-13) is wired with the bench in S2f, not here.
 
   `flush!` — the SYNCHRONOUS forcing of pending notifications — is SCOPED
   over that registry. The Q51 scope ruling, PINNED here:
@@ -406,15 +427,19 @@
   (swap! (state cell) update :revision inc)
   (notify-listeners! cell))
 
-;; ---- epoch coalescing + the notification scheduler (S2d) --------------------
+;; ---- drain coalescing + the notification scheduler (S2d) --------------------
 ;;
-;; `on-change` is constant-work (mark-dirty; never compute — I-5). A cell
-;; enters the module DIRTY REGISTRY exactly once per flush boundary (the
-;; set dedups by identity); N sub deltas in one epoch therefore advance
-;; the cell ONCE at flush. One coalesced async flush is scheduled per
-;; microtask (drain→React is microtask-aligned — 03 §3); `flush!` is the
-;; synchronous forcing, SCOPED so no epoch work leaks across roots. The
-;; Q51 scope ruling and the reentrancy contract live in the ns docstring.
+;; `on-change` is constant-work (mark-dirty; never compute — I-5), carrying
+;; the moving epoch as CAUSE EVIDENCE only. A cell enters the module DIRTY
+;; REGISTRY exactly once per flush boundary (the set dedups by identity; a
+;; re-mark while pending folds in regardless of epoch tag). N epochs
+;; committed in one run-to-completion drain therefore advance the cell ONCE
+;; at flush — the render batch boundary is DRAIN QUIESCENCE, not epoch close.
+;; On CLJS one coalesced async flush is armed per drain (the `next-tick`
+;; microtask fires only after the synchronous drain unwinds — 03 §3);
+;; `flush!` is the synchronous forcing, SCOPED so no pending work leaks
+;; across roots. The Q51 scope ruling and the reentrancy contract live in
+;; the ns docstring.
 
 (defonce ^:private dirty-cells
   ;; The set of ViewCells with a pending (unflushed) notification — the
@@ -442,9 +467,12 @@
 
 (defn- schedule-flush!
   "Arm ONE coalesced microtask that drains the whole registry — the CLJS
-  host's realization of the microtask-aligned epoch close (03 §3). Re-marks
-  before it runs fold into the same flush; a synchronous `flush!` beforehand
-  just leaves it an empty drain.
+  host's realization of the drain-quiescence render batch (03 §3). One
+  microtask per drain, NOT per epoch: it is armed by the first mark of a
+  drain and fires only after the synchronous run-to-completion drain
+  unwinds, so every epoch committed by the drain's queued events folds into
+  the same flush. Re-marks before it runs fold in; a synchronous `flush!`
+  beforehand just leaves it an empty drain.
 
   CLJS-only: `interop/next-tick` there is a true `goog.async.nextTick`
   microtask that fires AFTER the synchronous render pass. The JVM headless
@@ -465,11 +493,14 @@
 (defn mark-dirty!
   "The `on-change` body: mark `cell` dirty for `epoch` and enrol it in the
   dirty registry (once — a re-mark while already dirty coalesces), then
-  arm one microtask flush. Never acquires/releases (no reentrant-graph-op)
-  and never computes (I-5) — it flags a revision advance the scheduled
-  render re-probes. `epoch` (the moving frame's commit epoch, from the
-  `on-change` payload) tags the pending notification; nil when driven
-  without epoch evidence."
+  arm one per-drain microtask flush. Never acquires/releases (no reentrant-
+  graph-op) and never computes (I-5) — it flags a revision advance the
+  scheduled render re-probes. `epoch` (the moving frame's commit epoch,
+  from the `on-change` payload) tags the pending notification as CAUSE
+  EVIDENCE only: coalescing keys on the pending flag, NEVER on the epoch
+  tag, so epochs committed by later queued events in the same drain fold
+  into this one pending notification (the first mark's epoch stays the
+  anchor). nil when driven without epoch evidence."
   ([^ViewCell cell] (mark-dirty! cell nil))
   ([^ViewCell cell epoch]
    (let [st (state cell)]
@@ -549,6 +580,16 @@
   "True when `cell` has a pending (unflushed) notification (tool/test read)."
   [^ViewCell cell]
   (boolean (:dirty? @(state cell))))
+
+(defn pending-epoch
+  "The epoch tag anchoring `cell`'s pending notification — the CAUSE EVIDENCE
+  the FIRST `on-change` of the current pending window carried (nil when the
+  cell is not pending, or was dirtied without epoch evidence). Epoch ids are
+  movement/cause evidence ONLY; coalescing keys on the pending flag, never on
+  this tag, so later queued events' epochs fold into the same render batch
+  without re-anchoring or advancing it (tool/test read)."
+  [^ViewCell cell]
+  (:dirty-epoch @(state cell)))
 
 (defn pending-cell-count
   "The number of cells with a pending notification (tool/test read)."

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -9,9 +9,13 @@
 
   The rows:
 
-    - EPOCH COALESCING — N sub deltas within one epoch advance a cell's
-      revision ONCE (the sixth frozen invariant); a fresh epoch after the
-      flush notifies again;
+    - DRAIN COALESCING — N event/frame EPOCHS committed in ONE
+      run-to-completion drain advance a cell's revision ONCE, coalescing
+      into ONE render batch (the corrected sixth invariant: the render
+      boundary is drain quiescence, NOT epoch close; epoch ids are cause
+      evidence, never render triggers). A separate later drain notifies
+      again — later work stays observable, but NO render count follows from
+      the epoch count (replaces the retired false gate `N epochs ⇒ N renders`);
     - flush! SCOPE (the Q51 ruling) — the frame arity `flush-frame!` flushes
       only cells observing that frame; a scoped `flush-scope!` leaves
       out-of-scope cells pending; the global `flush-pending!` /
@@ -61,7 +65,7 @@
   cell)
 
 ;; ===========================================================================
-;; Epoch coalescing — N deltas within one epoch → ONE notification
+;; Drain coalescing — N epochs in ONE drain → ONE render batch
 ;; ===========================================================================
 
 (deftest n-deltas-in-one-epoch-notify-once
@@ -95,6 +99,40 @@
     (reactive/flush-pending!)
     (is (= 1 (reactive/revision cell)))
     (is (= 1 @hits) "still one notification across the flush boundary")))
+
+(deftest n-epochs-in-one-drain-coalesce-to-one-render-batch
+  ;; The corrected sixth invariant, replacing the retired false gate
+  ;; "N epochs ⇒ N renders". A run-to-completion drain may settle SEVERAL
+  ;; queued events, each committing its OWN epoch record, before the host
+  ;; regains control (and flushes). Every one of those epochs folds into ONE
+  ;; render batch — the render boundary is DRAIN QUIESCENCE, not epoch close.
+  ;; Epoch ids ride the invalidation as CAUSE EVIDENCE only: coalescing keys
+  ;; on the pending flag, never on the epoch tag. Render SEPARATION follows
+  ;; DRAIN boundaries, never the epoch count.
+  (let [cell (reactive/make-cell ::v)
+        hits (atom 0)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (testing "8 distinct epochs committed in ONE drain ⇒ ONE render batch"
+      ;; one drain: 8 queued events each commit their own epoch, each firing
+      ;; on-change with a DISTINCT epoch tag, all BEFORE the flush that rides
+      ;; drain quiescence (the CLJS microtask / the headless explicit flush)
+      (doseq [e (range 1 9)] (reactive/mark-dirty! cell e))
+      (is (reactive/dirty? cell) "the cell is pending after the drain")
+      (is (= 1 (reactive/pending-cell-count)) "enrolled ONCE despite 8 epochs")
+      (is (= 1 (reactive/pending-epoch cell))
+          "the pending notification stays anchored to the FIRST epoch's
+           evidence; later queued epochs fold in without re-anchoring")
+      (reactive/flush-pending!)              ;; the drain-quiescence read batch
+      (is (= 1 (reactive/revision cell)) "8 epochs in one drain ⇒ ONE revision advance")
+      (is (= 1 @hits) "⇒ ONE notification — one render batch, not eight")
+      (is (nil? (reactive/pending-epoch cell)) "the evidence tag clears with the flush"))
+    (testing "a SEPARATE later drain renders separately — later work stays observable"
+      (reactive/mark-dirty! cell 9)
+      (is (= 9 (reactive/pending-epoch cell)) "a fresh drain re-anchors the evidence")
+      (reactive/flush-pending!)
+      (is (= 2 (reactive/revision cell))
+          "render SEPARATION follows DRAIN boundaries, never the epoch count")
+      (is (= 2 @hits)))))
 
 ;; ===========================================================================
 ;; flush! scope (the Q51 ruling) + no epoch work leaks across roots

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -983,11 +983,23 @@ These are normative (R-2). Each names the bug class it deletes.
    movement in the render→commit gap advances the cell's revision and notifies, and the
    host corrects **before paint**. *(Deletes: painting a frame computed from stale
    reads.)*
-6. **One notification per cell per epoch.** Source-side notification is constant work —
-   mark the cell stale with target/version/epoch/cause evidence, never execute a
-   prop-dependent query (per I-5) — and epoch close flushes each dirty cell **exactly
-   once** (exact coalescing at the transaction boundary, never debounce-by-time; per
-   I-3/I-6). *(Deletes: zombie children; N-notifications-per-event fan-out.)*
+6. **One notification per cell per render batch — the boundary is drain quiescence, not
+   epoch close.** An event/frame **epoch** is a write-side commit + diagnostic-evidence
+   unit (one per dequeued event — per
+   [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)); it is
+   **not** a React render boundary. Source-side notification is constant work — mark the
+   cell stale with target/version/epoch/cause evidence, never execute a prop-dependent
+   query (per I-5) — carrying the moving epoch as **cause evidence only**. A single
+   run-to-completion drain may settle several queued events, each committing its own epoch
+   record; every dirty cell coalesces the **whole drain's** epochs and is flushed
+   **exactly once** when the drain reaches quiescence (exact coalescing at the drain
+   boundary, keyed on the cell's pending state — never on the epoch tag, never
+   debounce-by-time; per I-3/I-6). Render **separation** is therefore **per drain, not per
+   epoch**: epochs settled in one drain share one render batch; epochs settled in separate
+   drains (distinct external events, the host regaining control between them) render
+   separately — **no render count may be inferred from the number of event/frame epochs**.
+   *(Deletes: zombie children; N-notifications-per-event fan-out; the false
+   N-epochs⇒N-renders equation.)*
 
 ### The port operations (final)
 
@@ -1222,20 +1234,30 @@ commit reconciler's evidence comparison (invariant 5) catches movement of
 corrects before paint. No third mechanism exists or is needed. A memo table that
 outlives its slice is a conformance bug (a leak fixture pins it).
 
-### Epoch finalization — the adapter-internal final phase
+### Epoch finalization — the adapter-internal render-batch boundary
 
 On the observation-port substrate, the invalidation algorithm's Phase 3
 ([§Invalidation algorithm](#invalidation-algorithm) — "notify subscribers") is realised
-as constant-work stale-marking (invariant 6), and the commit sequence gains an
-**adapter-internal final phase — epoch close**: after the event drain settles
-derivations (Phases 1–2) and dirty cells are marked (Phase 3), the framework epoch
-closes and each dirty ViewCell is flushed **once** into the host scheduler. Drain→React
-scheduling is microtask-aligned. `flush-render!` (and the test flush built on it) closes
-the framework epoch **before** React renders; a re-entrant `flushSync`-style forcing
-into an open epoch is a dev error carrying epoch evidence
-(`:rf.error/flush-in-open-epoch`, dev tier — catalogue row required per
+as constant-work stale-marking (invariant 6). The commit sequence gains an
+**adapter-internal final phase — the drain-quiescence render batch**: a run-to-completion
+drain may settle several queued events, each settling its derivations (Phases 1–2) and
+marking dirty cells (Phase 3) as it commits its **own** epoch record; then, **when the
+drain reaches quiescence** (not at each epoch close), each dirty ViewCell is flushed
+**once** into the host scheduler and React performs **one read/render batch** over the
+whole drain's coalesced epochs. The moving epoch rides the stale-mark as **cause
+evidence only** — coalescing keys on the cell's pending state, never on the epoch tag —
+so N epochs committed in one drain produce exactly one render batch, and render
+separation follows **drain** boundaries, never the epoch count (see invariant 6). On
+CLJS the flush is microtask-aligned: a single `goog.async.nextTick` microtask, armed by
+the first mark of the drain, cannot run until the synchronous drain unwinds, so it fires
+strictly **after** drain quiescence and never between two queued events of the same
+drain. The headless (JVM/SSR) host has no async render loop and drains via the explicit
+`flush!` idiom. `flush-render!` (and the test flush built on it) closes the render batch
+**before** React renders; a re-entrant `flushSync`-style forcing into an open drain is a
+dev error carrying epoch evidence (`:rf.error/flush-in-open-epoch`, dev tier — catalogue
+row required per
 [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) when the
-epoch-close phase lands with the ViewCell layer, Stage 2b/2c). This phase is
+render-batch phase lands with the ViewCell layer, Stage 2b/2c). This phase is
 adapter-internal: it adds no public contract fn and does not alter `flush-render!`'s
 public signature or semantics.
 


### PR DESCRIPTION
## Summary

Corrects the `re-frame.ui` scheduling contract (P1 foundational scheduling bug, rf2-vxgfnd.45). The contract conflated two units. A frame/event **epoch** is a write-side commit + diagnostic-evidence unit (one per dequeued event, Spec 002 §Drain versus event); it is **not** a React render boundary. The `reactive.cljc` comments, spec/006 invariant 6, and the test framing still said/implied *one render per epoch* — the explicit false gate **"8 epochs ⇒ 8 renders"** — which would force unnecessary reads/renders between events already queued in the same run-to-completion drain.

## Model as implemented

Process the **write side** of every queued event to drain to quiescence (each event may commit its own epoch record); **then** advance each dirty ViewCell **once** and let React perform **one** read/render batch. Epoch ids remain movement/cause evidence only.

- Coalescing keys on the cell's **pending flag**, never on the epoch tag → all epochs committed in one drain fold into one render batch.
- Render **separation follows DRAIN boundaries**, never the epoch count: epochs in one drain share one batch; epochs in separate drains (host regains control between them) render separately.
- **No behavioural mechanism change was needed** — the CLJS scheduler already coalesces correctly: `schedule-flush!` arms **one** microtask per drain (`goog.async.nextTick`, CAS-guarded), and that microtask cannot run until the synchronous run-to-completion drain unwinds, so it fires strictly after drain quiescence. The JVM/headless host drains via the explicit `flush!`. The bug was purely the **contract statement** (comments/spec/test framing) misdescribing the mechanism. This change makes the contract match the (already correct) mechanism and pins it with a positive gate.

## router.cljc — NOT touched (flagged)

DELIVER 2 was conditional ("IF the integration requires it"). The core drain has **zero** UI/reactive/flush coupling (`git grep` over `router.cljc` for `flush-render|ui.reactive|reactive/|:ui/|notify-view` → no hits). The drain-to-quiescence boundary is the synchronous run-to-completion drain itself; the UI scheduler rides it via the host primitive (CLJS microtask / JVM explicit flush) with no explicit seam. So **no router change was required**, per the bead's DESIGN note ("may continue to use a host scheduling primitive if … it cannot run before the active drain reaches quiescence").

## ⚠️ NORMATIVE amendment — spec/006 (HOT-ZONE) — please review before merge

I am the sole 006 toucher. Two edits to `spec/006-ReactiveSubstrate.md`:

1. **Invariant 6** rewritten from *"One notification per cell per epoch"* → *"One notification per cell per render batch — the boundary is drain quiescence, not epoch close."* States the epoch = write/evidence-unit vs render = drain-quiescence-batch distinction; deletes the false N-epochs⇒N-renders equation.
2. **§Epoch finalization** section body rewritten to "the adapter-internal render-batch boundary": a drain may commit several epochs, all coalescing into one render batch at drain quiescence; the moving epoch rides the stale-mark as cause evidence only. The **anchor word "Epoch finalization" is preserved** so the three prose references to it (reactive.cljc ×2, the test ns) stay valid.

## Files

- `implementation/ui/src/re_frame/ui/reactive.cljc` — rewrite §Drain coalescing docstring + scheduler comments to the drain-then-one-render-batch model; epoch tag documented as cause evidence only; add `pending-epoch` tool/test read.
- `spec/006-ReactiveSubstrate.md` — the normative amendment above.
- `implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc` — replace the false gate with `n-epochs-in-one-drain-coalesce-to-one-render-batch` (8 epochs in one drain ⇒ 1 revision advance + 1 notification, epoch tag preserved as evidence via `pending-epoch`; a separate later drain renders separately, later work observable). Extends the directionally-correct `coalescing-is-independent-of-the-epoch-tag-while-pending`.

## Out of scope (flagged for follow-up, NOT edited — off my surface)

The same "per epoch" misstatement survives in two off-surface spots that should be reconciled with this contract in a follow-up bead:
- `implementation/ui/src/re_frame/ui/viewcell.cljs:30` — docstring "coalesced once per cell per epoch" (the render-advance genuinely lives in `reactive.cljc`, not here, so viewcell.cljs was left untouched per the surface rules; note its line 34 already correctly says "N cells flushed in one drain settle in ONE render pass").
- `spec/004-Views.md:272,291` — "one notification per cell per epoch, I-6" / "one notification per epoch — I-3/I-4/I-6".

The full G-5/G-13 end-to-end React fixture (dispatch → observation-port → useSyncExternalStore → React) lands with rf2-vxgfnd.12, per the bead's coordination note.

## Quality gates

Foreground, 0-fail (router.cljc untouched → core JVM gate not required):

- ui artefact JVM `clojure -M:test` — **250 tests, 4459 assertions, 0 failures, 0 errors**
- `npm run test:ui` (node CLJS, the epoch/coalescing suites) — **221 tests, 1207 assertions, 0 failures, 0 errors** (build: 189 files, 0 warnings)

The new test runs on both hosts (`.cljc` `-cljs-test`).
