### PR TITLE
fix(ui): Root Descriptor build identity complete + consistent across compiler and client (rf2-vxgfnd.68)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -53,6 +53,8 @@
   identity and stay in production."
   (:require ["react-dom/client" :as rdc]
             [re-frame.error :as error]
+            [re-frame.registrar :as registrar]
+            [re-frame.ui.fingerprint :as fingerprint]
             [re-frame.ui.frames :as frames]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.viewcell :as viewcell]))
@@ -96,6 +98,72 @@
   []
   (reset! live-roots {})
   nil)
+
+;; ---------------------------------------------------------------------------
+;; The COMPLETE Root Descriptor v1 — the client read-time projection (dev only)
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 004C §2 splits Root Descriptor v1 into a STATIC CORE (baked at
+;; expansion, NO `:build-digest` — it rides the emitted CLJS and each live-root
+;; entry's `:descriptor`) and the COMPLETE descriptor (static core PLUS the
+;; whole-build `:build-digest`). The digest is a READ-TIME projection on BOTH
+;; hosts, never baked: it is a whole-build aggregate the mount site cannot know
+;; at expansion — compile-order dependent AND stale under a view-only HMR edit
+;; (see `re-frame.ui.compiler.root/root-descriptor`). These fns are the CLIENT
+;; counterpart of the compiler's `re-frame.ui.compiler.root/descriptor-index`:
+;; they stamp the SAME `:build-digest` — byte-identical, because both hosts run
+;; the SAME `fingerprint/build-digest` algorithm over the SAME `[view-id
+;; template-fingerprint hook-signature]` per-view triples (the compiler feeds
+;; them from `build/committed-aggregate build/views`; the client reads the
+;; equal `tf`/`hs` the registrar `:view` manifests carry) — onto the live-root
+;; static cores. Recomputing over the live `:view` registry keeps it NON-STALE:
+;; a view-only HMR edit that re-runs `register-view!` refreshes the digest an
+;; already-mounted root observes WITHOUT the mount site re-expanding
+;; (rf2-vxgfnd.68). Dev only: `register-view!` is goog.DEBUG-gated, so the
+;; `:view` registry — and every projection over it — is absent from production
+;; (I-12); these reads return nil / {} under goog.DEBUG=false.
+
+(defn current-build-digest
+  "The client's whole-build view-identity digest (dev): the SAME
+  `re-frame.ui.fingerprint/build-digest` the compiler computes, over the
+  `[view-id template-fingerprint hook-signature]` triples of every registered
+  compiled view (the registrar `:view` manifests). Byte-identical to the JVM
+  compiler's `current-build-digest` for the same build — same algorithm, same
+  per-view triples — so the compiler and client projections AGREE. Recomputed
+  over the live registry, so a view-only HMR re-register refreshes it. nil in
+  production (goog.DEBUG=false — no view manifests ship)."
+  []
+  (when ^boolean js/goog.DEBUG
+    (fingerprint/build-digest
+     (map (fn [[id meta]]
+            (let [m (:rf.ui/manifest meta)]
+              [id (:template-fingerprint m) (:hook-signature m)]))
+          (registrar/registrations :view)))))
+
+(defn descriptor
+  "The COMPLETE Root Descriptor v1 for live root `root-id` (dev): its static
+  core from the live-root registry, stamped with the current whole-build
+  `:build-digest` (`current-build-digest`) — the client read-time projection
+  (Spec 004C §2). nil if `root-id` is not live, its entry carries no descriptor
+  yet (a `create-root` before its first `render!`), or in production."
+  [root-id]
+  (when-let [d (:descriptor (get @live-roots root-id))]
+    (assoc d :build-digest (current-build-digest))))
+
+(defn descriptor-index
+  "Every live root's COMPLETE Root Descriptor v1 (dev): root-id -> static core
+  + the current whole-build `:build-digest`. The CLIENT counterpart of the
+  compiler's `re-frame.ui.compiler.root/descriptor-index` — the same shape and
+  the same (byte-identical) digest — the Xray / tool read surface for the live
+  runtime descriptors. Roots still awaiting their first `render!` (no
+  descriptor yet) are omitted. Empty in production."
+  []
+  (let [bd (current-build-digest)]
+    (into {}
+          (keep (fn [[rid entry]]
+                  (when-let [d (:descriptor entry)]
+                    [rid (assoc d :build-digest bd)])))
+          @live-roots)))
 
 (defn- container-owner
   "root-id of the live root owning `container` (identical?), nil if

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -23,8 +23,10 @@
 ;; (`re-frame.ui.compiler.build`, rf2-df9873): a recompiled / edited /
 ;; renamed source replaces its whole prior contribution, and the independent
 ;; builds one daemon compiles never share rows. `current-build-digest` reads
-;; the ambient build's view aggregate (compile-order independent — the
-;; triples sort by view-id).
+;; the ambient build's COMMITTED (last-known-good) view aggregate, so the
+;; whole-build identity is finalized at df9873's successful commit / finish
+;; boundary and never a partial mid-pass value (compile-order independent —
+;; the triples sort by view-id).
 ;;
 ;; The compile-time custom-element declarations are a build-scoped registry
 ;; like the other four: WRITTEN here (macro expansion → `build/contribute!
@@ -38,9 +40,20 @@
 ;; `register-custom-element!`, read at render for dynamic `ui/spread` props);
 ;; it is separate from this compile registry.
 
-(defn current-build-digest []
+(defn current-build-digest
+  "The FINALIZED whole-build view-identity digest for the ambient build:
+  `fingerprint/build-digest` over the `[view-id template-fingerprint
+  hook-signature]` triples of the LAST SUCCESSFULLY COMMITTED views
+  (`build/committed-aggregate` — the committed layer, not the open pass's
+  effective/staged view). It therefore changes ONLY at a successful commit /
+  finish boundary (df9873's `finish-build!`): a read during an open, failed,
+  or interleaved pass returns the last known-good digest, never a partial
+  mid-pass identity (rf2-vxgfnd.68). Compile-order independent (triples sort
+  by view-id) and per-build-id isolated. This is the ONE build identity the
+  descriptor read-time projection publishes."
+  []
   (fingerprint/build-digest
-   (mapv (fn [[id [tf hs]]] [id tf hs]) (build/aggregate build/views))))
+   (mapv (fn [[id [tf hs]]] [id tf hs]) (build/committed-aggregate build/views))))
 
 (def ^:private defview-option-keys #{:props :id :display-name})
 

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -179,6 +179,23 @@
   ([reg-id build-id]
    (effective (get @state build-id empty-slice) reg-id ::none)))
 
+(defn committed-aggregate
+  "The build's LAST-KNOWN-GOOD aggregate for `reg-id`: the merge of the
+  COMMITTED rows only, IGNORING the open pass's staging. Unlike `aggregate`
+  (the effective view — committed-untouched PLUS staged), this reads solely
+  the committed layer, which changes ONLY at a successful commit / finish
+  boundary (`commit-build!` / `finish-build!`; `begin-build!` / `abort-build!`
+  never touch it). So a read during an OPEN, FAILED, or interleaved pass
+  returns the last finalized snapshot — never a partial mid-pass mix — and
+  the value a consumer reads is finalized-at-the-successful-build-boundary by
+  construction. Per-build-id like `aggregate`; on the no-pass REPL / plain-JVM
+  path a contribution upserts straight into committed, so this reader sees it
+  immediately. Pure."
+  ([reg-id] (committed-aggregate reg-id (current-build-id)))
+  ([reg-id build-id]
+   (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+              {} (:committed (get @state build-id empty-slice)))))
+
 (defn element-properties
   "The declared `:properties` set for custom-element `tag` in the ambient (or
   given) build's compile-time `elements` registry — the compile-path read the

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -348,16 +348,23 @@
   nil (the `render!` descriptor-base — the client completes identity from
   its Root, fixed at `create-root`).
 
-  Carries the per-root STATIC facts ONLY. `:build-digest` — a whole-build
-  aggregate, identical for every root in the build — is deliberately NOT
-  baked here: it is a READ-TIME projection stamped by `descriptor-index`
-  (rf2-vxgfnd.47). Baking it at expansion made it (a) compile-order
-  dependent — a mount site expanded before the rest of the build's views
-  compiled froze the digest over only the views seen so far — and (b) stale
-  under an incremental view edit — recompiling a view's file without
-  re-expanding the mount site left the descriptor carrying the old digest.
-  Resolving at read (over the sorted, JVM-stable view triples) is
-  compile-order independent and never stale."
+  This is the Root Descriptor v1 STATIC CORE (Spec 004C §2): the per-root
+  static facts, baked at expansion into the emitted CLJS and stored on the
+  client live-root registry entry. `:build-digest` — a whole-build aggregate,
+  identical for every root in the build — is deliberately NOT baked here: it
+  is the ONE field that cannot be a per-site static fact, so it is a READ-TIME
+  projection stamped onto the COMPLETE descriptor by `descriptor-index`
+  (compiler side) and by `re-frame.ui.client/descriptor-index` (client side).
+  Baking it at expansion made it (a) compile-order dependent — a mount site
+  expanded before the rest of the build's views compiled froze the digest over
+  only the views seen so far — and (b) stale under an incremental view edit —
+  recompiling a view's file without re-expanding the mount site left the
+  descriptor carrying the old digest. df9873's per-build authority does not
+  change that: `finish-build!` finalizes the digest at `:compile-finish`,
+  strictly AFTER every mount-site macroexpansion, so no expansion-time value
+  can be the finalized identity. Projecting it at read — over the finalized,
+  sorted, host-stable view triples — is compile-order independent and never
+  stale on either host (rf2-vxgfnd.47, rf2-vxgfnd.68)."
   [{:keys [root-id provenance views plans ast]}]
   (let [view (when (= 1 (count views)) (first views))]
     (cond-> {:rf.root/schema-version 1
@@ -419,17 +426,24 @@
 
 #?(:clj
    (defn descriptor-index
-     "The Root Descriptor index projected for READING (S5 tooling / Xray /
-     ui.test read compile output through here): every stored per-root static
-     descriptor stamped with the CURRENT whole-build `:build-digest`. The
-     digest is a whole-build aggregate — identical for every root — so it is
-     resolved HERE at read, never baked into a descriptor at expansion time,
-     where it would reflect only the views compiled before that mount site
-     (compile-order dependent) and go stale when a view recompiled without
-     re-expanding the mount site (rf2-vxgfnd.47). Compile-order independent +
-     incremental==clean by construction: the value is
-     `re-frame.ui.compiler/current-build-digest`, recomputed on every read
-     over the sorted view triples."
+     "The COMPLETE Root Descriptor v1 index projected for READING (the S5
+     tooling / Xray / ui.test compiler-side read; Spec 004C §2): every stored
+     per-root static core stamped with the finalized whole-build
+     `:build-digest`. The digest is a whole-build aggregate — identical for
+     every root — so it is resolved HERE at read, never baked into a
+     descriptor at expansion time, where it would reflect only the views
+     compiled before that mount site (compile-order dependent) and go stale
+     when a view recompiled without re-expanding the mount site
+     (rf2-vxgfnd.47). The value is
+     `re-frame.ui.compiler/current-build-digest`, which reads the COMMITTED
+     (last-known-good) view aggregate — finalized at df9873's successful
+     commit boundary, so a read during an open / failed / interleaved pass
+     stamps the last known-good digest, never a partial mid-pass identity
+     (rf2-vxgfnd.68). This is the compiler projection; its CLIENT counterpart
+     is `re-frame.ui.client/descriptor-index`, which projects the SAME
+     `:build-digest` (byte-identical — same `fingerprint/build-digest`
+     algorithm over the same per-view triples) onto the live-root static
+     cores. Compile-order independent + incremental==clean by construction."
      []
      (let [bd (compiler/current-build-digest)]
        (into {}

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -430,6 +430,28 @@
       (is (= (compiler/current-build-digest) d2)
           "the un-re-expanded mount-site descriptor reads the CURRENT digest (rf2-vxgfnd.47)"))))
 
+(deftest descriptor-digest-is-finalized-at-the-commit-boundary
+  ;; rf2-vxgfnd.68: the published digest reads the COMMITTED (last-known-good)
+  ;; view aggregate, so a read DURING an open / incomplete pass returns the last
+  ;; finalized identity — never a partial mid-pass mix of the staged edit. The
+  ;; digest advances only when the pass COMMITS.
+  (build/begin-build! :app)
+  (mount-site!   'app.m "app/m.cljs" '[app-view {}] {:root-id :page/m})
+  (declare-view! 'app.v 'v-view [:div "one"])
+  (build/commit-build! :app)
+  (let [committed-1 (get-in (root/descriptor-index) [:page/m :build-digest])]
+    ;; open an incremental pass and STAGE a view edit — do NOT commit yet.
+    (build/begin-build! :app)
+    (declare-view! 'app.v 'v-view [:div "two"])
+    (is (= committed-1 (get-in (root/descriptor-index) [:page/m :build-digest]))
+        "mid-pass read holds the last-known-good digest — the staged edit is not published")
+    (is (= committed-1 (compiler/current-build-digest))
+        "current-build-digest is the finalized (committed) identity, not the staged view")
+    ;; commit: NOW the finalized identity advances.
+    (build/commit-build! :app)
+    (is (not= committed-1 (get-in (root/descriptor-index) [:page/m :build-digest]))
+        "the digest advances only at the successful commit boundary")))
+
 (deftest repeated-rebuilds-stay-bounded
   ;; correctness across a watch session — re-declaring the same namespace N
   ;; times replaces (never grows).

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -8,7 +8,10 @@
   (:require [clojure.string :as str]
             [cljs.test :refer [deftest is testing use-fixtures]]
             [re-frame.error :as error]
-            [re-frame.ui.client :as client]))
+            [re-frame.registrar :as registrar]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.fingerprint :as fingerprint]
+            [re-frame.ui.runtime :as runtime]))
 
 (use-fixtures :each
   {:before client/reset-live-roots!
@@ -547,3 +550,74 @@
     (is (= :manifest (:missing data))
         "the data map names what is missing, contract-style")
     (is (error/message-has-id-token? msg))))
+
+;; ---------------------------------------------------------------------------
+;; The COMPLETE Root Descriptor v1 — client read-time :build-digest projection
+;; (rf2-vxgfnd.68). Spec 004C §2.1: the static core rides the entry's
+;; :descriptor with NO digest; `client/descriptor` / `descriptor-index` project
+;; the whole-build :build-digest at read from the registered view manifests —
+;; byte-identical to the compiler's digest (the same fingerprint/build-digest
+;; over the same [view-id template-fingerprint hook-signature] triples) and
+;; non-stale under a view-only re-register.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-view! [id tf hs]
+  (runtime/register-view! id (fn [_])
+                          {:template-fingerprint tf :hook-signature hs}))
+
+(defn- expected-digest []
+  (fingerprint/build-digest
+   (map (fn [[id meta]]
+          (let [m (:rf.ui/manifest meta)]
+            [id (:template-fingerprint m) (:hook-signature m)]))
+        (registrar/registrations :view))))
+
+(deftest client-descriptor-projects-the-build-digest
+  (reg-view! ::a "tf1-aaaaaaaaaaaaaaaa" "hs1-0000000000000000")
+  (reg-view! ::b "tf1-bbbbbbbbbbbbbbbb" "hs1-0000000000000000")
+  (try
+    (let [core {:rf.root/schema-version 1 :root-id :page/shop :view-id ::a
+                :props-shape :dynamic}]
+      (client/register-live-root!
+       {:root-id :page/shop :provenance :authored :descriptor core}
+       (js-obj) (fake-root :page/shop))
+      (testing "the static core on the entry carries NO :build-digest (§2.1)"
+        (is (not (contains? (:descriptor (client/live-root-entry :page/shop))
+                            :build-digest))))
+      (testing "the complete descriptor = static core + the projected digest"
+        (let [complete (client/descriptor :page/shop)]
+          (is (= core (dissoc complete :build-digest))
+              "the static core is unchanged; the digest is the only addition")
+          (is (str/starts-with? (:build-digest complete) "bd1-"))
+          (is (= (client/current-build-digest) (:build-digest complete)))
+          (is (= (expected-digest) (:build-digest complete))
+              "byte-identical to fingerprint/build-digest over the view triples — the compiler's algorithm")))
+      (testing "descriptor-index projects the SAME digest onto every live root"
+        (let [idx (client/descriptor-index)]
+          (is (= core (dissoc (get idx :page/shop) :build-digest)))
+          (is (= (client/current-build-digest)
+                 (:build-digest (get idx :page/shop)))))))
+    (finally
+      (registrar/unregister! :view ::a)
+      (registrar/unregister! :view ::b))))
+
+(deftest client-digest-tracks-a-view-only-re-register
+  ;; rf2-vxgfnd.68 acceptance: a view-only HMR edit that re-runs register-view!
+  ;; refreshes the digest an already-mounted root observes — WITHOUT the mount
+  ;; site re-expanding (the static core is untouched).
+  (reg-view! ::v "tf1-1111111111111111" "hs1-0000000000000000")
+  (try
+    (let [core {:rf.root/schema-version 1 :root-id :page/v :view-id ::v}]
+      (client/register-live-root!
+       {:root-id :page/v :provenance :authored :descriptor core}
+       (js-obj) (fake-root :page/v))
+      (let [d1 (:build-digest (client/descriptor :page/v))]
+        ;; the view file recompiles with a new template — re-register only.
+        (reg-view! ::v "tf1-2222222222222222" "hs1-0000000000000000")
+        (let [d2 (:build-digest (client/descriptor :page/v))]
+          (is (not= d1 d2)
+              "the view-only re-register changed the whole-build digest")
+          (is (= core (:descriptor (client/live-root-entry :page/v)))
+              "the mount site never re-expanded — the static core is untouched"))))
+    (finally
+      (registrar/unregister! :view ::v))))

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -74,8 +74,12 @@ server, no render, no reactivity.
  :frame-plans          [{:frame-id :shop
                          :config-fingerprint "…"}] ; extracted ENSURE plans (§6)
  :template-fingerprint "…"                        ; over the compiled root template
- :build-digest         "…"}                       ; build identity (algorithms: note below)
+ :build-digest         "…"}                       ; build identity — a READ-TIME projection, NOT baked at expansion (§2.1)
 ```
+
+`:build-digest` is the one field that is **not** a per-root static fact and is
+**never baked** into the emitted descriptor at expansion — see §2.1 for where it
+lives and why.
 
 **Fingerprint/digest algorithms — ownership.** `:render-fingerprint` and the semantic
 normalization `N` it hashes are owned by
@@ -114,6 +118,52 @@ hydration-salient fields 06 §2 shows:
 This split resolves the 12-§3-postpones-S5 / 08-§2-requires-S1 tension without moving
 either stage: S1 ships the descriptor (compiler artefact, `ui.test`/Xray consumer); S5
 ships the manifest as its extension.
+
+### 2.1 The static core, the whole-build digest, and the read-time projection
+
+`:build-digest` is a **whole-build aggregate** — a hash over *every* view in the build,
+**identical for every root**. It is therefore **not a per-root static fact** and, unlike
+every other descriptor key, **cannot be baked at the mount site's expansion**: at the
+moment a `ui/mount` / `ui/render!` / `ui/hydrate-root` form macroexpands, the build is
+still compiling and only the views seen so far are known — baking the digest there makes
+it *compile-order dependent*, and it goes *stale* the instant a view's file recompiles
+without the mount site re-expanding (an ordinary view-only hot-reload edit). The per-build
+compiler-state authority does not change this: the build's digest is finalized at its
+**successful build boundary** (`:compile-finish`), strictly *after* every mount-site
+macroexpansion, so no expansion-time value can ever be the finalized identity.
+
+Root Descriptor v1 is therefore realised as **two named shapes, one contract:**
+
+- **The static core** — the per-root static facts above **minus** `:build-digest`. This is
+  what the compiler bakes at expansion into the emitted client code and what rides each
+  live-root registry entry (its `:descriptor`) and the compiler's build-emitted descriptor
+  index. It is `:rf.root/schema-version 1` and schema-valid; the digest is simply supplied
+  by the projection, not the core.
+- **The complete descriptor** — the static core **plus** the finalized `:build-digest`,
+  assembled by a **read-time projection** at each consumer. Any value handed out *as* a
+  complete "Root Descriptor v1 / Root Manifest v1" carries the digest.
+
+The digest is projected — never baked — at read on **both hosts**, from the **same input
+via the same algorithm**, so the two projections **agree byte-for-byte** for a given build:
+
+- **Compiler / JVM** — `re-frame.ui.compiler.root/descriptor-index` stamps the digest over
+  the **last-successfully-committed** view triples (`[view-id template-fingerprint
+  hook-signature]`), so a read during an open, failed, or interleaved build returns the
+  last **known-good** identity, never a partial mid-pass one. This is the `ui.test` / Xray
+  / S5-tooling read of compile output.
+- **Client / dev runtime** — `re-frame.ui.client/descriptor-index` (and per-root
+  `re-frame.ui.client/descriptor`) stamps the digest computed from the **registered view
+  manifests** (the same `template-fingerprint` / `hook-signature` the compiler recorded).
+  Because it recomputes over the live view registry, a **view-only hot-reload** that
+  re-registers a view **refreshes the digest an already-mounted root observes without
+  re-expanding its mount site** — the requirement baking could not meet.
+
+**Home of the build identity, made explicit:** the finalized whole-build `:build-digest`
+lives in the **read-time projection**, not in the static core. Both projections are pure
+functions of the finalized per-build view set, so clean, incremental, watch, and REPL
+paths converge on the same digest through real consumers. Dev-only: view manifests and the
+descriptor/digest projections are elided from production builds (goog.DEBUG-gated), so a
+production client carries no descriptor or digest cost.
 
 ## 3. The mount grammar and the host signature set
 


### PR DESCRIPTION
## What & why

PR #5734 fixed expansion-time digest staleness by removing `:build-digest`
from the emitted `root-descriptor` and adding a JVM-only `descriptor-index`
read projection. That resolved the test index but silently created **two
descriptor shapes**: the compiler emitted a `root-descriptor` *without*
`:build-digest`, while a separate JVM-only projection carried the build
identity — and the client/live-root descriptor (the surface Xray/tooling
reads) had *no* build identity at all, contradicting Spec 004C's Root
Descriptor v1, which lists `:build-digest` as its build-identity field.

This makes the Root Descriptor build identity **complete and consistent
across the compiler and client projections**, matching a reconciled 004C.

## (a) restore-inline vs (b) two-shape-reconcile — decision: **(b)**, and why

**(a) is physically impossible to make non-stale.** `:build-digest` is a
*whole-build* aggregate (a hash over every view, identical for every root).
At the moment a mount site macroexpands, the build is still compiling — only
the views seen so far are known — so any value baked there is compile-order
dependent and goes stale the instant a view recompiles without the mount site
re-expanding (an ordinary view-only hot-reload). **df9873 does not rescue (a):**
the build digest is finalized at `:compile-finish`, strictly *after* every
mount-site macroexpansion, so no expansion-time value can ever be the
finalized identity. The digest therefore **cannot** be a per-site static fact.

So **(b)**: one contract, two *named* shapes (Spec 004C §2.1):

- **Static core** — per-root facts, **no** `:build-digest`; baked at expansion,
  rides the emitted CLJS and each live-root entry's `:descriptor`.
- **Complete descriptor** — static core **+** the finalized `:build-digest`,
  assembled by a **read-time projection** at each consumer.

The digest is projected — never baked — on **both hosts**, from the **same
input via the same algorithm**, so the two projections agree **byte-for-byte**:

- **Compiler/JVM**: `re-frame.ui.compiler.root/descriptor-index` (surface
  unchanged) stamps `fingerprint/build-digest` over the `[view-id
  template-fingerprint hook-signature]` triples.
- **Client/dev**: new `re-frame.ui.client/descriptor` + `descriptor-index`
  stamp the SAME digest, computed from the registered view manifests (which
  carry the identical `tf`/`hs` the compiler recorded).

**Finalized at the successful build boundary.** `current-build-digest` now
reads `build/committed-aggregate` (a new committed-only, last-known-good reader
added to `build.cljc`) instead of the effective/staged view — so a read during
an open, failed, or interleaved pass returns the last known-good digest, never
a partial mid-pass identity. The committed layer changes only at
`commit-build!`/`finish-build!`, so this composes with df9873's lifecycle
rather than inventing a second build-generation authority.

**Non-stale under view-only HMR.** The client recomputes over the live `:view`
registry, so a view-only re-register refreshes an already-mounted root's
observed digest without the mount site re-expanding.

## Confirmation of the acceptance fixture

- The two projections **agree** and **match 004C**: both stamp the same
  `fingerprint/build-digest` over the same per-view triples; the static core on
  both sides carries no digest; the complete descriptor carries it. Pinned by
  `client-descriptor-projects-the-build-digest` (asserts the client digest is
  byte-identical to `fingerprint/build-digest` over the view triples) and the
  existing JVM index tests.
- **Non-stale**: `descriptor-digest-is-finalized-at-the-commit-boundary` (JVM,
  new) proves a rebuild advances the digest only at commit and a mid-pass read
  holds last-known-good; `client-digest-tracks-a-view-only-re-register` (CLJS,
  new) proves a view-only re-register refreshes the digest while the static
  core is untouched.
- **Prod-elided**: the client digest is goog.DEBUG-gated and tool-only
  (DCE'd in production); `re-frame.ui.client` is not reachable from the
  elision-probe/counter production bundles, so there is no dev descriptor/digest
  cost at `goog.DEBUG=false`.

## Spec change (hot-zone)

`spec/004C-Roots-and-Mount.md` §2 — annotated `:build-digest` as a read-time
projection and added **§2.1** ("The static core, the whole-build digest, and
the read-time projection") defining both named shapes, making the digest's
home explicit (the read-time projection, finalized at the successful build
boundary), and specifying both the compiler and client projections. No
existing heading text changed (no slug churn).

## Quality gates

All run in the foreground, 0 failures:

- `scripts/check_doc_slugs.py` — exit 0 (004C touched)
- ui JVM `clojure -M:test` — **321 tests, 4793 assertions, 0 failures, 0 errors**
- `npm run test:ui` (compiles + runs `node-test-ui`) — build 0 warnings; **311 tests, 1608 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (`node-test`) — **9076 tests, 42894 assertions, 0 failures, 0 errors**
