### PR TITLE
rf2-s9mcy6: stabilize NaN observation and teardown races

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -293,11 +293,25 @@
 
 (defonce ^:private node-key-counter (atom 0))
 
+(defn- node-value=
+  "The observation-node spelling of the UI substrate's ruled `rf=` equality,
+  kept core-local so core does not depend on the UI artefact: identity or `=`,
+  plus numeric equality on the JVM and NaN self-equality on both hosts."
+  [a b]
+  (or (identical? a b)
+      (= a b)
+      (and (number? a)
+           (number? b)
+           #?(:clj  (or (== (double a) (double b))
+                         (and (Double/isNaN (double a))
+                              (Double/isNaN (double b))))
+              :cljs (and (js/isNaN a) (js/isNaN b))))))
+
 (defn- advance-node-record!
   "Record that value `v` was OBSERVED on `reaction`: mint the node record on
   first observation (a fresh process-unique `:node-key`), advance `:version`
-  when `v` differs from the last observed value by `rf=` (`=` on the CLJS
-  reference), else leave the record untouched. Returns the (post) record.
+  when `v` differs from the last observed value by the core-local `rf=`
+  spelling, else leave the record untouched. Returns the (post) record.
   Constant work — one compare + one small map write on movement."
   [reaction v]
   #?(:clj
@@ -307,7 +321,7 @@
                     (nil? rec)
                     {:node-key (swap! node-key-counter inc) :version 0 :value v}
 
-                    (not= (:value rec) v)
+                    (not (node-value= (:value rec) v))
                     (assoc rec :version (inc (:version rec)) :value v)
 
                     :else rec)]
@@ -320,7 +334,7 @@
                   (nil? rec)
                   {:node-key (swap! node-key-counter inc) :version 0 :value v}
 
-                  (not= (:value rec) v)
+                  (not (node-value= (:value rec) v))
                   (assoc rec :version (inc (:version rec)) :value v)
 
                   :else rec)]
@@ -1046,15 +1060,18 @@
   order that eviction before this read — so once a reaction has been disposed it
   is no longer the entry's `:reaction`. This is the authority `acquire!`'s
   first-owner handshake (rf2-vxgfnd.32) and the `current?` kept-check both read."
-  [{:keys [frame-id query-v] :as state}]
-  (boolean
-    ;; Derive the strong reaction (held WEAKLY in the state on the JVM —
-    ;; rf2-vxgfnd.37). A collected reaction is nil and can never be the live
-    ;; canonical node, so the `when-let` short-circuits — never falling into the
-    ;; `(identical? nil (:reaction absent-entry))` ≡ `(identical? nil nil)` trap.
-    (when-let [rx (lease-reaction state)]
-      (when-let [cache (:sub-cache (frame/frame frame-id))]
-        (identical? rx (:reaction (get @cache query-v)))))))
+  ([state]
+   ;; Derive the strong reaction (held WEAKLY in the state on the JVM —
+   ;; rf2-vxgfnd.37). A collected reaction is nil and can never be the live
+   ;; canonical node, so the `when-let` short-circuits — never falling into the
+   ;; `(identical? nil (:reaction absent-entry))` ≡ `(identical? nil nil)` trap.
+   (boolean
+     (when-let [rx (lease-reaction state)]
+       (node-still-canonical? state rx))))
+  ([{:keys [frame-id query-v]} rx]
+   (boolean
+     (when-let [cache (:sub-cache (frame/frame frame-id))]
+       (identical? rx (:reaction (get @cache query-v)))))))
 
 ;; ---- acquire! -------------------------------------------------------------------
 
@@ -1432,24 +1449,26 @@
               reason
               {:extra {:frame          (:frame-id st)
                        :rf.sub/query-v (:query-v st)}})))
-        (if (node-still-canonical? st)
-          ;; Canonical ⟹ the cache holds this reaction strongly, so the weakly
-          ;; held `lease-reaction` resolves (rf2-vxgfnd.37).
-          (let [[rec v] (observe-node! (lease-reaction st))]
-            (swap! (lease-state lease) assoc
-                   :last {:value v :version (:version rec)
-                          :node-key (:node-key rec)})
-            {:value          v
-             :version        (:version rec)
-             :node-key       (:node-key rec)
-             :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
-             :registry-epoch @registry-epoch*})
-          (let [{:keys [value version node-key]} (:last st)]
-            {:value          value
-             :version        version
-             :node-key       node-key
-             :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
-             :registry-epoch @registry-epoch*}))))))
+        ;; Resolve the JVM WeakReference ONCE and hold the result strongly across
+        ;; the canonicality check + deref. A GC between two lookups could clear
+        ;; the second lookup even after the first proved the node canonical.
+        (let [rx (lease-reaction st)]
+          (if (and (some? rx) (node-still-canonical? st rx))
+            (let [[rec v] (observe-node! rx)]
+              (swap! (lease-state lease) assoc
+                     :last {:value v :version (:version rec)
+                            :node-key (:node-key rec)})
+              {:value          v
+               :version        (:version rec)
+               :node-key       (:node-key rec)
+               :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
+               :registry-epoch @registry-epoch*})
+            (let [{:keys [value version node-key]} (:last st)]
+              {:value          value
+               :version        version
+               :node-key       node-key
+               :frame-epoch    (frame/frame-commit-epoch (:frame-id st))
+               :registry-epoch @registry-epoch*})))))))
 
 ;; ---- release! -------------------------------------------------------------------
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -77,6 +77,33 @@
 (defn- items-target []
   (obs/resolve-target {:frame fid :query-v [:obs/items]}))
 
+#?(:clj
+   (deftest canonical-read-holds-one-strong-reaction-across-the-jvm-gc-gap
+     (reg-items!)
+     (seed-items! [:a])
+     (let [target       (items-target)
+           lease        (obs/acquire! target (fn [_]))
+           expected     (obs/read lease)
+           reaction-var (ns-resolve 're-frame.substrate.observation
+                                    'lease-reaction)
+           original     (var-get reaction-var)
+           calls        (atom 0)]
+       (try
+         ;; Deterministically model the WeakReference clearing between the old
+         ;; canonicality check and its second lookup in read. The corrected read
+         ;; resolves once and holds that reaction strongly for the whole branch.
+         (with-redefs-fn
+           {reaction-var
+            (fn [state]
+              (if (= 1 (swap! calls inc))
+                (original state)
+                nil))}
+           #(is (= expected (obs/read lease))
+                "a canonical JVM read cannot deref nil after the GC gap"))
+         (is (= 1 @calls) "read resolves the weak reaction exactly once")
+         (finally
+           (obs/release! lease))))))
+
 ;; ===========================================================================
 ;; resolve-target
 ;; ===========================================================================

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -358,7 +358,9 @@
   ;;                             ;   in production (no StrictMode double-invoke)
   ;;    :committed {tk -> lease} ; installed dependency set
   ;;    :values    {tk -> value} ; last published site values (stabilization
-  ;;                             ;   + the revision snapshot's evidence)
+  ;;                             ;   + revision evidence); retained across a
+  ;;                             ;   disconnect, so frame teardown can identify
+  ;;                             ;   an Activity-hidden cell's last frames
   ;;    :revision  int           ; get-snapshot returns this (useSyncExternalStore)
   ;;    :dirty?    bool          ; pending-notification flag (drain coalescing)
   ;;    :evidence  ev|nil        ; DEBUG-only bounded causal evidence for the
@@ -595,17 +597,17 @@
 (defonce ^:private flush-scheduled? (atom false))
 
 (defonce ^:private live-cells
-  ;; The set of currently-CONNECTED ViewCells — the input to a frame-destroy
-  ;; sweep (`teardown-frame!`). A cell enrols on `connect!` (its first commit,
+  ;; The set of currently-CONNECTED ViewCells — the connected input to a
+  ;; frame-destroy sweep (`teardown-frame!`). A cell enrols on `connect!`,
   ;; when it starts observing a frame) and leaves on `disconnect!` (React
   ;; unmount / Activity hide, when it releases its committed dependency set) or
   ;; `teardown!` (it goes :dead). Membership therefore tracks EXACTLY the cells
   ;; carrying a live committed dependency set, so a destroyed frame can find the
-  ;; cells observing it and transition them to :dead (03 §4) rather than leave
-  ;; them live to throw `:rf.error/frame-destroyed` on their next read. Because
-  ;; a disconnected cell leaves the set, an unmounted cell never lingers here
-  ;; (no retention leak). `defonce` (module-lived); tests clear it via
-  ;; `reset-scheduler!`.
+  ;; connected cells observing it and transition them to :dead (03 §4) rather
+  ;; than leave them live to throw `:rf.error/frame-destroyed` on their next
+  ;; read. Because a disconnected cell leaves the set, an unmounted cell never
+  ;; lingers here (no retention leak). `defonce` (module-lived); tests clear it
+  ;; via `reset-scheduler!`.
   (atom #{}))
 
 (defonce ^:private root-cells
@@ -626,7 +628,8 @@
   ;; identity (`make-root-incarnation`), NOT the reusable root-id, so a stale
   ;; teardown can never reap the cells of a replacement root mounted under the same
   ;; root-id. `defonce` (module-lived); `reset-scheduler!` clears it between
-  ;; fixtures.
+  ;; fixtures. Frame teardown also consults its still-disconnected members,
+  ;; whose retained `:values` keys name their last published frames.
   (atom {}))
 
 (defonce ^:private teardown-collector
@@ -1002,6 +1005,17 @@
   [^ViewCell cell frame-id]
   (contains? (cell-frames cell) frame-id))
 
+(defn- cell-retained-frame?
+  "True when `cell`'s last published site values name `frame-id`. Unlike the
+  live committed set, `:values` survives an Activity disconnect for value
+  stabilization, so this is the bounded history a frame-destroy sweep uses for
+  still-disconnected, root-owned cells."
+  [^ViewCell cell frame-id]
+  (boolean
+    (some (fn [tk]
+            (and (= :sub (nth tk 0)) (= frame-id (nth tk 1))))
+          (keys (:values @(state cell))))))
+
 (defn flush-frame!
   "The FRAME arity of `flush!` — flush every pending cell observing frame
   `frame-id` (every root that observes that frame). Cells scoped to other
@@ -1349,8 +1363,9 @@
     cell))
 
 (defn teardown-frame!
-  "Frame-destroy sweep: transition every currently-connected ViewCell
-  observing frame `frame-id` to `:dead` (03 §4 dead-cell lifecycle). Each
+  "Frame-destroy sweep: transition every currently-connected ViewCell observing
+  frame `frame-id`, plus every still-disconnected root-owned ViewCell whose last
+  published site values name it, to `:dead` (03 §4 dead-cell lifecycle). Each
   matched cell's leases are detached, its pending notification dropped, and
   its retained interval proven an unmount (`:unmounted {:proof
   :host-teardown}`) — so a subsequent read/probe on such a cell follows the
@@ -1359,12 +1374,20 @@
   `:ui/on-frame-destroyed!` late-bind hook wired in `re-frame.ui.frames`;
   the sweep runs while the frame is still live, so each cell releases its
   leases against the live sub-cache (symmetric with `disconnect!`). The
-  membership test rides the cell's committed dependency set
-  (`cell-observes-frame?`); a disconnected cell holds none and is therefore
-  never a target. Iterates a snapshot, so the per-cell `teardown!` de-enrol
-  is safe. Returns the count torn down."
+  connected membership test rides the committed dependency set
+  (`cell-observes-frame?`). An Activity-hidden cell holds no committed deps, so
+  its bounded root ownership plus retained `:values` target keys supply the
+  corresponding discoverability without another global registry. Iterates
+  snapshots, so the per-cell `teardown!` de-enrol is safe. Returns the count
+  torn down."
   [frame-id]
-  (let [victims (filterv #(cell-observes-frame? % frame-id) @live-cells)]
+  (let [connected (filter #(cell-observes-frame? % frame-id) @live-cells)
+        hidden    (into #{}
+                        (comp (mapcat val)
+                              (filter #(= :disconnected (lifecycle %)))
+                              (filter #(cell-retained-frame? % frame-id)))
+                        @root-cells)
+        victims   (into hidden connected)]
     (doseq [cell victims]
       (teardown! cell))
     (count victims)))

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -96,6 +96,47 @@
           "the destroyed frame's cell followed the dead-cell lifecycle (03 §4)
            — NOT left live to throw :rf.error/frame-destroyed on next read"))))
 
+(deftest frame-destroy-reaps-an-activity-hidden-cell
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [fid  (make-frame! :td/hidden-frame {:a 1})
+        root (reactive/make-root-incarnation)
+        cell (reactive/attach-root! (reactive/make-cell ::hidden) root)]
+    (render+commit! cell fid [[:td/a]])
+    (reactive/disconnect! cell)
+    (testing "precondition — Activity cleanup released live deps but retained ownership"
+      (is (= :disconnected (reactive/lifecycle cell)))
+      (is (false? (reactive/cell-observes-frame? cell fid)))
+      (is (= 1 (reactive/root-cell-count root))))
+    (testing "destroying its last published frame follows the clean dead lifecycle"
+      (frame/destroy-frame! fid)
+      (is (= :dead (reactive/lifecycle cell))
+          "a later Activity reveal cannot read through a destroyed frame")
+      (is (= {:state :disconnected :reason :unmounted :proof :host-teardown}
+             (peek (reactive/intervals cell))))
+      (is (= 0 (reactive/root-cell-count root))
+          "final teardown drops the retained root membership"))))
+
+(deftest frame-destroy-leaves-another-frames-activity-hidden-cell-reconnectable
+  (rf/reg-sub :td/a (fn [db _] (:a db)))
+  (let [destroyed-fid (make-frame! :td/destroyed-hidden-frame {:a 1})
+        sibling-fid   (make-frame! :td/sibling-hidden-frame {:a 2})
+        destroyed     (reactive/attach-root! (reactive/make-cell ::destroyed)
+                                             (reactive/make-root-incarnation))
+        sibling       (reactive/attach-root! (reactive/make-cell ::sibling)
+                                             (reactive/make-root-incarnation))]
+    (render+commit! destroyed destroyed-fid [[:td/a]])
+    (render+commit! sibling sibling-fid [[:td/a]])
+    (reactive/disconnect! destroyed)
+    (reactive/disconnect! sibling)
+    (frame/destroy-frame! destroyed-fid)
+    (is (= :dead (reactive/lifecycle destroyed)))
+    (is (= :disconnected (reactive/lifecycle sibling))
+        "retained target keys scope the hidden-cell sweep to the destroyed frame")
+    (reactive/settle-disconnect! sibling)
+    (render+commit! sibling sibling-fid [[:td/a]])
+    (is (= :connected (reactive/lifecycle sibling))
+        "the other frame's hidden cell remains revealable")))
+
 (deftest frame-destroy-emits-the-unmount-fact
   (rf/reg-sub :td/a (fn [db _] (:a db)))
   (let [fid  (make-frame! :td/frame {:a 1})

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -494,3 +494,26 @@
         "G-4: an rf=-equal recompute ⇒ ZERO cell revision change ⇒ NO React render")
     (is (identical? v0 (get (reactive/committed-values cell) (tk [:r/coll])))
         "…and the committed value stays the prior exact reference (stable identity)")))
+
+(deftest nan-valued-node-is-version-and-revision-stable
+  (rf/reg-sub :r/nan (fn [db _]
+                       ;; Depend on :tick so each seed forces a recompute. The
+                       ;; JVM constructor prevents boxed-literal identity from
+                       ;; hiding the numeric equality boundary under test.
+                       (:tick db)
+                       #?(:clj  (Double/parseDouble "NaN")
+                          :cljs js/NaN)))
+  (seed! {:tick 0})
+  (let [cell  (render+commit! (reactive/make-cell ::nan) [[:r/nan]])
+        lease (reactive/committed-lease cell (tk [:r/nan]))
+        ver0  (:version (obs/read lease))]
+    (testing "repeated observation of a stable NaN does not move the node"
+      (dotimes [i 3]
+        (seed! {:tick (inc i)})
+        (is (= ver0 (:version (obs/read lease)))
+            "NaN is self-equal for observation-node versioning")))
+    (testing "render→commit reconciliation therefore cannot self-schedule forever"
+      (dotimes [_ 3]
+        (render+commit! cell [[:r/nan]]))
+      (is (= 0 (reactive/revision cell))
+          "stable NaN evidence causes zero corrective revisions"))))


### PR DESCRIPTION
Fixes rf2-s9mcy6.

## Summary
- version observation nodes with the core-local rf= truth table, including NaN self-equality
- hold one strong JVM reaction across canonicality checking and dereference
- reap Activity-hidden root-owned cells when their last published target keys name a destroyed frame

## Red-to-green evidence
- Pre-fix JVM GC-gap fixture errored with a nil dereference in observe-node! and recorded two lease-reaction lookups; fixed code returns the canonical read with exactly one lookup.
- Pre-fix hidden-frame fixture had three failures: lifecycle remained :disconnected, interval reason remained :unknown, and root membership remained 1; fixed code reaches :dead, records host teardown, and drops membership.
- Deliberate raw-= mutation against the final NaN fixture advanced the stable node version 0 to 1 to 2 to 3 (three failures); restored rf= predicate holds the version and cell revision stable.

## Verification
- core JVM full: 1885 tests, 8458 assertions, 0 failures/errors
- UI JVM full: 348 tests, 4975 assertions, 0 failures/errors
- CLJS UI full: 335 tests, 1772 assertions, 0 failures/errors
- latest-main focused rerun: observation 47/290, reconcile 23/81, frame teardown 8/31; all green
- clj-kondo on touched files: 0 errors
- git diff --check: clean

## Docstring audit
Touched claims were diff-checked against shipped behavior: the node equality truth table, the single weak-reaction resolution/fallback, and connected plus bounded hidden-cell frame teardown discovery all match the implementation.