### PR TITLE
fix(spec): manifest covers re-frame.ui/frame-root; frame-provider deferred to .24 (rf2-vxgfnd.71)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -43,11 +43,13 @@
       - `day8.re-frame2-xray.runtime` — the discovery sentinel + safe-egress
         entry points.
   - `re-frame.ui` (rf2-qz1h5d) — the Spec-004 compiled-view substrate. A
-    curated subset (direction 1 only): its blessed S1 export set is rowed, but
-    the live namespace also publishes `frame-root` / `frame-provider`
-    (intentionally unrowed under re-frame.ui — `frame-root` rides the
-    re-frame.core façade row; the compiled-view `frame-provider` is rowed in
-    spec/API.md §View ergonomics, not here), so it is NOT `:fully-rowed`.
+    curated subset (direction 1 only): its blessed S1 export set — INCLUDING
+    the namespace-specific `frame-root` row (rf2-vxgfnd.71) — is rowed. The
+    live namespace also publishes `frame-provider`, whose manifest + spec/API.md
+    classification is DEFERRED to the context-tier mechanism decision
+    rf2-vxgfnd.24 (if .24 picks a non-`frame-provider` mechanism the var may
+    become internal); it is intentionally left unrowed pending that ruling, so
+    re-frame.ui stays NOT `:fully-rowed`.
 
   The pair-MCP server (`re-frame2-pair-mcp.server`) is the third
   CLJS-only surface the keystone names. It compiles under the pair-MCP
@@ -121,9 +123,10 @@
    "day8.re-frame2-xray.open-in-editor"              (emit-ns-publics day8.re-frame2-xray.open-in-editor)
    "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)
    ;; rf2-qz1h5d — re-frame.ui compiled-view substrate. Curated subset
-   ;; (direction-1 only): the live namespace also publishes `frame-root` +
-   ;; `frame-provider`, intentionally NOT rowed under re-frame.ui, so it is
-   ;; absent from `fully-rowed` below.
+   ;; (direction-1 only): the blessed S1 export set is rowed (incl. the
+   ;; namespace-specific `frame-root` row, rf2-vxgfnd.71); the live namespace
+   ;; also publishes `frame-provider`, deferred to rf2-vxgfnd.24 and left
+   ;; intentionally unrowed, so re-frame.ui is absent from `fully-rowed` below.
    "re-frame.ui"                                     (emit-ns-publics re-frame.ui)})
 
 (def fully-rowed

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -201,16 +201,31 @@
   {:namespace "day8.re-frame2-xray.runtime" :var "session-id"    :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   ;; --- re-frame.ui (day8/re-frame2-ui) — the Spec-004 compiled-view substrate
   ;;     (epic rf2-vxgfnd). `re-frame.ui` is a `.cljc` namespace, but its rows
-  ;;     are carried HERE (not JVM-introspected by the generator) so the manifest
-  ;;     surface stays EXACTLY the blessed S1 export set: a whole-namespace JVM
-  ;;     `ns-publics` would additionally pull in `frame-root` / `frame-provider`,
-  ;;     live vars intentionally NOT rowed under re-frame.ui (`frame-root` rides
-  ;;     the re-frame.core façade row; the compiled-view `frame-provider` is
-  ;;     rowed in spec/API.md §View ergonomics, not here).
+  ;;     are carried HERE (not JVM-introspected by the generator) so the curated
+  ;;     order + tiers stay verbatim from spec/API.md §Compiled views. The rows
+  ;;     below ARE the blessed S1 export set (spec/API.md §Compiled views):
+  ;;     defview / custom-element / sub / lease / raw / html / raw-fn / spread /
+  ;;     mount / create-root / render! / hydrate-root / unmount! / frame-root.
+  ;;     `frame-root` (rf2-vxgfnd.71) is NAMESPACE-SPECIFIC — the compiled-view
+  ;;     ENSURE root-form marker (a compile-marker `defn`, :kind :fn), rowed
+  ;;     against re-frame.ui itself. It is NOT the re-frame.core / adapter façade
+  ;;     `frame-root` Var: manifest identity is namespace + var, so a re-frame.core
+  ;;     row cannot classify or verify `re-frame.ui/frame-root` (the earlier
+  ;;     "rides the core façade row" claim was the drift this bead reconciles).
+  ;;     ONE live public var is intentionally UNROWED here:
+  ;;     `re-frame.ui/frame-provider` (a live compile-marker `defn`). Its manifest
+  ;;     + spec/API.md classification is DEFERRED to the context-tier mechanism
+  ;;     decision rf2-vxgfnd.24 — if .24 picks a non-`frame-provider` mechanism
+  ;;     the var may become internal, so it is NOT blessed / rowed now. Recorded
+  ;;     here EXPLICITLY (not silently dropped): re-frame.ui stays a CURATED
+  ;;     SUBSET (NOT :fully-rowed) precisely so this one deferred var does not
+  ;;     force a row before .24 rules. When .24 lands, either row it under
+  ;;     re-frame.ui + add its spec/API.md §Compiled views row (and consider
+  ;;     making re-frame.ui :fully-rowed), or make the source Var `^:no-doc`.
   ;;     RUNTIME-VERIFIED via the 2mtte CLJS probe (rf2-qz1h5d): the probe loads
   ;;     re-frame.ui and reconciles these rows against its live CLJS publics
   ;;     DIRECTION-1 ONLY — a CURATED SUBSET, exactly like the Xray mount surface
-  ;;     (NOT :fully-rowed, so the two extra live vars above do not force rows),
+  ;;     (NOT :fully-rowed, so the deferred `frame-provider` does not force a row),
   ;;     so a row removed / renamed in source turns the probe RED. Hence
   ;;     :runtime-verified? true. The later-stage verbs (local / effect /
   ;;     dispatch-fn / presence / presence-phase / ->react / error-boundary /
@@ -230,7 +245,8 @@
   {:namespace "re-frame.ui" :var "create-root"    :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
   {:namespace "re-frame.ui" :var "render!"        :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
   {:namespace "re-frame.ui" :var "hydrate-root"   :kind :macro :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
-  {:namespace "re-frame.ui" :var "unmount!"       :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}]
+  {:namespace "re-frame.ui" :var "unmount!"       :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S1" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "frame-root"     :kind :fn    :facade? false :tier :front-porch :owner "004" :status "Spec-004 S1" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; API.md var-rows that are KNOWINGLY absent from the manifest. The

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 481,
+ :var-count 482,
  :tier-vocab
  [:front-porch
   :advanced
@@ -488,6 +488,7 @@
   {:namespace "re-frame.ui", :var "create-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "custom-element", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "defview", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "frame-root", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "html", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "hydrate-root", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "lease", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## What

PR #5739 enrolled `re-frame.ui` in the CLJS manifest probe and flipped 13 rows to `:runtime-verified? true`, but deliberately excluded two live public vars — `re-frame.ui/frame-root` and `re-frame.ui/frame-provider`. This splits and reconciles the `frame-root` half (clean) and explicitly records the `frame-provider` half (decision-coupled) as deferred.

### 1. `frame-root` — reconciled (the clean, contract-mandated half)

`spec/API.md` §Compiled views already blesses `frame-root` in the exact S1 export set (`#{… hydrate-root unmount! frame-root}`) **and** carries a compiled-view `frame-root` row. The manifest omitting `{re-frame.ui frame-root}` was pure drift, invisible only because `re-frame.ui` is a curated subset (not `:fully-rowed`) and the bare name `frame-root` already resolved against the `re-frame.core` / adapter rows.

- Added the **namespace-specific** `{:namespace "re-frame.ui" :var "frame-root"}` `:cljs-only` row: `:kind :fn` (a compile-marker `defn` in `implementation/ui/src/re_frame/ui.cljc`), `:tier :front-porch` (verbatim from API.md §Compiled views), `:owner "004"`, `:status "Spec-004 S1"`, `:runtime-verified? true` (the rf2-2mtte CLJS probe covers `re-frame.ui`).
- Regenerated `spec/api-manifest.edn` (var-count 481 → 482; one row, alphabetically sorted).
- Corrected the sidecar comment + the two probe-test comments that claimed `frame-root` "rides the re-frame.core façade row". Manifest identity is namespace + var, so a `re-frame.core` row can neither classify nor verify `re-frame.ui/frame-root` — that cross-namespace substitution was the drift this bead calls out.

**No `spec/API.md` edit was needed** — `frame-root` is already in its export set and has its row (hot-zone left untouched).

### 2. `frame-provider` — DEFERRED to rf2-vxgfnd.24 (not added)

`frame-provider` is a live public compile-marker `defn` in `re-frame.ui`, but it is **not** in API.md's blessed S1 export set. Whether it should be a blessed public export is **coupled to the unresolved context-tier mechanism decision rf2-vxgfnd.24** — if `.24` picks a non-`frame-provider` mechanism, this var may become internal. Adding a manifest row now would prematurely bless it.

So **no `frame-provider` row is added.** Instead, the exclusion is recorded **explicitly rather than silently**: the sidecar comment block and the probe-test docstrings now document that `re-frame.ui/frame-provider` is a live public var whose manifest + API.md classification is held pending the `.24` ruling, and that `re-frame.ui` deliberately stays a **curated subset** (`NOT :fully-rowed`) precisely so this one deferred var does not force a row before `.24` rules. When `.24` lands: either row it under `re-frame.ui` (+ add its API.md §Compiled views row, and consider making `re-frame.ui` `:fully-rowed`), or make the source Var `^:no-doc`.

There is no probe/allowlist entry to add for `frame-provider` today because a curated-subset namespace runs no direction-2 completeness check, so nothing goes red on the unrowed var — the explicit written record is the correct home for the deferral (mirroring how `:api-md-known-unmanifested` documents knowingly-absent surfaces).

## Surface

Three files, all within the allowed surface: `spec/api-manifest-metadata.edn` (sidecar), `spec/api-manifest.edn` (regenerated), and the probe test `cljs_manifest_probe_cljs_test.cljs`. `spec/API.md`, `implementation/**` runtime, and the Spec 004 in-flight surfaces were **not** touched.

## Quality gates

All foreground, 0-fail / 0-drift (JVM checks re-run post-rebase onto `origin/main`):

- `clojure -M -m re-frame.api-manifest.gen --check` → `OK: spec/api-manifest.edn in sync (482 public vars).`
- `clojure -M -m re-frame.api-manifest.api-md-check` → `OK: spec/API.md projection in sync (206 var-rows checked).`
- `story-spec-check` / `xray-spec-check` / `skills-check` / `doc-guide-check` / `doc-api-check` → all `OK`.
- `clojure -M:test` (reconciler regression tests) → `Ran 53 tests … 0 failures, 0 errors.`
- `npm run test:cljs` (full node-test suite, includes the `cljs-only-surface-in-sync` manifest probe) → `Ran 9005 tests containing 42503 assertions. 0 failures, 0 errors.` — confirms the new `frame-root` row resolves to a live public var (direction-1 verified) and the probe stays green with `frame-provider` deliberately unrowed.

Closes rf2-vxgfnd.71.
