### PR TITLE
Fix frame destroy drain cutoff

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -186,17 +186,13 @@
 ;; frame. Per Spec 002 §Destroy — re-entrant destroy is idempotent.
 ;;
 ;; Keyed by the bare frame-id. Each value carries the DESTROYING incarnation's
-;; token (its `:drain-lock`, captured while still live) and teardown-owner host
-;; thread: `{id {:token drain-lock :owner Thread|true}}`. The bare id is what
-;; the re-entrant guard + `frame-closing?` consult; the token is what
+;; token (its `:drain-lock`, captured while still live):
+;; `{id {:token drain-lock}}`. The bare id is what `frame-closing?` consults;
+;; the token is what the duplicate guard and
 ;; `frame-incarnation-closing?` consults so a stale close marker of an
 ;; already-torn-down incarnation A cannot be mistaken for a fresh same-id
-;; REPLACEMENT incarnation B being in-flight. The owner identifies the sole
-;; drain allowed after claim: the intentional `:on-destroy` event on the
-;; teardown thread. It is a host-thread identity, not a dynamic binding, because
-;; JVM `interop/next-tick` conveys dynamic bindings via `bound-fn` and must not
-;; grant queued executor work teardown authority. On CLJS the marker is `true`;
-;; destroy completes synchronously before a microtask can run.
+;; REPLACEMENT incarnation B being in-flight. A new B claim REPLACES A's stale
+;; marker; each destroy's terminal cleanup compare-removes only its own token.
 
 (defonce ^:private destroying-frames
   (atom {}))
@@ -645,8 +641,8 @@
         live-container teardown is still running before the `:destroyed?`
         flip. The claim is the queued-work cutoff: a cold serialization release
         never re-kicks that queue, and an already-scheduled drain drops rather
-        than executes it. The sole exception is the teardown-owner thread while
-        it runs the intentional `:on-destroy` event against the still-live frame.
+        than executes it. The intentional `:on-destroy` event uses a separate,
+        token-scoped internal cascade; ordinary drains have no exemption.
     (b) The frame record still exists but `:destroyed?` is flipped
         (post-step-3 of `destroy-frame!`, before step-6 dissoc), OR
     (c) The frame record is absent from the `frames` atom (post-step-6
@@ -665,12 +661,8 @@
   [id]
   (if-let [f (get @frames id)]
     (or (true? (-> f :lifecycle :destroyed?))
-        (let [{:keys [token owner]} (get @destroying-frames id)
-              owner-thread?
-              #?(:clj  (identical? owner (Thread/currentThread))
-                 :cljs (true? owner))]
+        (let [token (get-in @destroying-frames [id :token])]
           (and (some? token)
-               (not owner-thread?)
                (identical? token (:drain-lock f)))))
     ;; Absent from the atom — destroy-frame!'s step 6 ran, OR the id
     ;; was never registered. The drain-loop caller only consults this
@@ -718,7 +710,7 @@
   answers 'is this id anywhere in its close lifecycle' by BARE id,
   `frame-incarnation-closing?` answers 'is the destroy that is in flight for this
   id the one destroying the incarnation I acquired'. `destroying-frames` records
-  `{id {:token destroying-incarnation-token :owner host-thread}}`, so this
+  `{id {:token destroying-incarnation-token}}`, so this
   compares the caller's acquire-time token against the token the marker carries
   by identity.
 
@@ -2556,7 +2548,8 @@
   `trace/emit-error!`.
 
   This is also the ONLY always-on coverage for the defence-in-depth re-throw
-  branch (`dispatch-sync!` itself faulting): that path never produces a router
+  branch (the private teardown cascade itself faulting): that path never
+  produces a router
   `:rf.error/handler-exception`, so the always-on emission here is its only
   production observability.
 
@@ -2600,8 +2593,8 @@
   torn down.
 
   Mechanism: the router catches handler throws and converts them to
-  `:rf.error/handler-exception` — `dispatch-sync!` does not re-throw. To
-  surface the throw as the dedicated `:rf.error/on-destroy-handler-
+  `:rf.error/handler-exception` — the internal teardown cascade does not
+  re-throw. To surface the throw as the dedicated `:rf.error/on-destroy-handler-
   exception` category (Mike's decision), we install a TRANSIENT listener
   on the ALWAYS-ON error-emit axis for the duration of the dispatch under a
   UNIQUE per-destroy key (a constant key would let a nested / overlapping
@@ -2621,23 +2614,24 @@
   emission below rides `:error-emit/dispatch-on-error`).
 
   We ALSO wrap the dispatch itself in try/catch as a defence-in-depth: if
-  `dispatch-sync!` ever re-throws (e.g. a fault inside the dispatch
+  the internal teardown cascade ever re-throws (e.g. a fault inside the dispatch
   infrastructure itself, not the user handler), we catch it here — and
   per EP-0008 the dedicated category rides the always-on axis so this
   defence-in-depth branch (which never produces a router
   `:rf.error/handler-exception`) is observable in production. The two
   paths are mutually exclusive (a router-converted handler throw never
-  re-throws out of `dispatch-sync!`; an infra fault re-throws and never
-  produces a router handler-exception record), and a `re-entered?` guard
+  re-throws out of the cascade; an infra fault re-throws and never
+  produces a router handler-exception record), and an `infra-fault?` guard
   makes the single-record contract explicit either way.
 
   This mirrors the swallow-then-continue shape of `safe-call-hook!` below
   but ALSO emits a structured error event (where `safe-call-hook!` is
   silent) — the user's `:on-destroy` is application code; its failure
   is a first-class diagnostic event."
-  [id f]
+  [id expected-token f]
   (when-let [on-destroy (-> f :config :on-destroy)]
-    (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
+    (when-let [run-destroy-event (late-bind/get-fn
+                                   :router/run-frame-destroy-event!)]
       (let [captured     (atom nil)
             infra-fault? (atom false)
             ;; The always-on error-emit listener registry — the
@@ -2667,9 +2661,9 @@
           (register listener-k listener))
         (try
           (try
-            (dispatch-sync on-destroy {:frame id})
+            (run-destroy-event id expected-token on-destroy)
             (catch #?(:clj Throwable :cljs :default) ex
-              ;; Defence-in-depth: dispatch-sync! normally swallows
+              ;; Defence-in-depth: the router normally swallows
               ;; handler throws, but if the dispatch infrastructure
               ;; itself fails we still emit the dedicated category. This
               ;; branch never produces a router :rf.error/handler-exception,
@@ -2765,12 +2759,20 @@
 (defn- claim-frame-destroy!
   "Claim teardown authority for `expected-token`'s live incarnation of `id`.
 
-  The token check and `destroying-frames` publication run under the candidate
-  incarnation's drain lock. `call-serialized-with-drain!` may have captured A's
-  frame record before blocking and wake after A was replaced by B, so the thunk
-  revalidates the registry token after acquisition and retries against the
-  current record. A stale expected token therefore never claims B while holding
-  A's obsolete lock. Returns the claimed frame record, or nil."
+  The token check, `destroying-frames` publication, and pre-claim queue cutoff
+  run under the candidate incarnation's drain lock. The queue cutoff is atomic
+  on the router atom: every not-yet-dequeued envelope moves to the private
+  `:destroy-claim-dropped-count` evidence slot and the live queue becomes empty
+  before the lock releases. The later internal `:on-destroy` cascade therefore
+  cannot drain ordinary work behind its cleanup seed.
+
+  `call-serialized-with-drain!` may have captured A's frame record before
+  blocking and wake after A was replaced by B, so the thunk revalidates the
+  registry token after acquisition and retries against the current record. A
+  stale expected token therefore never claims B while holding A's obsolete
+  lock. An existing marker blocks only a duplicate claim for the SAME token; a
+  fresh same-id incarnation replaces a stale prior marker. Returns the claimed
+  frame record, or nil."
   [id expected-token]
   (loop []
     (when-let [candidate (frame id)]
@@ -2783,23 +2785,49 @@
                   id
                   (fn []
                     (when-let [current (frame id)]
-                      (cond
-                        (not (identical? candidate-token (:drain-lock current)))
-                        ::retry-destroy-claim
+                      (let [marker-token (get-in @destroying-frames [id :token])]
+                        (cond
+                          (not (identical? candidate-token (:drain-lock current)))
+                          ::retry-destroy-claim
 
-                        (contains? @destroying-frames id)
-                        nil
+                          (and (some? marker-token)
+                               (identical? candidate-token marker-token))
+                          nil
 
-                        :else
-                        (do
-                          (swap! destroying-frames assoc id
-                                 {:token candidate-token
-                                  :owner #?(:clj  (Thread/currentThread)
-                                            :cljs true)})
-                          current)))))]
+                          :else
+                          (let [router (:router current)]
+                            ;; Serialize claim publication + queue cutoff with
+                            ;; the router's scheduling/release monitor. A
+                            ;; submitter that linearized before this section is
+                            ;; included in the dropped queue; ordinary drains
+                            ;; after publication observe the claim and halt.
+                            (locking router
+                              (swap! destroying-frames assoc id
+                                     {:token candidate-token})
+                              (swap! router
+                                     (fn [{:keys [queue] :as state}]
+                                       (let [dropped (count queue)]
+                                         (cond-> (assoc state
+                                                        :queue interop/empty-queue
+                                                        :scheduled? false)
+                                           (pos? dropped)
+                                           (update :destroy-claim-dropped-count
+                                                   (fnil + 0) dropped)))))
+                              current)))))))]
             (if (= ::retry-destroy-claim claimed)
               (recur)
               claimed)))))))
+
+(defn- release-frame-destroy-claim!
+  "Compare-remove only `expected-token`'s claim. A stale incarnation A's
+  terminal `finally` must not erase a fresh same-id B claim that replaced A's
+  marker after A dissociated its frame record."
+  [id expected-token]
+  (swap! destroying-frames
+         (fn [claims]
+           (if (identical? expected-token (get-in claims [id :token]))
+             (dissoc claims id)
+             claims))))
 
 (defn- tear-down-sub-cache!
   "Dispose every cached subscription reaction for the destroyed frame.
@@ -3021,8 +3049,8 @@
   ;; targets the frame-id-keyed record directly.
   (when-let [f (claim-frame-destroy! id expected-incarnation-token)]
       ;; `claim-frame-destroy!` records the DESTROYING incarnation's token (the
-      ;; live record's `:drain-lock`) and actual teardown-owner host thread under
-      ;; that SAME lock, after revalidating the expected token.
+      ;; live record's `:drain-lock`) under that SAME lock, after revalidating
+      ;; the expected token.
       ;; `frame-incarnation-closing?` can therefore tell
       ;; this teardown apart from a fresh same-id replacement that goes live
       ;; under the reused id before this destroy's `finally` clears the marker
@@ -3056,7 +3084,7 @@
        (binding [*destroying-frame-id*    id
                  *teardown-hook-failures* hook-failures]
         (try
-        (fire-on-destroy-event! id f)
+        (fire-on-destroy-event! id expected-incarnation-token f)
         ;; Step 2 rides the SAME best-effort boundary as the later
         ;; `safe-call-hook!` steps (rf2-jt47s0). `notify-machine-destruction!`'s
         ;; `teardown!` hook call, its fallback `:rf.machine.lifecycle/destroyed`
@@ -3244,10 +3272,10 @@
                 (try
                   (emit-report id failures (interop/now-ms))
                   (catch #?(:clj Throwable :cljs :default) _ nil)))))
-          ;; Always clear the in-flight marker — even if a downstream step
-          ;; throws unexpectedly, future `destroy-frame!` calls for `id`
-          ;; (after a fresh construction) must not see a stale entry.
-          (swap! destroying-frames dissoc id)))))))))
+          ;; Compare-remove only this incarnation's in-flight marker. A fresh
+          ;; same-id incarnation may have replaced it after `dissoc-frame!`;
+          ;; stale A's finally must never erase B's claim.
+          (release-frame-destroy-claim! id expected-incarnation-token)))))))))
 
 ;; ---- reset-frame! — RETIRED (rf2-lxwpob) -----------------------------------
 ;;

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -185,17 +185,18 @@
 ;; re-disposing the sub-cache — and likely throw on a half-torn-down
 ;; frame. Per Spec 002 §Destroy — re-entrant destroy is idempotent.
 ;;
-;; Keyed by the bare frame-id, with the value carrying the DESTROYING
-;; incarnation's token (its `:drain-lock`, captured at the top of
-;; `destroy-frame!` while the frame is still live). The bare id is what the
-;; re-entrant guard + `frame-closing?` consult; the token is what
+;; Keyed by the bare frame-id. Each value carries the DESTROYING incarnation's
+;; token (its `:drain-lock`, captured while still live) and teardown-owner host
+;; thread: `{id {:token drain-lock :owner Thread|true}}`. The bare id is what
+;; the re-entrant guard + `frame-closing?` consult; the token is what
 ;; `frame-incarnation-closing?` consults so a stale close marker of an
 ;; already-torn-down incarnation A cannot be mistaken for a fresh same-id
-;; REPLACEMENT incarnation B being in-flight — the JVM window between step-6
-;; `dissoc-frame!` and the terminal `finally` where A's marker is still set
-;; while B is already live under the reused id (rf2-vxgfnd.94; the reciprocal
-;; of rf2-vxgfnd.88's Failure-2). On CLJS the window is unreachable (destroy
-;; runs to completion single-threaded before any recreate).
+;; REPLACEMENT incarnation B being in-flight. The owner identifies the sole
+;; drain allowed after claim: the intentional `:on-destroy` event on the
+;; teardown thread. It is a host-thread identity, not a dynamic binding, because
+;; JVM `interop/next-tick` conveys dynamic bindings via `bound-fn` and must not
+;; grant queued executor work teardown authority. On CLJS the marker is `true`;
+;; destroy completes synchronously before a microtask can run.
 
 (defonce ^:private destroying-frames
   (atom {}))
@@ -637,25 +638,40 @@
 
 (defn frame-disposed-for-drain?
   "Per Spec 002 §Frame disposal mid-drain: predicate used by the
-  router's drain loop to interrupt a pass when the frame was destroyed
-  mid-cycle. True when EITHER:
+  router's drain loop to interrupt a pass once destruction owns the current
+  incarnation. True when ANY of:
 
-    (a) The frame record still exists but `:destroyed?` is flipped
+    (a) `destroy-frame!` has claimed this exact incarnation, even while its
+        live-container teardown is still running before the `:destroyed?`
+        flip. The claim is the queued-work cutoff: a cold serialization release
+        never re-kicks that queue, and an already-scheduled drain drops rather
+        than executes it. The sole exception is the teardown-owner thread while
+        it runs the intentional `:on-destroy` event against the still-live frame.
+    (b) The frame record still exists but `:destroyed?` is flipped
         (post-step-3 of `destroy-frame!`, before step-6 dissoc), OR
-    (b) The frame record is absent from the `frames` atom (post-step-6
+    (c) The frame record is absent from the `frames` atom (post-step-6
         of `destroy-frame!` — the dissoc step has run).
 
-  Returns false when `id` is registered and not destroyed. Calling for
-  a never-registered `id` returns true — that case is benign for the
-  drain-loop caller (a drain cannot run on a frame that was never
-  registered), but the predicate is named `*-for-drain?` to make the
-  intended seam explicit and avoid suggesting general
-  destroyed-vs-never-registered discrimination.
+  The claim test is INCARNATION-SCOPED: a stale destroy marker for incarnation A
+  does not dispose a fresh same-id incarnation B installed after A's registry
+  dissoc but before A's terminal marker cleanup. Returns false when `id` is
+  registered, live, and not claimed for destruction. Calling for a
+  never-registered `id` returns true — that case is benign for the drain-loop
+  caller (a drain cannot run on a frame that was never registered), but the
+  predicate is named `*-for-drain?` to make the intended seam explicit and avoid
+  suggesting general destroyed-vs-never-registered discrimination.
 
   Keyed by the bare frame-id."
   [id]
   (if-let [f (get @frames id)]
-    (true? (-> f :lifecycle :destroyed?))
+    (or (true? (-> f :lifecycle :destroyed?))
+        (let [{:keys [token owner]} (get @destroying-frames id)
+              owner-thread?
+              #?(:clj  (identical? owner (Thread/currentThread))
+                 :cljs (true? owner))]
+          (and (some? token)
+               (not owner-thread?)
+               (identical? token (:drain-lock f)))))
     ;; Absent from the atom — destroy-frame!'s step 6 ran, OR the id
     ;; was never registered. The drain-loop caller only consults this
     ;; while a pass is already in flight, so the latter case cannot
@@ -702,8 +718,9 @@
   answers 'is this id anywhere in its close lifecycle' by BARE id,
   `frame-incarnation-closing?` answers 'is the destroy that is in flight for this
   id the one destroying the incarnation I acquired'. `destroying-frames` records
-  `{id -> destroying-incarnation-token}`, so this compares the caller's
-  acquire-time token against the token the marker carries by identity.
+  `{id {:token destroying-incarnation-token :owner host-thread}}`, so this
+  compares the caller's acquire-time token against the token the marker carries
+  by identity.
 
   This is what closes rf2-vxgfnd.88's reciprocal Failure-2 (rf2-vxgfnd.94): in the
   JVM window between `destroy-frame!`'s step-6 `dissoc-frame!` and its terminal
@@ -717,8 +734,8 @@
 
   Keyed by the bare frame-id; the incarnation is disambiguated by the token value."
   [id token]
-  (let [closing (get @destroying-frames id)]
-    (and (some? closing) (identical? token closing))))
+  (let [closing-token (get-in @destroying-frames [id :token])]
+    (and (some? closing-token) (identical? token closing-token))))
 
 (defn frame-address
   "Resolve the ADDRESS key for `frame-id` — the key a per-frame SIDE-CHANNEL
@@ -1345,14 +1362,22 @@
             ;; still hold `:drain-lock`, so no drainer is popping) and release;
             ;; if non-empty, re-kick a fresh async `drain-try!` (via the
             ;; `:router/reschedule-drain!` late-bind seam — frame cannot
-            ;; `:require` router) so the stranded events drain. Releasing
-            ;; first lets the re-kicked `drain-try!` CAS-acquire the now-free
-            ;; lock.
+            ;; `:require` router) so the stranded events drain. The one
+            ;; exception is a thunk that just CLAIMED destruction of this exact
+            ;; incarnation: claim is the queued-work cutoff, so re-kicking here
+            ;; would manufacture work inside the claim -> lifecycle-dead
+            ;; window. An already-submitted drain that has not CAS-lost yet is
+            ;; fenced independently by `frame-disposed-for-drain?`; suppressing
+            ;; this fresh kick handles the already-lost/no-retry case without
+            ;; stranding any LIVE frame. Releasing first lets an allowed
+            ;; re-kicked `drain-try!` CAS-acquire the now-free lock.
             (let [router  (:router frame-record)
                   strand? (locking router
-                            (let [pending? (seq (:queue @router))]
+                            (let [pending? (seq (:queue @router))
+                                  closing? (frame-incarnation-closing?
+                                             frame-id drain-lock)]
                               (reset! drain-lock false)
-                              (boolean pending?)))]
+                              (boolean (and pending? (not closing?)))))]
               (when strand?
                 (when-let [reschedule! (late-bind/get-fn :router/reschedule-drain!)]
                   (reschedule! frame-id))))))))
@@ -2375,9 +2400,8 @@
 ;; matters — see destroy-frame!'s docstring for the authoritative recipe.
 
 ;; Frame id of the in-flight `destroy-frame!`, bound for the duration of
-;; the teardown so `safe-call-hook!` can stamp `:frame` on a hook-failure
-;; diagnostic regardless of the hook's arg shape (the cache-reset hooks
-;; take no frame arg).
+;; teardown so `safe-call-hook!` can stamp `:frame` on a hook-failure diagnostic
+;; regardless of the hook's arg shape (the cache-reset hooks take no frame arg).
 (def ^:dynamic *destroying-frame-id* nil)
 
 ;; Per-destroy accumulator of cleanup-hook failures, bound to a fresh atom
@@ -2768,7 +2792,10 @@
 
                         :else
                         (do
-                          (swap! destroying-frames assoc id candidate-token)
+                          (swap! destroying-frames assoc id
+                                 {:token candidate-token
+                                  :owner #?(:clj  (Thread/currentThread)
+                                            :cljs true)})
                           current)))))]
             (if (= ::retry-destroy-claim claimed)
               (recur)
@@ -2994,8 +3021,9 @@
   ;; targets the frame-id-keyed record directly.
   (when-let [f (claim-frame-destroy! id expected-incarnation-token)]
       ;; `claim-frame-destroy!` records the DESTROYING incarnation's token (the
-      ;; live record's `:drain-lock`) under that SAME lock, after revalidating
-      ;; the expected token. `frame-incarnation-closing?` can therefore tell
+      ;; live record's `:drain-lock`) and actual teardown-owner host thread under
+      ;; that SAME lock, after revalidating the expected token.
+      ;; `frame-incarnation-closing?` can therefore tell
       ;; this teardown apart from a fresh same-id replacement that goes live
       ;; under the reused id before this destroy's `finally` clears the marker
       ;; (rf2-vxgfnd.94). `contains?`/keys keep the bare-id semantics the

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -103,6 +103,10 @@
    {:key         :router/dispatch-sync!
     :producer-ns 're-frame.router
     :description "Process an event synchronously, bypassing the drain queue."}
+   {:key         :router/run-frame-destroy-event!
+    :producer-ns 're-frame.router
+    :design-bead "rf2-f0otfl"
+    :description "Run a claimed frame incarnation's :on-destroy seed and synchronous same-frame descendants on an isolated, token-scoped teardown queue. This is private teardown authority, not generic dispatch-sync privilege; actual host-thread identity prevents JVM bound-fn propagation from authorising queued executor work."}
    {:key         :router/reschedule-drain!
     :producer-ns 're-frame.router
     :design-bead "rf2-x76af2.22"

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2903,8 +2903,9 @@
 
 (defn- handle-drain-interrupted!
   "Per rf2-68kok / Spec 002 §Edge cases worth pinning §Frame disposal
-  mid-drain: the drain-loop detected the frame was destroyed before
-  the next dequeue. Drop the remaining queue ONCE, clear `:scheduled?`,
+  mid-drain: the drain-loop detected that destruction owns the frame before
+  the next dequeue (claim is the cutoff; lifecycle-dead may publish later).
+  Drop the remaining queue ONCE, clear `:scheduled?`,
   and emit a single `:rf.frame/drain-interrupted` lifecycle trace
   carrying `:dropped-count` (per Spec 009 §`:rf.frame/drain-interrupted`
   and Spec-Schemas §DrainInterruptedTags).
@@ -2941,12 +2942,12 @@
 (defn- run-one-pass!
   "Process events from the queue to fixed point or until `drain-depth` is
   exceeded. Returns `::settled` when the queue empties cleanly or
-  `::halt` when the depth limit is reached OR the frame was destroyed
+  `::halt` when the depth limit is reached OR destruction owns the frame
   mid-pass (the depth-exceeded / drain-interrupted handler has already
   cleared the queue and the `:scheduled?` flag in either halt case).
 
-  Per rf2-68kok / Spec 002 §Frame disposal mid-drain: the destroyed-
-  frame check fires BEFORE each dequeue, so an in-flight event runs to
+  Per rf2-68kok / Spec 002 §Frame disposal mid-drain: the destruction-
+  ownership check fires BEFORE each dequeue, so an in-flight event runs to
   completion (run-to-completion per Spec 002 §Rules rule 1) but events
   still in the queue at the check point are dropped, with one
   `:rf.frame/drain-interrupted` lifecycle trace emitted carrying the
@@ -2979,7 +2980,7 @@
       (do (handle-depth-exceeded! frame-id router depth last-event tail-ring)
           ::halt)
 
-      ;; Per rf2-68kok: destroyed-frame check fires BEFORE the next
+      ;; Per rf2-68kok: destruction-ownership check fires BEFORE the next
       ;; dequeue. A handler in the just-completed event may have
       ;; called `destroy-frame!` on its own frame; the spec calls for
       ;; interrupting the drain at this exact seam — drop the

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2933,8 +2933,15 @@
   listeners. The drain-loop's responsibility is the lifecycle trace + queue
   drop; the epoch record is the destroy hook's."
   [frame-id router]
-  (let [dropped (count (:queue @router))]
-    (swap! router assoc :queue interop/empty-queue :scheduled? false)
+  (let [{:keys [queue destroy-claim-dropped-count]} @router
+        ;; `claim-frame-destroy!` atomically cuts off the pre-claim queue
+        ;; before `:on-destroy` runs. Preserve that count here so the one
+        ;; interrupted-drain record still reports every discarded envelope,
+        ;; including work removed at the earlier linearization point.
+        dropped (+ (count queue) (or destroy-claim-dropped-count 0))]
+    (swap! router #(-> %
+                       (assoc :queue interop/empty-queue :scheduled? false)
+                       (dissoc :destroy-claim-dropped-count)))
     (trace/emit! :rf.frame :rf.frame/drain-interrupted
                  {:frame         frame-id
                   :dropped-count dropped})))
@@ -2966,7 +2973,7 @@
   also bound to `frame/*run-frame-state-before*` around `process-event!`
   so a handler that destroys its own frame mid-drain can recover the
   pre-run snapshot for its `:halted-destroy` epoch record (rf2-9neiq)."
-  [frame-id router drain-depth]
+  [frame-id router drain-depth allowed-destroy-token]
   ;; rf2-fcbrjo: `tail-ring` accumulates the last K settled event-ids as the
   ;; drain runs — the CYCLE EVIDENCE the depth-halt attaches to the always-on
   ;; record. A bounded vector (drop the head past `cycle-evidence-depth`); ids
@@ -2997,7 +3004,14 @@
       ;; `:rf.frame/drain-interrupted` lifecycle trace. `restore-epoch!`
       ;; refuses non-:ok records, preserving the original "time-travel never
       ;; lands in a misleading state" invariant.
-      (frame/frame-disposed-for-drain? frame-id)
+      (and (frame/frame-disposed-for-drain? frame-id)
+           ;; The sole post-claim execution path is the internal teardown
+           ;; cascade. It presents the exact claimed incarnation token and
+           ;; drains an isolated local queue; ordinary drains always pass nil.
+           ;; If the marker no longer names this token, even that cascade halts.
+           (not (and (some? allowed-destroy-token)
+                     (frame/frame-incarnation-closing?
+                       frame-id allowed-destroy-token))))
       (do (handle-drain-interrupted! frame-id router)
           ::halt)
 
@@ -3121,7 +3135,7 @@
   (loop []
     (let [outcome (try
                     (mark-drainer! router)
-                    (run-one-pass! frame-id router drain-depth)
+                    (run-one-pass! frame-id router drain-depth nil)
                     (finally
                       (clear-drainer! router)))]
       (case outcome
@@ -3410,6 +3424,29 @@
     (swap! router update :queue front-insert-machine-internal envelope)
     (swap! router update :queue conj envelope)))
 
+;; Private authority for the synchronous `:on-destroy` event and the
+;; same-frame child dispatches it intentionally emits. The cascade drains an
+;; isolated router, never the dying frame's real queue. The value carries BOTH
+;; the incarnation claim token and the actual host thread that entered the
+;; cascade: JVM `bound-fn` may convey dynamic bindings to an executor, but it
+;; cannot make that executor thread identical to `:owner`. A callback that
+;; outlives teardown also loses authority when the claim is compare-removed.
+(def ^:dynamic ^:private *frame-destroy-cascade* nil)
+
+(defn- frame-destroy-cascade-router
+  "Return the isolated teardown router when this call is an authorised
+  same-frame child dispatch; nil for every ordinary dispatch."
+  [frame-id]
+  (when-let [{cascade-frame :frame
+              token         :token
+              router        :router
+              owner         :owner} *frame-destroy-cascade*]
+    (when (and (= cascade-frame frame-id)
+               #?(:clj  (identical? owner (Thread/currentThread))
+                  :cljs (true? owner))
+               (frame/frame-incarnation-closing? frame-id token))
+      router)))
+
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:
   FIFO at the runtime layer. The drain loop picks it up in this same
@@ -3438,8 +3475,10 @@
   §Canonical event-vector shape."
   ([event] (dispatch! event {}))
   ([event opts]
-   (let [envelope     (build-envelope event opts)
-         frame-record (frame/frame (:frame envelope))]
+   (let [envelope       (build-envelope event opts)
+         frame-id       (:frame envelope)
+         frame-record   (frame/frame frame-id)
+         cascade-router (frame-destroy-cascade-router frame-id)]
      (cond
        (nil? frame-record)
        ;; Per rf2-2hvga (= B + recover-but-emit): dispatch into a
@@ -3452,6 +3491,13 @@
        ;; dynamic call-site.
        (trace/with-call-site (:call-site envelope)
          (emit-frame-destroyed! (first event) event (:frame envelope)))
+
+       cascade-router
+       ;; Cleanup descendants stay on the private teardown queue. No scheduler
+       ;; is involved, and no ordinary/racing envelope can join this cascade.
+       (do
+         (emit-dispatched-trace! envelope false)
+         (enqueue-envelope! cascade-router envelope))
 
        :else
        (let [router (:router frame-record)]
@@ -3608,6 +3654,59 @@
              (swap! router assoc :in-sync-drain? false)))))
      nil)))
 
+(defn- run-frame-destroy-event!
+  "Run one claimed incarnation's `:on-destroy` event and its synchronous
+  same-frame queued descendants to fixed point.
+
+  This is deliberately NOT `dispatch-sync!` privilege. Destruction first cuts
+  off the frame's real queue, then this function creates an isolated queue for
+  the cleanup seed. `dispatch!` routes same-frame descendants to that local
+  queue only while all three authority checks hold: the exact claim token is
+  still current, the target frame matches, and the actual host thread is the
+  entering thread. Ordinary queued work can therefore neither run behind the
+  cleanup seed nor inherit authority through JVM `bound-fn` propagation.
+
+  The real router is marked as draining for an out-of-drain destroy so a generic
+  same-frame `dispatch-sync!` issued by cleanup remains the normal
+  `:rf.error/dispatch-sync-in-handler`; when destroy was called by an active
+  handler, its existing drainer marker is preserved."
+  [frame-id expected-token event]
+  (frame/call-serialized-with-drain!
+    frame-id
+    (fn []
+      (when-let [frame-record (frame/frame frame-id)]
+        (when (and (identical? expected-token (:drain-lock frame-record))
+                   (frame/frame-incarnation-closing? frame-id expected-token))
+          (let [real-router     (:router frame-record)
+                drain-depth    (get-in frame-record [:config :drain-depth]
+                                       drain-depth-default)
+                envelope       (build-envelope event {:frame frame-id})
+                teardown-router (atom {:queue            (conj interop/empty-queue
+                                                               envelope)
+                                       :scheduled?       true
+                                       :in-drain?        nil
+                                       :in-sync-drain?   false})
+                already-drainer?
+                #?(:clj  (identical? (:in-drain? @real-router)
+                                     (Thread/currentThread))
+                   :cljs (true? (:in-drain? @real-router)))]
+            (when-not already-drainer?
+              (mark-drainer! real-router))
+            (try
+              (emit-dispatched-trace! envelope true)
+              (binding [*frame-destroy-cascade*
+                        {:frame  frame-id
+                         :token  expected-token
+                         :router teardown-router
+                         :owner  #?(:clj  (Thread/currentThread)
+                                    :cljs true)}]
+                (run-one-pass! frame-id teardown-router drain-depth
+                               expected-token))
+              (finally
+                (when-not already-drainer?
+                  (clear-drainer! real-router)))))))))
+  nil)
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
 ;; Other namespaces that load BEFORE this one (re-frame.frame for :initial-events
@@ -3619,6 +3718,7 @@
 
 (late-bind/set-fn! :router/dispatch!       dispatch!)
 (late-bind/set-fn! :router/dispatch-sync!  dispatch-sync!)
+(late-bind/set-fn! :router/run-frame-destroy-event! run-frame-destroy-event!)
 
 ;; Per rf2-x76af2.22 (a): re-kick a fresh async drain for `frame-id`.
 ;; `frame/call-serialized-with-drain!`'s COLD release calls this — through

--- a/implementation/core/test/re_frame/core_contract_guards_test.clj
+++ b/implementation/core/test/re_frame/core_contract_guards_test.clj
@@ -15,8 +15,10 @@
          throwing hook is swallowed (try/catch) so a buggy listener
          can't block the registration.
 
-    G5 — `frame/frame-disposed-for-drain?` (frame.cljc) three branches:
-         destroyed-but-present → true, absent → true, live → false.
+    G5 — `frame/frame-disposed-for-drain?` (frame.cljc) record-state branches:
+         destroyed-but-present → true, absent → true, live → false. The fourth,
+         incarnation-scoped destroy-claim cutoff is exercised with real
+         serialization barriers in `frame-lifecycle-test`.
 
     G6 — `subs/reg-sub` malformed-form throw `:rf.error/reg-sub-bad-args`
          (subs.cljc). reg-event / reg-view bad-args are pinned elsewhere;
@@ -149,10 +151,10 @@
           "the new slot is in place"))))
 
 ;; =============================================================================
-;; G5 — frame/frame-disposed-for-drain? three branches
+;; G5 — frame/frame-disposed-for-drain? record-state branches
 ;; =============================================================================
 
-(deftest frame-disposed-for-drain?-distinguishes-the-three-branches
+(deftest frame-disposed-for-drain?-distinguishes-record-state-branches
   (testing "live frame → false; destroyed-but-present → true; absent → true"
     (reset! frame/frames
             {:f/live      {:lifecycle {:destroyed? false}}

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -94,3 +94,77 @@
         "the user cleanup event runs exactly once")
     (is (nil? (frame/frame :destroy/duplicate))
         "the claimed incarnation is fully destroyed")))
+
+(deftest fresh-same-id-destroy-replaces-stale-marker-token-safely
+  ;; Pause A after its registry dissoc but before its terminal finally. Install
+  ;; B under the reused id, claim B's destroy, then let A's finally run while B
+  ;; is paused pre-liveness-flip. B must be destroyable despite A's stale marker,
+  ;; and A's finally must not erase B's replacement marker.
+  (let [id              :destroy/marker-overlap
+        a-after-dissoc  (CountDownLatch. 1)
+        release-a       (CountDownLatch. 1)
+        b-claimed       (CountDownLatch. 1)
+        release-b       (CountDownLatch. 1)
+        first-epoch?    (atom true)
+        b-installed?    (atom false)
+        cleanup-runs    (atom 0)
+        original-epoch  (late-bind/get-fn :epoch/on-frame-destroyed)
+        original-ui     (late-bind/get-fn :ui/on-frame-destroyed!)]
+    (rf/make-frame {:id id})
+    (try
+      (late-bind/set-fn!
+        :epoch/on-frame-destroyed
+        (fn [& args]
+          ;; The epoch hook is after dissoc-frame!. Hold only A's first call.
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch
+            (apply original-epoch args))))
+      (late-bind/set-fn!
+        :ui/on-frame-destroyed!
+        (fn [frame-id]
+          (when original-ui (original-ui frame-id))
+          ;; The UI hook is after claim publication and before B's lifecycle
+          ;; flip. Hold every B teardown attempt here: an erroneously-authorised
+          ;; duplicate will block, making A-finally marker erasure observable.
+          (when (and (= id frame-id) @b-installed?)
+            (.countDown b-claimed)
+            (.await release-b 10 TimeUnit/SECONDS))))
+
+      (let [destroy-a (future (frame/destroy-frame! id))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "incarnation A is paused post-dissoc with its claim marker live")
+        (rf/reg-event :destroy/marker-overlap-cleanup
+          (fn [_ _]
+            (swap! cleanup-runs inc)
+            {}))
+        (rf/make-frame {:id id
+                        :on-destroy [:destroy/marker-overlap-cleanup]})
+        (let [token-b (frame/frame-incarnation-token id)]
+          (reset! b-installed? true)
+          (let [destroy-b (future (frame/destroy-frame! id token-b))]
+            (is (.await b-claimed 10 TimeUnit/SECONDS)
+                "fresh B replaces A's stale marker and claims its own destroy")
+
+            ;; A now reaches its terminal cleanup while B's distinct claim is
+            ;; active. Correct compare-remove leaves B's marker untouched.
+            (.countDown release-a)
+            (is (nil? (deref destroy-a 5000 ::timeout))
+                "A finishes while B remains paused under its own claim")
+            (let [duplicate-b (future (frame/destroy-frame! id token-b))]
+              (is (nil? (deref duplicate-b 2000 ::timeout))
+                  "A's finally did not erase B's marker; duplicate B is a prompt no-op"))
+
+            (.countDown release-b)
+            (is (nil? (deref destroy-b 5000 ::timeout))
+                "B's owning destroy completes")
+            (is (= 1 @cleanup-runs)
+                "B cleanup runs once; no duplicate teardown acquired authority")
+            (is (nil? (frame/frame id)) "the reused id is fully destroyed"))))
+      (finally
+        (.countDown release-a)
+        (.countDown release-b)
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)
+        (late-bind/set-fn! :ui/on-frame-destroyed! original-ui)))))

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
@@ -54,3 +55,42 @@
       (is (identical? token-b
                       (frame/frame-incarnation-token :destroy/race))
           "incarnation B survives stale teardown unchanged"))))
+
+(deftest concurrent-duplicate-destroy-is-a-non-blocking-no-op
+  (rf/make-frame {:id :destroy/duplicate
+                  :on-destroy [:destroy/duplicate-cleanup]})
+  (let [cleanup-runs (atom 0)
+        claimed      (CountDownLatch. 1)
+        release      (CountDownLatch. 1)
+        original     (late-bind/get-fn :ui/on-frame-destroyed!)]
+    (rf/reg-event :destroy/duplicate-cleanup
+      (fn [_ _]
+        (swap! cleanup-runs inc)
+        {}))
+    (try
+      ;; The UI hook is after claim publication and before lifecycle-dead
+      ;; publication. Hold the winning destroy there while a second thread
+      ;; attempts the same incarnation's destroy.
+      (late-bind/set-fn!
+        :ui/on-frame-destroyed!
+        (fn [id]
+          (when original (original id))
+          (when (= :destroy/duplicate id)
+            (.countDown claimed)
+            (.await release 10 TimeUnit/SECONDS))))
+      (let [winner (future (frame/destroy-frame! :destroy/duplicate))]
+        (is (.await claimed 10 TimeUnit/SECONDS)
+            "the winning destroy published its claim")
+        (let [duplicate (future (frame/destroy-frame! :destroy/duplicate))]
+          (is (nil? (deref duplicate 5000 ::timeout))
+              "the duplicate observes the claim and returns without waiting for teardown"))
+        (.countDown release)
+        (is (nil? (deref winner 5000 ::timeout))
+            "the winning destroy preserves the nil return contract"))
+      (finally
+        (.countDown release)
+        (late-bind/set-fn! :ui/on-frame-destroyed! original)))
+    (is (= 1 @cleanup-runs)
+        "the user cleanup event runs exactly once")
+    (is (nil? (frame/frame :destroy/duplicate))
+        "the claimed incarnation is fully destroyed")))

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -1024,6 +1024,116 @@
       (is (nil? (frame/frame frame-id))
           "destroy still completes after the claim-window barrier"))))
 
+(deftest on-destroy-cascade-is-isolated-from-preclaim-and-bound-work
+  (testing "only the cleanup seed and its queued descendants run after claim"
+    (let [frame-id        :destroy-claim/isolated-cleanup
+          ordinary-runs   (atom 0)
+          cleanup-runs    (atom 0)
+          child-runs      (atom 0)
+          effect-runs     (atom 0)
+          escaped-runs    (atom 0)
+          nested-sync-runs (atom 0)
+          captured-ticks  (atom [])]
+      (rf/make-frame {:id frame-id
+                      :on-destroy [:destroy-claim/cleanup]})
+      (rf/reg-event :destroy-claim/ordinary
+        (fn [{:keys [db]} _]
+          (swap! ordinary-runs inc)
+          {:db (assoc db :ordinary-ran? true)}))
+      (rf/reg-event :destroy-claim/escaped
+        (fn [{:keys [db]} _]
+          (swap! escaped-runs inc)
+          {:db (assoc db :escaped-ran? true)}))
+      (rf/reg-event :destroy-claim/nested-sync
+        (fn [{:keys [db]} _]
+          (swap! nested-sync-runs inc)
+          {:db (assoc db :nested-sync-ran? true)}))
+      (rf/reg-event :destroy-claim/cleanup-child
+        (fn [{:keys [db]} _]
+          (swap! child-runs inc)
+          {:db (assoc db :cleanup-child-ran? true)}))
+      (rf/reg-fx :destroy-claim/cleanup-effect
+        (fn [_ _] (swap! effect-runs inc)))
+      (rf/reg-event :destroy-claim/cleanup
+        (fn [{:keys [db]} _]
+          (swap! cleanup-runs inc)
+          ;; `next-tick` captures dynamic bindings with `bound-fn` on JVM.
+          ;; Force the callback to run while the claim is still live: actual
+          ;; host-thread identity must keep it out of the private cleanup queue.
+          (interop/next-tick
+            #(rf/dispatch [:destroy-claim/escaped] {:frame frame-id}))
+          (executor-barrier!)
+          ;; The internal teardown entry is narrow; it must not turn generic
+          ;; nested dispatch-sync into a legal handler operation.
+          (rf/dispatch-sync [:destroy-claim/nested-sync] {:frame frame-id})
+          {:db db
+           :fx [[:destroy-claim/cleanup-effect :payload]
+                [:dispatch [:destroy-claim/cleanup-child]]]}))
+
+      ;; Hold one ordinary event in the real router. It linearizes before the
+      ;; destroy claim but must never sit behind the cleanup seed.
+      (with-redefs [interop/next-tick
+                    (fn [f]
+                      (swap! captured-ticks conj f)
+                      nil)]
+        (rf/dispatch [:destroy-claim/ordinary] {:frame frame-id}))
+      (is (= 1 (count (:queue @(:router (frame/frame frame-id)))))
+          "ordinary pre-claim work is waiting on the real router")
+
+      (rf/destroy-frame! frame-id)
+      ;; Flush both the bound callback's real-router drain and the original
+      ;; pre-claim drain attempt. Neither may invoke application work.
+      (doseq [tick @captured-ticks] (tick))
+      (executor-barrier!)
+
+      (is (= 1 @cleanup-runs) ":on-destroy seed runs exactly once")
+      (is (= 1 @child-runs) "queued cleanup child runs on the isolated cascade")
+      (is (= 1 @effect-runs) "cleanup effects execute normally")
+      (is (zero? @ordinary-runs) "pre-claim ordinary work is discarded")
+      (is (zero? @escaped-runs)
+          "bound-fn executor work cannot inherit teardown authority")
+      (is (zero? @nested-sync-runs)
+          "generic nested dispatch-sync remains rejected during cleanup")
+      (is (nil? (frame/frame frame-id)) "teardown completes"))))
+
+(deftest destroy-from-active-handler-runs-cleanup-and-cuts-off-old-queue
+  (testing "self-destroy has one private cleanup cascade inside the active drain"
+    (let [frame-id      :destroy-claim/inside-handler
+          cleanup-runs  (atom 0)
+          ordinary-runs (atom 0)
+          captured-ticks (atom [])]
+      (rf/make-frame {:id frame-id
+                      :on-destroy [:destroy-claim/inside-cleanup]})
+      (rf/reg-event :destroy-claim/inside-cleanup
+        (fn [_ _]
+          (swap! cleanup-runs inc)
+          {}))
+      (rf/reg-event :destroy-claim/inside-ordinary
+        (fn [_ _]
+          (swap! ordinary-runs inc)
+          {}))
+      (rf/reg-event :destroy-claim/self-destroy
+        (fn [_ _]
+          (frame/destroy-frame! frame-id)
+          {}))
+
+      ;; Queue old work without letting its async drain start, then prepend a
+      ;; synchronous destroying event. The handler already owns the real
+      ;; router's drain serialization when destroy-frame! enters.
+      (with-redefs [interop/next-tick
+                    (fn [f]
+                      (swap! captured-ticks conj f)
+                      nil)]
+        (rf/dispatch [:destroy-claim/inside-ordinary] {:frame frame-id}))
+      (rf/dispatch-sync [:destroy-claim/self-destroy] {:frame frame-id})
+      (doseq [tick @captured-ticks] (tick))
+
+      (is (= 1 @cleanup-runs)
+          "the internal cleanup seed runs despite generic nested-sync rejection")
+      (is (zero? @ordinary-runs)
+          "the pre-existing queue is cut off by the handler's destroy claim")
+      (is (nil? (frame/frame frame-id)) "self-destroy completes exactly once"))))
+
 (deftest replace-container-on-destroyed-frame-does-not-npe
   ;; Tighter reproducer that hits the adapter guard directly via the
   ;; live runtime. The router's per-event :db commit reads the frame's

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -9,13 +9,15 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.source-store :as source-store]
             [re-frame.flows :as flows]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -32,6 +34,15 @@
   (test-fn))
 
 (use-fixtures :each reset-runtime)
+
+(defn- executor-barrier!
+  "Wait until work already submitted through `interop/next-tick` has run.
+  The JVM executor is single-threaded FIFO; the timeout is only a hang guard."
+  []
+  (let [latch (CountDownLatch. 1)]
+    (interop/next-tick #(.countDown latch))
+    (is (.await latch 5 TimeUnit/SECONDS)
+        "the executor reached the deterministic barrier")))
 
 ;; ---- Spec 002 §Re-registration — surgical update -------------------------
 
@@ -934,6 +945,84 @@
       ;; (e) Frame stays gone.
       (is (nil? (frame/frame :rf2-dpny/worker))
           "the frame did not somehow re-materialise from the post-destroy drain"))))
+
+(deftest destroy-claim-prevents-cold-release-from-running-queued-handlers
+  (testing "the destroy claim is the queued-work cutoff, before lifecycle-dead publication"
+    (let [frame-id       :destroy-claim/cold-release
+          parent-runs    (atom 0)
+          child-runs     (atom 0)
+          user-effects   (atom 0)
+          captured-ticks (atom [])
+          gap-observation (atom nil)
+          original-hook  (late-bind/get-fn :ui/on-frame-destroyed!)]
+      (rf/make-frame {:id frame-id})
+      (rf/reg-fx :destroy-claim/effect
+        (fn [_ _] (swap! user-effects inc)))
+      (rf/reg-event :destroy-claim/child
+        (fn [{:keys [db]} _]
+          (swap! child-runs inc)
+          {:db (assoc db :child-ran? true)}))
+      (rf/reg-event :destroy-claim/queued
+        (fn [{:keys [db]} _]
+          (swap! parent-runs inc)
+          {:db (assoc db :queued-handler-ran? true)
+           :fx [[:destroy-claim/effect :payload]
+                [:dispatch [:destroy-claim/child]]]}))
+
+      ;; Queue two events while suppressing their first scheduled drain. The
+      ;; destroy claim must both suppress a replacement kick from its COLD
+      ;; serialized release and fence this not-yet-fired original attempt.
+      (with-redefs [interop/next-tick
+                    (fn [f]
+                      (swap! captured-ticks conj f)
+                      nil)]
+        (rf/dispatch [:destroy-claim/queued] {:frame frame-id})
+        (rf/dispatch [:destroy-claim/queued] {:frame frame-id}))
+      (is (= 1 (count @captured-ticks))
+          "the initial dispatch pair scheduled one drain attempt")
+      (is (= 2 (count (:queue @(:router (frame/frame frame-id)))))
+          "both events are queued before destroy starts")
+
+      ;; `:ui/on-frame-destroyed!` runs after claim-frame-destroy! has returned
+      ;; (and therefore after the cold lock release) but before
+      ;; mark-frame-destroyed!. Its FIFO executor barrier forces the captured
+      ;; drain to finish inside that exact claim -> lifecycle-dead window.
+      (try
+        (late-bind/set-fn!
+          :ui/on-frame-destroyed!
+          (fn [id]
+            (when original-hook
+              (original-hook id))
+            (when (= frame-id id)
+              ;; Submit the drain attempt captured at enqueue time only AFTER
+              ;; claim-frame-destroy! has released the cold lock. This covers
+              ;; the path where that attempt had not yet CAS-lost when claim
+              ;; completed; the claim predicate, not scheduling luck, must
+              ;; prevent it from invoking either queued handler.
+              ;; `next-tick` deliberately conveys dynamic bindings through
+              ;; `bound-fn`. Scheduling from this teardown hook therefore also
+              ;; proves that owner privilege is ACTUAL host-thread identity,
+              ;; not the conveyed `*destroying-frame-id*` value.
+              (interop/next-tick (first @captured-ticks))
+              (executor-barrier!)
+              (let [record (get @frame/frames frame-id)]
+                (reset! gap-observation
+                        {:destroyed? (-> record :lifecycle :destroyed?)
+                         :queued     (count (:queue @(:router record)))})))))
+        (rf/destroy-frame! frame-id)
+        (finally
+          (late-bind/set-fn! :ui/on-frame-destroyed! original-hook)))
+
+      (is (= 0 @parent-runs)
+          "queued handlers are no-op as soon as this incarnation's destroy is claimed")
+      (is (= 0 @user-effects)
+          "a dropped queued handler cannot emit user effects")
+      (is (= 0 @child-runs)
+          "a dropped queued handler cannot enqueue or run child dispatches")
+      (is (= {:destroyed? false :queued 0} @gap-observation)
+          "the queued drain was disposed while the frame was claimed but still lifecycle-live")
+      (is (nil? (frame/frame frame-id))
+          "destroy still completes after the claim-window barrier"))))
 
 (deftest replace-container-on-destroyed-frame-does-not-npe
   ;; Tighter reproducer that hits the adapter guard directly via the

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -1024,6 +1024,71 @@
       (is (nil? (frame/frame frame-id))
           "destroy still completes after the claim-window barrier"))))
 
+(deftest post-claim-dispatch-is-rejected-before-lifecycle-dead-publication
+  (testing "ordinary work submitted after claim cannot run in the claim-to-dead gap"
+    (let [frame-id        :destroy-claim/post-claim-dispatch
+          parent-runs     (atom 0)
+          child-runs      (atom 0)
+          user-effects    (atom 0)
+          captured-ticks  (atom [])
+          gap-observation (atom nil)
+          original-hook   (late-bind/get-fn :ui/on-frame-destroyed!)]
+      (rf/make-frame {:id frame-id})
+      (rf/reg-fx :destroy-claim/post-claim-effect
+        (fn [_ _] (swap! user-effects inc)))
+      (rf/reg-event :destroy-claim/post-claim-child
+        (fn [{:keys [db]} _]
+          (swap! child-runs inc)
+          {:db (assoc db :post-claim-child-ran? true)}))
+      (rf/reg-event :destroy-claim/post-claim-parent
+        (fn [{:keys [db]} _]
+          (swap! parent-runs inc)
+          {:db (assoc db :post-claim-parent-ran? true)
+           :fx [[:destroy-claim/post-claim-effect :payload]
+                [:dispatch [:destroy-claim/post-claim-child]]]}))
+
+      (try
+        (late-bind/set-fn!
+          :ui/on-frame-destroyed!
+          (fn [id]
+            (when original-hook
+              (original-hook id))
+            (when (= frame-id id)
+              ;; This hook runs strictly AFTER `claim-frame-destroy!` returns
+              ;; and BEFORE `mark-frame-destroyed!` flips lifecycle liveness.
+              ;; Submit genuinely NEW ordinary work here, capture its scheduled
+              ;; drain, then force that drain through the real bound-fn executor
+              ;; before allowing teardown to advance.
+              (with-redefs [interop/next-tick
+                            (fn [f]
+                              (swap! captured-ticks conj f)
+                              nil)]
+                (rf/dispatch [:destroy-claim/post-claim-parent]
+                             {:frame frame-id}))
+              (is (= 1 (count @captured-ticks))
+                  "the post-claim submit schedules one real-router drain")
+              (is (= 1 (count (:queue @(:router (get @frame/frames frame-id)))))
+                  "the ordinary envelope was enqueued after the claim cutoff")
+              (interop/next-tick (first @captured-ticks))
+              (executor-barrier!)
+              (let [record (get @frame/frames frame-id)]
+                (reset! gap-observation
+                        {:destroyed? (-> record :lifecycle :destroyed?)
+                         :queued     (count (:queue @(:router record)))})))))
+        (rf/destroy-frame! frame-id)
+        (finally
+          (late-bind/set-fn! :ui/on-frame-destroyed! original-hook)))
+
+      (is (zero? @parent-runs)
+          "the post-claim ordinary handler never runs")
+      (is (zero? @user-effects)
+          "a rejected post-claim handler cannot emit user effects")
+      (is (zero? @child-runs)
+          "a rejected post-claim handler cannot enqueue or run children")
+      (is (= {:destroyed? false :queued 0} @gap-observation)
+          "the claim predicate emptied the real queue while lifecycle was still live")
+      (is (nil? (frame/frame frame-id)) "destroy completes after the gap proof"))))
+
 (deftest on-destroy-cascade-is-isolated-from-preclaim-and-bound-work
   (testing "only the cleanup seed and its queued descendants run after claim"
     (let [frame-id        :destroy-claim/isolated-cleanup

--- a/implementation/core/test/re_frame/on_destroy_handler_exception_always_on_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_destroy_handler_exception_always_on_cljs_test.cljc
@@ -25,8 +25,8 @@
         through the corpus-wide `register-error-listener!` substrate — the
         always-on axis, NOT gated by `interop/debug-enabled?`.
 
-    (b) the rf2-bxud9v defence-in-depth re-throw branch: if `dispatch-sync!`
-        ITSELF faults (not the user handler — a fault inside the dispatch
+    (b) the rf2-bxud9v defence-in-depth re-throw branch: if the private teardown
+        cascade faults (not the user handler — a fault inside the dispatch
         infrastructure), the dedicated category still fans out on the
         always-on axis. This branch never produced a router
         `:rf.error/handler-exception`, so before EP-0008 it had ZERO
@@ -123,31 +123,31 @@
           "no record when :on-destroy completes cleanly"))))
 
 ;; ===========================================================================
-;; (b) The rf2-bxud9v defence-in-depth re-throw branch — `dispatch-sync!`
-;; ITSELF faults. This branch never produced a router handler-exception, so
+;; (b) The rf2-bxud9v defence-in-depth re-throw branch — the internal teardown
+;; cascade ITSELF faults. This branch never produced a router handler-exception, so
 ;; the always-on emission here is its ONLY production observability.
 ;; ===========================================================================
 
-(deftest dispatch-sync-infra-fault-fans-out-on-always-on-axis
-  (testing "Per rf2-7b9r4l / rf2-bxud9v: if `dispatch-sync!` itself throws
+(deftest teardown-cascade-infra-fault-fans-out-on-always-on-axis
+  (testing "Per rf2-7b9r4l / rf2-bxud9v: if the teardown cascade itself throws
             (a fault inside the dispatch infrastructure, NOT the user
             handler), `fire-on-destroy-event!`'s defence-in-depth catch arm
             still fans a `:rf.error/on-destroy-handler-exception` record out
             on the always-on axis — the ONLY production coverage for this
             branch (it never produced a router :rf.error/handler-exception)."
     (let [seen     (atom [])
-          original (late-bind/get-fn :router/dispatch-sync!)]
+          original (late-bind/get-fn :router/run-frame-destroy-event!)]
       (rf/register-listener! :errors :test/recorder
                                    (fn [record] (swap! seen conj record)))
       (rf/make-frame {:id :ondestroy/infra-fault :on-destroy [:ondestroy/never-reached]})
-      ;; Make the dispatch-sync! infrastructure itself fault.
-      (late-bind/set-fn! :router/dispatch-sync!
+      ;; Make the private teardown dispatch infrastructure itself fault.
+      (late-bind/set-fn! :router/run-frame-destroy-event!
                          (fn [& _] (throw (ex-info "dispatch infra fault" {}))))
       (try
         (is (nil? (rf/destroy-frame! :ondestroy/infra-fault))
             "teardown does not propagate the infra fault")
         (finally
-          (late-bind/set-fn! :router/dispatch-sync! original)))
+          (late-bind/set-fn! :router/run-frame-destroy-event! original)))
       (let [reports (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen)]
         (is (= 1 (count reports))
             "the defence-in-depth branch fanned out on the always-on axis")

--- a/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
@@ -44,7 +44,8 @@
       dedicated category is the discriminator (it happened during
       destroy).
 
-    - DEFENCE-IN-DEPTH branch (`dispatch-sync!` itself faults, rf2-bxud9v):
+    - DEFENCE-IN-DEPTH branch (the private teardown cascade faults,
+      rf2-bxud9v):
       `fire-on-destroy-event!` calls `emit-on-destroy-handler-exception!`
       DIRECTLY (no capture), so the dedicated record DOES survive prod —
       and this branch never produced a router handler-exception, so the
@@ -280,9 +281,9 @@
     (is (nil? (frame/frame :prod.ondestroy/worker))
         "the frame is fully torn down (teardown continued past the throw)")))
 
-(deftest dispatch-sync-infra-fault-survives-prod
+(deftest teardown-cascade-infra-fault-survives-prod
   (testing "Per rf2-7b9r4l / rf2-bxud9v: under `:advanced` + `goog.DEBUG=
-            false`, if `dispatch-sync!` ITSELF faults (a fault inside the
+            false`, if the internal teardown cascade ITSELF faults (a fault inside the
             dispatch infrastructure, NOT the user handler),
             `fire-on-destroy-event!`'s defence-in-depth catch arm still fans
             a `:rf.error/on-destroy-handler-exception` record out on the
@@ -291,17 +292,17 @@
             its ONLY production observability — and this is the only test
             that proves it survives elision."
     (let [seen     (atom [])
-          original (late-bind/get-fn :router/dispatch-sync!)]
+          original (late-bind/get-fn :router/run-frame-destroy-event!)]
       (rf/register-listener! :errors :prod/recorder
                                    (fn [record] (swap! seen conj record)))
       (frame/upsert-frame! :prod.ondestroy/infra-fault {:on-destroy [:prod.ondestroy/never-reached]})
-      (late-bind/set-fn! :router/dispatch-sync!
+      (late-bind/set-fn! :router/run-frame-destroy-event!
                          (fn [& _] (throw (ex-info "dispatch infra fault" {}))))
       (try
         (is (nil? (rf/destroy-frame! :prod.ondestroy/infra-fault))
             "teardown does not propagate the infra fault under prod")
         (finally
-          (late-bind/set-fn! :router/dispatch-sync! original)))
+          (late-bind/set-fn! :router/run-frame-destroy-event! original)))
       (let [reports (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen)]
         (is (= 1 (count reports))
             "the defence-in-depth branch fanned out on the always-on axis under prod")


### PR DESCRIPTION
## What changed

- Make the incarnation-scoped destroy claim the queued-work cutoff used by every ordinary drain.
- Atomically remove all preclaim envelopes from the real router queue at claim time, retaining their count for the single `:rf.frame/drain-interrupted` evidence record.
- Run `:on-destroy` and its synchronous same-frame queued descendants on an isolated internal teardown queue. Ordinary or racing work cannot join that queue.
- Scope teardown authority to the exact claim token, target frame, and actual host thread. JVM `bound-fn` propagation therefore cannot authorise executor work.
- Let a fresh same-id incarnation B replace stale A's marker; each destroy compare-removes only its own token in `finally`.
- Keep generic nested `dispatch-sync` rejected during cleanup. The private teardown entry is not general dispatch privilege.

## Why the first head was replaced

Independent review found three correctness blockers in `52761c4`:

1. Its owner-thread exemption allowed the dying frame's real router to drain ordinary preclaim work behind `:on-destroy`.
2. A bare-id duplicate guard prevented fresh B from claiming destroy while old A was post-dissoc/pre-finally, and A's unconditional cleanup could erase B's marker.
3. Calling ordinary `dispatch-sync` for `:on-destroy` failed when destroy originated inside an active handler, because nested sync is intentionally rejected.

The corrected design removes the broad exemption. Cleanup is a token-scoped isolated cascade; the real router remains fenced throughout teardown.

## Deterministic regression coverage

The fixtures construct the adversarial windows directly:

- ordinary preclaim queue + `:on-destroy`: cleanup seed, cleanup effect, and queued cleanup child run; ordinary work does not;
- `destroy-frame!` from an active same-frame handler: cleanup runs exactly once and the old queue is suppressed;
- JVM executor callback carrying dynamic bindings through `bound-fn`: actual thread mismatch prevents teardown authority;
- generic nested `dispatch-sync` during cleanup remains rejected;
- A paused post-dissoc while B is created and claimed: B can destroy, A's finalizer cannot erase B's marker, and duplicate B is a prompt no-op;
- ordinary work submitted from `:ui/on-frame-destroyed!` strictly after claim: its forced real-router drain empties the queue while lifecycle remains live, with zero handler/effect/child execution.

### Fixture-teeth mutation proof

On the final test, deleting only the destroy-claim arm from `frame-disposed-for-drain?` produces a deterministic red:

```text
post-claim parent handler: expected 0, actual 1
post-claim user effect:    expected 0, actual 1
post-claim child handler:  expected 0, actual 1
Ran 39 tests containing 198 assertions.
3 failures, 0 errors.
```

Restoring the claim arm returns the namespace to **39 tests / 198 assertions green**. This proves the new fixture exercises the load-bearing claim-to-lifecycle-dead cutoff rather than merely replaying a preclaim queue case.

## Validation

Corrected exact head: `afdc73fea9822152f4031a13dd13df44e42b9d90`.

- Expanded focused JVM contracts: **81 tests, 1,020 assertions, 0 failures, 0 errors**.
- Full JVM core: **1,897 tests, 8,533 assertions, 0 failures, 0 errors**.
- Full CLJS Node on the unchanged implementation source: **9,116 tests, 43,141 assertions, 0 failures, 0 errors**.
- Production-elision browser gate on the unchanged implementation source: **77 tests, 242 assertions, 0 failures, 0 errors**.

## Contract follow-up

No spec file is touched because the Spec hot zone is sequenced behind other owners. Spec 002 §Edge cases worth pinning #4 still describes only the later `:destroyed?` check. It should eventually state that the incarnation-scoped claim is the ordinary queued-work cutoff and that the intentional `:on-destroy` event uses a private token-scoped cascade before lifecycle-dead publication.

Bead: `rf2-f0otfl` (left open for independent review and boundary disposition).
