### PR TITLE
chore(api-manifest): runtime-verify re-frame.ui manifest rows (rf2-qz1h5d)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -42,6 +42,12 @@
       - `day8.re-frame2-xray.open-in-editor` — the editor-URI chip.
       - `day8.re-frame2-xray.runtime` — the discovery sentinel + safe-egress
         entry points.
+  - `re-frame.ui` (rf2-qz1h5d) — the Spec-004 compiled-view substrate. A
+    curated subset (direction 1 only): its blessed S1 export set is rowed, but
+    the live namespace also publishes `frame-root` / `frame-provider`
+    (intentionally unrowed under re-frame.ui — `frame-root` rides the
+    re-frame.core façade row; the compiled-view `frame-provider` is rowed in
+    spec/API.md §View ergonomics, not here), so it is NOT `:fully-rowed`.
 
   The pair-MCP server (`re-frame2-pair-mcp.server`) is the third
   CLJS-only surface the keystone names. It compiles under the pair-MCP
@@ -78,7 +84,13 @@
             [day8.re-frame2-xray.static.schemas.panel]
             [day8.re-frame2-xray.config]
             [day8.re-frame2-xray.open-in-editor]
-            [day8.re-frame2-xray.runtime]))
+            [day8.re-frame2-xray.runtime]
+            ;; rf2-qz1h5d — the Spec-004 compiled-view substrate. A `.cljc`
+            ;; namespace already on the consolidated :node-test classpath
+            ;; (ui/src); the require forces its analysis so `emit-ns-publics`
+            ;; reads the live CLJS publics. Curated subset (direction-1 only —
+            ;; see the Coverage note), so NOT in `fully-rowed`.
+            [re-frame.ui]))
 
 ;; ---------------------------------------------------------------------------
 ;; The live CLJS public surface, captured at compile time.
@@ -107,7 +119,12 @@
    "day8.re-frame2-xray.static.schemas.panel"        (emit-ns-publics day8.re-frame2-xray.static.schemas.panel)
    "day8.re-frame2-xray.config"                      (emit-ns-publics day8.re-frame2-xray.config)
    "day8.re-frame2-xray.open-in-editor"              (emit-ns-publics day8.re-frame2-xray.open-in-editor)
-   "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)})
+   "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)
+   ;; rf2-qz1h5d — re-frame.ui compiled-view substrate. Curated subset
+   ;; (direction-1 only): the live namespace also publishes `frame-root` +
+   ;; `frame-provider`, intentionally NOT rowed under re-frame.ui, so it is
+   ;; absent from `fully-rowed` below.
+   "re-frame.ui"                                     (emit-ns-publics re-frame.ui)})
 
 (def fully-rowed
   "Namespaces whose ENTIRE public surface must be rowed (direction 2).

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -200,32 +200,37 @@
   {:namespace "day8.re-frame2-xray.runtime" :var "egress-value"  :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.runtime" :var "session-id"    :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   ;; --- re-frame.ui (day8/re-frame2-ui) — the Spec-004 compiled-view substrate
-  ;;     (epic rf2-vxgfnd). `re-frame.ui` is a `.cljc` namespace, but the
-  ;;     generator's classpath (implementation/scripts/api-manifest/deps.edn) does
-  ;;     NOT yet include day8/re-frame2-ui, so its public surface is not JVM-
-  ;;     introspected — its rows are carried here verbatim like the other non-
-  ;;     introspected surfaces. The blessed S1 export set is live now (the live
-  ;;     public vars of re-frame.ui, per spec/API.md §Compiled views — re-frame.ui);
-  ;;     the later-stage verbs (local / effect / dispatch-fn / presence /
-  ;;     presence-phase / ->react / error-boundary / client-only) are NOT yet
-  ;;     defined and stay on the :api-md-known-unmanifested allowlist below until
-  ;;     they ship. NOT probe-covered yet (the 2mtte CLJS probe loads adapters +
-  ;;     Xray, not re-frame.ui), so :runtime-verified? false — a follow-up wires
-  ;;     probe coverage. Tiers are verbatim from spec/API.md §Compiled views;
-  ;;     :kind is the source form (html is a `defn`, not a macro).
-  {:namespace "re-frame.ui" :var "defview"        :kind :macro :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "custom-element" :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "sub"            :kind :fn    :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "lease"          :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "raw"            :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "raw-fn"         :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "html"           :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "spread"         :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "mount"          :kind :macro :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "create-root"    :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "render!"        :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "hydrate-root"   :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}
-  {:namespace "re-frame.ui" :var "unmount!"       :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? false}]
+  ;;     (epic rf2-vxgfnd). `re-frame.ui` is a `.cljc` namespace, but its rows
+  ;;     are carried HERE (not JVM-introspected by the generator) so the manifest
+  ;;     surface stays EXACTLY the blessed S1 export set: a whole-namespace JVM
+  ;;     `ns-publics` would additionally pull in `frame-root` / `frame-provider`,
+  ;;     live vars intentionally NOT rowed under re-frame.ui (`frame-root` rides
+  ;;     the re-frame.core façade row; the compiled-view `frame-provider` is
+  ;;     rowed in spec/API.md §View ergonomics, not here).
+  ;;     RUNTIME-VERIFIED via the 2mtte CLJS probe (rf2-qz1h5d): the probe loads
+  ;;     re-frame.ui and reconciles these rows against its live CLJS publics
+  ;;     DIRECTION-1 ONLY — a CURATED SUBSET, exactly like the Xray mount surface
+  ;;     (NOT :fully-rowed, so the two extra live vars above do not force rows),
+  ;;     so a row removed / renamed in source turns the probe RED. Hence
+  ;;     :runtime-verified? true. The later-stage verbs (local / effect /
+  ;;     dispatch-fn / presence / presence-phase / ->react / error-boundary /
+  ;;     client-only) are NOT yet defined and stay on the
+  ;;     :api-md-known-unmanifested allowlist below until they ship. Tiers are
+  ;;     verbatim from spec/API.md §Compiled views; :kind is the source form
+  ;;     (html is a `defn`, not a macro).
+  {:namespace "re-frame.ui" :var "defview"        :kind :macro :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "custom-element" :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "sub"            :kind :fn    :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "lease"          :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "raw"            :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "raw-fn"         :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "html"           :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "spread"         :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "mount"          :kind :macro :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "create-root"    :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "render!"        :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "hydrate-root"   :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "unmount!"       :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; API.md var-rows that are KNOWINGLY absent from the manifest. The

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -485,16 +485,16 @@
   {:namespace "re-frame.test-support", :var "sequester-app-registration!", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "snapshot-registrar", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "with-trace-recorder!", :tier :testing, :kind :macro, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.ui", :var "create-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "custom-element", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "defview", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "html", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "hydrate-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "lease", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "mount", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "raw", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "raw-fn", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "render!", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "spread", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "sub", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.ui", :var "unmount!", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? false}]}
+  {:namespace "re-frame.ui", :var "create-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "custom-element", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "defview", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "html", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "hydrate-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "lease", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "mount", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "raw", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "raw-fn", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "render!", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "spread", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "sub", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "unmount!", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}]}


### PR DESCRIPTION
## Summary

The 13 shipped `re-frame.ui` manifest rows (landed via #5712) were `:runtime-verified? false` — hand-carried in the sidecar because `re-frame.ui` was not covered by the CLJS enumeration probe (rf2-2mtte). This enrolls `re-frame.ui` into the probe so those rows are runtime-verified and drift is caught automatically.

**Enrollment case: tool-local (no hot-zone edit).** `re-frame.ui` was already on both the generator's classpath and the probe build's `:node-test` classpath (`implementation/deps.edn` `day8/re-frame2-ui`, `implementation/shadow-cljs.edn` `ui/src`), so no top-level `deps.edn` / `shadow-cljs.edn` change was needed.

## What changed

- **CLJS probe** (`implementation/scripts/api-manifest/probe/test/.../cljs_manifest_probe_cljs_test.cljs`): add a `[re-frame.ui]` require + a `"re-frame.ui" (emit-ns-publics re-frame.ui)` entry to `live-publics`. Enrolled as a **curated subset (direction-1 only)** — like the Xray mount surface — deliberately **not** `:fully-rowed`, because the live namespace also publishes `frame-root` / `frame-provider` (intentionally unrowed under `re-frame.ui`: `frame-root` rides the `re-frame.core` façade row; the compiled-view `frame-provider` is rowed in spec/API.md §View ergonomics, not here). A row removed / renamed in `re-frame.ui` now turns the probe RED.
- **Sidecar** (`spec/api-manifest-metadata.edn`): flip the 13 `re-frame.ui` rows to `:runtime-verified? true`; refresh the explanatory comment block.
- **Manifest** (`spec/api-manifest.edn`): regenerated — the diff is **exactly** the 13 flag flips, no other churn.

## Quality gates

Run in the foreground from `implementation/scripts/api-manifest/` (+ `npm run test:cljs` from `implementation/`):

- `clojure -M -m re-frame.api-manifest.gen --check` → **OK: in sync (481 public vars)**
- `clojure -M -m re-frame.api-manifest.api-md-check` → **OK: in sync (206 var-rows)**
- `clojure -M:test` (api-manifest unit tests) → **53 tests, 105 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (runs the enrolled CLJS probe) → **8957 tests, 42288 assertions, 0 failures, 0 errors**