### PR TITLE
docs(ui): finish the drain-batch contract sweep (spec/004 + docstrings) (rf2-vxgfnd.66)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -597,7 +597,7 @@
   fires after the synchronous drain unwinds and BEFORE the next paint, so a
   watch-fired invalidation is corrected before a torn frame can show
   (rf2-vxgfnd.40). The JVM headless host has NO async render loop to align
-  to — its epoch close is the EXPLICIT `flush!` (07 §2 'the only flush
+  to — its drain-quiescence flush is the EXPLICIT `flush!` (07 §2 'the only flush
   idiom'; SSR renders one-shot) — and `interop/next-tick` there is a
   CONCURRENT executor, not a microtask, so a background auto-drain would
   race synchronous callers. One honest option per host, not a pretended same

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -26,7 +26,7 @@
       React unmount / Activity hide releases owners and reveal reacquires
       and corrects before paint.
 
-  ## Epoch close → React (S2d)
+  ## Drain quiescence → React (S2d)
 
   Sub deltas do NOT re-render synchronously. A moving site's `on-change`
   (registered at commit) marks the cell dirty in `reactive`'s dirty

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -1,7 +1,8 @@
 (ns re-frame.ui.reactive-epoch-cljs-test
   "rf2-vxgfnd.10 (S2d) — epoch coalescing + `flush!` scope over the ViewCell
-  notification scheduler (03 §3 invariant 6 'epoch close notifies each dirty
-  cell once'; Spec 006 §Epoch finalization). Headless fixtures on the REAL
+  notification scheduler (03 §3 invariant 6 'one notification per cell per
+  render batch — the boundary is drain quiescence, not epoch close'; Spec 006
+  §Epoch finalization). Headless fixtures on the REAL
   observation port + plain-atom sub-cache — the value-movement `on-change`
   watch channel is a reactive-host surface, so these fixtures drive the
   notification seam DIRECTLY (`mark-dirty!` with an epoch tag) exactly the

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -274,7 +274,8 @@ closure cost, and defeat the data idiom — the nudge is deliberate).
 **synchronously within the DOM event** — event → drain → commit → snapshot advance
 before React's discrete-event re-render — so value round-trips cannot drop characters,
 jump the caret, or break IME composition. This is the one sanctioned synchronous door;
-everything else batches (one notification per cell per epoch, I-6). Caret/IME
+everything else batches (one notification per cell per render batch — the
+drain-quiescence boundary, not epoch close; I-6). Caret/IME
 correctness gates first, latency second. **The trigger predicate (confirmed by the
 controlled-input door spike; the residual named gate is the G-8 real-browser input
 matrix, not the predicate):** the door applies where the compiler can *prove* the element
@@ -293,7 +294,7 @@ registers later can produce a false positive; the warning names that possibility
 `(sub [:query …])` returns the subscription's value — no deref, no manual memoization,
 no deps arrays. Each lexical `(sub …)` is a compile-indexed site; all of a view's sites
 share **one** React bridge (one `useSyncExternalStore`, one scalar revision snapshot,
-one notification per epoch — I-3/I-4/I-6). Conditional reads are legal; `sub` in loops
+one notification per render batch — I-3/I-4/I-6). Conditional reads are legal; `sub` in loops
 is a compile error (sites must be finite — extract a keyed child view). Literal queries
 are module constants; parametric sites reuse the prior query object while args are
 `rf=`; sites return the prior exact value when the new read is `rf=`. The observation


### PR DESCRIPTION
Finishes the drain-batch contract sweep (rf2-vxgfnd.66) across the remaining **tracked** re-frame.ui surfaces, so nothing still teaches the superseded "one notification per cell per epoch" / "epoch close flushes" model. Source of truth is the .45/.65 correction in spec/006 §Epoch finalization + invariant 6: the render batch boundary is **drain quiescence**, an epoch is the **write/evidence** unit (not a render trigger), N epochs in one drain fold into **one** render batch, and the CLJS flush is a **true microtask** (`queueMicrotask`, not `goog.async.nextTick`).

Scope note: the 01/03/05/07 synthesis docs named in the original bead are `ai/` gitignored working docs (mayor-local, not PR-able) and are deliberately **not** touched here. This PR is the tracked-surface remainder only.

## Changes

- **`spec/004-Views.md`** (HOT-ZONE — flagged): controlled-input door prose "one notification per cell per epoch" → "one notification per cell per render batch — the drain-quiescence boundary, not epoch close"; `sub`/React-bridge prose "one notification per epoch" → "one notification per render batch".
- **`implementation/ui/src/re_frame/ui/viewcell.cljs`** (docstring only): heading "Epoch close → React (S2d)" → "Drain quiescence → React (S2d)". The docstring body was already correct (coalesced once per cell per DRAIN; true microtask; NOT `goog.async.nextTick`).
- **`implementation/ui/src/re_frame/ui/reactive.cljc`** (docstring only): JVM headless flush described as "its epoch close is the EXPLICIT `flush!`" → "its drain-quiescence flush is the EXPLICIT `flush!`".
- **`implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc`** (ns docstring only): the quoted invariant-6 text `'epoch close notifies each dirty cell once'` was the *superseded* wording quoted as current — corrected to the shipped invariant. **No assertion changed** — the gate assertions ("8 epochs in one drain ⇒ ONE revision advance", "render separation follows DRAIN boundaries, never the epoch count") were already aligned to the corrected model.

Docstring/prose only; **no behavior change**. The `reactive.cljc` / test assertions and the rest of the viewcell docstring were already correct from .45/.65 — the only residual stale artefacts were the four wording spots above.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0 ✅ (spec/004 touched)
- ui `clojure -M:test` — 326 tests, 4820 assertions, 0 failures, 0 errors ✅
- `npm run test:cljs` — 9084 tests, 42943 assertions, 0 failures, 0 errors ✅

Closes rf2-vxgfnd.66.