### PR TITLE
fix(ui): linearize ViewCell commit against frame-destroy teardown (rf2-vxgfnd.61)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -650,6 +650,30 @@
     ;; arise from that seam.
     true))
 
+(defn frame-closing?
+  "True when `id` is anywhere in its CLOSE lifecycle: a `destroy-frame!` for it
+  is IN FLIGHT (its teardown recipe is running) OR the frame is already
+  destroyed / dissoc'd. False for a live, not-being-destroyed frame — including
+  a FRESH same-id incarnation created after a prior destroy fully completed.
+
+  The linearization read the compiled-view ViewCell commit consults so a cell
+  that acquires leases + enrols while a frame is being torn down does not
+  publish ownership onto a dying frame (rf2-vxgfnd.61). `destroying-frames` is
+  populated at the TOP of `destroy-frame!` — BEFORE the `:ui/on-frame-destroyed!`
+  sweep snapshots the live cells — and cleared only in `destroy-frame!`'s
+  terminal `finally`, AFTER `mark-frame-destroyed!` flips liveness and
+  `dissoc-frame!` forgets the record. So `frame-closing?` is CONTINUOUSLY true
+  across the entire teardown window (the in-flight-but-not-yet-flipped sub-window
+  the destroyed?/absent test alone MISSES). A commit that enrols into the
+  live-cell registry and THEN reads this predicate therefore linearizes the
+  sweep's victim SELECTION against the frame's CLOSURE: if its enrolment was too
+  late for the sweep's snapshot, the frame was necessarily already in
+  `destroying-frames` when the commit read it, so it observes the close and joins
+  the teardown instead of stranding `:connected`. Keyed by the bare frame-id."
+  [id]
+  (or (contains? @destroying-frames id)
+      (frame-disposed-for-drain? id)))
+
 (defn frame-address
   "Resolve the ADDRESS key for `frame-id` — the key a per-frame SIDE-CHANNEL
   (SSR request / response / error-trace / head snapshot, …) keys its entries by.

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1161,11 +1161,36 @@
           (doseq [[_ lease] to-release]
             (obs/release! lease))
           ;; lifecycle: connect (reconnect annotation when re-committing a
-          ;; hidden cell)
+          ;; hidden cell). This ENROLS the cell into the live-cell registry —
+          ;; the discoverability publish a frame-destroy sweep consults.
           (connect! cell)
-          ;; step 8 — moved evidence corrects before paint
-          (when moved?
-            (advance-revision! cell))
+          ;; Linearize this commit against a concurrent frame-destroy teardown
+          ;; (rf2-vxgfnd.61). #5731 wires destroy to a SNAPSHOT sweep of the
+          ;; live cells that runs while the frame is still live, with no
+          ;; ordering against acquisition on the JVM: a commit that acquires
+          ;; leases + enrols in the window between the sweep's snapshot and the
+          ;; liveness flip is MISSED by the sweep, would publish :connected, and
+          ;; then lose its cache under the remaining destroy recipe. The fix is a
+          ;; two-phase close with revalidation AFTER the enrolment publish:
+          ;; `connect!` has just added this cell to the live-cell registry, so if
+          ;; the sweep's snapshot could have missed us, the destroy necessarily
+          ;; added the frame to `destroying-frames` BEFORE snapshotting (it is
+          ;; populated at the very top of `destroy-frame!`), and `frame-closing?`
+          ;; is continuously true across the whole teardown window — so this
+          ;; read observes the close. Selection and closure thus become ONE
+          ;; linearized boundary: a cell enrolling mid-teardown is either in the
+          ;; sweep or, seeing a closing frame here, JOINS the teardown — tearing
+          ;; itself down against the still-releasable cache rather than lingering
+          ;; :connected on a dying frame. A live, not-being-destroyed frame (incl.
+          ;; a fresh same-id incarnation) makes this a constant false check, so
+          ;; disjoint frames commit/destroy concurrently and the single-threaded
+          ;; CLJS host — where destroy runs to completion without yielding to a
+          ;; commit — never sees it true.
+          (if (some frame/frame-closing? (cell-frames cell))
+            (teardown! cell)
+            ;; step 8 — moved evidence corrects before paint
+            (when moved?
+              (advance-revision! cell)))
           cell)))))
 
 ;; ---- test/inspection reads --------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
@@ -1,0 +1,156 @@
+(ns re-frame.ui.reactive-commit-destroy-race-jvm-test
+  "rf2-vxgfnd.61 — linearize ViewCell commit against frame-destroy teardown.
+
+  THE RACE (JVM-only; CLJS is single-threaded and runs destroy to completion
+  without yielding to a commit). #5731 wires `frame/destroy-frame!` to fire the
+  `:ui/on-frame-destroyed!` sweep, which snapshots the live-cell registry and
+  tears down its victims — WHILE the frame is intentionally still live — and
+  only AFTERWARDS flips the liveness bit (`mark-frame-destroyed!`) and tears
+  down the sub-cache. A ViewCell commit that acquires leases and enrols a cell
+  in the window BETWEEN the sweep's snapshot and the liveness flip is absent
+  from the sweep's victim vector, publishes `:connected`, and then loses its
+  cache underneath it during the remaining destroy recipe — the exact
+  live-cell/port-throw state #5731 meant to eliminate.
+
+  This fixture reproduces the window with a deterministic `CountDownLatch`
+  handoff (NO sleeps): the destroy pauses inside a wrapped hook after the sweep
+  and before the liveness flip; a racing thread commits a fresh cell into that
+  window; the destroy then resumes. The fix — a commit-side revalidation against
+  `frame/frame-closing?` after the enrolment publish — makes the racing cell
+  JOIN the teardown (`:dead`, leases released against the still-live cache)
+  instead of stranding `:connected`. Without the fix the racing cell is left
+  `:connected` on the dying frame, so this test FAILS on pre-fix code.
+
+  `.clj` (JVM-only) — the race is a genuine two-thread interleaving; the barrier
+  handoff means only one thread mutates the substrate at a time, so this is a
+  controlled linearization probe, not a stress test."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.late-bind             :as late-bind]
+            [re-frame.live-frame            :as live-frame]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            ;; Load-bearing: publishes the :ui/on-frame-destroyed! hook.
+            [re-frame.ui.frames]
+            [re-frame.ui.reactive           :as reactive])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- render+commit! [cell fid queries]
+  (rf/with-frame fid
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  (reactive/commit! cell)
+  cell)
+
+;; ===========================================================================
+;; The window: a commit that enrols AFTER the sweep snapshot, BEFORE the flip
+;; ===========================================================================
+
+(deftest commit-in-destroy-window-joins-teardown-not-stranded-connected
+  (rf/reg-sub :race/a (fn [db _] (:a db)))
+  (let [fid       (make-frame! :race/frame {:a 1})
+        ;; A cell committed BEFORE destroy — the sweep's ordinary victim.
+        old-cell  (render+commit! (reactive/make-cell ::old) fid [[:race/a]])
+        ;; The cell that races IN during the destroy window.
+        new-cell  (reactive/make-cell ::new)
+        swept     (CountDownLatch. 1)   ;; the sweep snapshot has run
+        committed (CountDownLatch. 1)   ;; the racing commit has finished
+        orig-hook (late-bind/get-fn :ui/on-frame-destroyed!)]
+    (is (= :connected (reactive/lifecycle old-cell)) "precondition: connected")
+    (try
+      ;; Wrap the real destroy hook so the destroy PAUSES between the sweep
+      ;; (which snapshots live-cells and tears down its victims) and the next
+      ;; step of destroy-frame! (mark-frame-destroyed! — the liveness flip).
+      ;; `destroying-frames` already contains fid here (populated at the top of
+      ;; destroy-frame!, before this hook), and the frame is still live.
+      (late-bind/set-fn! :ui/on-frame-destroyed!
+                         (fn [id]
+                           (orig-hook id)                        ;; real sweep
+                           (.countDown swept)                    ;; sweep done
+                           (.await committed 5 TimeUnit/SECONDS))) ;; hold the window open
+      (let [race (future
+                   (.await swept 5 TimeUnit/SECONDS)
+                   ;; Commit the fresh cell against the STILL-LIVE frame — it
+                   ;; acquires a lease and enrols into the live-cell registry
+                   ;; AFTER the sweep already snapshotted.
+                   (rf/with-frame fid
+                     (reactive/with-capture new-cell
+                       (fn [] (reactive/sub-read [:race/a]))))
+                   (reactive/commit! new-cell)
+                   (.countDown committed))]
+        ;; Drive the destroy on this thread — it blocks in the wrapped hook
+        ;; until the racing commit releases `committed`, then resumes (flip +
+        ;; sub-cache teardown) and returns.
+        (is (nil? (frame/destroy-frame! fid)) "destroy completes cleanly")
+        (is (nil? (deref race 5000 ::timeout)) "racing commit finished"))
+
+      (testing "the racing cell is NOT stranded :connected on the dying frame"
+        (is (= :dead (reactive/lifecycle new-cell))
+            "a cell enrolling during the destroy window joined the teardown via
+             the frame-closing? revalidation — not left :connected on a frame
+             whose cache is being torn down")
+        (is (empty? (reactive/committed-target-keys new-cell))
+            "its lease was released against the still-live cache — no port throw
+             on a later probe of the destroyed frame"))
+
+      (testing "the frame is genuinely destroyed"
+        (is (nil? (frame/frame fid)) "destroy-frame! forgot the frame record"))
+
+      (testing "the pre-existing cell was swept normally"
+        (is (= :dead (reactive/lifecycle old-cell))))
+      (finally
+        (late-bind/set-fn! :ui/on-frame-destroyed! orig-hook)))))
+
+;; ===========================================================================
+;; Disjoint frames still commit/destroy concurrently — no global serialization
+;; ===========================================================================
+
+(deftest disjoint-frame-commit-unaffected-by-another-frames-destroy
+  (rf/reg-sub :race/a (fn [db _] (:a db)))
+  (let [fa        (make-frame! :race/frame-a {:a 1})
+        fb        (make-frame! :race/frame-b {:a 2})
+        cell-a    (render+commit! (reactive/make-cell ::a) fa [[:race/a]])
+        cell-b    (reactive/make-cell ::b)
+        swept     (CountDownLatch. 1)
+        committed (CountDownLatch. 1)
+        orig-hook (late-bind/get-fn :ui/on-frame-destroyed!)]
+    (try
+      (late-bind/set-fn! :ui/on-frame-destroyed!
+                         (fn [id]
+                           (orig-hook id)
+                           (.countDown swept)
+                           (.await committed 5 TimeUnit/SECONDS)))
+      (let [race (future
+                   (.await swept 5 TimeUnit/SECONDS)
+                   ;; A commit onto the UNRELATED live frame B, mid-destroy of A.
+                   (rf/with-frame fb
+                     (reactive/with-capture cell-b
+                       (fn [] (reactive/sub-read [:race/a]))))
+                   (reactive/commit! cell-b)
+                   (.countDown committed))]
+        (frame/destroy-frame! fa)
+        (deref race 5000 ::timeout))
+      (testing "frame B's cell commits normally — B's destroy is not in flight"
+        (is (= :connected (reactive/lifecycle cell-b))
+            "a commit onto a disjoint live frame is untouched by frame A's
+             teardown — frame-closing? is false for B, so no global serialization")
+        (is (reactive/cell-observes-frame? cell-b fb))
+        (is (= 2 (rf/with-frame fb
+                   (reactive/with-capture cell-b
+                     (fn [] (reactive/sub-read [:race/a])))))
+            "frame B reads live after A was destroyed"))
+      (testing "frame A's own cell died with A"
+        (is (= :dead (reactive/lifecycle cell-a))))
+      (finally
+        (late-bind/set-fn! :ui/on-frame-destroyed! orig-hook)))))


### PR DESCRIPTION
## Problem

#5731 wires frame destruction to a **snapshot sweep** of the live-cell registry (`teardown-frame!` via the `:ui/on-frame-destroyed!` hook) that runs while the frame is intentionally still live, with **no linearization** against `reactive/commit!` on the JVM. A commit can acquire leases and enrol a cell **after** the sweep captured its victim vector but **before** core flips the frame's liveness bit (`mark-frame-destroyed!`). That cell is absent from the sweep, publishes `:connected`, then loses its cache underneath it during the remaining destroy recipe — the exact live-cell / port-throw state #5731 meant to eliminate.

The core `destroying-frames` guard only prevents re-entrant *destroy* calls; the commit path never consulted it. Atomically updating the cell set is not enough because **selection** and **closure** of the frame are separate operations.

## Fix

A two-phase close with revalidation **after** the enrolment publish, reusing the existing `destroying-frames` guard — **no new lock**.

- **core (`frame.cljc`)** — add `frame/frame-closing?`: true across the **entire** teardown window. `destroying-frames` is populated at the *top* of `destroy-frame!` (before the sweep snapshots) and cleared only in its terminal `finally` (after `mark-frame-destroyed!` and `dissoc-frame!`), so the predicate covers the in-flight-but-not-yet-flipped sub-window the destroyed?/absent test alone misses. It is `false` for a live frame — including a fresh same-id incarnation.

- **ui (`reactive.cljc` `commit!`)** — after `connect!` enrols the cell into the live-cell registry, if any frame it now owns is `frame-closing?`, **join the teardown** (`teardown!` the cell against the still-releasable cache) instead of leaving it `:connected`. Because enrolment happens *before* this read and `destroying-frames` is set *before* the sweep snapshots, a cell the snapshot missed necessarily observes the close here. Selection and closure become **one linearized boundary**.

`observation.cljc` was **not** touched (owned by a concurrent worker); the fix lives purely in the commit path + a core predicate.

### Why disjoint concurrency is preserved

`frame-closing?` is a constant `false` check for any live, not-being-destroyed frame, so disjoint frames commit/destroy concurrently — no global serialization. On the single-threaded CLJS host, destroy runs to completion without yielding to a commit, so the check is a cheap always-false read there.

## Test

`reactive_commit_destroy_race_jvm_test.clj` (JVM, deterministic `CountDownLatch` handoff, **no sleeps**):

1. `commit-in-destroy-window-joins-teardown-not-stranded-connected` — pauses a destroy between the sweep and the liveness flip, commits a fresh cell into that window, resumes; asserts the racing cell reaches `:dead` with no stranded lease. **Fails pre-fix** (left `:connected` owning `[:sub :race/frame [:race/a]]`), green after.
2. `disjoint-frame-commit-unaffected-by-another-frames-destroy` — a commit onto an unrelated live frame mid-destroy of another stays `:connected` and reads live.

## Quality gates

Foreground, 0-fail:

- core JVM `clojure -M:test` — **1867 tests / 8343 assertions / 0 fail**
- ui JVM `clojure -M:test` — **286 tests / 4652 assertions / 0 fail**
- `npm run test:cljs` (node) — **9024 tests / 42612 assertions / 0 fail**
- pre-fix red / post-fix green confirmed for the new race fixture.