### PR TITLE
fix(ui): incarnation-keyed frame-close + retained-lease movement caught at commit step-5 (rf2-vxgfnd.94, rf2-vxgfnd.39)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -184,9 +184,21 @@
 ;; teardown — re-firing `:on-destroy`, re-running the machine cascade,
 ;; re-disposing the sub-cache — and likely throw on a half-torn-down
 ;; frame. Per Spec 002 §Destroy — re-entrant destroy is idempotent.
+;;
+;; Keyed by the bare frame-id, with the value carrying the DESTROYING
+;; incarnation's token (its `:drain-lock`, captured at the top of
+;; `destroy-frame!` while the frame is still live). The bare id is what the
+;; re-entrant guard + `frame-closing?` consult; the token is what
+;; `frame-incarnation-closing?` consults so a stale close marker of an
+;; already-torn-down incarnation A cannot be mistaken for a fresh same-id
+;; REPLACEMENT incarnation B being in-flight — the JVM window between step-6
+;; `dissoc-frame!` and the terminal `finally` where A's marker is still set
+;; while B is already live under the reused id (rf2-vxgfnd.94; the reciprocal
+;; of rf2-vxgfnd.88's Failure-2). On CLJS the window is unreachable (destroy
+;; runs to completion single-threaded before any recreate).
 
 (defonce ^:private destroying-frames
-  (atom #{}))
+  (atom {}))
 
 ;; Monotonic counter for the per-destroy UNIQUE transient `:on-destroy`-throw
 ;; capture listener key. `fire-on-destroy-event!` installs a listener on the
@@ -669,10 +681,44 @@
   sweep's victim SELECTION against the frame's CLOSURE: if its enrolment was too
   late for the sweep's snapshot, the frame was necessarily already in
   `destroying-frames` when the commit read it, so it observes the close and joins
-  the teardown instead of stranding `:connected`. Keyed by the bare frame-id."
+  the teardown instead of stranding `:connected`. Keyed by the bare frame-id.
+
+  BARE-ID: this predicate cannot distinguish WHICH incarnation is closing. In the
+  JVM window where an old incarnation A's marker is still set (post-`dissoc-frame!`,
+  pre-`finally`) while a fresh same-id REPLACEMENT incarnation B is already live,
+  this reads true for the id — which would wrongly tear down a cell that owns B.
+  A commit that must resolve against the EXACT incarnation it acquired consults the
+  incarnation-scoped `frame-incarnation-closing?` instead (rf2-vxgfnd.94)."
   [id]
   (or (contains? @destroying-frames id)
       (frame-disposed-for-drain? id)))
+
+(defn frame-incarnation-closing?
+  "True when `id`'s in-flight `destroy-frame!` is tearing down EXACTLY the
+  incarnation identified by `token` (its `:drain-lock` — see
+  `frame-incarnation-token`), false otherwise.
+
+  The incarnation-scoped counterpart to `frame-closing?`: where `frame-closing?`
+  answers 'is this id anywhere in its close lifecycle' by BARE id,
+  `frame-incarnation-closing?` answers 'is the destroy that is in flight for this
+  id the one destroying the incarnation I acquired'. `destroying-frames` records
+  `{id -> destroying-incarnation-token}`, so this compares the caller's
+  acquire-time token against the token the marker carries by identity.
+
+  This is what closes rf2-vxgfnd.88's reciprocal Failure-2 (rf2-vxgfnd.94): in the
+  JVM window between `destroy-frame!`'s step-6 `dissoc-frame!` and its terminal
+  `finally`, incarnation A's marker is still set while a fresh same-id incarnation
+  B is already live under the reused id. A ViewCell commit that ACQUIRED B (its
+  captured token is B's) reads false here (B's token ≠ A's marker token), so B's
+  cell is not torn down by A's stale close authority — while the rf2-vxgfnd.61
+  in-flight case (a commit that acquired A while A is mid-teardown, still live
+  pre-flip) reads true (A's token IS the marker token) and correctly joins A's
+  teardown. Nil `token` (or no marker for `id`) reads false.
+
+  Keyed by the bare frame-id; the incarnation is disambiguated by the token value."
+  [id token]
+  (let [closing (get @destroying-frames id)]
+    (and (some? closing) (identical? token closing))))
 
 (defn frame-address
   "Resolve the ADDRESS key for `frame-id` — the key a per-frame SIDE-CHANNEL
@@ -2760,7 +2806,13 @@
   ;; targets the frame-id-keyed record directly.
   (when-let [f (frame id)]
       (when-not (contains? @destroying-frames id)
-      (swap! destroying-frames conj id)
+      ;; Record the DESTROYING incarnation's token (the live record's
+      ;; `:drain-lock`) so `frame-incarnation-closing?` can tell this
+      ;; incarnation's teardown apart from a fresh same-id replacement that goes
+      ;; live under the reused id before this destroy's `finally` clears the
+      ;; marker (rf2-vxgfnd.94). `contains?`/keys keep the bare-id semantics the
+      ;; re-entrant guard + `frame-closing?` rely on.
+      (swap! destroying-frames assoc id (:drain-lock f))
       ;; Capture the DESTROY-TIME frame-state value BEFORE any teardown step
       ;; runs. After `mark-frame-destroyed!` (step 3) flips :destroyed?,
       ;; `frame-state-value` returns nil; after `dissoc-frame!` (step 6)
@@ -2959,7 +3011,7 @@
           ;; Always clear the in-flight marker — even if a downstream step
           ;; throws unexpectedly, future `destroy-frame!` calls for `id`
           ;; (after a fresh construction) must not see a stale entry.
-          (swap! destroying-frames disj id)))))))))
+          (swap! destroying-frames dissoc id)))))))))
 
 ;; ---- reset-frame! — RETIRED (rf2-lxwpob) -----------------------------------
 ;;

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -16,8 +16,10 @@
   (no second probe at commit step 5); `resolve-target`'s `site-ctx` shape
   is `{:query-v … :frame pin? :override {:value :override-id :version}?}`;
   the value-movement `on-change` watch channel exists only on watchable
-  hosts, so headless movement is caught at the commit evidence comparison
-  (step 5), not by a callback.
+  hosts, so on a headless (non-watchable) host movement is caught at the
+  commit evidence comparison (step 5), not by a callback — for EVERY acquired
+  lease, RETAINED as well as staged (rf2-vxgfnd.39), since a retained site has
+  no watch to self-correct there.
 
   ## The ViewCell (03 §2)
 
@@ -129,9 +131,10 @@
   into every `probe`, so N sibling rows probing one query compute shared
   derivation parents once per synchronous execution slice, not once per
   row (the first-mount fan-out mitigation). The handle is created lazily
-  on the first probe of a slice and cleared on the next microtask
-  (`interop/next-tick`), so an abandoned slice's table is unreachable
-  garbage. The memo is an ECONOMY, never an authority — the commit
+  on the first probe of a slice and cleared on the next event-loop tick
+  (`interop/next-tick` — a MACROTASK, GC hygiene only, not a
+  correctness-before-paint boundary), so an abandoned slice's table is
+  unreachable garbage. The memo is an ECONOMY, never an authority — the commit
   evidence comparison (step 5) corrects any staleness before paint."
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
@@ -1350,7 +1353,9 @@
      lease is synchronously released in REVERSE acquisition order, the
      prior committed set stays installed, and the typed error propagates.
   5. Compare each acquired node's version + frame/registry epochs against
-     the render's probe evidence.
+     the render's probe evidence — for BOTH retained and staged leases, so a
+     retained site's movement is caught here on a non-watchable headless host
+     that has no value-movement watch (rf2-vxgfnd.39).
   6. Publish the committed site values + the new dependency set (retained +
      staged) — before the user can interact with the new DOM.
   7. Release the prior leases of dropped + retargeted sites.
@@ -1435,12 +1440,29 @@
               ;; was acquired from, so a same-id reincarnation before publish is
               ;; caught by token identity, not merely the reused frame-id.
               incarnations (committed-frame-incarnations (merge retained staged-map))
-              ;; step 5 — evidence comparison (moved in the render→commit gap)
-              moved?     (boolean
-                           (some (fn [[tk lease]]
-                                   (evidence-moved? (obs/read lease)
-                                                    (:evidence (new-by tk))))
-                                 staged))
+              ;; step 5 — evidence comparison: read EACH acquired node (staged AND
+              ;; retained) against the render's probe evidence, so movement in the
+              ;; render→commit gap is caught before paint (invariant 5).
+              ;;
+              ;;   - STAGED leases: their freshly-installed watch could not have
+              ;;     fired for a pre-acquire gap move, so step 5 is the SOLE catch
+              ;;     on every host.
+              ;;   - RETAINED leases: on a WATCHABLE host their live watch already
+              ;;     caught the move (the cell is pending; its scheduled flush
+              ;;     corrects before paint), but on a NON-WATCHABLE headless host
+              ;;     there is NO watch — so step 5 is the ONLY catch. Without this
+              ;;     read a retained site's headless movement is corrected by
+              ;;     nothing: `:values` publishes the stale render value and no
+              ;;     revision advances (rf2-vxgfnd.39).
+              ;;
+              ;; `read` recomputes the plain-atom node on deref, so a headless move
+              ;; is observed here; the two catches are kept distinct because the
+              ;; step-8 advance treats them differently (see below).
+              moved-in? (fn [[tk lease]]
+                          (evidence-moved? (obs/read lease)
+                                           (:evidence (new-by tk))))
+              staged-moved?   (boolean (some moved-in? staged))
+              retained-moved? (boolean (some moved-in? retained))
               new-values (persistent!
                            (reduce (fn [acc tk]
                                      (assoc! acc tk (:value (new-by tk))))
@@ -1509,8 +1531,13 @@
                           (frame/frame-incarnation-closing? fid token))
                         incarnations))
             (teardown! cell)
-            ;; step 8 — moved evidence corrects before paint
-            (when moved?
+            ;; step 8 — moved evidence corrects before paint. The staged catch
+            ;; always advances synchronously; a RETAINED catch advances only when
+            ;; no live watch already caught the move — a pending (`dirty?`) cell is
+            ;; a watchable host whose scheduled flush already corrects before paint,
+            ;; so advancing here too would add a redundant render (rf2-vxgfnd.39).
+            (when (or staged-moved?
+                      (and retained-moved? (not (dirty? cell))))
               (advance-revision! cell)))
           cell)))))
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1478,17 +1478,26 @@
           ;;       `:drain-lock`, distinct per incarnation) resolves the commit to
           ;;       exactly the incarnation it targeted.
           ;;
-          ;;   (b) `frame-closing?` — a frame is IN-FLIGHT closing (rf2-vxgfnd.61).
-          ;;       #5731 wires destroy to a SNAPSHOT sweep of the live cells that
-          ;;       runs while the frame is still LIVE (pre-flip), then flips
-          ;;       liveness. A commit that acquires + enrols between the sweep
-          ;;       snapshot and the flip is MISSED by the sweep, and its
-          ;;       incarnation token is UNCHANGED (the frame is still live
-          ;;       pre-flip) — so token identity alone would not catch it. But
+          ;;   (b) `frame-incarnation-closing?` — the ACQUIRED incarnation is
+          ;;       IN-FLIGHT closing (rf2-vxgfnd.61, scoped to the incarnation by
+          ;;       rf2-vxgfnd.94). #5731 wires destroy to a SNAPSHOT sweep of the
+          ;;       live cells that runs while the frame is still LIVE (pre-flip),
+          ;;       then flips liveness. A commit that acquires + enrols between the
+          ;;       sweep snapshot and the flip is MISSED by the sweep, and its
+          ;;       incarnation token is UNCHANGED (the frame is still live pre-flip)
+          ;;       — so `incarnation-superseded?` alone would not catch it. But
           ;;       `destroying-frames` is populated at the TOP of `destroy-frame!`,
-          ;;       so `frame-closing?` is continuously true across the whole
-          ;;       teardown window: the enrolled cell observes the close and joins
-          ;;       the teardown against the still-releasable cache.
+          ;;       so the marker is continuously present across the whole teardown
+          ;;       window: the enrolled cell observes the close and joins the
+          ;;       teardown against the still-releasable cache. Scoping to the
+          ;;       ACQUIRE-time token (not the bare id) is what closes .88's
+          ;;       reciprocal Failure-2: in the JVM window where an OLD incarnation
+          ;;       A's marker is still set (post-`dissoc-frame!`, pre-`finally`)
+          ;;       while a fresh same-id incarnation B is already live, a commit
+          ;;       that acquired B reads FALSE here (B's token ≠ A's marker token),
+          ;;       so A's stale close authority cannot tear down a cell that owns B
+          ;;       (rf2-vxgfnd.94). The bare-id `frame/frame-closing?` would read
+          ;;       true for the reused id and wrongly reap B's cell.
           ;;
           ;; A live, not-closing frame under an unchanged incarnation (incl. a
           ;; committed fresh same-id incarnation this commit legitimately acquired)
@@ -1496,7 +1505,9 @@
           ;; and the single-threaded CLJS host (destroy runs to completion without
           ;; yielding to a commit) never sees either true.
           (if (or (incarnation-superseded? incarnations)
-                  (some frame/frame-closing? (keys incarnations)))
+                  (some (fn [[fid token]]
+                          (frame/frame-incarnation-closing? fid token))
+                        incarnations))
             (teardown! cell)
             ;; step 8 — moved evidence corrects before paint
             (when moved?

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -20,13 +20,15 @@
   AND JVM (`clojure -M:test`) against the REAL observation port + sub-cache
   (plain-atom adapter).
 
-  KNOWN GAP (flagged, not fixed here): the reciprocal Failure-2 — an old
-  incarnation's stale bare-id close marker (present in the JVM window between
-  `dissoc-frame!` and `destroy-frame!`'s terminal `finally`) tearing down a
-  live REPLACEMENT incarnation's cell — cannot be closed from the ui artefact
-  alone: `frame/destroying-frames` is a set of bare ids, so reactive.cljc cannot
-  tell an A-marker from a B-marker. Closing it needs core to key the close marker
-  by incarnation token; tracked as a follow-up."
+  RECIPROCAL Failure-2 (CLOSED by rf2-vxgfnd.94): an old incarnation A's stale
+  close marker (present in the JVM window between `dissoc-frame!` and
+  `destroy-frame!`'s terminal `finally`) tearing down a live REPLACEMENT
+  incarnation B's cell. That could not be closed from the ui artefact alone —
+  `frame/destroying-frames` was a set of bare ids, so reactive.cljc could not tell
+  an A-marker from a B-marker. rf2-vxgfnd.94 keyed `destroying-frames` by the
+  destroying incarnation's token and had the commit consult the incarnation-scoped
+  `frame/frame-incarnation-closing?`; its JVM window fixture lives in
+  `reactive-incarnation-close-race-jvm-test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                 :as rf]

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
@@ -1,0 +1,122 @@
+(ns re-frame.ui.reactive-incarnation-close-race-jvm-test
+  "rf2-vxgfnd.94 — the reciprocal of rf2-vxgfnd.88's Failure-2: an OLD incarnation
+  A's stale close marker must NOT tear down a LIVE same-id REPLACEMENT incarnation
+  B's cell.
+
+  THE WINDOW (JVM-only; on CLJS destroy runs to completion single-threaded before
+  any recreate, so B can never be live while A's marker is set — the window is
+  unreachable). `frame/destroy-frame!` populates `frame/destroying-frames` at its
+  TOP and clears it only in its terminal `finally` — AFTER step-6 `dissoc-frame!`
+  frees the id. So there is a JVM window, BETWEEN `dissoc-frame!` and the
+  `finally`, where A's marker is still set while the id is already free for a fresh
+  incarnation B. A ViewCell commit that ACQUIRES B in that window used to be torn
+  down: the .61/.88 revalidation consulted the BARE-id `frame/frame-closing?`,
+  which reads true for the reused id regardless of WHICH incarnation is closing
+  (`destroying-frames` was a set of bare ids). The reactive artefact alone could
+  not tell A's marker from B being genuinely in-flight.
+
+  THE FIX (rf2-vxgfnd.94): core keys `destroying-frames` by the DESTROYING
+  incarnation's token `{id -> token}`, and the ViewCell commit consults the
+  incarnation-scoped `frame/frame-incarnation-closing?` against the token it
+  ACQUIRED — so A's stale marker (A's token) cannot reap a cell that owns B (B's
+  token). AC (rf2-vxgfnd.88): 'A's close authority cannot tear down a cell that
+  owns B.'
+
+  The window is opened deterministically with a `CountDownLatch` handoff (NO
+  sleeps): a wrapped `:epoch/on-frame-destroyed` hook — which `destroy-frame!`
+  fires at step 7, AFTER `dissoc-frame!` and BEFORE the `finally` — pauses A's
+  destroy exactly in the window; the main thread then constructs B under the reused
+  id and commits a cell against it; the destroy resumes and clears the marker.
+  `.clj` (JVM-only) — the window is a genuine two-thread interleaving; the barrier
+  handoff makes it a controlled linearization probe, not a stress test."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.late-bind             :as late-bind]
+            [re-frame.live-frame            :as live-frame]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            ;; Load-bearing: publishes the :ui/on-frame-destroyed! hook, so A's
+            ;; real destroy runs the ViewCell sweep (a no-op here — A owns no cells).
+            [re-frame.ui.frames]
+            [re-frame.ui.reactive           :as reactive])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- tk [fid q] [:sub fid q])
+
+;; ===========================================================================
+;; Failure-2: A's stale close marker must NOT reap a live replacement B's cell
+;; ===========================================================================
+
+(deftest stale-close-marker-of-A-does-not-tear-down-a-live-replacement-B
+  (rf/reg-sub :ic/a (fn [db _] (:a db)))
+  (let [fid       :ic/frame
+        _         (make-frame! fid {:a 1})
+        token-a   (frame/frame-incarnation-token fid)
+        b-cell    (reactive/make-cell ::b)
+        dissocd   (CountDownLatch. 1)   ;; A dissoc'd; marker still set; id free
+        b-done    (CountDownLatch. 1)   ;; B constructed + committed
+        orig-hook (late-bind/get-fn :epoch/on-frame-destroyed)
+        token-b   (atom nil)
+        b-error   (atom nil)]
+    (try
+      ;; Pause A's destroy in the post-`dissoc-frame!` / pre-`finally` window: the
+      ;; :epoch/on-frame-destroyed hook fires at destroy step 7, after the id is
+      ;; freed but before A's marker is cleared.
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+                         (fn [id & _args]
+                           (when (= id fid)
+                             (.countDown dissocd)
+                             (.await b-done 5 TimeUnit/SECONDS))))
+      (let [destroy (future (frame/destroy-frame! fid))] ;; A — pauses in the hook
+        (.await dissocd 5 TimeUnit/SECONDS)
+        ;; In the window: the id is free (A dissoc'd) but A's marker is still set.
+        (is (nil? (frame/frame fid)) "precondition: A is dissoc'd — the id is free")
+        ;; Construct B under the reused id — a DISTINCT incarnation, fresh state.
+        (make-frame! fid {:a 99})
+        (reset! token-b (frame/frame-incarnation-token fid))
+        (is (not (identical? token-a @token-b))
+            "precondition: B is a fresh incarnation under the reused id")
+        (is (true? (frame/frame-closing? fid))
+            "precondition: BARE-id frame-closing? reads true — A's stale marker is
+             still set for the reused id (the pre-fix hole reactive.cljc consulted)")
+        (is (false? (frame/frame-incarnation-closing? fid @token-b))
+            "the INCARNATION-scoped predicate reads false for B — A's marker carries
+             A's token, not B's (rf2-vxgfnd.94)")
+        ;; Commit B's cell IN the window. The incarnation-scoped revalidation must
+        ;; resolve against B's acquired token, NOT A's stale bare-id marker.
+        (try
+          (rf/with-frame fid
+            (reactive/with-capture b-cell (fn [] (reactive/sub-read [:ic/a]))))
+          (reactive/commit! b-cell)
+          (catch Throwable e (reset! b-error e)))
+        (.countDown b-done)
+        (is (nil? (deref destroy 5000 ::timeout)) "A's destroy completes cleanly"))
+
+      (is (nil? @b-error) "B's commit did not throw")
+      (testing "A's stale close marker did NOT tear down the live replacement B's cell"
+        (is (= :connected (reactive/lifecycle b-cell))
+            "the cell that ACQUIRED B stays connected — A's token ≠ B's token, so
+             frame-incarnation-closing? is false for B; the pre-fix bare-id
+             frame-closing? would have reaped it (rf2-vxgfnd.94)")
+        (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys b-cell))
+            "B's cell owns B's node")
+        (is (= 99 (get (reactive/committed-values b-cell) (tk fid [:ic/a])))
+            "B's cell reads B's own state — never joined A's teardown"))
+      (testing "B is live and not closing after A's destroy fully completes"
+        (is (some? (frame/frame fid)) "B survives A's teardown")
+        (is (false? (frame/frame-closing? fid))
+            "A's marker was cleared in its finally; B is live and not closing"))
+      (finally
+        (late-bind/set-fn! :epoch/on-frame-destroyed orig-hook)))))

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -25,7 +25,9 @@
   hosts. Host honesty: plain-atom derived values are not watchable, so the
   value-movement `on-change` channel is a reactive-host surface — here
   movement is caught at the commit evidence comparison (step 5), exactly
-  the headless contract."
+  the headless contract. Step 5 reads EVERY acquired lease, RETAINED as well
+  as staged, so a retained site's headless movement (which has no watch to
+  self-correct) is caught too (rf2-vxgfnd.39)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                 :as rf]
@@ -184,6 +186,44 @@
   (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])]
     (is (= 0 (reactive/revision cell))
         "no movement in the gap ⇒ no revision advance")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.39 — a RETAINED site's movement is caught at step 5 too. On a
+;; NON-WATCHABLE headless host (plain-atom) a retained lease has NO
+;; value-movement watch, so the commit evidence comparison is the ONLY
+;; correction — and it must read retained leases, not only staged ones.
+;; Pre-fix, step 5 read `staged` alone: a retained site's gap-movement was
+;; caught by NOTHING (`:values` published the stale render value, the revision
+;; never advanced, no watch existed to correct it).
+;; ---------------------------------------------------------------------------
+
+(deftest retained-lease-movement-caught-at-commit-step-5
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell   (render+commit! (reactive/make-cell ::v) [[:r/a]])
+        lease0 (reactive/committed-lease cell (tk [:r/a]))]
+    (is (= 0 (reactive/revision cell)) "precondition: committed, no revision yet")
+    (is (= {(tk [:r/a]) 1} (reactive/committed-values cell)))
+    (render! cell [[:r/a]])                 ;; render B probes the live node (value 1)
+    (seed! {:a 2})                          ;; move in the render→commit gap
+    (reactive/commit! cell)                 ;; kept-check RETAINS the lease
+    (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
+        "the site was RETAINED (same lease) — a kept, not staged/retargeted, site")
+    (is (= 1 (reactive/revision cell))
+        "a RETAINED site's gap-movement is caught at the commit evidence
+         comparison (step 5) — the revision advances so the host re-renders
+         before paint; pre-fix this was caught by nothing (rf2-vxgfnd.39)")))
+
+(deftest retained-lease-unmoved-does-not-false-advance
+  ;; The retained step-5 read must not introduce false movement: an unchanged
+  ;; retained site reads the same version/node-key across the render→commit gap.
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])]
+    (render! cell [[:r/a]])                 ;; render B — no seed between probe + commit
+    (reactive/commit! cell)
+    (is (= 0 (reactive/revision cell))
+        "an unchanged retained site reads the same evidence ⇒ no false advance")))
 
 ;; ===========================================================================
 ;; rf2-vxgfnd.93 — the reconciler consumes read's :node-key reincarnation axis

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -978,13 +978,17 @@ These are normative (R-2). Each names the bug class it deletes.
    in-tick (the 1 → 0 edge disposes synchronously, per the cache contract), and a second
    release of the same lease is a no-op. *(Deletes: deferred-release windows; cleanup
    paths that double-release under error recovery.)*
-5. **Moved evidence corrects before paint.** At commit, each acquired node's identity
-   (`:node-key`), version, and the frame/registry epochs are compared against the render's
-   probe evidence; any movement in the render→commit gap — including a same-id frame
-   **reincarnation** the `:node-key` axis catches when version + epochs coincide — advances
-   the cell's revision and notifies, and the host corrects **before paint**. *(Deletes:
-   painting a frame computed from stale reads; a coincident-version reincarnation misread
-   as unchanged.)*
+5. **Moved evidence corrects before paint.** At commit, **each acquired node** — both
+   the leases **retained** from the prior committed set and the newly **staged** ones —
+   has its identity (`:node-key`), version, and the frame/registry epochs compared against
+   the render's probe evidence; any movement in the render→commit gap — including a same-id
+   frame **reincarnation** the `:node-key` axis catches when version + epochs coincide —
+   advances the cell's revision and notifies, and the host corrects **before paint**. On a
+   **non-watchable headless host** a retained site has no value-movement watch, so this
+   comparison is its *only* correction — a staged-only comparison would leave a retained
+   site's headless movement caught by nothing. *(Deletes: painting a frame computed from
+   stale reads; a coincident-version reincarnation misread as unchanged; a retained
+   headless site that self-corrects through no channel.)*
 6. **One notification per cell per render batch — the boundary is drain quiescence, not
    epoch close.** An event/frame **epoch** is a write-side commit + diagnostic-evidence
    unit (one per dequeued event — per
@@ -1265,10 +1269,12 @@ interrupted or abandoned slice's table becomes unreachable garbage. ⟨S-3 §5, 
 **The memo is an economy, never an authority.** A stale memoized value that survives
 into a committed capture is harmless because the **two-guard rule** already covers it:
 (1) React's own snapshot re-check catches mid-pass movement of *watched* sites; (2) the
-commit reconciler's evidence comparison (invariant 5) catches movement of
-*newly-observed* sites — commit compares acquired versions against probe evidence and
-corrects before paint. No third mechanism exists or is needed. A memo table that
-outlives its slice is a conformance bug (a leak fixture pins it).
+commit reconciler's evidence comparison (invariant 5) catches movement of every
+*acquired* site — retained as well as newly-observed — by comparing acquired versions
+against probe evidence and correcting before paint (the retained arm is what covers a
+non-watchable headless site, which guard (1) never reaches). No third mechanism exists
+or is needed. A memo table that outlives its slice is a conformance bug (a leak fixture
+pins it).
 
 ### Epoch finalization — the adapter-internal render-batch boundary
 


### PR DESCRIPTION
Two S2b-reconciler bugs, both in the render→commit gap, both touching `reactive.cljc` (one worker). Commit 1 = rf2-vxgfnd.94 (core + ui), commit 2 = rf2-vxgfnd.39 (ui).

## rf2-vxgfnd.94 — incarnation-keyed frame-close revalidation (reciprocal of .88 Failure-2)

`frame/destroying-frames` was a set of BARE frame-ids. In the JVM window between `destroy-frame!`'s step-6 `dissoc-frame!` and its terminal `finally`, an old incarnation A's stale close marker was indistinguishable from a fresh same-id REPLACEMENT incarnation B being genuinely in-flight — both gave `frame-closing?`=true for the reused id — so a ViewCell commit that ACQUIRED B was torn down by A's stale close authority. The ui artefact could not close this alone (the marker carried no incarnation identity).

- **Core** (`frame.cljc`): `destroying-frames` is now keyed `{frame-id -> incarnation-token}` (the destroying incarnation's `:drain-lock`, captured at the top of `destroy-frame!`). Bare id still drives the re-entrant guard + `frame-closing?` (`contains?`/keys); the token drives a new `frame-incarnation-closing?` predicate.
- **UI** (`reactive.cljc`): the commit frame-close revalidation's in-flight clause consults `frame-incarnation-closing?` against the ACQUIRE-time token instead of the bare-id `frame-closing?`. A commit that acquired B reads false (B's token ≠ A's marker token) and publishes `:connected`; the rf2-vxgfnd.61 case (a commit that acquired A while A is mid-teardown, still live pre-flip) reads true and correctly joins A's teardown.

On CLJS the window is unreachable (single-threaded destroy runs to completion before any recreate); CLJS is correct/unaffected. AC (per .88): "A's close authority cannot tear down a cell that owns B."

Fixture (JVM-only, `reactive-incarnation-close-race-jvm-test`): a `CountDownLatch` barrier pauses A's destroy in the post-`dissoc-frame!` / pre-`finally` window via the `:epoch/on-frame-destroyed` hook, commits B's cell against the reused id, and asserts B's cell is `:connected`. Proven to fail pre-fix (B reaped `:dead`).

## rf2-vxgfnd.39 — retained-lease movement caught at commit step 5

Step-5's evidence comparison read only STAGED leases, so a RETAINED site whose value moved in the render→commit gap was caught by NOTHING on a non-watchable headless host (no value-movement watch exists there). `:values` published the stale render value and the revision never advanced — the ns docstring's "headless movement is caught at step 5" claim was FALSE for retained sites.

- Step 5 now reads EVERY acquired lease — retained as well as staged (plain-atom recomputes on deref, so a headless move is observed) — against the render's probe evidence.
- The synchronous step-8 advance for a RETAINED catch is gated on `(not (dirty? cell))`: on a watchable host the live watch already marked the cell pending and its scheduled flush corrects before paint, so advancing here too would add a redundant render; on a non-watchable headless host the cell is not pending, so step 5 is the sole (now honoured) correction. The staged catch is unchanged.
- Chose the FIX (read retained at step 5), not the walk-back: the substrate can honour the docstring's claim, so it is made TRUE. Docstrings + spec/006 invariant 5 + the memo two-guard rule now say step 5 spans retained + staged acquired nodes; also fixed the slice-memo docstring's stale "next microtask" label for `interop/next-tick` (a macrotask).

Fixtures: `retained-lease-movement-caught-at-commit-step-5` (proven to fail pre-fix — revision stays 0) + a no-false-advance counterpart.

**Hot-zone flag:** `spec/006-ReactiveSubstrate.md` (invariant 5 + the memo two-guard passage) — prose-only clarifications, no new anchors/links.

## Quality gates

Run in the foreground on the final committed state, 0-fail:

- core JVM `clojure -M:test` — 1879 tests / 8424 assertions, 0 failures, 0 errors
- ui JVM `clojure -M:test` — 323 tests / 4806 assertions, 0 failures, 0 errors
- `npm run test:cljs` (node core) — 9076 tests / 42890 assertions, 0 failures, 0 errors
- `npm run test:ui` (node ui) — 311 tests / 1604 assertions, 0 failures, 0 errors

No DOM fixture added (`.94` is JVM-only, `.39` are headless `.cljc`), so `test:browser` is not required. Both fixtures proven to fail pre-fix. `mkdocs build --strict` not run (mkdocs unavailable in this environment; spec/006 edit is prose-only within existing paragraphs).
