### PR TITLE
fix(core): observation read carries incarnation identity to detect same-id reincarnation (rf2-vxgfnd.14)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -64,10 +64,18 @@
     - `:registry-epoch` — bumped on every `:sub` registration (first-time or
       replacement), so an HMR re-registration in the gap is visible.
 
-  `read` on a node lease additionally returns the CURRENT `:frame-epoch` /
-  `:registry-epoch` (additive keys — the frozen `{:value v :version n}`
-  contract is unchanged) so the commit reconciler gets its step-5 comparison
-  inputs from the one acquire-time read instead of a second probe.
+  `read` on a node lease additionally returns the node's `:node-key` (its
+  process-unique IDENTITY — the SAME key probe emits) and the CURRENT
+  `:frame-epoch` / `:registry-epoch` (additive keys — the frozen
+  `{:value v :version n}` contract is unchanged) so the commit reconciler gets
+  its step-5 comparison inputs from the one acquire-time read instead of a
+  second probe. Carrying `:node-key` lets the reconciler distinguish a same-id
+  frame REINCARNATION (destroy + recreate mints a fresh reaction, so a
+  strictly-greater node-key) from an unmoved live node EVEN WHEN node-version
+  and frame/registry epochs coincide across the two incarnations — a
+  version+epoch tie `frame/dissoc-frame!`'s commit-epoch restart can produce,
+  which the version+epoch-only comparison would misread as unchanged
+  (rf2-vxgfnd.14).
 
   ## Error contract — internally fail-loud
 
@@ -168,8 +176,17 @@
   "Integer ABI version of this port. `day8/re-frame2-ui` records the version
   it compiled against and asserts it at load via [[assert-port-abi-version!]],
   failing loudly on skew — artifact drift is a boot error, never undefined
-  behaviour. Per Spec 006 §The internal observation port §Scope."
-  1)
+  behaviour. Per Spec 006 §The internal observation port §Scope.
+
+  v2 (rf2-vxgfnd.14): `read` on a node lease additionally carries `:node-key`
+  — the acquired node's process-unique IDENTITY (the same key `probe` already
+  emits) — so the S2b commit reconciler detects a same-id frame REINCARNATION
+  across the render→commit gap even when node-version and frame/registry
+  epochs coincide (a version+epoch tie `frame/dissoc-frame!`'s commit-epoch
+  restart can produce). The reconciler's evidence comparison relies on it, so
+  a consumer from v2 onward REQUIRES a core that emits it — the guard makes an
+  older core a boot error rather than a silently-missed correction."
+  2)
 
 (defn assert-port-abi-version!
   "Boot guard for the sole consumer: throw `:rf.error/observation-port-
@@ -1303,10 +1320,23 @@
 
 (defn read
   "Commit-side read through a lease. On a live node lease, derefs the owned
-  node fresh and returns `{:value v :version n :frame-epoch fe
-  :registry-epoch re}` (the epoch keys are additive — they hand the commit
-  reconciler its invariant-5 comparison inputs without a second probe). On
-  the static override lease, returns the pinned `{:value v :version n}`.
+  node fresh and returns `{:value v :version n :node-key nk :frame-epoch fe
+  :registry-epoch re}` (the `:node-key`/epoch keys are additive — they hand
+  the commit reconciler its invariant-5 comparison inputs without a second
+  probe). On the static override lease, returns the pinned `{:value v
+  :version n}`.
+
+  `:node-key` carries the acquired node's process-unique IDENTITY (the same
+  key `probe` already emits), so the reconciler can tell the node the RENDER
+  observed apart from a DIFFERENT node acquired at COMMIT — including a same-id
+  frame REINCARNATION (destroy + recreate) whose node-version and
+  frame/registry epochs coincide with the destroyed incarnation's:
+  `frame/dissoc-frame!` restarts the frame's commit epoch, so version+epoch
+  ALONE can tie across incarnations (rf2-vxgfnd.14). A reincarnated frame
+  builds a fresh reaction, which mints a strictly-greater node-key, so a
+  changed key is MOVEMENT the reconciler MUST correct before paint even when
+  version+epoch coincide. The unchanged-node fast path is preserved: the same
+  live node reads the same key/version/epochs, so no correction fires.
 
   `read` on a RELEASED lease throws `:rf.error/read-after-release` — always,
   production included; it is a substrate bug, unreachable in correct
@@ -1353,11 +1383,13 @@
                           :node-key (:node-key rec)})
             {:value          v
              :version        (:version rec)
+             :node-key       (:node-key rec)
              :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
              :registry-epoch @registry-epoch*})
-          (let [{:keys [value version]} (:last st)]
+          (let [{:keys [value version node-key]} (:last st)]
             {:value          value
              :version        version
+             :node-key       node-key
              :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
              :registry-epoch @registry-epoch*}))))))
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -952,6 +952,109 @@
           (is (= @builds (:attempts (ex-data e)))
               ":attempts equals the build attempts made"))))))
 
+;; ===========================================================================
+;; rf2-vxgfnd.14 — read carries the node's IDENTITY (:node-key) so a same-id
+;; frame REINCARNATION between render and commit is detected as movement, EVEN
+;; WHEN node-version + frame/registry epochs coincide across the incarnations.
+;;
+;; `frame/dissoc-frame!` clears the destroyed frame's commit-epoch entry, so a
+;; recreate + the same single install RESTARTS the epoch at the value the
+;; destroyed incarnation held; a fresh node observed once is version 0 on both;
+;; and no :sub re-registration in the gap leaves the registry epoch stable. So
+;; the S2b version+epoch-only LIVE comparison ties across incarnations and would
+;; misread the reincarnation as UNCHANGED — the frozen S2 invariant break.
+;; `read` now also returns :node-key (the same identity `probe` already emits);
+;; a reincarnated frame builds a FRESH reaction that mints a strictly-greater
+;; key, so the changed key is the movement signal the reconciler needs.
+;; Deterministic, no sleeps, both hosts (the plain-atom adapter is CLJC).
+;; ===========================================================================
+
+(deftest read-carries-node-key-so-same-id-reincarnation-is-detected
+  (let [rfid :obs/reincarnation]
+    (rf/reg-sub :obs/rv (fn [db _] (:v db)))
+    ;; --- render incarnation: a LIVE node observed by a render-time probe ---
+    (rf/make-frame {:id rfid :adapter plain-atom/adapter})
+    (frame/replace-app-db! rfid {:v 1})
+    (let [target       (obs/resolve-target {:frame rfid :query-v [:obs/rv]})
+          ;; Hold a public subscribe ref so the node is canonical + LIVE when the
+          ;; render-side probe reads it (probe never takes a ref of its own).
+          _render-node (subs/subscribe [:obs/rv] {:frame rfid})
+          render-ev    (obs/probe target)]
+      (is (true? (:live? render-ev)) "the render probe read a LIVE node")
+      (is (= 1 (:value render-ev)))
+      (is (= 0 (:node-version render-ev)) "fresh node observed once ⟹ version 0")
+      (is (int? (:node-key render-ev)))
+      ;; --- reincarnation in the render→commit gap: destroy + recreate the SAME
+      ;;     id, install a DIFFERENT value. The identical make-frame + single
+      ;;     replace-app-db! sequence (with dissoc-frame! clearing the epoch)
+      ;;     makes node-version + frame/registry epochs COINCIDE with the
+      ;;     destroyed incarnation's — the coincident-version reincarnation. ---
+      (frame/destroy-frame! rfid)
+      (rf/make-frame {:id rfid :adapter plain-atom/adapter})
+      (frame/replace-app-db! rfid {:v 2})
+      (let [_commit-node (subs/subscribe [:obs/rv] {:frame rfid})
+            commit-ev    (obs/probe target)          ;; new live node, node-key K2
+            lease        (obs/acquire! target (fn [_]))
+            r            (obs/read lease)]
+        (is (= 2 (:value r)) "acquired + read the reincarnated node's value")
+        (testing "the version + epoch axes COINCIDE across the reincarnation"
+          (is (= (:node-version render-ev) (:version r))
+              "node versions tie — both fresh nodes at version 0")
+          (is (= (:frame-epoch render-ev) (:frame-epoch r))
+              "frame epochs tie — dissoc-frame! restarted the commit epoch")
+          (is (= (:registry-epoch render-ev) (:registry-epoch r))
+              "registry epochs tie — no :sub re-registration in the gap"))
+        (testing "read now carries the node's IDENTITY, DISTINCT across the reincarnation"
+          (is (int? (:node-key r))
+              "read carries :node-key (the fix — omitted before, so nil)")
+          (is (= (:node-key commit-ev) (:node-key r))
+              "read's node-key is the node it actually owns at commit")
+          (is (not= (:node-key render-ev) (:node-key r))
+              "the reincarnated node has a DISTINCT identity from the destroyed one"))
+        (testing "so the S2b evidence comparison classifies it as MOVED, not unchanged"
+          ;; Mirror ui.reactive/evidence-moved?'s live branch: version+epoch ALONE
+          ;; MISSES it (the bug); the additive :node-key axis catches it.
+          (letfn [(version+epoch-moved? [rd pv]
+                    (or (not= (:version rd) (:node-version pv))
+                        (not= (:frame-epoch rd) (:frame-epoch pv))
+                        (not= (:registry-epoch rd) (:registry-epoch pv))))
+                  (node-key-moved? [rd pv]
+                    (or (version+epoch-moved? rd pv)
+                        (not= (:node-key rd) (:node-key pv))))]
+            (is (false? (version+epoch-moved? r render-ev))
+                "version+epoch-only comparison MISSES the reincarnation (the S2 break)")
+            (is (true? (node-key-moved? r render-ev))
+                "carrying :node-key makes the reincarnation detectable as movement")))
+        (obs/release! lease)))
+    (frame/destroy-frame! rfid)))
+
+(deftest unchanged-live-node-reads-the-same-node-key-no-false-movement
+  ;; The fast-path guard (rf2-vxgfnd.14 AC #4): a genuinely-unchanged live node
+  ;; reads the SAME node-key/version/epochs across a render probe and a commit
+  ;; read, so the reconciler's evidence comparison classifies it UNCHANGED — the
+  ;; new :node-key axis introduces no false movement.
+  (reg-items!)
+  (seed-items! [:a])
+  (let [target    (items-target)
+        _live     (subs/subscribe [:obs/items] {:frame fid})
+        render-ev (obs/probe target)
+        lease     (obs/acquire! target (fn [_]))
+        r         (obs/read lease)]
+    (is (true? (:live? render-ev)))
+    (is (= (:node-key render-ev) (:node-key r))
+        "same live node ⟹ same node-key across render and commit")
+    (is (= (:node-version render-ev) (:version r)))
+    (is (= (:frame-epoch render-ev) (:frame-epoch r)))
+    (is (= (:registry-epoch render-ev) (:registry-epoch r)))
+    (letfn [(moved? [rd pv]
+              (or (not= (:version rd) (:node-version pv))
+                  (not= (:frame-epoch rd) (:frame-epoch pv))
+                  (not= (:registry-epoch rd) (:registry-epoch pv))
+                  (not= (:node-key rd) (:node-key pv))))]
+      (is (false? (moved? r render-ev))
+          "no false movement for an unchanged live node — the fast path holds"))
+    (obs/release! lease)))
+
 (deftest reentrant-graph-op-is-dev-asserted-inside-the-fan-out
   (reg-items!)
   (seed-items! [:a])


### PR DESCRIPTION
## What

The observation port could not distinguish a live subscription node observed in one frame incarnation from a node acquired in a **later** incarnation that reused the same frame id, when their node-version + frame/registry epochs coincided — violating the frozen S2 invariant that render-to-commit movement is detected and corrected before paint.

`frame/dissoc-frame!` clears a destroyed frame's commit-epoch entry, so a destroy + recreate of the same id **restarts** its commit epoch; a fresh node observed once is `:version 0`; and with no `:sub` re-registration the registry epoch is stable. So the S2b live-branch evidence comparison (version + frame-epoch + registry-epoch) ties across incarnations and reads the reincarnation as **unchanged**.

## How

`read` on a node lease now additionally returns **`:node-key`** — the acquired node's process-unique IDENTITY, the same key `probe` already emits (an additive key, like the existing `:frame-epoch`/`:registry-epoch`). A reincarnated frame builds a fresh reaction that mints a strictly-greater `:node-key`, so a changed key is the movement signal the reconciler needs even when version+epoch coincide. This reuses the existing minted node identity rather than inventing a new id, and keeps the comparison constant-time (integer compare, no deep value equality on the commit path). The unchanged-node fast path is preserved (the same live node reads the same key/version/epochs).

`port-abi-version` bumped **1 → 2** (R-6 lockstep guard): a consumer from v2 onward requires a core that emits `:node-key`.

## Coordination follow-up — rf2-vxgfnd.93 (ui artefact)

Surface discipline: this PR is the **core port** side only. The S2b ViewCell reconciler `re-frame.ui.reactive/evidence-moved?` (ui artefact, worker .85/.86's surface) must add the `:node-key` comparison clause to complete the end-to-end fix, pin the consumer's expected ABI to 2, add a React layout-commit fixture, and note `:node-key` in Spec 006. The additive read key is **non-breaking** for the current reconciler (it ignores the extra key), so that lands as a follow-up. Filed as **rf2-vxgfnd.93**.

## Tests

- `read-carries-node-key-so-same-id-reincarnation-is-detected` — deterministic, cross-host (plain-atom CLJC), no sleeps. Destroys + recreates the same frame id with node-version + frame/registry epochs engineered to coincide; asserts those axes tie (so the version+epoch-only comparison misses it) yet `read`'s `:node-key` differs from the destroyed incarnation's, making the reincarnation detectable as movement. **Proven to fail pre-fix** (read omitted the key → `(= 16 nil)`, `(int? nil)`).
- `unchanged-live-node-reads-the-same-node-key-no-false-movement` — a genuinely-unchanged live node reads the same key/version/epochs → no false movement.

## Quality gates

Foreground, 0-fail:

- Core JVM `clojure -M:test` (full core suite): **1871 tests, 8382 assertions, 0 failures, 0 errors**
- Observation-port ns (`re-frame.observation-port-cljs-test`, JVM): **41 tests, 247 assertions, 0 failures, 0 errors**
- CLJS node-runtime `npm run test:cljs`: **9043 tests, 42703 assertions, 0 failures, 0 errors**