### PR TITLE
fix(machines-viz): unambiguous ns/name codec boundary + validate root-fallback :on (rf2-t69tdo, rf2-bj3sxo)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2080,8 +2080,8 @@ back.
 | `:always [...]`                       | `<transition target="..."/>` (eventless) |
 | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
 | `{:type :history :deep? <b> :default-target <t>}` (rf2-m285a) | W3C `<history type="shallow\|deep">` inside the owning compound; a `:default-target` rides a default `<transition target="…"/>`. NEVER occupiable (a transition TO it resolves to the recorded/default leaf), so it emits `<history>`, never `<state>`/`<final>`. Round-trips back to `:type :history`. |
-| Namespaced ids (`:auth/login`)        | `auth__login` (hex-escaped; `__` separates ns from name) |
-| Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp__login` (ns dots escaped to `_2e`) |
+| Namespaced ids (`:auth/login`)        | `auth-login` (hex-escaped; `-` separates ns from name) |
+| Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp-login` (ns dots escaped to `_2e`) |
 | Vector-path targets (`[:parent :child]`) | `parent___child` (`___` joins path SEGMENTS) |
 | Nested-state ids                      | fully qualified (root→leaf, `___`-joined) — unique xsd:ID |
 
@@ -2096,25 +2096,34 @@ back.
 > range** (rf2-qgtcvy — the pre-fix `_<var-hex>` was neither self-delimiting
 > nor reversible above `0xFF`: `:开始` mis-decoded and `đ` collided with
 > `U+0011`+`"1"`); the `u` sentinel (not a hex digit) keeps the two widths
-> unambiguous. Parts join with two RESERVED MARKERS the escaper can provably
-> never emit (a `_` is always followed by a hex digit or `u`, so neither
-> width mints two consecutive underscores):
+> unambiguous. A literal `-` is escaped to `_2d`, so no bare hyphen ever
+> arises from segment content either. Parts join with two RESERVED MARKERS
+> the escaper can provably never emit:
 >
-> - `__` (double underscore) separates a *namespaced keyword's* namespace
->   from its name: `:auth/login` → `auth__login`,
->   `:my.app.auth/login` → `my_2eapp_2eauth__login` (the namespace dots
->   are escaped, so the single `__` marks the ns/name boundary regardless
+> - `-` (a single hyphen) separates a *namespaced keyword's* namespace
+>   from its name: `:auth/login` → `auth-login`,
+>   `:my.app.auth/login` → `my_2eapp_2eauth-login` (the namespace dots
+>   are escaped, so the single `-` marks the ns/name boundary regardless
 >   of how many dots the namespace has).
 > - `___` (triple underscore) joins the *segments of a vector path*:
 >   `[:authenticated :browsing]` → `authenticated___browsing`;
->   a namespaced segment keeps its own `__`, e.g. `[:auth/region :browsing]`
->   → `auth__region___browsing`.
+>   a namespaced segment keeps its own `-`, e.g. `[:auth/region :browsing]`
+>   → `auth-region___browsing`.
 >
-> Because the segment escaper never produces two consecutive underscores,
-> neither marker can collide with segment content or with each other, so
-> the codec is **fully injective for ANY keyword** — including
-> multi-segment namespaces and dotted names, which the pre-mnp93.1
-> `.`-as-ns/name scheme corrupted (`:my.app.auth/login` and
+> The pre-`t69tdo` scheme used `__` (double underscore) for the ns/name
+> boundary, but because EVERY escape begins with `_`, a name segment whose
+> leading char escaped to `_…` (any CJK name, or `:a/-b`'s name `-b` →
+> `_2db`) grew the `__` boundary into a `___` run — the exact path
+> separator — so the namespaced keyword silently mis-decoded to a vector
+> (`:a/-b` → `[:a :2db]`). A non-underscore boundary token the escaper
+> never emits (`-`) removes the collision at its root: no ns/name boundary
+> can ever become a `___` run.
+>
+> Because the segment escaper never produces two consecutive underscores
+> and never a bare `-`, neither marker can collide with segment content or
+> with each other, so the codec is **fully injective for ANY keyword** —
+> including multi-segment namespaces and dotted names, which the
+> pre-mnp93.1 `.`-as-ns/name scheme corrupted (`:my.app.auth/login` and
 > `:my/app.auth.login` both encoded to `my.app.auth.login`). State ids
 > are additionally **fully PATH-QUALIFIED** (root→leaf), so two
 > same-named nested states emit UNIQUE xsd:IDs and transition targets

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -656,17 +656,29 @@
     :else
     {:category :rf.error/machine-bad-target :path (vec path) :slot slot}))
 
+(defn- transition-slot-shape-defect
+  "The SHARED transition-SLOT shape rule (rf2-qgtcvy node scope / rf2-bj3sxo
+  root scopes). A fallback-transition `:on` / `:after` slot present on `node`
+  at `path` must be a MAP of clause → spec. A non-map (e.g. `{:on :retry}`
+  from an LLM) would throw an uncaught ISeq exception the moment it is
+  iterated, instead of the clean `:invalid-definition` the emit paths promise.
+  Surface the runtime's own slot-specific defect category so the emit path
+  rejects cleanly.
+
+  Deliberately shared by EVERY scope that consumes the `:on` / `:after`
+  fallback grammar — compound state node (`transition-target-defect`), flat
+  root, region root, and parallel root (`flat-defect` / `region-defect` /
+  `parallel-defect`) — so the four scopes cannot drift and one path cannot
+  reintroduce an unchecked iteration (rf2-bj3sxo)."
+  [path node]
+  (or (when (and (contains? node :on) (not (map? (:on node))))
+        {:category :rf.error/machine-bad-on-clause :path (vec path)})
+      (when (and (contains? node :after) (not (map? (:after node))))
+        {:category :rf.error/machine-bad-after-spec :path (vec path)})))
+
 (defn- transition-target-defect [scope path node]
   (or
-    ;; rf2-qgtcvy — `:on` / `:after` must each be a MAP of clause → spec. A
-    ;; non-map (e.g. `{:on :retry}` from an LLM) previously threw an uncaught
-    ;; ISeq exception when iterated below, instead of the clean
-    ;; `:invalid-definition` the emit paths promise. Surface the runtime's own
-    ;; slot-specific defect category so the emit path rejects cleanly.
-    (when (and (contains? node :on) (not (map? (:on node))))
-      {:category :rf.error/machine-bad-on-clause :path (vec path)})
-    (when (and (contains? node :after) (not (map? (:after node))))
-      {:category :rf.error/machine-bad-after-spec :path (vec path)})
+    (transition-slot-shape-defect path node)
     (let [check (fn [slot v]
                   (some (fn [{:keys [present? target]}]
                           (when present? (target-defect scope path slot target)))
@@ -760,7 +772,10 @@
 (defn- root-on-target-defect
   "The non-parallel root's OWN `:on` (the ancestor-fallback slot, decl-path
   `[]`) target resolution — mirror of the engine's root `:on` branch in
-  `validate-transition-targets!`."
+  `validate-transition-targets!`. Assumes `:on` is a MAP: its shape is
+  guarded upstream in `flat-defect` by `transition-slot-shape-defect`, so a
+  malformed non-map root `:on` is rejected cleanly BEFORE this iterates it
+  (rf2-bj3sxo)."
   [scope d]
   (some (fn [[_ v]]
           (some (fn [{:keys [present? target]}]
@@ -778,6 +793,13 @@
     (let [scope (:states d)]
       (or (node-keys-defect [] d true)
           (tags-defect [] d)
+          ;; rf2-bj3sxo — the flat ROOT's own `:on` / `:after` fallback slot
+          ;; is validated for shape with the SAME rule as a state node's,
+          ;; BEFORE `root-on-target-defect` iterates it. A malformed root
+          ;; `:on` (`{… :on :retry}`) now returns the clean
+          ;; `machine-bad-on-clause` defect instead of throwing an ISeq
+          ;; exception out of `valid-definition?` / the emit paths.
+          (transition-slot-shape-defect [] d)
           (some (fn [[path node]] (node-defect scope path node)) (walk-scope-nodes scope))
           (history-scope-defect scope)
           (root-on-target-defect scope d)))))
@@ -798,6 +820,9 @@
     (let [scope (:states body)]
       (or (node-keys-defect [region-name] body false)
           (tags-defect [region-name] body)
+          ;; rf2-bj3sxo — the region ROOT's own `:on` / `:after` ancestor
+          ;; fallback slot gets the same shape guard as every other scope.
+          (transition-slot-shape-defect [region-name] body)
           (some (fn [[path node]]
                   (or (when (= :parallel (:type node))
                         {:category :rf.error/machine-parallel-nested-not-supported :path (vec path)})
@@ -814,6 +839,9 @@
       {:category :rf.error/machine-parallel-bad-shape :path []}
       :else
       (or (node-keys-defect [] d true)
+          ;; rf2-bj3sxo — the parallel ROOT's own `:on` / `:after` ancestor
+          ;; fallback slot gets the same shape guard as every other scope.
+          (transition-slot-shape-defect [] d)
           (some (fn [[region-name body]] (region-defect region-name body)) regions)))))
 
 (defn definition-defect

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -889,12 +889,13 @@
   `/`+`00`, never as one wide escape.
 
   Neither form ever mints two consecutive underscores (a `_` is always
-  followed by a hex digit or `u`), so the reserved markers the consumers
+  followed by a hex digit or `u`), and no `-` / `.` survives unescaped (a
+  literal `-` → `_2d`, `.` → `_2e`), so the reserved markers the consumers
   layer on top — `_2f` (the hex of `/`) for a keyword's ns/name boundary,
   `__` between path segments (xyflow `node-id` / mermaid `sanitise-id`),
-  `__`/`___` (SCXML ns-name / path separators) — can never arise from
-  segment content. This is the SINGLE injective scheme all three emitters'
-  id codecs build on, so they address every node identically."
+  `-` (SCXML ns-name) / `___` (SCXML path) separators — can never arise
+  from segment content. This is the SINGLE injective scheme all three
+  emitters' id codecs build on, so they address every node identically."
   [s]
   (str/join
     (map (fn [ch]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -49,8 +49,8 @@
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
   | Parallel-ROOT `:on` / `:after` (the ancestor fallback) | `<transition event=\"event\"\\|\"after.ms\" target=\"a___x b___y\"/>` as a DIRECT `<parallel>` child. A MULTI-region target is a SPACE-SEPARATED id list (W3C `target` grammar); a targetless / action-only root transition emits NO `target`. Round-trips back to the region-qualified grammar (`[:a :x]` / `[[:a :x] [:b :y]]`). |
   | `{:type :history :deep? <b> :default-target <t>}` | W3C `<history type=\"shallow\\|deep\">` inside the owning compound; a `:default-target` rides a default `<transition target=\"…\"/>`. Round-trips back to `:type :history`. A history pseudo-state is NEVER occupiable — it is a transition TARGET that resolves to the recorded/default leaf — so it emits `<history>`, never `<state>`/`<final>`. |
-  | Namespaced ids (`:auth/login`)        | `auth__login` (hex-escaped; `__` separates ns/name) |
-  | Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp__login` (dots in the ns are escaped to `_2e`) |
+  | Namespaced ids (`:auth/login`)        | `auth-login` (hex-escaped; `-` separates ns/name) |
+  | Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp-login` (dots in the ns are escaped to `_2e`) |
   | Vector-path targets (`[:parent :child]`) | `parent___child` (`___` joins path segments) |
   | Nested-state ids                      | FULLY QUALIFIED (root→leaf, `___`-joined) — unique xsd:ID |
 
@@ -58,10 +58,10 @@
 
   SCXML state ids are `xsd:ID` (XML NCName): letters / digits / `-` `.`
   `_`, NO `:`. The codec hex-escapes every keyword ns/name char to
-  `_<2-hex>` (`.` → `_2e`, `?` → `_3f`, `_` → `_5f`) — or `_u<4-hex>` above
-  U+00FF (CJK, emoji) — and uses two reserved markers the escaper can
-  provably never emit — `__` between a keyword's namespace and name, `___`
-  between vector-path segments — so:
+  `_<2-hex>` (`.` → `_2e`, `?` → `_3f`, `_` → `_5f`, `-` → `_2d`) — or
+  `_u<4-hex>` above U+00FF (CJK, emoji) — and uses two reserved markers
+  the escaper can provably never emit — `-` between a keyword's namespace
+  and name, `___` between vector-path segments — so:
 
   - ANY keyword round-trips EXACTLY, regardless of how many dots its
     namespace or name has (`:my.app.auth/login` ≠ `:my/app.auth.login`
@@ -190,39 +190,57 @@
 ;; The hex-escape codec (the same injective scheme `chart/layout`'s
 ;; `node-id` uses for xyflow ids) handles this. EVERY non-alphanumeric
 ;; char in a segment is escaped to `_<2-hex>` (≤ U+00FF: a literal `_` →
-;; `_5f`, `.` → `_2e`, `?` → `_3f`) or `_u<4-hex>` (> U+00FF: CJK, emoji).
-;; After escaping, an `_` is ALWAYS followed by a hex digit or the `u`
-;; sentinel — never another underscore — so we can use consecutive-
-;; underscore RESERVED MARKERS the escaper can provably never emit:
+;; `_5f`, `.` → `_2e`, `?` → `_3f`, `-` → `_2d`) or `_u<4-hex>` (> U+00FF:
+;; CJK, emoji). After escaping, a segment carries only alphanumerics and
+;; `_`+hex escapes — no `-`, no `.`, and no two consecutive underscores.
+;; Two RESERVED MARKERS the escaper can provably never emit join the parts:
 ;;
-;; - `__`  (DOUBLE underscore) joins a keyword's NAMESPACE and NAME:
-;;   `:auth/login`         → `"auth__login"`
-;;   `:my.app.auth/login`  → `"my_2eapp_2eauth__login"`
-;;   (the dots in the ns are escaped to `_2e`; the SINGLE `__` is the
+;; - `-`   (a single HYPHEN) joins a keyword's NAMESPACE and NAME. The
+;;   escaper always renders a literal `-` as `_2d`, so a bare `-` never
+;;   arises from segment content:
+;;   `:auth/login`         → `"auth-login"`
+;;   `:my.app.auth/login`  → `"my_2eapp_2eauth-login"`
+;;   (the dots in the ns are escaped to `_2e`; the SINGLE `-` is the
 ;;   unambiguous ns/name boundary regardless of how many dots the ns has)
-;; - `___` (TRIPLE underscore) joins the SEGMENTS of a vector path:
+;; - `___` (TRIPLE underscore) joins the SEGMENTS of a vector path. No
+;;   segment carries consecutive underscores, so a `___` run only ever
+;;   arises from this join:
 ;;   `[:authenticated :browsing]` → `"authenticated___browsing"`
-;;   `[:auth/region :browsing]`   → `"auth__region___browsing"`
+;;   `[:auth/region :browsing]`   → `"auth-region___browsing"`
 ;;
-;; Decode is unambiguous: split on `___` (longest marker first) to
-;; recover vector-path segments, then split each segment on `__` to
-;; recover ns vs name, then `_XX`-unescape each part. Because the escaper
-;; never emits `__` or `___`, neither boundary can collide with segment
-;; content for ANY keyword (multi-dot ns, dotted name, `/` in ns/name) —
-;; the codec is fully injective and every emitted id is a valid xsd:ID.
+;; Decode is unambiguous: split on `___` to recover vector-path segments,
+;; then split each segment on its FIRST `-` to recover ns vs name, then
+;; `_XX`-unescape each part. Because the escaper never emits `-` or a
+;; `___` run, neither boundary can collide with segment content for ANY
+;; keyword (multi-dot ns, dotted name, a name whose leading char escapes
+;; to `_…` — rf2-t69tdo) — the codec is fully injective and every emitted
+;; id is a valid xsd:ID.
 
 (def ^:private ns-name-sep
-  "The keyword NAMESPACE↔NAME boundary in an SCXML id. `__` (double
-  underscore) is impossible for `escape-id-segment` to emit (every escape
-  is `_` + 2 hex or `_u` + 4 hex — a `_` is never followed by a `_`), so it
-  is the injective ns/name marker."
-  "__")
+  "The keyword NAMESPACE↔NAME boundary in an SCXML id. `-` (a single
+  hyphen) is impossible for `escape-id-segment` to emit — a `-` is always
+  escaped to `_2d`, so a bare hyphen NEVER arises from segment content —
+  making it the injective ns/name marker AND a valid xsd:ID `NameChar`
+  (letters / digits / `-` / `.` / `_`).
+
+  rf2-t69tdo — the marker was `__` (double underscore). Because EVERY
+  escape starts with `_`, a name segment whose FIRST char is
+  non-alphanumeric (any CJK name → leading `_u…`, or `:a/-b`'s name `-b`
+  → `_2db`) began with `_`, so `<ns>` + `__` + `_<name-escape>` minted
+  `___` (triple underscore) at the boundary — the EXACT
+  `path-segment-sep`. `unescape-id-string` then mis-read the namespaced
+  keyword as a vector path (`:a/-b` → `[:a :2db]`). A non-underscore
+  boundary token the escaper can never emit removes the collision at its
+  root: no boundary can ever grow into a `___` run."
+  "-")
 
 (def ^:private path-segment-sep
   "The vector-PATH segment boundary in an SCXML id. `___` (triple
-  underscore) the escaper can never emit and is distinct from the `__`
+  underscore) the escaper can never emit — every escape is `_` + 2 hex or
+  `_u` + 4 hex, so a `_` is never followed by a `_`; segment content
+  carries no consecutive underscores at all. Distinct from the `-`
   ns/name marker, so a vector path can never collide with a single
-  namespaced keyword. A valid xsd:ID."
+  namespaced keyword (rf2-t69tdo). A valid xsd:ID."
   "___")
 
 ;; The xsd:ID-safe injective escape is the SHARED `grammar/escape-id-segment`
@@ -249,9 +267,9 @@
 (defn- keyword->id-string
   "Map a single keyword to its injective, xsd:ID-conformant SCXML id
   string. Namespace and name are each `escape-id-segment`-escaped and
-  joined with `__` (`ns-name-sep`); a bare keyword emits just its escaped
+  joined with `-` (`ns-name-sep`); a bare keyword emits just its escaped
   name. Exact round-trip for ANY keyword (multi-dot ns, dotted name,
-  `?`/`-`/`_` in either)."
+  `?`/`-`/`_` in either, or a name whose leading char escapes to `_…`)."
   [k]
   (if-let [ns (namespace k)]
     (str (escape-id-segment ns) ns-name-sep (escape-id-segment (name k)))
@@ -291,9 +309,11 @@
 
 (defn- id-string->keyword
   "Inverse of `keyword->id-string` for a SINGLE keyword segment (no `___`
-  path separator). Splits on the `__` ns/name marker (at most once),
-  `_XX`-unescaping each part: `\"auth__login\"` → `:auth/login`,
-  `\"my_2eapp_2eauth__login\"` → `:my.app.auth/login`, bare
+  path separator). Splits on the FIRST `-` ns/name marker (at most once —
+  the escaper renders any literal `-` as `_2d`, so the first bare `-` is
+  always the namespace boundary), `_XX`-unescaping each part:
+  `\"auth-login\"` → `:auth/login`,
+  `\"my_2eapp_2eauth-login\"` → `:my.app.auth/login`, bare
   `\"name\"` → `:name`. The symmetric inverse used by BOTH the id decoder
   and the guard `cond=` decoder."
   [s]
@@ -940,16 +960,19 @@
 
   - `___` (`path-segment-sep`) joins VECTOR-PATH segments. Its presence
     is the injective marker of a vector path.
-  - `__` (`ns-name-sep`) joins a namespaced keyword's namespace and name
+  - `-` (`ns-name-sep`) joins a namespaced keyword's namespace and name
     WITHIN a segment.
 
   So: an id containing `___` decodes to a vector of per-segment keywords
   (each segment via `id-string->keyword`); an id with NO `___` decodes to
-  a single keyword (one `__` ⇒ namespaced, none ⇒ bare). Because the
-  escaper never emits `__` or `___`, a vector path
+  a single keyword (one `-` ⇒ namespaced, none ⇒ bare). Because the
+  escaper never emits a bare `-` or a `___` run, a vector path
   (`\"authenticated___browsing\"`) can never collide with a namespaced
-  keyword (`\"authenticated__browsing\"`), and a multi-dot namespace
-  (`\"my_2eapp_2eauth__login\"`) round-trips its dots exactly."
+  keyword (`\"authenticated-browsing\"`), a multi-dot namespace
+  (`\"my_2eapp_2eauth-login\"`) round-trips its dots exactly, and a
+  namespaced keyword whose name's leading char escapes to `_…`
+  (`:a/-b` → `\"a-_2db\"`) no longer mints a spurious `___` at the
+  boundary (rf2-t69tdo)."
   [s]
   (when s
     (if (str/includes? s path-segment-sep)
@@ -1080,7 +1103,7 @@
   A numeric delay parses to a Long/int; a non-numeric delay is an
   id-encoded keyword (rf2-mnp93.1) decoded symmetrically with
   `keyword->id-string` so a namespaced keyword delay (`:a/b` →
-  `after.a__b`) round-trips its namespace. Shared by `consume-transitions`
+  `after.a-b`) round-trips its namespace. Shared by `consume-transitions`
   and `parse-root-parallel-transitions` (each keeps its own target decoder)."
   [event]
   (let [d-str (subs event 6)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
@@ -338,3 +338,53 @@
   (testing "a well-formed MAP `:on` / `:after` is still accepted"
     (is (nil? (g/definition-defect {:initial :a :states {:a {:on {:go :b}} :b {}}})))
     (is (nil? (g/definition-defect {:initial :a :states {:a {:after {500 :b}} :b {}}})))))
+
+;; rf2-bj3sxo — the SAME slot-shape rule must cover the FALLBACK `:on` /
+;; `:after` at every root scope (flat root, region root, parallel root), not
+;; only ordinary state nodes. Pre-fix `root-on-target-defect` iterated the flat
+;; root `:on` with NO shape guard, so `{:initial :a :states {:a {}} :on :retry}`
+;; threw an uncaught ISeq exception out of `valid-definition?` / the emitters
+;; instead of returning the catalogued defect.
+
+(deftest non-map-root-fallback-on-rejected-cleanly
+  (testing "a malformed FLAT-ROOT `:on` (`{… :on :retry}`) returns
+            :rf.error/machine-bad-on-clause at path [] — NOT a host exception"
+    (let [d {:initial :a :states {:a {}} :on :retry}]
+      (is (= :rf.error/machine-bad-on-clause (category d)))
+      (is (= [] (:path (g/definition-defect d))))
+      (is (false? (g/valid-definition? d)))))
+  (testing "a malformed flat-root `:after` returns :rf.error/machine-bad-after-spec"
+    (is (= :rf.error/machine-bad-after-spec
+           (category {:initial :a :states {:a {}} :after :later}))))
+  (testing "a malformed REGION-ROOT `:on` returns the same defect at the region path"
+    (let [d {:type :parallel
+             :regions {:r {:initial :a :states {:a {}} :on :retry}}}]
+      (is (= :rf.error/machine-bad-on-clause (category d)))
+      (is (= [:r] (:path (g/definition-defect d))))))
+  (testing "a malformed PARALLEL-ROOT `:on` returns the same defect at path []"
+    (let [d {:type :parallel
+             :on :retry
+             :regions {:r {:initial :a :states {:a {}}}}}]
+      (is (= :rf.error/machine-bad-on-clause (category d)))
+      (is (= [] (:path (g/definition-defect d))))))
+  (testing "the defect is VALUE-FREE — the malformed application value never leaks"
+    ;; a NON-map `:on` carrying a secret payload rejects with only the
+    ;; structural category + path; the offending value never rides the defect.
+    (let [defect (g/definition-defect {:initial :a :states {:a {}}
+                                       :on [:secret-token "leak-me-42"]})]
+      (is (= :rf.error/machine-bad-on-clause (:category defect)))
+      (is (= #{:category :path} (set (keys defect)))
+          "the defect carries ONLY :category + :path — no offending value")
+      (is (not (some #(and (string? %) (str/includes? % "leak-me-42"))
+                     (tree-seq coll? seq defect)))
+          "the malformed application value must not appear anywhere in the defect")))
+  (testing "a well-formed MAP root fallback `:on` / `:after` still PROJECTS
+            (handler normalization + ancestor-fallback precedence preserved)"
+    ;; flat root `:on` fallback (every state inherits :logout)
+    (is (nil? (g/definition-defect {:initial :a :on {:logout :a}
+                                    :states {:a {:on {:go :b}} :b {}}})))
+    ;; parallel root `:on` fallback (region-qualified target grammar)
+    (is (nil? (g/definition-defect {:type :parallel
+                                    :on {:one [:a :two]}
+                                    :regions {:a {:initial :one :states {:one {} :two {}}}
+                                              :b {:initial :one :states {:one {} :two {}}}}})))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -165,16 +165,22 @@
       (is (str/includes? out "<state id=\"authenticated___paying\"")))))
 
 (deftest emit-namespaced-ids-use-ns-name-marker
-  (testing "rf2-mnp93.1 — :auth/idle → id=\"auth__idle\" (the `__`
+  (testing "rf2-mnp93.1 / rf2-t69tdo — :auth/idle → id=\"auth-idle\" (the `-`
             ns/name marker; the keyword name/ns chars are hex-escaped so
-            the codec is fully injective and xsd:ID-conformant)"
+            the codec is fully injective and xsd:ID-conformant). The `-`
+            marker — which the escaper never emits (a literal `-` → `_2d`)
+            — can never grow into a `___` path-run at the ns/name boundary,
+            unlike the pre-fix `__` marker."
     (let [out (scxml/spec->scxml namespaced-machine)]
-      (is (str/includes? out "initial=\"auth__idle\""))
-      (is (str/includes? out "<state id=\"auth__idle\""))
-      (is (str/includes? out "<state id=\"auth__loading\""))
-      (is (str/includes? out "event=\"rf__load\""))
+      (is (str/includes? out "initial=\"auth-idle\""))
+      (is (str/includes? out "<state id=\"auth-idle\""))
+      (is (str/includes? out "<state id=\"auth-loading\""))
+      (is (str/includes? out "event=\"rf-load\""))
       ;; The old non-injective `.`-as-ns/name form must be gone.
-      (is (not (str/includes? out "id=\"auth.idle\""))))))
+      (is (not (str/includes? out "id=\"auth.idle\"")))
+      ;; rf2-t69tdo — the ns/name boundary must NOT be a `__` run that could
+      ;; collide with the `___` path separator.
+      (is (not (str/includes? out "id=\"auth__idle\""))))))
 
 (deftest emit-guards-render-as-cond-attribute
   (testing "rf2-mnp93.1 — guarded transitions render with cond= on
@@ -321,13 +327,67 @@
       (is (= done (get-in back [:states begin :on :go]))
           "the CJK transition target survives")))
   (testing "a bare CJK id decodes back to the SAME keyword (not a vector /
-            mis-split), since a plain name carries no `__` ns/name marker"
+            mis-split), since a plain name carries no `-` ns/name marker"
     (let [k    (keyword "结束")
           spec {:initial k :states {k {}}}
           back (-> spec scxml/spec->scxml scxml/scxml->spec)]
       (is (= spec back))
       (is (keyword? (:initial back)))
-      (is (= "结束" (name (:initial back)))))))
+      (is (= "结束" (name (:initial back))))))
+  (testing "rf2-t69tdo — a NAMESPACED CJK id (`:开始/名`) round-trips EXACTLY.
+            #5762 (rf2-qgtcvy) had to scope its CJK round-trip down to PLAIN
+            (non-namespaced) CJK because the pre-fix `__` ns/name marker +
+            the escaped (leading `_u…`) name segment minted `___` at the
+            boundary, so the namespaced keyword mis-decoded to a vector.
+            With the `-` ns/name marker the namespaced case round-trips too."
+    (let [k    (keyword "开始" "名")          ;; ns 开始 (U+5F00 U+59CB), name 名 (U+540D)
+          spec {:initial k
+                :states  {k {:on {(keyword "登录" "成功") :done}}
+                          :done {:final? true}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "the whole namespaced-CJK machine round-trips exactly")
+      (is (keyword? (:initial back)) "the namespaced CJK id stays a keyword")
+      (is (= "开始" (namespace (:initial back))) "the CJK namespace survives")
+      (is (= "名"  (name (:initial back)))       "the CJK name survives")
+      (is (keyword? (-> back :states (get k) :on keys first))
+          "the namespaced-CJK EVENT key stays a keyword, not a mis-split vector"))))
+
+(deftest round-trip-ns-name-boundary-escaped-leading-char
+  (testing "rf2-t69tdo — a namespaced keyword whose NAME segment begins with
+            an escaped char (leading `_…`) round-trips EXACTLY, not to a
+            vector. Pre-fix the `<ns>` + `__` + `_<name-escape>` boundary
+            minted `___` (the path separator), so `:a/-b` decoded to the
+            vector `[:a :2db]` instead of the namespaced keyword."
+    (doseq [k [:a/-b            ;; the bead's exact repro (name -b → _2db)
+               :auth/-flag      ;; another leading-hyphen name
+               :x/?ready        ;; leading `?` name (→ _3f)
+               (keyword "登录" "成功")]] ;; namespaced CJK (leading _u…)
+      (let [spec {:initial :s0
+                  :states  {:s0 {:on {:go {:target :s1 :guard k}}}
+                            :s1 {}}}
+            back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+        (is (= spec back)
+            (str "namespaced keyword with escaped-leading-char name round-trips: " k))
+        (is (= k (get-in back [:states :s0 :on :go :guard]))
+            (str "the guard keyword keeps its namespace + name exactly: " k))))
+    ;; and as a STATE / target id (not just a guard): the id must NOT
+    ;; mis-decode into a vector path.
+    (let [spec {:initial :a/-b
+                :states  {:a/-b {:on {:go :done}}
+                          :done {:final? true}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "an :a/-b STATE id round-trips exactly")
+      (is (keyword? (:initial back)) "the state id stays a keyword, not a vector"))
+    ;; and INSIDE a vector-path target: a namespaced segment whose name
+    ;; leads with an escape must not blur the `___` path boundary.
+    (let [spec {:initial :a
+                :states  {:a       {:on {:go [:auth/-region :browsing]}}
+                          :auth/-region {:initial :browsing
+                                         :states  {:browsing {}}}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "a vector path with a leading-escape-name namespaced segment round-trips")
+      (is (= [:auth/-region :browsing] (get-in back [:states :a :on :go]))
+          "the vector target stays a 2-segment vector, not mis-split"))))
 
 (deftest parse-attrs-accepts-single-quoted-attributes
   (testing "rf2-qgtcvy — `parse-attrs` matched only double-quoted values, so

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -420,7 +420,19 @@
                  (scxml/spec->scxml {:initial :idle}))))
   (testing "parallel without :regions throws"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                 (scxml/spec->scxml {:type :parallel})))))
+                 (scxml/spec->scxml {:type :parallel}))))
+  (testing "rf2-bj3sxo — a malformed flat-ROOT `:on` (non-map fallback slot)
+            is rejected as the clean :scxml/invalid-spec, NOT an uncaught host
+            ISeq exception (the emit path first validates via
+            grammar/valid-definition?)"
+    (let [d (try (scxml/spec->scxml {:initial :a :states {:a {}} :on :retry}) nil
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d))
+          "the malformed root :on surfaces the documented invalid-spec outcome")
+      ;; the value-free summary carries the canonical structural defect category
+      (is (= :rf.error/machine-bad-on-clause
+             (get-in d [:spec-summary :defect :category]))
+          "the summary carries the canonical bad-on-clause defect category"))))
 
 (deftest scxml->spec-rejects-non-string
   (testing "non-string input throws :scxml/parse-error"


### PR DESCRIPTION
Fixes a cluster of two review-found P2 bugs on the `tools/machines-viz/` surface, both latent after #5762. Two commits, `t69tdo` then `bj3sxo`.

## rf2-t69tdo — SCXML codec ns/name `___` path-sep collision

The SCXML id codec joined a keyword's escaped namespace and name with `__` (double underscore) and vector-path segments with `___` (triple underscore). Because **every** escape begins with `_`, a name segment whose leading char escaped to `_…` (any CJK name → leading `_u…`, or `:a/-b`'s name `-b` → `_2db`) grew the `__` boundary into a `___` run — the exact path separator — so `unescape-id-string` silently mis-decoded the namespaced keyword as a vector (`:a/-b` → `[:a :2db]`, `:开始/名` → a 2-vector).

**Fix:** switch the ns/name marker to `-` (a single hyphen). The shared segment escaper always renders a literal `-` as `_2d`, so a bare hyphen can never arise from segment content — a provably-unemittable, xsd:ID-conformant boundary token that can never grow into a `___` run. The path-segment marker stays `___`; the codec still never emits `.`, so the `after.*` / `done.state.*` event-delimiter invariant is preserved. Confined to `scxml.cljc` (the markers are `^:private`); the mermaid / chart emitters use a separate `_2f`/`__` scheme and are untouched.

Adds the namespaced-CJK round-trip assertion #5762 (rf2-qgtcvy) had to scope down to plain CJK, plus a dedicated escaped-leading-char boundary test (`:a/-b`, `:x/?ready`, namespaced CJK — as guard, state id, and vector-path segment). Updates `spec/API.md`'s SCXML codec section (contract change).

## rf2-bj3sxo — malformed root-fallback `:on` not validated

#5762 made malformed state-node `:on` / `:after` clauses produce clean defects, but the same shape rule was not applied to the flat-machine **root** fallback `:on`. `root-on-target-defect` iterated `(:on definition)` with no shape guard, so `{:initial :a :states {:a {}} :on :retry}` threw `IllegalArgumentException: Don't know how to create ISeq from Keyword` out of `valid-definition?` and every emitter's validate-first path.

**Fix:** centralize the transition-slot shape rule into one shared `transition-slot-shape-defect`, applied at **every** scope that consumes the `:on` / `:after` fallback grammar — compound state node, flat root, region root, and parallel root — so the scopes cannot drift. A malformed root `:on` now returns the catalogued `:rf.error/machine-bad-on-clause` defect (value-free category + path), `valid-definition?` returns false, and the SCXML emitter raises its documented `:scxml/invalid-spec`. Valid map `:on` fallbacks still project unchanged.

## Quality gates

- `clojure -M:test` from `tools/machines-viz/` (JVM artefact alias, covers the `.cljc` codec + validation tests): **632 tests, 2537 assertions, 0 failures, 0 errors** (re-run on the rebased HEAD).
- New/extended fixtures: namespaced-CJK + escaped-leading-char boundary round-trips (scxml); malformed root/region/parallel `:on` clean-rejection + value-free defect (grammar validation); malformed-root-`:on` SCXML emitter outcome.

Surface: only `tools/machines-viz/` (`scxml.cljc`, `grammar.cljc`, their `.cljc` tests, `spec/API.md`). No `implementation/machines/**`, ui/core, or top-level spec touched.