### PR TITLE
fix(core): per-lease disposal-drain containment + break observation WeakHashMap self-reference (rf2-vxgfnd.28, rf2-vxgfnd.37)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -439,17 +439,56 @@
                    :frame-epoch    (frame/frame-commit-epoch frame-id)
                    :registry-epoch @registry-epoch*})))))
 
+(defn- report-disposal-notify-escape!
+  "Fan a TYPED escaping former-owner `on-change` error onto the ALWAYS-ON
+  error-emit axis (surface #4) so it is SEEN even when the drain boundary
+  swallows the propagated throw. The `:hmr` drain runs INSIDE the registrar
+  replacement hook, whose per-hook `try/catch` DROPS the throw (registrar
+  isolates replacement-hook failures — `re-frame.registrar`), and the
+  `:disposed` drain rides `interop/next-tick` (a JVM Future whose result is
+  never inspected); either boundary would otherwise make the escape invisible
+  exactly where it matters. The dev `:rf.error/reentrant-graph-op` assert — an
+  `on-change` mutating graph ownership mid-notification — exists TO BE SEEN
+  (Spec 009); this puts it on the production-survivable axis regardless of the
+  boundary. Only TYPED re-frame errors are re-surfaced here (they carry a
+  catalogued `:rf.error/id`); an untyped `on-change` bug still propagates via
+  the drain's rethrow-after-drain."
+  [error-id lease exception]
+  (let [{:keys [frame-id query-v]} @(lease-state lease)]
+    (error-emit/dispatch-on-error!
+      error-id query-v (first query-v) frame-id exception 0 (interop/now-ms))))
+
 (defn ^:no-doc drain-pending-disposals!
   "Drain the queued node-disposed notifications, coalesced once per lease
   (identity), delivering only to still-live leases. `cause` is `:hmr` when
   drained at the sub re-registration boundary (the registrar replacement
   hook below), `:disposed` on the next-tick fallback (frame-destroy /
   explicit cache clears). INTERNAL — exposed un-private only so the port's
-  own tests can drive the fallback boundary deterministically."
+  own tests can drive the fallback boundary deterministically.
+
+  Each lease's notification is CONTAINED in its own `try/catch` so one owner's
+  throwing `on-change` cannot starve its siblings (rf2-vxgfnd.28 — this was the
+  one uncontained fan-out; it mirrors registrar's per-hook and subs.cache's
+  per-reaction dispose containment). Every sibling is notified; a TYPED escape
+  is ALSO fanned onto the always-on axis so it survives a swallowing boundary
+  (see [[report-disposal-notify-escape!]]); then the first escape is re-thrown
+  AFTER the whole drain so no failure is silently dropped — never silent, never
+  starving."
   [cause]
-  (let [[pending _] (reset-vals! pending-disposals [])]
-    (doseq [lease (distinct pending)]
-      (notify-disposal! lease cause)))
+  (let [[pending _] (reset-vals! pending-disposals [])
+        escapes     (reduce
+                      (fn [acc lease]
+                        (try
+                          (notify-disposal! lease cause)
+                          acc
+                          (catch #?(:clj Throwable :cljs :default) t
+                            (when-let [eid (:rf.error/id (ex-data t))]
+                              (report-disposal-notify-escape! eid lease t))
+                            (conj acc t))))
+                      []
+                      (distinct pending))]
+    (when (seq escapes)
+      (throw (first escapes))))
   nil)
 
 (defn- enqueue-disposal!

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -50,8 +50,13 @@
     - `:node-version` — a per-node counter this port advances whenever it
       OBSERVES the node's value change by `rf=` (at probe/acquire/read and on
       watch fires). Node bookkeeping lives in a WEAK identity-keyed side
-      table (`js/WeakMap` / `java.util.WeakHashMap`), so records die with
-      their reactions — no pruning, no retention.
+      table (`js/WeakMap` / `java.util.WeakHashMap`) keyed by the reaction, so
+      a record dies with its reaction — no pruning, no retention. The record's
+      VALUE must never transitively STRONG-reference its own reaction key:
+      `java.util.WeakHashMap` is NOT an ephemeron map (a value→key path pins
+      the key forever), so the owner leases in `:owners` hold their reaction
+      WEAKLY on the JVM (rf2-vxgfnd.37). `js/WeakMap` HAS ephemeron semantics,
+      so CLJS needs no such care.
     - `:frame-epoch` — `re-frame.frame/frame-commit-epoch`: bumped once per
       physical frame-state install. Any durable-state movement in the
       render→commit gap moves it, so a version tie on a multi-move gap is
@@ -222,13 +227,23 @@
 ;; ---- node records (weak identity-keyed) -------------------------------------
 ;;
 ;; Per-node observation bookkeeping — `{:node-key <int> :version <int>
-;; :value <last-observed>}` — keyed by the cache node's reaction OBJECT in a
-;; WEAK identity-keyed table, so a record's lifetime is exactly its
-;; reaction's: an evicted/disposed node's record becomes unreachable with the
-;; node, and the port never prunes, scans, or retains. The cache entry map
-;; itself stays exactly `{:reaction :inputs :ref-count}` (Spec 006 §Cache
-;; shape advertises EXACTLY that key-set; a port slot inside it would be a
-;; contract break).
+;; :value <last-observed> :owners #{lease…} :hooked? bool}` — keyed by the
+;; cache node's reaction OBJECT in a WEAK identity-keyed table, so a record's
+;; lifetime is exactly its reaction's: an evicted/disposed node's record
+;; becomes unreachable with the node, and the port never prunes, scans, or
+;; retains. The cache entry map itself stays exactly
+;; `{:reaction :inputs :ref-count}` (Spec 006 §Cache shape advertises EXACTLY
+;; that key-set; a port slot inside it would be a contract break).
+;;
+;; REACHABILITY INVARIANT (rf2-vxgfnd.37): the record VALUE must never
+;; transitively STRONG-reference its own reaction KEY. `java.util.WeakHashMap`
+;; is NOT an ephemeron map — it holds values strongly and never inspects
+;; value→key paths, so a value reaching its key pins that key (and the whole
+;; entry) for the process lifetime. The record's `:owners` leases reach their
+;; reaction, so each lease holds it WEAKLY on the JVM (`lease-reaction`) and the
+;; value→key edge is broken; an abandoned node (interrupted teardown, no
+;; `release!`) is then collectable. `js/WeakMap` HAS ephemeron semantics, so on
+;; CLJS the reaction is held plainly and no self-reference care is needed.
 
 #?(:clj
    (defonce ^:private ^java.util.Map node-records
@@ -419,6 +434,46 @@
   honestly — a pinned value owns nothing."
   [lease]
   (= :node (:lease-kind @(lease-state lease))))
+
+;; ---- weak reaction reference (JVM WeakHashMap self-reference break) ----------
+;;
+;; rf2-vxgfnd.37: the JVM node-records table is a `java.util.WeakHashMap` keyed
+;; by REACTION, and its VALUE carries the node's active-owner set (`:owners`) of
+;; `ObservationLease` objects. `java.util.WeakHashMap` is NOT an ephemeron map:
+;; a value that transitively STRONG-references its own weak key pins that key
+;; forever (the map holds values strongly and never inspects value→key paths).
+;; So a lease MUST NOT strong-reference its reaction, or the chain
+;;
+;;     node-records value → :owners → lease → state → reaction (= the weak key)
+;;
+;; would defeat the weak key and retain every abandoned node's leases for the
+;; process lifetime. The lease state therefore holds its reaction WEAKLY on the
+;; JVM (deriving the strong reaction on demand via [[lease-reaction]]), so an
+;; otherwise-unreachable reaction — e.g. an interrupted teardown that drops a
+;; cache/frame without completing `release!`/dispose — is GC-collectable and its
+;; node record dies with it. CLJS needs no such care: `js/WeakMap` HAS ephemeron
+;; semantics (a value→key path never pins the key), so the reaction is held as a
+;; plain reference there.
+
+(defn- weak-reaction-ref
+  "Wrap `reaction` for storage in a node lease's state: a `WeakReference` on the
+  JVM (so the weak node-records value cannot strong-reference its own weak key —
+  rf2-vxgfnd.37), the plain reaction on CLJS (`js/WeakMap` is ephemeron)."
+  [reaction]
+  #?(:clj  (java.lang.ref.WeakReference. reaction)
+     :cljs reaction))
+
+(defn- lease-reaction
+  "Derive the STRONG reaction from a node lease's `state` map — or nil when the
+  JVM `WeakReference` has already been collected (the reaction became
+  unreachable while the lease outlived it: an abandoned or displaced node). CLJS
+  returns the plain reference. Every caller guards the nil case — a collected
+  reaction is never the live canonical node, so `current?`/`read` fall back to
+  the last committed observation and `release!` no-ops the cache detach."
+  [state]
+  #?(:clj  (when-let [^java.lang.ref.WeakReference ref (:reaction state)]
+             (.get ref))
+     :cljs (:reaction state)))
 
 ;; ---- HMR / disposal notification queue ---------------------------------------
 
@@ -712,6 +767,15 @@
 ;; owners, storage O(current owners) not O(all owners ever acquired). The lease
 ;; is a `deftype` compared by identity, so a plain persistent set keys it by
 ;; identity on both hosts.
+;;
+;; Because the record VALUE now reaches leases (and a lease reaches its
+;; reaction, the weak KEY), the value→key STRONG-reference that would defeat the
+;; JVM `java.util.WeakHashMap` weak key is broken by holding the reaction WEAKLY
+;; in each lease's state (`lease-reaction`; rf2-vxgfnd.37) — see the node-records
+;; §REACHABILITY INVARIANT above. So even a lease left enrolled by an interrupted
+;; teardown cannot pin its own node's reaction: the record dies with the
+;; reaction on the JVM exactly as `js/WeakMap`'s ephemeron semantics already
+;; guarantee on CLJS.
 
 (defn- register-owner!
   "Enrol owner `lease` in `reaction`'s active-owner set within the weak node
@@ -818,10 +882,15 @@
   order that eviction before this read — so once a reaction has been disposed it
   is no longer the entry's `:reaction`. This is the authority `acquire!`'s
   first-owner handshake (rf2-vxgfnd.32) and the `current?` kept-check both read."
-  [{:keys [frame-id query-v reaction]}]
+  [{:keys [frame-id query-v] :as state}]
   (boolean
-    (when-let [cache (:sub-cache (frame/frame frame-id))]
-      (identical? reaction (:reaction (get @cache query-v))))))
+    ;; Derive the strong reaction (held WEAKLY in the state on the JVM —
+    ;; rf2-vxgfnd.37). A collected reaction is nil and can never be the live
+    ;; canonical node, so the `when-let` short-circuits — never falling into the
+    ;; `(identical? nil (:reaction absent-entry))` ≡ `(identical? nil nil)` trap.
+    (when-let [rx (lease-reaction state)]
+      (when-let [cache (:sub-cache (frame/frame frame-id))]
+        (identical? rx (:reaction (get @cache query-v)))))))
 
 ;; ---- acquire! -------------------------------------------------------------------
 
@@ -834,16 +903,19 @@
     (let [st @state]
       (when (and (= :live (:status st))
                  (not= prev nu))
-        (let [rec (advance-node-record! (:reaction st) nu)
-              last' {:value nu :version (:version rec) :node-key (:node-key rec)}]
-          (swap! state assoc :last last')
-          (fan-out! (:on-change st)
-                    {:cause          :value
-                     :target         (:target st)
-                     :node-key       (:node-key rec)
-                     :node-version   (:version rec)
-                     :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
-                     :registry-epoch @registry-epoch*}))))))
+        ;; The watch only fires while its reaction is live, so `lease-reaction`
+        ;; resolves; the `when-some` is belt-and-braces for a JVM weak reaction.
+        (when-some [rx (lease-reaction st)]
+          (let [rec   (advance-node-record! rx nu)
+                last' {:value nu :version (:version rec) :node-key (:node-key rec)}]
+            (swap! state assoc :last last')
+            (fan-out! (:on-change st)
+                      {:cause          :value
+                       :target         (:target st)
+                       :node-key       (:node-key rec)
+                       :node-version   (:version rec)
+                       :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
+                       :registry-epoch @registry-epoch*})))))))
 
 (defn- build-node-lease!
   "Wrap a CANONICAL cached `reaction` — one `subs/acquire-cache-reaction!` has
@@ -875,7 +947,12 @@
                      :target     target
                      :frame-id   frame-id
                      :query-v    query
-                     :reaction   reaction
+                     ;; Held WEAKLY on the JVM so the process-global weak
+                     ;; node-records table's value cannot strong-reference its
+                     ;; own weak key back into liveness (rf2-vxgfnd.37); plain
+                     ;; on CLJS (js/WeakMap is ephemeron). Derived via
+                     ;; `lease-reaction` at every read.
+                     :reaction   (weak-reaction-ref reaction)
                      :on-change  on-change
                      :status     :live})
         lease (->ObservationLease state)]
@@ -1105,7 +1182,9 @@
               {:extra {:frame          (:frame-id st)
                        :rf.sub/query-v (:query-v st)}})))
         (if (node-still-canonical? st)
-          (let [[rec v] (observe-node! (:reaction st))]
+          ;; Canonical ⟹ the cache holds this reaction strongly, so the weakly
+          ;; held `lease-reaction` resolves (rf2-vxgfnd.37).
+          (let [[rec v] (observe-node! (lease-reaction st))]
             (swap! (lease-state lease) assoc
                    :last {:value v :version (:version rec)
                           :node-key (:node-key rec)})
@@ -1147,13 +1226,19 @@
     ;; uses.
     (when (and (= :node (:lease-kind old))
                (= :live (:status old)))
-      (let [{:keys [reaction watch-key frame-id query-v]} old]
-        (when watch-key
+      (let [{:keys [watch-key frame-id query-v]} old
+            ;; Derived weakly on the JVM (rf2-vxgfnd.37); nil iff the reaction
+            ;; was already collected (an abandoned node the lease outlived), in
+            ;; which case every teardown step below is a correct no-op — the
+            ;; reference died with the eviction, exactly as for a rebuilt node.
+            reaction (lease-reaction old)]
+        (when (and watch-key reaction)
           (remove-watch reaction watch-key))
         ;; De-enrol this lease from the node's active-owner set so a released
         ;; lease is no longer reachable from the live reaction — the node's
         ;; single disposal hook then never sees it (rf2-vxgfnd.15).
-        (deregister-owner! reaction lease)
+        (when reaction
+          (deregister-owner! reaction lease))
         (when-let [cache (:sub-cache (frame/frame frame-id))]
           (let [[o n] (swap-vals! cache
                                   (fn [m]

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -533,6 +533,56 @@
       (obs/release! lease))))
 
 ;; ===========================================================================
+;; rf2-vxgfnd.28 — the disposal-notification drain contains a throwing owner
+;; and SURFACES the escape (it was the one uncontained fan-out)
+;;
+;; drain-pending-disposals! reset-vals!-empties the queue then notifies every
+;; queued owner. Pre-fix a throw from owner k aborted k+1..n, whose
+;; notifications were already dequeued and thus LOST — and on the :hmr path the
+;; drain runs inside the registrar replacement hook, whose per-hook catch DROPS
+;; the throw (no log/trace/record), swallowing even the dev
+;; :rf.error/reentrant-graph-op assert exactly where it matters. The fix wraps
+;; each lease's notify in its own try/catch (siblings never starve), fans a
+;; TYPED escape onto the always-on axis (SEEN through the registrar's swallow),
+;; and re-throws after the whole drain (never silent).
+;; ===========================================================================
+
+(deftest disposal-drain-contains-a-throwing-owner-and-surfaces-the-escape
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target    (items-target)
+        notes-b   (atom [])
+        bad-lease (atom nil)
+        ;; Owner A: its on-change does a FORBIDDEN reentrant release! from inside
+        ;; the fan-out → throws the dev :rf.error/reentrant-graph-op assert,
+        ;; escaping the notification (it does NOT catch its own throw).
+        la  (obs/acquire! target (fn [_n] (obs/release! @bad-lease)))
+        ;; Owner B: a well-behaved sibling that MUST still be notified.
+        lb  (obs/acquire! target (fn [n] (swap! notes-b conj n)))]
+    (reset! bad-lease la)
+    (is (= 2 (obs/active-owner-count (:reaction (entry [:obs/items]))))
+        "both owners are enrolled on the shared node")
+    ;; The HMR re-registration disposes the shared node and drains BOTH former
+    ;; owners at the registrar replacement boundary — the exact swallow-prone
+    ;; path. reg-items! itself returns normally: the registrar isolates the
+    ;; replacement hook, so the drain's rethrow is swallowed there and it is the
+    ;; ALWAYS-ON fan that carries visibility.
+    (let [[[outcome _] records] (with-error-records #(reg-items!))]
+      (testing "the throwing owner did NOT starve its sibling — B notified once"
+        (is (= 1 (count @notes-b)))
+        (is (= :hmr (:cause (first @notes-b)))))
+      (testing "the escape is SEEN on the always-on axis despite the registrar's
+                per-hook swallow (rf2-vxgfnd.28 — reentrant-graph-op exists to be seen)"
+        (is (some #(= :rf.error/reentrant-graph-op (:error %)) records)
+            "the swallowed reentrant-graph-op reached the always-on error surface"))
+      (testing "reg-items! returned normally — the registrar isolates the hook"
+        (is (= :ok outcome))))
+    ;; Owner A's release! never completed (it threw); both are cleanly releasable
+    ;; outside the fan-out now.
+    (obs/release! la)
+    (obs/release! lb)))
+
+;; ===========================================================================
 ;; rf2-vxgfnd.63 — a live-cache DISPLACEMENT must not be misclassified as frame
 ;; destruction during acquire!
 ;;

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -972,6 +972,82 @@
         (obs/release! keep)))))
 
 ;; ===========================================================================
+;; the JVM WeakHashMap self-reference leak fixture — rf2-vxgfnd.37
+;;
+;; The JVM node-records table is a process-global java.util.WeakHashMap keyed by
+;; REACTION; its VALUE carries :owners, a strong set of ObservationLease objects,
+;; and each lease's state references its reaction. java.util.WeakHashMap is NOT
+;; an ephemeron map, so a value transitively STRONG-referencing its own weak key
+;; pins that key forever:
+;;   node-records value → :owners → lease → state → reaction (= the weak key)
+;; An interrupted teardown (a committed owner whose cache/frame is dropped
+;; WITHOUT release!/dispose) then leaks the reaction + lease for the process
+;; lifetime. The fix holds the reaction WEAKLY in the lease state, breaking the
+;; value→key edge, so the entry is collectable once the reaction is otherwise
+;; unreachable. This is a deterministic WeakReference proof: an enrolled,
+;; abandoned reaction becomes collectable, and a matched un-enrolled control
+;; demonstrates the fixture can OBSERVE collection. CLJS is unaffected
+;; (js/WeakMap has ephemeron semantics) — this leg is JVM-only.
+;; ===========================================================================
+
+#?(:clj
+   (defn- gc-until-cleared?
+     "Force GC (bounded) until `wref`'s referent is collected; report whether it
+     was. Allocates transient heap pressure between cycles to prod the
+     collector. The bounded loop keeps the fixture deterministic — it never
+     blocks unboundedly (a still-strong-reachable referent returns false, which
+     is the pre-fix failure signal)."
+     [^java.lang.ref.WeakReference wref]
+     (loop [i 0]
+       (cond
+         (nil? (.get wref)) true
+         (>= i 40)          false
+         :else              (do (System/gc)
+                                (System/runFinalization)
+                                (make-array Object 200000) ;; transient pressure
+                                (recur (inc i)))))))
+
+#?(:clj
+   (deftest jvm-weak-node-record-does-not-strong-pin-its-abandoned-reaction
+     (reg-items!)
+     (seed-items! [:a])
+     (testing "CONTROL — an un-enrolled canonical reaction is collectable once
+               dropped (proves the fixture can OBSERVE collection in this JVM)"
+       (let [box (volatile! (do (subs/subscribe [:obs/items] {:frame fid})
+                                (:reaction (entry [:obs/items]))))
+             ref (java.lang.ref.WeakReference. ^Object @box)]
+         (subs/unsubscribe fid [:obs/items]) ;; ref-count → 0: dispose + evict
+         (vreset! box nil)                   ;; drop the last ordinary strong ref
+         (is (gc-until-cleared? ref)
+             "a dropped, un-enrolled reaction is collectable")))
+     (testing "ENROLLED — a committed owner left by an INTERRUPTED teardown does
+               NOT pin its reaction through the weak node-records value (rf2-vxgfnd.37)"
+       (let [lease-box (volatile! (obs/acquire! (items-target) (fn [_])))
+             rx-box    (volatile! (:reaction (entry [:obs/items])))
+             rx-ref    (java.lang.ref.WeakReference. ^Object @rx-box)
+             lease-ref (java.lang.ref.WeakReference. ^Object @lease-box)]
+         (is (= 1 (obs/active-owner-count @rx-box))
+             "the lease is enrolled as an active owner in the weak node record")
+         ;; Interrupted teardown: evict the cache entry (dropping the cache's
+         ;; strong ref to the reaction) WITHOUT release! — so the owner is NEVER
+         ;; de-enrolled and :owners still holds the lease. The ONLY remaining
+         ;; strong path to the reaction is node-records value → :owners → lease →
+         ;; state → reaction. Pre-fix (strong :reaction) that pins the weak key.
+         (swap! (sub-cache) dissoc [:obs/items])
+         (vreset! lease-box nil) ;; drop the last ordinary strong refs
+         (vreset! rx-box nil)
+         (is (gc-until-cleared? rx-ref)
+             (str "the abandoned reaction is GC-collectable — the weak "
+                  "node-records value no longer strong-references its own weak "
+                  "key (this assertion FAILS on PR #5710's strong :reaction)"))
+         ;; The reaction (weak KEY) is gone; a WeakHashMap operation now expunges
+         ;; the stale entry, dropping the map's strong ref to the VALUE (record →
+         ;; :owners → lease), which the next GC reclaims.
+         (.size ^java.util.Map @#'obs/node-records)
+         (is (gc-until-cleared? lease-ref)
+             "the abandoned lease was reclaimed once its node record's weak key died")))))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 


### PR DESCRIPTION
Two P2 correctness/memory bugs in the internal observation port (`re-frame.substrate.observation`), one PR, two commits.

## rf2-vxgfnd.28 — disposal-drain has no per-lease throw containment

`drain-pending-disposals!` `reset-vals!`-emptied the queue and then ran a bare `doseq` over `notify-disposal!`, so a throw from one owner's `on-change` aborted every subsequent owner — whose notifications were already dequeued and thus **lost** (siblings starved). On the `:hmr` path the drain runs inside the registrar replacement hook, whose per-hook `try/catch` **drops** the throw with no log/trace/record — swallowing even the dev `:rf.error/reentrant-graph-op` assert exactly where it matters; on `:disposed` it escaped into an uninspected `interop/next-tick` Future. This was the one uncontained fan-out (registrar wraps per-hook; subs.cache wraps per-reaction dispose).

**Fix:** wrap each lease's notify in its own `try/catch` so a bad `on-change` can never starve its siblings; fan a **typed** escape onto the always-on error-emit axis (surface #4) so it is SEEN through a swallowing boundary (009 `:rf.error/reentrant-graph-op` exists to be seen); then re-throw the first escape after the whole drain — never silent, never starving. No new catalogue id: the escape is re-surfaced under its own catalogued `:rf.error/id`.

## rf2-vxgfnd.37 — JVM WeakHashMap owner record defeats its own weak key

The JVM node-records table is a process-global `java.util.WeakHashMap` keyed by REACTION. #5710 moved active leases into the record VALUE (`:owners`), and each lease's state strongly referenced its reaction, closing a strong cycle `node-records value → :owners → lease → state → reaction (= the weak key)`. `java.util.WeakHashMap` is **not** an ephemeron map — a value reaching its own key pins that key (and entry) for the process lifetime. An interrupted teardown (a committed owner whose cache/frame is dropped without completing `release!`/dispose) then leaks the reaction + lease forever, defeating the exact failure-resilience the weak table was chosen for.

**Fix:** hold the reaction **weakly** in the lease state (a `java.lang.ref.WeakReference` on the JVM), deriving the strong reaction on demand via `lease-reaction`; every reader (`node-still-canonical?`, `read`, `release!`, the change watch) guards the already-collected (nil) case — a collected reaction is never the live canonical node, so `current?`/`read` fall back to the last observation and `release!` no-ops the detach. **CLJS is unchanged** — `js/WeakMap` has ephemeron semantics, so the reaction is held plainly there. The reachability invariant is now documented for both hosts (fixing the false "records die with reactions, no pruning" claims).

## Surface

Only `implementation/core/src/re_frame/substrate/observation.cljc` + its test `implementation/core/test/re_frame/observation_port_cljs_test.cljc`. No new error-catalogue id, no spec/hot-zone edits.

## Quality gates

Foreground, 0-fail:

- **observation-port ns (JVM)** `clojure -M:test -n re-frame.observation-port-cljs-test`: 34 tests, 187 assertions, 0 failures, 0 errors
- **full core JVM** `clojure -M:test`: 1864 tests, 8320 assertions, 0 failures, 0 errors
- **CLJS node-test** `npm run test:cljs`: 9004 tests, 42494 assertions, 0 failures, 0 errors

Regression proofs validated to FAIL without the fix:
- **.37**: with a strong reaction reference reinstated, the enrolled reaction and lease fail to collect (2 failures); the un-enrolled control still collects (proving the fixture observes collection). Passes after the fix.
- **.28**: the new fixture proves the throwing owner's sibling is still notified once and the reentrant-graph-op reaches the always-on surface despite the registrar's per-hook swallow.