### PR TITLE
test(ui): act-discipline the flushSync-only DOM test namespaces (rf2-powx4d)

### DIFF
--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -18,6 +18,7 @@
   the `:browser-test` build; under `:node-test` every DOM body gates on
   `(browser?)` and exits early."
   (:require [cljs.test :refer [deftest is use-fixtures]]
+            ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -29,15 +30,77 @@
 
 (defn- browser? [] (exists? js/document))
 
+;; ---------------------------------------------------------------------------
+;; The canonical React act() helper (rf2-vxgfnd.89 template; rf2-powx4d sweep)
+;;
+;; The repository's established native-React act pattern — the same
+;; get-act / enable-react-act-env! shape as core's shared React suite
+;; (react_shared_suite.cljs `with-browser-act`) and the frame-scope keystone
+;; fixture. It uses React's OWN `act()`, NOT UIx/Helix/Reagent machinery, so
+;; this fixture stays native re-frame.ui + plain-atom.
+;;
+;; `flushSync` is NOT an act substitute: React's test contract treats any
+;; update committed outside an act scope as "not wrapped in act(...)". The
+;; `:browser-test` build runs EVERY `-dom-cljs-test` namespace on one shared
+;; page, and sibling suites set IS_REACT_ACT_ENVIRONMENT=true and never reset
+;; it — so a flushSync-only mount here emits that warning once the flag has
+;; leaked true. Wrapping every committing mount in `act` — with the act env
+;; enabled per-test in the fixture — makes the fixture clean under act rather
+;; than silencing anything.
+(defn- get-act
+  "React's act() — React 19 promotes it to the React namespace proper
+  (react-dom/test-utils on 18)."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- act!
+  "Run `thunk` inside React `act()`, returning the thunk's value. The mount
+  work commits synchronously under IS_REACT_ACT_ENVIRONMENT (enabled per-test
+  in the fixture), so the callback runs eagerly and we capture its result."
+  [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
+
+(defn- flush-without-act!
+  "Run `thunk` inside `flushSync` with the act env toggled OFF, restoring the
+  prior flag after. For a mount that DELIBERATELY throws (`require-scope-frame!`
+  aborting a top-region provider with an absent frame): React `act` would
+  surface the intended error at the act boundary, and the best-effort teardown
+  commit during rollback would warn under the leaked act env. The canonical
+  'real flushSync commit path' (react_shared_suite.cljs) — the throw still
+  propagates for the surrounding `thrown-id`, and the clean retry commits
+  through the same act-env-off path."
+  [thunk]
+  (let [prior (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    (try (react-dom/flushSync thunk)
+         (finally (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
                                             :ambient-frame nil})
   (fn [t]
-    (client/reset-live-roots!)
-    (frames/reset-installed-plans!)
-    (t)
-    (client/reset-live-roots!)
-    (frames/reset-installed-plans!)))
+    ;; Enable React's act environment for this ns's DOM tests, then RESTORE the
+    ;; prior value so the fixture neither depends on nor leaks the shared-page
+    ;; flag.
+    (let [prior (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))]
+      (enable-react-act-env!)
+      (client/reset-live-roots!)
+      (frames/reset-installed-plans!)
+      (try
+        (t)
+        (finally
+          (client/reset-live-roots!)
+          (frames/reset-installed-plans!)
+          (when (browser?)
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))))
 
 (defn- container [] (js/document.createElement "div"))
 
@@ -59,7 +122,7 @@
   (when (browser?)
     (reg-events!)
     (let [c (container)]
-      (react-dom/flushSync
+      (act!
        #(ui/mount [frame-root {:id :app/shop :initial-events [[:test/set-db {:n 10}]]}
                    [mini {:label "shop"}]]
                   c {:root-id :dom-pf/shop}))
@@ -80,11 +143,11 @@
                                          :initial-events [[:test/set-db {:n 1}]]}
                              [mini {:label "keep"}]]
                             c {:root-id :dom-pf/keep})]
-      (react-dom/flushSync mount!)
+      (act! mount!)
       (rf/dispatch-sync [:test/inc] {:frame :app/keep})
       (is (= 2 (:n (rf/app-db-value :app/keep))))
       ;; same root-id + same container -> re-preflight finds the frame live
-      (react-dom/flushSync mount!)
+      (act! mount!)
       (is (= 2 (:n (rf/app-db-value :app/keep)))
           "the reload path re-runs preflight but does NOT re-seed"))))
 
@@ -96,7 +159,7 @@
   (when (browser?)
     (reg-events!)
     ;; root A installs :app/shared with one config
-    (react-dom/flushSync
+    (act!
      #(ui/mount [frame-root {:id :app/shared :initial-events [[:test/set-db {:n 1}]]}
                  [mini {:label "a"}]]
                 (container) {:root-id :dom-pf/a}))
@@ -133,7 +196,7 @@
   (when (browser?)
     (rf/make-frame {:id :app/live :doc "scope target"})
     (let [c (container)]
-      (react-dom/flushSync
+      (act!
        #(ui/mount [scoping-view {:frame-id :app/live}] c
                   {:root-id :dom-pf/scoped}))
       (is (re-find #"<div class=\"wrap\"><div class=\"mini\">inside</div></div>"
@@ -170,7 +233,7 @@
     (let [c (container)
           mount-provider!
           (fn []
-            (react-dom/flushSync
+            (flush-without-act!
              #(ui/mount [frame-provider {:frame :dom-absent/never}
                          [mini {:label "scoped"}]]
                         c {:root-id :dom-absent/root})))]
@@ -189,4 +252,4 @@
             "the freed root-id + container accept a clean retry")
         (is (re-find #"<div class=\"mini\">scoped</div>" (.-innerHTML c))
             "the provider scopes the now-live frame transparently")
-        (ui/unmount! root)))))
+        (act! #(ui/unmount! root))))))

--- a/implementation/ui/test/re_frame/ui/reactive_tear_browser_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_tear_browser_dom_cljs_test.cljs
@@ -73,11 +73,33 @@
 ;; test using `(async done …)` requires every `:each` fixture to be a map,
 ;; and this fixture must survive the microtask/macrotask checkpoints. The
 ;; live-root reset rides the same map form.
+;; This ns is a flushSync-TIMING discriminator, not an act test: every
+;; `flushSync` checkpoint below deliberately forces React to commit exactly
+;; what the reactive scheduler has notified SO FAR, to observe WHEN the
+;; coalesced flush fires. `act` would drain the pending microtask and collapse
+;; the microtask/macrotask distinction under test, so the whole ns runs the
+;; real flushSync path with IS_REACT_ACT_ENVIRONMENT OFF (the
+;; react_shared_suite.cljs pattern) — no "not wrapped in act" warning, timing
+;; preserved. Sibling suites on the shared `:browser-test` page leak the flag
+;; true; the fixture stashes the prior value and restores it in :after (which
+;; cljs.test runs after the async body completes), so it neither depends on nor
+;; leaks that flag.
+(defonce ^:private prior-act-env (atom nil))
+
+(defn- disable-act-env! []
+  (when (exists? js/globalThis)
+    (reset! prior-act-env (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)))
+
+(defn- restore-act-env! []
+  (when (exists? js/globalThis)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) @prior-act-env)))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter :ambient-frame nil :async? true})
-  {:before #(client/reset-live-roots!)
-   :after  #(client/reset-live-roots!)})
+  {:before #(do (disable-act-env!) (client/reset-live-roots!))
+   :after  #(do (client/reset-live-roots!) (restore-act-env!))})
 
 (def ^:private frame-kw :rf.tear/frame)
 

--- a/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
@@ -33,14 +33,35 @@
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
 
+;; This ns is a flushSync-TIMING / Activity-microtask discriminator, not an act
+;; test: each `flushSync` checkpoint below deliberately forces React to commit
+;; exactly what the reactive scheduler / Activity mode flip has notified SO FAR,
+;; to observe the disconnect/reconnect lifecycle across the microtask boundary.
+;; `act` would drain the pending microtask and collapse that timing, so the
+;; whole ns runs the real flushSync path with IS_REACT_ACT_ENVIRONMENT OFF (the
+;; react_shared_suite.cljs pattern) — no "not wrapped in act" warning, timing
+;; preserved. Sibling suites on the shared `:browser-test` page leak the flag
+;; true; the fixture stashes the prior value and restores it in :after (which
+;; cljs.test runs after the async body completes).
+(defonce ^:private prior-act-env (atom nil))
+
+(defn- disable-act-env! []
+  (when (exists? js/globalThis)
+    (reset! prior-act-env (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)))
+
+(defn- restore-act-env! []
+  (when (exists? js/globalThis)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) @prior-act-env)))
+
 ;; A WATCHABLE substrate (UIx spine) so a sub move fires the port's on-change
 ;; watch that drives the Activity-mode re-render; `:ambient-frame nil` so views
 ;; resolve their frame ONLY from the enclosing frame-provider.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
    {:adapter uix-adapter/adapter :ambient-frame nil :async? true})
-  {:before #(do (reactive/reset-scheduler!) (client/reset-live-roots!))
-   :after  #(do (reactive/reset-scheduler!) (client/reset-live-roots!))})
+  {:before #(do (disable-act-env!) (reactive/reset-scheduler!) (client/reset-live-roots!))
+   :after  #(do (reactive/reset-scheduler!) (client/reset-live-roots!) (restore-act-env!))})
 
 (def ^:private frame-kw :ract/frame)
 

--- a/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
@@ -19,9 +19,70 @@
 
 (defn- browser? [] (exists? js/document))
 
+;; ---------------------------------------------------------------------------
+;; The canonical React act() helper (rf2-vxgfnd.89 template; rf2-powx4d sweep)
+;;
+;; The repository's established native-React act pattern — the same
+;; get-act / enable-react-act-env! shape as core's shared React suite
+;; (react_shared_suite.cljs `with-browser-act`) and the frame-scope keystone
+;; fixture. It uses React's OWN `act()`, NOT UIx/Helix/Reagent machinery.
+;;
+;; `flushSync` is NOT an act substitute: React's test contract treats any
+;; update committed outside an act scope as "not wrapped in act(...)". The
+;; `:browser-test` build runs EVERY `-dom-cljs-test` namespace on one shared
+;; page, and sibling suites set IS_REACT_ACT_ENVIRONMENT=true and never reset
+;; it — so a flushSync-only mount here emits that warning once the flag has
+;; leaked true. Wrapping every mount / render / unmount in `act` — with the act
+;; env enabled per-test in the fixture — makes the fixture clean under act
+;; rather than silencing anything.
+(defn- get-act
+  "React's act() — React 19 promotes it to the React namespace proper
+  (react-dom/test-utils on 18)."
+  []
+  (or (when (exists? (.-act react)) (.-act react))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- act!
+  "Run `thunk` inside React `act()`, returning the thunk's value. The
+  mount/render/unmount work commits synchronously under
+  IS_REACT_ACT_ENVIRONMENT (enabled per-test in the fixture), so the callback
+  runs eagerly and we capture its result."
+  [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
+
+(defn- flush-without-act!
+  "Run `thunk` inside `flushSync` with the act env toggled OFF, restoring the
+  prior flag after. For deliberately-throwing / aborting mounts (a throwing
+  element thunk that mount* rolls back and re-throws): React `act` would
+  surface the intended error at the act boundary, and the best-effort teardown
+  commit during rollback would warn under the leaked act env. The canonical
+  'real flushSync commit path' (react_shared_suite.cljs) — the throw still
+  propagates for the surrounding `thrown-with-msg?` / `thrown-error`."
+  [thunk]
+  (let [prior (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    (try (react-dom/flushSync thunk)
+         (finally (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))
+
 (use-fixtures :each
-  {:before client/reset-live-roots!
-   :after  client/reset-live-roots!})
+  (fn [f]
+    ;; Enable React's act environment for this ns's DOM tests, then RESTORE the
+    ;; prior value so the fixture neither depends on nor leaks the shared-page
+    ;; flag.
+    (let [prior (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))]
+      (enable-react-act-env!)
+      (client/reset-live-roots!)
+      (try (f)
+           (finally (client/reset-live-roots!)
+                    (when (browser?)
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))))
 
 (defn- container []
   (js/document.createElement "div"))
@@ -72,7 +133,7 @@
 (deftest mount-smoke
   (when (browser?)
     (let [c (container)
-          root (react-dom/flushSync #(mount-main! c))]
+          root (act! #(mount-main! c))]
       (is (some? root))
       (is (= :dom-smoke/main (client/root-id-of root)))
       (is (re-find #"<div class=\"mini-app\"><h1>hello S1c</h1></div>"
@@ -92,8 +153,8 @@
 (deftest mount-is-idempotent-per-root
   (when (browser?)
     (let [c (container)
-          r1 (react-dom/flushSync #(mount-main! c))
-          r2 (react-dom/flushSync #(mount-main! c))]
+          r1 (act! #(mount-main! c))
+          r2 (act! #(mount-main! c))]
       (is (identical? r1 r2)
           "same root-id + same container re-renders the existing Root")
       (is (= 1 (count (client/live-root-ids)))))))
@@ -107,7 +168,7 @@
 
 (deftest duplicate-derived-root-id-fails-loud-live
   (when (browser?)
-    (react-dom/flushSync #(mount-derived! (container)))
+    (act! #(mount-derived! (container)))
     (let [{:keys [id msg]} (thrown-error #(mount-derived! (container)))]
       (is (= :rf.error/duplicate-root-id id)
           "same root-id on a DIFFERENT container fails loud (Layer 3)")
@@ -117,7 +178,7 @@
 (deftest container-in-use-fails-loud-live
   (when (browser?)
     (let [c (container)]
-      (react-dom/flushSync
+      (act!
        #(ui/mount [mini-app {:title "first"}] c {:root-id :dom-inuse/first}))
       (let [{:keys [id data]}
             (thrown-error
@@ -141,9 +202,9 @@
           root (ui/create-root c {:root-id :dom-cr/panel
                                   :identifier-prefix "rf2-custom-"})]
       (is (= "" (.-innerHTML c)) "create-root renders nothing")
-      (react-dom/flushSync #(ui/render! root [mini-app {:title "one"}]))
+      (act! #(ui/render! root [mini-app {:title "one"}]))
       (is (re-find #"one" (.-innerHTML c)))
-      (react-dom/flushSync #(ui/render! root [mini-app {:title "two"}]))
+      (act! #(ui/render! root [mini-app {:title "two"}]))
       (is (re-find #"two" (.-innerHTML c)) "render! re-renders")
       (let [entry (client/live-root-entry :dom-cr/panel)]
         (is (= :dom-cr/panel (get-in entry [:descriptor :root-id]))
@@ -168,10 +229,10 @@
         (is (= #{:dom-pfx/a} (client/live-root-ids))
             "the first root is untouched"))
       ;; release the owner — the prefix is now free for a fresh root
-      (ui/unmount! r1)
+      (act! #(ui/unmount! r1))
       (let [r2 (ui/create-root c2 {:root-id :dom-pfx/b :identifier-prefix "rf2-shared-"})]
         (is (some? r2) "the prefix is reclaimable once its owner unmounts")
-        (ui/unmount! r2)))))
+        (act! #(ui/unmount! r2))))))
 
 ;; ---------------------------------------------------------------------------
 ;; identifier-prefix reaches React useId; same-root prefix change fails loud
@@ -186,8 +247,8 @@
   ;; claim BEFORE createRoot / any commit — the colliding container stays empty.
   (when (browser?)
     (let [ca (container) cb (container) cc (container)
-          ra (react-dom/flushSync #(mount-probe! ca "rf2-uida-" :uid/a))
-          rb (react-dom/flushSync #(mount-probe! cb "rf2-uidb-" :uid/b))
+          ra (act! #(mount-probe! ca "rf2-uida-" :uid/a))
+          rb (act! #(mount-probe! cb "rf2-uidb-" :uid/b))
           id-a (.-textContent ca)
           id-b (.-textContent cb)]
       (is (str/includes? id-a "rf2-uida-")
@@ -204,8 +265,8 @@
         (is (= :uid/a (:owner-root-id data)))
         (is (= "" (.-innerHTML cc))
             "the colliding root committed nothing — stopped before createRoot"))
-      (client/unmount!* ra)
-      (client/unmount!* rb))))
+      (act! #(client/unmount!* ra))
+      (act! #(client/unmount!* rb)))))
 
 (deftest same-root-remount-changed-prefix-fails-loud-live
   ;; AC3 end-to-end: a real root mounted with prefix P1, then re-mounted on the
@@ -214,7 +275,7 @@
   ;; render + registered prefix stay intact (untouched).
   (when (browser?)
     (let [c   (container)
-          r1  (react-dom/flushSync #(mount-probe! c "rf2-p1-" :hmr/x))
+          r1  (act! #(mount-probe! c "rf2-p1-" :hmr/x))
           id1 (.-textContent c)]
       (is (str/includes? id1 "rf2-p1-"))
       (let [{:keys [id data msg]}
@@ -229,7 +290,7 @@
           "the original render is intact — the running root kept its prefix")
       (is (= "rf2-p1-" (:identifier-prefix (client/live-root-entry :hmr/x)))
           "the registry entry still carries the original prefix")
-      (client/unmount!* r1))))
+      (act! #(client/unmount!* r1)))))
 
 ;; ---------------------------------------------------------------------------
 ;; unmount! — total teardown + remount
@@ -238,19 +299,19 @@
 (deftest unmount-tears-down-and-frees-identity
   (when (browser?)
     (let [c (container)
-          root (react-dom/flushSync
+          root (act!
                 #(ui/mount [other-app {}] c {:root-id :dom-un/x}))]
       (is (re-find #"other content" (.-innerHTML c)))
-      (ui/unmount! root)
+      (act! #(ui/unmount! root))
       (is (= "" (.-innerHTML c)) "total teardown")
       (is (not (contains? (client/live-root-ids) :dom-un/x))
           "the root-id is unregistered")
-      (is (nil? (ui/unmount! root)) "idempotent")
-      (let [root2 (react-dom/flushSync
+      (is (nil? (act! #(ui/unmount! root))) "idempotent")
+      (let [root2 (act!
                    #(ui/mount [other-app {}] c {:root-id :dom-un/x}))]
         (is (re-find #"other content" (.-innerHTML c))
             "identity + container free for a fresh mount")
-        (ui/unmount! root2)))))
+        (act! #(ui/unmount! root2))))))
 
 ;; ---------------------------------------------------------------------------
 ;; exception-safety: total teardown + idempotent mount retry (rf2-vxgfnd.18)
@@ -265,18 +326,18 @@
           info {:root-id :dom-throw/x :provenance :authored}
           boom (fn [] (throw (ex-info "element thunk boom" {:tag :element})))]
       (is (thrown-with-msg? cljs.core/ExceptionInfo #"element thunk boom"
-                            (react-dom/flushSync #(client/mount* info c boom nil nil)))
+                            (flush-without-act! #(client/mount* info c boom nil nil)))
           "the original mount error propagates")
       (is (not (contains? (client/live-root-ids) :dom-throw/x))
           "no phantom live root remains after the failed first mount")
       (is (nil? (client/live-root-entry :dom-throw/x)))
       ;; retry on the SAME container + root-id via the public API succeeds
-      (let [root (react-dom/flushSync
+      (let [root (act!
                   #(ui/mount [mini-app {:title "retry ok"}] c {:root-id :dom-throw/x}))]
         (is (some? root))
         (is (re-find #"retry ok" (.-innerHTML c))
             "a clean retry mounts successfully into the freed container")
-        (ui/unmount! root)))))
+        (act! #(ui/unmount! root))))))
 
 ;; criterion 3 (a synchronous host `.render` throw AFTER host creation) is
 ;; covered by the SAME rollback catch as the thunk throw above: `mount*`
@@ -296,7 +357,7 @@
   ;; render intact (no rollback — the root was live before this call).
   (when (browser?)
     (let [c    (container)
-          root (react-dom/flushSync
+          root (act!
                 #(ui/mount [mini-app {:title "committed"}] c
                            {:root-id :dom-rerender/x}))]
       (is (re-find #"committed" (.-innerHTML c)))
@@ -304,14 +365,14 @@
             boom (fn [] (throw (ex-info "re-render boom" {})))]
         ;; same root-id + same container -> the idempotent re-render branch
         (is (thrown-with-msg? cljs.core/ExceptionInfo #"re-render boom"
-                              (react-dom/flushSync #(client/mount* info c boom nil nil))))
+                              (flush-without-act! #(client/mount* info c boom nil nil))))
         (is (contains? (client/live-root-ids) :dom-rerender/x)
             "the existing root stays registered on a failed re-render")
         (is (identical? root (:root (client/live-root-entry :dom-rerender/x)))
             "it is the same Root — not evicted or replaced")
         (is (re-find #"committed" (.-innerHTML c))
             "its last committed render is intact"))
-      (ui/unmount! root))))
+      (act! #(ui/unmount! root)))))
 
 ;; ---------------------------------------------------------------------------
 ;; stale-root render! guard (rf2-vxgfnd.31)
@@ -327,10 +388,10 @@
   (when (browser?)
     (let [c    (container)
           root (ui/create-root c {:root-id :dom-stale/panel})]
-      (react-dom/flushSync #(ui/render! root [mini-app {:title "live"}]))
+      (act! #(ui/render! root [mini-app {:title "live"}]))
       (is (re-find #"live" (.-innerHTML c)))
       ;; tear it down — the handle is now STALE
-      (ui/unmount! root)
+      (act! #(ui/unmount! root))
       (is (not (contains? (client/live-root-ids) :dom-stale/panel)))
       (is (= "" (.-innerHTML c)) "the container is cleared by unmount!")
       ;; a preflight capture hook stands in for the side-effecting frame
@@ -373,7 +434,16 @@
   ;; container. B's live React tree must survive and A must fail loud with no
   ;; orphan — the re-check (rf2-vxgfnd.52) fires before A createRoots/registers.
   (when (browser?)
-    (let [c-a (container)
+    ;; This re-entrant path mounts inner root B from INSIDE the outer mount's
+    ;; preflight (a bare ui/mount, deliberately outside any flushSync) while the
+    ;; outer mount throws. It is a real flushSync commit path, not an act path:
+    ;; run it with IS_REACT_ACT_ENVIRONMENT OFF (the react_shared_suite.cljs
+    ;; pattern) so B's scheduled render — flushed here, not under act — commits
+    ;; without an act warning, and the outer throw still propagates. The fixture
+    ;; restores the prior flag; we restore it in the finally too.
+    (let [prior  (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)
+          _      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+          c-a (container)
           c-b (container)
           b-root (atom nil)]
       (client/set-preflight-hook!
@@ -405,7 +475,8 @@
             "only B is live — A left no phantom entry")
         (finally
           (client/set-preflight-hook! nil)
-          (some-> @b-root ui/unmount!))))))
+          (some-> @b-root ui/unmount!)
+          (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior))))))
 
 ;; ---------------------------------------------------------------------------
 ;; frame-root: transparent render + the preflight seam
@@ -425,7 +496,7 @@
       ;; pinned by the preflight-frame-wiring fixtures)
       (client/set-preflight-hook! (fn [_root-id plans] (reset! seen plans)))
       (try
-        (react-dom/flushSync #(mount-framed! (container) 42))
+        (act! #(mount-framed! (container) 42))
         (let [[plan :as plans] @seen]
           (is (= 1 (count plans)))
           (is (= :dom-frames/session (:frame-id plan)))
@@ -447,7 +518,7 @@
     (let [calls (atom 0)]
       (client/set-preflight-hook! (fn [_ _] (swap! calls inc)))
       (try
-        (react-dom/flushSync
+        (act!
          #(ui/mount [mini-app {:title "plain"}] (container)
                     {:root-id :dom-plain/root}))
         (is (zero? @calls)

--- a/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
@@ -17,6 +17,7 @@
   substrate the other browser fixtures use; here it simply provides a real
   React mount surface for a compiled `defview`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.adapter.uix :as uix-adapter]
@@ -31,14 +32,62 @@
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
 
+;; ---------------------------------------------------------------------------
+;; The canonical React act() helper (rf2-vxgfnd.89 template; rf2-powx4d sweep)
+;;
+;; The repository's established native-React act pattern — the same
+;; get-act / enable-react-act-env! shape as core's shared React suite
+;; (react_shared_suite.cljs `with-browser-act`) and the frame-scope keystone
+;; fixture (frame_scope_resolve_dom_cljs_test.cljs). It uses React's OWN
+;; `act()`, NOT UIx/Helix/Reagent machinery, so this fixture stays native
+;; re-frame.ui + the substrate adapter under test.
+;;
+;; `flushSync` is NOT an act substitute: React's test contract treats any
+;; update committed outside an act scope as "not wrapped in act(...)". The
+;; `:browser-test` build runs EVERY `-dom-cljs-test` namespace on one shared
+;; page, and sibling suites set IS_REACT_ACT_ENVIRONMENT=true and never reset
+;; it — so a flushSync-only mount/unmount here emits that warning once the flag
+;; has leaked true. Wrapping every commit in `act` — with the act env enabled
+;; per-test in the fixture — makes the fixture clean under act rather than
+;; silencing anything.
+(defn- get-act
+  "React's act() — React 19 promotes it to the React namespace proper
+  (react-dom/test-utils on 18)."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- act!
+  "Run `thunk` inside React `act()`, returning the thunk's value. `act()`
+  itself returns a thenable (not the callback's value); the mount/unmount work
+  here commits synchronously under IS_REACT_ACT_ENVIRONMENT (enabled per-test
+  in the fixture), so the callback runs eagerly and we capture its result."
+  [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
    {:adapter uix-adapter/adapter :ambient-frame nil})
   (fn [f]
-    (reactive/reset-scheduler!)
-    (client/reset-live-roots!)
-    (try (f)
-         (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+    ;; Enable React's act environment for this ns's DOM tests, then RESTORE the
+    ;; prior value so the fixture neither depends on nor leaks the shared-page
+    ;; flag.
+    (let [prior (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))]
+      (enable-react-act-env!)
+      (reactive/reset-scheduler!)
+      (client/reset-live-roots!)
+      (try (f)
+           (finally (reactive/reset-scheduler!)
+                    (client/reset-live-roots!)
+                    (when (browser?)
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))))
 
 (def ^:private frame-kw :rt.dom/frame)
 
@@ -59,7 +108,7 @@
       (register-app!)
       (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
       (let [c    (container)
-            root (react-dom/flushSync
+            root (act!
                   #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
                              c {:root-id :rt.dom/root}))
             cells (reactive/current-live-cells)
@@ -69,7 +118,7 @@
           (is (= 1 (count cells)) "exactly one live ViewCell under the root")
           (is (= :connected (reactive/lifecycle cell))))
         (testing "a REAL root unmount proves the cell :unmounted → :dead"
-          (react-dom/flushSync #(ui/unmount! root))
+          (act! #(ui/unmount! root))
           (is (= :dead (reactive/lifecycle cell))
               "not stuck at the transient :unknown — the host teardown upgraded it")
           (is (= :unmounted (:reason (peek (reactive/intervals cell))))
@@ -87,16 +136,16 @@
       (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
       (let [ca    (container)
             cb    (container)
-            root-a (react-dom/flushSync
+            root-a (act!
                     #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
                                ca {:root-id :rt.dom/root-a}))
-            root-b (react-dom/flushSync
+            root-b (act!
                     #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
                                cb {:root-id :rt.dom/root-b}))]
         ;; two roots, two cells; root B still renders after root A unmounts
         (is (= 2 (count (reactive/current-live-cells))) "two live cells")
         (let [before (vec (reactive/current-live-cells))]
-          (react-dom/flushSync #(ui/unmount! root-a))
+          (act! #(ui/unmount! root-a))
           (testing "root A's cell is dead; root B's cell is untouched"
             (let [alive (filter #(= :connected (reactive/lifecycle %)) before)
                   dead  (filter #(= :dead (reactive/lifecycle %)) before)]
@@ -104,4 +153,4 @@
               (is (= 1 (count alive)) "exactly one cell still connected")
               (is (= "7" (.-textContent (.querySelector cb ".leaf")))
                   "root B still renders")))
-          (react-dom/flushSync #(ui/unmount! root-b)))))))
+          (act! #(ui/unmount! root-b)))))))


### PR DESCRIPTION
## What

Since **rf2-vxgfnd.90** made the browser gate run on all `implementation/ui/**` changes, the shared `:browser-test` page surfaced ~361 `An update to X inside a test was not wrapped in act(...)` warnings from sibling `*-dom-cljs-test` namespaces that mount via `flushSync` only. Sibling suites set `IS_REACT_ACT_ENVIRONMENT=true` and never reset it, so a `flushSync` commit warns once the flag has leaked true.

**Non-fatal** — the runner fails only on `cljs.test` failures/errors + uncaught `pageerror`s, not console warnings — so no gate was red. This is pure test hygiene.

This PR applies the canonical native-React `act` pattern (the rf2-vxgfnd.89 `frame_scope_resolve` template; core `react_shared_suite.cljs`) to the **first-party `implementation/ui/**` DOM tests**, using React's OWN `act()` — no UIx/Helix/Reagent machinery.

## Namespaces swept (act warnings before → after)

| namespace | before | after |
|---|---|---|
| `re-frame.ui.root-mount-dom-cljs-test` | 30 | 0 |
| `re-frame.ui.root-incarnation-activity-dom-cljs-test` | 9 | 0 |
| `re-frame.ui.preflight-frame-wiring-dom-cljs-test` | 8 | 0 |
| `re-frame.ui.root-teardown-dom-cljs-test` | 6 | 0 |
| `re-frame.ui.reactive-tear-browser-dom-cljs-test` | 4 | 0 |

Total shared-page `not wrapped in act` warnings dropped 483 → 426 (exactly −57).

Two treatments:

- **`root_mount` / `root_teardown` / `preflight_frame_wiring`** (synchronous): per-test fixture enables `IS_REACT_ACT_ENVIRONMENT` and restores the prior value; every committing mount / render / unmount runs inside React's own `act()`. Deliberately-throwing / rolling-back mounts use a `flushSync`-with-act-env-off helper so the intended error still propagates and the rollback teardown does not warn.
- **`reactive_tear_browser` / `root_incarnation_activity`** are flushSync-TIMING discriminators — they force React to commit exactly what the reactive scheduler / Activity mode-flip has notified *so far*, across microtask/macrotask checkpoints. `act()` would drain the pending microtask and collapse that timing, so these run the real flushSync path with `IS_REACT_ACT_ENVIRONMENT` **OFF** (the `react_shared_suite.cljs` pattern), stashing + restoring the prior flag in the map fixture. No warning, timing preserved.

All existing assertions preserved — this only wraps mounts/unmounts (browser run stays 304 tests / 1104 assertions).

## Out of scope / follow-up

- **`frame_scope_resolve_dom_cljs_test`** — already act-clean via rf2-vxgfnd.89 (untouched).
- **`reactive_reincarnation_dom_cljs_test`** — owned by the concurrent `worker/vxgfnd44-lifecycle-honesty` StrictMode worker (untouched; still warns 3).
- **`implementation/adapters/**` DOM tests** (~90 warnings: `frame-provider-context`, `cross-spec`, `reagent-slim-*`, `helix/uix use-subscribe / after-render / frame-provider-ensure / resource-lease`, …) — a different artefact; the use-subscribe/after-render/resource-lease probes are driven through the shared core `react_shared_suite.cljs`, so a coordinated follow-up rather than this focused pass.
- **`tools/story/**` and `tools/machines-viz/**`** DOM tests (`re-frame.story.*` ~33, `day8.re-frame2-machines-viz.*` ~295) — out of scope for this pass per the bead brief; remaining as a follow-up.

## Quality gates

Run in the foreground from `implementation/`:

- `npm run test:browser` (with `RF2_VERBOSE_TESTS=1`): **304 tests / 1104 assertions, 0 failures, 0 errors**; the 5 swept namespaces emit **0** `not wrapped in act` warnings.
- `npm run test:cljs`: **9082 tests / 42932 assertions, 0 failures, 0 errors**.