### PR TITLE
feat(ui): shadow :build-hooks adapter for per-build pass boundaries + deleted-source eviction (rf2-phlhfd)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -563,6 +563,18 @@
   {:target    :node-test
    :output-to "out/node-test.js"
    :ns-regexp "cljs-test$"
+   ;; rf2-phlhfd — the re-frame.ui compiler pass-boundary adapter. The
+   ;; hook marks `begin-build!` at :compile-prepare and `finish-build!`
+   ;; (commit + authoritative-membership eviction against :build-sources)
+   ;; at :compile-finish, so a source deleted between reloads in a WATCH
+   ;; daemon gets its compile-time registrations EVICTED (df9873 delivered
+   ;; the primitives + multi-build isolation; this only adds incremental
+   ;; deletion detection). Harmless on a one-shot compile: a clean pass
+   ;; commits the identical state the no-pass upsert posture would. The
+   ;; hook is a JVM-side `.clj` (shadow build hooks run on the JVM); the
+   ;; bundle-isolation contract is unaffected — build.cljc/build_hook.clj
+   ;; are compile-time authority, never in a client bundle.
+   :build-hooks [(re-frame.ui.compiler.build-hook/hook)]
    ;; rf2-try1x — silent-on-success reporter. Custom runner installs
    ;; the cljs.test/report defmethod overrides before discovery. Source
    ;; ns lives at
@@ -717,6 +729,10 @@
    :output-to "out/node-test-ui.js"
    :ns-regexp "^re-frame\\.ui\\..+-cljs-test$"
    :main      re-frame.test-quiet.shadow-node/main
+   ;; rf2-phlhfd — the focused re-frame.ui watch target: the pass-boundary
+   ;; adapter's primary home (deleted-source eviction on `shadow-cljs watch
+   ;; node-test-ui`). See the :node-test entry above for the full rationale.
+   :build-hooks [(re-frame.ui.compiler.build-hook/hook)]
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}
 
@@ -734,6 +750,11 @@
   {:target    :node-script
    :main      re-frame.ui.bench.main/-main
    :output-to "out/ui-bench.js"
+   ;; rf2-phlhfd — pass-boundary adapter (see :node-test above). A one-shot
+   ;; :advanced compile: begin at :compile-prepare, finish (commit, evict
+   ;; none — every bench source is a member) at :compile-finish, committing
+   ;; the identical registry state a hook-less clean build would.
+   :build-hooks [(re-frame.ui.compiler.build-hook/hook)]
    :compiler-options {:optimizations :advanced
                       :infer-externs :auto}}
 

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -1,0 +1,106 @@
+(ns re-frame.ui.compiler.build-hook
+  "The thin shadow-cljs `:build-hooks` ADAPTER for the re-frame.ui
+  compiler-state authority (rf2-df9873 → rf2-phlhfd).
+
+  df9873 delivered the authority itself: per-build-id keyed registries,
+  ambient build identity read from the compiler env, and the
+  `begin-build!` / `finish-build!` / `abort-build!` pass-boundary
+  primitives (all implemented + test-driven). Multi-build ISOLATION and
+  warm-cache-start COMPLETENESS already hold with no hook — isolation
+  comes from the ambient per-thread identity, completeness from the
+  `:cache-blockers` re-macroexpansion. This adapter adds the ONE thing a
+  hook is needed for: INCREMENTAL DELETED-SOURCE EVICTION in a live watch
+  daemon. A namespace that declared a root / view / custom-element in one
+  pass and whose FILE is then deleted between reloads drops out of the
+  build graph; this hook evicts its stale registrations at the next
+  `:compile-finish`.
+
+  ## The one seam shadow gives us: build-lifecycle stage boundaries
+
+  A `:build-hooks` fn is called by `shadow.build/process-stage` at the
+  stages named in its `:shadow.build/stages` metadata, with the whole
+  build-state, and MUST return a build-state. shadow's REPL eval path
+  compiles through `shadow.build.api/compile-sources` DIRECTLY and never
+  runs `shadow.build/compile` — so build hooks NEVER fire on a REPL form
+  eval. That is what keeps the RULED REPL posture intact: with no hook
+  firing, no pass opens, and a REPL contribution UPSERTS per-key straight
+  into committed (no sibling eviction, no wipe). See build.cljc.
+
+    :compile-prepare  ->  begin-build!  — open the pass BEFORE the
+                          (possibly parallel) source compilation stages;
+                          contributions made during the pass STAGE rather
+                          than upsert. begin-build! also DISCARDS any
+                          staging a prior FAILED pass left open — which is
+                          the abort/failure recovery in a live daemon (see
+                          below), so a doomed compile never half-commits.
+
+    :compile-finish   ->  finish-build! against the AUTHORITATIVE member
+                          set (the build graph's `:build-sources`). Commit
+                          the pass, then evict every committed source
+                          ABSENT from the current graph — a deleted FILE.
+                          `:build-sources` is the WHOLE resolved graph on
+                          every pass (incrementals included), so macro
+                          silence from a cache hit is never mistaken for a
+                          deletion: authoritative membership drives
+                          eviction, not `touched`. Guarded by `pass-open?`
+                          so a stray finish with no matching prepare can
+                          never commit/evict (belt-and-suspenders REPL /
+                          partial-state safety).
+
+  ## Why no `:flush` / failure stage is wired
+
+  shadow's build-hook pipeline exposes NO failure stage: when
+  `compile-sources` throws, the exception propagates before
+  `:compile-finish` runs, and `:flush` (the SUCCESS terminus, after
+  `:compile-finish` has already committed and closed the pass) never runs
+  on failure. So there is no stage at which an explicit `abort-build!`
+  would be both reachable and non-redundant. The abort semantics an
+  aborted pass needs — keep last-known-good, don't half-commit — are
+  delivered instead by begin-build!'s discard-on-open at the NEXT
+  `:compile-prepare`: the doomed pass's partial staging is dropped before
+  any macro of the retry pass can read it, and the committed
+  last-known-good is republished untouched. `abort-build!` remains the
+  primitive an out-of-band failure handler would call; this adapter does
+  not need a stage for it."
+  (:require [re-frame.ui.compiler.build :as build]))
+
+(defn- member-nss
+  "The authoritative member set for the current pass: the declaring
+  namespace symbols provided by every source in the resolved build graph.
+  `:build-sources` is a vector of resource-ids into `:sources`; a source's
+  `:provides` (falling back to its `:ns`) are the namespace symbols that
+  key the compiler registries (build.cljc keys per declaring ns). A
+  deleted FILE is absent from `:build-sources`, so its ns drops out of
+  this set and `finish-build!` evicts its registrations."
+  [{:keys [build-sources sources]}]
+  (reduce
+   (fn [acc resource-id]
+     (let [rc (get sources resource-id)]
+       (into acc (or (:provides rc)
+                     (when-let [n (:ns rc)] #{n})))))
+   #{}
+   build-sources))
+
+(defn hook
+  "shadow-cljs `:build-hooks` adapter — wire as
+  `:build-hooks [(re-frame.ui.compiler.build-hook/hook)]` on the
+  re-frame.ui-consuming builds. Marks the re-frame.ui compiler's pass
+  boundaries so a live watch daemon evicts a deleted source's stale
+  registrations. Pure dispatch over the stage; side-effects into the
+  build.cljc authority and returns the build-state unchanged."
+  {:shadow.build/stages #{:compile-prepare :compile-finish}}
+  [{build-id :shadow.build/build-id
+    stage    :shadow.build/stage
+    :as      build-state}]
+  (case stage
+    :compile-prepare
+    (build/begin-build! build-id)
+
+    :compile-finish
+    ;; Only finalize a pass THIS hook opened — a finish with no matching
+    ;; prepare (a stray/partial invocation) must never commit or evict.
+    (when (build/pass-open? build-id)
+      (build/finish-build! build-id (member-nss build-state)))
+
+    nil)
+  build-state)

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -1,0 +1,217 @@
+(ns re-frame.ui.compiler-build-hook-jvm-test
+  "The thin shadow `:build-hooks` ADAPTER (rf2-phlhfd) driven through its
+  real `hook` fn with synthetic shadow build-states.
+
+  The authority + its pass-boundary primitives are proven in
+  re-frame.ui.compiler-build-jvm-test; this suite proves the ADAPTER wires
+  the shadow lifecycle stages to those primitives correctly, and that the
+  ONE behaviour a hook adds — INCREMENTAL DELETED-SOURCE EVICTION in a live
+  watch daemon — actually fires through the real begin -> finish path.
+
+  The adversarial cruces:
+
+    - DELETED-SOURCE EVICTION: a source that declared a view in pass 1 and
+      whose FILE is deleted before pass 2 (absent from `:build-sources`)
+      gets its registration EVICTED after pass 2's `:compile-finish` —
+      isolation alone (df9873) can NOT detect this; the pass boundary can.
+    - NO FALSE EVICTION: an incremental recompile of ONE source keeps every
+      other LIVE member's registration — macro silence (a cache hit) is not
+      a deletion; authoritative `:build-sources` membership drives eviction.
+    - FAILED PASS keeps last-known-good: a compile that throws runs no
+      `:compile-finish`; the doomed pass's partial staging is discarded at
+      the next `:compile-prepare` (begin-build!'s discard-on-open), and the
+      committed last-known-good is republished — no half-commit. The
+      `abort-build!` primitive restores it explicitly too.
+    - REPL DOES NOT TRIP A WIPE: a REPL contribution opens no pass (hooks
+      never fire on REPL eval); a subsequent stray `:compile-finish` whose
+      member set omits the REPL ns is a no-op — the `pass-open?` guard skips
+      finish, so the REPL upsert survives."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.build-hook :as build-hook]))
+
+;; Each test starts from a clean authority.
+(use-fixtures :each
+  (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
+
+;; ---------------------------------------------------------------------------
+;; Harness — drive the REAL `build-hook/hook` fn with synthetic shadow
+;; build-states. A shadow build-state carries `:shadow.build/build-id`,
+;; `:shadow.build/stage`, and (at :compile-finish) `:build-sources` +
+;; `:sources`; the hook reads exactly those. Using the declaring ns-sym as
+;; its own opaque resource-id keeps the fixtures minimal.
+;; ---------------------------------------------------------------------------
+
+(defn- prepare!
+  "Fire the `:compile-prepare` hook for `build-id` (opens the pass)."
+  [build-id]
+  (build-hook/hook {:shadow.build/build-id build-id
+                    :shadow.build/stage    :compile-prepare}))
+
+(defn- finish!
+  "Fire the `:compile-finish` hook for `build-id` with `member-nss` as the
+  authoritative build graph (`:build-sources`) — commit + evict-deleted."
+  [build-id member-nss]
+  (build-hook/hook {:shadow.build/build-id build-id
+                    :shadow.build/stage    :compile-finish
+                    :build-sources         (vec member-nss)
+                    :sources               (into {} (map (fn [n] [n {:ns n :provides #{n}}]))
+                                                 member-nss)}))
+
+(defn- declare-view!
+  "A source `ns-sym` contributing one view digest to the ambient build —
+  the shape a `defview` macroexpansion produces (staged while a pass is
+  open, upserted otherwise)."
+  [build-id ns-sym view-id fp]
+  (binding [build/*build-id* build-id]
+    (build/contribute! build/views ns-sym view-id fp)))
+
+(defn- views-of [build-id]
+  (build/aggregate build/views build-id))
+
+;; ---------------------------------------------------------------------------
+;; The hook returns a valid build-state (shadow rejects a hook otherwise)
+;; ---------------------------------------------------------------------------
+
+(deftest hook-returns-the-build-state-unchanged
+  (let [prep {:shadow.build/build-id :node-test-ui
+              :shadow.build/stage    :compile-prepare}]
+    (is (identical? prep (build-hook/hook prep))
+        "the hook side-effects into the authority and returns the state it was given"))
+  (let [fin {:shadow.build/build-id :node-test-ui
+             :shadow.build/stage    :compile-finish
+             :build-sources         []
+             :sources               {}}]
+    (is (identical? fin (build-hook/hook fin)))))
+
+(deftest hook-declares-the-two-lifecycle-stages
+  (is (= #{:compile-prepare :compile-finish}
+         (:shadow.build/stages (meta #'build-hook/hook)))
+      "shadow invokes the hook at exactly the pass-boundary stages"))
+
+;; ---------------------------------------------------------------------------
+;; THE HEADLINE — incremental deleted-source eviction in a watch daemon
+;; ---------------------------------------------------------------------------
+
+(deftest hook-evicts-a-deleted-source-on-compile-finish
+  (let [bid :node-test-ui]
+    ;; pass 1: app.a and app.b both declare a view; both are graph members.
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :fp-a)
+    (declare-view! bid 'app.b :app.b/view :fp-b)
+    (finish! bid '#{app.a app.b})
+    (is (= {:app.a/view :fp-a :app.b/view :fp-b} (views-of bid))
+        "both survive pass 1's finish")
+
+    ;; pass 2: app.b's FILE is deleted → it is ABSENT from :build-sources and
+    ;; never re-declares (macro silence). app.a recompiles unchanged.
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :fp-a)
+    (finish! bid '#{app.a})
+    (is (= {:app.a/view :fp-a} (views-of bid))
+        "the deleted app.b's registration is EVICTED after compile-finish — the ONE thing the hook adds")))
+
+;; ---------------------------------------------------------------------------
+;; NO FALSE EVICTION — an incremental recompile keeps surviving declarations
+;; ---------------------------------------------------------------------------
+
+(deftest hook-incremental-recompile-keeps-untouched-live-members
+  (let [bid :node-test-ui]
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :fp-a)
+    (declare-view! bid 'app.b :app.b/view :fp-b)
+    (finish! bid '#{app.a app.b})
+
+    ;; incremental: ONLY app.a recompiles (app.b is a cache hit → no
+    ;; re-macroexpansion), but app.b is STILL a graph member.
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :fp-a2)
+    (finish! bid '#{app.a app.b})
+    (is (= {:app.a/view :fp-a2 :app.b/view :fp-b} (views-of bid))
+        "app.b survives — macro silence is not deletion; only app.a's digest changed")))
+
+;; ---------------------------------------------------------------------------
+;; FAILED PASS keeps last-known-good (no :compile-finish runs on failure)
+;; ---------------------------------------------------------------------------
+
+(deftest hook-failed-pass-converges-to-last-known-good
+  (let [bid :node-test-ui]
+    ;; a good pass
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :good)
+    (finish! bid '#{app.a})
+    (is (= {:app.a/view :good} (views-of bid)))
+
+    ;; a DOOMED pass: prepare + a partial contribution, then compile-sources
+    ;; throws so the hook's :compile-finish NEVER runs.
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :bad)
+    ;; ... exception; finish! deliberately NOT called ...
+
+    ;; the NEXT pass's :compile-prepare discards the doomed staging.
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :good)
+    (finish! bid '#{app.a})
+    (is (= {:app.a/view :good} (views-of bid))
+        "the doomed pass's partial was discarded at the next prepare; the retry converges — no half-commit")))
+
+(deftest explicit-abort-restores-last-known-good
+  ;; The abort-build! primitive the out-of-band failure path would call:
+  ;; discard staging, republish committed last-known-good, do not half-commit.
+  (let [bid :node-test-ui]
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :good)
+    (finish! bid '#{app.a})
+
+    (prepare! bid)
+    (declare-view! bid 'app.a :app.a/view :bad)
+    (declare-view! bid 'app.b :app.b/view :partial)
+    (is (= {:app.a/view :bad :app.b/view :partial} (views-of bid))
+        "the doomed staging is visible mid-pass")
+    (build/abort-build! bid)
+    (is (= {:app.a/view :good} (views-of bid))
+        "abort discards the partial + republishes last-known-good — the aborted pass does not half-commit")))
+
+;; ---------------------------------------------------------------------------
+;; REPL does not trip a wipe — hooks never fire on REPL eval, and even a
+;; stray finish is skipped by the pass-open? guard
+;; ---------------------------------------------------------------------------
+
+(deftest repl-eval-without-a-pass-is-not-wiped-by-a-stray-finish
+  (let [bid :node-test-ui]
+    ;; a REPL form eval: shadow's REPL never runs the build-hook pipeline, so
+    ;; NO prepare opens a pass — the contribution UPSERTS straight into
+    ;; committed (the ruled REPL posture, build.cljc).
+    (declare-view! bid 'app.repl :app.repl/view :r1)
+    (is (false? (build/pass-open? bid)) "a REPL contribution opens no pass")
+    (is (= {:app.repl/view :r1} (views-of bid)))
+
+    ;; a stray :compile-finish whose member set OMITS app.repl must NOT evict
+    ;; it: with no pass open, the guard skips finish-build! entirely.
+    (finish! bid '#{app.other})
+    (is (= {:app.repl/view :r1} (views-of bid))
+        "the pass-open? guard skips the stray finish — the REPL upsert survives, no wipe")))
+
+;; ---------------------------------------------------------------------------
+;; MULTI-BUILD — the hook keys per build-id (df9873 isolation, through the hook)
+;; ---------------------------------------------------------------------------
+
+(deftest hook-keeps-concurrent-builds-isolated
+  ;; two builds' passes are open at once (the daemon compiles both); each
+  ;; hook keys its own slice, and a deletion in one build never touches the
+  ;; other's registrations.
+  (prepare! :node-test-ui)
+  (prepare! :ui-bench)
+  (declare-view! :node-test-ui 'app.a :app.a/view :fp-ui)
+  (declare-view! :ui-bench     'app.a :app.a/view :fp-bench)
+  (finish! :node-test-ui '#{app.a})
+  (finish! :ui-bench     '#{app.a})
+  (is (= {:app.a/view :fp-ui}    (views-of :node-test-ui)))
+  (is (= {:app.a/view :fp-bench} (views-of :ui-bench)))
+
+  ;; app.a's file is deleted from :node-test-ui only; :ui-bench keeps it.
+  (prepare! :node-test-ui)
+  (finish! :node-test-ui '#{})
+  (is (= {} (views-of :node-test-ui)) "the deletion evicted app.a in :node-test-ui")
+  (is (= {:app.a/view :fp-bench} (views-of :ui-bench))
+      "the :ui-bench build is untouched — per-build isolation holds through the hook"))


### PR DESCRIPTION
## What

Wires the thin shadow `:build-hooks` adapter for the re-frame.ui compiler-state authority (rf2-df9873 → **rf2-phlhfd**, follow-up to #5770).

#5770 delivered the build-lifecycle **authority** — per-build-id keyed compiler registries, ambient identity from the compiler env, and the `begin-build!`/`finish-build!`/`abort-build!` pass-boundary primitives (all implemented + test-driven). Multi-build **isolation** and warm-cache-start **completeness** already hold with no hook. This PR adds only the thin shadow adapter that calls those primitives at the lifecycle phases — its sole added value is **incremental deleted-source eviction in a live watch daemon**: a source that declared a root/view/custom-element in one pass and whose file is deleted before the next reload gets its stale registrations dropped.

## The hook

New JVM-side `re-frame.ui.compiler.build-hook/hook` (a `.clj` — shadow build hooks run on the JVM). It reads the shadow build-state and dispatches on `:shadow.build/stage`:

| stage | primitive |
|---|---|
| `:compile-prepare` | `begin-build!` — opens the pass before the (possibly parallel) compile stages; also **discards any staging a prior FAILED pass left open** |
| `:compile-finish` | `finish-build!` against the authoritative `:build-sources` member set — commit, then evict every committed source **absent from the current build graph** (a deleted FILE). Guarded by `pass-open?` |

Design notes:
- **`:build-sources` is the whole resolved graph on every pass** (incrementals included), so macro silence from a cache hit is never mistaken for a deletion — authoritative membership, not `touched`, drives eviction.
- **REPL does not trip a wipe.** shadow's REPL eval compiles through `compile-sources` directly and never runs `shadow.build/compile`, so build hooks never fire on a REPL form — no pass opens, the ruled per-key upsert posture holds. The `pass-open?` guard on `:compile-finish` is belt-and-suspenders: a stray finish with no matching prepare can never commit or evict.
- **No `:flush`/failure stage is wired.** shadow's build-hook pipeline exposes no failure stage: `compile-sources` throws before `:compile-finish`, and `:flush` (the success terminus) never runs on failure. The abort semantics an aborted pass needs — keep last-known-good, don't half-commit — are delivered by `begin-build!`'s discard-on-open at the next `:compile-prepare`. `abort-build!` remains the primitive an out-of-band handler would call.

The authority (`build.cljc`) was **not** touched — the hook only *calls* the shipped primitives.

## Wiring (HOT-ZONE: `implementation/shadow-cljs.edn`)

Added `:build-hooks [(re-frame.ui.compiler.build-hook/hook)]` to the three re-frame.ui-consuming builds: `:node-test`, `:node-test-ui`, `:ui-bench`. Harmless on a one-shot compile — a clean pass commits the identical registry state the hook-less upsert posture would; the incremental-deletion behaviour is the addition for watch daemons.

## Test

`re-frame.ui.compiler-build-hook-jvm-test` drives the real `hook` fn with synthetic shadow build-states:
- **deleted-source eviction** fires through the real begin→finish path (a source absent from `:build-sources` in pass 2 is evicted after `:compile-finish`)
- an **incremental recompile** keeps every live member (macro silence ≠ deletion)
- a **failed pass** (no `:compile-finish`) converges to last-known-good at the next prepare
- **explicit abort** restores last-known-good without half-committing
- a **REPL upsert** (no pass) is not wiped by a stray finish (guard)
- **per-build isolation** holds through the hook

## Quality gates

All foreground, 0-fail:

- `clojure -M:test` (ui compiler alias): **305 tests, 4703 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (consolidated `:node-test`, hook wired): **9043 tests, 42718 assertions, 0 failures, 0 errors**
- `npx shadow-cljs compile node-test-ui` (hook loads + build compiles): **212 files, 0 warnings**; `node out/node-test-ui.js`: **282 tests, 1474 assertions, 0 failures, 0 errors**