### PR TITLE
ci(release): document day8/re-frame2-ui's deliberate absence from the release DAG (rf2-pc479y)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,24 @@
 # per rf2-2qit). The per-feature split set is now closed; further
 # additions require a new Spec-ulation increment.
 #
+# # The re-frame.ui substrate is deliberately absent (rf2-pc479y)
+#
+# implementation/ui/ (`day8/re-frame2-ui`; epic rf2-vxgfnd — the
+# compiled-view substrate that will replace the adapter trio) is a real,
+# JVM+CLJS-tested artefact — test.yml gates it at PR time via the jvm-ui
+# and cljs-ui-g1 jobs — but it is intentionally PRE-PUBLICATION: its
+# deps.edn carries no :clein/build alias "until the substrate is real".
+# So it has no pre-deploy test step and no deploy leaf here — by design,
+# not an omission. The publishing wiring (a jvm-ui pre-deploy step + a
+# deploy leaf after deploy-core + a verify-version-lockstep.sh inventory
+# entry + a release-notes line) lands in the SAME change that first gives
+# ui a :clein/build. That coupling is enforced, not merely documented:
+# verify-version-lockstep.sh's inventory guard (rf2-qmhysc) FAILS the
+# build the instant any implementation/*/deps.edn gains a :clein/build
+# without a matching lockstep-inventory + release-matrix entry — so ui
+# can neither be published nor silently omitted-once-publishable behind
+# the release train's back.
+#
 # # Lockstep versioning policy through 1.0
 #
 # Per the rf2-w05l decision: pre-1.0, every artefact ships at the same


### PR DESCRIPTION
## What this does

`rf2-pc479y` was filed by the W9 prep-doc sweep, which read `day8/re-frame2-ui`'s absence from `release.yml` (no pre-deploy test step, no deploy leaf) as a lockstep **violation-in-waiting**.

Investigation shows this is a **false positive**: `implementation/ui/` is *intentionally* pre-publication, and the concern the bead raises is **already structurally prevented**. So rather than add functional wiring (which would break things — see below), this PR converts the apparent-omission into a **documented, enforced decision** via a comment in `release.yml`'s topological-DAG header, so the next doc sweep doesn't re-file it.

## Why not add the deploy leaf / lockstep entry now

`implementation/ui/deps.edn` carries **no `:clein/build` alias** (and no `:clein` alias). Its header states this is deliberate — "publishing wiring lands with the stage that first publishes it" — and epic `rf2-vxgfnd` is mid-build (S1c; dozens of open S2–S7 sub-beads). Making the literal changes the bead requests would be actively harmful:

- A deploy leaf running `clojure -M:clein deploy` in `implementation/ui` would **fail** (no `:clein`/`:clein/build`) → breaks the release.
- Adding ui to `verify-version-lockstep.sh`'s `ARTEFACTS` inventory now would fail `check_version_and_no_mvn_literal` (ui has no `:version "../../VERSION"`) → **breaks the PR lockstep gate on every PR**.
- Adding `:clein/build` to ui's deps.edn is out-of-scope (implementation source), contradicts ui's documented intent, and would **prematurely publish an incomplete substrate to Clojars** (irreversible — Clojars has no yank).

## There is no silent-ship hole

`verify-version-lockstep.sh`'s inventory guard (`rf2-qmhysc`) **already** fails the build the instant any `implementation/*/deps.edn` gains a `:clein/build` without a matching lockstep-inventory + release-matrix entry. So ui can neither be published nor silently omitted-once-publishable behind the release train's back. ui is also already tested at PR time by `test.yml`'s `jvm-ui` + `cljs-ui-g1` jobs.

The functional publishing wiring (jvm-ui pre-deploy step + deploy leaf after `deploy-core` + `verify-version-lockstep.sh` inventory entry + release-notes line) lands with the ui-publishing stage that first gives ui a `:clein/build`.

## Quality gates

- YAML validity — `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → **OK** (before and after rebase).
- `verify-version-lockstep.sh` (unchanged by this PR) → **PASSED** — 18 artefacts (14 implementation/ + 4 tools/), ui correctly excluded.
- Comment-only change to a single hot-zone file (`release.yml`); no functional workflow change, no script change.

Recommendation for the mayor: close `rf2-pc479y` as premature/already-guarded, or relabel it a dependency of the ui-publishing epic stage.