### PR TITLE
Fix template repo-split override grammar (rf2-2jtujj)

### DIFF
--- a/tools/template/spec/005-Repo-Split.md
+++ b/tools/template/spec/005-Repo-Split.md
@@ -10,6 +10,11 @@
 > the external repo is live and the in-monorepo `tools/template/` is
 > stubbed or deleted.
 
+**Sequencing prerequisite.** Execute this repo split only after Stage-6 W8 has
+collapsed the three substrate variants into one `re-frame.ui` scaffold
+(synthesis `11-adoption-workstreams.md` W8); the split itself runs in Stage 7
+after every alpha gate is green (synthesis `08-delivery.md` §2, Stage 7).
+
 ## §1 Why split
 
 The template's published invocation surface is `clojure -Tnew create
@@ -117,7 +122,7 @@ template-body path), so only the `resources/` body moves.
 external repo ships the `io/github/day8/…` body *only*. The local-dev
 `:local/root` smoke (§4) resolves that same single body **without**
 auto-clone by using deps-new's `repo%root%template-sym` override form
-(`day8/re-frame2-template%%io.github.day8/re-frame2-template`): the
+(`day8/re-frame2-template%io.github.day8/re-frame2-template`): the
 `day8/re-frame2-template` repo part bypasses `auto-git-url` (no
 `io.github.*` prefix → no clone, the `:local/root` override stands),
 while the `io.github.day8/re-frame2-template` template-sym part drives
@@ -304,7 +309,7 @@ updates to the override form:
 
 ```clojure
 ;; post-retarget run-template! opts
-{:template 'day8/re-frame2-template%%io.github.day8/re-frame2-template
+{:template 'day8/re-frame2-template%io.github.day8/re-frame2-template
  ...}
 ```
 
@@ -389,7 +394,7 @@ cd /path/to/consumer
 clojure -Sdeps '{:deps {day8/re-frame2-template
                         {:local/root "/path/to/re-frame2-template"}}}' \
         -Tnew create \
-        :template day8/re-frame2-template%%io.github.day8/re-frame2-template \
+        :template day8/re-frame2-template%io.github.day8/re-frame2-template \
         :name acme/my-app
 ```
 
@@ -397,7 +402,7 @@ clojure -Sdeps '{:deps {day8/re-frame2-template
 `io.github.day8/re-frame2-template` — bypasses auto-clone: the
 `io.github.*` prefix would trigger a git-clone before classpath
 lookup, losing the local override. The trailing
-`%%io.github.day8/re-frame2-template` template-sym part drives
+`%io.github.day8/re-frame2-template` template-sym part drives
 `find-root` to the single canonical `io/github/day8/…` body that the
 published coord also uses, so there is no second on-disk copy.)
 

--- a/tools/template/test/day8/re_frame2_template/repo_split_spec_test.clj
+++ b/tools/template/test/day8/re_frame2_template/repo_split_spec_test.clj
@@ -1,0 +1,35 @@
+(ns day8.re-frame2-template.repo-split-spec-test
+  "Executable checks for the deps-new grammar documented by 005-Repo-Split."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-template.test-support :refer [repo-root]]
+            [org.corfield.new.impl :as deps-new.impl]))
+
+(defn- repo-split-spec-text
+  []
+  (slurp (io/file (repo-root) "tools/template/spec/005-Repo-Split.md")))
+
+(defn- documented-local-overrides
+  "Return the concrete local-root override spellings from the split spec."
+  []
+  (map (fn [[_ separator-and-template]]
+         (str "day8/re-frame2-template" separator-and-template))
+       (re-seq #"(%+io\.github\.day8/re-frame2-template)"
+               (repo-split-spec-text))))
+
+(deftest local-root-override-grammar-test
+  (testing "all four documented overrides parse to the canonical template symbol"
+    (let [overrides (documented-local-overrides)]
+      (is (= 4 (count overrides))
+          "the split procedure must keep its four concrete override examples under test")
+      (doseq [override overrides]
+        ;; Parsing a local-root override must not resolve or load a git lib. Stub only
+        ;; that side effect while exercising deps-new's production option parser.
+        (let [parsed (with-redefs [deps-new.impl/get-git-sha
+                                   (constantly [nil nil])]
+                       (deps-new.impl/preprocess-options
+                         {:template (symbol override)
+                          :name     'acme/example}))]
+          (is (= "io.github.day8/re-frame2-template" (:template parsed))
+              (str "deps-new must parse " override
+                   " as the canonical post-split template symbol")))))))


### PR DESCRIPTION
## What changed

- Correct all four concrete local-root override examples in `005-Repo-Split.md` from `%%` to deps-new's single-`%` form.
- Add an executable regression that extracts all four documented examples and passes them through deps-new's production `preprocess-options` parser.
- State the ruled sequencing: Stage-6 W8 first collapses the template to one `re-frame.ui` scaffold; the repo split executes in Stage 7 after the alpha gates are green.

## Why

deps-new parses `repo%template-sym` with one separator. With `%%`, the second `%` becomes part of the parsed template symbol, yielding `%io.github.day8/re-frame2-template`; the documented post-split local-root command would therefore resolve the wrong resource path. The sequencing note prevents exporting the three soon-to-be-deleted substrate variants into the external repository before the W8 collapse.

## Pre-fix proof

Command:

```text
clojure -M:test -n day8.re-frame2-template.repo-split-spec-test
```

Against the original spec, the new test found all four examples and failed all four parser assertions:

```text
expected: "io.github.day8/re-frame2-template"
actual:   "%io.github.day8/re-frame2-template"
Ran 1 tests containing 5 assertions.
4 failures, 0 errors.
```

## Green proof

- Focused parser regression: 1 test, 5 assertions, 0 failures/errors.
- Full `tools/template` JVM suite: 50 tests, 670 assertions, 0 failures/errors.
- `python scripts/check_doc_slugs.py`: green.
- `python scripts/check_readme_links.py --ci`: green.
- `python -m mkdocs build --strict`: green.
- `clj-kondo --lint tools/template/src tools/template/test`: 0 errors; one pre-existing warning in `template_emission_test.clj`.
- `git diff --check`: green.

Tracker: rf2-2jtujj
