### PR TITLE
fix(core): acquire! distinguishes live-cache displacement from frame destruction (rf2-vxgfnd.63)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -112,7 +112,21 @@
   a reaction that is no longer the frame's canonical node was disposed in the
   window — the staged owners are self-drained and enqueued exactly once
   (`take-owners!` is the single-drain point), so no acquired lease is ever left
-  behind an uninstalled/dead hook without its invalidation."
+  behind an uninstalled/dead hook without its invalidation.
+
+  The same eviction-before-dispose fact means a node the build itself just
+  installed can be DISPLACED — invalidated-and-rebuilt to a newer canonical node
+  — inside `subs/build-and-classify!`'s build→canonical-check window while the
+  frame stays LIVE (a concurrent HMR re-registration or explicit cache clear).
+  `build-and-classify!` maps that to a `:frame-destroyed` recovery via its `:else`
+  fallback, conflating a normal displacement with a teardown. `acquire!`
+  disambiguates against the targeted frame's incarnation token
+  (`frame/frame-incarnation-token`, captured while the frame is verified live):
+  a still-live incarnation means the node was merely displaced, so `acquire!`
+  retargets to the current canonical node by re-running the acquire (bounded
+  retry, gated on incarnation liveness); only a nil/changed incarnation is a
+  verified destruction of the targeted incarnation and throws
+  `:rf.error/frame-destroyed` (rf2-vxgfnd.63)."
   (:refer-clojure :exclude [read])
   (:require [re-frame.error :as error]
             [re-frame.error-emit :as error-emit]
@@ -792,6 +806,85 @@
                      :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
                      :registry-epoch @registry-epoch*}))))))
 
+(defn- build-node-lease!
+  "Wrap a CANONICAL cached `reaction` — one `subs/acquire-cache-reaction!` has
+  already taken a real +1 reference on — in a live NODE lease. Register the
+  per-lease change watch (on watchable hosts; `add-watch` never fires
+  synchronously), take the baseline observation through the activated node,
+  enrol the lease as an active owner, and — only for the FIRST owner — install
+  the node's single disposal hook (delivery is queued; see the ns docstring's
+  HMR section). `release!` de-enrols the lease, so a released lease is no longer
+  reachable from the live reaction: disposal work stays O(current owners), never
+  O(all owners ever acquired) (rf2-vxgfnd.15).
+
+  Closes the first-owner disposal-hook HANDSHAKE (rf2-vxgfnd.32): the record's
+  `:hooked?` flag flips as the lease enrols, BEFORE `add-on-dispose!` actually
+  registers the callback, so a disposal that linearizes in that gap can (a) fire
+  NO hook — the callback lands on an already-disposed reaction and is lost (every
+  substrate's `-dispose` snapshot-and-clears its callbacks, and the JVM
+  Reaction's field is even unsynchronized, so an install racing `-dispose` can be
+  dropped outright) — or (b) drain the owner set before this lease enrolled.
+  Since every disposal path evicts the cache entry BEFORE `interop/dispose!`
+  (`re-frame.subs.cache`), a reaction that is no longer the frame's canonical
+  node WAS disposed in the window; self-drain the staged owners so each is
+  enqueued exactly once (`take-owners!` is the single-drain point; the installed
+  hook, if it did fire, already drained). No synchronous `on-change`: the drain
+  only ENQUEUES — delivery rides the next-tick / HMR drain boundary off the
+  acquire stack, preserving acquire!'s no-fan-out guarantee. Returns the lease."
+  [target frame-id query reaction on-change]
+  (let [state (atom {:lease-kind :node
+                     :target     target
+                     :frame-id   frame-id
+                     :query-v    query
+                     :reaction   reaction
+                     :on-change  on-change
+                     :status     :live})
+        lease (->ObservationLease state)]
+    ;; Watch BEFORE the baseline observe: a watched reaction is live on the
+    ;; reactive hosts, so the observe below reads through the activated node.
+    (when (watchable? reaction)
+      (let [wk (gensym "rf-obs-lease")]
+        (add-watch reaction wk (make-watch-handler state))
+        (swap! state assoc :watch-key wk)))
+    (let [[rec v] (observe-node! reaction)]
+      (swap! state assoc :last {:value    v
+                                :version  (:version rec)
+                                :node-key (:node-key rec)}))
+    (when (register-owner! reaction lease)
+      (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
+    (when-not (node-still-canonical? @state)
+      (drain-owners! reaction))
+    lease))
+
+(def ^:private max-displacement-retries
+  "Retry budget for acquire!'s live-cache-displacement retarget (rf2-vxgfnd.63).
+  A DISPLACEMENT — the just-built canonical node invalidated-and-rebuilt (an HMR
+  sub re-registration or an explicit cache clear) in the build→canonical-check
+  window while the frame stays LIVE — is a NORMAL condition, not frame
+  destruction, so acquire! retargets by re-running `subs/acquire-cache-reaction!`
+  against the now-current cache. Each real displacement is a discrete finite
+  event whose very next build settles a canonical node, so convergence is
+  effectively immediate (attempt 2 wins); the retry is additionally gated on the
+  targeted incarnation staying live (`targeted-incarnation-still-live?`), so any
+  incarnation movement terminates it at once. This fixed budget is the belt: it
+  forecloses an unbounded live-lock under a pathological displacer that could
+  otherwise re-race every window, guaranteeing acquire! cannot spin forever."
+  32)
+
+(defn- targeted-incarnation-still-live?
+  "True when `frame-id`'s CURRENTLY-live incarnation is identical to the
+  `incarnation` token captured at acquire entry — i.e. the SAME frame
+  incarnation acquire! is targeting is still live (rf2-vxgfnd.63). A sub
+  re-registration or an explicit cache clear leaves the frame record — and its
+  `:drain-lock` incarnation token — untouched, so a live-cache displacement
+  reads true here (retarget). A nil-or-changed token means the targeted
+  incarnation was destroyed, or destroyed-and-reincarnated under a reused id;
+  either is a VERIFIED destruction of the targeted incarnation (frame-destroyed),
+  never a displacement."
+  [frame-id incarnation]
+  (let [now (frame/frame-incarnation-token frame-id)]
+    (and (some? now) (identical? now incarnation))))
+
 (defn acquire!
   "Commit-only: acquire ownership of `target`, returning a LEASE — the owner
   token (identity equality, never `=`).
@@ -830,8 +923,14 @@
   `:rf.error/sub-input-fn-exception` / `:rf.error/sub-input-fn-bad-return`,
   `:rf.error/frame-destroyed`) rather than lease a zero-ref recovery reaction
   (rf2-vxgfnd.27): a lease MUST NOT report `owned?` without a real cache ref +
-  attach. The static override lease and the public subscribe surface keep their
-  recover-to-nil semantics."
+  attach. `:rf.error/frame-destroyed` is reserved for a VERIFIED destruction of
+  the targeted frame incarnation: a `:frame-destroyed` recovery over a STILL-LIVE
+  incarnation is a live-cache DISPLACEMENT (the node invalidated-and-rebuilt in
+  the build→canonical-check window — HMR re-registration or an explicit cache
+  clear), NOT a teardown, so `acquire!` retargets to the current canonical node
+  (bounded retry, gated on the incarnation staying live) instead of throwing
+  (rf2-vxgfnd.63). The static override lease and the public subscribe surface
+  keep their recover-to-nil semantics."
   [target on-change]
   (assert-not-in-fan-out! 're-frame.substrate.observation/acquire!)
   (case (:kind target)
@@ -851,64 +950,42 @@
           (when (nil? (registrar/lookup :sub (first query)))
             (throw-no-such-sub! 're-frame.substrate.observation/acquire!
                                 frame-id query))))
-      (let [result (subs/acquire-cache-reaction! frame-id query)]
-        (if-some [reaction (:reaction result)]
-          ;; Canonical cached node — the real ref-count attach. Take ownership.
-          (let [state (atom {:lease-kind :node
-                             :target     target
-                             :frame-id   frame-id
-                             :query-v    query
-                             :reaction   reaction
-                             :on-change  on-change
-                             :status     :live})
-                lease (->ObservationLease state)]
-            ;; Watch BEFORE the baseline observe: a watched reaction is live
-            ;; on the reactive hosts, so the observe below reads through the
-            ;; activated node. `add-watch` never fires synchronously.
-            (when (watchable? reaction)
-              (let [wk (gensym "rf-obs-lease")]
-                (add-watch reaction wk (make-watch-handler state))
-                (swap! state assoc :watch-key wk)))
-            (let [[rec v] (observe-node! reaction)]
-              (swap! state assoc :last {:value    v
-                                        :version  (:version rec)
-                                        :node-key (:node-key rec)}))
-            ;; Node-disposed notification. Enrol this lease as an active owner
-            ;; and — only for the FIRST owner — install the node's single
-            ;; disposal hook (delivery is queued; see the ns docstring's HMR
-            ;; section). `release!` de-enrols the lease, so a released lease is no
-            ;; longer reachable from the live reaction: disposal work stays
-            ;; O(current owners), never O(all owners ever acquired) (rf2-vxgfnd.15).
-            (when (register-owner! reaction lease)
-              (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
-            ;; First-owner disposal-hook HANDSHAKE (rf2-vxgfnd.32). The record's
-            ;; :hooked? flag flips as the lease enrols, BEFORE add-on-dispose!
-            ;; actually registers the callback, so a disposal that linearizes in
-            ;; that gap can (a) fire NO hook — the callback lands on an
-            ;; already-disposed reaction and is lost (every substrate's -dispose
-            ;; snapshot-and-clears its callbacks, and the JVM Reaction's field is
-            ;; even unsynchronized, so an install racing -dispose can be dropped
-            ;; outright) — or (b) drain the owner set before this lease enrolled.
-            ;; Close the handshake with a canonicality re-check that EVERY owner
-            ;; (first or not) runs: since every disposal path evicts the cache
-            ;; entry BEFORE interop/dispose! (re-frame.subs.cache), a reaction
-            ;; that is no longer the frame's canonical node WAS disposed in the
-            ;; window. Self-drain the staged owners so each is enqueued exactly
-            ;; once (take-owners! is the single-drain point; the installed hook,
-            ;; if it did fire, already drained). No synchronous on-change: drain
-            ;; only ENQUEUES — delivery rides the next-tick / HMR drain boundary
-            ;; off the acquire stack, preserving acquire!'s no-fan-out guarantee.
-            (when-not (node-still-canonical? @state)
-              (drain-owners! reaction))
-            lease)
-          ;; NEVER-CACHED, zero-ref RECOVERY reaction (rf2-vxgfnd.27): a cyclic
-          ;; entry sub, a parametric input-fn failure, or a frame destroyed
-          ;; mid-build. There is no cache node to attach to — `acquire!` is the
-          ;; ref-count attach — so the port is fail-loud and throws the matching
-          ;; typed error rather than lease an owned?-true reaction that owns
-          ;; nothing (no entry, no ref) and re-churns a fresh orphan + node
-          ;; record + disposal hook + re-emit on EVERY commit.
-          (throw-acquire-recovery! frame-id query result))))))
+      ;; Capture the targeted frame incarnation while it is verified live
+      ;; (rf2-vxgfnd.63). A :frame-destroyed recovery below is disambiguated
+      ;; against THIS token, so :rf.error/frame-destroyed is reserved for a
+      ;; VERIFIED destruction of the targeted incarnation.
+      (let [incarnation (frame/frame-incarnation-token frame-id)]
+        (loop [attempt 0]
+          (let [result (subs/acquire-cache-reaction! frame-id query)]
+            (if-some [reaction (:reaction result)]
+              ;; Canonical cached node — the real ref-count attach. Take
+              ;; ownership (watch + baseline observe + first-owner disposal-hook
+              ;; handshake, rf2-vxgfnd.32/.15).
+              (build-node-lease! target frame-id query reaction on-change)
+              ;; No canonical node. The build handed back a NEVER-CACHED, zero-ref
+              ;; recovery reaction; there is no node to attach to — `acquire!` IS
+              ;; the ref-count attach — so the port is fail-loud rather than lease
+              ;; an owned?-true reaction that owns nothing (rf2-vxgfnd.27). But
+              ;; first DISAMBIGUATE a live-cache DISPLACEMENT from genuine frame
+              ;; destruction (rf2-vxgfnd.63): `subs/build-and-classify!` maps a
+              ;; just-built node that was invalidated-and-rebuilt (an HMR sub
+              ;; re-registration or an explicit cache clear) in the
+              ;; build→canonical-check window to :frame-destroyed via its :else
+              ;; fallback — conflating a NORMAL displacement (the frame is LIVE,
+              ;; the node merely displaced by a newer canonical node) with a real
+              ;; teardown. When the targeted incarnation is still live, the node
+              ;; was displaced, not destroyed: retarget by re-running
+              ;; acquire-cache-reaction! against the now-current cache (the very
+              ;; next build settles a canonical node), bounded by the retry budget
+              ;; so a pathological displacer cannot spin acquire! forever. Only a
+              ;; nil/changed incarnation (verified destruction), a
+              ;; non-displacement recovery (cycle / input-fn failure —
+              ;; deterministic, retry is futile), or an exhausted budget throws.
+              (if (and (= :frame-destroyed (:recovery result))
+                       (targeted-incarnation-still-live? frame-id incarnation)
+                       (< attempt max-displacement-retries))
+                (recur (inc attempt))
+                (throw-acquire-recovery! frame-id query result)))))))))
 
 ;; ---- current? -------------------------------------------------------------------
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -532,6 +532,142 @@
       (is (= :hmr (:cause (first @notes))))
       (obs/release! lease))))
 
+;; ===========================================================================
+;; rf2-vxgfnd.63 — a live-cache DISPLACEMENT must not be misclassified as frame
+;; destruction during acquire!
+;;
+;; subs/build-and-classify! drives compute-and-cache! then re-checks whether the
+;; just-built reaction is still the frame's canonical cache node. If that node is
+;; DISPLACED — invalidated-and-rebuilt to a newer canonical node — in that window
+;; (a concurrent HMR sub re-registration or an explicit cache clear) while the
+;; FRAME STAYS LIVE, the build succeeded (recovery sink nil) yet the node is no
+;; longer canonical, so build-and-classify!'s :else fallback returns
+;; {:recovery :frame-destroyed}. Pre-fix acquire! throws + fans a FALSE always-on
+;; :rf.error/frame-destroyed even though the frame is live. The fix: acquire!
+;; disambiguates against the targeted frame's incarnation token
+;; (frame/frame-incarnation-token) — a still-live incarnation means the node was
+;; merely displaced, so acquire! retargets to the current canonical node (bounded
+;; retry) instead of throwing; only a nil/changed incarnation is a verified
+;; teardown of the targeted incarnation.
+;;
+;; Deterministic barrier (no sleeps, both hosts): wrap subs/compute-and-cache!
+;; so the FIRST build of the target query displaces the just-built canonical node
+;; before returning it — landing the reaction non-canonical exactly in the
+;; build→canonical-check window, with the frame record (and its incarnation
+;; token) untouched. A compare-and-set! makes it fire once, so the acquire!-side
+;; retry settles the next canonical build.
+;; ===========================================================================
+
+(defn- evict-node!
+  "Evict the cache entry for `query-v` — the swap EVERY real disposal path does
+  BEFORE interop/dispose!. Models an explicit cache clear on a still-live frame."
+  [query-v]
+  (swap! (sub-cache) dissoc query-v))
+
+(defn- displace-node!
+  "Model an HMR-style displacement of the just-built canonical `reaction` for
+  `query-v`: evict the cache entry then dispose the reaction, leaving the frame
+  record — and its incarnation token — untouched (the frame stays LIVE)."
+  [query-v reaction]
+  (evict-node! query-v)
+  (interop/dispose! reaction))
+
+(deftest acquire-live-cache-displacement-retargets-not-frame-destroyed
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target  (items-target)
+        real-cc @#'subs/compute-and-cache!
+        raced?  (atom false)]
+    (with-redefs
+      [subs/compute-and-cache!
+       (fn [frame-id query-v]
+         (let [reaction (real-cc frame-id query-v)]
+           ;; Displace the just-built canonical node ONCE, in the
+           ;; build→canonical-check window, with the frame left LIVE.
+           (when (and (= query-v [:obs/items])
+                      (compare-and-set! raced? false true))
+             (displace-node! [:obs/items] reaction))
+           reaction))]
+      (let [[[outcome lease] records] (with-error-records #(obs/acquire! target (fn [_])))]
+        (is (true? @raced?) "the displacement fired in the build→check window")
+        (testing "acquire! did NOT throw or fan a false frame-destroyed while the frame is live"
+          (is (= :ok outcome) "acquire! returned a lease, not a throw")
+          (is (obs/lease? lease))
+          (is (empty? (filter #(= :rf.error/frame-destroyed (:error %)) records))
+              "no false always-on frame-destroyed record was fanned")
+          (is (some? (frame/frame fid)) "the frame remained live throughout"))
+        (testing "it converged on the CURRENT canonical node — an owned, current lease"
+          (is (obs/owned? lease) "the retarget adopted a real cache node")
+          (is (true? (obs/current? lease target))
+              "the lease covers the live canonical node")
+          (is (= 1 (ref-count [:obs/items])) "exactly one reference on the current node")
+          (is (= [:a] (:value (obs/read lease)))
+              "reads the live value through the adopted canonical node"))
+        (testing "no leak — release drops the last ref and disposes the current node"
+          (obs/release! lease)
+          (is (nil? (entry [:obs/items]))))))))
+
+(deftest acquire-repeated-live-displacement-is-bounded-and-converges
+  ;; Repeated displacement (explicit-cache-clear style: evict only) on the first
+  ;; K attempts, then quiescence. The bounded retry converges on a canonical
+  ;; current lease at attempt K+1 — it does not spin, and never fans a false
+  ;; frame-destroyed while the frame stays live (rf2-vxgfnd.63 — the retry is
+  ;; bounded and cannot spin forever under repeated HMR).
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target  (items-target)
+        real-cc @#'subs/compute-and-cache!
+        k       3
+        builds  (atom 0)]
+    (with-redefs
+      [subs/compute-and-cache!
+       (fn [frame-id query-v]
+         (let [reaction (real-cc frame-id query-v)]
+           (when (= query-v [:obs/items])
+             ;; Evict the first K builds in-window; the (K+1)th settles.
+             (when (<= (swap! builds inc) k)
+               (evict-node! [:obs/items])))
+           reaction))]
+      (let [[[outcome lease] records] (with-error-records #(obs/acquire! target (fn [_])))]
+        (is (= (inc k) @builds) "converged on the very next build after K displacements")
+        (is (= :ok outcome) "acquire! converged on a lease — it did not spin or throw")
+        (is (empty? (filter #(= :rf.error/frame-destroyed (:error %)) records))
+            "no false frame-destroyed under repeated live displacement")
+        (is (true? (obs/current? lease target)))
+        (is (= 1 (ref-count [:obs/items])))
+        (obs/release! lease)
+        (is (nil? (entry [:obs/items])))))))
+
+(deftest acquire-genuine-destruction-in-window-still-throws-frame-destroyed
+  ;; The disambiguation's OTHER side: when the TARGETED incarnation is actually
+  ;; destroyed in the build→check window (its incarnation token → nil), acquire!
+  ;; MUST still throw + fan exactly one :rf.error/frame-destroyed. Displacement
+  ;; retargeting must never swallow a real teardown (rf2-vxgfnd.63 regression).
+  (let [race-fid :obs/race-frame-63]
+    (rf/make-frame {:id race-fid :adapter plain-atom/adapter})
+    (rf/reg-sub :obs/items63 (fn [db _] (:items db)))
+    (frame/replace-app-db! race-fid {:items [:a]})
+    (let [target  (obs/resolve-target {:frame race-fid :query-v [:obs/items63]})
+          real-cc @#'subs/compute-and-cache!
+          raced?  (atom false)]
+      (with-redefs
+        [subs/compute-and-cache!
+         (fn [frame-id query-v]
+           (let [reaction (real-cc frame-id query-v)]
+             (when (and (= query-v [:obs/items63])
+                        (compare-and-set! raced? false true))
+               ;; Destroy the targeted incarnation in the window — token → nil.
+               (frame/destroy-frame! race-fid))
+             reaction))]
+        (let [[[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
+          (is (true? @raced?) "the destruction fired in the build→check window")
+          (is (= :threw outcome) "a real teardown still throws — it is not retargeted")
+          (is (= :rf.error/frame-destroyed (error-id e)))
+          (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:error %)) records)))
+              "exactly one always-on frame-destroyed record was fanned")
+          (is (nil? (frame/frame race-fid))
+              "the targeted incarnation is gone — nothing was leased"))))))
+
 (deftest reentrant-graph-op-is-dev-asserted-inside-the-fan-out
   (reg-items!)
   (seed-items! [:a])

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1193,6 +1193,21 @@ The port and the public read API split deliberately ⟨09 codex2 F1 — binding�
     diagnostic** (its 009 channel is unchanged — it is emitted on the dev trace channel
     by the build); the port throws the typed carrier to the ViewCell error boundary but
     does **not** promote sub-cycle to the always-on axis.
+  - **A live-cache DISPLACEMENT is not a destruction (rf2-vxgfnd.63).** The build's
+    canonical-node re-check can also fail while the frame is **live**: a just-built
+    canonical node **invalidated-and-rebuilt** to a newer node — an HMR sub
+    re-registration or an explicit cache clear landing in the build→check window — leaves
+    the built reaction non-canonical with the frame record untouched. That is a normal
+    **displacement**, not a teardown, so `:rf.error/frame-destroyed` is **reserved for a
+    verified destruction of the targeted frame incarnation**. `acquire!` disambiguates
+    against the targeted frame's **incarnation token** (captured while the frame is
+    verified live): on a still-live incarnation it **retargets** to the current canonical
+    node by re-running the acquire — a **bounded** retry gated on the incarnation staying
+    live, so it converges on a canonical current lease (no false frame-destroyed, no
+    leaked displaced reaction) and cannot spin forever under repeated HMR; only a
+    nil/changed incarnation is the mid-build destroy race that fans + throws
+    `:rf.error/frame-destroyed`. The retry preserves the no-synchronous-`on-change`
+    acquisition rule (it re-runs the acquire, never a callback).
   - **This is the entry-node line, not the mid-graph line.** The bullet above governs a
     sub **body's** `:<-` reference to a failing/cyclic INPUT: that recovers to nil and
     the ENTRY node still caches normally, so `acquire!` takes ownership of the real


### PR DESCRIPTION
## Problem

`subs/build-and-classify!`'s `:else` fallback maps a just-built canonical node that was **displaced** — invalidated-and-rebuilt to a newer canonical node — in the `build→canonical-check` window to `{:recovery :frame-destroyed}`. On the concurrent JVM host a live frame's node can be displaced by an HMR sub re-registration or an explicit cache clear between `compute-and-cache!` returning and `canonical-cache-reaction?` reading the cache: the build succeeded (recovery sink nil), the frame/cache is still **live**, yet `acquire!` emitted and threw a **false** `:rf.error/frame-destroyed`. This conflates a normal live-cache displacement with a real frame teardown. (rf2-vxgfnd.63, builds on rf2-vxgfnd.32.)

## Fix (observation port only)

`acquire!` now captures the targeted frame's **incarnation token** (`frame/frame-incarnation-token` — the frame record's `:drain-lock`, constant across one incarnation, distinct/nil across destroy) while the frame is verified live, and disambiguates a `:frame-destroyed` recovery against it:

- **Still-live incarnation** → the node was merely displaced, not destroyed → **retarget** to the current canonical node by re-running `subs/acquire-cache-reaction!`. The retry is **bounded** (`max-displacement-retries`) and gated on the incarnation staying live, so it converges on a canonical current lease (the very next build settles one) and **cannot spin forever** under repeated HMR.
- **nil/changed incarnation** → a **verified destruction** of the targeted incarnation → fan + throw `:rf.error/frame-destroyed` (unchanged).
- Non-displacement recoveries (`:cycle`, `:input-fn-*`) throw immediately (deterministic — retry is futile).

`:rf.error/frame-destroyed` is thereby reserved for verified destruction of the targeted incarnation. The `.32` first-owner canonicality re-check handshake is preserved verbatim, extracted into a `build-node-lease!` helper. No sub-cache/frames/reactive edits — the fix lives entirely in `re-frame.substrate.observation`. The retry preserves the no-synchronous-`on-change` acquisition rule (it re-runs the acquire, never a callback), and never leases/leaks a displaced reaction.

## Tests (`observation_port_cljs_test.cljc`, both hosts)

Deterministic barrier: wrap `subs/compute-and-cache!` so the first build of the target query displaces the just-built node in the `build→check` window, frame left live.

- `acquire-live-cache-displacement-retargets-not-frame-destroyed` — single HMR-style displacement (evict + dispose): acquire retargets to an owned, current lease, ref-count 1, reads the live value, releases cleanly; **no false frame-destroyed record** fanned; frame stays live.
- `acquire-repeated-live-displacement-is-bounded-and-converges` — explicit-cache-clear-style displacement on the first K builds then quiescence: converges at build K+1, no spin, no false frame-destroyed.
- `acquire-genuine-destruction-in-window-still-throws-frame-destroyed` — the incarnation is actually destroyed in-window (token → nil): still fans + throws **exactly one** `:rf.error/frame-destroyed` (regression — retargeting must not swallow a real teardown).

## Spec

Minimal clarifying sub-bullet in `spec/006` §The internal observation port — the `acquire!` fail-loud section — distinguishing a live-cache displacement (retarget) from the mid-build destroy race (throw). **Hot-zone file flagged.**

## Quality gates

- Full core JVM (`clojure -M:test`): **1862 tests, 8311 assertions, 0 failures, 0 errors**
- Observation-port ns (JVM, `-n re-frame.observation-port-cljs-test`): **32 tests, 178 assertions, 0 failures**
- Full CLJS (`npm run test:cljs`): **8973 tests, 42353 assertions, 0 failures, 0 errors**
