### PR TITLE
fix(core): close observation hook-install race + correct disposal-cause labelling (rf2-vxgfnd.70, rf2-x76af2.34)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -106,18 +106,29 @@
   (frame-destroy, explicit cache clears) drain on the next tick with cause
   `:disposed`.
 
-  The first owner's enrol + disposal-hook install is NOT one atomic step: the
-  node record advertises `:hooked?` as the lease enrols, before
-  `interop/add-on-dispose!` registers the callback. A disposal that linearizes
-  in that gap could fire no hook (the callback lands on an already-disposed
-  reaction and is silently lost — every substrate's `-dispose` clears its
-  callbacks first) or drain the owner set before a second owner enrolled. So
-  `acquire!` closes the handshake with a CANONICALITY RE-CHECK (rf2-vxgfnd.32):
-  because every disposal path evicts the cache entry before `interop/dispose!`,
-  a reaction that is no longer the frame's canonical node was disposed in the
-  window — the staged owners are self-drained and enqueued exactly once
-  (`take-owners!` is the single-drain point), so no acquired lease is ever left
-  behind an uninstalled/dead hook without its invalidation.
+  Readiness is published HONESTLY (rf2-vxgfnd.70): the node record's
+  `:hook-installed?` flag is set only AFTER `interop/add-on-dispose!` has
+  actually registered the callback, never as the lease merely enrols. So a
+  fresh follower — whose `register-owner!` reads that flag — can never observe a
+  ready hook before the hook exists. A concurrent follower whose enrolment
+  interleaves the install window (flag still unset) is told to install too: it
+  registers its OWN node-scoped disposal hook, an independent fallback that
+  observes disposal without waiting for the first owner to finish. Duplicate
+  hooks are harmless because `take-owners!` is the single-drain point — the
+  first to fire snapshots-and-clears the owners, the rest no-op — so the node
+  still fans out O(current owners) exactly once, and steady state (every later
+  owner a cache HIT behind a confirmed hook) keeps ONE hook per node.
+
+  `acquire!` still closes the disposed-before-my-install window with a
+  CANONICALITY RE-CHECK (rf2-vxgfnd.32): because every disposal path evicts the
+  cache entry before `interop/dispose!`, a reaction that is no longer the
+  frame's canonical node was disposed in the window — the staged owners are
+  self-drained and enqueued exactly once (`take-owners!` is the single-drain
+  point), so no acquired lease is ever left behind an uninstalled/dead hook
+  without its invalidation. If the install itself throws, the owner tears
+  itself down (ref/watch/enrolment balanced) and the exception propagates
+  through acquire!'s fail-loud path, leaving readiness unpublished so the node
+  is never poisoned.
 
   The same eviction-before-dispose fact means a node the build itself just
   installed can be DISPLACED — invalidated-and-rebuilt to a newer canonical node
@@ -227,7 +238,7 @@
 ;; ---- node records (weak identity-keyed) -------------------------------------
 ;;
 ;; Per-node observation bookkeeping — `{:node-key <int> :version <int>
-;; :value <last-observed> :owners #{lease…} :hooked? bool}` — keyed by the
+;; :value <last-observed> :owners #{lease…} :hook-installed? bool}` — keyed by the
 ;; cache node's reaction OBJECT in a WEAK identity-keyed table, so a record's
 ;; lifetime is exactly its reaction's: an evicted/disposed node's record
 ;; becomes unreachable with the node, and the port never prunes, scans, or
@@ -759,9 +770,13 @@
 ;; any node an owner keeps live (an unbounded leak, and O(all owners ever) at
 ;; the eventual disposal) — the port keeps an IDENTITY-keyed set of the node's
 ;; CURRENTLY-active owner leases inside the weak node record, and installs ONE
-;; node-scoped disposal hook per reaction. `acquire!` enrols the lease and
-;; installs the hook on the first owner; `release!` de-enrols it; node disposal
-;; snapshots-and-clears the live owners and enqueues each once. The owner set
+;; node-scoped disposal hook per reaction (steady state). `acquire!` enrols the
+;; lease and installs the hook when none is CONFIRMED installed yet — the first
+;; owner, plus any follower whose enrolment interleaves that install window
+;; (rf2-vxgfnd.70), whose own hook is an independent disposal fallback; `release!`
+;; de-enrols it; node disposal snapshots-and-clears the live owners and enqueues
+;; each once (`take-owners!` the single-drain point, so duplicate hooks are
+;; harmless). The owner set
 ;; rides the SAME weak record (and the same JVM lock discipline) as the version
 ;; bookkeeping, so it dies with the reaction — no pruning, no scan of historical
 ;; owners, storage O(current owners) not O(all owners ever acquired). The lease
@@ -780,26 +795,51 @@
 (defn- register-owner!
   "Enrol owner `lease` in `reaction`'s active-owner set within the weak node
   record (minting the record if a prior probe/observe has not — in practice
-  `acquire!` observes first, so the record exists). Returns true iff THIS call
-  must install the node's single disposal hook — i.e. it was the first owner
-  (`:hooked?` false → true). JVM: under the node-records lock, the same
-  discipline the version records use."
+  `acquire!` observes first, so the record exists). Returns true iff the node's
+  disposal hook is NOT yet CONFIRMED installed — i.e. THIS caller must install
+  it (rf2-vxgfnd.70). Crucially it does NOT flip the readiness flag: readiness
+  is published by [[mark-hook-installed!]] only AFTER `interop/add-on-dispose!`
+  has actually registered the callback, so a fresh follower can never observe a
+  ready hook before the hook exists. A follower whose enrolment interleaves the
+  install window (`:hook-installed?` still unset) is told to install too — its
+  own node-scoped hook is an independent disposal fallback, and duplicate hooks
+  are harmless because `take-owners!` is the single-drain point. JVM: under the
+  node-records lock, the same discipline the version records use."
   [reaction lease]
   #?(:clj
      (locking node-records
-       (let [rec     (or (.get node-records reaction)
-                         {:node-key (swap! node-key-counter inc) :version 0 :value nil})
-             hooked? (:hooked? rec)]
+       (let [rec        (or (.get node-records reaction)
+                            {:node-key (swap! node-key-counter inc) :version 0 :value nil})
+             installed? (:hook-installed? rec)]
          (.put node-records reaction
-               (assoc rec :owners (conj (or (:owners rec) #{}) lease) :hooked? true))
-         (not hooked?)))
+               (assoc rec :owners (conj (or (:owners rec) #{}) lease)))
+         (not installed?)))
      :cljs
-     (let [rec     (or (.get node-records reaction)
-                       {:node-key (swap! node-key-counter inc) :version 0 :value nil})
-           hooked? (:hooked? rec)]
+     (let [rec        (or (.get node-records reaction)
+                          {:node-key (swap! node-key-counter inc) :version 0 :value nil})
+           installed? (:hook-installed? rec)]
        (.set node-records reaction
-             (assoc rec :owners (conj (or (:owners rec) #{}) lease) :hooked? true))
-       (not hooked?))))
+             (assoc rec :owners (conj (or (:owners rec) #{}) lease)))
+       (not installed?))))
+
+(defn- mark-hook-installed!
+  "Publish the node's disposal-hook readiness: set `:hook-installed?` on the
+  weak node record AFTER `interop/add-on-dispose!` has actually registered the
+  callback (rf2-vxgfnd.70). Only from this point does a fresh follower's
+  [[register-owner!]] see a confirmed hook and skip installing its own; a
+  follower that enrolled earlier (in the install window) already installed an
+  independent backstop hook. Idempotent — a co-staged backstop installer may
+  set it too. No-op when the record has already died with a disposed reaction.
+  JVM: under the node-records lock. Returns nil."
+  [reaction]
+  #?(:clj
+     (locking node-records
+       (when-let [rec (.get node-records reaction)]
+         (.put node-records reaction (assoc rec :hook-installed? true))))
+     :cljs
+     (when-let [rec (.get node-records reaction)]
+       (.set node-records reaction (assoc rec :hook-installed? true))))
+  nil)
 
 (defn- deregister-owner!
   "Remove owner `lease` from `reaction`'s active-owner set. No-op when the
@@ -894,6 +934,10 @@
 
 ;; ---- acquire! -------------------------------------------------------------------
 
+;; `build-node-lease!`'s install-failure path reuses the full `release!`
+;; teardown (ref-count / watch / enrolment), which is defined below.
+(declare release!)
+
 (defn- make-watch-handler
   "Per-lease change watch: constant-work — advance the node record with the
   DELIVERED new value (no recompute, per I-5) and fan the mark-dirty payload
@@ -922,26 +966,36 @@
   already taken a real +1 reference on — in a live NODE lease. Register the
   per-lease change watch (on watchable hosts; `add-watch` never fires
   synchronously), take the baseline observation through the activated node,
-  enrol the lease as an active owner, and — only for the FIRST owner — install
-  the node's single disposal hook (delivery is queued; see the ns docstring's
-  HMR section). `release!` de-enrols the lease, so a released lease is no longer
-  reachable from the live reaction: disposal work stays O(current owners), never
-  O(all owners ever acquired) (rf2-vxgfnd.15).
+  enrol the lease as an active owner, and — whenever the node hook is not yet
+  CONFIRMED installed — install the node's disposal hook (delivery is queued;
+  see the ns docstring's HMR section). `release!` de-enrols the lease, so a
+  released lease is no longer reachable from the live reaction: disposal work
+  stays O(current owners), never O(all owners ever acquired) (rf2-vxgfnd.15).
 
-  Closes the first-owner disposal-hook HANDSHAKE (rf2-vxgfnd.32): the record's
-  `:hooked?` flag flips as the lease enrols, BEFORE `add-on-dispose!` actually
-  registers the callback, so a disposal that linearizes in that gap can (a) fire
-  NO hook — the callback lands on an already-disposed reaction and is lost (every
-  substrate's `-dispose` snapshot-and-clears its callbacks, and the JVM
-  Reaction's field is even unsynchronized, so an install racing `-dispose` can be
-  dropped outright) — or (b) drain the owner set before this lease enrolled.
-  Since every disposal path evicts the cache entry BEFORE `interop/dispose!`
-  (`re-frame.subs.cache`), a reaction that is no longer the frame's canonical
-  node WAS disposed in the window; self-drain the staged owners so each is
-  enqueued exactly once (`take-owners!` is the single-drain point; the installed
-  hook, if it did fire, already drained). No synchronous `on-change`: the drain
-  only ENQUEUES — delivery rides the next-tick / HMR drain boundary off the
-  acquire stack, preserving acquire!'s no-fan-out guarantee. Returns the lease."
+  Publishes readiness HONESTLY (rf2-vxgfnd.70): [[mark-hook-installed!]] sets
+  the record's `:hook-installed?` flag only AFTER `add-on-dispose!` has actually
+  registered the callback — never as the lease enrols — so a fresh follower can
+  never observe a ready hook before the hook exists. A concurrent follower whose
+  enrolment interleaves this install window ([[register-owner!]] still saw the
+  flag unset) installs its OWN node-scoped hook: an independent fallback that
+  observes disposal without waiting for the first owner, so no owner is ever
+  published behind a not-yet-installed hook. Duplicate hooks are harmless
+  because `take-owners!` is the single-drain point.
+
+  Closes the disposed-before-my-install window with the CANONICALITY RE-CHECK
+  (rf2-vxgfnd.32): since every disposal path evicts the cache entry BEFORE
+  `interop/dispose!` (`re-frame.subs.cache`), a reaction that is no longer the
+  frame's canonical node WAS disposed in the window; self-drain the staged
+  owners so each is enqueued exactly once (`take-owners!` is the single-drain
+  point; a hook that did fire already drained). No synchronous `on-change`: the
+  drain only ENQUEUES — delivery rides the next-tick / HMR drain boundary off
+  the acquire stack, preserving acquire!'s no-fan-out guarantee.
+
+  If `add-on-dispose!` itself throws, this owner has no hook of its own: tear it
+  down cleanly (`release!` balances ref-count / watch / enrolment) and rethrow,
+  leaving `:hook-installed?` unset so the node is not poisoned — a co-staged
+  backstop owner keeps its own hook and future acquirers install afresh. Returns
+  the lease."
   [target frame-id query reaction on-change]
   (let [state (atom {:lease-kind :node
                      :target     target
@@ -967,7 +1021,18 @@
                                 :version  (:version rec)
                                 :node-key (:node-key rec)}))
     (when (register-owner! reaction lease)
-      (interop/add-on-dispose! reaction (node-disposed-hook reaction)))
+      ;; Install the node's disposal hook, THEN publish readiness
+      ;; (rf2-vxgfnd.70): a fresh follower never observes a ready hook before
+      ;; the callback exists, and an install-window follower installs its OWN
+      ;; backstop hook (idempotent via take-owners!). On install failure, tear
+      ;; THIS owner down cleanly and rethrow — readiness stays unpublished so
+      ;; the node is not poisoned.
+      (try
+        (interop/add-on-dispose! reaction (node-disposed-hook reaction))
+        (mark-hook-installed! reaction)
+        (catch #?(:clj Throwable :cljs :default) t
+          (release! lease)
+          (throw t))))
     (when-not (node-still-canonical? @state)
       (drain-owners! reaction))
     lease))
@@ -1011,13 +1076,16 @@
   acquire is the cache's ref-count attach (Spec 006 §Lookup algorithm; a
   miss builds the node through the real cache-install path), plus per-lease
   callback registration: a unique change watch (on watchable hosts). The lease
-  is also enrolled as an active owner behind the node's single, once-installed
-  disposal hook; `release!` de-enrols it, so a released lease never leaks a
-  dormant closure (rf2-vxgfnd.15). A disposal that races the first-owner
-  hook install is caught by a canonicality re-check that self-drains the
-  staged owners (rf2-vxgfnd.32 — see the ns docstring's HMR section), so no
-  acquired lease is left behind an uninstalled/dead hook without its
-  invalidation. `acquire!` never invokes `on-change` synchronously — no
+  is also enrolled as an active owner behind the node's disposal hook (one hook
+  per node in steady state); `release!` de-enrols it, so a released lease never
+  leaks a dormant closure (rf2-vxgfnd.15). Readiness is published only AFTER the
+  hook is actually installed, and a follower that enrols in the install window
+  installs its own independent backstop hook rather than trusting a not-yet-
+  installed one (rf2-vxgfnd.70); a disposal that races the install is also
+  caught by a canonicality re-check that self-drains the staged owners
+  (rf2-vxgfnd.32 — see the ns docstring's HMR section), so no acquired lease is
+  left behind an uninstalled/dead hook without its invalidation. `acquire!`
+  never invokes `on-change` synchronously — no
   fan-out during acquire (movement in the render→commit gap is the commit
   evidence comparison's job, invariant 5).
 

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1279,7 +1279,11 @@
   is a no-op (its reference died with the eviction). Idempotent — a second
   `release!` no-ops; the static override lease no-ops entirely. Never
   invokes `on-change` (no fan-out during release). Dev-asserted
-  `:rf.error/reentrant-graph-op` from inside the fan-out. Returns nil."
+  `:rf.error/reentrant-graph-op` from inside the fan-out. The live→released
+  transition also nils the lease's `:reaction` and `:on-change` — both unused
+  after release — so a consumer-retained released lease pins neither the
+  on-change closure nor (on CLJS) the disposed reaction (rf2-x76af2.34). Returns
+  nil."
   [lease]
   (assert-not-in-fan-out! 're-frame.substrate.observation/release!)
   (let [state (lease-state lease)
@@ -1287,7 +1291,20 @@
                                (fn [st]
                                  (if (and (= :node (:lease-kind st))
                                           (= :live (:status st)))
-                                   (assoc st :status :released)
+                                   ;; Drop the reaction + on-change refs as the
+                                   ;; lease goes released (rf2-x76af2.34 FINDING
+                                   ;; 2): both are unused after release (read /
+                                   ;; current?/notify all short-circuit on
+                                   ;; :released, and read-after-release needs
+                                   ;; only :query-v/:frame-id), so a
+                                   ;; consumer-retained released lease pins
+                                   ;; neither the on-change closure (either host)
+                                   ;; nor the CLJS reaction. #5753's .37 already
+                                   ;; broke the JVM reaction strong-pin (weak
+                                   ;; ref); this drops the remaining dangling
+                                   ;; refs on both hosts.
+                                   (assoc st :status :released
+                                             :reaction nil :on-change nil)
                                    st)))]
     ;; We won the live→released transition iff `old` was a live node lease —
     ;; exactly-once teardown under the same swap-vals! discipline the cache

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -1097,6 +1097,44 @@
         (obs/release! keep)))))
 
 ;; ===========================================================================
+;; rf2-x76af2.34 FINDING 2 — a released node lease drops its reaction +
+;; on-change refs
+;;
+;; #5753's .37 change broke the JVM node-records value→key strong-pin by
+;; holding the reaction WEAKLY in the lease state. This complements it: the
+;; live→released transition also nils :reaction and :on-change — both unused
+;; after release (read/current?/notify short-circuit on :released;
+;; read-after-release needs only :query-v/:frame-id) — so a consumer that
+;; retains a released lease pins neither the on-change closure (either host)
+;; nor the CLJS reaction. Hygiene, not a true leak, but it drops the dangling
+;; refs promptly and matches the "released lease retains nothing" intent.
+;; ===========================================================================
+
+(deftest released-node-lease-drops-reaction-and-on-change-refs
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target    (items-target)
+        on-change (fn [_] :never)
+        lease     (obs/acquire! target on-change)
+        state     (@#'obs/lease-state lease)]
+    (testing "a live node lease holds its reaction + on-change"
+      (is (= :live (:status @state)))
+      (is (some? (:reaction @state)))
+      (is (some? (:on-change @state))))
+    (obs/release! lease)
+    (testing "the released lease dropped both refs — nothing dangling"
+      (is (= :released (:status @state)))
+      (is (nil? (:reaction @state)) "the reaction ref was dropped on release")
+      (is (nil? (:on-change @state)) "the on-change closure was dropped on release"))
+    (testing "read-after-release still throws from :query-v/:frame-id alone"
+      (is (= :rf.error/read-after-release
+             (error-id (try (obs/read lease)
+                            (catch #?(:clj Throwable :cljs :default) e e))))))
+    (testing "release! stays idempotent after the drop"
+      (obs/release! lease)
+      (is (= :released (:status @state))))))
+
+;; ===========================================================================
 ;; the JVM WeakHashMap self-reference leak fixture — rf2-vxgfnd.37
 ;;
 ;; The JVM node-records table is a process-global java.util.WeakHashMap keyed by

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -533,6 +533,131 @@
       (obs/release! lease))))
 
 ;; ===========================================================================
+;; rf2-vxgfnd.70 — a follower must not publish a lease behind the FIRST owner's
+;; still-installing hook.
+;;
+;; PR #5737's handshake flips the node record's readiness flag as the lease
+;; ENROLS, before interop/add-on-dispose! actually registers the callback. A
+;; follower that reads the flag true installs no hook of its own and trusts a
+;; hook that does not yet exist. If disposal wins before the first owner
+;; resumes, no hook fires and the follower's invalidation is lost (or delayed
+;; without bound). The fix publishes readiness (`:hook-installed?`) only AFTER
+;; the callback is registered; a follower enrolling in the install window
+;; installs its OWN backstop hook — an independent disposal fallback — so no
+;; owner is ever published behind a not-yet-installed hook (take-owners! keeps
+;; duplicate hooks harmless).
+;; ===========================================================================
+
+#?(:clj
+   (deftest first-owner-hook-install-window-follower-covered-before-first-owner-resumes
+     ;; Three-party JVM barrier (CountDownLatch, no sleeps). Thread A is the
+     ;; first owner, PAUSED mid-install (inside add-on-dispose!, before the
+     ;; callback registers). Thread B follows during that window. Thread C
+     ;; disposes the node BEFORE A resumes. With the fix, B installed its own
+     ;; backstop hook, so C's disposal drains BOTH owners here — the
+     ;; invalidation never waits for A. Pre-fix B installs no hook (it trusts
+     ;; A's not-yet-installed readiness flag), so C's disposal fires nothing and
+     ;; the pending queue is empty — the discriminating assertion fails.
+     (reg-items!)
+     (seed-items! [:a])
+     (let [target             (items-target)
+           notes-a            (atom [])
+           notes-b            (atom [])
+           l1                 (atom nil)
+           l2                 (atom nil)
+           real-add           interop/add-on-dispose!
+           a-installing       (java.util.concurrent.CountDownLatch. 1)
+           b-done             (java.util.concurrent.CountDownLatch. 1)
+           a-proceed          (java.util.concurrent.CountDownLatch. 1)
+           canonical-installs (atom 0)
+           pending-at-dispose (atom nil)]
+       (with-redefs
+         [interop/next-tick (fn [_f] nil)
+          interop/add-on-dispose!
+          (fn [reaction f]
+            (if (and (identical? reaction (:reaction (entry [:obs/items])))
+                     (= 1 (swap! canonical-installs inc)))
+              ;; A's node-disposed-hook install: signal mid-install, then BLOCK
+              ;; until released — the paused first installer.
+              (do (.countDown a-installing)
+                  (.await a-proceed)
+                  (real-add reaction f))
+              ;; B's backstop install (and the construction-time input-release
+              ;; closure, which the entry does not yet hold) proceed at once.
+              (real-add reaction f)))]
+         (let [fa (future (reset! l1 (obs/acquire! target (fn [n] (swap! notes-a conj n)))))]
+           (.await a-installing) ;; A is paused mid-install (no sleeps)
+           (let [fb (future
+                      (reset! l2 (obs/acquire! target (fn [n] (swap! notes-b conj n))))
+                      (.countDown b-done))]
+             (.await b-done)
+             (is (some? @l2)
+                 "B completed the follower acquire while A is paused mid-install")
+             ;; C disposes the node BEFORE A resumes.
+             (force-dispose-node! [:obs/items])
+             (reset! pending-at-dispose (vec @@#'obs/pending-disposals))
+             (is (= 2 (count @pending-at-dispose))
+                 (str "B's OWN backstop hook drained BOTH owners on disposal — "
+                      "the invalidation did not wait for the first owner to "
+                      "resume; pre-fix B installs no hook and this queue is empty "
+                      "(saw " (count @pending-at-dispose) ")"))
+             ;; Release A: it lands its now-dead hook, marks readiness, re-checks
+             ;; non-canonical, and self-drains to an already-empty owner set.
+             (.countDown a-proceed)
+             @fa
+             @fb
+             (is (some? @l1) "the first owner completed and returned its lease")
+             (testing "no synchronous fan-out — the drain only ENQUEUED"
+               (is (empty? @notes-a))
+               (is (empty? @notes-b)))
+             (obs/drain-pending-disposals! :disposed)
+             (is (= 1 (count @notes-a)) "first owner notified exactly once")
+             (is (= 1 (count @notes-b)) "follower notified exactly once")
+             (obs/release! @l1)
+             (obs/release! @l2)))))))
+
+(deftest first-owner-hook-install-failure-tears-down-and-recovers
+  ;; rf2-vxgfnd.70 — if interop/add-on-dispose! THROWS while an owner installs
+  ;; the node hook, acquire! must not leak: tear THIS owner down (ref-count /
+  ;; watch / enrolment balanced), leave readiness UNPUBLISHED so the node is
+  ;; not poisoned, and propagate the original exception through acquire!'s
+  ;; fail-loud path. A later acquire (install healthy) then succeeds — future
+  ;; acquirers are never stranded. Both hosts (single-threaded, with-redefs).
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target   (items-target)
+        real-add interop/add-on-dispose!
+        boom     (ex-info "add-on-dispose! boom" {::boom true})
+        fail?    (atom true)]
+    (with-redefs
+      [interop/next-tick (fn [_f] nil)
+       interop/add-on-dispose!
+       (fn [reaction f]
+         ;; Fail ONLY the observation node-disposed-hook install on the
+         ;; canonical node, once; the construction-time input-release closure
+         ;; (entry does not yet hold the reaction) and later installs proceed.
+         (if (and @fail?
+                  (identical? reaction (:reaction (entry [:obs/items]))))
+           (do (reset! fail? false) (throw boom))
+           (real-add reaction f)))]
+      (testing "the install throw propagates through acquire!'s fail-loud path"
+        (let [e (try (obs/acquire! target (fn [_])) nil
+                     (catch #?(:clj Throwable :cljs :default) e e))]
+          (is (identical? boom e) "acquire! rethrew the original install exception")))
+      (testing "the failed owner was torn down cleanly — ref-count balanced"
+        (is (nil? (entry [:obs/items]))
+            "the sole owner's ref was released, disposing the node — no leaked ref"))
+      (testing "readiness stayed unpublished — a fresh acquire installs + succeeds"
+        (let [lease (obs/acquire! target (fn [_]))]
+          (is (obs/lease? lease))
+          (is (true? (obs/owned? lease)))
+          (is (= 1 (ref-count [:obs/items])) "exactly one reference on the rebuilt node")
+          (is (= [:a] (:value (obs/read lease))))
+          (is (true? (obs/current? lease target)))
+          (obs/release! lease)
+          (is (nil? (entry [:obs/items]))))))))
+
+;; ===========================================================================
 ;; rf2-vxgfnd.28 — the disposal-notification drain contains a throwing owner
 ;; and SURFACES the escape (it was the one uncontained fan-out)
 ;;


### PR DESCRIPTION
Two commits on the observation-port (`implementation/core/src/re_frame/substrate/observation.cljc` + its test), built on #5753 (rf2-vxgfnd.28 drain containment + .37 weak reaction ref, merged just before this branch).

## Commit 1 — rf2-vxgfnd.70 (P1): close the follower hook-install race

`register-owner!` flipped the node record's readiness flag as the lease *enrolled*, BEFORE `interop/add-on-dispose!` actually registered the callback. On the JVM a follower could observe "ready", install nothing, pass its #5737 canonicality re-check (reaction still live), and return a **live lease behind a hook that did not yet exist** — so a disposal linearizing in that window fired no hook and the follower's invalidation was lost (or delayed unbounded on the first owner's resume/throw).

**Fix — honest readiness + independent backstop hook:**
- New `mark-hook-installed!` sets the record's `:hook-installed?` flag **only after** `add-on-dispose!` registers the callback. `register-owner!` no longer flips it; it reports whether a *confirmed* hook exists.
- A follower whose enrolment interleaves the install window installs its **own** node-scoped disposal hook — an independent fallback that never waits for the first owner. `take-owners!` is the single-drain point, so duplicate hooks are harmless (O(current owners) fan-out, exactly-once; **one hook per node in steady state** — sequential cache-HIT followers see `:hook-installed?` and install nothing, so rf2-vxgfnd.15's O(1) fixture is unaffected).
- The rf2-vxgfnd.32 canonicality re-check still covers the disposed-before-my-install window. On install **failure** the owner tears itself down via `release!` (ref-count / watch / enrolment balanced) and rethrows through `acquire!`'s fail-loud path, leaving readiness unpublished so the node is not poisoned.
- `:hooked?` renamed to `:hook-installed?` and all docstrings/comments rewritten to describe readiness honestly (acceptance criterion 8).

**Fixtures (no sleeps):**
- `first-owner-hook-install-window-follower-covered-before-first-owner-resumes` — three-party JVM `CountDownLatch` barrier: first owner paused mid-install, follower completes, node disposed **before** the first owner resumes; asserts the follower's own hook drained BOTH owners without waiting. **Verified it FAILS pre-fix** (empty disposal queue, "saw 0") by temporarily restoring the readiness-on-enrol behaviour.
- `first-owner-hook-install-failure-tears-down-and-recovers` — both-host `add-on-dispose!`-throws fixture: asserts clean teardown, balanced ref-counts (node evicted), the original exception propagated, and a healthy re-acquire (future acquirers not stranded).

## Commit 2 — rf2-x76af2.34 (P3 review): disposal-cause + hygiene

Verify-first against the current (#5753) code:

- **FINDING 1 (correctness, the primary one) — REAL, filed as follow-up rf2-r8jmdb.** Disposal `:cause` is still decided by *which drain boundary* fires, not by why the node died, so a frame-destroy/cache-clear lease pending when an unrelated `:sub` re-registration drains is mislabeled `:cause :hmr` (a documented `on-change` contract violation). #5753 did **not** thread the cause. The proper fix requires the four disposal sites in `subs/cache.cljc` (`:hot-reload` / `:frame-destroy` / `:cache-clear` / `:no-more-derefers`) to pass their cause into the port's enqueue — a cross-ns change (`subs.cache` is required *by* `observation`, so it needs late-bound plumbing) that is **outside this worker's observation.cljc-only surface**. Filed with the full fix plan + acceptance test in **rf2-r8jmdb**, per the surface-discipline STOP-and-flag instruction.
- **FINDING 2 (leak-hygiene) — JVM half resolved by #5753, remainder fixed here.** #5753's .37 already broke the JVM reaction strong-pin (weak ref). This nils `:reaction` **and** `:on-change` on the live→released transition (both unused after release), so a consumer-retained released lease pins neither the on-change closure (either host) nor the CLJS reaction. New both-host fixture `released-node-lease-drops-reaction-and-on-change-refs`.
- **FINDING 3 (JVM hardening note) — subsumed by Commit 1.** The install-on-disposed-reaction window is covered by the rf2-vxgfnd.32 canonicality re-check, and Commit 1's honest-readiness rewrite (own-backstop-hook + re-check) makes the reliance explicit in the docstrings — no separate change needed.

## Quality gates (all foreground, 0-fail)
- `clojure -M:test -n re-frame.observation-port-cljs-test` (core JVM, ns): **37 tests, 210 assertions, 0 failures/0 errors**
- `clojure -M:test` (full core JVM): **1866 tests, 8335 assertions, 0 failures/0 errors**
- `npm run test:cljs` (post-rebase): **9021 tests, 42576 assertions, 0 failures/0 errors**

Surface: only `observation.cljc` + `observation_port_cljs_test.cljc`. No spec/009 rows added; no new error-ids (install failure rethrows the original exception).