### PR TITLE
test(ui): harden keystone DOM fixture act discipline (rf2-vxgfnd.87)

### DIFF
--- a/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
@@ -25,21 +25,43 @@
             [re-frame.test-support :as test-support]
             [re-frame.ui :as ui :refer [defview frame-root frame-provider sub]]
             [re-frame.ui.client :as client]
-            [re-frame.ui.frames :as frames]))
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]))
 
 (defn- browser? [] (exists? js/document))
 
+;; reset-live-roots! / reset-installed-plans! / reset-scheduler! are BOOKKEEPING
+;; resets — a clean framework slate between tests. They are NOT host teardown:
+;; each test OWNS the React root it mounts and `ui/unmount!`s it in a `finally`
+;; (see `assert-torn-down!`). This fixture is only the belt-and-suspenders slate,
+;; not a substitute for `.unmount()`.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
                                             :ambient-frame nil})
   (fn [t]
+    (reactive/reset-scheduler!)
     (client/reset-live-roots!)
     (frames/reset-installed-plans!)
-    (t)
-    (client/reset-live-roots!)
-    (frames/reset-installed-plans!)))
+    (try
+      (t)
+      (finally
+        (reactive/reset-scheduler!)
+        (client/reset-live-roots!)
+        (frames/reset-installed-plans!)))))
 
 (defn- container [] (js/document.createElement "div"))
+
+;; Host teardown + the leak proof, run in each test's `finally` so it fires on
+;; BOTH the happy render and the expected no-frame-context abort. `ui/unmount!`
+;; is the REAL teardown (bookkeeping reset is not) — it fires each ViewCell's
+;; layout-effect cleanup synchronously inside `root.unmount()` (03 §4). After it,
+;; no live-root claim and no connected ViewCell may survive into the next test.
+(defn- assert-torn-down! [root]
+  (react-dom/flushSync #(some-> root ui/unmount!))
+  (is (= #{} (client/live-root-ids))
+      "the root's claim is released — no live-root survives the test")
+  (is (empty? (reactive/current-live-cells))
+      "the mounted ViewCell was torn down — no connected cell leaks"))
 
 (defn- reg! []
   (rf/reg-event :test/set-db (fn [_ [_ db]] {:db db}))
@@ -63,13 +85,16 @@
     (reg!)
     (rf/make-frame {:id :app/live})
     (rf/dispatch-sync [:test/set-db {:n 42}] {:frame :app/live})
-    (let [c (container)]
-      (react-dom/flushSync
-       #(ui/mount [provider-wrap {:frame-id :app/live}] c {:root-id :dom-scope/prov}))
-      (is (re-find #"n=42" (.-innerHTML c))
-          (str "the ambient (sub …) resolved the frame-provider-scoped frame "
-               "through the React-context tier — the :adapter/current-frame "
-               "reader is live on the compiled sub-read path (rf2-vxgfnd.24)")))))
+    (let [c    (container)
+          root (react-dom/flushSync
+                #(ui/mount [provider-wrap {:frame-id :app/live}] c {:root-id :dom-scope/prov}))]
+      (try
+        (is (re-find #"n=42" (.-innerHTML c))
+            (str "the ambient (sub …) resolved the frame-provider-scoped frame "
+                 "through the React-context tier — the :adapter/current-frame "
+                 "reader is live on the compiled sub-read path (rf2-vxgfnd.24)"))
+        (finally
+          (assert-torn-down! root))))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-vxgfnd.25 — a compiled sub under a bare frame-root resolves ambiently
@@ -79,15 +104,18 @@
 (deftest sub-under-frame-root-resolves-scoped-frame-ambiently
   (when (browser?)
     (reg!)
-    (let [c (container)]
-      (react-dom/flushSync
-       #(ui/mount [frame-root {:id :app/rooted :initial-events [[:test/set-db {:n 7}]]}
-                   [n-view]]
-                  c {:root-id :dom-scope/root}))
-      (is (re-find #"n=7" (.-innerHTML c))
-          (str "the ambient (sub …) resolved the frame-root-scoped frame — "
-               "frame-root now emits its scope through frames/scope-element "
-               "(rf2-vxgfnd.25), and .24's published reader consults it")))))
+    (let [c    (container)
+          root (react-dom/flushSync
+                #(ui/mount [frame-root {:id :app/rooted :initial-events [[:test/set-db {:n 7}]]}
+                            [n-view]]
+                           c {:root-id :dom-scope/root}))]
+      (try
+        (is (re-find #"n=7" (.-innerHTML c))
+            (str "the ambient (sub …) resolved the frame-root-scoped frame — "
+                 "frame-root now emits its scope through frames/scope-element "
+                 "(rf2-vxgfnd.25), and .24's published reader consults it"))
+        (finally
+          (assert-torn-down! root))))))
 
 ;; ---------------------------------------------------------------------------
 ;; NEGATIVE — a compiled sub OUTSIDE any provider/root still fails loud
@@ -105,25 +133,31 @@
     (rf/make-frame {:id :app/orphan})
     (rf/dispatch-sync [:test/set-db {:n 99}] {:frame :app/orphan})
     (let [c        (container)
-          captured (atom nil)]
-      ;; No frame-provider / frame-root anywhere above n-view → the ambient
-      ;; sub-read finds no scope and throws :rf.error/no-frame-context during
-      ;; render. Under React 19 an uncaught render-phase throw is NOT re-thrown
-      ;; out of `.render`; React aborts the commit and reports the error through
-      ;; the root's `onUncaughtError` HOST callback (see root_mount_dom_cljs_test
-      ;; §criterion-3). We route that callback into `captured` so (a) the
-      ;; fail-loud error is asserted at the host tier, and (b) React's DEFAULT
-      ;; onUncaughtError — which calls `reportError`, surfacing an uncaught
-      ;; window error the browser-test runner rejects even on a green cljs.test
-      ;; summary (rf2-mwx08) — is REPLACED rather than left to fire.
-      (react-dom/flushSync
-       #(ui/mount [bare-sub-root {}] c
-                  {:root-id :dom-scope/orphan
-                   :on-uncaught-error (fn [error _info] (reset! captured error))}))
-      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data @captured)))
-          (str "the ambient sub with NO provider/root above it FAILED LOUD with "
-               ":rf.error/no-frame-context, routed to the root's onUncaughtError "
-               "host callback (rf2-vxgfnd.24/.25)"))
-      (is (not (re-find #"n=99" (.-innerHTML c)))
-          (str "React aborted the commit — the ambient sub did not silently "
-               "resolve some frame; the scoped value never renders")))))
+          captured (atom nil)
+          ;; No frame-provider / frame-root anywhere above n-view → the ambient
+          ;; sub-read finds no scope and throws :rf.error/no-frame-context during
+          ;; render. Under React 19 an uncaught render-phase throw is NOT
+          ;; re-thrown out of `.render`; React aborts the commit and reports the
+          ;; error through the root's `onUncaughtError` HOST callback (see
+          ;; root_mount_dom_cljs_test §criterion-3). We route that callback into
+          ;; `captured` so (a) the fail-loud error is asserted at the host tier,
+          ;; and (b) React's DEFAULT onUncaughtError — which calls `reportError`,
+          ;; surfacing an uncaught window error the browser-test runner rejects
+          ;; even on a green cljs.test summary (rf2-mwx08) — is REPLACED rather
+          ;; than left to fire. React internally unmounts the aborted tree but
+          ;; the ROOT stays registered (§criterion-3), so this test still OWNS
+          ;; the root-id claim and releases it in `finally` (rf2-vxgfnd.87).
+          root     (react-dom/flushSync
+                    #(ui/mount [bare-sub-root {}] c
+                               {:root-id :dom-scope/orphan
+                                :on-uncaught-error (fn [error _info] (reset! captured error))}))]
+      (try
+        (is (= :rf.error/no-frame-context (:rf.error/id (ex-data @captured)))
+            (str "the ambient sub with NO provider/root above it FAILED LOUD with "
+                 ":rf.error/no-frame-context, routed to the root's onUncaughtError "
+                 "host callback (rf2-vxgfnd.24/.25)"))
+        (is (not (re-find #"n=99" (.-innerHTML c)))
+            (str "React aborted the commit — the ambient sub did not silently "
+                 "resolve some frame; the scoped value never renders"))
+        (finally
+          (assert-torn-down! root))))))


### PR DESCRIPTION
## What

Hardens the #5760 keystone frame-scope DOM tests (`frame_scope_resolve_dom_cljs_test.cljs`) for **fixture ownership**. Test-only; no production source, no spec.

**Verify-first:** the original #5760 pageerror was already resolved by the merged keystone CI-fix (negative-case throw routed through the root's `:on-uncaught-error` host callback). `npm run test:browser` was already green. The remaining gap the CI-fix did **not** cover: all three tests discarded the `Root` returned by `ui/mount` and leaned on the fixture's `client/reset-live-roots!` — a bookkeeping wipe, **not** `.unmount()`. Real React roots + connected ViewCells therefore survived into fixture reset and the next test (order-dependent leak; the negative test also left the root React keeps registered after an aborted commit).

## Change

- Each test now **owns** its root: retains the `ui/mount` handle and, in a `finally` (fires on both the happy render and the expected no-frame-context abort), runs `assert-torn-down!` → `flushSync` `ui/unmount!` + the leak proof (`client/live-root-ids` empty, `reactive/current-live-cells` empty).
- Fixture additionally resets the reactive scheduler for a clean slate — matching `root_teardown_dom_cljs_test`'s canonical ownership pattern (native `re-frame.ui` + plain-atom; no `act`/`test-utils`/adapter machinery introduced, per the AC).
- **Behaviour-neutral:** the keystone's real assertions are unchanged — ambient `(sub …)` resolves under `frame-provider`/`frame-root`, and the no-provider case still fails loud with `:rf.error/no-frame-context`.

## Quality gates

Run foreground in the worktree (`implementation/`):

- `npm run test:browser` — **300 tests / 1087 assertions / 0 failures / 0 errors / exit 0 / 0 pageerrors** (1081 → 1087: +6 = 2 leak assertions × 3 tests)
- `npm run test:cljs` — **9039 tests / 42664 assertions / 0 failures / 0 errors / exit 0**

Closes rf2-vxgfnd.87.