### PR TITLE
fix(ui): failed re-preflight of a live root must not report mount-incomplete (rf2-vxgfnd.72)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -74,9 +74,15 @@
   as a false conflict. A later plan for the same id is a genuinely new
   frame lifetime — created fresh, `:initial-events` REPLAYED (the opt-in
   destroy-then-reseat composition, rf2-lxwpob). A plan that throws mid-run
-  tags the siblings it already installed `:mount-incomplete`
-  (rf2-vxgfnd.30 (b)), so a later conflict names an incomplete mount, not
-  a phantom completed owner.
+  labels the siblings it already wrote by PROVENANCE (rf2-vxgfnd.30 (b),
+  rf2-vxgfnd.72): a sibling that this run FRESH-installed is tagged
+  `:mount-incomplete` — its mount never completed and no root yet scopes
+  it. A sibling that was ALREADY LIVE (a refresh of an installed root, or
+  an adopt of a boot frame) keeps its live-root state and carries neutral
+  `:preflight-attempt-failed` evidence instead: the frame and its scoping
+  root PERSIST (Q49), only the re-preflight ATTEMPT failed. So a later
+  conflict names an incomplete FRESH mount without ever claiming that a
+  still-live root does not scope its refreshed frame.
 
   ## Atomicity posture (the rf2-ktmto9 mirror)
 
@@ -155,8 +161,11 @@
   ;;   ADOPTED (a boot / external frame this root merely SCOPES — NO refresh
   ;;     rights; boot config stays authoritative):
   ;;     {:config-fingerprint "cf1-…" :adopted-by root-id :adopted true}
-  ;; A failed mount that installed earlier siblings tags their surviving
-  ;; records `:mount-incomplete true` (rf2-vxgfnd.30 (b)). Records are
+  ;; A failed run labels the surviving records it wrote by provenance
+  ;; (rf2-vxgfnd.30 (b), rf2-vxgfnd.72): a FRESH install → `:mount-incomplete
+  ;; true` (mount never completed, no root scopes it); an ALREADY-LIVE refresh
+  ;; or adopt → `:preflight-attempt-failed true` (neutral attempt evidence —
+  ;; the live frame + its scoping root persist, Q49). Records are
   ;; PRUNED on `frame/destroy-frame!` (rf2-vxgfnd.30 (a)) — the destroy hook
   ;; dissocs the id, so a re-created same-id frame is a genuinely new
   ;; lifetime rather than a resurrected dead-lifetime record.
@@ -197,10 +206,19 @@
         (pr-str frame-id) " whose config fingerprint differs from the "
         "installed frame's recorded plan (installed by root "
         (pr-str (:installed-by installed)) ")"
-        (when (:mount-incomplete installed)
+        (cond
+          ;; FRESH first mount that never completed — truthful "no root scopes"
+          (:mount-incomplete installed)
           (str ", whose mount did NOT complete — a later plan in that "
                "root's run threw, so the frame is live only from its "
-               "already-fired :initial-events and no root actually scopes it"))
+               "already-fired :initial-events and no root actually scopes it")
+          ;; ALREADY-LIVE root whose re-preflight run failed — the frame and
+          ;; its scoping root PERSIST (Q49); only the last attempt failed.
+          (:preflight-attempt-failed installed)
+          (str ", whose most recent preflight run did NOT complete — a later "
+               "plan in that root's re-preflight threw. The installed frame is "
+               "still LIVE and scoped by root " (pr-str (:installed-by installed))
+               "; its prior mount and last committed render are untouched (Q49)"))
         ". One frame, one plan: align "
         "the configs, or drop the duplicate frame-root. The installed "
         "frame and the roots already using it are untouched — this root "
@@ -226,7 +244,11 @@
         (pr-str frame-id) ", but that frame is already live and "
         "boot-authoritative"
         (if installed
-          (str " (adopted by root " (pr-str (:adopted-by installed)) ")")
+          (str " (adopted by root " (pr-str (:adopted-by installed)) ")"
+               (when (:preflight-attempt-failed installed)
+                 (str " — the run that recorded that adoption did not fully "
+                      "complete (a later plan threw), though the boot frame "
+                      "remains live and authoritative")))
           " (created outside the plan registry — a boot rf/make-frame)")
         ". A frame-root plan cannot install or refresh its config over a "
         "frame it does not OWN — adoption only SCOPES a boot frame, it never "
@@ -242,9 +264,10 @@
                         :root-id root-id}}}))
 
 (defn- mark-mount-incomplete!
-  "Tag the surviving install records `frame-ids` (siblings this run wrote
-  before a later plan threw) `:mount-incomplete true`, so a later conflict
-  never presents their root as a completed owner it never became."
+  "Tag the surviving FRESH-installed records `frame-ids` (siblings this run
+  created for the first time before a later plan threw) `:mount-incomplete
+  true`, so a later conflict never presents their root as a completed owner
+  it never became — their mount did not complete and no root scopes them yet."
   [frame-ids]
   (when (seq frame-ids)
     (swap! installed-plans
@@ -253,17 +276,38 @@
                                (contains? m id) (assoc-in [id :mount-incomplete] true)))
                            m frame-ids)))))
 
-(defn- clear-mount-incomplete!
-  "A run completed: every frame it touched is backed by a completed mount,
-  so drop any stale `:mount-incomplete` tag left by an earlier failed run.
-  Only entries that carry the tag are rewritten (the found-live no-op path
-  stays write-free in the common, unmarked case)."
+(defn- mark-preflight-attempt-failed!
+  "Tag the surviving ALREADY-LIVE records `frame-ids` (a refresh of an
+  installed root, or an adopt of a boot frame, that this run wrote before a
+  later plan threw) `:preflight-attempt-failed true` (rf2-vxgfnd.72). Neutral
+  attempt evidence: the frame and its scoping root PERSIST (Q49), so this
+  records that the re-preflight ATTEMPT did not complete WITHOUT overwriting
+  the live root's completed-mount state with a mount-incomplete claim."
+  [frame-ids]
+  (when (seq frame-ids)
+    (swap! installed-plans
+           (fn [m] (reduce (fn [m id]
+                             (cond-> m
+                               (contains? m id)
+                               (assoc-in [id :preflight-attempt-failed] true)))
+                           m frame-ids)))))
+
+(defn- clear-run-incomplete-evidence!
+  "A run completed: every frame it touched is backed by a completed mount, so
+  drop any stale failed-run evidence an earlier throwing run left — both the
+  fresh-mount `:mount-incomplete` tag and the live-root
+  `:preflight-attempt-failed` attempt tag. Only entries that carry a tag are
+  rewritten (the found-live no-op path stays write-free in the common,
+  unmarked case)."
   [frame-ids]
   (swap! installed-plans
          (fn [m] (reduce (fn [m id]
-                           (cond-> m
-                             (:mount-incomplete (get m id))
-                             (update id dissoc :mount-incomplete)))
+                           (let [rec (get m id)]
+                             (cond-> m
+                               (or (:mount-incomplete rec)
+                                   (:preflight-attempt-failed rec))
+                               (update id dissoc :mount-incomplete
+                                       :preflight-attempt-failed))))
                          m frame-ids))))
 
 (defn execute-frame-plans!
@@ -281,9 +325,11 @@
   (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
   met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
   config/generation untouched, only the fingerprint recorded
-  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run tags the
-  siblings it already installed `:mount-incomplete` (rf2-vxgfnd.30 (b)).
-  Returns nil."
+  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run labels the
+  siblings it already wrote by provenance: a FRESH install →
+  `:mount-incomplete`; an ALREADY-LIVE refresh/adopt →
+  `:preflight-attempt-failed` (the live root persists, Q49 — rf2-vxgfnd.30
+  (b), rf2-vxgfnd.72). Returns nil."
   [root-id plans]
   (let [decided
         (mapv (fn [{:keys [frame-id config config-fingerprint] :as plan}]
@@ -327,9 +373,15 @@
                     :else
                     (assoc plan ::action :install))))
               plans)
-        ;; frame-ids whose record THIS run writes (install/refresh/adopt),
-        ;; accumulated in document order so a mid-run throw can tag the
-        ;; siblings already written (rf2-vxgfnd.30 (b)).
+        ;; frame-ids whose record THIS run writes, each tagged by PROVENANCE
+        ;; so a mid-run throw can label it honestly (rf2-vxgfnd.30 (b),
+        ;; rf2-vxgfnd.72):
+        ;;   :fresh — an :install that created the frame this run. On a later
+        ;;     throw its mount never completed and no root yet scopes it.
+        ;;   :live  — a :refresh of an already-live installed root, or an
+        ;;     :adopt of an already-live boot frame. On a later throw the frame
+        ;;     and its scoping root PERSIST (Q49); only the ATTEMPT failed.
+        ;; Accumulated in document order.
         written (volatile! [])]
     (try
       (doseq [{:keys [frame-id config config-fingerprint] :as plan} decided]
@@ -342,33 +394,45 @@
           ;; ADOPTED (non-owning) record so a later cross-root arrival is
           ;; conflict-scoped — the boot frame's config/generation/`:images`
           ;; are left entirely untouched (rf2-vxgfnd.26), and the record can
-          ;; never enter a root-owned refresh path (rf2-vxgfnd.56).
+          ;; never enter a root-owned refresh path (rf2-vxgfnd.56). The boot
+          ;; frame was already LIVE, so a later throw is an attempt failure,
+          ;; not a mount-incomplete over never-mounted state.
           :adopt (do (swap! installed-plans assoc frame-id
                             {:config-fingerprint config-fingerprint
                              :adopted-by root-id
                              :adopted true})
-                     (vswap! written conj frame-id))
+                     (vswap! written conj [frame-id :live]))
 
           ;; :install / :refresh — create-if-absent / surgical refresh;
           ;; :initial-events drain synchronously inside the engine, in
           ;; document order across plans. The record lands only AFTER a
           ;; successful install, so a throwing plan leaves no install record
-          ;; (and the engine leaves no frame residue).
+          ;; (and the engine leaves no frame residue). An :install is FRESH
+          ;; (nothing scoped this id before); a :refresh acts on an
+          ;; ALREADY-LIVE installed root (its prior mount + render persist).
           (do
             (live-frame/make-frame (assoc (or config {}) :id frame-id))
             (swap! installed-plans assoc frame-id
                    {:config-fingerprint config-fingerprint
                     :installed-by root-id})
-            (vswap! written conj frame-id))))
+            (vswap! written conj
+                    [frame-id (if (= :install (::action plan)) :fresh :live)]))))
       ;; the whole run completed — every touched frame is backed by a
-      ;; completed mount, so drop any stale mount-incomplete tag.
-      (clear-mount-incomplete! (map :frame-id decided))
+      ;; completed mount, so drop any stale failed-run evidence.
+      (clear-run-incomplete-evidence! (map :frame-id decided))
       (catch #?(:clj Throwable :cljs :default) e
-        ;; a plan threw mid-run: the siblings this run already installed stay
-        ;; live (irreversible :initial-events — the atomicity posture), but
-        ;; the mount did NOT complete. Tag their records so a later conflict
-        ;; names an incomplete mount, not a phantom completed owner.
-        (mark-mount-incomplete! @written)
+        ;; a plan threw mid-run: the siblings this run wrote stay live
+        ;; (irreversible :initial-events — the atomicity posture). Label each
+        ;; by provenance (rf2-vxgfnd.72): a FRESH install whose mount never
+        ;; completed is :mount-incomplete + "no root scopes"; an already-LIVE
+        ;; refresh/adopt keeps its live-root state and carries neutral
+        ;; :preflight-attempt-failed evidence instead — its live root and last
+        ;; committed render are untouched (Q49).
+        (let [w @written]
+          (mark-mount-incomplete!
+           (into [] (comp (filter #(= :fresh (second %))) (map first)) w))
+          (mark-preflight-attempt-failed!
+           (into [] (comp (filter #(= :live (second %))) (map first)) w)))
         (throw e)))
     nil))
 

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -343,6 +343,106 @@
         "a completed run clears the stale :mount-incomplete tag")
     (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
 
+;; ---- rf2-vxgfnd.72: a failed RE-preflight of an ALREADY-LIVE root --------
+;; `execute-frame-plans!` is ALSO the preflight for idempotent remount / HMR /
+;; `render!` on an already-live root. Per Q49 a failing re-preflight leaves the
+;; existing root AND its last committed render untouched. So a live root whose
+;; re-preflight throws on a LATER plan must NOT be tagged :mount-incomplete and
+;; the conflict diagnostic must NOT claim "no root scopes" — that is the fresh-
+;; mount case's truth, and a lie about a still-live root. The refresh/adopt of
+;; an already-live frame carries neutral :preflight-attempt-failed evidence.
+
+(deftest failed-re-preflight-of-a-live-root-keeps-live-state-not-mount-incomplete
+  (reg-events!)
+  ;; root A mounts :frame/live and COMPLETES — a genuinely live, scoped root.
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 5}]]}
+                  "cf1-live1111111111")])
+  (is (some? (frame/frame :frame/live)) "the frame is live after the first mount")
+  (rf/dispatch-sync [:test/inc] {:frame :frame/live})
+  (is (= 6 (:n (rf/app-db-value :frame/live)))
+      "durable state = 6 (the last committed render's state)")
+  (is (nil? (:mount-incomplete (frames/installed-plan-entry :frame/live)))
+      "sanity: the completed first mount carries no incomplete tag")
+  ;; root A RE-PREFLIGHTS (an HMR / reload run): plan 1 REFRESHES :frame/live to
+  ;; a NEW config; plan 2 (:frame/bad) throws AFTER the refresh succeeds.
+  (let [id (err-id
+            #(frames/execute-frame-plans!
+              :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 999}]]}
+                             "cf1-live2222222222")
+                       (plan :frame/bad {:initial-events [:not-a-vector]}
+                             "cf1-bad11111111111")]))]
+    (is (some? id) "the later malformed plan throws — the re-preflight fails"))
+  ;; Q49: the pre-existing live root + its last committed render are UNTOUCHED.
+  (is (some? (frame/frame :frame/live)) "the pre-existing live root persists")
+  (is (= 6 (:n (rf/app-db-value :frame/live)))
+      "durable state is untouched — the refresh does not replay, the failure does not roll back")
+  (let [entry (frames/installed-plan-entry :frame/live)]
+    (is (= :root/a (:installed-by entry)) "root A still OWNS + scopes the frame")
+    (is (nil? (:mount-incomplete entry))
+        "the live root is NOT falsely tagged :mount-incomplete (rf2-vxgfnd.72)")
+    (is (true? (:preflight-attempt-failed entry))
+        "instead the record carries neutral failed-attempt evidence"))
+  ;; a later cross-root config conflict on :frame/live must NOT claim the frame
+  ;; is unmounted / unscoped — the live root persists.
+  (let [msg (try (frames/execute-frame-plans!
+                  :root/c [(plan :frame/live {:initial-events [[:test/set-db {:n 1}]]}
+                                 "cf1-ccc11111111111")])
+                 nil
+                 (catch cljs.core/ExceptionInfo e (ex-message e)))]
+    (is (some? msg) "the cross-root arrival still fails loud")
+    (is (nil? (re-find #"no root actually scopes it" msg))
+        "the diagnostic never says no root scopes the still-live frame")
+    (is (nil? (re-find #"live only from its already-fired" msg))
+        "nor that it is live only from its initial-events (the fresh-mount claim)")
+    (is (some? (re-find #"still LIVE and scoped by root" msg))
+        "instead it states the frame is still live + scoped; only the re-preflight attempt failed")))
+
+(deftest completed-retry-clears-the-preflight-attempt-failed-tag
+  (reg-events!)
+  ;; A mounts + completes, then a re-preflight refresh fails on a later plan.
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 1}]]}
+                  "cf1-r1aaaaaaaaaaaa")])
+  (err-id #(frames/execute-frame-plans!
+            :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 2}]]}
+                           "cf1-r2bbbbbbbbbbbb")
+                     (plan :frame/bad {:initial-events [:not-a-vector]}
+                           "cf1-badrrrrrrrrrr")]))
+  (is (true? (:preflight-attempt-failed (frames/installed-plan-entry :frame/live)))
+      "sanity: the failed re-preflight tagged the live record")
+  ;; A retries WITHOUT the bad plan -> the run completes -> the tag clears.
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 2}]]}
+                  "cf1-r2bbbbbbbbbbbb")])
+  (let [entry (frames/installed-plan-entry :frame/live)]
+    (is (nil? (:preflight-attempt-failed entry))
+        "a completed run clears the stale :preflight-attempt-failed tag")
+    (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
+
+(deftest failed-run-after-adopt-marks-attempt-failed-not-mount-incomplete
+  (reg-events!)
+  ;; a boot rf/make-frame owns :app/boot (boot-authoritative, live).
+  (rf/make-frame {:id :app/boot :doc "boot"})
+  (rf/dispatch-sync [:test/set-db {:n 42}] {:frame :app/boot})
+  ;; root A ADOPTS it (config-less scope), then a later plan throws.
+  (let [id (err-id
+            #(frames/execute-frame-plans!
+              :root/a [(plan :app/boot {} "cf1-adopt1111111111")
+                       (plan :app/bad {:initial-events [:not-a-vector]}
+                             "cf1-badadoptttttt")]))]
+    (is (some? id) "the later malformed plan throws"))
+  ;; the boot frame is untouched + still authoritative (adopt creates nothing).
+  (is (some? (frame/frame :app/boot)) "the boot frame persists")
+  (is (= 42 (:n (rf/app-db-value :app/boot))) "the boot frame's state is untouched")
+  (is (= "boot" (:doc (frame/frame-meta :app/boot))) "the boot config stays authoritative")
+  (let [entry (frames/installed-plan-entry :app/boot)]
+    (is (true? (:adopted entry)) "the record stays an ADOPTED (non-owning) record")
+    (is (nil? (:mount-incomplete entry))
+        "an adopted boot frame is never falsely tagged :mount-incomplete")
+    (is (true? (:preflight-attempt-failed entry))
+        "it carries the same neutral failed-attempt evidence as a live refresh")))
+
 ;; ---- rf2-vxgfnd.56: adoption never grants installation authority ---------
 ;; A boot/external frame is boot-authoritative. A config-less [frame-root
 ;; {:id …}] may ADOPT (scope) it, but an adopted record must NEVER enter a


### PR DESCRIPTION
## What

`re-frame.ui.frames/execute-frame-plans!` is the preflight for a FRESH first mount AND for idempotent remount / `render!` on an already-live root. #5738 stamped `:mount-incomplete` on every install/adopt/refresh record a run wrote before a later plan threw, and the conflict diagnostic then claimed the mount "did NOT complete" and "no root actually scopes" the frame.

That is truthful for a fresh first mount. But for a failed **RE-preflight of an already-live root** it lies: per the namespace's Q49 ruling the existing root and its last committed render are untouched — the live root is still there and still scoping. Stamping `:mount-incomplete` + "no root scopes" over live state is the inverse falsehood #5738 set out to prevent.

## Fix

Distinguish the two cases by **provenance at write time** — no new liveness lookups needed, the `::action` already classifies each plan:

- **FRESH install** (nothing scoped this id before): keeps `:mount-incomplete true` + "no root actually scopes it" — unchanged, still truthful.
- **ALREADY-LIVE refresh** (installed root re-declares its own frame) or **adopt** (a boot frame): carries neutral `:preflight-attempt-failed true` evidence instead. The frame and its scoping root PERSIST (Q49); only the re-preflight ATTEMPT failed. The live root's completed-mount state is never overwritten with a mount-incomplete claim.

`execute-frame-plans!` tags each written frame-id `:fresh` (install) or `:live` (refresh/adopt) in document order; the catch partitions them and stamps the matching marker. `throw-plan-conflict!` branches on the two markers so every sentence stays true for fresh mount, idempotent remount, and `render!`. `throw-boot-authority-conflict!` now surfaces the failed-attempt evidence on adopted records, so installed and adopted authority read consistently. A completed retry clears both markers.

No render-path change — the fix is entirely in the install-record marking and the conflict diagnostic text. No rollback/reseed introduced; irreversible successful sibling work is kept (Q49 / FX-atomicity).

## Tests (`preflight_frame_wiring_cljs_test.cljs`)

- `failed-re-preflight-of-a-live-root-keeps-live-state-not-mount-incomplete`: a live root re-preflights (refresh succeeds), a later plan throws — the frame + its last committed state persist, the record is NOT `:mount-incomplete` (carries `:preflight-attempt-failed`), and a subsequent cross-root conflict diagnostic no longer says "no root actually scopes it" / "live only from its initial-events" but states the frame is "still LIVE and scoped by root".
- `completed-retry-clears-the-preflight-attempt-failed-tag`: a clean retry drops the neutral marker.
- `failed-run-after-adopt-marks-attempt-failed-not-mount-incomplete`: an adopt-then-throw run marks the boot-frame record `:preflight-attempt-failed`, never `:mount-incomplete`; the boot frame stays authoritative and untouched.
- Existing fresh-mount tests (`failed-mount-tags-surviving-records-mount-incomplete`, `completed-retry-clears-the-mount-incomplete-tag`) retained as the fresh-case regression guard.

Proven RED pre-fix (8 assertions fail against HEAD source), GREEN post-fix.

## Quality gates

Run in the foreground on the rebased branch head (0-fail):

- `implementation/ui` `clojure -M:test` — 315 tests / 4771 assertions, 0 failures, 0 errors
- `npm run test:cljs` (full node CLJS suite) — 9056 tests / 42820 assertions, 0 failures, 0 errors
- `node-test-ui` build (ui node twin) — 293 tests / 1557 assertions, 0 failures, 0 errors

No DOM fixture added (the change has no render-path effect; the "last committed render untouched" property is Q49's, covered in the DOM twin), so `npm run test:browser` was not required.
