### PR TITLE
fix(ui): close watch-fired tear window + preserve bounded invalidation evidence (rf2-vxgfnd.40, rf2-vxgfnd.46)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -320,8 +320,10 @@
   ;;    :values    {tk -> value} ; last published site values (stabilization
   ;;                             ;   + the revision snapshot's evidence)
   ;;    :revision  int           ; get-snapshot returns this (useSyncExternalStore)
-  ;;    :dirty?    bool          ; pending-notification flag (epoch coalescing)
-  ;;    :dirty-epoch epoch|nil   ; the epoch the pending notification tags
+  ;;    :dirty?    bool          ; pending-notification flag (drain coalescing)
+  ;;    :evidence  ev|nil        ; DEBUG-only bounded causal evidence for the
+  ;;                             ;   pending window (see `fold-evidence`); nil
+  ;;                             ;   in production (elided) + between flushes
   ;;    :latest-capture cap|nil  ; last finished render capture (commit input)
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]}   ; lifecycle facts (dev/tool; 03 §4)
@@ -348,7 +350,7 @@
             :values         {}
             :revision       0
             :dirty?         false
-            :dirty-epoch    nil
+            :evidence       nil
             :latest-capture nil
             :listeners      {}
             :intervals      []}))))
@@ -435,10 +437,12 @@
 
 ;; ---- drain coalescing + the notification scheduler (S2d) --------------------
 ;;
-;; `on-change` is constant-work (mark-dirty; never compute — I-5), carrying
-;; the moving epoch as CAUSE EVIDENCE only. A cell enters the module DIRTY
-;; REGISTRY exactly once per flush boundary (the set dedups by identity; a
-;; re-mark while pending folds in regardless of epoch tag). N epochs
+;; `on-change` is constant-work (mark-dirty; never compute — I-5). The moving
+;; epoch/cause rides as EVIDENCE only (bounded + DEBUG-gated — see the
+;; evidence plane below; production carries just the pending flag). A cell
+;; enters the module DIRTY REGISTRY exactly once per flush boundary (the set
+;; dedups by identity; a re-mark while pending folds in regardless of epoch
+;; tag). N epochs
 ;; committed in one run-to-completion drain therefore advance the cell ONCE
 ;; at flush — the render batch boundary is DRAIN QUIESCENCE, not epoch close.
 ;; On CLJS one coalesced flush is armed per drain on the host MICROTASK queue
@@ -518,33 +522,125 @@
            (flush-pending!))))
      :clj nil))
 
+;; ---- the DEBUG invalidation-evidence plane (rf2-vxgfnd.46) ------------------
+;;
+;; TWO SEPARATE PLANES. The PRODUCTION scheduler needs only the pending flag
+;; + identity-deduped registry membership (`enrol-dirty!`); that is the WHOLE
+;; production invalidation cost — no per-cause allocation, nothing that scales
+;; with the queued-event count. The DEBUG plane accumulates a BOUNDED
+;; (constant-size) causal summary of the coalesced batch for tooling (Xray),
+;; gated behind `interop/debug-enabled?` so it DCEs out of `:advanced` +
+;; goog.DEBUG=false. Notification coalescing and causal evidence stay distinct:
+;; one dirty enrolment / one render, while dev/tool builds retain enough to
+;; attribute the render batch to its contributing movement (Spec 006 §The
+;; internal observation port; 03 §3).
+
+(def ^:private ^:const target-cap
+  ;; Distinct moving targets kept per pending window before overflow folds
+  ;; into a running dropped-count — bounds the evidence to constant size.
+  8)
+
+(defn- fold-evidence
+  "DEBUG plane: fold one invalidation `payload` into a cell's pending-window
+  evidence `ev` (nil = a fresh window). Returns a BOUNDED, constant-size
+  record — never an unbounded payload vector:
+
+    {:first-epoch  e0    ; the FIRST movement's frame-epoch (the anchor)
+     :latest-epoch eN    ; the most-recent movement's frame-epoch
+     :count        n     ; total invalidations folded this window
+     :causes       #{…}  ; the SET of causes seen (:value/:hmr/:disposed — ≤3)
+     :targets      [tk…] ; distinct moved target keys, capped at `target-cap`
+     :dropped      m}    ; distinct targets dropped past the cap (loss account)
+
+  The cause set and epoch scalars are naturally bounded; the target vector is
+  explicitly capped with a dropped-count, so overflow is REPORTED, never
+  silently lost (acceptance-criterion 3)."
+  [ev {:keys [cause target frame-epoch]}]
+  (let [tk (when target (target-key target))]
+    (if (nil? ev)
+      {:first-epoch  frame-epoch
+       :latest-epoch frame-epoch
+       :count        1
+       :causes       (if cause #{cause} #{})
+       :targets      (if tk [tk] [])
+       :dropped      0}
+      (let [known?  (or (nil? tk) (some #(= tk %) (:targets ev)))
+            at-cap? (>= (count (:targets ev)) target-cap)]
+        (cond-> (-> ev
+                    (assoc :latest-epoch frame-epoch)
+                    (update :count inc))
+          cause                            (update :causes conj cause)
+          (and (not known?) (not at-cap?)) (update :targets conj tk)
+          (and (not known?) at-cap?)       (update :dropped inc))))))
+
+(defn- record-evidence!
+  "DEBUG plane: fold `payload`'s bounded causal evidence into `cell`'s
+  pending-window accumulator. Elided in production (every caller gates on
+  `interop/debug-enabled?`)."
+  [^ViewCell cell payload]
+  (swap! (state cell) update :evidence fold-evidence payload))
+
+(defonce ^:private evidence-sink
+  ;; DEBUG-only consumer seam: `(fn [cell evidence] …)` | nil. Invoked at each
+  ;; flush with the coalesced bounded evidence BEFORE it is cleared, so a tool
+  ;; (Xray) receives the causal summary of the render batch rather than it
+  ;; being dead cell state (rf2-vxgfnd.46). `defonce` (module-lived);
+  ;; `reset-scheduler!` clears it between fixtures.
+  (atom nil))
+
+(defn set-evidence-sink!
+  "Install (or clear, with nil) the DEBUG-only invalidation-evidence consumer
+  — a `(fn [cell evidence] …)` the flush invokes with each pending cell's
+  coalesced bounded evidence just before advancing its revision. The intended
+  `re-frame.ui.tool`/Xray projection point; the flush's call is gated on
+  `interop/debug-enabled?`, so it is a no-op in production. Returns nil."
+  [f]
+  (reset! evidence-sink f)
+  nil)
+
+(defn- enrol-dirty!
+  "The PRODUCTION scheduling core: flag `cell` pending, enrol it in the dirty
+  registry once (identity-deduped — a re-mark while already dirty coalesces),
+  and arm one per-drain microtask flush. NO evidence, no compute, no
+  acquire/release (I-5) — this is the WHOLE production invalidation cost, flat
+  in the number of queued events."
+  [^ViewCell cell]
+  (let [st (state cell)]
+    (when-not (:dirty? @st)
+      (swap! st assoc :dirty? true)
+      (swap! dirty-cells conj cell)
+      (schedule-flush!))))
+
 (defn mark-dirty!
-  "The `on-change` body: mark `cell` dirty for `epoch` and enrol it in the
-  dirty registry (once — a re-mark while already dirty coalesces), then
-  arm one per-drain microtask flush. Never acquires/releases (no reentrant-
-  graph-op) and never computes (I-5) — it flags a revision advance the
-  scheduled render re-probes. `epoch` (the moving frame's commit epoch,
-  from the `on-change` payload) tags the pending notification as CAUSE
-  EVIDENCE only: coalescing keys on the pending flag, NEVER on the epoch
-  tag, so epochs committed by later queued events in the same drain fold
-  into this one pending notification (the first mark's epoch stays the
-  anchor). nil when driven without epoch evidence."
+  "The `on-change` body / test seam: enrol `cell` for a coalesced flush
+  (`enrol-dirty!`) and — in DEV/tool builds only — fold `epoch` as minimal
+  cause evidence. Never acquires/releases and never computes (I-5). Coalescing
+  keys on the pending flag, NEVER on any cause tag: a re-mark while already
+  pending advances nothing, yet its evidence still FOLDS into the same bounded
+  pending-window record — so N invalidations in one drain coalesce to ONE
+  render while the debug plane preserves first/latest epoch plus a bounded
+  cause/target summary (rf2-vxgfnd.46). `on-change-fn` folds the RICHER port
+  payload (cause + target); this arity carries only an epoch, for the JVM/test
+  seam. nil when driven without epoch evidence."
   ([^ViewCell cell] (mark-dirty! cell nil))
   ([^ViewCell cell epoch]
-   (let [st (state cell)]
-     (when-not (:dirty? @st)
-       (swap! st assoc :dirty? true :dirty-epoch epoch)
-       (swap! dirty-cells conj cell)
-       (schedule-flush!)))))
+   (when interop/debug-enabled?
+     (record-evidence! cell {:frame-epoch epoch}))
+   (enrol-dirty! cell)))
 
 (defn- flush-one!
-  "Clear `cell`'s pending flag and advance its revision once (the caller
-  has already removed it from the registry). No-op when not dirty —
-  idempotent under a concurrent drain."
+  "Clear `cell`'s pending flag and advance its revision once (the caller has
+  already removed it from the registry). No-op when not dirty — idempotent
+  under a concurrent drain. In DEV/tool builds, first hands the coalesced
+  bounded evidence to the installed `evidence-sink` (Xray): the flush CARRIES
+  the causal summary to its consumer before clearing it (rf2-vxgfnd.46)."
   [^ViewCell cell]
   (let [st (state cell)]
     (when (:dirty? @st)
-      (swap! st assoc :dirty? false :dirty-epoch nil)
+      (when interop/debug-enabled?
+        (when-some [sink @evidence-sink]
+          (sink cell (:evidence @st))))
+      (swap! st assoc :dirty? false :evidence nil)
       (advance-revision! cell))))
 
 (defn flush-scope!
@@ -601,7 +697,7 @@
   in the registry or fires a stale flush. Returns nil."
   [^ViewCell cell]
   (swap! dirty-cells disj cell)
-  (swap! (state cell) assoc :dirty? false :dirty-epoch nil)
+  (swap! (state cell) assoc :dirty? false :evidence nil)
   nil)
 
 (defn dirty?
@@ -610,14 +706,30 @@
   (boolean (:dirty? @(state cell))))
 
 (defn pending-epoch
-  "The epoch tag anchoring `cell`'s pending notification — the CAUSE EVIDENCE
-  the FIRST `on-change` of the current pending window carried (nil when the
-  cell is not pending, or was dirtied without epoch evidence). Epoch ids are
-  movement/cause evidence ONLY; coalescing keys on the pending flag, never on
-  this tag, so later queued events' epochs fold into the same render batch
-  without re-anchoring or advancing it (tool/test read)."
+  "The FIRST-epoch ANCHOR of `cell`'s pending-window evidence — the frame-epoch
+  the FIRST `on-change` of the current window carried (nil when the cell is not
+  pending, was dirtied without epoch evidence, or in a production build where
+  the debug evidence plane is elided). A convenience read over
+  `pending-evidence`. Epoch ids are movement/cause evidence ONLY; coalescing
+  keys on the pending flag, never on this tag, so later queued events' epochs
+  fold into the same render batch without re-anchoring or advancing it. For the
+  FULL coalesced batch — latest epoch, the cause/target span, the loss account
+  — read `pending-evidence` (tool/test read)."
   [^ViewCell cell]
-  (:dirty-epoch @(state cell)))
+  (:first-epoch (:evidence @(state cell))))
+
+(defn pending-evidence
+  "The BOUNDED causal-evidence record for `cell`'s current pending window (nil
+  when the cell is not pending, or in a production build where the debug plane
+  is elided). The coalesced summary of every invalidation folded into this one
+  render batch — see `fold-evidence` for the shape: first/latest frame-epoch,
+  the fold count, the cause set, a capped distinct-target vector, and a
+  dropped-count. The `re-frame.ui.tool`/Xray projection reads this (or receives
+  it via `set-evidence-sink!`) to attribute a coalesced render to its
+  contributing movement WITHOUT forcing a render per epoch (rf2-vxgfnd.46;
+  tool/test read)."
+  [^ViewCell cell]
+  (:evidence @(state cell)))
 
 (defn pending-cell-count
   "The number of cells with a pending notification (tool/test read)."
@@ -632,11 +744,22 @@
   (reset! flush-scheduled? false)
   (reset! slice-memo* nil)
   (reset! live-cells #{})
+  (reset! evidence-sink nil)
   nil)
 
 (defn- on-change-fn
+  "Build the per-lease `on-change` the commit registers on each acquired
+  target (Spec 006 §The internal observation port). Constant-work: enrol
+  `cell` for a coalesced flush and — in DEV/tool builds only — fold the port's
+  rich invalidation payload (`:cause`/`:target`/`:frame-epoch`, plus the
+  `:node-*`/`:registry-epoch` axes it carries) into the bounded pending-window
+  evidence. Production carries only the enrolment (I-5; the evidence fold DCEs
+  out under goog.DEBUG=false)."
   [^ViewCell cell]
-  (fn [payload] (mark-dirty! cell (:frame-epoch payload))))
+  (fn [payload]
+    (when interop/debug-enabled?
+      (record-evidence! cell payload))
+    (enrol-dirty! cell)))
 
 ;; ---- lifecycle (03 §4) ------------------------------------------------------
 ;;

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -68,11 +68,14 @@
   exactly once (a set, deduped by cell identity); a re-mark while already
   pending FOLDS IN regardless of its epoch tag — the pending flag is the
   coalescing key, the epoch tag is NEVER a second key. On CLJS one
-  coalesced flush is armed per drain (`interop/next-tick` — a
-  `goog.async.nextTick` MICROTASK that cannot run until the synchronous
-  run-to-completion drain unwinds, so it fires strictly AFTER drain
-  quiescence, never between two queued events of the same drain); the JVM
-  headless host has no async render loop, so it auto-schedules NOTHING and
+  coalesced flush is armed per drain on the host MICROTASK queue
+  (`queue-microtask!` — `js/queueMicrotask`, NOT `goog.async.nextTick`,
+  which is a macrotask): the microtask checkpoint runs after the
+  synchronous run-to-completion drain unwinds and BEFORE the next paint, so
+  the flush fires strictly after drain quiescence — never between two queued
+  events of the same drain, and always before a torn frame can show
+  (rf2-vxgfnd.40); the JVM headless host has no async render loop, so it
+  auto-schedules NOTHING and
   drains via the EXPLICIT `flush!` (07 §2's only flush idiom; SSR is
   one-shot) — one honest option per host. Either way, N epochs committed
   in one drain advance each dirty cell's revision ONCE and let React
@@ -269,8 +272,10 @@
 ;; ONE memo handle per synchronous execution slice, shared by every probe
 ;; in the slice so sibling rows compute shared derivation parents once
 ;; (the first-mount fan-out mitigation). Created lazily on the first probe
-;; of a slice; cleared on the next microtask so an abandoned slice's table
-;; is unreachable garbage. The memo is an ECONOMY only — commit step 5
+;; of a slice; released on the next event-loop tick (`interop/next-tick` —
+;; a macrotask, which is fine here: this is GC hygiene, not a
+;; correctness-before-paint boundary) so an abandoned slice's table is
+;; unreachable garbage. The memo is an ECONOMY only — commit step 5
 ;; corrects any staleness before paint — so a single module holder (probes
 ;; never nest across slices synchronously) is sufficient.
 ;; ---------------------------------------------------------------------------
@@ -280,8 +285,9 @@
 (defn- current-slice-memo
   "The current slice's probe memo handle — reused across every probe of
   this synchronous slice, created lazily. On CLJS a fresh slice mints a
-  fresh handle and the old one is released on the next microtask (a true
-  `goog.async.nextTick` boundary firing AFTER the synchronous render pass).
+  fresh handle and the old one is released on the next event-loop tick
+  (`interop/next-tick` — `goog.async.nextTick`, a macrotask firing after the
+  synchronous render pass; GC hygiene only, not a before-paint boundary).
   On the JVM `next-tick` is a concurrent executor, not a microtask, so a
   timer-driven clear would race a synchronous render; there the handle is
   invalidated by the memo's own `(frame, frame-epoch, registry-epoch)` tag
@@ -435,8 +441,10 @@
 ;; re-mark while pending folds in regardless of epoch tag). N epochs
 ;; committed in one run-to-completion drain therefore advance the cell ONCE
 ;; at flush — the render batch boundary is DRAIN QUIESCENCE, not epoch close.
-;; On CLJS one coalesced async flush is armed per drain (the `next-tick`
-;; microtask fires only after the synchronous drain unwinds — 03 §3);
+;; On CLJS one coalesced flush is armed per drain on the host MICROTASK queue
+;; (`queue-microtask!`), which drains after the synchronous run-to-completion
+;; drain unwinds and BEFORE the next paint — so a watch-fired movement is
+;; corrected before the host can show a torn frame (rf2-vxgfnd.40; 03 §3).
 ;; `flush!` is the synchronous forcing, SCOPED so no pending work leaks
 ;; across roots. The Q51 scope ruling and the reentrancy contract live in
 ;; the ns docstring.
@@ -465,6 +473,24 @@
 
 (declare flush-pending!)
 
+#?(:cljs
+   (defn- queue-microtask!
+     "Enqueue `f` on the host MICROTASK queue. The HTML event loop runs its
+     microtask checkpoint after the current synchronous task and BEFORE the
+     'update the rendering' (paint) step, so a microtask-scheduled flush
+     corrects a moved sub before the host can present a torn frame — the
+     property the drain-quiescence render batch leans on (rf2-vxgfnd.40).
+
+     `js/queueMicrotask` where present (all modern browsers + Node ≥ 11);
+     a resolved-Promise job is the fallback. DELIBERATELY NOT
+     `goog.async.nextTick` (`interop/next-tick`), which is a MACROTASK
+     (`setImmediate` / `MessageChannel` / `setTimeout`) — it yields to the
+     event loop and may let a torn frame paint before it runs."
+     [f]
+     (if (exists? js/queueMicrotask)
+       (js/queueMicrotask f)
+       (.then (js/Promise.resolve) (fn [_] (f))))))
+
 (defn- schedule-flush!
   "Arm ONE coalesced microtask that drains the whole registry — the CLJS
   host's realization of the drain-quiescence render batch (03 §3). One
@@ -474,17 +500,19 @@
   the same flush. Re-marks before it runs fold in; a synchronous `flush!`
   beforehand just leaves it an empty drain.
 
-  CLJS-only: `interop/next-tick` there is a true `goog.async.nextTick`
-  microtask that fires AFTER the synchronous render pass. The JVM headless
-  host has NO async render loop to align to — its epoch close is the
-  EXPLICIT `flush!` (07 §2 'the only flush idiom'; SSR renders one-shot) —
-  and `next-tick` there is a CONCURRENT executor, not a microtask, so a
-  background auto-drain would race synchronous callers. One honest option
-  per host, not a pretended same mechanism (03 §3)."
+  CLJS-only: the flush rides `queue-microtask!` — a TRUE host microtask that
+  fires after the synchronous drain unwinds and BEFORE the next paint, so a
+  watch-fired invalidation is corrected before a torn frame can show
+  (rf2-vxgfnd.40). The JVM headless host has NO async render loop to align
+  to — its epoch close is the EXPLICIT `flush!` (07 §2 'the only flush
+  idiom'; SSR renders one-shot) — and `interop/next-tick` there is a
+  CONCURRENT executor, not a microtask, so a background auto-drain would
+  race synchronous callers. One honest option per host, not a pretended same
+  mechanism (03 §3)."
   []
   #?(:cljs
      (when (compare-and-set! flush-scheduled? false true)
-       (interop/next-tick
+       (queue-microtask!
          (fn []
            (reset! flush-scheduled? false)
            (flush-pending!))))

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -26,10 +26,15 @@
   ## Epoch close → React (S2d)
 
   Sub deltas do NOT re-render synchronously. A moving site's `on-change`
-  (registered at commit) marks the cell dirty in `reactive`'s epoch-scoped
-  registry (constant-work, coalesced once per cell per epoch); one
-  microtask-aligned flush advances the cell's revision, `getSnapshot`
-  moves, and this component re-renders. React BATCHING is inherited, not
+  (registered at commit) marks the cell dirty in `reactive`'s dirty
+  registry (constant-work, coalesced once per cell per DRAIN — every epoch
+  a run-to-completion drain commits folds into one render batch, 03 §3);
+  one flush on the host MICROTASK queue (`reactive/schedule-flush!` →
+  `queue-microtask!`, a true microtask that runs before the next paint —
+  rf2-vxgfnd.40, NOT `goog.async.nextTick`) advances the cell's revision,
+  `getSnapshot` moves, and this component re-renders — so a watch-fired
+  movement is corrected before a torn frame can show. React BATCHING is
+  inherited, not
   hand-rolled: `useSyncExternalStore` routes every revision advance
   through React's own scheduler, so N cells flushed in one drain settle in
   ONE render pass, and adding an explicit batch wrapper here would only

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -259,3 +259,83 @@
           "sibling cold probes in ONE render compute the shared parent ONCE
            via the slice-scoped memo threaded through sub-read")
       (is (nil? (entry [:s/parent])) "probes stayed ownership-free — no cache node"))))
+
+;; ===========================================================================
+;; Bounded invalidation evidence across a coalesced batch (rf2-vxgfnd.46)
+;; ===========================================================================
+;;
+;; The observation port emits a rich constant-work invalidation payload
+;; (`:cause`/`:target`/`:node-*`/`:frame-epoch`/`:registry-epoch`). re-frame.ui
+;; keeps TWO planes: the production scheduler folds only the pending flag +
+;; identity-deduped registry membership; a DEBUG plane accumulates a BOUNDED,
+;; constant-size causal summary of the coalesced batch for tooling. Coalescing
+;; and evidence stay independent — one dirty enrolment / one render, yet the
+;; debug plane retains enough to attribute that render to its contributing
+;; movement (first/latest epoch, a cause set, a capped target vector + a
+;; dropped-count) WITHOUT forcing a render per epoch.
+
+(deftest n-invalidations-in-one-drain-preserve-bounded-evidence
+  ;; N invalidations with DISTINCT epochs fold before one flush: ONE revision
+  ;; advance + ONE notification, while the evidence plane summarizes the whole
+  ;; batch (first/latest epoch + fold count) and the flush CARRIES it to the
+  ;; consumer sink — never a per-epoch render (AC 2/3/5).
+  (let [cell (reactive/make-cell ::v)
+        hits (atom 0)
+        seen (atom [])]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/set-evidence-sink! (fn [c ev] (swap! seen conj [c ev])))
+    (doseq [e (range 1 9)] (reactive/mark-dirty! cell e))
+    (testing "the pending window's evidence summarizes the whole batch"
+      (let [ev (reactive/pending-evidence cell)]
+        (is (= 1 (:first-epoch ev)) "anchored to the FIRST epoch")
+        (is (= 8 (:latest-epoch ev)) "…and tracks the LATEST")
+        (is (= 8 (:count ev)) "all 8 invalidations folded")
+        (is (= 0 (:dropped ev)) "nothing dropped")))
+    (is (= 1 (reactive/pending-cell-count)) "enrolled ONCE despite 8 marks")
+    (reactive/flush-pending!)
+    (testing "coalesced to ONE render, and the flush CARRIED the evidence"
+      (is (= 1 (reactive/revision cell)) "ONE revision advance")
+      (is (= 1 @hits) "ONE notification — one render batch, not eight")
+      (is (= 1 (count @seen)) "the sink received the coalesced batch exactly once")
+      (is (identical? cell (first (first @seen))))
+      (is (= 8 (:count (second (first @seen)))) "…with the full coalesced count")
+      (is (nil? (reactive/pending-evidence cell)) "evidence clears with the flush"))))
+
+(deftest evidence-folds-the-real-cause-and-target-from-the-port-payload
+  ;; The rich port payload is CONSUMED at on-change, not discarded (AC 1/4). A
+  ;; committed cell whose sub is re-registered receives a REAL `:hmr`
+  ;; invalidation carrying the moving target; the evidence records both.
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! fid {:a 1})
+  (let [cell (rc! (reactive/make-cell ::v) fid [[:r/a]])]
+    (is (nil? (reactive/pending-evidence cell)) "clean before any movement")
+    (rf/reg-sub :r/a (fn [db _] (:a db)))   ;; HMR re-registration → real :hmr fan-out
+    (let [ev (reactive/pending-evidence cell)]
+      (is (reactive/dirty? cell) "the HMR invalidation marked the cell dirty")
+      (is (= #{:hmr} (:causes ev)) "the real :hmr cause is recorded, not thrown away")
+      (is (= [(tk fid [:r/a])] (:targets ev)) "…with the moving target key")
+      (is (= 1 (:count ev))))))
+
+(deftest evidence-target-vector-is-bounded-with-a-loss-account
+  ;; MORE distinct moving targets than the cap fold into a CAPPED target vector
+  ;; plus an explicit dropped-count — the evidence is constant-size, and
+  ;; overflow is reported rather than silently lost (AC 3).
+  (let [n       10                          ;; > the target cap (8)
+        ids     (mapv (fn [i] (keyword "r" (str "s" i))) (range n))
+        queries (mapv vector ids)]
+    (doseq [i (range n)]
+      (rf/reg-sub (ids i) (fn [db _] (get db i))))
+    (seed! fid (into {} (map (fn [i] [i i])) (range n)))
+    (let [cell (rc! (reactive/make-cell ::v) fid queries)]
+      (doseq [i (range n)]                  ;; re-register each → n distinct :hmr targets
+        (rf/reg-sub (ids i) (fn [db _] (get db i))))
+      (let [ev (reactive/pending-evidence cell)]
+        (is (= n (:count ev)) "every invalidation is counted")
+        (is (= 8 (count (:targets ev))) "the target vector is capped at target-cap")
+        (is (= 2 (:dropped ev)) "the 2 overflow targets are counted, not silently lost")
+        (is (= #{:hmr} (:causes ev)) "the cause set stays bounded"))
+      (testing "the whole capped batch still coalesces to ONE render"
+        (let [hits (atom 0)]
+          (reactive/subscribe cell (fn [] (swap! hits inc)))
+          (reactive/flush-dirty! cell)
+          (is (= 1 @hits) "one notification for the whole bounded batch"))))))

--- a/implementation/ui/test/re_frame/ui/reactive_tear_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_tear_cljs_test.cljs
@@ -1,0 +1,86 @@
+(ns re-frame.ui.reactive-tear-cljs-test
+  "rf2-vxgfnd.40 — the watch-fired uSES TEAR WINDOW is closed before paint.
+
+  The scenario (03 §2 two-guard rule, guard-1 leg; Spec 006 invariant 5
+  'host corrects before paint'): a mounted ViewCell A has committed observing
+  sub S. Under React time-slicing React renders A (value v1) then YIELDS. A
+  drain moves S; S's watch fires A's `on-change`, marking A dirty — a
+  WATCH-FIRED invalidation, NOT an epoch-batched one, so it rides the
+  notification scheduler, not a synchronous flush. React resumes and renders a
+  sibling B, which reads the moved value v2. At the synchronous commit instant
+  A's revision is UNMOVED (React's `checkIfSnapshotChanged` sees no change), so
+  the frame is momentarily TORN (A=v1, B=v2). The correction MUST land before
+  the host paints.
+
+  Before rf2-vxgfnd.40 the flush rode `interop/next-tick` = `goog.async.nextTick`
+  — a MACROTASK (`setImmediate`/`MessageChannel`/`setTimeout`) that yields to
+  the event loop, so a torn frame could paint before the correction ran. The
+  fix schedules the flush on the host MICROTASK queue (`queue-microtask!`),
+  whose checkpoint runs after the synchronous drain unwinds and BEFORE the
+  'update the rendering' step — closing the window.
+
+  These fixtures PIN the timing deterministically on Node, the host where
+  microtask-vs-macrotask ordering is observable (a real React concurrent tear
+  is not deterministically reproducible; the full observation-port → uSES →
+  React browser gate is rf2-vxgfnd.65). The discriminator: in a microtask
+  queued right after the mark, the flush has ALREADY run (revision advanced).
+  Were the flush still a macrotask, that microtask observer would run FIRST and
+  see the revision unmoved — the pre-fix torn state."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame.ui.reactive :as reactive]))
+
+(deftest watch-fired-flush-corrects-before-paint-via-a-microtask
+  (reactive/reset-scheduler!)
+  (let [cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)
+        hits   (atom 0)]
+    (reactive/subscribe cell-a (fn [] (swap! hits inc)))
+    (reactive/subscribe cell-b (fn []))
+    (async done
+      ;; --- the watch fires on the move (A already committed, mid-yield) ---
+      (reactive/mark-dirty! cell-a 7)
+      ;; SYNCHRONOUS commit instant: the flush is DEFERRED (coalescing is
+      ;; preserved — it is NOT a synchronous per-mark flush), so A's revision
+      ;; is still unmoved. This is the torn instant B would render against.
+      (testing "deferred off the synchronous drain (torn instant)"
+        (is (= 0 (reactive/revision cell-a)))
+        (is (reactive/dirty? cell-a) "A carries a pending correction")
+        (is (= 0 @hits)))
+      ;; --- MICROTASK checkpoint (before paint) ---
+      ;; Queued AFTER the flush microtask, so if the flush rides the microtask
+      ;; queue the correction has already landed here. A macrotask flush (the
+      ;; pre-fix `goog.async.nextTick`) would still be pending at this point.
+      (js/queueMicrotask
+        (fn []
+          (testing "the flush ran in the MICROTASK phase — before any paint"
+            (is (= 1 (reactive/revision cell-a))
+                "A corrected before paint (microtask, not macrotask)")
+            (is (= 1 @hits) "exactly one coalesced notification")
+            (is (not (reactive/dirty? cell-a))))
+          ;; --- MACROTASK (a later task / where a paint could interleave) ---
+          ;; The corrected, coalesced state is stable one macrotask on.
+          (js/setTimeout
+            (fn []
+              (testing "stable across the macrotask boundary"
+                (is (= 1 (reactive/revision cell-a)))
+                (is (= 1 @hits)))
+              (done))
+            0))))))
+
+(deftest many-watch-fired-marks-in-one-task-coalesce-to-one-microtask-flush
+  ;; N watch-fired invalidations arriving within one synchronous task arm ONE
+  ;; microtask flush and advance the cell ONCE — the drain-quiescence render
+  ;; batch, realised on the microtask queue rather than a macrotask.
+  (reactive/reset-scheduler!)
+  (let [cell (reactive/make-cell ::c)
+        hits (atom 0)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (async done
+      (dotimes [_ 6] (reactive/mark-dirty! cell 1))
+      (is (= 0 (reactive/revision cell)) "still deferred after 6 marks")
+      (is (= 1 (reactive/pending-cell-count)) "enrolled once")
+      (js/queueMicrotask
+        (fn []
+          (is (= 1 (reactive/revision cell)) "6 marks in one task ⇒ ONE advance")
+          (is (= 1 @hits) "⇒ ONE notification — one render batch")
+          (done))))))


### PR DESCRIPTION
Closes the watch-fired uSES tear window and preserves bounded ViewCell
invalidation evidence across a coalesced render batch. Two commits, on top of
the just-merged rf2-vxgfnd.45 (drain-quiescence render batch) + S2d.

## rf2-vxgfnd.40 — the tear window (VERIFIED OPEN, then fixed)

**Verdict: the window was genuinely still OPEN for watch-fired dirt.**

- `interop/next-tick` = `goog.async.nextTick` is a **macrotask**
  (`setImmediate` / `MessageChannel` / `setTimeout`), NOT a microtask — the
  docstrings claiming "true `goog.async.nextTick` microtask" were false.
- The CLJS auto-flush for a **watch-fired** invalidation (a sub moving mid-render,
  outside an epoch batch) went only through that macrotask. There is no
  synchronous epoch-close flush that covers it: the `flush!` family are explicit
  forcing primitives, and commit step-8 only catches movement in an
  already-committing cell's own render→commit gap — not a *sibling's* commit.
  So: cell A commits v1, the sub moves and fires A's `on-change`, sibling B
  renders v2, React's commit-time snapshot check sees A's revision unmoved →
  **A=v1 / B=v2 paints torn**, corrected one macrotask later (violating 006
  invariant 5 and the 03 §2 guard-1 leg).

**Fix:** schedule the coalesced flush on the host **microtask** queue
(`queue-microtask!` → `js/queueMicrotask`, Promise fallback). The HTML event
loop drains microtasks after the synchronous drain unwinds and **before** the
"update the rendering" step, so the correction lands before any paint while
still coalescing one flush per drain. JVM headless is unchanged (explicit
`flush!`). All the false "microtask" docstrings are corrected; the slice-memo
GC clear stays on `next-tick` (a macrotask is fine for GC) with honest prose.

Deterministic Node fixture pins the microtask-before-macrotask ordering (in a
microtask queued right after the mark, the flush has already run — a macrotask
flush would still be pending).

Scope note: this lands the microtask **primitive** the tear fix needs. The full
end-to-end observation-port → `useSyncExternalStore` → React browser gate,
deterministic scheduler control, and Spec 006 primitive-naming sweep remain
**rf2-vxgfnd.65**'s (P1) — this PR does not close it, but supplies its core seam.

## rf2-vxgfnd.46 — bounded invalidation evidence

The port emits a rich payload (`:cause`/`:target`/`:node-key`/`:node-version`/
`:frame-epoch`/`:registry-epoch`); `on-change` projected it to only
`:frame-epoch`, recorded once, cleared with no consumer. Now **two planes**:

- **Production** (`enrol-dirty!`): pending flag + identity-deduped registry
  membership only — the whole invalidation cost, flat in the queued-event count.
- **Debug** (behind `interop/debug-enabled?`, DCE'd in `:advanced` +
  goog.DEBUG=false): a **bounded, constant-size** summary per pending window —
  `{:first-epoch :latest-epoch :count :causes #{…} :targets [tk…] :dropped}`,
  the target vector capped at `target-cap` (8) with an explicit dropped-count so
  overflow is reported, never silently lost.

Coalescing and evidence stay independent: one dirty enrolment / one render, yet
a re-mark folds its evidence into the same window. The flush **carries** the
coalesced evidence to a consumer via `set-evidence-sink!` (the intended
`re-frame.ui.tool`/Xray projection point); `pending-evidence` exposes the record
and `pending-epoch` is redefined as an honest first-epoch anchor over it.
`:dirty-epoch` removed.

Deferred (flagged, not silently dropped): Spec 006 / synthesis-03 prose
alignment (AC 7) rides the drain-batch doc sweep **rf2-vxgfnd.66**; the
compiled-output elision assertion (AC 6) rides the elision-probe gate (the code
is structurally DCE-gated + a unit test proves the scheduler plane never
allocates evidence); the value-cause end-to-end fixture completes with the
browser gate (rf2-vxgfnd.65) — value is covered via the direct seam here, HMR
end-to-end, and the cap via >cap real targets. **No spec/006 hot-zone edit in
this PR** (all evidence docs live in the artefact's own docstrings).

## Surface

`implementation/ui/src/re_frame/ui/reactive.cljc`,
`implementation/ui/src/re_frame/ui/viewcell.cljs` (docstring), and the two ui
test files. `observation.cljc` / `frames.cljc` / `client.cljs` / `compiler/*` /
`ui/test.cljc` / `semantic.cljc` untouched (the port's payload is consumed, not
changed — compatible with the rf2-vxgfnd.32 disposal-hook change now on main).

## Quality gates

All foreground, 0-fail, on the rebased base:

- UI artefact JVM `clojure -M:test` — **262 tests, 4508 assertions, 0 failures, 0 errors**
- `npm run test:ui` (node UI: epoch/coalescing/tear suites) — **236 tests, 1266 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full consolidated node-test) — **8962 tests, 42320 assertions, 0 failures, 0 errors** (pre-rebase; unaffected surface)

No DOM tear fixture added (the tear pin is the deterministic Node microtask-ordering
test; the real concurrent-tear browser gate is rf2-vxgfnd.65), so `test:browser`
is not required by this change.
