### PR TITLE
fix(story): close silent-green :error projection + canonicalizer tie-order + JVM :wait recursion (rf2-f13zth, rf2-8r5yzb, rf2-epqsvh)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1546,7 +1546,7 @@
   ordered vector of clojure.test report maps (`{:type :pass|:fail|:error
   …}`), one per assertion record plus a run-level report when the verdict
   is not covered by a single assertion (a tape-floor `:fail`, a run-level
-  `:cannot-run`, or a vacuous-green `:pass`). Pure data → data — the same
+  `:cannot-run` / `:error`, or a vacuous-green `:pass`). Pure data → data — the same
   projection `story/is` emits, exposed for tooling that wants the reports
   without firing `do-report`."
   [result]
@@ -1665,7 +1665,7 @@
   On the JVM (the canonical headless test gate) `is` runs the target,
   BLOCKS until it resolves, fires one `clojure.test` report per assertion
   (plus a run-level report for a tape-floor `:fail` / run-level
-  `:cannot-run` / vacuous-green `:pass`), and returns the unified
+  `:cannot-run` / `:error` / vacuous-green `:pass`), and returns the unified
   run-result. On CLJS — where the run is async and the caller cannot block
   — `is` returns the run promise; chain `then` (or use `cljs.test`'s async
   `(async done …)` form) and call `(story/report-result! result)` when it

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -656,15 +656,33 @@
   (-canon [x]))
 
 (defn- canon-map-entries
-  "Map canon: sort by the canonicalised key (via `pr-str` of the
-  canon-key), flatten into a `[k v k v ...]` vector, then wrap under the
+  "Map canon: sort each canonicalised entry by the `pr-str` of its
+  canon-KEY, breaking a key `pr-str` tie by the `pr-str` of its
+  canon-VALUE, flatten into a `[k v k v ...]` vector, then wrap under the
   reserved `map-tag` so a map is never byte-identical to a vector / set of
   the same flattened shape. Symmetric across JVM + CLJS because
-  `pr-str` over canonical scalars is host-identical."
+  `pr-str` over canonical scalars is host-identical.
+
+  The value is a STRICTLY SECONDARY sort key, never a primary one: two
+  entries with DISTINCT canon-key `pr-str`s order EXACTLY as a bare
+  `(sort-by (comp pr-str key))` ordered them — the value is never consulted
+  — so an ordinary map's canonical bytes, and every golden captured from
+  them, are UNCHANGED (no rebase). It only bites when two DISTINCT keys
+  canonicalise to the SAME `pr-str`: every fn folds to `:rf/opaque-fn`,
+  every `##NaN` to `:rf/nan`, and `1.0` / `1` both to `1` (rf2-8r5yzb).
+  There the bare key sort fell back to Clojure's map ITERATION order, so two
+  `=`-equal maps built in different insertion orders (`{f1 :a f2 :b}` vs
+  `{f2 :b f1 :a}`) produced DIFFERENT canonical bytes → unequal hash → a
+  spurious `:non-deterministic` verdict / golden mismatch, breaking the
+  'equivalent values hash equal' contract. The value tiebreak makes the
+  order content-derived and iteration-INDEPENDENT: two entries whose key AND
+  value both canonicalise identically ARE byte-identical, so their relative
+  order cannot perturb the flattened form (the deliberate fn-identity
+  collapse, spec/017 — two values differing ONLY in fn identity hash equal)."
   [m]
   (let [entries (->> m
                      (map (fn [[k v]] [(-canon k) (-canon v)]))
-                     (sort-by (fn [[k _]] (pr-str k))))]
+                     (sort-by (fn [[k v]] [(pr-str k) (pr-str v)])))]
     [map-tag (into [] (mapcat identity) entries)]))
 
 (defn- stable-canon-order

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1187,15 +1187,19 @@
 
 ;; ---- async scheduler -----------------------------------------------------
 
-(defn- schedule!
-  "Run `f` after `ms` milliseconds. CLJS → `js/setTimeout`; JVM →
-  block the calling thread via `Thread/sleep` then invoke. Returns a
-  cancellable handle on CLJS, nil on JVM."
-  [ms f]
-  #?(:cljs (js/setTimeout f ms)
-     :clj  (do (when (pos? ms) (Thread/sleep ^long ms))
-               (f)
-               nil)))
+#?(:cljs
+   (defn- schedule!
+     "Run `f` after `ms` milliseconds via `js/setTimeout`, yielding to the
+     event loop so queued effects drain before the next step. Returns a
+     cancellable timeout handle.
+
+     CLJS-only. On the JVM the run loop folds a `:wait` INLINE (a
+     `Thread/sleep` then a `recur`) so it stays in tail position rather than
+     nesting a scheduled continuation per wait — a JVM `schedule!` would do
+     `(Thread/sleep ms)(f)`, a fresh `run-loop!` frame per wait, growing the
+     call stack (rf2-epqsvh)."
+     [ms f]
+     (js/setTimeout f ms)))
 
 ;; ---- assertion-slot recording -------------------------------------------
 ;;
@@ -1310,9 +1314,18 @@
             nm   (:name state)]
         (cond
           (= :wait (runner/step-type step))
-          (let [ms (runner/step-wait-ms step)]
+          (let [ms (or (runner/step-wait-ms step) 0)]
             (record-result! frame-id play-key nm idx step (runner/step-skip idx step))
-            (schedule! (or ms 0) #(run-loop! frame-id play-key token done-cb)))
+            ;; JVM: fold the wait INTO the loop so it stays in TAIL position.
+            ;; `schedule!` on the JVM used to nest `(Thread/sleep ms)(f)` — a
+            ;; fresh `run-loop!` frame per wait — so a script of many
+            ;; `[:wait ms]` steps grew the call stack (StackOverflowError) and
+            ;; blocked the caller for the summed waits. `recur` keeps the stack
+            ;; flat. CLJS keeps async `setTimeout` scheduling so the event loop
+            ;; drains between steps (rf2-epqsvh).
+            #?(:clj  (do (when (pos? ms) (Thread/sleep ^long ms))
+                         (recur frame-id play-key token done-cb))
+               :cljs (schedule! ms #(run-loop! frame-id play-key token done-cb))))
 
           :else
           (let [_      (record-settle-boundary! frame-id play-key step)

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -1001,7 +1001,18 @@
   therefore 'no per-assertion report already
   conveys the refusal' — `(not-any? #(= :fail (:type %)) per-assertion)` —
   so a mixed run (an unrelated passing assertion + a run-level refusal)
-  still gets the run-level `:cannot-run` report."
+  still gets the run-level `:cannot-run` report.
+
+  A run-level `:error` verdict is the same shape one status up: a
+  schema-conforming `{:status :error :assertions []}` (or an `:error` run
+  whose assertions carry no `:error` record) MUST project a failing
+  run-level `:error` report. Without it the `cond` fell through to `[]`,
+  `cljs.test`/`clojure.test` tallied zero, and the most SEVERE verdict a run
+  can carry read GREEN — exactly the silent-pass class this ns exists to
+  prevent. The gate mirrors `:cannot-run`'s: 'no per-assertion report
+  already conveys the error' — `(not-any? #(= :error (:type %))
+  per-assertion)` — so an `:error` already surfaced by an assertion record
+  reports exactly once (no run-level double)."
   [{:keys [status assertions schema-violations cannot-run] :as _result}]
   (let [per-assertion (mapv assertion->report assertions)
         worst         (requirements/aggregate-status assertions cannot-run)
@@ -1024,6 +1035,18 @@
             :message "run :cannot-run — the runner could not attempt this plan"
             :expected :rf.story/runnable
             :actual   :rf.story/cannot-run}]
+
+          ;; A run-level :error (the most SEVERE verdict) not already carried
+          ;; by an :error assertion record → emit a failing run-level :error
+          ;; report. Without this branch a schema-conforming
+          ;; {:status :error :assertions []} fell through to [] and the test
+          ;; runner tallied zero — a silent GREEN on an errored run (rf2-f13zth).
+          (and (= :error status)
+               (not-any? #(= :error (:type %)) per-assertion))
+          [{:type :error
+            :message "run :error — the runner errored"
+            :expected :rf.story/runnable
+            :actual   :rf.story/error}]
 
           (and (= :pass status) (empty? per-assertion))
           [{:type :pass

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -331,6 +331,39 @@
     (is (nil? (settle-abort! :story.abort/no-cb nil nil))
         "no done-cb → settle-abort! returns nil without throwing")))
 
+;; ---- JVM-only: many :wait steps do not grow the call stack (rf2-epqsvh) --
+;;
+;; On the JVM the `:wait` branch used to call `(schedule! ms #(run-loop! …))`,
+;; and `schedule!` did `(Thread/sleep ms)(f)` — a NESTED run-loop! call, not a
+;; `recur`. Every wait added a run-loop! frame, so a script with many
+;; `[:wait ms]` steps risked StackOverflowError and blocked the caller for the
+;; summed waits. The fix folds the JVM wait inline (`Thread/sleep` + `recur`)
+;; so the loop stays tail-position; CLJS keeps async `setTimeout` scheduling.
+;; This drives `run-loop!` directly (the established var-quoted seam) with a
+;; high wait-count and ms 0 — the nested path would deepen the stack past
+;; overflow well before completing; the recur path settles flat + fast.
+
+#?(:clj
+   (deftest jvm-many-wait-steps-do-not-grow-the-stack
+     (testing "rf2-epqsvh — a JVM run of MANY [:wait 0] steps completes
+               through the loop (done-cb fires, every step consumed, terminal
+               :pass) WITHOUT StackOverflowError — the wait recurs in tail
+               position instead of nesting a schedule! frame per wait"
+       (let [frame-id :story.wait/deep
+             n        10000
+             spec     {:name nil :script (vec (repeat n [:wait 0]))}
+             started  (-> (runner/start (runner/initial-state spec) 0)
+                          (assoc :run-token "tok-WAIT"))
+             settled  (atom :unset)]
+         (set-state! frame-id nil started)
+         (run-loop! frame-id nil "tok-WAIT" (fn [final] (reset! settled final)))
+         (is (not= :unset @settled)
+             "done-cb fired — the loop ran to completion through every wait")
+         (is (= n (:step-idx @settled))
+             "every wait step was consumed (step-idx reached :total)")
+         (is (= :pass (:status @settled))
+             "an all-:wait run has no failures/refusals → terminal :pass")))))
+
 ;; ---- JVM-only: integration tests against a live re-frame frame ----------
 ;;
 ;; These reuse the namespace-wide `bridge-reset!` fixture above (which

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -1155,6 +1155,41 @@
       (is (= :fail (:type (last reports))))
       (is (re-find #"unconsumed failure" (:message (last reports)))))))
 
+(deftest result->reports-run-level-error-is-not-silent-green
+  (testing "rf2-f13zth — a run carrying :status :error with NO :error
+            assertion projects a FAILING run-level :error report, never [].
+            Before the fix the run-level cond had no :error branch, so
+            {:status :error :assertions []} fell through to [] → cljs.test
+            tallied zero → the MOST SEVERE verdict a run can carry read GREEN.
+            This is the public-projection path story/is drives for an
+            already-resolved result (story.cljc sync branch)."
+    (let [reports (result/result->reports {:status :error :assertions []})]
+      (is (seq reports)
+          "an :error run must NOT project to zero reports (that reads green)")
+      (is (= 1 (count reports)) "exactly one run-level error report")
+      (is (= :error (:type (first reports)))
+          "the report is an :error — cljs.test/clojure.test tallies it red")
+      (is (re-find #":error" (:message (first reports)))
+          "the message names the run-level error"))))
+
+(deftest result->reports-error-already-in-assertion-reports-once
+  (testing "rf2-f13zth — an :error run whose :error is ALREADY carried by a
+            per-assertion :error record reports EXACTLY once (no run-level
+            double) — the gate mirrors :cannot-run's 'no per-assertion report
+            already conveys it' guard"
+    (let [r       {:status :error
+                   :assertions [{:assertion :rf.assert/path-equals
+                                 :status :error :passed? false
+                                 :reason "handler threw"}]}
+          reports (result/result->reports r)
+          errors  (filterv #(= :error (:type %)) reports)]
+      (is (= 1 (count reports))
+          "no extra run-level report appended when an assertion carries the error")
+      (is (= 1 (count errors))
+          "exactly one :error report — the per-assertion one")
+      (is (= :error (:type (first reports)))
+          "the single report is the assertion's :error projection"))))
+
 (deftest passed?-only-pass
   (testing "result/passed? is true ONLY for :pass — :cannot-run is not a pass"
     (is (true?  (result/passed? {:status :pass})))

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -580,6 +580,55 @@
     (is (= [fp/set-tag [:a :b :c]] (fp/canonical-form #{:c :a :b})))))
 
 ;; ===========================================================================
+;; MAP-KEY TIE ORDER — same-`pr-str` keys sort iteration-INDEPENDENTLY (rf2-8r5yzb)
+;; ===========================================================================
+;;
+;; `canon-map-entries` used to sort entries by the canon-KEY `pr-str` alone.
+;; Keys that canonicalise to the SAME `pr-str` — every fn folds to
+;; `:rf/opaque-fn`, every `##NaN` to `:rf/nan`, and `1.0` / `1` both to `1` —
+;; tied, and the bare sort fell back to Clojure's map ITERATION order. So two
+;; `=`-equal maps built in DIFFERENT insertion orders produced DIFFERENT
+;; canonical bytes → unequal hash, breaking the 'equivalent values hash equal'
+;; contract determinism + goldens rest on. The fix adds the canon-VALUE as a
+;; strictly SECONDARY sort key, iteration-independent for tied keys and inert
+;; for distinct ones (no golden rebase).
+
+(deftest canon-map-tied-keys-order-iteration-independently
+  (testing "rf2-8r5yzb — two =-equal maps whose keys canonicalise to the SAME
+            `pr-str` (distinct fns both fold to `:rf/opaque-fn`), built in
+            OPPOSITE insertion orders, canonical-hash EQUAL"
+    (let [f1 (fn [] :one)
+          f2 (fn [] :two)
+          ;; array-maps preserve insertion order, so the two literals seq in
+          ;; opposite orders — the exact iteration-order divergence 8r5yzb hit.
+          m-ab (array-map f1 :a f2 :b)
+          m-ba (array-map f2 :b f1 :a)]
+      (is (= m-ab m-ba) "precondition: the two maps are =-equal")
+      (is (= (fp/canonical-form m-ab) (fp/canonical-form m-ba))
+          "insertion/iteration order must not change the canonical form")
+      (is (= (fp/canonical-hash m-ab) (fp/canonical-hash m-ba))
+          "…so the canonical hashes are equal — the determinism floor")))
+  (testing "a GENUINE value difference under a tied key still SEPARATES — the
+            secondary key is a tiebreak, not a collapse"
+    (let [f1 (fn [] 1) f2 (fn [] 2)]
+      (is (not= (fp/canonical-hash (array-map f1 :a f2 :b))
+                (fp/canonical-hash (array-map f1 :a f2 :c)))
+          "{f1 :a f2 :b} and {f1 :a f2 :c} differ in a value → distinct hash")))
+  (testing "the number-folding tie (`1` and `1.0` both canon to `1`) is
+            likewise iteration-independent — the fix generalises past fn/NaN"
+    (let [m1 (array-map 1 :a 1.0 :b)
+          m2 (array-map 1.0 :b 1 :a)]
+      (is (and (= 2 (count m1)) (= 2 (count m2)))
+          "precondition: 1 and 1.0 are DISTINCT keys (Clojure `=` is category-sensitive)")
+      (is (= (fp/canonical-hash m1) (fp/canonical-hash m2))
+          "same-canon-key entries order by value, so the hashes are equal")))
+  (testing "ordinary distinct-`pr-str` map key order is UNCHANGED — the value
+            tiebreak never fires, so no golden rebase"
+    (is (= [fp/map-tag [:a 1 :b 2 :c 3]]
+           (fp/canonical-form (array-map :c 3 :a 1 :b 2)))
+        "distinct keys still sort by key alone — identical to the pre-fix bytes")))
+
+;; ===========================================================================
 ;; CANONICAL VERSION — the bumped tag is recorded (rf2-lvrqa)
 ;; ===========================================================================
 


### PR DESCRIPTION
Three `tools/story/` bugs surfaced by a read-only Causa/Story review-wave, fixed as one PR. Commits are ordered smallest → biggest-correctness.

## rf2-8r5yzb (P3) — canonicalizer breaks pr-str ties by iteration order

`fingerprint.cljc` `canon-map-entries` sorted map entries by the canon-**key** `pr-str` alone. Keys that canonicalise to the same `pr-str` — every fn to `:rf/opaque-fn`, every `##NaN` to `:rf/nan`, `1.0`/`1` both to `1` — tied, and the bare sort fell back to Clojure map **iteration** order. Two `=`-equal maps built in different insertion orders (`{f1 :a f2 :b}` vs `{f2 :b f1 :a}`) then produced different canonical bytes and unequal hashes, breaking the "equivalent values hash equal" contract that determinism + goldens rest on.

**Fix:** add the canon-**value** as a strictly secondary sort key. Distinct-key maps order exactly as before (no golden rebase — proven by the unchanged ordinary-value goldens); tied-key maps order iteration-independently (entries whose key *and* value canonicalise identically are byte-identical, so order can't perturb the flattened form). Sets were already sound — they sort by the whole canonical element.

## rf2-epqsvh (P3) — JVM `:wait` steps grow the call stack

`runner_events.cljc` `run-loop!`'s `:wait` branch called `(schedule! ms #(run-loop! …))`; on the JVM `schedule!` did `(Thread/sleep ms)(f)` — a **nested** `run-loop!` call, not a `recur`. Every `:wait` added run-loop! frames, so a script with many `[:wait ms]` steps risked `StackOverflowError` and blocked the caller for the summed waits.

**Fix:** on the JVM fold the wait inline — `(Thread/sleep ms)` then `(recur …)`, tail-position, so the stack stays flat. CLJS keeps async `setTimeout` scheduling (the event loop must drain between steps), so `schedule!` is now CLJS-only.

## rf2-f13zth (P2) — `result->reports` silently drops a run-level `:error`

`result.cljc` `result->reports`' run-level `cond` had branches for a tape-floor `:fail`, a run-level `:cannot-run`, and a vacuous `:pass`, but **no** `:status :error` branch. A schema-conforming `{:status :error :assertions []}` fell through to `[]`, `cljs.test`/`clojure.test` tallied zero reports, and a `deftest` read **GREEN** on the most severe verdict a run can carry — exactly the silent-pass class this ns exists to prevent. (Latent in the public projection API — the in-repo run path always backs `:error` with an `:error` assertion.)

**Fix:** add an `:error` branch mirroring `:cannot-run` — emit a failing run-level `:error` report gated on `(not-any? #(= :error (:type %)) per-assertion)`, so a bare `:error` run surfaces red and an `:error` already carried by an assertion record reports exactly once. The public re-exports (`story/result->reports`, `story/is`) inherit it via delegation.

## Quality gates

All foreground, 0-fail:

- Story JVM alias (`clojure -M:test` from `tools/story/`): **1806 tests, 6662 assertions, 0 failures, 0 errors**
- CLJS node-test (`npm run test:cljs`): **9018 tests, 42549 assertions, 0 failures, 0 errors** (build: 1575 files, 4 pre-existing warnings, none in the changed files)
- Focused namespaces: `story-fingerprint-test` (26 tests / 168 assertions), `runner-events-cljs-test` (55 / 178), `result-test` (48 / 241) — all green

New regression tests: fn/NaN/number-fold tied-key map ordering (`story_fingerprint_test.clj`), a 10k-`:wait` JVM run that completes without stack growth (`runner_events_cljs_test.cljc`), and `{:status :error :assertions []}` → failing report + no-double-on-error-assertion (`result_test.cljc`).
