### PR TITLE
fix(core): exclusive-CAS trace-policy linearization + best-effort destroy step-2 teardown (rf2-umsyo9, rf2-jt47s0)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2092,25 +2092,69 @@
         ;; rf2-vxgfnd.76: a SPECULATIVE first snapshot. The authoritative decide
         ;; happens inside the guarded-CAS loop below (which re-reads under the
         ;; CAS); this read only lets `new-frame-record` (with its adapter
-        ;; `make-state-container` call) be built ONCE, ABOVE the trace writes, so
-        ;; a no-adapter construction throw still escapes before any process-global
-        ;; write (rf2-hhlzky, preserved). The loop reuses this record when it wins
-        ;; a create and rebuilds only in the rare decide-changed-to-create recur.
+        ;; `make-state-container` call) be built ONCE, ABOVE the loop, so a
+        ;; no-adapter construction throw escapes before the decide probe, the
+        ;; guarded CAS, and the winner's trace-policy writes (rf2-hhlzky preserved
+        ;; — and strengthened by rf2-umsyo9, which moved those policy writes BELOW
+        ;; the CAS into the winning branch). The loop reuses this record when it
+        ;; wins a create and rebuilds only in the rare decide-changed-to-create
+        ;; recur.
         existing0      (get @frames id)
-        ;; rf2-hhlzky: construct the frame record BEFORE any process-global
-        ;; write (the trace-suppression flags below).
+        ;; rf2-hhlzky: construct the frame record BEFORE any process-global write.
         ;; `new-frame-record` calls `adapter/make-state-container`, which THROWS
         ;; (`:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed`) when
         ;; no adapter is installed — a construction issued before `rf/init!` or
-        ;; after `destroy-adapter!`. Building the record here means such a
-        ;; construction failure escapes this `let` BEFORE
-        ;; `trace/set-frame-no-emit!` runs, so a frame that never came into
-        ;; existence leaves NO trace-disabled residue (which
-        ;; would otherwise persist with no destroy path to clear it). This is the
-        ;; DEFER form of the rollback the bead calls for — there is nothing to
-        ;; unwind because nothing was written. Re-registration is a surgical
+        ;; after `destroy-adapter!`. Building the record here means such a failure
+        ;; escapes this `let` BEFORE any process-global write, so a frame that
+        ;; never came into existence leaves NO residue to unwind.
+        ;;
+        ;; rf2-umsyo9 (speculative-allocation lifecycle): on a create/create loss
+        ;; the guarded CAS installs nothing and this speculatively-built record is
+        ;; ABANDONED. That needs no explicit disposal — DISPOSAL-FREE ALLOCATION
+        ;; CONTRACT: `new-frame-record` produces only an atom-backed state
+        ;; container (`make-state-container` → a plain / substrate atom) plus its
+        ;; two derived-value projections and a handful of atoms, ALL mutually
+        ;; referenced WITHIN the record. It opens no OS / host resource and
+        ;; performs no adapter-side or registry-side registration (the sole
+        ;; install is the `frames` assoc the loser never made), so an abandoned
+        ;; record is a self-contained GC island collected with the lost `let`
+        ;; value. This is the DEFER form of the rollback the bead calls for —
+        ;; nothing installed, nothing to unwind. Re-registration is a surgical
         ;; update (no container is built), so `new-record` is nil there.
-        new-record     (when (nil? existing0) (new-frame-record id config))]
+        new-record     (when (nil? existing0) (new-frame-record id config))
+        ;; rf2-umsyo9: the frame-scoped TRACE POLICY writes (the suppression flag
+        ;; + the `:rf.trace/events-retained` retention override) are process-global
+        ;; stores SEPARATE from the `frames` registry, so the guarded CAS below
+        ;; does NOT linearize them. PR #5776 ran them speculatively ABOVE the CAS,
+        ;; which let a must-create LOSER — or a create/create loser — overwrite
+        ;; the WINNER's trace policy for this id even though the loser installed
+        ;; nothing, corrupting the live winner's tracing. They now ride the WINNING
+        ;; branch via this thunk, so an exclusive collision is truly ZERO-WRITE
+        ;; across every frame-owned store (the record AND its auxiliary
+        ;; trace/retention stores), while first-registration and ordinary
+        ;; re-registration still apply the winning config's policy EXACTLY ONCE.
+        ;; Honoured on BOTH create and re-register so a hot-reload can flip either
+        ;; flag either way; the won-create branch calls it BEFORE
+        ;; `run-setup-events!` so an init-cascade against a trace-disabled tool
+        ;; frame stays redacted.
+        apply-trace-policy!
+        (fn []
+          ;; Frame-level trace-emission gate: a frame registered with
+          ;; `:rf.trace/frame-no-emit? true` is a tool / inspector frame (e.g.
+          ;; Xray's `:rf/xray`) whose own reactive substrate must NOT flood the
+          ;; shared trace ring it inspects. The flag is the frame-scoped sibling
+          ;; of the handler-scoped `:rf.trace/no-emit?` (Spec 009 §Trace-emission
+          ;; opt-out); `trace.cljc` owns the canonical set + predicate.
+          (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
+          ;; Per Spec 009 §Retention contract: apply the per-frame
+          ;; `:rf.trace/events-retained` override. When the key is absent the
+          ;; frame inherits the process-default. Routed via late-bind so
+          ;; production CLJS bundles (where trace.tooling is not loaded)
+          ;; short-circuit cleanly — the trace-ring machinery is dev-only.
+          (when (contains? config :rf.trace/events-retained)
+            (when-let [set-retained! (late-bind/get-fn-cached
+                                      :trace.tooling/set-frame-events-retained!)]
+              (set-retained! id (:rf.trace/events-retained config)))))]
     ;; SUBSTRATE OWNERSHIP (rf2-h1vqa4): deliberately NO `registrar/register!`
     ;; here. A seated frame lives in the `frames` registry alone. The former
     ;; `:frame` registrar row leaked into the registration SOURCE STORE
@@ -2121,37 +2165,21 @@
     ;; Routing (the one former consumer) reads frame config via
     ;; `frame-meta` / `frame-ids`; the registrar `:frame` kind is reserved with
     ;; an intentionally EMPTY slot (the `:flow` precedent, rf2-en00bk).
-    ;; Frame-level trace-emission gate: a frame registered
-    ;; with `:rf.trace/frame-no-emit? true` is a tool / inspector frame
-    ;; (e.g. Xray's `:rf/xray`) whose own reactive substrate must NOT
-    ;; flood the shared trace ring it inspects. The flag is the frame-
-    ;; scoped sibling of the handler-scoped `:rf.trace/no-emit?`
-    ;; (Spec 009 §Trace-emission opt-out). Honoured on BOTH first
-    ;; registration and re-registration so a hot-reload can flip it
-    ;; either way; `trace.cljc` owns the canonical set + predicate.
-    (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
-    ;; Per Spec 009 §Retention contract: apply
-    ;; the per-frame `:rf.trace/events-retained` override at
-    ;; registration time. Honoured on BOTH first registration and re-
-    ;; registration so a hot-reload can flip it either way. When the
-    ;; key is absent the frame inherits the process-default. Routed via
-    ;; late-bind so production CLJS bundles (where trace.tooling is
-    ;; not loaded) short-circuit cleanly — the trace-ring machinery is
-    ;; dev-only and there's nothing to configure in prod.
-    (when (contains? config :rf.trace/events-retained)
-      (when-let [set-retained! (late-bind/get-fn-cached
-                                :trace.tooling/set-frame-events-retained!)]
-        (set-retained! id (:rf.trace/events-retained config))))
     ;; A-prime linearization (rf2-vxgfnd.76): the DECIDE (existing?) + INSTALL
     ;; (the `frames` swap) run as a guarded-CAS RETRY loop through the `frames`
     ;; atom ITSELF — the `set-generation!` discipline — so a create linearizes
     ;; against a concurrent create/destroy with NO last-writer clobber and NO
-    ;; zombie-resurrection of a dissoc'd record. The pure preflight validation +
-    ;; the idempotent trace writes above ran ONCE (they stay ABOVE the loop);
-    ;; only decide+install repeats. `run-setup-events!` runs EXACTLY ONCE, in the
-    ;; won-create branch (EP-0027: setup drains before the constructor returns —
-    ;; preserved because ONLY decide+install moved into the loop). The one-shot
-    ;; decide→install-window test probe fires here (before the first CAS).
+    ;; zombie-resurrection of a dissoc'd record. Only the pure, side-effect-free
+    ;; preflight validation ran ONCE above the loop; the frame-scoped TRACE
+    ;; POLICY writes now ride the WINNING branch (`apply-trace-policy!`,
+    ;; rf2-umsyo9) so an exclusive / CAS LOSER never mutates the winner's policy.
+    ;; `run-setup-events!` runs EXACTLY ONCE, in the won-create branch (EP-0027:
+    ;; setup drains before the constructor returns — preserved because only
+    ;; decide + install + the winner's writes are inside the loop). The one-shot
+    ;; decide→install-window test probe fires HERE — after the decide snapshot
+    ;; but BEFORE any side effect (the CAS AND the winner's trace-policy writes),
+    ;; so the concurrency seam opens the actual PRE-SIDE-EFFECT race window
+    ;; (rf2-umsyo9).
     (when-let [probe *upsert-decide-probe*] (probe id))
     (loop []
       (let [existing (get @frames id)]
@@ -2204,6 +2232,14 @@
                          "the view tree, or to top-level boot.")
                     {:recovery :construct-frames-in-view-or-top-level
                      :extra    {:frame id}}))
+                ;; rf2-umsyo9: apply the winning config's frame-scoped trace
+                ;; policy now that this create WON the guarded CAS and passed the
+                ;; handler-time guard — BEFORE `run-setup-events!` so a
+                ;; trace-disabled tool frame's init cascade stays redacted, and
+                ;; BEFORE the `:rf.frame/created` emit so that emit is suppressed
+                ;; for a no-emit frame. A create that LOST the CAS never reaches
+                ;; here, so it leaves the winner's policy untouched.
+                (apply-trace-policy!)
                 ;; Run the :initial-events setup steps synchronously, in order,
                 ;; BEFORE emitting :frame/created (Spec 002 §Frame creation;
                 ;; EP-0027 §Construction). `setup-steps` was PREFLIGHT-validated
@@ -2246,6 +2282,13 @@
                                     m)))]
             (if (contains? old id)
               (do
+                ;; rf2-umsyo9: apply the winning config's frame-scoped trace
+                ;; policy now that this refresh WON its guarded CAS — BEFORE the
+                ;; `:rf.frame/re-registered` emit so a hot-reload that flips the
+                ;; frame to no-emit suppresses its own re-registration trace. A
+                ;; re-registration that LOST (the id vanished under a concurrent
+                ;; destroy) recurs into a create and never reaches here.
+                (apply-trace-policy!)
                 (trace/emit! :rf.frame :rf.frame/re-registered
                              {:frame id :config stored-config})
                 (fire-frame-registered-hook! id)

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2395,6 +2395,37 @@
 ;; record, so the epoch surface's nil-tolerant fallback applies.
 (def ^:dynamic *run-time-ms* nil)
 
+(defn- record-teardown-failure!
+  "Record a best-effort teardown-step failure on BOTH Spec 009
+  observability channels, then return nil so the caller swallows the
+  throw and teardown continues. Shared by `safe-call-hook!` (late-bound
+  keyed cleanup hooks) and `safe-teardown-step!` (direct-call ordered
+  steps) so every best-effort teardown step reports identically:
+
+    1. ALWAYS-ON axis (EP-0008 R1) — conj `{:hook <step-key> :exception
+       <ex> :where <where>}` onto the per-destroy `*teardown-hook-
+       failures*` accumulator, which `destroy-frame!` flushes ONCE as the
+       bounded `:rf.error/frame-teardown-failed` report.
+    2. DIAGNOSTIC channel (EP-0008 R2) — emit the per-step
+       `:rf.warning/teardown-hook-exception` trace (DCE'd in production)
+       carrying the step key, the in-flight `*destroying-frame-id*`, and
+       the exception, at its causal position.
+
+  `step-key` labels the failing step (a hook key, or the recipe-step
+  name for a direct call); `where` names the boundary that caught it."
+  [step-key where ex]
+  (when-let [acc *teardown-hook-failures*]
+    (swap! acc conj {:hook      step-key
+                     :exception ex
+                     :where     where}))
+  (trace/emit-error! :rf.warning/teardown-hook-exception
+                     {:category  :rf.warning/teardown-hook-exception
+                      :hook      step-key
+                      :frame     *destroying-frame-id*
+                      :exception ex
+                      :where     where})
+  nil)
+
 (defn- safe-call-hook!
   "Fire a late-bound cleanup hook by key. No-op when unbound. Exceptions
   are caught so one bad hook can't block the rest of teardown — but the
@@ -2429,19 +2460,31 @@
   (when-let [f (late-bind/get-fn hook-key)]
     (try (apply f args)
          (catch #?(:clj Throwable :cljs :default) ex
-           ;; Always-on axis: accumulate (flushed once by destroy-frame!).
-           (when-let [acc *teardown-hook-failures*]
-             (swap! acc conj {:hook      hook-key
-                              :exception ex
-                              :where     :safe-call-hook!}))
-           ;; Diagnostic channel: per-hook dev trace at its causal position.
-           (trace/emit-error! :rf.warning/teardown-hook-exception
-                              {:category  :rf.warning/teardown-hook-exception
-                               :hook      hook-key
-                               :frame     *destroying-frame-id*
-                               :exception ex
-                               :where     :safe-call-hook!})
-           nil))))
+           (record-teardown-failure! hook-key :safe-call-hook! ex)))))
+
+(defn- safe-teardown-step!
+  "Run an ordered teardown step that is a DIRECT call (not a late-bound
+  hook) under the SAME best-effort boundary as `safe-call-hook!`: catch
+  any throw, record it on both Spec 009 channels via
+  `record-teardown-failure!`, and swallow it so NO teardown step escapes
+  the recipe mid-flight.
+
+  `safe-call-hook!` covers the optional late-bound cleanup hooks; this
+  covers the ordered direct-call steps that would otherwise throw
+  straight out of `destroy-frame!`'s `try` — notably
+  `notify-machine-destruction!` (step 2), whose `teardown!` hook call,
+  fallback `:rf.machine.lifecycle/destroyed` trace emits, and
+  trace-listener fan-out are all reachable throw sites (rf2-jt47s0). An
+  unguarded throw there left the frame LIVE + HALF-TORN-DOWN
+  (`:destroyed?` never flipped, sub-cache intact, record not dissoc'd) —
+  the `:on-destroy` (step 1) had already run, so a subsequent
+  `destroy-frame!` saw the still-live record and RE-RAN the whole recipe,
+  re-firing the user `:on-destroy`. Guarding the step keeps teardown
+  best-effort end-to-end. `step-key` labels the step in both channels."
+  [step-key thunk]
+  (try (thunk)
+       (catch #?(:clj Throwable :cljs :default) ex
+         (record-teardown-failure! step-key :safe-teardown-step! ex))))
 
 (defn- emit-on-destroy-handler-exception!
   "Surface `:rf.error/on-destroy-handler-exception` through BOTH the
@@ -2885,7 +2928,19 @@
                  *teardown-hook-failures* hook-failures]
         (try
         (fire-on-destroy-event! id f)
-        (notify-machine-destruction! id)
+        ;; Step 2 rides the SAME best-effort boundary as the later
+        ;; `safe-call-hook!` steps (rf2-jt47s0). `notify-machine-destruction!`'s
+        ;; `teardown!` hook call, its fallback `:rf.machine.lifecycle/destroyed`
+        ;; trace emits, and the trace-listener fan-out are all reachable throw
+        ;; sites (a non-machines `:machines/teardown-on-frame-destroy!` consumer,
+        ;; or a throwing tap). Left unguarded, a throw here escaped the recipe
+        ;; BEFORE the liveness flip / sub-cache teardown — the frame stayed LIVE +
+        ;; half-torn-down with `:on-destroy` already run, so a retry re-ran the
+        ;; whole recipe and re-fired `:on-destroy`. Accumulated into
+        ;; `*teardown-hook-failures*` + surfaced on the diagnostic trace, then
+        ;; teardown continues so the frame is fully torn down exactly once.
+        (safe-teardown-step! :frame/notify-machine-destruction!
+                             (fn [] (notify-machine-destruction! id)))
         ;; Detach the compiled-view (day8/re-frame2-ui) observers BEFORE the
         ;; liveness flip / sub-cache teardown, so every currently-connected
         ;; ViewCell observing this frame transitions to :dead (03 §4 dead-cell

--- a/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
@@ -391,6 +391,78 @@
             "both same-key entries are preserved in order")))))
 
 ;; ===========================================================================
+;; (h) Step 2 (notify-machine-destruction!) is best-effort — a throw there must
+;; NOT leave the frame live + half-torn-down (rf2-jt47s0)
+;; ---------------------------------------------------------------------------
+;; `destroy-frame!` step 1 (`fire-on-destroy-event!`) has its own catch and
+;; every step from `:ui/on-frame-destroyed!` onward rides `safe-call-hook!`, but
+;; step 2 — `notify-machine-destruction!` (the `:machines/teardown-on-frame-
+;; destroy!` hook call, its fallback `:rf.machine.lifecycle/destroyed` trace
+;; emits, and the trace-listener fan-out) — was UNGUARDED. A throwing
+;; non-machines hook consumer escaped `destroy-frame!`'s `try`: the finally
+;; cleared the in-flight marker and the throw propagated, but `:destroyed?` was
+;; never flipped and the record was never dissoc'd → the frame stayed LIVE +
+;; HALF-TORN-DOWN with `:on-destroy` already run. A subsequent `destroy-frame!`
+;; saw the still-live record and RE-RAN the whole recipe, re-firing `:on-destroy`.
+;; The fix runs step 2 through the SAME accumulate-into-`*teardown-hook-
+;; failures*` boundary the later steps use. (The shipped machines callee
+;; self-defends per-actor and trace listeners are isolated at the tooling
+;; fan-out, so the reachable trigger is a non-machines hook consumer — hence P3.)
+;; ===========================================================================
+
+(deftest step2-teardown-throw-is-accumulated-frame-fully-torn-down
+  (testing "Per rf2-jt47s0: a throwing step-2 consumer
+            (`:machines/teardown-on-frame-destroy!`) is ACCUMULATED into the
+            best-effort teardown report — NOT escaped — the frame still fully
+            tears down (record dissoc'd), and a second destroy is a clean no-op
+            that does NOT re-fire `:on-destroy`."
+    (let [on-destroy-runs (atom 0)
+          reports         (atom [])]
+      (rf/register-listener! :errors :test/recorder
+                                   (fn [record] (swap! reports conj record)))
+      (rf/reg-event :teardown/count-on-destroy
+                       (fn [{:keys [db]} _]
+                         (swap! on-destroy-runs inc)
+                         {:db db}))
+      (rf/make-frame {:id         :teardown/step2 :doc "step-2 consumer throws"
+                      :on-destroy [:teardown/count-on-destroy]})
+      (with-hooks*
+        ;; A non-machines step-2 consumer that throws — the reachable P3 trigger.
+        {:machines/teardown-on-frame-destroy! (throwing-hook :machines-teardown)}
+        (fn []
+          (let [thrown (try (rf/destroy-frame! :teardown/step2) nil
+                            (catch #?(:clj Throwable :cljs :default) e e))]
+            (is (nil? thrown)
+                "the step-2 throw did NOT escape destroy-frame! — the best-effort
+                 boundary caught it (pre-fix: the throw propagated out)"))))
+      ;; The frame fully tore down despite the step-2 throw.
+      (is (nil? (frame/frame :teardown/step2))
+          "the record is dissoc'd — fully torn down, NOT left LIVE + half-torn-
+           down (pre-fix: :destroyed? unflipped + record intact → non-nil)")
+      (is (= 1 @on-destroy-runs)
+          ":on-destroy ran exactly once during the completed teardown")
+      ;; The step-2 failure was accumulated into the ONE always-on report.
+      (let [reps (filter #(= :rf.error/frame-teardown-failed (:error %)) @reports)]
+        (is (= 1 (count reps))
+            "the step-2 failure flushed ONE always-on teardown report (pre-fix:
+             the throw escaped before it could be accumulated → no report)")
+        (let [step2 (filter #(= :frame/notify-machine-destruction! (:hook %))
+                            (:hook-failures (first reps)))]
+          (is (= 1 (count step2))
+              "the report carries the step-2 recipe step's failure entry")
+          (is (= :safe-teardown-step! (:where (first step2)))
+              "recorded via the direct-call teardown boundary")))
+      ;; A second destroy is a clean no-op — the frame is already gone, so the
+      ;; recipe does not re-run and :on-destroy is NOT re-fired. (Wrapped so the
+      ;; pre-fix re-run's own step-2 throw surfaces as a FAILED assertion below,
+      ;; not an errored test.)
+      (try (rf/destroy-frame! :teardown/step2)
+           (catch #?(:clj Throwable :cljs :default) _ nil))
+      (is (= 1 @on-destroy-runs)
+          "a second destroy is a clean no-op — :on-destroy is NOT re-fired
+           (pre-fix: the still-live half-torn-down frame re-ran the recipe → 2)"))))
+
+;; ===========================================================================
 ;; (g) Re-entrant / nested destroy accumulator isolation (rf2-chpdkr)
 ;; ---------------------------------------------------------------------------
 ;; `destroy-frame!` holds the per-destroy hook-failure accumulator in a fresh

--- a/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
@@ -31,15 +31,35 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace])
+            [re-frame.trace :as trace]
+            ;; Loads the trace-tooling artefact so its
+            ;; `:trace.tooling/set-frame-events-retained!` late-bind is published
+            ;; before these tests run (the retention override is otherwise a
+            ;; silent no-op) and so the per-frame retention store is observable.
+            [re-frame.trace.tooling :as trace-tooling])
   (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (trace/clear-listeners!)
+  ;; Clear the process-global trace-policy stores so a frame-scoped no-emit /
+  ;; retention override written by one test never leaks into the next
+  ;; (rf2-umsyo9 — these stores are SEPARATE from `frames`, which the reset
+  ;; above does unwind).
+  (trace/clear-frame-no-emit!)
+  (trace-tooling/clear-trace-rings!)
   (rf/init! plain-atom/adapter)
   (test-fn))
+
+;; The per-frame retention cap the winning config's `:rf.trace/events-retained`
+;; override installed, read straight from the trace-tooling ring store (a
+;; white-box read of the process-global store the guarded CAS must linearize).
+;; nil when no override ring was written for the frame.
+(defn- retained-cap [frame-id]
+  ;; Double deref: `#'…/trace-rings` is the VAR, its value is the store ATOM,
+  ;; and the atom's value is the rings map.
+  (get-in @@#'re-frame.trace.tooling/trace-rings [frame-id :events-retained]))
 
 (use-fixtures :each reset-runtime)
 
@@ -169,3 +189,57 @@
           "A's exclusive construction loses the window race → typed collision, not adoption")
       (is (identical? token-b (frame/frame-incarnation-token :mc/race))
           "B's frame is untouched — the losing exclusive construction wrote nothing"))))
+
+;; ===========================================================================
+;; rf2-umsyo9 — the exclusive-CAS loser must not overwrite the WINNER's
+;; frame-scoped trace policy.
+;;
+;; `upsert-frame!`'s two frame-scoped TRACE POLICY writes — the `set-frame-
+;; no-emit!` suppression flag (always written) and the `:rf.trace/events-
+;; retained` retention override — live in process-global stores SEPARATE from
+;; the `frames` registry, so the guarded CAS does not linearize them. PR #5776
+;; ran them ABOVE the CAS, so a must-create LOSER (or a create/create loser)
+;; already mutated the WINNER's trace policy for the id by the time its CAS
+;; failed — an exclusive collision that claims to write NOTHING corrupted the
+;; live winner's tracing (self-noise from an inspector frame, a rewritten ring
+;; cap). The `*upsert-decide-probe*` seam now fires BEFORE those writes, opening
+;; the actual pre-side-effect window; the fix makes them ride the winning
+;; branch. Fails against PR #5776's ordering (the loser's writes clobber the
+;; winner's policy); passes once the writes are linearized onto the winner.
+;; ===========================================================================
+
+(deftest exclusive-cas-loser-must-not-overwrite-winner-trace-policy
+  ;; LOSER A: exclusive (must-create) construction with DISTINCT trace policy —
+  ;; no-emit? FALSE, retention 10. A reads the id absent and pauses in the
+  ;; PRE-side-effect window (after the decide snapshot, before its policy writes
+  ;; / CAS). WINNER B: ordinary construction, no-emit? TRUE, retention 99 —
+  ;; installs the id and writes its policy fully on the main thread. A resumes;
+  ;; its guarded CAS finds the id present → typed `:rf.error/frame-id-taken`. The
+  ;; winner's suppression flag AND retention override must be UNCHANGED. Pre-fix:
+  ;; A's policy writes ran on CAS loss and overwrote B's (no-emit? → false,
+  ;; retention → 10) → both post-collision assertions fail.
+  (let [reached (CountDownLatch. 1)
+        release (CountDownLatch. 1)
+        a (binding [frame/*upsert-decide-probe* (window-probe :tp/race reached release)]
+            (future (err-id #(frame/upsert-frame! :tp/race
+                               {:rf.frame/must-create?    true
+                                :rf.trace/frame-no-emit?  false
+                                :rf.trace/events-retained 10}))))]
+    (.await reached 10 TimeUnit/SECONDS)
+    (frame/upsert-frame! :tp/race {:rf.trace/frame-no-emit?  true
+                                   :rf.trace/events-retained 99})
+    (is (true? (trace/frame-trace-disabled? :tp/race))
+        "precondition: winner B registered trace-disabled (no-emit? true)")
+    (is (= 99 (retained-cap :tp/race))
+        "precondition: winner B installed its retention override (99)")
+    (.countDown release)
+    (is (= :rf.error/frame-id-taken @a)
+        "the exclusive loser threw the typed collision — it installed nothing")
+    (is (true? (trace/frame-trace-disabled? :tp/race))
+        "winner B's trace SUPPRESSION survives the collision — the loser never
+         overwrote the winner's frame-scoped no-emit flag (rf2-umsyo9). Pre-fix:
+         the loser's `set-frame-no-emit! false` on CAS loss cleared it → fails")
+    (is (= 99 (retained-cap :tp/race))
+        "winner B's RETENTION override survives — the loser never rewrote the
+         winner's per-frame :rf.trace/events-retained store (rf2-umsyo9).
+         Pre-fix: the loser's write dropped the cap to 10 → fails")))


### PR DESCRIPTION
Cluster of two core `frame.cljc` correctness bugs on the frame CAS / destroy surface. One PR, umsyo9 then jt47s0.

## rf2-umsyo9 (P2) — exclusive-CAS loser overwrote the winner's trace policy

`upsert-frame!` mutated two frame-scoped, process-global trace-policy stores — `trace/set-frame-no-emit!` (the suppression flag) and the `:trace.tooling/set-frame-events-retained!` retention override — ABOVE the guarded CAS. Those stores are SEPARATE from the `frames` registry, so the CAS did not linearize them: a must-create LOSER (or a create/create loser) had already overwritten the WINNER's trace policy for that id even though it installed nothing, corrupting the live winner's tracing (an inspector frame self-noises; its ring cap is rewritten). PR #5776's exclusive-collision contract claimed the loser wrote nothing; the auxiliary stores broke that claim.

**Fix.** The two policy writes now ride the WINNING branch via a local `apply-trace-policy!` thunk — the won-create branch (BEFORE `run-setup-events!`, so an init-cascade against a trace-disabled tool frame stays redacted) and the won-re-register branch (BEFORE the `:rf.frame/re-registered` emit). An exclusive/CAS loser never reaches either call, so a collision is truly zero-write across every frame-owned store — the record AND its auxiliary trace/retention stores. First-registration and ordinary re-registration still apply the winning config's policy exactly once. The `*upsert-decide-probe*` seam now fires BEFORE any side effect (the CAS and the policy writes), opening the actual pre-side-effect race window. Also documents the disposal-free allocation contract for the speculatively-built state container (an abandoned create/create-loss record is a self-contained atom-backed GC island — no unwind needed).

`destroy-frame!`'s signature was NOT touched.

## rf2-jt47s0 (P3) — destroy step 2 teardown was unguarded

`destroy-frame!` step 1 has its own catch and every step from `:ui/on-frame-destroyed!` onward rides `safe-call-hook!`, but step 2 — `notify-machine-destruction!` (the `:machines/teardown-on-frame-destroy!` hook call, its fallback `:rf.machine.lifecycle/destroyed` trace emits, and the trace-listener fan-out) — was UNGUARDED. A throwing non-machines hook consumer escaped the `try`: the finally cleared the in-flight marker and the throw propagated, but `:destroyed?` was never flipped and the record was never dissoc'd, leaving the frame LIVE + HALF-TORN-DOWN with `:on-destroy` already run. A retry re-ran the whole recipe and re-fired the user `:on-destroy`.

**Fix.** Step 2 now runs through the same accumulate-into-`*teardown-hook-failures*` best-effort boundary as the later steps, via a new `safe-teardown-step!` (the direct-call sibling of `safe-call-hook!`); both delegate to a shared `record-teardown-failure!` reporting on the two Spec 009 channels. A step-2 throw is accumulated, not propagated, so the frame tears down fully exactly once and a retry is a clean no-op. Step 5's unguarded `emit-frame-destroyed-trace!` is deliberately left as-is (a teardown-report test relies on its throw propagating).

## Fixtures

- **umsyo9** (`frame_upsert_linearization_jvm_test.clj`, JVM barrier, no sleeps): a must-create loser pauses in the pre-side-effect window; an ordinary winner installs the id with distinct no-emit + retention policy; the loser's CAS loses and throws `:rf.error/frame-id-taken` — the winner's suppression flag AND retention override are unchanged. Verified to FAIL against PR #5776's ordering (loser clears no-emit to `false`, rewrites retention 99→10).
- **jt47s0** (`frame_teardown_report_cljs_test.cljc`, dual-runtime): a throwing `:machines/teardown-on-frame-destroy!` consumer during destroy — the frame still fully tears down (record dissoc'd), the throw is accumulated into the one always-on report (not escaped), a second destroy is a clean no-op that does not re-fire `:on-destroy`. Verified to FAIL pre-fix (throw escapes, frame left LIVE with `:destroyed? false`, no report, retry re-fires).

Surface: `implementation/core/src/re_frame/frame.cljc` + its two test files only.

## Quality gates

- Core JVM `clojure -M:test` (from `implementation/core`): **1882 tests, 8450 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (from `implementation`): **9101 tests, 43069 assertions, 0 failures, 0 errors**.
- Both new fixtures confirmed to fail pre-fix and pass post-fix (temporary ordering reversals, reverted).