### PR TITLE
Fix incarnation-owned frame teardown (rf2-idowh9)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2682,10 +2682,64 @@
                       :reason     :parent-frame-destroyed})))))
 
 (defn- mark-frame-destroyed!
-  ;; The `frames` registry is keyed by the bare frame-id, so flip `:destroyed?`
-  ;; on that record.
-  [id]
-  (swap! frames update id assoc-in [:lifecycle :destroyed?] true))
+  "CAS-flip `:destroyed?` only while `id` still names `expected-token`'s
+  incarnation. The caller holds that incarnation's `:drain-lock`; the registry
+  CAS is still required because unrelated frame ids share the `frames` atom.
+  Returns true on the flip, false when the expected incarnation is no longer
+  live."
+  [id expected-token]
+  (loop []
+    (let [registry @frames
+          f        (get registry id)]
+      (if (and f
+               (not (-> f :lifecycle :destroyed?))
+               (identical? expected-token (:drain-lock f)))
+        (if (compare-and-set! frames registry
+                              (assoc-in registry [id :lifecycle :destroyed?] true))
+          true
+          (recur))
+        false))))
+
+(def ^:private ^:dynamic *destroy-claim-probe*
+  "JVM concurrency-test seam fired after `destroy-frame!` captures the candidate
+  incarnation and before it enters drain serialization. nil in production."
+  nil)
+
+(defn- claim-frame-destroy!
+  "Claim teardown authority for `expected-token`'s live incarnation of `id`.
+
+  The token check and `destroying-frames` publication run under the candidate
+  incarnation's drain lock. `call-serialized-with-drain!` may have captured A's
+  frame record before blocking and wake after A was replaced by B, so the thunk
+  revalidates the registry token after acquisition and retries against the
+  current record. A stale expected token therefore never claims B while holding
+  A's obsolete lock. Returns the claimed frame record, or nil."
+  [id expected-token]
+  (loop []
+    (when-let [candidate (frame id)]
+      (let [candidate-token (:drain-lock candidate)]
+        (when (identical? expected-token candidate-token)
+          (when *destroy-claim-probe*
+            (*destroy-claim-probe* id candidate-token))
+          (let [claimed
+                (call-serialized-with-drain!
+                  id
+                  (fn []
+                    (when-let [current (frame id)]
+                      (cond
+                        (not (identical? candidate-token (:drain-lock current)))
+                        ::retry-destroy-claim
+
+                        (contains? @destroying-frames id)
+                        nil
+
+                        :else
+                        (do
+                          (swap! destroying-frames assoc id candidate-token)
+                          current)))))]
+            (if (= ::retry-destroy-claim claimed)
+              (recur)
+              claimed)))))))
 
 (defn- tear-down-sub-cache!
   "Dispose every cached subscription reaction for the destroyed frame.
@@ -2804,7 +2858,10 @@
                                       lifecycle rather than throwing
                                       :rf.error/frame-destroyed. No-op when
                                       the artefact is absent (rf2-vxgfnd.42).
-    3. mark-frame-destroyed!        — flip :lifecycle :destroyed?.
+    3. mark-frame-destroyed!        — CAS-flip :lifecycle :destroyed? only
+                                      while the claimed incarnation token still
+                                      matches, under that incarnation's
+                                      :drain-lock.
     4. tear-down-sub-cache!         — dispose every cached reaction
                                       via the sub-cache-owned
                                       `:subs.cache/dispose-all-for-
@@ -2878,8 +2935,20 @@
   (`rf/make-frame`'s return token). A value is normalized to its id via
   `frame-target->id` so the whole recipe keys the ONE registry's record
   unchanged; `dissoc-frame!` IS the forget (the resolved generation rides the
-  record, dropped with it — one registry, no separate forget hook)."
-  [target]
+  record, dropped with it — one registry, no separate forget hook).
+
+  The two-argument arity is incarnation-owned teardown: it is a silent no-op
+  unless `expected-incarnation-token` is still the live frame's identity token.
+  The check is revalidated after acquiring that incarnation's `:drain-lock`,
+  and the liveness flip CAS-checks the same token under the same lifecycle gate,
+  so a stale teardown can never destroy a fresh same-id incarnation. The
+  one-argument arity preserves ordinary destroy semantics by pinning the live
+  token at invocation and delegating to the incarnation-owned arity."
+  ([target]
+   (let [id (frame-target->id target)]
+     (when-let [expected-token (frame-incarnation-token id)]
+       (destroy-frame! target expected-token))))
+  ([target expected-incarnation-token]
   ;; Accept a frame VALUE or a frame-id keyword. Normalize a value to its id so
   ;; every keyed teardown step below targets the record; a keyword passes
   ;; through unchanged.
@@ -2890,15 +2959,14 @@
   ;; The registry is keyed by the bare frame-id, so every keyed teardown step
   ;; (the in-flight guard, `mark-frame-destroyed!`, `dissoc-frame!`)
   ;; targets the frame-id-keyed record directly.
-  (when-let [f (frame id)]
-      (when-not (contains? @destroying-frames id)
-      ;; Record the DESTROYING incarnation's token (the live record's
-      ;; `:drain-lock`) so `frame-incarnation-closing?` can tell this
-      ;; incarnation's teardown apart from a fresh same-id replacement that goes
-      ;; live under the reused id before this destroy's `finally` clears the
-      ;; marker (rf2-vxgfnd.94). `contains?`/keys keep the bare-id semantics the
+  (when-let [f (claim-frame-destroy! id expected-incarnation-token)]
+      ;; `claim-frame-destroy!` records the DESTROYING incarnation's token (the
+      ;; live record's `:drain-lock`) under that SAME lock, after revalidating
+      ;; the expected token. `frame-incarnation-closing?` can therefore tell
+      ;; this teardown apart from a fresh same-id replacement that goes live
+      ;; under the reused id before this destroy's `finally` clears the marker
+      ;; (rf2-vxgfnd.94). `contains?`/keys keep the bare-id semantics the
       ;; re-entrant guard + `frame-closing?` rely on.
-      (swap! destroying-frames assoc id (:drain-lock f))
       ;; Capture the DESTROY-TIME frame-state value BEFORE any teardown step
       ;; runs. After `mark-frame-destroyed!` (step 3) flips :destroyed?,
       ;; `frame-state-value` returns nil; after `dissoc-frame!` (step 6)
@@ -2970,7 +3038,10 @@
         ;; op's `:serialized-holder` — either way the flip runs directly rather
         ;; than self-deadlocking, and the `frame-disposed-for-drain?` interrupt
         ;; seam is unchanged.
-        (call-serialized-with-drain! id (fn [] (mark-frame-destroyed! id)))
+        (when (call-serialized-with-drain!
+                id
+                (fn []
+                  (mark-frame-destroyed! id expected-incarnation-token)))
         (tear-down-sub-cache! id f)
         ;; Dispose the app-db / runtime-db projection reactions
         ;; AFTER the sub-cache (the sub-cache's layer-1 reactions watch the
@@ -3083,7 +3154,7 @@
         ;; forget hook is needed.
         (dissoc-frame! id)
         (notify-epoch-listeners! id run-fs-before fs-at-destroy run-time-ms)
-        nil
+        nil)
         (finally
           ;; EP-0008 R1 — FINALLY-shaped flush of the always-on
           ;; teardown report. If any cleanup hook threw (entries accumulated

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -1,0 +1,56 @@
+(ns re-frame.frame-destroy-incarnation-jvm-test
+  "Deterministic JVM barriers for incarnation-owned frame teardown."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest expected-incarnation-token-controls-destroy-authority
+  (rf/make-frame {:id :destroy/token})
+  (let [live-token (frame/frame-incarnation-token :destroy/token)]
+    (is (nil? (frame/destroy-frame! :destroy/token (atom false)))
+        "a mismatched token is a silent no-op")
+    (is (identical? live-token
+                    (frame/frame-incarnation-token :destroy/token))
+        "a mismatched token leaves the live incarnation unchanged")
+    (is (nil? (frame/destroy-frame! :destroy/token live-token))
+        "the matching token keeps destroy-frame!'s nil return contract")
+    (is (nil? (frame/frame :destroy/token))
+        "the matching token destroys its incarnation")))
+
+(deftest stale-destroy-revalidates-after-candidate-capture
+  ;; Pause the expected-token destroy AFTER it captures incarnation A. Another
+  ;; actor replaces the id with B before the destroy enters drain serialization.
+  ;; On resume, core must revalidate the token under the lifecycle gate and no-op
+  ;; rather than applying A's stale authority to B.
+  (rf/make-frame {:id :destroy/race})
+  (let [token-a   (frame/frame-incarnation-token :destroy/race)
+        captured  (CountDownLatch. 1)
+        release   (CountDownLatch. 1)
+        probe-var (ns-resolve 're-frame.frame '*destroy-claim-probe*)
+        stale     (with-bindings
+                    {probe-var
+                     (fn [id token]
+                       (when (and (= :destroy/race id)
+                                  (identical? token-a token))
+                         (.countDown captured)
+                         (.await release 10 TimeUnit/SECONDS)))}
+                    (future
+                      (frame/destroy-frame! :destroy/race token-a)))]
+    (is (.await captured 10 TimeUnit/SECONDS)
+        "the stale destroy captured incarnation A before the replacement")
+    (frame/destroy-frame! :destroy/race)
+    (rf/make-frame {:id :destroy/race})
+    (let [token-b (frame/frame-incarnation-token :destroy/race)]
+      (is (and (some? token-b) (not (identical? token-a token-b)))
+          "the actor installed a distinct incarnation B")
+      (.countDown release)
+      (is (nil? @stale) "the stale expected-token destroy returns a silent no-op")
+      (is (identical? token-b
+                      (frame/frame-incarnation-token :destroy/race))
+          "incarnation B survives stale teardown unchanged"))))

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -738,8 +738,7 @@
              ;; destroy+recreate under the same id (a distinct token), or a
              ;; colliding actor's frame, survives. Never a bare id.
              (doseq [[fid t] @owned]
-               (when (identical? t (rframe/frame-incarnation-token fid))
-                 (rframe/destroy-frame! fid)))
+               (rframe/destroy-frame! fid t))
              (release-plan-frames! wanted)))))))
 
 #?(:clj

--- a/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
@@ -611,42 +611,52 @@
             "zero residue once the actor's own frame is cleaned up")))))
 
 (deftest plan-bearing-teardown-is-incarnation-owned
-  ;; Destroy/recreate-before-cleanup: teardown must destroy the EXACT
-  ;; incarnation this render created — not whatever frame later occupies the id.
-  ;; The render is held open (mid-render, between install and teardown) while a
-  ;; concurrent actor destroys the render's incarnation and RE-creates a fresh
-  ;; one under the same id; the render's teardown must leave that NEW
-  ;; incarnation alive. (#5732's bare-id teardown destroyed it.)
-  (let [installed (CountDownLatch. 1)   ; render installed + is rendering
-        swapped   (CountDownLatch. 1)   ; actor destroyed + re-created the id
-        before    (set (keys @frame/frames))]
-    (binding [*render-gate* (fn []
-                              (.countDown installed)
-                              (.await swapped 10 TimeUnit/SECONDS))]
-      (let [render  (future
-                      (uit/render [ui/frame-root {:id :test/incarn
-                                                  :initial-events [[:rf/set-db {:n 1}]]}
-                                   [gated {}]]))]
-        (.await installed 10 TimeUnit/SECONDS)
+  ;; Deterministically open the OLD check-to-act window: the render has decided
+  ;; to destroy its frame and entered `destroy-frame!`, but the actual destroy is
+  ;; held while another actor replaces the id. The render must carry its pinned
+  ;; token INTO core so the resumed destroy cannot tear down the replacement.
+  (let [teardown-entered (CountDownLatch. 1)
+        swapped          (CountDownLatch. 1)
+        render-thread    (atom nil)
+        original-destroy frame/destroy-frame!
+        before           (set (keys @frame/frames))
+        gate-render-destroy
+        (fn [destroy]
+          (if (identical? @render-thread (Thread/currentThread))
+            (do
+              (.countDown teardown-entered)
+              (.await swapped 10 TimeUnit/SECONDS)
+              (destroy))
+            (destroy)))]
+    (with-redefs [frame/destroy-frame!
+                  (fn
+                    ([target]
+                     (gate-render-destroy #(original-destroy target)))
+                    ([target expected-token]
+                     (gate-render-destroy
+                       #(original-destroy target expected-token))))]
+      (let [render (future
+                     (reset! render-thread (Thread/currentThread))
+                     (uit/render [ui/frame-root {:id :test/incarn
+                                                 :initial-events [[:rf/set-db {:n 1}]]}
+                                  [gated {}]]))]
+        (is (.await teardown-entered 10 TimeUnit/SECONDS)
+            "the render reached its teardown decision barrier")
         (let [token-a (frame/frame-incarnation-token :test/incarn)]
-          (is (some? token-a) "the render installed its own incarnation of :test/incarn")
-          ;; actor destroys the render's incarnation and re-creates a FRESH one.
-          (frame/destroy-frame! :test/incarn)
-          (rf/make-frame {:id :test/incarn :initial-events [[:rf/set-db {:n 2}]]})
+          (is (some? token-a) "the render installed its own incarnation")
+          (original-destroy :test/incarn)
+          (rf/make-frame {:id :test/incarn
+                          :initial-events [[:rf/set-db {:n 2}]]})
           (let [token-b (frame/frame-incarnation-token :test/incarn)]
             (is (and (some? token-b) (not (identical? token-a token-b)))
-                "the actor's re-created frame is a DISTINCT incarnation")
-            (.countDown swapped)          ; release the render → it tears down
-            (is (map? @render) "the held render completes and returns its tree")
-            (is (some? (frame/frame :test/incarn))
-                "the actor's re-created incarnation SURVIVES — teardown is
-                 incarnation-owned, not by bare id")
+                "the actor installed a distinct replacement incarnation")
+            (.countDown swapped)
+            (is (map? @render) "the held render completes")
             (is (identical? token-b (frame/frame-incarnation-token :test/incarn))
-                "…and it is unchanged — the render tore down only ITS incarnation")
-            ;; clean up the actor-owned frame; then no residue.
-            (frame/destroy-frame! :test/incarn)
+                "the replacement survives the stale render teardown unchanged")
+            (original-destroy :test/incarn)
             (is (= before (set (keys @frame/frames)))
-                "no residue: the render left nothing, the actor's frame is cleaned")))))))
+                "no residue after the actor cleans up its replacement")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry-rested EXCLUSIVE install (rf2-vxgfnd.76). The claim linearizes


### PR DESCRIPTION
## What changed

- add an incarnation-owned `destroy-frame!` arity accepting an expected incarnation token while preserving the existing one-argument API
- claim teardown authority under the candidate drain lock, revalidate after lock acquisition, and CAS-flip liveness only while the same token remains live
- pass each pinned frame-plan token from `re-frame.ui.test/render` into core teardown
- add deterministic JVM barriers at both the UI caller and core lifecycle boundary

## Why

The UI test host previously read the current incarnation token and then called bare-id `destroy-frame!` in a separate action. A concurrent actor could destroy incarnation A and install same-id incarnation B in that check-to-act gap; the stale UI teardown would then destroy B.

The new expected-token path makes stale teardown a silent no-op. It also revalidates after drain serialization because a waiter can capture candidate A before blocking and resume after the registry names B.

## Red-to-green evidence

Before the production fix, the new deterministic UI barrier ran:

`clojure -M:test -n re-frame.ui.test-render-jvm-test`

Result: **38 tests, 103 assertions, 1 failure**. `plan-bearing-teardown-is-incarnation-owned` expected replacement token B to remain live, but `frame-incarnation-token` returned `nil`; stale render teardown had destroyed B.

With the fix, the identical fixture is green: **38 tests, 103 assertions, 0 failures, 0 errors**. The focused core barrier is also green: **2 tests, 8 assertions, 0 failures, 0 errors**.

## Validation

- core JVM: 1,886 tests / 8,464 assertions, green
- UI JVM: 345 tests / 4,962 assertions, green
- full CLJS: 9,104 tests / 43,091 assertions, green
- UI CLJS: 332 tests / 1,759 assertions, green
- clj-kondo touched-file error gate: 0 errors
- Splint touched-file error gate: green
- post-rebase focused core and UI JVM suites: green
- post-rebase full CLJS and UI CLJS suites: green

## Docstring audit

Every touched docstring claim was checked against behavior: the one-argument arity pins the live token and delegates; the two-argument arity is a no-op on mismatch; claim revalidation occurs after serialization; and the liveness CAS checks the expected token under the drain lifecycle gate.

Fixes `rf2-idowh9`.
