### PR TITLE
fix(ui): recover a live root when host .unmount throws (rf2-vxgfnd.53)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -508,12 +508,53 @@
   ownership is released in a `finally`, so a throwing host `.unmount`
   still frees the exact root-id/container claim (identity-guarded — never
   evicts a newer claim) and a second `unmount!*` is then a no-op; the
-  host teardown error still propagates to the caller. Returns nil."
+  host teardown error still propagates to the caller (rf2-vxgfnd.18 AC4).
+
+  AFTERMATH of a THROWING host `.unmount` (rf2-vxgfnd.53). The concrete
+  case is React 18/19 refusing to `.unmount` synchronously from inside a
+  render pass (\"attempted to synchronously unmount a root while React was
+  already rendering\"): React did NOT tear the tree down, yet the `finally`
+  releases the claim (the AC4 total-teardown contract, KEPT — the
+  root-id/container must not strand). So the live React tree is now
+  ORPHANED in a container the registry no longer tracks, and — because
+  release makes a second `unmount!*` a no-op (the membership guard) — the
+  framework can never retry the host unmount for that handle. A later
+  `mount` into the same container would `createRoot` OVER the still-live
+  tree (a double-root). The claim-release is deliberate; the orphaned tree
+  is the price of AC4.
+
+  So this is NOT silent: in a dev build a throwing `.unmount` emits a
+  console diagnostic naming the MANUAL ESCAPE — once you are out of the
+  render pass, tear the orphaned tree down yourself with
+  `(.unmount (.-react-root root))` on the SAME `Root` handle BEFORE
+  mounting into that container again. The diagnostic is goog.DEBUG-gated
+  (Closure-DCE'd from production — I-12). Returns nil."
   [^Root root]
   (when (and (some? root)
              (identical? (:root (get @live-roots (.-root-id root))) root))
     (try
       (.unmount (.-react-root root))
+      (catch :default e
+        ;; rf2-vxgfnd.53 — React did NOT unmount, yet the `finally` below
+        ;; still releases the claim (AC4). The live tree is now orphaned and
+        ;; the host root is unrecoverable through the framework (a second
+        ;; `unmount!*` is a no-op). Make the aftermath non-silent: name the
+        ;; manual escape + the remount double-root hazard. Dev-only
+        ;; (goog.DEBUG-stripped in production). Then rethrow the ORIGINAL host
+        ;; error so it still propagates to the caller (AC4).
+        (when (and ^boolean js/goog.DEBUG (exists? js/console))
+          (.warn js/console
+                 (str "[re-frame.ui] host .unmount threw while tearing down root "
+                      (pr-str (.-root-id root)) " — React did NOT unmount it, so "
+                      "its live React tree is now orphaned in a container the "
+                      "framework no longer tracks (the claim is released per the "
+                      "total-teardown contract, so a second unmount! is a no-op). "
+                      "A remount into this container would createRoot OVER the "
+                      "still-live tree (a double-root). Escape: once you are out "
+                      "of the render pass, tear the orphaned tree down yourself "
+                      "with (.unmount (.-react-root root)) on the SAME Root handle "
+                      "before mounting into that container again.")))
+        (throw e))
       (finally
         (release-root! (.-root-id root) root))))
   nil)

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -5,7 +5,8 @@
   preflight seam, and the S1 hydrate fail-loud. No DOM — containers are
   plain JS objects (ownership is identity-based); the full React mount
   path is the browser smoke (`re-frame.ui.root-mount-dom-cljs-test`)."
-  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [cljs.test :refer [deftest is testing use-fixtures]]
             [re-frame.error :as error]
             [re-frame.ui.client :as client]))
 
@@ -417,6 +418,77 @@
     (is (= #{:reg/id} (client/live-root-ids))
         "the newer claim survives")
     (is (identical? newer (:root (client/live-root-entry :reg/id))))))
+
+(defn- root-with-unmount-throws-once
+  "A Root whose host react-root's `.unmount` THROWS on its first call and
+  SUCCEEDS on every call after — models the concrete rf2-vxgfnd.53 case:
+  React refuses a synchronous unmount from inside a render pass, but the
+  SAME call succeeds once out of it. `calls` counts every `.unmount`."
+  [root-id container calls]
+  (let [rr (js-obj)]
+    (unchecked-set rr "unmount"
+                   (fn []
+                     (when (= 1 (swap! calls inc))
+                       (throw (js/Error. "unmount during render boom")))))
+    (client/->Root rr container root-id)))
+
+(deftest unmount-throw-aftermath-warns-and-names-the-escape
+  ;; rf2-vxgfnd.53 — the UNCOVERED aftermath of .18 AC4's release-on-throw
+  ;; (no test covered the React-didn't-unmount case). RULING (b): KEEP AC4
+  ;; (release the claim on a throwing host .unmount; a second unmount!* is a
+  ;; no-op; the host error propagates) — reversing it would contradict AC4's
+  ;; dedicated `unmount-releases-claim-even-when-host-teardown-throws` test —
+  ;; but make the ORPHANED-TREE aftermath non-silent with a dev diagnostic
+  ;; that names the manual escape, and prove the escape recovers the
+  ;; container so a subsequent mount does not double-root over a live tree.
+  (let [c        (js-obj)
+        calls    (atom 0)
+        root     (root-with-unmount-throws-once :reg/orphan c calls)
+        captured (atom [])
+        orig     (.-warn js/console)]
+    (client/register-live-root! {:root-id :reg/orphan :provenance :authored} c root)
+    (is (= #{:reg/orphan} (client/live-root-ids)))
+    ;; (1) AC4 preserved: the host error propagates, and a dev diagnostic
+    ;; fires on the throwing teardown (captured around this one call).
+    (try
+      (set! (.-warn js/console)
+            (fn [& args] (swap! captured conj (apply str args))))
+      (is (thrown-with-msg? js/Error #"unmount during render boom"
+                            (client/unmount!* root))
+          "the host teardown error still propagates (.18 AC4)")
+      (finally
+        (set! (.-warn js/console) orig)))
+    (is (= 1 @calls) "React's .unmount was reached exactly once (and it threw)")
+    (is (= #{} (client/live-root-ids))
+        "the exact claim is released despite the throw (.18 AC4, finally-shaped)")
+    (is (nil? (client/unmount!* root))
+        "a second unmount!* is a no-op — the framework cannot retry the host unmount")
+    (is (= 1 @calls)
+        "the no-op second unmount!* never reaches React's .unmount again")
+    ;; (2) rf2-vxgfnd.53: the aftermath is NON-SILENT — one dev diagnostic
+    ;; naming the manual escape VERBATIM + the double-root hazard.
+    (let [msg (str/join "\n" @captured)]
+      (is (seq @captured) "a dev diagnostic fired on the throwing unmount")
+      (is (str/includes? msg "(.unmount (.-react-root root))")
+          "the diagnostic names the manual escape verbatim")
+      (is (str/includes? msg "double-root")
+          "the diagnostic warns about the remount double-root hazard")
+      (is (str/includes? msg "orphaned")
+          "the diagnostic names the orphaned live tree"))
+    ;; (3) the documented ESCAPE WORKS: calling .unmount on the SAME handle
+    ;; now succeeds (out of the render pass), tearing the orphaned tree down.
+    (is (nil? (.unmount (.-react-root root)))
+        "the manual escape (.unmount (.-react-root root)) succeeds on retry")
+    (is (= 2 @calls) "the escape actually invoked React's .unmount again")
+    ;; (4) NO SILENT DOUBLE-ROOT: with the tree torn down (via the escape)
+    ;; AND the claim already released, a subsequent create-root* / mount
+    ;; re-claims the container cleanly — no createRoot over a live tree.
+    (client/check-root-claim! 're-frame.ui/mount
+                              {:root-id :reg/remount :provenance :authored} c)
+    (client/register-live-root! {:root-id :reg/remount :provenance :authored}
+                                c (fake-root :reg/remount))
+    (is (= #{:reg/remount} (client/live-root-ids))
+        "the container re-claims cleanly after the escape — no double-root")))
 
 ;; ---------------------------------------------------------------------------
 ;; React root options


### PR DESCRIPTION
## What

`unmount!*` releases the framework claim in a `finally`, so a **throwing host `.unmount`** — the concrete case being React 18/19 refusing to `.unmount` synchronously from inside a render pass (*"attempted to synchronously unmount a root while React was already rendering"*) — frees the exact root-id/container claim **even though React did NOT unmount**. Aftermath (rf2-vxgfnd.53, review finding A1):

- (a) a live React tree orphaned in a container the registry no longer tracks;
- (b) a second `unmount!*` is a guaranteed no-op (the membership guard) — the host root is unrecoverable *through the framework*;
- (c) a later `mount` into that container `createRoot`s **over** the still-live tree (a silent double-root).

This is the **uncovered aftermath** of rf2-vxgfnd.18's ruled release-in-finally design (AC4), **not a regression**. The error correctly propagates; no test covered the React-didn't-unmount case.

## Ruling — (b) document + dev diagnostic (NOT retain-claim)

Both options were on the table:

- **(a) retain-claim-on-unmount-throw (retryable)** — on a throwing `.unmount`, do *not* release; keep the entry so a later `unmount!` retries the host unmount (tree stays framework-recoverable).
- **(b) keep AC4's release-on-throw, add a dev diagnostic + docs.**

**I picked (b), because (a) directly contradicts rf2-vxgfnd.18 AC4.** AC4 is not merely "release on the success path" — it has a **dedicated test**, `unmount-releases-claim-even-when-host-teardown-throws`, that exercises the *throwing* teardown and asserts `(= #{} (client/live-root-ids))` *after* the throw ("the exact claim is released despite the throw (finally-shaped)"), plus a docstring stating "a throwing host `.unmount` still frees the exact root-id/container claim." Option (a) would require **inverting that sibling test's assertion** — i.e. reopening a ruled-and-tested design (AC4: the root-id/container must not strand). That is a Mike/mayor-level re-litigation, out of scope for a P3 aftermath bead. So AC4 stays; the fix makes the aftermath **non-silent** instead.

On a throwing `.unmount`, `unmount!*` now emits a **goog.DEBUG-gated** console diagnostic that names the **manual escape** `(.unmount (.-react-root root))` and the remount double-root hazard. The host error still propagates (rethrown after the diagnostic); the claim still releases in the `finally`. The `unmount!*` docstring documents the full aftermath + escape.

**No new catalogued `:rf.warning/*` id.** The diagnostic is a bare `[re-frame.ui]` dev advisory — precedented by the existing `ui/spread` `:key`/`:ref` advisories in `runtime.cljs`. This deliberately avoids a hot-zone touch: a stable `:rf.warning/*` id would trip the one-catalogue rule (rf2-cs0kd1, spec/004 §484-490) and force a spec/009 + spec/004 edit for a single dev advisory. If a first-class catalogued id is wanted, that's a trivial follow-up.

### Follow-up worth a decision bead (optional)
If Mike prefers the retryable-retain semantics (option a) over AC4's release-on-throw, that means **reopening rf2-vxgfnd.18 AC4** and inverting its `unmount-releases-claim-even-when-host-teardown-throws` test — a deliberate decision, not a drive-by. Flagging it rather than silently reversing.

## Coverage added

New node-level fixture `unmount-throw-aftermath-warns-and-names-the-escape` (react-root whose `.unmount` throws-then-succeeds, modelling "refuses during render, succeeds once out of it"):

1. AC4 preserved — the host error propagates, the claim releases (`live-root-ids` → `#{}`), a second `unmount!*` is a no-op that never re-reaches React's `.unmount`;
2. the aftermath is **non-silent** — the dev diagnostic fires and names the escape **verbatim** + the double-root hazard + the orphaned tree;
3. the documented **escape works** — a direct `(.unmount (.-react-root root))` tears the orphaned tree down (proven by the call counter);
4. **no silent double-root** — after the escape, the container **re-claims cleanly** (no `duplicate-root`/`container-in-use`, no createRoot over a live tree).

## Surface

`implementation/ui/src/re_frame/ui/client.cljs` (unmount!* + its docstring) and its ui test `implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs`. No other file touched — no hot-zone edit.

## Quality gates

Foreground, unpiped, 0-fail (incl. rf2-vxgfnd.18's existing throwing-teardown tests staying green):

- `npm run test:ui` (focused ui node) — **244 tests / 1332 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full node-runtime CLJS) — **8985 tests / 42434 assertions, 0 failures, 0 errors**
- `implementation/ui` `clojure -M:test` (ui JVM) — **263 tests / 4535 assertions, 0 failures, 0 errors**

`test:browser` not run: the new coverage injects the throw via a fake react-root (no DOM fixture added).
