### PR TITLE
fix(ui/test): atomic incarnation-owned plan-frame acquisition + teardown (rf2-vxgfnd.64)

### DIFF
--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -605,6 +605,55 @@
          :extra {:root-id     root-id
                  :collisions  (vec live-collisions)}}))))
 
+;; ---------------------------------------------------------------------------
+;; The Tier-1 atomic plan-frame claim registry (rf2-vxgfnd.64)
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   ;; A plan-bearing render RESERVES its declared frame ids here — as one
+   ;; all-or-nothing claim — before installing anything. Without a claim, two
+   ;; renders racing on the same id could BOTH pass a bare liveness check and
+   ;; then silently share one frame (the production ENSURE adopt path), and a
+   ;; stale before/after id snapshot could let a concurrently-created frame be
+   ;; adopted (and later destroyed) by a losing render. The claim closes both
+   ;; windows. Keyed by the bare frame-id: the set of ids currently owned by an
+   ;; in-flight render. Process-global; each render's `finally` releases its
+   ;; OWN ids, so a completed or failed render never leaks a claim. This is the
+   ;; test HOST's stronger ownership rule — production ENSURE is unchanged.
+   (defonce ^:private claimed-plan-ids (atom #{})))
+
+#?(:clj
+   (defn- claim-plan-frames!
+     "ATOMIC all-or-nothing acquisition of a plan-bearing render's declared
+  frame ids (`wanted`, document order). Reserves EVERY id iff none is already
+  claimed by another in-flight render AND none is LIVE in the frames registry;
+  the liveness read and the reservation linearize through a single CAS on the
+  claim set, so two renders racing on the same id cannot both win — one CAS
+  succeeds and installs, the other sees the id claimed (or live) and loses.
+  Returns nil on a successful claim (the ids are now this render's to install
+  and tear down), or the document-order vector of colliding ids on failure —
+  a fail-BEFORE-write: nothing is reserved, no frame is installed, no initial
+  event drains."
+     [wanted]
+     (loop []
+       (let [claimed @claimed-plan-ids
+             busy    (filterv (fn [fid]
+                                (or (contains? claimed fid)
+                                    (some? (rframe/frame fid))))
+                              wanted)]
+         (cond
+           (seq busy) busy
+           (compare-and-set! claimed-plan-ids claimed (into claimed wanted)) nil
+           :else (recur))))))
+
+#?(:clj
+   (defn- release-plan-frames!
+     "Release this render's claim on `wanted` (the `finally` half of the
+  acquisition — a completed or failed render leaves no claim behind)."
+     [wanted]
+     (swap! claimed-plan-ids #(reduce disj % wanted))
+     nil))
+
 #?(:clj
    (defn- render-plan-bearing
      "Runtime half of a PLAN-BEARING literal root form: run the root's static
@@ -612,40 +661,80 @@
   (`re-frame.ui.frames/execute-frame-plans!` — the same executor `ui/mount`
   drives), bind the resolved ambient frame (the innermost top-region
   frame-root enclosing the mounted view) for the JVM structural render, and
-  tear down EVERY test-owned frame (those this render created) in a
-  `finally` — a preflight failure leaves no frame residue and preserves the
-  typed error. Plan config expressions evaluate exactly once, here at
-  preflight, before any tree traversal.
+  tear down every frame THIS render created in a `finally`. Plan config
+  expressions evaluate exactly once, here at preflight, before any tree
+  traversal.
 
-  Fresh-frame contract (rf2-vxgfnd.55): before executing ANY plan, reject if
-  any declared plan frame-id is already LIVE — otherwise the production
-  ENSURE path would ADOPT it and the render would silently reuse ambient
-  state instead of the fresh, seeded frame the harness advertises. The check
-  runs over ALL plans first, so a collision in a later plan cannot leave an
-  earlier one installed (zero writes on failure); the pre-existing frame(s)
-  are untouched."
+  ATOMIC, INCARNATION-OWNED acquisition (rf2-vxgfnd.64, strengthening the
+  rf2-vxgfnd.55 fresh-frame contract):
+
+    - CLAIM (all-or-nothing): the declared plan ids are reserved together
+      (`claim-plan-frames!`). If ANY is already claimed by a concurrent render
+      or LIVE at the claim point, the render fails BEFORE installing any frame
+      or draining any initial event (production ENSURE would otherwise ADOPT a
+      live id and silently reuse ambient state instead of the fresh, seeded
+      frame the harness advertises). The claim linearizes concurrent same-id
+      renders through a single CAS — closing the stale-snapshot window where a
+      bare before/after id check let a concurrently-created frame slip through
+      and be adopted (then wrongly destroyed) by a losing render. A collision
+      on a later plan rejects the whole render (zero writes).
+
+    - TEARDOWN (by incarnation, never by bare id): each installed frame's
+      incarnation token (`frame-incarnation-token`) is PINNED right after
+      install, and the `finally` destroys a frame ONLY while that exact token
+      is still the live one. A frame this render's id was destroyed and
+      RE-created under (a different incarnation, a later actor's frame) is left
+      untouched. A partial install — a later plan throws after earlier plans
+      installed — tears down the frames this render already created and
+      preserves the typed error (the Tier-1 no-residue guarantee).
+
+  Production `execute-frame-plans!` adoption/HMR semantics are deliberately
+  unchanged; this stronger rule is the test HOST's, not a `frame-root`
+  behaviour."
      [opts thunk root-id plans-thunk ambient-frame-id]
-     (let [plans      (plans-thunk)
-           before     (set (keys @rframe/frames))
-           collisions (filterv before (map :frame-id plans))]
-       (when (seq collisions)
-         (reject-frame-collision! root-id collisions))
-       (let [run (if (contains? opts :sub-overrides)
-                   #(binding [reactive/*sub-overrides* (:sub-overrides opts)] (thunk))
-                   thunk)]
+     (let [plans  (plans-thunk)
+           wanted (mapv :frame-id plans)
+           busy   (claim-plan-frames! wanted)]
+       (when (seq busy)
+         (reject-frame-collision! root-id busy))
+       (let [run   (if (contains? opts :sub-overrides)
+                     #(binding [reactive/*sub-overrides* (:sub-overrides opts)] (thunk))
+                     thunk)
+             ;; frame-id -> the incarnation token THIS render installed, pinned
+             ;; after a successful install so teardown can prove it is
+             ;; destroying its OWN incarnation and not a later same-id frame.
+             owned (volatile! {})]
          (try
-           (frames/execute-frame-plans! root-id plans)
+           (try
+             (frames/execute-frame-plans! root-id plans)
+             (catch Throwable e
+               ;; Partial install: a later plan threw after earlier plans
+               ;; installed. The claim is held and every id was confirmed
+               ;; absent at the claim point, so any now-live wanted id is THIS
+               ;; render's — tear it down (no residue) and re-raise the typed
+               ;; error unchanged.
+               (doseq [fid wanted]
+                 (when (some? (rframe/frame-incarnation-token fid))
+                   (rframe/destroy-frame! fid)))
+               (throw e)))
+           (vreset! owned
+                    (reduce (fn [m fid]
+                              (if-let [t (rframe/frame-incarnation-token fid)]
+                                (assoc m fid t)
+                                m))
+                            {} wanted))
            (let [root (if (some? ambient-frame-id)
                         (binding [rframe/*current-frame* ambient-frame-id] (run))
                         (run))]
              (assoc root :rf.ui/tree-version tree/tree-version))
            (finally
-             ;; test-owned = the plan frames not already live before preflight
-             ;; (siblings installed before a failing plan are torn down too —
-             ;; the Tier-1 no-residue guarantee, not production's irreversible-
-             ;; fx posture).
-             (doseq [fid (remove before (map :frame-id plans))]
-               (rframe/destroy-frame! fid))))))))
+             ;; Incarnation-owned teardown: destroy each frame we installed
+             ;; ONLY while its pinned incarnation is still the live one. A
+             ;; destroy+recreate under the same id (a distinct token) survives.
+             (doseq [[fid t] @owned]
+               (when (identical? t (rframe/frame-incarnation-token fid))
+                 (rframe/destroy-frame! fid)))
+             (release-plan-frames! wanted)))))))
 
 #?(:clj
    (defn ^:no-doc render-view*

--- a/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
@@ -10,7 +10,8 @@
             [re-frame.test-support :as test-support]
             [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.frames :as frames]
-            [re-frame.ui.test :as uit]))
+            [re-frame.ui.test :as uit])
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
@@ -37,6 +38,22 @@
   "Reads a sub — the Tier-1 headless read path (03 §3)."
   []
   [:h1.greeting (ui/sub [:greeting/text])])
+
+(def ^:dynamic *render-gate*
+  "Concurrency-test seam: the `gated` view calls this thunk while it renders —
+  the window BETWEEN a plan-bearing render's frame install and its teardown. A
+  top-level view cannot close over a test's latches, so the barrier rides this
+  dynamic var (conveyed into the render's thread by `future`). Default no-op."
+  (fn []))
+
+(defview gated
+  "A pure structural view that trips `*render-gate*` as it renders, so a test
+  can hold a plan-bearing render open between install and teardown — no sleeps,
+  and no sub read, so a concurrent actor may destroy/re-create the frame under
+  the same id without the render's own read racing the swap."
+  []
+  (let [_ (*render-gate*)]
+    [:h1.gated "gated"]))
 
 (defn- err-id [thunk]
   (try
@@ -516,3 +533,117 @@
          harness advertises")
     (is (= before (set (keys @frame/frames)))
         "the fresh test-owned frame is torn down after the render — no residue")))
+
+;; ---------------------------------------------------------------------------
+;; Atomic + incarnation-owned acquisition (rf2-vxgfnd.64) — the residual gap
+;; rf2-vxgfnd.55 (#5732) left open. #5732 snapshotted live ids BEFORE the plan
+;; ran and tore frames down by BARE id: a TOCTOU where a concurrently-created
+;; frame could be adopted (and then destroyed) by a losing render, and where
+;; teardown could destroy a LATER same-id incarnation it never owned. The fix
+;; makes plan-frame acquisition an ATOMIC all-or-nothing claim and teardown
+;; INCARNATION-owned. Deterministic barrier fixtures, no sleeps.
+;; ---------------------------------------------------------------------------
+
+(deftest plan-frame-claim-is-atomic-one-of-two-racers-wins
+  ;; The claim linearizes: two acquisitions for the SAME id cannot both win.
+  ;; A rendezvous barrier releases both racers together, then each attempts the
+  ;; atomic claim; exactly one reserves the id (nil), the other sees it already
+  ;; claimed. (White-box on the private claim primitive — the atomic core of
+  ;; the acquisition protocol.)
+  (let [claim!   #'re-frame.ui.test/claim-plan-frames!
+        release! #'re-frame.ui.test/release-plan-frames!
+        gate     (CyclicBarrier. 2)
+        attempt  (fn [] (future
+                          (.await gate 10 TimeUnit/SECONDS)
+                          (claim! [:test/claim-race])))
+        r1       (attempt)
+        r2       (attempt)
+        outcomes [@r1 @r2]]
+    (try
+      (is (= 1 (count (filter nil? outcomes)))
+          "exactly ONE racer wins the claim (nil) — the CAS linearizes them")
+      (is (= 1 (count (filter #{[:test/claim-race]} outcomes)))
+          "the OTHER racer loses — it sees the id already claimed, no double claim")
+      (finally
+        (release! [:test/claim-race])))))
+
+(deftest plan-bearing-render-rejects-a-concurrently-created-frame
+  ;; Absent-at-snapshot / concurrent-create: the collision check reads LIVE
+  ;; state at the ATOMIC CLAIM point, not a snapshot frozen when the render
+  ;; began. A frame a concurrent actor creates AFTER the render evaluated its
+  ;; plans (id absent then) but BEFORE the claim is seen — the render REJECTS
+  ;; (never adopts the ambient frame) and destroys nothing it did not create.
+  (reg-greeting!)
+  (let [at-plans (CountDownLatch. 1)   ; render evaluated its plans (pre-claim)
+        created  (CountDownLatch. 1)   ; actor created the id in the window
+        before   (set (keys @frame/frames))
+        ;; the plan's config EXPRESSION evaluates at preflight, before the
+        ;; claim; it closes over these latches to open a deterministic
+        ;; pre-claim window (the render blocks here until the actor creates).
+        render   (future
+                   (err-id
+                    #(uit/render
+                      [ui/frame-root {:id :test/appear
+                                      :initial-events [[:rf/set-db
+                                                        (do (.countDown at-plans)
+                                                            (.await created 10 TimeUnit/SECONDS)
+                                                            {:greeting "planned"})]]}
+                       [greeting {}]])))]
+    (.await at-plans 10 TimeUnit/SECONDS)
+    (is (nil? (frame/frame :test/appear))
+        "the id was ABSENT when the render evaluated its plans")
+    ;; a concurrent actor creates :test/appear with its OWN seed, in the window
+    ;; between the render's plan evaluation and its atomic claim.
+    (let [actor (rf/make-frame {:id :test/appear
+                                :initial-events [[:rf/set-db {:greeting "actor"}]]})]
+      (.countDown created)
+      (let [result @render]
+        (is (= :rf.error/ui-test-frame-collision result)
+            "the render rejects the concurrently-created frame at its claim — it
+             does NOT adopt ambient state (the stale-snapshot false pass)")
+        (is (some? (frame/frame :test/appear))
+            "the actor's frame is untouched — the losing render destroys nothing")
+        (is (= {:greeting "actor"} (rf/app-db-value actor))
+            "…and its app-db is the actor's seed, never the render's plan (an
+             adopt would have rendered/kept ambient state)")
+        (frame/destroy-frame! :test/appear)
+        (is (= before (set (keys @frame/frames)))
+            "zero residue once the actor's own frame is cleaned up")))))
+
+(deftest plan-bearing-teardown-is-incarnation-owned
+  ;; Destroy/recreate-before-cleanup: teardown must destroy the EXACT
+  ;; incarnation this render created — not whatever frame later occupies the id.
+  ;; The render is held open (mid-render, between install and teardown) while a
+  ;; concurrent actor destroys the render's incarnation and RE-creates a fresh
+  ;; one under the same id; the render's teardown must leave that NEW
+  ;; incarnation alive. (#5732's bare-id teardown destroyed it.)
+  (let [installed (CountDownLatch. 1)   ; render installed + is rendering
+        swapped   (CountDownLatch. 1)   ; actor destroyed + re-created the id
+        before    (set (keys @frame/frames))]
+    (binding [*render-gate* (fn []
+                              (.countDown installed)
+                              (.await swapped 10 TimeUnit/SECONDS))]
+      (let [render  (future
+                      (uit/render [ui/frame-root {:id :test/incarn
+                                                  :initial-events [[:rf/set-db {:n 1}]]}
+                                   [gated {}]]))]
+        (.await installed 10 TimeUnit/SECONDS)
+        (let [token-a (frame/frame-incarnation-token :test/incarn)]
+          (is (some? token-a) "the render installed its own incarnation of :test/incarn")
+          ;; actor destroys the render's incarnation and re-creates a FRESH one.
+          (frame/destroy-frame! :test/incarn)
+          (rf/make-frame {:id :test/incarn :initial-events [[:rf/set-db {:n 2}]]})
+          (let [token-b (frame/frame-incarnation-token :test/incarn)]
+            (is (and (some? token-b) (not (identical? token-a token-b)))
+                "the actor's re-created frame is a DISTINCT incarnation")
+            (.countDown swapped)          ; release the render → it tears down
+            (is (map? @render) "the held render completes and returns its tree")
+            (is (some? (frame/frame :test/incarn))
+                "the actor's re-created incarnation SURVIVES — teardown is
+                 incarnation-owned, not by bare id")
+            (is (identical? token-b (frame/frame-incarnation-token :test/incarn))
+                "…and it is unchanged — the render tore down only ITS incarnation")
+            ;; clean up the actor-owned frame; then no residue.
+            (frame/destroy-frame! :test/incarn)
+            (is (= before (set (keys @frame/frames)))
+                "no residue: the render left nothing, the actor's frame is cleaned")))))))


### PR DESCRIPTION
## What

Closes the residual gap **rf2-vxgfnd.55 (#5732)** left open (confirmed by triage — not a duplicate). A plan-bearing `ui.test/render` promised fresh, isolated test frames, but #5732 implemented that promise by:

- snapshotting live frame ids **before** the plan ran (a stale `before` set), then
- tearing down on teardown by **bare id**.

Both are unsound:

1. **Non-atomic / TOCTOU acquisition** — the pre-existing-id check and the install were not atomic. A frame created between the snapshot and `execute-frame-plans!` would be silently **ADOPTED** by the production ENSURE path (create-if-absent), reusing ambient state instead of the fresh, seeded frame the harness advertises — and then the `finally` (id ∉ `before`) would **destroy that concurrently-created frame it never owned**.
2. **Teardown by bare id, not incarnation** — if the test's frame id had been destroyed and **re-created** (a different incarnation) before cleanup, the `finally` destroyed the **wrong incarnation**.

## Fix — test HOST scope only

Production ENSURE / adoption / HMR semantics in `frames.cljc` are **unchanged**; this stronger rule belongs to `ui.test` (as the bead directs).

- **Atomic, all-or-nothing claim** (`claim-plan-frames!`): the declared plan ids are reserved **together** over a test-host claim registry, with the liveness read and the reservation linearized through a single CAS. If **any** id is already claimed by a concurrent render **or** live at the claim point, the render fails **before** installing any frame or draining any initial event. Two renders racing on the same id cannot both win; unrelated ids still render concurrently. A collision on a later plan rejects the whole render (zero writes).
- **Incarnation-owned teardown**: each installed frame's `frame-incarnation-token` (the core primitive — stable per incarnation, distinct across destroy+recreate) is pinned right after install; the `finally` destroys a frame **only while that exact token is still the live one**. A later same-id incarnation survives untouched. A partial install tears down only this render's frames and preserves the typed error (the Tier-1 no-residue guarantee).

## Surface

Only `implementation/ui/src/re_frame/ui/test.cljc` (+ its JVM test file). No changes to `frames.cljc`, `client.cljs`, `reactive.cljc`, `observation.cljc`, `compiler/*`, or `semantic.cljc`.

## Tests (deterministic barriers, no sleeps)

- `plan-frame-claim-is-atomic-one-of-two-racers-wins` — two racers hit a rendezvous barrier then both attempt the claim; exactly one wins (atomicity / can't slip a collision).
- `plan-bearing-render-rejects-a-concurrently-created-frame` — absent-at-snapshot: a plan config expression opens a pre-claim window; a concurrent actor creates the id; the render rejects at its claim (no adopt), the actor's frame is untouched, zero residue.
- `plan-bearing-teardown-is-incarnation-owned` — destroy/recreate-before-cleanup: the render is held mid-render while an actor destroys + re-creates the id; teardown leaves the new incarnation alive.

## Quality gates

- `cd implementation/ui && clojure -M:test` → **262 tests, 4500 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **8967 tests, 42313 assertions, 0 failures, 0 errors**
