### PR TITLE
feat(ui): publish frame-provider context via :adapter/current-frame; frame-root scope live (rf2-vxgfnd.24, rf2-vxgfnd.25)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -927,10 +927,11 @@
                    re-frame.adapter.reagent-slim
                    re-frame.adapter.uix
                    re-frame.adapter.helix
-                   re-frame.adapter.test-react]
+                   re-frame.adapter.test-react
+                   re-frame.ui.adapter]
     :chained?    true
     :design-bead "rf2-d4sf"
-    :description "React-context-tier frame-id reader (each adapter routes via current-adapter)."}
+    :description "React-context-tier frame-id reader (each adapter routes via current-adapter). rf2-vxgfnd.24: re-frame.ui.adapter routes it against plain-atom for the pure compiled-view runtime."}
    {:key         :adapter/current-component
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim]

--- a/implementation/ui/src/re_frame/ui/adapter.cljs
+++ b/implementation/ui/src/re_frame/ui/adapter.cljs
@@ -1,0 +1,59 @@
+(ns re-frame.ui.adapter
+  "The compiled-view substrate's adapter-side touchpoint (rf2-vxgfnd.24).
+
+  ## Why this ns exists
+
+  `re-frame.ui.frames/resolve-frame` reads the shared React frame context
+  (`re-frame.adapter.context/frame-context`) DIRECTLY, so frame-scoped
+  operations that route through it already see the `frame-provider` /
+  `frame-root` scope. But the compiled view SUB-READ path does not go
+  through that primitive: `re-frame.ui.reactive/sub-read` →
+  `re-frame.substrate.observation/resolve-target` →
+  `re-frame.frame/require-current-frame!` → `resolve-current-frame`, which
+  consults the `:adapter/current-frame` late-bind hook for the React-context
+  tier (Spec 006 §Frame-provider via React context). In a PURE compiled-ui
+  app — one running on the plain-atom reactive adapter with no
+  Reagent/UIx/Helix adapter loaded — that hook has no publisher, so a
+  mounted `(sub …)` under a provider resolved the dynamic tier only and
+  raised `:rf.error/no-frame-context`.
+
+  ## The publish (Mike-ruled mechanism (a), 2026-07-12)
+
+  This ns publishes the SAME React-context reader UIx/Helix publish —
+  `re-frame.adapter.context/function-component-current-frame` — through the
+  SAME `:adapter/current-frame` hook, so core's `resolve-current-frame`
+  reaches the context tier on the compiled-view sub-read path. There is ONE
+  resolution order (frames.cljc §The ambient frame chain); this reuses the
+  shared reader rather than duplicating it.
+
+  Homed in the ui artefact (not core's `plain-atom`) because the reader is a
+  React-context read — the React dependency belongs with the substrate that
+  renders React, keeping plain-atom's headless CLJS bundle React-free.
+
+  ## Routing, not clobbering
+
+  Published via `substrate-adapter/route-hook!` against the plain-atom
+  adapter spec — exactly the mechanism UIx/Helix/test-react (and plain-atom
+  itself, for `:adapter/*` disposal) use. The pure compiled-view runtime
+  runs on the plain-atom reactive adapter (rf2-uatcy), so the reader fires
+  when — and only when — plain-atom is the `(rf/init!)`-installed adapter.
+  A React adapter installed instead routes to its OWN impl through the same
+  chain (`same-adapter?` gating, rf2-dkl5z1): this publisher is ADDITIVE and
+  behaviour-preserving for the classic adapters, in any ns-load order.
+
+  MIXED-app arbitration — a compiled-view app that ALSO installs a classic
+  React adapter, where the single hook slot has two candidate publishers —
+  is out of scope here (rf2-3yij); this is the pure compiled-view publish."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; The React-context-tier frame-id reader for the pure compiled-view runtime.
+;; Routed against plain-atom so `resolve-current-frame` sees the context tier
+;; when plain-atom is installed (the pure-ui case); the classic-adapter chain
+;; is untouched. Fallback `#(frame/current-frame)` mirrors the UIx/Helix
+;; routing — the dynamic-var tier when neither this nor a chained handler runs.
+(substrate-adapter/route-hook! plain-atom/adapter :adapter/current-frame
+  adapter-context/function-component-current-frame
+  #(frame/current-frame))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -256,15 +256,20 @@
        ~arr)))
 
 (defn- emit-frame-root
-  "A top-region `frame-root` renders TRANSPARENTLY — children under a
-  Fragment. Its ENSURE semantics ride the extracted static plan (the
-  descriptor `:frame-plans` + the client preflight, `re-frame.ui.frames`),
-  which runs at host preflight BEFORE any render — never the rendered
-  tree. The emitted component then only scopes the already-live frame."
+  "A top-region `frame-root` SCOPES its preflight-ensured frame to its
+  children through the shared React frame context (rf2-vxgfnd.25 —
+  `frames/scope-element`), so an ambient `(sub …)` in a descendant view
+  resolves the frame-root's frame (the compiled sub-read consults the
+  React-context tier via the rf2-vxgfnd.24 `:adapter/current-frame` reader).
+  Its ENSURE semantics ride the extracted static plan (the descriptor
+  `:frame-plans` + the client preflight, `re-frame.ui.frames`), which runs
+  at host preflight BEFORE any render — never the rendered tree; the emitted
+  Provider only SCOPES the already-live frame. Children stay in an array so
+  the Provider keys them (mirrors `emit-frame-provider`)."
   [node st inline?]
-  (jsx-call `re-frame.ui.runtime/Fragment []
-            (children-forms st (:children node) inline?)
-            {:present? false}))
+  `(re-frame.ui.frames/scope-element
+    ~(:frame-id node)
+    (cljs.core/array ~@(children-forms st (:children node) inline?))))
 
 (defn- emit-frame-provider
   "S2c: `frame-provider` scopes its children to an already-live frame

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -193,11 +193,18 @@
                 `(re-frame.ui.tree/fragment
                   ~(:present? k) ~(:expr k)
                   ~@(keep emit-node (:children node))))
-    ;; A top-region frame-root is TRANSPARENT in the structural tree —
-    ;; its ENSURE plan rides the root descriptor + host preflight, not the
-    ;; render output
-    :frame-root `(re-frame.ui.tree/fragment
-                  false nil ~@(keep emit-node (:children node)))
+    ;; A top-region frame-root SCOPES its ensured frame (rf2-vxgfnd.25): the
+    ;; JVM has no React context, so it BINDS the dynamic-tier ambient frame
+    ;; to the frame-root's literal :id around the subtree's construction (the
+    ;; mirror of the CLJS scope-element / of jvm-provider-scope). ENSURE
+    ;; already ran at host preflight; the subtree itself is a transparent
+    ;; fragment in the structural tree. So an ambient (sub …) in a descendant
+    ;; view resolves the frame-root's frame during a Tier-1 structural render.
+    :frame-root `(re-frame.ui.frames/jvm-root-scope
+                  ~(:frame-id node)
+                  (fn []
+                    (re-frame.ui.tree/fragment
+                     false nil ~@(keep emit-node (:children node)))))
     ;; S2c: frame-provider scopes by BINDING the dynamic-tier ambient frame
     ;; around the subtree's construction (the JVM has no React context); the
     ;; subtree itself is a transparent fragment in the structural tree

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -112,14 +112,16 @@
       React context (`frame-root` / `frame-provider` scope) >
       loud `:rf.error/no-frame-context`
 
-  There is NO `:rf/default` floor (the EP-0002 carried invariant). The
-  chain reads the SHARED React context object
-  (`re-frame.adapter.context/frame-context`) directly rather than the
-  `:adapter/current-frame` late-bind hook: that hook is published by the
-  per-adapter routing chains and is dead in an app running the compiled
-  substrate alone. (When the ui substrate grows its own adapter spec, it
-  should ALSO route the hook so core's ambient `dispatch`/`subscribe`
-  see the context tier — an adapter-side touchpoint, out of S2c scope.)
+  There is NO `:rf/default` floor (the EP-0002 carried invariant). This
+  primitive reads the SHARED React context object
+  (`re-frame.adapter.context/frame-context`) DIRECTLY. The COMPILED
+  sub-read path (`reactive/sub-read` → `observation/resolve-target` →
+  `frame/require-current-frame!`) instead reaches the context tier through
+  the `:adapter/current-frame` late-bind hook, which `re-frame.ui.adapter`
+  now publishes for the pure compiled-view runtime (rf2-vxgfnd.24) — the
+  same reader, routed against the plain-atom adapter — so an app running the
+  compiled substrate alone resolves the React-context tier on ambient
+  `dispatch`/`subscribe` too, not only through this primitive.
 
   Scope has React context semantics: it applies to descendant VIEW
   boundaries rendered under the provider; sites in the SAME template body
@@ -134,7 +136,13 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.live-frame :as live-frame]
             [re-frame.ui.reactive :as reactive]
-            #?@(:cljs [[re-frame.adapter.context :as adapter-context]])))
+            ;; rf2-vxgfnd.24: loading `re-frame.ui.adapter` publishes the
+            ;; `:adapter/current-frame` reader for the pure compiled-view
+            ;; runtime (React-context tier on the sub-read path). Required for
+            ;; the ns-load side-effect — frames is on every ui mount/render
+            ;; path, so the hook is live before any sub-read runs.
+            #?@(:cljs [[re-frame.adapter.context :as adapter-context]
+                       [re-frame.ui.adapter]])))
 
 ;; ---------------------------------------------------------------------------
 ;; The plan-install registry

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -474,6 +474,21 @@
             (require-scope-frame! target 're-frame.ui/frame-provider)]
     (body-thunk)))
 
+(defn jvm-root-scope
+  "The emitted JVM half of a top-region `frame-root` (rf2-vxgfnd.25): BIND
+  the dynamic-tier ambient frame to the frame-root's literal `:id` around
+  the subtree's structural construction (`body-thunk` builds and returns the
+  children fragment). The JVM has no React context; the dynamic binding is
+  the same scope tier `rf/with-frame` uses, so ambient frame-scoped reads
+  inside the subtree resolve the frame-root's frame during a Tier-1
+  structural render — the JVM mirror of the CLJS `scope-element`. PURE scope:
+  ENSURE already ran at host preflight (03 §8), so — unlike the provider
+  half — no runtime target validation happens here; the frame-root OWNS/
+  ensured the frame it names. Returns the built subtree."
+  [frame-id body-thunk]
+  (binding [frame/*current-frame* frame-id]
+    (body-thunk)))
+
 ;; ---------------------------------------------------------------------------
 ;; Frame-destroy → ViewCell teardown wiring (03 §4; rf2-vxgfnd.42)
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
@@ -1,0 +1,73 @@
+(ns re-frame.ui.frame-context-hook-cljs-test
+  "rf2-vxgfnd.24 — the pure compiled-view `:adapter/current-frame` publish,
+  exercised through a REAL ViewCell sub-read (not a direct call) on the
+  headless plain-atom runtime Node can run:
+
+    - the reader IS published once `re-frame.ui.frames` (hence
+      `re-frame.ui.adapter`) is on the classpath;
+    - with the reader live, an ambient compiled sub-read with NO scope
+      established still fails loud with `:rf.error/no-frame-context` (the
+      fail-loud contract is PRESERVED — .24 is additive, not a default
+      floor);
+    - the published reader still honours the dynamic tier (`with-frame`).
+
+  The React-CONTEXT tier itself (a `frame-provider` / `frame-root` scope
+  read through `_currentValue` under a mounted root) is exercised in the DOM
+  twin `re-frame.ui.frame-scope-resolve-dom-cljs-test`. CLJS-only: the reader
+  is a React-context read and is published only on the plain-atom CLJS
+  runtime."
+  (:require [cljs.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.frames :as frames]      ;; loads re-frame.ui.adapter (the publish)
+            [re-frame.ui.reactive :as reactive]))
+
+;; :ambient-frame nil — opt OUT of the fixture's default `:rf/default`
+;; *current-frame* binding, so the no-scope arms genuinely have no dynamic
+;; tier and the dynamic-tier arm establishes its own scope via `with-frame`.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil}))
+
+(def ^:private fid :rf/default)
+
+(defn- throws-id [thunk]
+  (try (thunk) nil
+       (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+;; one ViewCell render pass — the REAL sub-read path (obs/resolve-target →
+;; frame/require-current-frame! → the :adapter/current-frame hook), recorded
+;; into a live cell's capture. NOT a direct sub-read.
+(defn- render-cell! [cell queries]
+  (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+
+(deftest reader-is-published-under-plain-atom
+  (is (some? (late-bind/get-fn :adapter/current-frame))
+      "re-frame.ui.adapter routed the :adapter/current-frame reader")
+  ;; with plain-atom installed and no scope established, the published reader
+  ;; resolves nil — no :rf/default floor (EP-0002 carried invariant).
+  (is (nil? (frame/resolve-current-frame))
+      "no scope → the published reader resolves nil, not a synthesised default"))
+
+(deftest ambient-sub-with-no-scope-fails-loud
+  (rf/reg-sub :hook/n (fn [db _] (:n db)))
+  (let [cell (reactive/make-cell ::v)]
+    (is (= :rf.error/no-frame-context
+           (throws-id #(render-cell! cell [[:hook/n]])))
+        (str "with the reader PUBLISHED, an ambient ViewCell sub-read with no "
+             "carried pin and no established scope still throws "
+             ":rf.error/no-frame-context — the fail-loud contract is preserved"))))
+
+(deftest ambient-sub-resolves-dynamic-tier
+  (rf/reg-sub :hook/n (fn [db _] (:n db)))
+  (rf/make-frame {:id fid})
+  (frame/replace-app-db! fid {:n 7})
+  (let [cell (reactive/make-cell ::v)]
+    (is (= [7]
+           (rf/with-frame fid
+             (render-cell! cell [[:hook/n]])))
+        (str "the published reader honours the dynamic-var tier: a with-frame "
+             "binding resolves the compiled sub-read"))))

--- a/implementation/ui/test/re_frame/ui/frame_root_scope_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_root_scope_jvm_test.clj
@@ -1,0 +1,63 @@
+(ns re-frame.ui.frame-root-scope-jvm-test
+  "rf2-vxgfnd.25 — `frame-root` now EMITS its frame scope on the JVM
+  (structural / SSR) host too: the compiled `:frame-root` node binds the
+  dynamic-tier ambient frame to its literal `:id` around the subtree's
+  construction (`frames/jvm-root-scope`), the mirror of the CLJS
+  `scope-element` and of `jvm-provider-scope`. So an ambient `(sub …)` in a
+  descendant view resolves the frame-root's frame during a Tier-1 render.
+
+    - the `jvm-root-scope` helper binds `*current-frame*` (the emit mechanism,
+      exercised directly, independent of the test render host);
+    - end to end: a `(sub …)` under a `frame-root` reads that frame's app-db
+      through `ui.test/render`."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.test :as uit]))
+
+;; :ambient-frame nil — opt OUT of the fixture's default `:rf/default`
+;; *current-frame* binding, so the jvm-root-scope unit arm sees a clean
+;; nil ambient outside its own binding.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil})
+  (fn [t] (frames/reset-installed-plans!) (t) (frames/reset-installed-plans!)))
+
+(defview rooted-greeting
+  "Reads a sub ambiently — resolves the enclosing frame-root's frame."
+  []
+  [:h1.greet (ui/sub [:greet/text])])
+
+;; ---------------------------------------------------------------------------
+;; the emit mechanism: jvm-root-scope binds the dynamic-tier ambient frame
+;; ---------------------------------------------------------------------------
+
+(deftest jvm-root-scope-binds-the-ambient-frame
+  ;; PURE scope (no validation): outside the scope *current-frame* is nil;
+  ;; inside, it is the frame-root's literal id — exactly what an ambient
+  ;; sub-read resolves. This is the JVM half the emitted :frame-root node calls.
+  (is (nil? frame/*current-frame*) "no ambient frame before the scope")
+  (is (= :app/rooted
+         (frames/jvm-root-scope :app/rooted (fn [] frame/*current-frame*)))
+      "jvm-root-scope binds *current-frame* to the frame-root's id for its subtree")
+  (is (nil? frame/*current-frame*) "the binding is scoped — unwinds after the thunk"))
+
+;; ---------------------------------------------------------------------------
+;; end to end: an ambient (sub …) under a frame-root reads its frame's app-db
+;; ---------------------------------------------------------------------------
+
+(deftest sub-under-frame-root-resolves-its-frame-jvm
+  (rf/reg-sub :greet/text (fn [db _] (:greet db)))
+  (let [before (set (keys @frame/frames))
+        tree   (uit/render
+                [ui/frame-root {:id :app/rooted
+                                :initial-events [[:rf/set-db {:greet "scoped"}]]}
+                 [rooted-greeting {}]])]
+    (is (= "scoped" (uit/text (uit/find tree :h1)))
+        "the ambient (sub …) resolved the frame-root's frame on the JVM")
+    (is (= before (set (keys @frame/frames)))
+        "the test-owned frame is torn down — no residue")))

--- a/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.ui.frame-scope-resolve-dom-cljs-test
+  "rf2-vxgfnd.24 + rf2-vxgfnd.25 — the KEYSTONE, proven end to end on a REAL
+  react-dom root through a REAL ViewCell: a compiled `(sub …)` mounted
+  inside a `frame-provider` / `frame-root` subtree resolves the scoped
+  frame's app-db on the AMBIENT React-context path — no explicit pin, no
+  dynamic `with-frame` binding.
+
+    - .24 publishes the `:adapter/current-frame` reader (re-frame.ui.adapter),
+      so core's `require-current-frame!` — reached by the compiled sub-read
+      (`reactive/sub-read` → `observation/resolve-target`) — sees the
+      React-context tier under the plain-atom runtime.
+    - .25 makes `frame-root` EMIT that scope (frames/scope-element), so a sub
+      under a bare `frame-root` (no enclosing `frame-provider`) resolves too.
+
+  The `(sub …)` lives in a DESCENDANT view boundary (`n-view`), not the
+  provider's own body — React-context semantics scope descendants, and a
+  ViewCell render is where `_currentValue` is live.
+
+  Browser-only bodies — `-dom-cljs-test$` opts this file into `:browser-test`;
+  under `:node-test` every DOM body gates on `(browser?)` and exits early."
+  (:require [cljs.test :refer [deftest is use-fixtures]]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-root frame-provider sub]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.frames :as frames]))
+
+(defn- browser? [] (exists? js/document))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil})
+  (fn [t]
+    (client/reset-live-roots!)
+    (frames/reset-installed-plans!)
+    (t)
+    (client/reset-live-roots!)
+    (frames/reset-installed-plans!)))
+
+(defn- container [] (js/document.createElement "div"))
+
+(defn- reg! []
+  (rf/reg-event :test/set-db (fn [_ [_ db]] {:db db}))
+  (rf/reg-sub :scope/n (fn [db _] (:n db))))
+
+;; n-view SUBS ambiently — a descendant view boundary, so its ViewCell render
+;; reads the enclosing provider/root scope through the React context.
+(defview n-view [] [:div.n (str "n=" (sub [:scope/n]))])
+
+;; the sub sits UNDER a frame-provider, in a descendant view (n-view), never
+;; in the provider's own template body.
+(defview provider-wrap [{:keys [frame-id]}]
+  [:div.wrap [frame-provider {:frame frame-id} [n-view]]])
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.24 — a compiled sub under a frame-provider resolves ambiently
+;; ---------------------------------------------------------------------------
+
+(deftest sub-under-frame-provider-resolves-scoped-frame-ambiently
+  (when (browser?)
+    (reg!)
+    (rf/make-frame {:id :app/live})
+    (rf/dispatch-sync [:test/set-db {:n 42}] {:frame :app/live})
+    (let [c (container)]
+      (react-dom/flushSync
+       #(ui/mount [provider-wrap {:frame-id :app/live}] c {:root-id :dom-scope/prov}))
+      (is (re-find #"n=42" (.-innerHTML c))
+          (str "the ambient (sub …) resolved the frame-provider-scoped frame "
+               "through the React-context tier — the :adapter/current-frame "
+               "reader is live on the compiled sub-read path (rf2-vxgfnd.24)")))))
+
+;; NOTE: the frame-ROOT counterpart (`sub-under-frame-root-resolves-…`) lands
+;; with rf2-vxgfnd.25 below (frame-root must EMIT its scope first).
+
+;; ---------------------------------------------------------------------------
+;; NEGATIVE — a compiled sub OUTSIDE any provider/root still fails loud
+;; (React captures the render-phase throw; the container never commits).
+;; The synchronous, assert-the-id form of this negative rides the headless
+;; twin (frame-context-hook-cljs-test); here we pin the mount-level effect:
+;; no scope → nothing renders.
+;; ---------------------------------------------------------------------------
+
+(defview bare-sub-root [] [:div.bare [n-view]])
+
+(deftest sub-outside-any-provider-does-not-resolve
+  (when (browser?)
+    (reg!)
+    (rf/make-frame {:id :app/orphan})
+    (rf/dispatch-sync [:test/set-db {:n 99}] {:frame :app/orphan})
+    (let [c (container)]
+      ;; no frame-provider / frame-root anywhere above n-view → the ambient
+      ;; sub-read finds no scope and throws :rf.error/no-frame-context during
+      ;; render; React aborts the commit, so the scoped value never appears.
+      (try (react-dom/flushSync
+            #(ui/mount [bare-sub-root {}] c {:root-id :dom-scope/orphan}))
+           (catch :default _e nil))
+      (is (not (re-find #"n=99" (.-innerHTML c)))
+          (str "with NO provider/root above it, the ambient sub does not "
+               "silently resolve some frame — the fail-loud contract holds")))))

--- a/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
@@ -71,8 +71,23 @@
                "through the React-context tier — the :adapter/current-frame "
                "reader is live on the compiled sub-read path (rf2-vxgfnd.24)")))))
 
-;; NOTE: the frame-ROOT counterpart (`sub-under-frame-root-resolves-…`) lands
-;; with rf2-vxgfnd.25 below (frame-root must EMIT its scope first).
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.25 — a compiled sub under a bare frame-root resolves ambiently
+;; (frame-root now EMITS its scope; scope-element is reached, not dead)
+;; ---------------------------------------------------------------------------
+
+(deftest sub-under-frame-root-resolves-scoped-frame-ambiently
+  (when (browser?)
+    (reg!)
+    (let [c (container)]
+      (react-dom/flushSync
+       #(ui/mount [frame-root {:id :app/rooted :initial-events [[:test/set-db {:n 7}]]}
+                   [n-view]]
+                  c {:root-id :dom-scope/root}))
+      (is (re-find #"n=7" (.-innerHTML c))
+          (str "the ambient (sub …) resolved the frame-root-scoped frame — "
+               "frame-root now emits its scope through frames/scope-element "
+               "(rf2-vxgfnd.25), and .24's published reader consults it")))))
 
 ;; ---------------------------------------------------------------------------
 ;; NEGATIVE — a compiled sub OUTSIDE any provider/root still fails loud

--- a/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
@@ -91,10 +91,10 @@
 
 ;; ---------------------------------------------------------------------------
 ;; NEGATIVE — a compiled sub OUTSIDE any provider/root still fails loud
-;; (React captures the render-phase throw; the container never commits).
+;; (React aborts the commit; the container never renders the scoped value).
 ;; The synchronous, assert-the-id form of this negative rides the headless
-;; twin (frame-context-hook-cljs-test); here we pin the mount-level effect:
-;; no scope → nothing renders.
+;; twin (frame-context-hook-cljs-test); here we pin the mount-level effect on
+;; a REAL root: no scope → nothing renders.
 ;; ---------------------------------------------------------------------------
 
 (defview bare-sub-root [] [:div.bare [n-view]])
@@ -104,13 +104,26 @@
     (reg!)
     (rf/make-frame {:id :app/orphan})
     (rf/dispatch-sync [:test/set-db {:n 99}] {:frame :app/orphan})
-    (let [c (container)]
-      ;; no frame-provider / frame-root anywhere above n-view → the ambient
+    (let [c        (container)
+          captured (atom nil)]
+      ;; No frame-provider / frame-root anywhere above n-view → the ambient
       ;; sub-read finds no scope and throws :rf.error/no-frame-context during
-      ;; render; React aborts the commit, so the scoped value never appears.
-      (try (react-dom/flushSync
-            #(ui/mount [bare-sub-root {}] c {:root-id :dom-scope/orphan}))
-           (catch :default _e nil))
+      ;; render. Under React 19 an uncaught render-phase throw is NOT re-thrown
+      ;; out of `.render`; React aborts the commit and reports the error through
+      ;; the root's `onUncaughtError` HOST callback (see root_mount_dom_cljs_test
+      ;; §criterion-3). We route that callback into `captured` so (a) the
+      ;; fail-loud error is asserted at the host tier, and (b) React's DEFAULT
+      ;; onUncaughtError — which calls `reportError`, surfacing an uncaught
+      ;; window error the browser-test runner rejects even on a green cljs.test
+      ;; summary (rf2-mwx08) — is REPLACED rather than left to fire.
+      (react-dom/flushSync
+       #(ui/mount [bare-sub-root {}] c
+                  {:root-id :dom-scope/orphan
+                   :on-uncaught-error (fn [error _info] (reset! captured error))}))
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data @captured)))
+          (str "the ambient sub with NO provider/root above it FAILED LOUD with "
+               ":rf.error/no-frame-context, routed to the root's onUncaughtError "
+               "host callback (rf2-vxgfnd.24/.25)"))
       (is (not (re-find #"n=99" (.-innerHTML c)))
-          (str "with NO provider/root above it, the ambient sub does not "
-               "silently resolve some frame — the fail-loud contract holds")))))
+          (str "React aborted the commit — the ambient sub did not silently "
+               "resolve some frame; the scoped value never renders")))))

--- a/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
@@ -366,12 +366,24 @@
     (is (contains? #{'clojure.core/let 'cljs.core/let} (first emitted))
         "hoisted constants become let bindings around the body")))
 
-(deftest emitters-render-frame-root-transparently
+(deftest emitters-scope-frame-root-to-its-frame
+  ;; rf2-vxgfnd.25: a top-region frame-root SCOPES its ensured frame to its
+  ;; children so an ambient (sub …) resolves it — no longer a bare transparent
+  ;; Fragment. The wrappers add no DOM (a React context Provider on CLJS, a
+  ;; dynamic binding on the JVM); the tree stays transparent, but the frame is
+  ;; now in ambient scope.
   (let [{:keys [ast]} (analyze-root*
                        '[frame-root {:id :shop} [app-view {}]])]
-    (testing "CLJS: children under a Fragment"
-      (let [emitted (emit-cljs/emit-inline ast 'rf-ui-root)]
-        (is (some #{'re-frame.ui.runtime/Fragment} (forms-of emitted)))))
-    (testing "JVM: children spliced under a keyless tree fragment"
+    (testing "CLJS: children scoped via frames/scope-element with the frame id"
+      (let [emitted (emit-cljs/emit-inline ast 'rf-ui-root)
+            forms   (forms-of emitted)]
+        (is (some #{'re-frame.ui.frames/scope-element} forms))
+        (is (some #{:shop} forms)
+            "the frame-root's literal :id is the scope target")
+        (is (not-any? #{'re-frame.ui.runtime/Fragment} forms)
+            "no bare transparent Fragment — the frame-root emits a scope")))
+    (testing "JVM: children bound under frames/jvm-root-scope with the frame id"
       (let [emitted (emit-jvm/emit-node ast)]
-        (is (= 're-frame.ui.tree/fragment (first emitted)))))))
+        (is (= 're-frame.ui.frames/jvm-root-scope (first emitted)))
+        (is (= :shop (second emitted))
+            "the frame-root's literal :id is bound as the ambient frame")))))


### PR DESCRIPTION
The KEYSTONE pair that unblocks the frame-provider downstream cluster
(.14/.58/.43/.71-frame-provider-row + S2e/S2f). A compiled `(sub …)` mounted
inside a `frame-provider` / `frame-root` subtree now resolves the scoped
frame ambiently — no explicit pin, no dynamic `with-frame` binding.

## Mike ruling (2026-07-12)

Mechanism **(a)**: the pure compiled-view runtime PUBLISHES its React-context
frame reader through the SAME `:adapter/current-frame` late-bind hook UIx/Helix
already use — additive, behaviour-preserving. Mixed-app arbitration (two
publishers on the single hook slot, last-writer-wins) is **scoped OUT to
rf2-3yij**; this is the pure compiled-view publish only.

## rf2-vxgfnd.24 — publish the reader

The compiled sub-read path (`reactive/sub-read` → `observation/resolve-target`
→ `frame/require-current-frame!` → `resolve-current-frame`) consults the
`:adapter/current-frame` hook for the React-context tier. A pure compiled-view
app runs on the **plain-atom** reactive adapter (rf2-uatcy) with no
Reagent/UIx/Helix adapter loaded, so that hook had no publisher and a mounted
`(sub …)` under a provider resolved the dynamic tier only → `:rf.error/no-frame-context`.

- **How** — `re-frame.ui.adapter` publishes the SAME reader UIx/Helix publish
  (`adapter.context/function-component-current-frame`) via
  `substrate-adapter/route-hook!` against the **plain-atom** adapter spec.
  `same-adapter?` gating (rf2-dkl5z1) makes it fire only when plain-atom is the
  installed adapter (the pure compiled-view case) and defer to the classic
  adapters' routed chain otherwise — additive and behaviour-preserving in any
  ns-load order, exactly how plain-atom already routes its `:adapter/*` disposal
  hooks.
- **Where** — homed in the **ui artefact** (not core's plain-atom) so the
  React-context dependency stays out of plain-atom's headless CLJS bundle;
  loaded via `re-frame.ui.frames` (on every ui mount/render path). Directory
  entry updated (`late_bind/directory.cljc`).

## rf2-vxgfnd.25 — frame-root scope live (WIRE, not remove)

`frame-root` rendered TRANSPARENTLY: emit_cljs put children under a bare
Fragment (no context Provider), emit_jvm under a bare fragment (no
`*current-frame*` binding), so `frames/scope-element` had **ZERO callers**
(dead code). Publishing the .24 reader alone does not fix this — the reader
consults a context that `frame-root` never SET.

**Decision: WIRE (not remove).** scope-element was the intended-but-unwired
frame-root client half; frame-root should scope its ensured frame, symmetric
with `frame-provider` (which already scopes in the emit). So it is now REACHED,
not removed:
- **CLJS** — `emit-frame-root` → `frames/scope-element` (the shared React
  context Provider, keyed children). Genuinely broken before this.
- **JVM** — `:frame-root` → new `frames/jvm-root-scope`, binding the
  dynamic-tier ambient frame to the frame-root's literal `:id` (mirror of
  scope-element / `jvm-provider-scope`; pure scope, no validation — ENSURE
  already ran). On the JVM this is currently redundant with the test render
  host's stopgap ambient binding (`test.cljc render-plan-bearing`), but makes
  frame-root self-scoping in the emit — correct for the eventual real SSR path
  and consistent with frame-provider.

The Provider/binding add no DOM — the tree stays transparent, the frame is now
in ambient scope.

## Acceptance (proven end to end)

- **CLJS DOM, real react-dom + ViewCell** (`frame_scope_resolve_dom_cljs_test`):
  a compiled `(sub …)` in a descendant view under a `frame-provider` resolves
  the scoped frame's app-db (.24); the same under a bare `frame-root` resolves
  (.25); OUTSIDE any provider/root the sub throws `:rf.error/no-frame-context`
  during render and nothing resolves (fail-loud preserved).
- **Headless node ViewCell** (`frame_context_hook_cljs_test`): the reader is
  published; an ambient sub-read with no scope still fails loud; the dynamic
  tier (`with-frame`) resolves.
- **JVM/SSR** (`frame_root_scope_jvm_test`): `jvm-root-scope` binds
  `*current-frame*`; a `(sub …)` under a `frame-root` reads its frame's app-db.

## Quality gates

All foreground, 0-fail:

| Gate | Result |
| --- | --- |
| core JVM `clojure -M:test` | 1862 tests / 8311 assertions — 0 fail |
| ui JVM `clojure -M:test` | 275 tests / 4575 assertions — 0 fail |
| ui node `npm run test:ui` | 266 tests — 0 fail |
| full node `npm run test:cljs` (all adapters + ui) | 9011 tests / 42510 assertions — 0 fail |
| **`:browser-test` headless Chromium (the CI gate) `npm run test:browser`** | **300 tests / 1081 assertions — 0 fail** |
| late-bind drift test | 6 tests / 632 assertions — 0 fail |

**Browser-test fix (follow-up commit).** The negative DOM case
`sub-outside-any-provider-does-not-resolve` mounted a scopeless `(sub …)`
whose render-phase throw was left to React 19's DEFAULT `onUncaughtError`,
which calls `reportError` — an uncaught window error the browser-test runner
rejects even on a green cljs.test summary (rf2-mwx08), reddening the
`:browser-test` headless-Chromium CI gate (the local run used the same command
but the pageerror-on-green failure mode only surfaced in the gated runner). The
keystone behaviour is correct — the fix routes the throw through the root's
`:on-uncaught-error` host callback (which the ui runtime already plumbs),
asserting the fail-loud `:rf.error/no-frame-context` at the host tier instead of
letting the default handler leak the pageerror. Test-only; no source change.

The full node bundle (Reagent/UIx/Helix/reagent-slim/test-react + ui in one
runtime) confirms existing `:adapter/current-frame` behaviour is UNCHANGED.

Surface: `re-frame.ui.adapter` (new), `ui/frames.cljc`, `compiler/emit_cljs.cljc`
+ `emit_jvm.cljc` (the frame-root emit — the only way to make its scope live),
`core/.../late_bind/directory.cljc` (producer registration), + tests.
