### PR TITLE
fix(ui): wire the custom-element reload ledger to a real reloaded-source producer (rf2-vxgfnd.77)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -731,11 +731,12 @@
 ;;   register-custom-element!     a declaration re-runs — STAGES into the open
 ;;                                cycle (or, at initial load / in production where
 ;;                                no cycle is open, writes through directly).
-;;   (note-reloaded-sources! ..)  the reload machinery (rf2-df9873's shadow build
-;;                                hook) records WHICH sources re-ran / were removed
-;;                                this cycle — the signal a zero-declaration or
-;;                                deleted source cannot emit for itself. Optional:
-;;                                absent, only the staged sources are reconciled.
+;;   (note-reloaded-sources! ..)  the SHADOW_NS_RESET producer (rf2-vxgfnd.77;
+;;                                see below) records WHICH sources re-ran this
+;;                                cycle — the signal a zero-declaration source
+;;                                cannot emit for itself (absence cannot
+;;                                self-report). Optional: absent, only the
+;;                                staged sources are reconciled.
 ;;   (commit-reload! [build?])    ^:dev/after-load — COMMIT atomically: every
 ;;                                staged source REPLACES its whole prior
 ;;                                contribution, every reloaded-but-unstaged /
@@ -826,10 +827,11 @@
 
 (defn note-reloaded-sources!
   "Record the sources that re-ran (or were removed) in the open reload cycle —
-  the signal a zero-declaration or deleted source cannot emit for itself, fed by
-  the reload machinery (rf2-df9873's shadow build hook). `sources` is a coll of
-  ns-syms (paired with `build-id`) or ready-made [build ns] pairs. A no-op when
-  no cycle is open; unions into the cycle so it can be called repeatedly."
+  the signal a zero-declaration source cannot emit for itself, fed in the shipped
+  browser reload path by `reload-source-reset!` (the SHADOW_NS_RESET producer;
+  rf2-vxgfnd.77). `sources` is a coll of ns-syms (paired with `build-id`) or
+  ready-made [build ns] pairs. A no-op when no cycle is open; unions into the
+  cycle so it can be called repeatedly."
   ([sources] (note-reloaded-sources! sources default-build))
   ([sources build-id]
    (when (contains? @reload-cycles build-id)
@@ -861,6 +863,75 @@
        (rebuild-live!)
        (swap! reload-cycles dissoc build-id)))
    nil))
+
+;; ---------------------------------------------------------------------------
+;; The production producer: shadow-cljs's real reload machinery feeds
+;; `note-reloaded-sources!` (rf2-vxgfnd.77)
+;;
+;; The ledger above evicts a source that dropped its last declaration ONLY when
+;; `note-reloaded-sources!` is told the source re-ran. But a source that re-runs
+;; declaring NOTHING emits no code to announce itself — absence cannot
+;; self-report — so the signal cannot come from the emitted
+;; `register-custom-element!` calls (a zero-declaration source emits none). It
+;; must come from the reload machinery, which knows which namespaces re-ran
+;; regardless of what they declared.
+;;
+;; shadow-cljs exposes exactly that seam: its `before-load-src` calls every fn on
+;; `js/goog.global.SHADOW_NS_RESET` with the ns symbol of each source it reloads,
+;; DURING the code-load phase — after the `^:dev/before-load` `notify-reload!`
+;; opened the cycle and before the `^:dev/after-load` `commit-reload!` closes it.
+;; `reload-source-reset!` rides that seam: for every reloaded ns it stages a
+;; `:touched` entry, so `commit-reload!` reconciles the sources that ACTUALLY
+;; re-ran and evicts the stale rows of one that now declares nothing — the exact
+;; runtime analogue of the compile side, where `build/commit-slice` evicts a
+;; source that recompiled contributing nothing.
+;;
+;; Bounded case (matches rf2-df9873's ruling AND the compile side): a source FILE
+;; deleted with no reloading dependent never re-runs, so shadow never reports it
+;; and its runtime rows persist until the next full page load — "no design can
+;; observe an unsaved deletion." The compile-side `finish-build!` evicts the
+;; deleted source from the COMPILE registry via `:build-sources` membership; the
+;; runtime arm converges on the next full reload. `note-reloaded-sources!` stays
+;; the seam an authoritative removed-source manifest would feed if one is wired.
+;;
+;; Dev-only: the whole install is `js/goog.DEBUG`-gated, so `:advanced`
+;; production carries no producer and never references SHADOW_NS_RESET.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn reload-source-reset!
+     "The per-source action shadow-cljs's reload machinery drives (through
+     `js/goog.global.SHADOW_NS_RESET`) for every namespace it reloads this cycle:
+     record `ns` as a source that re-ran, so `commit-reload!` evicts it when it
+     staged no declaration this cycle. A no-op when no reload cycle is open
+     (initial load / production). `ns` is a CLJS ns symbol; a string is coerced."
+     [ns]
+     (note-reloaded-sources! [(cond-> ns (string? ns) symbol)])
+     nil))
+
+#?(:cljs
+   (defn install-reload-source-producer!
+     "Wire the runtime reload ledger to shadow-cljs's real reload machinery — the
+     PRODUCER that feeds `note-reloaded-sources!` in the shipped browser reload
+     path (rf2-vxgfnd.77). Pushes `reload-source-reset!` onto
+     `js/goog.global.SHADOW_NS_RESET` (ensuring the array `||`-style, so it
+     neither clobbers nor is clobbered by shadow's own init), so shadow calls it
+     with each reloaded source's ns from `before-load-src`. Dev-only (gated on
+     `js/goog.DEBUG`, elided from `:advanced` production) and installed exactly
+     once via the `defonce` below (a hot-reload of THIS ns never double-registers)."
+     []
+     (when ^boolean js/goog.DEBUG
+       (let [arr (or js/goog.global.SHADOW_NS_RESET #js [])]
+         (set! (.-SHADOW_NS_RESET js/goog.global) arr)
+         (.push arr reload-source-reset!)
+         true))))
+
+#?(:cljs
+   (defonce ^:private _reload-source-producer
+     ;; Install at client load so the shipped reload path has a producer the
+     ;; moment this ns is present; `defonce` survives a hot-reload of rules.cljc
+     ;; itself, so the callback is registered exactly once.
+     (install-reload-source-producer!)))
 
 (defn reset-custom-elements!
   "Test support: clear the runtime custom-element registry, the per-source

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -332,3 +332,105 @@
             @rules/custom-elements)]
     (is (= (full-reload!) (incremental!))
         "incremental reload equals a clean full-page-reload rebuild")))
+
+;; ---------------------------------------------------------------------------
+;; The production producer (rf2-vxgfnd.77) — the reload ledger's zero-declaration
+;; eviction fired THROUGH the shipped browser reload path, not a direct
+;; `note-reloaded-sources!` call. `reload-source-reset!` is what shadow-cljs's
+;; `before-load-src` drives (through `js/goog.global.SHADOW_NS_RESET`) for every
+;; reloaded ns; `install-reload-source-producer!` (run once at ns load via a
+;; `defonce`) is the wire. These tests are CLJS-only — the producer is the
+;; runtime arm and does not exist on the JVM compile host.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- fire-shadow-ns-reset!
+     "Simulate shadow-cljs's `before-load-src`: call every fn registered on the
+     `SHADOW_NS_RESET` array with the reloaded ns, exactly as the real reload
+     machinery does mid-cycle. Wrapped so an unrelated resetter registered by
+     other code can't fail the ledger assertion."
+     [ns]
+     (doseq [f (array-seq js/goog.global.SHADOW_NS_RESET)]
+       (try (f ns) (catch :default _ nil)))))
+
+#?(:cljs
+   (deftest reload-producer-is-wired-to-shadow-reset-array
+     ;; The wire itself: install-reload-source-producer! (run at ns load) must
+     ;; have registered reload-source-reset! on shadow's per-reload callback
+     ;; array, so the shipped reload path has a real caller for the ledger seam.
+     (is (exists? js/goog.global.SHADOW_NS_RESET)
+         "install-reload-source-producer! ensured the SHADOW_NS_RESET array")
+     (is (some #(identical? % rules/reload-source-reset!)
+               (array-seq js/goog.global.SHADOW_NS_RESET))
+         "the shipped producer is registered on shadow's per-reload callback array")))
+
+#?(:cljs
+   (deftest reload-producer-evicts-zero-declaration-source-end-to-end
+     ;; The headline gap (rf2-vxgfnd.67 shipped the seam with NO production
+     ;; caller): a source that re-runs declaring NOTHING must have its stale rows
+     ;; evicted. Here the eviction fires through the SHIPPED producer — we drive
+     ;; shadow's SHADOW_NS_RESET callback (as before-load-src does), NOT
+     ;; note-reloaded-sources! directly — proving the browser reload path now
+     ;; fires what the ledger always could but never had a caller for.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+     (is (= #{:help-text} (rules/custom-element-properties :x-el))
+         "initial load classifies :help-text as a property")
+     (rules/notify-reload!)                        ; ^:dev/before-load
+     (fire-shadow-ns-reset! 'app.a)                ; before-load-src: app.a re-runs, declares nothing
+     (rules/commit-reload!)                        ; ^:dev/after-load
+     (is (= #{} (rules/custom-element-properties :x-el))
+         "the shipped SHADOW_NS_RESET producer evicts the zero-declaration source")
+     (is (= {} @rules/custom-elements)
+         "no stale rows survive the zero-declaration reload through the real path")))
+
+#?(:cljs
+   (deftest reload-producer-preserves-untouched-and-updates-reloaded
+     ;; Through the shipped producer: reloading only app.b (which re-declares)
+     ;; must update B and leave A's rows intact — A is neither fired by
+     ;; SHADOW_NS_RESET nor re-staged, so it is untouched.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :a-el {:properties #{:a-prop}} 'app.a)
+     (rules/register-custom-element! :b-el {:properties #{:b-prop}} 'app.b)
+     (rules/notify-reload!)
+     (fire-shadow-ns-reset! 'app.b)                                          ; only app.b reloads
+     (rules/register-custom-element! :b-el {:properties #{:b-prop2}} 'app.b) ; ...re-declaring
+     (rules/commit-reload!)
+     (is (= #{:a-prop} (rules/custom-element-properties :a-el))
+         "untouched source A keeps its classification across B's reload")
+     (is (= #{:b-prop2} (rules/custom-element-properties :b-el))
+         "reloaded source B's classification updates through the real path")))
+
+#?(:cljs
+   (deftest reload-producer-drops-last-declaration-but-keeps-a-sibling
+     ;; app.a reloads, dropping :x-el but keeping :y-el. The producer fires
+     ;; app.a (touched); :y-el stages; commit replaces app.a's WHOLE contribution
+     ;; so the dropped :x-el is evicted while :y-el survives — all through the
+     ;; shipped path, no direct seam call.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+     (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)
+     (rules/notify-reload!)
+     (fire-shadow-ns-reset! 'app.a)
+     (rules/register-custom-element! :y-el {:properties #{:label}} 'app.a)   ; only :y-el survives
+     (rules/commit-reload!)
+     (is (= #{} (rules/custom-element-properties :x-el))
+         "the dropped :x-el is evicted through the real producer")
+     (is (= #{:label} (rules/custom-element-properties :y-el))
+         "the surviving :y-el is retained")))
+
+#?(:cljs
+   (deftest reload-producer-is-build-isolated
+     ;; The producer notes into the ::default build (one compiled bundle = one
+     ;; build). Explicit-build rows are untouched by a ::default-build reload —
+     ;; the [build-id ns] ownership holds through the real path too.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :app-el {:properties #{:a-prop}} 'app.core)       ; ::default
+     (rules/register-custom-element! :lib-el {:properties #{:l-prop}} 'lib.core :lib)  ; build :lib
+     (rules/notify-reload!)                       ; opens the ::default cycle
+     (fire-shadow-ns-reset! 'app.core)            ; app.core re-runs, declares nothing
+     (rules/commit-reload!)
+     (is (= #{} (rules/custom-element-properties :app-el))
+         "the ::default reload evicts its own zero-declaration source")
+     (is (= #{:l-prop} (rules/custom-element-properties :lib-el))
+         "build :lib's row is untouched — the producer cannot cross builds")))


### PR DESCRIPTION
## What

The `.67`/#5744 transactional custom-element reload ledger (`rules.cljc`) shipped `notify-reload!` (`^:dev/before-load`), `note-reloaded-sources!`, and `commit-reload!` (`^:dev/after-load`) — but **`note-reloaded-sources!` had no production caller**. Outside tests it had zero callers, so in the real browser reload path a source that stops declaring a custom-element (or drops its last declaration) never had its stale rows evicted: the ledger never learned which sources re-ran. The `.67` tests called `note-reloaded-sources!` directly, proving the seam but not the shipped integration.

This wires the real producer.

## The mechanism — shadow's own reload machinery

Self-report from the emitted `register-custom-element!` **cannot** fix this: a source that re-runs declaring nothing emits no code to announce itself — *absence cannot self-report*. The authoritative "which namespaces re-ran this cycle" signal must come from the reload machinery.

shadow-cljs's `before-load-src` calls every fn on `js/goog.global.SHADOW_NS_RESET` with the ns symbol of each source it reloads, **during the code-load phase** — after `^:dev/before-load` `notify-reload!` opened the cycle and before `^:dev/after-load` `commit-reload!` closes it.

- `reload-source-reset!` rides that seam: for each reloaded ns it feeds `note-reloaded-sources!`, so `commit-reload!` reconciles the sources that actually re-ran and evicts the stale rows of one that now declares nothing — the runtime analogue of the compile side's `build/commit-slice`.
- `install-reload-source-producer!` is the wire: it pushes `reload-source-reset!` onto `SHADOW_NS_RESET` (ensuring the array `||`-style so it neither clobbers nor is clobbered by shadow's init), run exactly once at ns load via a `defonce`.

**Dev-only:** the whole install is `js/goog.DEBUG`-gated, so `:advanced` production carries no producer and never references `SHADOW_NS_RESET`. Production classification stays a direct lookup.

## Bounded case (documented, matches rf2-df9873 + the compile side)

A source **file deleted** with no reloading dependent never re-runs, so shadow never reports it and its runtime rows converge at the next full page load — "no design can observe an unsaved deletion" (df9873). The compile-side `finish-build!` (phlhfd #5777) already evicts a deleted source from the compile registry via `:build-sources` membership. `note-reloaded-sources!` remains the seam an authoritative removed-source manifest would feed if one is later wired.

## Surface

- `implementation/ui/src/re_frame/ui/rules.cljc` — the producer (`reload-source-reset!` + `install-reload-source-producer!` + the `defonce` install) and doc updates. No emit-path change was needed (the producer does not depend on emitted code).
- `implementation/ui/test/re_frame/ui/rules_cljs_test.cljc` — 5 CLJS tests that drive the **shipped** producer (shadow's `SHADOW_NS_RESET` callback), not `note-reloaded-sources!` directly: the wire itself, zero-declaration eviction end-to-end, drop-last-keep-sibling, preserve-untouched-update-reloaded, and build isolation.

## Quality gates

All foreground, 0-fail:

- `implementation/ui` `clojure -M:test` (JVM): **316 tests, 4776 assertions, 0 failures, 0 errors**
- `node-test-ui` (CLJS, `npx shadow-cljs compile node-test-ui && node out/node-test-ui.js`): **295 tests, 1545 assertions, 0 failures, 0 errors** — the 5 new tests confirmed running + passing (isolated fqn run: 5 tests, 11 assertions, 0 failures)
- core `node-test` (CLJS): **9058 tests, 42808 assertions, 0 failures, 0 errors**

Closes rf2-vxgfnd.77.