### PR TITLE
fix(ui): per-build-id compiler state authority with pass boundaries (rf2-df9873)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -378,6 +378,22 @@
                 ;; sanitization contract.
                 [io.github.nextjournal/markdown "0.7.225"]]
 
+ ;; rf2-df9873 — the re-frame.ui compiler registries (view digests, the
+ ;; Layer-1 root/plan indexes, the Root Descriptor index, the compile-time
+ ;; custom-element declarations) are populated as a SIDE EFFECT of expanding
+ ;; the re-frame.ui macros (defview / mount / custom-element / …). shadow's
+ ;; resource cache skips macroexpansion for a cached namespace, so on a
+ ;; warm-cache daemon start those registries would be INCOMPLETE — a
+ ;; namespace loaded from cache never re-runs its registrations. Blocking the
+ ;; cache for every namespace that uses re-frame.ui's macros forces
+ ;; re-macroexpansion on each compile, keeping the registries a pure function
+ ;; of the current build inputs. NON-NEGOTIABLE for correctness under any
+ ;; build-lifecycle option (the registries are otherwise incomplete on every
+ ;; warm-cache start). Cost: defview/mount-consuming namespaces recompile on
+ ;; daemon start; warm-watch incrementals are unaffected. (Follow-up: move the
+ ;; contributions into cacheable analyzer data to recover caching.)
+ :build-defaults {:cache-blockers #{re-frame.ui}}
+
  ;; Top-level dev-http servers (rf2-aqcix). shadow-cljs's `:dev-http`
  ;; map binds a port to a list of file roots; the dev server cascades
  ;; through the roots in order, returning the first match. Used here for

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -20,26 +20,25 @@
 #?(:clj
    (do
 
-(defonce ^{:doc "view-id -> [template-fingerprint hook-signature-hash],
-  contributed at macro-expansion time through the build-scoped model
-  (`re-frame.ui.compiler.build`) so a recompiled / edited / renamed source
-  replaces its whole prior contribution; `current-build-digest` derives the
-  bd1- digest (compile-order independent — the triples sort by view-id)."}
-  build-views
-  (atom {}))
-
-;; Enrol the two compiler-owned aggregates in the one build-scoped state
-;; model (rf2-vxgfnd.16): views live here; the compile-time custom-element
-;; declarations live in `re-frame.ui.rules/custom-elements` but are WRITTEN
-;; from this ns (macro expansion), so their build boundary is coordinated
-;; here too. The Layer-1 root/plan/descriptor registries enrol from
-;; `re-frame.ui.compiler.root`.
-(build/register! build/views build-views)
+;; The view digest is keyed PER build id in the one build-scoped authority
+;; (`re-frame.ui.compiler.build`, rf2-df9873): a recompiled / edited /
+;; renamed source replaces its whole prior contribution, and the independent
+;; builds one daemon compiles never share rows. `current-build-digest` reads
+;; the ambient build's view aggregate (compile-order independent — the
+;; triples sort by view-id).
+;;
+;; The compile-time custom-element declarations are the one registry that
+;; keeps an external MIRROR atom: they are WRITTEN here (macro expansion) but
+;; READ on the JVM by the tree builder through `re-frame.ui.rules/custom-
+;; elements` (the same var the CLJS RUNTIME arm owns on the client). Register
+;; it as `build/elements`' mirror so build.cljc keeps it synced to the
+;; ambient build's aggregate for that JVM read. The Layer-1 root/plan/
+;; descriptor registries and the view digest read through `build/aggregate`.
 (build/register! build/elements rules/custom-elements)
 
 (defn current-build-digest []
   (fingerprint/build-digest
-   (mapv (fn [[id [tf hs]]] [id tf hs]) @build-views)))
+   (mapv (fn [[id [tf hs]]] [id tf hs]) (build/aggregate build/views))))
 
 (def ^:private defview-option-keys #{:props :id :display-name})
 
@@ -217,7 +216,7 @@
                  :manifest manifest
                  :closed-keys closed-keys
                  :children? children?}]
-    (build/contribute! build/views (:file src) view-id [tf hs])
+    (build/contribute! build/views ns-sym view-id [tf hs])
     (if cljs?
       (emit-cljs/emit-defview args)
       (emit-jvm/emit-defview args))))
@@ -269,7 +268,7 @@
     ;; declaring ns so a hot-reload that DROPS this declaration evicts its
     ;; stale runtime row — the runtime arm of the same eviction model
     ;; (rf2-vxgfnd.48).
-    (build/contribute! build/elements (:file coords) tag {:properties props})
+    (build/contribute! build/elements ns-sym tag {:properties props})
     `(re-frame.ui.rules/register-custom-element!
       ~tag {:properties ~props} '~ns-sym)))
 

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -1,5 +1,6 @@
 (ns re-frame.ui.compiler.build
-  "The ONE build-scoped compiler state model (rf2-vxgfnd.16).
+  "The ONE build-scoped compiler-state authority, keyed PER shadow build id
+  (rf2-vxgfnd.16 → rf2-df9873).
 
   The S1 compiler runs inside a long-lived JVM (the shadow-cljs daemon, a
   REPL, a whole test run). Its build registries — view digests, the
@@ -10,71 +11,79 @@
   exactly as a clean process would: the process lifetime is NOT the build
   lifetime.
 
-  Before this model the registries were process-global `defonce` atoms
-  that only ever `assoc`ed the current declaration, so a deleted or
-  renamed `defview` / root / frame plan / `ui/custom-element` left its old
-  contribution behind — watch builds, sequential builds in one daemon, and
-  REPL reloads observed ghosts a fresh process never would, and a live
-  file could take a false cross-file `:rf.error/duplicate-root-id` /
-  `:rf.error/frame-payload-conflict` from a deleted site.
+  One daemon compiles `re-frame.ui` for MULTIPLE builds at once
+  (`:node-test`, `:node-test-ui`, `:ui-bench`, browser builds). The prior
+  model held a single GLOBAL build-id and WIPED on switch, so two builds
+  compiling the same namespaces wiped each other's registries — regressing
+  cross-file duplicate detection. This model keys everything PER build id,
+  so independent builds are isolated by construction and never cross-
+  contribute.
 
-  ## The model
+  ## Build identity comes from the compiler env, not a hook
 
-  Each registry stays a plain aggregate atom (`{k v}`) so every existing
-  consumer reads it unchanged — no hot-path lookup pays for this
-  bookkeeping. Alongside, this namespace holds a per-SOURCE contribution
-  ledger: for each registry, which keys each source (a source-file path,
-  the compile unit) contributed, and the build generation it last did so.
+  A contribution's owning build is read AMBIENTLY from the per-thread CLJS
+  compiler env (`cljs.env/*compiler*` -> `:shadow.build.cljs-bridge/state`
+  -> `:shadow.build/build-id`) — correct even under shadow's default
+  PARALLEL compile, where each build's analysis threads carry that build's
+  compiler env. Lifecycle hooks own ONLY pass BOUNDARIES (begin / commit /
+  abort); they never assign identity. Outside a real compile (a REPL, the
+  plain-JVM `clojure -M:test` path) identity falls back to the id the most
+  recent `begin-build!` opened, then to `::default`; tests/REPL can pin it
+  with the `*build-id*` dynamic.
 
-  A source's whole contribution is replaced ATOMICALLY the first time it
-  declares in a new build generation (self-arming — never the unsound
-  'clear on the first macro', which breaks multiple declarations in one
-  file and file deletion). So:
+  ## The one atom + pure transitions
 
-    - multiple declarations in one file accumulate, then replace together;
-    - a recompiled / edited / renamed file drops its entire prior
-      contribution and re-accumulates only what it now declares;
-    - a deleted DECLARATION vanishes when its file re-declares without it.
+  ONE atom holds `{build-id -> slice}`; every mutation is a single `swap!`
+  with a PURE transition. A slice:
 
-  ## Lifecycle hooks (the smallest integration)
+    {:pass-open? bool
+     :committed  {source {reg-id {k v}}}   ; last-known-good, per source
+     :staged     {source {reg-id {k v}}}   ; the OPEN pass's re-declarations
+     :touched    #{source}}                ; sources that re-ran this pass
 
-    (begin-build! [build-id?])  a compile pass starts. Same build-id bumps
-                                the generation (incremental — every source
-                                re-opens fresh on its next declaration); a
-                                different build-id starts an isolated slice
-                                (independent builds in one JVM never cross-
-                                contribute — the wipe is `reset-build!`).
-    (reconcile!)                a WHOLE build pass ended: drop every source
-                                that did NOT re-declare this generation (a
-                                deleted / renamed FILE). Only sound after a
-                                full pass — an incremental pass recompiles a
-                                SUBSET, whose untouched files legitimately
-                                keep their prior generation, so it must NOT
-                                reconcile.
-    (reset-build!)              hard-clear every registered aggregate + the
-                                ledger — the clean-build / test-isolation /
-                                build-id-switch boundary.
+  `source` is the declaring NAMESPACE symbol (the compile unit — matching
+  the runtime arm's `[build-id ns-sym]` key; file/line live in error coords
+  only, so a REPL pseudo-file never forges a false duplicate and Windows
+  path normalization is a non-issue).
 
-  Owners register their aggregate atom (`register!`) at load and route
-  every write through `contribute!` (plain assoc registries) or
-  `open-source!` + `note!` (the Layer-1 indexes, whose pre-write conflict
-  check must read the aggregate AFTER the source's stale rows are evicted,
-  so a source never conflicts with its own ghost).
+  A registry's OBSERVABLE aggregate (`aggregate`) is the EFFECTIVE view:
+  committed rows of sources NOT touched this pass, PLUS the staged rows of
+  the sources that re-ran. So a source's whole prior contribution is
+  superseded ATOMICALLY the moment it re-declares (touched → its committed
+  rows drop out of the effective view), and a pass that ABORTS discards its
+  staging and republishes the committed last-known-good untouched.
 
-  ## One open per source, across every registry
+  ## Pass boundaries (last-known-good publication)
 
-  A source's generation is tracked ONCE (globally), not per registry, and
-  `open-source!` fires exactly once per source per generation — at the
-  source's FIRST declaration of the pass — evicting that source's ENTIRE
-  prior contribution from EVERY registry before it re-accumulates. That
-  cross-registry sweep is what makes a deleted declaration disappear even
-  from a registry the recompiled source no longer touches at all (a file
-  that drops its only frame plan but keeps a root): the plan is gone the
-  moment the file re-declares anything, so it cannot fail a later file
-  with a false `:rf.error/frame-payload-conflict`.
+    (begin-build! [id])   a compile pass starts: open the pass and DISCARD
+                          any staging a failed prior pass left (a successful
+                          pass committed at its close, so there is none).
+    (commit-build! [id])  the pass succeeded: every touched source REPLACES
+                          its committed contribution with what it staged
+                          (or is evicted if it staged nothing — a dropped
+                          declaration); untouched sources are kept.
+    (reconcile! [id])     a WHOLE-build pass ended: commit, THEN drop every
+                          committed source that did not re-declare (a
+                          deleted / renamed FILE). Sound only after a full
+                          pass; an incremental pass recompiles a SUBSET.
+    (finish-build! id ms) whole-build finalize against an AUTHORITATIVE
+                          member set (the shadow hook's `:build-sources`):
+                          commit, then drop committed sources absent from
+                          `ms`. Safe on EVERY pass — macro silence is never
+                          the deletion signal.
+    (abort-build! [id])   the pass failed: discard staging, keep committed.
+    (reset-build!)        hard-clear every slice — the clean-build /
+                          test-isolation boundary.
 
-  Compile-time state is mutated single-threaded (macro expansion), so the
-  aggregate + ledger updates need no coordination.")
+  With NO pass open (a REPL form eval; the plain-JVM test path) a
+  contribution UPSERTS per-key straight into committed (no begin/commit
+  cycle, no sibling eviction) — the RULED REPL posture. A deletion made by
+  a bare REPL re-eval converges at the next watch pass; no design can
+  observe an unsaved deletion.
+
+  Every check-then-act (the Layer-1 duplicate/conflict indexes) runs INSIDE
+  one `swap!` via `contribute-checked!`, so parallel namespace compilation
+  can never expose an evict-then-readd gap or a check-then-assoc race.")
 
 ;; ---------------------------------------------------------------------------
 ;; Registry ids (opaque keys naming the five build-scoped registries)
@@ -90,141 +99,271 @@
 ;; State
 ;; ---------------------------------------------------------------------------
 
-(defonce ^{:private true
-           :doc "Monotonic build-pass counter. `begin-build!` bumps it; a
-  source re-opens (once, across every registry) the first time it declares
-  at a generation newer than the one it last opened at."}
-  generation (atom 0))
+(def ^{:private true
+       :doc "An empty per-build slice — the pure transition seed."}
+  empty-slice
+  {:pass-open? false :committed {} :staged {} :touched #{}})
 
 (defonce ^{:private true
-           :doc "The build-id of the current slice — a different id at
-  `begin-build!` isolates by wiping (independent builds never share rows)."}
-  build-id (atom ::none))
+           :doc "The ONE authority: build-id -> slice. Every registry, every
+  build, one atom, pure transitions."}
+  state (atom {}))
 
 (defonce ^{:private true
-           :doc "source -> the generation it last opened at (tracked ONCE,
-  globally, so a source's cross-registry contribution is evicted together)."}
-  source-gen (atom {}))
+           :doc "The build-id the most recent `begin-build!` opened — the
+  identity fallback for the REPL / plain-JVM paths, where no CLJS compiler
+  env is bound. Never consulted under a real compile (the compiler env wins,
+  and is per-thread correct under parallel builds)."}
+  session-build (atom ::default))
 
 (defonce ^{:private true
-           :doc "registry-id -> {:agg <aggregate atom>
-                                 :keys {source #{k}}}.
-  `:agg` is the plain-map atom consumers read; `:keys` records which keys
-  each source contributed, so a re-opening source's rows evict cleanly."}
-  registries (atom {}))
+           :doc "reg-id -> external MIRROR atom kept synced to the ambient
+  build's aggregate, so a JVM-side reader that derefs a plain atom (the JVM
+  tree builder's custom-element registry) sees the current build's rows. Only
+  the compile-time custom-element registry mirrors; every other registry
+  reads through `aggregate`."}
+  mirrors (atom {}))
+
+(def ^:dynamic *build-id*
+  "Explicit identity override (tests / REPL). Wins over the compiler env and
+  the session fallback; bind it per-thread to drive interleaved builds."
+  nil)
 
 ;; ---------------------------------------------------------------------------
-;; Registration (owners declare their aggregate at load)
+;; Ambient build identity
 ;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- shadow-build-id
+     "The build id of the compile currently running on THIS thread, read from
+     the CLJS compiler env: `cljs.env/*compiler*` (an atom) ->
+     `:shadow.build.cljs-bridge/state` -> `:shadow.build/build-id`. nil
+     outside a shadow compile. Pinned behind this one fn so a shadow upgrade
+     that moves the key breaks here, loudly and in one place."
+     []
+     (try
+       (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
+         (when-let [compiler-atom @compiler-var]
+           (get-in @compiler-atom
+                   [:shadow.build.cljs-bridge/state :shadow.build/build-id])))
+       (catch Throwable _ nil))))
+
+(defn current-build-id
+  "The build id a contribution belongs to: the explicit `*build-id*`
+  override, else the ambient shadow compile (per-thread compiler env), else
+  the last `begin-build!` id, else `::default`."
+  []
+  (or *build-id*
+      #?(:clj (shadow-build-id) :cljs nil)
+      @session-build
+      ::default))
+
+;; ---------------------------------------------------------------------------
+;; Pure reads
+;; ---------------------------------------------------------------------------
+
+(defn- effective
+  "One slice's EFFECTIVE aggregate for `reg-id`: committed rows of the
+  sources NOT touched this pass, merged with the staged rows of the sources
+  that re-ran — EXCLUDING `exclude` (pass `::none` to exclude nothing). Pure."
+  [slice reg-id exclude]
+  (let [touched (:touched slice)
+        committed (reduce-kv
+                   (fn [m src regs]
+                     (if (or (= src exclude) (contains? touched src))
+                       m
+                       (merge m (get regs reg-id))))
+                   {} (:committed slice))]
+    (reduce-kv
+     (fn [m src regs] (if (= src exclude) m (merge m (get regs reg-id))))
+     committed (:staged slice))))
+
+(defn aggregate
+  "The ambient (or given) build's current aggregate for `reg-id` — the
+  effective view (committed last-known-good for untouched sources plus the
+  open pass's staged rows). A pure function of the current build inputs; the
+  read every consumer uses in place of a bare atom deref."
+  ([reg-id] (aggregate reg-id (current-build-id)))
+  ([reg-id build-id]
+   (effective (get @state build-id empty-slice) reg-id ::none)))
+
+(defn pass-open?
+  "Whether a compile pass is currently open for the ambient (or given)
+  build (tests / tooling)."
+  ([] (pass-open? (current-build-id)))
+  ([build-id] (:pass-open? (get @state build-id empty-slice) false)))
+
+;; ---------------------------------------------------------------------------
+;; External mirrors (the compile-time custom-element registry)
+;; ---------------------------------------------------------------------------
+
+(defn- sync-mirror! [reg-id build-id]
+  (when-let [mirror (get @mirrors reg-id)]
+    (reset! mirror (aggregate reg-id build-id)))
+  nil)
+
+(defn- sync-mirrors! [build-id]
+  (doseq [[reg-id _] @mirrors] (sync-mirror! reg-id build-id))
+  nil)
 
 (defn register!
-  "Declare a build-scoped registry: `reg-id` names it, `agg` is the
-  plain-map atom consumers read. Idempotent — the existing ledger is kept
-  so a hot ns reload never drops live contributions."
-  [reg-id agg]
-  (swap! registries update reg-id
-         (fn [r] (if r (assoc r :agg agg) {:agg agg :keys {}})))
+  "Register an external MIRROR atom for `reg-id`: build.cljc keeps it synced
+  to the ambient build's aggregate so a JVM reader that derefs the plain atom
+  (the JVM tree builder's custom-element registry) sees the current build's
+  contributions. Idempotent. Only the compile-time custom-element registry
+  uses this — the Layer-1 indexes and the view digest read through
+  `aggregate`."
+  [reg-id mirror]
+  (swap! mirrors assoc reg-id mirror)
+  (sync-mirror! reg-id (current-build-id))
   nil)
 
 ;; ---------------------------------------------------------------------------
-;; Per-source contribution
+;; Contribution (pure transitions)
 ;; ---------------------------------------------------------------------------
 
-(defn open-source!
-  "Open `source`'s contribution for the current build generation. On
-  `source`'s FIRST declaration this generation, evict its prior keys from
-  EVERY registry's aggregate (the atomic, cross-registry per-source
-  replace) and reset its key sets; idempotent for later same-generation
-  declarations. Call BEFORE reading any aggregate for a conflict check so a
-  source never conflicts with its own stale row (and a dropped declaration
-  is gone from registries the source no longer touches this pass)."
-  [source]
-  (let [g @generation]
-    (when (not= g (get @source-gen source))
-      (doseq [[reg-id r] @registries]
-        (when-let [ks (seq (get-in r [:keys source]))]
-          (apply swap! (:agg r) dissoc ks))
-        (swap! registries assoc-in [reg-id :keys source] #{}))
-      (swap! source-gen assoc source g)))
-  nil)
-
-(defn note!
-  "Record that `source` contributed key `k` to `reg-id` (after storing it
-  in the aggregate). Pairs with `open-source!`."
-  [reg-id source k]
-  (swap! registries update-in [reg-id :keys source] (fnil conj #{}) k)
-  nil)
+(defn- write-slice
+  "Pure: record `source` contributing `k`->`v` to `reg-id`. A pass open →
+  STAGE it (and mark the source touched, so its committed contribution is
+  superseded on commit). No pass → UPSERT straight into committed (the REPL
+  posture: per-key, no sibling eviction)."
+  [slice reg-id source k v]
+  (if (:pass-open? slice)
+    (-> slice
+        (update :touched conj source)
+        (assoc-in [:staged source reg-id k] v))
+    (assoc-in slice [:committed source reg-id k] v)))
 
 (defn contribute!
-  "The plain-registry case: open `source`'s scope, store `k` -> `v` in the
-  aggregate, and note it. Registries with a pre-write conflict check use
-  `open-source!` + `note!` around the check instead."
+  "Contribute `source`'s `k`->`v` to the plain registry `reg-id` in the
+  ambient build — one `swap!`, pure. The Layer-1 indexes use
+  `contribute-checked!` for their pre-write conflict check."
   [reg-id source k v]
-  (open-source! source)
-  (swap! (:agg (get @registries reg-id)) assoc k v)
-  (note! reg-id source k)
-  nil)
+  (let [build-id (current-build-id)]
+    (swap! state update build-id (fnil write-slice empty-slice) reg-id source k v)
+    (sync-mirror! reg-id build-id)
+    nil))
+
+(defn contribute-checked!
+  "The atomic conflict-checked contribution for a Layer-1 index. Inside ONE
+  `swap!`: look up `k` in the ambient build's EFFECTIVE map for `reg-id`,
+  EXCLUDING `source`'s own rows (a source never conflicts with itself —
+  same-source re-declaration replaces), and call `(conflict-fn existing)`. If
+  it returns a non-nil value the write is REJECTED and that value is returned
+  (the caller builds + throws its domain error); otherwise `source`
+  contributes `k`->`v` (staged or upserted) and nil is returned. Atomic, so
+  parallel compilation can neither drop a concurrent write (check-then-assoc
+  race) nor miss a genuine duplicate."
+  [reg-id source k v conflict-fn]
+  (let [build-id (current-build-id)
+        outcome  (atom nil)]           ; call-local — only this call's retries touch it
+    (swap! state update build-id
+           (fn [slice]
+             (let [slice    (or slice empty-slice)
+                   existing (get (effective slice reg-id source) k)
+                   conflict (conflict-fn existing)]
+               (if conflict
+                 (do (reset! outcome {:conflict conflict}) slice)
+                 (do (reset! outcome nil)
+                     (write-slice slice reg-id source k v))))))
+    (sync-mirror! reg-id build-id)
+    @outcome))
 
 ;; ---------------------------------------------------------------------------
-;; Lifecycle hooks
+;; Pass boundaries
 ;; ---------------------------------------------------------------------------
-
-(defn reset-build!
-  "Hard-clear every registered aggregate and the whole ledger — the
-  clean-build / independent-build / test-isolation boundary (generalises
-  the old per-namespace `reset-build-registries!`). `begin-build!`'s
-  per-source replace covers incremental correctness; this is the fresh
-  top-level slice."
-  []
-  (doseq [[reg-id r] @registries]
-    (reset! (:agg r) {})
-    (swap! registries assoc-in [reg-id :keys] {}))
-  (reset! source-gen {})
-  nil)
 
 (defn begin-build!
-  "Open a compile pass. The SAME `build-id` bumps the generation
-  (incremental — every source re-opens fresh on its next declaration, so
-  edits / renames / declaration deletions replace rather than accumulate);
-  a DIFFERENT `build-id` starts an isolated slice (wipes first, so two
-  build-ids sharing one JVM never contribute rows or conflicts to each
-  other). The zero-arg form uses the sole default build."
+  "Open a compile pass for `build-id` (the zero-arg form uses the sole
+  default build). DISCARDS any staging a failed prior pass left — a
+  successful pass commits at its close, so there is normally none — and marks
+  the pass open. Sets the session-build identity fallback so subsequent
+  contributions on the REPL / plain-JVM path route here."
   ([] (begin-build! ::default))
-  ([id]
-   (when (not= id @build-id)
-     (reset! build-id id)
-     (reset-build!))
-   (swap! generation inc)
+  ([build-id]
+   (reset! session-build build-id)
+   (swap! state update build-id
+          (fn [s] (assoc (or s empty-slice) :pass-open? true :staged {} :touched #{})))
+   (sync-mirrors! build-id)
    nil))
 
+(defn- commit-slice
+  "Pure: fold the open pass's staging into committed — every touched source
+  REPLACES its committed contribution with what it staged, or is evicted if
+  it staged nothing."
+  [slice]
+  (let [committed (reduce
+                   (fn [c src]
+                     (let [staged (get-in slice [:staged src])]
+                       (if (seq staged) (assoc c src staged) (dissoc c src))))
+                   (:committed slice)
+                   (:touched slice))]
+    (assoc slice :committed committed :staged {} :touched #{} :pass-open? false)))
+
+(defn commit-build!
+  "Commit the open pass for `build-id`: every touched source's staged
+  contribution replaces its committed one (or evicts it), untouched committed
+  sources are kept, and the pass closes. The last-known-good publication
+  point for an INCREMENTAL pass."
+  ([] (commit-build! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id (fn [s] (commit-slice (or s empty-slice))))
+   (sync-mirrors! build-id)
+   nil))
+
+(defn- keep-members
+  "Pure: drop every committed source absent from `keep?` (a membership
+  predicate over sources)."
+  [slice keep?]
+  (update slice :committed
+          (fn [committed]
+            (select-keys committed (filter keep? (keys committed))))))
+
 (defn reconcile!
-  "Whole-build end hook: drop every source that did NOT re-declare in the
-  current generation (a deleted or renamed FILE no longer contributes),
-  evicting its keys from every aggregate — so the registries equal a clean
-  build over exactly the files that declared this pass. Sound ONLY after a
-  WHOLE pass; an incremental pass that recompiles a subset must not call it
-  (its untouched files keep their prior generation, which is correct)."
-  []
-  (let [g @generation
-        stale (for [[source sg] @source-gen :when (not= sg g)] source)]
-    (doseq [source stale]
-      (doseq [[reg-id r] @registries]
-        (when-let [ks (seq (get-in r [:keys source]))]
-          (apply swap! (:agg r) dissoc ks))
-        (swap! registries update-in [reg-id :keys] dissoc source))
-      (swap! source-gen dissoc source)))
+  "Whole-build finalize for `build-id`: commit the open pass, THEN drop every
+  committed source that did NOT re-declare this pass (a deleted / renamed
+  FILE). Sound ONLY after a WHOLE pass — an incremental pass recompiles a
+  subset, whose untouched sources legitimately keep their prior contribution,
+  so it must NOT reconcile."
+  ([] (reconcile! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id
+          (fn [s]
+            (let [s (or s empty-slice)
+                  touched (:touched s)]
+              (-> s commit-slice (keep-members touched)))))
+   (sync-mirrors! build-id)
+   nil))
+
+(defn finish-build!
+  "Whole-build finalize against an AUTHORITATIVE member set (the shadow
+  hook's `:build-sources`): commit the open pass, then drop every committed
+  source absent from `members` (a coll/set of source ns-syms). Safe on EVERY
+  pass, incrementals included — macro silence is never the deletion signal,
+  so authoritative membership, not `touched`, drives eviction."
+  [build-id members]
+  (let [members (set members)]
+    (swap! state update build-id
+           (fn [s] (-> (or s empty-slice) commit-slice (keep-members members))))
+    (sync-mirrors! build-id))
   nil)
 
-;; ---------------------------------------------------------------------------
-;; Introspection (tests / tooling)
-;; ---------------------------------------------------------------------------
+(defn abort-build!
+  "Discard the open pass's staging for `build-id`; the committed
+  last-known-good survives untouched. A failed / aborted compile."
+  ([] (abort-build! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id
+          (fn [s] (assoc (or s empty-slice) :staged {} :touched #{} :pass-open? false)))
+   (sync-mirrors! build-id)
+   nil))
 
-(defn current-generation
-  "The current build generation (tests / tooling)."
+(defn reset-build!
+  "Hard-clear every build slice — the clean-build / independent-build /
+  test-isolation boundary. `begin-build!`'s per-source replace covers
+  incremental correctness; this is the fresh top-level state."
   []
-  @generation)
-
-(defn source-keys
-  "The keys `source` currently contributes to `reg-id` (tests / tooling)."
-  [reg-id source]
-  (get-in @registries [reg-id :keys source] #{}))
+  (reset! state {})
+  (reset! session-build ::default)
+  (doseq [[_ mirror] @mirrors] (reset! mirror {}))
+  nil)

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -373,34 +373,38 @@
 ;; Layer 1 — the build-tier duplicate/conflict indexes (contract §7)
 ;; ---------------------------------------------------------------------------
 
-(defonce ^{:doc "Layer-1 root-site index: root-id -> {:file :line :provenance}.
-  Cross-FILE duplicates fail the build; same-file re-registration replaces
-  (watch-mode re-expansion tolerance — Layer 3 backstops same-file
-  duplicates at runtime). See the ns docstring §Build scope."}
-  build-roots
-  (atom {}))
+;; The Layer-1 / descriptor aggregates are keyed PER build id in the one
+;; build-scoped authority (`re-frame.ui.compiler.build`, rf2-df9873) — no
+;; process-global atom to cross-contaminate between the builds one daemon
+;; compiles in parallel. Consumers read the ambient build's aggregate through
+;; these accessors (a pure function of the current build inputs): a
+;; recompiled / edited / renamed / removed source replaces its whole prior
+;; contribution atomically, so a deleted root or plan cannot linger to raise
+;; a FALSE cross-file duplicate/conflict.
 
-(defonce ^{:doc "Layer-1 frame-plan index: frame-id -> {:config-fingerprint
-  :file :line}. Two plans for one frame-id with differing fingerprints from
-  different files fail the build (:rf.error/frame-payload-conflict)."}
-  build-plans
-  (atom {}))
+(defn build-roots
+  "The ambient build's Layer-1 root-site index: root-id ->
+  {:file :line :provenance}. Cross-NAMESPACE duplicates fail the build;
+  same-namespace re-registration replaces (watch-mode re-expansion tolerance
+  — Layer 3 backstops same-namespace duplicates at runtime)."
+  []
+  (build/aggregate build/roots))
 
-(defonce ^{:doc "Compile-emitted Root Descriptors, root-id -> descriptor —
-  the build-artefact side of \"S1 emits descriptors\" (S5 tooling / Xray
-  read compile output through this index; the runtime copy rides the
-  live-root registry, dev-only)."}
-  build-descriptors
-  (atom {}))
+(defn build-plans
+  "The ambient build's Layer-1 frame-plan index: frame-id ->
+  {:config-fingerprint :file :line}. Two plans for one frame-id with
+  differing fingerprints from different namespaces fail the build
+  (:rf.error/frame-payload-conflict)."
+  []
+  (build/aggregate build/plans))
 
-;; Enrol the three Layer-1 / descriptor aggregates in the one build-scoped
-;; state model (rf2-vxgfnd.16) so a recompiled / edited / renamed / removed
-;; source replaces its whole prior contribution atomically — a deleted root
-;; or plan cannot linger to raise a FALSE cross-file duplicate/conflict, and
-;; the indexes stay a pure function of the current build inputs.
-(build/register! build/roots build-roots)
-(build/register! build/plans build-plans)
-(build/register! build/descriptors build-descriptors)
+(defn build-descriptors
+  "The ambient build's compile-emitted Root Descriptor index: root-id ->
+  descriptor — the build-artefact side of \"S1 emits descriptors\" (S5
+  tooling / Xray read compile output through here; the runtime copy rides the
+  live-root registry, dev-only)."
+  []
+  (build/aggregate build/descriptors))
 
 (defn reset-build-registries!
   "Hard-clear every build-scoped compiler registry (views, the Layer-1
@@ -430,75 +434,70 @@
      (let [bd (compiler/current-build-digest)]
        (into {}
              (map (fn [[rid desc]] [rid (assoc desc :build-digest bd)]))
-             @build-descriptors))))
+             (build-descriptors)))))
 
 (defn- site-str [{:keys [file line]}]
   (str (or file "<unknown-file>") (when line (str ":" line))))
 
 (defn register-root-site!
-  "Index one root site's statically resolved root-id (Layer 1). A second
-  site in a DIFFERENT file with an equal root-id is the build-tier
-  `:rf.error/duplicate-root-id` — thrown through the canonical builder,
-  with the both-derived didactic fix per the contract."
-  [where root-id provenance coords]
-  ;; Open THIS source (cross-registry, once per pass): a moved / renamed /
-  ;; deleted site never conflicts with its own ghost, and a deleted site
-  ;; cannot fail a later file (rf2-vxgfnd.16).
-  (build/open-source! (:file coords))
-  (let [existing (get @build-roots root-id)]
-    (when (and existing
-               (:file existing) (:file coords)
-               (not= (:file existing) (:file coords)))
-      (error/throw-error!
-       :rf.error/duplicate-root-id where
-       (str "two root sites in one build resolve to root-id "
-            (pr-str root-id) " — " (site-str existing) " and "
-            (site-str coords) ". Root-ids are page-unique identity; "
-            (if (= :derived (:provenance existing) provenance)
-              (str "both ids derived from the same view — add "
-                   ":disambiguator or author :root-id")
-              "author distinct :root-id values"))
-       {:recovery :make-root-ids-unique
-        :extra {:root-id    root-id
-                :provenance [(:provenance existing) provenance]
-                :sites      [(dissoc existing :provenance) coords]}}))
-    (swap! build-roots assoc root-id (assoc coords :provenance provenance))
-    (build/note! build/roots (:file coords) root-id)
-    nil))
+  "Index one root site's statically resolved root-id (Layer 1), owned by its
+  declaring namespace `ns-sym`. A second site in a DIFFERENT namespace with
+  an equal root-id is the build-tier `:rf.error/duplicate-root-id` — thrown
+  through the canonical builder, with the both-derived didactic fix per the
+  contract. Same-namespace re-registration REPLACES (watch-mode re-expansion
+  tolerance — a moved / renamed / deleted site never conflicts with its own
+  ghost). The check-then-write is ONE atomic transition, so parallel
+  compilation cannot miss a duplicate or drop a concurrent write."
+  [where root-id provenance ns-sym coords]
+  (when-let [{:keys [conflict]}
+             (build/contribute-checked!
+              build/roots ns-sym root-id (assoc coords :provenance provenance)
+              ;; any OTHER namespace's row for this root-id is the conflict
+              (fn [existing] existing))]
+    (error/throw-error!
+     :rf.error/duplicate-root-id where
+     (str "two root sites in one build resolve to root-id "
+          (pr-str root-id) " — " (site-str conflict) " and "
+          (site-str coords) ". Root-ids are page-unique identity; "
+          (if (= :derived (:provenance conflict) provenance)
+            (str "both ids derived from the same view — add "
+                 ":disambiguator or author :root-id")
+            "author distinct :root-id values"))
+     {:recovery :make-root-ids-unique
+      :extra {:root-id    root-id
+              :provenance [(:provenance conflict) provenance]
+              :sites      [(dissoc conflict :provenance) coords]}}))
+  nil)
 
 (defn register-plan-site!
-  "Index one site's static frame plan (Layer 1). A plan for the same
-  frame-id with a DIFFERING config fingerprint from a different file is
-  the build-tier `:rf.error/frame-payload-conflict` (same-file
-  re-registration replaces — watch tolerance; matching fingerprints are
-  the ratified idempotent no-op)."
-  [where {:keys [frame-id config-fingerprint]} coords]
-  ;; Open THIS source (cross-registry, once per pass) — a deleted / edited
-  ;; plan never conflicts with its own ghost, and a removed plan cannot fail
-  ;; a later file (rf2-vxgfnd.16).
-  (build/open-source! (:file coords))
-  (let [existing (get @build-plans frame-id)]
-    (when (and existing
-               (not= (:config-fingerprint existing) config-fingerprint)
-               (:file existing) (:file coords)
-               (not= (:file existing) (:file coords)))
-      (error/throw-error!
-       :rf.error/frame-payload-conflict where
-       (str "two root sites in one build carry static frame plans for "
-            "frame " (pr-str frame-id) " with DIFFERING config "
-            "fingerprints — " (site-str existing) " and " (site-str coords)
-            ". One frame, one plan: keep the frame's config in ONE "
-            "boot/root site, or align the configs")
-       {:recovery :align-frame-plan-config
-        :extra {:frame-id     frame-id
-                :fingerprints [(:config-fingerprint existing)
-                               config-fingerprint]
-                :sites        [(dissoc existing :config-fingerprint) coords]}}))
-    (swap! build-plans assoc frame-id {:config-fingerprint config-fingerprint
-                                       :file (:file coords)
-                                       :line (:line coords)})
-    (build/note! build/plans (:file coords) frame-id)
-    nil))
+  "Index one site's static frame plan (Layer 1), owned by its declaring
+  namespace `ns-sym`. A plan for the same frame-id with a DIFFERING config
+  fingerprint from a different namespace is the build-tier
+  `:rf.error/frame-payload-conflict` (same-namespace re-registration replaces
+  — watch tolerance; matching fingerprints are the ratified idempotent
+  no-op). The check-then-write is ONE atomic transition."
+  [where {:keys [frame-id config-fingerprint]} ns-sym coords]
+  (when-let [{:keys [conflict]}
+             (build/contribute-checked!
+              build/plans ns-sym frame-id
+              {:config-fingerprint config-fingerprint
+               :file (:file coords) :line (:line coords)}
+              (fn [existing]
+                (when (and existing
+                           (not= (:config-fingerprint existing) config-fingerprint))
+                  existing)))]
+    (error/throw-error!
+     :rf.error/frame-payload-conflict where
+     (str "two root sites in one build carry static frame plans for "
+          "frame " (pr-str frame-id) " with DIFFERING config "
+          "fingerprints — " (site-str conflict) " and " (site-str coords)
+          ". One frame, one plan: keep the frame's config in ONE "
+          "boot/root site, or align the configs")
+     {:recovery :align-frame-plan-config
+      :extra {:frame-id     frame-id
+              :fingerprints [(:config-fingerprint conflict) config-fingerprint]
+              :sites        [(dissoc conflict :config-fingerprint) coords]}}))
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; Root opts (contract §3)
@@ -635,7 +634,8 @@
   "`(ui/mount root-form dom-node opts)` — the one-shot client mount:
   create-root + frame preflight + render!, idempotent per root."
   [form menv root-form dom-node opts]
-  (let [coords (source-coords form (some? (:ns menv)))]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
     (anchored coords
       (fn []
         (let [e      (expand-env! 'ui/mount menv)
@@ -646,11 +646,13 @@
                                             'ui/mount opts views)
               prefix (or (:identifier-prefix opts)
                          (default-identifier-prefix root-id))
-              _      (register-root-site! 'ui/mount root-id provenance coords)
-              _      (doseq [p plans] (register-plan-site! 'ui/mount p coords))
+              _      (register-root-site! 'ui/mount root-id provenance
+                                          ns-sym coords)
+              _      (doseq [p plans]
+                       (register-plan-site! 'ui/mount p ns-sym coords))
               desc   (root-descriptor {:root-id root-id :provenance provenance
                                        :views views :plans plans :ast ast})
-              _      (build/contribute! build/descriptors (:file coords)
+              _      (build/contribute! build/descriptors ns-sym
                                         root-id desc)
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
           `(re-frame.ui.client/mount*
@@ -670,7 +672,8 @@
   authored `:root-id` is REQUIRED (the derivation default belongs to the
   root-form-bearing entry points; `ui/mount` is the one-liner path)."
   [form menv dom-node opts]
-  (let [coords (source-coords form (some? (:ns menv)))]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
     (anchored coords
       (fn []
         (expand-env! 'ui/create-root menv)
@@ -691,7 +694,7 @@
                   nil))
           (let [prefix (or (:identifier-prefix opts)
                            (default-identifier-prefix root-id))]
-            (register-root-site! 'ui/create-root root-id :authored coords)
+            (register-root-site! 'ui/create-root root-id :authored ns-sym coords)
             `(re-frame.ui.client/create-root*
               {:root-id ~root-id
                :provenance :authored
@@ -706,14 +709,15 @@
   identity resolution happens here; the descriptor-base is completed with
   the Root's identity at runtime (dev)."
   [form menv root root-form]
-  (let [coords (source-coords form (some? (:ns menv)))]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
     (anchored coords
       (fn []
         (let [e      (expand-env! 'ui/render! menv)
               {:keys [ast views plans]} (analyze-root e 'ui/render! root-form)
               _      (print-warnings! e 'ui/render!)
               _      (doseq [p plans]
-                       (register-plan-site! 'ui/render! p coords))
+                       (register-plan-site! 'ui/render! p ns-sym coords))
               desc   (root-descriptor {:views views :plans plans :ast ast})
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
           `(re-frame.ui.client/render!*
@@ -730,7 +734,8 @@
   the same id in the aligned case); the S1 runtime fails loud — manifests
   land S5."
   [form menv dom-node root-form opts]
-  (let [coords (source-coords form (some? (:ns menv)))]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
     (anchored coords
       (fn []
         (let [e (expand-env! 'ui/hydrate-root menv)]
@@ -749,11 +754,13 @@
                 _    (print-warnings! e 'ui/hydrate-root)]
             (when (= 1 (count views))
               (let [derived (:view-id (first views))]
-                (register-root-site! 'ui/hydrate-root derived :derived coords)
-                (build/contribute! build/descriptors (:file coords) derived
+                (register-root-site! 'ui/hydrate-root derived :derived
+                                     ns-sym coords)
+                (build/contribute! build/descriptors ns-sym derived
                        (root-descriptor {:root-id derived :provenance :derived
                                          :views views :plans plans :ast ast}))))
-            (doseq [p plans] (register-plan-site! 'ui/hydrate-root p coords))
+            (doseq [p plans]
+              (register-plan-site! 'ui/hydrate-root p ns-sym coords))
             (let [body (emit-cljs/emit-inline ast 'rf-ui-root)]
               `(re-frame.ui.client/hydrate-root*
                 ~dom-node

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -1,29 +1,31 @@
 (ns re-frame.ui.compiler-build-jvm-test
-  "rf2-vxgfnd.16 — the S1 compiler build registries are a PURE FUNCTION of
-  the current build inputs, not of process history.
+  "The ONE build-scoped compiler-state authority (rf2-vxgfnd.16 → rf2-df9873):
+  the S1 compiler's build registries are a PURE FUNCTION of the current build
+  inputs, keyed PER shadow build id, with explicit begin/commit/abort pass
+  boundaries and last-known-good publication.
 
-  The adversarial crux: in ONE long-lived JVM (never restarted), declare a
-  source's contributions to all five build registries — a `defview`, a root
-  site + static frame plan + descriptor, a `ui/custom-element` — then
-  rebuild after edits / renames / deletions and assert the registries +
-  `current-build-digest` equal a CLEAN-process build of the edited source.
-  Before this model those registries were process-global `defonce` atoms
-  that only ever `assoc`ed, so a deleted or renamed declaration lingered and
-  a live file could take a FALSE cross-file duplicate-root /
-  frame-payload-conflict from a deleted site.
+  The adversarial cruces:
+
+    - MULTI-BUILD ISOLATION (the headline regression): one long-lived JVM
+      compiles `re-frame.ui` for several builds at once; two build ids must
+      NOT wipe each other's registries (the prior global-build-id +
+      wipe-on-switch model did — regressing cross-file duplicate detection).
+    - PASS BOUNDARIES: an incremental commit replaces only the touched
+      source's contribution and keeps untouched sources; a WHOLE-build
+      reconcile drops sources that did not re-declare; an ABORTED pass
+      republishes the last-known-good, not a partial.
+    - ATOMICITY: `register-root-site!` / `register-plan-site!` check-then-write
+      inside ONE transition, so parallel compilation neither drops a
+      concurrent write nor misses a genuine duplicate.
+    - REPL UPSERT: with no pass open a contribution upserts one key straight
+      into committed (no begin/commit cycle, no sibling eviction).
 
   The mount-surface macros are client entry points (JVM-host expansion is a
   compile error), so the Layer-1 / descriptor writes are driven the way
   `re-frame.ui.compiler.root/mount-form` drives them — `mount-site!` runs the
-  REAL assembly path (analyze-root + resolve-root-identity +
-  register-root-site! + register-plan-site! + the `root/root-descriptor`
-  contribution), NOT a hand-built descriptor, so the descriptor's
-  `:build-digest` (read-time projected by `root/descriptor-index`) is
-  actually exercised by the incremental-equals-clean assertion (rf2-vxgfnd.47
-  — the prior hand-built descriptors carried no digest, masking the bug).
-  `defview` and `ui/custom-element` ARE JVM-expandable and run their real
-  macro bodies, with the source file bound so distinct 'files' are
-  addressable in the ledger."
+  REAL assembly path. `defview` and `ui/custom-element` run their real macro
+  bodies under a bound `*ns*` so distinct declaring namespaces (the ledger's
+  source key, rf2-df9873) are addressable."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
@@ -31,30 +33,32 @@
             [re-frame.ui.compiler.root :as root]
             [re-frame.ui.rules :as rules]))
 
-;; Every test starts from a clean slice; correctness across a watch session
-;; comes from per-source replacement on begin-build!, but tests want
-;; independence, so the fixture uses the hard boundary.
+;; Every test starts from a clean authority; correctness across a watch
+;; session comes from per-source replacement on the pass boundaries, but
+;; tests want independence, so the fixture uses the hard boundary.
 (use-fixtures :each
   (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness — drive the five registries the way real compilation does, with a
-;; controllable source-file key.
+;; controllable declaring namespace (the ledger source key).
 ;; ---------------------------------------------------------------------------
 
 (defn- declare-view!
-  "Run the real `defview` macro body (JVM emitter path) with `file` bound as
-  the source — contributes [template-fp hook-sig] under the derived view-id."
-  [file vname template]
-  (binding [*file* file]
+  "Run the real `defview` macro body (JVM emitter path) with `ns-sym` bound as
+  the declaring namespace — contributes [template-fp hook-sig] under the
+  derived view-id, owned by `ns-sym`."
+  [ns-sym vname template]
+  (binding [*ns* (create-ns ns-sym)]
     (compiler/defview* (with-meta (list 'defview vname [] template) {:line 1})
                        {} vname (list [] template))))
 
 (defn- declare-element!
-  "Run the real `ui/custom-element` macro body with `file` bound as the
-  source — contributes the compile-time property classification for `tag`."
-  [file tag properties]
-  (binding [*file* file]
+  "Run the real `ui/custom-element` macro body with `ns-sym` bound as the
+  declaring namespace — contributes the compile-time property classification
+  for `tag`, owned by `ns-sym`."
+  [ns-sym tag properties]
+  (binding [*ns* (create-ns ns-sym)]
     (compiler/custom-element* (with-meta (list 'custom-element tag
                                                {:properties properties})
                                          {:line 1})
@@ -71,129 +75,305 @@
       nil)))
 
 (defn- mount-site!
-  "Drive the REAL `mount-form` descriptor path for one root site in `file`:
-  analyze the LITERAL root form, resolve identity, index the root-id + each
-  EXTRACTED frame plan, and contribute the Root Descriptor built by the
-  actual `root/root-descriptor` assembly — exactly the sequence a `ui/mount`
-  expansion performs (no hand-built descriptor, no baked digest). The
-  descriptor's `:build-digest` is thus a read-time projection
-  (`root/descriptor-index`), so the incremental-equals-clean assertion
-  exercises it (rf2-vxgfnd.47)."
-  [file root-form opts]
+  "Drive the REAL `mount-form` descriptor path for one root site owned by
+  `ns-sym` (file only feeds the error coords): analyze the LITERAL root form,
+  resolve identity, index the root-id + each EXTRACTED frame plan, and
+  contribute the Root Descriptor built by the actual `root/root-descriptor`
+  assembly — exactly the sequence a `ui/mount` expansion performs."
+  [ns-sym file root-form opts]
   (binding [*file* file]
     (let [coords {:file file :line 1}
           e (env/make-env {:host :clj :ns-sym 'app.test :resolver resolver})
           {:keys [ast views plans]} (root/analyze-root e 'ui/mount root-form)
           {:keys [root-id provenance]} (root/resolve-root-identity
                                         'ui/mount opts views)]
-      (root/register-root-site! 'ui/mount root-id provenance coords)
-      (doseq [p plans] (root/register-plan-site! 'ui/mount p coords))
-      (build/contribute! build/descriptors file root-id
+      (root/register-root-site! 'ui/mount root-id provenance ns-sym coords)
+      (doseq [p plans] (root/register-plan-site! 'ui/mount p ns-sym coords))
+      (build/contribute! build/descriptors ns-sym root-id
                          (root/root-descriptor
                           {:root-id root-id :provenance provenance
                            :views views :plans plans :ast ast})))))
 
 (defn- snapshot
-  "The observable state of all five build registries + the build digest. The
-  descriptor index is read through `root/descriptor-index` so its read-time
-  `:build-digest` projection is part of what clean-vs-incremental compares."
+  "The observable state of all five build registries + the build digest for
+  the ambient build. The descriptor index is read through
+  `root/descriptor-index` so its read-time `:build-digest` projection is part
+  of what clean-vs-incremental compares."
   []
-  {:views       @compiler/build-views
+  {:views       (build/aggregate build/views)
    :digest      (compiler/current-build-digest)
-   :roots       @root/build-roots
-   :plans       @root/build-plans
+   :roots       (root/build-roots)
+   :plans       (root/build-plans)
    :descriptors (root/descriptor-index)
-   :elements    @rules/custom-elements})
+   :elements    (build/aggregate build/elements)})
 
 ;; ---------------------------------------------------------------------------
-;; The build-scoped model itself (re-frame.ui.compiler.build)
+;; The pure-transition model itself (re-frame.ui.compiler.build)
 ;; ---------------------------------------------------------------------------
-
-(def ^:private probe (atom {}))
-(def ^:private probe2 (atom {}))
-(build/register! ::probe probe)
-(build/register! ::probe2 probe2)
 
 (deftest per-source-contribution-replaces-atomically
-  (build/begin-build!)
-  (build/contribute! ::probe "a.cljs" :x 1)
-  (build/contribute! ::probe "a.cljs" :y 2)
-  (is (= {:x 1 :y 2} @probe)
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :x 1)
+  (build/contribute! ::probe 'ns.a :y 2)
+  (is (= {:x 1 :y 2} (build/aggregate ::probe :app))
       "multiple declarations in one source accumulate — never clear-on-first-macro")
-  (build/begin-build!)                       ; a fresh pass
-  (build/contribute! ::probe "a.cljs" :x 10) ; the source is edited: :y removed, :x changed
-  (is (= {:x 10} @probe)
+  (build/commit-build! :app)
+  (build/begin-build! :app)                      ; a fresh pass
+  (build/contribute! ::probe 'ns.a :x 10)        ; the source is edited: :y removed
+  (is (= {:x 10} (build/aggregate ::probe :app))
       "recompiling a source replaces its WHOLE prior contribution — :y is gone"))
 
 (deftest open-source-evicts-across-every-registry
   ;; a source contributing to TWO registries, then re-declaring in only one,
   ;; must drop its stale rows from the registry it no longer touches.
-  (build/begin-build!)
-  (build/contribute! ::probe  "a.cljs" :p 1)
-  (build/contribute! ::probe2 "a.cljs" :q 2)
-  (is (= {:p 1} @probe))
-  (is (= {:q 2} @probe2))
-  (build/begin-build!)
-  (build/contribute! ::probe "a.cljs" :p 11) ; a.cljs re-declares only in ::probe
-  (is (= {:p 11} @probe))
-  (is (= {} @probe2)
-      "opening a.cljs evicted its ::probe2 row even though it did not re-touch ::probe2"))
-
-(deftest incremental-preserves-untouched-reconcile-drops-deleted-files
-  (build/begin-build!)
-  (build/contribute! ::probe "a.cljs" :a 1)
-  (build/contribute! ::probe "b.cljs" :b 2)
-  (is (= {:a 1 :b 2} @probe))
-  (build/begin-build!)                       ; incremental: only a.cljs recompiles
-  (build/contribute! ::probe "a.cljs" :a 11)
-  (is (= {:a 11 :b 2} @probe)
-      "an incremental pass recompiles a SUBSET — b.cljs's row is untouched")
-  (build/reconcile!)
-  (is (= {:a 11} @probe)
-      "a whole-build reconcile drops b.cljs — a deleted/renamed FILE that did not re-declare"))
-
-(deftest build-ids-are-isolated
   (build/begin-build! :app)
-  (build/contribute! ::probe "a.cljs" :x 1)
-  (is (= {:x 1} @probe))
+  (build/contribute! ::probe  'ns.a :p 1)
+  (build/contribute! ::probe2 'ns.a :q 2)
+  (is (= {:p 1} (build/aggregate ::probe :app)))
+  (is (= {:q 2} (build/aggregate ::probe2 :app)))
+  (build/commit-build! :app)
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :p 11)        ; ns.a re-declares only in ::probe
+  (is (= {:p 11} (build/aggregate ::probe :app)))
+  (is (= {} (build/aggregate ::probe2 :app))
+      "re-touching ns.a evicted its ::probe2 row even though it did not re-touch it")
+  (build/commit-build! :app)
+  (is (= {:p 11} (build/aggregate ::probe :app)))
+  (is (= {} (build/aggregate ::probe2 :app)) "the eviction survives commit"))
+
+(deftest incremental-commit-preserves-untouched-sources
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :a 1)
+  (build/contribute! ::probe 'ns.b :b 2)
+  (is (= {:a 1 :b 2} (build/aggregate ::probe :app)))
+  (build/commit-build! :app)
+  (build/begin-build! :app)                       ; incremental: only ns.a recompiles
+  (build/contribute! ::probe 'ns.a :a 11)
+  (is (= {:a 11 :b 2} (build/aggregate ::probe :app))
+      "an incremental pass recompiles a SUBSET — ns.b's row is untouched")
+  (build/commit-build! :app)
+  (is (= {:a 11 :b 2} (build/aggregate ::probe :app))
+      "an incremental commit keeps the untouched source"))
+
+(deftest whole-build-reconcile-drops-deleted-sources
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :a 1)
+  (build/contribute! ::probe 'ns.b :b 2)
+  (build/commit-build! :app)
+  (build/begin-build! :app)                       ; WHOLE-build pass: ns.b is gone
+  (build/contribute! ::probe 'ns.a :a 11)
+  (build/reconcile! :app)
+  (is (= {:a 11} (build/aggregate ::probe :app))
+      "a whole-build reconcile drops ns.b — a deleted/renamed FILE that did not re-declare"))
+
+(deftest finish-build-uses-authoritative-membership
+  ;; The shadow-hook primitive: commit + drop committed sources absent from
+  ;; the authoritative :build-sources — safe on EVERY pass (macro silence is
+  ;; never the deletion signal).
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :a 1)
+  (build/contribute! ::probe 'ns.b :b 2)
+  (build/finish-build! :app '#{ns.a ns.b})
+  (is (= {:a 1 :b 2} (build/aggregate ::probe :app)) "both members retained")
+  ;; incremental pass recompiles ONLY ns.a; ns.b is untouched but still a member
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :a 11)
+  (build/finish-build! :app '#{ns.a ns.b})
+  (is (= {:a 11 :b 2} (build/aggregate ::probe :app))
+      "incremental finish keeps the untouched MEMBER ns.b — silence is not deletion")
+  ;; ns.b's file is deleted → authoritative membership drops it
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :a 111)
+  (build/finish-build! :app '#{ns.a})
+  (is (= {:a 111} (build/aggregate ::probe :app))
+      "the deleted ns.b is evicted by authoritative membership, on any pass"))
+
+(deftest aborted-pass-publishes-last-known-good
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :good 1)
+  (build/commit-build! :app)
+  (is (= {:good 1} (build/aggregate ::probe :app)))
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :bad 2)         ; a doomed pass
+  (build/contribute! ::probe 'ns.b :partial 3)
+  (is (= {:bad 2 :partial 3} (build/aggregate ::probe :app))
+      "the open pass's staging is visible mid-pass")
+  (build/abort-build! :app)                        ; compile failed → skip commit
+  (is (= {:good 1} (build/aggregate ::probe :app))
+      "abort discards the partial staging and republishes last-known-good"))
+
+(deftest begin-discards-a-failed-passes-staging
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :ok 1)
+  (build/commit-build! :app)
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :doomed 2)      ; compile throws — no commit
+  (build/begin-build! :app)                        ; shadow ran no :compile-finish
+  (build/contribute! ::probe 'ns.a :retry 1)
+  (build/commit-build! :app)
+  (is (= {:retry 1} (build/aggregate ::probe :app))
+      "the failed pass's staging was discarded at the next begin; the retry converges"))
+
+(deftest repl-eval-upserts-committed-without-a-pass
+  ;; No begin-build! → no pass → each contribution UPSERTS one key straight
+  ;; into committed, with NO sibling eviction (the RULED REPL posture).
+  (build/contribute! ::probe 'ns.a :x 1)
+  (build/contribute! ::probe 'ns.a :y 2)
+  (is (= {:x 1 :y 2} (build/aggregate ::probe)) "both keys upserted (no pass, ::default build)")
+  (build/contribute! ::probe 'ns.a :x 10)          ; a bare REPL re-eval of one form
+  (is (= {:x 10 :y 2} (build/aggregate ::probe))
+      "a REPL re-eval upserts the one key — :y is NOT evicted (no begin/commit cycle)")
+  (is (false? (build/pass-open?)) "no pass was ever opened"))
+
+;; ---------------------------------------------------------------------------
+;; MULTI-BUILD ISOLATION — the headline regression (rf2-df9873)
+;; ---------------------------------------------------------------------------
+
+(deftest interleaved-builds-do-not-wipe-each-others-registries
+  ;; ONE JVM compiling `re-frame.ui` for two builds. The prior model held a
+  ;; single GLOBAL build-id and WIPED on switch, so opening the node-test
+  ;; pass BETWEEN app's two root registrations would erase app's first root —
+  ;; regressing app's own cross-file duplicate detection. Per-build slices
+  ;; make the builds independent by construction.
+  (build/begin-build! :app)
   (build/begin-build! :node-test)
-  (is (= {} @probe) "switching build-id starts an isolated (wiped) slice")
-  (build/contribute! ::probe "a.cljs" :y 2)
-  (is (= {:y 2} @probe) "the :app rows never reach the :node-test build"))
+  (binding [build/*build-id* :app]
+    (root/register-root-site! 'ui/mount :page/one :authored 'app.a
+                              {:file "app/a.cljs" :line 1}))
+  ;; the node-test build compiles the SAME namespaces — its :page/one is a
+  ;; different build's row, must not touch app's slice
+  (binding [build/*build-id* :node-test]
+    (root/register-root-site! 'ui/mount :page/one :authored 'ntest.x
+                              {:file "app/a.cljs" :line 1}))
+  (binding [build/*build-id* :app]
+    (root/register-root-site! 'ui/mount :page/two :authored 'app.b
+                              {:file "app/b.cljs" :line 1}))
+  (is (= #{:page/one :page/two}
+         (set (keys (build/aggregate build/roots :app))))
+      "app keeps BOTH roots despite the interleaved node-test build (no wipe)")
+  (is (= #{:page/one}
+         (set (keys (build/aggregate build/roots :node-test))))
+      "the node-test slice is isolated — app's rows never reach it")
+  (testing "app STILL detects its own cross-namespace duplicate"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (binding [build/*build-id* :app]
+                   (root/register-root-site! 'ui/mount :page/one :authored 'app.c
+                                             {:file "app/c.cljs" :line 1})))
+        "a genuine duplicate in app fires — the interleaved build did not erase :page/one")))
+
+(deftest real-defview-contributions-are-isolated-per-build
+  ;; drive the REAL defview macro body under two build ids
+  (binding [build/*build-id* :app]       (declare-view! 'app.a 'foo [:div "foo"]))
+  (binding [build/*build-id* :node-test] (declare-view! 'app.a 'bar [:section "bar"]))
+  (is (contains? (build/aggregate build/views :app) :app.a/foo)
+      "the app build keeps its view")
+  (is (contains? (build/aggregate build/views :node-test) :app.a/bar)
+      "the node-test build keeps its view")
+  (is (not (contains? (build/aggregate build/views :app) :app.a/bar))
+      "the node-test build's view never reaches the app slice")
+  (is (not (contains? (build/aggregate build/views :node-test) :app.a/foo))
+      "and vice versa"))
+
+(deftest builds-are-isolated-per-build-id
+  (build/begin-build! :app)
+  (build/contribute! ::probe 'ns.a :x 1)
+  (is (= {:x 1} (build/aggregate ::probe :app)))
+  (build/begin-build! :node-test)
+  (is (= {} (build/aggregate ::probe :node-test))
+      "opening the node-test slice does NOT wipe :app")
+  (build/contribute! ::probe 'ns.a :y 2)          ; ambient = session-build = :node-test
+  (is (= {:y 2} (build/aggregate ::probe :node-test)))
+  (is (= {:x 1} (build/aggregate ::probe :app))
+      "the :app slice is untouched by the node-test build"))
+
+;; ---------------------------------------------------------------------------
+;; ATOMICITY under simulated parallel compilation
+;; ---------------------------------------------------------------------------
+
+(deftest register-root-site-is-atomic-under-parallel-writes
+  ;; No lost writes: two builds × N distinct roots, hammered concurrently,
+  ;; ALL land — the one-atom transition has no check-then-assoc gap that a
+  ;; separate-atoms model would drop under contention.
+  (build/begin-build! :app)
+  (build/begin-build! :node-test)
+  (let [n 150
+        futs (doall
+              (for [b [:app :node-test], i (range n)]
+                (future
+                  (binding [build/*build-id* b]
+                    (root/register-root-site!
+                     'ui/mount (keyword "page" (str (name b) "-" i))
+                     :authored (symbol (str "ns." (name b) "." i))
+                     {:file (str (name b) "-" i ".cljs") :line 1})))))]
+    (run! deref futs)
+    (build/commit-build! :app)
+    (build/commit-build! :node-test)
+    (is (= n (count (build/aggregate build/roots :app)))
+        "every concurrent :app write landed — no TOCTOU drop")
+    (is (= n (count (build/aggregate build/roots :node-test)))
+        "every concurrent :node-test write landed, isolated from :app")))
+
+(deftest concurrent-duplicate-root-resolves-to-exactly-one
+  ;; N threads race to register the SAME root-id from distinct namespaces into
+  ;; one build. The atomic transition guarantees exactly one winner and every
+  ;; other thread sees the duplicate — no interleaving lets two through.
+  (build/begin-build! :app)
+  (let [n 40
+        outcomes
+        (->> (for [i (range n)]
+               (future
+                 (binding [build/*build-id* :app]
+                   (try
+                     (root/register-root-site! 'ui/mount :page/dup :authored
+                                               (symbol (str "ns.dup." i))
+                                               {:file (str "dup-" i ".cljs") :line 1})
+                     :ok
+                     (catch clojure.lang.ExceptionInfo e
+                       (:rf.error/id (ex-data e)))))))
+             doall
+             (map deref))]
+    (build/commit-build! :app)
+    (is (= 1 (count (filter #{:ok} outcomes)))
+        "exactly one concurrent registrant wins")
+    (is (= (dec n) (count (filter #{:rf.error/duplicate-root-id} outcomes)))
+        "every other thread sees the atomic duplicate")
+    (is (= 1 (count (build/aggregate build/roots :app)))
+        "exactly one root is committed")))
 
 ;; ---------------------------------------------------------------------------
 ;; Integration — clean-vs-incremental parity across all five registries
 ;; ---------------------------------------------------------------------------
 
-(defn- declare-edited-source!
-  "The EDITED file app/a.cljs: a renamed view, a different root + frame plan,
-  a renamed custom-element (the original declared `foo` / :page/shop / :shop
-  / :x-el)."
-  []
-  (declare-view! "app/a.cljs" 'bar [:section "bar"])
-  (mount-site!   "app/a.cljs"
-                 '[frame-root {:id :cart :initial-events [[:cart/boot]]}
-                   [app-view {:promo :winter}]]
-                 {:root-id :page/cart})
-  (declare-element! "app/a.cljs" :y-el #{:label}))
+(defn- declare-edited-source! []
+  ;; the EDITED namespace app.a: a renamed view, a different root + frame
+  ;; plan, a renamed custom-element (originally foo / :page/shop / :shop / :x-el)
+  (declare-view!   'app.a 'bar [:section "bar"])
+  (mount-site!     'app.a "app/a.cljs"
+                   '[frame-root {:id :cart :initial-events [[:cart/boot]]}
+                     [app-view {:promo :winter}]]
+                   {:root-id :page/cart})
+  (declare-element! 'app.a :y-el #{:label}))
 
 (deftest incremental-edit-equals-clean-build
-  ;; 1) the ORIGINAL source A, built in this JVM
+  ;; 1) the ORIGINAL namespace app.a, built in this JVM
   (build/begin-build! :app)
-  (declare-view! "app/a.cljs" 'foo [:div "foo"])
-  (mount-site!   "app/a.cljs"
-                 '[frame-root {:id :shop :initial-events [[:shop/boot]]}
-                   [app-view {:promo :spring}]]
-                 {:root-id :page/shop})
-  (declare-element! "app/a.cljs" :x-el #{:help-text})
-  ;; 2) EDIT the same file in the SAME JVM (no restart) — incremental rebuild
+  (declare-view!   'app.a 'foo [:div "foo"])
+  (mount-site!     'app.a "app/a.cljs"
+                   '[frame-root {:id :shop :initial-events [[:shop/boot]]}
+                     [app-view {:promo :spring}]]
+                   {:root-id :page/shop})
+  (declare-element! 'app.a :x-el #{:help-text})
+  (build/commit-build! :app)
+  ;; 2) EDIT app.a in the SAME JVM (no restart) — incremental rebuild
   (build/begin-build! :app)
   (declare-edited-source!)
+  (build/commit-build! :app)
   (let [incremental (snapshot)]
-    ;; 3) a CLEAN-process build of the edited source (fresh slice)
+    ;; 3) a CLEAN-process build of the edited namespace (fresh authority)
     (build/reset-build!)
     (build/begin-build! :app)
     (declare-edited-source!)
+    (build/commit-build! :app)
     (let [clean (snapshot)]
       (is (= clean incremental)
           "incremental output after edit/rename/delete EQUALS a clean build")
@@ -210,84 +390,82 @@
 ;; ---------------------------------------------------------------------------
 ;; The descriptor :build-digest is a READ-TIME projection (rf2-vxgfnd.47) —
 ;; compile-order independent + never stale under an incremental view edit.
-;; The prior harness hand-built digest-free descriptors, masking both.
 ;; ---------------------------------------------------------------------------
 
 (deftest descriptor-digest-is-compile-order-independent-and-covers-all-views
   ;; ORDER 1: the mount site expands BEFORE the rest of the build's views
-  ;; compile. Baked-at-expansion would freeze its descriptor digest over only
-  ;; a-view; the read-time projection reads the WHOLE-build digest.
   (build/begin-build! :app)
-  (declare-view! "app/a.cljs" 'a-view [:div "a"])
-  (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
-  (declare-view! "app/b.cljs" 'b-view [:section "b"])
+  (declare-view! 'app.a 'a-view [:div "a"])
+  (mount-site!   'app.m "app/m.cljs" '[app-view {}] {:root-id :page/m})
+  (declare-view! 'app.b 'b-view [:section "b"])
+  (build/commit-build! :app)
   (let [digest-1 (get-in (root/descriptor-index) [:page/m :build-digest])]
     (is (= (compiler/current-build-digest) digest-1)
-        "the descriptor digest reflects ALL build views (a-view AND b-view),
-         not only those compiled before the mount site expanded")
-    ;; ORDER 2: same two views, but the mount site expands LAST.
+        "the descriptor digest reflects ALL build views (a-view AND b-view)")
+    ;; ORDER 2: same two views, but the mount site expands LAST
     (build/reset-build!)
     (build/begin-build! :app)
-    (declare-view! "app/b.cljs" 'b-view [:section "b"])
-    (declare-view! "app/a.cljs" 'a-view [:div "a"])
-    (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
+    (declare-view! 'app.b 'b-view [:section "b"])
+    (declare-view! 'app.a 'a-view [:div "a"])
+    (mount-site!   'app.m "app/m.cljs" '[app-view {}] {:root-id :page/m})
+    (build/commit-build! :app)
     (is (= digest-1 (get-in (root/descriptor-index) [:page/m :build-digest]))
-        "same whole-build digest whether the mount site expands first or last
-         (compile-order independent — .16 AC7)")))
+        "same whole-build digest whether the mount site expands first or last")))
 
 (deftest descriptor-digest-tracks-an-incremental-view-only-edit
-  ;; A mount site in m.cljs + a view in v.cljs.
   (build/begin-build! :app)
-  (mount-site!   "app/m.cljs" '[app-view {}] {:root-id :page/m})
-  (declare-view! "app/v.cljs" 'v-view [:div "one"])
+  (mount-site!   'app.m "app/m.cljs" '[app-view {}] {:root-id :page/m})
+  (declare-view! 'app.v 'v-view [:div "one"])
+  (build/commit-build! :app)
   (let [d1 (get-in (root/descriptor-index) [:page/m :build-digest])]
     (is (= (compiler/current-build-digest) d1))
-    ;; INCREMENTAL pass: recompile ONLY the view file (its template changes).
-    ;; The mount site is NOT re-expanded — under baked-at-expansion its stored
-    ;; descriptor would keep the OLD digest; the read-time projection tracks
-    ;; the new whole-build digest.
+    ;; INCREMENTAL pass: recompile ONLY the view file. The mount site is NOT
+    ;; re-expanded — under baked-at-expansion its descriptor would keep the OLD
+    ;; digest; the read-time projection tracks the new whole-build digest.
     (build/begin-build! :app)
-    (declare-view! "app/v.cljs" 'v-view [:div "two"])
+    (declare-view! 'app.v 'v-view [:div "two"])
+    (build/commit-build! :app)
     (let [d2 (get-in (root/descriptor-index) [:page/m :build-digest])]
-      (is (not= d1 d2)
-          "the view edit changed the whole-build digest")
+      (is (not= d1 d2) "the view edit changed the whole-build digest")
       (is (= (compiler/current-build-digest) d2)
-          "the un-re-expanded mount-site descriptor reads the CURRENT digest,
-           not a stale expansion-time snapshot (rf2-vxgfnd.47)"))))
+          "the un-re-expanded mount-site descriptor reads the CURRENT digest (rf2-vxgfnd.47)"))))
 
-(deftest repeated-rebuilds-stay-bounded-without-a-reset
-  ;; AC6: correctness across a watch session needs NO test-only global reset —
-  ;; re-declaring the same file N times replaces (never grows).
+(deftest repeated-rebuilds-stay-bounded
+  ;; correctness across a watch session — re-declaring the same namespace N
+  ;; times replaces (never grows).
   (dotimes [_ 25]
     (build/begin-build! :app)
-    (declare-view! "app/a.cljs" 'only [:div "only"])
-    (mount-site! "app/a.cljs" '[app-view {}] {:root-id :page/shop}))
-  (is (= 1 (count @compiler/build-views)) "views bounded across repeated rebuilds")
-  (is (= #{:page/shop} (set (keys @root/build-roots))) "roots bounded")
-  (is (= #{:page/shop} (set (keys @root/build-descriptors))) "descriptors bounded"))
+    (declare-view! 'app.a 'only [:div "only"])
+    (mount-site!   'app.a "app/a.cljs" '[app-view {}] {:root-id :page/shop})
+    (build/commit-build! :app))
+  (is (= 1 (count (build/aggregate build/views :app))) "views bounded across repeated rebuilds")
+  (is (= #{:page/shop} (set (keys (root/build-roots)))) "roots bounded")
+  (is (= #{:page/shop} (set (keys (build/aggregate build/descriptors :app)))) "descriptors bounded"))
 
 ;; ---------------------------------------------------------------------------
-;; The false cross-file duplicate/conflict from a DELETED site (bead §Steps)
+;; The false cross-file duplicate/conflict from a DELETED site
 ;; ---------------------------------------------------------------------------
 
 (deftest deleted-root-site-does-not-falsely-duplicate-a-later-file
-  ;; original: a.cljs mounts :page/shop
-  (build/begin-build!)
-  (root/register-root-site! 'ui/mount :page/shop :authored {:file "a.cljs" :line 1})
-  ;; edit a.cljs: the :page/shop site is DELETED (a.cljs now mounts :page/cart)
-  (build/begin-build!)
-  (root/register-root-site! 'ui/mount :page/cart :authored {:file "a.cljs" :line 1})
-  ;; b.cljs legitimately takes over the now-free :page/shop — the deleted
-  ;; a.cljs site must NOT raise a false :rf.error/duplicate-root-id
-  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored
+  ;; original: app.a mounts :page/shop
+  (build/begin-build! :app)
+  (root/register-root-site! 'ui/mount :page/shop :authored 'app.a {:file "a.cljs" :line 1})
+  (build/commit-build! :app)
+  ;; edit app.a: the :page/shop site is DELETED (app.a now mounts :page/cart)
+  (build/begin-build! :app)
+  (root/register-root-site! 'ui/mount :page/cart :authored 'app.a {:file "a.cljs" :line 1})
+  ;; app.b legitimately takes over the now-free :page/shop — the deleted
+  ;; app.a site must NOT raise a false :rf.error/duplicate-root-id
+  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored 'app.b
                                       {:file "b.cljs" :line 1}))
-      "a deleted root site cannot fail a later file (rf2-vxgfnd.16)")
-  (is (= #{:page/cart :page/shop} (set (keys @root/build-roots)))))
+      "a deleted root site cannot fail a later file (rf2-df9873)")
+  (build/commit-build! :app)
+  (is (= #{:page/cart :page/shop} (set (keys (root/build-roots))))))
 
 (deftest genuine-current-cross-file-duplicate-still-fails
-  (build/begin-build!)
-  (root/register-root-site! 'ui/mount :page/dup :authored {:file "a.cljs" :line 1})
-  (let [ex (try (root/register-root-site! 'ui/mount :page/dup :authored
+  (build/begin-build! :app)
+  (root/register-root-site! 'ui/mount :page/dup :authored 'app.a {:file "a.cljs" :line 1})
+  (let [ex (try (root/register-root-site! 'ui/mount :page/dup :authored 'app.b
                                           {:file "b.cljs" :line 2})
                 nil (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "two LIVE sites for one root-id still fail the build")
@@ -295,49 +473,53 @@
     (is (= 2 (count (:sites (ex-data ex)))) "both current sites named with coords")))
 
 (deftest deleted-frame-plan-does-not-falsely-conflict-a-later-file
-  ;; original: a.cljs carries a :shop plan
-  (build/begin-build!)
+  ;; original: app.a carries a :shop plan
+  (build/begin-build! :app)
   (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
-                            {:file "a.cljs" :line 1})
-  (is (contains? @root/build-plans :shop))
-  ;; edit a.cljs: the :shop plan is DELETED — a.cljs now declares only a root
-  ;; (it no longer touches the plan registry at all). Opening a.cljs must
-  ;; still evict its stale :shop plan (cross-registry sweep).
-  (build/begin-build!)
-  (root/register-root-site! 'ui/mount :page/a :authored {:file "a.cljs" :line 1})
-  (is (not (contains? @root/build-plans :shop))
-      "opening the recompiled a.cljs evicted its dropped :shop plan")
-  ;; b.cljs now carries :shop with a DIFFERENT fingerprint — no false conflict
+                            'app.a {:file "a.cljs" :line 1})
+  (is (contains? (root/build-plans) :shop))
+  (build/commit-build! :app)
+  ;; edit app.a: the :shop plan is DELETED — app.a now declares only a root
+  ;; (it no longer touches the plan registry at all). Re-touching app.a must
+  ;; still evict its stale :shop plan (cross-registry sweep at commit).
+  (build/begin-build! :app)
+  (root/register-root-site! 'ui/mount :page/a :authored 'app.a {:file "a.cljs" :line 1})
+  (is (not (contains? (root/build-plans) :shop))
+      "re-touching the recompiled app.a evicted its dropped :shop plan")
+  ;; app.b now carries :shop with a DIFFERENT fingerprint — no false conflict
   (is (nil? (root/register-plan-site! 'ui/mount
                                       {:frame-id :shop :config-fingerprint "cf1-b"}
-                                      {:file "b.cljs" :line 1}))
-      "a deleted plan cannot fail a later file's differing plan (rf2-vxgfnd.16)")
-  (is (= "cf1-b" (:config-fingerprint (get @root/build-plans :shop)))))
+                                      'app.b {:file "b.cljs" :line 1}))
+      "a deleted plan cannot fail a later file's differing plan (rf2-df9873)")
+  (build/commit-build! :app)
+  (is (= "cf1-b" (:config-fingerprint (get (root/build-plans) :shop)))))
 
 (deftest genuine-current-cross-file-plan-conflict-still-fails
-  (build/begin-build!)
+  (build/begin-build! :app)
   (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
-                            {:file "a.cljs" :line 1})
+                            'app.a {:file "a.cljs" :line 1})
   (let [ex (try (root/register-plan-site! 'ui/mount
                                           {:frame-id :shop :config-fingerprint "cf1-b"}
-                                          {:file "b.cljs" :line 2})
+                                          'app.b {:file "b.cljs" :line 2})
                 nil (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "two LIVE differing plans for one frame still fail the build")
     (is (= :rf.error/frame-payload-conflict (:rf.error/id (ex-data ex))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Custom-element declaration removal clears stale property classification
-;; (AC5, compile side)
+;; (AC5, compile side — read through the JVM mirror `rules/custom-elements`)
 ;; ---------------------------------------------------------------------------
 
 (deftest removed-custom-element-clears-stale-property-classification
   (build/begin-build! :app)
-  (declare-element! "app/a.cljs" :x-el #{:help-text})
+  (declare-element! 'app.a :x-el #{:help-text})
+  (build/commit-build! :app)
   (is (= #{:help-text} (rules/custom-element-properties :x-el))
       "the declaration classifies :help-text as a property")
-  ;; edit a.cljs: :x-el renamed to :y-el (its declaration deleted)
+  ;; edit app.a: :x-el renamed to :y-el (its declaration deleted)
   (build/begin-build! :app)
-  (declare-element! "app/a.cljs" :y-el #{:label})
+  (declare-element! 'app.a :y-el #{:label})
+  (build/commit-build! :app)
   (is (= #{} (rules/custom-element-properties :x-el))
       "the removed :x-el no longer classifies any property (was leaking)")
   (is (= #{:label} (rules/custom-element-properties :y-el))

--- a/implementation/ui/test/re_frame/ui/root_mount_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/root_mount_jvm_test.clj
@@ -2,9 +2,10 @@
   "S1c Layer-1 (build-tier) duplicate/conflict detection + the
   client-entry host guard (rf2-vxgfnd.3). The Layer-1 indexes live in
   `re-frame.ui.compiler.root` and are exercised directly — the
-  whole-build scoping with same-file replacement tolerance ([S1-CONFIRM]
-  item 3, resolved in the ns docstring there). The mount-surface macros
-  are CLIENT entry points: expanding them for the JVM host is the
+  whole-build scoping with same-NAMESPACE replacement tolerance
+  ([S1-CONFIRM] item 3, resolved in the ns docstring there; the ledger is
+  keyed by declaring ns-sym per rf2-df9873). The mount-surface macros are
+  CLIENT entry points: expanding them for the JVM host is the
   `:rf.ui.compile/client-entry-on-jvm` compile error, pinned here via
   `macroexpand`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -29,11 +30,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest cross-file-duplicate-root-id-fails-the-build
-  (root/register-root-site! 'ui/mount :page/shop :authored
+  (root/register-root-site! 'ui/mount :page/shop :authored 'app.entry
                             {:file "app/entry.cljs" :line 10})
   (let [{:keys [id msg data]}
         (thrown-error
-         #(root/register-root-site! 'ui/mount :page/shop :authored
+         #(root/register-root-site! 'ui/mount :page/shop :authored 'app.other
                                     {:file "app/other.cljs" :line 4}))]
     (is (= :rf.error/duplicate-root-id id))
     (is (error/message-has-id-token? msg)
@@ -43,29 +44,29 @@
         "the data map names both parties with source coordinates")))
 
 (deftest both-derived-duplicate-names-the-fix
-  (root/register-root-site! 'ui/mount :app.views/app :derived
+  (root/register-root-site! 'ui/mount :app.views/app :derived 'app.a
                             {:file "app/a.cljs" :line 1})
   (let [{:keys [msg]}
         (thrown-error
-         #(root/register-root-site! 'ui/mount :app.views/app :derived
+         #(root/register-root-site! 'ui/mount :app.views/app :derived 'app.b
                                     {:file "app/b.cljs" :line 1}))]
     (is (re-find #"add :disambiguator or author :root-id" msg)
         "the contract-pinned didactic fix when both ids are derived")))
 
-(deftest same-file-re-registration-replaces
-  (root/register-root-site! 'ui/mount :page/shop :authored
+(deftest same-namespace-re-registration-replaces
+  (root/register-root-site! 'ui/mount :page/shop :authored 'app.entry
                             {:file "app/entry.cljs" :line 10})
-  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored
+  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored 'app.entry
                                       {:file "app/entry.cljs" :line 22}))
       "watch-mode re-expansion tolerance — a moved line is not a second site")
-  (is (= 22 (:line (get @root/build-roots :page/shop)))))
+  (is (= 22 (:line (get (root/build-roots) :page/shop)))))
 
 (deftest distinct-root-ids-coexist
-  (root/register-root-site! 'ui/mount :page/shop :authored
+  (root/register-root-site! 'ui/mount :page/shop :authored 'app.a
                             {:file "a.cljs" :line 1})
-  (is (nil? (root/register-root-site! 'ui/mount :page/cart :authored
+  (is (nil? (root/register-root-site! 'ui/mount :page/cart :authored 'app.b
                                       {:file "b.cljs" :line 1})))
-  (is (= #{:page/shop :page/cart} (set (keys @root/build-roots)))))
+  (is (= #{:page/shop :page/cart} (set (keys (root/build-roots))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — frame-plan index
@@ -74,33 +75,33 @@
 (deftest matching-plan-fingerprints-are-idempotent
   (root/register-plan-site! 'ui/mount
                             {:frame-id :shop :config-fingerprint "cf1-aaaa"}
-                            {:file "a.cljs" :line 1})
+                            'app.a {:file "a.cljs" :line 1})
   (is (nil? (root/register-plan-site!
              'ui/mount {:frame-id :shop :config-fingerprint "cf1-aaaa"}
-             {:file "b.cljs" :line 9}))
+             'app.b {:file "b.cljs" :line 9}))
       "matching fingerprint = the ratified idempotent no-op"))
 
 (deftest cross-file-plan-fingerprint-conflict-fails-the-build
   (root/register-plan-site! 'ui/mount
                             {:frame-id :shop :config-fingerprint "cf1-aaaa"}
-                            {:file "a.cljs" :line 1})
+                            'app.a {:file "a.cljs" :line 1})
   (let [{:keys [id data]}
         (thrown-error
          #(root/register-plan-site!
            'ui/mount {:frame-id :shop :config-fingerprint "cf1-bbbb"}
-           {:file "b.cljs" :line 9}))]
+           'app.b {:file "b.cljs" :line 9}))]
     (is (= :rf.error/frame-payload-conflict id))
     (is (= ["cf1-aaaa" "cf1-bbbb"] (:fingerprints data)))))
 
-(deftest same-file-plan-change-replaces
+(deftest same-namespace-plan-change-replaces
   (root/register-plan-site! 'ui/mount
                             {:frame-id :shop :config-fingerprint "cf1-aaaa"}
-                            {:file "a.cljs" :line 1})
+                            'app.a {:file "a.cljs" :line 1})
   (is (nil? (root/register-plan-site!
              'ui/mount {:frame-id :shop :config-fingerprint "cf1-cccc"}
-             {:file "a.cljs" :line 1}))
+             'app.a {:file "a.cljs" :line 1}))
       "editing a plan's config in place is a replacement, not a conflict")
-  (is (= "cf1-cccc" (:config-fingerprint (get @root/build-plans :shop)))))
+  (is (= "cf1-cccc" (:config-fingerprint (get (root/build-plans) :shop)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The client-entry host guard


### PR DESCRIPTION
Implements the ruled **Option A** for rf2-df9873: re-key ALL build-scoped
compiler state per shadow build id, with explicit begin/commit/abort pass
boundaries and last-known-good publication. Closes the headline regression —
one daemon compiling `re-frame.ui` for `:node-test` / `:node-test-ui` /
`:ui-bench` no longer lets those builds wipe each other's registries.

## How the ruling landed

**Build identity from the compiler env, not a hook.** A contribution's owning
build is read ambiently from the per-thread CLJS compiler env
(`cljs.env/*compiler*` → `:shadow.build.cljs-bridge/state` →
`:shadow.build/build-id`), pinned behind one fn so a shadow upgrade breaks
loudly. Correct even under shadow's default parallel compile (each build's
analysis threads carry that build's compiler env). Outside a real compile
(REPL, plain-JVM `clojure -M:test`) identity falls back to the last
`begin-build!` id, then `::default`; `*build-id*` pins it for tests. Hooks own
only pass boundaries — never identity.

**One atom, pure transitions.** `build.cljc` collapses the four ledger atoms +
the registered aggregate atoms into ONE atom `{build-id → slice}` where a
slice is `{:pass-open? :committed :staged :touched}`. A registry's observable
aggregate is the *effective* view (committed rows of untouched sources +
staged rows of sources that re-ran), so a source's whole prior contribution is
superseded the moment it re-declares, and an aborted pass republishes the
committed last-known-good untouched.

**Pass boundaries with last-known-good.** `begin-build!` opens a pass and
discards any staging a failed prior pass left; `commit-build!` folds
staged→committed (touched sources replace or evict); `reconcile!` /
`finish-build!` drop deleted sources (by touched-set / authoritative
`:build-sources` membership); `abort-build!` discards staging and keeps
committed. **REPL amended:** with no pass open a contribution upserts one key
straight into committed — no begin/commit cycle, no sibling eviction.

**Atomicity.** `register-root-site!` / `register-plan-site!` do their
check-then-write inside ONE `swap!` transition (`contribute-checked!`), so
parallel namespace compilation can neither drop a concurrent write
(check-then-assoc race) nor miss a genuine duplicate. The ledger is keyed by
declaring **ns-sym** (matching the runtime arm's `[build-id ns-sym]`);
file/line live in error coords only, dissolving the REPL pseudo-file false
duplicate and the Windows path-normalization risk. The compile-time
custom-element registry keeps an external mirror atom (`rules/custom-elements`,
unchanged) for the JVM tree builder's read.

**`:cache-blockers #{re-frame.ui}` (HOT ZONE `shadow-cljs.edn`).** Added via a
top-level `:build-defaults`. Non-negotiable: shadow's resource cache skips
macroexpansion for a cached namespace, so without it the registries are
incomplete on every warm-cache daemon start. Cost: defview/mount-consuming
namespaces recompile on daemon start; warm-watch incrementals are unaffected.

The runtime arm (`rules.cljc` element ledger) is the model this compile side
converges on — read, not changed.

## Multi-build-wipe regression

`interleaved-builds-do-not-wipe-each-others-registries` opens two build
passes, registers roots across both interleaved, and asserts each build keeps
its own roots **simultaneously** plus its own duplicate detection — an outcome
the prior single global-slice + wipe-on-switch model was structurally unable
to represent. `real-defview-contributions-are-isolated-per-build` drives the
real `defview` macro under two build ids for the same guarantee.

## Scope note

Per the ruling's PR split, this PR is the **authority + pass-boundary fns +
`:cache-blockers`**. The thin shadow `:build-hooks` adapter that calls
`begin-build!` / `finish-build!` / `abort-build!` at `:compile-prepare` /
`:compile-finish` / `:flush` is a small follow-up (JVM-side hook ns + one
`:build-defaults {:build-hooks …}` line); the pass-boundary semantics it wires
are already implemented and test-driven here (`finish-build!` is the hook's
whole-build primitive). Multi-build isolation is delivered *now* via
ambient-identity — contributions during macroexpansion already read the
correct build id from the compiler env, independent of any hook.

## Quality gates

All foreground, 0-fail:

- `clojure -M:test` (ui artefact): **293 tests, 4667 assertions, 0 failures, 0 errors**
- `npm run test:ui` (focused shadow node-test-ui, cache-blockers active): **276 tests, 1467 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full repo compile + node suite): **9024 tests, 42612 assertions, 0 failures, 0 errors**
- `npx shadow-cljs compile ui-bench` (`:advanced` release incl. re-frame.ui): Build completed, 0 errors
- `npm run test:elision`: PASS (48/48 absent, control 48/48 present)
