### PR TITLE
rf2-xwmpm4: pair G-1 with a memo-matched hand baseline

### DIFF
--- a/implementation/scripts/run-ui-bench.cjs
+++ b/implementation/scripts/run-ui-bench.cjs
@@ -93,11 +93,11 @@ function emittedJsGolden() {
   // return unnoticed while calls elsewhere continue to satisfy the counts.
   const todoLiteralProps = countMatches(
     src,
-    /\(0,[$\w]+(?:\.[$\w]+)*\.jsxs\)\("li",\{className:"todo-item"/g,
+    /\(0,[$\w]+(?:\.[$\w]+)*\.jsxs\)\("li",\{className:[^,]+,"data-priority":/g,
   );
   const todoPropsIife = countMatches(
     src,
-    /function\(\)\{return\{className:"todo-item"/g,
+    /function\(\)\{return\{className:[^,]+,"data-priority":/g,
   );
 
   const MIN_DIRECT = 10;

--- a/implementation/scripts/run-ui-bench.cjs
+++ b/implementation/scripts/run-ui-bench.cjs
@@ -13,10 +13,11 @@
 //          literal-tag jsx calls (`X.jsx("div", ...)` / aliased
 //          `Y("div", {...})` still matches via the `("tag"` shape on
 //          the known bench tag set);
-//      (b) trap absence — zero occurrences of the IFn fallback shape
-//          on a literal tag (`.call(null,"div"` / Closure-minified
-//          `.call(null,"x"` over the bench tag set).
-//      (c) digest-carrier elision — the dev sentinel, bd1 literal and carrier
+//      (b) compiler-direct presence — generated sites carry the unbound
+//          module-property form `(0,X.jsx)("div", ...)`; wrapper bodies and
+//          the hand baseline cannot satisfy this assertion;
+//      (c) IFn-trap absence — zero `.call(null,"div",...)` shapes.
+//      (d) digest-carrier elision — the dev sentinel, bd1 literal and carrier
 //          namespace are all absent from the :advanced production bundle.
 // 3. Run the bundle under NODE_ENV=production — the estimator +
 //    byte-equality precheck + budget enforcement live in CLJS
@@ -70,17 +71,42 @@ function emittedJsGolden() {
     new RegExp(`[$\\w]+(?:\\.[$\\w]+)*\\("(?:${tagAlt})"\\s*,`, 'g'),
   );
 
-  // (b) the IFn-dispatch fallback on a literal tag. The trap emits
-  //   f.cljs$core$IFn$_invoke$arity$2 ? f.cljs...(t,p) : f.call(null,t,p)
-  // and `.call(null,` survives every renaming pass.
+  // (b) compiler-authored direct module-property calls. The `(0, property)`
+  // spelling explicitly discards the receiver (jsx/jsxs do not use `this`)
+  // and therefore cannot degrade to Closure's `f.call(module, ...)` alias.
+  const compilerDirect = countMatches(
+    src,
+    new RegExp(
+      `\\(0,[$\\w]+(?:\\.[$\\w]+)*\\)\\("(?:${tagAlt})"\\s*,`,
+      'g',
+    ),
+  );
+
+  // (c) the CLJS-var IFn fallback on a literal tag.
   const trap = countMatches(
     src,
     new RegExp(`\\.call\\(null,\\s*"(?:${tagAlt})"`, 'g'),
   );
 
+  // The measured keyed row is the compile-known literal-props case. Pin the
+  // exact advanced call site so a generic `js-obj` assignment IIFE cannot
+  // return unnoticed while calls elsewhere continue to satisfy the counts.
+  const todoLiteralProps = countMatches(
+    src,
+    /\(0,[$\w]+(?:\.[$\w]+)*\.jsxs\)\("li",\{className:"todo-item"/g,
+  );
+  const todoPropsIife = countMatches(
+    src,
+    /function\(\)\{return\{className:"todo-item"/g,
+  );
+
   const MIN_DIRECT = 10;
+  const MIN_COMPILER_DIRECT = 20;
   console.log(
-    `emitted-JS golden: ${direct} direct literal-tag jsx calls, ${trap} IFn-fallback call sites`,
+    `emitted-JS golden: ${direct} direct literal-tag jsx calls, ` +
+      `${compilerDirect} compiler-direct module-property calls, ` +
+      `${trap} IFn-fallback call sites, ` +
+      `${todoLiteralProps} direct todo literal / ${todoPropsIife} todo props IIFEs`,
   );
   if (direct < MIN_DIRECT) {
     console.error(
@@ -90,11 +116,25 @@ function emittedJsGolden() {
     );
     process.exit(1);
   }
+  if (compilerDirect < MIN_COMPILER_DIRECT) {
+    console.error(
+      `FAIL: expected >= ${MIN_COMPILER_DIRECT} compiler-authored direct ` +
+        'jsx-runtime module-property calls; wrapper bodies and hand JSX do ' +
+        'not carry the `(0,module.jsx)("tag",...)` signature.',
+    );
+    process.exit(1);
+  }
   if (trap !== 0) {
     console.error(
       'FAIL: IFn-protocol dispatch fallback found on the jsx path — a ' +
-        'var-bound jsx fn reintroduced dynamic dispatch under :advanced ' +
-        '(S-1 landmine; ~5-8% silent regression).',
+        'var-bound jsx fn reintroduced dynamic dispatch under :advanced.',
+    );
+    process.exit(1);
+  }
+  if (todoLiteralProps < 1 || todoPropsIife !== 0) {
+    console.error(
+      'FAIL: the compiled todo row is not passing its compile-known props as ' +
+        'one ordered object literal directly to jsxs.',
     );
     process.exit(1);
   }

--- a/implementation/ui/bench/re_frame/ui/bench/hand.cljs
+++ b/implementation/ui/bench/re_frame/ui/bench/hand.cljs
@@ -5,7 +5,9 @@
   the constant-elements plugin). Semantics must match the compiled
   views byte-for-byte on renderToStaticMarkup output; the bench runner
   asserts that before measuring."
-  (:require ["react/jsx-runtime" :as jsx]))
+  (:require ["react" :as react]
+            ["react/jsx-runtime" :as jsx]
+            [re-frame.ui.eq :as eq]))
 
 (defonce ^:private sink (volatile! nil))
 
@@ -89,6 +91,18 @@
                           (jsx/jsx "span" #js {:className "flag" :children "HIGH"})
                           nil)]})))
 
+;; `defview` memoizes every compiled view. Match that policy in the G-1
+;; denominator so the keyed-list gate measures lowering overhead, not the
+;; cost of crossing a React.memo boundary during an initial server render.
+;; The generated todo-row comparator has exactly one slot (`todo`) and uses
+;; rf=; keep this spelling visibly parallel to emit-cljs/comparator-form.
+(def todo-row*-memo
+  (react/memo
+   todo-row*
+   (fn [^js prev ^js next]
+     (eq/rf= (unchecked-get prev "todo")
+             (unchecked-get next "todo")))))
+
 (defn todo-list* [^js props]
   (let [title (unchecked-get props "title")
         todos (unchecked-get props "todos")]
@@ -105,6 +119,37 @@
                                         arr)})
                         (jsx/jsxs "p" #js {:className "count"
                                            :children #js [(count todos) " items"]})]})))
+
+(defn todo-list*-memo$render [^js props]
+  ;; Deliberately duplicate the tiny list body: sharing a helper would add a
+  ;; call to both hand baselines that the compiled view does not perform.
+  (let [title (unchecked-get props "title")
+        todos (unchecked-get props "todos")]
+    (jsx/jsxs "section"
+              #js {:className "todos"
+                   :children
+                   #js [(jsx/jsx "h2" #js {:children title})
+                        (jsx/jsx "ul"
+                                 #js {:className "todo-ul"
+                                      :children
+                                      (let [arr #js []]
+                                        (doseq [t todos]
+                                          (.push arr (jsx/jsx todo-row*-memo #js {:todo t} (:id t))))
+                                        arr)})
+                        (jsx/jsxs "p" #js {:className "count"
+                                           :children #js [(count todos) " items"]})]})))
+
+(def todo-list*-memo
+  ;; The compiled parent is also a defview. Match its two-slot comparator as
+  ;; well as its memoized row boundary; otherwise the denominator still omits
+  ;; one of the component boundaries whose lowering it is meant to isolate.
+  (react/memo
+   todo-list*-memo$render
+   (fn [^js prev ^js next]
+     (and (eq/rf= (unchecked-get prev "title")
+                  (unchecked-get next "title"))
+          (eq/rf= (unchecked-get prev "todos")
+                  (unchecked-get next "todos"))))))
 
 (defn status-panel* [^js props]
   (let [state   (unchecked-get props "state")

--- a/implementation/ui/bench/re_frame/ui/bench/main.cljs
+++ b/implementation/ui/bench/re_frame/ui/bench/main.cljs
@@ -5,15 +5,22 @@
 
   ## The estimator (07 §5 — supersedes the S-1 spike's best-round/min)
 
-  Alternating INTERLEAVED rounds, MEDIAN-of-rounds: within each round
-  the two implementations alternate sample-by-sample (each sample = one
-  timed batch), with the starting order flipped every round — thermal /
-  GC / scheduler drift lands on both impls symmetrically. Per round and
-  impl, sample p50 + p95 are computed; the final estimate per impl is
-  the MEDIAN across rounds of the round-p50s and round-p95s (an odd
-  round count keeps the median a real observation). Ratios are
-  RELATIVE (same process, interleaved), so the gate is robust to
-  absolute machine speed — the property CI runners violate.
+  Alternating INTERLEAVED rounds, PAIRED sample ratios, MEDIAN-of-rounds:
+  within each round every sample is one local order-balanced stratum: four
+  timed pairs alternate AB/BA (A=compiled, B=hand), so both
+  implementations occupy first and second position exactly twice. The
+  highest and lowest observation on each side are discarded and the
+  middle pair is averaged LOCALLY, then that sample's compiled/hand ratio
+  is formed before any cross-sample aggregation. The larger timed batch
+  keeps each observation out of the sub-millisecond scheduler-noise
+  regime; the local trim prevents one GC/scheduler interruption from
+  dominating ratio p95. Each sample slot is repeated across the seven
+  rounds; its final paired ratio is the median of those seven local ratios
+  (an odd count keeps it a real observation). Gate p50 + p95 are then
+  computed across the 40 stabilized paired samples. Raw implementation
+  timings and round summaries are retained as evidence, but the gate never
+  divides independently aggregated timings: preserving local covariance
+  is what makes the relative gate robust to shared CI-runner noise.
 
   ## The precheck
 
@@ -29,6 +36,7 @@
             ["os" :as os]
             [re-frame.ui.bench.hand :as hand]
             [re-frame.ui.bench.views :as v]
+            [re-frame.ui.rules :as rules]
             [re-frame.ui.runtime :as rt]))
 
 ;; ---------------------------------------------------------------------------
@@ -48,6 +56,7 @@
    {:id "counter-42"   :compiled v/counter      :hand hand/counter*
     :props {:n 42 :step 10 :locked? false}}
    {:id "todos-20"     :compiled v/todo-list    :hand hand/todo-list*
+    :gate-hand hand/todo-list*-memo
     :props {:title "Twenty" :todos todos-20}}
    {:id "status-error" :compiled v/status-panel :hand hand/status-panel*
     :props {:state :error :message "boom & <bust> \"quoted\"" :retries 2}}])
@@ -56,7 +65,7 @@
   "07 §5 G-1: within 10% of hand-written JSX CLJS on p50 and p95."
   {:p50 1.10 :p95 1.10})
 
-(def opts {:batch 100 :samples 120 :rounds 7 :warmup 2000})
+(def opts {:batch 400 :samples 40 :rounds 7 :warmup 2000})
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -85,34 +94,61 @@
 
 (defn- median [xs] (percentile xs 0.5))
 
+(defn- distribution-stats [xs]
+  {:p50 (median xs) :p95 (percentile xs 0.95)})
+
+(defn- middle-mean4 [xs]
+  (let [v (vec (sort xs))]
+    (/ (+ (nth v 1) (nth v 2)) 2.0)))
+
 (defn- bench-round
-  "One interleaved round: samples alternate compiled/hand (order per
-  `flip?`). -> {:c {:p50 .. :p95 ..} :h {..}}"
+  "One interleaved round. Each sample contains four AB/BA-alternating
+  pairs. Each side's middle two observations are averaged locally, then
+  the paired ratio is formed before any percentile is computed."
   [cf hf {:keys [batch samples]} flip?]
   (let [ca (js/Array. samples)
-        ha (js/Array. samples)]
+        ha (js/Array. samples)
+        ra (js/Array. samples)]
     (dotimes [s samples]
-      (if flip?
-        (do (aset ha s (sample-us hf batch))
-            (aset ca s (sample-us cf batch)))
-        (do (aset ca s (sample-us cf batch))
-            (aset ha s (sample-us hf batch)))))
-    (let [stats (fn [arr]
-                  (let [xs (vec arr)]
-                    {:p50 (median xs) :p95 (percentile xs 0.95)}))]
-      {:c (stats ca) :h (stats ha)})))
+      (let [cs (js/Array.)
+            hs (js/Array.)]
+        (dotimes [pair-idx 4]
+          (if (= flip? (odd? (+ s pair-idx)))
+            (do (.push cs (sample-us cf batch))
+                (.push hs (sample-us hf batch)))
+            (do (.push hs (sample-us hf batch))
+                (.push cs (sample-us cf batch)))))
+        (let [c (middle-mean4 cs)
+              h (middle-mean4 hs)]
+          (aset ca s c)
+          (aset ha s h)
+          (aset ra s (/ c h)))))
+    {:c (distribution-stats (vec ca))
+     :h (distribution-stats (vec ha))
+     :ratio (distribution-stats (vec ra))
+     :ratio-samples (vec ra)}))
 
 (defn- bench-pair
-  "Alternating interleaved rounds; median-of-rounds per estimate."
-  [cf hf {:keys [rounds warmup] :as o}]
+  "Alternating interleaved rounds. Each sample slot is stabilized by the
+  median of its per-round paired ratios; gate p50/p95 are computed across
+  only those stabilized paired ratios."
+  [cf hf {:keys [rounds warmup samples] :as o}]
   (dotimes [_ warmup] (cf) (hf))
-  (let [rs   (mapv #(bench-round cf hf o (odd? %)) (range rounds))
-        agg  (fn [k stat] (median (mapv #(get-in % [k stat]) rs)))]
+  (let [rs (mapv #(bench-round cf hf o (odd? %)) (range rounds))
+        agg (fn [k stat] (median (mapv #(get-in % [k stat]) rs)))
+        paired-ratios
+        (mapv (fn [sample-idx]
+                (median (mapv #(nth (:ratio-samples %) sample-idx) rs)))
+              (range samples))]
     {:compiled {:p50 (agg :c :p50) :p95 (agg :c :p95)}
      :hand     {:p50 (agg :h :p50) :p95 (agg :h :p95)}
-     :rounds   (mapv (fn [r] {:c (:c r) :h (:h r)}) rs)}))
+     :ratio    (distribution-stats paired-ratios)
+     :paired-ratio-samples paired-ratios
+     :rounds   (mapv (fn [r] (select-keys r [:c :h :ratio])) rs)}))
 
 (defn- round2 [x] (/ (js/Math.round (* 100 x)) 100))
+(defn- round4 [x] (/ (js/Math.round (* 10000 x)) 10000))
+(defn- fixed4 [x] (.toFixed x 4))
 
 ;; ---------------------------------------------------------------------------
 ;; Main
@@ -120,55 +156,132 @@
 
 (defn- byte-equality! []
   (let [fails (atom 0)]
-    (doseq [{:keys [id compiled hand props]} cases]
+    (doseq [{:keys [id compiled hand gate-hand props]} cases]
       (let [pj (->props props)
             c  (render-html compiled pj)
-            h  (render-html hand pj)]
-        (when (not= c h)
-          (swap! fails inc)
-          (println "  BYTE-DIFF" id)
-          (println "    compiled:" c)
-          (println "    hand:    " h))))
+            baselines (cond-> [["unwrapped hand" hand]]
+                        gate-hand (conj ["memo-matched hand" gate-hand]))]
+        (doseq [[label baseline] baselines]
+          (let [h (render-html baseline pj)]
+            (when (not= c h)
+              (swap! fails inc)
+              (println "  BYTE-DIFF" id "against" label)
+              (println "    compiled:" c)
+              (println "    hand:    " h))))))
     (if (zero? @fails)
-      (println "precheck: compiled HTML == hand HTML byte-for-byte on"
-               (count cases) "fixtures")
-      (do (println "precheck FAILED:" @fails "fixtures differ — ratios would be meaningless")
+      (println "precheck: compiled HTML == every measured hand baseline byte-for-byte")
+      (do (println "precheck FAILED:" @fails "baseline comparisons differ — ratios would be meaningless")
           (js/process.exit 1)))))
+
+(defn- within-budget? [{:keys [p50 p95]}]
+  (and (<= p50 (:p50 budget))
+       (<= p95 (:p95 budget))))
+
+(defonce ^:private mutation-sink (volatile! nil))
+
+(defn- simulated-flag-map-lowering-regression! []
+  ;; Controlled equivalent of the slow shape caught while building G-1: do
+  ;; the generic classes-str vector/join work once per keyed row instead of
+  ;; the compiler's straight-line static-base + flag append. The separate
+  ;; loop is test-only mutation scaffolding; the volatile keeps Closure from
+  ;; proving the intentionally wasted result dead.
+  (doseq [{:keys [done?]} todos-20]
+    (vreset! mutation-sink
+             (rules/classes-str ["todo-item" (when done? "done")]))))
+
+(defn- lowering-regression-control []
+  (let [{:keys [compiled gate-hand props]}
+        (some #(when (= "todos-20" (:id %)) %) cases)
+        pj (->props props)
+        r  (bench-pair #(do (simulated-flag-map-lowering-regression!)
+                            (render-html compiled pj))
+                       #(render-html gate-hand pj)
+                       opts)
+        detected? (not (within-budget? (:ratio r)))]
+    (println
+     (str (if detected? "  CONTROL PASS " "  CONTROL FAIL ")
+          "todos-20 simulated generic flag-map lowering [must exceed budget]"
+          "  ratio p50=" (fixed4 (get-in r [:ratio :p50]))
+          " p95=" (fixed4 (get-in r [:ratio :p95]))
+          "  limits p50<=" (fixed4 (:p50 budget))
+          " p95<=" (fixed4 (:p95 budget))))
+    {:id "todos-20-generic-flag-map-lowering"
+     :expected "budget breach"
+     :detected? detected?
+     :ratio {:p50 (round4 (get-in r [:ratio :p50]))
+             :p95 (round4 (get-in r [:ratio :p95]))}
+     :paired-ratio-samples (mapv round4 (:paired-ratio-samples r))
+     :rounds (:rounds r)}))
 
 (defn -main [& _args]
   (println "G-1 direct-render parity gate — revised estimator"
-           (pr-str opts) "budget" (pr-str budget))
+           (pr-str opts)
+           "budget p50<=" (fixed4 (:p50 budget))
+           "p95<=" (fixed4 (:p95 budget)))
   (when (not= "production" (unchecked-get js/process.env "NODE_ENV"))
     (println "FATAL: NODE_ENV must be 'production' (react dev-build costs would pollute the ratio)")
     (js/process.exit 1))
   (byte-equality!)
   (let [results
         (vec
-         (for [{:keys [id compiled hand props]} cases]
+         (for [{:keys [id compiled hand gate-hand props]} cases]
            (let [pj (->props props)
                  cf #(render-html compiled pj)
                  hf #(render-html hand pj)
-                 r  (bench-pair cf hf opts)
+                 gate-hf #(render-html (or gate-hand hand) pj)
+                 r  (bench-pair cf gate-hf opts)
                  c  (:compiled r) h (:hand r)
-                 r50 (/ (:p50 c) (:p50 h))
-                 r95 (/ (:p95 c) (:p95 h))
-                 ok? (and (<= r50 (:p50 budget)) (<= r95 (:p95 budget)))]
+                 r50 (get-in r [:ratio :p50])
+                 r95 (get-in r [:ratio :p95])
+                 ok? (within-budget? (:ratio r))
+                 policy-r (when gate-hand (bench-pair cf hf opts))
+                 policy-c (:compiled policy-r)
+                 policy-h (:hand policy-r)
+                 policy-r50 (get-in policy-r [:ratio :p50])
+                 policy-r95 (get-in policy-r [:ratio :p95])]
              (println (str (if ok? "  OK   " "  FAIL ") id
+                           (when gate-hand " [memo-matched hand baseline]")
                            "  compiled p50=" (round2 (:p50 c)) "us p95=" (round2 (:p95 c)) "us"
                            "  hand p50=" (round2 (:p50 h)) "us p95=" (round2 (:p95 h)) "us"
-                           "  ratio p50=" (round2 r50) " p95=" (round2 r95)))
-             {:id id
-              :compiled {:p50-us (round2 (:p50 c)) :p95-us (round2 (:p95 c))}
-              :hand     {:p50-us (round2 (:p50 h)) :p95-us (round2 (:p95 h))}
-              :ratio    {:p50 (round2 r50) :p95 (round2 r95)}
-              :ok?      ok?
-              :rounds   (:rounds r)})))]
+                           "  ratio p50=" (fixed4 r50) " p95=" (fixed4 r95)
+                           "  limits p50<=" (fixed4 (:p50 budget))
+                           " p95<=" (fixed4 (:p95 budget))))
+             (when policy-r
+               (println
+                (str "  INFO " id
+                     " always-memo SSR policy cost [non-gating]"
+                     "  compiled p50=" (round2 (:p50 policy-c)) "us p95=" (round2 (:p95 policy-c)) "us"
+                     "  unwrapped-hand p50=" (round2 (:p50 policy-h)) "us p95=" (round2 (:p95 policy-h)) "us"
+                     "  ratio p50=" (fixed4 policy-r50) " p95=" (fixed4 policy-r95))))
+             (cond->
+              {:id id
+               :baseline (if gate-hand "memo-matched hand JSX" "hand JSX")
+               :compiled {:p50-us (round2 (:p50 c)) :p95-us (round2 (:p95 c))}
+               :hand     {:p50-us (round2 (:p50 h)) :p95-us (round2 (:p95 h))}
+               :ratio    {:p50 (round4 r50) :p95 (round4 r95)}
+               :ok?      ok?
+               :paired-ratio-samples (mapv round4 (:paired-ratio-samples r))
+               :rounds   (:rounds r)}
+               policy-r
+               (assoc :always-memo-ssr-policy-cost
+                      {:label "always-memo SSR policy cost"
+                       :gating? false
+                       :hand-baseline "unwrapped hand JSX"
+                       :compiled {:p50-us (round2 (:p50 policy-c))
+                                  :p95-us (round2 (:p95 policy-c))}
+                       :hand {:p50-us (round2 (:p50 policy-h))
+                              :p95-us (round2 (:p95 policy-h))}
+                       :ratio {:p50 (round4 policy-r50)
+                               :p95 (round4 policy-r95)}
+                       :paired-ratio-samples
+                       (mapv round4 (:paired-ratio-samples policy-r))})))))
+        lowering-control (lowering-regression-control)]
     (when-not (fs/existsSync "out") (fs/mkdirSync "out"))
     (fs/writeFileSync
      "out/ui-bench.json"
      (js/JSON.stringify
       (clj->js {:gate "G-1"
-                :estimator "alternating interleaved rounds, median-of-rounds"
+                :estimator "order-balanced locally trimmed samples, per-sample paired ratios stabilized across rounds"
                 :opts opts
                 :budget budget
                 :cpu (.-model (aget (os/cpus) 0))
@@ -176,10 +289,23 @@
                 :react "19.2.0"
                 :optimizations "advanced"
                 :per-render-unit "microseconds"
-                :results results})
+                :results results
+                :lowering-regression-control lowering-control})
       nil 2))
     (println "wrote out/ui-bench.json")
-    (if (every? :ok? results)
-      (println "G-1: PASS — every component within" (pr-str budget))
-      (do (println "G-1: FAIL — a component exceeded the budget")
+    (when-let [summary-path (unchecked-get js/process.env "GITHUB_STEP_SUMMARY")]
+      (when-let [policy (some :always-memo-ssr-policy-cost results)]
+        (fs/appendFileSync
+         summary-path
+         (str "\n### G-1 policy evidence (non-gating)\n\n"
+              "- always-memo SSR policy cost: p50 `"
+              (fixed4 (get-in policy [:ratio :p50]))
+              "`, p95 `" (fixed4 (get-in policy [:ratio :p95]))
+              "` (compiled / unwrapped hand JSX; non-gating)\n"))))
+    (if (and (every? :ok? results)
+             (:detected? lowering-control))
+      (println "G-1: PASS — every component within"
+               (str "p50<=" (fixed4 (:p50 budget))
+                    ", p95<=" (fixed4 (:p95 budget))))
+      (do (println "G-1: FAIL — a component exceeded the budget or the lowering-regression control escaped detection")
           (js/process.exit 1)))))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -85,6 +85,14 @@
       (and (empty? flags) (nil? dyn))
       (when (seq base-str) base-str)
 
+      ;; The common one-flag/static-base case is exactly a binary string
+      ;; choice. Avoid generic `str`'s conversion of the false `when` arm;
+      ;; the condition is still evaluated once and the non-empty static base
+      ;; keeps both results canonical.
+      (and (seq base-str) (nil? dyn) (= 1 (count flags)))
+      (let [[n f] (first flags)]
+        `(if ~f ~(str base-str " " n) ~base-str))
+
       ;; literal flag maps over a non-empty static base (the `.sugar
       ;; {:class {:flag cond}}` idiom) compile STRAIGHT-LINE: the flag
       ;; order is compile-time-known (analyzer pre-sorts), the base

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -161,6 +161,39 @@
 (defn- children-forms [st nodes inline?]
   (into [] (keep #(emit-node % st inline?)) nodes))
 
+(defn- ordered-literal-object
+  "Emit an object literal for compile-known string keys. `js-obj` preserves
+  dynamic value order through an IIFE; here the literal's own left-to-right
+  property evaluation provides that guarantee without the per-render call.
+  Keys remain string expressions, so :advanced cannot rename React/custom
+  property spelling."
+  [pairs]
+  (let [pairs (vec pairs)]
+    (list* 'js*
+           (str "({" (str/join "," (repeat (count pairs) "~{}:~{}")) "})")
+           (mapcat identity pairs))))
+
+(defn- jsx-runtime-call [multi? tag-form props-form key-info]
+  ;; Invoke the imported JS MODULE PROPERTY, not a CLJS var holding the
+  ;; imported function and not a forwarding wrapper. `js*` is intentional at
+  ;; this emitter boundary: a CLJS property-read invocation is otherwise
+  ;; treated as IFn (or as a receiver-preserving method call), while the JS
+  ;; module alias that makes `(jsxrt/jsx ...)` direct exists only in runtime's
+  ;; namespace. These four closed templates emit exactly the same plain JS
+  ;; call shape as a caller-local `react/jsx-runtime` alias.
+  ;; `:present?` deliberately selects React's 3-argument API even when the
+  ;; authored key expression is nil or false.
+  (list* 'js*
+         (case [multi? (boolean (:present? key-info))]
+           [false false] "(0,~{}.jsx)(~{},~{})"
+           [false true]  "(0,~{}.jsx)(~{},~{},~{})"
+           [true false]  "(0,~{}.jsxs)(~{},~{})"
+           [true true]   "(0,~{}.jsxs)(~{},~{},~{})")
+         're-frame.ui.runtime/jsx-runtime
+         tag-form
+         props-form
+         (when (:present? key-info) [(:expr key-info)])))
+
 (defn- jsx-call [tag-form pairs children-forms key-info]
   (let [nch           (count children-forms)
         multi?        (> nch 1)
@@ -168,15 +201,11 @@
                         (zero? nch) nil
                         (= 1 nch)   (first children-forms)
                         :else       `(cljs.core/array ~@children-forms))
-        props-form    `(cljs.core/js-obj
-                        ~@(mapcat (fn [{:keys [name form]}] [name form]) pairs)
-                        ~@(when (some? children-form) ["children" children-form]))
-        has-key?      (:present? key-info)]
-    (if has-key?
-      (list (if multi? `re-frame.ui.runtime/jsxs3 `re-frame.ui.runtime/jsx3)
-            tag-form props-form (:expr key-info))
-      (list (if multi? `re-frame.ui.runtime/jsxs2 `re-frame.ui.runtime/jsx2)
-            tag-form props-form))))
+        props-form    (ordered-literal-object
+                       (concat (map (fn [{:keys [name form]}] [name form]) pairs)
+                               (when (some? children-form)
+                                 [["children" children-form]])))]
+    (jsx-runtime-call multi? tag-form props-form key-info)))
 
 (defn- emit-element [node st inline?]
   (let [static?       (:static? node)
@@ -225,17 +254,14 @@
                         :else       `(cljs.core/array ~@chs))
         entries  (get-in node [:props :entries])
         ref-a    (get-in node [:props :ref])
-        props-form `(cljs.core/js-obj
-                     ~@(mapcat (fn [{:keys [slot value]}] [slot value]) entries)
-                     ~@(when (and ref-a (= :foreign (:op node)))
-                         ["ref" (:form ref-a)])
-                     ~@(when (some? children-form) ["children" children-form]))
+        props-form (ordered-literal-object
+                    (concat (map (fn [{:keys [slot value]}] [slot value]) entries)
+                            (when (and ref-a (= :foreign (:op node)))
+                              [["ref" (:form ref-a)]])
+                            (when (some? children-form)
+                              [["children" children-form]])))
         multi?   (> nch 1)]
-    (if (:present? key-info)
-      (list (if multi? `re-frame.ui.runtime/jsxs3 `re-frame.ui.runtime/jsx3)
-            (:sym node) props-form (:expr key-info))
-      (list (if multi? `re-frame.ui.runtime/jsxs2 `re-frame.ui.runtime/jsx2)
-            (:sym node) props-form))))
+    (jsx-runtime-call multi? (:sym node) props-form key-info)))
 
 (defn- row-key-expr [body]
   (or (get-in body [:props :key :expr]) (get-in body [:key :expr])))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -174,11 +174,19 @@
   dynamic value order through an IIFE; here the literal's own left-to-right
   property evaluation provides that guarantee without the per-render call.
   Keys remain string expressions, so :advanced cannot rename React/custom
-  property spelling."
+  property spelling. JavaScript gives a colon-form `__proto__` definition
+  prototype-setter semantics, so that one magic key uses a computed property:
+  an ordinary own data property with the same evaluation order."
   [pairs]
   (let [pairs (vec pairs)]
     (list* 'js*
-           (str "({" (str/join "," (repeat (count pairs) "~{}:~{}")) "})")
+           (str "({"
+                (str/join "," (map (fn [[k _]]
+                                      (if (= "__proto__" k)
+                                        "[~{}]:~{}"
+                                        "~{}:~{}"))
+                                    pairs))
+                "})")
            (mapcat identity pairs))))
 
 (defn- jsx-runtime-call [multi? tag-form props-form key-info]

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -20,13 +20,14 @@
             [re-frame.ui.rules :as rules]))
 
 ;; ---------------------------------------------------------------------------
-;; jsx bindings — fixed-arity defns, NOT var-bound imports: a CLJS var
-;; bound to an imported JS value forces IFn-protocol dispatch at every
-;; call site under :advanced; fixed-arity defns compile to direct static
-;; calls Closure inlines to direct shim.jsx(...) calls (spike-measured
-;; ~5% on a 20-row list render).
+;; jsx binding.  Generated templates invoke `.jsx` / `.jsxs` on this module
+;; object directly.  Binding the imported FUNCTIONS as CLJS vars would force
+;; IFn-protocol dispatch; retaining the module object lets the emitter invoke
+;; the property unbound with React's exact 2/3-argument shape.
+;; The fixed-arity helpers remain for handwritten/runtime call sites.
 ;; ---------------------------------------------------------------------------
 
+(def ^js jsx-runtime jsxrt)
 (defn jsx2  [t p]   (jsxrt/jsx t p))
 (defn jsx3  [t p k] (jsxrt/jsx t p k))
 (defn jsxs2 [t p]   (jsxrt/jsxs t p))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -72,3 +72,18 @@
     (is (re-find #"^\(\{~\{\}:~\{\},~\{\}:~\{\}\}\)$"
                  (second props-form))
         "the narrow lowering is one ordered literal, not an assignment IIFE")))
+
+(deftest one-class-flag-with-static-base-is-a-binary-string-choice
+  (let [call       (first (jsx-calls
+                           (emitted '[:div.todo-item
+                                      {:class {:done done?}}])))
+        props-form (nth call 4)
+        class-form (nth props-form 3)]
+    (is (= '(if done? "todo-item done" "todo-item") class-form)
+        "one flag evaluates its condition once and needs no generic str")
+    (is (= 1 (count (filter #{'done?} (forms-of class-form))))))
+  (let [call       (first (jsx-calls
+                           (emitted '[:div {:class {:done done?}}])))
+        props-form (nth call 4)]
+    (is (some #{'re-frame.ui.rules/classes-str} (forms-of props-form))
+        "without a static base the general empty-class semantics remain")))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -9,6 +9,7 @@
   (case sym
     child-view {:fqn 'app.views/child-view
                 :meta {:rf.ui/view true :rf.ui/children? true}}
+    ForeignComp {:fqn 'app.interop/ForeignComp :meta {}}
     nil))
 
 (defn- emitted [form]
@@ -87,3 +88,20 @@
         props-form (nth call 4)]
     (is (some #{'re-frame.ui.rules/classes-str} (forms-of props-form))
         "without a static base the general empty-class semantics remain")))
+
+(deftest prototype-setter-key-is-computed-on-every-literal-props-surface
+  (doseq [[surface form]
+          [[:dom '[:div {:__proto__ value}]]
+           [:custom-element '[:proto-widget {:__proto__ value}]]
+           [:view '[child-view {:__proto__ value}]]
+           [:foreign '[ForeignComp {:__proto__ value}]]]]
+    (let [call       (first (jsx-calls (emitted form)))
+          props-form (nth call 4)]
+      (is (= 'js* (first props-form)) (name surface))
+      (is (= "({[~{}]:~{}})" (second props-form))
+          (str (name surface) " avoids object-literal prototype-setter grammar"))
+      (is (= (if (contains? #{:dom :custom-element} surface)
+               '("__proto__" (re-frame.ui.runtime/attr-val value))
+               '("__proto__" value))
+             (drop 2 props-form))
+          (str (name surface) " retains the authored own property and value")))))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -1,0 +1,74 @@
+(ns re-frame.ui.emit-cljs-lowering-cljs-test
+  "Focused golden for the production JSX call shape (rf2-dj7pav)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.emit-cljs :as emit]
+            [re-frame.ui.compiler.env :as env]))
+
+(defn- resolve-sym [sym]
+  (case sym
+    child-view {:fqn 'app.views/child-view
+                :meta {:rf.ui/view true :rf.ui/children? true}}
+    nil))
+
+(defn- emitted [form]
+  (let [e   (env/make-env {:host :clj
+                           :ns-sym 'app.test
+                           :resolver resolve-sym})
+        ast (ana/analyze e form)]
+    (emit/emit-inline ast 'lowering-golden)))
+
+(defn- forms-of [form]
+  (tree-seq coll? seq form))
+
+(defn- jsx-calls [form]
+  (filter #(and (seq? %)
+                (= 'js* (first %))
+                (string? (second %))
+                (re-find #"^\(0,~\{\}\.jsx" (second %)))
+          (forms-of form)))
+
+(def wrapper-symbols
+  '#{re-frame.ui.runtime/jsx2 re-frame.ui.runtime/jsx3
+     re-frame.ui.runtime/jsxs2 re-frame.ui.runtime/jsxs3})
+
+(deftest compiler-authored-sites-call-jsx-runtime-module-directly
+  (let [form  (emitted '[:div [child-view {:label label}] [:span "tail"]])
+        calls (vec (jsx-calls form))]
+    (is (seq calls))
+    (is (every? #(= 're-frame.ui.runtime/jsx-runtime
+                    (nth % 2)) calls)
+        "every ordinary element/component call uses the imported module object")
+    (is (not-any? wrapper-symbols (forms-of form))
+        "no compiler-authored site routes through the retained runtime helpers")
+    (is (some #(re-find #"\.jsxs\)" (second %)) calls)
+        "multi-child sites select React's jsxs property")))
+
+(deftest key-presence-selects-exact-react-arity
+  (testing "an absent key uses jsx(type, props)"
+    (let [call (first (jsx-calls (emitted '[:div "x"])))]
+      (is (= "(0,~{}.jsx)(~{},~{})" (second call)))
+      (is (= 5 (count call))
+          "js* template + module + exactly two React arguments")))
+  (testing "present falsey keys still use jsx(type, props, key)"
+    (doseq [k [nil false]]
+      (let [call (first (jsx-calls (emitted [:div {:key k} "x"])))]
+        (is (= "(0,~{}.jsx)(~{},~{},~{})" (second call)))
+        (is (= 6 (count call))
+            "js* template + module + exactly three React arguments")
+        (is (= k (last call))
+            "the authored falsey key is passed through, not treated as absent")))))
+
+(deftest literal-props-preserve-key-spelling-and-value-order
+  (let [call       (first (jsx-calls
+                           (emitted '[:input {:data-z (mark! :first)
+                                              :checked (mark! :second)}])))
+        props-form (nth call 4)]
+    (is (= 'js* (first props-form)))
+    (is (= '("data-z" (re-frame.ui.runtime/attr-val (mark! :first))
+             "checked" (re-frame.ui.runtime/attr-val (mark! :second)))
+           (drop 2 props-form))
+        "literal string keys and authored value order are explicit arguments")
+    (is (re-find #"^\(\{~\{\}:~\{\},~\{\}:~\{\}\}\)$"
+                 (second props-form))
+        "the narrow lowering is one ordered literal, not an assignment IIFE")))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -116,6 +116,15 @@
   [{:keys [l]}]
   [:div [plain-fc {:label l}]])
 
+;; `__proto__` is the one string key with prototype-setter grammar in a JS
+;; object literal. Keep one dynamic fixture for each props surface so the
+;; generated config object can be captured before React transforms it.
+(defview proto-child [] [:span])
+(defview proto-dom [{:keys [v]}] [:div {:__proto__ v}])
+(defview proto-custom [{:keys [v]}] [:fancy-input {:__proto__ v}])
+(defview proto-view [{:keys [v]}] [proto-child {:__proto__ v}])
+(defview proto-foreign [{:keys [v]}] [plain-fc {:__proto__ v}])
+
 ;; ---------------------------------------------------------------------------
 ;; Renders
 ;; ---------------------------------------------------------------------------
@@ -216,6 +225,40 @@
 (deftest foreign-component-renders
   (is (= "<div><b>L</b></div>"
          (render (rt/jsx2 uses-foreign (js-obj "l" "L"))))))
+
+(defn- has-own? [o k]
+  (.call (.-hasOwnProperty (.-prototype js/Object)) o k))
+
+(defn- captured-jsx-props [view value]
+  (let [module   rt/jsx-runtime
+        original (.-jsx module)
+        captured (atom nil)]
+    (try
+      (set! (.-jsx module)
+            (fn [_type props & _]
+              (reset! captured props)
+              #js {}))
+      ((.-type view) (js-obj "v" value))
+      @captured
+      (finally
+        (set! (.-jsx module) original)))))
+
+(deftest prototype-setter-key-remains-an-own-prop-on-every-jsx-surface
+  (doseq [[surface view]
+          [[:dom proto-dom]
+           [:custom-element proto-custom]
+           [:view proto-view]
+           [:foreign proto-foreign]]]
+    (let [value (js-obj "surface" (name surface))
+          props (captured-jsx-props view value)]
+      (is (some? props) (name surface))
+      (is (has-own? props "__proto__")
+          (str (name surface) " has an own __proto__ data property"))
+      (is (identical? value (unchecked-get props "__proto__"))
+          (str (name surface) " retains the exact authored value"))
+      (is (identical? (js/Object.getPrototypeOf props)
+                      (.-prototype js/Object))
+          (str (name surface) " keeps Object.prototype unchanged")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Handlers — compile-time placeholder splice + dispatch hook


### PR DESCRIPTION
## What changed

- Adds a contract-matched hand baseline for `todos-20`: both the parent and keyed row use `React.memo` with the same generated `rf=` slot comparators as the compiled views.
- Computes the unchanged 1.10 p50/p95 gate from locally paired compiled/matched-hand sample ratios. Each sample is order-balanced, locally trimmed, and median-stabilized across rounds; the gate never divides independently aggregated compiled and hand percentiles.
- Retains the unwrapped hand comparison as labelled, non-gating `always-memo SSR policy cost` evidence in console output, JSON, and the GitHub step summary.
- Hardens byte equality across both hand baselines, preserves the emitted-JS golden, prints ratios and limits to four decimal places, and adds a controlled generic flag-map lowering mutation which must breach the budget.

## Why

The previous gate compared a memoized compiled row with an unwrapped hand row, mixing the framework's always-memo policy cost into its lowering-overhead gate. It also derived ratios from independently aggregated distributions, losing paired covariance.

This change implements the ruled matched-baseline and paired-ratio contract without widening or demoting the 1.10 gate.

## Validation

- `implementation/ui: clojure -M:test` — 358 tests, 5,026 assertions, zero failures/errors.
- Advanced build and emitted-JS golden — PASS: 86 direct literal-tag calls, zero IFn fallback sites.
- Byte equality against both memo-matched and unwrapped hand baselines — PASS.
- Repeated exact-bundle evidence:
  - matched `todos-20`: 1.0817/1.1335, then 1.0921/1.1398 (p50/p95)
  - controlled generic flag-map mutation: 1.4662/1.5498, then 1.4423/1.4933

## Current gate disposition

This draft intentionally exposes a real remaining lowering-cost miss: matched `todos-20` still exceeds the unchanged p95 1.10 limit and lacks the requested ~0.03 headroom. Inspection of the advanced bundle shows compiled calls still crossing the fixed `runtime/jsx*` wrapper functions, plus generated dynamic props-object IIFEs and value conversions that the competent hand JSX does not pay.

The benchmark contract is ready for review, but this PR is not merge-ready until a separately scoped compiler optimization closes that measured gap.

---

## Final disposition (addendum, 2026-07-15; rf2-vxgfnd.206)

The "Current gate disposition" section above is **historical, pre-optimization
evidence** — it predates the specialization optimization that closed the
measured p95 gap. It is retained for the record; its "not merge-ready"
conclusion is **superseded** by this addendum.

- **Merged head:** `b75fce0570caadd4450691fe6af3c5aebda2cea1`, merged 2026-07-13.
  The separately scoped compiler optimization referenced above landed before
  merge, so the exact final head passed the unchanged p50+p95 ≤ 1.10 gate with
  headroom (the pre-optimization 1.08/1.13 matched `todos-20` figures listed
  above are historical, not the final head).
- **Current main** (post-merge, with the rf2-vxgfnd.206 hardening): the
  matched `todos-20` gate passes with headroom across repeated runs
  (p50 ≈ 1.00, p95 ≈ 1.01–1.05, limit 1.10), and the real-lowering mutation
  control (`v/todo-list-generic-class`, generic `classes-str` at the todo-row
  class-property site) sits ≈ 1.54 — comfortably red, as required.

rf2-vxgfnd.206 additionally hardened this gate so **every** gated workload is
memo-matched (not only `todos-20`) and the mutation control exercises the
**real** generic `classes-str` class-property lowering rather than a side-loop
proxy. See that PR for the memo-matched baselines, the real-site mutation, and
the bypass proof (specialized candidate ⇒ control ratio ≈ 1.00 ⇒ gate reddens).
