### PR TITLE
fix(machines): reap already-terminal spawn-all children without a duplicate cancellation reply (rf2-tj3l6a)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -307,15 +307,41 @@
   teardown projection, registrar cleanup, and `spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
 
-  See Spec 005 §Destroy is silent-idempotent for the normative paragraph."
+  See Spec 005 §Destroy is silent-idempotent for the normative paragraph.
+
+  ## The reap form (rf2-tj3l6a)
+
+  A THIRD arg shape — the map `{:rf/actor-id <id> :rf/reason <reason>}` —
+  is the DIRECT-actor REAP form the `:spawn-all` join uses to tear down an
+  ALREADY-TERMINAL child at resolution. Unlike the imperative keyword form,
+  it carries the destroy `:reason` explicitly so `emit-destroyed!` stamps a
+  NON-cancellation reason (`:rf.machine/join-reaped`) and therefore attaches
+  NO cancelled reply facts — the reaped child already has a closed terminal
+  status (its `join-child-reply` `:completed` / `:failed`), so a
+  `:cancelled` teardown reply would be a SECOND, contradictory terminal for
+  the same work-id. The teardown itself is IDENTICAL to the keyword /
+  imperative destroy (snapshot, timers, resource leases, spawn-order removal);
+  only the reply-emitting reason differs. Distinct from the tracked map form:
+  the reap carries the actor-id DIRECTLY (a `:spawn-all` child's join slot
+  holds the whole join-state map, not a single actor-id, so the
+  slot-resolution the tracked form uses does not apply)."
   [frame-id args]
-  (let [tracked?  (map? args)
+  (let [mapped?   (map? args)
+        ;; The reap form carries the actor-id directly + an explicit
+        ;; non-cancellation `:reason`; the tracked form resolves the actor-id
+        ;; from the `[:spawned parent-id invoke-id]` slot.
+        reap?     (and mapped? (contains? args :rf/actor-id))
+        reason    (if reap? (:rf/reason args :explicit) :explicit)
+        tracked?  (and mapped? (not reap?))
         parent-id (when tracked? (:rf/parent-id args))
         invoke-id (when tracked? (:rf/invoke-id args))
         old-db    (frame/frame-runtime-db-value frame-id)
         slot-id   (when (and tracked? old-db)
                     (get-in old-db (paths/spawned-path parent-id invoke-id)))
-        actor-id  (if tracked? slot-id args)
+        actor-id  (cond
+                    reap?    (:rf/actor-id args)
+                    tracked? slot-id
+                    :else    args)
         ;; Silent-idempotent guard. `live?` is true iff ANY
         ;; liveness signal survives. The first three (registrar entry /
         ;; snapshot present / spawn-order entry) are the resolved-actor-id
@@ -339,21 +365,26 @@
       (teardown-live-actor!
         frame-id actor-id
         {:actor-id actor-id :parent-id parent-id :invoke-id invoke-id}
-        ;; D6 — `:reason :explicit` discriminates "an action / fx
-        ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
-        ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
-        ;; the destroyed-trace-shape contract for the `destroy-single!` site.
-        ;; `released-sid` is the binding the teardown projection released —
-        ;; resolved from the reverse index BEFORE the dissoc, symmetric with
-        ;; `finalize-machine` and with the pre-teardown `old-db` read it
-        ;; replaces (the `:system-ids` index is untouched by the exit cascade
-        ;; / abort / mark-clear / timer-cancel steps, so the value is equal).
+        ;; D6 — `:reason` discriminates "an action / fx tore the actor down"
+        ;; (`:explicit`, a cancellation) from `:rf.machine/finished` (the
+        ;; auto-destroy on `:final?`) and, for the reap form,
+        ;; `:rf.machine/join-reaped` (post-completion cleanup of an
+        ;; already-terminal `:spawn-all` join child — NOT a cancellation, so
+        ;; no second-terminal cancelled reply, rf2-tj3l6a). Always stamp
+        ;; `:system-id` (nil when not bound) per the destroyed-trace-shape
+        ;; contract for the `destroy-single!` site. `released-sid` is the
+        ;; binding the teardown projection released — resolved from the reverse
+        ;; index BEFORE the dissoc, symmetric with `finalize-machine` and with
+        ;; the pre-teardown `old-db` read it replaces (the `:system-ids` index
+        ;; is untouched by the exit cascade / abort / mark-clear / timer-cancel
+        ;; steps, so the value is equal).
         (fn [released-sid]
           (traces/emit-destroyed! {:frame     frame-id
                                    :actor-id  actor-id
                                    :system-id released-sid
                                    :parent-id parent-id
-                                   :invoke-id invoke-id}))))
+                                   :invoke-id invoke-id
+                                   :reason    reason}))))
     nil))
 
 (defn destroy-machine-fx

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -25,8 +25,13 @@
    6. Else evaluates the join condition. The join grammar is a CLOSED
       two-member enum — `:all` (default) + `:any`. On resolution:
         - latches `:resolved?` true,
-        - unconditionally emits per-sibling `:rf.machine/destroy` fx and
-          `:rf.machine.spawn/cancelled-on-join-resolution` traces,
+        - tears down EVERY child: SURVIVORS (never reported completion) via
+          the `:explicit` `:rf.machine/destroy` fx + a
+          `:rf.machine.spawn/cancelled-on-join-resolution` trace each (their
+          teardown IS a cancellation); COMPLETED / FAILED children via the
+          non-cancellation `:rf.machine/join-reaped` reap form (they already
+          closed their attempt as a join-child completion — reaping avoids a
+          second, contradictory terminal reply, rf2-tj3l6a),
         - dispatches the parent join event via `:fx [[:dispatch ...]]`.
    7. Writes the new join state back into runtime-db.
 
@@ -283,12 +288,13 @@
                             reply-facts))))))
 
 (defn- build-resolution-fx
-  "Build the fx vector to fire on resolution: per-survivor
-  `:rf.machine/destroy` (with one
-  `:rf.machine.spawn/cancelled-on-join-resolution` trace each), followed by
-  the join-event dispatch carrying the decisive child's forwarded payload.
-  Cancelling surviving siblings on the join decision is unconditional.
-  Per Spec 005 §Spawn-and-join, the
+  "Build the fx vector to fire on resolution: a `:rf.machine/destroy` per
+  child (survivors via the `:explicit` cancellation form with one
+  `:rf.machine.spawn/cancelled-on-join-resolution` trace each; completed /
+  failed children via the non-cancellation `:rf.machine/join-reaped` reap
+  form — rf2-tj3l6a), followed by the join-event dispatch carrying the
+  decisive child's forwarded payload. Cancelling surviving siblings on the
+  join decision is unconditional. Per Spec 005 §Spawn-and-join, the
   dispatched event shape is:
 
       [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
@@ -345,7 +351,7 @@
                               :rf.reply/cancelled?  (:cancelled? survivor-summary)
                               :rf.reply/cancel-reason (:rf.reply/cancel-reason survivor-summary)
                               :rf.reply/correlation (:correlation survivor-summary)})))
-            ;; Destroy EVERY child of the resolved join — the survivors
+            ;; Tear down EVERY child of the resolved join — the survivors
             ;; (cancelled, traced above) AND the COMPLETED children. A
             ;; `:spawn-all` child's `:on-child-done` / `:on-child-error`
             ;; terminal state is NOT necessarily `:final?`, so a "completed"
@@ -356,13 +362,34 @@
             ;; cascade) — so an INTERNAL/self resolution handler (or a parent
             ;; with no `:on` for the resolution event, which stays in the
             ;; state) leaked all N completed children's
-            ;; snapshots/timers/resources (rf2-qb1j5z). Destroying every child
-            ;; HERE closes that leak regardless of whether the resolution
-            ;; transition exits the state. Destroying an already-torn-down
+            ;; snapshots/timers/resources (rf2-qb1j5z). Tearing down every
+            ;; child HERE closes that leak regardless of whether the resolution
+            ;; transition exits the state. Tearing down an already-torn-down
             ;; child (a `:final?` terminal that already auto-destroyed, or the
             ;; exit-cascade's later sweep) is a silent-idempotent no-op.
-            (mapv (fn [[_ spawned-id]]
-                    [:rf.machine/destroy spawned-id])
+            ;;
+            ;; But the teardown of a COMPLETED child is NOT a cancellation
+            ;; (rf2-tj3l6a). A completed / failed child has ALREADY closed its
+            ;; work attempt as a join-child completion — its `join-child-reply`
+            ;; stamped the closed `:completed` / `:failed` terminal for the
+            ;; canonical `[:rf.work/machine spawned-id invoke-id generation]`.
+            ;; Routing it through the ordinary `:explicit` keyword destroy would
+            ;; make `emit-destroyed!` attach a SECOND, contradictory
+            ;; `:cancelled` terminal for the same work-id, so a work-ledger /
+            ;; Xray projection could not decide whether the child completed,
+            ;; failed, or was cancelled. So split by completion:
+            ;;   - COMPLETED / FAILED children (`completed-ids`) → the direct-
+            ;;     actor REAP form `{:rf/actor-id … :rf/reason
+            ;;     :rf.machine/join-reaped}`, which does the IDENTICAL teardown
+            ;;     but stamps a non-cancellation reason (no second terminal);
+            ;;   - SURVIVORS (never reported completion) → the `:explicit`
+            ;;     keyword destroy, whose cancellation reply is legitimate and
+            ;;     matches the `cancelled-on-join-resolution` trace above.
+            (mapv (fn [[cid spawned-id]]
+                    (if (contains? completed-ids cid)
+                      [:rf.machine/destroy {:rf/actor-id spawned-id
+                                            :rf/reason   :rf.machine/join-reaped}]
+                      [:rf.machine/destroy spawned-id]))
                   children)))
         dispatch-fx
         (when resolution-event

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -34,21 +34,37 @@
   passing the key).
 
   `reason` is the discriminator — `:explicit` for direct-destroy
-  cascades, `:rf.machine/finished` for final-state auto-destroy.
+  cascades, `:rf.machine/finished` for final-state auto-destroy,
+  `:rf.machine/join-reaped` for a `:spawn-all` join reaping an
+  ALREADY-TERMINAL child at resolution (rf2-tj3l6a).
 
-  An `:explicit` destroy is a CANCELLATION of an in-progress actor work
-  attempt (the actor was torn down before reaching a `:final?` leaf), so
-  it closes the work attempt the reply-envelope way: a
+  Only an `:explicit` destroy is a CANCELLATION of an IN-PROGRESS actor work
+  attempt (the actor was torn down before reaching a terminal outcome), so
+  ONLY it closes the work attempt the reply-envelope way: a
   `:status :cancelled` reply (cancellation as DATA, not the absence of a
   reply — Managed-Effects §Cancellation; EP-0011 §Cancellation). The
   reply-envelope facts (`:rf.reply/work-id` keyed on the destroyed actor instance,
   `:rf.reply/status :cancelled`, `:rf.reply/work-status :cancelled`,
   `:rf.reply/cancel-reason`) ride ADDITIVELY so the cancelled completion joins the
   same uniform work/reply row the spawn started, classified the same way
-  the single-`:spawn` `:rf.machine/done` reply is. A `:rf.machine/finished`
-  destroy is NOT a cancellation — the actor already closed its attempt
-  through `finalize-machine`'s `:rf.machine/done` reply — so it carries no
-  cancelled reply facts. The public destroyed-trace shape is unchanged."
+  the single-`:spawn` `:rf.machine/done` reply is.
+
+  A NON-`:explicit` destroy is POST-COMPLETION cleanup, NOT a cancellation,
+  so it carries NO cancelled reply facts (the second-terminal contradiction
+  the `cancelled?` gate below avoids):
+
+    - `:rf.machine/finished` — the actor already closed its attempt through
+      `finalize-machine`'s `:rf.machine/done` reply.
+    - `:rf.machine/join-reaped` — the child already closed its attempt as a
+      `:spawn-all` join-child completion (`join-child-reply`'s
+      `:completed` / `:failed` terminal for the same canonical
+      `[:rf.work/machine spawned-id invoke-id generation]`); its
+      `:on-child-done` / `:on-child-error` terminal state was NOT `:final?`,
+      so it stays a LIVE actor that the join tears down at resolution — but
+      its terminal status is already decided, so re-classifying the teardown
+      as `:cancelled` would emit a SECOND, contradictory terminal (rf2-tj3l6a).
+
+  The public destroyed-trace shape is unchanged."
   [{:keys [frame actor-id system-id parent-id invoke-id child-id reason]
     :or {reason :explicit}
     :as args}]

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -108,12 +108,14 @@
       ;; (3) Reason discriminator always present.
       (is (contains? tags :reason)
           (str label ": :reason discriminator is always emitted"))
-      (is (#{:explicit :rf.machine/finished} (:reason tags))
-          (str label ": :reason is one of :explicit / :rf.machine/finished"))
+      (is (#{:explicit :rf.machine/finished :rf.machine/join-reaped} (:reason tags))
+          (str label ": :reason is one of :explicit / :rf.machine/finished / :rf.machine/join-reaped"))
       ;; An :explicit destroy is a cancellation; it carries the
-      ;; reply-envelope cancellation facts. A :rf.machine/finished destroy is
-      ;; NOT a cancellation (the actor closed through :rf.machine/done) — no
-      ;; cancelled reply facts.
+      ;; reply-envelope cancellation facts. A NON-:explicit destroy is
+      ;; post-completion cleanup, NOT a cancellation, so it carries no
+      ;; cancelled reply facts — :rf.machine/finished (the actor closed
+      ;; through :rf.machine/done) and :rf.machine/join-reaped (an
+      ;; already-terminal :spawn-all join child, rf2-tj3l6a).
       (if (= :explicit (:reason tags))
         (do
           (is (= :cancelled (:rf.reply/status tags))

--- a/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
@@ -214,3 +214,182 @@
                  (:rf.reply/stale-reason (:tags late))))
           (is (some? (:rf.reply/work-id (:tags late)))
               "the suppressed late completion carries the canonical :work/id"))))))
+
+;; ---- rf2-tj3l6a: reap already-terminal join children without a 2nd terminal
+;;
+;; #5763 closed the completed-children lifecycle leak by tearing down EVERY
+;; child at join resolution. But it routed the COMPLETED children through the
+;; ordinary `:explicit` `[:rf.machine/destroy spawned-id]` fx, whose
+;; `emit-destroyed!` treats every explicit destroy as CANCELLATION of an
+;; in-progress actor — so a child that ALREADY closed its attempt as a
+;; `join-child-reply` `:completed` / `:failed` got a SECOND, contradictory
+;; `:cancelled` terminal for the same work-id. #5763's fixture only checked
+;; that snapshots disappear, not the reply facts, so it stayed green.
+;;
+;; These tests group reply facts by `:rf.reply/work-id` (a durable
+;; work-ledger / Xray projection's view) and pin: a completed / failed join
+;; child has EXACTLY ONE terminal work-reply (its completion), never a later
+;; `:cancelled`; a surviving sibling still emits its cancellation. Reverting
+;; the join reap (routing completed children back through the `:explicit`
+;; keyword destroy) fires the "exactly one terminal" assertions.
+
+(defn- work-statuses-for-spawned
+  "Every `:rf.reply/work-status` carried by a captured trace whose
+  `:rf.reply/work-id` names `spawned-id` (its 2nd element — the child's
+  spawned instance address), across ALL trace ops. This is how a durable
+  work-ledger / Xray projection groups one child attempt's terminal reply
+  facts: one child attempt, one work-id (EP-0007). rf2-tj3l6a's contract is
+  that this list holds EXACTLY ONE terminal status for a completed / failed
+  child — never a completion AND a later cancellation."
+  [captured spawned-id]
+  (into []
+        (comp (map :tags)
+              (filter #(= spawned-id (second (:rf.reply/work-id %))))
+              (keep :rf.reply/work-status))
+        @captured))
+
+(def ^:private terminal-work-statuses
+  "The closed TERMINAL work-status set — a child attempt closes on exactly
+  one of these (`:suppressed` is the stale/late non-terminal fold)."
+  #{:completed :failed :cancelled})
+
+(deftest completed-any-child-is-reaped-not-cancelled
+  (testing "rf2-tj3l6a — success-side :any: the decisive COMPLETED child A emits
+            EXACTLY ONE terminal work-reply (:completed) and is NEVER
+            re-classified :cancelled by the join teardown, while the surviving
+            sibling B still emits its cancelled-on-join-resolution cancellation"
+    (let [child  (mk-child :sup/tj-ok :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states
+                  {:idle   {:on {:start :racing}}
+                   ;; NO :on for :race/won → the parent STAYS in :racing when
+                   ;; the :any join resolves (internal/self resolution — the
+                   ;; join reap is the SOLE teardown of the completed child).
+                   :racing {:spawn-all
+                            {:children         [{:id :a :machine-id :tjok/a :start [:set-id :a]}
+                                                {:id :b :machine-id :tjok/b :start [:set-id :b]}]
+                             :join             :any
+                             :on-child-done    :asset/loaded
+                             :on-child-error   :asset/failed
+                             :on-some-complete [:race/won]}}}}]
+      (rf/reg-machine :tjok/a child)
+      (rf/reg-machine :tjok/b child)
+      (rf/reg-machine :sup/tj-ok parent)
+      (mtest/with-trace-capture captured
+        (rf/dispatch-sync [:sup/tj-ok [:start]])
+        (let [ids  (get-in (mtest/runtime-db)
+                           [:rf.runtime/machines :spawned :sup/tj-ok [:racing] :children])
+              a-id (:a ids)
+              b-id (:b ids)]
+          ;; :a completes → the :any join resolves; :b survives.
+          (rf/dispatch-sync [a-id [:go]])
+          (let [a-statuses  (work-statuses-for-spawned captured a-id)
+                a-terminals (filterv terminal-work-statuses a-statuses)
+                b-statuses  (set (work-statuses-for-spawned captured b-id))]
+            ;; A: EXACTLY ONE terminal, :completed — the reap emits NO second
+            ;; (cancellation) terminal. This FIRES on the pre-fix code, where
+            ;; the completed child's :explicit destroy adds a :cancelled
+            ;; terminal for the same work-id.
+            (is (= [:completed] a-terminals)
+                (str "completed child A emits EXACTLY ONE terminal work-reply "
+                     "(:completed), NOT a subsequent :cancelled; saw " a-statuses))
+            (is (not (contains? (set a-statuses) :cancelled))
+                "the completed child A is never classified :cancelled by teardown")
+            ;; B: survivor still closes :cancelled (legitimate cancellation).
+            (is (contains? b-statuses :cancelled)
+                "surviving sibling B still closes :cancelled")
+            (is (not (contains? b-statuses :completed))
+                "surviving sibling B never reported completion")
+            (is (some #(and (= :rf.machine.spawn/cancelled-on-join-resolution
+                               (:operation %))
+                            (= b-id (:spawned-id (:tags %))))
+                      @captured)
+                "surviving sibling B still emits its cancelled-on-join-resolution trace")))))))
+
+(deftest failed-any-child-is-reaped-not-cancelled
+  (testing "rf2-tj3l6a — failure-side :any (:on-any-failed): the decisive FAILED
+            child A emits EXACTLY ONE terminal work-reply (:failed) and is NEVER
+            re-classified :cancelled, while the surviving sibling B still emits
+            its cancellation"
+    (let [child  (mk-child :sup/tj-fail :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states
+                  {:idle   {:on {:start :racing}}
+                   ;; NO :on for :race/lost → the parent STAYS in :racing when
+                   ;; the failure resolves the :any join.
+                   :racing {:spawn-all
+                            {:children         [{:id :a :machine-id :tjf/a :start [:set-id :a]}
+                                                {:id :b :machine-id :tjf/b :start [:set-id :b]}]
+                             :join             :any
+                             :on-child-done    :asset/loaded
+                             :on-child-error   :asset/failed
+                             :on-some-complete [:race/won]
+                             :on-any-failed    [:race/lost]}}}}]
+      (rf/reg-machine :tjf/a child)
+      (rf/reg-machine :tjf/b child)
+      (rf/reg-machine :sup/tj-fail parent)
+      (mtest/with-trace-capture captured
+        (rf/dispatch-sync [:sup/tj-fail [:start]])
+        (let [ids  (get-in (mtest/runtime-db)
+                           [:rf.runtime/machines :spawned :sup/tj-fail [:racing] :children])
+              a-id (:a ids)
+              b-id (:b ids)]
+          ;; :a fails → :on-any-failed resolves the :any join; :b survives.
+          (rf/dispatch-sync [a-id [:fail]])
+          (let [a-statuses  (work-statuses-for-spawned captured a-id)
+                a-terminals (filterv terminal-work-statuses a-statuses)
+                b-statuses  (set (work-statuses-for-spawned captured b-id))]
+            (is (= [:failed] a-terminals)
+                (str "failed child A emits EXACTLY ONE terminal work-reply "
+                     "(:failed), NOT a subsequent :cancelled; saw " a-statuses))
+            (is (not (contains? (set a-statuses) :cancelled))
+                "the failed child A is never classified :cancelled by teardown")
+            (is (contains? b-statuses :cancelled)
+                "surviving sibling B still closes :cancelled")
+            (is (some #(and (= :rf.machine.spawn/cancelled-on-join-resolution
+                               (:operation %))
+                            (= b-id (:spawned-id (:tags %))))
+                      @captured)
+                "surviving sibling B still emits its cancelled-on-join-resolution trace")))))))
+
+(deftest all-join-completed-children-have-consistent-terminals
+  (testing "rf2-tj3l6a — :all join: every completed child has terminal-status
+            consistency — no work-id carries both a completion and a
+            cancellation. There are no survivors in an all-complete, so NO child
+            is spuriously :cancelled; the decisive child closes :completed"
+    (let [child  (mk-child :sup/tj-all :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   ;; NO :on for :hydrate/done → parent STAYS in :hydrating
+                   ;; (internal resolution — the join reap is the sole teardown).
+                   :hydrating {:spawn-all
+                               {:children        [{:id :a :machine-id :tja/a :start [:set-id :a]}
+                                                  {:id :b :machine-id :tja/b :start [:set-id :b]}]
+                                :join            :all
+                                :on-child-done   :asset/loaded
+                                :on-child-error  :asset/failed
+                                :on-all-complete [:hydrate/done]}}}}]
+      (rf/reg-machine :tja/a child)
+      (rf/reg-machine :tja/b child)
+      (rf/reg-machine :sup/tj-all parent)
+      (mtest/with-trace-capture captured
+        (rf/dispatch-sync [:sup/tj-all [:start]])
+        (let [ids  (get-in (mtest/runtime-db)
+                           [:rf.runtime/machines :spawned :sup/tj-all [:hydrating] :children])
+              a-id (:a ids)
+              b-id (:b ids)]
+          ;; :a folds (not resolved), then :b resolves the :all join (decisive).
+          (rf/dispatch-sync [a-id [:go]])
+          (rf/dispatch-sync [b-id [:go]])
+          (let [a-statuses  (set (work-statuses-for-spawned captured a-id))
+                b-terminals (filterv terminal-work-statuses
+                                     (work-statuses-for-spawned captured b-id))]
+            ;; No child is spuriously cancelled — both completed, none survived.
+            (is (not (contains? a-statuses :cancelled))
+                "non-decisive completed child A is reaped, never :cancelled")
+            (is (= [:completed] b-terminals)
+                (str "decisive completed child B closes EXACTLY ONE terminal "
+                     "(:completed), never :cancelled; saw " b-terminals))
+            (is (some #(= :rf.machine.spawn-all/all-completed (:operation %)) @captured)
+                ":all-completed resolution trace fired")))))))


### PR DESCRIPTION
## Problem

#5763 closed the `:spawn-all` completed-children lifecycle leak by tearing down **every** child when a join resolves — including a child that reported completion from a **non-`:final?`** terminal state and therefore stays a live actor. But it routed those completed children through the ordinary `:explicit` `[:rf.machine/destroy spawned-id]` fx.

`lifecycle-fx.traces/emit-destroyed!` treats every `:explicit` destroy as **cancellation of an in-progress actor** and attaches a `cancelled-actor-reply`. For a completed join child, the join interceptor had **already** emitted `join-child-reply` for the same canonical `[:rf.work/machine spawned-id invoke-id generation]` with `:status :ok` / `:completed` (or `:error` / `:failed`). The subsequent destroy therefore emitted a **second, contradictory terminal** — `:status :cancelled` / `:work-status :cancelled` — for the same work-id. A durable work-ledger / Xray projection could not decide whether the decisive child completed, failed, or was cancelled. #5763's fixture only checked that snapshots disappear, not the reply facts, so CI stayed green.

Surviving siblings are different: they never reported completion, so their `:explicit` destroy is a **legitimate** cancellation and must keep the existing `cancelled-on-join-resolution` + destroyed-cancellation behaviour.

## Fix

At join resolution (`join.cljc/build-resolution-fx`), split the per-child teardown by completion:

- **COMPLETED / FAILED children** (`completed-ids`) → reaped via a new direct-actor form `[:rf.machine/destroy {:rf/actor-id spawned-id :rf/reason :rf.machine/join-reaped}]`. The teardown (snapshot, timers, resource leases, spawn-order removal) is **identical** to #5763 — only the reply-emitting reason differs. `:rf.machine/join-reaped` is a **non-cancellation** post-completion cleanup reason (sibling of `:rf.machine/finished`), so `emit-destroyed!` attaches **no** cancelled reply facts. No second terminal; no reintroduced leak.
- **SURVIVORS** (never reported completion) → keep the `:explicit` keyword destroy + the `:rf.machine.spawn/cancelled-on-join-resolution` trace. Their teardown **is** a cancellation.

`destroy.cljc/destroy-single!` gains a third arg shape — the reap form `{:rf/actor-id … :rf/reason …}` — which carries the actor-id directly (a `:spawn-all` child's join slot holds the whole join-state map, not a single actor-id) and threads the reason to `emit-destroyed!`. `emit-destroyed!`'s existing `cancelled? (= reason :explicit)` gate already excludes any non-`:explicit` reason; docstrings updated to name the new reason.

## How reap (completed) is distinguished from cancel (surviving)

`completed-ids = (:done ∪ :failed)` of the resolved join. A child in that set closed its attempt as a join-child completion → reap (no cancellation reply). A child **not** in it is a survivor → `:explicit` cancellation, unchanged.

## Tests

`spawn_all_reply_envelope_test` adds three deftests that group reply facts by `:rf.reply/work-id` (the durable-ledger view) and pin **exactly one terminal work-reply** per completed/failed child, never a later `:cancelled`:

- success-side `:any` — decisive completed child A emits exactly `[:completed]`; survivor B still closes `:cancelled` + emits its `cancelled-on-join-resolution` trace;
- failure-side `:any` (`:on-any-failed`) — decisive failed child A emits exactly `[:failed]`; survivor B cancelled;
- `:all` — no completed child is spuriously `:cancelled`; the decisive child closes exactly `[:completed]`.

Reverting the join reap (routing completed children back through the `:explicit` keyword destroy) fires exactly the six "exactly one terminal / not cancelled" assertions — the survivor-cancellation and resolution-trace assertions stay green, confirming the fix is surgical.

`destroyed_trace_shape_test` widens the pinned `:reason` set to `#{:explicit :rf.machine/finished :rf.machine/join-reaped}` and keeps the non-`:explicit` = no-cancelled-facts invariant.

## Follow-up

The new fx-substrate `:rf.machine/destroyed` `:reason` (`:rf.machine/join-reaped`) needs enumerating in the spec catalogues (005 §D6, 009 §op-type vocabulary + frame-exit reason table, Spec-Schemas `:machine` family) as a non-cancellation reason. Filed as **rf2-280kc2** (spec is hot-zone; dispatch after this merges).

## Quality gates

- Machines JVM `clojure -M:test` (post-rebase): **965 tests, 3075 assertions, 0 failures, 0 errors**
- CLJS node-test `npm run test:cljs`: **9039 tests, 42664 assertions, 0 failures, 0 errors**
- Double-terminal reproduced on pre-fix code (fix reverted): the 6 terminal-consistency assertions fail; then green with the fix.

Closes rf2-tj3l6a.