### PR TITLE
chore: sweep the last Causa product-name residue to Xray

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -183,9 +183,9 @@ jobs:
 
       - name: Run MCP client conformance
         # rf2-mw1c0: previously had `npm run test:xray` here, a stale
-        # leftover from the rf2-3pdp9 Causa→Xray rename (PR #2067). The
-        # underlying `test:causa` npm script was deleted a week earlier
-        # in rf2-bu21t (the causa-mcp drop) so the rename mechanically
+        # leftover from the rf2-3pdp9 Xray rename (PR #2067; from the tool's pre-rename name). The
+        # underlying pre-rename npm test script was deleted a week earlier
+        # in rf2-bu21t (the tool-MCP drop) so the rename mechanically
         # produced a reference to a script that has never existed. The
         # Xray MCP server isn't built yet — there is nothing to invoke
         # here. Remove the line; revisit if/when an Xray MCP conformance

--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -6,8 +6,8 @@
 # silent until the workflow next fires. For cron-only workflows
 # (`expensive-tests.yml` runs at 15:17 UTC daily) that's up to 24h of
 # silent breakage. The rf2-mw1c0 incident burnt 5+ consecutive nights:
-# the Causa→Xray rename (PR #2067) mechanically renamed
-# `npm run test:causa` to `npm run test:xray` at expensive-tests.yml
+# the rf2-3pdp9 Xray rename (PR #2067; from the tool's pre-rename name) mechanically renamed
+# the tool's pre-rename npm test script to `npm run test:xray` at expensive-tests.yml
 # line 191, but the underlying npm script had already been deleted a
 # week earlier — and nobody noticed for 5 nights because nightly is the
 # only thing that runs it.

--- a/docs/EP/EP-0002-frame-target-resolution.md
+++ b/docs/EP/EP-0002-frame-target-resolution.md
@@ -1212,7 +1212,7 @@ The contract is authored as the appendix argues — *one carried invariant*, the
   ambiguous → unselected*.
 - **R6 — Lead the rationale with replay determinism (appendix G).** A
   silently-defaulted frame **poisons replay** — epoch replay, `restore-epoch!`,
-  time-travel, and Story / Causa determinism become unsound. "Frames are carried so
+  time-travel, and Story / Xray determinism become unsound. "Frames are carried so
   history is replayable" is the central argument; the benchmark libraries
   (TanStack / Redux / Apollo / Relay) are supporting, not central. Detection shifts
   left where the shape allows (conformance lint + registration-time flagging), and
@@ -1562,7 +1562,7 @@ Then reconcile `:rf.error/no-frame-context`, `:ambiguous-frame`, and `:rf.tool/n
 
 Three sharpenings that use machinery the project already has:
 
-- **Lead with replay determinism, not the benchmark libraries.** TanStack / Redux / Apollo justify explicit providers for *view hooks*. re-frame2's decisive argument is one none of them can make: a silently-defaulted frame **poisons replay**. If an operation's target frame cannot be reconstructed *from data*, then epoch replay, `restore-epoch!`, time-travel, and Story / Causa determinism are unsound — the same record can re-run against a different frame. "Frames must be *carried* so history is *replayable*" is the re-frame2 sentence; the benchmark table is supporting, not central.
+- **Lead with replay determinism, not the benchmark libraries.** TanStack / Redux / Apollo justify explicit providers for *view hooks*. re-frame2's decisive argument is one none of them can make: a silently-defaulted frame **poisons replay**. If an operation's target frame cannot be reconstructed *from data*, then epoch replay, `restore-epoch!`, time-travel, and Story / Xray determinism are unsound — the same record can re-run against a different frame. "Frames must be *carried* so history is *replayable*" is the re-frame2 sentence; the benchmark table is supporting, not central.
 - **Shift detection left.** The EP makes every failure a *runtime* error and adds a *grep* as the regression guard. The best error is the one that cannot be written. Promote the static sweep to a first-class **conformance lint** in CI (part of the contract, not a regex in prose), and let `reg-view` / macro expansion flag a bare `rf/dispatch` in a view body where the injected frame-bound `dispatch` was the intended call. Catch at compile / registration where the shape allows; reserve runtime errors for the genuinely dynamic async case.
 - **Attribute the frameless error causally.** The suggested payload is *static* (`:operation :where :event-id`). re-frame2 already threads `:rf.trace/dispatch-id` / `:rf.trace/parent-dispatch-id`. A no-frame error should carry its *capture-site ancestry* — "this callback was captured at handler X in frame Y; the cascade ended; the continuation fired with no stamp" — so the hardest case (the EP's own "brutal to debug" async clobber) becomes fully attributed through the existing correlation graph, even though the error itself is frameless.
 

--- a/docs/EP/EP-0021-infinite-resources.md
+++ b/docs/EP/EP-0021-infinite-resources.md
@@ -663,7 +663,7 @@ guide-impact assessment.
 7. **Guide + dogfood**: rewrite `docs/core/how-to/paginate-a-feed.md` to teach
    numbered-vs-infinite and the new primitive; add a flagship example feed; add
    conformance + small synthetic tests (not Playwright — per the standing
-   Causa/Story CLJS-unit-test default).
+   Xray/Story CLJS-unit-test default).
 
 ## Open Issues
 

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -233,7 +233,7 @@
 ;; NOT purity (per EP-0002 §Resolved Decisions R1-R7):
 ;;
 ;;   - A silently-defaulted frame poisons replay — `restore-epoch!`,
-;;     time-travel, and Story / Causa determinism all become unsound the
+;;     time-travel, and Story / Xray determinism all become unsound the
 ;;     moment an operation's target depends on which frame happened to be
 ;;     ambient rather than on a value carried in the token being replayed.
 ;;   - "sole live frame" is true only until a second frame appears, so an

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -198,7 +198,7 @@ different policy on absence.
   wrong target writes silently, and the operation must replay. Absence is
   `:rf.error/no-frame-context`. The justification is **replay determinism +
   temporal non-locality**, not purity: a silently-defaulted frame poisons replay
-  (`restore-epoch!`, time-travel, Story / Causa determinism all become unsound), and
+  (`restore-epoch!`, time-travel, Story / Xray determinism all become unsound), and
   "sole live frame" is true only until a second frame appears — so an ambient floor
   would let adding Xray, Story, or an SSR frame silently change the meaning of
   distant, untouched application code.

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -1168,7 +1168,7 @@ The `:variants` map desugars at macro-expansion time to N independent `reg-varia
 - **The component and every dispatched event are already registered** (`:view` / `:event` kinds). A story is a demonstration, not a place to define new app behaviour.
 - **Ids follow the library-owned prefixes** (`:story.*` / `:Workspace.*`); the hierarchy is recoverable from the id alone — no separate `:title` field.
 - **Args resolve by precedence:** global < story < variant (deep-merge). Declare shared args once on the story; override per-variant.
-- **A variant tagged `:test`** doubles as a headless fixture — drive it from a `cljs.test` deftest via `run-variant` (Story is Causa/Story CLJS-unit-first; a Playwright spec is the exception, not the default).
+- **A variant tagged `:test`** doubles as a headless fixture — drive it from a `cljs.test` deftest via `run-variant` (Story is Xray/Story CLJS-unit-first; a Playwright spec is the exception, not the default).
 
 **Smoke test (headless via `run-variant`, per [tools/story/spec/Tutorial-CLJS-Unit.md](../tools/story/spec/Tutorial-CLJS-Unit.md)):**
 

--- a/tools/story/spec/Migration-Audit.md
+++ b/tools/story/spec/Migration-Audit.md
@@ -330,7 +330,7 @@ A path-filter that runs Playwright only when:
 - `testbeds/ssr_*/**` or `implementation/ssr/**` touched (SSR impact)
 - `tools/xray/spine/**` or `tools/story/render-shell/**` touched (chrome impact)
 
-Otherwise skip. This was the rf2-k9ekz sister bead — **now landed** (CLOSED, PR #1688: the Story/Causa browser Playwright trigger was tightened to fire only on `tools/{story,causa}/src/**` + the framework-testbeds split).
+Otherwise skip. This was the rf2-k9ekz sister bead — **now landed** (CLOSED, PR #1688: the Story/Xray browser Playwright trigger was tightened to fire only on the story + xray src trees (path spellings as they were pre-rename) + the framework-testbeds split).
 
 **Screenshot-baseline subset?** Not warranted yet. The palette-drift gate (rf2-z7ms8) already deterministically catches token/color regressions. A pixel-baseline subset adds Argos/Chromatic egress + flakiness risk for marginal coverage. Defer until a chrome regression slips through palette-drift in practice.
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -37,8 +37,8 @@
       rf2-l0us2).
 
   Asserting the projected ROWS / LABELS / records are unambiguous is the
-  testable proxy for 'the devtools render legibly' — this is a Causa/Story-
-  style CLJS unit test (per `feedback_causa_story_cljs_unit_tests_not_playwright`),
+  testable proxy for 'the devtools render legibly' — this is a Xray/Story-
+  style CLJS unit test (per the Xray/Story-as-CLJS-unit-test ruling),
   NOT a Playwright spec. The render facts are pinned against REALITY: drive
   the substrate, read what the projection produces.
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -27,7 +27,7 @@
   substrate, projects the cascade Xray's Epoch panel reads, renders the
   HANDLER step, and asserts the inline action's source CODE renders (the
   `pr-str` of the fn body), NOT the `#object[Function]` token. This is a
-  Causa/Story-style CLJS unit test (NOT a Playwright spec)."
+  Xray/Story-style CLJS unit test (NOT a Playwright spec)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as string]
             [re-frame.core :as rf]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -37,7 +37,7 @@
     (c) RENDERED rows — the Epoch-panel projection emits the expected row
         kinds / verbs.
 
-  Causa/Story-as-CLJS-unit-test (feedback_causa_story_cljs_unit_tests_not_playwright),
+  Xray/Story-as-CLJS-unit-test (the Xray/Story-as-CLJS-unit-test ruling),
   NOT Playwright. The render facts are pinned against REALITY: drive the
   substrate, read what the projection produces."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]

--- a/tools/xray/test/day8/re_frame2_xray/two_instance_isolation_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/two_instance_isolation_cljs_test.cljs
@@ -20,7 +20,7 @@
 
   ## How it's tested at the data layer
 
-  This is a data-layer test (per the rf2-dhoc9 / Causa-as-CLJS-unit-test
+  This is a data-layer test (per the rf2-dhoc9 / Xray-as-CLJS-unit-test
   posture): frame isolation is an app-db property, so we register two
   shell frames, drive each via `(rf/with-frame <frame-id> …)` — exactly
   the binding the parameterized `shell-view` establishes through its

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -21,8 +21,8 @@
   7. **Sentinels** (`:rf/redacted`, `:rf.size/large-elided`, combined)
      render their first-class chip chrome.
 
-  Pure-data unit tests; no DOM mount. Default for new Causa/Story
-  tests per `feedback-causa-story-cljs-unit-tests-not-playwright`."
+  Pure-data unit tests; no DOM mount. Default for new Xray/Story
+  tests per the Xray/Story-as-CLJS-unit-test ruling."
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
@@ -24,8 +24,7 @@
      default rf-dispatch.
 
   Pure-data unit tests; no DOM mount. Default for new
-  Causa/Story tests per `feedback-causa-story-cljs-unit-tests-not-
-  playwright`."
+  Xray/Story tests per the Xray/Story-as-CLJS-unit-test ruling."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2379,7 +2379,7 @@ async function runPaletteOpenExecute(page, state) {
   };
 }
 
-// A deliberate exception to the "default Causa/Story tests to CLJS" rule:
+// A deliberate exception to the "default Xray/Story tests to CLJS" rule:
 // real-browser CSS-variable resolution is the signal under test. The CLJS
 // render-tree tests pin the inline-style → `var(--rf-xray-*)` contract at
 // the hiccup layer but cannot prove the browser actually substitutes a
@@ -2874,7 +2874,7 @@ async function runMachineEpochs(page, state) {
   // reading `:machine/<track>`). The deep RENDER-FIDELITY assertions (cascade
   // kinds/order, microsteps, timer-cancel, spawn/destroy, set-diff,
   // throw-as-error) live in the CLJS unit test
-  // `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/Story-as-
+  // `panels.epoch.machine-epochs-harness-cljs-test` per the Xray/Story-as-
   // CLJS rule. Here we confirm each step lands the expected configuration in
   // its OWN frame, prove the per-machine frame isolation with a cross-frame
   // flip, and confirm the Machine Inspector mounts.
@@ -3621,7 +3621,7 @@ const SCENARIOS = [
   },
   {
     // Theme-token CSS-variable resolution probe. A deliberate exception
-    // to the "default Causa/Story tests to CLJS" rule — real-browser
+    // to the "default Xray/Story tests to CLJS" rule — real-browser
     // CSS-variable resolution is the signal under test, which CLJS unit
     // tests can't reach. Guards against the regression class where a boot
     // path that embeds bare Xray widgets without calling
@@ -3685,7 +3685,7 @@ const SCENARIOS = [
     // boot-on-select is the SOLE machine-action-exception trigger). The deep
     // RENDER-FIDELITY assertions (cascade kinds/order, microsteps, timer-
     // cancel, spawn/destroy, set-diff, throw-as-error) live in the CLJS unit
-    // test `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/
+    // test `panels.epoch.machine-epochs-harness-cljs-test` per the Xray/
     // Story-as-CLJS rule (the chart-render shim-survival probe stays owned by
     // the `deep machine inspector substrate` scenario).
     name: 'machine-epochs multi-machine frame-isolated stepper (rf2-q3lfm: pick a machine -> Xray follows its own epoch ring; per-track door/traffic/quiz/brew/session/fuse/hvac/media/modal/gate paths; cross-frame flip isolation; restart = frame reset; boot-on-select fuse THROW)',


### PR DESCRIPTION
Mike flagged that "Causa" should no longer appear in the codebase (renamed to Xray, rf2-3pdp9 / PR #2067). Authoritative `git grep` sweep over tracked files found 19 product-name mentions in 15 files (everything else is legitimate English — causal/causality/causation/causable — or immutable `.beads/issues.jsonl` history, untouched).

- **Live-term prose → Xray**: "Story / Causa determinism" (EP-0002 ×2, `frame.cljc`, spec/002), "Causa/Story CLJS-unit-*" (EP-0021, Construction-Prompts, 6 xray test docstrings, 4 feature-matrix comments)
- **Memory-slug citations** (`feedback_causa_story_...`) → plain-prose "the Xray/Story-as-CLJS-unit-test ruling"
- **Rename-record comments** (expensive-tests.yml, post-merge-workflow-sanity.yml, story Migration-Audit) reworded to preserve their historical meaning ("the tool''s pre-rename name / pre-rename npm test script") without the old name

Post-sweep: `git grep -i causa` on tracked files (excl. `.beads`) filtered of legitimate English = **0 hits**.

Gates: mkdocs --strict green; check_doc_slugs green. Comment/docstring/prose-only — no behavior. HOT-ZONE note: touches spec/002 + Construction-Prompts one-line each; no open PR owns either.