### PR TITLE
fix(ssr): suppress hydration deltas for failed streaming boundaries (rf2-x76af2.40)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -333,48 +333,91 @@
                           {:malformed-value-type (pr-str (type parsed))})
         nil))))
 
-(defn- apply-ready-deltas!
-  "Apply + consume every `data-rf2-suspense-hydrate` delta `<script>` whose
-  boundary has already been swapped in (its id is in `seen`), independent of
-  whether the resolved `<template>` is still in the DOM. For each, read its
-  bare delta-map EDN, merge it into `frame-id`'s app-db, and drop the script
-  node. Matched by id attribute (not sibling position) — DOM order after a
-  swap is not guaranteed. A malformed delta (unparseable EDN, or parseable
-  but non-map) is skipped with a trace — a bad speculative chunk must not
-  break hydration (the final payload is the correctness lock), but it must
-  also not silently pass for a successful hydration.
+(defn- quarantined-failed-delta!
+  "Emit the `:rf.ssr/suspense-boundary-failed` / `:quarantined-delta` trace for
+  a hydrate-delta `<script>` whose boundary the server flagged FAILED. The
+  shipped server emits NO delta for a failed continuation (Spec 011 §Failure
+  semantics — inline fallback), so a delta matching a `:failed` boundary is a
+  contradictory / duplicated / reordered wire shape. We fail CLOSED: the delta
+  is consumed (its script dropped by the caller) but NEVER merged, so an
+  explicit failed continuation cannot inject speculative state — the final
+  `__rf_payload` `:rf/hydrate` stays the correctness lock. One bounded
+  diagnostic per contradictory script (the script is dropped, so no re-emit on
+  a later sweep). Reuses the catalogued `:rf.ssr/suspense-boundary-failed`
+  event with a distinct `:recovery :quarantined-delta` disposition — the
+  sibling of `malformed-delta!`'s `:skipped-delta` and the swap-time
+  `:inline-fallback`."
+  [frame-id id-str]
+  (trace/emit-error! :rf.ssr/suspense-boundary-failed
+                     {:id       (read-boundary-id id-str)
+                      :frame    frame-id
+                      :where    'rf.ssr/streaming-client
+                      :reason   (str "Hydration-delta script present for boundary " id-str
+                                      " which the server flagged FAILED; a failed continuation "
+                                      "carries no delta — quarantined without merging "
+                                      "(contradictory/reordered wire shape)")
+                      :recovery :quarantined-delta}))
 
-  This decouples delta application from the resolved-template's transient
+(defn- apply-ready-deltas!
+  "Apply, quarantine, or defer every `data-rf2-suspense-hydrate` delta
+  `<script>` by its boundary's recorded SWAP OUTCOME (`@seen` maps
+  `id-str → :resolved | :failed`), independent of whether the resolved
+  `<template>` is still in the DOM. Matched by id attribute (not sibling
+  position) — DOM order after a swap is not guaranteed.
+
+    - `:resolved` — a SUCCESSFUL swap authorizes the delta: read its bare
+      delta-map EDN and merge it into `frame-id`'s app-db, then drop the
+      script. A malformed delta (unparseable EDN, or parseable but non-map)
+      is skipped with a trace — a bad speculative chunk must not break
+      hydration (the final payload is the correctness lock), but it must also
+      not silently pass for a successful hydration.
+    - `:failed` — the server flagged this boundary FAILED and emits no delta
+      for it (Spec 011 §Failure semantics — inline fallback). A matching
+      delta is therefore a contradictory / duplicated / reordered stream:
+      QUARANTINE it (never merged) with one bounded diagnostic, then drop the
+      script. This is the fail-closed rule (rf2-x76af2.40) — #5728's
+      undifferentiated `seen` set would otherwise merge a failed boundary's
+      delta.
+    - not yet swapped (`nil` outcome) — a delta racing ahead of its template:
+      LEFT in the DOM (not consumed) for a future sweep to reclassify.
+
+  This decouples delta handling from the resolved-template's transient
   presence. The server flushes the resolved `<template>` and its delta
   `<script>` as TWO SEPARATE chunks — each `.flush`ed (see
   `re-frame.ssr.ring.streaming/write-chunk!`) — so the client's HTML parser
   can surface them in SEPARATE `MutationObserver` batches, in EITHER order:
 
-    - template first, delta later: the template is swapped + REMOVED + marked
-      `seen` in an earlier sweep; scanning the delta `<script>`s here (rather
-      than only as a side effect of processing the — now gone — template)
-      merges the delta when it lands in a later sweep. Without this scan the
-      delta is orphaned and its `(into existing delta)` merge is LOST until
-      the final `__rf_payload` self-heals it (rf2-x76af2.35).
+    - template first, delta later: the template is swapped + REMOVED + its
+      outcome recorded in an earlier sweep; scanning the delta `<script>`s
+      here (rather than only as a side effect of processing the — now gone —
+      template) resolves the delta when it lands in a later sweep. Without
+      this scan a successful boundary's delta is orphaned and its
+      `(into existing delta)` merge is LOST until the final `__rf_payload`
+      self-heals it (rf2-x76af2.35).
     - delta first, template later: a delta whose boundary has NOT swapped yet
-      (id not in `seen`) is LEFT in the DOM for a future sweep; a later
-      sweep's swap marks the id `seen`, and the delta then merges.
+      (no outcome) is LEFT in the DOM for a future sweep; a later sweep's swap
+      records the outcome, and the delta is then applied (`:resolved`) or
+      quarantined (`:failed`) accordingly — order-independent (rf2-x76af2.40).
 
-  Idempotent by script removal: a consumed delta `<script>` is dropped from
-  the DOM, so no later sweep can re-merge it — mirroring the swap's own
-  once-only-by-node-removal guarantee, so no separate `delta-applied` set is
-  needed."
+  Idempotent by script removal: a consumed (applied OR quarantined) delta
+  `<script>` is dropped from the DOM, so no later sweep can re-process it —
+  mirroring the swap's own once-only-by-node-removal guarantee, so no separate
+  `delta-applied` set is needed."
   [root frame-id seen]
   (doseq [script (query-by-attr root attr-suspense-hydrate)]
-    (let [id-str (.getAttribute script attr-suspense-hydrate)]
-      ;; Gate on the SWAP: apply a delta only for a boundary already swapped
-      ;; this-or-an-earlier sweep. A delta racing ahead of its template waits
-      ;; in the DOM (not consumed) until the swap marks its id `seen`.
-      (when (contains? @seen id-str)
-        (when-let [delta (read-delta frame-id id-str (.-textContent script))]
-          (merge-delta! frame-id delta))
-        ;; The delta is consumed (or skipped); drop the script node so the DOM
-        ;; is left in its final, script-free shape regardless of delta validity.
+    (let [id-str  (.getAttribute script attr-suspense-hydrate)
+          outcome (get @seen id-str)]
+      ;; `:resolved` and `:failed` both CONSUME the script (drop it) so it
+      ;; cannot be reconsidered on a later sweep; a nil outcome (boundary not
+      ;; swapped yet — a delta racing ahead of its template) leaves it for a
+      ;; future sweep to reclassify.
+      (when (some? outcome)
+        (case outcome
+          :resolved (when-let [delta (read-delta frame-id id-str (.-textContent script))]
+                      (merge-delta! frame-id delta))
+          :failed   (quarantined-failed-delta! frame-id id-str))
+        ;; The delta is consumed (merged, skipped, or quarantined); drop the
+        ;; script so the DOM is left in its final, script-free shape.
         (when-let [sp (.-parentNode script)]
           (.removeChild sp script))))))
 
@@ -391,10 +434,14 @@
   for observability without a 500 (Spec 011 §Failure semantics — inline
   fallback).
 
-  `seen` is an atom of the id-strings already SUCCESSFULLY processed so a
-  chunk is applied at most once even if the observer fires twice for the
-  same node (defensive — MutationObserver batching + the initial sweep
-  can both surface the same node). Idempotent.
+  `seen` is an atom MAP of `id-str → outcome` (`:resolved` for a successful
+  content swap, `:failed` for a failed-boundary fallback swap) recording every
+  boundary already processed, so a chunk is applied at most once even if the
+  observer fires twice for the same node (defensive — MutationObserver
+  batching + the initial sweep can both surface the same node). The outcome is
+  what lets `apply-ready-deltas!` authorize a delta only for a `:resolved`
+  boundary while quarantining one matching a `:failed` boundary
+  (rf2-x76af2.40). Idempotent.
 
   An id is marked `seen` only after a successful
   swap, and the swapped-in content is re-scanned for fallback templates
@@ -433,9 +480,12 @@
     (if (and id-str (not (contains? @seen id-str)))
       (let [swapped? (replace-mount-content! root id-str resolved-tmpl)]
         (when swapped?
-          ;; Mark seen ONLY on success — an unresolved mount is retryable
-          ;; on the next pass rather than permanently skipped (finding 4).
-          (swap! seen conj id-str)
+          ;; Record the OUTCOME ONLY on success — an unresolved mount is
+          ;; retryable on the next pass rather than permanently skipped
+          ;; (finding 4). The outcome (`:resolved` vs `:failed`) is what gates
+          ;; delta application: a `:failed` boundary's delta is quarantined,
+          ;; not merged (rf2-x76af2.40).
+          (swap! seen assoc id-str (if failed? :failed :resolved))
           ;; The just-swapped content may carry NESTED fallback templates
           ;; that were inert inside the resolved <template> and are now
           ;; live DOM. Materialise them so a nested resolved chunk found
@@ -620,7 +670,7 @@
      ;; → no-op stop fn. The runtime is a DOM consumer by definition.
      (if (or (nil? root) (not (exists? js/MutationObserver)))
        (fn no-op-stop! [])
-       (let [seen      (atom #{})
+       (let [seen      (atom {})   ;; id-str → :resolved | :failed (swap outcome)
              observer  (atom nil)
              stop!     (fn stop! []
                          (when-let [o @observer]

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -103,6 +103,17 @@
   [id fallback-html]
   (ssr/streaming-failed-template id fallback-html))
 
+(defn- failed-chunk-with-delta-html
+  "A CONTRADICTORY wire shape (rf2-x76af2.40): a failed `<template>` (the
+  server's inline-fallback marker) followed by a hydrate-delta `<script>` for
+  the SAME id — which the shipped server NEVER emits for a failed
+  continuation. Models a malformed / duplicated / reordered stream the client
+  must fail CLOSED on: the failed fallback swaps, but the delta must be
+  quarantined, not merged."
+  [id fallback-html delta]
+  (str (ssr/streaming-failed-template id fallback-html)
+       (ssr/streaming-hydrate-delta-script id (pr-str delta))))
+
 (defn- final-payload-html []
   (str "<script id=\"" constants/payload-script-id
        "\" type=\"application/edn\">{:rf/version 1 :rf/app-db {} :rf/render-hash \"00000000\"}</script>"))
@@ -295,6 +306,109 @@
           (finally
             (trace-tooling/unregister-listener! k)
             (remove-root! host)))))))
+
+(deftest failed-boundary-suppresses-matching-hydration-delta
+  (testing "rf2-x76af2.40 — a boundary the server flagged FAILED must NEVER
+            merge a matching hydrate-delta into app-db, even under a
+            contradictory / duplicated / reordered stream that pairs a
+            `data-rf2-suspense-failed` template with a (valid-map) delta
+            `<script>` for the same id. #5728 made `seen` an undifferentiated
+            set, so `apply-ready-deltas!` would merge ANY seen id's delta —
+            including a failed boundary's. The delta must be QUARANTINED (not
+            merged), its script consumed, and exactly one `:quarantined-delta`
+            diagnostic emitted; the failed fallback still swaps and emits its
+            `:inline-fallback` signal exactly once. (Initial-sweep path — both
+            nodes present at install, synchronous + deterministic.)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (let [fid       (make-client-frame!)
+            host      (make-root! [:card.flaky])
+            captured  (atom [])
+            k         (str (gensym "stream-failquarantine-cb"))
+            failed-of #(filter (fn [ev] (= :rf.ssr/suspense-boundary-failed (:operation ev)))
+                               @captured)]
+        (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+        (try
+          ;; A failed template AND a VALID-MAP delta for the SAME id — the
+          ;; contradictory shape. The delta WOULD merge for a successful
+          ;; boundary; it must NOT for a failed one.
+          (append-chunk!
+            host
+            (failed-chunk-with-delta-html
+              :card.flaky "<div class=\"card card-failed\">unavailable</div>"
+              {:cards {:flaky {:value 99}}}))
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (try
+              (is (= 1 (card-count host "card-failed"))
+                  "the failed chunk's fallback HTML swapped in")
+              (is (= {} (frame/frame-app-db-value fid))
+                  "the failed boundary's delta is NOT merged (fail-closed)")
+              (is (nil? @(rf/subscribe [:sct/card :flaky] {:frame fid}))
+                  "a subscription reads no speculative state for the failed boundary")
+              (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                  "the contradictory delta script is consumed (DOM left script-free)")
+              ;; exactly one :quarantined-delta diagnostic.
+              (let [q (filter #(= :quarantined-delta (:recovery %)) (failed-of))]
+                (is (= 1 (count q))
+                    (str "exactly one :quarantined-delta diagnostic; saw recoveries: "
+                         (pr-str (mapv :recovery (failed-of))))))
+              ;; the inline-fallback failed signal still fires exactly once.
+              (let [f (filter #(= :inline-fallback (:recovery %)) (failed-of))]
+                (is (= 1 (count f))
+                    "the failed fallback swap still emits its :inline-fallback signal exactly once"))
+              (finally (stop!))))
+          (finally
+            (trace-tooling/unregister-listener! k)
+            (remove-root! host)))))))
+
+(deftest failed-boundary-suppresses-delta-arriving-first
+  (testing "rf2-x76af2.40 — order independence + observer batching: the
+            hydrate-delta `<script>` arrives in a SEPARATE, EARLIER batch than
+            the failed `<template>`. The first sweep must HOLD the delta (the
+            boundary has not swapped → no outcome recorded); when the failed
+            template arrives and swaps, the boundary's outcome is `:failed`, so
+            the still-present delta is quarantined — never merged — regardless
+            of arrival order. Proves the fail-closed rule is not FIFO-only."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (async
+        done
+        (let [fid      (make-client-frame!)
+              host     (make-root! [:card.flaky])
+              captured (atom [])
+              k        (str (gensym "stream-failfirst-cb"))]
+          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          ;; Batch 1: ONLY the delta <script> — its (failed) template has not arrived.
+          (append-chunk!
+            host
+            (ssr/streaming-hydrate-delta-script
+              :card.flaky (pr-str {:cards {:flaky {:value 99}}})))
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            ;; First sweep: boundary not swapped → delta held, not applied.
+            (is (= {} (frame/frame-app-db-value fid))
+                "delta held (boundary not swapped yet) — nothing merged speculatively")
+            (is (= 1 (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                "the delta <script> waits in the DOM (not consumed before its swap)")
+            ;; Batch 2: the FAILED template arrives → swaps → outcome :failed.
+            (append-chunk!
+              host
+              (failed-chunk-html :card.flaky "<div class=\"card card-failed\">unavailable</div>"))
+            (js/setTimeout
+              (fn []
+                (is (= 1 (card-count host "card-failed"))
+                    "failed fallback swapped in the later sweep")
+                (is (= {} (frame/frame-app-db-value fid))
+                    "the delta (which arrived FIRST) is quarantined once its boundary resolved FAILED — never merged")
+                (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                    "the contradictory delta script is consumed")
+                (is (some #(and (= :rf.ssr/suspense-boundary-failed (:operation %))
+                                (= :quarantined-delta (:recovery %)))
+                          @captured)
+                    ":quarantined-delta diagnostic emitted for the failed-boundary delta")
+                (stop!)
+                (remove-root! host)
+                (done))
+              0)))))))
 
 (deftest parseable-non-map-delta-fails-closed
   (testing "rf2-l3paoi — a resolved chunk whose hydrate-delta `<script>` body


### PR DESCRIPTION
## Problem

#5728 (rf2-x76af2.35) correctly decoupled hydration-delta application from resolved-`<template>` presence, but changed `seen` into an undifferentiated set of **every successfully swapped boundary — failed boundaries included** (`process-resolved-template!` conjes the id on any successful swap, including the failed-fallback swap). `apply-ready-deltas!` then applied a delta for **any** `seen` id.

So a contradictory / duplicated / reordered stream that pairs a `data-rf2-suspense-failed` template with a hydrate-delta `<script>` for the same id would **merge speculative state into app-db for a boundary the server explicitly flagged failed** — the delta's own trace still says `no delta applied` while the sweep applies one. The shipped server emits no delta for a failed continuation, so this only manifests under a malformed/reordered wire shape; client failure semantics should remain **fail-closed** there.

## Fix

`seen` becomes a map `id-str → :resolved | :failed` (the swap outcome). `apply-ready-deltas!` dispatches on the outcome:

- **`:resolved`** — a successful swap authorizes the delta: read + merge (unchanged .35 behaviour).
- **`:failed`** — QUARANTINE: never merged; the script is dropped; one bounded `:rf.ssr/suspense-boundary-failed` `:quarantined-delta` diagnostic is emitted (sibling of the existing `:skipped-delta` / `:inline-fallback` recoveries on the same catalogued event).
- **not swapped yet (nil)** — the delta is left in the DOM for a future sweep to reclassify (order-independent).

Fail-closed regardless of node arrival order or observer batching; the final `__rf_payload` `:rf/hydrate` stays the correctness lock. Split-batch success cases (template-first / delta-first), script-removal idempotence, nested-boundary isolation, and duplicate-observer-sweep isolation are all preserved.

Surface: `implementation/ssr/src/re_frame/ssr/streaming/client.cljs` + its DOM test only. No spec/catalogue edit needed — `:recovery` is a free-form top-level disposition and the `:rf.ssr/suspense-boundary-failed` operation is already catalogued.

## Tests

Two DOM fixtures added to `streaming_client_dom_cljs_test.cljs`:

- `failed-boundary-suppresses-matching-hydration-delta` — a failed template + a valid-map delta for the same id present at install: fallback swaps, app-db stays `{}`, script consumed, exactly one `:quarantined-delta` diagnostic, `:inline-fallback` still fires once.
- `failed-boundary-suppresses-delta-arriving-first` — delta arrives in an earlier batch than the failed template (async): held on the first sweep, quarantined (never merged) once the boundary resolves `:failed`.

## Quality gates

All foreground, 0-fail:

- `ssr` artefact `clojure -M:test` — 395 tests, 1670 assertions, **0 failures, 0 errors**
- `npm run test:cljs` — 8969 tests, 42315 assertions, **0 failures, 0 errors**
- `npm run test:browser` (exercises the new DOM assertions) — 291 tests, 1042 assertions, **0 failures, 0 errors**