### PR TITLE
fix(machines): forget! finished actors + close :spawn-all sibling/completed leaks (rf2-p6fw3q, rf2-qb1j5z)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -48,6 +48,7 @@
             [re-frame.machines.paths :as paths]
             [re-frame.machines.reply :as m-reply]
             [re-frame.machines.result :as result]
+            [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.machines.timer :as timer]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
@@ -548,6 +549,19 @@
     ;; no-op, so the registry entry added at spawn dies with the instance (no
     ;; leak).
     (classification/drop-at-destroy! frame-id machine-id machine)
+    ;; Forget the finished actor from the per-frame spawn-order channel —
+    ;; the ONE synchronous teardown side-effect the `:final?`-auto-destroy
+    ;; path shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).
+    ;; `spawn-order/frame-order` is `actor-live?`'s "most reliable
+    ;; alive-or-gone bit" (destroy.cljc:83); without this call a finished
+    ;; actor stays recorded → a later stale `[:rf.machine/destroy id]` sees
+    ;; it live → `teardown-live-actor!` RE-RUNS (phantom `:rf.machine/destroyed`
+    ;; trace + re-fired resource release, violating silent-idempotent destroy)
+    ;; and frame-destroy emits a phantom straggler destroy for it. Matches the
+    ;; exact `(frame-id actor-id)` args destroy.cljc uses, so the forget! runs
+    ;; atomically per finalize-machine — the invariant destroy.cljc:306-308
+    ;; already documents.
+    (spawn-order/forget! frame-id machine-id)
     (traces/emit-system-id-released! frame-id released-sid machine-id)
     (registrar/unregister! :event machine-id)
     ;; (7) Per Spec 005 §Final states §`:on-error`: when the child

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -300,11 +300,12 @@
   cancellation traces reach the cascade's `:trace-events` slot."
   [frame-id parent-id invoke-id spec join-state'' child-id child-extra
    {:keys [resolved? resolution-event join-event-kw]}]
-  (let [cancel-fx
+  (let [destroy-fx
         (when resolved?
-          (let [completed-ids (into #{} (concat (:done   join-state'')
+          (let [children      (:children join-state'')
+                completed-ids (into #{} (concat (:done   join-state'')
                                                 (:failed join-state'')))
-                survivors     (->> (:children join-state'')
+                survivors     (->> children
                                    (remove (fn [[cid _]]
                                              (contains? completed-ids cid))))]
             (doseq [[cid spawned-id] survivors]
@@ -344,14 +345,30 @@
                               :rf.reply/cancelled?  (:cancelled? survivor-summary)
                               :rf.reply/cancel-reason (:rf.reply/cancel-reason survivor-summary)
                               :rf.reply/correlation (:correlation survivor-summary)})))
+            ;; Destroy EVERY child of the resolved join — the survivors
+            ;; (cancelled, traced above) AND the COMPLETED children. A
+            ;; `:spawn-all` child's `:on-child-done` / `:on-child-error`
+            ;; terminal state is NOT necessarily `:final?`, so a "completed"
+            ;; child stays a LIVE actor after dispatching its completion.
+            ;; Completed children were previously torn down ONLY when the
+            ;; parent's resolution transition EXITED the `:spawn-all` state
+            ;; (destroy.cljc `destroy-spawn-all-children!` in the exit
+            ;; cascade) — so an INTERNAL/self resolution handler (or a parent
+            ;; with no `:on` for the resolution event, which stays in the
+            ;; state) leaked all N completed children's
+            ;; snapshots/timers/resources (rf2-qb1j5z). Destroying every child
+            ;; HERE closes that leak regardless of whether the resolution
+            ;; transition exits the state. Destroying an already-torn-down
+            ;; child (a `:final?` terminal that already auto-destroyed, or the
+            ;; exit-cascade's later sweep) is a silent-idempotent no-op.
             (mapv (fn [[_ spawned-id]]
                     [:rf.machine/destroy spawned-id])
-                  survivors)))
+                  children)))
         dispatch-fx
         (when resolution-event
           (let [inner (vec (concat resolution-event [child-id] child-extra))]
             [[:dispatch [parent-id inner]]]))]
-    (vec (concat (or cancel-fx []) (or dispatch-fx [])))))
+    (vec (concat (or destroy-fx []) (or dispatch-fx [])))))
 
 (defn intercept-spawn-all-event
   "Per Spec 005 §Child completion protocol. When the parent's

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -155,6 +155,36 @@
                         :reason     reason})
     nil))
 
+(def ^:private spawn-all-reject-sentinel
+  "The join-slot value `spawn-all-init-fx` writes when it REJECTS a
+  `:spawn-all` invoke (some child names an UNREGISTERED TYPE). It carries NO
+  `:children`, so `join.cljc`'s interceptor treats it as an unseeded no-op
+  and `destroy.cljc`'s `destroy-spawn-all-children!` finds nothing to tear
+  down and clears the slot on parent exit.
+
+  Its sole purpose is to make the reject ATOMIC: the registered siblings'
+  per-child `:rf.machine/spawn` fxs — SEPARATE entries later in the SAME
+  entry `:fx` vector — read this sentinel (via `spawn-all-invoke-rejected?`)
+  and suppress themselves, so a malformed `:spawn-all` spawns NOTHING rather
+  than orphaning the registered siblings with no seeded join to ever tear
+  them down (rf2-qb1j5z)."
+  {:rf/spawn-all-rejected? true})
+
+(defn- spawn-all-invoke-rejected?
+  "True iff `args` is a `:spawn-all` per-child spawn whose invoke was
+  REJECTED by `spawn-all-init-fx` (an unregistered sibling TYPE). The reject
+  seeds `spawn-all-reject-sentinel` at the join slot BEFORE the per-child
+  spawns run — `spawn-all-init-fx` is the FIRST fx in the entry vector, ahead
+  of every per-child `:rf.machine/spawn` — so a sibling spawn reads it here
+  and suppresses itself. Keyed on the child's `:rf/spawn-all-id` (== the
+  parent's invoke-id / join-slot key), so it fires ONLY for `:spawn-all`
+  children, never a single `:spawn`."
+  [frame-id args]
+  (when-let [invoke-id (:rf/spawn-all-id args)]
+    (let [slot (get-in (frame/frame-runtime-db-value frame-id)
+                       (paths/spawned-path (:rf/parent-id args) invoke-id))]
+      (boolean (and (map? slot) (:rf/spawn-all-rejected? slot))))))
+
 (defn- machine-type-ref
   "The revertible TYPE reference stamped onto a spawned actor's snapshot root
   under `:rf/machine-type`, so the lazy resolver (`lifecycle-fx.resolver`)
@@ -334,8 +364,21 @@
     ;; `:rf.error/machine-spawn-unregistered-type` and returns nil — the
     ;; strongest atomicity (there is no spec-less spawn path, so there is no
     ;; half-installed bookkeeping the next op could trip over).
-    (if (unregistered-spawn-type? args)
+    (cond
+      (unregistered-spawn-type? args)
       (reject-unregistered-spawn! frame-id (:machine-id args))
+
+      ;; Step 0b — atomic `:spawn-all` reject. When a SIBLING in this
+      ;; `:spawn-all` set named an UNREGISTERED TYPE, `spawn-all-init-fx`
+      ;; (the first fx in this entry vector) rejected the whole invoke and
+      ;; seeded `spawn-all-reject-sentinel` at the join slot. Suppress this
+      ;; registered sibling's spawn so the reject is ATOMIC — no live orphan
+      ;; with no seeded join to ever tear it down (rf2-qb1j5z). Silent: the
+      ;; invoke-level reject trace already fired from `spawn-all-init-fx`.
+      (spawn-all-invoke-rejected? frame-id args)
+      nil
+
+      :else
       (spawn-fx* frame-id args))))
 
 (defn- spawn-fx*
@@ -556,12 +599,29 @@
         unregistered (->> (get-in join-state [:spec :children])
                           (filterv unregistered-spawn-type?))]
     (if (seq unregistered)
-      ;; Fail-closed: reject the join — seed NO join-state — so the never-
-      ;; running spec-less child cannot hang the `:all` join forever. Emit
-      ;; one reject per offending child (structural-only tags, per the
-      ;; privacy contract). The per-child `:rf.machine/spawn` fx rejects too.
+      ;; Fail-closed: reject the join so the never-running spec-less child
+      ;; cannot hang the `:all` join forever. Emit one reject per offending
+      ;; child (structural-only tags, per the privacy contract). The
+      ;; per-child `:rf.machine/spawn` fx rejects each unregistered child too.
+      ;;
+      ;; ATOMIC reject (rf2-qb1j5z): seed `spawn-all-reject-sentinel` at the
+      ;; join slot rather than seeding NO join-state. The registered
+      ;; siblings' per-child `:rf.machine/spawn` fxs — SEPARATE entries later
+      ;; in THIS entry `:fx` vector — would otherwise install live orphan
+      ;; actors that no seeded join ever tears down (they carry
+      ;; `:rf/spawn-all-id`, `track? false`, are recorded only in
+      ;; spawn-order, and leak until frame-destroy). The sentinel signals the
+      ;; rejected invoke so those siblings suppress themselves
+      ;; (`spawn-all-invoke-rejected?`) — the whole malformed invoke spawns
+      ;; NOTHING, the consistent analogue of a single `:spawn`'s atomic
+      ;; reject. The sentinel carries no `:children`, so the join interceptor
+      ;; treats it as unseeded (no deadlock) and `destroy-spawn-all-children!`
+      ;; finds nothing to tear down and clears the slot on parent exit.
       (do (doseq [child unregistered]
             (reject-unregistered-spawn! frame-id (:machine-id child)))
+          (frame/swap-runtime-db! frame-id assoc-in
+                                  (paths/spawned-path parent-id invoke-id)
+                                  spawn-all-reject-sentinel)
           nil)
       (do
         ;; Machine spawn-registry state is durable runtime-db state.

--- a/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
@@ -1,0 +1,158 @@
+(ns re-frame.final-state-spawn-order-forget-cljs-test
+  "rf2-p6fw3q — the `:final?`-state AUTO-DESTROY path (`finalize-machine`)
+  MUST forget the finished actor from the per-frame `spawn-order` channel,
+  exactly like the explicit-destroy path (`destroy/teardown-live-actor!`,
+  destroy.cljc step 7).
+
+  `spawn-order/frame-order` is `actor-live?`'s \"most reliable
+  alive-or-gone bit\" (destroy.cljc:83): `record!` runs unconditionally on
+  spawn, `forget!` unconditionally on destroy. If finalize omits the
+  `forget!`, a finished actor STAYS recorded even though its snapshot is
+  dissoc'd — so:
+
+    - a later stale `[:rf.machine/destroy id]` sees it LIVE (spawn-order
+      hit) → `teardown-live-actor!` RE-RUNS → a PHANTOM
+      `:rf.machine/destroyed` trace + a RE-FIRED resource release, violating
+      the silent-idempotent destroy contract (Spec 005 §Destroy is
+      silent-idempotent); and
+    - frame-destroy's spawn-order walk (frame_destroy.cljc segment (b))
+      emits a PHANTOM `:rf.machine.lifecycle/destroyed :parent-frame-destroyed`
+      for the already-finished actor.
+
+  These JVM+CLJS tests pin: (1) finalize forgets the actor from
+  spawn-order; (2) a subsequent stale destroy is a SILENT no-op — no phantom
+  destroyed trace, no re-fired release; (3) frame-destroy emits no phantom
+  for the finished actor.
+
+  Named `*-cljs-test.cljc` so both cognitect.test-runner (JVM, plain-atom)
+  and shadow-cljs (CLJS, reagent) discover it."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.events :as events]
+   [re-frame.machines]
+   [re-frame.machines.spawn-order :as spawn-order]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(def ^:private snapshot mtest/snapshot)
+
+;; A stub `:rf.resource/release-owner` handler recording every released
+;; owner — the machine side dispatches this by NAME (machines never
+;; :requires resources), so a stub stands in for the real resources
+;; artefact. Mirrors `actor_resource_lease_release_cljs_test`.
+(def ^:private released (atom []))
+
+(defn- install-release-stub! []
+  (reset! released [])
+  (events/reg-event :rf.resource/release-owner
+    (fn [_ [_ {:keys [owner]}]]
+      (swap! released conj owner)
+      {})))
+
+;; A parent that spawns one child of a registered TYPE on entry to
+;; :working (the synthetic `[:rf.machine.spawn/spawned]` initial-entry
+;; event drives the `:spawn`). The child reaches a `:final?` leaf on
+;; `[:fin]` → auto-destroy.
+(defn- reg-parent-and-child! [parent-id child-id]
+  (rf/reg-machine child-id
+    {:initial :running
+     :data    {}
+     :states  {:running {:on {:fin :done}}
+               :done    {:final? true}}})
+  (rf/reg-machine parent-id
+    {:initial :working
+     :states  {:working {:spawn {:machine-id child-id}}}}))
+
+(defn- spawn-child! [parent-id frame-id]
+  (rf/dispatch-sync [parent-id [:rf.machine.spawn/spawned]] {:frame frame-id})
+  (get-in (mtest/runtime-db frame-id)
+          [:rf.runtime/machines :spawned parent-id [:working]]))
+
+;; ===========================================================================
+;; 1. finalize forgets the finished actor from spawn-order
+;; ===========================================================================
+
+(deftest final-state-forgets-actor-from-spawn-order
+  (testing "rf2-p6fw3q — a spawned child reaching a :final? leaf is removed
+            from the per-frame spawn-order channel by finalize-machine"
+    (reg-parent-and-child! :fsf1/parent :fsf1/child)
+    (let [spawned-id (spawn-child! :fsf1/parent :rf/default)]
+      (is (some? spawned-id) "child was spawned")
+      (is (some #(= spawned-id %) (spawn-order/frame-order :rf/default))
+          "the live spawned child is recorded in spawn-order")
+      ;; Drive the child into its :final? leaf → auto-destroy.
+      (rf/dispatch-sync [spawned-id [:fin]])
+      (is (nil? (snapshot spawned-id))
+          "the finished child's snapshot was synchronously dissoc'd")
+      (is (not-any? #(= spawned-id %) (spawn-order/frame-order :rf/default))
+          "the finished child was forgotten from spawn-order (the fix) —
+           without it the liveness bit strands and destroy re-runs"))))
+
+;; ===========================================================================
+;; 2. a stale destroy after finish is a SILENT no-op
+;;    (no phantom destroyed trace, no re-fired release)
+;; ===========================================================================
+
+(deftest stale-destroy-after-final-is-silent-no-op
+  (testing "rf2-p6fw3q — after a spawned child auto-destroys on :final?, a
+            later [:rf.machine/destroy id] is a silent no-op: NO phantom
+            :rf.machine/destroyed trace, NO re-fired resource release"
+    (install-release-stub!)
+    (reg-parent-and-child! :fsf2/parent :fsf2/child)
+    (rf/reg-event ::stale-destroy
+      (fn [_ [_ id]] {:fx [[:rf.machine/destroy id]]}))
+    (let [spawned-id (spawn-child! :fsf2/parent :rf/default)]
+      ;; Finish the child — finalize releases the [:machine spawned-id] lease
+      ;; once (via its appended :fx) and emits ONE :rf.machine/destroyed.
+      (rf/dispatch-sync [spawned-id [:fin]])
+      (is (= [[:machine spawned-id]] @released)
+          "the finish released the actor's [:machine actor-id] lease exactly once")
+      ;; Scope the phantom check to the stale-destroy window only.
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [::stale-destroy spawned-id])
+      (is (empty? (mtest/events-of :rf.machine/destroyed))
+          "the stale destroy fired NO phantom :rf.machine/destroyed trace
+           (silent-idempotent) — without the forget! it RE-RUNS teardown")
+      (is (= [[:machine spawned-id]] @released)
+          "the stale destroy did NOT re-fire the resource release
+           (still exactly one release) — a re-run would double it"))))
+
+;; ===========================================================================
+;; 3. frame-destroy emits no phantom for the finished actor
+;; ===========================================================================
+
+(defn- parent-frame-destroyed-actor-ids []
+  (->> (mtest/events-of :rf.machine.lifecycle/destroyed)
+       (filter #(= :parent-frame-destroyed (-> % :tags :reason)))
+       (map #(-> % :tags :actor-id))
+       set))
+
+(deftest frame-destroy-after-final-emits-no-phantom
+  (testing "rf2-p6fw3q — a spawned child that finished (auto-destroyed) is
+            NOT re-reaped by frame-destroy: no phantom
+            :rf.machine.lifecycle/destroyed :parent-frame-destroyed for it"
+    (rf/make-frame {:id :fsf3/scratch :doc "final-state / frame-destroy scratch frame"})
+    (reg-parent-and-child! :fsf3/parent :fsf3/child)
+    (let [spawned-id (spawn-child! :fsf3/parent :fsf3/scratch)]
+      (is (some? spawned-id) "child spawned in the scratch frame")
+      ;; Finish the child in the scratch frame.
+      (rf/dispatch-sync [spawned-id [:fin]] {:frame :fsf3/scratch})
+      (is (nil? (snapshot :fsf3/scratch spawned-id))
+          "the child auto-destroyed in the scratch frame")
+      (is (not-any? #(= spawned-id %) (spawn-order/frame-order :fsf3/scratch))
+          "the finished child was forgotten from the scratch frame's spawn-order")
+      ;; Scope the trace check to the frame-destroy window.
+      (mtest/reset-captured!)
+      (rf/destroy-frame! :fsf3/scratch)
+      (is (not (contains? (parent-frame-destroyed-actor-ids) spawned-id))
+          "frame-destroy emitted NO :parent-frame-destroyed phantom for the
+           already-finished child (its spawn-order entry was cleared at finish)"))))

--- a/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
+++ b/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
@@ -26,13 +26,17 @@
       payloads / `:data` may hold application secrets, and the always-on
       record is production-surviving + not privacy-gated).
 
-   4. **`:spawn-all` join-no-hang (the correctness call-out).** An
-      unregistered child TYPE in a `:spawn-all` set REJECTS — it does not
-      DEADLOCK the `:all` join (a never-running spec-less child would never
-      dispatch `:on-child-done`, blocking `(= n-done n-total)` forever).
-      No join-state is seeded, so a registered sibling's later
-      `:on-child-done` falls through to the documented no-op and the join
-      cannot hang.
+   4. **`:spawn-all` join-no-hang + ATOMIC reject (the correctness
+      call-out).** An unregistered child TYPE in a `:spawn-all` set REJECTS
+      the WHOLE invoke — it does not DEADLOCK the `:all` join (a never-running
+      spec-less child would never dispatch `:on-child-done`, blocking
+      `(= n-done n-total)` forever) AND it does not orphan the registered
+      siblings (rf2-qb1j5z). `spawn-all-init-fx` seeds a reject SENTINEL
+      (`{:rf/spawn-all-rejected? true}`, no `:children`): the join interceptor
+      treats it as unseeded so a stray sibling completion is the documented
+      no-op (no hang), and the registered siblings' per-child spawns detect
+      the sentinel and SUPPRESS themselves (no live orphan actor with no
+      seeded join to ever tear it down).
 
    5. **No false reject.** A registered `:machine-id` and an inline
       `:definition` spawn still install cleanly (the gate fires only on the
@@ -194,9 +198,10 @@
 
 (deftest spawn-all-with-unregistered-child-rejects-not-hangs
   (testing "an UNREGISTERED child TYPE in a :spawn-all :all set REJECTS the
-            whole join (no join-state seeded) rather than deadlocking it
-            forever — the never-running spec-less child can never satisfy
-            (= n-done n-total)"
+            whole invoke ATOMICALLY (a reject sentinel is seeded, no
+            :children; the registered sibling is suppressed) rather than
+            deadlocking the join or orphaning the sibling — the never-running
+            spec-less child can never satisfy (= n-done n-total)"
     (let [ok-child {:initial :running :data {} :states {:running {}}}
           ;; :gc/missing is NEVER reg-machine'd — the unregistered child.
           parent   {:initial :idle
@@ -221,10 +226,18 @@
             "the unregistered child fans at least one always-on reject")
         (is (every? #(= :gc/missing (:machine-id %)) records)
             "every reject names the unregistered child TYPE :gc/missing")
-        ;; NO join-state was seeded — the join cannot hang because there is
-        ;; no slot for a sibling completion to drive toward (= n-done n-total).
-        (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/join [:forking]]))
-            "no join-state seeded for a :spawn-all containing an unregistered child")
+        ;; A reject SENTINEL was seeded (no :children) — the join cannot hang
+        ;; because the interceptor treats a childless slot as unseeded, so a
+        ;; sibling completion drives nothing toward (= n-done n-total).
+        (is (= {:rf/spawn-all-rejected? true}
+               (get-in (frame-db) [:rf.runtime/machines :spawned :sup/join [:forking]]))
+            "the reject sentinel (no :children) is seeded for a :spawn-all with an unregistered child")
+        ;; ATOMIC reject: the registered sibling :gc/ok was SUPPRESSED — no
+        ;; orphan actor installed (rf2-qb1j5z).
+        (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots :gc/ok#1]))
+            "the registered sibling was suppressed — no orphan snapshot")
+        (is (not (some #{:gc/ok#1} (spawn-order/frame-order :rf/default)))
+            "the registered sibling was suppressed — nothing recorded in spawn-order")
         ;; The parent is still in :forking — it did NOT advance to :ready
         ;; (the join never resolves) but it also did NOT hang the dispatch
         ;; (dispatch-sync returned).
@@ -232,10 +245,9 @@
             "parent stays in :forking — no deadlock, just a refused join")))))
 
 (deftest spawn-all-registered-sibling-completion-is-noop-not-hang
-  (testing "after the join is rejected, the registered sibling's eventual
-            :on-child-done finds NO seeded join-state and falls through to
-            the documented no-op — proving the join cannot be driven into a
-            hang post-reject"
+  (testing "after the join is rejected, a hand-driven :on-child-done finds the
+            childless reject sentinel and falls through to the documented
+            no-op — proving the join cannot be driven into a hang post-reject"
     (let [ok-child {:initial :running
                     :data    {}
                     :states  {:running {:on {:finish {:target :done}}}
@@ -255,12 +267,14 @@
       (rf/reg-machine :gc/ok2 ok-child)
       (rf/reg-machine :sup/join2 parent)
       (rf/dispatch-sync [:sup/join2 [:start]])
-      ;; No join-state — the precondition for "cannot hang".
-      (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/join2 [:forking]]))
-          "(precondition) no join-state seeded")
-      ;; Hand-drive a child-done event into the parent — the registered
-      ;; sibling would normally drive the join. With no join-state it is a
-      ;; documented no-op; crucially it does NOT throw and does NOT hang.
+      ;; A childless reject sentinel — the precondition for "cannot hang".
+      (is (= {:rf/spawn-all-rejected? true}
+             (get-in (frame-db) [:rf.runtime/machines :spawned :sup/join2 [:forking]]))
+          "(precondition) the childless reject sentinel is seeded")
+      ;; Hand-drive a child-done event into the parent. The registered sibling
+      ;; :gc/ok2 was suppressed, so this stands in for any stray completion:
+      ;; the interceptor sees the childless sentinel, treats it as unseeded,
+      ;; and it is a documented no-op — it does NOT throw and does NOT hang.
       (rf/dispatch-sync [:sup/join2 [:gc/done :ok]])
       (is (= :forking (mtest/machine-state :sup/join2))
           "a child-done with no seeded join-state is a no-op — never resolves, never hangs"))))

--- a/implementation/machines/test/re_frame/spawn_all_lifecycle_leak_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_lifecycle_leak_test.clj
@@ -1,0 +1,154 @@
+(ns re-frame.spawn-all-lifecycle-leak-test
+  "rf2-qb1j5z — two related `:spawn-all` lifecycle leaks.
+
+  (a) MIXED registered/unregistered `:spawn-all`. When any child names an
+      UNREGISTERED TYPE, `spawn-all-init-fx` rejects the join. Previously it
+      seeded NO join-state and returned nil WITHOUT aborting the entry `:fx`
+      vector, so the registered siblings' per-child `:rf.machine/spawn` fxs
+      still ran and installed LIVE actors that no seeded join ever tore down
+      — orphans leaking until frame-destroy. The fix seeds a reject sentinel
+      so the registered siblings suppress themselves: the whole malformed
+      invoke spawns NOTHING (the atomic-reject analogue of a single `:spawn`).
+
+  (b) COMPLETED-children leak at join resolution. `build-resolution-fx`
+      destroyed only SURVIVORS; completed children (whose `:on-child-done` /
+      `:on-child-error` terminal states are NOT necessarily `:final?`, so they
+      stay LIVE) relied on the parent's resolution transition EXITING the
+      `:spawn-all` state to be torn down by the exit cascade. An INTERNAL/self
+      resolution handler (or a parent with no `:on` for the resolution event)
+      leaked all N completed children. The fix destroys every child at
+      resolution, regardless of whether the transition exits the state.
+
+  JVM plain-atom, mirroring `spawn_all_test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Loading `re-frame.machines` registers the late-bind hooks
+            ;; (`:machines/reg-machine`, …) the tests below exercise — keep the
+            ;; require even though the ns is reached only via `rf/...` facades.
+            [re-frame.machines]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot mtest/snapshot)
+
+(defn- mk-child
+  "A child that on :go / :fail transitions to a PLAIN (non-:final?) terminal
+  state and dispatches its completion back to `parent-id` — so a 'completed'
+  child stays a LIVE actor (the (b) leak's precondition)."
+  [parent-id done-kw error-kw]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:dispatch-done  (fn [{data :data}]
+                               {:fx [[:dispatch [parent-id [done-kw (:id data)]]]]})
+             :dispatch-error (fn [{data :data}]
+                               {:fx [[:dispatch [parent-id [error-kw (:id data)]]]]})
+             :record-id      (fn [{data :data ev :event}]
+                               {:data (assoc data :id (second ev))})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-error}}}
+             :done   {}
+             :failed {}}})
+
+(defn- collect-traces
+  "Run `body-fn` with a trace listener; return the collected envelopes."
+  [body-fn]
+  (let [traces (atom [])
+        cb-key (gensym ::leak-cb)]
+    (rf/register-listener! :trace cb-key (fn [ev] (swap! traces conj ev)))
+    (try (body-fn) (finally (rf/unregister-listener! :trace cb-key)))
+    @traces))
+
+;; ===========================================================================
+;; (a) mixed registered/unregistered :spawn-all — atomic reject, no orphan
+;; ===========================================================================
+
+(deftest mixed-registered-unregistered-spawn-all-rejects-whole-invoke-atomically
+  (testing "rf2-qb1j5z(a): a :spawn-all naming an unregistered sibling TYPE
+            spawns NOTHING — the registered sibling is suppressed atomically,
+            leaving no orphan actor to leak"
+    ;; Only :qb/registered is registered; :qb/never-registered is NOT.
+    (rf/reg-machine :qb/registered (mk-child :qb/parent-a :done :err))
+    (rf/reg-machine :qb/parent-a
+      {:initial :idle
+       :states
+       {:idle {:on {:start :hydrating}}
+        :hydrating
+        {:spawn-all
+         {:children        [{:id :reg   :machine-id :qb/registered       :start [:set-id :reg]}
+                            {:id :unreg :machine-id :qb/never-registered :start [:set-id :unreg]}]
+          :join            :all
+          :on-child-done   :done
+          :on-child-error  :err
+          :on-all-complete [:hydrate/done]}
+         :on {:hydrate/done :ready}}
+        :ready {}}})
+    (let [traces (collect-traces (fn [] (rf/dispatch-sync [:qb/parent-a [:start]])))
+          errs   (->> traces
+                      (filter #(= :rf.error/machine-spawn-unregistered-type (:operation %))))
+          slot   (get-in (frame-db) [:rf.runtime/machines :spawned :qb/parent-a [:hydrating]])
+          snaps  (get-in (frame-db) [:rf.runtime/machines :snapshots])]
+      (is (seq errs)
+          "the unregistered sibling TYPE was rejected (:rf.error/machine-spawn-unregistered-type)")
+      (is (= {:rf/spawn-all-rejected? true} slot)
+          "the join slot holds the reject sentinel (join NOT seeded — cannot deadlock)")
+      (is (not (contains? slot :children))
+          "the sentinel carries no :children, so the join interceptor treats it as unseeded")
+      (is (= #{:qb/parent-a} (set (keys snaps)))
+          "NO orphan: the ONLY snapshot is the parent's — the registered sibling never installed")
+      (is (= [] (spawn-order/frame-order :rf/default))
+          "NO orphan: nothing recorded in spawn-order (the registered sibling was suppressed)")
+      (is (= :hydrating (:state (snapshot :qb/parent-a)))
+          "the parent rests on the (malformed) :spawn-all state — the config error to fix"))))
+
+;; ===========================================================================
+;; (b) internal/self join-resolution destroys COMPLETED children
+;; ===========================================================================
+
+(deftest internal-self-join-resolution-destroys-completed-children
+  (testing "rf2-qb1j5z(b): when the join resolves but the resolution transition
+            does NOT exit the :spawn-all state (no :on for the resolution
+            event), the COMPLETED children are torn down at resolution, not
+            leaked"
+    (let [child  (mk-child :qb/parent-b :done :err)
+          parent {:initial :idle
+                  :states
+                  {:idle {:on {:start :racing}}
+                   ;; :racing declares NO :on for :race/won → the parent STAYS
+                   ;; in :racing when the :any join resolves (the internal/self
+                   ;; resolution shape — the resolution transition does not exit
+                   ;; the :spawn-all state, so the exit-cascade teardown of
+                   ;; completed children never runs).
+                   :racing
+                   {:spawn-all
+                    {:children         [{:id :a :machine-id :qb/child-ba :start [:set-id :a]}
+                                       {:id :b :machine-id :qb/child-bb :start [:set-id :b]}]
+                     :join             :any
+                     :on-child-done    :done
+                     :on-child-error   :err
+                     :on-some-complete [:race/won]}}}}]
+      (rf/reg-machine :qb/child-ba child)
+      (rf/reg-machine :qb/child-bb child)
+      (rf/reg-machine :qb/parent-b parent)
+      (rf/dispatch-sync [:qb/parent-b [:start]])
+      (let [ids  (:children (get-in (frame-db) [:rf.runtime/machines :spawned :qb/parent-b [:racing]]))
+            a-id (:a ids)
+            b-id (:b ids)]
+        (is (some? (snapshot a-id)) "child :a live before resolution")
+        (is (some? (snapshot b-id)) "child :b live before resolution")
+        ;; :a completes → the :any join resolves. Parent stays in :racing.
+        (rf/dispatch-sync [a-id [:go]])
+        (let [j (get-in (frame-db) [:rf.runtime/machines :spawned :qb/parent-b [:racing]])]
+          (is (true? (:resolved? j)) ":any resolved on :a's completion")
+          (is (= #{:a} (:done j)) "record holds the decisive child at resolution"))
+        (is (= :racing (:state (snapshot :qb/parent-b)))
+            "the parent STAYED in :racing — the resolution transition did NOT exit the :spawn-all state")
+        (is (nil? (snapshot b-id))
+            "survivor :b was destroyed at resolution (unconditional sibling cancellation)")
+        (is (nil? (snapshot a-id))
+            "COMPLETED child :a was ALSO destroyed at resolution — no leak (the fix)")))))


### PR DESCRIPTION
Fixes a cluster of two state-machine lifecycle-leak bugs found by the 2026-07-12 machines review-wave. One commit per bead.

## Commit 1 — `finalize` omits `spawn-order/forget!` (rf2-p6fw3q, P2)

The `:final?`-state auto-destroy teardown (`finalize-machine`) replicated every synchronous teardown step EXCEPT removing the finished actor from the per-frame `spawn-order` channel — the bit `actor-live?` (`destroy.cljc:83`) calls "the most reliable alive-or-gone bit". A finished actor therefore stayed recorded in `spawn-order` even though its snapshot was dissoc'd, so:

- a later stale `[:rf.machine/destroy id]` saw it live (spawn-order hit) → `teardown-live-actor!` RE-RAN → a phantom `:rf.machine/destroyed` trace + a re-fired `[:rf.resource/release-owner]` release, violating the silent-idempotent destroy contract; and
- frame-destroy's spawn-order walk emitted a phantom `:rf.machine.lifecycle/destroyed :parent-frame-destroyed` for the already-finished actor.

**Fix:** require `re-frame.machines.spawn-order` in `finalize.cljc` and call `(spawn-order/forget! frame-id machine-id)` alongside the other synchronous teardown side-effects — matching the exact ids/args `destroy.cljc` uses, so `forget!` now runs atomically per `finalize-machine`, the invariant `destroy.cljc:306-308` already documents.

## Commit 2 — `:spawn-all` sibling + completed-children leaks (rf2-qb1j5z, P3)

**(a) Mixed registered/unregistered `:spawn-all` orphaned registered siblings.** When any child named an unregistered TYPE, `spawn-all-init-fx` rejected the join but seeded NO join-state and returned nil WITHOUT aborting the entry `:fx` vector, so the registered siblings' per-child `:rf.machine/spawn` fxs still ran and installed live actors that no seeded join ever tore down — orphans (snapshot/timers/resources) leaking until frame-destroy.

Chose the **atomic-reject** design (the bead's first option): `spawn-all-init-fx` seeds a reject **sentinel** (`{:rf/spawn-all-rejected? true}`, no `:children`) at the join slot; the registered siblings' per-child spawns detect it (`spawn-all-invoke-rejected?`) and suppress themselves. The whole malformed invoke now spawns NOTHING — the consistent analogue of a single `:spawn`'s atomic reject, and strictly better than "seed a minimal join-state" (the parent never exits the malformed state, so that option would still leak the siblings until frame-destroy). The childless sentinel keeps the no-deadlock guarantee (the join interceptor treats it as unseeded) and `destroy-spawn-all-children!` finds nothing to tear down and clears the slot on parent exit — so `destroy.cljc` needs no change.

**(b) Completed-children leak at join resolution.** `build-resolution-fx` destroyed only SURVIVORS; completed children (whose `:on-child-done` / `:on-child-error` terminal states are not necessarily `:final?`, so they stay live) relied on the parent's resolution transition EXITING the `:spawn-all` state to be torn down by the exit cascade. An internal/self resolution handler (or a parent with no `:on` for the resolution event) leaked all N completed children.

**Fix:** destroy every child at resolution — keeping the survivor-only cancellation traces — so completed children are torn down regardless of whether the resolution transition exits the state. Already-torn-down children (a `:final?` terminal that already auto-destroyed, or the exit-cascade's later sweep) are silent-idempotent no-ops.

## Tests

- `final_state_spawn_order_forget_cljs_test.cljc` (new, JVM+CLJS) — finish forgets the actor from spawn-order; a subsequent stale destroy is a silent no-op (no phantom destroyed trace, no re-fired release); frame-destroy emits no phantom for the finished actor. All three fail without the fix (verified: phantom `:rf.machine/destroyed` fires + release doubles).
- `spawn_all_lifecycle_leak_test.clj` (new, JVM) — the atomic reject leaves no orphan (no sibling snapshot / spawn-order entry); an internal/self resolution destroys completed children. Both fail without the fix (verified: orphan `:qb/registered#1` installed; completed `:a` left live).
- `machine_spawn_unregistered_type_test.clj` — updated the two `:spawn-all` join-no-hang tests to the corrected atomic-reject contract (reject sentinel + sibling suppression).

## Quality gates

All foreground, 0-fail:

- Machines JVM alias (`clojure -M:test` from `implementation/machines/`): **959 tests, 3043 assertions, 0 failures/0 errors** (re-run green post-rebase).
- CLJS node integration (`npm run test:cljs`): **9021 tests, 42560 assertions, 0 failures/0 errors**.
- Full fast-PR regression spine (`scripts/test-fast-pr.sh`): **PASS** (drift guards + core JVM + CLJS node integration + per-ns isolation).

Surface: only `finalize.cljc`, `spawn.cljc`, `join.cljc` (+ their tests). `destroy.cljc` unchanged (the childless sentinel is already a clean no-op there).
