### PR TITLE
fix(core): linearize frame trace policy publication

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1951,16 +1951,71 @@
 (def ^:dynamic ^:no-doc *upsert-decide-probe*
   "JVM linearization TEST SEAM — `nil` in production (one `nil` check per
   construction, zero further cost). When bound to a 1-arg fn, `upsert-frame!`
-  calls `(*upsert-decide-probe* id)` exactly ONCE, AFTER it snapshots the
-  `frames` registry for `id` and BEFORE its guarded-CAS decide→install loop —
-  i.e. INSIDE the read→CAS window the A-prime retry loop closes (rf2-vxgfnd.76).
+  calls `(*upsert-decide-probe* id)` exactly ONCE immediately BEFORE the
+  authoritative registry decision/install path.
   A concurrency fixture binds it (conveyed into the racing thread by `future`'s
-  binding-conveyance) to pause one actor precisely in that window while another
-  installs or destroys the same id, then releases it — proving the guarded CAS
-  linearizes create/create, re-register/destroy, and must-create collisions with
-  no clobber, no zombie resurrection, and no lost update. NEVER bound off the JVM
-  test path."
+  binding-conveyance) to pause one actor while another installs or destroys the
+  same id, then releases it — proving serialized create and guarded
+  re-register/destroy decisions produce no clobber, zombie resurrection, or
+  lost update. NEVER bound off the JVM test path."
   nil)
+
+(defn- fresh-trace-policy-token
+  "Return an identity token for one attempted frame-config commit. A successful
+  registry mutation stores it on the frame record; auxiliary trace-policy
+  writers publish only while that exact token remains current."
+  []
+  #?(:clj (Object.) :cljs (js-obj)))
+
+#?(:clj
+   (do
+     (defonce ^:private frame-create-lock
+       ;; JVM-only serialization for the cold absent-id allocation path.
+       (Object.))
+     (defn- call-with-frame-create-lock [f]
+       (locking frame-create-lock (f)))))
+
+(def ^:dynamic ^:no-doc *upsert-policy-probe*
+  "JVM test seam fired after a successful frame-registry commit and immediately
+  before its auxiliary trace policy enters publication serialization."
+  nil)
+
+#?(:clj
+   (do
+     (defonce ^:private frame-trace-policy-lock
+       ;; Auxiliary policy lives in two independent atoms. Serialize the
+       ;; tiny/cold publication section on the concurrent host.
+       (Object.))
+     (defn- call-with-frame-trace-policy-lock [f]
+       (locking frame-trace-policy-lock (f)))))
+
+(defn- publish-trace-policy!
+  [id publish!]
+  (when-let [probe *upsert-policy-probe*] (probe id))
+  #?(:clj  (call-with-frame-trace-policy-lock publish!)
+     :cljs (publish!)))
+
+(defn- try-install-new-frame!
+  "Install a freshly allocated record iff `id` is still absent.
+
+  JVM creators are serialized around the authoritative absence recheck,
+  container allocation, and registry install. A losing creator therefore
+  allocates nothing: every state container returned by the adapter is installed
+  as an owned frame record. This avoids inventing a disposal-free adapter
+  contract for abandoned speculative containers. Returns true on install."
+  [id config policy-token]
+  (letfn [(install! []
+            (if (contains? @frames id)
+              false
+              (let [f (assoc (new-frame-record id config)
+                             :trace-policy-token policy-token)]
+                ;; `upsert-frame!` is the sole creator. Under `frame-create-lock`
+                ;; no other JVM creator can seat this id between the absence
+                ;; recheck and assoc; CLJS runs the block synchronously.
+                (swap! frames assoc id f)
+                true)))]
+    #?(:clj  (call-with-frame-create-lock install!)
+       :cljs (install!))))
 
 (defn- throw-frame-id-taken!
   "Throw the typed `:rf.error/frame-id-taken` collision (rf2-vxgfnd.76) — the
@@ -2089,43 +2144,19 @@
                                   "boot, BEFORE the frame is constructed, so the "
                                   "strategy can be validated at registration time.")
                              {:extra {:frame id}})))
-        ;; rf2-vxgfnd.76: a SPECULATIVE first snapshot. The authoritative decide
-        ;; happens inside the guarded-CAS loop below (which re-reads under the
-        ;; CAS); this read only lets `new-frame-record` (with its adapter
-        ;; `make-state-container` call) be built ONCE, ABOVE the loop, so a
-        ;; no-adapter construction throw escapes before the decide probe, the
-        ;; guarded CAS, and the winner's trace-policy writes (rf2-hhlzky preserved
-        ;; — and strengthened by rf2-umsyo9, which moved those policy writes BELOW
-        ;; the CAS into the winning branch). The loop reuses this record when it
-        ;; wins a create and rebuilds only in the rare decide-changed-to-create
-        ;; recur.
-        existing0      (get @frames id)
-        ;; rf2-hhlzky: construct the frame record BEFORE any process-global write.
-        ;; `new-frame-record` calls `adapter/make-state-container`, which THROWS
-        ;; (`:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed`) when
-        ;; no adapter is installed — a construction issued before `rf/init!` or
-        ;; after `destroy-adapter!`. Building the record here means such a failure
-        ;; escapes this `let` BEFORE any process-global write, so a frame that
-        ;; never came into existence leaves NO residue to unwind.
-        ;;
-        ;; rf2-umsyo9 (speculative-allocation lifecycle): on a create/create loss
-        ;; the guarded CAS installs nothing and this speculatively-built record is
-        ;; ABANDONED. That needs no explicit disposal — DISPOSAL-FREE ALLOCATION
-        ;; CONTRACT: `new-frame-record` produces only an atom-backed state
-        ;; container (`make-state-container` → a plain / substrate atom) plus its
-        ;; two derived-value projections and a handful of atoms, ALL mutually
-        ;; referenced WITHIN the record. It opens no OS / host resource and
-        ;; performs no adapter-side or registry-side registration (the sole
-        ;; install is the `frames` assoc the loser never made), so an abandoned
-        ;; record is a self-contained GC island collected with the lost `let`
-        ;; value. This is the DEFER form of the rollback the bead calls for —
-        ;; nothing installed, nothing to unwind. Re-registration is a surgical
-        ;; update (no container is built), so `new-record` is nil there.
-        new-record     (when (nil? existing0) (new-frame-record id config))
+        ;; One identity token per attempted config commit. Only a successful
+        ;; create/re-register installs it. Auxiliary policy stores consult the
+        ;; installed token inside their own atomic updates, so publication from
+        ;; an older successful actor is rejected after a newer actor commits.
+        policy-token   (fresh-trace-policy-token)
+        policy-current?
+        (fn []
+          (identical? policy-token (:trace-policy-token (get @frames id))))
         ;; rf2-umsyo9: the frame-scoped TRACE POLICY writes (the suppression flag
         ;; + the `:rf.trace/events-retained` retention override) are process-global
-        ;; stores SEPARATE from the `frames` registry, so the guarded CAS below
-        ;; does NOT linearize them. PR #5776 ran them speculatively ABOVE the CAS,
+        ;; stores SEPARATE from the `frames` registry, so the registry commit
+        ;; alone does NOT linearize them. PR #5776 ran them speculatively before
+        ;; the commit,
         ;; which let a must-create LOSER — or a create/create loser — overwrite
         ;; the WINNER's trace policy for this id even though the loser installed
         ;; nothing, corrupting the live winner's tracing. They now ride the WINNING
@@ -2145,16 +2176,20 @@
           ;; shared trace ring it inspects. The flag is the frame-scoped sibling
           ;; of the handler-scoped `:rf.trace/no-emit?` (Spec 009 §Trace-emission
           ;; opt-out); `trace.cljc` owns the canonical set + predicate.
-          (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
+          (trace/set-frame-no-emit! id
+                                    (true? (:rf.trace/frame-no-emit? config))
+                                    policy-current?)
           ;; Per Spec 009 §Retention contract: apply the per-frame
           ;; `:rf.trace/events-retained` override. When the key is absent the
           ;; frame inherits the process-default. Routed via late-bind so
           ;; production CLJS bundles (where trace.tooling is not loaded)
           ;; short-circuit cleanly — the trace-ring machinery is dev-only.
-          (when (contains? config :rf.trace/events-retained)
-            (when-let [set-retained! (late-bind/get-fn-cached
-                                      :trace.tooling/set-frame-events-retained!)]
-              (set-retained! id (:rf.trace/events-retained config)))))]
+          (when-let [apply-retention! (late-bind/get-fn-cached
+                                       :trace.tooling/apply-frame-events-retained-policy!)]
+            (apply-retention! id
+                              (contains? config :rf.trace/events-retained)
+                              (:rf.trace/events-retained config)
+                              policy-current?)))]
     ;; SUBSTRATE OWNERSHIP (rf2-h1vqa4): deliberately NO `registrar/register!`
     ;; here. A seated frame lives in the `frames` registry alone. The former
     ;; `:frame` registrar row leaked into the registration SOURCE STORE
@@ -2165,37 +2200,27 @@
     ;; Routing (the one former consumer) reads frame config via
     ;; `frame-meta` / `frame-ids`; the registrar `:frame` kind is reserved with
     ;; an intentionally EMPTY slot (the `:flow` precedent, rf2-en00bk).
-    ;; A-prime linearization (rf2-vxgfnd.76): the DECIDE (existing?) + INSTALL
-    ;; (the `frames` swap) run as a guarded-CAS RETRY loop through the `frames`
-    ;; atom ITSELF — the `set-generation!` discipline — so a create linearizes
-    ;; against a concurrent create/destroy with NO last-writer clobber and NO
-    ;; zombie-resurrection of a dissoc'd record. Only the pure, side-effect-free
-    ;; preflight validation ran ONCE above the loop; the frame-scoped TRACE
-    ;; POLICY writes now ride the WINNING branch (`apply-trace-policy!`,
-    ;; rf2-umsyo9) so an exclusive / CAS LOSER never mutates the winner's policy.
+    ;; A-prime linearization (rf2-vxgfnd.76): create rechecks absence + allocates
+    ;; + installs under the cold JVM create lock (CLJS is single-threaded), so a
+    ;; losing creator allocates nothing; re-registration remains a guarded-CAS
+    ;; retry through `frames`, closing concurrent destroy resurrection. The
+    ;; frame-scoped TRACE POLICY writes run only after a successful registry
+    ;; commit, serialize across the two auxiliary atoms, and are guarded there
+    ;; by the installed `:trace-policy-token`. A superseded successful actor
+    ;; therefore cannot publish after the newer record, while an exclusive
+    ;; loser writes nothing.
     ;; `run-setup-events!` runs EXACTLY ONCE, in the won-create branch (EP-0027:
     ;; setup drains before the constructor returns — preserved because only
     ;; decide + install + the winner's writes are inside the loop). The one-shot
-    ;; decide→install-window test probe fires HERE — after the decide snapshot
-    ;; but BEFORE any side effect (the CAS AND the winner's trace-policy writes),
-    ;; so the concurrency seam opens the actual PRE-SIDE-EFFECT race window
-    ;; (rf2-umsyo9).
+    ;; decision-window test probe fires HERE, before the authoritative registry
+    ;; path and before any side effect.
     (when-let [probe *upsert-decide-probe*] (probe id))
     (loop []
       (let [existing (get @frames id)]
         (cond
           ;; ---- CREATE: install the record iff the id is STILL absent ---------
           (nil? existing)
-          (let [f (or new-record (new-frame-record id config))
-                ;; Guarded CAS: assoc our record ONLY when the id is absent in
-                ;; the winning snapshot. `swap-vals!` returns [old new]; we WON
-                ;; the create iff `id` was absent in `old` (our assoc actually
-                ;; ran). A concurrent installer between the decide read and here
-                ;; leaves `id` present in `old` → we lost, and `f` was NEVER
-                ;; installed (the guard returned `m` unchanged), so nothing to
-                ;; unwind.
-                [old _] (swap-vals! frames (fn [m] (if (contains? m id) m (assoc m id f))))]
-            (if (contains? old id)
+          (if-not (try-install-new-frame! id config policy-token)
               (if must-create?
                 ;; Exclusive mode (ui.test): a taken id is a hard COLLISION, not
                 ;; an adoption — throw the typed error (nothing was installed).
@@ -2233,25 +2258,25 @@
                     {:recovery :construct-frames-in-view-or-top-level
                      :extra    {:frame id}}))
                 ;; rf2-umsyo9: apply the winning config's frame-scoped trace
-                ;; policy now that this create WON the guarded CAS and passed the
+                ;; policy now that this create WON installation and passed the
                 ;; handler-time guard — BEFORE `run-setup-events!` so a
                 ;; trace-disabled tool frame's init cascade stays redacted, and
                 ;; BEFORE the `:rf.frame/created` emit so that emit is suppressed
                 ;; for a no-emit frame. A create that LOST the CAS never reaches
                 ;; here, so it leaves the winner's policy untouched.
-                (apply-trace-policy!)
+                (publish-trace-policy! id apply-trace-policy!)
                 ;; Run the :initial-events setup steps synchronously, in order,
                 ;; BEFORE emitting :frame/created (Spec 002 §Frame creation;
                 ;; EP-0027 §Construction). `setup-steps` was PREFLIGHT-validated
                 ;; at the top of the engine. A step that throws at runtime tears
                 ;; down the partial frame inside the runner and rethrows. Runs
-                ;; ONCE — only on the WON install, never on a CAS-loss recur.
+                ;; ONCE — only on the WON install, never on a lost-create recur.
                 (run-setup-events! id setup-steps {} 'rf/make-frame)
                 (trace/emit! :rf.frame :rf.frame/created
                              {:frame id :config (dissoc config :rf.frame/generation
                                                         :rf.frame/initial-db)})
                 (fire-frame-registered-hook! id)
-                id)))
+                id))
 
           ;; ---- must-create met a LIVE frame at the decide read → COLLISION ---
           ;; Exclusive mode never adopts or surgically refreshes; a present id is
@@ -2277,8 +2302,10 @@
                 ;; state container and no `:drain-lock`).
                 [old _] (swap-vals! frames
                           (fn [m] (if (contains? m id)
-                                    (update m id assoc :config stored-config
-                                            :generation (get config :rf.frame/generation))
+                                    (update m id assoc
+                                            :config stored-config
+                                            :generation (get config :rf.frame/generation)
+                                            :trace-policy-token policy-token)
                                     m)))]
             (if (contains? old id)
               (do
@@ -2288,7 +2315,7 @@
                 ;; frame to no-emit suppresses its own re-registration trace. A
                 ;; re-registration that LOST (the id vanished under a concurrent
                 ;; destroy) recurs into a create and never reaches here.
-                (apply-trace-policy!)
+                (publish-trace-policy! id apply-trace-policy!)
                 (trace/emit! :rf.frame :rf.frame/re-registered
                              {:frame id :config stored-config})
                 (fire-frame-registered-hook! id)

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1989,11 +1989,17 @@
      (defn- call-with-frame-trace-policy-lock [f]
        (locking frame-trace-policy-lock (f)))))
 
+(defn- serialize-frame-trace-policy!
+  "Run one auxiliary trace-policy publication/clear section. JVM callers
+  serialize across both stores; CLJS is single-threaded."
+  [f]
+  #?(:clj  (call-with-frame-trace-policy-lock f)
+     :cljs (f)))
+
 (defn- publish-trace-policy!
   [id publish!]
   (when-let [probe *upsert-policy-probe*] (probe id))
-  #?(:clj  (call-with-frame-trace-policy-lock publish!)
-     :cljs (publish!)))
+  (serialize-frame-trace-policy! publish!))
 
 (defn- try-install-new-frame!
   "Install a freshly allocated record iff `id` is still absent.
@@ -2151,7 +2157,7 @@
         policy-token   (fresh-trace-policy-token)
         policy-current?
         (fn []
-          (identical? policy-token (:trace-policy-token (get @frames id))))
+          (identical? policy-token (:trace-policy-token (frame id))))
         ;; rf2-umsyo9: the frame-scoped TRACE POLICY writes (the suppression flag
         ;; + the `:rf.trace/events-retained` retention override) are process-global
         ;; stores SEPARATE from the `frames` registry, so the registry commit
@@ -3162,19 +3168,25 @@
         ;; itself (which is frameless and bypasses the ring anyway)
         ;; still flows through the live stream cleanly. Routed via
         ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
-        (safe-call-hook! :trace.tooling/release-frame-ring! id)
-        ;; rf2-zcl055: release the destroyed frame's trace-emission gate
-        ;; flag — the teardown counterpart to construction's
-        ;; `trace/set-frame-no-emit!`. A tool / inspector frame registered
-        ;; with `:rf.trace/frame-no-emit? true` (e.g. `:rf/xray`) otherwise
-        ;; leaves a permanent entry in trace.cljc's process-global
-        ;; `trace-disabled-frames` set (the ring IS freed above; the flag
-        ;; was not — a teardown asymmetry). Called directly (not via a
-        ;; tooling hook) because `trace.cljc` is always loaded — the set +
-        ;; predicate live on the core trace surface, same as the construction
-        ;; registration call. Idempotent no-op for application frames (the
-        ;; common case, where the id was never added).
-        (trace/clear-frame-no-emit-for! id)
+        ;; Serialize teardown's two clears with successful upsert publication.
+        ;; The frame is already lifecycle-dead, so a delayed publisher that
+        ;; enters afterwards fails its live-token predicate; a publisher that
+        ;; entered before the flip completes first and these clears win last.
+        ;; No interleaving can repopulate either auxiliary store after cleanup.
+        (serialize-frame-trace-policy!
+         (fn []
+           (safe-call-hook! :trace.tooling/release-frame-ring! id)
+           ;; rf2-zcl055: release the destroyed frame's trace-emission gate
+           ;; flag — the teardown counterpart to construction's
+           ;; `trace/set-frame-no-emit!`. A tool / inspector frame registered
+           ;; with `:rf.trace/frame-no-emit? true` (e.g. `:rf/xray`) otherwise
+           ;; leaves a permanent entry in trace.cljc's process-global
+           ;; `trace-disabled-frames` set (the ring IS freed above; the flag
+           ;; was not — a teardown asymmetry). Called directly (not via a
+           ;; tooling hook) because `trace.cljc` is always loaded — the set +
+           ;; predicate live on the core trace surface, same as construction.
+           ;; Idempotent no-op for application frames (the common case).
+           (trace/clear-frame-no-emit-for! id)))
         ;; EP-0024: there is ONE `frames` registry, and `dissoc-frame!` below IS
         ;; the forget. The frame's resolved generation rides the record's
         ;; `:generation` slot, so dropping the record drops it too — no separate

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1067,10 +1067,10 @@
     :producer-ns 're-frame.trace.tooling
     :design-bead "rf2-g1b2m"
     :description "Frame-destroy ring cleanup. `re-frame.frame/destroy-frame!` invokes this once the destroyed-trace has fired so the destroyed frame leaves no residual ring state in memory."}
-   {:key         :trace.tooling/set-frame-events-retained!
+   {:key         :trace.tooling/apply-frame-events-retained-policy!
     :producer-ns 're-frame.trace.tooling
-    :design-bead "rf2-g1b2m"
-    :description "Apply a per-frame `:rf.trace/events-retained` override. The frame engine (`re-frame.frame/upsert-frame!`) invokes this when the config carries the key; raises / lowers the ring's slot cap (one slot per event / pipeline run), trimming evictions in-place when lowering."}
+    :design-bead "rf2-4vism7"
+    :description "Publish one committed frame config's retention policy under its current-owner predicate. Explicit values resize and pin the frame ring; omission clears a prior override back to the process default. The frame engine serializes auxiliary publication, and the guarded ring update rejects a superseded successful upsert."}
    {:key         :live-frame/mark-projection-dirty!
     :producer-ns 're-frame.live-frame
     :design-bead "rf2-h1vqa4"

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -205,10 +205,22 @@
   the frame is added to the trace-disabled set; otherwise it is removed.
   `emit!` / `emit-error!` short-circuit for any event whose `:frame` tag
   is in the set. Idempotent. Per Spec 009 §Trace-emission opt-out
-  (frame-level) and rf2-2qaqh."
-  [frame-id no-emit?]
-  (swap! trace-disabled-frames (if no-emit? conj disj) frame-id)
-  nil)
+  (frame-level) and rf2-2qaqh.
+
+  The three-argument engine arity performs the liveness predicate INSIDE the
+  atom update. The frame engine serializes auxiliary publication and supplies
+  the committed config's owner predicate, so a superseded config is rejected
+  before this store changes. The two-argument arity remains the direct
+  teardown/test primitive."
+  ([frame-id no-emit?]
+   (set-frame-no-emit! frame-id no-emit? (constantly true)))
+  ([frame-id no-emit? current?]
+   (swap! trace-disabled-frames
+          (fn [disabled]
+            (if (current?)
+              ((if no-emit? conj disj) disabled frame-id)
+              disabled)))
+   nil))
 
 (defn frame-trace-disabled?
   "Canonical predicate: true iff `frame-id` is currently registered

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -118,8 +118,8 @@
 ;; - The slot count is bounded by `:events-retained` (default 50) — one
 ;;   slot per EVENT (one dequeued event / pipeline run), regardless of how
 ;;   many trace events that run emitted.
-;; - `:override?` true iff the cap is an explicit per-frame override
-;;   (`set-frame-events-retained!`); false for an inherited default.
+;; - `:override?` true iff the cap is an explicit per-frame override;
+;;   false for an inherited default.
 ;;   `configure-trace-buffer!` retunes inherited rings, skips overrides.
 ;; - Frames lazily allocate slots on first emit. Apps with one frame
 ;;   pay one slot of ring overhead.
@@ -160,56 +160,58 @@
   (or (get-in rings [frame-id :events-retained])
       @process-events-retained))
 
-(defn set-frame-events-retained!
-  "Apply a per-frame `:rf.trace/events-retained` override (called
-  from `frame.cljc`'s engine when the config carries the key).
-  The retained unit is one slot per EVENT (one dequeued event / pipeline
-  run), regardless of how many trace events that run emitted. Trims
-  existing slots if the new value is lower than current occupancy;
-  raising keeps existing slots and grows the slot cap.
+(defn- resize-ring
+  "Return `existing` resized to `retained`, preserving the newest slots and
+  stamping whether the cap is a frame override or the inherited process
+  default. Always returns a complete ring."
+  [existing retained override?]
+  (let [order (or (:run-order existing) [])
+        runs  (or (:runs existing) {})]
+    (cond
+      (zero? retained)
+      (empty-ring 0 override?)
 
-  Always writes a COMPLETE ring (`:run-order` + `:runs` present)
-  and stamps `:override? true`. Registering a per-frame cap BEFORE the
-  frame's first emit therefore leaves a valid (empty) ring rather than a
-  partial `{:events-retained N}` map — a partial map would later make
-  `push-to-ring!` start `:run-order` from nil, `conj` a list, and
-  crash `subvec` once the cap was exceeded (rf2-va65k finding 2).
+      (> (count order) retained)
+      (let [drop-n     (- (count order) retained)
+            evicted    (subvec order 0 drop-n)
+            kept-order (subvec order drop-n)]
+        {:events-retained retained
+         :override?      override?
+         :run-order      kept-order
+         :runs           (apply dissoc runs evicted)})
 
-  Per Spec 009 §Lowering events-retained on a populated ring."
-  [frame-id retained]
-  (when (and interop/debug-enabled? (number? retained) (not (neg? retained)))
+      :else
+      {:events-retained retained
+       :override?      override?
+       :run-order      order
+       :runs           runs})))
+
+(defn apply-frame-events-retained-policy!
+  "Publish one frame config's retention policy when `current?` still says that
+  config owns the authoritative frame record.
+
+  `override? true` applies `retained` as the explicit
+  `:rf.trace/events-retained` cap. `override? false` removes any prior override,
+  resizes the existing ring to the live process default, and marks it inherited
+  so later process-default changes continue to reach it. The liveness predicate
+  runs INSIDE the trace-ring atom update; the frame engine serializes auxiliary
+  publication around it. This makes the store respect the frame registry's
+  winner without a second ownership registry."
+  [frame-id override? retained current?]
+  (when (and interop/debug-enabled?
+             (or (not override?)
+                 (and (number? retained) (not (neg? retained)))))
     (swap! trace-rings
            (fn [rings]
-             (let [existing (get rings frame-id)
-                   order    (or (:run-order existing) [])
-                   runs (or (:runs existing) {})]
-               (cond
-                 ;; retained = 0: drop everything; slot persists with depth 0
-                 ;; so reads return [] cleanly.
-                 (zero? retained)
+             (if-not (current?)
+               rings
+               (if override?
                  (assoc rings frame-id
-                        (empty-ring 0 true))
-
-                 ;; Trim if existing order exceeds the new cap.
-                 (> (count order) retained)
-                 (let [drop-n     (- (count order) retained)
-                       evicted    (subvec order 0 drop-n)
-                       kept-order (subvec order drop-n)]
+                        (resize-ring (get rings frame-id) retained true))
+                 (if-let [existing (get rings frame-id)]
                    (assoc rings frame-id
-                          {:events-retained retained
-                           :override?         true
-                           :run-order     kept-order
-                           :runs          (apply dissoc runs evicted)}))
-
-                 ;; New cap fits the current occupancy: keep the slots,
-                 ;; write a full ring (a never-emitted frame gets a valid
-                 ;; empty ring instead of a partial map — finding 2).
-                 :else
-                 (assoc rings frame-id
-                        {:events-retained retained
-                         :override?         true
-                         :run-order     order
-                         :runs          runs}))))))
+                          (resize-ring existing @process-events-retained false))
+                   rings))))))
   nil)
 
 (defn release-frame-ring!
@@ -723,8 +725,8 @@
 (late-bind/set-fn! :trace.tooling/dedup-allow?        dedup-allow?)
 (late-bind/set-fn! :trace.tooling/clear-dedup-table!  clear-dedup-table!)
 (late-bind/set-fn! :trace.tooling/release-frame-ring! release-frame-ring!)
-(late-bind/set-fn! :trace.tooling/set-frame-events-retained!
-                   set-frame-events-retained!)
+(late-bind/set-fn! :trace.tooling/apply-frame-events-retained-policy!
+                   apply-frame-events-retained-policy!)
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
@@ -323,6 +323,50 @@
     (is (= 99 (retained-cap :tp/successful))
         "the retention auxiliary store remains B — stale A was rejected")))
 
+(deftest destroyed-frame-rejects-delayed-successful-policy-publication
+  ;; A successfully commits config, then pauses before publishing its auxiliary
+  ;; policy. B destroys that SAME incarnation and pauses after BOTH policy stores
+  ;; have been cleared (ring release precedes no-emit clear) but before the frame
+  ;; record is dissociated. A must not treat the destroyed raw record's matching
+  ;; token as live authority and repopulate either store.
+  (frame/upsert-frame! :tp/destroy-race
+                       {:rf.trace/frame-no-emit? false
+                        :rf.trace/events-retained 5})
+  (let [policy-reached   (CountDownLatch. 1)
+        release-policy   (CountDownLatch. 1)
+        teardown-cleared (CountDownLatch. 1)
+        release-teardown (CountDownLatch. 1)
+        original-clear   trace/clear-frame-no-emit-for!]
+    (with-redefs [trace/clear-frame-no-emit-for!
+                  (fn [frame-id]
+                    (original-clear frame-id)
+                    (when (= :tp/destroy-race frame-id)
+                      (.countDown teardown-cleared)
+                      (.await release-teardown 10 TimeUnit/SECONDS)))]
+      (let [a (binding [frame/*upsert-policy-probe*
+                        (window-probe :tp/destroy-race
+                                      policy-reached release-policy)]
+                (future
+                  (frame/upsert-frame! :tp/destroy-race
+                                       {:rf.trace/frame-no-emit? true
+                                        :rf.trace/events-retained 77})))]
+        (is (.await policy-reached 10 TimeUnit/SECONDS)
+            "A committed config and paused before policy publication")
+        (let [b (future (frame/destroy-frame! :tp/destroy-race))]
+          (is (.await teardown-cleared 10 TimeUnit/SECONDS)
+              "B cleared the ring and no-emit store, then paused before dissoc")
+          (is (nil? (frame/frame :tp/destroy-race))
+              "the matching raw record is already lifecycle-dead")
+          (.countDown release-policy)
+          (.countDown release-teardown)
+          (is (= :tp/destroy-race @a) "A's earlier config commit still returns")
+          (is (nil? @b) "B completes teardown")
+          (is (nil? (frame/frame :tp/destroy-race)) "the frame stays absent")
+          (is (false? (trace/frame-trace-disabled? :tp/destroy-race))
+              "delayed A cannot repopulate no-emit after B cleared it")
+          (is (nil? (retained-cap :tp/destroy-race))
+              "delayed A cannot recreate a ring override after B released it"))))))
+
 (deftest omitting-retention-on-reregistration-clears-frame-override
   (rf/configure! {:trace-buffer {:events-retained 7}})
   (frame/upsert-frame! :tp/inherit {:rf.trace/events-retained 99})

--- a/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_upsert_linearization_jvm_test.clj
@@ -2,8 +2,8 @@
   "rf2-vxgfnd.76 — linearize frame-id creation through the `frames` registry
   atom itself.
 
-  THE WINDOW (JVM-only; CLJS is single-threaded so the guarded CAS is
-  uncontended there). Before the A-prime fix `upsert-frame!` read `(get @frames
+  THE WINDOW (JVM-only; CLJS is single-threaded). Before the A-prime fix
+  `upsert-frame!` read `(get @frames
   id)` and THEN wrote (`swap! frames assoc id …` on create / `swap! frames update
   id assoc …` on re-register) as two separate steps. Two actors racing in the
   read→write window both read the id absent and both `assoc` — a LAST-WRITER
@@ -12,32 +12,33 @@
   assoc …)` on a dissoc'd id, RESURRECTING a partial `{:config … :generation …}`
   zombie with no state container and no `:drain-lock`.
 
-  The fix makes decide+install a GUARDED-CAS RETRY loop through the `frames`
-  atom (the `set-generation!` discipline): a create installs via `swap-vals!`
-  with a contains-guard and, on CAS loss, recurs (now a re-registration); a
-  re-registration is contains-guarded too and, if the id vanished under a
-  concurrent destroy, recurs as a create. Plus an internal create-exclusive mode
+  The fix serializes the cold create absence-check/allocation/install path so a
+  losing creator allocates nothing; re-registration is contains-guarded and, if
+  the id vanished under a concurrent destroy, recurs as a create. Plus an
+  internal create-exclusive mode
   (`:rf.frame/must-create?`) that throws typed `:rf.error/frame-id-taken` on a
   taken id — the primitive `ui.test` rests its fresh-isolated-frame contract on.
 
-  These fixtures open the read→CAS window DETERMINISTICALLY via the
+  These fixtures open the decision window DETERMINISTICALLY via the
   `frame/*upsert-decide-probe*` JVM linearization seam (a `nil`-in-production
-  dynamic hook fired once after the decide read and before the guarded CAS),
+  dynamic hook fired once before the authoritative registry path),
   conveyed into the racing thread by `future` binding-conveyance — NO sleeps.
   Each FAILS against the pre-fix read-then-write shape (clobber / zombie / no
   such error id)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as substrate]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]
             ;; Loads the trace-tooling artefact so its
-            ;; `:trace.tooling/set-frame-events-retained!` late-bind is published
+            ;; The trace-tooling retention-policy late-bind is published
             ;; before these tests run (the retention override is otherwise a
             ;; silent no-op) and so the per-frame retention store is observable.
             [re-frame.trace.tooling :as trace-tooling])
-  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier
+            LinkedBlockingQueue TimeUnit]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -54,7 +55,7 @@
 
 ;; The per-frame retention cap the winning config's `:rf.trace/events-retained`
 ;; override installed, read straight from the trace-tooling ring store (a
-;; white-box read of the process-global store the guarded CAS must linearize).
+;; white-box read of the process-global store config publication must linearize).
 ;; nil when no override ring was written for the frame.
 (defn- retained-cap [frame-id]
   ;; Double deref: `#'…/trace-rings` is the VAR, its value is the store ATOM,
@@ -76,13 +77,13 @@
       (.await ^CountDownLatch release 10 TimeUnit/SECONDS))))
 
 ;; ===========================================================================
-;; Create/create: the loser of the guarded CAS re-registers surgically — no
+;; Create/create: the loser of the serialized create decision re-registers — no
 ;; last-writer clobber of the winner's durable record.
 ;; ===========================================================================
 
-(deftest guarded-cas-create-loser-reregisters-surgically-never-clobbers
+(deftest serialized-create-loser-reregisters-surgically-never-clobbers
   ;; A reads the id absent, pauses in the decide→install window; B installs its
-  ;; frame and seeds durable app-db; A resumes and its guarded CAS finds the id
+  ;; frame and seeds durable app-db; A resumes and its create decision finds the id
   ;; PRESENT, so it re-registers surgically (metadata refresh, runtime state
   ;; preserved) instead of assoc-clobbering B's record. B's incarnation + seeded
   ;; app-db SURVIVE. Pre-fix: A's unconditional `assoc` clobbered B → this fails.
@@ -99,7 +100,7 @@
       (.countDown release)
       (is (= :race/x @a) "A's upsert returns the id — it re-registered, did not throw")
       (is (identical? token-b (frame/frame-incarnation-token :race/x))
-          "B's incarnation SURVIVES — A lost the guarded CAS and re-registered
+          "B's incarnation SURVIVES — A lost the create decision and re-registered
            surgically rather than clobbering B's record (the pre-fix hole)")
       (is (= {:who :b} (frame/frame-app-db-value :race/x))
           "B's durable app-db is preserved through A's surgical re-registration —
@@ -108,7 +109,7 @@
           "the record is FULL (a real state container), never a partial zombie"))))
 
 (deftest concurrent-creates-linearize-to-one-full-live-frame
-  ;; A barrier releases two ordinary creates together; the guarded CAS
+  ;; A barrier releases two ordinary creates together; the serialized create path
   ;; linearizes them — exactly one live, FULL record survives (both calls return
   ;; the id; the loser re-registered).
   (let [gate (CyclicBarrier. 2)
@@ -120,7 +121,32 @@
     (is (= [:cc/x :cc/x] outs) "both calls returned the id (one installed, one re-registered)")
     (is (some? (frame/frame :cc/x)) "one live frame exists")
     (is (some? (frame/frame-state-container :cc/x))
-        "with a real state container — the CAS never left a clobbered/partial record")))
+        "with a real state container — serialization never left a clobbered/partial record")))
+
+(deftest losing-creator-does-not-allocate-an-unowned-state-container
+  ;; A pauses before the authoritative create path. B creates and owns the sole
+  ;; container; A resumes, observes B, and re-registers without calling the
+  ;; adapter allocator. The former speculative shape allocated once in A above
+  ;; the race and once in B, abandoning A's opaque adapter value.
+  (let [reached       (CountDownLatch. 1)
+        release       (CountDownLatch. 1)
+        allocations   (atom 0)
+        original-make substrate/make-state-container]
+    (with-redefs [substrate/make-state-container
+                  (fn [initial]
+                    (swap! allocations inc)
+                    (original-make initial))]
+      (let [a (binding [frame/*upsert-decide-probe*
+                        (window-probe :cc/owned reached release)]
+                (future (frame/upsert-frame! :cc/owned {:tags #{:a}})))]
+        (is (.await reached 10 TimeUnit/SECONDS)
+            "A reached the pre-create barrier without allocating")
+        (is (= :cc/owned (frame/upsert-frame! :cc/owned {:tags #{:b}}))
+            "B installs the frame")
+        (.countDown release)
+        (is (= :cc/owned @a) "A falls through to surgical re-registration")
+        (is (= 1 @allocations)
+            "exactly the installed frame's state container was allocated")))))
 
 ;; ===========================================================================
 ;; Re-register vs destroy: the losing re-registration recurs as a CREATE — no
@@ -191,13 +217,13 @@
           "B's frame is untouched — the losing exclusive construction wrote nothing"))))
 
 ;; ===========================================================================
-;; rf2-umsyo9 — the exclusive-CAS loser must not overwrite the WINNER's
+;; rf2-umsyo9 — the exclusive create loser must not overwrite the WINNER's
 ;; frame-scoped trace policy.
 ;;
 ;; `upsert-frame!`'s two frame-scoped TRACE POLICY writes — the `set-frame-
 ;; no-emit!` suppression flag (always written) and the `:rf.trace/events-
 ;; retained` retention override — live in process-global stores SEPARATE from
-;; the `frames` registry, so the guarded CAS does not linearize them. PR #5776
+;; the `frames` registry, so the registry commit does not linearize them. PR #5776
 ;; ran them ABOVE the CAS, so a must-create LOSER (or a create/create loser)
 ;; already mutated the WINNER's trace policy for the id by the time its CAS
 ;; failed — an exclusive collision that claims to write NOTHING corrupted the
@@ -208,38 +234,106 @@
 ;; winner's policy); passes once the writes are linearized onto the winner.
 ;; ===========================================================================
 
-(deftest exclusive-cas-loser-must-not-overwrite-winner-trace-policy
+(deftest exclusive-create-loser-must-not-overwrite-winner-trace-policy
   ;; LOSER A: exclusive (must-create) construction with DISTINCT trace policy —
   ;; no-emit? FALSE, retention 10. A reads the id absent and pauses in the
   ;; PRE-side-effect window (after the decide snapshot, before its policy writes
   ;; / CAS). WINNER B: ordinary construction, no-emit? TRUE, retention 99 —
   ;; installs the id and writes its policy fully on the main thread. A resumes;
-  ;; its guarded CAS finds the id present → typed `:rf.error/frame-id-taken`. The
+  ;; its create decision finds the id present → typed `:rf.error/frame-id-taken`. The
   ;; winner's suppression flag AND retention override must be UNCHANGED. Pre-fix:
   ;; A's policy writes ran on CAS loss and overwrote B's (no-emit? → false,
   ;; retention → 10) → both post-collision assertions fail.
+  (let [stage        (LinkedBlockingQueue.)
+        release      (CountDownLatch. 1)
+        original-set trace/set-frame-no-emit!
+        probe        (fn [id]
+                       (when (= :tp/race id)
+                         (.put stage :decide-probe)
+                         (.await release 10 TimeUnit/SECONDS)))]
+    ;; The auxiliary-writer barrier makes this fixture independent of where a
+    ;; historical implementation placed *upsert-decide-probe*. Correct/current
+    ;; ordering reaches :decide-probe first. PR #5776's pre-CAS policy ordering
+    ;; reaches :policy-write first. In either case B then wins before A resumes.
+    (with-redefs [trace/set-frame-no-emit!
+                  (fn [frame-id no-emit? & guard]
+                    (when (and (= :tp/race frame-id) (false? no-emit?))
+                      (.put stage :policy-write)
+                      (.await release 10 TimeUnit/SECONDS))
+                    (apply original-set frame-id no-emit? guard))]
+      (let [a (binding [frame/*upsert-decide-probe* probe]
+                (future (err-id #(frame/upsert-frame! :tp/race
+                                   {:rf.frame/must-create?     true
+                                    :rf.trace/frame-no-emit?   false
+                                    :rf.trace/events-retained 10}))))
+            first-stage (.poll stage 10 TimeUnit/SECONDS)]
+        (is (contains? #{:decide-probe :policy-write} first-stage)
+            "A reached either the decision barrier (fixed ordering) or the
+             policy barrier (PR #5776 ordering) before B runs")
+        (frame/upsert-frame! :tp/race {:rf.trace/frame-no-emit?  true
+                                       :rf.trace/events-retained 99})
+        (is (true? (trace/frame-trace-disabled? :tp/race))
+            "precondition: winner B registered trace-disabled (no-emit? true)")
+        (is (= 99 (retained-cap :tp/race))
+            "precondition: winner B installed its retention override (99)")
+        (.countDown release)
+        (is (= :rf.error/frame-id-taken @a)
+            "the exclusive loser threw the typed collision — it installed nothing")
+        (is (true? (trace/frame-trace-disabled? :tp/race))
+            "winner B's trace SUPPRESSION survives. Under PR #5776, A resumes
+             its already-entered pre-CAS writer and clears B here → fails")
+        (is (= 99 (retained-cap :tp/race))
+            "winner B's RETENTION override survives. Under PR #5776, A writes
+             its pre-CAS cap 10 after B's cap 99 here → fails")))))
+
+(deftest older-successful-reregistration-cannot-publish-policy-after-newer-winner
+  ;; Both A and B successfully commit a surgical re-registration. A commits
+  ;; config A first, then pauses immediately before its first auxiliary policy
+  ;; write. B commits config + policy B and returns. When A resumes, its stale
+  ;; policy publication must be rejected: the authoritative record and BOTH
+  ;; auxiliary stores stay at B. This is the successful-winner race that merely
+  ;; moving policy writes below the registry CAS does not close.
+  (frame/upsert-frame! :tp/successful
+                       {:tags #{:initial}
+                        :rf.trace/frame-no-emit? true
+                        :rf.trace/events-retained 5})
   (let [reached (CountDownLatch. 1)
         release (CountDownLatch. 1)
-        a (binding [frame/*upsert-decide-probe* (window-probe :tp/race reached release)]
-            (future (err-id #(frame/upsert-frame! :tp/race
-                               {:rf.frame/must-create?    true
-                                :rf.trace/frame-no-emit?  false
-                                :rf.trace/events-retained 10}))))]
-    (.await reached 10 TimeUnit/SECONDS)
-    (frame/upsert-frame! :tp/race {:rf.trace/frame-no-emit?  true
-                                   :rf.trace/events-retained 99})
-    (is (true? (trace/frame-trace-disabled? :tp/race))
-        "precondition: winner B registered trace-disabled (no-emit? true)")
-    (is (= 99 (retained-cap :tp/race))
-        "precondition: winner B installed its retention override (99)")
+        a       (binding [frame/*upsert-policy-probe*
+                          (window-probe :tp/successful reached release)]
+                  (future
+                    (frame/upsert-frame! :tp/successful
+                                         {:tags #{:a}
+                                          :rf.trace/frame-no-emit? false
+                                          :rf.trace/events-retained 10})))]
+    (is (.await reached 10 TimeUnit/SECONDS)
+        "A committed config A and reached the pre-policy barrier")
+    (is (= :tp/successful
+           (frame/upsert-frame! :tp/successful
+                                {:tags #{:b}
+                                 :rf.trace/frame-no-emit? true
+                                 :rf.trace/events-retained 99}))
+        "newer actor B committed config + policy and returned")
     (.countDown release)
-    (is (= :rf.error/frame-id-taken @a)
-        "the exclusive loser threw the typed collision — it installed nothing")
-    (is (true? (trace/frame-trace-disabled? :tp/race))
-        "winner B's trace SUPPRESSION survives the collision — the loser never
-         overwrote the winner's frame-scoped no-emit flag (rf2-umsyo9). Pre-fix:
-         the loser's `set-frame-no-emit! false` on CAS loss cleared it → fails")
-    (is (= 99 (retained-cap :tp/race))
-        "winner B's RETENTION override survives — the loser never rewrote the
-         winner's per-frame :rf.trace/events-retained store (rf2-umsyo9).
-         Pre-fix: the loser's write dropped the cap to 10 → fails")))
+    (is (= :tp/successful @a) "older actor A also returns successfully")
+    (is (= #{:b} (get-in (frame/frame :tp/successful) [:config :tags]))
+        "the authoritative frame record remains B")
+    (is (true? (trace/frame-trace-disabled? :tp/successful))
+        "the no-emit auxiliary store remains B — stale A was rejected")
+    (is (= 99 (retained-cap :tp/successful))
+        "the retention auxiliary store remains B — stale A was rejected")))
+
+(deftest omitting-retention-on-reregistration-clears-frame-override
+  (rf/configure! {:trace-buffer {:events-retained 7}})
+  (frame/upsert-frame! :tp/inherit {:rf.trace/events-retained 99})
+  (is (= 99 (retained-cap :tp/inherit))
+      "precondition: the first config installed an explicit frame override")
+  (frame/upsert-frame! :tp/inherit {:tags #{:override-removed}})
+  (is (= 7 (retained-cap :tp/inherit))
+      "omission restores the current process default instead of retaining 99")
+  (is (false? (get-in @@#'re-frame.trace.tooling/trace-rings
+                       [:tp/inherit :override?]))
+      "the ring is marked inherited, so later process-default changes follow")
+  (rf/configure! {:trace-buffer {:events-retained 3}})
+  (is (= 3 (retained-cap :tp/inherit))
+      "a later process-default change reaches the now-inherited frame"))


### PR DESCRIPTION
Closes rf2-4vism7.

## What changed

- serialize the cold frame create allocation/install window so a losing creator allocates no unowned opaque adapter container
- stamp each successful frame-config commit with an identity token and serialize the two auxiliary trace-policy publications
- reject superseded successful publishers inside each auxiliary atom update
- treat omission of `:rf.trace/events-retained` as clearing the frame override back to the live process default
- add deterministic barriers for successful-A/newer-B publication, the historical exclusive loser ordering, unowned allocation, and retention inheritance

## Mandatory red proof

Current-main behavior was restored locally while retaining only the neutral post-commit test seam: the guarded 3-argument no-emit call was changed back to the unguarded 2-argument call, retention publication used `(constantly true)`, and omission skipped retention publication. Then:

```
cd implementation/core
clojure -M:test -n re-frame.frame-upsert-linearization-jvm-test
```

Result: **5 failures**. The successful-winner fixture ended with no-emit `false` and retention `10` after config B; the omission fixture retained override `99` instead of inherited defaults `7` then `3`.

PR #5776 ordering was also restored locally by inserting the unguarded no-emit + retention writes immediately before `*upsert-decide-probe*`. The exact historical fixture command:

```
clojure -M:test -v re-frame.frame-upsert-linearization-jvm-test/exclusive-create-loser-must-not-overwrite-winner-trace-policy
```

Result: **2 failures**: winner B's suppression became `false` and retention became `10` after exclusive loser A resumed. The mutation was reverted before commit.

## Green proof

```
cd implementation/core
clojure -M:test -n re-frame.frame-upsert-linearization-jvm-test
```

Result after final rebase: **10 tests, 39 assertions, 0 failures, 0 errors**.

Additional focused proof before rebase:

- frame policy/lifecycle/trace/config group: 100 tests, 350 assertions green on its first run
- late-bind drift inventory: 6 tests, 632 assertions green
- `git diff --check`: green
- clj-kondo on touched files: no new warnings (two pre-existing trace-tooling warnings remain)

The Windows-local full core command reached the repository's known bounded-run timeout with no emitted failure; broad CI is authoritative per `TESTING.md`.
## Follow-up destroy-race proof

Independent review found a second successful-upsert window: actor A committed config and paused before policy publication; actor B marked the same frame lifecycle-dead, released its ring, cleared no-emit, and paused before registry dissociation; A then repopulated both cleared stores because the owner predicate read the matching token from raw `@frames` without checking liveness.

The deterministic barrier fixture was added first and run against head `695eee8eb3`:

```
clojure -M:test -v re-frame.frame-upsert-linearization-jvm-test/destroyed-frame-rejects-delayed-successful-policy-publication
```

Red result: **1 test / 8 assertions / 2 failures** — no-emit was `true` and retained cap was `77` after destroy.

The fix resolves owner identity through live-only `frame` and serializes destroy's ring/no-emit clears with successful publication. Green results:

- destroy-race fixture: 1 test / 8 assertions / 0 failures
- complete frame-upsert linearization namespace: 11 tests / 47 assertions / 0 failures
- frame lifecycle namespace: 35 tests / 169 assertions / 0 failures
