### PR TITLE
fix(ui): honest bounded-invalidation loss accounting — :dropped no longer overstates fan-out (rf2-vxgfnd.74)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -704,42 +704,76 @@
 ;; internal observation port; 03 §3).
 
 (def ^:private ^:const target-cap
-  ;; Distinct moving targets kept per pending window before overflow folds
-  ;; into a running dropped-count — bounds the evidence to constant size.
+  ;; Distinct moving targets SHOWN per pending window — a bounded SAMPLE of what
+  ;; moved. Further distinct targets fold into the bounded `:dropped` loss SET
+  ;; (not a running occurrence count), keeping the shown sample constant-size.
   8)
+
+(def ^:private ^:const dropped-cap
+  ;; The SECOND bound: distinct OMITTED target keys tracked in `:dropped` before
+  ;; the loss account ITSELF saturates. Past this many distinct omissions,
+  ;; `:dropped-exact?` flips false and `(count :dropped)` becomes a LOWER bound.
+  ;; The whole record therefore stays constant-size (≤ target-cap shown +
+  ;; ≤ dropped-cap omitted, all small sub-query-vector keys).
+  64)
 
 (defn- fold-evidence
   "DEBUG plane: fold one invalidation `payload` into a cell's pending-window
   evidence `ev` (nil = a fresh window). Returns a BOUNDED, constant-size
   record — never an unbounded payload vector:
 
-    {:first-epoch  e0    ; the FIRST movement's frame-epoch (the anchor)
-     :latest-epoch eN    ; the most-recent movement's frame-epoch
-     :count        n     ; total invalidations folded this window
-     :causes       #{…}  ; the SET of causes seen (:value/:hmr/:disposed — ≤3)
-     :targets      [tk…] ; distinct moved target keys, capped at `target-cap`
-     :dropped      m}    ; distinct targets dropped past the cap (loss account)
+    {:first-epoch    e0    ; the FIRST movement's frame-epoch (the anchor)
+     :latest-epoch   eN    ; the most-recent movement's frame-epoch
+     :count          n     ; total invalidation OCCURRENCES folded this window
+     :causes         #{…}  ; the SET of causes seen (:value/:hmr/:disposed — ≤3)
+     :targets        [tk…] ; distinct moving targets SHOWN, capped at `target-cap`
+     :dropped        #{tk} ; distinct moving targets OMITTED past the shown cap —
+                           ;   a BOUNDED SET; its COUNT is the honest fan-out loss
+     :dropped-exact? b}    ; true ⇒ every omission is individually tracked;
+                           ;   false ⇒ the loss set saturated at `dropped-cap`, so
+                           ;   `(count :dropped)` is a LOWER bound
 
-  The cause set and epoch scalars are naturally bounded; the target vector is
-  explicitly capped with a dropped-count, so overflow is REPORTED, never
-  silently lost (acceptance-criterion 3)."
+  Honesty (rf2-vxgfnd.74). `:count` is the OCCURRENCE axis (every fold, including
+  repeats of an already-seen target); `:dropped` is the DISTINCT-target LOSS
+  axis. They are complementary, never duplicates: re-invalidating one already-
+  omitted target N times advances `:count` by N but leaves `:dropped` unchanged
+  (that target's identity is already recorded). So a window that invalidates
+  eight retained targets once then a NINTH target 100 times reports `:count 108`
+  yet `:dropped #{tk9}` — ONE distinct omission, not 100. The field means what it
+  says (distinct omitted targets), so it never overstates fan-out.
+
+  The cause set and epoch scalars are naturally bounded; BOTH the shown-target
+  vector and the omitted-target set are explicitly capped, so overflow is
+  REPORTED (never silently lost) yet the record stays constant-size — a
+  distinct omission past `dropped-cap` sets `:dropped-exact? false` rather than
+  growing the set (acceptance-criteria 3/5)."
   [ev {:keys [cause target frame-epoch]}]
   (let [tk (when target (target-key target))]
     (if (nil? ev)
-      {:first-epoch  frame-epoch
-       :latest-epoch frame-epoch
-       :count        1
-       :causes       (if cause #{cause} #{})
-       :targets      (if tk [tk] [])
-       :dropped      0}
-      (let [known?  (or (nil? tk) (some #(= tk %) (:targets ev)))
-            at-cap? (>= (count (:targets ev)) target-cap)]
+      {:first-epoch    frame-epoch
+       :latest-epoch   frame-epoch
+       :count          1
+       :causes         (if cause #{cause} #{})
+       :targets        (if tk [tk] [])
+       :dropped        #{}
+       :dropped-exact? true}
+      (let [known?     (or (nil? tk)
+                           (some #(= tk %) (:targets ev))
+                           (contains? (:dropped ev) tk))
+            at-cap?    (>= (count (:targets ev)) target-cap)
+            drop-full? (>= (count (:dropped ev)) dropped-cap)]
         (cond-> (-> ev
                     (assoc :latest-epoch frame-epoch)
                     (update :count inc))
-          cause                            (update :causes conj cause)
-          (and (not known?) (not at-cap?)) (update :targets conj tk)
-          (and (not known?) at-cap?)       (update :dropped inc))))))
+          cause                                       (update :causes conj cause)
+          ;; a NEW distinct target with room in the shown sample
+          (and (not known?) (not at-cap?))            (update :targets conj tk)
+          ;; a NEW distinct target past the shown cap, with room in the loss set:
+          ;; record its IDENTITY so `:dropped` counts DISTINCT omissions
+          (and (not known?) at-cap? (not drop-full?)) (update :dropped conj tk)
+          ;; a NEW distinct omission but the loss set is FULL: the count is now a
+          ;; floor — mark it inexact (the honest "≥ dropped-cap distinct" signal)
+          (and (not known?) at-cap? drop-full?)       (assoc :dropped-exact? false))))))
 
 (defn- record-evidence!
   "DEBUG plane: fold `payload`'s bounded causal evidence into `cell`'s
@@ -1016,8 +1050,10 @@
   when the cell is not pending, or in a production build where the debug plane
   is elided). The coalesced summary of every invalidation folded into this one
   render batch — see `fold-evidence` for the shape: first/latest frame-epoch,
-  the fold count, the cause set, a capped distinct-target vector, and a
-  dropped-count. The `re-frame.ui.tool`/Xray projection reads this (or receives
+  the total occurrence `:count`, the cause set, a capped SHOWN distinct-target
+  vector, and a bounded `:dropped` SET of the distinct targets OMITTED past the
+  shown cap (its count is the honest fan-out loss, `:dropped-exact?` flags
+  saturation). The `re-frame.ui.tool`/Xray projection reads this (or receives
   it via `set-evidence-sink!`) to attribute a coalesced render to its
   contributing movement WITHOUT forcing a render per epoch (rf2-vxgfnd.46;
   tool/test read)."

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -418,7 +418,8 @@
         (is (= 1 (:first-epoch ev)) "anchored to the FIRST epoch")
         (is (= 8 (:latest-epoch ev)) "…and tracks the LATEST")
         (is (= 8 (:count ev)) "all 8 invalidations folded")
-        (is (= 0 (:dropped ev)) "nothing dropped")))
+        (is (= #{} (:dropped ev)) "nothing dropped — the loss set is empty")
+        (is (:dropped-exact? ev) "…and the loss account is exact")))
     (is (= 1 (reactive/pending-cell-count)) "enrolled ONCE despite 8 marks")
     (reactive/flush-pending!)
     (testing "coalesced to ONE render, and the flush CARRIED the evidence"
@@ -445,9 +446,10 @@
       (is (= 1 (:count ev))))))
 
 (deftest evidence-target-vector-is-bounded-with-a-loss-account
-  ;; MORE distinct moving targets than the cap fold into a CAPPED target vector
-  ;; plus an explicit dropped-count — the evidence is constant-size, and
-  ;; overflow is reported rather than silently lost (AC 3).
+  ;; MORE distinct moving targets than the cap fold into a CAPPED SHOWN vector
+  ;; plus a bounded `:dropped` SET of the distinct OMITTED targets — the evidence
+  ;; is constant-size, and overflow is reported by IDENTITY rather than silently
+  ;; lost (AC 3). End-to-end through the real :hmr fan-out.
   (let [n       10                          ;; > the target cap (8)
         ids     (mapv (fn [i] (keyword "r" (str "s" i))) (range n))
         queries (mapv vector ids)]
@@ -459,11 +461,56 @@
         (rf/reg-sub (ids i) (fn [db _] (get db i))))
       (let [ev (reactive/pending-evidence cell)]
         (is (= n (:count ev)) "every invalidation is counted")
-        (is (= 8 (count (:targets ev))) "the target vector is capped at target-cap")
-        (is (= 2 (:dropped ev)) "the 2 overflow targets are counted, not silently lost")
+        (is (= 8 (count (:targets ev))) "the shown target vector is capped at target-cap")
+        (is (= 2 (count (:dropped ev)))
+            "the 2 DISTINCT overflow targets are recorded by identity, not silently lost")
+        (is (every? vector? (:dropped ev)) ":dropped holds target KEYS, not a bare count")
+        (is (:dropped-exact? ev) "the loss account is exact — well under dropped-cap")
         (is (= #{:hmr} (:causes ev)) "the cause set stays bounded"))
       (testing "the whole capped batch still coalesces to ONE render"
         (let [hits (atom 0)]
           (reactive/subscribe cell (fn [] (swap! hits inc)))
           (reactive/flush-dirty! cell)
           (is (= 1 @hits) "one notification for the whole bounded batch"))))))
+
+(deftest evidence-dropped-counts-distinct-omissions-not-occurrences
+  ;; rf2-vxgfnd.74 — the HONESTY fix, exercised at the fold unit. `:dropped` is
+  ;; the DISTINCT-omitted-target axis, NOT overflow OCCURRENCES: re-invalidating
+  ;; one already-omitted target N times advances `:count` by N but must NOT
+  ;; inflate the loss. The fold unit is the right level here — a SAME-target
+  ;; re-invalidation storm can't be staged through the real :hmr path (an HMR
+  ;; dispose fires a target's live lease exactly once), yet it is the exact
+  ;; shape that made the old occurrence-counting `:dropped` dishonest.
+  (let [fold    @#'reactive/fold-evidence
+        target  (fn [i] {:kind :subscription :frame-id fid :query [(keyword "r" (str "s" i))]})
+        key-i   (fn [i] (tk fid [(keyword "r" (str "s" i))]))
+        payload (fn [i] {:cause :hmr :target (target i) :frame-epoch i})
+        after-8 (reduce fold nil (map payload (range 8)))]  ;; 8 distinct shown, once each
+    (testing "the headline example — 8 retained once, then ONE ninth target 100×"
+      ;; PRE-FIX this window read {:count 108 :targets 8 :dropped 100} — claiming
+      ;; 100 omitted targets when only ONE distinct target was ever dropped.
+      (let [ev (reduce fold after-8 (repeat 100 (payload 8)))]
+        (is (= 108 (:count ev)) ":count still totals every invalidation OCCURRENCE")
+        (is (= 8 (count (:targets ev))) "the shown sample stays capped at target-cap")
+        (is (= #{(key-i 8)} (:dropped ev))
+            "ONE distinct target omitted — the field reports its IDENTITY, not 100")
+        (is (= 1 (count (:dropped ev)))
+            "…so the fan-out loss is 1, NOT 100 — the field no longer overstates")
+        (is (:dropped-exact? ev) "and the loss account is exact — far under dropped-cap")))
+    (testing "genuinely-distinct overflow — the distinct-omission set grows honestly"
+      (let [ev (reduce fold after-8 (map payload (range 8 11)))]  ;; 9th/10th/11th distinct
+        (is (= 11 (:count ev)))
+        (is (= 8 (count (:targets ev))))
+        (is (= #{(key-i 8) (key-i 9) (key-i 10)} (:dropped ev))
+            "three DISTINCT overflow targets → three distinct omissions, by identity")
+        (is (:dropped-exact? ev))))
+    (testing "the loss set is ITSELF bounded — saturation flips :dropped-exact? false"
+      (let [cap @#'reactive/dropped-cap
+            n   (+ 8 cap 50)                        ;; far past BOTH caps
+            ev  (reduce fold nil (map payload (range n)))]
+        (is (= n (:count ev)) "every occurrence still counts")
+        (is (= 8 (count (:targets ev))) "shown sample bounded")
+        (is (= cap (count (:dropped ev)))
+            "the loss set is bounded at dropped-cap — constant-size, never unbounded")
+        (is (false? (:dropped-exact? ev))
+            "…and honestly flags that (count :dropped) is now a LOWER bound")))))


### PR DESCRIPTION
## What & why

The bounded ViewCell invalidation-evidence field `:dropped` (in `re_frame/ui/reactive.cljc`, the `fold-evidence` DEBUG plane from rf2-vxgfnd.46) was **documented** as "distinct targets dropped past the cap" but the implementation **could not** provide that meaning. Once `:targets` reached the shown cap (`target-cap` = 8), an overflow target was retained *nowhere*, so every *later* invalidation of that **same** unretained target still read as unknown and incremented `:dropped` **again**.

Concretely — invalidate 8 retained targets once, then ONE ninth target 100× in the same pending window (proven pre-fix):

```
:count 108 | :targets 8 | :dropped 100
```

…but only **one** distinct target was ever omitted. Xray/tooling reading the documented field as "100 omitted targets" would overstate fan-out by two orders of magnitude. Since `:count` already reports invalidation OCCURRENCES, `:dropped`-as-occurrences was a confusing duplicate rather than a complementary axis.

## Fix — option (a): make the field mean what it says

I chose **(a)** over (b) because target keys are small `[:sub frame-id query]` / `[:override id]` sub-query-vectors — an exact bounded distinct-key set is cheap and gives the genuinely useful signal (distinct fan-out omitted, by identity), which is exactly what the held rf2-vxgfnd.75 Xray wiring wants to project.

- `:dropped` is now a **bounded SET of the distinct omitted target keys**; its `count` is the honest distinct fan-out loss. A repeat of an already-omitted target is `known?` (via `contains?`) and folds into `:count` only.
- `:count` stays the **total-occurrence** axis — the two are now complementary, never duplicates.
- The loss set is itself capped at a second bound `dropped-cap` (64). A distinct omission past it flips a new `:dropped-exact?` to `false` rather than growing the set, so the record stays **constant-size** and honestly signals that `(count :dropped)` is a lower bound (the "distinct overflow exceeded N" marker).

Post-fix, the same three windows report:

```
headline  8 + ninth×100  → :count 108  :targets 8  :dropped #{tk9}  (loss 1)      :dropped-exact? true
distinct  8 + 3 distinct → :count 11   :targets 8  (count :dropped) 3             :dropped-exact? true
saturation 8 + 200       → :count 208  :targets 8  (count :dropped) 64 (dropped-cap) :dropped-exact? false
```

The 100×-one-target window no longer overstates fan-out: `:dropped #{tk9}`, loss = 1, not 100.

## Surface

- `implementation/ui/src/re_frame/ui/reactive.cljc` — `fold-evidence` + `target-cap`/new `dropped-cap`, and the `fold-evidence` / `pending-evidence` docstrings (the `:dropped` field docs).
- `implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc` — new fold-unit test for the headline bug + distinct-growth + saturation; the existing real-:hmr 10-distinct case and the "nothing dropped" assertion updated to the set semantics.

Debug-plane only: the production scheduler (`enrol-dirty!`) and elision are untouched; the whole evidence fold DCEs under `goog.DEBUG=false`. Confined to `reactive.cljc` + its test — no `observation.cljc`/`client.cljs`/`viewcell.cljs`/spec edits. spec/006 does not pin the evidence-field shape (its "dropped" mentions are unrelated: write-after-destroy, cache, leases), so no HOT-ZONE spec note needs updating.

## Quality gates

Run in the foreground, 0-fail:

- `implementation/ui` `clojure -M:test` (JVM) — **345 tests, 4962 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` (node) — **9101 tests, 43078 assertions, 0 failures, 0 errors**

Closes rf2-vxgfnd.74.
