### PR TITLE
fix(machines): region-relative spawn-error event + timer work-id correlation + :same-state doc (rf2-cttpk4)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -237,6 +237,23 @@
   (let [delay-key    (:delay k)
         delay-source (:delay-source entry)
         sub-vec      (when (vector? delay-key) delay-key)
+        ;; The timer-table `:spawn` is the region-PREFIXED invoke-id for a
+        ;; region `:after` (`prefix-region-invoke-id`). The fired / stale
+        ;; replies strip the region head (`pick-after-transition`'s
+        ;; `carried-decl-path`), so strip it here too — using the `:region`
+        ;; name recorded at schedule time — before building the reply's
+        ;; `:rf.reply/work-id`. Without the strip the cancelled row's
+        ;; `[:rf.work/timer [<actor> <region> <state...>] epoch]` work-id
+        ;; would split from the fired / stale `[:rf.work/timer
+        ;; [<actor> <state...>] epoch]` rows of the SAME logical `:after`
+        ;; across the work/reply ledger (correlation only — the runtime
+        ;; stale-gate keys on the region-scoped epoch slot and is unaffected).
+        ;; A flat / root timer has no `:region`, so its decl-path is unchanged.
+        region       (:region entry)
+        decl-path    (let [sp (:spawn k)]
+                       (if (and region (seq sp) (= region (first sp)))
+                         (vec (rest sp))
+                         sp))
         ;; Close the timer work attempt the reply-envelope way: a cancelled
         ;; `:after` timer is `:status :cancelled` DATA, not the absence of a
         ;; reply (Managed-Effects §Cancellation). The canonical `:rf.reply/work-id`
@@ -250,7 +267,7 @@
                        {:actor-id  (:parent k)
                         :state     (:state entry)
                         :delay     (:resolved-ms entry)
-                        :decl-path (:spawn k)
+                        :decl-path decl-path
                         :epoch     (:epoch entry)
                         :frame     frame-id
                         :reason    reason})
@@ -364,7 +381,22 @@
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
-        k            (after-timer-key parent-id invoke-id delay-key)]
+        k            (after-timer-key parent-id invoke-id delay-key)
+        ;; A region `:after`'s `invoke-id` is region-PREFIXED
+        ;; (`prefix-region-invoke-id` prepends the region name). Record that
+        ;; region name in the entry so `emit-cancelled!` can strip it before
+        ;; building the reply's `:rf.reply/work-id` — matching the fired / stale
+        ;; rows (whose `carried-decl-path` is region-stripped by
+        ;; `pick-after-transition`) so all four rows of ONE logical `:after`
+        ;; share one work-id in the work/reply ledger. Parallel machines carry
+        ;; a region-name → state MAP as `:state` (mirrors `on-sub-changed!`);
+        ;; a flat / compound machine's `:state` is a keyword / vector path (no
+        ;; region head), and the parallel-ROOT timer's `invoke-id` is empty
+        ;; (`[]`, no head) — both yield nil, so nothing is stripped.
+        region       (when (and snapshot
+                                 (map? (:state snapshot))
+                                 (seq invoke-id))
+                       (first invoke-id))]
     (cancel-after-timer-entry! frame-id k :on-supersede)
     (cond
       server?
@@ -440,6 +472,7 @@
                     :resolved-ms     resolved-ms
                     :epoch           epoch
                     :state           state
+                    :region          region
                     :delay-source    delay-source
                     :token           token})
             (let [handle

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -2078,7 +2078,18 @@
               ;; snapshot), so a parent and a child entered in the same
               ;; cascade get independent epochs and the synthetic event
               ;; carries the decl-path for unambiguous staleness routing.
-              (let [leaf-state (last prefix)
+              (let [;; A parallel-ROOT `:after` (decl-path `[]`, scheduled via
+                    ;; `schedule-root-after-fx` passing `[[[] machine]]`) has
+                    ;; `(last prefix)` nil; mark it with the root sentinel
+                    ;; `:rf/parallel-root` so the `:scheduled` / `:cancelled`
+                    ;; `:state` matches the `:fired` / `:stale-after` rows
+                    ;; (`root-after-match` / the fired-reply emit both set
+                    ;; `:rf/parallel-root`) and the `(actor,state,epoch)` pairing
+                    ;; `emit-cancelled!` promises holds. A flat / region-root
+                    ;; `:after` is rejected at registration
+                    ;; (`validate-non-parallel-root-after!`), so an empty prefix
+                    ;; here is ALWAYS the supported parallel-root case.
+                    leaf-state (if (empty? prefix) :rf/parallel-root (last prefix))
                     epoch      (node-epoch machine snap-final prefix)]
                 (mapv
                   (fn [[delay-key _target]]

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1476,18 +1476,25 @@
 (defn- target-path
   "Compute the absolute target path for a transition. Per Spec 005:
    - `:same-state` sentinel → the declaring state's OWN path (`decl-path`).
-     Marks an EXTERNAL self-transition: the state is exited and re-entered
-     (`:exit` then `:entry` both fire), the configuration unchanged. The
-     self-re-entry geometry — pulling the LCA up to the declaring state's
-     parent so the state appears in both the exit and entry cascades — is
-     `compute-cascade-paths`' job; here `:same-state` simply names the
-     declaring state as the target. Per Spec 005 §Self-transitions +
-     Spec-Schemas TransitionTarget.
+     Names a SELF-transition, which is INTERNAL BY DEFAULT under the
+     XState-v5 model re-frame2 tracks: a target landing on the active path
+     (here the declaring state itself) fires NEITHER `:exit` NOR `:entry` —
+     only the transition's `:action` runs, and (on a compound) the active
+     descendants below the target re-resolve to their `:initial`. It becomes
+     an EXTERNAL self-transition — the state is exited and re-entered
+     (`:exit` then `:entry` both fire, with the `:action` in between; a
+     compound restarts its `:after` timers and respawns its `:spawn`
+     children) — ONLY when the transition opts in with `:reenter? true`.
+     That internal/external distinction and the external-restart geometry —
+     pulling the LCA up to the declaring state's parent so the state appears
+     in both the exit and entry cascades — are `compute-cascade-paths`' job;
+     here `:same-state` simply names the declaring state as the target. Per
+     Spec 005 §Self-transitions + Spec-Schemas TransitionTarget.
    - keyword target → sibling at decl-path's level (replace last element).
      A keyword that names the declaring state's OWN key resolves to
-     `decl-path` too, so it is the same external self-transition as
-     `:same-state` (Spec 005 §Entry/exit cascading — \"if `:target` names
-     the same state as the source, the transition is external\").
+     `decl-path` too, so it is the same internal-by-default self-transition
+     as `:same-state` — external (exit + re-entry) only under
+     `:reenter? true` (Spec 005 §Self-transitions).
    - vector target → absolute path from root.
    - nil target (internal transition) → nil; the caller wraps the call
      in `some->>` so the nil short-circuits the initial-cascade descent.

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1344,6 +1344,16 @@
                          (not (vector? raw-invoke-id)) raw-invoke-id
                          region (vec (rest raw-invoke-id))
                          :else  raw-invoke-id)
+        ;; The invoke-id also rides on `:event` (`(nth event 1)`) for a guard /
+        ;; action reading which spawn failed; re-stamp it region-relative so the
+        ;; in-region view is consistent (the region-name head is an internal
+        ;; routing detail). Symmetric with `pick-done-transition`'s event
+        ;; re-stamp — without it a region `:on-error` guard reading `(nth ev 1)`
+        ;; sees the region-PREFIXED invoke-id and never matches. The error
+        ;; payload `(nth event 2)` is region-agnostic and left untouched.
+        event          (if (and region (vector? raw-invoke-id))
+                         (assoc (vec event) 1 invoke-id)
+                         event)
         ;; The `:spawn`-bearing state lives at `invoke-id` (absolute prefix
         ;; path, region-stripped above). It is only resolvable when still on
         ;; the active `path` — a transition that already exited the spawning

--- a/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
@@ -62,6 +62,72 @@
               "canonical timer :work/id closes the cancelled work attempt")
           (is (= :rf.work/timer (first (:rf.reply/work-id (:tags cancelled))))))))))
 
+;; ---- region :after timer work-id correlation (rf2-cttpk4) --------------
+;;
+;; An `:after` declared inside a parallel REGION carries a region-PREFIXED
+;; invoke-id (`prefix-region-invoke-id` prepends the region name). The FIRED /
+;; STALE timer replies strip that region head (`pick-after-transition`'s
+;; `carried-decl-path`) when building their `:rf.reply/work-id`, but the
+;; CANCELLED reply historically used the raw region-prefixed `:spawn` — so the
+;; SAME logical `:after`'s cancelled row landed under a different
+;; `[:rf.work/timer <logical-id> <epoch>]` than its fired / stale rows,
+;; splitting one timer across the work/reply ledger. This drives ONE region
+;; `:after` to BOTH fire and (on the firing exit) cancel its still-pending host
+;; handle in a single dispatch, and asserts the two rows share ONE work-id.
+
+(deftest region-after-fired-and-cancelled-share-one-work-id
+  (testing "rf2-cttpk4 — a region :after's :fired and :cancelled rows carry the
+            SAME region-stripped :rf.reply/work-id (was split by the region head)"
+    (rf/reg-machine :cttpk4-tw/timer
+      {:type    :parallel
+       :data    {}
+       :regions {:loader {:initial :working
+                          :states  {:working {:after {30000 :timeout}}
+                                    :timeout {}}}
+                 :other  {:initial :idle
+                          :states  {:idle {}}}}})
+    (mtest/with-trace-capture captured
+      ;; Birth the singleton parallel machine (schedules :loader/:working's
+      ;; :after at its per-region epoch — a still-pending 30s host handle).
+      (rf/dispatch-sync [:cttpk4-tw/timer [:rf.machine.spawn/spawned]])
+      (let [snap  (mtest/snapshot :cttpk4-tw/timer)
+            epoch (get-in snap [:data :rf/after-epoch-by-region :loader [:working]])]
+        (is (= :working (get-in snap [:state :loader])) ":loader entered :working")
+        (is (some? epoch) "the region :after was scheduled at a per-region epoch")
+        ;; Fire the :loader :after via its synthetic elapsed event carrying the
+        ;; region-PREFIXED decl-path (exactly what the real host timer
+        ;; dispatches). The :working→:timeout transition ALSO exits :working,
+        ;; cancelling the still-pending host handle → ONE dispatch emits BOTH
+        ;; :fired and :cancelled for the SAME logical :after.
+        (rf/dispatch-sync
+          [:cttpk4-tw/timer
+           [:rf.machine.timer/after-elapsed 30000 epoch [:loader :working]]])
+        (is (= :timeout (get-in (mtest/snapshot :cttpk4-tw/timer) [:state :loader]))
+            "the region :after fired → :loader moved to :timeout")
+        (let [fired         (->> @captured
+                                 (filter #(and (= :rf.machine.timer/fired (:operation %))
+                                               (true? (:fired? (:tags %)))))
+                                 first)
+              cancelled     (->> @captured
+                                 (filter #(= :rf.machine.timer/cancelled (:operation %)))
+                                 first)
+              fired-wid     (:rf.reply/work-id (:tags fired))
+              cancelled-wid (:rf.reply/work-id (:tags cancelled))]
+          (is (some? fired)     ":rf.machine.timer/fired trace fired")
+          (is (some? cancelled) ":rf.machine.timer/cancelled trace fired (the firing exit released the host handle)")
+          (is (= :rf.work/timer (first cancelled-wid)))
+          ;; The cancelled work-id's logical-id is region-STRIPPED: it ends in
+          ;; the region-RELATIVE state :working and does NOT carry the region
+          ;; name :loader (which the raw region-prefixed :spawn had put at
+          ;; position 1 of the logical-id, splitting the ledger row).
+          (is (= :working (last (second cancelled-wid))))
+          (is (not (some #{:loader} (second cancelled-wid)))
+              "the region name is stripped from the cancelled work-id logical-id")
+          ;; The headline correlation: fired and cancelled share ONE work-id, so
+          ;; both rows of this ONE :after join the same work/reply ledger row.
+          (is (= fired-wid cancelled-wid)
+              "the region :after's :fired and :cancelled rows share one :rf.reply/work-id"))))))
+
 ;; ---- actor destroy (explicit cancellation) -----------------------------
 
 (deftest explicit-destroy-trace-carries-cancelled-reply

--- a/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
@@ -128,6 +128,47 @@
           (is (= fired-wid cancelled-wid)
               "the region :after's :fired and :cancelled rows share one :rf.reply/work-id"))))))
 
+;; ---- parallel-root :after :state consistency (rf2-cttpk4) --------------
+;;
+;; A parallel-ROOT `:after` (decl-path `[]`) is scheduled via
+;; `schedule-root-after-fx` → `build-after-fx` with an EMPTY prefix, so
+;; `(last prefix)` is nil. The FIRED / STALE resolvers stamp the root sentinel
+;; `:rf/parallel-root` as the `:state`; the SCHEDULED / CANCELLED traces used to
+;; emit `:state nil`, breaking the `(actor, state, epoch)` pairing
+;; `emit-cancelled!`'s docstring promises. Both the scheduled and cancelled
+;; root-timer traces must carry `:rf/parallel-root` too.
+
+(deftest parallel-root-after-scheduled-and-cancelled-state-is-parallel-root
+  (testing "rf2-cttpk4 — a parallel-root :after's :scheduled and :cancelled traces
+            carry :state :rf/parallel-root (matching :fired / :stale), not nil"
+    (rf/reg-machine :cttpk4-root/m
+      {:type    :parallel
+       :data    {}
+       :after   {30000 {:target [[:a :two]]}}
+       :regions {:a {:initial :one :states {:one {} :two {}}}}})
+    (rf/make-frame {:id :cttpk4-root/f :doc "root-after :state test frame"})
+    (mtest/with-trace-capture captured
+      ;; Birth in the named frame → schedules the root :after (a still-pending
+      ;; 30s host handle) and emits the :scheduled trace.
+      (rf/dispatch-sync [:cttpk4-root/m [:rf.machine/start]] {:frame :cttpk4-root/f})
+      (let [scheduled (->> @captured
+                           (filter #(and (= :rf.machine.timer/scheduled (:operation %))
+                                         (= 30000 (:delay (:tags %)))))
+                           first)]
+        (is (some? scheduled) "the root :after emitted a :scheduled trace at birth")
+        (is (= :rf/parallel-root (:state (:tags scheduled)))
+            "the scheduled root-timer :state is the :rf/parallel-root sentinel (was nil)"))
+      ;; Frame teardown cancels the still-pending root timer with
+      ;; :reason :on-frame-destroy → a :cancelled trace.
+      (rf/destroy-frame! :cttpk4-root/f)
+      (let [cancelled (->> @captured
+                           (filter #(and (= :rf.machine.timer/cancelled (:operation %))
+                                         (= :on-frame-destroy (:reason (:tags %)))))
+                           first)]
+        (is (some? cancelled) "frame teardown cancelled the pending root timer")
+        (is (= :rf/parallel-root (:state (:tags cancelled)))
+            "the cancelled root-timer :state is the :rf/parallel-root sentinel (was nil)")))))
+
 ;; ---- actor destroy (explicit cancellation) -----------------------------
 
 (deftest explicit-destroy-trace-carries-cancelled-reply

--- a/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
@@ -37,6 +37,10 @@
     (h) parallel-region explicit `:on {:rf.machine.spawn/error …}` escape
         hatch is REGION-scoped — a sibling region's explicit
         handler must NOT catch another region's child failure.
+    (i) a parallel-region `:spawn :on-error` GUARD reading the invoke-id off
+        `(nth ev 1)` sees the region-RELATIVE path (`[:working]`), NOT the
+        region-prefixed `[:loader :working]`, so it matches (before the
+        region-relative event re-stamp the guard never matched).
 
   Named `*-cljs-test.cljc` so it runs under both cognitect.test-runner (JVM)
   and shadow-cljs (CLJS), matching `final_state_cljs_test.cljc`."
@@ -526,3 +530,51 @@
           "the :loader region's own explicit :on {:rf.machine.spawn/error …} caught its child's failure (its guarded :on-error missed → fell through to the in-region explicit :on)")
       (is (= :idle (get-in (snapshot :rf2-w84jv-h/parent) [:state :other]))
           "the sibling :other region's DECOY explicit :on handler did NOT fire — the explicit escape hatch is region-scoped"))))
+
+;; ---- (i) region :spawn :on-error GUARD reads the region-RELATIVE invoke-id ----
+;;
+;; The synthetic spawn-error event is `[:rf.machine.spawn/error <invoke-id>
+;; <error>]`. For a `:spawn` declared inside a parallel REGION the invoke-id is
+;; region-PREFIXED (`[:loader :working]`). `pick-spawn-error-transition` strips
+;; the region head so the resolver routes region-relative — but the event a
+;; guard / action reads off `(nth ev 1)` must be re-stamped region-relative too,
+;; SYMMETRIC with `pick-done-transition`. Without the re-stamp a region
+;; `:on-error` guard testing the invoke-id sees the region-PREFIXED
+;; `[:loader :working]` and NEVER matches (the region stays put). This asserts
+;; the guard reading `(nth ev 1)` sees the region-RELATIVE `[:working]` and
+;; fires the transition.
+
+(deftest parallel-region-spawn-on-error-guard-reads-region-relative-invoke-id
+  (testing "a region :spawn :on-error guard reading (nth ev 1) matches on the region-RELATIVE invoke-id (rf2-cttpk4)"
+    (rf/reg-machine :rf2-cttpk4-i/child
+      {:initial :running
+       :data    {}
+       :states  {:running {:on {:boom {:target :failed
+                                       :action (fn [{data :data ev :event}]
+                                                 {:data (assoc data :err (second ev))})}}}
+                 :failed  {:final?     true
+                           :error?     true
+                           :output-key :err}}})
+    (rf/reg-machine :rf2-cttpk4-i/parent
+      {:type    :parallel
+       :data    {}
+       :regions {:loader {:initial :working
+                          :states  {:working {:spawn {:machine-id :rf2-cttpk4-i/child
+                                                      ;; The guard branches on the invoke-id
+                                                      ;; carried at (nth ev 1). It must be the
+                                                      ;; region-RELATIVE [:working], NOT the
+                                                      ;; region-prefixed [:loader :working].
+                                                      :on-error {:guard  (fn [{ev :event}]
+                                                                           (= [:working] (nth ev 1)))
+                                                                 :target :errored}}}
+                                    :errored {}}}
+                 :other  {:initial :idle
+                          :states  {:idle {}}}}})
+    (rf/dispatch-sync [:rf2-cttpk4-i/parent [:rf.machine.spawn/spawned]])
+    (let [child (spawned-id-for :rf2-cttpk4-i/parent [:loader :working])]
+      (is (some? child) "child spawned under the real parent in the :loader region")
+      (rf/dispatch-sync [child [:boom :network-down]])
+      (is (= :errored (get-in (snapshot :rf2-cttpk4-i/parent) [:state :loader]))
+          "the :on-error guard matched on the region-RELATIVE invoke-id [:working] → :loader moved to :errored (before the region-relative re-stamp the guard saw the region-prefixed [:loader :working], never matched, and the region stayed :working)")
+      (is (= :idle (get-in (snapshot :rf2-cttpk4-i/parent) [:state :other]))
+          "the sibling :other region is untouched"))))


### PR DESCRIPTION
Machines review-wave remainder (rf2-cttpk4): the transition/timer/reply slice. Four fixes, smallest→correctness, one PR. Surface: `transition.cljc` / `timer.cljc` / `reply.cljc` + their tests only. XState-v6 behavioural parity; pre-alpha, no shims.

## Fixes

1. **[DOC] `target-path` `:same-state` docstring** — said a `:same-state` (or self-keyword) target marks an EXTERNAL self-transition (`:exit` then `:entry` both fire). `compute-cascade-paths` implements the XState-v5 internal-by-default rule: a self / active-path target WITHOUT `:reenter? true` fires NEITHER `:exit` NOR `:entry` (only the `:action` runs; a compound re-resolves descendants). Rewrote the bullets to internal-by-default; external is opt-in via `:reenter? true`. Doc-only.

2. **[CORRECTNESS] `pick-spawn-error-transition` didn't re-stamp `:event` region-relative** — asymmetric with `pick-done-transition`. It region-stripped the invoke-id used to *route* the `:on-error`, but left the region-PREFIXED invoke-id on the `:event` a guard / action reads off `(nth event 1)`. A region `:spawn :on-error` guard branching on the invoke-id therefore saw `[<region> …]` and **never matched**. Now re-stamped region-relative (payload `(nth event 2)` untouched). Confirmed the guard now matches: with the re-stamp disabled the new test fails (`:loader` stays `:working`); with it, `:loader` → `:errored`.

3. **[OBSERVABILITY] region `:after` timer work-id split** — the cancelled reply's `:decl-path` used the region-PREFIXED `:spawn` while fired/stale strip the region head, so the same logical `:after`'s cancelled row landed under a different `:rf.reply/work-id` than its fired/stale rows. Record the region name in the timer-table entry at schedule time and strip it in `emit-cancelled!` so all rows share one work-id. Correlation only — the runtime stale-gate keys on the region-scoped epoch slot and was already correct.

4. **[MINOR] root/parallel-root `:after` trace `:state`** — `scheduled`/`cancelled` emitted `:state nil` for a `decl-path []` root timer while `fired`/`stale` emit `:rf/parallel-root`, breaking the `(actor,state,epoch)` pairing. Emit `:rf/parallel-root` consistently (a flat / region-root `:after` is rejected at registration, so an empty prefix is always the parallel-root case).

Untouched per dispatch guard: `finalize/spawn/destroy/join.cljc` (concurrent lifecycle worker), `parallel.cljc` (decision-held), `tools/machines-viz/**`, core/ui/spec.

## Quality gates

- `clojure -M:test` (machines artefact, JVM) — **957 tests, 3033 assertions, 0 failures, 0 errors**.
- New tests: region `:on-error` region-relative guard (proves fix 2 — fails without the re-stamp), region `:after` fired+cancelled share one work-id (fix 3), parallel-root scheduled+cancelled `:state :rf/parallel-root` (fix 4). All green; each targeted var run confirmed.
- Node CLJS gate (`npm run test:cljs`) not run locally — `node_modules` is not installed in this repo's worktrees (JVM is the established local machines gate); covered by CI on this PR. The fix-2 test lives in a `.cljc` and passes under JVM.
