### PR TITLE
fix(ui): don't fabricate an Activity-hide proof under StrictMode replay + honest capture retention (rf2-vxgfnd.44)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -30,9 +30,11 @@
   Render probes WITHOUT
   ownership (resolve-target + probe, no ref-count / watch / cache node);
   the layout commit acquires the CAPTURED targets. Abandoned renders
-  (StrictMode double-render, time-sliced tear-off) retain NOTHING because
-  render never acquires — the 10k-abandoned-renders-retain-zero property
-  is structural, mirroring the port's S-3 §5 cold-probe exit criterion.
+  (StrictMode double-render, time-sliced tear-off) acquire NO OWNERSHIP —
+  the 10k-abandoned-renders-retain-zero-OWNERSHIP property is structural,
+  mirroring the port's S-3 §5 cold-probe exit criterion. (They do retain
+  their single `:latest-capture` of values until the next render overwrites
+  it — at most one, never accumulating; see `with-capture`.)
 
   ## The render capture
 
@@ -347,6 +349,13 @@
   ;;                             ;   identity that SURVIVES an Activity hide, so
   ;;                             ;   root teardown reaps a cell hidden before its
   ;;                             ;   window (rf2-vxgfnd.85; see `root-cells`)
+  ;;    :disconnect-provisional? bool ; DEV-only (rf2-vxgfnd.44): a just-emitted
+  ;;                             ;   :disconnected interval that has NOT yet
+  ;;                             ;   settled past its synchronous commit. A
+  ;;                             ;   reconnect while still provisional is a
+  ;;                             ;   same-tick StrictMode dev replay (no hide);
+  ;;                             ;   `settle-disconnect!` clears it. false/absent
+  ;;                             ;   in production (no StrictMode double-invoke)
   ;;    :committed {tk -> lease} ; installed dependency set
   ;;    :values    {tk -> value} ; last published site values (stabilization
   ;;                             ;   + the revision snapshot's evidence)
@@ -378,6 +387,7 @@
             :generation     generation
             :lifecycle      :fresh
             :root           nil
+            :disconnect-provisional? false
             :committed      {}
             :values         {}
             :revision       0
@@ -422,10 +432,22 @@
       v)))
 
 (defn with-capture
-  "Run `thunk` (a compiled view body) under a fresh ambient capture, stash
-  the finished capture on `cell` as the commit input, and return the
-  thunk's value (the host element). Ownership-free: an abandoned render (a
-  thunk whose result the host discards) leaves only unreachable garbage."
+  "Run `thunk` (a compiled view body) under a fresh ambient capture, stash the
+  finished capture on `cell` as the layout commit's input, and return the
+  thunk's value (the host element).
+
+  Ownership-free: the render acquires NO ref-count, watch, or cache node, so an
+  abandoned render (a thunk whose result the host discards — StrictMode
+  double-render, time-sliced tear-off) leaks ZERO ownership. It does, however,
+  RETAIN its capture: the finished capture (its targets + probe evidence +
+  values, possibly a large probed collection) is stashed on the cell as
+  `:latest-capture` and stays there until the NEXT render overwrites it. The
+  honest bound is therefore AT MOST ONE capture retained per cell — never
+  accumulating, never ownership — not zero. That retention is REQUIRED, not a
+  leak: the layout commit reads `:latest-capture` in a later effect, and
+  StrictMode's effect mount→cleanup→remount re-commits the SAME capture with no
+  intervening render, so clearing it here would break the reacquire
+  (rf2-vxgfnd.44)."
   [^ViewCell cell thunk]
   (let [cap  (volatile! (fresh-capture (:generation @(state cell))))
         prev @ambient]
@@ -958,11 +980,21 @@
 ;; ---- lifecycle (03 §4) ------------------------------------------------------
 ;;
 ;; Three OBSERVABLE runtime states. The fact emitted at cleanup is always
-;; `:disconnected {:reason :unknown}` — the platform gives no
-;; hide-vs-unmount signal. Later evidence annotates the PRIOR interval,
-;; never the present: a reconnect proves an Activity hide
-;; (`:activity-hidden {:proof :reconnect}`); an explicit host/root teardown
-;; proves an unmount (`:unmounted {:proof :host-teardown}`).
+;; `:disconnected {:reason :unknown}` — the platform gives no hide-vs-unmount
+;; signal. Later evidence annotates the PRIOR interval, never the present: a
+;; SETTLED reconnect proves an Activity hide (`:activity-hidden {:proof
+;; :reconnect}`); an explicit host/root teardown proves an unmount (`:unmounted
+;; {:proof :host-teardown}`).
+;;
+;; The settle qualifier is the rf2-vxgfnd.44 honesty fix: a reconnect within the
+;; SAME synchronous commit as its disconnect is NOT a hide — it is React
+;; StrictMode's dev mount→cleanup→remount replay, and asserting `:activity-hidden`
+;; for it would fabricate a proof the runtime never observed. So `disconnect!`
+;; marks each cleanup PROVISIONAL and `settle-disconnect!` (a microtask on CLJS)
+;; clears it once the disconnect outlives its commit; only a disconnect that
+;; survived a host yield can then be proven a hide. DEV-only — production has no
+;; StrictMode double-invoke, so `:disconnect-provisional?` is never set and a
+;; reveal is proven exactly as before.
 
 (defn lifecycle
   "The cell's current runtime state keyword."
@@ -1071,14 +1103,55 @@
                    (assoc (peek ivs) :reason reason :proof proof))
              ivs))))
 
+(defn settle-disconnect!
+  "Settle `cell`'s open PROVISIONAL disconnect — mark it a disconnect that
+  outlived the synchronous commit that produced it, so a subsequent reconnect
+  honestly proves an Activity hide rather than a same-tick React StrictMode
+  replay (rf2-vxgfnd.44). No-op unless the cell is still `:disconnected` (a cell
+  already reconnected or torn down needs no settle). On CLJS `disconnect!` arms
+  this as a microtask — it fires after the synchronous commit unwinds and before
+  the next paint, so ONLY a same-commit StrictMode replay can reconnect ahead of
+  it; a genuine reveal (a later task) always finds the disconnect already
+  settled. A headless/JVM fixture calls this explicitly to model the host yield
+  of a real reveal. Returns nil."
+  [^ViewCell cell]
+  (let [st (state cell)]
+    (when (= :disconnected (:lifecycle @st))
+      (swap! st assoc :disconnect-provisional? false)))
+  nil)
+
+(defn- arm-disconnect-settle!
+  "Arm the settle of `cell`'s provisional disconnect. On CLJS a host microtask
+  (`queue-microtask!`) that runs after the current synchronous commit unwinds
+  and before the next paint — so React StrictMode's synchronous
+  mount→cleanup→remount reconnects BEFORE it (a replay, un-annotated), while a
+  genuine reveal (a later task) reconnects after it (proven a hide). No
+  auto-settle on the JVM headless host (no StrictMode, no async render loop); a
+  fixture there settles explicitly."
+  [^ViewCell cell]
+  #?(:cljs (queue-microtask! (fn [] (settle-disconnect! cell)))
+     :clj  nil))
+
 (defn- connect!
   "Commit-time lifecycle transition into `:connected`. A transition FROM
-  `:disconnected` is a reconnect — it retroactively proves the prior
-  interval was an Activity hide."
+  `:disconnected` is a reconnect. A reconnect proves an Activity hide ONLY when
+  the prior disconnect had SETTLED — i.e. it outlived the synchronous commit
+  that produced it. A SETTLED-then-reconnected interval is a genuine hide→reveal
+  and is annotated `:activity-hidden {:proof :reconnect}`. An UNSETTLED reconnect
+  is a React StrictMode dev replay — the same cell's effect
+  mount→cleanup→remount within ONE synchronous commit, where NO hide and NO
+  unmount happened — so it is NOT annotated: the runtime must not fabricate an
+  Activity-hide proof it never observed (rf2-vxgfnd.44). In production
+  `:disconnect-provisional?` is never set (no StrictMode double-invoke), so a
+  reveal is proven exactly as before."
   [^ViewCell cell]
   (let [st @(state cell)]
     (when (= :disconnected (:lifecycle st))
-      (annotate-open-disconnect! cell :activity-hidden :reconnect))
+      (if (:disconnect-provisional? st)
+        ;; same-tick StrictMode replay — the disconnect never settled; clear the
+        ;; provisional flag and DO NOT fabricate an Activity-hide proof.
+        (swap! (state cell) assoc :disconnect-provisional? false)
+        (annotate-open-disconnect! cell :activity-hidden :reconnect)))
     (swap! (state cell) assoc :lifecycle :connected)
     ;; Enrol in the live-cell registry (idempotent — a set) so a frame-destroy
     ;; sweep can find this cell while it observes a live committed dep set.
@@ -1111,6 +1184,14 @@
                   (-> m
                       (assoc :lifecycle :disconnected)
                       (update :intervals conj {:state :disconnected :reason :unknown}))))
+      ;; Same-tick StrictMode-replay guard (DEV-only — DCEs in production, which
+      ;; has no StrictMode double-invoke): mark this disconnect PROVISIONAL and
+      ;; arm its settle. A reconnect BEFORE the settle is a synchronous replay
+      ;; (mount→cleanup→remount in one commit — no hide); a reconnect AFTER it is
+      ;; a genuine reveal that `connect!` proves an Activity hide (rf2-vxgfnd.44).
+      (when interop/debug-enabled?
+        (swap! st assoc :disconnect-provisional? true)
+        (arm-disconnect-settle! cell))
       ;; Host/root teardown in flight: attribute this cell to it (03 §4).
       (when (some? @teardown-collector)
         (swap! teardown-collector conj cell)))
@@ -1557,6 +1638,14 @@
   "The installed lease for target key `tk` (tool/test read), or nil."
   [^ViewCell cell tk]
   (get (:committed @(state cell)) tk))
+
+(defn latest-capture
+  "The cell's last finished render capture — the layout commit's input, and the
+  single capture a cell retains between renders (tool/test read; nil before the
+  first render). See `with-capture`: a render retains AT MOST this one capture,
+  overwritten by the next render, never accumulating (rf2-vxgfnd.44)."
+  [^ViewCell cell]
+  (:latest-capture @(state cell)))
 
 (defn revision
   "The cell's current revision integer (tool/test read)."

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -16,7 +16,10 @@
     - render RESOLVES + PROBES without ownership (via `reactive/with-capture`
       → `sub` → the observation port's `resolve-target`/`probe`); the
       LAYOUT commit acquires the CAPTURED targets. Abandoned renders
-      (StrictMode double-render, time-sliced tear-off) retain nothing.
+      (StrictMode double-render, time-sliced tear-off) acquire no ownership;
+      they retain only their one `:latest-capture` of values until the next
+      render overwrites it (at most one, never accumulating — see
+      `reactive/with-capture`).
     - the reconcile layout effect runs after EVERY committed render and is
       idempotent (kept-check retains unchanged leases untouched); the
       lifecycle layout effect (empty deps) owns connect/disconnect, so
@@ -106,7 +109,12 @@
         ;; lifecycle — connect implicitly via the reconcile above; the cleanup
         ;; releases owners on React unmount AND Activity hide (indistinguishable
         ;; here — 03 §4). Reveal re-mounts this effect and the reconcile
-        ;; reacquires + corrects before paint. On mount the cell ENROLS under its
+        ;; reacquires + corrects before paint. In DEV, React StrictMode
+        ;; double-invokes this effect (mount→cleanup→remount in one commit), so
+        ;; every sub node churns through a zero-owner dispose/rebuild — an
+        ;; inherent dev cost, balanced by the idempotent reconcile; the
+        ;; same-commit reconnect is NOT a hide and `reactive/connect!` does not
+        ;; log an Activity-hide proof for it (rf2-vxgfnd.44). On mount the cell ENROLS under its
         ;; root incarnation (`attach-root!`, rf2-vxgfnd.85/.92) — an ownership that
         ;; SURVIVES the hide-cleanup, so root teardown reaps a cell hidden before
         ;; its unmount window. Keyed on the incarnation identity, so a re-mount

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -87,6 +87,35 @@
       (is (nil? (entry [:r/b]))
           "the 10k-abandoned-renders-retain-zero property holds at the cell"))))
 
+(deftest abandoned-render-retains-at-most-one-capture
+  ;; rf2-vxgfnd.44 (finding b) — an abandoned render acquires no OWNERSHIP
+  ;; (proven above), but it DOES stash its one `:latest-capture` of values, which
+  ;; lingers until the next render overwrites it. The honest bound is AT MOST ONE
+  ;; capture retained per cell — never accumulating. (`with-capture` cannot clear
+  ;; on abandon: StrictMode's effect replay re-commits the SAME capture with no
+  ;; intervening render, so the stash is REQUIRED, not a leak — hence the
+  ;; docstring is the fix, not a clear.)
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [cell (reactive/make-cell ::v)]
+    (is (nil? (reactive/latest-capture cell)) "no capture before the first render")
+    ;; an abandoned render (never committed) stashes exactly its one capture
+    (render! cell [[:r/a]])
+    (let [cap1 (reactive/latest-capture cell)]
+      (is (some? cap1) "the abandoned render retained its capture")
+      (is (= [(tk [:r/a])] (:order cap1)) "the capture holds this render's site")
+      ;; the NEXT render OVERWRITES it — captures never accumulate
+      (render! cell [[:r/b]])
+      (let [cap2 (reactive/latest-capture cell)]
+        (is (not (identical? cap1 cap2)) "the next render replaced the capture")
+        (is (= [(tk [:r/b])] (:order cap2))
+            "exactly ONE capture retained — the latest; the prior is gone")))
+    ;; N further abandoned renders still leave exactly ONE capture, not N
+    (dotimes [_ 1000] (render! cell [[:r/a]]))
+    (is (= [(tk [:r/a])] (:order (reactive/latest-capture cell)))
+        "1000 abandoned renders retain ONE capture (the last) — never accumulate")))
+
 ;; ===========================================================================
 ;; commit installs + reads; kept-check retains untouched
 ;; ===========================================================================
@@ -350,13 +379,45 @@
       (is (= {:state :disconnected :reason :unknown}
              (peek (reactive/intervals cell)))))
 
-    (testing "a reconnect reacquires AND retroactively proves an Activity hide"
+    (testing "a SETTLED disconnect then reconnect proves a genuine Activity hide"
+      ;; Model the host yield of a genuine reveal: the disconnect outlived its
+      ;; synchronous commit (on CLJS a microtask settles it; headless we settle
+      ;; explicitly). Only a SETTLED disconnect, on reconnect, proves a hide —
+      ;; an UNSETTLED same-commit reconnect is a StrictMode replay (rf2-vxgfnd.44,
+      ;; see `lifecycle-strictmode-replay-does-not-fabricate-hide-proof`).
+      (reactive/settle-disconnect! cell)
       (render+commit! cell [[:r/a]])
       (is (= :connected (reactive/lifecycle cell)))
       (is (= 1 (ref-count [:r/a])) "reveal reacquires")
       (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
              (peek (reactive/intervals cell)))
           "the PRIOR interval is annotated — never the present"))))
+
+(deftest lifecycle-strictmode-replay-does-not-fabricate-hide-proof
+  ;; rf2-vxgfnd.44 — React StrictMode's dev effect double-invoke is
+  ;; mount→cleanup→remount within ONE synchronous commit: connect → disconnect →
+  ;; reconnect with NO host yield between them, so the disconnect never settles.
+  ;; That reconnect is NOT an Activity hide — the runtime observed neither a hide
+  ;; nor an unmount — and it must NOT be annotated `:activity-hidden` (the pre-fix
+  ;; false proof). Headless model of the replay: drive the sequence with NO
+  ;; `settle-disconnect!` before the reconnect, exactly as the synchronous
+  ;; StrictMode replay leaves it (the settle microtask has not yet fired).
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[:r/a]])
+    (is (= :connected (reactive/lifecycle cell)))
+    (reactive/disconnect! cell)
+    (is (= :disconnected (reactive/lifecycle cell)))
+    ;; NO settle — the replay reconnects within the same synchronous commit.
+    (render+commit! cell [[:r/a]])
+    (is (= :connected (reactive/lifecycle cell)) "the replay reconnects")
+    (is (= {:state :disconnected :reason :unknown}
+           (peek (reactive/intervals cell)))
+        "the same-commit replay disconnect stays :unknown — NOT upgraded to
+         :activity-hidden; the runtime never observed a hide (rf2-vxgfnd.44)")
+    (is (not-any? #(= :activity-hidden (:reason %)) (reactive/intervals cell))
+        "no interval carries a fabricated Activity-hide proof")))
 
 (deftest lifecycle-host-teardown-proves-unmount
   (rf/reg-sub :r/a (fn [db _] (:a db)))

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -126,6 +126,11 @@
              (peek (reactive/intervals cell)))
           "the immediate fact — not :unmounted, and the cell is NOT :dead"))
     (testing "a reveal reconnects and proves the prior interval an Activity hide"
+      ;; a GENUINE hide→reveal: the disconnect outlived its commit (settle models
+      ;; the host yield a real reveal spans; on CLJS a microtask does this). Only
+      ;; a SETTLED disconnect proves a hide — an unsettled same-commit reconnect
+      ;; is a StrictMode dev replay (rf2-vxgfnd.44).
+      (reactive/settle-disconnect! cell)
       (render+commit! cell fid [[:rt/a]])
       (is (= :connected (reactive/lifecycle cell)) "reconnected, never :dead")
       (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
@@ -183,6 +188,10 @@
     (is (= :disconnected (reactive/lifecycle cell)) "hidden, not :dead")
     (is (= 1 (reactive/root-cell-count inc)) "still owned — reapable only by ITS root")
     (testing "a reveal reconnects and proves the interval an Activity hide"
+      ;; GENUINE hide→reveal — settle models the host yield a real reveal spans;
+      ;; an unsettled same-commit reconnect would be a StrictMode dev replay and
+      ;; must NOT be proven a hide (rf2-vxgfnd.44).
+      (reactive/settle-disconnect! cell)
       (render+commit! cell fid [[:rt/a]])
       (is (= :connected (reactive/lifecycle cell)))
       (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}

--- a/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
@@ -105,6 +105,10 @@
     (reactive/disconnect! cell)
     (is (= :disconnected (reactive/lifecycle cell)) "hidden, not :dead")
     (testing "a reveal reconnects and proves the interval an Activity hide"
+      ;; GENUINE hide→reveal — settle models the host yield a real reveal spans;
+      ;; an unsettled same-commit reconnect is a StrictMode dev replay and must
+      ;; NOT be proven a hide (rf2-vxgfnd.44).
+      (reactive/settle-disconnect! cell)
       (rf/with-frame :ri/frame
         (reactive/with-capture cell (fn [] (reactive/sub-read [:ri/a]))))
       (reactive/commit! cell)


### PR DESCRIPTION
Two dev-only lifecycle-evidence honesty fixes in the S2b reactive core (03 §4). Both live in `viewcell.cljs` + `reactive.cljc`.

## (a) StrictMode replay no longer fabricates a proven Activity hide

`connect!` treated **every** `:disconnected` → `:connected` transition as proof of an Activity hide (`:activity-hidden {:proof :reconnect}`). But React StrictMode's dev effect double-invoke is mount→cleanup→remount within **one synchronous commit**: the cell goes connect → disconnect → reconnect with no host yield between them. That reconnect is neither a hide nor an unmount, so the annotation was a proof the runtime never observed — logged on **every** dev mount of a sub-bearing view.

**Fix (settle model):** a disconnect is marked **provisional** and **settles** once it outlives its synchronous commit — a CLJS microtask armed by `disconnect!` (fires after the commit unwinds, before paint, so only a same-commit StrictMode replay can reconnect ahead of it), or an explicit `settle-disconnect!` on a headless host (models the host yield of a real reveal). Only a **settled** disconnect, on reconnect, proves a hide; an unsettled same-commit reconnect (the StrictMode replay) leaves the interval `:unknown`. DEV-only and DCE-gated on `interop/debug-enabled?` — production has no StrictMode double-invoke, so `:disconnect-provisional?` is never set and a reveal is proven exactly as before.

Approach chosen: **behaviour fix via a same-commit/host-yield heuristic** (not a blanket downgrade) — it keeps the genuine hide→reveal proof intact while refusing the fabricated one.

## (b) `with-capture` docstring now tells the truth

The docstring claimed an abandoned render "leaves only unreachable garbage." In fact every completed thunk stashes its capture on the cell as `:latest-capture` (targets + evidence + values) until the next render overwrites it — at most one, never accumulating, but **not zero**. Clearing on abandon is not viable: StrictMode's effect replay re-commits the **same** capture with no intervening render, so the stash is required, not a leak. **Docstring corrected** (option: honest docstring, per the bead); `latest-capture` tool/test read added. The ns + `viewcell.cljs` docstrings' "retain nothing" claims are clarified to "no ownership; at most one capture".

## Tests

- **Headless graft** (`reactive-reconcile-cljs-test`, `.cljc`, both hosts): new `lifecycle-strictmode-replay-does-not-fabricate-hide-proof` models the replay (no settle → interval stays `:unknown`, no `:activity-hidden`); the existing genuine-reveal test now settles before reconnect (settle → `:activity-hidden`). **Verified the false proof FIRES pre-fix** (temporarily reverting the `connect!` gating makes the replay test fail with `{:reason :activity-hidden :proof :reconnect}`).
- New `abandoned-render-retains-at-most-one-capture` pins finding (b): exactly one capture retained, overwritten by the next render, never accumulating across 1000 renders.
- Genuine hide→reveal callers updated to settle (`reactive-root-teardown-cljs-test` ×2, `root-incarnation-wiring-cljs-test`).
- The real-spine genuine Activity-hide→reveal DOM test (`root-incarnation-activity-dom-cljs-test`) still proves `:activity-hidden` — stays green under the new microtask settle. (A real-React StrictMode double-invoke DOM fixture was attempted but the `flushSync` mount path in this browser runner does not trigger the double-invoke without the `act()`/`IS_REACT_ACT_ENVIRONMENT` scaffolding; the headless graft is the definitive replay proof, per the established pattern.)

## Quality gates

All foreground, 0-fail:

- `clojure -M:test` (ui, JVM): **326 tests, 4820 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node): **9085 tests, 42944 assertions, 0 failures, 0 errors**
- `npm run test:browser`: **304 tests, 1104 assertions, 0 failures, 0 errors**
