### PR TITLE
docs(spec): discharge 004B S1-CONFIRM rows + close 004D demand-bar to the shipped impl (rf2-vxgfnd.49, rf2-vxgfnd.50)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -195,8 +195,13 @@ emitter emits attributes only; property-props are applied at hydration. Rejected
 Lit-style rich schema (no consumer — demand bar), React-19-style runtime `in` check
 (breaks compile-time totality + gives SSR no static answer), attribute-only-v1 deferral
 (makes property-accepting web components unusable, hollowing "never through
-`ui/raw`"). Ships with the S4 epic; `ui/custom-element` added to the 12 §2 freeze
-table as the delta protocol's first row-level delta.
+`ui/raw`"). **Export-at-S1, assert-at-S4:** the *name* is in the blessed **S1** export
+set (`re-frame.ui`'s S1 public surface, per [API.md](API.md) §Compiled views), so
+`ui/custom-element` is exported and callable from S1 — declaring a name never errors as
+an unknown symbol — but its property-vs-attribute **classification behaviour and
+stage-conformance assertion ship with the S4 epic** (the API.md table stages the row
+S4). `ui/custom-element` is added to the 12 §2 freeze table as the delta protocol's
+first row-level delta.
 
 ## Handlers are data — the callback law
 

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -97,7 +97,10 @@ read surface. Text is therefore not a *queryable node*: selectors never match it
   px rule, values stringified verbatim **[S1-CONFIRM]**; keyword values → `name`;
   nil entries dropped.
 - keyword/symbol values (any attr) → `(name x)` (`:data-priority :high` → `"high"`
-  ); a namespaced keyword's namespace is ignored with a dev diagnostic.
+  ); a namespaced keyword's namespace is **silently ignored** — the shipped dynamic
+  path (`re-frame.ui.rules/attr-val-semantic`, `css-val->str`) applies `(name x)` with
+  no diagnostic (`:data-priority ::high` → `"high"`, the namespace dropped without a
+  warning).
 - numbers → **JS `ToString` semantics** — integral doubles render without a trailing
   `.0` (the JVM emitter must not leak `(str 1.0)` → `"1.0"`) **[S1-CONFIRM]** for the
   integral-double case; integer fixtures.
@@ -140,9 +143,12 @@ tree). Children of void elements are a compile error **[S1-CONFIRM]** (React thr
 render; we reject earlier).
 
 **Canonical uniqueness, stated once:** absent-when-empty for `:attrs`/`:events`/
-`:children`; no nil attr entries; `:ns` absent for HTML; text coalesced. One semantic
-tree has exactly one representation — this is what makes the tree a legitimate
-fingerprint input.
+`:children`; no nil attr entries; `:ns` absent for HTML; text coalesced. **One pinned
+exception:** a **fragment** node retains `:children []` when empty, because `:children`
+is its *required discriminator* (§Node schema) — an empty fragment is `{:children []}`,
+never `{}` (which is malformed). Element and view-boundary `:children`, being optional,
+are absent when empty as normal. One semantic tree has exactly one representation — this
+is what makes the tree a legitimate fingerprint input.
 
 ### Versioning
 
@@ -214,8 +220,10 @@ parsed into semantic nodes (the spike comparator is the reference).
 ## The DOM conversion table — normative rows
 
 One table, two consumers (the client emitter and the JVM serialiser), exactly as the
-spike validated. Provenance per row: = spike-exercised; **[S1-CONFIRM]** =
-written to React's published behaviour, unexercised — Stage 1 confirms.
+spike validated. Provenance per row: = exercised (the spike, or the **S1b/S1f
+react-dom 19.2.0 probes** — the latter noted inline where they *corrected* the
+pre-probe draft); **[S1-CONFIRM]** = written to React's published behaviour,
+unexercised — Stage 1 confirms.
 
 ### Namespaces
 
@@ -243,16 +251,16 @@ written to React's published behaviour, unexercised — Stage 1 confirms.
 
 | Row | Rule |
 |---|---|
-| boolean attrs | `true` → `checked=""` (empty-string presence), `false`/absent → omitted; the set is React's published HTML boolean-attribute list **[S1-CONFIRM]** |
-| enumerated exception | `hidden` accepts `"until-found"` as a string value in addition to boolean behaviour **[S1-CONFIRM]** |
-| booleanish strings | `:content-editable` / `:draggable` / `:spell-check`: `true`/`false` → `"true"`/`"false"`, never omitted **[S1-CONFIRM]** |
-| overloaded booleans | `:download`, `:capture`: `true` → bare presence, `false` → omitted, any other value → stringified value **[S1-CONFIRM]** |
+| boolean attrs | `true` → `checked=""` (empty-string presence), `false`/absent → omitted; the set is the react-dom/server 19.2.0 boolean-attribute list, probed row-by-row (S1b) — it includes `hidden`, `muted`, and `ismap` (React 19 dropped the camel `isMap` prop) |
+| `hidden` (probe-corrected) | a **pure boolean** attr, not an enumerated exception: `true`/`"until-found"`/any truthy → bare presence (`hidden=""`), `false`/absent → omitted. The pre-probe draft's `"until-found"` string-value carve-out was **falsified** — react-dom/server 19.2.0 renders `hidden="until-found"` as bare presence like any truthy value (S1b probe) |
+| booleanish strings | `:content-editable` / `:draggable` / `:spell-check`: `true`/`false` → `"true"`/`"false"`, never omitted (S1b probe: `contentEditable`/`draggable`/`spellCheck`) |
+| overloaded booleans | `:download`, `:capture`: `true` → bare presence, `false` → omitted, any other value → stringified value (S1b probe) |
 
 ### Property-only and form-control special forms
 
 | Row | Rule |
 |---|---|
-| property-only names | names React never serialises to markup (`:muted` is the known citizen) emit **nothing** on the JVM; the client emitter sets the DOM property **[S1-CONFIRM]** |
+| property-only names | names React never serialises to markup emit **nothing** on the JVM (the client emitter sets the DOM property). **Probe-corrected (S1b):** the pre-probe draft's `:muted` citizen was **falsified** — react-dom/server 19.2.0 *does* serialise `muted=""` on `<video>` (so `:muted` is a boolean attr, above); **no S1 member remains**, and the `property-only-attrs` set is kept **empty** as the named home for any future member the parity corpus finds |
 | `:value` on `:input` | serialises as the `value` attribute |
 | `:default-value` / `:default-checked` | serialise as `value` / `checked` attributes **[S1-CONFIRM]** |
 | `:value` on `:textarea` | serialises as the element's **text child**, not an attribute **[S1-CONFIRM]** |
@@ -290,7 +298,7 @@ written to React's published behaviour, unexercised — Stage 1 confirms.
 | Row | Rule |
 |---|---|
 | escaping | full 5-char escaping (`& < > " '`) in text and attribute values; `ui/html` is the single bypass |
-| void elements | the HTML void set (`area base br col embed hr img input link meta source track wbr`); self-closing normalized; children = compile error **[S1-CONFIRM]** |
+| void elements | the void set that self-closes and rejects children (compile error): `area base br col embed hr img input keygen link meta param source track wbr` — **15** tags, the S1b probe adding `param` + `keygen` to the pre-probe draft's 13 (react-dom/server 19.2.0 throws for children on both). `menuitem` **also rejects children** but is *not* self-closing, so it lives in the children-rejected set only (`children-rejected-tags` = void ∪ `{:menuitem}`). Self-closing normalized (S1b probe) |
 | numeric text | JS `ToString` (integral doubles without `.0`) **[S1-CONFIRM]** |
 | adjacent text | coalesced in the tree (canonical form); **the serialiser's hydration text-separator behaviour (`<!-- -->` between originally-distinct dynamic text runs) is an open 011-owned row** — React hydration distinguishes text-node boundaries, `renderToStaticMarkup` does not; a hydration fixture must settle what our emitter writes **[S1-CONFIRM]** |
 | no handler attributes | event data never serialises into HTML — no `onclick="…"`, ever |
@@ -333,7 +341,12 @@ shapes.
   `{:got … :supported #{1}}` — fail-loud at the boundary, matching the artifact's
   construction-time error posture (`:rf.error/ssr-missing-payload-policy` style).
   Malformed nodes past the version gate throw `:rf.error/ui-tree-malformed` (shared
-  with all tree consumers). Both ids need Spec 009 catalogue rows at promotion.
+  with all tree consumers). Spec 009 rows land with the stage that ships each id (004's
+  rows-land-with-stages rule): `:rf.error/ui-tree-malformed` **already has its catalogue
+  row** (landed with S1 — the shared tree-consumer id, which also carries the
+  semantic-`N` root-version-gate arm); `:rf.error/ssr-ui-tree-version-unsupported` is the
+  SSR-seam sibling whose row **lands with the S5 serialiser** that raises it — not yet
+  catalogued, by design.
 - The compiled root render pipeline (011's per-root flow) is: JVM emitter → tree →
   `emit-ui-tree`; the response accumulator, error projection, and payload machinery are
   unchanged `re-frame2-ssr` surfaces.
@@ -344,16 +357,23 @@ shapes.
 2. Namespace context rules: svg inheritance, `foreignObject` reversion, MathML,
    `annotation-xml` HTML island.
 3. `xlink:`/`xml:` attribute mapping.
-4. Boolean-attribute set completeness + `hidden="until-found"` enumerated exception.
-5. Booleanish strings (`content-editable`/`draggable`/`spell-check`).
-6. Overloaded booleans (`download`, `capture`).
-7. Property-only never-serialised names (`muted` et al.).
+4. Boolean-attribute set completeness — **DISCHARGED (S1b probe).** No
+   `hidden="until-found"` enumerated exception: `hidden` is a **pure boolean** (the
+   pre-probe string-value carve-out was falsified).
+5. Booleanish strings (`content-editable`/`draggable`/`spell-check`) — **DISCHARGED
+   (S1b probe).**
+6. Overloaded booleans (`download`, `capture`) — **DISCHARGED (S1b probe).**
+7. Property-only never-serialised names — **DISCHARGED (S1b probe):** `muted`
+   *does* serialise (`muted=""`); no S1 member remains, the set is kept empty.
 8. Form-control special forms (`textarea` value→child; `select` value→`selected`;
    `default-value`/`default-checked`→`value`/`checked`).
 9. Style unitless-set copy + custom-property (`--*`) rows.
 10. Integral-double text/attr values (JS `ToString`, no `.0`).
 11. Duplicate-key detection under React string coercion.
-12. Void-element set + children-rejection parity with React's throw list.
+12. Void-element set + children-rejection parity with React's throw list —
+    **DISCHARGED (S1b probe):** 15-tag void set (`param` + `keygen` added to the draft's
+    13); `menuitem` rejects children but is not self-closing, so it is children-rejected
+    only.
 13. Adjacent-text hydration separators (011-owned fixture).
 14. `:for` → `for`/`htmlFor` alias.
 15. Custom-element event-type registration (kebab tail verbatim) vs React 19.

--- a/spec/004D-UI-Test-Selectors.md
+++ b/spec/004D-UI-Test-Selectors.md
@@ -27,12 +27,14 @@ selector := tag-kw        ; unqualified keyword — element tag
           | view-sel      ; qualified keyword (registered view id) or the defview Var
           | attr-map      ; map of attr-key → expected value, matched by rf=
           | pred-fn       ; (fn [node] boolean) — the escape
-          | [selector+]   ; path composition (descendant steps)
 ```
 
 No other form is a selector. Deliberately absent: sibling/nth/positional combinators,
 wildcard, text-content selectors, attribute-presence-without-value — no guide example or
-07 §3 fixture needs them; `pred-fn` covers the residue.
+07 §3 fixture needs them; `pred-fn` covers the residue. The path/vector form
+`[selector+]` is a **demand-bar-deferred item — not shipped at S1** (Stage 1 answered
+the demand bar; see [OPEN-2]); a vector selector raises `:rf.error/ui-test-bad-selector`
+naming the composed-`find` idiom `(find (find tree :form) :button)`.
 
 - **`tag-kw`** — an **unqualified** keyword matches a node whose element tag is that
   keyword, exactly (`:button` matches a `:button` element node; no substring, no
@@ -65,27 +67,20 @@ wildcard, text-content selectors, attribute-presence-without-value — no guide 
   hatch (escapes advertise their cost, I-14): reach for it only when the three data
   forms cannot express the match. *Consumer:* harness completeness; keeps the data
   grammar closed instead of growing combinators.
-- **`[selector+]`** — path composition: `[:form :button]` finds a `:button` **descendant**
-  of a `:form` match. Pure composition — zero new matcher semantics (see below).
-  *Consumer:* row-scoped assertions in keyed-list fixtures (Stage 1 "keyed lists" +
-  G-9-style Tier-1 intent checks: the button *inside* row 42's node). *(See [OPEN-2].)*
 
 ## Matching semantics
 
 - **Traversal order** is depth-first pre-order — document order — over the tree's
   **map nodes** (elements, fragments, view boundaries, trusted-HTML), descending
   through fragment and view-boundary children alike; trusted-HTML nodes are leaves
-  (their markup is unparsed) and text content is not visited. A single (non-vector)
-  selector is tested against the given node itself **and** its descendants, in that
-  order.
+  (their markup is unparsed) and text content is not visited. A selector is tested
+  against the given node itself **and** its descendants, in that order.
 - **`find`** returns the **first** match in document order, or misses (§Failure).
   **`find-all`** returns a vector of **all** matches in document order (possibly empty).
-- **Path steps** — for `[s1 s2 … sn]`: match `s1` per the rule above; each subsequent
-  step `sk+1` is matched against the **strict descendants** (excluding the step-`k` node
-  itself) of each step-`k` match. The result set is the union of final-step matches,
-  de-duplicated, in document order of the whole tree. Consequences: `[s]` ≡ `s`;
-  `[:form :form]` finds a *nested* form, never the same node twice; steps are the
-  descendant axis, not direct-child (no child combinator — unearned).
+- **Descendant-scoped assertions compose `find`** — a found node is itself a valid
+  `tree` argument, so `(find (find tree :form) :button)` finds a `:button` descendant of
+  the first `:form` match. This composition is the supported idiom; the sugar `[selector+]`
+  path form is demand-bar-deferred and not shipped (see [OPEN-2]).
 
 ## What `find` returns
 
@@ -95,7 +90,8 @@ field names (`:tag` / `:attrs` / `:events` / `:children` / `:view-id` / …) are
 contract's versioned public ABI. Its read surface:
 
 - **Queryable.** A node is itself a valid `tree` argument: `(find (find tree :form)
-  :button)` composes (this is what the vector form folds over).
+  :button)` composes — the supported idiom for descendant-scoped assertions (the
+  `[selector+]` path sugar that would fold over it is demand-bar-deferred; see [OPEN-2]).
 - **Keyword lookup reads the node's *fields*, never its attributes.** Attrs and events
   live under their own keys (`(:events node)`, `(:attrs node)`), so `(:on-click node)`
   is a field miss — the ruled node-reading contract (09 §codex2 row 2). The attribute
@@ -125,13 +121,15 @@ the tree contract, which this grammar consumes.
   `(ui.test/attrs nil)` is `nil` per the tree contract's projection rules — so
   assertions fail with `nil ≠ expected`.
 - **`find-all` → `[]`** on no match.
-- **`ui.test/find!`** — the strict variant: identical selector semantics; **throws** a
-  typed `ex-info` on zero matches, carrying the selector, the search root's tag/view-id,
-  and a bounded tree digest (the miss diagnostics `nil` cannot give). It does **not**
-  police uniqueness — first match wins even when several exist; a getBy-style
-  uniqueness-asserting variant is unearned (no consumer). Recommended error id:
-  `:rf.error/ui-test-find-miss` — needs its Spec 009 catalogue row and a 07 §2 contract
-  row on promotion. *(See [OPEN-3].)*
+- **`ui.test/find!`** — the recommended strict variant (demand-bar item OPEN-3, **not
+  shipped at S1**): identical selector semantics; it would **throw** a typed `ex-info` on
+  zero matches, carrying the selector, the search root's tag/view-id, and a bounded tree
+  digest (the miss diagnostics `nil` cannot give). It would **not** police uniqueness —
+  first match wins even when several exist; a getBy-style uniqueness-asserting variant is
+  unearned (no consumer). Recommended error id: `:rf.error/ui-test-find-miss` — its Spec
+  009 catalogue row and 07 §2 contract row land **with the feature** when it ships
+  (rows-land-with-features), not at S1 promotion. S1 promoted without `find!`, so
+  `:rf.error/ui-test-find-miss` is correctly **un-catalogued** today. *(See [OPEN-3].)*
 
 ## Tier-3 by contrast — `(ui.test/query root css-selector)`
 
@@ -163,13 +161,17 @@ only when a fixture does. `attrs`/`text` on a DOM element, or a CSS string hande
   view-id selector matches the boundary marker itself. Fragment-rooted and nil-rooted
   views **are matchable** — the boundary node exists (with several children, or none)
   even when no single root element does.
-- **[OPEN-2] Path-form demand.** The vector form's named consumer (row-scoped keyed-list
-  assertions) is projected from Stage-1 fixtures, not yet a written guide example. If no
-  Stage-1 fixture or guide example materialises the need, drop the form at the demand-bar
-  audit — it is pure sugar over node-composed `find`, so dropping it costs nothing.
-  *(Premise unchanged by the tree contract.)*
-- **[OPEN-3] `find!` inclusion.** Recommended in (miss diagnostics; every Tier-1 test is
-  the 08 §3 consumer for `ui.test/*`), but it is the one name here beyond 07 §2's table —
-  confirm at the demand-bar audit and add the 07 §2 row + 009 catalogue row together.
-  *(Premise unchanged; the "bounded tree digest" it carries can now be defined as a
-  truncated canonical-EDN print per the tree contract's canonical form.)*
+- ~~**[OPEN-2] Path-form demand.**~~ — **RESOLVED (2026-07-12): dropped.** No Stage-1
+  fixture or guide example materialised the need, so the vector/path form was **not
+  shipped** — `re-frame.ui.test` raises `:rf.error/ui-test-bad-selector` for any vector
+  selector, naming the composed-`find` idiom `(find (find tree :form) :button)`. The form
+  was pure sugar over node-composed `find`, so dropping it cost nothing; re-open only when
+  a fixture demands it.
+- **[OPEN-3] `find!` inclusion — deferred at the S1 demand-bar audit.** Recommended (miss
+  diagnostics; every Tier-1 test is the 08 §3 consumer for `ui.test/*`), but it is the one
+  name here beyond 07 §2's table and no Stage-1 fixture forced it — S1 shipped **without**
+  `find!` (`find` nil-punning + composed asserts covered the need). It remains a
+  recommended future addition: when it ships, add the 07 §2 row and the
+  `:rf.error/ui-test-find-miss` 009 catalogue row **together with the feature**. *(The
+  "bounded tree digest" it carries can now be defined as a truncated canonical-EDN print
+  per the tree contract's canonical form.)*


### PR DESCRIPTION
Two spec-discharge beads reconciling normative 004 spec text with what the **shipped S1 implementation** actually does (the spec is the artefact — spec contradicting the probe-validated impl is a real defect). Both rulings: **align-spec-to-shipped** (pre-alpha, demand-gated). Every claim was verified against `implementation/ui/src/re_frame/ui/{rules,tree,test}.cljc`; no impl-is-outlier findings. One PR, two commits.

## Commit 1 — rf2-vxgfnd.49 (004B [S1-CONFIRM] discharge)

The S1b/S1f react-dom 19.2.0 probes exercised rows 004B still carried as pre-probe text; three were **falsified**. An emitter built from 004B alone would diverge from the reference.

- **`hidden` (a)** — NOT an enumerated exception; a **pure boolean** (`rules.cljc` `boolean-attrs`). `"until-found"` renders bare presence like any truthy value. Row + roster corrected.
- **`:muted` property-only (b)** — **falsified**: react-dom/server serialises `muted=""`; `property-only-attrs` is deliberately **empty** (no S1 member). Row + roster corrected.
- **void set (c)** — **15** tags (`:param` + `:keygen` added to the draft's 13); `:menuitem` rejects children but is not self-closing → `children-rejected-tags` only. Row + roster corrected.
- **fragment `:children []` (d)** — added the pinned carve-out: absent-when-empty does NOT apply to a fragment's *required `:children` discriminator* (`tree.cljc` keeps `[]`; `{}` is malformed).
- **SSR 009 pledge (e)** — aligned to rows-land-with-stages: `:rf.error/ui-tree-malformed` already has its row (landed S1); `:rf.error/ssr-ui-tree-version-unsupported` lands with the S5 serialiser (verified current 009 state post-#5741).
- **namespaced attr keyword (f)** — the shipped dynamic path (`attr-val-semantic`/`css-val->str`) drops the namespace **silently, no diagnostic**. Removed the never-built dev-diagnostic promise. *(See ruling below.)*
- **custom-element (g)** — 004-Views clarified **export-at-S1 / assert-at-S4** (name in the blessed S1 export set; classification behaviour + conformance ship with S4). **API.md NOT touched** — the tension resolves in 004 alone; API.md's table already carries the per-row S4 stage, so it is self-consistent.

Discharged the `[S1-CONFIRM]` markers on the five probe-exercised rows (boolean/hidden/booleanish/overloaded/void); genuinely-unexercised rows (SVG aliases, namespaces, form-control, unitless, integral-double, dup-key, hydration separators, custom-element events) keep theirs.

## Commit 2 — rf2-vxgfnd.50 (004D demand-bar closure)

- **`[selector+]` path form** — DROPPED from §The grammar (closed) and §Matching semantics. `re-frame.ui.test` throws `:rf.error/ui-test-bad-selector` for ANY vector selector (demand-bar OPEN-2, `test.cljc:315-324`); the shipped error already teaches composed `find` — `(find (find tree :form) :button)`. Recorded as OPEN-2 RESOLVED: dropped.
- **`find!`** — its 009-row pledge said "on promotion"; promotion happened and `find!` is unshipped (`:rf.error/ui-test-find-miss` = zero 009 hits). Aligned to rows-land-with-features; OPEN-3 marked deferred at the S1 demand-bar audit.

The 009 `ui-test-bad-selector` row already describes the OPEN-2 form as not-shipped, so no 009 change was needed.

## Rulings

- **Both align-spec-to-shipped, confirmed.** No impl-is-outlier findings — every probed/shipped behaviour is the correct SOTA answer; the spec was the stale party.
- **(f): amended the spec, did NOT add a rules.cljc diagnostic.** The diagnostic option was considered and rejected — it would change behaviour on a hot render path (`attr-val-semantic` runs for every dynamic keyword attr value, shared with `ui/spread`) for a soft edge case (a namespaced keyword *value* still yields a sensible `name` string, not garbage). If a diagnostic is later wanted, that's a separate feature bead, not a spec-discharge. **No runtime files changed.**
- **API.md (hot-zone) NOT touched.** Flagged per the brief — the (g) tension resolves entirely in 004-Views.md.

## Quality gates

- `python scripts/check_doc_slugs.py` → **exit 0** (run after each commit + post-rebase).
- `mkdocs --strict` soft-skips locally (CI covers it).
- **No runtime change** → ui `clojure -M:test` / `npm run test:cljs` not required (spec-only PR).
- Rebased clean onto `origin/main`; 0 behind.
