### PR TITLE
fix(ui): root teardown reaps Activity-hidden cells + order-independent re-entrant flush (rf2-vxgfnd.85, rf2-vxgfnd.86)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -708,40 +708,82 @@
      (record-evidence! cell {:frame-epoch epoch}))
    (enrol-dirty! cell)))
 
-(defn- flush-one!
-  "Clear `cell`'s pending flag and advance its revision once (the caller has
-  already removed it from the registry). No-op when not dirty — idempotent
-  under a concurrent drain.
+(defn- complete-flush!
+  "PHASE 1 of a batch flush (rf2-vxgfnd.86): complete `cell`'s SCHEDULER STATE
+  with NO arbitrary user code — capture the pre-clear DEBUG evidence, clear
+  `:dirty?`/evidence, and advance the revision (WITHOUT notifying listeners yet).
+  No-op / nil when the cell is not dirty. Returns `[cell ev]` for the cell it
+  completed (`ev` nil in production / when the window carried none), else nil.
 
-  SCHEDULER COMPLETION IS ISOLATED FROM THE DEBUG OBSERVER (rf2-vxgfnd.73).
-  The flush COMPLETES first — captures the pre-clear bounded evidence, clears
-  `:dirty?`/evidence, and advances the revision (notifying listeners) — and
-  only THEN hands the captured summary to the installed `evidence-sink` (Xray;
-  rf2-vxgfnd.46), inside a guard. A THROWING sink is a broken DEBUG tool, never
-  an authority over the render correction: its throw is CONTAINED here (caught
-  and returned to `flush-scope!` for one bounded batch diagnostic) so it can
-  neither strand this cell in a dirty-but-unregistered limbo nor abort the
-  batch's remaining cells. Because the flush already cleared `:dirty?` and
-  advanced the revision, a re-entrant sink that re-marks this (or any) cell
-  enrols a FRESH pending window rather than losing the notification. The sink
-  still receives the exact pre-clear bounded summary once per flushed cell.
-  Returns `{:cell cell :error e}` on a contained sink escape (DEV only), else
-  nil; the whole evidence/containment path DCEs under `goog.DEBUG=false`."
+  Splitting completion from notification is the order-independence fix. The batch
+  core runs this over the WHOLE drained batch BEFORE `deliver-flush!` runs ANY
+  listener or evidence-sink, so a re-entrant re-mark (from a phase-2 listener or
+  sink) always finds every drained cell already completed and, seeing a cleared
+  `:dirty?`, enrols a FRESH pending window (next-batch semantics) — independent of
+  set iteration order. Previously each cell was completed-and-notified one at a
+  time, so whether a re-marked cell was already cleared (→ fresh window) or still
+  in the drained-but-uncompleted batch (→ mark lost) depended on hash order."
   [^ViewCell cell]
   (let [st (state cell)]
     (when (:dirty? @st)
-      (let [ev   (when interop/debug-enabled? (:evidence @st))
-            sink (when interop/debug-enabled? @evidence-sink)]
-        ;; complete the flush FIRST — a throwing sink below cannot pre-empt it
+      (let [ev (when interop/debug-enabled? (:evidence @st))]
         (swap! st assoc :dirty? false :evidence nil)
-        (advance-revision! cell)
-        ;; DEV: best-effort evidence delivery, CONTAINED (never re-enters here)
-        (when (and interop/debug-enabled? (some? sink))
-          (try
-            (sink cell ev)
-            nil
-            (catch #?(:clj Throwable :cljs :default) e
-              {:cell cell :error e})))))))
+        (swap! st update :revision inc)
+        [cell ev]))))
+
+(defn- deliver-flush!
+  "PHASE 2 of a batch flush (rf2-vxgfnd.86): now that `complete-flush!` has
+  settled the WHOLE batch's scheduler state, notify `cell`'s listeners (the
+  production re-render trigger — one coalesced React render batch, since every
+  listener fires synchronously within this flush) and, in DEV, hand the captured
+  `ev` to the installed `evidence-sink` (Xray; rf2-vxgfnd.46) inside a guard.
+
+  A THROWING sink is a broken DEBUG tool, never an authority over the render
+  correction: its throw is CONTAINED here (caught and returned to the batch core
+  for one bounded diagnostic) so it can neither strand a cell nor abort the
+  batch's remaining cells (rf2-vxgfnd.73). Because completion already finished for
+  the whole batch, a re-entrant sink/listener that re-marks this (or ANY) cell
+  enrols a FRESH pending window rather than losing the notification. The sink
+  still receives the exact pre-clear bounded summary once per flushed cell.
+  Returns `{:cell cell :error e}` on a contained sink escape (DEV only), else nil;
+  the whole evidence/containment path DCEs under `goog.DEBUG=false`."
+  [^ViewCell cell ev]
+  (notify-listeners! cell)
+  (when interop/debug-enabled?
+    (when-some [sink @evidence-sink]
+      (try
+        (sink cell ev)
+        nil
+        (catch #?(:clj Throwable :cljs :default) e
+          {:cell cell :error e})))))
+
+(defn- run-flush-batch!
+  "The two-phase batch-flush CORE over an explicit ordered `cells` seq
+  (rf2-vxgfnd.86). PHASE 1 (`complete-flush!`) settles every dirty cell's
+  scheduler state — with no user code — so the whole batch is complete before
+  PHASE 2 (`deliver-flush!`) runs any listener or evidence-sink. A re-entrant
+  re-mark in phase 2 therefore always sees a fully-completed batch and opens the
+  NEXT window, regardless of iteration order. Preserves the DEV containment:
+  each `deliver-flush!` contains a throwing sink, the batch captures the FIRST
+  escape and emits ONE bounded diagnostic (never through the sink), and the whole
+  DEBUG branch DCEs under `goog.DEBUG=false`. Returns the count actually flushed."
+  [cells]
+  (let [completed (into [] (keep complete-flush!) cells)]
+    (if interop/debug-enabled?
+      ;; deliver EVERY cell regardless of tool behaviour — a throwing sink is
+      ;; contained per-cell (returns the escape, never propagates). Evaluate the
+      ;; delivery FIRST (never inside `or`, which would short-circuit the rest of
+      ;; the batch after the first escape), keep the FIRST escape, emit ONE
+      ;; bounded diagnostic — never through the sink.
+      (let [escape (reduce (fn [acc [cell ev]]
+                             (let [e (deliver-flush! cell ev)] (or acc e)))
+                           nil
+                           completed)]
+        (when (some? escape)
+          (report-sink-escape! escape)))
+      (doseq [[cell _] completed]
+        (deliver-flush! cell nil)))
+    (count completed)))
 
 (defn flush-scope!
   "The scoped-flush PRIMITIVE: synchronously flush every pending cell for
@@ -749,27 +791,26 @@
   the scope stay pending (no epoch work leaks across scopes). Reentrancy-
   SAFE by construction — the matching cells are removed from the registry
   ATOMICALLY (`swap-vals!`) before any notify, so a notify-triggered
-  re-entrant flush sees an already-drained set. Returns the count flushed."
+  re-entrant flush sees an already-drained set. The drained batch runs through
+  the two-phase `run-flush-batch!` core, so a re-entrant re-mark of ANOTHER cell
+  in the same batch is order-INDEPENDENT (rf2-vxgfnd.86). Returns the count
+  flushed."
   [scope-pred]
   (let [[old _] (swap-vals! dirty-cells
                             (fn [cells] (into #{} (remove scope-pred) cells)))
         flushed (filterv scope-pred old)]
-    (if interop/debug-enabled?
-      ;; DEV: complete EVERY cell's flush regardless of tool behaviour — a
-      ;; throwing `evidence-sink` is contained per-cell in `flush-one!` (which
-      ;; returns the escape rather than propagating), so one bad debug callback
-      ;; can neither strand its cell nor abort the batch. Capture the FIRST
-      ;; escape and emit ONE bounded diagnostic for the batch; never through
-      ;; the sink. This whole branch DCEs under `goog.DEBUG=false`, leaving the
-      ;; production `doseq` below.
-      (let [escape (reduce (fn [acc cell] (let [e (flush-one! cell)] (or acc e)))
-                           nil
-                           flushed)]
-        (when (some? escape)
-          (report-sink-escape! escape)))
-      (doseq [cell flushed]
-        (flush-one! cell)))
-    (count flushed)))
+    (run-flush-batch! flushed)))
+
+(defn flush-batch-in-order!
+  "Test seam (rf2-vxgfnd.86): drain and flush EXACTLY `cells` in the GIVEN order
+  through the same two-phase `run-flush-batch!` core `flush-scope!` uses, so a
+  fixture can FORCE a deterministic iteration order and prove the flush is
+  order-independent (drive `[a b]` and `[b a]`, assert identical outcomes).
+  Removes them from the dirty registry first (mirroring `flush-scope!`'s atomic
+  drain), then runs the ordered two-phase flush. Returns the count flushed."
+  [cells]
+  (swap! dirty-cells #(reduce disj % cells))
+  (run-flush-batch! (vec cells)))
 
 (defn flush-pending!
   "GLOBAL drain — flush EVERY pending cell once (the test-only all-roots

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -316,6 +316,10 @@
   ;;    :generation g            ; view-body generation (HMR); commit rejects
   ;;                             ;   a stale capture (step 1)
   ;;    :lifecycle :fresh|:connected|:disconnected|:dead
+  ;;    :root incarnation|nil    ; owning root-incarnation token — a per-mount
+  ;;                             ;   identity that SURVIVES an Activity hide, so
+  ;;                             ;   root teardown reaps a cell hidden before its
+  ;;                             ;   window (rf2-vxgfnd.85; see `root-cells`)
   ;;    :committed {tk -> lease} ; installed dependency set
   ;;    :values    {tk -> value} ; last published site values (stabilization
   ;;                             ;   + the revision snapshot's evidence)
@@ -346,6 +350,7 @@
      (atom {:view-id        view-id
             :generation     generation
             :lifecycle      :fresh
+            :root           nil
             :committed      {}
             :values         {}
             :revision       0
@@ -474,6 +479,27 @@
   ;; (no retention leak). `defonce` (module-lived); tests clear it via
   ;; `reset-scheduler!`.
   (atom #{}))
+
+(defonce ^:private root-cells
+  ;; ROOT-INCARNATION OWNERSHIP: `incarnation -> #{owned cells}`. Every ViewCell
+  ;; attached to a root (`attach-root!`, the mount seam) enrols here under its
+  ;; root's incarnation and STAYS enrolled across a transient Activity hide — a
+  ;; hide removes the cell from `live-cells` (it holds no committed deps) but NOT
+  ;; from its root membership. This is the piece `teardown-collector` alone cannot
+  ;; supply: a cell hidden by React Activity BEFORE the root's teardown window is
+  ;; armed already left `:fresh`/`:connected`, so its cleanup can never enrol it in
+  ;; the window, and it would otherwise linger `:disconnected {:reason :unknown}`
+  ;; and RECONNECTABLE after its root is gone (rf2-vxgfnd.85). `teardown-root!`
+  ;; consults this registry to reap those already-hidden cells alongside the ones
+  ;; the window captures. Membership is bounded to CURRENTLY-retained cells: a cell
+  ;; leaves on final `teardown!` (`detach-root!`), and an incarnation's entry is
+  ;; dropped the moment its last cell leaves — so repeated mount/hide/unmount
+  ;; cycles never grow a historical registry. The incarnation is a FRESH per-mount
+  ;; identity (`make-root-incarnation`), NOT the reusable root-id, so a stale
+  ;; teardown can never reap the cells of a replacement root mounted under the same
+  ;; root-id. `defonce` (module-lived); `reset-scheduler!` clears it between
+  ;; fixtures.
+  (atom {}))
 
 (defonce ^:private teardown-collector
   ;; The COLLECTION WINDOW of an in-flight host/root teardown (`teardown-root!`),
@@ -841,6 +867,7 @@
   (reset! flush-scheduled? false)
   (reset! slice-memo* nil)
   (reset! live-cells #{})
+  (reset! root-cells {})
   (reset! teardown-collector nil)
   (reset! evidence-sink nil)
   (reset! last-sink-escape nil)
@@ -879,6 +906,80 @@
   plus any retroactive annotations."
   [^ViewCell cell]
   (:intervals @(state cell)))
+
+;; ---- root-incarnation ownership (03 §4; rf2-vxgfnd.85) ----------------------
+;;
+;; A ViewCell's committed dependency set (`live-cells`) is the discoverability
+;; surface a FRAME-destroy sweep consults, but it is dropped the instant the cell
+;; disconnects — so it cannot survive an Activity hide. Root teardown needs an
+;; ownership association that DOES survive a transient hide: the `root-cells`
+;; registry keyed by a per-mount root incarnation. `attach-root!` (the mount seam)
+;; enrols a cell under its root's incarnation; the cell stays enrolled across a
+;; hide and leaves only when it is proven dead (`detach-root!` from `teardown!`).
+;; `teardown-root!` reaps a root's already-hidden cells through this registry.
+
+(defn make-root-incarnation
+  "Mint a FRESH, opaque root-incarnation token — a per-mount identity with no
+  structure, compared only by `identical?`. A root that re-mounts under the same
+  (reusable) root-id gets a DISTINCT incarnation, so a stale teardown carrying an
+  old incarnation can never reap a replacement root's cells (rf2-vxgfnd.85). The
+  mount seam mints one per root and threads it to every ViewCell under that root
+  via `attach-root!`."
+  []
+  #?(:clj (Object.) :cljs (js-obj)))
+
+(defn- forget-root-cell!
+  "Remove `cell` from `incarnation`'s membership set, DROPPING the incarnation
+  entry entirely when its last cell leaves — so repeated mount/hide/unmount
+  cycles never grow a historical registry (rf2-vxgfnd.85 AC5)."
+  [^ViewCell cell incarnation]
+  (when (some? incarnation)
+    (swap! root-cells
+           (fn [m]
+             (let [s (disj (get m incarnation #{}) cell)]
+               (if (empty? s) (dissoc m incarnation) (assoc m incarnation s)))))))
+
+(defn attach-root!
+  "Mount seam: associate `cell` with root `incarnation` — the per-mount ownership
+  token (`make-root-incarnation`) that SURVIVES a transient Activity disconnect
+  and lets `teardown-root!` reap a cell already Activity-hidden BEFORE the host
+  unmount window (rf2-vxgfnd.85). Enrols the cell in `root-cells` under
+  `incarnation` (idempotent — a set); re-attaching to a DIFFERENT incarnation
+  first drops the old membership, so a cell can never straddle two roots. An
+  Activity hide (which removes the cell from `live-cells`) does NOT drop this
+  membership — that is the whole point. Returns the cell."
+  [^ViewCell cell incarnation]
+  (let [st  (state cell)
+        old (:root @st)]
+    (when (and (some? old) (not (identical? old incarnation)))
+      (forget-root-cell! cell old))
+    (swap! st assoc :root incarnation)
+    (swap! root-cells update incarnation (fnil conj #{}) cell))
+  cell)
+
+(defn- detach-root!
+  "Drop `cell`'s root-incarnation membership on FINAL teardown — the cell is
+  proven dead, so it leaves the registry (membership is bounded to
+  currently-retained cells). Idempotent; a no-op when the cell owns no root."
+  [^ViewCell cell]
+  (let [st  (state cell)
+        inc (:root @st)]
+    (when (some? inc)
+      (forget-root-cell! cell inc)
+      (swap! st assoc :root nil))))
+
+(defn cell-root
+  "The root incarnation `cell` is attached to, or nil (tool/test read)."
+  [^ViewCell cell]
+  (:root @(state cell)))
+
+(defn root-cell-count
+  "The number of root incarnations currently tracked, or — with `incarnation` —
+  the number of cells owned by it (tool/test read). Proves the ownership registry
+  is bounded to retained/mounted cells and drops empty incarnations on final
+  teardown (rf2-vxgfnd.85 AC5)."
+  ([] (count @root-cells))
+  ([incarnation] (count (get @root-cells incarnation))))
 
 (defn- release-committed!
   "Release every lease in the committed dependency set and clear it —
@@ -965,7 +1066,10 @@
       (release-committed! cell)
       (discard-pending! cell)
       (swap! st assoc :lifecycle :dead)
-      (swap! live-cells disj cell))
+      (swap! live-cells disj cell)
+      ;; leave the root-incarnation registry — a dead cell is no longer
+      ;; retained, so it must not linger as reapable ownership (rf2-vxgfnd.85).
+      (detach-root! cell))
     cell))
 
 (defn teardown-frame!
@@ -1011,23 +1115,65 @@
   disconnects with NO window armed, is never captured, and stays reconnectable —
   a reveal proves it `:activity-hidden {:proof :reconnect}`.
 
+  ## Reaping cells already Activity-hidden before the window (rf2-vxgfnd.85)
+
+  The window alone captures ONLY cells whose effect cleanup fires DURING the host
+  unmount. A ViewCell hidden by React Activity/Offscreen BEFORE the window is
+  armed already left `:fresh`/`:connected` for `:disconnected`, so its cleanup can
+  never re-enrol it — React does not re-run an already-destroyed effect when it
+  discards the hidden fiber at root unmount. Such a cell would linger
+  `:disconnected {:reason :unknown}` and RECONNECTABLE after its root is gone. So
+  teardown ALSO consults the `root-cells` ownership registry: after the window
+  closes it reaps every still-`:disconnected` cell owned by a torn-down root
+  incarnation. Two incarnation sources, unioned:
+
+    - `root-incarnation` — the explicit incarnation the caller (the mount/root
+      layer) names for the root being unmounted. This is the deterministic path:
+      it reaps a root's hidden cells even when the window captured NONE (the whole
+      root hidden, or a single already-hidden cell).
+    - the incarnations of every WINDOW-CAPTURED cell — a captured cell names its
+      own root's incarnation, so its still-hidden siblings under the same root are
+      reaped too, even when no explicit incarnation is supplied.
+
+  Only `:disconnected` owned cells are reaped; a still-`:connected` cell of a
+  SIBLING root's incarnation is never in the set, and an incarnation is a fresh
+  per-mount identity, so a replacement root under the same root-id is untouched.
+
   Ordering-robust and re-entrancy-safe by save/restore. If `unmount-thunk`
   THROWS (React refused to unmount — it did NOT tear the tree down, so no
   cleanup ran and nothing was collected), the window is restored and the throw
   propagates WITHOUT tearing any cell down: the orphaned tree's cells stay live,
   and the original host error is never masked (the ruled host-teardown
-  behaviour, rf2-vxgfnd.53). Returns the count of cells torn down."
-  [unmount-thunk]
-  (let [prev      @teardown-collector
-        collected (do (reset! teardown-collector #{})
-                      (try
-                        (unmount-thunk)
-                        @teardown-collector
-                        (finally
-                          (reset! teardown-collector prev))))]
-    (doseq [cell collected]
-      (teardown! cell))
-    (count collected)))
+  behaviour, rf2-vxgfnd.53). A throwing thunk reaps NOTHING — including the
+  registry sweep — because the root was not actually torn down. Returns the count
+  of cells torn down.
+
+  Two arities: `[unmount-thunk]` (no explicit incarnation — window + captured-cell
+  incarnations only, the current `client/unmount!*` call) and
+  `[root-incarnation unmount-thunk]` (the incarnation-aware path)."
+  ([unmount-thunk] (teardown-root! nil unmount-thunk))
+  ([root-incarnation unmount-thunk]
+   (let [prev      @teardown-collector
+         collected (do (reset! teardown-collector #{})
+                       (try
+                         (unmount-thunk)
+                         @teardown-collector
+                         (finally
+                           (reset! teardown-collector prev))))
+         ;; the incarnations whose hidden cells this teardown owns: the explicit
+         ;; one plus every window-captured cell's own incarnation.
+         incs      (cond-> (into #{} (keep cell-root) collected)
+                     (some? root-incarnation) (conj root-incarnation))
+         ;; already-Activity-hidden owned cells the window could NOT capture —
+         ;; still `:disconnected`, belonging to a torn-down incarnation.
+         hidden    (into #{}
+                         (comp (mapcat #(get @root-cells %))
+                               (filter #(= :disconnected (lifecycle %))))
+                         incs)
+         victims   (into collected hidden)]
+     (doseq [cell victims]
+       (teardown! cell))
+     (count victims))))
 
 ;; ---------------------------------------------------------------------------
 ;; The 8-step layout-commit reconciler (03 §3)

--- a/implementation/ui/test/re_frame/ui/reactive_reentrant_flush_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reentrant_flush_cljs_test.cljc
@@ -1,0 +1,191 @@
+(ns re-frame.ui.reactive-reentrant-flush-cljs-test
+  "rf2-vxgfnd.86 — re-entrant MULTI-CELL flush semantics must be
+  ORDER-INDEPENDENT.
+
+  #5759 completes each ViewCell before the DEBUG evidence sink, but the old
+  `flush-scope!` removed the whole matching batch from `dirty-cells` up front
+  then completed/delivered cells one at a time from an IDENTITY SET — so whether
+  a cell re-marked mid-flush (by a sink or a listener re-entered through another
+  cell's notification) opened a fresh pending window or lost its mark depended on
+  arbitrary set iteration order: a re-marked cell already cleared → fresh window;
+  a re-marked cell still in the drained-but-uncompleted batch → mark folded into
+  the window the flush was about to clear, then lost.
+
+  The fix is an explicit batch phase boundary: PHASE 1 completes the WHOLE
+  batch's scheduler state (capture evidence, clear `:dirty?`, advance revision)
+  with no arbitrary user code, then PHASE 2 delivers notifications + evidence.
+  A re-entrant re-mark can only fire in phase 2, by which point every drained
+  cell is already completed, so it always enrols a FRESH next-batch window —
+  independent of iteration order.
+
+  These fixtures drive the two ORDERS explicitly through the `flush-batch-in-order!`
+  test seam (the same two-phase core `flush-scope!` uses) and assert an identical
+  outcome, cover both the DEBUG sink AND the production listener re-entry vector,
+  and pin the real `flush-scope!`/`flush-pending!` primitive too.
+
+  `.cljc` ending `-cljs-test` graft-checks on node (`test:cljs`) AND JVM
+  (`clojure -M:test`)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+;; ===========================================================================
+;; A DEBUG evidence-sink on cell A re-marks a SIBLING cell B in the same batch
+;; ===========================================================================
+
+(defn- run-sink-scenario
+  "Batch {A,B}; A's evidence-sink re-marks B (epoch 99). Flush in `order-fn`'s
+  order through the two-phase seam. Returns the final observable state."
+  [order-fn]
+  (reactive/reset-scheduler!)
+  (let [ha     (atom 0)
+        hb     (atom 0)
+        cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)]
+    (reactive/subscribe cell-a (fn [] (swap! ha inc)))
+    (reactive/subscribe cell-b (fn [] (swap! hb inc)))
+    (reactive/set-evidence-sink!
+      (fn [c _ev]
+        (when (identical? c cell-a)
+          (reactive/mark-dirty! cell-b 99))))     ;; re-mark the sibling
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [n (reactive/flush-batch-in-order! (order-fn [cell-a cell-b]))]
+      {:flushed         n
+       :rev-a           (reactive/revision cell-a)
+       :rev-b           (reactive/revision cell-b)
+       :hits-a          @ha
+       :hits-b          @hb
+       :b-dirty?        (reactive/dirty? cell-b)
+       :b-pending-epoch (reactive/pending-epoch cell-b)
+       :pending-count   (reactive/pending-cell-count)
+       :escape          (some? (reactive/last-evidence-sink-escape))})))
+
+(deftest re-entrant-sink-cross-cell-remark-is-order-independent
+  (let [fwd (run-sink-scenario identity)              ;; A then B
+        rev (run-sink-scenario (fn [[a b]] [b a]))]   ;; B then A
+    (testing "both iteration orders yield the IDENTICAL final state (rf2-vxgfnd.86)"
+      (is (= fwd rev)
+          "the re-entrant cross-cell re-mark is order-independent"))
+    (testing "…and the re-marked sibling opened a FRESH next-batch window (not lost)"
+      (is (= 2 (:flushed fwd)) "both original cells flushed once")
+      (is (= 1 (:rev-a fwd)) "A advanced exactly once")
+      (is (= 1 (:rev-b fwd)) "B's original window advanced exactly once")
+      (is (= 1 (:hits-a fwd)))
+      (is (= 1 (:hits-b fwd)))
+      (is (true? (:b-dirty? fwd)) "B re-enrolled by A's re-entrant mark")
+      (is (= 99 (:b-pending-epoch fwd)) "…anchored to the re-mark's own epoch")
+      (is (= 1 (:pending-count fwd)) "exactly the fresh B window is pending")
+      (is (false? (:escape fwd)) "a well-behaved sink records no escape"))))
+
+;; ===========================================================================
+;; The PRODUCTION vector: a LISTENER on A re-marks a sibling B (useSyncExternal-
+;; Store notification re-entry) — must be order-independent under the same
+;; phase discipline, with no DEBUG machinery in play
+;; ===========================================================================
+
+(defn- run-listener-scenario
+  [order-fn]
+  (reactive/reset-scheduler!)
+  (let [cell-a   (reactive/make-cell ::a)
+        cell-b   (reactive/make-cell ::b)
+        remarked (atom false)]
+    ;; A's LISTENER (the production re-render trigger) re-marks B once.
+    (reactive/subscribe cell-a
+      (fn [] (when (compare-and-set! remarked false true)
+               (reactive/mark-dirty! cell-b 77))))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [n (reactive/flush-batch-in-order! (order-fn [cell-a cell-b]))]
+      {:flushed         n
+       :rev-b           (reactive/revision cell-b)
+       :b-dirty?        (reactive/dirty? cell-b)
+       :b-pending-epoch (reactive/pending-epoch cell-b)
+       :pending-count   (reactive/pending-cell-count)})))
+
+(deftest listener-induced-cross-cell-remark-is-order-independent
+  (let [fwd (run-listener-scenario identity)
+        rev (run-listener-scenario (fn [[a b]] [b a]))]
+    (testing "listener re-entry through a sibling is order-independent too"
+      (is (= fwd rev) "the production notification path is covered by the same discipline"))
+    (testing "the re-marked sibling opened a fresh next-batch window"
+      (is (= 2 (:flushed fwd)))
+      (is (= 1 (:rev-b fwd)) "B's original window advanced exactly once")
+      (is (true? (:b-dirty? fwd)) "B re-enrolled by A's listener")
+      (is (= 77 (:b-pending-epoch fwd)))
+      (is (= 1 (:pending-count fwd))))))
+
+;; ===========================================================================
+;; The real primitive: flush-scope!/flush-pending! runs the same two-phase core,
+;; so the invariant holds regardless of the hash-set's natural drain order
+;; ===========================================================================
+
+(deftest flush-pending-multi-cell-reentrant-remark-preserves-next-window
+  (reactive/reset-scheduler!)
+  (let [cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)]
+    (reactive/set-evidence-sink!
+      (fn [c _ev] (when (identical? c cell-a) (reactive/mark-dirty! cell-b 42))))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (is (= 2 (reactive/flush-pending!)) "both original cells flushed once")
+    (testing "whatever order the set drained, B's fresh window survives (rf2-vxgfnd.86)"
+      (is (reactive/dirty? cell-b))
+      (is (= 42 (reactive/pending-epoch cell-b)))
+      (is (= 1 (reactive/pending-cell-count)))
+      (is (= 1 (reactive/revision cell-b)) "B's original batch advanced exactly once"))
+    (testing "the preserved window flushes on the next drain"
+      (reactive/set-evidence-sink! nil)
+      (is (= 1 (reactive/flush-pending!)))
+      (is (= 2 (reactive/revision cell-b)))
+      (is (= 0 (reactive/pending-cell-count))))))
+
+;; ===========================================================================
+;; Containment survives the two-phase batch: a throwing sink that ALSO re-marks
+;; a sibling neither strands nor aborts, and the outcome stays order-independent
+;; ===========================================================================
+
+(defn- run-throwing-reentrant-scenario
+  [order-fn]
+  (reactive/reset-scheduler!)
+  (let [cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)
+        seen   (atom #{})]
+    (reactive/set-evidence-sink!
+      (fn [c _ev]
+        (swap! seen conj c)                       ;; record delivery FIRST
+        (when (identical? c cell-a)
+          (reactive/mark-dirty! cell-b 55)        ;; re-mark the sibling…
+          (throw (ex-info "sink boom" {})))))     ;; …then throw
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (reactive/flush-batch-in-order! (order-fn [cell-a cell-b]))
+    {:rev-a         (reactive/revision cell-a)
+     :rev-b         (reactive/revision cell-b)
+     :both-seen?    (= #{cell-a cell-b} @seen)
+     :b-dirty?      (reactive/dirty? cell-b)
+     :b-epoch       (reactive/pending-epoch cell-b)
+     :pending-count (reactive/pending-cell-count)
+     :escape-a?     (identical? cell-a (:cell (reactive/last-evidence-sink-escape)))}))
+
+(deftest throwing-re-entrant-sink-is-contained-and-order-independent
+  (let [fwd (run-throwing-reentrant-scenario identity)
+        rev (run-throwing-reentrant-scenario (fn [[a b]] [b a]))]
+    (testing "the throwing + re-marking sink yields the same contained outcome either order"
+      (is (= fwd rev)))
+    (testing "both cells completed, delivery reached both, the sibling re-enrolled"
+      (is (= 1 (:rev-a fwd)) "A completed despite its sink throwing")
+      (is (= 1 (:rev-b fwd)) "B completed (throw did not abort the batch)")
+      (is (true? (:both-seen? fwd)) "delivery reached both cells")
+      (is (true? (:b-dirty? fwd)) "the re-entrant mark opened a fresh window")
+      (is (= 55 (:b-epoch fwd)))
+      (is (= 1 (:pending-count fwd)))
+      (is (true? (:escape-a? fwd)) "the escape names the offending cell — not silent"))))

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -13,7 +13,10 @@
   host `.unmount` thunk, so every cell whose cleanup (`disconnect!`) fires
   DURING the unmount is captured, then upgraded via the shared `teardown!`
   primitive. An Activity hide (a `disconnect!` with the window UNARMED) is never
-  captured and stays reconnectable — the discriminator this file pins.
+  captured — but a cell hidden BEFORE the window still belongs to its root, so
+  root teardown reaps it through the root-incarnation ownership registry
+  (rf2-vxgfnd.85), while a hide with NO teardown stays reconnectable. Both are
+  the discriminators this file pins.
 
   `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
   (`clojure -M:test`), so the ownership/lifecycle logic is graft-checked on
@@ -49,6 +52,15 @@
     (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
   (reactive/commit! cell)
   cell)
+
+(defn- mount!
+  "Graft analogue of a real mount UNDER a root: mint a cell for view `vid`,
+  attach it to root `incarnation` (the ownership that survives an Activity hide),
+  then commit it connected under frame `fid` observing `queries`."
+  [vid incarnation fid queries]
+  (let [cell (reactive/make-cell vid)]
+    (reactive/attach-root! cell incarnation)
+    (render+commit! cell fid queries)))
 
 (defn- throws-id [thunk]
   (try (thunk) nil
@@ -120,18 +132,125 @@
              (peek (reactive/intervals cell)))
           "annotated :activity-hidden {:proof :reconnect} — never mislabeled unmounted"))))
 
-(deftest hide-outside-a-window-is-not-captured-by-a-later-teardown
-  ;; A cell hidden BEFORE any root teardown left the window unarmed, so it is
-  ;; not captured — the collection is bounded to cells disconnecting DURING the
-  ;; host unmount (matching live-cells' removed-on-disconnect membership).
+;; ===========================================================================
+;; rf2-vxgfnd.85 — root teardown reaps cells ALREADY Activity-hidden before the
+;; window, via the root-incarnation ownership that survives the hide
+;; ===========================================================================
+
+(deftest root-teardown-reaps-a-cell-hidden-before-the-window
+  ;; The corrected contract (replaces the #5755 test that blessed the miss). A
+  ;; cell hidden by Activity BEFORE any teardown window left :connected, so its
+  ;; cleanup can never enrol it in the window — and React does not re-run an
+  ;; already-destroyed effect when it discards the hidden fiber at root unmount.
+  ;; Root membership SURVIVES the hide via `root-cells`, so an explicit root
+  ;; teardown reaps the already-hidden cell: it must NOT linger reconnectable
+  ;; after its root is gone.
   (rf/reg-sub :rt/a (fn [db _] (:a db)))
   (let [fid  (make-frame! :rt/frame {:a 1})
-        cell (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])]
-    (reactive/disconnect! cell)                       ;; hide, window unarmed
-    (is (= 0 (reactive/teardown-root! (fn [] nil)))   ;; an empty host unmount
-        "a teardown whose unmount disconnects nothing tears down nothing")
-    (is (= :disconnected (reactive/lifecycle cell))
-        "the already-hidden cell is untouched — still reconnectable, not :dead")))
+        inc  (reactive/make-root-incarnation)
+        cell (mount! ::v inc fid [[:rt/a]])]
+    (testing "Activity hide — window unarmed — is the transient :unknown, still owned"
+      (reactive/disconnect! cell)
+      (is (= :disconnected (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :unknown} (peek (reactive/intervals cell))))
+      (is (identical? inc (reactive/cell-root cell)) "root membership SURVIVES the hide")
+      (is (= 1 (reactive/root-cell-count inc)) "…the cell is still owned"))
+    (testing "root teardown reaps the already-hidden cell → :dead {:proof :host-teardown}"
+      (is (= 1 (reactive/teardown-root! inc (fn [] nil)))
+          "the empty host unmount collects nothing, yet the owned hidden cell is reaped")
+      (is (= :dead (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+             (peek (reactive/intervals cell)))
+          "the prior :unknown disconnect is upgraded — never left reconnectable"))
+    (testing "ownership is bounded — the incarnation is dropped on final teardown"
+      (is (= 0 (reactive/root-cell-count inc)) "no membership lingers for the incarnation")
+      (is (= 0 (reactive/root-cell-count)) "no historical incarnation retained"))
+    (testing "the reaped cell fails a recommit through the dead-cell lifecycle"
+      (rf/with-frame fid
+        (reactive/with-capture cell (fn [] (reactive/sub-read [:rt/a]))))
+      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))
+          "a retained handle cannot reconnect after its root is gone"))))
+
+(deftest a-hide-without-root-teardown-stays-reconnectable
+  ;; The discriminator: an Activity hide with NO root teardown must stay
+  ;; reconnectable and be proven :activity-hidden on reveal — the ownership
+  ;; registry must never itself kill a merely-hidden cell.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :rt/frame {:a 1})
+        inc  (reactive/make-root-incarnation)
+        cell (mount! ::v inc fid [[:rt/a]])]
+    (reactive/disconnect! cell)
+    (is (= :disconnected (reactive/lifecycle cell)) "hidden, not :dead")
+    (is (= 1 (reactive/root-cell-count inc)) "still owned — reapable only by ITS root")
+    (testing "a reveal reconnects and proves the interval an Activity hide"
+      (render+commit! cell fid [[:rt/a]])
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
+             (peek (reactive/intervals cell)))
+          "never mislabeled unmounted — the registry did not kill a live-again cell"))))
+
+(deftest root-teardown-reaps-hidden-siblings-via-a-captured-cells-incarnation
+  ;; The `[unmount-thunk]` arity (the current client call, no explicit
+  ;; incarnation): a cell that disconnects DURING the window names its root's
+  ;; incarnation, so a SIBLING under the same root that was hidden BEFORE the
+  ;; window is reaped too — the common real unmount (some cells shown, some
+  ;; already Activity-hidden).
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        inc    (reactive/make-root-incarnation)
+        shown  (mount! ::shown inc fid [[:rt/a]])
+        hidden (mount! ::hidden inc fid [[:rt/a]])]
+    (reactive/disconnect! hidden)                      ;; hidden BEFORE the window
+    (is (= :disconnected (reactive/lifecycle hidden)))
+    (is (= :connected (reactive/lifecycle shown)))
+    (is (= 2 (reactive/teardown-root! (fn [] (reactive/disconnect! shown))))
+        "both reaped: the window-captured cell + its already-hidden sibling")
+    (is (= :dead (reactive/lifecycle shown)) "the captured cell")
+    (is (= :dead (reactive/lifecycle hidden))
+        "the pre-hidden sibling is reaped via the captured cell's incarnation")
+    (is (= 0 (reactive/root-cell-count inc)) "the incarnation is fully drained")))
+
+(deftest root-teardown-does-not-reap-a-sibling-roots-hidden-cell
+  ;; Incarnation-scoped: tearing down root A never reaps root B's hidden cell,
+  ;; even though both are :disconnected at once (sibling-root isolation).
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        inc-a  (reactive/make-root-incarnation)
+        inc-b  (reactive/make-root-incarnation)
+        cell-a (mount! ::a inc-a fid [[:rt/a]])
+        cell-b (mount! ::b inc-b fid [[:rt/a]])]
+    (reactive/disconnect! cell-a)                      ;; both hidden at once
+    (reactive/disconnect! cell-b)
+    (is (= 1 (reactive/teardown-root! inc-a (fn [] nil))) "root A reaps only its own")
+    (is (= :dead (reactive/lifecycle cell-a)) "root A's hidden cell dies")
+    (is (= :disconnected (reactive/lifecycle cell-b))
+        "root B's hidden cell is untouched — still reconnectable")
+    (is (= 1 (reactive/root-cell-count inc-b)) "…and still owned by B")
+    (testing "root B's hidden cell still reconnects cleanly"
+      (render+commit! cell-b fid [[:rt/a]])
+      (is (= :connected (reactive/lifecycle cell-b))))))
+
+(deftest a-stale-incarnation-teardown-cannot-reap-a-replacement-roots-cell
+  ;; Root incarnation is a per-mount identity, NOT the reusable root-id. A root
+  ;; torn down and re-mounted under the SAME root-id gets a FRESH incarnation, so
+  ;; replaying the STALE incarnation's teardown reaps nothing in the replacement
+  ;; (rf2-vxgfnd.85 — incarnation-safety).
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid   (make-frame! :rt/frame {:a 1})
+        inc-1 (reactive/make-root-incarnation)
+        cell1 (mount! ::v inc-1 fid [[:rt/a]])]
+    (reactive/disconnect! cell1)
+    (reactive/teardown-root! inc-1 (fn [] nil))
+    (is (= :dead (reactive/lifecycle cell1)) "the first incarnation is torn down")
+    (let [inc-2 (reactive/make-root-incarnation)
+          cell2 (mount! ::v inc-2 fid [[:rt/a]])]     ;; replacement, same view-id
+      (reactive/disconnect! cell2)                     ;; hidden
+      (is (not (identical? inc-1 inc-2)) "a fresh incarnation despite the same root-id")
+      (is (= 0 (reactive/teardown-root! inc-1 (fn [] nil)))
+          "replaying the stale incarnation reaps nothing")
+      (is (= :disconnected (reactive/lifecycle cell2))
+          "the replacement root's hidden cell is untouched")
+      (is (= 1 (reactive/root-cell-count inc-2))))))
 
 ;; ===========================================================================
 ;; Root isolation — a teardown only claims the cells its own unmount disconnects


### PR DESCRIPTION
Two `reactive.cljc` lifecycle/scheduler correctness fixes, `.85` then `.86`. Both bugs proven to FAIL pre-fix (temporary reverts observed to break the new fixtures).

## rf2-vxgfnd.85 — root teardown misses ViewCells already Activity-hidden (P1)

#5755's `teardown-root!` only upgraded cells that disconnected DURING its collection window. A ViewCell hidden by React Activity/Offscreen BEFORE the window is armed already left `:fresh`/`:connected`, so its cleanup can never enrol it — and React does not re-run an already-destroyed effect when it discards the hidden fiber at root unmount. Such a cell lingered `:disconnected {:reason :unknown}` and reconnectable after its root was gone.

Fix: each mounted ViewCell gets a per-mount **root-incarnation** ownership association (`attach-root!` → `root-cells` registry) that SURVIVES a transient Activity disconnect (a hide removes it from `live-cells` but not from its root membership). `teardown-root!` now reaps every still-`:disconnected` owned cell of a torn-down incarnation — sourced from an explicit incarnation arg AND from every window-captured cell's own incarnation — alongside the window's captures. The incarnation is a fresh per-mount identity, so a stale teardown can never reap a replacement root's cells (same root-id, new incarnation), and empty incarnations are dropped so repeated mount/hide/unmount cycles grow no historical registry. The 1-arg `teardown-root!` (the untouched `client/unmount!*` call) keeps its exact behaviour and additionally reaps hidden siblings via captured-cell incarnations.

Replaces the #5755 test that blessed the missed already-hidden cell with the corrected contract.

## rf2-vxgfnd.86 — order-dependent re-entrant multi-cell flush (P2)

#5759 completes each ViewCell before the DEBUG evidence sink, but the batch was drained from an identity set and each cell completed+delivered one at a time. A cell re-marked mid-flush (by a sink, or a listener re-entered through another cell's notification) either opened a fresh window or lost its mark depending on arbitrary set iteration order.

Fix: an explicit batch phase boundary in a shared `run-flush-batch!` core. PHASE 1 (`complete-flush!`) settles the WHOLE batch's scheduler state — capture evidence, clear `:dirty?`, advance revision — with no arbitrary user code; PHASE 2 (`deliver-flush!`) then notifies listeners and delivers evidence. A re-entrant re-mark can only fire in phase 2, by which point every drained cell is already completed, so it always enrols a FRESH next-batch window — independent of iteration order. Preserves #5759's complete-before-sink + contained-sink-throw behaviour (now stronger: the whole batch completes before ANY sink runs), keeps one coalesced render batch in production, and covers the listener re-entry vector. `flush-batch-in-order!` is the deterministic ordered test seam the fixtures drive both orders through.

## Scope note

Surface limited to `reactive.cljc` + its `.cljc` graft tests (per dispatch discipline: `client.cljs`/`frame.cljc`/`observation.cljc` left untouched). The `.85` mechanism + graft proof land here; wiring the REAL production path — `client/unmount!*` passing the root incarnation and establishing per-cell root ownership at mount via a root-provided React context — needs `client.cljs` + `viewcell.cljs` and is a sequenced follow-up (filed).

## Quality gates

All foreground, 0-fail:
- ui JVM `clojure -M:test` — 296 tests, 4720 assertions, 0 failures
- core JVM `clojure -M:test` — 1867 tests, 8343 assertions, 0 failures
- node `npm run test:cljs` — 9047 tests, 42724 assertions, 0 failures
- `test:browser` not run: no DOM lifecycle fixture added (both new fixtures are `.cljc` graft, host-checked on node + JVM).