### PR TITLE
fix(ui/compiler): custom-element registry evicts zero-declaration + deleted + failed-HMR sources (rf2-vxgfnd.67)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -706,89 +706,169 @@
   (when (contains? #{:svg :mathml} ctx) ctx))
 
 ;; ---------------------------------------------------------------------------
-;; Custom-element declarations (RULED grammar) — runtime registry
+;; Custom-element declarations (RULED grammar) — runtime reconciliation registry
 ;;
-;; The RUNTIME arm of the compile-side build-scoped model (rf2-vxgfnd.16 AC5,
-;; runtime/HMR half; rf2-vxgfnd.48). #5719 made the COMPILE-time custom-element
-;; ledger build-scoped — a removed / renamed declaration drops its stale
-;; property classification with its source — but the RUNTIME registry stayed
-;; append-only: after a declaration is deleted and its ns hot-reloads, the
-;; emitted registration simply stops executing, so the stale row lingered in
-;; the browser's atom and `ui/spread` kept classifying the removed
-;; `:properties` until a full page reload. The inverse operation the registry
-;; lacked is a per-source eviction, mirrored here on the runtime atom: emitted
-;; registrations carry their declaring ns, and a hot-reload generation bump
-;; (the shadow-cljs `^:dev/before-load` hook) makes a re-registering source
-;; replace its WHOLE prior contribution — so a dropped declaration vanishes.
+;; The RUNTIME arm of the compile-side build-scoped model (rf2-vxgfnd.16 AC5;
+;; rf2-vxgfnd.48 shipped the first cut; rf2-vxgfnd.67 makes it a full
+;; reconciliation protocol). `ui/spread` and the JVM tree builder classify a
+;; custom element's `:properties` by reading the LIVE aggregate
+;; `custom-elements` (tag -> decl). That aggregate must be a PURE FUNCTION of
+;; the CURRENT set of live sources — never of process history — exactly like
+;; the compile-side build registries (`re-frame.ui.compiler.build`).
+;;
+;; .48 evicted a source's contribution ONLY when it re-registered — i.e. it used
+;; a SURVIVING declaration as the signal that the source was rebuilt. That left
+;; three holes: a source that deletes its LAST declaration (or whose file is
+;; deleted) never re-registers, so its stale rows lingered until a full page
+;; reload; a reload that threw mid-way left the live registry half-mutated; and
+;; two builds sharing one runtime atom cross-contaminated. .67 replaces
+;; registration-triggered eviction with an explicit reload-cycle protocol driven
+;; from the reload BOUNDARY, not from re-registration:
+;;
+;;   (notify-reload! [build?])    ^:dev/before-load — OPEN a reload cycle. From
+;;                                here re-registrations STAGE; the live aggregate
+;;                                stays at its last-known-good until commit.
+;;   register-custom-element!     a declaration re-runs — STAGES into the open
+;;                                cycle (or, at initial load / in production where
+;;                                no cycle is open, writes through directly).
+;;   (note-reloaded-sources! ..)  the reload machinery (rf2-df9873's shadow build
+;;                                hook) records WHICH sources re-ran / were removed
+;;                                this cycle — the signal a zero-declaration or
+;;                                deleted source cannot emit for itself. Optional:
+;;                                absent, only the staged sources are reconciled.
+;;   (commit-reload! [build?])    ^:dev/after-load — COMMIT atomically: every
+;;                                staged source REPLACES its whole prior
+;;                                contribution, every reloaded-but-unstaged /
+;;                                removed source is EVICTED, untouched sources are
+;;                                kept, and the live aggregate is rebuilt from the
+;;                                reconciled ledger in ONE swap. shadow-cljs runs
+;;                                after-load only on a SUCCESSFUL reload, so a
+;;                                thrown / aborted reload never commits — the last
+;;                                known-good manifest survives.
+;;
+;; Ownership is [build-id ns-sym] so two builds sharing one atom (a shared JVM /
+;; a test) reconcile independently — evicting one build's source can never drop
+;; another's rows. The emitted 3-arg registration uses ns-only ownership under
+;; the sole ::default build (one compiled bundle = one build, its own atoms); the
+;; explicit build-scoped arities exist for multi-build reconciliation and tests.
+;;
+;; Production never opens a cycle (`notify-reload!` is a dev-only hook), so every
+;; registration writes through directly and classification stays a plain lookup —
+;; all reconciliation machinery is reload-only.
 ;; ---------------------------------------------------------------------------
 
-(defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. Populated by
-  `ui/custom-element` (top-level, compile-resolvable; undeclared elements
-  need no declaration — all-attributes default). Consumers (`ui/spread`, the
-  JVM tree builder) read this unchanged."}
+(defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. The LIVE aggregate
+  `ui/spread` and the JVM tree builder read (unchanged; undeclared elements need
+  no declaration — all-attributes default). A pure function of the current live
+  sources: rebuilt from the ledger on every reload commit."}
   custom-elements
   (atom {}))
 
 (defonce ^{:private true
-           :doc "ns-sym -> {:gen <reload-gen> :tags #{tag}} — the per-source
-  RUNTIME ledger mirroring the compile-side build ledger, so a hot-reload that
-  DROPS a declaration evicts its now-stale runtime row."}
+           :doc "[build-id ns-sym] -> {tag decl} — the per-source committed
+  contribution ledger (the runtime mirror of the compile-side build ledger). The
+  live aggregate is the merge of every source's map, so a source whose file is
+  deleted, or whose last declaration is dropped, vanishes the moment its ledger
+  row is reconciled away — no surviving declaration required."}
   element-sources
   (atom {}))
 
 (defonce ^{:private true
-           :doc "Monotonic hot-reload counter — the runtime analogue of the
-  compile-side build generation. `notify-reload!` (the shadow-cljs
-  `^:dev/before-load` hook) bumps it; a source re-opens (evicts its prior
-  rows) the first time it re-registers at a newer generation."}
-  reload-generation
-  (atom 0))
+           :doc "build-id -> {:staged {[build ns] {tag decl}} :touched #{[build ns]}}
+  for each build whose reload cycle is IN FLIGHT (absent = no cycle → direct
+  write-through). `:staged` accumulates this cycle's re-registrations, held back
+  from the live aggregate until commit; `:touched` is the reloaded/removed source
+  set `note-reloaded-sources!` records — the sources to reconcile even when they
+  staged nothing (zero-declaration / deletion)."}
+  reload-cycles
+  (atom {}))
 
-(defn- open-element-source!
-  "Evict `ns-sym`'s prior custom-element rows the FIRST time it (re-)registers
-  in the current reload generation — idempotent for its later same-generation
-  declarations. The runtime mirror of the compile-side `open-source!`: a
-  dropped / renamed declaration vanishes because the source's whole prior
-  contribution is replaced on re-registration, not merely overwritten
-  tag-by-tag (which never removes a row the new code no longer declares)."
-  [ns-sym]
-  (let [g @reload-generation]
-    (when (not= g (:gen (get @element-sources ns-sym)))
-      (doseq [tag (:tags (get @element-sources ns-sym))]
-        (swap! custom-elements dissoc tag))
-      (swap! element-sources assoc ns-sym {:gen g :tags #{}})))
+(def ^:private default-build ::default)
+
+(defn- rebuild-live!
+  "Rebuild the live aggregate as the merge of every ledger source's map — the
+  live registry is a PURE FUNCTION of the ledger. One `reset!` (sources merged in
+  a stable order), so consumers never observe a partial manifest."
+  []
+  (reset! custom-elements
+          (reduce (fn [agg src] (merge agg (get @element-sources src)))
+                  {}
+                  (sort-by str (keys @element-sources))))
   nil)
 
 (defn register-custom-element!
-  "Register (or, on hot-reload, re-register) `tag`'s runtime property
-  classification under its declaring `ns-sym`. Emitted top-level by
-  `ui/custom-element`, so it re-runs on every ns hot-reload; opening the
-  source first replaces the ns's whole prior contribution, so a removed /
-  renamed declaration's classification is evicted rather than leaking until a
-  full page reload (rf2-vxgfnd.48)."
-  [tag decl ns-sym]
-  (open-element-source! ns-sym)
-  (swap! custom-elements assoc tag decl)
-  (swap! element-sources update-in [ns-sym :tags] (fnil conj #{}) tag)
-  tag)
+  "Register `tag`'s runtime property classification under its declaring source.
+  Emitted top-level by `ui/custom-element`, so it re-runs on every ns hot-reload.
+  While a reload cycle is open for the build it STAGES (the live aggregate stays
+  last-known-good until `commit-reload!`); otherwise — initial load, production —
+  it writes through directly. Ownership is [build-id ns-sym]; the 3-arg emit uses
+  the sole ::default build."
+  ([tag decl ns-sym] (register-custom-element! tag decl ns-sym default-build))
+  ([tag decl ns-sym build-id]
+   (let [source [build-id ns-sym]]
+     (if (contains? @reload-cycles build-id)
+       (swap! reload-cycles update-in [build-id :staged source]
+              (fnil assoc {}) tag decl)
+       (do (swap! element-sources update source (fnil assoc {}) tag decl)
+           (swap! custom-elements assoc tag decl))))
+   tag))
 
 (defn ^:dev/before-load notify-reload!
-  "shadow-cljs hot-reload hook (dev only): bump the reload generation so each
-  reloaded source re-opens — evicting its stale rows — on its next
-  re-registration this cycle. The runtime analogue of the compile-side
-  `begin-build!` generation bump; production never hot-reloads, so this never
-  fires there."
-  []
-  (swap! reload-generation inc)
-  nil)
+  "shadow-cljs hot-reload hook (dev only): OPEN a reload cycle for `build-id`
+  (the runtime analogue of the compile-side `begin-build!`). Re-registrations
+  from here stage instead of mutating the live aggregate; opening a fresh cycle
+  discards any staging left by a previously ABORTED reload. Production never hot-
+  reloads, so this never fires there."
+  ([] (notify-reload! default-build))
+  ([build-id]
+   (swap! reload-cycles assoc build-id {:staged {} :touched #{}})
+   nil))
+
+(defn note-reloaded-sources!
+  "Record the sources that re-ran (or were removed) in the open reload cycle —
+  the signal a zero-declaration or deleted source cannot emit for itself, fed by
+  the reload machinery (rf2-df9873's shadow build hook). `sources` is a coll of
+  ns-syms (paired with `build-id`) or ready-made [build ns] pairs. A no-op when
+  no cycle is open; unions into the cycle so it can be called repeatedly."
+  ([sources] (note-reloaded-sources! sources default-build))
+  ([sources build-id]
+   (when (contains? @reload-cycles build-id)
+     (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
+       (swap! reload-cycles update-in [build-id :touched] (fnil into #{}) pairs)))
+   nil))
+
+(defn ^:dev/after-load commit-reload!
+  "shadow-cljs hot-reload hook (dev only): COMMIT the open reload cycle for
+  `build-id` atomically. Every STAGED source replaces its whole prior
+  contribution; every source flagged by `note-reloaded-sources!` that staged
+  NOTHING (a zero-declaration edit or a deleted file) is evicted; untouched
+  sources are kept; then the live aggregate is rebuilt from the reconciled ledger
+  in one swap. shadow-cljs runs after-load only on a SUCCESSFUL reload, so an
+  aborted reload never reaches here and the last known-good manifest survives.
+  A no-op when no cycle is open."
+  ([] (commit-reload! default-build))
+  ([build-id]
+   (when-let [{:keys [staged touched]} (get @reload-cycles build-id)]
+     (let [sources (into (set (keys staged)) touched)]
+       (swap! element-sources
+              (fn [ledger]
+                (reduce (fn [l src]
+                          (if-let [decls (get staged src)]
+                            (assoc l src decls)   ; re-declared: replace whole contribution
+                            (dissoc l src)))      ; zero-declaration / removed: evict
+                        ledger
+                        sources)))
+       (rebuild-live!)
+       (swap! reload-cycles dissoc build-id)))
+   nil))
 
 (defn reset-custom-elements!
   "Test support: clear the runtime custom-element registry, the per-source
-  ledger, and the reload generation."
+  ledger, and any in-flight reload cycles."
   []
   (reset! custom-elements {})
   (reset! element-sources {})
-  (reset! reload-generation 0)
+  (reset! reload-cycles {})
   nil)
 
 (defn custom-element-properties [tag]

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -167,45 +167,81 @@
       "undeclared elements default to all-attributes"))
 
 ;; ---------------------------------------------------------------------------
-;; Custom-element runtime registry — hot-reload eviction (rf2-vxgfnd.48). The
-;; RUNTIME arm of .16 AC5; the compile/JVM arm lives in
-;; re-frame.ui.compiler-build-jvm-test.
+;; Custom-element runtime reconciliation registry — the reload-cycle protocol
+;; (rf2-vxgfnd.67, residual of .48). The RUNTIME arm of .16 AC5; the compile/JVM
+;; arm lives in re-frame.ui.compiler-build-jvm-test. Eviction is driven from the
+;; reload BOUNDARY (notify-reload! / commit-reload!), NOT from a surviving
+;; re-registration — so a source that now declares zero elements, or whose file
+;; is deleted, is reconciled away too.
 ;; ---------------------------------------------------------------------------
 
-(deftest removed-custom-element-clears-runtime-property-classification
+(deftest edit-reload-replaces-a-source-contribution-atomically
+  ;; AC3: a rename — app.a's :x-el becomes :y-el — replaces the WHOLE source
+  ;; contribution on commit; the live union never retains the stale :x-el after.
   (rules/reset-custom-elements!)
-  ;; initial load: app.a declares :x-el with :help-text
   (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
   (is (= #{:help-text} (rules/custom-element-properties :x-el))
-      "the declaration classifies :help-text as a property")
-  ;; hot-reload app.a: :x-el renamed to :y-el (its declaration deleted). The
-  ;; ^:dev/before-load hook bumps the generation; re-running app.a's forms
-  ;; re-opens the source, evicting its whole prior contribution first.
-  (rules/notify-reload!)
-  (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)
+      "initial load classifies :help-text as a property (direct write-through)")
+  (rules/notify-reload!)                                       ; ^:dev/before-load
+  (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a) ; stages
+  (is (= #{:help-text} (rules/custom-element-properties :x-el))
+      "mid-cycle the live aggregate stays last-known-good (staged, not committed)")
+  (rules/commit-reload!)                                       ; ^:dev/after-load
   (is (= #{} (rules/custom-element-properties :x-el))
-      "the removed :x-el no longer classifies any property (was leaking until
-       a full page reload)")
+      "on commit the renamed-away :x-el is evicted (was leaking until page reload)")
   (is (= #{:label} (rules/custom-element-properties :y-el))
       "the current :y-el declaration classifies its property"))
 
+(deftest zero-declaration-reload-evicts-the-whole-source
+  ;; AC1: app.a removes its LAST custom-element declaration. On reload it
+  ;; re-runs but registers NOTHING, so .48's re-registration trigger never
+  ;; fired and :x-el leaked. The reload machinery notes app.a re-ran; commit
+  ;; evicts its now-empty contribution without a page reload.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+  (is (= #{:help-text} (rules/custom-element-properties :x-el)))
+  (rules/notify-reload!)
+  (rules/note-reloaded-sources! ['app.a])   ; app.a re-ran (its build hook says so)
+  ;; ...and registered no declarations this cycle.
+  (rules/commit-reload!)
+  (is (= #{} (rules/custom-element-properties :x-el))
+      "a source that drops its last declaration is evicted (residual .48 gap)")
+  (is (= {} @rules/custom-elements)
+      "no stale rows survive the zero-declaration reload"))
+
+(deftest deleted-source-file-is-reconciled-away
+  ;; AC2: app.a's FILE is deleted — it does not reload at all, but the reload
+  ;; machinery reports it removed. app.b is untouched and keeps its rows.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.a)
+  (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
+  (rules/notify-reload!)
+  (rules/note-reloaded-sources! ['app.a])   ; app.a's file removed this cycle
+  (rules/commit-reload!)
+  (is (= #{} (rules/custom-element-properties :a-el))
+      "the deleted source's former contribution is reconciled away")
+  (is (= #{:b-prop} (rules/custom-element-properties :b-el))
+      "an untouched source keeps its classification across the reload"))
+
 (deftest hot-reload-preserves-untouched-sources
-  ;; A reload cycle that reloads source B must NOT drop source A's rows — A's
-  ;; forms did not re-run, so it keeps its prior generation (the runtime mirror
-  ;; of the compile-side incremental-preserves-untouched semantics).
+  ;; A reload cycle that reloads only source B must NOT drop source A's rows —
+  ;; A did not re-run, so it is neither staged nor touched (the runtime mirror of
+  ;; compile-side incremental-preserves-untouched).
   (rules/reset-custom-elements!)
   (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.a)
   (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
   (rules/notify-reload!)
   (rules/register-custom-element! :b-el {:properties #{:b-prop2}} 'app.b) ; only B reloads
+  (rules/commit-reload!)
   (is (= #{:a-prop} (rules/custom-element-properties :a-el))
       "untouched source A keeps its classification across B's reload")
   (is (= #{:b-prop2} (rules/custom-element-properties :b-el))
       "reloaded source B's classification updates"))
 
 (deftest multiple-declarations-in-one-source-accumulate-then-replace
-  ;; Two elements in one source accumulate; on reload, both re-open together
-  ;; and only the survivors remain (never clear-on-first-declaration).
+  ;; Two elements in one source accumulate in the staged cycle; on commit the
+  ;; whole contribution replaces, so a dropped declaration is evicted even though
+  ;; the source no longer touches it (never clear-on-first-declaration).
   (rules/reset-custom-elements!)
   (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.multi)
   (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.multi)
@@ -214,7 +250,85 @@
   ;; reload app.multi keeping only :a-el (with a changed decl); :b-el deleted
   (rules/notify-reload!)
   (rules/register-custom-element! :a-el {:properties #{:a-prop2}} 'app.multi)
+  (rules/commit-reload!)
   (is (= #{:a-prop2} (rules/custom-element-properties :a-el))
       "the surviving declaration's classification updates")
   (is (= #{} (rules/custom-element-properties :b-el))
       "the dropped :b-el is evicted even though app.multi no longer touches it"))
+
+(deftest aborted-reload-retains-the-last-known-good-manifest
+  ;; AC4: a reload throws after staging a partial new set. shadow-cljs never
+  ;; runs ^:dev/after-load, so commit-reload! is not reached — the live manifest
+  ;; must stay exactly the last known-good, never a half-applied union.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.a)
+  (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
+  (let [known-good @rules/custom-elements]
+    (rules/notify-reload!)
+    (rules/register-custom-element! :a-el {:properties #{:a-prop2}} 'app.a) ; partial
+    ;; ...a later top-level form throws → after-load never fires (no commit).
+    (is (= known-good @rules/custom-elements)
+        "a mid-reload throw leaves the live registry untouched (staged, uncommitted)")
+    ;; the NEXT reload opens a fresh cycle, discarding the aborted staging.
+    (rules/notify-reload!)
+    (rules/register-custom-element! :a-el {:properties #{:a-prop2}} 'app.a)
+    (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
+    (rules/commit-reload!)
+    (is (= {:a-el {:properties #{:a-prop2}}
+            :b-el {:properties #{:b-prop}}} @rules/custom-elements)
+        "the recovering reload commits the full new manifest, no ghost of the abort")))
+
+(deftest build-ids-are-isolated
+  ;; AC5: two builds sharing one runtime atom own their rows independently.
+  ;; Reloading (and evicting a source in) build :app cannot touch build :lib.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :app-el {:properties #{:a-prop}} 'app.core :app)
+  (rules/register-custom-element! :lib-el {:properties #{:l-prop}} 'lib.core :lib)
+  (is (= #{:a-prop} (rules/custom-element-properties :app-el)))
+  (is (= #{:l-prop} (rules/custom-element-properties :lib-el)))
+  ;; build :app reloads app.core with its declaration deleted
+  (rules/notify-reload! :app)
+  (rules/note-reloaded-sources! ['app.core] :app)
+  (rules/commit-reload! :app)
+  (is (= #{} (rules/custom-element-properties :app-el))
+      "reconciling build :app evicts its own source")
+  (is (= #{:l-prop} (rules/custom-element-properties :lib-el))
+      "build :lib's row is untouched — reconciling one build cannot delete another's"))
+
+(deftest repl-reeval-converges-to-the-same-manifest-as-file-save-hmr
+  ;; AC6: REPL re-evaluation of a source (including a zero-declaration one) goes
+  ;; through the SAME begin/stage/commit protocol as a file-save reload, so it
+  ;; converges to an identical manifest.
+  (letfn [(build-then-drop! []
+            (rules/reset-custom-elements!)
+            (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+            (rules/register-custom-element! :k-el {:properties #{:keep-me}} 'app.b)
+            (rules/notify-reload!)
+            (rules/note-reloaded-sources! ['app.a])   ; app.a re-evaluated, now empty
+            (rules/commit-reload!)
+            @rules/custom-elements)]
+    (let [file-save (build-then-drop!)
+          repl      (build-then-drop!)]
+      (is (= file-save repl)
+          "REPL re-eval and file-save HMR converge to the same manifest")
+      (is (= {:k-el {:properties #{:keep-me}}} file-save)
+          "the zero-declaration source's rows are gone; the untouched one survives"))))
+
+(deftest incremental-reconcile-equals-a-full-page-reload
+  ;; AC7: the manifest after an incremental reload cycle equals the one a full
+  ;; page reload (a clean rebuild of exactly the current live sources) produces.
+  (letfn [(full-reload! []       ; clean process: every live source registers direct
+            (rules/reset-custom-elements!)
+            (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)
+            (rules/register-custom-element! :k-el {:properties #{:keep-me}} 'app.b)
+            @rules/custom-elements)
+          (incremental! []       ; edit app.a (:x-el -> :y-el) in a live session
+            (rules/reset-custom-elements!)
+            (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+            (rules/register-custom-element! :k-el {:properties #{:keep-me}} 'app.b)
+            (rules/notify-reload!)
+            (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)
+            (rules/commit-reload!)
+            @rules/custom-elements)]
+    (is (= (full-reload!) (incremental!))
+        "incremental reload equals a clean full-page-reload rebuild")))


### PR DESCRIPTION
## What

Residual of #5734/.48. That PR added a generation-led runtime custom-element ledger, but eviction fired **only** inside `register-custom-element!` when a source re-registered a surviving declaration — using a surviving declaration as the signal that a source was rebuilt. Uncovered:

- **(a) zero-declaration deletion** — a source that drops its *last* `ui/custom-element` never re-registers, so its stale rows classified `:properties` until a full page reload.
- **(b) source-file deletion** — a deleted file never reloads at all; its rows persisted.
- **(c) failed/partial HMR** — the first re-registration immediately mutated the live registry, so a later throw left a half-applied manifest.
- **(d) multi-build isolation** — namespace alone keyed ownership, so builds sharing one atom cross-contaminated.

## Fix

Replace registration-triggered eviction with an explicit reload-cycle reconciliation protocol in `re-frame.ui.rules`, driven from the reload **boundary**, mirroring the compile-side `re-frame.ui.compiler.build` discipline and adding the transactional commit HMR needs:

- `notify-reload!` (`^:dev/before-load`) **opens a cycle**; re-registrations **stage**, leaving the live aggregate at its last-known-good until commit (and discarding any staging from a prior aborted reload).
- `note-reloaded-sources!` records **which sources re-ran / were removed** this cycle — the signal a zero-declaration or deleted source cannot emit for itself.
- `commit-reload!` (`^:dev/after-load`) reconciles **atomically**: each staged source replaces its whole prior contribution, each reloaded-but-unstaged / removed source is evicted, untouched sources are kept, and the live aggregate is rebuilt from the ledger in one swap. shadow-cljs runs after-load only on a **successful** reload, so an aborted reload keeps the last known-good manifest.

The ledger is keyed `[build-id ns-sym]` so builds sharing one atom reconcile independently. The emitted 3-arg registration is unchanged (sole `::default` build), so `compiler.cljc` needed no change. Production never opens a cycle, so classification stays a direct `custom-elements` lookup and all reconciliation machinery is reload-only.

`note-reloaded-sources!` is a self-contained seam any reload machinery can feed; it does not depend on the (now decision-gated) rf2-df9873 shadow build-hook wiring.

## Fixtures

Rewrote the runtime HMR suite (`rules_cljs_test.cljc`) onto the new protocol, adding the previously-missing cases: atomic per-source replace, **zero-declaration eviction**, **source-file deletion**, **aborted-reload atomicity**, **multi-build isolation**, **REPL=HMR convergence**, and **full-reload equivalence** — not only rename-with-one-survivor.

## Quality gates

Foreground, 0-fail:

- ui artefact `clojure -M:test` — **265 tests, 4502 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **8973 tests, 42328 assertions, 0 failures, 0 errors** (4 warnings are pre-existing, in unrelated resources/routing/story files)

## Surface

Only `implementation/ui/src/re_frame/ui/rules.cljc` + its test. No `compiler.cljc`, shadow-cljs.edn, or `begin-build!`-wiring changes.