### PR TITLE
fix(ui): root/host teardown retroactively proves :unmounted → :dead (rf2-vxgfnd.62)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -53,7 +53,8 @@
   identity and stay in production."
   (:require ["react-dom/client" :as rdc]
             [re-frame.error :as error]
-            [re-frame.ui.frames :as frames]))
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]))
 
 ;; ---------------------------------------------------------------------------
 ;; The Root handle
@@ -510,6 +511,19 @@
   evicts a newer claim) and a second `unmount!*` is then a no-op; the
   host teardown error still propagates to the caller (rf2-vxgfnd.18 AC4).
 
+  LIFECYCLE (03 §4; rf2-vxgfnd.62). The host `.unmount` is driven through
+  `reactive/teardown-root!`, which arms a collection window around it: React
+  runs the effect-cleanups of this root's tree synchronously during `.unmount`,
+  and each ViewCell's cleanup (`disconnect!`) — which emits the transient
+  `:disconnected {:reason :unknown}` fact, indistinguishable from an Activity
+  hide at that moment — is captured. AFTER `.unmount` returns, those captured
+  cells (exactly this root's cells — the sweep is React-scoped, so sibling and
+  nested-portal roots are untouched) are retroactively proven `:unmounted
+  {:proof :host-teardown}` → `:dead`, so a real root unmount no longer leaves an
+  `:unknown` disconnect forever and a retained handle can never reconnect after
+  its root is gone. A throwing `.unmount` (React refused) collected nothing and
+  tears no cell down — the orphaned tree's cells stay live (see below).
+
   AFTERMATH of a THROWING host `.unmount` (rf2-vxgfnd.53). The concrete
   case is React 18/19 refusing to `.unmount` synchronously from inside a
   render pass (\"attempted to synchronously unmount a root while React was
@@ -533,7 +547,12 @@
   (when (and (some? root)
              (identical? (:root (get @live-roots (.-root-id root))) root))
     (try
-      (.unmount (.-react-root root))
+      ;; rf2-vxgfnd.62 — drive the host unmount through the root-teardown window
+      ;; so this root's ViewCells are retroactively proven :unmounted → :dead
+      ;; after React sweeps their effect cleanups (see the docstring LIFECYCLE
+      ;; note). teardown-root! rethrows a throwing host `.unmount` unchanged, so
+      ;; the catch/finally below keep the rf2-vxgfnd.53 ownership behaviour.
+      (reactive/teardown-root! (fn [] (.unmount (.-react-root root))))
       (catch :default e
         ;; rf2-vxgfnd.53 — React did NOT unmount, yet the `finally` below
         ;; still releases the claim (AC4). The live tree is now orphaned and

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -475,6 +475,20 @@
   ;; `reset-scheduler!`.
   (atom #{}))
 
+(defonce ^:private teardown-collector
+  ;; The COLLECTION WINDOW of an in-flight host/root teardown (`teardown-root!`),
+  ;; or nil at rest. `teardown-root!` arms it (a set) around the host React
+  ;; `.unmount`; while armed, `disconnect!` attributes each disconnecting cell
+  ;; to it — because a host `.unmount` sweeps the effect-cleanups of EXACTLY its
+  ;; own root's tree (React scopes the unmount), every captured cell belongs to
+  ;; that root and no sibling root's cell can enter the window. The driver then
+  ;; retroactively proves each captured cell an unmount (03 §4). nil while no
+  ;; teardown runs, so an Activity hide (a `disconnect!` with the window unarmed)
+  ;; stays a transient reconnectable disconnect. Save/restored around a teardown
+  ;; so a re-entrant one nests. `defonce` (module-lived); `reset-scheduler!`
+  ;; clears it between fixtures.
+  (atom nil))
+
 (declare flush-pending!)
 
 #?(:cljs
@@ -744,6 +758,7 @@
   (reset! flush-scheduled? false)
   (reset! slice-memo* nil)
   (reset! live-cells #{})
+  (reset! teardown-collector nil)
   (reset! evidence-sink nil)
   nil)
 
@@ -821,7 +836,16 @@
   indistinguishable at this moment): release lease owners (hidden UI must
   not poll) and emit `:disconnected {:reason :unknown}`. The cell is
   reconnectable — a later commit on the same cell reacquires and
-  corrects. Idempotent. Returns the cell."
+  corrects. Idempotent. Returns the cell.
+
+  When a host/root teardown is in flight (`teardown-root!` armed the
+  collection window — this cleanup is firing DURING a real `.unmount`), the
+  disconnecting cell is captured so the driver can retroactively prove it an
+  unmount. The emitted fact is STILL `:disconnected {:reason :unknown}` (the
+  same immediate cleanup fact as an Activity hide — the two are
+  indistinguishable here, 03 §4); the upgrade to `:unmounted` happens later, in
+  `teardown-root!`. With the window unarmed (an Activity hide) nothing is
+  captured and the cell stays reconnectable."
   [^ViewCell cell]
   (let [st (state cell)]
     (when (contains? #{:fresh :connected} (:lifecycle @st))
@@ -833,7 +857,10 @@
       (swap! st (fn [m]
                   (-> m
                       (assoc :lifecycle :disconnected)
-                      (update :intervals conj {:state :disconnected :reason :unknown})))))
+                      (update :intervals conj {:state :disconnected :reason :unknown}))))
+      ;; Host/root teardown in flight: attribute this cell to it (03 §4).
+      (when (some? @teardown-collector)
+        (swap! teardown-collector conj cell)))
     cell))
 
 (defn teardown!
@@ -877,6 +904,46 @@
     (doseq [cell victims]
       (teardown! cell))
     (count victims)))
+
+(defn teardown-root!
+  "Explicit host/ROOT teardown driver (03 §4) — the root-path counterpart to
+  the frame-destroy sweep, driven from `re-frame.ui.client/unmount!*` at the
+  host teardown moment. Runs `unmount-thunk` (the host React `.unmount`) with a
+  collection window armed, so every ViewCell whose effect-cleanup fires DURING
+  the host unmount is captured (`disconnect!` enrols it — see the
+  `teardown-collector` window). Because a host `.unmount` sweeps the cleanups of
+  EXACTLY its own root's tree, the captured set is precisely the cells belonging
+  to that root — sibling and nested-portal roots are structurally isolated (they
+  are separate React roots the sweep never touches).
+
+  Each captured cell is then retroactively proven an unmount via the shared
+  `teardown!` primitive (the SAME machinery the frame-destroy path uses, not a
+  parallel one): its transient `:disconnected {:reason :unknown}` interval —
+  which effect cleanup ALREADY emitted, indistinguishable from an Activity hide
+  at that moment — is upgraded to `:unmounted {:proof :host-teardown}` and the
+  cell goes `:dead`, so a retained handle can never reconnect after its root is
+  gone and a late recommit fails through the dead-cell lifecycle (commit! step
+  2) rather than by probing a torn-down context. An Activity hide, by contrast,
+  disconnects with NO window armed, is never captured, and stays reconnectable —
+  a reveal proves it `:activity-hidden {:proof :reconnect}`.
+
+  Ordering-robust and re-entrancy-safe by save/restore. If `unmount-thunk`
+  THROWS (React refused to unmount — it did NOT tear the tree down, so no
+  cleanup ran and nothing was collected), the window is restored and the throw
+  propagates WITHOUT tearing any cell down: the orphaned tree's cells stay live,
+  and the original host error is never masked (the ruled host-teardown
+  behaviour, rf2-vxgfnd.53). Returns the count of cells torn down."
+  [unmount-thunk]
+  (let [prev      @teardown-collector
+        collected (do (reset! teardown-collector #{})
+                      (try
+                        (unmount-thunk)
+                        @teardown-collector
+                        (finally
+                          (reset! teardown-collector prev))))]
+    (doseq [cell collected]
+      (teardown! cell))
+    (count collected)))
 
 ;; ---------------------------------------------------------------------------
 ;; The 8-step layout-commit reconciler (03 §3)
@@ -1038,3 +1105,10 @@
   "The cell's current revision integer (tool/test read)."
   [^ViewCell cell]
   (:revision @(state cell)))
+
+(defn current-live-cells
+  "The set of currently-CONNECTED ViewCells (tool/test read) — the live-cell
+  registry a frame-destroy sweep consults, and the seam a DOM lifecycle fixture
+  grabs a mounted cell through to observe its post-unmount lifecycle."
+  []
+  @live-cells)

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -1,0 +1,196 @@
+(ns re-frame.ui.reactive-root-teardown-cljs-test
+  "rf2-vxgfnd.62 — explicit host/ROOT teardown → ViewCell dead-state wiring.
+
+  The frame-destroy arm (rf2-vxgfnd.42) gave `teardown!` a caller for the
+  frame path; this fixture pins the ROOT path — the counterpart driven from
+  `re-frame.ui.client/unmount!*`. The contract (03 §4): React effect cleanup
+  fires FIRST during a real `.unmount` and emits `:disconnected {:reason
+  :unknown}` (indistinguishable from an Activity hide at that moment); an
+  explicit root teardown then retroactively proves those cells `:unmounted
+  {:proof :host-teardown}` → `:dead`.
+
+  `reactive/teardown-root!` models this: it arms a collection window around the
+  host `.unmount` thunk, so every cell whose cleanup (`disconnect!`) fires
+  DURING the unmount is captured, then upgraded via the shared `teardown!`
+  primitive. An Activity hide (a `disconnect!` with the window UNARMED) is never
+  captured and stays reconnectable — the discriminator this file pins.
+
+  `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
+  (`clojure -M:test`), so the ownership/lifecycle logic is graft-checked on
+  both hosts against the REAL observation port + sub-cache (plain-atom
+  adapter). The end-to-end `client/unmount!*` wiring is pinned by the cljs-only
+  `re-frame.ui.root-teardown-wiring-cljs-test`; the real-DOM proof by the
+  browser `re-frame.ui.root-teardown-dom-cljs-test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.test-support         :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- ref-count [fid q]
+  (:ref-count (get @(:sub-cache (frame/frame fid)) q)))
+
+(defn- render+commit! [cell fid queries]
+  (rf/with-frame fid
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  (reactive/commit! cell)
+  cell)
+
+(defn- throws-id [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+;; ===========================================================================
+;; The core contract: a real root unmount proves :unmounted → :dead, and the
+;; cleanup fact seen DURING the unmount is the same transient :unknown as a hide
+;; ===========================================================================
+
+(deftest root-teardown-collects-a-disconnect-and-proves-unmount
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        cell   (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])
+        during (atom nil)]
+    (testing "precondition — connected, observing the frame, one owner"
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= 1 (ref-count fid [:rt/a]))))
+    ;; The thunk is the host `.unmount`: it fires the cell's effect cleanup
+    ;; (`disconnect!`) synchronously, exactly as React does inside `.unmount`.
+    (reactive/teardown-root!
+     (fn []
+       (reactive/disconnect! cell)
+       (reset! during (peek (reactive/intervals cell)))))
+    (testing "DURING the unmount the fact is the transient :unknown (03 §4)"
+      (is (= {:state :disconnected :reason :unknown} @during)
+          "cleanup emits the same immediate fact a real unmount and a hide share"))
+    (testing "AFTER the unmount the interval is retroactively proven an unmount"
+      (is (= :dead (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+             (peek (reactive/intervals cell)))
+          "the prior disconnect is upgraded to :unmounted {:proof :host-teardown}"))
+    (testing "the dead cell holds no leases and no pending notification"
+      (is (empty? (reactive/committed-target-keys cell)))
+      (is (false? (reactive/dirty? cell)))
+      (is (nil? (ref-count fid [:rt/a])) "the lease was released, ref-count gone"))))
+
+(deftest dead-cell-fails-loud-on-recommit-no-resume
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :rt/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])]
+    (reactive/teardown-root! (fn [] (reactive/disconnect! cell)))
+    (is (= :dead (reactive/lifecycle cell)))
+    (testing "a retained handle recommit fails through the dead-cell lifecycle,
+              not by probing a torn-down context (03 §4; commit! step 2)"
+      (rf/with-frame fid
+        (reactive/with-capture cell (fn [] (reactive/sub-read [:rt/a]))))
+      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))))))
+
+;; ===========================================================================
+;; The Activity-hide transient path is untouched — a hide never goes :dead
+;; ===========================================================================
+
+(deftest activity-hide-then-reveal-stays-transient-never-dead
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :rt/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])]
+    (testing "a hide is a `disconnect!` with NO teardown window armed"
+      (reactive/disconnect! cell)
+      (is (= :disconnected (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :unknown}
+             (peek (reactive/intervals cell)))
+          "the immediate fact — not :unmounted, and the cell is NOT :dead"))
+    (testing "a reveal reconnects and proves the prior interval an Activity hide"
+      (render+commit! cell fid [[:rt/a]])
+      (is (= :connected (reactive/lifecycle cell)) "reconnected, never :dead")
+      (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
+             (peek (reactive/intervals cell)))
+          "annotated :activity-hidden {:proof :reconnect} — never mislabeled unmounted"))))
+
+(deftest hide-outside-a-window-is-not-captured-by-a-later-teardown
+  ;; A cell hidden BEFORE any root teardown left the window unarmed, so it is
+  ;; not captured — the collection is bounded to cells disconnecting DURING the
+  ;; host unmount (matching live-cells' removed-on-disconnect membership).
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :rt/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])]
+    (reactive/disconnect! cell)                       ;; hide, window unarmed
+    (is (= 0 (reactive/teardown-root! (fn [] nil)))   ;; an empty host unmount
+        "a teardown whose unmount disconnects nothing tears down nothing")
+    (is (= :disconnected (reactive/lifecycle cell))
+        "the already-hidden cell is untouched — still reconnectable, not :dead")))
+
+;; ===========================================================================
+;; Root isolation — a teardown only claims the cells its own unmount disconnects
+;; ===========================================================================
+
+(deftest root-teardown-isolates-sibling-roots
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        cell-a (render+commit! (reactive/make-cell ::a) fid [[:rt/a]])
+        cell-b (render+commit! (reactive/make-cell ::b) fid [[:rt/a]])]
+    (is (= :connected (reactive/lifecycle cell-a)))
+    (is (= :connected (reactive/lifecycle cell-b)))
+    ;; Root A's `.unmount` sweeps only root A's tree — only cell-a disconnects.
+    (reactive/teardown-root! (fn [] (reactive/disconnect! cell-a)))
+    (testing "only the unmounted root's cells die"
+      (is (= :dead (reactive/lifecycle cell-a)) "root A's cell")
+      (is (= :connected (reactive/lifecycle cell-b))
+          "a sibling root's cell is neither annotated nor killed")
+      (is (= 1 (ref-count fid [:rt/a]))
+          "the sibling's lease is neither released nor churned"))
+    (testing "the sibling cell still reads live"
+      (is (= 1 (rf/with-frame fid
+                 (reactive/with-capture cell-b
+                   (fn [] (reactive/sub-read [:rt/a])))))))))
+
+;; ===========================================================================
+;; A throwing host `.unmount` — nothing torn down, original error preserved
+;; ===========================================================================
+
+(deftest throwing-host-unmount-tears-down-nothing-and-rethrows
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :rt/frame {:a 1})
+        cell (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])
+        boom (ex-info "host .unmount refused" {:host :react})]
+    (testing "the host refused to unmount — React did NOT tear the tree down"
+      (is (identical? boom
+                      (try (reactive/teardown-root! (fn [] (throw boom)))
+                           nil
+                           (catch #?(:clj Throwable :cljs :default) e e)))
+          "the original host error propagates, never masked"))
+    (testing "the orphaned tree's cell stays live — never falsely killed"
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= 1 (ref-count fid [:rt/a]))))))
+
+;; ===========================================================================
+;; Re-entrancy — a nested teardown does not corrupt the outer window
+;; ===========================================================================
+
+(deftest teardown-window-is-reentrancy-safe
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        outer  (render+commit! (reactive/make-cell ::outer) fid [[:rt/a]])
+        inner  (render+commit! (reactive/make-cell ::inner) fid [[:rt/a]])]
+    (reactive/teardown-root!
+     (fn []
+       ;; a nested teardown claims ONLY the inner cell it disconnects…
+       (reactive/teardown-root! (fn [] (reactive/disconnect! inner)))
+       (is (= :dead (reactive/lifecycle inner)) "inner torn down by the nested window")
+       ;; …then the outer window is restored and claims the outer cell.
+       (reactive/disconnect! outer)))
+    (is (= :dead (reactive/lifecycle outer))
+        "the outer window survived the nested one and proved its own cell")))

--- a/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
@@ -1,0 +1,107 @@
+(ns re-frame.ui.root-teardown-dom-cljs-test
+  "rf2-vxgfnd.62 — the ROOT teardown proof under REAL React + real DOM.
+
+  `reactive-root-teardown-cljs-test` graft-checks the window logic on both
+  hosts and `root-teardown-wiring-cljs-test` pins the client kernel with a fake
+  root; this file closes the loop end-to-end: a real `ui/mount` then
+  `ui/unmount!`, asserting the mounted ViewCell followed the 03 §4 dead-cell
+  lifecycle. It proves the load-bearing runtime assumption of the whole
+  approach — that React fires each cell's layout-effect cleanup SYNCHRONOUSLY
+  inside `root.unmount()`, so the teardown window catches the real cells and a
+  real root unmount ends `:unmounted {:proof :host-teardown}` → `:dead` rather
+  than stuck at the transient `:disconnected {:reason :unknown}`.
+
+  Browser-only bodies — the `-dom-cljs-test$` suffix opts this file into the
+  `:browser-test` build; `:node-test` loads it too, where the DOM body gates on
+  `(browser?)` and no-ops. The UIx function-component spine is the watchable
+  substrate the other browser fixtures use; here it simply provides a real
+  React mount surface for a compiled `defview`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider sub]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
+            ;; Load-bearing: the CLJS emitter wraps a sub-bearing view in
+            ;; `viewcell/render`, so a consumer must load the runtime.
+            [re-frame.ui.viewcell]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter uix-adapter/adapter :ambient-frame nil})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (client/reset-live-roots!)
+    (try (f)
+         (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+
+(def ^:private frame-kw :rt.dom/frame)
+
+(defn- container [] (js/document.createElement "div"))
+
+;; One sub-bearing view → one ViewCell under the mounted root.
+(defview leaf [_] [:span.leaf (str (sub [:rt.dom/n]))])
+
+(defn- register-app! []
+  (rf/make-frame {:id frame-kw :doc "root-teardown DOM probe frame"})
+  (rf/reg-sub :rt.dom/n (fn [db _] (:n db)))
+  (rf/reg-event :rt.dom/seed (fn [_ _] {:db {:n 7}})))
+
+(deftest real-root-unmount-proves-cell-unmounted-then-dead
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                             c {:root-id :rt.dom/root}))
+            cells (reactive/current-live-cells)
+            cell  (first cells)]
+        (testing "the sub-bearing view mounted one connected ViewCell"
+          (is (= "7" (.-textContent (.querySelector c ".leaf"))))
+          (is (= 1 (count cells)) "exactly one live ViewCell under the root")
+          (is (= :connected (reactive/lifecycle cell))))
+        (testing "a REAL root unmount proves the cell :unmounted → :dead"
+          (react-dom/flushSync #(ui/unmount! root))
+          (is (= :dead (reactive/lifecycle cell))
+              "not stuck at the transient :unknown — the host teardown upgraded it")
+          (is (= :unmounted (:reason (peek (reactive/intervals cell))))
+              "the interval carries the :unmounted reason")
+          (is (= :host-teardown (:proof (peek (reactive/intervals cell))))
+              "…proven by the host teardown (03 §4)"))
+        (testing "the container is re-mountable — the claim was released"
+          (is (= #{} (client/live-root-ids))))))))
+
+(deftest real-root-unmount-isolates-a-sibling-root
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
+      (let [ca    (container)
+            cb    (container)
+            root-a (react-dom/flushSync
+                    #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                               ca {:root-id :rt.dom/root-a}))
+            root-b (react-dom/flushSync
+                    #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                               cb {:root-id :rt.dom/root-b}))]
+        ;; two roots, two cells; root B still renders after root A unmounts
+        (is (= 2 (count (reactive/current-live-cells))) "two live cells")
+        (let [before (vec (reactive/current-live-cells))]
+          (react-dom/flushSync #(ui/unmount! root-a))
+          (testing "root A's cell is dead; root B's cell is untouched"
+            (let [alive (filter #(= :connected (reactive/lifecycle %)) before)
+                  dead  (filter #(= :dead (reactive/lifecycle %)) before)]
+              (is (= 1 (count dead)) "exactly one cell died")
+              (is (= 1 (count alive)) "exactly one cell still connected")
+              (is (= "7" (.-textContent (.querySelector cb ".leaf")))
+                  "root B still renders")))
+          (react-dom/flushSync #(ui/unmount! root-b)))))))

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -1,0 +1,99 @@
+(ns re-frame.ui.root-teardown-wiring-cljs-test
+  "rf2-vxgfnd.62 — the `client/unmount!*` → `reactive/teardown-root!` WIRING.
+
+  `reactive-root-teardown-cljs-test` graft-checks the teardown-window logic on
+  both hosts; this file pins the client-kernel wiring on node WITHOUT real
+  React: a fake `Root` whose host `react-root.unmount` fires a ViewCell's
+  effect cleanup (`disconnect!`) exactly as React does synchronously inside
+  `.unmount`. `unmount!*` must drive that through the teardown window, so the
+  cell ends `:unmounted` → `:dead` (not stuck `:unknown`), while still
+  releasing the live-root claim in its `finally` (contract §7 / AC4).
+
+  No DOM — the react-root is a plain JS object with an `unmount` method;
+  container ownership is identity-based. The real-React counterpart is the
+  browser `re-frame.ui.root-teardown-dom-cljs-test`."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.test-support         :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.ui.client            :as client]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (client/reset-live-roots!)
+    (try (f) (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+
+(defn- connected-cell! [fid queries]
+  (let [cell (reactive/make-cell ::v)]
+    (rf/with-frame fid
+      (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+    (reactive/commit! cell)
+    cell))
+
+(defn- register!
+  "Register a fake Root whose host `.unmount` runs `on-unmount` — the seam
+  React's synchronous effect-cleanup sweep fires through."
+  [root-id on-unmount]
+  (let [react-root #js {:unmount (fn [] (when on-unmount (on-unmount)))}
+        container  (js-obj)
+        root       (client/->Root react-root container root-id)]
+    (client/register-live-root! {:root-id root-id :provenance :authored}
+                                container root)
+    root))
+
+(deftest unmount-drives-the-cell-to-dead-and-releases-the-claim
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell (connected-cell! :rtw/frame [[:rtw/a]])
+        ;; the host `.unmount` fires the cell's cleanup, as React does
+        root (register! :rtw/root #(reactive/disconnect! cell))]
+    (is (= :connected (reactive/lifecycle cell)) "precondition: mounted + connected")
+    (is (= #{:rtw/root} (client/live-root-ids)) "precondition: root is live")
+    (is (nil? (client/unmount!* root)) "unmount!* returns nil")
+    (testing "the root's cell is proven :unmounted → :dead through the wiring"
+      (is (= :dead (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+             (peek (reactive/intervals cell)))))
+    (testing "the live-root claim is released (contract §7)"
+      (is (= #{} (client/live-root-ids))))))
+
+(deftest a-throwing-host-unmount-still-releases-the-claim-and-rethrows
+  ;; rf2-vxgfnd.53 aftermath, preserved through the new teardown wiring: React
+  ;; refused to unmount, no cleanup ran, no cell was collected, the claim is
+  ;; still released, and the original host error propagates.
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell (connected-cell! :rtw/frame [[:rtw/a]])
+        boom (ex-info "React refused synchronous unmount" {:host :react})
+        root (register! :rtw/root (fn [] (throw boom)))]
+    (is (identical? boom
+                    (try (client/unmount!* root) nil
+                         (catch :default e e)))
+        "the original host error propagates, never masked")
+    (testing "the claim is released despite the throw (AC4)"
+      (is (= #{} (client/live-root-ids))))
+    (testing "the orphaned tree's cell stays live — not falsely killed"
+      (is (= :connected (reactive/lifecycle cell))))))
+
+(deftest unmount-on-a-stale-root-is-a-noop
+  ;; A superseded/already-torn-down handle must not run the teardown window at
+  ;; all — the membership guard short-circuits before `.unmount`.
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell    (connected-cell! :rtw/frame [[:rtw/a]])
+        fired?  (atom false)
+        ;; a Root that is NOT registered in live-roots (stale handle)
+        stale   (client/->Root #js {:unmount (fn [] (reset! fired? true)
+                                               (reactive/disconnect! cell))}
+                               (js-obj) :rtw/gone)]
+    (is (nil? (client/unmount!* stale)) "stale unmount is an idempotent no-op")
+    (is (false? @fired?) "the host `.unmount` was never called")
+    (is (= :connected (reactive/lifecycle cell)) "the cell is untouched")))


### PR DESCRIPTION
## What

Completes the Stage-2 lifecycle matrix's host/ROOT teardown proof arm (rf2-vxgfnd.62). PR #5731 gave `reactive/teardown!` a production caller for FRAME destruction, but explicit root/host teardown was unwired: `client/unmount!*` only called React `.unmount` + released the live-root claim. React effect cleanup emitted `:disconnected {:reason :unknown}` (an Activity hide and a real unmount are indistinguishable at cleanup time), but nothing subsequently proved that disconnect an unmount — so a real root unmount stayed `:unknown` forever and `teardown!` was never invoked on the root path.

## How

- **`reactive/teardown-root!`** (new, `reactive.cljc`) — the root-path counterpart to the frame-destroy sweep. It arms a collection window around the host `.unmount` thunk; each ViewCell whose effect-cleanup (`disconnect!`) fires DURING `.unmount` is captured, then retroactively proven `:unmounted {:proof :host-teardown}` → `:dead` via the **shared `teardown!` primitive** (the frame-destroy machinery, not a parallel one). Because a host `.unmount` sweeps the effect-cleanups of exactly its own root's tree, the captured set is precisely that root's cells — sibling and nested-portal roots are structurally isolated (they are separate React roots the sweep never touches).
- **`client/unmount!*`** (`client.cljs`) — drives the host `.unmount` through `teardown-root!`. The `catch`/`finally` (claim release, dev warning, original-error rethrow — rf2-vxgfnd.53) are preserved: `teardown-root!` rethrows a throwing host `.unmount` unchanged.
- **Ordering + facts** — cleanup still emits the transient `:disconnected {:reason :unknown}` first, so the immediate fact is identical for a real unmount and an Activity hide; the `:unmounted` upgrade happens after `.unmount` returns. An Activity hide disconnects with the window unarmed, is never captured, stays reconnectable, and a reveal proves `:activity-hidden {:proof :reconnect}`. A throwing `.unmount` (React refused, nothing cleaned up) tears down no cell and rethrows the original error.

## Quality gates

Run in the worktree, foreground, 0-fail:

| Gate | Result |
| --- | --- |
| `implementation/core` `clojure -M:test` | 1862 tests, 8311 assertions, **0 failures, 0 errors** |
| `implementation/ui` `clojure -M:test` | 280 tests, 4594 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` (node) | 9017 tests, 42544 assertions, **0 failures, 0 errors** |
| `npm run test:browser` (Playwright, real React 19.2) | 297 tests, 1077 assertions, **0 failures, 0 errors** |

New coverage:
- `reactive-root-teardown-cljs-test` (`.cljc`, node + JVM) — the window logic + the hide-vs-unmount discriminator: collect→prove, the transient `:unknown` fact seen during unmount, dead-cell recommit fails loud, Activity hide/reveal stays transient, root isolation, throwing `.unmount`, re-entrancy.
- `root-teardown-wiring-cljs-test` (`.cljs`) — the real `client/unmount!*` path with a fake root whose `.unmount` fires the cleanup; proves cell `:dead` + claim released, throwing-unmount aftermath, stale-handle no-op.
- `root-teardown-dom-cljs-test` (`.cljs`, browser) — real React `ui/mount` → `ui/unmount!` ends the mounted cell `:dead` (not stuck `:unknown`) and isolates a sibling root.

Note: one non-deterministic flake observed in the unrelated `reactive-epoch-cljs-test` (`evidence-target-vector-is-bounded`, an extra `:disposed` cause from async lease-disposal timing) on the first ui-JVM run; it passed in isolation and on re-run. My change is inert when no teardown is in flight, so this is a pre-existing JVM ordering flake, not introduced here.

Closes rf2-vxgfnd.62.