### PR TITLE
fix(ui): reconcile frame-payload-conflict ex-data + canonicalize map-key fingerprints (rf2-vxgfnd.33)

### DIFF
--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -44,6 +44,10 @@
 
   `canonical-edn` prints with maps recursively sorted by `pr-str` of key
   and sets sorted likewise — one value, one string, on both hosts.
+  Canonicalization recurses into map KEYS and set ELEMENTS as well as
+  values, so a map (or nested collection) used as a key or a set member
+  reaches a stable form regardless of its authoring order — two `=`-equal
+  plans always digest identically (no spurious plan-conflict).
   Cross-host equality of the hex output is pinned by
   `re-frame.ui.fingerprint-cljs-test`."
   (:require [clojure.string :as str]))
@@ -54,10 +58,20 @@
 
 (defn- canonicalize [x]
   (cond
+    ;; Recurse into BOTH key and value: a map (or any nested collection) used
+    ;; AS A KEY must canonicalize to a stable form too, or its authoring order
+    ;; survives into the printed digest and two semantically identical plans
+    ;; fingerprint differently (a spurious cross-root
+    ;; `:rf.error/frame-payload-conflict`). The sorted-map-by comparator then
+    ;; sorts on the ALREADY-canonical key, so entry order is stable regardless
+    ;; of key shape.
     (map? x)  (into (sorted-map-by (fn [a b] (compare (pr-str a) (pr-str b))))
-                    (map (fn [[k v]] [k (canonicalize v)]))
+                    (map (fn [[k v]] [(canonicalize k) (canonicalize v)]))
                     x)
-    (set? x)  (vec (sort (map pr-str x)))          ; sets as sorted printed vec
+    ;; Elements canonicalize before they are printed for the sorted vec — a
+    ;; map (or nested collection) inside a set has the same authoring-order
+    ;; hazard as a map-as-key.
+    (set? x)  (vec (sort (map (comp pr-str canonicalize) x)))  ; sets as sorted printed vec
     (vector? x) (mapv canonicalize x)
     (seq? x)  (apply list (map canonicalize x))
     :else x))

--- a/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
@@ -15,6 +15,30 @@
   (is (not= (fp/canonical-edn [:a :b]) (fp/canonical-edn [:b :a]))
       "vectors stay order-significant"))
 
+(deftest canonicalize-recurses-into-map-keys-and-set-elements
+  ;; A map (or nested collection) used AS A KEY — or as a set element — must
+  ;; canonicalize to a stable form regardless of its authoring order.
+  ;; Otherwise the key's/element's authoring order survives into the printed
+  ;; digest and two `=`-equal plans fingerprint differently, raising a
+  ;; SPURIOUS cross-root `:rf.error/frame-payload-conflict` (rf2-vxgfnd.33).
+  (is (= (fp/canonical-edn {{:a 1 :b 2} :v})
+         (fp/canonical-edn {{:b 2 :a 1} :v}))
+      "a map-as-key canonicalizes regardless of authoring order")
+  (is (= (fp/canonical-edn #{{:a 1 :b 2}})
+         (fp/canonical-edn #{{:b 2 :a 1}}))
+      "a map inside a set canonicalizes regardless of authoring order")
+  ;; the whole point: two frame plans identical up to map-key authoring order
+  ;; MUST fingerprint EQUAL, so preflight sees the idempotent no-op, not a
+  ;; spurious conflict.
+  (is (= (fp/config-fingerprint :frame/f {:routes {{:a 1 :b 2} :left}})
+         (fp/config-fingerprint :frame/f {:routes {{:b 2 :a 1} :left}}))
+      "two plans identical up to map-key authoring order fingerprint EQUAL")
+  ;; a GENUINELY different config still separates — the fix does not collapse
+  ;; distinct plans.
+  (is (not= (fp/config-fingerprint :frame/f {:routes {{:a 1 :b 2} :left}})
+            (fp/config-fingerprint :frame/f {:routes {{:a 1 :b 2} :right}}))
+      "a real config difference still fingerprints differently"))
+
 (deftest fnv1a-64-cross-host-golden
   ;; FNV-1a 64 reference vector: "a" -> af63dc4c8601ec8c; our digest input
   ;; is (canonical-edn "a") = "\"a\"" so pin OUR pipeline's value instead:

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -40,6 +40,10 @@
   (try (thunk) nil
        (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
 
+(defn- err-data [thunk]
+  (try (thunk) nil
+       (catch cljs.core/ExceptionInfo e (ex-data e))))
+
 (defn- plan
   ([frame-id] (plan frame-id {} "cf1-aaaaaaaaaaaaaaaa"))
   ([frame-id config fp]
@@ -110,6 +114,27 @@
       "the installed frame is untouched — no last-wins overwrite")
   (is (= :page/shop (:installed-by (frames/installed-plan-entry :frame/session)))
       "the installing root's record survives the rejected arrival"))
+
+(deftest cross-root-conflict-ex-data-carries-config-fingerprint-shape
+  ;; The reconciled ex-data contract (rf2-vxgfnd.33 / 004C §7): the runtime
+  ;; plan-conflict arm carries :config-fingerprint (NOT :digest) in BOTH the
+  ;; :installed record and the :arriving slot, so tooling written to the 004C
+  ;; roster finds the fingerprint under the spec-named key. (:extra merges to
+  ;; top-level ex-data keys — see re-frame.error/thrown-ex-info.)
+  (reg-events!)
+  (frames/execute-frame-plans!
+   :page/shop [(plan :frame/session {} "cf1-1111111111111111")])
+  (let [data (err-data
+              #(frames/execute-frame-plans!
+                :page/admin [(plan :frame/session {} "cf1-2222222222222222")]))]
+    (is (= :rf.error/frame-payload-conflict (:rf.error/id data)))
+    (is (= :frame/session (:frame-id data)))
+    (is (= {:config-fingerprint "cf1-1111111111111111" :installed-by :page/shop}
+           (:installed data))
+        ":installed carries :config-fingerprint + :installed-by (004C §7)")
+    (is (= {:config-fingerprint "cf1-2222222222222222" :root-id :page/admin}
+           (:arriving data))
+        ":arriving carries :config-fingerprint + :root-id (004C §7) — never :digest")))
 
 (deftest conflict-detection-is-pure-before-any-install
   ;; a root carries a GOOD plan followed by a CONFLICTING plan; conflict

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -315,17 +315,25 @@ prefix-uniqueness backstop share the roster:
 
 - a referenced **payload id already installed with a different content digest**, or
 - a **frame plan whose `:config-fingerprint` differs** from the installed frame's
-  recorded plan fingerprint,
+  recorded plan fingerprint **and was recorded by a *different* root**,
 
-fails **that root** with `:rf.error/frame-payload-conflict`, data
-`{:frame-id … :installed {:digest … :installed-by root-id} :arriving {:digest …
-:root-id …}}`. The installed frame and the roots already using it are untouched —
-exactly 06 §2's failure scoping ("a bad frame payload affects exactly the roots
-referencing it"). There is no first-wins silent merge and no last-wins overwrite.
-Matching digest/fingerprint = the ratified idempotent no-op. Layer 1 additionally
-rejects at build time two *plans* for one frame-id with differing config fingerprints
-inside one entry closure (compile error — the didactic message points at boot/event
-infrastructure per 03 §8).
+fails **that root** with `:rf.error/frame-payload-conflict`. The runtime plan-conflict
+arm carries data `{:frame-id … :installed {:config-fingerprint … :installed-by root-id}
+:arriving {:config-fingerprint … :root-id …}}` — `:installed` is the recorded install
+record *verbatim*, so it may instead carry `:adopted-by`/`:adopted true` (a boot-
+authoritative frame this root only scopes) or an extra `:mount-incomplete true` (a
+sibling mount that threw mid-run). The installed frame and the roots already using it
+are untouched — exactly 06 §2's failure scoping ("a bad frame payload affects exactly
+the roots referencing it"). There is no first-wins silent merge and no last-wins
+overwrite. A **same-root** re-declaration whose fingerprint differs is a surgical
+**refresh** (an HMR config edit — durable state survives, `:initial-events` re-recorded
+not replayed), **not** a conflict; a **matching** fingerprint is the ratified idempotent
+no-op (no re-seed). Layer 1 additionally rejects at build time two *plans* for one
+frame-id with differing config fingerprints inside one entry closure (compile error —
+the didactic message points at boot/event infrastructure per 03 §8). (The S5 hydrate
+arm — a referenced payload id already installed with a different **content** digest —
+carries its own content-`:digest` slot when server rendering lands: the same error id,
+a distinct conflict trigger.)
 
 ## 8. Client-only non-hydrating mounts — identity and defaults
 
@@ -376,8 +384,8 @@ unregisters (a leaked registration failing a later mount is a test-harness bug, 
 
 | Surface | Stage |
 |---|---|
-| Root Descriptor v1, mount grammar + identity opts, derivation + slug, Layer-1 + Layer-3 duplicate detection, client mount/`create-root`/`render!`/`unmount!`, `ui.test/render` forms | **S1** (the 08 §2 "root descriptor" row, now defined) |
-| Root Manifest v1 extension keys, `hydrate-root` preflight (manifest discovery/validation → payload install → hydrate), locator generation, Layer-2 registry, payload-conflict preflight, `render-static` identity participation | **S5** (12 §3's "root manifests" row, now the additive extension of S1) |
+| Root Descriptor v1, mount grammar + identity opts, derivation + slug, Layer-1 + Layer-3 duplicate detection, client mount/`create-root`/`render!`/`unmount!`, `ui.test/render` forms, frame-plan-conflict preflight (the `:config-fingerprint` ENSURE arm — build tier S1c, client-mount/`render!` runtime tier S2c) | **S1** (the 08 §2 "root descriptor" row, now defined) |
+| Root Manifest v1 extension keys, `hydrate-root` preflight (manifest discovery/validation → payload install → hydrate), locator generation, Layer-2 registry, payload-**content-digest** conflict preflight (the hydrate arm of `:rf.error/frame-payload-conflict` only — the plan-fingerprint arm ships at S1c/S2c, row above), `render-static` identity participation | **S5** (12 §3's "root manifests" row, now the additive extension of S1) |
 
 ## Q24–Q28 coverage
 


### PR DESCRIPTION
## What

Conflict-surface polish (rf2-vxgfnd.33), two sub-bugs on `:rf.error/frame-payload-conflict` / the plan fingerprint. Fixed **before** the S5 payload-digest arm lands on the same error id.

### (a) ex-data drift — reconciled SPEC-SIDE

The runtime frame-payload-conflict arm (`re-frame.ui.frames`) emits `:config-fingerprint` in both `:installed` and `:arriving`; **004C §7 pinned `:digest`**. Tooling written to the 004C roster wouldn't find the fingerprint.

**Ruling: align the SPEC to the impl (`:digest` -> `:config-fingerprint`).** Rationale:
- **Spec 009:2302** (the error-catalogue row of record for ex-data shapes) already enumerates `:installed` + `:arriving` with *fingerprint* language and does not pin `:digest`.
- The shipped implementation emits `:config-fingerprint`, and **every** ui test (`preflight_frame_wiring*`, `root_analysis`, `compiler_build`) asserts `:config-fingerprint` / `:installed-by`. None assert `:digest`.
- So **004C §7 was the sole outlier** — the reconcile is 004C vs (009 + impl + tests). Changing the impl would have churned working code + tests to match one stale spec map; the fingerprint arm's quantity genuinely *is* a config-fingerprint.

004C changes:
- §7 data map `:digest` -> `:config-fingerprint`; noted `:installed` is the recorded record *verbatim* (may carry `:adopted-by`/`:adopted` or `:mount-incomplete`).
- §7 normative text: added the **same-root-refresh carve-out** — only a *different* root triggers the conflict; a same-root re-declaration with a differing fingerprint is a surgical HMR **refresh**, a matching fingerprint the idempotent no-op (matches `frames.cljc` + 009).
- §10 stage table: the plan-fingerprint conflict preflight ships **S1c (build) / S2c (client-mount)**, not S5 — only the **payload-content-digest** hydrate arm is S5. Fixed both rows.
- Noted the S5 hydrate arm carries its own content-`:digest` slot (same error id, distinct trigger) when server rendering lands.

Impl unchanged for (a); added a preflight test pinning the reconciled `:extra` shape so the S5 arm can't drift it back.

004C is HOT-ZONE for this dispatch — sole toucher. **Spec 009 was NOT edited** (already consistent).

### (b) fingerprint canonicalization missed map KEYS

`fingerprint/canonicalize` sorted map entries but recursed into **values only** — a map literal used **as a key** (or as a set element) kept its authoring order, so two `=`-equal plans fingerprinted differently -> spurious cross-root `:rf.error/frame-payload-conflict`.

Fix: canonicalize keys and set elements recursively (the sorted-map-by comparator then sorts on already-canonical keys). Added a fixture proving two plans identical up to map-key authoring order fingerprint EQUAL, plus a negative (a real config difference still separates). Cross-host golden unaffected (string inputs are identity through canonicalize).

## Quality gates

Foreground, 0-fail:
- ui artefact `clojure -M:test` — **261 tests, 4518 assertions, 0 failures, 0 errors**
- ui CLJS `node-test-ui` — **240 tests, 1294 assertions, 0 failures, 0 errors**
- broad `npm run test:cljs` (`node-test`) — **8979 tests, 42393 assertions, 0 failures, 0 errors** (4 pre-existing warnings in untouched test files)
- `scripts/check_doc_slugs.py` (004C edited) — exit 0, no broken links
