### PR TITLE
fix(ui): activate reincarnation-detection + root-incarnation reap on the live path (rf2-vxgfnd.93, rf2-vxgfnd.88, rf2-vxgfnd.92)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -54,7 +54,8 @@
   (:require ["react-dom/client" :as rdc]
             [re-frame.error :as error]
             [re-frame.ui.frames :as frames]
-            [re-frame.ui.reactive :as reactive]))
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.viewcell :as viewcell]))
 
 ;; ---------------------------------------------------------------------------
 ;; The Root handle
@@ -214,15 +215,32 @@
 (defn register-live-root!
   "Register a claimed root (checks already passed) — before any render.
   The effective `:identifier-prefix` rides the entry so a later claim can
-  assert prefix uniqueness and release frees it by dissoc (rf2-ez3fqk)."
+  assert prefix uniqueness and release frees it by dissoc (rf2-ez3fqk).
+
+  MINTS the root's per-mount INCARNATION here (rf2-vxgfnd.85/.92) — a fresh
+  opaque token that scopes every ViewCell under this Root (provided via the
+  root-incarnation React context at render) and drives the incarnation-aware
+  root teardown reap at `unmount!*`. Stable for the Root's lifetime (registration
+  runs once per Root); a re-mount under the same root-id after `unmount!` mints a
+  DISTINCT incarnation, so a stale teardown can never reap the replacement's
+  cells."
   [{:keys [root-id provenance site descriptor identifier-prefix]} container root]
   (swap! live-roots assoc root-id {:root root
                                    :container container
                                    :provenance provenance
                                    :identifier-prefix identifier-prefix
                                    :site site
-                                   :descriptor descriptor})
+                                   :descriptor descriptor
+                                   :root-incarnation (reactive/make-root-incarnation)})
   nil)
+
+(defn- root-incarnation-of
+  "The per-mount root incarnation minted for live root `root-id` at
+  registration (rf2-vxgfnd.92), or nil if the id is not live. Read at every
+  render (to provide the root-incarnation context) and at `unmount!*` (to drive
+  the incarnation-aware root-teardown reap)."
+  [root-id]
+  (:root-incarnation (get @live-roots root-id)))
 
 (defn release-root!
   "Unregister `root-id` iff the entry still belongs to `root` (a stale
@@ -388,7 +406,9 @@
         ;; never commit, and `.render`ing the stale handle would write into a
         ;; root the replacement now owns. Mirrors the fresh-path re-check.
         (require-live-root! root 're-frame.ui/mount)
-        (.render (.-react-root root) (element-thunk))
+        (.render (.-react-root root)
+                 (viewcell/provide-root-incarnation
+                  (root-incarnation-of root-id) (element-thunk)))
         root)
       (do
         (check-root-claim! 're-frame.ui/mount info container)
@@ -413,10 +433,13 @@
         (check-root-claim! 're-frame.ui/mount info container)
         (let [react-root (rdc/createRoot container react-opts)
               root       (Root. react-root container root-id)]
-          ;; register BEFORE any render (contract §7 Layer 3)
+          ;; register BEFORE any render (contract §7 Layer 3) — this MINTS the
+          ;; root incarnation the provider below scopes every ViewCell to.
           (register-live-root! info container root)
           (try
-            (.render react-root (element-thunk))
+            (.render react-root
+                     (viewcell/provide-root-incarnation
+                      (root-incarnation-of root-id) (element-thunk)))
             root
             (catch :default e
               ;; TOTAL rollback of a failed FIRST mount — the element thunk
@@ -483,7 +506,9 @@
                                           :root-id rid
                                           :root-id-provenance (:provenance entry))))
                      m))))))
-    (.render (.-react-root root) (element-thunk))
+    (.render (.-react-root root)
+             (viewcell/provide-root-incarnation
+              (root-incarnation-of rid) (element-thunk)))
     root))
 
 (defn hydrate-root*
@@ -552,7 +577,12 @@
       ;; after React sweeps their effect cleanups (see the docstring LIFECYCLE
       ;; note). teardown-root! rethrows a throwing host `.unmount` unchanged, so
       ;; the catch/finally below keep the rf2-vxgfnd.53 ownership behaviour.
-      (reactive/teardown-root! (fn [] (.unmount (.-react-root root))))
+      ;; rf2-vxgfnd.85/.92 — pass this root's INCARNATION so a cell Activity-hidden
+      ;; BEFORE the unmount window (which the window can never capture) is still
+      ;; reaped through the root-incarnation ownership registry, even when the
+      ;; whole root was hidden and the window collects nothing.
+      (reactive/teardown-root! (root-incarnation-of (.-root-id root))
+                               (fn [] (.unmount (.-react-root root))))
       (catch :default e
         ;; rf2-vxgfnd.53 — React did NOT unmount, yet the `finally` below
         ;; still releases the claim (AC4). The live tree is now orphaned and

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -145,6 +145,30 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 ;; ---------------------------------------------------------------------------
+;; Observation-port ABI lockstep (Spec 006 §The internal observation port)
+;;
+;; This ns is the SOLE reactive consumer of the internal observation port, and
+;; from ABI v2 onward it RELIES on the `read` evidence axis `:node-key` — the
+;; reincarnation-identity `evidence-moved?` consumes below (rf2-vxgfnd.14/.93).
+;; So it PINS the ABI it compiled against and asserts it AT LOAD: a core that
+;; predates the `:node-key` read axis is a BOOT ERROR
+;; (`:rf.error/observation-port-version-mismatch`, always-on + fanned through
+;; the production error-emit axis), never a silently-missed reincarnation
+;; correction. Core and re-frame2-ui release on a lockstep train.
+;; ---------------------------------------------------------------------------
+
+(def ^:const expected-observation-port-abi
+  "The observation-port ABI version this reactive consumer is written against —
+  v2 (rf2-vxgfnd.14): `read` on a node lease carries `:node-key`, which
+  `evidence-moved?` compares to classify a same-id frame REINCARNATION across
+  the render→commit gap as MOVEMENT even when node-version + frame/registry
+  epochs coincide. Asserted against the live port at load
+  (`assert-port-abi-version!`) so artifact drift fails loud at boot."
+  2)
+
+(obs/assert-port-abi-version! expected-observation-port-abi)
+
+;; ---------------------------------------------------------------------------
 ;; The static override door (03 §3)
 ;;
 ;; `resolve-target` consumes a Story-override HIT off the site-ctx. On the
@@ -1224,14 +1248,45 @@
   "Did the target move in the render→commit gap? Compares the acquire-time
   `read` against the render's `probe` evidence. A cold probe
   (`:node-version nil`) falls back to `rf=` on value; a live probe compares
-  the node version and the frame/registry epochs (belt-and-braces the
-  two-guard rule leans on)."
+  the node IDENTITY (`:node-key`), the node version, and the frame/registry
+  epochs (belt-and-braces the two-guard rule leans on).
+
+  The `:node-key` clause (ABI v2, rf2-vxgfnd.14/.93) is the reincarnation axis:
+  a same-id frame DESTROY + RECREATE across the gap builds a FRESH reaction with
+  a strictly-greater `:node-key`, so the render probed one node's key and the
+  commit read a DIFFERENT node's key — MOVEMENT the reconciler must correct
+  before paint. Version + epochs ALONE can tie across the two incarnations
+  (`frame/dissoc-frame!` restarts the commit epoch), so without this clause the
+  reincarnation reads as unchanged. The unchanged-node fast path is preserved:
+  the same live node reads the same key/version/epochs, so no correction fires.
+  The cold-probe (`:node-version nil`) and static-override (`read` returns no
+  `:node-key`, probed cold) branches are untouched."
   [read-result probe-ev]
   (if (nil? (:node-version probe-ev))
     (not (eq/rf= (:value read-result) (:value probe-ev)))
     (or (not= (:version read-result) (:node-version probe-ev))
+        (not= (:node-key read-result) (:node-key probe-ev))
         (not= (:frame-epoch read-result) (:frame-epoch probe-ev))
         (not= (:registry-epoch read-result) (:registry-epoch probe-ev)))))
+
+(def ^:dynamic ^:no-doc *commit-barrier*
+  "JVM/DOM linearization TEST SEAM — nil in production (two nil checks per commit,
+  zero further cost), NEVER bound off a test path (the `*upsert-decide-probe*`
+  idiom). Bound to a `(fn [phase cell] …)`, `commit!` calls it at two
+  deterministic points so a fixture can interleave a frame destroy / same-id
+  reincarnation with a commit:
+
+    :pre-acquire   — after the render capture is loaded, BEFORE the kept-check /
+                     stage-acquire. A same-id DESTROY+RECREATE here makes the
+                     commit ACQUIRE the FRESH incarnation while the render probed
+                     the destroyed one — the `:node-key` reincarnation
+                     `evidence-moved?` must correct before paint (rf2-vxgfnd.93).
+    :post-acquire  — after stage-acquire + the evidence read, BEFORE the publish.
+                     A full destroy of the ACQUIRED incarnation + a fresh same-id
+                     incarnation here proves the frame-close revalidation joins the
+                     commit to the acquired incarnation's teardown, not the
+                     replacement id (rf2-vxgfnd.88)."
+  nil)
 
 (defn commit!
   "Run the 8-step layout commit for `cell` against its latest render
@@ -1287,6 +1342,10 @@
                  ") — the frame/root was torn down under a retained handle; a "
                  "dead cell cannot resume")
             {:extra {:view-id (:view-id st0)}}))
+        ;; :pre-acquire test seam — a fixture may reincarnate the frame in the
+        ;; render→commit gap here so the stage-acquire below binds the FRESH
+        ;; incarnation while the render probed the destroyed one (rf2-vxgfnd.93).
+        (when-some [barrier *commit-barrier*] (barrier :pre-acquire cell))
         (let [committed  (:committed st0)          ;; tk -> lease
               new-order  (:order cap)              ;; tk, render order
               new-by     (:by-key cap)
@@ -1340,6 +1399,11 @@
                                      (assoc! acc tk (:value (new-by tk))))
                                    (transient {})
                                    new-order))]
+          ;; :post-acquire test seam — a fixture may destroy the ACQUIRED
+          ;; incarnation + recreate the id here to prove the revalidation below
+          ;; joins this commit to the acquired incarnation's teardown, not the
+          ;; replacement id (rf2-vxgfnd.88).
+          (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
           ;; step 6 — publish (committed values + dependency set)
           (swap! st assoc
                  :committed (merge retained staged-map)

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1269,6 +1269,48 @@
         (not= (:frame-epoch read-result) (:frame-epoch probe-ev))
         (not= (:registry-epoch read-result) (:registry-epoch probe-ev)))))
 
+;; ---- frame-close revalidation: incarnation-safe (rf2-vxgfnd.88, extends .61) ---
+;;
+;; A commit publishing ownership must resolve against the EXACT frame incarnation
+;; it acquired its leases from — never merely the reused frame-id. `destroy-frame!`
+;; + a fresh same-id construction mints a DISTINCT incarnation token
+;; (`frame/frame-incarnation-token` — the record's `:drain-lock`, stable across one
+;; incarnation, distinct across destroy+recreate), so comparing the token captured
+;; at ACQUIRE against the live token catches a same-id reincarnation the bare-id
+;; `frame-closing?` check alone misses: a commit that acquired incarnation A but
+;; finds B live under the id must JOIN A's teardown, not publish `:connected`
+;; against the replacement (rf2-vxgfnd.88). The bare-id `frame-closing?` clause is
+;; RETAINED for the .61 in-flight window (A mid-teardown, still live pre-flip,
+;; token unchanged — the marker is the only signal there).
+
+(defn- committed-frame-incarnations
+  "Snapshot `{frame-id -> incarnation-token}` for every frame the committed map
+  `committed` observes — captured at ACQUIRE time so the frame-close revalidation
+  compares each frame's LIVE incarnation against the one this commit acquired from
+  (rf2-vxgfnd.88). A frame absent/destroyed reads nil. O(observed frames)."
+  [committed]
+  (persistent!
+    (reduce (fn [acc tk]
+              (if (= :sub (nth tk 0))
+                (assoc! acc (nth tk 1) (frame/frame-incarnation-token (nth tk 1)))
+                acc))
+            (transient {})
+            (keys committed))))
+
+(defn- incarnation-superseded?
+  "True when ANY frame in the acquire-time `incarnations` snapshot is no longer
+  live under the SAME incarnation token — its incarnation was destroyed (nil now)
+  or REPLACED by a fresh same-id incarnation (a distinct token). The
+  exact-identity half of the frame-close revalidation (rf2-vxgfnd.88): a commit
+  must resolve against the incarnation it ACQUIRED from, never the reused id."
+  [incarnations]
+  (reduce-kv (fn [_ fid captured]
+               (if (identical? captured (frame/frame-incarnation-token fid))
+                 false
+                 (reduced true)))
+             false
+             incarnations))
+
 (def ^:dynamic ^:no-doc *commit-barrier*
   "JVM/DOM linearization TEST SEAM — nil in production (two nil checks per commit,
   zero further cost), NEVER bound off a test path (the `*upsert-decide-probe*`
@@ -1388,6 +1430,11 @@
                                               (throw e)))]
                                (recur (rest ks) (conj acc [tk lease])))))
               staged-map (into {} staged)
+              ;; ACQUIRE-time incarnation snapshot for the frame-close
+              ;; revalidation (rf2-vxgfnd.88): the exact incarnation each lease
+              ;; was acquired from, so a same-id reincarnation before publish is
+              ;; caught by token identity, not merely the reused frame-id.
+              incarnations (committed-frame-incarnations (merge retained staged-map))
               ;; step 5 — evidence comparison (moved in the render→commit gap)
               moved?     (boolean
                            (some (fn [[tk lease]]
@@ -1415,29 +1462,41 @@
           ;; hidden cell). This ENROLS the cell into the live-cell registry —
           ;; the discoverability publish a frame-destroy sweep consults.
           (connect! cell)
-          ;; Linearize this commit against a concurrent frame-destroy teardown
-          ;; (rf2-vxgfnd.61). #5731 wires destroy to a SNAPSHOT sweep of the
-          ;; live cells that runs while the frame is still live, with no
-          ;; ordering against acquisition on the JVM: a commit that acquires
-          ;; leases + enrols in the window between the sweep's snapshot and the
-          ;; liveness flip is MISSED by the sweep, would publish :connected, and
-          ;; then lose its cache under the remaining destroy recipe. The fix is a
-          ;; two-phase close with revalidation AFTER the enrolment publish:
-          ;; `connect!` has just added this cell to the live-cell registry, so if
-          ;; the sweep's snapshot could have missed us, the destroy necessarily
-          ;; added the frame to `destroying-frames` BEFORE snapshotting (it is
-          ;; populated at the very top of `destroy-frame!`), and `frame-closing?`
-          ;; is continuously true across the whole teardown window — so this
-          ;; read observes the close. Selection and closure thus become ONE
-          ;; linearized boundary: a cell enrolling mid-teardown is either in the
-          ;; sweep or, seeing a closing frame here, JOINS the teardown — tearing
-          ;; itself down against the still-releasable cache rather than lingering
-          ;; :connected on a dying frame. A live, not-being-destroyed frame (incl.
-          ;; a fresh same-id incarnation) makes this a constant false check, so
-          ;; disjoint frames commit/destroy concurrently and the single-threaded
-          ;; CLJS host — where destroy runs to completion without yielding to a
-          ;; commit — never sees it true.
-          (if (some frame/frame-closing? (cell-frames cell))
+          ;; INCARNATION-SAFE frame-close revalidation (rf2-vxgfnd.88, extending
+          ;; rf2-vxgfnd.61). Two reasons this commit must JOIN a teardown instead
+          ;; of publishing `:connected`, checked against the ACQUIRE-time
+          ;; incarnation snapshot rather than the bare frame-id:
+          ;;
+          ;;   (a) `incarnation-superseded?` — a frame this commit acquired from
+          ;;       is no longer live under the SAME incarnation token: it was
+          ;;       destroyed, OR a fresh same-id incarnation replaced it in the
+          ;;       render→commit gap. The bare-id `frame-closing?` MISSES this once
+          ;;       the old incarnation's teardown completed and cleared its marker
+          ;;       while a replacement went live under the id — so an old lease
+          ;;       would otherwise survive on the replacement id (rf2-vxgfnd.88).
+          ;;       Token identity (`frame/frame-incarnation-token`, the record's
+          ;;       `:drain-lock`, distinct per incarnation) resolves the commit to
+          ;;       exactly the incarnation it targeted.
+          ;;
+          ;;   (b) `frame-closing?` — a frame is IN-FLIGHT closing (rf2-vxgfnd.61).
+          ;;       #5731 wires destroy to a SNAPSHOT sweep of the live cells that
+          ;;       runs while the frame is still LIVE (pre-flip), then flips
+          ;;       liveness. A commit that acquires + enrols between the sweep
+          ;;       snapshot and the flip is MISSED by the sweep, and its
+          ;;       incarnation token is UNCHANGED (the frame is still live
+          ;;       pre-flip) — so token identity alone would not catch it. But
+          ;;       `destroying-frames` is populated at the TOP of `destroy-frame!`,
+          ;;       so `frame-closing?` is continuously true across the whole
+          ;;       teardown window: the enrolled cell observes the close and joins
+          ;;       the teardown against the still-releasable cache.
+          ;;
+          ;; A live, not-closing frame under an unchanged incarnation (incl. a
+          ;; committed fresh same-id incarnation this commit legitimately acquired)
+          ;; makes both checks false — disjoint frames commit/destroy concurrently,
+          ;; and the single-threaded CLJS host (destroy runs to completion without
+          ;; yielding to a commit) never sees either true.
+          (if (or (incarnation-superseded? incarnations)
+                  (some frame/frame-closing? (keys incarnations)))
             (teardown! cell)
             ;; step 8 — moved evidence corrects before paint
             (when moved?

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -46,17 +46,44 @@
   (:require ["react" :as react]
             [re-frame.ui.reactive :as reactive]))
 
+;; ---------------------------------------------------------------------------
+;; Root-incarnation context (03 §4; rf2-vxgfnd.85/.92)
+;;
+;; The ROOT scoping for per-cell root-incarnation ownership. `client/mount!`
+;; mints ONE incarnation per Root (`reactive/make-root-incarnation`) and wraps
+;; the root element in this context's Provider, so EVERY ViewCell under a root —
+;; across the whole tree, however deeply nested — reads the SAME incarnation via
+;; `useContext` and enrols under it (`attach-root!`). That true root scope is why
+;; an entirely-hidden sibling subtree is still reaped at root unmount: the
+;; ownership follows the ROOT, not the topmost still-mounted subtree. nil above a
+;; root that supplies no provider (bare/test mounts) — `attach-root!` is skipped.
+;; ---------------------------------------------------------------------------
+
+(defonce root-incarnation-context
+  (react/createContext nil))
+
+(defn provide-root-incarnation
+  "Wrap `element` in the root-incarnation context Provider carrying
+  `incarnation` — the seam `client/mount!` (and `render!`) render through so
+  every ViewCell in the root's tree shares ONE incarnation (rf2-vxgfnd.92).
+  A nil `incarnation` still provides (a root with no reactive cells is inert)."
+  [incarnation element]
+  (react/createElement (.-Provider root-incarnation-context)
+                       #js {:value incarnation}
+                       element))
+
 (defn render
   "Wrap a compiled view's render `thunk` (a zero-arg fn returning the host
   element) in its ViewCell. Establishes the cell (stable per React
   instance), subscribes the component to the cell's revision, runs the body
-  under a fresh render capture, and wires the reconcile + lifecycle layout
-  commits. Returns the host element."
+  under a fresh render capture, reads its root incarnation from context, and
+  wires the reconcile + lifecycle layout commits. Returns the host element."
   [view-id thunk]
   (let [cell-ref (react/useRef nil)]
     (when (nil? (.-current cell-ref))
       (set! (.-current cell-ref) (reactive/make-cell view-id)))
-    (let [cell      (.-current cell-ref)
+    (let [cell             (.-current cell-ref)
+          root-incarnation (react/useContext root-incarnation-context)
           subscribe (react/useCallback
                       (fn [listener] (reactive/subscribe cell listener))
                       #js [cell])]
@@ -76,12 +103,20 @@
           (fn reconcile []
             (reactive/commit! cell)
             js/undefined))
-        ;; lifecycle — empty deps: connect implicitly via the reconcile
-        ;; above; the cleanup releases owners on React unmount AND Activity
-        ;; hide (indistinguishable here — 03 §4). Reveal re-mounts this
-        ;; effect and the reconcile reacquires + corrects before paint.
+        ;; lifecycle — connect implicitly via the reconcile above; the cleanup
+        ;; releases owners on React unmount AND Activity hide (indistinguishable
+        ;; here — 03 §4). Reveal re-mounts this effect and the reconcile
+        ;; reacquires + corrects before paint. On mount the cell ENROLS under its
+        ;; root incarnation (`attach-root!`, rf2-vxgfnd.85/.92) — an ownership that
+        ;; SURVIVES the hide-cleanup, so root teardown reaps a cell hidden before
+        ;; its unmount window. Keyed on the incarnation identity, so a re-mount
+        ;; under a fresh root re-enrols. `attach-root!` is idempotent; the cleanup
+        ;; NEVER detaches the root (that is `teardown!`'s job — the hide must stay
+        ;; reapable-by-its-root).
         (react/useLayoutEffect
           (fn lifecycle []
+            (when (some? root-incarnation)
+              (reactive/attach-root! cell root-incarnation))
             (fn cleanup [] (reactive/disconnect! cell)))
-          #js [])
+          #js [root-incarnation])
         element))))

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -1,0 +1,124 @@
+(ns re-frame.ui.reactive-incarnation-close-cljs-test
+  "rf2-vxgfnd.88 — the ViewCell frame-close revalidation is INCARNATION-safe
+  (extending rf2-vxgfnd.61's linearization).
+
+  #5764 (.61) made `commit!` consult `frame/frame-closing?` after the enrolment
+  publish, so a cell enrolling mid-teardown JOINS the teardown instead of
+  stranding `:connected`. But that check keyed on the BARE frame-id: a same-id
+  DESTROY + RECREATE in the render→commit gap left the reused id NOT closing
+  (`frame-closing?` false — the replacement is live and the old marker cleared),
+  so a commit holding the DESTROYED incarnation's lease would publish `:connected`
+  against the REPLACEMENT. The fix compares the incarnation TOKEN
+  (`frame/frame-incarnation-token`) captured at ACQUIRE against the live token, so
+  a commit resolves against exactly the incarnation it targeted.
+
+  Staging is deterministic and host-agnostic via the `reactive/*commit-barrier*`
+  test seam: it fires synchronously INSIDE `commit!` at `:post-acquire` — after
+  the lease is acquired + read but BEFORE the publish — exactly the window
+  rf2-vxgfnd.88 names. The fixture reincarnates the frame there, so no threads
+  are needed; `.cljc` ending `-cljs-test` graft-checks it on node (`test:cljs`)
+  AND JVM (`clojure -M:test`) against the REAL observation port + sub-cache
+  (plain-atom adapter).
+
+  KNOWN GAP (flagged, not fixed here): the reciprocal Failure-2 — an old
+  incarnation's stale bare-id close marker (present in the JVM window between
+  `dissoc-frame!` and `destroy-frame!`'s terminal `finally`) tearing down a
+  live REPLACEMENT incarnation's cell — cannot be closed from the ui artefact
+  alone: `frame/destroying-frames` is a set of bare ids, so reactive.cljc cannot
+  tell an A-marker from a B-marker. Closing it needs core to key the close marker
+  by incarnation token; tracked as a follow-up."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            ;; Load-bearing: publishes the :ui/on-frame-destroyed! hook, so a real
+            ;; destroy runs the ViewCell sweep — proving the mid-commit cell is
+            ;; NOT caught by it (it enrols only at the post-publish connect!).
+            [re-frame.ui.frames]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- tk [fid q] [:sub fid q])
+
+;; ===========================================================================
+;; Failure-1: an old-incarnation commit must NOT survive on the replacement id
+;; ===========================================================================
+
+(deftest commit-of-a-superseded-incarnation-joins-its-teardown-not-the-replacement
+  (rf/reg-sub :ic/a (fn [db _] (:a db)))
+  (let [fid     :ic/frame
+        _       (make-frame! fid {:a 1})
+        token-a (frame/frame-incarnation-token fid)
+        cell    (reactive/make-cell ::v)]
+    ;; render probes incarnation A (ownership-free)
+    (rf/with-frame fid
+      (reactive/with-capture cell (fn [] (reactive/sub-read [:ic/a]))))
+    ;; commit: step 4 acquires A's lease + step 5 reads it (A still live), THEN
+    ;; the :post-acquire seam fully destroys A and recreates B under the same id
+    ;; BEFORE the publish. The incarnation-safe revalidation must join THIS commit
+    ;; (which holds A's lease) to A's teardown, never publish :connected on B.
+    (binding [reactive/*commit-barrier*
+              (fn [phase _]
+                (when (= :post-acquire phase)
+                  (frame/destroy-frame! fid)     ;; A fully destroyed (marker cleared)
+                  (make-frame! fid {:a 99})))]    ;; B — a DISTINCT incarnation, new state
+      (reactive/commit! cell))
+    (testing "precondition — B is a distinct incarnation under the reused id"
+      (is (not (identical? token-a (frame/frame-incarnation-token fid)))
+          "destroy + recreate minted a fresh incarnation token")
+      (is (false? (frame/frame-closing? fid))
+          "the reused id is NOT closing — bare-id frame-closing? MISSES this (the pre-fix hole)"))
+    (testing "the commit resolved against the incarnation it ACQUIRED (A), not the id"
+      (is (= :dead (reactive/lifecycle cell))
+          "the cell holding A's lease joined A's teardown — not left :connected on B")
+      (is (empty? (reactive/committed-target-keys cell))
+          "A's stale lease is released — no old ownership survives on the replacement id"))
+    (testing "the replacement incarnation B is wholly untouched and commits cleanly"
+      ;; Clear the slice PROBE MEMO first: a cold probe caches its computed value
+      ;; under a `(frame, frame-epoch, registry-epoch)` tag, and those tie across
+      ;; the reincarnation by construction — so a stale A-tagged entry would be
+      ;; reused. The memo is an economy (commit corrects before paint); resetting
+      ;; it isolates B's OWN read. The dead cell already left every registry.
+      (reactive/reset-scheduler!)
+      (let [cell-b (reactive/make-cell ::b)]
+        (rf/with-frame fid
+          (reactive/with-capture cell-b (fn [] (reactive/sub-read [:ic/a]))))
+        (reactive/commit! cell-b)
+        (is (= :connected (reactive/lifecycle cell-b)) "B's own cell connects")
+        (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys cell-b))
+            "B's cell owns B's node")
+        (is (= 1 (:ref-count (get @(:sub-cache (frame/frame fid)) [:ic/a])))
+            "B's node has exactly ONE owner — the stale A release never decremented
+             B's cache entry (identity-guarded release, rf2-vxgfnd.88 AC4)")
+        (is (= 99 (get (reactive/committed-values cell-b) (tk fid [:ic/a])))
+            "B reads its OWN state — the stale commit never clobbered B's cache")))))
+
+;; ===========================================================================
+;; The ordinary (non-reincarnation) commit is unaffected — a live, unchanged
+;; incarnation is neither superseded nor closing, so the commit publishes
+;; :connected (the constant false check).
+;; ===========================================================================
+
+(deftest live-unchanged-incarnation-commit-stays-connected
+  (rf/reg-sub :ic/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :ic/frame2 {:a 1})
+        cell (reactive/make-cell ::v)]
+    (rf/with-frame fid
+      (reactive/with-capture cell (fn [] (reactive/sub-read [:ic/a]))))
+    (reactive/commit! cell)
+    (is (= :connected (reactive/lifecycle cell))
+        "no supersede, no close ⇒ ordinary connected commit (incarnation check is false)")
+    (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys cell)))))

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -30,6 +30,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                 :as rf]
             [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
             [re-frame.subs                 :as subs]
             [re-frame.substrate.observation :as obs]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -183,6 +184,61 @@
   (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])]
     (is (= 0 (reactive/revision cell))
         "no movement in the gap ⇒ no revision advance")))
+
+;; ===========================================================================
+;; rf2-vxgfnd.93 — the reconciler consumes read's :node-key reincarnation axis
+;; (completes rf2-vxgfnd.14 / #5774 on the S2b live branch). A same-id frame
+;; DESTROY + RECREATE across the render→commit gap must classify as MOVED even
+;; when node-version + frame/registry epochs COINCIDE across the incarnations —
+;; the S2 invariant break the version+epoch-only comparison would misread as
+;; unchanged. Uses a NAMED frame so the destroy+recreate is real; the plain-atom
+;; adapter is CLJC so this graft-checks on node (`test:cljs`) AND JVM.
+;; ===========================================================================
+
+(deftest reincarnation-in-the-gap-detected-via-node-key-advances-revision
+  (rf/reg-sub :re/v (fn [db _] (:v db)))
+  (live-frame/make-frame {:id :re/frame})
+  (frame/replace-app-db! :re/frame {:v 1})
+  (let [cell (reactive/make-cell ::v)]
+    ;; render probes a LIVE node (hold a subscribe ref so the ownership-free
+    ;; probe reads a canonical node — captures node-key K_A at version 0).
+    (subs/subscribe [:re/v] {:frame :re/frame})
+    (rf/with-frame :re/frame
+      (reactive/with-capture cell (fn [] (reactive/sub-read [:re/v]))))
+    (is (= 0 (reactive/revision cell)) "precondition: no revision yet")
+    ;; reincarnate in the gap: identical construction + a single replace-app-db!
+    ;; makes node-version + frame/registry epochs COINCIDE with the destroyed
+    ;; incarnation's (dissoc restarts the commit epoch, fresh node ⟹ version 0,
+    ;; no :sub re-registration) — only the FRESH reaction's node-key differs.
+    (frame/destroy-frame! :re/frame)
+    (live-frame/make-frame {:id :re/frame})
+    (frame/replace-app-db! :re/frame {:v 1})
+    ;; commit acquires the FRESH node K_B; read K_B ≠ probe K_A ⟹ moved via the
+    ;; node-key axis alone (version+epoch tie) ⟹ corrective revision advance.
+    (reactive/commit! cell)
+    (is (= 1 (reactive/revision cell))
+        "same-id reincarnation classified MOVED via :node-key — a corrective
+         render before paint (version+epoch alone MISS it — the pre-fix break)")
+    (is (= :connected (reactive/lifecycle cell))
+        "resolved against the LIVE fresh incarnation it acquired — not torn down")
+    (frame/destroy-frame! :re/frame)))
+
+(deftest unchanged-live-node-across-commit-does-not-false-advance
+  ;; The node-key fast-path guard (rf2-vxgfnd.14 AC #4, at the ui layer): a
+  ;; genuinely-unchanged live node reads the SAME node-key/version/epochs across
+  ;; the render probe and the commit read, so the new :node-key clause introduces
+  ;; NO false movement.
+  (rf/reg-sub :re/v (fn [db _] (:v db)))
+  (live-frame/make-frame {:id :re/frame2})
+  (frame/replace-app-db! :re/frame2 {:v 7})
+  (let [cell (reactive/make-cell ::v)]
+    (subs/subscribe [:re/v] {:frame :re/frame2})   ;; a live canonical node
+    (rf/with-frame :re/frame2
+      (reactive/with-capture cell (fn [] (reactive/sub-read [:re/v]))))
+    (reactive/commit! cell)                         ;; same live node at commit
+    (is (= 0 (reactive/revision cell))
+        "an unchanged live node reads the same node-key — no false movement")
+    (frame/destroy-frame! :re/frame2)))
 
 ;; ===========================================================================
 ;; useSyncExternalStore contract — subscribe / snapshot / notify

--- a/implementation/ui/test/re_frame/ui/reactive_reincarnation_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_reincarnation_dom_cljs_test.cljs
@@ -1,0 +1,81 @@
+(ns re-frame.ui.reactive-reincarnation-dom-cljs-test
+  "rf2-vxgfnd.93 — the same-id reincarnation correction fires in the layout
+  commit BEFORE paint, under REAL React 19 + real DOM (bead rf2-vxgfnd.14 AC #2
+  on the React spine).
+
+  `reactive-reconcile-cljs-test` graft-checks the `:node-key` reincarnation
+  detection headlessly (and fails-pre-fix there); this file proves the SAME
+  correction rides the `useLayoutEffect` commit on the real spine. The staging is
+  deterministic: the `reactive/*commit-barrier* :pre-acquire` seam fires inside
+  the leaf's layout commit — after the render probed incarnation A but BEFORE the
+  commit's stage-acquire — where the fixture DESTROYS + RECREATES the frame under
+  the same id. The commit then ACQUIRES the fresh incarnation (a strictly-greater
+  node-key) while holding the render's probe of the destroyed one, so
+  `evidence-moved?` classifies it MOVED via the node-key axis and advances the
+  revision, which re-renders SYNCHRONOUSLY inside the same `flushSync` — before
+  any paint. The DOM reads the reincarnated value with no macrotask/paint between.
+
+  Browser-only bodies — `-dom-cljs-test$` opts into `:browser-test`; `:node-test`
+  loads it too, where the DOM body gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider sub]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
+            ;; the CLJS emitter wraps a sub-bearing view in viewcell/render.
+            [re-frame.ui.viewcell]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter uix-adapter/adapter :ambient-frame nil})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (client/reset-live-roots!)
+    (try (f) (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+
+(def ^:private frame-kw :rre/frame)
+
+(defn- container [] (js/document.createElement "div"))
+
+(defview leaf [_] [:span.leaf (str (sub [:rre/n]))])
+
+(defn- register-app! []
+  (rf/make-frame {:id frame-kw :doc "reincarnation before-paint probe frame"})
+  (rf/reg-sub :rre/n (fn [db _] (:n db)))
+  (rf/reg-event :rre/seed (fn [_ _] {:db {:n 1}})))
+
+(deftest reincarnation-in-the-gap-corrects-before-paint
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:rre/seed] {:frame frame-kw})
+      (let [c     (container)
+            armed (atom true)]
+        ;; Arm the :pre-acquire seam to reincarnate the frame ONCE, inside the
+        ;; mount's layout commit: destroy A (which the not-yet-connected leaf cell
+        ;; escapes — it enrols only at the post-publish connect!) and recreate B
+        ;; under the same id with a DIFFERENT value. The commit then acquires B's
+        ;; fresh node (a distinct node-key) while holding the render's probe of A.
+        (binding [reactive/*commit-barrier*
+                  (fn [phase _cell]
+                    (when (and @armed (= :pre-acquire phase))
+                      (reset! armed false)              ;; once — disarm the re-commit
+                      (frame/destroy-frame! frame-kw)
+                      (rf/make-frame {:id frame-kw})
+                      (frame/replace-app-db! frame-kw {:n 2})))]
+          (let [root (react-dom/flushSync
+                      #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                 c {:root-id :rre/root}))]
+            (testing "the node-key reincarnation was corrected in the layout commit, before paint"
+              (is (= "2" (.-textContent (.querySelector c ".leaf")))
+                  "the corrective render fired synchronously inside flushSync (before
+                   any paint/macrotask) — the reincarnated value is on the DOM"))
+            (react-dom/flushSync #(ui/unmount! root))))))))

--- a/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.ui.root-incarnation-activity-dom-cljs-test
+  "rf2-vxgfnd.92 / .85 — root-incarnation ownership on the REAL React 19 + real
+  DOM path (not just the graft).
+
+  rf2-vxgfnd.85 landed the substrate reap; .92 wires the live path —
+  `client/mount` mints a root incarnation and provides it via context so every
+  ViewCell enrols under it (`attach-root!`), and `client/unmount!` passes it to
+  `teardown-root!`. This file closes the loop end-to-end:
+
+    - MOUNT-ATTACH: a real `ui/mount` enrols the cell under the root's incarnation
+      (the context→attach seam), and a real `ui/unmount!` reaps it :dead.
+    - ACTIVITY: a real React 19 `<Activity mode=\"hidden\">` fires the cell's
+      layout-effect cleanup (`disconnect!`) while PRESERVING the cell — so the
+      cell is hidden BEFORE any unmount window. A root unmount then reaps that
+      pre-hidden cell via the incarnation (`:unmounted {:proof :host-teardown}` →
+      `:dead`); an Activity hide with NO root unmount stays reconnectable
+      (`:activity-hidden {:proof :reconnect}` on reveal). This activates .85's
+      P1 on the real path.
+
+  Browser-only bodies — `-dom-cljs-test$` opts into `:browser-test`; `:node-test`
+  loads it too, where each DOM body gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider sub]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.viewcell]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; A WATCHABLE substrate (UIx spine) so a sub move fires the port's on-change
+;; watch that drives the Activity-mode re-render; `:ambient-frame nil` so views
+;; resolve their frame ONLY from the enclosing frame-provider.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter uix-adapter/adapter :ambient-frame nil :async? true})
+  {:before #(do (reactive/reset-scheduler!) (client/reset-live-roots!))
+   :after  #(do (reactive/reset-scheduler!) (client/reset-live-roots!))})
+
+(def ^:private frame-kw :ract/frame)
+
+(defn- container [] (js/document.createElement "div"))
+
+(def ^:private Activity react/Activity)
+
+(defview leaf [_] [:span.leaf (str (sub [:ract/n]))])
+
+;; Wraps the leaf in a React 19 <Activity>, its mode driven by a sub — flipping
+;; :ract/hidden? re-renders this cell, hides the Activity subtree, and fires the
+;; leaf's layout-effect cleanup (disconnect!) while preserving the leaf cell.
+(defview act-app [_]
+  [Activity {:mode (if (sub [:ract/hidden?]) "hidden" "visible")}
+   [leaf {}]])
+
+(defn- register-app! []
+  (rf/make-frame {:id frame-kw :doc "root-incarnation Activity probe frame"})
+  (rf/reg-sub :ract/n (fn [db _] (:n db)))
+  (rf/reg-sub :ract/hidden? (fn [db _] (:hidden? db)))
+  (rf/reg-event :ract/seed (fn [_ _] {:db {:n 7 :hidden? false}}))
+  (rf/reg-event :ract/hide (fn [{:keys [db]} _] {:db (assoc db :hidden? true)}))
+  (rf/reg-event :ract/show (fn [{:keys [db]} _] {:db (assoc db :hidden? false)})))
+
+(defn- incarnation [] (:root-incarnation (client/live-root-entry :ract/root)))
+
+(defn- leaf-cell
+  "The mounted ViewCell whose committed dependency set observes [:ract/n]."
+  []
+  (some (fn [cell]
+          (when (contains? (reactive/committed-target-keys cell)
+                           [:sub frame-kw [:ract/n]])
+            cell))
+        (reactive/current-live-cells)))
+
+;; ===========================================================================
+;; MOUNT-ATTACH — a real mount enrols the cell under the root incarnation, and a
+;; real unmount reaps it (the context→attach + unmount-passes-incarnation wiring)
+;; ===========================================================================
+
+(deftest real-mount-attaches-cell-to-root-incarnation-and-unmount-reaps
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:ract/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                             c {:root-id :ract/root}))
+            cell (leaf-cell)]
+        (testing "the mounted cell is enrolled under the root's incarnation (context→attach)"
+          (is (= "7" (.-textContent (.querySelector c ".leaf"))))
+          (is (some? (incarnation)) "the client minted a root incarnation")
+          (is (identical? (incarnation) (reactive/cell-root cell))
+              "viewcell attached the cell to the root incarnation via the context (rf2-vxgfnd.92)"))
+        (testing "a real unmount reaps the cell via the incarnation → :dead"
+          (react-dom/flushSync #(ui/unmount! root))
+          (is (= :dead (reactive/lifecycle cell)))
+          (is (= :host-teardown (:proof (peek (reactive/intervals cell)))))
+          (is (= #{} (client/live-root-ids))))))))
+
+;; ===========================================================================
+;; ACTIVITY — hide (before any window) → root unmount reaps the pre-hidden cell
+;; ===========================================================================
+
+(deftest activity-hidden-then-root-unmount-reaps-the-pre-hidden-cell
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:ract/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [frame-provider {:frame frame-kw} [act-app {}]]
+                             c {:root-id :ract/root}))
+            cell (leaf-cell)]
+        (async done
+          (is (= "7" (.-textContent (.querySelector c ".leaf"))) "leaf mounted")
+          (is (identical? (incarnation) (reactive/cell-root cell))
+              "the leaf cell is owned by the root incarnation")
+          ;; Activity-hide the leaf — a sub move re-renders act-app on the
+          ;; microtask, flipping the Activity to mode=hidden.
+          (rf/dispatch-sync [:ract/hide] {:frame frame-kw})
+          (js/queueMicrotask
+           (fn []
+             (react-dom/flushSync (fn []))    ;; commit the mode flip
+             (testing "React 19 Activity fired the leaf's cleanup — hidden, cell preserved + owned"
+               (is (= :disconnected (reactive/lifecycle cell))
+                   "the pre-window hide is a transient disconnect")
+               (is (identical? (incarnation) (reactive/cell-root cell))
+                   "root ownership SURVIVES the Activity hide"))
+             (testing "a real root unmount reaps the pre-hidden cell via the incarnation"
+               (react-dom/flushSync #(ui/unmount! root))
+               (is (= :dead (reactive/lifecycle cell))
+                   "the pre-hidden leaf is reaped on the LIVE path — not left reconnectable")
+               (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+                      (peek (reactive/intervals cell)))
+                   ":unmounted {:proof :host-teardown} — activates .85's P1 on the real path")
+               (is (= #{} (client/live-root-ids))))
+             (done))))))))
+
+(deftest activity-hidden-without-unmount-stays-reconnectable
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:ract/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [frame-provider {:frame frame-kw} [act-app {}]]
+                             c {:root-id :ract/root}))
+            cell (leaf-cell)]
+        (async done
+          (rf/dispatch-sync [:ract/hide] {:frame frame-kw})
+          (js/queueMicrotask
+           (fn []
+             (react-dom/flushSync (fn []))
+             (is (= :disconnected (reactive/lifecycle cell)) "hidden, not :dead")
+             ;; reveal — no root unmount ever ran
+             (rf/dispatch-sync [:ract/show] {:frame frame-kw})
+             (js/queueMicrotask
+              (fn []
+                (react-dom/flushSync (fn []))
+                (testing "a reveal reconnects and proves the interval an Activity hide"
+                  (is (= :connected (reactive/lifecycle cell)) "reconnected, never :dead")
+                  (is (= :activity-hidden (:reason (peek (reactive/intervals cell))))
+                      "proven :activity-hidden {:proof :reconnect} — the registry never killed it"))
+                (react-dom/flushSync #(ui/unmount! root))
+                (done))))))))))

--- a/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
@@ -1,0 +1,114 @@
+(ns re-frame.ui.root-incarnation-wiring-cljs-test
+  "rf2-vxgfnd.92 — the `client` root-incarnation WIRING on node (no real React).
+
+  rf2-vxgfnd.85 (#5773) landed the substrate mechanism — per-cell root-incarnation
+  ownership (`attach-root!` / `root-cells` / `make-root-incarnation`) and the
+  incarnation-aware `teardown-root!` that reaps Activity-hidden cells — but the
+  .85+.86 cluster was surface-restricted to reactive.cljc, so the REAL mount /
+  unmount path did not mint, thread, or pass a root incarnation. .92 wires it:
+
+    - `register-live-root!` MINTS one incarnation per Root (read via the entry);
+    - `unmount!*` PASSES it to `teardown-root!` (the 2-arg arity), so a cell hidden
+      BEFORE the unmount window — which the window can never capture — is still
+      reaped through the root-incarnation ownership registry.
+
+  This pins the client kernel with a FAKE Root (a plain JS object with an
+  `unmount` method), mimicking what `viewcell/render` does at mount by enrolling
+  a cell under the entry's incarnation via `attach-root!`. The real-React /
+  real-DOM counterpart (context→attach + Activity hide) is the browser fixture
+  `re-frame.ui.root-incarnation-activity-dom-cljs-test`."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.test-support         :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.ui.client            :as client]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (client/reset-live-roots!)
+    (try (f) (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+
+(defn- root-incarnation
+  "The incarnation the client minted for live root `root-id`, read off the
+  public registry entry (`register-live-root!` stores it there)."
+  [root-id]
+  (:root-incarnation (client/live-root-entry root-id)))
+
+(defn- register!
+  "Register a fake Root whose host `.unmount` runs `on-unmount`."
+  [root-id on-unmount]
+  (let [react-root #js {:unmount (fn [] (when on-unmount (on-unmount)))}
+        container  (js-obj)
+        root       (client/->Root react-root container root-id)]
+    (client/register-live-root! {:root-id root-id :provenance :authored}
+                                container root)
+    root))
+
+(defn- owned-cell!
+  "Graft analogue of a real mount UNDER a root: a connected cell ENROLLED under
+  the root's incarnation, exactly as `viewcell/render` does via `attach-root!`
+  once it reads the root-incarnation context at mount (rf2-vxgfnd.92)."
+  [root-id fid queries]
+  (let [cell (reactive/make-cell ::v)]
+    (reactive/attach-root! cell (root-incarnation root-id))
+    (rf/with-frame fid
+      (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+    (reactive/commit! cell)
+    cell))
+
+(deftest register-mints-a-fresh-incarnation-per-root
+  (let [_a (register! :ri/root-a nil)
+        _b (register! :ri/root-b nil)]
+    (is (some? (root-incarnation :ri/root-a)) "root A got an incarnation")
+    (is (some? (root-incarnation :ri/root-b)) "root B got an incarnation")
+    (is (not (identical? (root-incarnation :ri/root-a)
+                         (root-incarnation :ri/root-b)))
+        "each root's incarnation is distinct")))
+
+(deftest unmount-passes-the-incarnation-and-reaps-a-cell-hidden-before-the-window
+  ;; The core .92 live-path proof: `unmount!*` passes the root incarnation, so a
+  ;; cell Activity-hidden BEFORE the unmount window (which the window can never
+  ;; capture) is still reaped through the ownership registry.
+  (rf/reg-sub :ri/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :ri/frame})
+  (frame/replace-app-db! :ri/frame {:a 1})
+  (let [root (register! :ri/root nil)                  ;; host .unmount collects NOTHING
+        cell (owned-cell! :ri/root :ri/frame [[:ri/a]])]
+    (is (identical? (root-incarnation :ri/root) (reactive/cell-root cell))
+        "the cell is enrolled under its root's incarnation (the mount seam)")
+    (testing "an Activity hide BEFORE the window is a transient disconnect, still owned"
+      (reactive/disconnect! cell)
+      (is (= :disconnected (reactive/lifecycle cell)))
+      (is (= 1 (reactive/root-cell-count (root-incarnation :ri/root)))
+          "root ownership SURVIVES the hide"))
+    (testing "unmount!* reaps the pre-hidden cell via the incarnation it passed"
+      (is (nil? (client/unmount!* root)))
+      (is (= :dead (reactive/lifecycle cell))
+          "the pre-hidden cell is reaped — not left reconnectable after its root is gone")
+      (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+             (peek (reactive/intervals cell))))
+      (is (= #{} (client/live-root-ids)) "the claim is still released (contract §7)"))))
+
+(deftest a-hide-without-unmount-stays-reconnectable
+  ;; The discriminator: a hide with NO root teardown must stay reconnectable —
+  ;; the ownership registry must never itself kill a merely-hidden cell.
+  (rf/reg-sub :ri/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :ri/frame})
+  (frame/replace-app-db! :ri/frame {:a 1})
+  (let [_root (register! :ri/root nil)
+        cell  (owned-cell! :ri/root :ri/frame [[:ri/a]])]
+    (reactive/disconnect! cell)
+    (is (= :disconnected (reactive/lifecycle cell)) "hidden, not :dead")
+    (testing "a reveal reconnects and proves the interval an Activity hide"
+      (rf/with-frame :ri/frame
+        (reactive/with-capture cell (fn [] (reactive/sub-read [:ri/a]))))
+      (reactive/commit! cell)
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
+             (peek (reactive/intervals cell)))
+          "the registry did not kill a merely-hidden cell"))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -978,11 +978,13 @@ These are normative (R-2). Each names the bug class it deletes.
    in-tick (the 1 → 0 edge disposes synchronously, per the cache contract), and a second
    release of the same lease is a no-op. *(Deletes: deferred-release windows; cleanup
    paths that double-release under error recovery.)*
-5. **Moved evidence corrects before paint.** At commit, each acquired node's version
-   (and the frame/registry epochs) is compared against the render's probe evidence; any
-   movement in the render→commit gap advances the cell's revision and notifies, and the
-   host corrects **before paint**. *(Deletes: painting a frame computed from stale
-   reads.)*
+5. **Moved evidence corrects before paint.** At commit, each acquired node's identity
+   (`:node-key`), version, and the frame/registry epochs are compared against the render's
+   probe evidence; any movement in the render→commit gap — including a same-id frame
+   **reincarnation** the `:node-key` axis catches when version + epochs coincide — advances
+   the cell's revision and notifies, and the host corrects **before paint**. *(Deletes:
+   painting a frame computed from stale reads; a coincident-version reincarnation misread
+   as unchanged.)*
 6. **One notification per cell per render batch — the boundary is drain quiescence, not
    epoch close.** An event/frame **epoch** is a write-side commit + diagnostic-evidence
    unit (one per dequeued event — per
@@ -1010,7 +1012,7 @@ These are normative (R-2). Each names the bug class it deletes.
 (probe target ?slice-memo)    ; render: pure evidence read (shape above)
 (acquire! target on-change)   ; commit-only: re-resolves canonical node, +1 owner → lease
 (current? lease target)       ; the commit kept-check, one predicate
-(read lease)                  ; => {:value v :version n}; typed error after release
+(read lease)                  ; => {:value v :version n :node-key k :frame-epoch fe :registry-epoch re}; typed error after release
 (release! lease)              ; synchronous, idempotent (second call no-ops)
 ```
 
@@ -1023,12 +1025,19 @@ cache-contract counterpart — they are the capture and kept-check layer a concu
 host requires.
 
 The movement-evidence axes are realised as: a per-node observation **version** the port
-advances whenever it observes the node's value change by `rf=`; the frame's
-**commit epoch** (one bump per physical frame-state install); and a **registry epoch**
-(one bump per `:sub` registration). `read` on a node lease additionally returns the
-CURRENT `:frame-epoch` / `:registry-epoch` alongside the frozen `{:value v :version n}`
-keys (additive), so the commit reconciler's invariant-5 comparison needs no second
-probe.
+advances whenever it observes the node's value change by `rf=`; the node's process-unique
+**`:node-key`** identity (the same key `probe` emits — the reincarnation-identity axis);
+the frame's **commit epoch** (one bump per physical frame-state install); and a
+**registry epoch** (one bump per `:sub` registration). `read` on a node lease
+additionally returns the acquired node's `:node-key` and the CURRENT `:frame-epoch` /
+`:registry-epoch` alongside the frozen `{:value v :version n}` keys (**additive** — the
+frozen shape is unchanged), so the commit reconciler's invariant-5 comparison needs no
+second probe. `:node-key` is what lets that comparison distinguish a **same-id frame
+reincarnation** (`destroy-frame!` + a fresh same-id construction builds a new reaction
+with a strictly-greater key) from an unmoved live node **even when version + frame /
+registry epochs coincide** across the two incarnations — a version+epoch tie
+`dissoc-frame!`'s commit-epoch restart can produce, which a version+epoch-only comparison
+would misread as unchanged.
 
 ### Lease semantics
 


### PR DESCRIPTION
Completes the live-path wiring for two merged P1 substrate fixes (rf2-vxgfnd.14's `:node-key` read axis, #5774; rf2-vxgfnd.85's root-incarnation reap, #5773) plus makes the .61 frame-close revalidation incarnation-safe. One worker — all three touch `reactive.cljc` / `client.cljs` / `viewcell.cljs`. Three commits, ordered .93 → .88 → .92.

## rf2-vxgfnd.93 (P1) — reconciler consumes read's `:node-key`
`evidence-moved?` now adds `(not= (:node-key read-result) (:node-key probe-ev))` to its live branch, so a same-id frame DESTROY+RECREATE across the render→commit gap is classified MOVED even when node-version + frame/registry epochs coincide (the pre-fix S2 invariant break). The consumer pins the observation-port ABI to **v2** at load (`assert-port-abi-version!`), so artifact drift is a boot error. Introduces the `*commit-barrier*` test seam.

## rf2-vxgfnd.88 (P1) — incarnation-safe frame-close revalidation
The commit-close revalidation now captures each frame's incarnation token (`frame/frame-incarnation-token`) at ACQUIRE and compares it to the live token, so a commit joins **exactly** the incarnation it targeted rather than the reused id: a superseded incarnation's commit joins its own teardown instead of surviving on a same-id replacement. The bare-id `frame-closing?` clause is retained for the .61 in-flight window (token unchanged there). The reciprocal Failure-2 (a stale bare-id close marker in the JVM dissoc→finally window) needs core to key `destroying-frames` by incarnation token — flagged as a follow-up (off this artefact's surface).

## rf2-vxgfnd.92 (P2) — live-path root-incarnation wiring
`client/register-live-root!` mints one incarnation per Root; `viewcell/render` reads it via a new root-incarnation React context and enrols each cell (`attach-root!`) at mount — true ROOT scope; `client/unmount!*` passes it to `teardown-root!` (2-arg arity), so a cell Activity-hidden before the unmount window is still reaped. Activates .85's P1 on the real DOM unmount path.

## Fixtures (each fails pre-fix where applicable)
- **.93**: headless reconcile proof (node-key is the sole discriminator when version+epoch tie — fails pre-fix) + a real React 19 before-paint DOM proof (in-gap reincarnation corrected inside the layout commit, before paint).
- **.88**: deterministic post-acquire reincarnation via `*commit-barrier*` — the commit joins A's teardown, not B (fails pre-fix); node + JVM.
- **.92**: a node wiring proof (client mints + passes the incarnation) + a real React 19 `<Activity>` DOM proof (hide → root-unmount reaps `:dead {:proof :host-teardown}`; hide without unmount stays reconnectable).

## Quality gates
All foreground, 0-fail, on the rebased tree:
- ui `clojure -M:test` — **320 tests, 4790 assertions, 0 failures, 0 errors**
- core `clojure -M:test` — **1879 tests, 8424 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **9069 tests, 42874 assertions, 0 failures, 0 errors**
- `npm run test:browser` — **304 tests, 1104 assertions, 0 failures, 0 errors** (0 pageerrors)

Each new fixture confirmed to fail on pre-fix code (node-key clause removed / bare-id revalidation restored) and pass post-fix.