### PR TITLE
rf2-m1dsuw: Guard live frame plan publication

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -23,8 +23,8 @@
   Per-plan disposition (document order; conflicts validated FIRST):
 
     - NO live frame         -> INSTALL: `make-frame` creates it
-      (create-if-absent), then record `{:config-fingerprint
-      :installed-by}` (root-OWNED authority).
+      (create-if-absent), then — only while that incarnation remains live —
+      record `{:config-fingerprint :installed-by}` (root-OWNED authority).
     - LIVE frame, NO install
       record (a boot `rf/make-frame`
       the plan registry never saw):
@@ -71,9 +71,12 @@
   A destroyed frame invalidates its install record — the
   `:ui/on-frame-destroyed!` hook PRUNES it (rf2-vxgfnd.30 (a)), so a boot
   re-create of the same id can no longer resurrect a dead-lifetime record
-  as a false conflict. A later plan for the same id is a genuinely new
-  frame lifetime — created fresh, `:initial-events` REPLAYED (the opt-in
-  destroy-then-reseat composition, rf2-lxwpob). A plan that throws mid-run
+  as a false conflict. Publication uses the same incarnation's lifecycle
+  gate, so an `:initial-events` handler that destroys its own frame cannot
+  re-add the dead lifetime's record after the hook prunes it. A later plan
+  for the same id is a genuinely new frame lifetime — created fresh,
+  `:initial-events` REPLAYED (the opt-in destroy-then-reseat composition,
+  rf2-lxwpob). A plan that throws mid-run
   labels the siblings it already wrote by PROVENANCE (rf2-vxgfnd.30 (b),
   rf2-vxgfnd.72): a sibling that this run FRESH-installed is tagged
   `:mount-incomplete` — its mount never completed and no root yet scopes
@@ -193,6 +196,23 @@
   []
   (reset! installed-plans {})
   nil)
+
+(defn- publish-plan-for-live-incarnation!
+  "Publish `record` for `frame-id` only while the currently-live incarnation
+  stays current. Returns true when published, nil otherwise.
+
+  The incarnation pin rejects a destroy/recreate that overtakes publication;
+  the frame's drain serialization orders this write against `destroy-frame!`'s
+  liveness flip. Therefore either the record lands first and the destroy hook
+  prunes it, or destruction wins and no dead-lifetime record is written."
+  [frame-id record]
+  (when-let [incarnation (frame/frame-incarnation-token frame-id)]
+    (frame/call-serialized-with-drain!
+     frame-id
+     (fn []
+       (when (identical? incarnation (frame/frame-incarnation-token frame-id))
+         (swap! installed-plans assoc frame-id record)
+         true)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Preflight ENSURE — the live plan executor
@@ -321,7 +341,8 @@
   `:rf.error/frame-payload-conflict` before ANY install). Phase 2
   installs/adopts/refreshes in document order: `make-frame` creates the
   frame if absent and drains `:initial-events` synchronously before
-  returning (EP-0027); a found-live same-fingerprint plan is a pure no-op
+  returning (EP-0027); its install record is published only if that
+  incarnation remains live; a found-live same-fingerprint plan is a pure no-op
   (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
   met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
   config/generation untouched, only the fingerprint recorded
@@ -397,28 +418,32 @@
           ;; never enter a root-owned refresh path (rf2-vxgfnd.56). The boot
           ;; frame was already LIVE, so a later throw is an attempt failure,
           ;; not a mount-incomplete over never-mounted state.
-          :adopt (do (swap! installed-plans assoc frame-id
-                            {:config-fingerprint config-fingerprint
-                             :adopted-by root-id
-                             :adopted true})
-                     (vswap! written conj [frame-id :live]))
+          :adopt (when (publish-plan-for-live-incarnation!
+                        frame-id
+                        {:config-fingerprint config-fingerprint
+                         :adopted-by root-id
+                         :adopted true})
+                   (vswap! written conj [frame-id :live]))
 
           ;; :install / :refresh — create-if-absent / surgical refresh;
           ;; :initial-events drain synchronously inside the engine, in
           ;; document order across plans. The record lands only AFTER a
-          ;; successful install, so a throwing plan leaves no install record
-          ;; (and the engine leaves no frame residue). An :install is FRESH
-          ;; (nothing scoped this id before); a :refresh acts on an
-          ;; ALREADY-LIVE installed root (its prior mount + render persist).
+          ;; successful install AND only while that incarnation is still live,
+          ;; so a throwing or self-destroying setup leaves no install record.
+          ;; An :install is FRESH (nothing scoped this id before); a :refresh
+          ;; acts on an ALREADY-LIVE installed root (its prior mount + render
+          ;; persist).
           (do
             (live-frame/make-frame (assoc (or config {}) :id frame-id))
-            (swap! installed-plans assoc frame-id
+            (when (publish-plan-for-live-incarnation!
+                   frame-id
                    {:config-fingerprint config-fingerprint
                     :installed-by root-id})
-            (vswap! written conj
-                    [frame-id (if (= :install (::action plan)) :fresh :live)]))))
-      ;; the whole run completed — every touched frame is backed by a
-      ;; completed mount, so drop any stale failed-run evidence.
+              (vswap! written conj
+                      [frame-id (if (= :install (::action plan)) :fresh :live)])))))
+      ;; The whole run completed. Drop stale failed-run evidence from records
+      ;; that survived; a self-destroying setup has neither a live frame nor a
+      ;; published record here, so the missing id is a no-op.
       (clear-run-incomplete-evidence! (map :frame-id decided))
       (catch #?(:clj Throwable :cljs :default) e
         ;; a plan threw mid-run: the siblings this run wrote stay live

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -201,18 +201,37 @@
   "Publish `record` for `frame-id` only while the currently-live incarnation
   stays current. Returns true when published, nil otherwise.
 
-  The incarnation pin rejects a destroy/recreate that overtakes publication;
-  the frame's drain serialization orders this write against `destroy-frame!`'s
-  liveness flip. Therefore either the record lands first and the destroy hook
-  prunes it, or destruction wins and no dead-lifetime record is written."
+  The incarnation pin rejects a destroy/recreate that overtakes publication.
+  The incarnation-scoped closing check also covers `destroy-frame!`'s earlier
+  pre-liveness-flip window: its close marker is installed BEFORE the UI hook
+  prunes plan authority, while `frame/frame` still returns the dying record.
+
+  Both checks run under the frame's drain serialization. Revalidation after the
+  write covers a destroy that starts between the first check and the registry
+  swap: that tentative record is removed. Thus a record published before a
+  later destroy is pruned by its UI hook, while an already-started or overtaking
+  destroy leaves no dead-lifetime record. The incarnation-scoped predicate (not
+  bare `frame-closing?`) permits a fresh B while A is only finishing teardown."
   [frame-id record]
   (when-let [incarnation (frame/frame-incarnation-token frame-id)]
     (frame/call-serialized-with-drain!
      frame-id
      (fn []
-       (when (identical? incarnation (frame/frame-incarnation-token frame-id))
+       (when (and (identical? incarnation
+                              (frame/frame-incarnation-token frame-id))
+                  (not (frame/frame-incarnation-closing? frame-id incarnation)))
          (swap! installed-plans assoc frame-id record)
-         true)))))
+         (if (and (identical? incarnation
+                              (frame/frame-incarnation-token frame-id))
+                  (not (frame/frame-incarnation-closing? frame-id incarnation)))
+           true
+           (do
+             (swap! installed-plans
+                    (fn [plans]
+                      (if (= record (get plans frame-id))
+                        (dissoc plans frame-id)
+                        plans)))
+             nil)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Preflight ENSURE — the live plan executor

--- a/implementation/ui/test/re_frame/ui/frame_plan_publication_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_plan_publication_race_jvm_test.clj
@@ -1,0 +1,101 @@
+(ns re-frame.ui.frame-plan-publication-race-jvm-test
+  "JVM lifecycle race coverage for frame-plan record publication.
+
+  `destroy-frame!` marks an incarnation CLOSING before it runs the UI teardown
+  hook, but does not flip the frame's `:destroyed?` bit until after that hook.
+  The hook prunes the installed-plan record. Publication in the post-prune /
+  pre-liveness-flip window must therefore reject the closing incarnation, or it
+  can write a dead-lifetime record after the only prune has already happened.
+
+  A wrapped real UI hook opens that window with a CountDownLatch handoff; there
+  are no sleeps or scheduler guesses. CLJS cannot interleave a second publisher
+  while synchronous destruction is paused, so this fixture is JVM-only."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.late-bind            :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.frames            :as frames])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil})
+  (fn [test-fn]
+    (frames/reset-installed-plans!)
+    (try
+      (test-fn)
+      (finally
+        (frames/reset-installed-plans!)))))
+
+(defn- plan [frame-id fingerprint]
+  {:frame-id frame-id :config {} :config-fingerprint fingerprint})
+
+(defn- err-id [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (:rf.error/id (ex-data e)))))
+
+(deftest closing-incarnation-cannot-republish-after-the-destroy-prune
+  (let [fid          :plan-race/frame
+        _            (rf/make-frame {:id fid :doc "incarnation A"})
+        token-a      (frame/frame-incarnation-token fid)
+        pruned       (CountDownLatch. 1)
+        release      (CountDownLatch. 1)
+        orig-ui-hook (late-bind/get-fn :ui/on-frame-destroyed!)
+        destroy*     (atom nil)]
+    (try
+      ;; Run the REAL UI teardown first (including installed-plan pruning), then
+      ;; pause before destroy-frame! advances to its liveness flip.
+      (late-bind/set-fn!
+       :ui/on-frame-destroyed!
+       (fn [frame-id]
+         (orig-ui-hook frame-id)
+         (when (= fid frame-id)
+           (.countDown pruned)
+           (.await release 10 TimeUnit/SECONDS))))
+
+      (reset! destroy* (future (frame/destroy-frame! fid)))
+      (is (.await pruned 10 TimeUnit/SECONDS)
+          "destroy reached the deterministic post-UI-prune barrier")
+      (is (some? (frame/frame fid))
+          "precondition: liveness has not flipped yet")
+      (is (true? (frame/frame-incarnation-closing? fid token-a))
+          "precondition: incarnation A is already marked closing")
+      (is (nil? (frames/installed-plan-entry fid))
+          "precondition: the real UI hook already pruned plan authority")
+
+      ;; This config-less plan would ordinarily adopt the live boot frame. A
+      ;; closing incarnation is not publishable even though frame/frame and its
+      ;; incarnation token remain visible until the destroy's next step.
+      (frames/execute-frame-plans!
+       :root/a [(plan fid "cf1-closing-aaaaaaaa")])
+      (is (nil? (frames/installed-plan-entry fid))
+          "publication rejects the closing incarnation after the prune")
+
+      (.countDown release)
+      (is (nil? (deref @destroy* 10000 ::timeout))
+          "incarnation A finishes destruction")
+      (is (nil? (frame/frame fid)) "incarnation A is absent")
+
+      ;; A boot replacement makes any stale record observable again. Root B's
+      ;; different fingerprint must adopt that new lifetime, not conflict with
+      ;; the record root A attempted to publish after A's prune.
+      (rf/make-frame {:id fid :doc "incarnation B"})
+      (is (nil? (frames/installed-plan-entry fid))
+          "incarnation B inherits no dead-lifetime plan record")
+      (is (nil? (err-id
+                 #(frames/execute-frame-plans!
+                   :root/b [(plan fid "cf1-replacement-bbbbb")])))
+          "root B adopts incarnation B without a stale payload conflict")
+      (is (= :root/b (:adopted-by (frames/installed-plan-entry fid)))
+          "incarnation B records only its real adopter")
+      (finally
+        ;; Never strand the destroy future if an assertion or setup step fails.
+        (.countDown release)
+        (when-let [destroy @destroy*]
+          (deref destroy 10000 ::timeout))
+        (late-bind/set-fn! :ui/on-frame-destroyed! orig-ui-hook)))))

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -185,6 +185,41 @@
     (is (= 1 (:n (rf/app-db-value :frame/session)))
         "new lifetime re-seeds from :initial-events")))
 
+(deftest self-destroying-initial-events-do-not-publish-a-dead-lifetime
+  ;; `make-frame` runs :initial-events synchronously before the plan executor
+  ;; publishes its install record. A handler may destroy its own frame and still
+  ;; return normally (run-to-completion), so publication must be conditional on
+  ;; that just-created lifetime still being live.
+  (rf/reg-event :test/destroy-self
+    (fn [_ _]
+      (frame/destroy-frame! :frame/self-destroy)
+      {}))
+  (frames/execute-frame-plans!
+   :root/a [(plan :frame/self-destroy
+                  {:initial-events [[:test/destroy-self]]}
+                  "cf1-dead111111111111")])
+  (is (nil? (frame/frame :frame/self-destroy))
+      "sanity: the setup handler destroyed the frame under construction")
+  (is (nil? (frames/installed-plan-entry :frame/self-destroy))
+      "the dead lifetime has no visible install record")
+
+  ;; Recreate the same id outside the plan registry. A stale record that was
+  ;; merely hidden by installed-plan-entry's liveness guard becomes visible now.
+  (rf/make-frame {:id :frame/self-destroy :doc "replacement lifetime"})
+  (is (nil? (frames/installed-plan-entry :frame/self-destroy))
+      "the replacement must not resurrect root A's dead-lifetime record")
+
+  ;; Root B can now adopt the replacement with a different fingerprint. Before
+  ;; the publication guard this threw a false frame-payload-conflict naming A.
+  (is (nil? (err-id
+             #(frames/execute-frame-plans!
+               :root/b [(plan :frame/self-destroy {}
+                              "cf1-live22222222222")])))
+      "a new root adopts the replacement without a dead-installer conflict")
+  (is (= :root/b
+         (:adopted-by (frames/installed-plan-entry :frame/self-destroy)))
+      "the surviving replacement is recorded under its real adopting root"))
+
 ;; ---- ADOPT — a live plan-less (boot-created) frame (rf2-vxgfnd.26) --------
 ;; ENSURE is create-if-absent (03 §8 / 004C §6): when a plan meets a frame that
 ;; is already LIVE but was never plan-installed (a boot `rf/make-frame`), the


### PR DESCRIPTION
## Summary

- publish installed/adopted frame-plan records only while the pinned frame incarnation remains current and is not closing
- serialize publication against the frame lifecycle gate and revalidate after the write, removing a tentative record if destruction overtakes the initial check
- cover both synchronous self-destruction from `:initial-events` and the JVM post-UI-prune / pre-liveness-flip destroy window

## Root cause and impact

`execute-frame-plans!` called `make-frame` and then unconditionally associated the installed-plan record. Because `:initial-events` run synchronously inside `make-frame`, a handler could destroy the frame and trigger the install-record prune hook before `make-frame` returned. The later unconditional association then recreated a record for the dead lifetime. The read-side liveness guard hid it only while the frame was absent; recreating the same id exposed it and caused a false `:rf.error/frame-payload-conflict` against the dead installer.

The first publication guard pinned the frame incarnation and wrote under its drain serialization, but token identity alone missed an earlier destroy window. `destroy-frame!` installs the incarnation-aware closing marker before the UI prune hook, while the frame remains token-identical and `frame/frame` remains live until the later liveness flip. A publisher entering after the prune could therefore still write a dead record.

Publication now requires both token identity and `frame/frame-incarnation-closing?` to show that the pinned incarnation is open. These checks run inside the serialized thunk and are repeated after the registry swap. This gives the helper a sound ordering contract:

- a record that lands before a later destroy is removed by that destroy's UI hook
- an already-started destroy is rejected by the incarnation-aware closing marker, including the pre-liveness-flip window
- a destroy that starts between validation and the swap causes the tentative record to be removed by post-write revalidation
- the incarnation-aware predicate permits a fresh B while old A is only finishing teardown; the bare-id `frame-closing?` would misclassify B

## Red-to-green proof

### Self-destroying setup

The CLJS regression was added and run before changing the original executor:

`npx shadow-cljs compile node-test-ui && node out/node-test-ui.js`

Pre-fix result: 333 tests / 1,764 assertions, with 3 failures in `self-destroying-initial-events-do-not-publish-a-dead-lifetime`:

1. boot recreation revealed `{:config-fingerprint "cf1-dead111111111111", :installed-by :root/a}`
2. root B received a false `:rf.error/frame-payload-conflict`
3. the replacement could not be recorded under root B's adoption

### Post-prune destroy race

The deterministic JVM fixture wraps the real `:ui/on-frame-destroyed!` hook. It runs the real prune, signals a `CountDownLatch`, then pauses destruction before the liveness flip while another thread attempts adoption. There are no sleeps or scheduler guesses.

The fixture was run against the token-only publication helper before adding the closing check:

`clojure -M:test -n re-frame.ui.frame-plan-publication-race-jvm-test`

Pre-fix result: 1 test / 10 assertions, with 3 failures:

1. root A republished an adopted record after the real UI prune
2. the dead-lifetime record became visible on replacement incarnation B
3. B retained root A as adopter instead of recording root B

After the incarnation-aware closing guard, the focused fixture passes 1 test / 10 assertions with 0 failures and 0 errors.

## Validation

- `clojure -M:test -n re-frame.ui.frame-plan-publication-race-jvm-test` — 1 test, 10 assertions, green
- `npx shadow-cljs compile node-test-ui && node out/node-test-ui.js` — 333 tests, 1,764 assertions, green
- `clojure -M:test` from `implementation/ui` — 346 tests, 4,972 assertions, green
- rebased onto current `origin/main` and reran all affected gates green

Tracks rf2-m1dsuw.
