### PR TITLE
fix(ui): prune install records on destroy + preserve boot-frame authority under adoption (rf2-vxgfnd.30, rf2-vxgfnd.56)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -15,36 +15,53 @@
   it is untouched by abandoned renders, StrictMode replay, HMR, and error
   recovery — there is nothing render-phased to replay.
 
+  Two authorities, kept DISTINCT (rf2-vxgfnd.56). An INSTALLED record
+  means this root OWNS the frame lifetime and may refresh it; an ADOPTED
+  record means the frame is boot/externally authoritative and the root
+  merely SCOPES it — adoption never grants refresh rights.
+
   Per-plan disposition (document order; conflicts validated FIRST):
 
     - NO live frame         -> INSTALL: `make-frame` creates it
       (create-if-absent), then record `{:config-fingerprint
-      :installed-by}`.
+      :installed-by}` (root-OWNED authority).
     - LIVE frame, NO install
       record (a boot `rf/make-frame`
-      the plan registry never saw) -> ADOPT: create-if-absent means
-      create NOTHING (03 §8 / 004C §6 — later roots find it live and do
-      not re-seed). The boot frame's OWN config + image generation are
-      AUTHORITATIVE and left UNTOUCHED — no `make-frame`, so no
-      config/generation clobber, no `:images` discard, no re-seed. Only
-      the plan's `{:config-fingerprint :installed-by}` is recorded, so a
-      later cross-root arrival is conflict-scoped against it. This is the
-      shared-frame case: an app boots the frame with its images /
-      `:fx-overrides` and a root then declares `[frame-root {:id …}]`
-      merely to SCOPE it. (rf2-vxgfnd.26: adopting via a config-carrying
-      `make-frame` used to swap the generation to the default and wipe
-      the boot config — the durable app-db survived, masking the clobber.)
+      the plan registry never saw):
+        · CONFIG-LESS plan `[frame-root {:id …}]` -> ADOPT: create-if-
+          absent means create NOTHING (03 §8 / 004C §6). The boot frame's
+          OWN config + image generation are AUTHORITATIVE and left
+          UNTOUCHED — no `make-frame`, no clobber, no `:images` discard,
+          no re-seed. An ADOPTED record `{:config-fingerprint :adopted-by
+          :adopted true}` is written (for cross-root conflict scoping)
+          that can NEVER enter a refresh path. This is the shared-frame
+          case: an app boots the frame with its images / `:fx-overrides`
+          and a root declares `[frame-root {:id …}]` merely to SCOPE it.
+          (rf2-vxgfnd.26: adopting via a config-carrying `make-frame` used
+          to swap the generation to the default and wipe the boot config —
+          the durable app-db survived, masking the clobber.)
+        · CONFIG-BEARING plan -> `:rf.error/frame-payload-conflict`: the
+          plan would silently discard its config onto a boot-authoritative
+          frame. Fail loud instead (rf2-vxgfnd.56) — either boot the frame
+          config-less and scope it, or drop the boot `make-frame` and let
+          the frame-root own the lifetime.
+    - ADOPTED frame, later
+      SAME-root plan:
+        · CONFIG-LESS  -> found live: PURE NO-OP.
+        · CONFIG-BEARING -> `:rf.error/frame-payload-conflict`: an adopt
+          record confers no ownership, so a later config edit can NOT
+          `make-frame`/refresh over the boot config (rf2-vxgfnd.56).
     - SAME fingerprint      -> found live: PURE NO-OP (the ratified
       idempotent install — no re-seed, no config churn, no trace noise).
       This is the HMR / remount / shared-frame non-reseed guarantee.
     - DIFFERENT fingerprint,
-      SAME installing root  -> REFRESH: the root re-declares its OWN
-      frame (an HMR config edit). `make-frame`'s surgical update applies
-      the new config; durable state survives; `:initial-events` are
-      RE-RECORDED, never REPLAYED (EP-0027). The recorded fingerprint
-      advances. (The §7 conflict names two DIFFERENT parties —
-      `:installed-by` — so same-party re-declaration is the Clojure
-      re-def model, exactly the Layer-1 same-file watch tolerance.)
+      SAME installing root  -> REFRESH (INSTALLED records only): the root
+      re-declares its OWN frame (an HMR config edit). `make-frame`'s
+      surgical update applies the new config; durable state survives;
+      `:initial-events` are RE-RECORDED, never REPLAYED (EP-0027). The
+      recorded fingerprint advances. (The §7 conflict names two DIFFERENT
+      parties — `:installed-by` — so same-party re-declaration is the
+      Clojure re-def model, exactly the Layer-1 same-file watch tolerance.)
     - DIFFERENT fingerprint,
       DIFFERENT root        -> `:rf.error/frame-payload-conflict`:
       fail THE ARRIVING ROOT; the installed frame and the roots already
@@ -124,7 +141,12 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private installed-plans
-  ;; frame-id -> {:config-fingerprint "cf1-…" :installed-by root-id}
+  ;; frame-id -> ONE of two records, discriminated by authority:
+  ;;   INSTALLED (this root OWNS the frame lifetime — refresh rights):
+  ;;     {:config-fingerprint "cf1-…" :installed-by root-id}
+  ;;   ADOPTED (a boot / external frame this root merely SCOPES — NO refresh
+  ;;     rights; boot config stays authoritative):
+  ;;     {:config-fingerprint "cf1-…" :adopted-by root-id :adopted true}
   ;; A failed mount that installed earlier siblings tags their surviving
   ;; records `:mount-incomplete true` (rf2-vxgfnd.30 (b)). Records are
   ;; PRUNED on `frame/destroy-frame!` (rf2-vxgfnd.30 (a)) — the destroy hook
@@ -132,11 +154,18 @@
   ;; lifetime rather than a resurrected dead-lifetime record.
   (atom {}))
 
+(defn- adopted-record?
+  "True when `record` marks a boot/external frame this root merely SCOPES
+  (no installation authority — never a refresh target)."
+  [record]
+  (true? (:adopted record)))
+
 (defn installed-plan-entry
-  "The recorded install for `frame-id` (tool/test read):
-  `{:config-fingerprint … :installed-by root-id}` or nil. Records are pruned
-  on destroy; the extra live-guard keeps a never-hooked path from surfacing
-  a stale record as an install."
+  "The recorded install/adoption for `frame-id` (tool/test read):
+  `{:config-fingerprint … :installed-by root-id}` (installed) or
+  `{:config-fingerprint … :adopted-by root-id :adopted true}` (adopted), or
+  nil. Records are pruned on destroy; the extra live-guard keeps a
+  never-hooked path from surfacing a stale record as an install."
   [frame-id]
   (when (some? (frame/frame frame-id))
     (get @installed-plans frame-id)))
@@ -174,6 +203,36 @@
             :arriving  {:config-fingerprint config-fingerprint
                         :root-id root-id}}}))
 
+(defn- throw-boot-authority-conflict!
+  "A config-BEARING plan met a boot / external frame this root does not own
+  (a live plan-less frame, or one already ADOPTED as boot-authoritative).
+  Adoption is create-if-absent SCOPING, never an ownership transfer: a
+  frame-root carrying config cannot install/refresh over boot authority.
+  Fails loud instead of silently discarding the config (rf2-vxgfnd.56).
+  Same `:rf.error/frame-payload-conflict` id — the arriving plan's payload
+  conflicts with the frame's authoritative boot config."
+  [root-id {:keys [frame-id config-fingerprint]} installed]
+  (error/throw-error!
+   :rf.error/frame-payload-conflict 're-frame.ui/preflight
+   (str "root " (pr-str root-id) " declares a CONFIG-BEARING frame-root for "
+        (pr-str frame-id) ", but that frame is already live and "
+        "boot-authoritative"
+        (if installed
+          (str " (adopted by root " (pr-str (:adopted-by installed)) ")")
+          " (created outside the plan registry — a boot rf/make-frame)")
+        ". A frame-root plan cannot install or refresh its config over a "
+        "frame it does not OWN — adoption only SCOPES a boot frame, it never "
+        "transfers ownership. Either (a) boot the frame WITHOUT config and "
+        "scope it with a config-less [frame-root {:id " (pr-str frame-id)
+        "}], or (b) drop the boot rf/make-frame and let this frame-root own "
+        "the lifetime. The boot frame's config is untouched — this root "
+        "failed before any install")
+   {:recovery :scope-config-less-or-own-the-lifetime
+    :extra {:frame-id  frame-id
+            :installed installed
+            :arriving  {:config-fingerprint config-fingerprint
+                        :root-id root-id}}}))
+
 (defn- mark-mount-incomplete!
   "Tag the surviving install records `frame-ids` (siblings this run wrote
   before a later plan threw) `:mount-incomplete true`, so a later conflict
@@ -206,39 +265,56 @@
   :config {…}} …]` in document order; `root-id` is the arriving root.
 
   Phase 1 VALIDATES every plan (pure — cross-root fingerprint conflicts
-  throw `:rf.error/frame-payload-conflict` before ANY install). Phase 2
+  AND config-bearing-vs-boot-authority conflicts throw
+  `:rf.error/frame-payload-conflict` before ANY install). Phase 2
   installs/adopts/refreshes in document order: `make-frame` creates the
   frame if absent and drains `:initial-events` synchronously before
   returning (EP-0027); a found-live same-fingerprint plan is a pure no-op
   (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
-  is ADOPTED — its config/generation untouched, only the fingerprint
-  recorded (rf2-vxgfnd.26). A plan that throws mid-run tags the siblings it
-  already installed `:mount-incomplete` (rf2-vxgfnd.30 (b)). Returns nil."
+  met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
+  config/generation untouched, only the fingerprint recorded
+  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run tags the
+  siblings it already installed `:mount-incomplete` (rf2-vxgfnd.30 (b)).
+  Returns nil."
   [root-id plans]
   (let [decided
-        (mapv (fn [{:keys [frame-id config-fingerprint] :as plan}]
-                (let [installed (installed-plan-entry frame-id)]
+        (mapv (fn [{:keys [frame-id config config-fingerprint] :as plan}]
+                (let [installed       (installed-plan-entry frame-id)
+                      config-bearing? (boolean (seq config))]
                   (cond
+                    ;; a recorded plan/adoption already governs this LIVE frame
                     (some? installed)
-                    ;; a recorded plan already governs this LIVE frame
-                    (cond
-                      (= (:config-fingerprint installed) config-fingerprint)
-                      (assoc plan ::action :found-live)
+                    (if (adopted-record? installed)
+                      ;; ADOPTED = boot-authoritative; NO refresh rights. A
+                      ;; config-less re-scope is a pure no-op; a config-bearing
+                      ;; plan cannot install its config over boot authority
+                      ;; (rf2-vxgfnd.56 — adoption never grants refresh rights).
+                      (if config-bearing?
+                        (throw-boot-authority-conflict! root-id plan installed)
+                        (assoc plan ::action :found-live))
+                      ;; INSTALLED = this-or-another root OWNS the lifetime.
+                      (cond
+                        (= (:config-fingerprint installed) config-fingerprint)
+                        (assoc plan ::action :found-live)
 
-                      (= (:installed-by installed) root-id)
-                      (assoc plan ::action :refresh)
+                        (= (:installed-by installed) root-id)
+                        (assoc plan ::action :refresh)
 
-                      :else
-                      (throw-plan-conflict! root-id plan installed))
+                        :else
+                        (throw-plan-conflict! root-id plan installed)))
 
-                    ;; No install record. Either the id is genuinely absent
-                    ;; (INSTALL) or a frame is already LIVE under it but was
-                    ;; created OUTSIDE the plan registry — a boot
-                    ;; `rf/make-frame`. ENSURE is create-if-absent (03 §8):
-                    ;; a live frame is ADOPTED, never re-created, so its
-                    ;; boot config + image generation stay authoritative.
+                    ;; No install record, but a frame is already LIVE under
+                    ;; this id — created OUTSIDE the plan registry (a boot
+                    ;; `rf/make-frame`). ENSURE is create-if-absent (03 §8): a
+                    ;; CONFIG-LESS plan ADOPTS it (scopes, never re-creates —
+                    ;; boot config/generation stay authoritative). A
+                    ;; CONFIG-BEARING plan would silently discard its config
+                    ;; onto a boot-authoritative frame — fail loud instead
+                    ;; (rf2-vxgfnd.56).
                     (some? (frame/frame frame-id))
-                    (assoc plan ::action :adopt)
+                    (if config-bearing?
+                      (throw-boot-authority-conflict! root-id plan nil)
+                      (assoc plan ::action :adopt))
 
                     :else
                     (assoc plan ::action :install))))
@@ -254,14 +330,15 @@
           :found-live nil
 
           ;; a live plan-less (boot-created) frame: create-if-absent means
-          ;; create NOTHING. Record only the plan's fingerprint so a later
-          ;; cross-root arrival is conflict-scoped — the boot frame's
-          ;; config/generation/`:images` are left entirely untouched
-          ;; (rf2-vxgfnd.26: a config-carrying `make-frame` here clobbered
-          ;; them, masked by the durable app-db surviving).
+          ;; create NOTHING. Record only the plan's fingerprint under an
+          ;; ADOPTED (non-owning) record so a later cross-root arrival is
+          ;; conflict-scoped — the boot frame's config/generation/`:images`
+          ;; are left entirely untouched (rf2-vxgfnd.26), and the record can
+          ;; never enter a root-owned refresh path (rf2-vxgfnd.56).
           :adopt (do (swap! installed-plans assoc frame-id
                             {:config-fingerprint config-fingerprint
-                             :installed-by root-id})
+                             :adopted-by root-id
+                             :adopted true})
                      (vswap! written conj frame-id))
 
           ;; :install / :refresh — create-if-absent / surgical refresh;

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -51,10 +51,15 @@
       using it are untouched (06 §2 failure scoping). No first-wins
       silent merge, no last-wins overwrite.
 
-  A destroyed frame invalidates its install record: a later plan for the
-  same id is a genuinely new frame lifetime — created fresh,
-  `:initial-events` REPLAYED (the opt-in destroy-then-reseat composition,
-  rf2-lxwpob).
+  A destroyed frame invalidates its install record — the
+  `:ui/on-frame-destroyed!` hook PRUNES it (rf2-vxgfnd.30 (a)), so a boot
+  re-create of the same id can no longer resurrect a dead-lifetime record
+  as a false conflict. A later plan for the same id is a genuinely new
+  frame lifetime — created fresh, `:initial-events` REPLAYED (the opt-in
+  destroy-then-reseat composition, rf2-lxwpob). A plan that throws mid-run
+  tags the siblings it already installed `:mount-incomplete`
+  (rf2-vxgfnd.30 (b)), so a later conflict names an incomplete mount, not
+  a phantom completed owner.
 
   ## Atomicity posture (the rf2-ktmto9 mirror)
 
@@ -120,14 +125,18 @@
 
 (defonce ^:private installed-plans
   ;; frame-id -> {:config-fingerprint "cf1-…" :installed-by root-id}
-  ;; An entry is live only while its frame is (a destroyed frame's record
-  ;; is stale and replaced on the next install).
+  ;; A failed mount that installed earlier siblings tags their surviving
+  ;; records `:mount-incomplete true` (rf2-vxgfnd.30 (b)). Records are
+  ;; PRUNED on `frame/destroy-frame!` (rf2-vxgfnd.30 (a)) — the destroy hook
+  ;; dissocs the id, so a re-created same-id frame is a genuinely new
+  ;; lifetime rather than a resurrected dead-lifetime record.
   (atom {}))
 
 (defn installed-plan-entry
   "The recorded install for `frame-id` (tool/test read):
-  `{:config-fingerprint … :installed-by root-id}` or nil. nil when the
-  frame is no longer live (a stale record is not an install)."
+  `{:config-fingerprint … :installed-by root-id}` or nil. Records are pruned
+  on destroy; the extra live-guard keeps a never-hooked path from surfacing
+  a stale record as an install."
   [frame-id]
   (when (some? (frame/frame frame-id))
     (get @installed-plans frame-id)))
@@ -150,7 +159,12 @@
    (str "root " (pr-str root-id) " arrives with a frame plan for "
         (pr-str frame-id) " whose config fingerprint differs from the "
         "installed frame's recorded plan (installed by root "
-        (pr-str (:installed-by installed)) "). One frame, one plan: align "
+        (pr-str (:installed-by installed)) ")"
+        (when (:mount-incomplete installed)
+          (str ", whose mount did NOT complete — a later plan in that "
+               "root's run threw, so the frame is live only from its "
+               "already-fired :initial-events and no root actually scopes it"))
+        ". One frame, one plan: align "
         "the configs, or drop the duplicate frame-root. The installed "
         "frame and the roots already using it are untouched — this root "
         "failed before any install")
@@ -159,6 +173,31 @@
             :installed installed
             :arriving  {:config-fingerprint config-fingerprint
                         :root-id root-id}}}))
+
+(defn- mark-mount-incomplete!
+  "Tag the surviving install records `frame-ids` (siblings this run wrote
+  before a later plan threw) `:mount-incomplete true`, so a later conflict
+  never presents their root as a completed owner it never became."
+  [frame-ids]
+  (when (seq frame-ids)
+    (swap! installed-plans
+           (fn [m] (reduce (fn [m id]
+                             (cond-> m
+                               (contains? m id) (assoc-in [id :mount-incomplete] true)))
+                           m frame-ids)))))
+
+(defn- clear-mount-incomplete!
+  "A run completed: every frame it touched is backed by a completed mount,
+  so drop any stale `:mount-incomplete` tag left by an earlier failed run.
+  Only entries that carry the tag are rewritten (the found-live no-op path
+  stays write-free in the common, unmarked case)."
+  [frame-ids]
+  (swap! installed-plans
+         (fn [m] (reduce (fn [m id]
+                           (cond-> m
+                             (:mount-incomplete (get m id))
+                             (update id dissoc :mount-incomplete)))
+                         m frame-ids))))
 
 (defn execute-frame-plans!
   "Execute a root's static frame plans (the LIVE preflight ENSURE — see
@@ -173,7 +212,8 @@
   returning (EP-0027); a found-live same-fingerprint plan is a pure no-op
   (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
   is ADOPTED — its config/generation untouched, only the fingerprint
-  recorded (rf2-vxgfnd.26). Returns nil."
+  recorded (rf2-vxgfnd.26). A plan that throws mid-run tags the siblings it
+  already installed `:mount-incomplete` (rf2-vxgfnd.30 (b)). Returns nil."
   [root-id plans]
   (let [decided
         (mapv (fn [{:keys [frame-id config-fingerprint] :as plan}]
@@ -202,32 +242,49 @@
 
                     :else
                     (assoc plan ::action :install))))
-              plans)]
-    (doseq [{:keys [frame-id config config-fingerprint] :as plan} decided]
-      (case (::action plan)
-        ;; the ratified idempotent no-op: no re-seed, no record churn.
-        :found-live nil
+              plans)
+        ;; frame-ids whose record THIS run writes (install/refresh/adopt),
+        ;; accumulated in document order so a mid-run throw can tag the
+        ;; siblings already written (rf2-vxgfnd.30 (b)).
+        written (volatile! [])]
+    (try
+      (doseq [{:keys [frame-id config config-fingerprint] :as plan} decided]
+        (case (::action plan)
+          ;; the ratified idempotent no-op: no re-seed, no record churn.
+          :found-live nil
 
-        ;; a live plan-less (boot-created) frame: create-if-absent means
-        ;; create NOTHING. Record only the plan's fingerprint so a later
-        ;; cross-root arrival is conflict-scoped — the boot frame's
-        ;; config/generation/`:images` are left entirely untouched
-        ;; (rf2-vxgfnd.26: a config-carrying `make-frame` here clobbered
-        ;; them, masked by the durable app-db surviving).
-        :adopt (swap! installed-plans assoc frame-id
-                      {:config-fingerprint config-fingerprint
-                       :installed-by root-id})
+          ;; a live plan-less (boot-created) frame: create-if-absent means
+          ;; create NOTHING. Record only the plan's fingerprint so a later
+          ;; cross-root arrival is conflict-scoped — the boot frame's
+          ;; config/generation/`:images` are left entirely untouched
+          ;; (rf2-vxgfnd.26: a config-carrying `make-frame` here clobbered
+          ;; them, masked by the durable app-db surviving).
+          :adopt (do (swap! installed-plans assoc frame-id
+                            {:config-fingerprint config-fingerprint
+                             :installed-by root-id})
+                     (vswap! written conj frame-id))
 
-        ;; :install / :refresh — create-if-absent / surgical refresh;
-        ;; :initial-events drain synchronously inside the engine, in
-        ;; document order across plans. The record lands only AFTER a
-        ;; successful install, so a throwing plan leaves no install record
-        ;; (and the engine leaves no frame residue).
-        (do
-          (live-frame/make-frame (assoc (or config {}) :id frame-id))
-          (swap! installed-plans assoc frame-id
-                 {:config-fingerprint config-fingerprint
-                  :installed-by root-id}))))
+          ;; :install / :refresh — create-if-absent / surgical refresh;
+          ;; :initial-events drain synchronously inside the engine, in
+          ;; document order across plans. The record lands only AFTER a
+          ;; successful install, so a throwing plan leaves no install record
+          ;; (and the engine leaves no frame residue).
+          (do
+            (live-frame/make-frame (assoc (or config {}) :id frame-id))
+            (swap! installed-plans assoc frame-id
+                   {:config-fingerprint config-fingerprint
+                    :installed-by root-id})
+            (vswap! written conj frame-id))))
+      ;; the whole run completed — every touched frame is backed by a
+      ;; completed mount, so drop any stale mount-incomplete tag.
+      (clear-mount-incomplete! (map :frame-id decided))
+      (catch #?(:clj Throwable :cljs :default) e
+        ;; a plan threw mid-run: the siblings this run already installed stay
+        ;; live (irreversible :initial-events — the atomicity posture), but
+        ;; the mount did NOT complete. Tag their records so a later conflict
+        ;; names an incomplete mount, not a phantom completed owner.
+        (mark-mount-incomplete! @written)
+        (throw e)))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -346,4 +403,14 @@
 ;; throwing `:rf.error/frame-destroyed` off the observation port. Late-bound so
 ;; core never statically requires this artefact — the hook is simply unbound
 ;; (a no-op) when day8/re-frame2-ui is absent from the classpath.
-(late-bind/set-fn! :ui/on-frame-destroyed! reactive/teardown-frame!)
+;;
+;; The hook ALSO prunes the destroyed id's install record (rf2-vxgfnd.30 (a)):
+;; `installed-plan-entry` only HID a dead record behind a liveness guard, so a
+;; boot re-create of the same id resurrected the stale record as a false
+;; `:rf.error/frame-payload-conflict` blaming the dead lifetime's installer.
+;; Pruning makes the invariant real — a destroyed frame invalidates its install
+;; record, so a later same-id plan is a genuinely new lifetime.
+(late-bind/set-fn! :ui/on-frame-destroyed!
+                   (fn [frame-id]
+                     (swap! installed-plans dissoc frame-id)
+                     (reactive/teardown-frame! frame-id)))

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -239,6 +239,85 @@
            (frames/installed-plan-entry :app/fresh))
         "the new install is recorded with its fingerprint + installing root")))
 
+;; ---- rf2-vxgfnd.30 (a): destroy PRUNES the install record ----------------
+;; `installed-plan-entry` used to only HIDE a dead record behind a liveness
+;; guard, so a boot re-create of the same id resurrected the stale record as a
+;; false frame-payload-conflict blaming the dead lifetime's installer. The
+;; `:ui/on-frame-destroyed!` hook now prunes the record on destroy.
+
+(deftest destroy-then-recreate-then-replan-no-false-conflict
+  (reg-events!)
+  ;; root A installs :frame/f (fingerprint X)
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/f {:initial-events [[:test/set-db {:n 1}]]}
+                  "cf1-x111111111111111")])
+  (frame/destroy-frame! :frame/f)
+  (is (nil? (frames/installed-plan-entry :frame/f))
+      "the destroyed frame's install record is pruned, not merely hidden")
+  ;; a boot rf/make-frame re-creates :frame/f OUTSIDE the plan registry
+  (rf/make-frame {:id :frame/f :doc "re-booted"})
+  (is (nil? (frames/installed-plan-entry :frame/f))
+      "the re-created frame carries NO resurrected record from the dead lifetime")
+  ;; root B (fingerprint Y) declares a config-less [frame-root {:id :frame/f}]
+  ;; to SCOPE the re-booted frame — it ADOPTS cleanly, NO false conflict on A.
+  (frames/execute-frame-plans! :root/b [(plan :frame/f {} "cf1-y222222222222222")])
+  (is (= :root/b (:installed-by (frames/installed-plan-entry :frame/f)))
+      "root B adopts the re-booted frame — the dead A-lifetime record never resurrected")
+  (is (= "re-booted" (:doc (frame/frame-meta :frame/f)))
+      "the re-booted boot config is authoritative (adoption does not clobber it)"))
+
+;; ---- rf2-vxgfnd.30 (b): a failed mount tags surviving records -------------
+;; When a later plan in a root's run throws, the siblings it already installed
+;; stay live (irreversible :initial-events) but the mount did NOT complete —
+;; their records are tagged :mount-incomplete so a later conflict names an
+;; incomplete mount, not a phantom completed owner.
+
+(deftest failed-mount-tags-surviving-records-mount-incomplete
+  (reg-events!)
+  ;; root A: plan 1 installs :frame/ok; plan 2 (:frame/bad) throws in make-frame.
+  (let [id (err-id
+            #(frames/execute-frame-plans!
+              :root/a [(plan :frame/ok {:initial-events [[:test/set-db {:n 1}]]}
+                             "cf1-ok11111111111111")
+                       (plan :frame/bad {:initial-events [:not-a-vector]}
+                             "cf1-bad1111111111111")]))]
+    (is (some? id) "the malformed sibling plan throws — the mount fails"))
+  (is (some? (frame/frame :frame/ok))
+      "the earlier sibling stays live (irreversible-fx atomicity posture)")
+  (let [entry (frames/installed-plan-entry :frame/ok)]
+    (is (= :root/a (:installed-by entry)) "the record still names its installing root")
+    (is (true? (:mount-incomplete entry))
+        "but is tagged :mount-incomplete — the root's mount never completed"))
+  ;; a later cross-root config conflict on :frame/ok names root A AND flags the
+  ;; incomplete mount, instead of presenting A as a clean completed owner.
+  (let [msg (try (frames/execute-frame-plans!
+                  :root/c [(plan :frame/ok {:initial-events [[:test/set-db {:n 9}]]}
+                                 "cf1-ccc1111111111111")])
+                 nil
+                 (catch cljs.core/ExceptionInfo e (ex-message e)))]
+    (is (some? msg) "the cross-root arrival still fails loud")
+    (is (some? (re-find #"did NOT complete" msg))
+        "the conflict diagnostic flags the phantom installer's incomplete mount")))
+
+(deftest completed-retry-clears-the-mount-incomplete-tag
+  (reg-events!)
+  ;; A's first mount fails at plan 2 -> :frame/ok tagged incomplete
+  (err-id #(frames/execute-frame-plans!
+            :root/a [(plan :frame/ok {:initial-events [[:test/set-db {:n 1}]]}
+                           "cf1-ok22222222222222")
+                     (plan :frame/bad {:initial-events [:not-a-vector]}
+                           "cf1-bad2222222222222")]))
+  (is (true? (:mount-incomplete (frames/installed-plan-entry :frame/ok)))
+      "sanity: the failed mount tagged the surviving record")
+  ;; A retries WITHOUT the bad plan -> the mount completes -> the tag clears.
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/ok {:initial-events [[:test/set-db {:n 1}]]}
+                  "cf1-ok22222222222222")])
+  (let [entry (frames/installed-plan-entry :frame/ok)]
+    (is (nil? (:mount-incomplete entry))
+        "a completed run clears the stale :mount-incomplete tag")
+    (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
+
 ;; ===========================================================================
 ;; G-6 — the ambient frame chain + scope
 ;; ===========================================================================

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -195,22 +195,22 @@
         ":fx-overrides survive adoption (the boot config is not replaced wholesale)")
     (is (= "boot-authored config" (:doc (frame/frame-meta :app/session)))
         "the boot :doc config survives adoption")
-    (is (= {:config-fingerprint "cf1-adopt-aaaaaaaaa" :installed-by :page/app}
+    (is (= {:config-fingerprint "cf1-adopt-aaaaaaaaa" :adopted-by :page/app :adopted true}
            (frames/installed-plan-entry :app/session))
-        "adoption records the plan fingerprint (for conflict scoping) and NOTHING else")))
+        "adoption records a NON-OWNING record (fingerprint + adopter, marked :adopted) — never installed-by")))
 
 (deftest adoption-then-same-fingerprint-second-root-is-a-found-live-no-op
   (rf/make-frame {:id :app/session :images [(rf/image {:id :app/img})]})
   (let [gen0 (frame/frame-generation :app/session)
         p    (plan :app/session {} "cf1-adopt-bbbbbbbbb")]
     (frames/execute-frame-plans! :page/one [p])
-    (is (= :page/one (:installed-by (frames/installed-plan-entry :app/session)))
+    (is (= :page/one (:adopted-by (frames/installed-plan-entry :app/session)))
         "the first adopter is recorded")
     ;; a second root sharing the same frame with the same (config-less) plan
     (frames/execute-frame-plans! :page/two [p])
     (is (identical? gen0 (frame/frame-generation :app/session))
         "the second-root found-live pass leaves the generation untouched too")
-    (is (= :page/one (:installed-by (frames/installed-plan-entry :app/session)))
+    (is (= :page/one (:adopted-by (frames/installed-plan-entry :app/session)))
         "found-live writes nothing — the first adopter is retained")))
 
 (deftest adoption-coexists-with-a-fresh-install-in-the-same-root
@@ -261,7 +261,7 @@
   ;; root B (fingerprint Y) declares a config-less [frame-root {:id :frame/f}]
   ;; to SCOPE the re-booted frame — it ADOPTS cleanly, NO false conflict on A.
   (frames/execute-frame-plans! :root/b [(plan :frame/f {} "cf1-y222222222222222")])
-  (is (= :root/b (:installed-by (frames/installed-plan-entry :frame/f)))
+  (is (= :root/b (:adopted-by (frames/installed-plan-entry :frame/f)))
       "root B adopts the re-booted frame — the dead A-lifetime record never resurrected")
   (is (= "re-booted" (:doc (frame/frame-meta :frame/f)))
       "the re-booted boot config is authoritative (adoption does not clobber it)"))
@@ -317,6 +317,79 @@
     (is (nil? (:mount-incomplete entry))
         "a completed run clears the stale :mount-incomplete tag")
     (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
+
+;; ---- rf2-vxgfnd.56: adoption never grants installation authority ---------
+;; A boot/external frame is boot-authoritative. A config-less [frame-root
+;; {:id …}] may ADOPT (scope) it, but an adopted record must NEVER enter a
+;; root-owned refresh path, and a CONFIG-BEARING plan meeting a boot frame
+;; must fail loud rather than silently discard its config then later clobber.
+
+(deftest config-bearing-plan-against-a-boot-frame-fails-loud
+  (reg-events!)
+  ;; a boot rf/make-frame owns :app/boot with authoritative config + state
+  (rf/make-frame {:id :app/boot :doc "boot-authoritative"})
+  (rf/dispatch-sync [:test/set-db {:n 42}] {:frame :app/boot})
+  (let [id (err-id
+            #(frames/execute-frame-plans!
+              :page/x [(plan :app/boot {:initial-events [[:test/set-db {:n 0}]]}
+                             "cf1-cfgbearingaaaa1")]))]
+    (is (= :rf.error/frame-payload-conflict id)
+        "a config-BEARING frame-root cannot install its config over a boot frame"))
+  (is (= 42 (:n (rf/app-db-value :app/boot)))
+      "preflight rollback: boot state untouched — the conflict fails before any write")
+  (is (= "boot-authoritative" (:doc (frame/frame-meta :app/boot)))
+      "the boot config is untouched")
+  (is (nil? (frames/installed-plan-entry :app/boot))
+      "no record is written for the rejected config-bearing plan"))
+
+(deftest adopted-frame-later-config-bearing-same-root-cannot-refresh
+  ;; THE rf2-vxgfnd.56 repro: boot-authoritative -> config-less adopt (A) ->
+  ;; a later same-root CONFIG-BEARING plan (B) must NOT be classified :refresh
+  ;; and make-frame over the boot state.
+  (reg-events!)
+  (rf/make-frame {:id :app/boot :doc "boot-authoritative"})
+  (rf/dispatch-sync [:test/set-db {:n 7}] {:frame :app/boot})
+  ;; step A: a config-less frame-root adopts the boot frame (scope only)
+  (frames/execute-frame-plans! :page/x [(plan :app/boot {} "cf1-adopt-eeeeeeeee")])
+  (is (= :page/x (:adopted-by (frames/installed-plan-entry :app/boot)))
+      "the config-less plan adopts the boot frame (non-owning record)")
+  ;; step B: the SAME root now sends a CONFIG-BEARING plan (different fp)
+  (let [id (err-id
+            #(frames/execute-frame-plans!
+              :page/x [(plan :app/boot {:initial-events [[:test/set-db {:n 999}]]}
+                             "cf1-refresh-ffffff1")]))]
+    (is (= :rf.error/frame-payload-conflict id)
+        "an adopt record confers NO refresh rights — the config-bearing edit fails loud"))
+  (is (= 7 (:n (rf/app-db-value :app/boot)))
+      "boot authority preserved: no make-frame, no reseed, no clobber")
+  (is (= "boot-authoritative" (:doc (frame/frame-meta :app/boot)))
+      "the boot config survives the rejected refresh"))
+
+(deftest boot-frame-destroyed-then-absent-plan-installs-a-root-owned-lifetime
+  ;; acceptance: destroying the external frame invalidates the adoption record;
+  ;; a later absent-frame plan installs a NEW root-owned lifetime and then uses
+  ;; normal same-owner refresh semantics.
+  (reg-events!)
+  (rf/make-frame {:id :app/boot :doc "boot-authoritative"})
+  (frames/execute-frame-plans! :page/x [(plan :app/boot {} "cf1-adopt-ggggggggg")])
+  (is (:adopted (frames/installed-plan-entry :app/boot)) "sanity: adopted")
+  (frame/destroy-frame! :app/boot)
+  (is (nil? (frames/installed-plan-entry :app/boot))
+      "destroy prunes the adoption record")
+  ;; now an absent-frame config-bearing plan INSTALLS a root-owned lifetime
+  (frames/execute-frame-plans!
+   :page/x [(plan :app/boot {:initial-events [[:test/set-db {:n 3}]]}
+                  "cf1-install-hhhhhh1")])
+  (is (= :page/x (:installed-by (frames/installed-plan-entry :app/boot)))
+      "the re-declared plan now OWNS the frame (installed-by, not adopted)")
+  (is (= 3 (:n (rf/app-db-value :app/boot))) "the new lifetime re-seeds")
+  ;; and normal same-owner refresh now works over the root-owned frame
+  (frames/execute-frame-plans!
+   :page/x [(plan :app/boot {:initial-events [[:test/set-db {:n 3}]]}
+                  "cf1-install-iiiiii2")])
+  (is (= "cf1-install-iiiiii2"
+         (:config-fingerprint (frames/installed-plan-entry :app/boot)))
+      "same-owner refresh advances the fingerprint on the now root-owned frame"))
 
 ;; ===========================================================================
 ;; G-6 — the ambient frame chain + scope

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -63,9 +63,17 @@
   (is (some? (late-bind/get-fn :ui/on-frame-destroyed!))
       "re-frame.ui.frames must publish :ui/on-frame-destroyed! at load — the
        seam frame/destroy-frame! reaches the compiled-view substrate through")
-  (is (identical? reactive/teardown-frame!
-                  (late-bind/get-fn :ui/on-frame-destroyed!))
-      "the hook resolves to the substrate's frame-destroy sweep"))
+  ;; rf2-vxgfnd.30 (a): the hook now COMPOSES install-record pruning with the
+  ;; ViewCell teardown sweep, so it is no longer identical? to teardown-frame!.
+  ;; Assert it still drives the sweep behaviourally — firing the registered
+  ;; hook directly transitions a connected cell to :dead.
+  (rf/reg-sub :hk/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :hk/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::hook-v) fid [[:hk/a]])]
+    (is (= :connected (reactive/lifecycle cell)) "precondition: connected")
+    ((late-bind/get-fn :ui/on-frame-destroyed!) fid)
+    (is (= :dead (reactive/lifecycle cell))
+        "the registered hook runs the substrate's frame-destroy sweep")))
 
 ;; ===========================================================================
 ;; The core contract: a destroyed frame transitions its cells to :dead


### PR DESCRIPTION
Two intertwined `frames.cljc` install/adoption bug fixes, both follow-ups to the S2c ENSURE/adoption work. One PR, two commits (.30 then .56).

## rf2-vxgfnd.30 — install-record bookkeeping

- **(a) dead-lifetime resurrection.** Install records were never removed at `destroy-frame!`; `installed-plan-entry` only HID a dead record behind a liveness guard. A boot re-create of the same id resurrected the stale record as a false `:rf.error/frame-payload-conflict` blaming the dead lifetime's installer. The `:ui/on-frame-destroyed!` hook now **prunes** the record on destroy (composed with the existing ViewCell teardown sweep), so a re-created same-id frame is a genuinely new lifetime.
- **(b) phantom installer on failed mounts.** When a later plan in a root's run threw, the siblings it already installed stayed live (irreversible `:initial-events`) but were attributed `:installed-by` a root that never completed its mount — a later cross-root conflict then named a phantom completed owner. `execute-frame-plans!` now wraps phase 2 in try/catch and tags the surviving records `:mount-incomplete` (and clears the tag when a later run over the frame completes); the conflict diagnostic flags the incomplete mount.

## rf2-vxgfnd.56 — adoption vs installation authority

`:adopt` (from #5722) stored the incoming plan's fingerprint + installer as though the root owned the frame, so a later same-root config-bearing plan took the `:refresh` path and `make-frame`'d over boot-authoritative state. The registry now discriminates **INSTALLED** (root-owned, refresh rights) from **ADOPTED** (`{:adopted-by … :adopted true}`, never a refresh target). A config-less `[frame-root {:id x}]` adopts a live boot frame; a **config-bearing** plan meeting a boot-authoritative frame (live plan-less, or already adopted) **fails loud** before any registry/frame mutation instead of silently discarding its config then clobbering. Consistent with .30: destroying the boot frame prunes the adoption record, so a later absent-frame plan installs a new root-owned lifetime and regains normal same-owner refresh.

## Surface

Only `implementation/ui/src/re_frame/ui/frames.cljc` + its two ui test files. Reuses the catalogued `:rf.error/frame-payload-conflict` id (no new error id / no Spec 009 edit).

## Quality gates

- ui artefact JVM `clojure -M:test` — **249 tests, 4451 assertions, 0 failures, 0 errors**
- node CLJS `npm run test:cljs` — **8962 tests, 42305 assertions, 0 failures, 0 errors**

New fixtures: destroy→boot-recreate→replan (no false conflict); failed-mount tags surviving records; completed retry clears the tag; config-bearing-vs-boot fails loud (preflight rollback); boot→adopt-A→config-bearing-B preserves boot authority; destruction→root-owned reincarnation with refresh.