### PR TITLE
fix(machines-viz): reversible full-codepoint id codec + emit robustness (rf2-qgtcvy)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2088,10 +2088,17 @@ back.
 > **Id codec — injective + xsd:ID-conformant (rf2-mnp93.1/.7,
 > supersedes rf2-csq75).** SCXML state ids are `xsd:ID` (XML NCName):
 > letters / digits / `-` `.` `_`, and crucially **no `:`**. The codec
-> HEX-ESCAPES every keyword namespace/name char outside `[A-Za-z0-9]` to
-> `_<2-hex>` (`.` → `_2e`, `?` → `_3f`, and the underscore itself → `_5f`)
-> and joins parts with two RESERVED MARKERS the escaper can provably
-> never emit:
+> HEX-ESCAPES every keyword namespace/name char outside `[A-Za-z0-9]` to a
+> FIXED-WIDTH, self-delimiting escape of its UTF-16 code unit — `_<2-hex>`
+> at or below `U+00FF` (`.` → `_2e`, `?` → `_3f`, the underscore itself →
+> `_5f`) and `_u<4-hex>` above it (CJK, emoji: `开` → `_u5f00`). Both forms
+> are fixed-width, so the codec is **reversible across the whole code-unit
+> range** (rf2-qgtcvy — the pre-fix `_<var-hex>` was neither self-delimiting
+> nor reversible above `0xFF`: `:开始` mis-decoded and `đ` collided with
+> `U+0011`+`"1"`); the `u` sentinel (not a hex digit) keeps the two widths
+> unambiguous. Parts join with two RESERVED MARKERS the escaper can provably
+> never emit (a `_` is always followed by a hex digit or `u`, so neither
+> width mints two consecutive underscores):
 >
 > - `__` (double underscore) separates a *namespaced keyword's* namespace
 >   from its name: `:auth/login` → `auth__login`,

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -864,21 +864,39 @@
   Hyphens are pervasive in re-frame keywords (`:logged-in`,
   `:rate-limited`), so the collision is reachable.
 
-  Scheme: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
-  underscore itself included → `_5f`), so the mapping is reversible and no
-  two distinct chars share an encoding. Because the result contains no two
-  consecutive underscores, the reserved markers the consumers layer on top
-  — `_2f` (the hex of `/`) for a keyword's ns/name boundary, `__` between
-  path segments (xyflow `node-id` / mermaid `sanitise-id`), `__`/`___`
-  (SCXML ns-name / path separators) — can never arise from segment
-  content. This is the SINGLE injective scheme all three emitters' id
-  codecs build on, so they address every node identically."
+  Scheme: every char outside `[A-Za-z0-9]` becomes a FIXED-WIDTH,
+  self-delimiting escape of its UTF-16 code unit —
+
+    - `≤ U+00FF`  → `_<2-hex>`  (the underscore itself → `_5f`)
+    - `> U+00FF`  → `_u<4-hex>` (CJK, emoji surrogate halves, …)
+
+  Both forms are fixed-width, so the codec is REVERSIBLE across the whole
+  code-unit range and no two distinct inputs share an encoding (rf2-qgtcvy:
+  the pre-fix `_<var-hex>` was neither self-delimiting nor reversible above
+  0xFF — `:开始` mis-decoded and `đ` collided with `\\u0011`+`\"1\"`). The `u`
+  sentinel (not a hex digit) keeps the two widths unambiguous: `_2f` is
+  always a 2-hex escape, `_u5f00` always a 4-hex one, so `_2f00` reads as
+  `/`+`00`, never as one wide escape.
+
+  Neither form ever mints two consecutive underscores (a `_` is always
+  followed by a hex digit or `u`), so the reserved markers the consumers
+  layer on top — `_2f` (the hex of `/`) for a keyword's ns/name boundary,
+  `__` between path segments (xyflow `node-id` / mermaid `sanitise-id`),
+  `__`/`___` (SCXML ns-name / path separators) — can never arise from
+  segment content. This is the SINGLE injective scheme all three emitters'
+  id codecs build on, so they address every node identically."
   [s]
   (str/join
     (map (fn [ch]
            (if (re-matches #"[A-Za-z0-9]" (str ch))
              (str ch)
-             (str "_" #?(:clj  (format "%02x" (int ch))
-                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
-                                 (if (= 1 (count h)) (str "0" h) h))))))
+             (let [cu #?(:clj  (int ch)
+                         :cljs (.charCodeAt (str ch) 0))]
+               (if (<= cu 0xff)
+                 (str "_" #?(:clj  (format "%02x" cu)
+                             :cljs (let [h (.toString cu 16)]
+                                     (if (= 1 (count h)) (str "0" h) h))))
+                 (str "_u" #?(:clj  (format "%04x" cu)
+                              :cljs (let [h (.toString cu 16)]
+                                      (str (subs "0000" (count h)) h))))))))
          s)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -657,15 +657,25 @@
     {:category :rf.error/machine-bad-target :path (vec path) :slot slot}))
 
 (defn- transition-target-defect [scope path node]
-  (let [check (fn [slot v]
-                (some (fn [{:keys [present? target]}]
-                        (when present? (target-defect scope path slot target)))
-                      (candidate-targets v)))]
-    (or (some (fn [[_ v]] (check :on v)) (:on node))
-        (some (fn [[_ v]] (check :after v)) (:after node))
-        (some (fn [entry] (check :always entry)) (always-entries node))
-        (when (contains? node :on-done) (check :on-done (:on-done node)))
-        (when-let [oe (get-in node [:spawn :on-error])] (check :spawn/on-error oe)))))
+  (or
+    ;; rf2-qgtcvy — `:on` / `:after` must each be a MAP of clause → spec. A
+    ;; non-map (e.g. `{:on :retry}` from an LLM) previously threw an uncaught
+    ;; ISeq exception when iterated below, instead of the clean
+    ;; `:invalid-definition` the emit paths promise. Surface the runtime's own
+    ;; slot-specific defect category so the emit path rejects cleanly.
+    (when (and (contains? node :on) (not (map? (:on node))))
+      {:category :rf.error/machine-bad-on-clause :path (vec path)})
+    (when (and (contains? node :after) (not (map? (:after node))))
+      {:category :rf.error/machine-bad-after-spec :path (vec path)})
+    (let [check (fn [slot v]
+                  (some (fn [{:keys [present? target]}]
+                          (when present? (target-defect scope path slot target)))
+                        (candidate-targets v)))]
+      (or (some (fn [[_ v]] (check :on v)) (:on node))
+          (some (fn [[_ v]] (check :after v)) (:after node))
+          (some (fn [entry] (check :always entry)) (always-entries node))
+          (when (contains? node :on-done) (check :on-done (:on-done node)))
+          (when-let [oe (get-in node [:spawn :on-error])] (check :spawn/on-error oe))))))
 
 (defn- node-defect
   "First defect on one MAP state-node at `path` within `scope` (its region /

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -39,11 +39,18 @@
   keyword-label g/name-of)
 
 (defn- label-value
-  "Return a label string for values that appear on Mermaid edges."
+  "Return a label string for values that appear on Mermaid edges.
+
+  rf2-qgtcvy — an INLINE-FN guard/action renders via the SHARED fn-tolerant
+  `grammar/name-of` (its `:name` meta or a stable `\"fn\"`), the SAME way the
+  chart `name-of` + SCXML `ref->label` render it. The pre-fix `pr-str` arm
+  leaked the host object string (`#object[Function]` / `#object[...]`),
+  diverging from the other two emitters for the very same fn ref."
   [v]
   (cond
     (keyword? v) (keyword-label v)
     (string? v)  v
+    (fn? v)      (g/name-of v)
     :else        (pr-str v)))
 
 ;; rf2-b2ygd2 — grammar walker + injective id codec aliased from the SHARED

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -58,9 +58,10 @@
 
   SCXML state ids are `xsd:ID` (XML NCName): letters / digits / `-` `.`
   `_`, NO `:`. The codec hex-escapes every keyword ns/name char to
-  `_<2-hex>` (`.` → `_2e`, `?` → `_3f`, `_` → `_5f`) and uses two
-  reserved markers the escaper can provably never emit — `__` between a
-  keyword's namespace and name, `___` between vector-path segments — so:
+  `_<2-hex>` (`.` → `_2e`, `?` → `_3f`, `_` → `_5f`) — or `_u<4-hex>` above
+  U+00FF (CJK, emoji) — and uses two reserved markers the escaper can
+  provably never emit — `__` between a keyword's namespace and name, `___`
+  between vector-path segments — so:
 
   - ANY keyword round-trips EXACTLY, regardless of how many dots its
     namespace or name has (`:my.app.auth/login` ≠ `:my/app.auth.login`
@@ -188,11 +189,11 @@
 ;;
 ;; The hex-escape codec (the same injective scheme `chart/layout`'s
 ;; `node-id` uses for xyflow ids) handles this. EVERY non-alphanumeric
-;; char in a segment is escaped to `_<2-hex>` (so a literal `_` → `_5f`,
-;; `.` → `_2e`, `?` → `_3f`). After escaping, an `_` appears ONLY as the
-;; lead of a `_XX` hex triple — never two underscores in a row — so we can
-;; use consecutive-underscore RESERVED MARKERS the escaper can provably
-;; never emit:
+;; char in a segment is escaped to `_<2-hex>` (≤ U+00FF: a literal `_` →
+;; `_5f`, `.` → `_2e`, `?` → `_3f`) or `_u<4-hex>` (> U+00FF: CJK, emoji).
+;; After escaping, an `_` is ALWAYS followed by a hex digit or the `u`
+;; sentinel — never another underscore — so we can use consecutive-
+;; underscore RESERVED MARKERS the escaper can provably never emit:
 ;;
 ;; - `__`  (DOUBLE underscore) joins a keyword's NAMESPACE and NAME:
 ;;   `:auth/login`         → `"auth__login"`
@@ -212,8 +213,9 @@
 
 (def ^:private ns-name-sep
   "The keyword NAMESPACE↔NAME boundary in an SCXML id. `__` (double
-  underscore) is impossible for `escape-id-segment` to emit (it only ever
-  emits `_` + 2 hex digits), so it is the injective ns/name marker."
+  underscore) is impossible for `escape-id-segment` to emit (every escape
+  is `_` + 2 hex or `_u` + 4 hex — a `_` is never followed by a `_`), so it
+  is the injective ns/name marker."
   "__")
 
 (def ^:private path-segment-sep
@@ -224,22 +226,25 @@
   "___")
 
 ;; The xsd:ID-safe injective escape is the SHARED `grammar/escape-id-segment`
-;; (every char outside `[A-Za-z0-9]` → `_<2-hex>`, the underscore itself →
-;; `_5f`; no two consecutive underscores, so the `__` / `___` reserved markers
-;; can never arise from segment content). The SINGLE injective scheme across
+;; (every char outside `[A-Za-z0-9]` → `_<2-hex>` ≤ U+00FF / `_u<4-hex>` above,
+;; the underscore itself → `_5f`; no two consecutive underscores, so the `__` /
+;; `___` reserved markers can never arise from segment content). The SINGLE
+;; injective scheme across
 ;; all machines-viz id emitters, so the SCXML codec mints byte-identical
 ;; segment escapes to the chart `node-id` + mermaid `sanitise-id`.
 (def ^:private escape-id-segment g/escape-id-segment)
 
 (defn- unescape-id-segment
-  "Inverse of `escape-id-segment`: replace every `_<2-hex>` triple with
-  the char it encodes."
+  "Inverse of `escape-id-segment`: replace every escape with the code unit
+  it encodes — `_u<4-hex>` (> U+00FF) OR `_<2-hex>` (≤ U+00FF). The `u`
+  sentinel keeps the two widths unambiguous, so the decode is exact across
+  the whole code-unit range (rf2-qgtcvy)."
   [s]
   (str/replace s
-               #"_([0-9a-fA-F]{2})"
-               (fn [[_ hex]]
-                 (str (char #?(:clj  (Integer/parseInt hex 16)
-                               :cljs (js/parseInt hex 16)))))))
+               #"_u([0-9a-fA-F]{4})|_([0-9a-fA-F]{2})"
+               (fn [[_ wide narrow]]
+                 (str (char #?(:clj  (Integer/parseInt (or wide narrow) 16)
+                               :cljs (js/parseInt (or wide narrow) 16)))))))
 
 (defn- keyword->id-string
   "Map a single keyword to its injective, xsd:ID-conformant SCXML id

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -916,11 +916,14 @@
   map of string keys to unescaped string values. Tolerant of any
   attribute order; recognises both single and double quotes."
   [^String attr-string]
-  (let [pattern #"(\w+)\s*=\s*\"([^\"]*)\""
+  ;; rf2-qgtcvy — match DOUBLE- OR SINGLE-quoted values. Pre-fix the pattern
+  ;; only matched `"…"`, so an imported `<state id='idle'>` (single-quoted, a
+  ;; legal XML form) parsed no `id` and keyed the state under nil.
+  (let [pattern #"(\w+)\s*=\s*(?:\"([^\"]*)\"|'([^']*)')"
         matches (re-seq pattern attr-string)]
     (into {}
-          (map (fn [[_ k v]]
-                 [k (-> v
+          (map (fn [[_ k dq sq]]
+                 [k (-> (or dq sq)
                         (str/replace "&apos;" "'")
                         (str/replace "&quot;" "\"")
                         (str/replace "&gt;"   ">")

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
@@ -318,3 +318,23 @@
     (let [segs ["/" "-" "_" "?" (str (char 0x11)) "đ" "开" "始"
                 (str (char 0x11) "1") "a-b" "a/b" "a_b"]]
       (is (= (count segs) (count (distinct (map g/escape-id-segment segs))))))))
+
+;; rf2-qgtcvy — a non-MAP `:on` / `:after` (e.g. `{:on :retry}` from an LLM)
+;; must return the clean slot-specific defect, NOT throw an uncaught ISeq
+;; exception (which bypassed the emit paths' `:invalid-definition` promise).
+
+(deftest non-map-on-after-rejected-cleanly
+  (testing "a non-map `:on` yields :rf.error/machine-bad-on-clause (no throw)"
+    (is (= :rf.error/machine-bad-on-clause
+           (category {:initial :a :states {:a {:on :retry}}})))
+    (is (= :rf.error/machine-bad-on-clause
+           (category {:initial :a :states {:a {:on [:retry]}}}))))
+  (testing "a non-map `:after` yields :rf.error/machine-bad-after-spec (no throw)"
+    (is (= :rf.error/machine-bad-after-spec
+           (category {:initial :a :states {:a {:after :later}}}))))
+  (testing "`valid-definition?` returns false (rather than throwing) for both"
+    (is (false? (g/valid-definition? {:initial :a :states {:a {:on :retry}}})))
+    (is (false? (g/valid-definition? {:initial :a :states {:a {:after 500}}}))))
+  (testing "a well-formed MAP `:on` / `:after` is still accepted"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:on {:go :b}} :b {}}})))
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:after {500 :b}} :b {}}})))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
@@ -289,3 +289,32 @@
     (testing "definition-summary embeds the canonical defect category so every
               surface that stashes it carries the same category"
       (is (= :rf.error/machine-unknown-node-key (get-in summary [:defect :category]))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-qgtcvy — injective id codec: fixed-width escape, reversible + collision-
+;; free across the whole UTF-16 code-unit range (the pre-fix `_<var-hex>` was
+;; neither self-delimiting nor reversible above 0xFF).
+
+(deftest escape-id-segment-fixed-width-and-injective
+  (testing "≤ U+00FF keeps the 2-hex `_XX` form (Latin-1 golden ids unchanged)"
+    (is (= "_2f" (g/escape-id-segment "/")))
+    (is (= "_2d" (g/escape-id-segment "-")))
+    (is (= "_5f" (g/escape-id-segment "_")))
+    (is (= "_3f" (g/escape-id-segment "?")))
+    (is (= "_11" (g/escape-id-segment (str (char 0x11))))))
+  (testing "> U+00FF uses the self-delimiting `_u<4-hex>` form"
+    (is (= "_u5f00" (g/escape-id-segment "开")))      ;; 开
+    (is (= "_u59cb" (g/escape-id-segment "始")))      ;; 始
+    (is (= "_u0111" (g/escape-id-segment "đ"))))     ;; đ
+  (testing "the pre-fix collision is gone: đ (U+0111) vs \\u0011 + \"1\""
+    (is (not= (g/escape-id-segment "đ")
+              (g/escape-id-segment (str (char 0x11) "1")))
+        "distinct inputs must mint distinct ids"))
+  (testing "no two consecutive underscores, so the `__`/`___`/`_2f` markers
+            can never arise from segment content"
+    (is (not (str/includes? (g/escape-id-segment "开始") "__")))
+    (is (not (str/includes? (g/escape-id-segment "đ") "__"))))
+  (testing "distinct segment strings always mint distinct escapes (injective)"
+    (let [segs ["/" "-" "_" "?" (str (char 0x11)) "đ" "开" "始"
+                (str (char 0x11) "1") "a-b" "a/b" "a_b"]]
+      (is (= (count segs) (count (distinct (map g/escape-id-segment segs))))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -277,6 +277,28 @@
           out (m/emit m)]
       (is (str/includes? out "a --> b : go [ready?]")))))
 
+(deftest emit-renders-inline-fn-guard-consistently
+  (testing "rf2-qgtcvy — an INLINE-FN guard renders via the shared
+            `grammar/name-of` (its :name meta or a stable \"fn\"), the SAME
+            way the chart + SCXML emitters do — NOT the host object string
+            (`#object[...]`) the pre-fix `label-value` `pr-str` arm leaked"
+    (let [named {:initial :a
+                 :states  {:a {:on {:go {:target :b
+                                         :guard (with-meta (fn [_] true)
+                                                  {:name 'ready?})}}}
+                           :b {}}}
+          anon  {:initial :a
+                 :states  {:a {:on {:go {:target :b :guard (fn [_] true)}}}
+                           :b {}}}
+          out-n (m/emit named)
+          out-a (m/emit anon)]
+      (is (str/includes? out-n "a --> b : go [ready?]")
+          "a :name-tagged inline-fn guard surfaces its name (mirrors SCXML cond)")
+      (is (str/includes? out-a "a --> b : go [fn]")
+          "an anonymous inline-fn guard reads as the stable [fn] placeholder")
+      (is (not (str/includes? out-a "#object"))
+          "never the host Function object string"))))
+
 (deftest emit-renders-multiple-candidate-transition-vectors
   (testing "candidate vectors render every target-bearing branch"
     (let [m   {:initial :editing

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -329,6 +329,25 @@
       (is (keyword? (:initial back)))
       (is (= "结束" (name (:initial back)))))))
 
+(deftest parse-attrs-accepts-single-quoted-attributes
+  (testing "rf2-qgtcvy — `parse-attrs` matched only double-quoted values, so
+            an imported `<state id='idle'>` keyed the state under nil. Every
+            attribute in a single-quoted document must parse identically"
+    (let [spec   {:initial :idle
+                  :states  {:idle {:on {:go :done}}
+                            :done {:final? true}}}
+          xml    (scxml/spec->scxml spec)
+          ;; the emitter escapes `"`/`'` INSIDE values (&quot;/&apos;), so raw
+          ;; quotes are only attribute delimiters — swapping them wholesale
+          ;; yields a valid single-quoted document.
+          single (str/replace xml "\"" "'")]
+      (is (str/includes? single "id='"))
+      (is (not (str/includes? single "id=\"")))
+      (is (= (scxml/scxml->spec xml) (scxml/scxml->spec single))
+          "single-quoted attributes parse identically to double-quoted")
+      (is (= spec (scxml/scxml->spec single))
+          "and the single-quoted document round-trips to the original spec"))))
+
 ;; ---------------------------------------------------------------------------
 ;; Error cases
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -306,6 +306,29 @@
             "single namespaced keyword must NOT become [:auth :login]")
         (is (keyword? (get-in back [:states :a :on :go])))))))
 
+(deftest round-trip-non-latin1-ids
+  (testing "rf2-qgtcvy — state ids above U+00FF (CJK) round-trip EXACTLY.
+            The pre-fix `_<var-hex>` encode + `_XX` (2-hex) decode mis-read
+            `:开始` (`_5f00_59cb`) as `:_00Ycb`; the fixed-width `_u<4-hex>`
+            codec is now reversible across the whole code-unit range"
+    (let [begin (keyword "开始")            ;; U+5F00 U+59CB
+          done  (keyword "结束")            ;; U+7ED3 U+675F
+          spec  {:initial begin
+                 :states  {begin {:on {:go done}}
+                           done  {}}}
+          back  (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "the whole CJK-id machine round-trips exactly")
+      (is (= done (get-in back [:states begin :on :go]))
+          "the CJK transition target survives")))
+  (testing "a bare CJK id decodes back to the SAME keyword (not a vector /
+            mis-split), since a plain name carries no `__` ns/name marker"
+    (let [k    (keyword "结束")
+          spec {:initial k :states {k {}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back))
+      (is (keyword? (:initial back)))
+      (is (= "结束" (name (:initial back)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Error cases
 


### PR DESCRIPTION
Closes rf2-qgtcvy (P2 silent-corruption bug found by a read-only review). One PR, two commits.

## Commit 1 — reversible full-codepoint id codec (the P2)

`escape-id-segment` emitted `_<hex>` with **variable-length** hex (`%02x` / `.toString 16` on the full UTF-16 code unit) while `unescape-id-segment` matched **exactly two** hex digits. Above U+00FF the escape was neither self-delimiting nor reversible, breaking the codec's "distinct inputs → distinct outputs" / "ANY keyword round-trips EXACTLY" contract:

- **round-trip corruption** — `:开始` encodes `_5f00_59cb`, decodes (via the 2-hex regex) to a wrong keyword, silently.
- **encode collision** — `đ` (U+0111) → `_111` **and** U+0011 + `"1"` → `_11`+`1` → `_111`; two distinct inputs mint the same node id (the rf2-mnp93.6 collision class, in the >0xFF regime).

**Approach.** A **fixed-width, self-delimiting** escape of each UTF-16 code unit:

| code unit | escape |
|---|---|
| ≤ U+00FF | `_<2-hex>` (unchanged — `/` → `_2f`, `_` → `_5f`, …) |
| > U+00FF | `_u<4-hex>` (`开` → `_u5f00`) |

The `u` sentinel (not a hex digit) keeps the two widths unambiguous (`_2f00` reads as `/`+`00`, never one wide escape). Both forms are fixed-width ⇒ reversible across the whole code-unit range; neither ever mints two consecutive underscores, so the `__`/`___`/`_2f` reserved markers still can never arise from segment content. The decode regex widens to `_u<4-hex> | _<2-hex>`.

Because the ≤U+00FF form is byte-identical, **all existing Latin-1 golden ids and the `_2f` ns/name markers are untouched** — only the previously-broken >0xFF regime changes. CJK/emoji ids now round-trip; the collision is gone. `spec/API.md` codec section + doc comments updated to match.

## Commit 2 — emit robustness minors (P3)

- `grammar/transition-target-defect`: a non-map `:on`/`:after` (e.g. `{:on :retry}`) threw an uncaught ISeq exception in `definition-defect` instead of the clean `:invalid-definition` the emit paths promise. Now returns the runtime's own slot-specific defect (`:rf.error/machine-bad-on-clause` / `-bad-after-spec`).
- `mermaid/label-value`: rendered inline-fn guards via `pr-str` (`#object[...]`), diverging from chart + SCXML. Now routes fn refs through the shared `grammar/name-of` (`:name` meta or `"fn"`).
- `scxml/parse-attrs`: matched only double-quoted attributes despite claiming single+double, so `<state id='idle'>` keyed the state under nil. Now matches single **and** double quotes.

Each with a test.

## Quality gates

- `clojure -M:test` (from `tools/machines-viz/`): **630 tests / 2504 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime, includes the machines-viz suite): **9023 tests / 42580 assertions, 0 failures, 0 errors**

machines-viz `spec/` updated (`API.md` codec section), per the xray-specs-kept-current convention.