### PR TITLE
fix(adapters/reagent-slim): re-establish render Reaction after StrictMode remount (rf2-6b6pex, rf2-a07937)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -384,11 +384,33 @@
   binding."
   [^js klass spec]
   (let [proto (.-prototype klass)]
-    (when-let [f (:component-did-mount spec)]
+    ;; componentDidMount: always installed (even without a user
+    ;; :component-did-mount) so a React.StrictMode simulated
+    ;; unmount→remount can re-establish the per-instance render Reaction
+    ;; (rf2-6b6pex). StrictMode's dev init sequence for a slim class is
+    ;; `render ×2 → componentDidMount → componentWillUnmount →
+    ;; componentDidMount`: the transient componentWillUnmount disposes +
+    ;; nils this instance's render Reaction (below), and React reuses the
+    ;; committed fiber on the remount — so the second componentDidMount
+    ;; fires with NO intervening render() to recreate it. Slim recreates
+    ;; the render Reaction only lazily inside render() (make-render-method),
+    ;; so the remounted instance would be left with `cljsRenderRea = nil`
+    ;; and no subscription watches: it renders once then ignores app-db
+    ;; changes (reactively dead). When the reattach marker the transient
+    ;; componentWillUnmount set is present, force a re-render:
+    ;; make-render-method then recreates the Reaction and re-subscribes its
+    ;; deref'd watches. The marker is set ONLY when a live render Reaction
+    ;; was disposed by an unmount, so a normal first mount (render() already
+    ;; ran, `cljsRenderRea` live, no marker) is a no-op here.
+    (let [user-fn (:component-did-mount spec)]
       (set! (.-componentDidMount proto)
             (fn []
-              (this-as this
-                (bind-and-call this #(f this))))))
+              (this-as ^js this
+                (when (.-cljsRemountReattach this)
+                  (set! (.-cljsRemountReattach this) false)
+                  (batching/queue-render! this))
+                (when user-fn
+                  (bind-and-call this #(user-fn this)))))))
 
     ;; componentWillUnmount: always installed (even without
     ;; :component-will-unmount) so the per-instance render Reaction
@@ -407,7 +429,15 @@
                 (batching/mark-rendered this)
                 (when-some [rea (.-cljsRenderRea this)]
                   (ratom/dispose! rea)
-                  (set! (.-cljsRenderRea this) nil))
+                  (set! (.-cljsRenderRea this) nil)
+                  ;; Mark for reattach on a StrictMode remount (rf2-6b6pex).
+                  ;; If React remounts THIS same instance (its dev
+                  ;; unmount→remount reuses the committed fiber and fires
+                  ;; componentDidMount with no intervening render()),
+                  ;; componentDidMount forces a re-render to re-establish the
+                  ;; render Reaction + its watches. A genuine unmount never
+                  ;; remounts, so the marker is discarded with the instance.
+                  (set! (.-cljsRemountReattach this) true))
                 (when user-fn
                   (bind-and-call this #(user-fn this)))))))
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
@@ -1,0 +1,251 @@
+(ns re-frame.adapter.reagent-slim-strict-mode-dom-cljs-test
+  "rf2-a07937 — the reagent-slim React.StrictMode double-mount DOM proof for
+  the bespoke class lifecycle + per-component render Reaction, under a React 19
+  `createRoot`.
+
+  STATUS (read before running): this file is the ACCEPTANCE GATE for a genuine
+  slim production bug this coverage exercise surfaced — see the FINDING block
+  below. Until that bug is fixed in `reagent2.impl.*`, assertions (a) and (b)
+  FAIL BY DESIGN (they encode the correct contract, which the substrate does
+  not yet honour). Do NOT weaken them to green; they go green when the
+  production fix lands. Per rf2-a07937's charter this file changes NO production
+  code — the fix is a separate bead.
+
+  WHY THIS FILE EXISTS. reagent-slim hand-rolls the entire class lifecycle
+  (`reagent2.impl.component`), the microtask render scheduler
+  (`reagent2.impl.batching`), and a per-component render Reaction. Its
+  `componentWillUnmount` UNCONDITIONALLY disposes + nils that render Reaction
+  (`install-lifecycle!`), and the render method lazily RECREATES it on the next
+  render (`make-render-method`). React.StrictMode's development simulated
+  unmount→remount stresses exactly that dispose/recreate + subscription re-wire.
+  Stock reagent / uix / helix all carry a StrictMode DOM scenario; slim did not
+  (Finding 1 of the rf2-x76af2.37 clarity-nit review, deferred here). The
+  sibling `reagent2/dom/client_cljs_test` proves the dispose by CALLING the
+  prototype `componentWillUnmount` directly — but that never drives React's real
+  reconciler, so the StrictMode reuse-state remount is unexercised. This file is
+  the load-bearing real-DOM regression.
+
+  ─────────────────────────────────────────────────────────────────────────────
+  FINDING (rf2-a07937 — a real slim bug this test surfaced):
+
+    Under React.StrictMode a slim component renders ONCE and then goes
+    reactively DEAD. StrictMode's dev sequence for a slim class is:
+
+        render ×2  →  componentDidMount  →  componentWillUnmount
+                   →  componentDidMount  (NO intervening render)
+
+    The transient `componentWillUnmount` disposes + nils the per-component
+    render Reaction. The remount's second `componentDidMount` fires WITHOUT React
+    calling `render()` again (StrictMode reuses the committed fiber output), so
+    slim — which recreates the render Reaction only lazily inside `render()` —
+    never re-establishes it. The remounted instance is left with
+    `cljsRenderRea = nil` and NO subscription watches: it never re-renders on an
+    app-db change. A/B empirically confirmed (same view, same harness): WITHOUT
+    StrictMode the component is fully reactive (dispatch → DOM updates); WITH
+    StrictMode a post-mount dispatch leaves the DOM stale.
+
+    Impact: any slim app wrapped in `<React.StrictMode>` (the React-recommended
+    dev default, scaffolded by CRA / Next.js) has components that stop
+    responding to state changes after mount. Fix belongs in `reagent2.impl.*`
+    (e.g. re-establish the render Reaction on `componentDidMount`, or force a
+    re-render when the cached reaction is absent) — a separate bead, NOT here.
+  ─────────────────────────────────────────────────────────────────────────────
+
+  WHAT IT ASSERTS, under `<React.StrictMode>` and driven by `act()` (which
+  drives StrictMode's mount→unmount→remount deterministically — `flushSync`
+  does NOT run the StrictMode remount synchronously; only `act` does, per the
+  stock frame-provider scenario-6 harness this file mirrors):
+
+    (a) DOM RE-RENDERS with the NEW value after the strict double-mount. A
+        subscribing slim reg-view is mounted under StrictMode; after the
+        double-mount settles the committed DOM shows the seeded value, and a
+        `dispatch` + `flush-render!` advances it to the dispatched value — i.e.
+        the surviving (remounted) instance's render Reaction is live + re-wired.
+
+    (b) The upstream RAtom's watch count RETURNS TO BASELINE across the
+        lifecycle. The probe view also derefs a plain upstream `r/atom`; the
+        render Reaction registers a watch on it via the same deref-capture edge
+        it uses for the subscription (so this RAtom is a faithful, churn-free
+        proxy for the render Reaction's watch graph — unlike the subscription
+        Reaction, which the sub-cache disposes + rebuilds across the remount).
+        Baseline is 0 before mount; EXACTLY 1 while mounted after the strict
+        double-mount (one live render Reaction — a leaked transient would read
+        2, a dead component reads 0); and 0 again after a genuine unmount.
+
+  TEST-ONLY. ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  discovers it for the real-DOM assertion; the `:node-test` runner also loads it
+  (matches `cljs-test$`), where the body gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent2.dom.client :as rdc]
+            [reagent2.core :as r]
+            ["react" :as React]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+;; MAP-FORM fixture (`:async? true`): cljs.test requires `:each` fixtures to be
+;; maps when the ns contains ANY `async` test (a fn-form fixture's teardown runs
+;; before the async body's `done` fires). The deftest below is act-driven across
+;; a real React StrictMode lifecycle, so it is async.
+;;
+;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's default
+;; ambient `*current-frame*` :rf/default scope. The probe is a reg-view whose
+;; `subscribe` resolves its frame from the enclosing `frame-provider` via the
+;; React-context tier — an ambient :rf/default scope would shadow that tier and
+;; read the wrong (empty) app-db. Mirrors the flush-render / sCU-gate DOM twins.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter
+     :async? true
+     :ambient-frame nil}))
+
+;; ---- browser gate ----------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(defn- get-act
+  "Return React's `act()` if available, else nil. React 19 promotes `act` to
+  the React namespace proper (the test infra pins react/react-dom 19.2.0). Used
+  to drive StrictMode's mount→unmount→remount double-invoke deterministically —
+  `flushSync` does NOT run the StrictMode remount synchronously."
+  []
+  (when (exists? (.-act React)) (.-act React)))
+
+(defn- watch-count
+  "Number of reagent2-level watchers currently wired on RAtom `ra`. `.-watches`
+  is the deftype's watch map (nil until the first watcher, then a CLJS map);
+  `count` of nil is 0. Each live render Reaction that derefs `ra` inside its
+  reactive context registers exactly one watch, so this counts live render
+  Reactions holding `ra` as a dependency."
+  [ra]
+  (count (.-watches ^js ra)))
+
+(defn- settle-macrotasks
+  "Resolve after `n` macrotask turns so the StrictMode remount + the microtask
+  render scheduler fully settle before asserting."
+  [n]
+  (js/Promise.
+    (fn [resolve _]
+      (letfn [(step [k] (if (zero? k) (resolve nil) (js/setTimeout #(step (dec k)) 4)))]
+        (step n)))))
+
+;; ---- the StrictMode double-mount DOM proof ---------------------------------
+
+(deftest strict-mode-double-mount-rerenders-and-returns-watch-to-baseline
+  "reagent-slim — a subscribing reg-view mounted under `<React.StrictMode>`
+   re-renders with the dispatched value across the strict double-mount, and the
+   upstream RAtom's watch count returns to baseline across the lifecycle
+   (rf2-a07937). ACCEPTANCE GATE — see the ns FINDING block: (a)/(b) fail until
+   the slim StrictMode-remount reactivity bug is fixed in production."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — :browser-test runner exercises the assertions")
+    (async done
+      (let [frame-kw     :rf.reagent-slim-strict/probe-frame
+            flush!       (:flush-render! reagent-slim-adapter/adapter)
+            ;; A plain reagent2 RAtom the probe view ALSO derefs. The render
+            ;; Reaction wires a watch onto it via the SAME deref-capture edge it
+            ;; uses for the subscription, so its `.-watches` count is a
+            ;; churn-free proxy for the render Reaction's watch graph. An RAtom
+            ;; (unlike a Reaction) never auto-disposes on empty watches, so its
+            ;; count is a clean baseline probe across the sub-cache churn the
+            ;; StrictMode remount causes.
+            upstream     (r/atom :leak-probe-baseline)
+            render-count (atom 0)
+            done?        (atom false)
+            ;; `done`-once guard: the act() thenable + macrotask chain has
+            ;; several exit paths (success, a thrown assertion, a rejection).
+            ;; Calling cljs.test's `done` twice aborts the suite, so funnel
+            ;; every exit through one guarded call.
+            done!        (fn [] (when (compare-and-set! done? false true) (done)))
+            mount-node   (make-mount-node!)
+            root         (rdc/create-root mount-node)
+            cleanup!     (fn [] (try (rdc/unmount root) (catch :default _ nil)))
+            act-fn       (get-act)]
+        (rf/make-frame {:id frame-kw :doc "StrictMode double-mount probe frame"})
+        (rf/reg-event ::seed (fn [{:keys [db]} _] {:db {:n 1}}))
+        (rf/reg-event ::inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+        (rf/dispatch-sync [::seed] {:frame frame-kw})
+        (rf/reg-sub ::n (fn [db _] (:n db)))
+        (rf/reg-view* :rf.reagent-slim-strict/probe
+                      (fn probe []
+                        ;; SUBSCRIBING view (drives the DOM assertion) that ALSO
+                        ;; derefs the upstream leak-probe RAtom (drives the
+                        ;; watch-count assertion). Both derefs register on this
+                        ;; render's Reaction.
+                        (let [n      @(rf/subscribe [::n])
+                              _probe @upstream]
+                          (swap! render-count inc)
+                          [:div "n=" n])))
+        (if (nil? act-fn)
+          (do (is true "act() not reachable from this runner; StrictMode scenario skipped")
+              (done!))
+          (let [render-fn (rf/view :rf.reagent-slim-strict/probe)]
+            ;; Baseline: nothing watches the upstream RAtom before mount.
+            (is (= 0 (watch-count upstream))
+                "baseline: no watcher on the upstream RAtom before mount")
+            (-> (js/Promise.resolve
+                  (act-fn
+                    (fn []
+                      ;; StrictMode wraps the frame-provider'd subscribing view.
+                      ;; `act` drives StrictMode's mount→unmount→remount so the
+                      ;; transient first instance's componentWillUnmount (which
+                      ;; disposes + nils its render Reaction) actually fires.
+                      (rdc/render root
+                                  [:> (.-StrictMode React)
+                                   [rf/frame-provider {:frame frame-kw}
+                                    [render-fn]]]))))
+                (.then (fn [_] (settle-macrotasks 3)))
+                (.then
+                  (fn [_]
+                    ;; StrictMode double-invokes the render body — the probe ran
+                    ;; more than once (evidence StrictMode is actually active, so
+                    ;; the assertions below are not vacuous).
+                    (is (>= @render-count 2)
+                        (str "StrictMode double-invoked the render body (got "
+                             @render-count " renders)"))
+                    ;; (a) initial: committed DOM shows the seeded value.
+                    (is (= "n=1" (.-textContent mount-node))
+                        "committed DOM shows the seeded value n=1 after the strict double-mount")
+                    ;; (b) after the strict double-mount, EXACTLY ONE live render
+                    ;; Reaction watches the upstream RAtom — the remounted
+                    ;; instance is reactive and no transient watch leaked. (Reads
+                    ;; 0 today: the remount leaves the render Reaction nil — the
+                    ;; FINDING bug. A leak would read 2.)
+                    (is (= 1 (watch-count upstream))
+                        (str "exactly one live render Reaction watches the upstream RAtom "
+                             "after the strict double-mount (remounted instance reactive, "
+                             "no leaked transient watch); got " (watch-count upstream)))
+                    ;; (a) re-render: dispatch advances the subscription; the
+                    ;; surviving instance's render Reaction is re-wired, so
+                    ;; flush-render! commits the new value.
+                    (flush! (fn [] (rf/dispatch-sync [::inc] {:frame frame-kw})))
+                    (is (= "n=2" (.-textContent mount-node))
+                        "DOM re-rendered with the dispatched value n=2 (render Reaction re-wired)")
+                    ;; Still exactly one watcher after the re-render — the
+                    ;; recreate-on-render path did not accumulate a second watch.
+                    (is (= 1 (watch-count upstream))
+                        "still exactly one watcher after the post-dispatch re-render (no accretion)")
+                    ;; Genuine final unmount under act.
+                    (js/Promise.resolve (act-fn (fn [] (rdc/unmount root))))))
+                (.then
+                  (fn [_]
+                    ;; After a genuine unmount the upstream watch count returns to
+                    ;; its pre-mount baseline of 0 — the render Reaction's
+                    ;; componentWillUnmount cleanly tore down its watch graph.
+                    (is (= 0 (watch-count upstream))
+                        (str "upstream watch count returned to baseline 0 after the genuine "
+                             "unmount (clean teardown); got " (watch-count upstream)))
+                    (cleanup!)
+                    (done!)))
+                (.catch
+                  (fn [err]
+                    (is false (str "StrictMode double-mount scenario threw: " (pr-str err)))
+                    (cleanup!)
+                    (done!))))))))))


### PR DESCRIPTION
## What

Lands **rf2-6b6pex** (P1 production fix) together with its acceptance test **rf2-a07937** in one green PR.

Under `React.StrictMode` a reagent-slim class runs `render ×2 → componentDidMount → componentWillUnmount → componentDidMount` with **no intervening render** on the remount (React reuses the committed fiber). The transient `componentWillUnmount` disposes + nils the per-instance render Reaction (`cljsRenderRea`); slim recreates that Reaction only lazily inside `render()` (`make-render-method`), so the remounted instance was left with `cljsRenderRea = nil` and no subscription watches — it rendered once, then ignored app-db changes (reactively dead). Any slim app wrapped in `<React.StrictMode>` (the CRA/Next dev default) stopped updating after mount.

## Fix

Surgical, in `reagent2.impl.component`:

- `componentWillUnmount`, when it disposes a **live** render Reaction, sets a `cljsRemountReattach` marker.
- `componentDidMount` is now **always installed** and, when that marker is present, clears it and forces a re-render via `batching/queue-render!` — `make-render-method` then recreates the Reaction and re-subscribes its deref'd watches.

The marker fires **only** on a dispose→remount of the same instance, so a normal first mount (render already ran, `cljsRenderRea` live, no marker) is untouched. The eager dispose+nil and dirty-flag clear in `componentWillUnmount` are unchanged, so the synchronous-dispose (`render-componentwillunmount-disposes-render-reaction`) and rf2-mdgt8t unit tests stay green — this is why the fix re-establishes on remount rather than adopting stock Reagent's deferred-dispose trick (which would regress those synchronous assertions).

The acceptance test's 3 previously-red assertions now pass: upstream RAtom watch count `0 → 1 → 0` across the lifecycle, and the DOM shows the dispatched value (`n=2`) after the strict double-mount.

## Quality gates

Run in the worktree, foreground, 0-fail:

- `npm run test:browser` — **290 tests, 1037 assertions, 0 failures, 0 errors** (includes the rf2-a07937 real-DOM gate).
- `npm run test:cljs` — **8978 tests, 42386 assertions, 0 failures, 0 errors** (no slim regression).
- `npm run test:reagent-slim:smoke` — **1 smoke, 0 failures**.

Closes rf2-6b6pex, rf2-a07937.