### PR TITLE
test(core): cover observation-port :cause :value, :disposed drain, and 10k watch-count leg (rf2-vxgfnd.29)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
@@ -1,0 +1,187 @@
+(ns re-frame.observation-port-watchable-host-cljs-test
+  "rf2-vxgfnd.29 (gap a) — the observation port's per-lease VALUE-MOVEMENT
+  watch channel (`make-watch-handler`, `re-frame.substrate.observation`),
+  exercised end-to-end on a WATCHABLE host.
+
+  The plain-atom port suites (`re-frame.observation-port-cljs-test`) are
+  IDeref-only: their derived sub values are NOT `IWatchable`, so the per-lease
+  `add-watch` the port installs never fires and the entire `{:cause :value}`
+  fan-out — the delivered-value node-record advance, the lease `:last` update,
+  and that path's dev reentrancy guard — runs in no test there (the untested
+  half of `acquire!`). This file grafts the SAME port onto the stock Reagent
+  adapter, whose derived sub reactions ARE `IWatchable`
+  (`reagent.ratom/Reaction`), so an observed value MOVEMENT actually fires the
+  port's watch — the real trigger the reactive-tear gates (.40 / .65) depend on.
+
+  THE EAGER-CONSUMER REQUIREMENT (why we stand a `ratom/run!` driver). The port
+  watch is a PASSIVE observer: it `add-watch`es the node but does not itself
+  keep the (lazy) Reagent reaction on the push path. In production the ViewCell
+  render is the ACTIVE consumer that re-derefs the node every flush, so a value
+  movement re-runs the node and fires the port's watch. A test with only a
+  passive port watch never re-runs the node (a lazy deref pulls once — the same
+  methodological point the standard-epochs diamond fixture makes), so each
+  fixture stands a `reagent.ratom/run!` driver — an auto-running reaction that
+  eagerly derefs the sub, standing in for the mounted ViewCell render. It
+  warms + activates the node BEFORE the lease's baseline observe (mirroring
+  render-then-commit: no first-run priming notification on the measured lease),
+  and keeps it on the push path so the genuine value MOVEMENT fires the watch.
+
+  The push path: a `dispatch-sync` MOVES the sub's value; `reagent.ratom/flush!`
+  re-runs the driver (and through it the node), and — the value changed — the
+  node notifies the port watch, which advances the node record with the
+  DELIVERED value (no recompute, I-5) and fans `{:cause :value …}` to the
+  lease's own `on-change`.
+
+  CLJS-only (Reagent is CLJS); ns ends in `-cljs-test` so the consolidated
+  shadow-cljs `:node-test` build (`npm run test:cljs`, whose source-paths carry
+  `adapters/reagent`) picks it up headlessly — no DOM, no React."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.ratom :as ratom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.test-support :as test-support]))
+
+;; A WATCHABLE host: the stock Reagent adapter's derived sub reactions are
+;; `reagent.ratom/Reaction`, which reify `IWatchable`. Default ambient
+;; `:rf/default` scope (so `dispatch-sync` / `subscribe` / `resolve-target`
+;; target it without an explicit frame), mirroring the diamond fixture.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(def ^:private fid :rf/default)
+
+(defn- lease-state [lease] @(@#'obs/lease-state lease))
+(defn- lease-last  [lease] (:last (lease-state lease)))
+
+(defn- node-reaction []
+  (:reaction (get @(:sub-cache (frame/frame fid)) [:obs/n])))
+
+(defn- register! []
+  (rf/reg-sub :obs/n (fn [db _] (:n db)))
+  (rf/reg-event :obs/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)})))
+
+;; The eager consumer standing in for a mounted ViewCell render: an
+;; auto-running reaction that derefs the sub, keeping the node warm + on the
+;; push path so a value movement re-runs it (and fires the port's watch).
+(defn- make-driver [] (ratom/run! (deref (rf/subscribe [:obs/n]))))
+
+;; ===========================================================================
+;; the value-movement watch channel — {:cause :value} end-to-end
+;; ===========================================================================
+
+(deftest watchable-host-value-movement-fires-cause-value-end-to-end
+  (testing "on a WATCHABLE (Reagent) host, a sub value MOVEMENT fires the
+            port's per-lease watch → {:cause :value} with an ADVANCED
+            node-version and the lease :last updated to the DELIVERED value —
+            the make-watch-handler channel the plain-atom suites cannot reach"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [driver (make-driver)]
+      (ratom/flush!)                       ;; settle: node warm + active
+      (let [notes  (atom [])
+            target (obs/resolve-target {:frame fid :query-v [:obs/n]})
+            lease  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
+        (try
+          ;; --- preconditions: the port armed the value-movement channel ---
+          (is (obs/lease? lease))
+          (is (satisfies? IWatchable (node-reaction))
+              "the Reagent sub reaction IS IWatchable — the port installed its
+               per-lease value-movement watch (on a non-watchable host this
+               whole channel is dead, which is the very gap under test)")
+          (is (some? (:watch-key (lease-state lease)))
+              "acquire! registered a per-lease change watch key on the node")
+          (is (empty? @notes)
+              "acquire! on a WARM node fans nothing synchronously (I-5
+               no-sync-fan-out holds on a watchable host too)")
+          (let [v0    (:version (lease-last lease))
+                node0 (:node-key (lease-last lease))]
+            (is (= 1 (:value (lease-last lease))) "baseline observed value")
+            ;; --- MOVE the value; flush the reaction queue (the push) ---
+            (rf/dispatch-sync [:obs/set-n 2])
+            (ratom/flush!)
+            (testing "the value-movement watch fired the {:cause :value} channel"
+              (is (pos? (count @notes))
+                  "the port's per-lease watch fired on the value movement")
+              (is (every? #(= :value (:cause %)) @notes)
+                  "every fan-out on this path carries {:cause :value}")
+              (let [ev (peek @notes)]
+                (is (= target (:target ev)) "the payload carries the lease target")
+                (is (= node0 (:node-key ev)) "same node — a MOVEMENT, not a rebuild")
+                (is (> (:node-version ev) v0)
+                    "the delivered-value node-version ADVANCED past the baseline")
+                (is (= (:node-version ev) (:version (lease-last lease)))
+                    "the lease :last was advanced to the delivered version")
+                (is (= 2 (:value (lease-last lease)))
+                    "the lease :last holds the DELIVERED new value (no recompute)")
+                (is (int? (:frame-epoch ev)))
+                (is (int? (:registry-epoch ev))))))
+          (finally
+            (obs/release! lease)
+            (ratom/dispose! driver)))))))
+
+(deftest watchable-host-idempotent-move-does-not-fan-cause-value
+  (testing "a commit that leaves the sub value UNMOVED does not fire the
+            {:cause :value} channel — the reaction's `=` notify gate (and the
+            node-record's rf= version hold) mean an equal re-commit is silent"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 7])
+    (let [driver (make-driver)]
+      (ratom/flush!)
+      (let [notes  (atom [])
+            target (obs/resolve-target {:frame fid :query-v [:obs/n]})
+            lease  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
+        (try
+          (is (empty? @notes) "acquire! on a WARM node is silent")
+          (let [v0 (:version (lease-last lease))]
+            ;; Re-commit the SAME value: the node re-runs to an equal value, so
+            ;; no watch notification and no version advance.
+            (rf/dispatch-sync [:obs/set-n 7])
+            (ratom/flush!)
+            (is (empty? @notes)
+                "an unmoved value fans nothing on the :value channel")
+            (is (= v0 (:version (lease-last lease)))
+                "the node-version did not advance for an equal re-commit"))
+          (finally
+            (obs/release! lease)
+            (ratom/dispose! driver)))))))
+
+;; ===========================================================================
+;; the reentrancy guard on the value-movement fan-out
+;; ===========================================================================
+
+(deftest watchable-host-value-fan-out-holds-the-reentrancy-guard
+  (testing "an on-change that mutates graph ownership (release!) from INSIDE
+            the {:cause :value} fan-out trips the dev reentrancy guard —
+            :rf.error/reentrant-graph-op — the make-watch-handler-path leg of
+            the guard the plain-atom suites cannot reach"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [driver (make-driver)]
+      (ratom/flush!)
+      (let [target  (obs/resolve-target {:frame fid :query-v [:obs/n]})
+            outcome (atom :guard-not-fired)
+            ;; The on-change attempts a FORBIDDEN reentrant self-release from
+            ;; inside the value fan-out; the guard must throw before any
+            ;; teardown, so the lease stays intact and `finally` is a clean op.
+            lease   (atom nil)]
+        (reset! lease
+          (obs/acquire! target
+            (fn [_ev]
+              (reset! outcome
+                (try (obs/release! @lease) :released-no-throw
+                     (catch :default e (:rf.error/id (ex-data e))))))))
+        (try
+          ;; MOVE the value so the measured lease's watch fires on a warm node.
+          (rf/dispatch-sync [:obs/set-n 2])
+          (ratom/flush!)
+          (is (= :rf.error/reentrant-graph-op @outcome)
+              "release! from inside the value-movement fan-out threw the dev
+               reentrant-graph-op assert (fan-out! bound *in-owner-fan-out?*)")
+          (is (= :live (:status (lease-state @lease)))
+              "the guard threw BEFORE any teardown — the lease is untouched")
+          (finally
+            (obs/release! @lease)
+            (ratom/dispose! driver)))))))

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -40,6 +40,15 @@
 (defn- ref-count [query-v]
   (:ref-count (entry query-v)))
 
+(defn- container-watch-count
+  "Count the watches currently registered on a `clojure.core/atom` container,
+  portably across hosts. The plain-atom frame-state container is a bare atom
+  (`re-frame.substrate.atom-container/make-state-container`); a leaking read
+  that `add-watch`'d it (a cold probe must never subscribe) would bump this."
+  [container]
+  #?(:clj  (count (.getWatches ^clojure.lang.IRef container))
+     :cljs (count (.-watches container))))
+
 (defn- error-id [e]
   (:rf.error/id (ex-data e)))
 
@@ -583,6 +592,75 @@
              (pre-fix the co-pending :hmr drain delivered :hmr here)")
         (is (= target (:target (first @notes))))
         (obs/release! lease)))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.29 (gap b) — the :disposed drain boundary driven END-TO-END from
+;; a real frame/destroy-frame!.
+;;
+;; The sibling :disposed fixtures above drive `drain-pending-disposals!`
+;; directly, after a SIMULATED eviction / cache-clear, with `interop/next-tick`
+;; swallowed to a no-op. That leaves three legs of the fallback path uncovered:
+;;   1. a REAL `frame/destroy-frame!` -> `tear-down-sub-cache!` disposal enqueue
+;;      (intrinsic cause `:frame-destroy` -> `:disposed`),
+;;   2. the next-tick CAS auto-schedule — `compare-and-set!
+;;      disposal-drain-scheduled? false->true` plus the scheduled drain closure
+;;      `(reset! disposal-drain-scheduled? false) (drain-pending-disposals!
+;;      :disposed)` — which every swallow-next-tick sibling skips, and
+;;   3. `frame-commit-epoch` 0 in the delivered payload for the now-destroyed
+;;      frame (its epoch counter was dissoc'd by `dissoc-frame!`).
+;;
+;; This fixture CAPTURES the scheduled next-tick thunk(s) (instead of no-op'ing
+;; next-tick) and DRIVES that exact closure, so the CAS transition, the
+;; closure's latch reset, and the `:disposed` delivery all genuinely run —
+;; deterministically, both hosts, no sleeps.
+;; ===========================================================================
+
+(deftest frame-destroy-schedules-and-drives-the-disposed-drain-with-epoch-zero
+  (reg-items!)
+  (seed-items! [:a])
+  (let [pending    @#'obs/pending-disposals
+        scheduled? @#'obs/disposal-drain-scheduled?]
+    ;; Hermetic start: clear the process-global drain latches so the CAS
+    ;; false->true transition is observable regardless of sibling test order.
+    (reset! pending [])
+    (reset! scheduled? false)
+    (let [target   (items-target)
+          notes    (atom [])
+          captured (atom [])
+          lease    (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
+      (is (= :live (:status @(@#'obs/lease-state lease))))
+      (is (int? (frame/frame-commit-epoch fid)) "the live frame has a commit epoch")
+      ;; CAPTURE the next-tick thunk(s) instead of running them — so the CAS
+      ;; scheduling is observable and the scheduled drain is driven by hand.
+      (with-redefs [interop/next-tick (fn [f] (swap! captured conj f))]
+        (frame/destroy-frame! fid))
+      (testing "the frame-destroy disposal enqueued a :disposed entry and the
+                next-tick CAS scheduled the fallback drain — nothing fanned yet"
+        (is (true? @scheduled?)
+            "compare-and-set! disposal-drain-scheduled? false->true fired")
+        (is (pos? (count @captured)) "interop/next-tick received the drain closure")
+        (is (some (fn [[_lease cause]] (= :disposed cause)) @pending)
+            "the queued entry carries the INTRINSIC :disposed cause
+             (frame-destroy -> :frame-destroy -> :disposed), never :hmr")
+        (is (empty? @notes)
+            "delivery is QUEUED — no synchronous on-change on the destroy stack"))
+      (testing "the destroyed frame's commit-epoch counter is cleared to 0"
+        (is (zero? (frame/frame-commit-epoch fid))
+            "dissoc-frame! dropped the destroyed frame's commit-epoch"))
+      ;; DRIVE the captured next-tick closure(s) = the REAL scheduled path.
+      (doseq [thunk @captured] (thunk))
+      (testing "the scheduled closure ran the :disposed drain and reset the latch"
+        (is (false? @scheduled?)
+            "the drain closure reset disposal-drain-scheduled? to false")
+        (is (empty? @pending) "the :disposed drain emptied the pending queue"))
+      (testing "the still-live destroyed-frame lease received {:cause :disposed}
+                carrying frame-commit-epoch 0"
+        (is (= 1 (count @notes)) "exactly one coalesced disposal notification")
+        (let [ev (first @notes)]
+          (is (= :disposed (:cause ev)) "the intrinsic :frame-destroy cause -> :disposed")
+          (is (= target (:target ev)))
+          (is (zero? (:frame-epoch ev))
+              "the payload's :frame-epoch is 0 for the destroyed frame"))))))
 
 ;; ===========================================================================
 ;; rf2-vxgfnd.70 — a follower must not publish a lease behind the FIRST owner's
@@ -1318,6 +1396,7 @@
   (frame/replace-app-db! fid {:leaf 3})
   (let [cache-count-before   (count @(sub-cache))
         #?@(:clj [node-records-before (.size ^java.util.Map @#'obs/node-records)])
+        watch-count-before   (container-watch-count (frame/frame-state-container fid))
         dispose-traces        (atom 0)]
     (rf/register-listener! :trace ::dispose-watch
       (fn [ev] (when (= :rf.sub/dispose (:operation ev))
@@ -1337,6 +1416,11 @@
         (is (nil? (entry [:obs/leaf2])))
         (is (zero? @dispose-traces)
             "no disposal obligations were created (nothing disposed)")
+        (is (= watch-count-before
+               (container-watch-count (frame/frame-state-container fid)))
+            "10k cold probes installed ZERO watches — a cold probe is a pure
+             read, never a live subscription (which would add-watch the
+             frame-state container); no watch-count leak on either host")
         #?(:clj (is (<= (.size ^java.util.Map @#'obs/node-records)
                         node-records-before)
                     "cold probes never touch the weak node-record table")))


### PR DESCRIPTION
Closes the three observation-port test-coverage gaps from rf2-vxgfnd.29. **Test-only** — no change to production `observation.cljc`; every path is reachable via already-exposed seams.

## (a) The `:cause :value` value-movement watch channel

`make-watch-handler` (the `:cause :value` fan-out, the delivered-value node-record advance, the `:last` update, and that path's dev reentrancy guard) ran in **no** test — the plain-atom port suites are `IDeref`-only, so the port's per-lease `add-watch` never fires.

New CLJS fixture `re_frame/observation_port_watchable_host_cljs_test.cljs` (Reagent adapter, whose sub reactions are `IWatchable`) exercises value movement end-to-end:
- A `reagent.ratom/run!` **driver** stands in for a mounted ViewCell render — the eager consumer that keeps the (lazy) node on the push path. Production acquires *after* render reads the sub (render-then-commit), so the node is warm/active at commit; a passive port watch alone never re-runs the node (the same methodological point the standard-epochs diamond fixture makes).
- `dispatch-sync` moves the value, `ratom/flush!` re-runs the node, the port watch fires `{:cause :value}` with an **advanced** `node-version` and the lease `:last` updated to the **delivered** value (no recompute, I-5).
- A sibling asserts an equal re-commit is **silent** (the `=` notify gate / rf= version hold).
- A third trips `:rf.error/reentrant-graph-op` from a `release!` **inside** the value fan-out.

## (b) The `:disposed` drain boundary from a real frame-destroy

`drain-pending-disposals!` was de-privatised for tests; the sibling `:disposed` fixtures drive it directly after a *simulated* eviction with `next-tick` swallowed. The **real** `frame/destroy-frame!` enqueue, the next-tick CAS, and epoch-0 ran nowhere.

New fixture `frame-destroy-schedules-and-drives-the-disposed-drain-with-epoch-zero`:
- `frame/destroy-frame!` → `tear-down-sub-cache!` disposes the node with intrinsic `:frame-destroy` → `:disposed`.
- **Captures** the scheduled `interop/next-tick` thunk (instead of no-op'ing it), asserts `compare-and-set! disposal-drain-scheduled? false→true` fired, the queued entry carries `:disposed`, and **no** synchronous fan-out on the destroy stack.
- **Drives the captured closure** (the real `(reset! … false) (drain-pending-disposals! :disposed)`), asserting the latch reset, the queue emptied, the coalesced `{:cause :disposed}` delivery, and `:frame-epoch 0` (the destroyed frame's counter was dissoc'd).

## (c) The 10k fixture's missing watch-count leg

`ten-thousand-cold-probes-retain-zero` asserted cache entries + dispose traces but never a watch-count leg. Added a portable `container-watch-count` assertion: 10k cold probes install **zero** watches on the frame-state container (a cold probe is a pure read, never a live subscription), on both hosts.

## Quality gates

Foreground, 0-fail:
- core JVM `clojure -M:test` — **1880 tests, 8438 assertions, 0 failures, 0 errors**
- observation-port ns (JVM, focused) — **44 tests, 282 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **9062 tests, 42876 assertions, 0 failures, 0 errors**

`npm run test:browser` not required — the watchable-host fixture is headless (Reagent ratom, no DOM).