### PR TITLE
test(ui): prove digest carrier fail-closed cases

### DIFF
--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -12,7 +12,10 @@ const fs = require('fs');
 const path = require('path');
 const { chromium } = require('playwright');
 const {
+  createHarnessCleanup,
+  resolveServePort,
   spawnHarnessProcess,
+  startLocalHttpServer,
   terminateProcessTree,
 } = require('./lib/local-browser-harness.cjs');
 
@@ -25,8 +28,17 @@ const TARGET = path.join(IMPL, 'target', 'ui-digest-probe');
 const FAIL_MARKER = path.join(TARGET, 'fail-after-compile');
 const ACCEPTED_FILE = path.join(TARGET, 'accepted-digest.txt');
 const PREPARE_FILE = path.join(TARGET, 'prepare-snapshots.tsv');
+const HOOKLESS_CONFIG_ROOT = path.join(
+  IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'hookless',
+);
+const HOOKLESS_OUT = path.join(IMPL, 'out', 'ui-digest-probe-hookless');
+const HOOKLESS_CARRIER = path.join(
+  HOOKLESS_OUT, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
+);
+const DIGEST_SENTINEL = '__RF2_UI_DIGEST_XX__';
 const URL = 'http://127.0.0.1:8059/index.html';
 const TIMEOUT = 90000;
+const HOOKLESS_ERROR_TIMEOUT = 15000;
 
 function fail(message) {
   throw new Error(`FAIL: ${message}`);
@@ -119,6 +131,42 @@ function watchShadow(shadowRunner) {
   };
 }
 
+function compileHooklessShadow(shadowRunner) {
+  const child = spawnHarnessProcess(process.execPath, [
+    shadowRunner, 'compile', 'ui-digest-probe-hookless',
+  ], {
+    cwd: HOOKLESS_CONFIG_ROOT,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let transcript = '';
+  const capture = (chunk) => {
+    const text = chunk.toString();
+    transcript += text;
+    process.stdout.write(text);
+  };
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+
+  const completed = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`hookless Shadow compile timed out\n${transcript}`));
+    }, TIMEOUT);
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) resolve(transcript);
+      else reject(new Error(
+        `hookless Shadow compile failed (code=${code}, signal=${signal})\n${transcript}`,
+      ));
+    });
+  });
+  return { child, completed };
+}
+
 async function readBrowserDigest(page) {
   await page.waitForFunction(
     () => typeof globalThis.__rf2ReadDigest === 'function' &&
@@ -158,6 +206,93 @@ function lastPrepareSnapshot() {
     fail(`test hook wrote invalid prepare snapshot ${JSON.stringify(lines.at(-1))}`);
   }
   return { version, digest };
+}
+
+async function proveHooklessBuildFailsClosed(shadowRunner, browser, activePage, lkg) {
+  const config = fs.readFileSync(
+    path.join(HOOKLESS_CONFIG_ROOT, 'shadow-cljs.edn'), 'utf8',
+  );
+  if (/:build-hooks\b/.test(config.replace(/;.*$/gm, ''))) {
+    fail('hookless fixture unexpectedly configures a build hook');
+  }
+
+  fs.rmSync(HOOKLESS_OUT, { recursive: true, force: true });
+  const cleanup = createHarnessCleanup();
+  let tearingDown = false;
+  let compile;
+  let page;
+  try {
+    compile = compileHooklessShadow(shadowRunner);
+    await compile.completed;
+
+    const carrier = fs.readFileSync(HOOKLESS_CARRIER, 'utf8');
+    if (!carrier.includes(DIGEST_SENTINEL) || /bd1-[0-9a-f]{16}/.test(carrier)) {
+      fail('hookless output unexpectedly published a compiler digest');
+    }
+
+    fs.writeFileSync(
+      path.join(HOOKLESS_OUT, 'index.html'),
+      '<!doctype html><meta charset="utf-8"><script src="/base.js"></script>',
+    );
+    const httpServerBin = require.resolve('http-server/bin/http-server', {
+      paths: [IMPL],
+    });
+    const port = await resolveServePort(8061);
+    const served = await startLocalHttpServer({
+      cleanup,
+      httpServerBin,
+      root: HOOKLESS_OUT,
+      port,
+      cwd: IMPL,
+      captureOutput: true,
+      readyTimeoutMs: 30000,
+      suppressExitDiagnostic: () => tearingDown,
+    });
+    if (!served.ready) fail('hookless output server did not become ready');
+
+    page = await browser.newPage();
+    const rejected = page.waitForEvent('pageerror', {
+      predicate: (error) => error.message.includes(
+        're-frame.ui build digest was not finalized',
+      ),
+      timeout: HOOKLESS_ERROR_TIMEOUT,
+    });
+    await page.goto(`http://127.0.0.1:${port}/index.html`, {
+      waitUntil: 'load', timeout: TIMEOUT,
+    });
+    const error = await rejected;
+    if (error.name !== 'Error' ||
+        !error.message.includes('Configure (re-frame.ui.compiler.build-hook/hook)')) {
+      fail(`hookless runtime produced the wrong diagnostic: ${error.name}: ${error.message}`);
+    }
+    // Script-loader mode reports the top-level throw as a pageerror, then the
+    // browser may continue loading later independent scripts. If base init ran,
+    // its diagnostic accessor must still expose the unfinalized sentinel —
+    // never a plausible accepted bd1 digest.
+    const unfinalized = await page.evaluate(
+      () => typeof globalThis.__rf2ReadDigest === 'function'
+        ? globalThis.__rf2ReadDigest()
+        : null,
+    );
+    if (unfinalized !== DIGEST_SENTINEL) {
+      fail(`hookless runtime exposed a digest after rejection: ${unfinalized}`);
+    }
+
+    const activeDigest = await activePage.evaluate(() => globalThis.__rf2ReadDigest());
+    const stillAccepted = acceptedSnapshot();
+    if (activeDigest !== lkg.digest ||
+        stillAccepted.digest !== lkg.digest ||
+        stillAccepted.version !== lkg.version) {
+      fail('hookless build disturbed the active runtime or accepted JVM snapshot');
+    }
+    console.log('ui digest carrier: hookless build rejected before publication (LKG preserved)');
+  } finally {
+    if (page) await page.close();
+    tearingDown = true;
+    await cleanup.cleanup();
+    if (compile) await terminateProcessTree(compile.child, { timeoutMs: 5000 });
+    fs.rmSync(HOOKLESS_OUT, { recursive: true, force: true });
+  }
 }
 
 async function main() {
@@ -205,6 +340,13 @@ async function main() {
     if (await page.evaluate(() => globalThis.__rf2LazyExecuted === true)) {
       fail('lazy module executed during initial base load');
     }
+
+    // A separate, real Shadow configuration deliberately omits every build
+    // hook while compiling the same client entry. Its raw sentinel must throw
+    // before base init; the active hooked build remains the LKG witness.
+    await proveHooklessBuildFailsClosed(
+      shadowRunner, browser, page, accepted1,
+    );
 
     // Warm successful pass: only the unexecuted lazy view changes. The
     // ^:dev/always carrier must be regenerated from its sentinel and reloaded.

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -7,6 +7,7 @@
             [re-frame.ui.compiler.build-hook :as build-hook]))
 
 (def ^:private carrier-rid [:cljs "re_frame/ui/digest_carrier.cljs"])
+(def ^:private client-rid [:cljs "re_frame/ui/client.cljs"])
 (def ^:private app-rid [:cljs "app/view.cljs"])
 
 (defn- shadow-state [build-id js]
@@ -133,6 +134,55 @@
                      (declare 'app.view :app/view ["tf1-new" "hs1-new"]))]
     (is (thrown? clojure.lang.ExceptionInfo (finish compiled)))
     (is (= {} (build/accepted-aggregate build/views input)))))
+
+(deftest zero-carrier-resource-preserves-the-last-accepted-snapshot
+  (let [good (-> (shadow-state :zero-carrier build-hook/digest-sentinel)
+                 prepare
+                 (declare 'app.view :app/view ["tf1-good" "hs1-good"])
+                 finish)
+        accepted (build/accepted-snapshot good)
+        zero-carrier-input
+        (-> good
+            ;; Keep a real UI-client graph member while removing the carrier
+            ;; resource itself. This distinguishes count zero from a non-UI
+            ;; build, which is correctly allowed to have no carrier.
+            (assoc :build-sources [client-rid app-rid])
+            (update :sources dissoc carrier-rid)
+            (assoc-in [:sources client-rid]
+                      {:ns 're-frame.ui.client
+                       :provides #{'re-frame.ui.client}
+                       :requires '#{re-frame.ui.digest-carrier}
+                       :type :cljs})
+            (update :output dissoc carrier-rid)
+            (assoc-in [:output client-rid]
+                      {:resource-id client-rid
+                       :js "re_frame.ui.client = {};"
+                       :cached true})
+            (assoc :build-modules
+                   [{:module-id :base :sources [client-rid]}
+                    {:module-id :lazy :sources [app-rid]
+                     :depends-on #{:base}}]))
+        compiled (-> zero-carrier-input
+                     prepare
+                     (declare 'app.view :app/view ["tf1-doomed" "hs1-doomed"]))
+        ex (try (finish compiled) nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (= :re-frame.ui.compiler.build-hook/carrier-output-invalid
+           (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
+    (is (= "re-frame.ui expected exactly one compiled digest carrier output"
+           (ex-message ex)))
+    (is (= [] (:carrier-resource-ids (ex-data ex))))
+    (is (= 0 (:count (ex-data ex))))
+    (is (= accepted (build/accepted-snapshot zero-carrier-input))
+        "the incoming accepted value remains the last-known-good authority")
+    (is (= accepted (build/accepted-snapshot compiled))
+        "opening and populating scratch does not publish the candidate")
+    (is (= {:app/view ["tf1-good" "hs1-good"]}
+           (build/accepted-aggregate build/views compiled)))
+    (is (some? (get-in compiled [:compiler-env build/scratch-key]))
+        "the rejected candidate remains disposable scratch")
+    (is (nil? (get-in compiled [:output carrier-rid]))
+        "zero carrier output cannot be mistaken for an accepted publication")))
 
 (deftest interleaved-build-values-carry-isolated-digests
   (let [a (-> (shadow-state :a build-hook/digest-sentinel)

--- a/implementation/ui/test/re_frame/ui/digest_probe/hookless/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/hookless/shadow-cljs.edn
@@ -1,0 +1,22 @@
+;; Adversarial Spec 004C fixture: a real UI client build with the
+;; compiler-authoritative digest hook deliberately absent. Keep this config
+;; independent of implementation/shadow-cljs.edn: its defining property is
+;; that no :build-defaults / :build-hooks value can be inherited or merged in.
+{:source-paths ["../../../../../../core/src"
+                "../../../../../src"
+                "../../../.."]
+ :cache-root "../../../../../../target/ui-digest-probe/hookless-shadow-cache"
+ :cache-blockers #{re-frame.ui}
+ :js-options {:js-package-dirs ["../../../../../../node_modules"]}
+ :builds
+ {:ui-digest-probe-hookless
+  {:target :browser
+   :output-dir "../../../../../../out/ui-digest-probe-hookless"
+   :asset-path "."
+   ;; Script loading leaves a top-level namespace failure uncaught, so the
+   ;; browser exposes the runtime sentinel as the pageerror it is. Shadow's
+   ;; default :eval loader catches namespace failures inside evalLoad.
+   :devtools {:loader-mode :script}
+   :modules
+   {:base {:entries [re-frame.ui.digest-probe.base]
+           :init-fn re-frame.ui.digest-probe.base/init}}}}}


### PR DESCRIPTION
## Summary

- add a direct JVM proof that a UI build with zero digest-carrier resources fails closed
- compile a separate, real Shadow configuration with no build hook and prove its sentinel is rejected before digest publication
- prove both failures preserve the prior accepted JVM snapshot and active browser last-known-good digest

## Adversarial proof

- Weakened the count-zero carrier guard so the build returned unchanged: the new JVM fixture failed red (3 assertion failures and 1 error).
- Removed the runtime unfinalized-sentinel guard: the real hookless browser fixture failed red by timing out while waiting for the required page error.
- Restored both guards: all checks below pass.

## Validation

- `cd implementation/ui && clojure -M:test` — 368 tests, 5,085 assertions
- `cd implementation && npm run test:ui-digest-carrier` — hookless rejection + initial/warm/failure/recovery digest proof
- `cd implementation && npm run test:browser` — 306 tests, 1,117 assertions
- `cd implementation && npm run test:browser-prod-elision` — 77 tests, 242 assertions
- `cd implementation && npm run test:script-policy` — pass

Bead: `rf2-vxgfnd.108`