### PR TITLE
fix(ui): custom-element compiler reads use per-build aggregate, not a global mirror (rf2-vxgfnd.91)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -14,8 +14,7 @@
                       [re-frame.ui.compiler.emit-jvm :as emit-jvm]
                       [re-frame.ui.compiler.env :as env]
                       [re-frame.ui.compiler.header :as header]
-                      [re-frame.ui.fingerprint :as fingerprint]
-                      [re-frame.ui.rules :as rules]])))
+                      [re-frame.ui.fingerprint :as fingerprint]])))
 
 #?(:clj
    (do
@@ -27,14 +26,17 @@
 ;; the ambient build's view aggregate (compile-order independent — the
 ;; triples sort by view-id).
 ;;
-;; The compile-time custom-element declarations are the one registry that
-;; keeps an external MIRROR atom: they are WRITTEN here (macro expansion) but
-;; READ on the JVM by the tree builder through `re-frame.ui.rules/custom-
-;; elements` (the same var the CLJS RUNTIME arm owns on the client). Register
-;; it as `build/elements`' mirror so build.cljc keeps it synced to the
-;; ambient build's aggregate for that JVM read. The Layer-1 root/plan/
-;; descriptor registries and the view digest read through `build/aggregate`.
-(build/register! build/elements rules/custom-elements)
+;; The compile-time custom-element declarations are a build-scoped registry
+;; like the other four: WRITTEN here (macro expansion → `build/contribute!
+;; build/elements`) and READ on the compile path by the template analyzer
+;; through `build/element-properties`, which resolves the AMBIENT build's
+;; slice (rf2-vxgfnd.91). No process-global mirror atom: the former
+;; `build/register! build/elements rules/custom-elements` bridge was a
+;; last-writer-wins hazard where a sibling build's contribution could flip
+;; another build's classification. The CLJS/JVM RUNTIME arm keeps its own
+;; `re-frame.ui.rules/custom-elements` ledger (populated by the emitted
+;; `register-custom-element!`, read at render for dynamic `ui/spread` props);
+;; it is separate from this compile registry.
 
 (defn current-build-digest []
   (fingerprint/build-digest

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -12,6 +12,7 @@
   branches. Rejected forms throw compile errors with
   {:rf.ui.compile/error <id>} ex-data (the S1e roster keys off the ids)."
   (:require [clojure.string :as str]
+            [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.rules :as rules]))
 
@@ -405,7 +406,13 @@
   :property-props #{kw} :static? bool}"
   [e tag-info custom? props-form]
   (let [tag        (:tag tag-info)
-        properties (when custom? (rules/custom-element-properties tag))
+        ;; Per-build compile-time property classification, read from the
+        ;; ambient build's `elements` slice (rf2-vxgfnd.91). This analysis
+        ;; runs under `cljs.env/*compiler*`, so `build/element-properties`
+        ;; resolves the CURRENT build's declarations — never a process-global
+        ;; last-writer-wins mirror that a sibling build could clobber between
+        ;; this tag's declaration and this classification read.
+        properties (when custom? (build/element-properties tag))
         spread?    (spread-form? e props-form)]
     (when (and (some? props-form) (not (map? props-form)) (not spread?))
       (env/fail! e :rf.ui.compile/dynamic-props-map

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -116,14 +116,6 @@
   and is per-thread correct under parallel builds)."}
   session-build (atom ::default))
 
-(defonce ^{:private true
-           :doc "reg-id -> external MIRROR atom kept synced to the ambient
-  build's aggregate, so a JVM-side reader that derefs a plain atom (the JVM
-  tree builder's custom-element registry) sees the current build's rows. Only
-  the compile-time custom-element registry mirrors; every other registry
-  reads through `aggregate`."}
-  mirrors (atom {}))
-
 (def ^:dynamic *build-id*
   "Explicit identity override (tests / REPL). Wins over the compiler env and
   the session fallback; bind it per-thread to drive interleaved builds."
@@ -187,36 +179,22 @@
   ([reg-id build-id]
    (effective (get @state build-id empty-slice) reg-id ::none)))
 
+(defn element-properties
+  "The declared `:properties` set for custom-element `tag` in the ambient (or
+  given) build's compile-time `elements` registry — the compile-path read the
+  template analyzer uses to classify a custom element's props (property vs
+  attribute). Per-build, resolved through the ambient compiler build identity
+  (the SAME `current-build-id` mechanism every other registry read uses), so
+  one daemon's parallel builds never cross-classify; NEVER a process-global
+  last-writer-wins mirror. Empty set when `tag` is undeclared in this build."
+  ([tag] (element-properties tag (current-build-id)))
+  ([tag build-id] (get-in (aggregate elements build-id) [tag :properties] #{})))
+
 (defn pass-open?
   "Whether a compile pass is currently open for the ambient (or given)
   build (tests / tooling)."
   ([] (pass-open? (current-build-id)))
   ([build-id] (:pass-open? (get @state build-id empty-slice) false)))
-
-;; ---------------------------------------------------------------------------
-;; External mirrors (the compile-time custom-element registry)
-;; ---------------------------------------------------------------------------
-
-(defn- sync-mirror! [reg-id build-id]
-  (when-let [mirror (get @mirrors reg-id)]
-    (reset! mirror (aggregate reg-id build-id)))
-  nil)
-
-(defn- sync-mirrors! [build-id]
-  (doseq [[reg-id _] @mirrors] (sync-mirror! reg-id build-id))
-  nil)
-
-(defn register!
-  "Register an external MIRROR atom for `reg-id`: build.cljc keeps it synced
-  to the ambient build's aggregate so a JVM reader that derefs the plain atom
-  (the JVM tree builder's custom-element registry) sees the current build's
-  contributions. Idempotent. Only the compile-time custom-element registry
-  uses this — the Layer-1 indexes and the view digest read through
-  `aggregate`."
-  [reg-id mirror]
-  (swap! mirrors assoc reg-id mirror)
-  (sync-mirror! reg-id (current-build-id))
-  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; Contribution (pure transitions)
@@ -239,10 +217,9 @@
   ambient build — one `swap!`, pure. The Layer-1 indexes use
   `contribute-checked!` for their pre-write conflict check."
   [reg-id source k v]
-  (let [build-id (current-build-id)]
-    (swap! state update build-id (fnil write-slice empty-slice) reg-id source k v)
-    (sync-mirror! reg-id build-id)
-    nil))
+  (swap! state update (current-build-id)
+         (fnil write-slice empty-slice) reg-id source k v)
+  nil)
 
 (defn contribute-checked!
   "The atomic conflict-checked contribution for a Layer-1 index. Inside ONE
@@ -255,9 +232,8 @@
   parallel compilation can neither drop a concurrent write (check-then-assoc
   race) nor miss a genuine duplicate."
   [reg-id source k v conflict-fn]
-  (let [build-id (current-build-id)
-        outcome  (atom nil)]           ; call-local — only this call's retries touch it
-    (swap! state update build-id
+  (let [outcome (atom nil)]             ; call-local — only this call's retries touch it
+    (swap! state update (current-build-id)
            (fn [slice]
              (let [slice    (or slice empty-slice)
                    existing (get (effective slice reg-id source) k)
@@ -266,7 +242,6 @@
                  (do (reset! outcome {:conflict conflict}) slice)
                  (do (reset! outcome nil)
                      (write-slice slice reg-id source k v))))))
-    (sync-mirror! reg-id build-id)
     @outcome))
 
 ;; ---------------------------------------------------------------------------
@@ -284,7 +259,6 @@
    (reset! session-build build-id)
    (swap! state update build-id
           (fn [s] (assoc (or s empty-slice) :pass-open? true :staged {} :touched #{})))
-   (sync-mirrors! build-id)
    nil))
 
 (defn- commit-slice
@@ -308,7 +282,6 @@
   ([] (commit-build! (current-build-id)))
   ([build-id]
    (swap! state update build-id (fn [s] (commit-slice (or s empty-slice))))
-   (sync-mirrors! build-id)
    nil))
 
 (defn- keep-members
@@ -332,7 +305,6 @@
             (let [s (or s empty-slice)
                   touched (:touched s)]
               (-> s commit-slice (keep-members touched)))))
-   (sync-mirrors! build-id)
    nil))
 
 (defn finish-build!
@@ -344,8 +316,7 @@
   [build-id members]
   (let [members (set members)]
     (swap! state update build-id
-           (fn [s] (-> (or s empty-slice) commit-slice (keep-members members))))
-    (sync-mirrors! build-id))
+           (fn [s] (-> (or s empty-slice) commit-slice (keep-members members)))))
   nil)
 
 (defn abort-build!
@@ -355,7 +326,6 @@
   ([build-id]
    (swap! state update build-id
           (fn [s] (assoc (or s empty-slice) :staged {} :touched #{} :pass-open? false)))
-   (sync-mirrors! build-id)
    nil))
 
 (defn reset-build!
@@ -365,5 +335,4 @@
   []
   (reset! state {})
   (reset! session-build ::default)
-  (doseq [[_ mirror] @mirrors] (reset! mirror {}))
   nil)

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -183,6 +183,15 @@
     :props   compile-time property-prop set (custom elements)
     :children thunk building the children vector (bound ns context)"
   [tag {:keys [static norm dyn events dyn-events key? key-val props children]}]
+  ;; Property classification for DYNAMIC (`ui/spread`) props needs the tag's
+  ;; declared properties at RENDER time. This builder is emitted into the view
+  ;; fn (emit-jvm), so it runs with NO `cljs.env/*compiler*` bound — a pure
+  ;; runtime read, not a compile read. Its correct source is therefore the
+  ;; RUNTIME arm ledger `re-frame.ui.rules/custom-elements` (populated on this
+  ;; host by the emitted `register-custom-element!`, keyed `[build-id ns-sym]`),
+  ;; NOT the compile-time `build/elements` slice. With the process-global
+  ;; compiler mirror removed (rf2-vxgfnd.91), that ledger is no longer clobbered
+  ;; by a sibling build's contribution, so this render read is now stable.
   (let [properties (when (str/includes? (name tag) "-")
                      (rules/custom-element-properties tag))
         base    (reduce-kv (fn [m k v] (if (nil? v) m (assoc m k v)))

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -28,10 +28,10 @@
   source key, rf2-df9873) are addressable."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ui.compiler :as compiler]
+            [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
-            [re-frame.ui.compiler.root :as root]
-            [re-frame.ui.rules :as rules]))
+            [re-frame.ui.compiler.root :as root]))
 
 ;; Every test starts from a clean authority; correctness across a watch
 ;; session comes from per-source replacement on the pass boundaries, but
@@ -507,20 +507,76 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Custom-element declaration removal clears stale property classification
-;; (AC5, compile side — read through the JVM mirror `rules/custom-elements`)
+;; (AC5, compile side — read through the per-build `build/element-properties`
+;; slice, the compile-path reader that replaced the process-global mirror,
+;; rf2-vxgfnd.91)
 ;; ---------------------------------------------------------------------------
 
 (deftest removed-custom-element-clears-stale-property-classification
   (build/begin-build! :app)
   (declare-element! 'app.a :x-el #{:help-text})
   (build/commit-build! :app)
-  (is (= #{:help-text} (rules/custom-element-properties :x-el))
+  (is (= #{:help-text} (build/element-properties :x-el :app))
       "the declaration classifies :help-text as a property")
   ;; edit app.a: :x-el renamed to :y-el (its declaration deleted)
   (build/begin-build! :app)
   (declare-element! 'app.a :y-el #{:label})
   (build/commit-build! :app)
-  (is (= #{} (rules/custom-element-properties :x-el))
+  (is (= #{} (build/element-properties :x-el :app))
       "the removed :x-el no longer classifies any property (was leaking)")
-  (is (= #{:label} (rules/custom-element-properties :y-el))
+  (is (= #{:label} (build/element-properties :y-el :app))
       "the current :y-el declaration classifies its property"))
+
+;; ---------------------------------------------------------------------------
+;; The cross-build interleave the per-build-isolation tests above miss: a
+;; custom-element contribution in ONE build BETWEEN another build's declaration
+;; and its property-classification READ. Under the former process-global mirror
+;; (`build/register! build/elements rules/custom-elements` + `sync-mirror!`),
+;; every contribution reset the single mirror atom to whichever build wrote
+;; last, so the analyzer's classification read flipped with parallel scheduling
+;; — the exact fifth registry #5770 claimed to isolate (rf2-vxgfnd.91).
+;; ---------------------------------------------------------------------------
+
+(defn- analyze-property-props
+  "Drive the REAL compile-path consumer (`analyze-element-props`) for a literal
+  custom-element props map under `build-id`, returning the set of props it
+  lowered as PROPERTIES (vs attributes)."
+  [build-id tag propmap]
+  (binding [build/*build-id* build-id]
+    (:property-props
+     (ana/analyze-element-props
+      (env/make-env {:host :clj :ns-sym 'app.test})
+      {:tag tag :classes [] :id nil}
+      true
+      propmap))))
+
+(deftest custom-element-classification-is-build-scoped-under-interleave
+  ;; build :app declares :x-card's :model property
+  (build/begin-build! :app)
+  (binding [build/*build-id* :app]
+    (declare-element! 'app.card :x-card #{:model}))
+  ;; build :node-test then contributes a DIFFERENT table — the write that, under
+  ;; the old global mirror, reset the single mirror atom to node-test's
+  ;; aggregate (no :x-card), between app's declaration and app's read below
+  (build/begin-build! :node-test)
+  (binding [build/*build-id* :node-test]
+    (declare-element! 'ntest.card :y-card #{:flavour}))
+  ;; app's compile thread classifies :x-card {:model ...}: it must read APP's
+  ;; slice and lower :model as a PROPERTY, deterministically — regardless of the
+  ;; interleaved node-test contribution. (On the pre-fix mirror this read
+  ;; returned node-test's clobbered table, lowering :model as an ATTRIBUTE.)
+  (is (= #{:model} (analyze-property-props :app :x-card {:model "m"}))
+      "app lowers :model as a PROPERTY from its own slice, not the mirror")
+  (is (= #{} (analyze-property-props :node-test :x-card {:model "m"}))
+      "node-test's slice has no :x-card — :model stays an attribute there")
+  (is (= #{:flavour} (analyze-property-props :node-test :y-card {:flavour "f"}))
+      "node-test reads its OWN table for its OWN tag")
+  (is (= #{} (analyze-property-props :app :y-card {:flavour "f"}))
+      "node-test's :y-card never leaks into app's classification")
+  (testing "output is stable no matter which build wrote most recently"
+    ;; a fresh node-test write (the 'last writer') cannot move app's read
+    (build/begin-build! :node-test)
+    (binding [build/*build-id* :node-test]
+      (declare-element! 'ntest.card2 :z-card #{:zz}))
+    (is (= #{:model} (analyze-property-props :app :x-card {:model "m"}))
+        "app's classification is unchanged by a later node-test contribution")))


### PR DESCRIPTION
## What & why

PR #5770 (df9873) made the S1 compiler registry authority one atom keyed per shadow build id, and most consumers read `build/aggregate` through the ambient compiler build identity. The **custom-element** path was the exception: `build/register! build/elements rules/custom-elements` registered one **process-global mirror atom**, and every `contribution`/`begin`/`commit`/`abort` called `sync-mirror!` to reset that single atom to the aggregate of **whichever build mutated most recently**. The template analyzer (`analyze.cljc`) then read `rules/custom-element-properties` — a deref of that global mirror, with no build id.

Result: build `:app` declares `:x-card` property `:model`; build `:node-test`'s contribution resets the mirror; the `:app` compile thread analyzes `:x-card {:model ...}` and reads node-test's mirror → lowers `:model` as an **attribute** instead of a **property**. Output depended on parallel scheduling — reintroducing cross-build timing dependence on exactly the fifth registry #5770 isolates.

## Fix

- **`build.cljc`** — removed the global mirror entirely: the `mirrors` atom, `sync-mirror!`/`sync-mirrors!`, `register!`, every `sync-mirror(s)!` call in `contribute!`/`contribute-checked!`/`begin`/`commit`/`reconcile`/`finish`/`abort`, and the mirror-reset in `reset-build!`. Added `element-properties`, a per-build compile-path reader (`get-in (aggregate elements build-id) [tag :properties]`) resolved through the same `current-build-id` mechanism every other registry uses.
- **`analyze.cljc`** — the compile-path read now calls `build/element-properties` (ambient build slice), never the mirror. This is the raced site; it runs under `cljs.env/*compiler*`, so the ambient identity is the correct build.
- **`compiler.cljc`** — dropped the `build/register! build/elements rules/custom-elements` bridge and the now-unused `rules` alias; updated the explanatory comment.
- **`tree.cljc`** — the JVM tree builder's `build-element` is **emitted into render-time view code** (emit-jvm), so it runs with **no** `cljs.env/*compiler*` bound — a pure runtime read, not a compile read. Its correct source is the RUNTIME arm ledger `rules/custom-elements` (populated on-host by the emitted `register-custom-element!`, keyed `[build-id ns-sym]`). Removing the mirror stops that ledger from being clobbered by a sibling build, so this render read is now stable **without changing the read itself**. Added a comment documenting this; see "Scope note" below.

The CLJS/JVM runtime reconciliation arm (`register-custom-element!`, the `[build-id ns-sym]` element ledger) is untouched — it was already correct.

## Scope note (deviation from the bead's letter)

The bead directed switching *both* `analyze.cljc` and `tree.cljc` to `build/aggregate build/elements`, on the premise that both "run under `cljs.env/*compiler*`". That premise holds for `analyze.cljc` but **not** for `tree.cljc`: `tree/element` (build-element) is emitted into the view fn and executes at **render** time with no compiler env. Per the bead's own escape hatch ("if a consumer genuinely has no compiler env in scope … determine the correct build-id source or flag it"), the correct render-time source is the runtime-arm ledger, not the compile slice — which the mirror removal makes clean. Forcing a `build/elements` read at render time would be *less* correct (build slices are wiped/evicted by the compile lifecycle long before render). Flagging here for review.

## Race proof

Against the pre-fix code (mirror present), a probe driving the real `analyze-element-props` consumer under the interleave — `:app` declares `:x-card #{:model}`, `:node-test` contributes between the declaration and the read — returns `#{}` (`:model` lowered as an **attribute**): FAIL. With the fix it returns `#{:model}`: PASS. Encoded as `custom-element-classification-is-build-scoped-under-interleave` in `compiler_build_jvm_test.clj`, plus the existing `removed-custom-element-clears-stale-property-classification` retargeted to the per-build reader. The per-build-isolation and sequential-removal tests stay green.

## Quality gates

Run in the foreground on the rebased HEAD (base `main`):

- `clojure -M:test` (ui compiler artefact): **316 tests / 4776 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **9043 tests / 42718 assertions, 0 failures, 0 errors**
- `npx shadow-cljs compile node-test-ui`: **211 compiled, 0 warnings**
- Pre-fix race probe: FAIL on old code (`#{}`), PASS after fix (`#{:model}`)
