### PR TITLE
fix(ci): trigger the browser gate on re-frame.ui changes + act-discipline the frame-scope fixture (rf2-vxgfnd.90, rf2-vxgfnd.89)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -392,12 +392,32 @@ else
         # invariants + G-14 compile budget); cljs_node_test fires the
         # consolidated node suite (the live cross-emitter parity
         # corpus rides it); ui_gates fires the cljs-ui-g1 bench gate
-        # (test.yml). No production build :requires re-frame.ui.* yet,
-        # so no cljs_browser / cljs_prod / bundle_isolation fan-out —
-        # widen when the S2+ slices give it a production surface.
+        # (test.yml).
+        #
+        # rf2-vxgfnd.90 — false-green fix. re-frame.ui now ships REAL DOM
+        # tests: the `*-dom-cljs-test.{cljs,cljc}` namespaces (the S1c/S2
+        # mount + reactivity + frame-scope keystone fixtures) opt into the
+        # `:browser-test` build (headless Chromium) and are the ONLY place
+        # React act discipline, real react-dom/client roots, and live
+        # ViewCell teardown are exercised — none of which the JVM/node
+        # suites can validate. The stale "no production build :requires
+        # re-frame.ui.* yet, so no cljs_browser" reasoning conflated a
+        # PRODUCTION-bundle surface (still absent) with a browser-TEST
+        # surface (now present): a test-only UI PR (e.g. #5767, which
+        # changed exactly one `*-dom-cljs-test`) merged GREEN while its
+        # only relevant browser test reported SKIPPED. Fire cljs_browser
+        # for EVERY implementation/ui/** source or test change — UI runtime
+        # changes affect those DOM tests transitively, and the conservative
+        # direction is to trigger the gate MORE (worst case: slower CI),
+        # never to skip it (worst case: a false-green). cljs_prod
+        # (elision probe) and bundle_isolation stay OFF: they gate the
+        # PRODUCTION `:advanced` builds, and no production build :requires
+        # re-frame.ui.* yet — widen them when the S2+ slices give it a
+        # production surface.
         implementation_jvm=true
         cljs_node_test=true
         ui_gates=true
+        cljs_browser=true
         ;;
       implementation/scripts/run-ui-bench.cjs)
         # rf2-vxgfnd.6 — false-green fix, mirroring the launcher cases

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1086,6 +1086,84 @@ test('all-required-passed aggregator needs jvm-ui + cljs-ui-g1 (rf2-vxgfnd.6)', 
   assert.match(block, /- cljs-ui-g1\r?\n/, 'aggregator must list cljs-ui-g1 in needs:');
 });
 
+// rf2-vxgfnd.90 — re-frame.ui now ships REAL DOM tests
+// (`*-dom-cljs-test.{cljs,cljc}`) in the `:browser-test` build (the S1c/S2
+// mount + reactivity + frame-scope keystone fixtures — the ONLY place
+// React act discipline / real react-dom/client roots / live ViewCell
+// teardown are exercised). The `implementation/ui/*` case previously left
+// cljs_browser=false on a stale "no production build :requires
+// re-frame.ui.* yet" comment, so a test-only UI PR (e.g. #5767, which
+// changed exactly one `*-dom-cljs-test`) merged GREEN while its only
+// relevant browser test reported SKIPPED — a false-green hole. The gate
+// now fires cljs_browser for EVERY implementation/ui/** source or test
+// change (conservative: trigger the browser gate MORE, never less).
+// cljs_prod (elision) + bundle_isolation stay OFF — they gate the
+// PRODUCTION `:advanced` builds and no production build :requires
+// re-frame.ui.* yet.
+
+test('implementation/ui SOURCE change fires cljs_browser (transitive DOM-test coverage) (rf2-vxgfnd.90)', () => {
+  const result = classify('implementation/ui/src/re_frame/ui/reactive.cljc');
+  assert.equal(
+    result.cljs_browser,
+    'true',
+    'a UI runtime source change affects the *-dom-cljs-test namespaces transitively; it must run the browser gate',
+  );
+  // Regression: the rf2-vxgfnd.6 trio stays armed alongside the new browser gate.
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.ui_gates, 'true');
+});
+
+test('the frame-scope keystone DOM test fires cljs_browser (the #5767 false-green path) (rf2-vxgfnd.90)', () => {
+  const result = classify(
+    'implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs',
+  );
+  assert.equal(
+    result.cljs_browser,
+    'true',
+    'a *-dom-cljs-test change must run the :browser-test gate instead of reporting SKIPPED (the exact #5767 regression)',
+  );
+});
+
+test('representative other *-dom-cljs-test paths fire cljs_browser (rf2-vxgfnd.90)', () => {
+  for (const file of [
+    'implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs',
+    'implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs',
+    'implementation/ui/test/re_frame/ui/reactive_tear_browser_dom_cljs_test.cljs',
+    'implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.cljs_browser,
+      'true',
+      `${file} is a browser-only DOM test; it must fire cljs_browser`,
+    );
+  }
+});
+
+test('an ordinary UI cljs test (non-DOM) also fires cljs_browser + node-test (rf2-vxgfnd.90)', () => {
+  // The whole implementation/ui/** tree fires the browser gate — an
+  // ordinary *_cljs_test.cljc under ui/test is not exempted (conservative
+  // routing: UI test changes can move a shared fixture a DOM test :requires).
+  const result = classify('implementation/ui/test/re_frame/ui/eq_cljs_test.cljc');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('implementation/ui/* does NOT arm cljs_prod / bundle_isolation — no production surface yet (rf2-vxgfnd.90 scope)', () => {
+  // The browser-TEST surface is present (cljs_browser), but no PRODUCTION
+  // build :requires re-frame.ui.*, so the `:advanced` elision + bundle
+  // gates stay off until an S2+ slice gives it a production surface.
+  const result = classify('implementation/ui/src/re_frame/ui/reactive.cljc');
+  assert.equal(result.cljs_prod, 'false');
+  assert.equal(result.bundle_isolation, 'false');
+});
+
+test('a docs/spec-only change does NOT arm cljs_browser (negative — scope discipline) (rf2-vxgfnd.90)', () => {
+  assert.equal(classify('spec/006-ReactiveSubstrate.md').cljs_browser, 'false');
+  assert.equal(classify('docs/core/intro.md').cljs_browser, 'false');
+});
+
 let failed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_scope_resolve_dom_cljs_test.cljs
@@ -19,6 +19,7 @@
   Browser-only bodies — `-dom-cljs-test$` opts this file into `:browser-test`;
   under `:node-test` every DOM body gates on `(browser?)` and exits early."
   (:require [cljs.test :refer [deftest is use-fixtures]]
+            ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -30,6 +31,70 @@
 
 (defn- browser? [] (exists? js/document))
 
+;; ---------------------------------------------------------------------------
+;; The canonical React act() helper (rf2-vxgfnd.89)
+;;
+;; This is the repository's established native-React act pattern — the same
+;; get-act / enable-react-act-env! shape as re-frame.adapter's shared React
+;; suite (core/.../react_shared_suite.cljs `with-browser-act`) and the
+;; machines-viz `*-dom-cljs-test` namespaces. It uses React's OWN `act()`, NOT
+;; UIx/Helix/Reagent machinery, so this fixture stays native re-frame.ui +
+;; plain-atom.
+;;
+;; `flushSync` is NOT an act substitute: React's test contract treats any
+;; update committed outside an act scope as "not wrapped in act(...)". The
+;; `:browser-test` build runs EVERY `-dom-cljs-test` namespace on one shared
+;; page, and sibling suites (the adapter + machines-viz DOM tests) set
+;; IS_REACT_ACT_ENVIRONMENT=true and never reset it — so once the browser gate
+;; actually runs this file (rf2-vxgfnd.90), a flushSync-only mount here emits
+;; that warning as soon as the flag has leaked true. Wrapping every mount /
+;; unmount in `act` — with the act env explicitly enabled per-test below —
+;; makes the fixture clean under act rather than silencing anything.
+(defn- get-act
+  "React's act() — React 19 promotes it to the React namespace proper
+  (react-dom/test-utils on 18)."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- act!
+  "Run `thunk` inside React `act()`, returning the thunk's value. `act()`
+  itself returns a thenable (not the callback's value); the mount/unmount work
+  here commits synchronously under IS_REACT_ACT_ENVIRONMENT (enabled per-test
+  in the fixture), so the callback runs eagerly and we capture its result.
+  Wraps the mount (returns the root handle) AND the unmount (returns nil) so
+  every React commit — the happy render AND the render-abort teardown — settles
+  inside an act scope."
+  [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
+
+(defn- mount-expecting-abort!
+  "Run a mount whose render DELIBERATELY throws (the no-provider negative
+  case). React 19 routes the render-phase throw to the root's
+  `onUncaughtError` and aborts the commit WITHOUT re-throwing out of
+  `.render` — but React `act` SURFACES that error at the act boundary, so
+  wrapping this path in `act!` would turn the deliberate abort into an
+  uncaught test error. Use `flushSync` with the act env toggled OFF (the
+  canonical 'real flushSync commit path' pattern — react_shared_suite.cljs)
+  so the error is captured by `onUncaughtError`, not re-thrown, and the
+  aborted render — which commits nothing — emits no act warning. The act env
+  is restored afterwards so `assert-torn-down!`'s unmount still runs under
+  `act!`. Returns the registered root (its claim is still owned)."
+  [thunk]
+  (let [prior (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    (try
+      (react-dom/flushSync thunk)
+      (finally
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))
+
 ;; reset-live-roots! / reset-installed-plans! / reset-scheduler! are BOOKKEEPING
 ;; resets — a clean framework slate between tests. They are NOT host teardown:
 ;; each test OWNS the React root it mounts and `ui/unmount!`s it in a `finally`
@@ -39,15 +104,22 @@
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
                                             :ambient-frame nil})
   (fn [t]
-    (reactive/reset-scheduler!)
-    (client/reset-live-roots!)
-    (frames/reset-installed-plans!)
-    (try
-      (t)
-      (finally
-        (reactive/reset-scheduler!)
-        (client/reset-live-roots!)
-        (frames/reset-installed-plans!)))))
+    ;; Enable React's act environment for this ns's DOM tests (act() warns /
+    ;; no-ops unless IS_REACT_ACT_ENVIRONMENT is set), then RESTORE the prior
+    ;; value so the fixture neither depends on nor leaks the shared-page flag.
+    (let [prior (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))]
+      (enable-react-act-env!)
+      (reactive/reset-scheduler!)
+      (client/reset-live-roots!)
+      (frames/reset-installed-plans!)
+      (try
+        (t)
+        (finally
+          (reactive/reset-scheduler!)
+          (client/reset-live-roots!)
+          (frames/reset-installed-plans!)
+          (when (browser?)
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))))
 
 (defn- container [] (js/document.createElement "div"))
 
@@ -57,7 +129,7 @@
 ;; layout-effect cleanup synchronously inside `root.unmount()` (03 §4). After it,
 ;; no live-root claim and no connected ViewCell may survive into the next test.
 (defn- assert-torn-down! [root]
-  (react-dom/flushSync #(some-> root ui/unmount!))
+  (act! #(some-> root ui/unmount!))
   (is (= #{} (client/live-root-ids))
       "the root's claim is released — no live-root survives the test")
   (is (empty? (reactive/current-live-cells))
@@ -86,7 +158,7 @@
     (rf/make-frame {:id :app/live})
     (rf/dispatch-sync [:test/set-db {:n 42}] {:frame :app/live})
     (let [c    (container)
-          root (react-dom/flushSync
+          root (act!
                 #(ui/mount [provider-wrap {:frame-id :app/live}] c {:root-id :dom-scope/prov}))]
       (try
         (is (re-find #"n=42" (.-innerHTML c))
@@ -105,7 +177,7 @@
   (when (browser?)
     (reg!)
     (let [c    (container)
-          root (react-dom/flushSync
+          root (act!
                 #(ui/mount [frame-root {:id :app/rooted :initial-events [[:test/set-db {:n 7}]]}
                             [n-view]]
                            c {:root-id :dom-scope/root}))]
@@ -147,7 +219,12 @@
           ;; than left to fire. React internally unmounts the aborted tree but
           ;; the ROOT stays registered (§criterion-3), so this test still OWNS
           ;; the root-id claim and releases it in `finally` (rf2-vxgfnd.87).
-          root     (react-dom/flushSync
+          ;; The render throw is DELIBERATE, so this mount uses
+          ;; `mount-expecting-abort!` (flushSync, act env off) rather than
+          ;; `act!` — React `act` would surface the intended error instead of
+          ;; letting `onUncaughtError` own it (rf2-vxgfnd.89). The teardown
+          ;; unmount below still runs under `act!` (assert-torn-down!).
+          root     (mount-expecting-abort!
                     #(ui/mount [bare-sub-root {}] c
                                {:root-id :dom-scope/orphan
                                 :on-uncaught-error (fn [error _info] (reset! captured error))}))]


### PR DESCRIPTION
Closes a linked pair of P1 re-frame.ui browser-CI bugs. **Commit order is load-bearing:** the classifier fix (`.90`) lands first so this PR's OWN now-enabled browser gate validates the fixture fix (`.89`).

## rf2-vxgfnd.90 — CI classifier false-green (HOT-ZONE `.github`)

`.github/scripts/report-changed-surfaces.sh`'s `implementation/ui/*` case set `implementation_jvm` / `cljs_node_test` / `ui_gates` but deliberately left `cljs_browser=false` on the now-stale comment *"No production build :requires re-frame.ui.* yet"*. re-frame.ui now ships REAL DOM tests (`*-dom-cljs-test.{cljs,cljc}`) in the `:browser-test` build — the ONLY place React act discipline, real `react-dom/client` roots, and live ViewCell teardown are exercised. So a test-only UI PR merged GREEN while its only relevant browser test reported **SKIPPED** — exactly how #5767's browser job was skipped.

- Fire `cljs_browser` for **every** `implementation/ui/**` source or test change (conservative: trigger the gate MORE, never less — worst case slower CI, never a false-green).
- `cljs_prod` (elision) + `bundle_isolation` stay OFF: they gate the PRODUCTION `:advanced` builds and no production build `:requires` re-frame.ui.* yet.
- Stale comment updated; **classifier self-tests added** (representative paths → expected flags): UI source, the frame-scope keystone DOM test, other `*-dom-cljs-test` paths, an ordinary UI cljs test, the `cljs_prod`/`bundle_isolation` scope exclusion, and a docs-only negative.

**HOT-ZONE (`.github/**`):** sole toucher; flagged.

## rf2-vxgfnd.89 — frame-scope DOM fixture act discipline

`frame_scope_resolve_dom_cljs_test.cljs` wrapped every mount/unmount — including `assert-torn-down!` — in `react-dom/flushSync` only, never React `act`. React's test contract treats an update committed outside an act scope as *"not wrapped in act(...)"*. The `:browser-test` build runs every `-dom-cljs-test` namespace on ONE shared page, and sibling suites (adapter + machines-viz DOM tests) set `IS_REACT_ACT_ENVIRONMENT=true` and never reset it — so once the browser gate actually runs this file, a flushSync-only mount here emits that warning.

- Adopt the repository's canonical native-React act pattern (the same `get-act` / `enable-react-act-env!` shape as core's `react_shared_suite.cljs` `with-browser-act` and the machines-viz DOM tests — React's OWN `act()`, **not** UIx/Helix/Reagent machinery). Native re-frame.ui + plain-atom throughout; no adapter dependency.
- Happy render paths + the teardown unmount (`assert-torn-down!`) run inside `act`; the act env is enabled per-test and its prior value restored so the fixture neither depends on nor leaks the shared-page flag.
- The negative (no-provider) test's render throws DELIBERATELY and is routed to `onUncaughtError`; React `act` would surface that intended error, so that one mount uses `flushSync` with the act env toggled off (the canonical "real flushSync commit path" pattern) — the aborted render commits nothing, so it emits no act warning either.
- No console suppression: the fixture is clean under act, not silenced. #5767's ownership + leak assertions and the keystone's real assertions are preserved.

> Corrects the #5767 (`.87`) brief, which wrongly told that worker to avoid `act` as "adapter machinery" — the canonical React `act` is not adapter machinery.

## Quality gates

All run in the FOREGROUND on this branch (Windows, headless Chromium, React 19.2.0):

- `npm run test:browser` — **EXIT 0**, `Ran 300 tests containing 1087 assertions. 0 failures, 0 errors.`, **0 pageerrors**. Verified under `RF2_VERBOSE_TESTS=1` that the frame-scope fixture emits **0 "not wrapped in act" warnings** even though `IS_REACT_ACT_ENVIRONMENT` is leaked-true by the time it runs (the very next namespace's flushSync-only mount does warn — proving the flag is on and my fixture is genuinely act-clean). This is the first time this fixture has run under the gate — `.90` enables it, `.89` makes it clean.
- `npm run test:cljs` — `Ran 9051 tests containing 42778 assertions. 0 failures, 0 errors.`
- Classifier self-test (`node scripts/_changed-surfaces.test.cjs`) — `126 passed`.

The 361 total act warnings in the browser run are all from OTHER, out-of-scope namespaces (flushSync-only adapter / machines-viz / story / sibling ui DOM tests); they are console-noise-only and non-fatal per the runner's policy (only cljs.test failures/errors + uncaught pageerrors fail the run). Confirmed the false-green path is closed: a test-only UI PR now runs the `CLJS (shadow-cljs :browser-test, headless Chromium)` job instead of SKIPPED.