### PR TITLE
fix(core): atomic first-owner disposal-hook install in observation acquire! (rf2-vxgfnd.32)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -99,7 +99,20 @@
   drain runs once the registry mutation + cache eviction completed, never
   mid-mutation), coalesced once per lease. Non-registrar disposal paths
   (frame-destroy, explicit cache clears) drain on the next tick with cause
-  `:disposed`."
+  `:disposed`.
+
+  The first owner's enrol + disposal-hook install is NOT one atomic step: the
+  node record advertises `:hooked?` as the lease enrols, before
+  `interop/add-on-dispose!` registers the callback. A disposal that linearizes
+  in that gap could fire no hook (the callback lands on an already-disposed
+  reaction and is silently lost — every substrate's `-dispose` clears its
+  callbacks first) or drain the owner set before a second owner enrolled. So
+  `acquire!` closes the handshake with a CANONICALITY RE-CHECK (rf2-vxgfnd.32):
+  because every disposal path evicts the cache entry before `interop/dispose!`,
+  a reaction that is no longer the frame's canonical node was disposed in the
+  window — the staged owners are self-drained and enqueued exactly once
+  (`take-owners!` is the single-drain point), so no acquired lease is ever left
+  behind an uninstalled/dead hook without its invalidation."
   (:refer-clojure :exclude [read])
   (:require [re-frame.error :as error]
             [re-frame.error-emit :as error-emit]
@@ -717,18 +730,45 @@
   (count #?(:clj  (locking node-records (:owners (.get node-records reaction)))
             :cljs (:owners (.get node-records reaction)))))
 
+(defn- drain-owners!
+  "Snapshot-and-clear `reaction`'s active owners and enqueue a former-owner
+  disposal notification for each still-live lease. `take-owners!` is the
+  SINGLE-DRAIN point (idempotent under the node-records lock), so whichever of
+  the node's disposal hook OR `acquire!`'s handshake re-check (rf2-vxgfnd.32)
+  reaches a disposed node first drains its owners; the other call finds an empty
+  set and no-ops — every active owner is enqueued exactly once. Delivery is
+  QUEUED (never a synchronous `on-change`) and rides the drain boundary (see the
+  ns docstring's HMR section)."
+  [reaction]
+  (doseq [lease (take-owners! reaction)]
+    (when (= :live (:status @(lease-state lease)))
+      (enqueue-disposal! lease)))
+  nil)
+
 (defn- node-disposed-hook
   "The ONE node-scoped on-dispose callback for `reaction` (installed exactly
-  once, on the first owner). On node disposal it snapshots-and-clears the
-  CURRENT active owners and enqueues a former-owner notification for each
-  still-live lease — coalesced once per lease at the drain boundary (see the ns
-  docstring's HMR section). It closes over the reaction only, never a lease, so
-  released owners (de-enrolled by `release!`) are unreachable from it."
+  once, on the first owner). On node disposal it drains the CURRENT active
+  owners and enqueues a former-owner notification for each still-live lease —
+  coalesced once per lease at the drain boundary (see the ns docstring's HMR
+  section). It closes over the reaction only, never a lease, so released owners
+  (de-enrolled by `release!`) are unreachable from it."
   [reaction]
   (fn observation-node-disposed []
-    (doseq [lease (take-owners! reaction)]
-      (when (= :live (:status @(lease-state lease)))
-        (enqueue-disposal! lease)))))
+    (drain-owners! reaction)))
+
+(defn- node-still-canonical?
+  "True when the lease's acquired reaction is still the frame's live cache node
+  for its query — i.e. not disposed, not evicted, not rebuilt. A false result
+  means a disposal / eviction / HMR-replacement has linearized: EVERY disposal
+  path in `re-frame.subs.cache` evicts the cache entry (a cache-atom swap/reset)
+  BEFORE it calls `interop/dispose!`, and the cache atom's volatile semantics
+  order that eviction before this read — so once a reaction has been disposed it
+  is no longer the entry's `:reaction`. This is the authority `acquire!`'s
+  first-owner handshake (rf2-vxgfnd.32) and the `current?` kept-check both read."
+  [{:keys [frame-id query-v reaction]}]
+  (boolean
+    (when-let [cache (:sub-cache (frame/frame frame-id))]
+      (identical? reaction (:reaction (get @cache query-v))))))
 
 ;; ---- acquire! -------------------------------------------------------------------
 
@@ -764,9 +804,13 @@
   callback registration: a unique change watch (on watchable hosts). The lease
   is also enrolled as an active owner behind the node's single, once-installed
   disposal hook; `release!` de-enrols it, so a released lease never leaks a
-  dormant closure (rf2-vxgfnd.15). `acquire!` never invokes `on-change`
-  synchronously — no fan-out during acquire (movement in the render→commit
-  gap is the commit evidence comparison's job, invariant 5).
+  dormant closure (rf2-vxgfnd.15). A disposal that races the first-owner
+  hook install is caught by a canonicality re-check that self-drains the
+  staged owners (rf2-vxgfnd.32 — see the ns docstring's HMR section), so no
+  acquired lease is left behind an uninstalled/dead hook without its
+  invalidation. `acquire!` never invokes `on-change` synchronously — no
+  fan-out during acquire (movement in the render→commit gap is the commit
+  evidence comparison's job, invariant 5).
 
   `on-change` MUST be constant-work (mark-dirty with the payload
   `{:cause :value|:hmr|:disposed :target … :node-key … :node-version …
@@ -837,6 +881,25 @@
             ;; O(current owners), never O(all owners ever acquired) (rf2-vxgfnd.15).
             (when (register-owner! reaction lease)
               (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
+            ;; First-owner disposal-hook HANDSHAKE (rf2-vxgfnd.32). The record's
+            ;; :hooked? flag flips as the lease enrols, BEFORE add-on-dispose!
+            ;; actually registers the callback, so a disposal that linearizes in
+            ;; that gap can (a) fire NO hook — the callback lands on an
+            ;; already-disposed reaction and is lost (every substrate's -dispose
+            ;; snapshot-and-clears its callbacks, and the JVM Reaction's field is
+            ;; even unsynchronized, so an install racing -dispose can be dropped
+            ;; outright) — or (b) drain the owner set before this lease enrolled.
+            ;; Close the handshake with a canonicality re-check that EVERY owner
+            ;; (first or not) runs: since every disposal path evicts the cache
+            ;; entry BEFORE interop/dispose! (re-frame.subs.cache), a reaction
+            ;; that is no longer the frame's canonical node WAS disposed in the
+            ;; window. Self-drain the staged owners so each is enqueued exactly
+            ;; once (take-owners! is the single-drain point; the installed hook,
+            ;; if it did fire, already drained). No synchronous on-change: drain
+            ;; only ENQUEUES — delivery rides the next-tick / HMR drain boundary
+            ;; off the acquire stack, preserving acquire!'s no-fan-out guarantee.
+            (when-not (node-still-canonical? @state)
+              (drain-owners! reaction))
             lease)
           ;; NEVER-CACHED, zero-ref RECOVERY reaction (rf2-vxgfnd.27): a cyclic
           ;; entry sub, a parametric input-fn failure, or a frame destroyed
@@ -848,14 +911,6 @@
           (throw-acquire-recovery! frame-id query result))))))
 
 ;; ---- current? -------------------------------------------------------------------
-
-(defn- node-still-canonical?
-  "True when the lease's acquired reaction is still the frame's live cache
-  node for its query — i.e. not disposed, not evicted, not rebuilt."
-  [{:keys [frame-id query-v reaction]}]
-  (boolean
-    (when-let [cache (:sub-cache (frame/frame frame-id))]
-      (identical? reaction (:reaction (get @cache query-v))))))
 
 (defn current?
   "The commit kept-check, one predicate: `lease` still exactly covers

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -19,6 +19,7 @@
             [re-frame.core                  :as rf]
             [re-frame.error-emit            :as error-emit]
             [re-frame.frame                 :as frame]
+            [re-frame.interop               :as interop]
             [re-frame.subs                  :as subs]
             [re-frame.substrate.observation :as obs]
             [re-frame.substrate.plain-atom  :as plain-atom]
@@ -391,6 +392,145 @@
           (is (= 1 (ref-count [:obs/items]))))
         (obs/release! lease2)
         (is (nil? (entry [:obs/items])))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.32 — first-owner disposal-hook install races node disposal
+;;
+;; PR #5710 enrols the first active owner (marking the node record :hooked?)
+;; and THEN, as a SEPARATE step, installs the one node-scoped disposal hook via
+;; interop/add-on-dispose!. A disposal that linearizes in that gap fires no hook
+;; (the callback lands on an already-disposed reaction and is silently lost —
+;; every substrate's -dispose snapshot-and-clears its callbacks first; the JVM
+;; Reaction's field is even unsynchronized). Pre-fix the acquired lease is left
+;; :hooked? with a dead callback and receives NO invalidation. The fix closes
+;; the handshake with a canonicality re-check in acquire! that self-drains the
+;; staged owners when the reaction is no longer the frame's live cache node.
+;;
+;; Deterministic race (no sleeps, both hosts): wrap interop/add-on-dispose! so
+;; the FIRST-owner hook install — the call that targets the already-CANONICAL
+;; cached reaction (the construction-time input-release closure is wired BEFORE
+;; the reaction is installed, so the entry does not yet hold it — the identity
+;; gate skips it) — first disposes+evicts the node, then registers the dead
+;; callback. This linearizes disposal EXACTLY in the enrol → hook-install gap.
+;; ===========================================================================
+
+(defn- force-dispose-node!
+  "Simulate a real disposal winning a race: evict the cache entry (as EVERY
+  real disposal path does — swap the cache atom BEFORE interop/dispose!), then
+  dispose the reaction. Bypasses the ref-count guard the way HMR re-registration
+  and frame-destroy eviction do."
+  [query-v]
+  (let [cache    (sub-cache)
+        reaction (:reaction (entry query-v))]
+    (swap! cache dissoc query-v)
+    (interop/dispose! reaction)))
+
+;; Delivery of the :disposed fallback is queued and rides interop/next-tick
+;; (an async executor on the JVM; an unfired-mid-run microtask on CLJS-node).
+;; Swallow next-tick so no async drain fires during the test, assert the
+;; handshake enqueued WITHOUT any synchronous fan-out, then drive the drain
+;; boundary deterministically via the port's own drain-pending-disposals!
+;; (its documented test seam) — no sleeps as the ordering mechanism, identical
+;; on both hosts.
+
+(deftest first-owner-hook-install-races-disposal-invalidation-still-delivered
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target   (items-target)
+        notes    (atom [])
+        real-add interop/add-on-dispose!
+        raced?   (atom false)]
+    (with-redefs
+      [interop/next-tick (fn [_f] nil)
+       interop/add-on-dispose!
+       (fn [reaction f]
+         ;; Race ONLY the observation node-disposed hook install — it targets
+         ;; the reaction once it is the CANONICAL cached node. The
+         ;; construction-time input-release closure is wired before the entry
+         ;; holds the reaction, so this identity gate skips it.
+         (when (and (identical? reaction (:reaction (entry [:obs/items])))
+                    (compare-and-set! raced? false true))
+           (force-dispose-node! [:obs/items]))
+         (real-add reaction f))]
+      (let [lease (obs/acquire! target (fn [n] (swap! notes conj n)))]
+        (is (true? @raced?) "the race fired at the first-owner hook install")
+        (is (nil? (entry [:obs/items]))
+            "the racing disposal evicted the canonical node during the gap")
+        (testing "acquire! never invokes on-change synchronously — the
+                  handshake self-drain only ENQUEUES ([S2-CONFIRM]
+                  no-sync-fan-out)"
+          (is (empty? @notes) "no notification fired on the acquire stack"))
+        (testing "the lease is NOT current — the node was disposed under it"
+          (is (false? (obs/current? lease target))))
+        ;; Drive the queued drain boundary deterministically.
+        (obs/drain-pending-disposals! :disposed)
+        (testing "the invalidation is STILL delivered — never silently lost to
+                  a dead first-owner hook (rf2-vxgfnd.32)"
+          (is (= 1 (count @notes))
+              "the raced first owner received exactly one disposal notification")
+          (is (= :disposed (:cause (first @notes)))))
+        (testing "release! on the raced lease is a clean, identity-guarded no-op"
+          (obs/release! lease)
+          (is (nil? (entry [:obs/items]))))))))
+
+(deftest first-owner-hook-race-drains-every-staged-owner-exactly-once
+  ;; Two concurrent acquirers on ONE node: L2 enrols behind L1's :hooked? flag
+  ;; (a cache HIT — registers no hook of its own), and disposal wins the gap
+  ;; during L1's hook install. Neither may be left un-notified: acquire!'s
+  ;; re-check self-drains ALL current owners (take-owners! is the single-drain
+  ;; point), so L1 AND L2 each receive exactly one invalidation.
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target   (items-target)
+        notes1   (atom [])
+        notes2   (atom [])
+        l2       (atom nil)
+        real-add interop/add-on-dispose!
+        raced?   (atom false)]
+    (with-redefs
+      [interop/next-tick (fn [_f] nil)
+       interop/add-on-dispose!
+       (fn [reaction f]
+         (when (and (identical? reaction (:reaction (entry [:obs/items])))
+                    (compare-and-set! raced? false true))
+           ;; A second owner stages behind the first owner's not-yet-installed
+           ;; hook, THEN disposal wins the gap.
+           (reset! l2 (obs/acquire! target (fn [n] (swap! notes2 conj n))))
+           (force-dispose-node! [:obs/items]))
+         (real-add reaction f))]
+      (let [l1 (obs/acquire! target (fn [n] (swap! notes1 conj n)))]
+        (is (true? @raced?))
+        (is (nil? (entry [:obs/items])) "the node was disposed during the gap")
+        (is (some? @l2) "the second owner staged during the race")
+        (testing "no synchronous fan-out from inside either acquire!"
+          (is (empty? @notes1))
+          (is (empty? @notes2)))
+        (obs/drain-pending-disposals! :disposed)
+        (testing "BOTH staged owners were notified exactly once — no owner is
+                  left behind an uninstalled hook (rf2-vxgfnd.32)"
+          (is (= 1 (count @notes1)) "first owner notified once")
+          (is (= 1 (count @notes2)) "second owner notified once"))
+        (obs/release! l1)
+        (obs/release! @l2)))))
+
+(deftest first-owner-non-raced-acquire-installs-live-hook-no-self-drain
+  ;; The common path must be untouched: with no racing disposal, acquire!'s
+  ;; handshake re-check finds the reaction canonical and does NOT self-drain;
+  ;; the installed hook remains the single delivery channel on real disposal.
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target (items-target)
+        notes  (atom [])
+        lease  (obs/acquire! target (fn [n] (swap! notes conj n)))]
+    (testing "canonical acquire took one ref and enqueued nothing"
+      (is (= 1 (ref-count [:obs/items])))
+      (is (empty? @notes))
+      (is (true? (obs/current? lease target))))
+    (testing "a real HMR disposal delivers via the installed hook exactly once"
+      (reg-items!)
+      (is (= 1 (count @notes)))
+      (is (= :hmr (:cause (first @notes))))
+      (obs/release! lease))))
 
 (deftest reentrant-graph-op-is-dev-asserted-inside-the-fan-out
   (reg-items!)


### PR DESCRIPTION
## Problem (rf2-vxgfnd.32, P1 correctness-under-race)

The observation port enrols the first active owner (marking the node record `:hooked?`) and THEN, as a **separate** step, installs the one node-scoped disposal hook via `interop/add-on-dispose!`. The record advertises `:hooked? true` **before** the callback is registered. A disposal that linearizes in that gap fires **no** hook — the callback lands on an already-disposed reaction and is silently lost (every substrate's `-dispose` snapshot-and-clears its callbacks first; the JVM `Reaction`'s field is even `^:unsynchronized-mutable`, so an install racing `-dispose` can be dropped outright). The acquired lease is left `:hooked?` with a dead callback and **never receives its invalidation**. A second owner that enrols behind `:hooked? true` is equally stranded.

## Fix

Close the handshake with a **canonicality re-check** that *every* owner runs after enrol/install. Because every disposal path in `re-frame.subs.cache` evicts the cache entry **before** it calls `interop/dispose!` (and the cache atom's volatile semantics order that eviction before the read), a reaction that is no longer the frame's canonical cache node **was disposed in the window**. When that is detected, `acquire!` self-drains the staged owners so each is enqueued exactly once (`take-owners!` is the single drain point; the installed hook, if it fired, already drained). The drain only **enqueues** — delivery rides the existing next-tick / HMR boundary off the acquire stack, so `acquire!`'s no-synchronous-fan-out guarantee is preserved.

**No interop primitive was needed.** The eviction-before-dispose invariant (verified across `dispose-entry-now!`, `invalidate-sub-on-replace!`, `clear-sub-cache!`, `dispose-all-for-frame-destroy!`) makes the observation-layer re-check universally sound across all substrates (JVM `Reaction`, CLJS plain-atom reify, React spine, Reagent family). This matches the bead's own steering ("enrol-then-verify liveness + self-notify if dead" / "local observation-port state plus a canonicality retry over widening every adapter API").

## Surface

- `implementation/core/src/re_frame/substrate/observation.cljc` — factor `drain-owners!` (shared by the node hook and the handshake), move `node-still-canonical?` above `acquire!`, add the re-check + self-drain, update docstrings.
- `implementation/core/test/re_frame/observation_port_cljs_test.cljc` — barrier fixtures.

`reactive.cljc`, `subs.cljc`, `client.cljs`, `compiler/*`, `frames.cljc`, `ui/test.cljc`, `viewcell.cljs`, and the `interop` primitive are untouched.

## Tests

Deterministic barrier fixtures (`.cljc`, run on **both** hosts) that linearize disposal exactly in the enrol → hook-install gap via a `with-redefs` of `interop/add-on-dispose!` (gated by node-canonicality so only the observation hook install is raced, not the construction-time input-release closure):

- `first-owner-hook-install-races-disposal-invalidation-still-delivered` — the invalidation is delivered exactly once (cause `:disposed`), lease is not-current, `release!` is a clean no-op.
- `first-owner-hook-race-drains-every-staged-owner-exactly-once` — two concurrent acquirers; both notified exactly once.
- `first-owner-non-raced-acquire-installs-live-hook-no-self-drain` — control: the common path is untouched (no self-drain, HMR delivers via the installed hook once).

The two race fixtures **fail on the pre-fix code** (verified by temporarily disabling the re-check → 5 assertion failures). Deferred delivery is driven deterministically via the port's `drain-pending-disposals!` seam (no sleeps as the ordering mechanism).

## Quality gates

All foreground, 0-fail:

- Core JVM full suite — `clojure -M:test`: **1859 tests, 8290 assertions, 0 failures, 0 errors**.
- Observation-port ns — `clojure -M:test -n re-frame.observation-port-cljs-test`: **29 tests, 0 failures** (run 3x, deterministic; re-run green post-rebase).
- CLJS node gate — `npm run test:cljs`: **8959 tests, 42297 assertions, 0 failures, 0 errors**.
