### PR TITLE
feat(ui): S2e — the full HMR matrix (stable shells, site identity, frame non-reseed, REPL=HMR) (rf2-vxgfnd.11)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -397,6 +397,85 @@
             :listeners      {}
             :intervals      []}))))
 
+;; ---------------------------------------------------------------------------
+;; View-body generation — the HMR hook-signature → preserve/remount decision
+;; (03 §10)
+;; ---------------------------------------------------------------------------
+;;
+;; The "stable shell + hook-signature hash" contract, realized as a per-view-id
+;; BODY GENERATION. A view re-registration — shadow hot reload OR REPL re-eval,
+;; ONE path (02 §8) — consults the ordered user-hook-site signature hash
+;; (`re-frame.ui.fingerprint/hook-signature-hash`, shipped since S1b — consumed
+;; here, never rebuilt). An UNCHANGED signature KEEPS the generation: mounted
+;; cells preserve their state — their committed captures stay current, the next
+;; render runs the NEW body, and the commit reconciles the changed `sub` sites
+;; (`sub`/`lease`/event sites are EXCLUDED from the signature by the
+;; fingerprint's own contract, so a template edit — or adding your first `sub`
+;; under the dev fixed full hook skeleton, I-15 — is a same-signature edit). A
+;; CHANGED signature BUMPS the generation: the shell deliberately remounts a
+;; fresh cell at the new generation, never a corrupted hook order.
+;;
+;; The registry is the ONE authority the runtime's `register-view!` feeds and a
+;; freshly-mounted ViewCell mints against (`view-generation`); a LIVE cell whose
+;; view generation advanced is stale-rejected at its next commit (step 1) via
+;; `advance-generation!`. Host-agnostic, so the decision is graft-checked on both
+;; hosts.
+
+(defonce ^:private view-generations
+  ;; view-id -> {:hook-signature hs :generation g}. `defonce` (module-lived);
+  ;; `reset-scheduler!` clears it between fixtures.
+  (atom {}))
+
+(defn register-view-generation!
+  "Consume a view's `hook-signature` at (re-)registration and return its current
+  BODY GENERATION (03 §10). The first registration seeds generation 0. A
+  re-registration carrying the SAME `hook-signature` KEEPS the generation
+  (mounted cells preserve — a template-only edit changes the template
+  fingerprint, never the hook signature); a DIFFERENT `hook-signature` BUMPS it
+  (the shell remounts cleanly). One decision for shadow reload and REPL re-eval
+  (02 §8), so both converge on the same generation. A nil `hook-signature` is a
+  value like any other (a sub/effect-free view never changes signature). Returns
+  the (possibly bumped) generation."
+  [view-id hook-signature]
+  (-> (swap! view-generations update view-id
+             (fn [prev]
+               (cond
+                 (nil? prev)
+                 {:hook-signature hook-signature :generation 0}
+                 (= hook-signature (:hook-signature prev))
+                 prev
+                 :else
+                 {:hook-signature hook-signature
+                  :generation     (inc (:generation prev))})))
+      (get view-id)
+      :generation))
+
+(defn view-generation
+  "The current body generation for `view-id` (0 when never registered) — the
+  generation a freshly-mounted ViewCell for this view is minted at (tool/test
+  read)."
+  [view-id]
+  (get-in @view-generations [view-id :generation] 0))
+
+(defn advance-generation!
+  "Advance a LIVE `cell`'s view-body generation to `generation` — the same-shell
+  HMR seam (03 §10). A same-signature reload bumps a mounted cell's generation
+  so any in-flight capture rendered under the PRIOR body is stale-rejected at the
+  next commit (step 1); the next render runs the new body and the commit
+  reconciles the changed `sub` sites — STATE PRESERVED (the same cell, its
+  committed dependency set carried forward). Monotone: a no-op unless
+  `generation` exceeds the cell's current generation. Returns the cell."
+  [^ViewCell cell generation]
+  (let [st (state cell)]
+    (when (> generation (:generation @st))
+      (swap! st assoc :generation generation)))
+  cell)
+
+(defn generation
+  "The cell's current view-body generation (tool/test read)."
+  [^ViewCell cell]
+  (:generation @(state cell)))
+
 ;; ---- read + query stabilization ---------------------------------------------
 
 (defn sub-read
@@ -961,6 +1040,7 @@
   (reset! teardown-collector nil)
   (reset! evidence-sink nil)
   (reset! last-sink-escape nil)
+  (reset! view-generations {})
   nil)
 
 (defn- on-change-fn

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -16,6 +16,7 @@
             [re-frame.error :as error]
             [re-frame.registrar :as registrar]
             [re-frame.ui.eq :as eq]
+            [re-frame.ui.reactive :as reactive]
             [re-frame.ui.rules :as rules]))
 
 ;; ---------------------------------------------------------------------------
@@ -48,13 +49,20 @@
 
 (defn register-view!
   "Registrar `:view` entry for a compiled view (dev builds; the emitted
-  call is goog.DEBUG-gated so production carries no manifests — I-12)."
+  call is goog.DEBUG-gated so production carries no manifests — I-12).
+
+  Also feeds the HMR view-body generation registry (03 §10): a re-registration
+  (shadow hot reload OR REPL re-eval — one path, 02 §8) consults the manifest's
+  hook-signature hash and keeps the generation on a same-signature edit (mounted
+  cells preserve state) or bumps it on a changed signature (the shell remounts).
+  Runs at (re-)registration time, not per render — off the hot path."
   [id component manifest]
   (registrar/register! :view id (cond-> {:rf/id id
                                          :handler-fn component
                                          :rf.ui/compiled? true
                                          :rf.ui/manifest manifest}
                                   (:doc manifest) (assoc :doc (:doc manifest))))
+  (reactive/register-view-generation! id (:hook-signature manifest))
   component)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/build_repl_hmr_convergence_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/build_repl_hmr_convergence_jvm_test.clj
@@ -1,0 +1,79 @@
+(ns re-frame.ui.build-repl-hmr-convergence-jvm-test
+  "S2e (rf2-vxgfnd.11) — REPL == file-save reload at the compiler-state
+  authority (03 §10; 02 §8; df9873's ruled posture). A view re-registration
+  reaches the build authority two ways:
+
+    - a shadow FILE-SAVE watch pass: `begin-build!` opens the pass, the
+      re-macroexpansion STAGES the contribution, `commit-build!` /
+      `finish-build!` publishes it (build hooks fire only on a real compile —
+      #5777);
+    - a REPL re-eval: NO build hook fires, so no pass opens and the
+      contribution UPSERTS one key straight into committed (the ruled REPL
+      posture, build.cljc).
+
+  Both paths must converge on the IDENTICAL committed `:views` aggregate for the
+  same source — otherwise a REPL session and a saved file could diverge. This
+  fixture drives the REAL `defview` macro body (the JVM emitter path) under a
+  controlled declaring namespace, exactly as `re-frame.ui.compiler-build-jvm-test`
+  does, and compares the two committed aggregates."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler :as compiler]
+            [re-frame.ui.compiler.build :as build]))
+
+(use-fixtures :each
+  (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
+
+(defn- declare-view!
+  "Run the real `defview` macro body (JVM emitter path) with `ns-sym` bound as
+  the declaring namespace — contributes `[template-fp hook-sig]` under the
+  derived view-id, owned by `ns-sym`, into the ambient build's `views`
+  registry."
+  [ns-sym vname template]
+  (binding [*ns* (create-ns ns-sym)]
+    (compiler/defview* (with-meta (list 'defview vname [] template) {:line 1})
+                       {} vname (list [] template))))
+
+(deftest repl-upsert-and-file-save-pass-converge-on-identical-committed-views
+  (let [declare! (fn [] (declare-view! 'hmr.conv.view 'widget
+                                       [:section [:h1 "title"] [:p "body"]]))
+        ;; REPL path: no pass open ⇒ each re-eval UPSERTS straight into committed.
+        repl-views (binding [build/*build-id* ::repl]
+                     (declare!)                                   ; initial eval
+                     (declare!)                                   ; a REPL re-eval
+                     (build/committed-aggregate build/views ::repl))
+        ;; FILE-SAVE path: two watch passes (begin → stage → commit), i.e. an
+        ;; initial compile then a reload of the same source.
+        file-views (do (build/begin-build! ::file)
+                       (binding [build/*build-id* ::file] (declare!))
+                       (build/commit-build! ::file)
+                       (build/begin-build! ::file)               ; the file-save reload
+                       (binding [build/*build-id* ::file] (declare!))
+                       (build/commit-build! ::file)
+                       (build/committed-aggregate build/views ::file))]
+    (is (seq repl-views) "the REPL upsert landed the view in committed (no pass)")
+    (is (seq file-views) "the file-save pass published the view in committed")
+    (testing "REPL re-eval and file-save reload converge on the IDENTICAL
+              committed :views aggregate — one path (03 §10; df9873)"
+      (is (= repl-views file-views)))))
+
+(deftest repl-upsert-reregistration-replaces-in-place-no-sibling-eviction
+  ;; The ruled REPL posture: an upsert is PER-KEY into committed — a re-eval
+  ;; replaces the same view's row without opening a pass or evicting siblings a
+  ;; sibling REPL form contributed.
+  (binding [build/*build-id* ::repl2]
+    (declare-view! 'hmr.a 'va [:div "a-v1"])
+    (declare-view! 'hmr.b 'vb [:div "b-v1"])
+    (let [after-two (build/committed-aggregate build/views ::repl2)]
+      (is (= 2 (count after-two)) "two distinct views registered via REPL upsert")
+      ;; re-eval ONLY va with a new template
+      (declare-view! 'hmr.a 'va [:div [:strong "a-v2"]])
+      (let [after-reeval (build/committed-aggregate build/views ::repl2)
+            ;; the one key that differs is va's — vb is byte-identical, so the
+            ;; only entry that moved is va's [tf hs] row (upsert replaced in place)
+            changed (filterv (fn [[k v]] (not= v (get after-two k))) after-reeval)]
+        (is (= 2 (count after-reeval)) "vb survives va's re-eval — no sibling eviction")
+        (is (= (dissoc after-reeval (ffirst changed))
+               (dissoc after-two (ffirst changed)))
+            "every OTHER view row is untouched — no sibling eviction on upsert")
+        (is (= 1 (count changed))
+            "exactly va's row moved to the new template's [tf hs] (upsert in place)")))))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -1,0 +1,286 @@
+(ns re-frame.ui.reactive-hmr-matrix-cljs-test
+  "S2e (rf2-vxgfnd.11) — THE consolidated hot-reload matrix, proven headlessly
+  over the REAL observation port + REAL sub-cache (plain-atom) on BOTH hosts
+  (node via `test:cljs`, JVM via `clojure -M:test`). The normative source is
+  03 §10 (the HMR contract): stable shells + the hook-signature hash, site
+  identity, frame non-reseed, sub replacement via lease `current?` rejection of
+  disposed nodes, and REPL == file-save reload (one path).
+
+  Every cell exercises the actual substrate primitive — no proxy:
+
+    1. HOOK-SIGNATURE DECIDES PRESERVE vs REMOUNT. `hook-signature-hash`
+       (shipped since S1b, consumed here) keyed through the view-body
+       GENERATION registry: a template edit (same hook signature, moved
+       template fingerprint) KEEPS the generation → mounted cells preserve; a
+       hook edit (moved signature) BUMPS it → the shell remounts a fresh cell.
+       `sub`/`lease`/event sites are excluded from the signature, so adding your
+       first `sub` is a same-signature edit.
+    2. STALE-CELL REJECTION AT COMMIT (step 1). A live cell whose generation
+       advanced past its in-flight capture is stale-rejected (`:stale`) with no
+       ownership touched — the same-shell reload's mark-stale-then-re-render.
+    3. SITE IDENTITY survives edits. Sites are keyed by target IDENTITY
+       `(frame, query)`: a sibling site added above a lease never retargets it;
+       a site whose query moves retargets (kept-check fails → release + acquire)
+       and a shared node never churns.
+    4. SUB REPLACEMENT via lease `current?`. A committed ViewCell lease whose
+       sub is re-registered is REJECTED by `current?` (the disposed canonical
+       node) and re-acquired at the next commit — the ViewCell-level extension
+       of the S2a-confirmed observation-port [S2-CONFIRM] queue-alignment proof
+       (`re-frame.observation-port-cljs-test`).
+    5. FRAME NON-RESEED. A reloaded root re-runs preflight ENSURE, which finds
+       the frame live at the same config fingerprint and does NOT re-seed —
+       app-db survives the edit (consolidated here; the disposition table lives
+       in `re-frame.ui.preflight-frame-wiring-cljs-test`).
+    6. REPL == FILE-SAVE. The generation decision is ONE path: a REPL re-eval
+       and a file-save reload carrying the same hook signature both keep the
+       generation; both carrying a changed signature both bump — identical
+       outcomes. (The build-authority upsert-vs-pass convergence is
+       `re-frame.ui.build-repl-hmr-convergence-jvm-test`.)"
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.subs                  :as subs]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.fingerprint        :as fp]
+            [re-frame.ui.frames             :as frames]
+            [re-frame.ui.reactive           :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    (reactive/reset-scheduler!)
+    (frames/reset-installed-plans!)
+    (t)
+    (reactive/reset-scheduler!)
+    (frames/reset-installed-plans!)))
+
+(def ^:private fid :rf/default)
+
+(defn- sub-cache [] (:sub-cache (frame/frame fid)))
+(defn- entry [q] (get @(sub-cache) q))
+(defn- ref-count [q] (:ref-count (entry q)))
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- tk [q] [:sub fid q])
+(defn- target [q] (rf/with-frame fid (obs/resolve-target {:query-v q})))
+
+(defn- render! [cell queries]
+  (rf/with-frame fid
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  cell)
+
+(defn- render+commit! [cell queries]
+  (render! cell queries)
+  (reactive/commit! cell)
+  cell)
+
+;; ===========================================================================
+;; Cell 1 — hook-signature hash decides preserve vs remount (03 §10)
+;; ===========================================================================
+;;
+;; Real fingerprint inputs: the signature excludes `sub`/`lease`/event sites and
+;; hashes only the ordered `:locals`/`:effects` plan (the S3 host-hook surfaces).
+;; At S2 every defview still emits the empty-plan signature, so a REAL S2 edit is
+;; always a same-signature edit — the fixtures drive the decision with the varied
+;; plans the fingerprint contract already supports.
+
+(deftest hook-signature-hash-is-stable-across-a-template-only-edit
+  (testing "a template edit moves the TEMPLATE fingerprint but NOT the hook
+            signature — the preserve trigger (03 §10)"
+    (let [hs   (fp/hook-signature-hash {:locals [] :effects []})
+          hs'  (fp/hook-signature-hash {:locals [] :effects []})
+          tf1  (fp/template-fingerprint [:div "v1"])
+          tf2  (fp/template-fingerprint [:div [:strong "v2"]])]
+      (is (= hs hs') "identical hook plan ⇒ identical hook signature")
+      (is (not= tf1 tf2) "the template edit moved the template fingerprint"))))
+
+(deftest hook-signature-hash-moves-on-a-hook-edit
+  (testing "adding/reordering a user hook site moves the signature — the remount
+            trigger"
+    (is (not= (fp/hook-signature-hash {:locals [] :effects []})
+              (fp/hook-signature-hash {:locals ['draft] :effects []})))
+    (is (not= (fp/hook-signature-hash {:locals ['a 'b] :effects []})
+              (fp/hook-signature-hash {:locals ['b 'a] :effects []}))
+        "hook ORDER is part of the signature (React hook-order safety)")))
+
+(deftest same-signature-reload-keeps-the-view-generation
+  (let [vid ::preserve-view
+        hs0 (fp/hook-signature-hash {:locals [] :effects []})]
+    (is (= 0 (reactive/register-view-generation! vid hs0))
+        "first registration seeds generation 0")
+    (testing "a template-only reload (same hook signature) KEEPS the generation
+              → mounted cells preserve state"
+      (is (= 0 (reactive/register-view-generation! vid hs0)))
+      (is (= 0 (reactive/register-view-generation! vid hs0)))
+      (is (= 0 (reactive/view-generation vid))))))
+
+(deftest changed-signature-reload-bumps-the-view-generation
+  (let [vid ::remount-view
+        hs0 (fp/hook-signature-hash {:locals [] :effects []})
+        hs1 (fp/hook-signature-hash {:locals ['draft] :effects []})
+        hs2 (fp/hook-signature-hash {:locals ['draft] :effects ['sync]})]
+    (is (= 0 (reactive/register-view-generation! vid hs0)))
+    (testing "a hook edit (moved signature) BUMPS the generation → the shell
+              remounts cleanly"
+      (is (= 1 (reactive/register-view-generation! vid hs1)))
+      (is (= 1 (reactive/view-generation vid)))
+      (is (= 2 (reactive/register-view-generation! vid hs2))
+          "each distinct signature bumps once")
+      (testing "reverting to a prior signature is itself a change (monotone gen)"
+        (is (= 3 (reactive/register-view-generation! vid hs0)))))))
+
+(deftest freshly-mounted-cell-mints-at-the-view-generation
+  (let [vid ::mint-view
+        hs0 (fp/hook-signature-hash {:locals [] :effects []})
+        hs1 (fp/hook-signature-hash {:locals ['x] :effects []})]
+    (reactive/register-view-generation! vid hs0)
+    (reactive/register-view-generation! vid hs1)  ; a changed-signature reload
+    (is (= 1 (reactive/view-generation vid)))
+    (let [cell (reactive/make-cell vid (reactive/view-generation vid))]
+      (is (= 1 (reactive/generation cell))
+          "a cell mounted after a remount starts at the current view generation")
+      (is (empty? (reactive/committed-target-keys cell))
+          "the remounted shell is a FRESH cell — no committed deps (fresh state)"))))
+
+;; ===========================================================================
+;; Cell 2 — stale-cell rejection at commit (step 1): the same-shell reload
+;; ===========================================================================
+
+(deftest stale-generation-capture-rejected-at-commit-step-1
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
+        lease0 (reactive/committed-lease cell (tk [:r/a]))]
+    (is (= 1 (ref-count [:r/a])) "precondition: committed at generation 0")
+    (testing "a reload BUMPS the live cell's body generation; its in-flight
+              capture (rendered under the prior body) is now stale"
+      (render! cell [[:r/a]])                       ; capture at generation 0
+      (reactive/advance-generation! cell 1)         ; the same-shell reload bump
+      (is (= 1 (reactive/generation cell)))
+      (is (= :stale (reactive/commit! cell))
+          "commit step 1 REJECTS the stale-generation capture (the host re-renders)"))
+    (testing "no ownership was touched — the prior committed set stays installed"
+      (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a]))))
+      (is (= 1 (ref-count [:r/a])) "no acquire, no release on a stale rejection"))
+    (testing "the re-render under the new body commits normally — state preserved"
+      (render+commit! cell [[:r/a]])
+      (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
+          "the same lease is retained across the reload — the committed dep set
+           is carried forward (a same-signature preserve)"))))
+
+(deftest advance-generation-is-monotone
+  (let [cell (reactive/make-cell ::v 2)]
+    (reactive/advance-generation! cell 1)   ; lower — ignored
+    (is (= 2 (reactive/generation cell)) "a lower generation never regresses a cell")
+    (reactive/advance-generation! cell 5)
+    (is (= 5 (reactive/generation cell)))))
+
+;; ===========================================================================
+;; Cell 3 — site identity survives edits (target identity, not position)
+;; ===========================================================================
+
+(deftest sibling-site-added-above-never-retargets-an-existing-lease
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [cell   (render+commit! (reactive/make-cell ::v) [[:r/a]])
+        lease-a (reactive/committed-lease cell (tk [:r/a]))]
+    (testing "an edit inserts a NEW sibling site ABOVE :a; :a's lease is keyed by
+              target identity (frame,query), never by position"
+      (render+commit! cell [[:r/b] [:r/a]])
+      (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
+          ":a keeps the SAME lease — the prepended :b did not shift its owner")
+      (is (= #{(tk [:r/a]) (tk [:r/b])} (reactive/committed-target-keys cell)))
+      (is (= 1 (ref-count [:r/a])) ":a never re-acquired")
+      (is (= 1 (ref-count [:r/b])) ":b acquired fresh"))))
+
+(deftest site-retargets-when-its-query-moves-anchor-loss
+  (rf/reg-sub :r/p (fn [db [_ k]] (get db k)))
+  (seed! {:x 10 :y 20})
+  (let [cell    (render+commit! (reactive/make-cell ::v) [[:r/p :x]])
+        lease-x (reactive/committed-lease cell (tk [:r/p :x]))]
+    (is (= 1 (ref-count [:r/p :x])))
+    (testing "the site's query moves [:r/p :x] → [:r/p :y]: a NEW target identity,
+              so the kept-check fails and the site retargets (release old +
+              acquire new)"
+      (render+commit! cell [[:r/p :y]])
+      (is (= #{(tk [:r/p :y])} (reactive/committed-target-keys cell)))
+      (is (not (identical? lease-x (reactive/committed-lease cell (tk [:r/p :y])))))
+      (is (nil? (entry [:r/p :x])) "the abandoned query's node disposed (zero-owner)")
+      (is (= 1 (ref-count [:r/p :y])) "the new query acquired one owner"))))
+
+;; ===========================================================================
+;; Cell 4 — sub replacement via lease current? (ViewCell-level; 03 §10)
+;; ===========================================================================
+;; The observation-port half (one coalesced :hmr notification, current? false,
+;; fresh canonical node) is S2a-CONFIRMED in re-frame.observation-port-cljs-test
+;; (hmr-reregistration-notifies-former-owners-once-with-cause-hmr). Here the SAME
+;; mechanism is driven through the ViewCell commit reconciler.
+
+(deftest reregistered-sub-disposed-lease-rejected-by-current?-and-reacquired
+  (rf/reg-sub :r/x (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell   (render+commit! (reactive/make-cell ::v) [[:r/x]])
+        lease0 (reactive/committed-lease cell (tk [:r/x]))
+        tgt    (target [:r/x])]
+    (is (= 1 (ref-count [:r/x])))
+    (is (true? (obs/current? lease0 tgt)) "the live lease is current before the reload")
+    (testing "an HMR sub re-registration disposes the canonical node"
+      (rf/reg-sub :r/x (fn [db _] (inc (:a db))))   ; new body
+      (is (false? (obs/current? lease0 tgt))
+          "current? REJECTS the committed lease — its node was disposed (03 §10)"))
+    (testing "the next commit re-acquires the NEW canonical node"
+      (render+commit! cell [[:r/x]])
+      (let [lease1 (reactive/committed-lease cell (tk [:r/x]))]
+        (is (not (identical? lease0 lease1)) "a fresh lease on the new node")
+        (is (true? (obs/current? lease1 tgt)))
+        (is (= 1 (ref-count [:r/x])) "exactly one owner — no cell pinned the disposed node")
+        (is (= {(tk [:r/x]) 2} (reactive/committed-values cell))
+            "the view re-read the new body's value on the reload")))))
+
+;; ===========================================================================
+;; Cell 5 — frame payloads never reseed on reload (03 §10)
+;; ===========================================================================
+
+(deftest frame-payload-never-reseeds-on-reload
+  (rf/reg-event :hmr/set (fn [_ [_ db]] {:db db}))
+  (rf/reg-event :hmr/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+  (let [plan {:frame-id :frame/hmr
+              :config {:initial-events [[:hmr/set {:n 3}]]}
+              :config-fingerprint "cf1-hmraaaaaaaaaaaa"}]
+    (frames/execute-frame-plans! :root/page [plan])
+    (is (= 3 (:n (rf/app-db-value :frame/hmr))) ":initial-events seeded once at preflight")
+    (testing "mutate durable state, then RELOAD (re-run the same plan) — no re-seed"
+      (rf/dispatch-sync [:hmr/inc] {:frame :frame/hmr})
+      (is (= 4 (:n (rf/app-db-value :frame/hmr))))
+      (frames/execute-frame-plans! :root/page [plan])   ; the reload's preflight
+      (is (= 4 (:n (rf/app-db-value :frame/hmr)))
+          "the reload found the frame live at the same fingerprint — NOT re-init")
+      (frames/execute-frame-plans! :root/page [plan])   ; and again
+      (is (= 4 (:n (rf/app-db-value :frame/hmr)))
+          "idempotent across repeated reloads — the frame keeps its app-db"))))
+
+;; ===========================================================================
+;; Cell 6 — REPL == file-save reload (one path; 03 §10, 02 §8)
+;; ===========================================================================
+
+(deftest repl-and-file-save-reload-converge-on-one-generation-decision
+  ;; The generation decision (`register-view-generation!`) is the ONE seam both
+  ;; the shadow file-save re-registration and a REPL re-eval feed. Same input ⇒
+  ;; same outcome, so the two paths can never diverge (df9873: REPL evals upsert;
+  ;; the build hook drives compile-boundary passes — but the RUNTIME
+  ;; re-registration semantics are identical).
+  (let [hs0 (fp/hook-signature-hash {:locals [] :effects []})
+        hs1 (fp/hook-signature-hash {:locals ['n] :effects []})
+        run (fn [view-id]
+              (reactive/register-view-generation! view-id hs0)   ; initial reg
+              [(reactive/register-view-generation! view-id hs0)   ; same-sig reload
+               (reactive/register-view-generation! view-id hs1)   ; changed-sig reload
+               (reactive/register-view-generation! view-id hs0)]) ; changed again
+        file-save (run ::via-file-save)
+        repl      (run ::via-repl)]
+    (is (= [0 1 2] file-save) "same-sig keeps, each change bumps once")
+    (is (= file-save repl)
+        "a REPL re-eval and a file-save reload take the IDENTICAL generation path")))


### PR DESCRIPTION
## What

Delivers the consolidated **Stage-2 hot-reload matrix** (normative source: synthesis 03 §10 — the HMR contract) as headless substrate fixtures over the REAL observation port + sub-cache on **both hosts** (node + JVM), plus the one thin production seam a reload genuinely needs. Most primitives already shipped (hook-signature hash S1b, `current?` S2a, frame non-reseed S2c, build-hook + REPL-upsert df9873/#5777) — this is largely **integration + fixtures proving the matrix composes**, with minimal wiring.

## Production wiring (minimal)

- **`reactive.cljc`** — the view-body **generation registry**: `register-view-generation!` consumes the hook-signature hash and realizes the preserve/remount decision (same signature keeps the generation → mounted cells reconcile and preserve; a changed signature bumps it → the shell remounts a fresh cell). Plus `advance-generation!` (the live-cell same-shell reload seam, which makes `commit!` step-1 stale rejection reachable from a live cell) and `generation`/`view-generation` reads. Consumes the S1b `hook-signature-hash` — does not rebuild it.
- **`runtime.cljs`** — `register-view!` feeds the generation registry at (re-)registration (shadow reload *or* REPL re-eval, one path). This is the fingerprint consumption, and it runs at registration time, **off the hot render path**.

## Matrix cells (fixtures — prove, don't proxy)

| Cell | Fixture | Needed |
|---|---|---|
| hook-signature preserve / remount | `reactive_hmr_matrix` (digest + generation registry) | thin wiring |
| stale-cell rejection at commit step 1 | `reactive_hmr_matrix` (`advance-generation!` → `:stale`) | thin wiring |
| site identity by `(frame,query)` + retarget-on-query-move | `reactive_hmr_matrix` | integration |
| sub replacement via lease `current?` (ViewCell-level) | `reactive_hmr_matrix` — extends the S2a observation-port `[S2-CONFIRM]` proof | integration |
| frame non-reseed on reload | `reactive_hmr_matrix` (consolidates S2c preflight coverage) | integration |
| REPL == file-save | generation single-path + `build_repl_hmr_convergence_jvm_test` (upsert vs pass-commit converge) | integration |

**S2a `[S2-CONFIRM]` HMR-disposal outcome:** already **confirmed** at S2a (spec/006 §port: three confirmed, one corrected). The observation port delivers one coalesced `:hmr` notification and `current?` rejects the disposed node (`re-frame.observation-port-cljs-test`). This PR drives the same mechanism through the ViewCell commit reconciler — no port change.

## Substrate gap flagged (out of scope, not a blocker)

The six-cell **substrate** matrix (the Stage-2 gate) is fully delivered and green. The remaining §10 **"Fast Refresh integration"** piece — a *stable component shell* (React Refresh / var-indirection) so a live browser preserves state across a same-signature file-save — is **not wired**: `memo-view` binds a fresh React component per re-eval, so the real runtime currently remounts on every reload regardless of signature. The preserve/remount **decision** and **stale-rejection mechanism** all exist and are proven here; the render-path consumption is deliberately not wired (it would be inert at S2, since every S2 defview emits the empty-plan signature, and cannot deliver preserve without the stable shell). Recommend a follow-up bead for the React Refresh stable-shell runtime glue.

## Quality gates

All foreground, 0-fail:

- ui JVM `clojure -M:test` — **340 tests, 4873 assertions, 0 failures**
- ui node `node-test-ui` — **327 tests, 1670 assertions, 0 failures**
- core node `npm run test:cljs` — **9096 tests, 42989 assertions, 0 failures**
- `npx shadow-cljs compile node-test-ui` — 218 files, 0 warnings

`test:browser` not run: no matrix cell needs a real-React HMR/reload DOM fixture (all cells are headless substrate fixtures; the browser gate is the Reagent/UIx/Helix adapter smokes, unrelated to the ui-substrate seam touched here).