### PR TITLE
rf2-1rxznn: harden compiler build authority

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -22,11 +22,14 @@
 ;; The view digest is keyed PER build id in the one build-scoped authority
 ;; (`re-frame.ui.compiler.build`, rf2-df9873): a recompiled / edited /
 ;; renamed source replaces its whole prior contribution, and the independent
-;; builds one daemon compiles never share rows. `current-build-digest` reads
-;; the ambient build's COMMITTED (last-known-good) view aggregate, so the
-;; whole-build identity is finalized at df9873's successful commit / finish
-;; boundary and never a partial mid-pass value (compile-order independent —
-;; the triples sort by view-id).
+;; builds one daemon compiles never share rows. Distinct defview declarations
+;; with equal view ids are rejected atomically rather than merged (including
+;; two vars in one namespace), while the exact same var retains ordinary HMR
+;; replacement. Thus no compile order can choose a digest row or runtime
+;; registrar winner. `current-build-digest` reads the ambient build's COMMITTED
+;; (last-known-good) view aggregate, so the whole-build identity is finalized
+;; at df9873's successful commit / finish boundary and never a partial mid-pass
+;; value (compile-order independent — the triples sort by view-id).
 ;;
 ;; The compile-time custom-element declarations are a build-scoped registry
 ;; like the other four: WRITTEN here (macro expansion → `build/contribute!
@@ -231,7 +234,20 @@
                  :manifest manifest
                  :closed-keys closed-keys
                  :children? children?}]
-    (build/contribute! build/views ns-sym view-id [tf hs])
+    (when-let [{:keys [conflict]}
+               (build/contribute-view-checked!
+                ns-sym [ns-sym vname] view-id [tf hs])]
+      (fail :rf.ui.compile/bad-view-id
+            (str "defview " vname ": view id " (pr-str view-id)
+                 " is already owned by a different defview declaration. "
+                 "Explicit :id overrides must be unique across declarations; "
+                 "give this view a distinct qualified keyword (re-expanding "
+                 "the exact same var remains the HMR replacement path)")
+            {:view vname
+             :id view-id
+             :namespace ns-sym
+             :declaration [ns-sym vname]
+             :existing-declaration conflict}))
     (if cljs?
       (emit-cljs/emit-defview args)
       (emit-jvm/emit-defview args))))

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -37,6 +37,7 @@
   with a PURE transition. A slice:
 
     {:pass-open? bool
+     :authoritative-members #{ns ...} | nil
      :committed  {source {reg-id {k v}}}   ; last-known-good, per source
      :staged     {source {reg-id {k v}}}   ; the OPEN pass's re-declarations
      :touched    #{source}}                ; sources that re-ran this pass
@@ -55,9 +56,10 @@
 
   ## Pass boundaries (last-known-good publication)
 
-    (begin-build! [id])   a compile pass starts: open the pass and DISCARD
-                          any staging a failed prior pass left (a successful
-                          pass committed at its close, so there is none).
+    (begin-build! [id ms]) a compile pass starts: open the pass, capture the
+                           optional authoritative member set, and DISCARD any
+                           staging a failed prior pass left (a successful pass
+                           committed at its close, so there is none).
     (commit-build! [id])  the pass succeeded: every touched source REPLACES
                           its committed contribution with what it staged
                           (or is evicted if it staged nothing — a dropped
@@ -90,6 +92,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
+(def ^:private view-declarations ::view-declarations) ; view-id -> [ns var]
 (def roots       ::roots)        ; Layer-1 root-site index
 (def plans       ::plans)        ; Layer-1 frame-plan index
 (def descriptors ::descriptors)  ; Root Descriptor index
@@ -102,7 +105,11 @@
 (def ^{:private true
        :doc "An empty per-build slice — the pure transition seed."}
   empty-slice
-  {:pass-open? false :committed {} :staged {} :touched #{}})
+  {:pass-open? false
+   :authoritative-members nil
+   :committed {}
+   :staged {}
+   :touched #{}})
 
 (defonce ^{:private true
            :doc "The ONE authority: build-id -> slice. Every registry, every
@@ -125,20 +132,46 @@
 ;; Ambient build identity
 ;; ---------------------------------------------------------------------------
 
+(defn- any-pass-open?
+  "Whether a lifecycle hook has an open compiler pass in this JVM. Used only
+  with a Shadow-shaped compiler env to reject an unresolved per-thread build
+  id while retaining the documented session fallback for plain CLJS compiler
+  and REPL contexts."
+  []
+  (boolean (some (comp true? :pass-open?) (vals @state))))
+
 #?(:clj
    (defn- shadow-build-id
      "The build id of the compile currently running on THIS thread, read from
      the CLJS compiler env: `cljs.env/*compiler*` (an atom) ->
-     `:shadow.build.cljs-bridge/state` -> `:shadow.build/build-id`. nil
-     outside a shadow compile. Pinned behind this one fn so a shadow upgrade
-     that moves the key breaks here, loudly and in one place."
+     `:shadow.build.cljs-bridge/state` -> `:shadow.build/build-id`. A compiler
+     env is recognized as Shadow-shaped only when that outer bridge marker is
+     present. While a hook-opened pass is live, a recognized bridge with a
+     missing build-id leaf fails loudly rather than using the process-global
+     session fallback. A plain/no-marker compiler env returns nil and uses the
+     documented session fallback. A future migration of the OUTER bridge
+     marker is therefore not independently diagnosable here."
      []
-     (try
-       (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
-         (when-let [compiler-atom @compiler-var]
-           (get-in @compiler-atom
-                   [:shadow.build.cljs-bridge/state :shadow.build/build-id])))
-       (catch Throwable _ nil))))
+     (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
+       (when-let [compiler-atom @compiler-var]
+         (let [compiler-state @compiler-atom
+               shadow-shaped? (contains? compiler-state
+                                         :shadow.build.cljs-bridge/state)
+               build-id (get-in compiler-state
+                                [:shadow.build.cljs-bridge/state
+                                 :shadow.build/build-id])]
+           (when (and shadow-shaped? (nil? build-id) (any-pass-open?))
+             (throw
+              (ex-info
+               (str "re-frame.ui compiler could not resolve shadow's build id "
+                    "while a build pass is open; refusing the session-build "
+                    "fallback because it can route this compilation into a "
+                    "different parallel build")
+               {::error ::shadow-build-id-unresolved
+                :recovery :check-shadow-compiler-env
+                :expected-path [:shadow.build.cljs-bridge/state
+                                :shadow.build/build-id]})))
+           build-id)))))
 
 (defn current-build-id
   "The build id a contribution belongs to: the explicit `*build-id*`
@@ -231,7 +264,7 @@
 
 (defn contribute!
   "Contribute `source`'s `k`->`v` to the plain registry `reg-id` in the
-  ambient build — one `swap!`, pure. The Layer-1 indexes use
+  ambient build — one `swap!`, pure. Collision-sensitive registries use
   `contribute-checked!` for their pre-write conflict check."
   [reg-id source k v]
   (swap! state update (current-build-id)
@@ -239,7 +272,7 @@
   nil)
 
 (defn contribute-checked!
-  "The atomic conflict-checked contribution for a Layer-1 index. Inside ONE
+  "An atomic conflict-checked registry contribution. Inside ONE
   `swap!`: look up `k` in the ambient build's EFFECTIVE map for `reg-id`,
   EXCLUDING `source`'s own rows (a source never conflicts with itself —
   same-source re-declaration replaces), and call `(conflict-fn existing)`. If
@@ -261,6 +294,74 @@
                      (write-slice slice reg-id source k v))))))
     @outcome))
 
+(defn contribute-view-checked!
+  "Atomically contribute one compiled view digest while enforcing declaration
+  identity. `source` (the namespace) remains the pass replacement/eviction
+  unit; `declaration` (`[ns-sym var-name]`) distinguishes an exact same-var
+  HMR/REPL replacement from a different defview claiming the same `view-id`.
+
+  During an open pass, the source's COMMITTED owner is deliberately ignored:
+  that namespace is being replaced wholesale, so its first current
+  declaration may reuse an id after a rename/removal. Its STAGED owner is not
+  ignored, so two distinct current declarations in the same namespace fail.
+  With no pass open, the committed owner is checked so a REPL declaration can
+  replace only itself. Other sources that remain authoritative members always
+  conflict (as do other sources when no prepare membership context exists).
+  The one exception is a COMMITTED owner whose source is absent from the open
+  pass's authoritative member set: it is ignored for admission, but remains
+  committed last-known-good until successful finish evicts it; abort leaves it
+  as last-known-good. Owner + digest writes occur in the SAME `swap!`,
+  preserving cross-namespace atomicity. Returns nil on success or
+  `{:conflict <existing-declaration>}` without writing on conflict."
+  [source declaration view-id digest]
+  (let [outcome (atom nil)]
+    (swap! state update (current-build-id)
+           (fn [slice]
+             (let [slice          (or slice empty-slice)
+                   other-views    (effective slice views source)
+                   other-owner    (get (effective slice view-declarations source)
+                                       view-id)
+                   source-owner   (if (:pass-open? slice)
+                                    (get-in slice
+                                            [:staged source view-declarations view-id])
+                                    (get-in slice
+                                            [:committed source view-declarations view-id]))
+                   ;; A prepare hook captures the already-resolved whole graph.
+                   ;; A committed owner absent from it is stale but remains
+                   ;; last-known-good until successful finish. It must not
+                   ;; block the current member that will replace it.
+                   owner-source   (when (vector? other-owner)
+                                    (first other-owner))
+                   stale-owner?   (and (:pass-open? slice)
+                                       (some? (:authoritative-members slice))
+                                       owner-source
+                                       (not (contains? (:authoritative-members slice)
+                                                       owner-source))
+                                       (= other-owner
+                                          (get-in slice
+                                                  [:committed owner-source
+                                                   view-declarations view-id]))
+                                       (nil? (get-in slice
+                                                     [:staged owner-source
+                                                      view-declarations view-id])))
+                   conflict       (cond
+                                    (and (contains? other-views view-id)
+                                         (not stale-owner?))
+                                    (or other-owner ::other-source)
+
+                                    (and source-owner
+                                         (not= source-owner declaration))
+                                    source-owner
+
+                                    :else nil)]
+               (if conflict
+                 (do (reset! outcome {:conflict conflict}) slice)
+                 (do (reset! outcome nil)
+                     (-> slice
+                         (write-slice view-declarations source view-id declaration)
+                         (write-slice views source view-id digest)))))))
+    @outcome))
+
 ;; ---------------------------------------------------------------------------
 ;; Pass boundaries
 ;; ---------------------------------------------------------------------------
@@ -269,13 +370,24 @@
   "Open a compile pass for `build-id` (the zero-arg form uses the sole
   default build). DISCARDS any staging a failed prior pass left — a
   successful pass commits at its close, so there is normally none — and marks
-  the pass open. Sets the session-build identity fallback so subsequent
-  contributions on the REPL / plain-JVM path route here."
-  ([] (begin-build! ::default))
-  ([build-id]
+  the pass open. `authoritative-members`, when supplied by the build hook from
+  Shadow's already-resolved graph, is open-pass conflict context: a committed
+  declaration owned by a nonmember cannot block its current replacement, but
+  stays last-known-good until successful finish. Sets the session-build
+  identity fallback so subsequent contributions on the REPL / plain-JVM path
+  route here."
+  ([] (begin-build! ::default nil))
+  ([build-id] (begin-build! build-id nil))
+  ([build-id authoritative-members]
    (reset! session-build build-id)
    (swap! state update build-id
-          (fn [s] (assoc (or s empty-slice) :pass-open? true :staged {} :touched #{})))
+          (fn [s]
+            (assoc (or s empty-slice)
+                   :pass-open? true
+                   :authoritative-members (when (some? authoritative-members)
+                                            (set authoritative-members))
+                   :staged {}
+                   :touched #{})))
    nil))
 
 (defn- commit-slice
@@ -289,7 +401,12 @@
                        (if (seq staged) (assoc c src staged) (dissoc c src))))
                    (:committed slice)
                    (:touched slice))]
-    (assoc slice :committed committed :staged {} :touched #{} :pass-open? false)))
+    (assoc slice
+           :committed committed
+           :staged {}
+           :touched #{}
+           :pass-open? false
+           :authoritative-members nil)))
 
 (defn commit-build!
   "Commit the open pass for `build-id`: every touched source's staged
@@ -342,7 +459,12 @@
   ([] (abort-build! (current-build-id)))
   ([build-id]
    (swap! state update build-id
-          (fn [s] (assoc (or s empty-slice) :staged {} :touched #{} :pass-open? false)))
+          (fn [s]
+            (assoc (or s empty-slice)
+                   :staged {}
+                   :touched #{}
+                   :pass-open? false
+                   :authoritative-members nil)))
    nil))
 
 (defn reset-build!

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -28,6 +28,10 @@
 
     :compile-prepare  ->  begin-build!  — open the pass BEFORE the
                           (possibly parallel) source compilation stages;
+                          capture the AUTHORITATIVE member set from the
+                          already-resolved `:build-sources` graph so a deleted
+                          namespace's committed declaration cannot deadlock an
+                          id transfer before finish evicts it;
                           contributions made during the pass STAGE rather
                           than upsert. begin-build! also DISCARDS any
                           staging a prior FAILED pass left open — which is
@@ -71,7 +75,8 @@
   `:provides` (falling back to its `:ns`) are the namespace symbols that
   key the compiler registries (build.cljc keys per declaring ns). A
   deleted FILE is absent from `:build-sources`, so its ns drops out of
-  this set and `finish-build!` evicts its registrations."
+  this set. Prepare captures that absence for declaration conflict checks;
+  `finish-build!` performs the actual registration eviction."
   [{:keys [build-sources sources]}]
   (reduce
    (fn [acc resource-id]
@@ -94,7 +99,7 @@
     :as      build-state}]
   (case stage
     :compile-prepare
-    (build/begin-build! build-id)
+    (build/begin-build! build-id (member-nss build-state))
 
     :compile-finish
     ;; Only finalize a pass THIS hook opened — a finish with no matching

--- a/implementation/ui/test/re_frame/ui/build_probe.clj
+++ b/implementation/ui/test/re_frame/ui/build_probe.clj
@@ -1,0 +1,6 @@
+(ns re-frame.ui.build-probe
+  "Macro-expansion probe for the real shadow compiler-env build identity."
+  (:require [re-frame.ui.compiler.build :as build]))
+
+(defmacro ambient-shadow-build-id []
+  (build/current-build-id))

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -17,6 +17,9 @@
     - NO FALSE EVICTION: an incremental recompile of ONE source keeps every
       other LIVE member's registration — macro silence (a cache hit) is not
       a deletion; authoritative `:build-sources` membership drives eviction.
+    - PRE-FINISH ID TRANSFER: a deleted/renamed namespace's committed view id
+      does not block the new authoritative member that claims it before finish;
+      if both namespaces remain members the duplicate still fails loud.
     - FAILED PASS keeps last-known-good: a compile that throws runs no
       `:compile-finish`; the doomed pass's partial staging is discarded at
       the next `:compile-prepare` (begin-build!'s discard-on-open), and the
@@ -27,6 +30,7 @@
       member set omits the REPL ns is a no-op — the `pass-open?` guard skips
       finish, so the REPL upsert survives."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.build-hook :as build-hook]))
 
@@ -37,26 +41,30 @@
 ;; ---------------------------------------------------------------------------
 ;; Harness — drive the REAL `build-hook/hook` fn with synthetic shadow
 ;; build-states. A shadow build-state carries `:shadow.build/build-id`,
-;; `:shadow.build/stage`, and (at :compile-finish) `:build-sources` +
-;; `:sources`; the hook reads exactly those. Using the declaring ns-sym as
-;; its own opaque resource-id keeps the fixtures minimal.
+;; `:shadow.build/stage`, `:build-sources`, and `:sources` at BOTH lifecycle
+;; stages; Shadow resolves the graph before :compile-prepare, and the hook reads
+;; exactly those keys. Using the declaring ns-sym as its own opaque resource-id
+;; keeps the fixtures minimal.
 ;; ---------------------------------------------------------------------------
 
+(defn- graph-state
+  [build-id stage member-nss]
+  {:shadow.build/build-id build-id
+   :shadow.build/stage    stage
+   :build-sources         (vec member-nss)
+   :sources               (into {} (map (fn [n] [n {:ns n :provides #{n}}]))
+                                member-nss)})
+
 (defn- prepare!
-  "Fire the `:compile-prepare` hook for `build-id` (opens the pass)."
-  [build-id]
-  (build-hook/hook {:shadow.build/build-id build-id
-                    :shadow.build/stage    :compile-prepare}))
+  "Fire `:compile-prepare` with the already-resolved authoritative graph."
+  [build-id member-nss]
+  (build-hook/hook (graph-state build-id :compile-prepare member-nss)))
 
 (defn- finish!
   "Fire the `:compile-finish` hook for `build-id` with `member-nss` as the
   authoritative build graph (`:build-sources`) — commit + evict-deleted."
   [build-id member-nss]
-  (build-hook/hook {:shadow.build/build-id build-id
-                    :shadow.build/stage    :compile-finish
-                    :build-sources         (vec member-nss)
-                    :sources               (into {} (map (fn [n] [n {:ns n :provides #{n}}]))
-                                                 member-nss)}))
+  (build-hook/hook (graph-state build-id :compile-finish member-nss)))
 
 (defn- declare-view!
   "A source `ns-sym` contributing one view digest to the ambient build —
@@ -66,6 +74,15 @@
   (binding [build/*build-id* build-id]
     (build/contribute! build/views ns-sym view-id fp)))
 
+(defn- declare-explicit-view!
+  "Drive the real defview compiler contribution under the hook-opened pass."
+  [build-id ns-sym vname view-id template]
+  (binding [build/*build-id* build-id
+            *ns* (create-ns ns-sym)]
+    (compiler/defview*
+     (with-meta (list 'defview vname {:id view-id} [] template) {:line 1})
+     {} vname (list {:id view-id} [] template))))
+
 (defn- views-of [build-id]
   (build/aggregate build/views build-id))
 
@@ -74,8 +91,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest hook-returns-the-build-state-unchanged
-  (let [prep {:shadow.build/build-id :node-test-ui
-              :shadow.build/stage    :compile-prepare}]
+  (let [prep (graph-state :node-test-ui :compile-prepare '#{app.a})]
     (is (identical? prep (build-hook/hook prep))
         "the hook side-effects into the authority and returns the state it was given"))
   (let [fin {:shadow.build/build-id :node-test-ui
@@ -96,7 +112,7 @@
 (deftest hook-evicts-a-deleted-source-on-compile-finish
   (let [bid :node-test-ui]
     ;; pass 1: app.a and app.b both declare a view; both are graph members.
-    (prepare! bid)
+    (prepare! bid '#{app.a app.b})
     (declare-view! bid 'app.a :app.a/view :fp-a)
     (declare-view! bid 'app.b :app.b/view :fp-b)
     (finish! bid '#{app.a app.b})
@@ -105,7 +121,7 @@
 
     ;; pass 2: app.b's FILE is deleted → it is ABSENT from :build-sources and
     ;; never re-declares (macro silence). app.a recompiles unchanged.
-    (prepare! bid)
+    (prepare! bid '#{app.a})
     (declare-view! bid 'app.a :app.a/view :fp-a)
     (finish! bid '#{app.a})
     (is (= {:app.a/view :fp-a} (views-of bid))
@@ -117,14 +133,14 @@
 
 (deftest hook-incremental-recompile-keeps-untouched-live-members
   (let [bid :node-test-ui]
-    (prepare! bid)
+    (prepare! bid '#{app.a app.b})
     (declare-view! bid 'app.a :app.a/view :fp-a)
     (declare-view! bid 'app.b :app.b/view :fp-b)
     (finish! bid '#{app.a app.b})
 
     ;; incremental: ONLY app.a recompiles (app.b is a cache hit → no
     ;; re-macroexpansion), but app.b is STILL a graph member.
-    (prepare! bid)
+    (prepare! bid '#{app.a app.b})
     (declare-view! bid 'app.a :app.a/view :fp-a2)
     (finish! bid '#{app.a app.b})
     (is (= {:app.a/view :fp-a2 :app.b/view :fp-b} (views-of bid))
@@ -137,19 +153,19 @@
 (deftest hook-failed-pass-converges-to-last-known-good
   (let [bid :node-test-ui]
     ;; a good pass
-    (prepare! bid)
+    (prepare! bid '#{app.a})
     (declare-view! bid 'app.a :app.a/view :good)
     (finish! bid '#{app.a})
     (is (= {:app.a/view :good} (views-of bid)))
 
     ;; a DOOMED pass: prepare + a partial contribution, then compile-sources
     ;; throws so the hook's :compile-finish NEVER runs.
-    (prepare! bid)
+    (prepare! bid '#{app.a})
     (declare-view! bid 'app.a :app.a/view :bad)
     ;; ... exception; finish! deliberately NOT called ...
 
     ;; the NEXT pass's :compile-prepare discards the doomed staging.
-    (prepare! bid)
+    (prepare! bid '#{app.a})
     (declare-view! bid 'app.a :app.a/view :good)
     (finish! bid '#{app.a})
     (is (= {:app.a/view :good} (views-of bid))
@@ -159,11 +175,11 @@
   ;; The abort-build! primitive the out-of-band failure path would call:
   ;; discard staging, republish committed last-known-good, do not half-commit.
   (let [bid :node-test-ui]
-    (prepare! bid)
+    (prepare! bid '#{app.a})
     (declare-view! bid 'app.a :app.a/view :good)
     (finish! bid '#{app.a})
 
-    (prepare! bid)
+    (prepare! bid '#{app.a app.b})
     (declare-view! bid 'app.a :app.a/view :bad)
     (declare-view! bid 'app.b :app.b/view :partial)
     (is (= {:app.a/view :bad :app.b/view :partial} (views-of bid))
@@ -200,8 +216,8 @@
   ;; two builds' passes are open at once (the daemon compiles both); each
   ;; hook keys its own slice, and a deletion in one build never touches the
   ;; other's registrations.
-  (prepare! :node-test-ui)
-  (prepare! :ui-bench)
+  (prepare! :node-test-ui '#{app.a})
+  (prepare! :ui-bench '#{app.a})
   (declare-view! :node-test-ui 'app.a :app.a/view :fp-ui)
   (declare-view! :ui-bench     'app.a :app.a/view :fp-bench)
   (finish! :node-test-ui '#{app.a})
@@ -210,8 +226,59 @@
   (is (= {:app.a/view :fp-bench} (views-of :ui-bench)))
 
   ;; app.a's file is deleted from :node-test-ui only; :ui-bench keeps it.
-  (prepare! :node-test-ui)
+  (prepare! :node-test-ui '#{})
   (finish! :node-test-ui '#{})
   (is (= {} (views-of :node-test-ui)) "the deletion evicted app.a in :node-test-ui")
   (is (= {:app.a/view :fp-bench} (views-of :ui-bench))
       "the :ui-bench build is untouched — per-build isolation holds through the hook"))
+
+;; ---------------------------------------------------------------------------
+;; A deleted/renamed namespace may hand its stable explicit id to a new member
+;; BEFORE finish evicts the stale committed source. Prepare's resolved graph is
+;; the authority that distinguishes this from a live duplicate.
+;; ---------------------------------------------------------------------------
+
+(deftest hook-admits-id-transfer-from-a-nonmember-source
+  (let [bid :node-test-ui]
+    (prepare! bid '#{app.old})
+    (declare-explicit-view! bid 'app.old 'card :shared/card [:div "old"])
+    (finish! bid '#{app.old})
+
+    ;; The next resolved graph has replaced app.old with app.new. app.old is
+    ;; still committed until finish, but it is no longer authoritative.
+    (prepare! bid '#{app.new})
+    (is (some? (declare-explicit-view! bid 'app.new 'card
+                                       :shared/card [:div "new"])))
+    (let [new-digest (get (views-of bid) :shared/card)]
+      (finish! bid '#{app.new})
+      (is (= {:shared/card new-digest} (views-of bid))
+          "finish evicted app.old and committed only app.new's row"))))
+
+(deftest hook-live-member-collision-rejects-and-retry-converges
+  (let [bid :node-test-ui]
+    (prepare! bid '#{app.old})
+    (declare-explicit-view! bid 'app.old 'card :shared/card [:div "old"])
+    (finish! bid '#{app.old})
+    (let [last-known-good (build/committed-aggregate build/views bid)]
+      ;; Both sources remain authoritative: this is a genuine collision.
+      (prepare! bid '#{app.old app.new})
+      (let [ex (try
+                 (declare-explicit-view! bid 'app.new 'card
+                                         :shared/card [:div "new"])
+                 nil
+                 (catch clojure.lang.ExceptionInfo ex ex))]
+        (is (= :rf.ui.compile/bad-view-id
+               (:rf.ui.compile/error (ex-data ex)))))
+      (is (= last-known-good (build/committed-aggregate build/views bid))
+          "the rejected pass preserves committed last-known-good")
+
+      ;; No finish ran after rejection. The retry's prepare discards staging,
+      ;; and the now-authoritative replacement graph converges without reset.
+      (prepare! bid '#{app.new})
+      (is (some? (declare-explicit-view! bid 'app.new 'card
+                                         :shared/card [:div "new"])))
+      (let [new-digest (get (views-of bid) :shared/card)]
+        (finish! bid '#{app.new})
+        (is (= {:shared/card new-digest} (views-of bid)))
+        (is (not= last-known-good (build/committed-aggregate build/views bid))
+            "the retry advances from old last-known-good to app.new")))))

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -26,7 +26,8 @@
   REAL assembly path. `defview` and `ui/custom-element` run their real macro
   bodies under a bound `*ns*` so distinct declaring namespaces (the ledger's
   source key, rf2-df9873) are addressable."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [cljs.env :as cljs-env]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.compiler.build :as build]
@@ -52,6 +53,14 @@
   (binding [*ns* (create-ns ns-sym)]
     (compiler/defview* (with-meta (list 'defview vname [] template) {:line 1})
                        {} vname (list [] template))))
+
+(defn- declare-explicit-view!
+  "Run the real defview body with an explicit registry id."
+  [ns-sym vname view-id template line]
+  (binding [*ns* (create-ns ns-sym)]
+    (compiler/defview*
+     (with-meta (list 'defview vname {:id view-id} [] template) {:line line})
+     {} vname (list {:id view-id} [] template))))
 
 (defn- declare-element!
   "Run the real `ui/custom-element` macro body with `ns-sym` bound as the
@@ -224,6 +233,116 @@
   (is (= {:x 10 :y 2} (build/aggregate ::probe))
       "a REPL re-eval upserts the one key — :y is NOT evicted (no begin/commit cycle)")
   (is (false? (build/pass-open?)) "no pass was ever opened"))
+
+(deftest hook-open-shadow-compile-without-build-id-fails-loud
+  ;; Exact shadow-contract mutation: keep the bridge state that marks a real
+  ;; shadow compiler env, but remove :shadow.build/build-id as a shadow upgrade
+  ;; could. A hook-opened pass makes session fallback actively unsafe: another
+  ;; build may have opened most recently, so this contribution must stop here.
+  (build/begin-build! :node-test-ui)
+  (binding [cljs-env/*compiler*
+            (atom {:shadow.build.cljs-bridge/state {}})]
+    (let [ex (try
+               (build/current-build-id)
+               nil
+               (catch clojure.lang.ExceptionInfo ex ex))]
+      (is (some? ex)
+          "a shadow compiler env with no build id must not use session-build")
+      (is (= :re-frame.ui.compiler.build/shadow-build-id-unresolved
+             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+
+(deftest hook-open-plain-cljs-compiler-uses-session-fallback
+  ;; A bound cljs compiler atom is not necessarily shadow. An unrelated/open
+  ;; shadow slice must not turn the documented plain-compiler/REPL fallback
+  ;; into an error when THIS env carries no shadow bridge marker at all.
+  (build/begin-build! :plain-cljs)
+  (binding [cljs-env/*compiler* (atom {:cljs.analyzer/namespaces {}})]
+    (is (= :plain-cljs (build/current-build-id))
+        "a non-shadow compiler env uses the intended session build fallback")))
+
+(deftest explicit-view-id-collision-fails-in-either-compile-order
+  (doseq [[first-ns second-ns] [['app.alpha 'app.beta]
+                                ['app.beta 'app.alpha]]]
+    (build/reset-build!)
+    (build/begin-build! :app)
+    (binding [build/*build-id* :app]
+      (declare-explicit-view! first-ns 'first-view :shared/card [:div] 1)
+      (let [ex (try
+                 (declare-explicit-view! second-ns 'second-view
+                                         :shared/card [:section] 2)
+                 nil
+                 (catch clojure.lang.ExceptionInfo ex ex))]
+        (is (= :rf.ui.compile/bad-view-id
+               (:rf.ui.compile/error (ex-data ex)))
+            (str "cross-namespace explicit :id collision fails with "
+                 first-ns " compiled before " second-ns))
+        (is (= [first-ns 'first-view]
+               (:existing-declaration (ex-data ex))))
+        (is (= [second-ns 'second-view]
+               (:declaration (ex-data ex))))
+        (is (re-find #"different defview declaration" (ex-message ex)))
+        (is (= 1 (count (build/aggregate build/views :app)))
+            "the rejected declaration never overwrites the first row")))))
+
+(deftest same-namespace-distinct-vars-cannot-share-an-explicit-view-id
+  (doseq [[first-var second-var] [['alpha-view 'beta-view]
+                                  ['beta-view 'alpha-view]]]
+    (build/reset-build!)
+    (build/begin-build! :app)
+    (binding [build/*build-id* :app]
+      (declare-explicit-view! 'app.cards first-var :shared/card [:div] 1)
+      (let [ex (try
+                 (declare-explicit-view! 'app.cards second-var
+                                         :shared/card [:section] 2)
+                 nil
+                 (catch clojure.lang.ExceptionInfo ex ex))]
+        (is (= :rf.ui.compile/bad-view-id
+               (:rf.ui.compile/error (ex-data ex)))
+            (str "same-namespace distinct vars collide with " first-var
+                 " declared before " second-var))
+        (is (= ['app.cards first-var]
+               (:existing-declaration (ex-data ex))))
+        (is (= ['app.cards second-var]
+               (:declaration (ex-data ex))))
+        (is (= 1 (count (build/aggregate build/views :app)))
+            "the rejected same-namespace declaration does not overwrite")))))
+
+(deftest same-var-explicit-view-id-reexpansion-remains-legal
+  (build/begin-build! :app)
+  (binding [build/*build-id* :app]
+    (declare-explicit-view! 'app.cards 'card :shared/card [:div "v1"] 1)
+    (let [v1 (get (build/aggregate build/views :app) :shared/card)]
+      (is (some? (declare-explicit-view! 'app.cards 'card
+                                         :shared/card [:section "v2"] 1))
+          "the same declaration may replace itself during an open pass")
+      (is (not= v1 (get (build/aggregate build/views :app) :shared/card))
+          "same-var HMR publishes the replacement digest"))
+    (build/commit-build! :app)
+    (is (= 1 (count (build/aggregate build/views :app)))))
+  ;; No-pass REPL re-evaluation is the other same-var replacement path.
+  (build/reset-build!)
+  (binding [build/*build-id* :repl]
+    (declare-explicit-view! 'app.cards 'card :shared/card [:div "v1"] 1)
+    (let [v1 (get (build/aggregate build/views :repl) :shared/card)]
+      (is (some? (declare-explicit-view! 'app.cards 'card
+                                         :shared/card [:section "v2"] 1)))
+      (is (not= v1 (get (build/aggregate build/views :repl) :shared/card))))
+    (is (= 1 (count (build/aggregate build/views :repl))))))
+
+(deftest fresh-namespace-pass-may-replace-an-old-declaration-owner
+  ;; The source namespace remains the whole-pass replacement unit: a var rename
+  ;; between passes is not a simultaneous duplicate and may retain the stable
+  ;; explicit registry id.
+  (build/begin-build! :app)
+  (binding [build/*build-id* :app]
+    (declare-explicit-view! 'app.cards 'old-card :shared/card [:div "old"] 1))
+  (build/commit-build! :app)
+  (build/begin-build! :app)
+  (binding [build/*build-id* :app]
+    (is (some? (declare-explicit-view! 'app.cards 'renamed-card
+                                       :shared/card [:div "new"] 1))))
+  (build/commit-build! :app)
+  (is (= 1 (count (build/aggregate build/views :app)))))
 
 ;; ---------------------------------------------------------------------------
 ;; MULTI-BUILD ISOLATION — the headline regression (rf2-df9873)

--- a/implementation/ui/test/re_frame/ui/skeleton_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/skeleton_cljs_test.cljc
@@ -14,10 +14,19 @@
             [re-frame.ui :as ui]
             [re-frame.ui.compiler]
             [re-frame.ui.rules :as rules]
-            #?(:cljs [re-frame.ui.runtime])))
+            #?(:cljs [re-frame.ui.runtime]))
+  #?(:cljs (:require-macros
+            [re-frame.ui.build-probe :refer [ambient-shadow-build-id]])))
 
 (deftest ui-artefact-loads-with-real-surface
   (is (fn? ui/sub)
       "the re-frame.ui public surface loads on the cross-artefact classpath")
   (is (contains? rules/void-tags :br)
       "the conversion rule table is loaded"))
+
+#?(:cljs
+   (deftest real-shadow-compile-emits-an-expected-ambient-build-id
+     (let [build-id (ambient-shadow-build-id)]
+       (is (keyword? build-id))
+       (is (not= :re-frame.ui.compiler.build/default build-id)
+           "pinned-version smoke: the real Shadow compile emits a non-default ambient id"))))


### PR DESCRIPTION
## Summary

- fail loudly when a hook-opened Shadow compiler env has a bridge marker but its per-thread build id cannot be resolved; retain session fallback for bound plain/non-Shadow CLJS compiler envs
- reject equal view ids from distinct defview declarations atomically, including distinct vars in one namespace, while preserving exact same-var HMR/REPL replacement and whole-namespace pass replacement
- admit a stable explicit view id transfer from a namespace removed from the resolved build graph to its new authoritative owner before successful finish evicts the stale committed row
- add pinned-version real-Shadow smoke and real-build-hook authority regressions

## Red to green

Original boundary fixtures, run before implementation:

- missing `:shadow.build/build-id` leaf under an existing Shadow bridge during an open pass silently used session fallback
- `app.alpha` and `app.beta` both declaring `:shared/card` succeeded in both compile orders

Original red: 26 tests, 82 assertions, 4 failures.

First exact-head review fixtures, run red before correction:

- bound plain CLJS compiler state with no Shadow bridge incorrectly threw during an open pass
- two distinct vars in one namespace claiming `:shared/card` overwrote in both declaration orders

Review red: 29 tests, 91 assertions, 2 failures and 1 error.

Second exact-head lifecycle review fixture, driven through real `build-hook/hook` prepare/finish states and real `defview*` declarations:

- pass 1 committed `app.old` owning `:shared/card`; pass 2's graph contained only `app.new`, but `app.old`'s last-known-good row blocked `app.new` before finish could evict it
- retry without clean reset deadlocked on the same stale row
- control kept both sources authoritative and correctly required a collision

Lifecycle red: 10 tests, 24 assertions, 3 failures and 2 errors. Final focused compiler+hook result: 40 tests, 129 assertions, 0 failures/errors.

## Authority model

The namespace remains the pass replacement/eviction source. A private declaration-owner registry stores `[ns-sym var-name]` alongside the unchanged observable view digest. Owner and digest are conflict-checked/written in one state transition.

The build hook captures the resolved authoritative member namespace set at `:compile-prepare`. This is supported by pinned Shadow 3.4.10: `shadow.build/compile` runs `resolve` before `process-stage :compile-prepare`, so `:build-sources` and `:sources` are already the whole graph.

The real Shadow compile assertion is a pinned-version smoke that compilation emits the expected keyword/non-default ambient ID. It cannot independently distinguish compiler-env resolution from a same-valued session fallback. The Shadow-shaped missing-build-id-leaf mutation above is the fixture that proves fallback refusal.

During the open pass, conflict checking may ignore a committed owner only when its source is absent from that authoritative set. The row is not dropped or committed early: failed/rejected passes retain committed last-known-good, successful `:compile-finish` performs the actual eviction, and retry prepare discards staging and replaces the member context.

Controls prove:

- two live authoritative sources still collide
- same-var HMR/REPL replacement remains legal
- same-namespace distinct vars collide
- rejected-pass last-known-good survives and retry converges without reset

Commit/finish/abort clear the open-pass membership context; the next prepare always replaces it with the new resolved graph.

## Scope decision

Finding 3 (compiler/client digest-set divergence for compiled-but-unloaded multi-entry views) remains intentionally excluded pending Mike's contract ruling. This PR does not change client digest code or spec prose.

## Tests

- focused compiler + hook JVM — 40 tests, 129 assertions
- full `implementation/ui` JVM — 357 tests, 5021 assertions
- `npm run test:ui` — 337 tests, 1779 assertions; Shadow compile 0 warnings
- `npm run test:elision` — production 48/48 absent; control 48/48 present

Tracks rf2-1rxznn.
