### PR TITLE
fix(ui/compiler): read-time descriptor digest + runtime custom-element eviction (rf2-vxgfnd.47, rf2-vxgfnd.48)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -231,7 +231,7 @@
             #(defview** form menv vname forms)))
 
 (defn- custom-element**
-  [coords tag opts]
+  [coords ns-sym tag opts]
   (when-not (and (keyword? tag) (nil? (namespace tag))
                  (str/includes? (name tag) "-"))
     (fail :rf.ui.compile/bad-custom-element
@@ -264,10 +264,14 @@
     ;; compile-time registration (this JVM performs macroexpansion for
     ;; both hosts) routed through the build-scoped model so a removed /
     ;; renamed declaration drops its stale property classification with
-    ;; its file (rf2-vxgfnd.16) + emitted runtime registration (ui/spread
-    ;; classifies at render via the same registry, on the client).
+    ;; its file (rf2-vxgfnd.16). The emitted runtime registration (ui/spread
+    ;; classifies at render via the same registry, on the client) carries the
+    ;; declaring ns so a hot-reload that DROPS this declaration evicts its
+    ;; stale runtime row — the runtime arm of the same eviction model
+    ;; (rf2-vxgfnd.48).
     (build/contribute! build/elements (:file coords) tag {:properties props})
-    `(re-frame.ui.rules/register-custom-element! ~tag {:properties ~props})))
+    `(re-frame.ui.rules/register-custom-element!
+      ~tag {:properties ~props} '~ns-sym)))
 
 (defn custom-element*
   "The RULED custom-element declaration grammar (Mike, 2026-07-12):
@@ -277,8 +281,9 @@
   not silent growth. `form` = &form, `menv` = &env — compile errors are
   anchored with the declaration form's source coordinates (S1e)."
   [form menv tag opts]
-  (let [coords (source-coords form (some? (:ns menv)))]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (if (:ns menv) (-> menv :ns :name) (ns-name *ns*))]
     (anchored coords
-              #(custom-element** coords tag opts))))
+              #(custom-element** coords ns-sym tag opts))))
 
 ))

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -346,14 +346,24 @@
   mount zero or several); `:root-id-provenance` is dev-only and never
   reaches shipped manifests. Identity keys are omitted when `root-id` is
   nil (the `render!` descriptor-base — the client completes identity from
-  its Root, fixed at `create-root`)."
-  [{:keys [root-id provenance views plans ast build-digest]}]
+  its Root, fixed at `create-root`).
+
+  Carries the per-root STATIC facts ONLY. `:build-digest` — a whole-build
+  aggregate, identical for every root in the build — is deliberately NOT
+  baked here: it is a READ-TIME projection stamped by `descriptor-index`
+  (rf2-vxgfnd.47). Baking it at expansion made it (a) compile-order
+  dependent — a mount site expanded before the rest of the build's views
+  compiled froze the digest over only the views seen so far — and (b) stale
+  under an incremental view edit — recompiling a view's file without
+  re-expanding the mount site left the descriptor carrying the old digest.
+  Resolving at read (over the sorted, JVM-stable view triples) is
+  compile-order independent and never stale."
+  [{:keys [root-id provenance views plans ast]}]
   (let [view (when (= 1 (count views)) (first views))]
     (cond-> {:rf.root/schema-version 1
              :frame-plans (mapv #(select-keys % [:frame-id :config-fingerprint])
                                 plans)
-             :template-fingerprint (fingerprint/template-fingerprint ast)
-             :build-digest build-digest}
+             :template-fingerprint (fingerprint/template-fingerprint ast)}
       (some? root-id)   (assoc :root-id root-id)
       (some? provenance) (assoc :root-id-provenance provenance)
       view (assoc :view-id (:view-id view))
@@ -402,6 +412,25 @@
   []
   (build/reset-build!)
   nil)
+
+#?(:clj
+   (defn descriptor-index
+     "The Root Descriptor index projected for READING (S5 tooling / Xray /
+     ui.test read compile output through here): every stored per-root static
+     descriptor stamped with the CURRENT whole-build `:build-digest`. The
+     digest is a whole-build aggregate — identical for every root — so it is
+     resolved HERE at read, never baked into a descriptor at expansion time,
+     where it would reflect only the views compiled before that mount site
+     (compile-order dependent) and go stale when a view recompiled without
+     re-expanding the mount site (rf2-vxgfnd.47). Compile-order independent +
+     incremental==clean by construction: the value is
+     `re-frame.ui.compiler/current-build-digest`, recomputed on every read
+     over the sorted view triples."
+     []
+     (let [bd (compiler/current-build-digest)]
+       (into {}
+             (map (fn [[rid desc]] [rid (assoc desc :build-digest bd)]))
+             @build-descriptors))))
 
 (defn- site-str [{:keys [file line]}]
   (str (or file "<unknown-file>") (when line (str ":" line))))
@@ -620,8 +649,7 @@
               _      (register-root-site! 'ui/mount root-id provenance coords)
               _      (doseq [p plans] (register-plan-site! 'ui/mount p coords))
               desc   (root-descriptor {:root-id root-id :provenance provenance
-                                       :views views :plans plans :ast ast
-                                       :build-digest (compiler/current-build-digest)})
+                                       :views views :plans plans :ast ast})
               _      (build/contribute! build/descriptors (:file coords)
                                         root-id desc)
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
@@ -686,8 +714,7 @@
               _      (print-warnings! e 'ui/render!)
               _      (doseq [p plans]
                        (register-plan-site! 'ui/render! p coords))
-              desc   (root-descriptor {:views views :plans plans :ast ast
-                                       :build-digest (compiler/current-build-digest)})
+              desc   (root-descriptor {:views views :plans plans :ast ast})
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
           `(re-frame.ui.client/render!*
             ~root
@@ -725,8 +752,7 @@
                 (register-root-site! 'ui/hydrate-root derived :derived coords)
                 (build/contribute! build/descriptors (:file coords) derived
                        (root-descriptor {:root-id derived :provenance :derived
-                                         :views views :plans plans :ast ast
-                                         :build-digest (compiler/current-build-digest)}))))
+                                         :views views :plans plans :ast ast}))))
             (doseq [p plans] (register-plan-site! 'ui/hydrate-root p coords))
             (let [body (emit-cljs/emit-inline ast 'rf-ui-root)]
               `(re-frame.ui.client/hydrate-root*

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -707,17 +707,89 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Custom-element declarations (RULED grammar) — runtime registry
+;;
+;; The RUNTIME arm of the compile-side build-scoped model (rf2-vxgfnd.16 AC5,
+;; runtime/HMR half; rf2-vxgfnd.48). #5719 made the COMPILE-time custom-element
+;; ledger build-scoped — a removed / renamed declaration drops its stale
+;; property classification with its source — but the RUNTIME registry stayed
+;; append-only: after a declaration is deleted and its ns hot-reloads, the
+;; emitted registration simply stops executing, so the stale row lingered in
+;; the browser's atom and `ui/spread` kept classifying the removed
+;; `:properties` until a full page reload. The inverse operation the registry
+;; lacked is a per-source eviction, mirrored here on the runtime atom: emitted
+;; registrations carry their declaring ns, and a hot-reload generation bump
+;; (the shadow-cljs `^:dev/before-load` hook) makes a re-registering source
+;; replace its WHOLE prior contribution — so a dropped declaration vanishes.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. Populated by
   `ui/custom-element` (top-level, compile-resolvable; undeclared elements
-  need no declaration — all-attributes default)."}
+  need no declaration — all-attributes default). Consumers (`ui/spread`, the
+  JVM tree builder) read this unchanged."}
   custom-elements
   (atom {}))
 
-(defn register-custom-element! [tag decl]
+(defonce ^{:private true
+           :doc "ns-sym -> {:gen <reload-gen> :tags #{tag}} — the per-source
+  RUNTIME ledger mirroring the compile-side build ledger, so a hot-reload that
+  DROPS a declaration evicts its now-stale runtime row."}
+  element-sources
+  (atom {}))
+
+(defonce ^{:private true
+           :doc "Monotonic hot-reload counter — the runtime analogue of the
+  compile-side build generation. `notify-reload!` (the shadow-cljs
+  `^:dev/before-load` hook) bumps it; a source re-opens (evicts its prior
+  rows) the first time it re-registers at a newer generation."}
+  reload-generation
+  (atom 0))
+
+(defn- open-element-source!
+  "Evict `ns-sym`'s prior custom-element rows the FIRST time it (re-)registers
+  in the current reload generation — idempotent for its later same-generation
+  declarations. The runtime mirror of the compile-side `open-source!`: a
+  dropped / renamed declaration vanishes because the source's whole prior
+  contribution is replaced on re-registration, not merely overwritten
+  tag-by-tag (which never removes a row the new code no longer declares)."
+  [ns-sym]
+  (let [g @reload-generation]
+    (when (not= g (:gen (get @element-sources ns-sym)))
+      (doseq [tag (:tags (get @element-sources ns-sym))]
+        (swap! custom-elements dissoc tag))
+      (swap! element-sources assoc ns-sym {:gen g :tags #{}})))
+  nil)
+
+(defn register-custom-element!
+  "Register (or, on hot-reload, re-register) `tag`'s runtime property
+  classification under its declaring `ns-sym`. Emitted top-level by
+  `ui/custom-element`, so it re-runs on every ns hot-reload; opening the
+  source first replaces the ns's whole prior contribution, so a removed /
+  renamed declaration's classification is evicted rather than leaking until a
+  full page reload (rf2-vxgfnd.48)."
+  [tag decl ns-sym]
+  (open-element-source! ns-sym)
   (swap! custom-elements assoc tag decl)
+  (swap! element-sources update-in [ns-sym :tags] (fnil conj #{}) tag)
   tag)
+
+(defn ^:dev/before-load notify-reload!
+  "shadow-cljs hot-reload hook (dev only): bump the reload generation so each
+  reloaded source re-opens — evicting its stale rows — on its next
+  re-registration this cycle. The runtime analogue of the compile-side
+  `begin-build!` generation bump; production never hot-reloads, so this never
+  fires there."
+  []
+  (swap! reload-generation inc)
+  nil)
+
+(defn reset-custom-elements!
+  "Test support: clear the runtime custom-element registry, the per-source
+  ledger, and the reload generation."
+  []
+  (reset! custom-elements {})
+  (reset! element-sources {})
+  (reset! reload-generation 0)
+  nil)
 
 (defn custom-element-properties [tag]
   (get-in @custom-elements [tag :properties] #{}))

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -14,14 +14,20 @@
 
   The mount-surface macros are client entry points (JVM-host expansion is a
   compile error), so the Layer-1 / descriptor writes are driven the way
-  `re-frame.ui.compiler.root/mount-form` drives them (register-root-site! +
-  register-plan-site! + the descriptor contribution) — the same call
-  sequence one mount site performs. `defview` and `ui/custom-element` ARE
-  JVM-expandable and run their real macro bodies, with the source file bound
-  so distinct 'files' are addressable in the ledger."
+  `re-frame.ui.compiler.root/mount-form` drives them — `mount-site!` runs the
+  REAL assembly path (analyze-root + resolve-root-identity +
+  register-root-site! + register-plan-site! + the `root/root-descriptor`
+  contribution), NOT a hand-built descriptor, so the descriptor's
+  `:build-digest` (read-time projected by `root/descriptor-index`) is
+  actually exercised by the incremental-equals-clean assertion (rf2-vxgfnd.47
+  — the prior hand-built descriptors carried no digest, masking the bug).
+  `defview` and `ui/custom-element` ARE JVM-expandable and run their real
+  macro bodies, with the source file bound so distinct 'files' are
+  addressable in the ledger."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.env :as env]
             [re-frame.ui.compiler.root :as root]
             [re-frame.ui.rules :as rules]))
 
@@ -54,24 +60,49 @@
                                          {:line 1})
                               {} tag {:properties properties})))
 
+(def ^:private resolver
+  "Injected Q5 resolution stub for the root-form analyzer driven by
+  `mount-site!` (mirrors root-analysis-cljs-test's stub)."
+  (fn [sym]
+    (case sym
+      frame-root {:fqn 're-frame.ui/frame-root :meta {}}
+      app-view   {:fqn 'app.views/app-view
+                  :meta {:rf.ui/view true :rf.ui/view-id :app.views/app-view}}
+      nil)))
+
 (defn- mount-site!
-  "Mirror `mount-form`'s Layer-1 / descriptor writes for one root site in
-  `file`: index the root-id, index each frame plan, and contribute the Root
-  Descriptor — exactly the sequence a `ui/mount` expansion performs."
-  [file root-id plans desc]
-  (let [coords {:file file :line 1}]
-    (root/register-root-site! 'ui/mount root-id :authored coords)
-    (doseq [p plans] (root/register-plan-site! 'ui/mount p coords))
-    (build/contribute! build/descriptors file root-id desc)))
+  "Drive the REAL `mount-form` descriptor path for one root site in `file`:
+  analyze the LITERAL root form, resolve identity, index the root-id + each
+  EXTRACTED frame plan, and contribute the Root Descriptor built by the
+  actual `root/root-descriptor` assembly — exactly the sequence a `ui/mount`
+  expansion performs (no hand-built descriptor, no baked digest). The
+  descriptor's `:build-digest` is thus a read-time projection
+  (`root/descriptor-index`), so the incremental-equals-clean assertion
+  exercises it (rf2-vxgfnd.47)."
+  [file root-form opts]
+  (binding [*file* file]
+    (let [coords {:file file :line 1}
+          e (env/make-env {:host :clj :ns-sym 'app.test :resolver resolver})
+          {:keys [ast views plans]} (root/analyze-root e 'ui/mount root-form)
+          {:keys [root-id provenance]} (root/resolve-root-identity
+                                        'ui/mount opts views)]
+      (root/register-root-site! 'ui/mount root-id provenance coords)
+      (doseq [p plans] (root/register-plan-site! 'ui/mount p coords))
+      (build/contribute! build/descriptors file root-id
+                         (root/root-descriptor
+                          {:root-id root-id :provenance provenance
+                           :views views :plans plans :ast ast})))))
 
 (defn- snapshot
-  "The observable state of all five build registries + the build digest."
+  "The observable state of all five build registries + the build digest. The
+  descriptor index is read through `root/descriptor-index` so its read-time
+  `:build-digest` projection is part of what clean-vs-incremental compares."
   []
   {:views       @compiler/build-views
    :digest      (compiler/current-build-digest)
    :roots       @root/build-roots
    :plans       @root/build-plans
-   :descriptors @root/build-descriptors
+   :descriptors (root/descriptor-index)
    :elements    @rules/custom-elements})
 
 ;; ---------------------------------------------------------------------------
@@ -140,18 +171,20 @@
   / :x-el)."
   []
   (declare-view! "app/a.cljs" 'bar [:section "bar"])
-  (mount-site!   "app/a.cljs" :page/cart
-                 [{:frame-id :cart :config-fingerprint "cf1-cart"}]
-                 {:rf.root/schema-version 1 :root-id :page/cart})
+  (mount-site!   "app/a.cljs"
+                 '[frame-root {:id :cart :initial-events [[:cart/boot]]}
+                   [app-view {:promo :winter}]]
+                 {:root-id :page/cart})
   (declare-element! "app/a.cljs" :y-el #{:label}))
 
 (deftest incremental-edit-equals-clean-build
   ;; 1) the ORIGINAL source A, built in this JVM
   (build/begin-build! :app)
   (declare-view! "app/a.cljs" 'foo [:div "foo"])
-  (mount-site!   "app/a.cljs" :page/shop
-                 [{:frame-id :shop :config-fingerprint "cf1-shop"}]
-                 {:rf.root/schema-version 1 :root-id :page/shop})
+  (mount-site!   "app/a.cljs"
+                 '[frame-root {:id :shop :initial-events [[:shop/boot]]}
+                   [app-view {:promo :spring}]]
+                 {:root-id :page/shop})
   (declare-element! "app/a.cljs" :x-el #{:help-text})
   ;; 2) EDIT the same file in the SAME JVM (no restart) — incremental rebuild
   (build/begin-build! :app)
@@ -174,13 +207,61 @@
       (testing "the digest is a function of current views only"
         (is (= (:digest clean) (:digest incremental)))))))
 
+;; ---------------------------------------------------------------------------
+;; The descriptor :build-digest is a READ-TIME projection (rf2-vxgfnd.47) —
+;; compile-order independent + never stale under an incremental view edit.
+;; The prior harness hand-built digest-free descriptors, masking both.
+;; ---------------------------------------------------------------------------
+
+(deftest descriptor-digest-is-compile-order-independent-and-covers-all-views
+  ;; ORDER 1: the mount site expands BEFORE the rest of the build's views
+  ;; compile. Baked-at-expansion would freeze its descriptor digest over only
+  ;; a-view; the read-time projection reads the WHOLE-build digest.
+  (build/begin-build! :app)
+  (declare-view! "app/a.cljs" 'a-view [:div "a"])
+  (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
+  (declare-view! "app/b.cljs" 'b-view [:section "b"])
+  (let [digest-1 (get-in (root/descriptor-index) [:page/m :build-digest])]
+    (is (= (compiler/current-build-digest) digest-1)
+        "the descriptor digest reflects ALL build views (a-view AND b-view),
+         not only those compiled before the mount site expanded")
+    ;; ORDER 2: same two views, but the mount site expands LAST.
+    (build/reset-build!)
+    (build/begin-build! :app)
+    (declare-view! "app/b.cljs" 'b-view [:section "b"])
+    (declare-view! "app/a.cljs" 'a-view [:div "a"])
+    (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
+    (is (= digest-1 (get-in (root/descriptor-index) [:page/m :build-digest]))
+        "same whole-build digest whether the mount site expands first or last
+         (compile-order independent — .16 AC7)")))
+
+(deftest descriptor-digest-tracks-an-incremental-view-only-edit
+  ;; A mount site in m.cljs + a view in v.cljs.
+  (build/begin-build! :app)
+  (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
+  (declare-view! "app/v.cljs" 'v-view [:div "one"])
+  (let [d1 (get-in (root/descriptor-index) [:page/m :build-digest])]
+    (is (= (compiler/current-build-digest) d1))
+    ;; INCREMENTAL pass: recompile ONLY the view file (its template changes).
+    ;; The mount site is NOT re-expanded — under baked-at-expansion its stored
+    ;; descriptor would keep the OLD digest; the read-time projection tracks
+    ;; the new whole-build digest.
+    (build/begin-build! :app)
+    (declare-view! "app/v.cljs" 'v-view [:div "two"])
+    (let [d2 (get-in (root/descriptor-index) [:page/m :build-digest])]
+      (is (not= d1 d2)
+          "the view edit changed the whole-build digest")
+      (is (= (compiler/current-build-digest) d2)
+          "the un-re-expanded mount-site descriptor reads the CURRENT digest,
+           not a stale expansion-time snapshot (rf2-vxgfnd.47)"))))
+
 (deftest repeated-rebuilds-stay-bounded-without-a-reset
   ;; AC6: correctness across a watch session needs NO test-only global reset —
   ;; re-declaring the same file N times replaces (never grows).
   (dotimes [_ 25]
     (build/begin-build! :app)
     (declare-view! "app/a.cljs" 'only [:div "only"])
-    (mount-site! "app/a.cljs" :page/shop [] {:rf.root/schema-version 1 :root-id :page/shop}))
+    (mount-site! "app/a.cljs" '[app-view {}] {:root-id :page/shop}))
   (is (= 1 (count @compiler/build-views)) "views bounded across repeated rebuilds")
   (is (= #{:page/shop} (set (keys @root/build-roots))) "roots bounded")
   (is (= #{:page/shop} (set (keys @root/build-descriptors))) "descriptors bounded"))

--- a/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
@@ -275,8 +275,7 @@
         {:keys [root-id provenance]}
         (root/resolve-root-identity 'ui/mount opts views)]
     (root/root-descriptor {:root-id root-id :provenance provenance
-                           :views views :plans plans :ast ast
-                           :build-digest "bd1-test"})))
+                           :views views :plans plans :ast ast})))
 
 (deftest descriptor-literal-props
   (let [d (descriptor* '[app-view {:promo :spring :sizes [1 2] :opts {:a 1}}]
@@ -290,7 +289,9 @@
     (is (= {:promo :spring :sizes [1 2] :opts {:a 1}} (:static-props d))
         ":static-props records the literal map verbatim")
     (is (re-find #"^tf1-[0-9a-f]{16}$" (:template-fingerprint d)))
-    (is (= "bd1-test" (:build-digest d)))))
+    (is (not (contains? d :build-digest))
+        "root-descriptor bakes NO :build-digest — the whole-build digest is a
+         read-time projection stamped by descriptor-index (rf2-vxgfnd.47)")))
 
 (deftest descriptor-dynamic-props
   (let [d (descriptor* '[app-view {:promo (current-promo)}] {})]

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -160,7 +160,61 @@
 (deftest custom-element-rows
   (is (= "helpText" (rules/custom-element-property-name "help-text"))
       "declared names -> camelCase JS property (RULED grammar)")
-  (rules/register-custom-element! :rules-test-el {:properties #{:some-prop}})
+  (rules/register-custom-element! :rules-test-el {:properties #{:some-prop}}
+                                  're-frame.ui.rules-test)
   (is (= #{:some-prop} (rules/custom-element-properties :rules-test-el)))
   (is (= #{} (rules/custom-element-properties :never-declared-el))
       "undeclared elements default to all-attributes"))
+
+;; ---------------------------------------------------------------------------
+;; Custom-element runtime registry — hot-reload eviction (rf2-vxgfnd.48). The
+;; RUNTIME arm of .16 AC5; the compile/JVM arm lives in
+;; re-frame.ui.compiler-build-jvm-test.
+;; ---------------------------------------------------------------------------
+
+(deftest removed-custom-element-clears-runtime-property-classification
+  (rules/reset-custom-elements!)
+  ;; initial load: app.a declares :x-el with :help-text
+  (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+  (is (= #{:help-text} (rules/custom-element-properties :x-el))
+      "the declaration classifies :help-text as a property")
+  ;; hot-reload app.a: :x-el renamed to :y-el (its declaration deleted). The
+  ;; ^:dev/before-load hook bumps the generation; re-running app.a's forms
+  ;; re-opens the source, evicting its whole prior contribution first.
+  (rules/notify-reload!)
+  (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)
+  (is (= #{} (rules/custom-element-properties :x-el))
+      "the removed :x-el no longer classifies any property (was leaking until
+       a full page reload)")
+  (is (= #{:label} (rules/custom-element-properties :y-el))
+      "the current :y-el declaration classifies its property"))
+
+(deftest hot-reload-preserves-untouched-sources
+  ;; A reload cycle that reloads source B must NOT drop source A's rows — A's
+  ;; forms did not re-run, so it keeps its prior generation (the runtime mirror
+  ;; of the compile-side incremental-preserves-untouched semantics).
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.a)
+  (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
+  (rules/notify-reload!)
+  (rules/register-custom-element! :b-el {:properties #{:b-prop2}} 'app.b) ; only B reloads
+  (is (= #{:a-prop} (rules/custom-element-properties :a-el))
+      "untouched source A keeps its classification across B's reload")
+  (is (= #{:b-prop2} (rules/custom-element-properties :b-el))
+      "reloaded source B's classification updates"))
+
+(deftest multiple-declarations-in-one-source-accumulate-then-replace
+  ;; Two elements in one source accumulate; on reload, both re-open together
+  ;; and only the survivors remain (never clear-on-first-declaration).
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.multi)
+  (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.multi)
+  (is (= #{:a-prop} (rules/custom-element-properties :a-el)))
+  (is (= #{:b-prop} (rules/custom-element-properties :b-el)))
+  ;; reload app.multi keeping only :a-el (with a changed decl); :b-el deleted
+  (rules/notify-reload!)
+  (rules/register-custom-element! :a-el {:properties #{:a-prop2}} 'app.multi)
+  (is (= #{:a-prop2} (rules/custom-element-properties :a-el))
+      "the surviving declaration's classification updates")
+  (is (= #{} (rules/custom-element-properties :b-el))
+      "the dropped :b-el is evicted even though app.multi no longer touches it"))


### PR DESCRIPTION
Two follow-ups to #5719's build-boundary work, one PR, two commits.

## rf2-vxgfnd.47 — read-time descriptor build-digest projection

The Root Descriptor's `:build-digest` was baked into each descriptor at macro-expansion time via `(compiler/current-build-digest)`. That whole-build aggregate then depended on how many unrelated views had compiled before the mount site expanded — **compile-order dependent** (violates .16 AC7) — and went **stale** when a view's file recompiled without re-expanding the mount site (descriptor index != clean-process build). The aggregate digest itself was already sound (sorted, JVM-stable); only its per-descriptor baking was wrong.

Fix: make the digest a **read-time projection**. `root-descriptor` now assembles the per-root static subset only (no `:build-digest`); the new `root/descriptor-index` stamps the current whole-build digest onto every entry at read. Resolving over the sorted view triples is compile-order independent and never stale by construction. The emitted runtime dev descriptor likewise carries the static subset (a per-site baked digest could only ever be the wrong, expansion-time snapshot).

The harness masked the bug: `mount-site!` hand-built descriptors *without* a digest, so incremental-equals-clean held trivially. It now drives the real assembly path (`analyze-root` + `resolve-root-identity` + `register-root-site!` + `register-plan-site!` + `root-descriptor`) and reads through `descriptor-index`, so the digest is actually exercised. Two dedicated tests added: compile-order independence (mount site expanded first vs last) and the incremental view-only-edit staleness killer.

## rf2-vxgfnd.48 — runtime custom-element eviction on hot-reload

`register-custom-element!` only `assoc`'d. After a declaration was deleted and its ns hot-reloaded, the emitted top-level registration simply stopped executing, so the stale row lingered in the browser's `custom-elements` atom and `ui/spread` kept classifying the removed `:properties` until a full page reload. #5719 made the compile-side ledger build-scoped but left the runtime append-only — the asymmetry was structural. .16's AC5 required removal from compile **and** runtime/HMR; only the compile half had landed.

Fix: add the runtime arm, mirroring the compile-side per-source eviction on the runtime atom. Emitted registrations now carry their declaring ns; a per-source runtime ledger tracks each ns's tags; and a hot-reload generation bump (the shadow-cljs `^:dev/before-load` hook, `notify-reload!`) makes a re-registering source re-open — replacing its whole prior contribution — so a dropped/renamed declaration is evicted rather than leaking. Untouched sources keep their generation across another source's reload. CLJS HMR-style fixtures added. Does **not** touch the shadow-cljs `begin-build!` wiring (rf2-df9873).

## Quality gates

- ui artefact JVM `clojure -M:test` — **248 tests, 4443 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime CLJS) — **8950 tests, 42240 assertions, 0 failures, 0 errors**

Both foreground.