### PR TITLE
fix(ui): type-preserving non-lossy config fingerprint canonicalization (rf2-vxgfnd.78)

### DIFF
--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -40,46 +40,112 @@
                             at preflight; the fingerprint is what
                             build-time plan-conflict detection compares)
 
-  ## Canonical EDN
+  ## Canonical serialization
 
-  `canonical-edn` prints with maps recursively sorted by `pr-str` of key
-  and sets sorted likewise — one value, one string, on both hosts.
-  Canonicalization recurses into map KEYS and set ELEMENTS as well as
-  values, so a map (or nested collection) used as a key or a set member
-  reaches a stable form regardless of its authoring order — two `=`-equal
-  plans always digest identically (no spurious plan-conflict).
+  `canonical-string` is a TYPE-PRESERVING, INJECTIVE canonical string (not
+  EDN). Every node is one self-delimiting token — a type-tag char, the
+  char length of its body, a `:`, then the body — so a set / vector / list /
+  map carry DISTINCT tags and a set never collides with a vector (or map) of
+  the same flattened elements. Sets and map keys are order-normalized;
+  vectors and lists stay order-sensitive; scalars carry their host-identical
+  `pr-str`. Two `=`-equal plans (up to map-key / set authoring order) always
+  digest identically (no spurious plan-conflict); a genuine config change —
+  including a set↔vector↔list type flip — always digests differently.
   Cross-host equality of the hex output is pinned by
   `re-frame.ui.fingerprint-cljs-test`."
   (:require [clojure.string :as str]))
 
 ;; ---------------------------------------------------------------------------
-;; Canonical EDN
+;; Canonical serialization
 ;; ---------------------------------------------------------------------------
+;;
+;; The digest input is a TYPE-PRESERVING, INJECTIVE canonical string — not
+;; EDN. Every node is emitted as one self-delimiting token
+;;
+;;     <type-tag><char-length of body>":"<body>
+;;
+;; — a single type-tag char, the CHARACTER count of the body, a ":"
+;; separator, then the body. The length turns each token into a netstring:
+;; a parent collection's body is just its child tokens concatenated, and no
+;; two distinct child sequences can share an encoding (the concatenation
+;; parses back unambiguously).
+;;
+;; The TYPE TAG is what makes the encoding type-preserving. A set (`s`),
+;; vector (`v`), list/seq (`l`), and map (`m`) carry DISTINCT tags, so a set
+;; never collides with a vector — or a map — of the same flattened elements.
+;; That was the pre-#5745 hazard: a set was flattened to a bare vector of its
+;; elements' `pr-str` STRINGS, so the distinct configs `#{:a}` and `[":a"]`
+;; shared one canonical form (`[":a"]`). That is a GUARANTEED pre-hash
+;; collision — a real config change reads as an idempotent no-op — closed here
+;; because `#{:a}` -> "s.." and `[":a"]` -> "v.." can never coincide, and the
+;; inner keyword `:a` -> "t..:a" and string `":a"` -> "t..\":a\"" differ too.
+;;
+;; ORDER handling: sets sort their child tokens (order-INSENSITIVE), map
+;; entries sort by their canonical KEY token (authoring-order-insensitive,
+;; #5745), and vectors/lists preserve producer order (order-SENSITIVE).
+;; Emitting map entries as a length-delimited token stream — rather than
+;; reducing them into an intermediate `sorted-map-by` — means two DISTINCT
+;; keys that share a comparator rank can never overwrite one another; both
+;; entries survive into the digest.
+;;
+;; SCALARS (`t`) carry their `pr-str`, which is host-identical for the
+;; supported terminal types and already type-distinct: a keyword `:a`, the
+;; string `":a"`, and the symbol `a` print differently, so they never collide.
 
-(defn- canonicalize [x]
-  (cond
-    ;; Recurse into BOTH key and value: a map (or any nested collection) used
-    ;; AS A KEY must canonicalize to a stable form too, or its authoring order
-    ;; survives into the printed digest and two semantically identical plans
-    ;; fingerprint differently (a spurious cross-root
-    ;; `:rf.error/frame-payload-conflict`). The sorted-map-by comparator then
-    ;; sorts on the ALREADY-canonical key, so entry order is stable regardless
-    ;; of key shape.
-    (map? x)  (into (sorted-map-by (fn [a b] (compare (pr-str a) (pr-str b))))
-                    (map (fn [[k v]] [(canonicalize k) (canonicalize v)]))
-                    x)
-    ;; Elements canonicalize before they are printed for the sorted vec — a
-    ;; map (or nested collection) inside a set has the same authoring-order
-    ;; hazard as a map-as-key.
-    (set? x)  (vec (sort (map (comp pr-str canonicalize) x)))  ; sets as sorted printed vec
-    (vector? x) (mapv canonicalize x)
-    (seq? x)  (apply list (map canonicalize x))
-    :else x))
+(def ^:private canonical-version
+  "Version marker prefixing every canonical string. It is hashed with the
+  body, so a fingerprint computed under an older encoding is detectably
+  distinct — never silently reinterpreted — when the encoding is revised.
+  `cfp2` is the type-preserving, length-delimited writer (rf2-vxgfnd.78);
+  the unversioned `pr-str`-flattening form (pre-#5745 / #5745) was v1."
+  "cfp2:")
 
-(defn canonical-edn
-  "One deterministic EDN string per value, both hosts."
+(declare -write)
+
+(defn- token
+  "A self-delimiting canonical token: the `tag` char, the CHARACTER length
+  of `body`, a `:` separator, then `body`. The length makes the token a
+  netstring, so concatenated child tokens parse back unambiguously and no
+  two distinct child sequences share an encoding."
+  [tag body]
+  (str tag (count body) ":" body))
+
+(defn- -write
+  "Emit the injective, type-preserving canonical token for `x`. Collections
+  carry a distinct type tag (`m`/`s`/`v`/`l`) so a map, set, vector, and
+  list never collide; sets and map keys are order-normalized while vectors
+  and lists keep producer order; scalars (`t`) carry their host-identical,
+  type-distinct `pr-str`."
   [x]
-  (pr-str (canonicalize x)))
+  (cond
+    ;; Map — sort ENTRIES by their canonical KEY token, then emit key and
+    ;; value tokens in that order. A token stream (not a sorted-map) means
+    ;; two distinct keys can never overwrite one another.
+    (map? x)    (token "m" (->> x
+                                (map (fn [[k v]] [(-write k) (-write v)]))
+                                (sort-by first)
+                                (mapcat (fn [[k v]] [k v]))
+                                (apply str)))
+    ;; Set — order-INSENSITIVE: sort the child tokens. The `s` tag keeps a
+    ;; set distinct from a vector/list of the same elements.
+    (set? x)    (token "s" (apply str (sort (map -write x))))
+    ;; Vector — order-SENSITIVE: preserve producer order.
+    (vector? x) (token "v" (apply str (map -write x)))
+    ;; List / seq — order-SENSITIVE; the `l` tag keeps it distinct from a
+    ;; vector of the same elements.
+    (seq? x)    (token "l" (apply str (map -write x)))
+    ;; Scalar — `pr-str` is host-identical and type-distinct for the
+    ;; supported terminals (keyword vs string vs symbol vs number vs nil).
+    :else       (token "t" (pr-str x))))
+
+(defn canonical-string
+  "One deterministic, type-preserving canonical string per value, identical
+  on both hosts (see the section comment above for the token grammar).
+  Equal values — up to map-key / set authoring order — produce the same
+  string; distinct values, including a set vs a vector vs a list of the same
+  elements, produce different strings."
+  [x]
+  (str canonical-version (-write x)))
 
 ;; ---------------------------------------------------------------------------
 ;; FNV-1a 64
@@ -120,9 +186,9 @@
      :cljs (.encode (js/TextEncoder.) s)))
 
 (defn digest
-  "prefix + FNV-1a-64 hex of the canonical EDN of `form`."
+  "prefix + FNV-1a-64 hex of the canonical string of `form`."
   [prefix form]
-  (str prefix (hex64 (fnv1a-64 (utf8-bytes (canonical-edn form))))))
+  (str prefix (hex64 (fnv1a-64 (utf8-bytes (canonical-string form))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The three named digests

--- a/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
@@ -7,13 +7,64 @@
             [clojure.test :refer [deftest is]]
             [re-frame.ui.fingerprint :as fp]))
 
-(deftest canonical-edn-is-order-insensitive
-  (is (= (fp/canonical-edn {:b 2 :a 1})
-         (fp/canonical-edn {:a 1 :b 2})))
-  (is (= (fp/canonical-edn {:x #{:c :a :b}})
-         (fp/canonical-edn {:x #{:b :a :c}})))
-  (is (not= (fp/canonical-edn [:a :b]) (fp/canonical-edn [:b :a]))
+(deftest canonical-string-is-order-insensitive
+  (is (= (fp/canonical-string {:b 2 :a 1})
+         (fp/canonical-string {:a 1 :b 2})))
+  (is (= (fp/canonical-string {:x #{:c :a :b}})
+         (fp/canonical-string {:x #{:b :a :c}})))
+  (is (not= (fp/canonical-string [:a :b]) (fp/canonical-string [:b :a]))
       "vectors stay order-significant"))
+
+(deftest canonical-string-is-type-preserving
+  ;; rf2-vxgfnd.78: the canonical form must be INJECTIVE across collection
+  ;; types and element types. The pre-#5745/#5745 form flattened a set to a
+  ;; bare vector of its elements' `pr-str` STRINGS, so distinct configs
+  ;; collided BEFORE the hash ran (a set/vector/list-lossiness bug): a real
+  ;; config change could read as an idempotent no-op, or two distinct configs
+  ;; be wrongly deduped.
+  ;; (a) the deterministic collision from the bead: a set and a vector of the
+  ;; same-`pr-str` element must NOT collide.
+  (is (not= (fp/canonical-string #{:a}) (fp/canonical-string [":a"]))
+      "a set and a vector-of-the-stringified-element must not collide")
+  (is (not= (fp/config-fingerprint :f #{:a}) (fp/config-fingerprint :f [":a"]))
+      "and neither may their config fingerprints")
+  ;; a set, vector, and list of the SAME elements are three distinct shapes.
+  (is (apply distinct? [(fp/canonical-string #{:a :b})
+                        (fp/canonical-string [:a :b])
+                        (fp/canonical-string (list :a :b))])
+      "set vs vector vs list of the same elements are all distinct")
+  ;; empty collections don't collapse together either.
+  (is (apply distinct? [(fp/canonical-string #{})
+                        (fp/canonical-string [])
+                        (fp/canonical-string {})
+                        (fp/canonical-string (list))])
+      "empty set/vector/map/list are all distinct")
+  ;; (b) a set stays order-INSENSITIVE.
+  (is (= (fp/canonical-string #{:a :b}) (fp/canonical-string #{:b :a}))
+      "a set is order-insensitive")
+  ;; (c) a vector stays order-SENSITIVE.
+  (is (not= (fp/canonical-string [:a :b]) (fp/canonical-string [:b :a]))
+      "a vector is order-sensitive")
+  ;; (d) type-distinct scalar elements must not collide: keyword `:a`, string
+  ;; `":a"`, symbol `a` are three different values.
+  (is (apply distinct? [(fp/canonical-string :a)
+                        (fp/canonical-string ":a")
+                        (fp/canonical-string 'a)])
+      "keyword vs string vs symbol scalars are distinct")
+  (is (apply distinct? [(fp/canonical-string #{:a})
+                        (fp/canonical-string #{":a"})
+                        (fp/canonical-string #{'a})])
+      "and they stay distinct nested inside a set")
+  ;; nested-collection types are preserved through map keys and values too.
+  (is (not= (fp/canonical-string {:k {}}) (fp/canonical-string {:k []}))
+      "a map-valued vs vector-valued entry is distinguishable")
+  ;; a config map may legally carry BOTH the set key #{:a} and the vector key
+  ;; [":a"]; canonicalization must retain BOTH entries (the pre-fix
+  ;; sorted-map-by merged them, discarding one before the hash).
+  (let [both  (fp/canonical-string {#{:a} 1 [":a"] 2})
+        one   (fp/canonical-string {#{:a} 1})]
+    (is (not= both one)
+        "both distinct keys survive canonicalization — neither is overwritten")))
 
 (deftest canonicalize-recurses-into-map-keys-and-set-elements
   ;; A map (or nested collection) used AS A KEY — or as a set element — must
@@ -21,11 +72,11 @@
   ;; Otherwise the key's/element's authoring order survives into the printed
   ;; digest and two `=`-equal plans fingerprint differently, raising a
   ;; SPURIOUS cross-root `:rf.error/frame-payload-conflict` (rf2-vxgfnd.33).
-  (is (= (fp/canonical-edn {{:a 1 :b 2} :v})
-         (fp/canonical-edn {{:b 2 :a 1} :v}))
+  (is (= (fp/canonical-string {{:a 1 :b 2} :v})
+         (fp/canonical-string {{:b 2 :a 1} :v}))
       "a map-as-key canonicalizes regardless of authoring order")
-  (is (= (fp/canonical-edn #{{:a 1 :b 2}})
-         (fp/canonical-edn #{{:b 2 :a 1}}))
+  (is (= (fp/canonical-string #{{:a 1 :b 2}})
+         (fp/canonical-string #{{:b 2 :a 1}}))
       "a map inside a set canonicalizes regardless of authoring order")
   ;; the whole point: two frame plans identical up to map-key authoring order
   ;; MUST fingerprint EQUAL, so preflight sees the idempotent no-op, not a
@@ -40,10 +91,16 @@
       "a real config difference still fingerprints differently"))
 
 (deftest fnv1a-64-cross-host-golden
-  ;; FNV-1a 64 reference vector: "a" -> af63dc4c8601ec8c; our digest input
-  ;; is (canonical-edn "a") = "\"a\"" so pin OUR pipeline's value instead:
-  (is (= "tf1-d4272417d7c77eea" (fp/digest "tf1-" "a"))
+  ;; The digest input is (canonical-string "a") = "cfp2:t3:\"a\"", so pin OUR
+  ;; pipeline's value — a JVM-computed literal the CLJS run must reproduce.
+  (is (= "tf1-c783a8a97ba1ec42" (fp/digest "tf1-" "a"))
       "cross-host golden — JVM-computed literal; the CLJS run must match")
+  ;; a representative nested value (set + vector + nested map inside a map)
+  ;; digests identically regardless of authoring order, on BOTH hosts.
+  (is (= "cf1-012724d9085f1a27"
+         (fp/config-fingerprint :frame/f
+                                {:b [2 3] :a #{:s2 :s1} :m {:y 2 :x 1}}))
+      "cross-host golden — nested set/vector/map value")
   (is (= (fp/digest "x-" {:b [2 3] :a #{:s2 :s1}})
          (fp/digest "x-" {:a #{:s1 :s2} :b [2 3]}))))
 


### PR DESCRIPTION
## What

Fixes rf2-vxgfnd.78 (P1 correctness). The config-fingerprint canonicalizer
was **lossy / type-conflating**: a set was flattened to a bare vector of its
elements' `pr-str` **strings**

```clojure
(set? x) (vec (sort (map (comp pr-str canonicalize) x)))
```

so the distinct configs `#{:a}` and `[":a"]` produced the **same** canonical
form `[":a"]` — a *guaranteed* pre-hash collision. Two different plans then
share a fingerprint: a real config change reads as an idempotent no-op, or two
distinct configs are wrongly deduped. The #5745 `sorted-map-by` compounded it —
two distinct keys sharing a `pr-str` rank merged, silently discarding a map
entry before hashing.

## Fix

A dedicated **type-preserving, injective canonical writer** replaces the
`pr-str`-flattening form. Every node is a self-delimiting netstring token
`<type-tag><len>":"<body>`, where the type tag distinguishes the four
collection kinds:

- **set** (`s`), **vector** (`v`), **list/seq** (`l`), **map** (`m`) carry
  DISTINCT tags — a set can never collide with a vector/list/map of the same
  flattened elements.
- **sets** sort their child tokens (order-insensitive); **map** entries sort by
  their canonical KEY token (authoring-order-insensitive, #5745 preserved);
  **vectors/lists** keep producer order (order-sensitive).
- map entries are emitted as a length-delimited **token stream** (not reduced
  into a `sorted-map`), so two distinct keys can never overwrite one another —
  both survive into the digest.
- **scalars** (`t`) keep their host-identical, type-distinct `pr-str` (keyword
  `:a` vs string `":a"` vs symbol `a`).
- a `cfp2:` **version marker** is hashed with the body, so a fingerprint
  computed under an older encoding is detectably distinct — never silently
  reinterpreted.

No render-path cost is added; fingerprinting stays compiler/preflight metadata
work. `canonical-edn` (not EDN anymore) is renamed to `canonical-string`; it is
not in the API manifest and only this module's test referenced it.

## Quality gates

Foreground, 0-fail:

- `implementation/ui` `clojure -M:test` — **274 tests, 4578 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` — **9007 tests, 42519 assertions, 0 failures, 0 errors** (cross-host `.cljc` goldens `tf1-c783a8a97ba1ec42` + `cf1-012724d9085f1a27` reproduced on CLJS == JVM)

New table coverage proves: the `#{:a}`/`[":a"]` collision is closed; set vs
vector vs list of the same elements are distinct; empty `#{}`/`[]`/`{}`/`()`
are distinct; sets stay order-insensitive and vectors order-sensitive;
keyword/string/symbol scalars separate (bare and nested in a set); both
distinct keys survive canonicalization; the #5745 map-key-order-insensitivity
and genuine-config-difference separation still hold.