### PR TITLE
fix(ui): isolate a throwing evidence-sink from ViewCell flush completion (rf2-vxgfnd.73)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -605,12 +605,52 @@
 (defn set-evidence-sink!
   "Install (or clear, with nil) the DEBUG-only invalidation-evidence consumer
   — a `(fn [cell evidence] …)` the flush invokes with each pending cell's
-  coalesced bounded evidence just before advancing its revision. The intended
-  `re-frame.ui.tool`/Xray projection point; the flush's call is gated on
-  `interop/debug-enabled?`, so it is a no-op in production. Returns nil."
+  coalesced bounded evidence just after it completes that cell's flush. The
+  intended `re-frame.ui.tool`/Xray projection point; the flush's call is gated
+  on `interop/debug-enabled?`, so it is a no-op in production. A THROWING sink
+  is contained by the flush (see `flush-one!` / `report-sink-escape!`) and can
+  never strand a cell or abort the render batch. Returns nil."
   [f]
   (reset! evidence-sink f)
   nil)
+
+(defonce ^:private last-sink-escape
+  ;; The single bounded diagnostic slot for a CONTAINED evidence-sink throw
+  ;; (`{:cell cell :error e}` | nil). The evidence-sink is a DEBUG-only tool
+  ;; consumer of the scheduler, NEVER an authority over it: a throwing sink
+  ;; must never strand a cell (the acceptance bug rf2-vxgfnd.73) — so
+  ;; `flush-one!` completes every cell's flush FIRST and CONTAINS the sink's
+  ;; throw, and `flush-scope!` records the escape here (overwritten — one slot,
+  ;; the newest escape) plus one host-console diagnostic per batch. Observable
+  ;; via `last-evidence-sink-escape` so the escape is never silent. `defonce`
+  ;; (module-lived); `reset-scheduler!` clears it between fixtures.
+  (atom nil))
+
+(defn- report-sink-escape!
+  "DEV plane: contain the fallout of a THROWING `evidence-sink`. The flush has
+  ALREADY completed every drained cell's scheduler state (`:dirty?`/evidence
+  cleared, revision advanced, listeners notified), so this is a pure
+  after-the-fact report that can neither strand a cell nor abort the batch.
+  Record the escape in the single bounded `last-sink-escape` slot (a
+  tool/test read — `last-evidence-sink-escape`) and, on CLJS, emit ONE host
+  `console.warn` naming the offending view. Reporting NEVER routes back through
+  `evidence-sink` (no recursion). Called at most once per `flush-scope!` batch,
+  and only from its debug-gated branch, so the whole helper DCEs under
+  `goog.DEBUG=false`. `escape` is `{:cell cell :error e}`."
+  [{:keys [cell error] :as escape}]
+  (reset! last-sink-escape escape)
+  #?(:cljs
+     (when (exists? js/console)
+       (.warn js/console
+              (str "[re-frame.ui] an evidence-sink (the DEBUG "
+                   "invalidation-evidence consumer — e.g. Xray) threw while the "
+                   "scheduler flushed view " (pr-str (:view-id @(state cell)))
+                   " — the throw was CONTAINED so the render correction still "
+                   "completed and the batch was not aborted; a debug observer "
+                   "cannot corrupt flush completion. Fix the sink callback "
+                   "installed with (set-evidence-sink! …). Cause: "
+                   (error/ex-message-safe error))))
+     :clj nil))
 
 (defn- enrol-dirty!
   "The PRODUCTION scheduling core: flag `cell` pending, enrol it in the dirty
@@ -645,17 +685,37 @@
 (defn- flush-one!
   "Clear `cell`'s pending flag and advance its revision once (the caller has
   already removed it from the registry). No-op when not dirty — idempotent
-  under a concurrent drain. In DEV/tool builds, first hands the coalesced
-  bounded evidence to the installed `evidence-sink` (Xray): the flush CARRIES
-  the causal summary to its consumer before clearing it (rf2-vxgfnd.46)."
+  under a concurrent drain.
+
+  SCHEDULER COMPLETION IS ISOLATED FROM THE DEBUG OBSERVER (rf2-vxgfnd.73).
+  The flush COMPLETES first — captures the pre-clear bounded evidence, clears
+  `:dirty?`/evidence, and advances the revision (notifying listeners) — and
+  only THEN hands the captured summary to the installed `evidence-sink` (Xray;
+  rf2-vxgfnd.46), inside a guard. A THROWING sink is a broken DEBUG tool, never
+  an authority over the render correction: its throw is CONTAINED here (caught
+  and returned to `flush-scope!` for one bounded batch diagnostic) so it can
+  neither strand this cell in a dirty-but-unregistered limbo nor abort the
+  batch's remaining cells. Because the flush already cleared `:dirty?` and
+  advanced the revision, a re-entrant sink that re-marks this (or any) cell
+  enrols a FRESH pending window rather than losing the notification. The sink
+  still receives the exact pre-clear bounded summary once per flushed cell.
+  Returns `{:cell cell :error e}` on a contained sink escape (DEV only), else
+  nil; the whole evidence/containment path DCEs under `goog.DEBUG=false`."
   [^ViewCell cell]
   (let [st (state cell)]
     (when (:dirty? @st)
-      (when interop/debug-enabled?
-        (when-some [sink @evidence-sink]
-          (sink cell (:evidence @st))))
-      (swap! st assoc :dirty? false :evidence nil)
-      (advance-revision! cell))))
+      (let [ev   (when interop/debug-enabled? (:evidence @st))
+            sink (when interop/debug-enabled? @evidence-sink)]
+        ;; complete the flush FIRST — a throwing sink below cannot pre-empt it
+        (swap! st assoc :dirty? false :evidence nil)
+        (advance-revision! cell)
+        ;; DEV: best-effort evidence delivery, CONTAINED (never re-enters here)
+        (when (and interop/debug-enabled? (some? sink))
+          (try
+            (sink cell ev)
+            nil
+            (catch #?(:clj Throwable :cljs :default) e
+              {:cell cell :error e})))))))
 
 (defn flush-scope!
   "The scoped-flush PRIMITIVE: synchronously flush every pending cell for
@@ -668,8 +728,21 @@
   (let [[old _] (swap-vals! dirty-cells
                             (fn [cells] (into #{} (remove scope-pred) cells)))
         flushed (filterv scope-pred old)]
-    (doseq [cell flushed]
-      (flush-one! cell))
+    (if interop/debug-enabled?
+      ;; DEV: complete EVERY cell's flush regardless of tool behaviour — a
+      ;; throwing `evidence-sink` is contained per-cell in `flush-one!` (which
+      ;; returns the escape rather than propagating), so one bad debug callback
+      ;; can neither strand its cell nor abort the batch. Capture the FIRST
+      ;; escape and emit ONE bounded diagnostic for the batch; never through
+      ;; the sink. This whole branch DCEs under `goog.DEBUG=false`, leaving the
+      ;; production `doseq` below.
+      (let [escape (reduce (fn [acc cell] (let [e (flush-one! cell)] (or acc e)))
+                           nil
+                           flushed)]
+        (when (some? escape)
+          (report-sink-escape! escape)))
+      (doseq [cell flushed]
+        (flush-one! cell)))
     (count flushed)))
 
 (defn flush-pending!
@@ -750,6 +823,16 @@
   []
   (count @dirty-cells))
 
+(defn last-evidence-sink-escape
+  "The most recent CONTAINED `evidence-sink` throw as `{:cell cell :error e}`,
+  or nil when no sink has thrown since the last `reset-scheduler!` (or in a
+  production build, where the debug evidence plane is elided). A throwing
+  DEBUG sink never strands a cell or aborts a flush batch (rf2-vxgfnd.73) — it
+  is contained and surfaced HERE (plus a host `console.warn`) so the escape is
+  never silent (tool/test read)."
+  []
+  @last-sink-escape)
+
 (defn reset-scheduler!
   "Test support: drop every pending notification and the slice memo without
   advancing any revision — a clean slate between fixtures. Returns nil."
@@ -760,6 +843,7 @@
   (reset! live-cells #{})
   (reset! teardown-collector nil)
   (reset! evidence-sink nil)
+  (reset! last-sink-escape nil)
   nil)
 
 (defn- on-change-fn

--- a/implementation/ui/test/re_frame/ui/reactive_evidence_sink_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_evidence_sink_cljs_test.cljc
@@ -1,0 +1,154 @@
+(ns re-frame.ui.reactive-evidence-sink-cljs-test
+  "rf2-vxgfnd.73 — a THROWING `evidence-sink` (the DEBUG invalidation-evidence
+  consumer, e.g. Xray) must never corrupt ViewCell flush completion. The
+  evidence-sink is a CONSUMER of the scheduler, never an authority over it, so
+  a sink that throws is CONTAINED: every drained cell still leaves `:dirty?`,
+  advances its revision exactly once, notifies its listeners, and stays
+  re-enrollable; the throw neither strands a cell in the
+  dirty-removed-but-unflushed limbo nor aborts the rest of the batch; a normal
+  sink still receives the exact pre-clear bounded summary once per cell; a
+  re-entrant sink that re-marks a cell keeps its freshly-scheduled window; and
+  the escape is surfaced (not silent) via `last-evidence-sink-escape` (plus a
+  host `console.warn` on CLJS).
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` / `test:ui` (node) AND
+  `clojure -M:test` (JVM), so the containment is graft-checked on both hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- dirty-cell!
+  "A fresh cell (view `id`) marked dirty at `epoch` (folds DEBUG evidence),
+  carrying a listener that counts notifications into `hits`."
+  [id epoch hits]
+  (let [cell (reactive/make-cell id)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/mark-dirty! cell epoch)
+    cell))
+
+;; ===========================================================================
+;; The bug: a throwing sink must not strand a cell nor abort the batch
+;; ===========================================================================
+
+(deftest a-throwing-sink-does-not-strand-cells-and-is-not-silent
+  ;; rf2-vxgfnd.73: the sink was called INSIDE flush-one! BEFORE the scheduler
+  ;; state was completed, and its throw PROPAGATED — so the throwing cell was
+  ;; left `:dirty? true` yet already removed from `dirty-cells` (permanent
+  ;; limbo; a later mark-dirty! finds it still dirty and refuses to re-enrol),
+  ;; and the throw aborted the doseq so every later cell in the same batch was
+  ;; stranded too. On current code `flush-pending!` THROWS here (an errored
+  ;; test); on the fixed path the flush COMPLETES and the throw is CONTAINED.
+  (let [ha     (atom 0)
+        hb     (atom 0)
+        cell-a (dirty-cell! ::a 1 ha)
+        cell-b (dirty-cell! ::b 2 hb)
+        seen   (atom [])]
+    ;; a sink that throws deterministically for cell-a BY IDENTITY (not by
+    ;; delivery order) — so every assertion holds regardless of the batch's
+    ;; set-iteration order. It records each delivery FIRST, then throws.
+    (reactive/set-evidence-sink!
+      (fn [c ev]
+        (swap! seen conj [c ev])
+        (when (identical? c cell-a)
+          (throw (ex-info "evidence-sink boom" {})))))
+    (is (= 2 (reactive/pending-cell-count)) "both cells pending before the flush")
+
+    (reactive/flush-pending!)          ;; must NOT throw — the sink throw is contained
+
+    (testing "the throwing cell's flush still COMPLETED (was stranded pre-fix)"
+      (is (not (reactive/dirty? cell-a)) ":dirty? cleared despite the sink throw")
+      (is (nil? (reactive/pending-evidence cell-a)) "evidence cleared")
+      (is (= 1 (reactive/revision cell-a)) "revision advanced exactly once")
+      (is (= 1 @ha) "listeners notified exactly once"))
+    (testing "later cells in the same batch also completed (throw did not abort)"
+      (is (not (reactive/dirty? cell-b)))
+      (is (= 1 (reactive/revision cell-b)))
+      (is (= 1 @hb)))
+    (testing "no cell left in the dirty-removed-but-unflushed limbo"
+      (is (= 0 (reactive/pending-cell-count))))
+    (testing "evidence delivery reached BOTH cells despite the first throw (AC3)"
+      (is (= #{cell-a cell-b} (set (map first @seen)))
+          "one cell's tool failure did not abort delivery to the other"))
+    (testing "the escape is VISIBLE (not silent)"
+      (let [escape (reactive/last-evidence-sink-escape)]
+        (is (some? escape) "the contained escape is surfaced for tooling")
+        (is (identical? cell-a (:cell escape)) "…naming the offending cell")
+        (is (some? (:error escape)) "…and carrying the thrown value")))
+    (testing "both cells remain RE-ENROLLABLE on a later invalidation (AC1)"
+      (reactive/set-evidence-sink! nil)          ;; drop the broken tool
+      (reactive/mark-dirty! cell-a 3)
+      (reactive/mark-dirty! cell-b 4)
+      (is (reactive/dirty? cell-a) "the cleared cell re-enrols on a fresh mark")
+      (is (reactive/dirty? cell-b))
+      (is (= 2 (reactive/pending-cell-count)))
+      (reactive/flush-pending!)
+      (is (= 2 (reactive/revision cell-a)))
+      (is (= 2 (reactive/revision cell-b)))
+      (is (= 2 @ha))
+      (is (= 2 @hb)))))
+
+;; ===========================================================================
+;; A normal (non-throwing) sink is unchanged — AC6
+;; ===========================================================================
+
+(deftest a-normal-sink-still-receives-the-pre-clear-summary-once
+  ;; Containment must preserve the normal contract exactly: the sink receives
+  ;; the coalesced pre-clear bounded summary EXACTLY ONCE per flushed cell, and
+  ;; no escape is recorded when nothing throws.
+  (let [hits (atom 0)
+        cell (reactive/make-cell ::v)
+        seen (atom [])]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/set-evidence-sink! (fn [c ev] (swap! seen conj [c ev])))
+    (doseq [e (range 1 6)] (reactive/mark-dirty! cell e))   ;; 5 folds → one window
+    (reactive/flush-pending!)
+    (is (= 1 (count @seen)) "the sink received the coalesced batch exactly once")
+    (is (identical? cell (first (first @seen))))
+    (let [ev (second (first @seen))]
+      (is (= 1 (:first-epoch ev)) "…the PRE-CLEAR summary (anchored to the first epoch)")
+      (is (= 5 (:count ev)) "…with the full coalesced fold count"))
+    (is (= 1 (reactive/revision cell)) "one revision advance for the whole batch")
+    (is (= 1 @hits) "one notification")
+    (is (nil? (reactive/pending-evidence cell)) "evidence cleared after delivery")
+    (is (nil? (reactive/last-evidence-sink-escape)) "a well-behaved sink records no escape")))
+
+;; ===========================================================================
+;; A re-entrant sink that re-marks a cell keeps the fresh batch — AC5
+;; ===========================================================================
+
+(deftest a-re-entrant-sink-that-remarks-preserves-the-next-window
+  ;; Because the flush CLEARS `:dirty?` and advances the revision BEFORE the
+  ;; sink runs, a sink that re-marks the same cell during delivery enrols a
+  ;; FRESH pending window rather than folding into (and losing) the window the
+  ;; flush is clearing. The newly-scheduled invalidation survives to the next
+  ;; flush; the drain-coalescing contract (one enrolment / one advance per
+  ;; window) is preserved.
+  (let [hits     (atom 0)
+        cell     (reactive/make-cell ::v)
+        remarked (atom false)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/set-evidence-sink!
+      (fn [c _ev]
+        (when (compare-and-set! remarked false true)   ;; re-mark exactly once
+          (reactive/mark-dirty! c 99))))
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (testing "the flush completed once AND the re-entrant mark opened a fresh window"
+      (is (= 1 (reactive/revision cell)) "the coalesced window advanced exactly once")
+      (is (= 1 @hits))
+      (is (reactive/dirty? cell) "the re-entrant mark re-enrolled the cell")
+      (is (= 1 (reactive/pending-cell-count)) "the freshly-scheduled batch was not lost")
+      (is (= 99 (reactive/pending-epoch cell)) "…anchored to the re-mark's own epoch")
+      (is (nil? (reactive/last-evidence-sink-escape)) "no throw, no escape"))
+    (testing "the preserved window flushes on the next drain"
+      (reactive/flush-pending!)
+      (is (= 2 (reactive/revision cell)) "the fresh window advances on the next flush")
+      (is (= 2 @hits)))))


### PR DESCRIPTION
## What

The DEBUG invalidation-evidence sink (Xray; `set-evidence-sink!`) was invoked synchronously inside `flush-one!` **before** the cell's scheduler state was completed, and its throw propagated. Because `flush-scope!` atomically removes every matching cell from `dirty-cells` (via `swap-vals!`) **before** the drain begins, a throwing tool callback left the cell:

- `:dirty? true` yet already de-registered from `dirty-cells` — permanent limbo (a later `mark-dirty!` sees it still dirty and refuses to re-enrol/schedule); and
- the throw aborted the `doseq`, so every later cell removed in the same batch was stranded too.

One diagnostic-tool bug could therefore strand an arbitrary batch of mounted views. A debug **observer** must never corrupt production flush **completion** — observability is a consumer of the scheduler, not an authority over it.

## Fix (only `re_frame/ui/reactive.cljc` + a new headless test)

- `flush-one!` now **completes the flush first** — captures the pre-clear bounded evidence into a local, clears `:dirty?`/evidence, advances the revision and notifies listeners — and only **then** delivers the captured summary to the sink inside a guard, **returning** any caught escape instead of propagating it.
- `flush-scope!` drains **every** cell regardless of tool behaviour and reports **one** bounded diagnostic per batch (the first escape), recorded in a single observable slot (`last-evidence-sink-escape`) plus a host `console.warn` — **never** routed back through the sink (no recursion).
- Because the flush clears state before the sink runs, a **re-entrant** sink that re-marks a cell now enrols a **fresh** pending window instead of folding into (and losing) the window being cleared.
- The production `doseq` path is preserved byte-identical behind the `interop/debug-enabled?` gate, so the containment machinery + `console.warn` DCE under `goog.DEBUG=false`.
- Normal (non-throwing) sinks still receive the exact pre-clear bounded summary once per flushed cell.

No new thrown error-id / Spec 009 catalogue row is needed: the contained escape is a dev `console.warn` using the existing `[re-frame.ui]` prefix convention (mirroring the throwing-host-`.unmount` diagnostic in `client.cljs`), not a thrown `:rf.error/*`.

## Quality gates

Red-before-green verified: with the flush containment temporarily reverted (API kept so the test still loads), the new test ERRORs at `flush-pending!` (throw propagates) and the re-entrant case fails 5 assertions (re-mark lost). Restoring the fix → green.

| Gate | Result |
| --- | --- |
| `clojure -M:test` (ui, JVM) | 283 tests, 4630 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` (node) | 9021 tests, 42585 assertions, **0 failures, 0 errors** |
| new ns `reactive-evidence-sink-cljs-test` (JVM) | 3 tests, 36 assertions, **0 failures, 0 errors** |

`npm run test:browser` not applicable — the fixture is headless (flush-path), no DOM.
