### PR TITLE
Gate re-frame.ui push economics in G-13

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -435,6 +435,17 @@ else
         reagent_slim_bundle=true
         ui_gates=true
         ;;
+      implementation/scripts/run-ui-g13.cjs)
+        # rf2-vxgfnd.12.3 — this is the complete G-13 compile/serve/browser/
+        # advanced-elision orchestrator. A launcher-only change must run the
+        # ui_gates job it owns; retain the generic scripts fan-out too.
+        cljs_node_test=true
+        cljs_browser=true
+        cljs_prod=true
+        bundle_isolation=true
+        reagent_slim_bundle=true
+        ui_gates=true
+        ;;
       implementation/scripts/check-ui-adapter-isolation.cjs)
         # The checker IS the focused re-frame.ui dependency-closure gate.
         # A checker-only PR must start the consolidated CLJS job that owns

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -656,6 +656,62 @@ jobs:
           path: implementation/out/ui-bench.json
           if-no-files-found: ignore
 
+  cljs-ui-g13:
+    name: CLJS ui G-13 exact push economics (browser + advanced elision)
+    # rf2-vxgfnd.12.3 — Q=8 queued write epochs affect C=8 ViewCells,
+    # then settle through one read/render root commit at V=100 and V=500.
+    # Exact counts are gating; cold/warm p50+p95 are evidence only. The
+    # companion :advanced build proves all gate-local instrumentation elides.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.ui_gates == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install pinned Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: G-13 exact push-economics and advanced-elision gate
+        run: npm run test:ui-g13
+
+      - name: Upload G-13 evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: ui-g13-json
+          path: implementation/out/ui-g13.json
+          if-no-files-found: error
+
   jvm-reagent:
     name: Diagnostic skip-ok JVM reagent-adapter classpath probe
     needs: detect_changed_surfaces
@@ -3571,6 +3627,7 @@ jobs:
       - jvm-core
       - jvm-ui
       - cljs-ui-g1
+      - cljs-ui-g13
       - jvm-reagent
       - jvm-reagent-slim
       - jvm-uix

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -32,6 +32,7 @@
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && shadow-cljs compile node-test-ui && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-digest-carrier": "node scripts/check-ui-digest-carrier.cjs",
     "test:ui-g1": "node scripts/run-ui-bench.cjs",
+    "test:ui-g13": "node scripts/run-ui-g13.cjs",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
     "test:browser-schemas-boundary-prod": "shadow-cljs release browser-test-schemas-boundary-prod && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-schemas-boundary-prod --port 8022",

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1056,6 +1056,14 @@ test('the G-1 launcher script fires the gate it drives (rf2-vxgfnd.6)', () => {
   assert.equal(result.bundle_isolation, 'true');
 });
 
+test('the G-13 launcher script fires the gate it drives (rf2-vxgfnd.12.3)', () => {
+  const result = classify('implementation/scripts/run-ui-g13.cjs');
+  assert.equal(result.ui_gates, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
 test('the UI isolation checker fires the focused gate it implements', () => {
   const result = classify('implementation/scripts/check-ui-adapter-isolation.cjs');
   assert.equal(
@@ -1127,10 +1135,24 @@ test('cljs-ui-g1 is job-level gated on ui_gates and runs the gate script (rf2-vx
   assert.match(block, /npm run test:ui-g1/);
 });
 
+test('cljs-ui-g13 is job-level gated and runs the exact-count browser gate', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs-ui-g13');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.ui_gates == 'true'/,
+  );
+  assert.match(block, /npm run test:ui-g13/);
+  assert.match(block, /playwright install --with-deps chromium/);
+  assert.match(block, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(block, /implementation\/out\/ui-g13\.json/);
+});
+
 test('all-required-passed aggregator needs jvm-ui + cljs-ui-g1 (rf2-vxgfnd.6)', () => {
   const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'all-required-passed');
   assert.match(block, /- jvm-ui\r?\n/, 'aggregator must list jvm-ui in needs:');
   assert.match(block, /- cljs-ui-g1\r?\n/, 'aggregator must list cljs-ui-g1 in needs:');
+  assert.match(block, /- cljs-ui-g13\r?\n/, 'aggregator must list cljs-ui-g13 in needs:');
 });
 
 // rf2-vxgfnd.90 — re-frame.ui now ships REAL DOM tests

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+'use strict';
+
+// G-13 owns an isolated real-browser fixture. Correctness is exact work
+// accounting (not a wall-clock budget); timing is retained only as evidence.
+// The companion :advanced build proves the gate's counters, React Profiler,
+// debug evidence and result channel do not ship with the ordinary view.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { chromium } = require('playwright');
+const {
+  createHarnessCleanup,
+  resolveServePort,
+  startLocalHttpServer,
+} = require('./lib/local-browser-harness.cjs');
+const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
+
+const IMPL = path.resolve(__dirname, '..');
+const OUT = path.join(IMPL, 'out');
+const DEV = path.join(OUT, 'ui-g13');
+const PROD = path.join(OUT, 'ui-g13-prod');
+const REPORT = path.join(OUT, 'ui-g13.json');
+const TIMEOUT = 90000;
+const SENTINELS = [
+  'RF2_G13_COUNTER_SENTINEL',
+  'RF2_G13_PROFILER_SENTINEL',
+  'RF2_G13_DEBUG_EVIDENCE_SENTINEL',
+  '__RF2_G13_RESULT_SENTINEL__',
+];
+
+function fail(message) {
+  throw new Error(`G-13 FAIL: ${message}`);
+}
+
+function resolveBin(modulePath) {
+  return require.resolve(modulePath, { paths: [IMPL] });
+}
+
+function shadow(...args) {
+  const runner = resolveBin('shadow-cljs/cli/runner.js');
+  console.log(`> shadow-cljs ${args.join(' ')}`);
+  const result = spawnSync(process.execPath, [runner, ...args], {
+    cwd: IMPL,
+    env: process.env,
+    shell: false,
+    stdio: 'inherit',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) fail(`shadow-cljs ${args.join(' ')} exited ${result.status}`);
+}
+
+function writePage(dir) {
+  fs.writeFileSync(
+    path.join(dir, 'index.html'),
+    '<!doctype html><meta charset="utf-8"><div id="app"></div>' +
+      '<script src="./main.js"></script>\n',
+    'utf8',
+  );
+}
+
+function recursiveJsBlob(dir) {
+  const chunks = [];
+  function walk(at) {
+    for (const entry of fs.readdirSync(at, { withFileTypes: true })) {
+      const p = path.join(at, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.isFile() && entry.name.endsWith('.js')) {
+        chunks.push(fs.readFileSync(p, 'utf8'));
+      }
+    }
+  }
+  walk(dir);
+  return chunks.join('\n');
+}
+
+function assertBundleElision() {
+  const devBlob = recursiveJsBlob(DEV);
+  for (const sentinel of SENTINELS) {
+    if (!devBlob.includes(sentinel)) {
+      fail(`development non-vacuity control omitted ${sentinel}`);
+    }
+  }
+  const release = classifyReleaseBundle(PROD);
+  if (release.status !== 'ok') {
+    fail(`advanced companion bundle is ${release.status}, not inspectable`);
+  }
+  for (const sentinel of SENTINELS) {
+    if (release.blob.includes(sentinel)) {
+      fail(`advanced companion leaked ${sentinel}`);
+    }
+  }
+  return { devSentinelsPresent: SENTINELS, advancedSentinelsAbsent: SENTINELS };
+}
+
+function expectedProjection() {
+  return {
+    enrolled: 8,
+    advances: 8,
+    'revision-delta': 8,
+    'hot-renders': 8,
+    'cold-renders': 0,
+    'root-commits': 1,
+    'hot-base': 8,
+    'stable-parent': 8,
+    'cold-leaf': 0,
+  };
+}
+
+function sameJson(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function assertDevResult(result) {
+  if (!result || result.gate !== 'G-13' || result.status !== 'pass') {
+    fail(`invalid development result: ${JSON.stringify(result)}`);
+  }
+  if (!sameJson(result.sizes, [100, 500])) fail('fixture sizes are not [100,500]');
+  if (result['queued-writes'] !== 8 || result['affected-viewcells'] !== 8) {
+    fail('Q/C cardinalities are not 8/8');
+  }
+  if (result['timing-posture'] !== 'evidence-only; no threshold') {
+    fail('timing evidence grew a threshold posture');
+  }
+  const expected = expectedProjection();
+  const projections = [];
+  for (const size of result.results || []) {
+    if (![100, 500].includes(size.v)) fail(`unexpected V=${size.v}`);
+    if (!sameJson(size.cold.projection, expected)) {
+      fail(`cold projection drift at V=${size.v}: ${JSON.stringify(size.cold.projection)}`);
+    }
+    if (!Array.isArray(size.samples) || size.samples.length !== 9) {
+      fail(`V=${size.v} did not retain exactly nine warm samples`);
+    }
+    if (!Array.isArray(size.warm['raw-ms']) || size.warm['raw-ms'].length !== 9) {
+      fail(`V=${size.v} raw timing evidence is not the odd nine-sample set`);
+    }
+    if (!Number.isFinite(size.cold['elapsed-ms']) ||
+        !Number.isFinite(size.warm['p50-ms']) ||
+        !Number.isFinite(size.warm['p95-ms'])) {
+      fail(`V=${size.v} timing evidence is incomplete`);
+    }
+    for (const sample of size.samples) {
+      if (!sameJson(sample.projection, expected)) {
+        fail(`warm projection drift at V=${size.v}/${sample.label}`);
+      }
+    }
+    projections.push(size.cold.projection);
+  }
+  if (projections.length !== 2 || !sameJson(projections[0], projections[1])) {
+    fail('count projection is not V-independent');
+  }
+}
+
+function writeReport(report) {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(REPORT, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}
+
+function appendSummary(report) {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target || report.status !== 'pass') return;
+  const lines = [
+    '### re-frame.ui G-13 push economics',
+    '',
+    '| V | cold ms | warm p50 ms | warm p95 ms | exact projection |',
+    '|---:|---:|---:|---:|:---:|',
+  ];
+  for (const row of report.development.results) {
+    lines.push(`| ${row.v} | ${row.cold['elapsed-ms'].toFixed(3)} | ` +
+      `${row.warm['p50-ms'].toFixed(3)} | ${row.warm['p95-ms'].toFixed(3)} | yes |`);
+  }
+  lines.push('', 'Timing is evidence-only; G-13 has no wall-clock threshold.', '');
+  fs.appendFileSync(target, `${lines.join('\n')}\n`, 'utf8');
+}
+
+async function main() {
+  const cleanup = createHarnessCleanup();
+  cleanup.installSignalHandlers();
+  let browser;
+  try {
+    shadow('compile', 'ui-g13');
+    shadow('release', 'ui-g13-prod');
+    writePage(DEV);
+    writePage(PROD);
+    const bundles = assertBundleElision();
+
+    const devPort = await resolveServePort(Number(process.env.UI_G13_PORT) || 8061);
+    const prodPort = await resolveServePort(Number(process.env.UI_G13_PROD_PORT) || 8062);
+    const httpServerBin = resolveBin('http-server/bin/http-server');
+    const devServer = await startLocalHttpServer({
+      cleanup, httpServerBin, root: DEV, port: devPort, cwd: IMPL,
+    });
+    if (!devServer.ready) fail('development server did not prove owned readiness');
+    const prodServer = await startLocalHttpServer({
+      cleanup, httpServerBin, root: PROD, port: prodPort, cwd: IMPL,
+    });
+    if (!prodServer.ready) fail('advanced server did not prove owned readiness');
+
+    browser = await chromium.launch({ headless: true });
+    const dev = await browser.newPage();
+    const pageErrors = [];
+    dev.on('pageerror', (e) => pageErrors.push(e.stack || String(e)));
+    await dev.goto(`http://127.0.0.1:${devPort}/index.html`);
+    await dev.waitForFunction(
+      () => globalThis.__RF2_G13_RESULT_SENTINEL__ || globalThis.__RF2_G13_ERROR__,
+      null,
+      { timeout: TIMEOUT },
+    );
+    const devState = await dev.evaluate(() => ({
+      result: globalThis.__RF2_G13_RESULT_SENTINEL__ || null,
+      error: globalThis.__RF2_G13_ERROR__ || null,
+    }));
+    if (devState.error) fail(devState.error);
+    if (pageErrors.length) fail(`development page errors:\n${pageErrors.join('\n')}`);
+    assertDevResult(devState.result);
+
+    const prod = await browser.newPage();
+    const prodErrors = [];
+    prod.on('pageerror', (e) => prodErrors.push(e.stack || String(e)));
+    await prod.goto(`http://127.0.0.1:${prodPort}/index.html`);
+    await prod.waitForSelector('[data-g13-ready="true"]', { timeout: TIMEOUT });
+    const prodState = await prod.evaluate(() => ({
+      rows: document.querySelectorAll('[data-g13-kind]').length,
+      hot: document.querySelectorAll('[data-g13-kind="hot"]').length,
+      cold: document.querySelectorAll('[data-g13-kind="cold"]').length,
+      firstHot: document.querySelector('[data-g13-kind="hot"]')?.textContent,
+      lastCold: document.querySelector('[data-g13-index="99"]')?.textContent,
+      resultGlobal: typeof globalThis.__RF2_G13_RESULT_SENTINEL__,
+    }));
+    if (prodErrors.length) fail(`advanced page errors:\n${prodErrors.join('\n')}`);
+    if (!sameJson(prodState, {
+      rows: 100, hot: 8, cold: 92, firstHot: '0', lastCold: 'cold-99',
+      resultGlobal: 'undefined',
+    })) {
+      fail(`advanced DOM result drift: ${JSON.stringify(prodState)}`);
+    }
+
+    const report = {
+      gate: 'G-13',
+      status: 'pass',
+      correctness: 'exact counts; one post-drain root commit',
+      timing: 'evidence-only; no threshold',
+      development: devState.result,
+      advanced: { bundles, dom: prodState },
+    };
+    writeReport(report);
+    appendSummary(report);
+    console.log(`G-13 PASS — report: ${REPORT}`);
+  } catch (error) {
+    writeReport({ gate: 'G-13', status: 'fail', error: error.stack || String(error) });
+    throw error;
+  } finally {
+    if (browser) await browser.close();
+    await cleanup.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exitCode = 1;
+});
+

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -9,6 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { isDeepStrictEqual } = require('util');
 const { chromium } = require('playwright');
 const {
   createHarnessCleanup,
@@ -86,12 +87,14 @@ function assertBundleElision() {
   if (release.status !== 'ok') {
     fail(`advanced companion bundle is ${release.status}, not inspectable`);
   }
-  for (const sentinel of SENTINELS) {
-    if (release.blob.includes(sentinel)) {
-      fail(`advanced companion leaked ${sentinel}`);
-    }
-  }
+  assertNoProductionSentinels(release.blob);
   return { devSentinelsPresent: SENTINELS, advancedSentinelsAbsent: SENTINELS };
+}
+
+function assertNoProductionSentinels(blob) {
+  for (const sentinel of SENTINELS) {
+    if (blob.includes(sentinel)) fail(`advanced companion leaked ${sentinel}`);
+  }
 }
 
 function expectedProjection() {
@@ -109,7 +112,7 @@ function expectedProjection() {
 }
 
 function sameJson(a, b) {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return isDeepStrictEqual(a, b);
 }
 
 function assertDevResult(result) {
@@ -153,6 +156,34 @@ function assertDevResult(result) {
   }
 }
 
+function expectMutationFailure(label, thunk) {
+  try {
+    thunk();
+  } catch (_) {
+    return label;
+  }
+  fail(`mutation tooth was green: ${label}`);
+}
+
+function assertMutationTeeth(result) {
+  const mutations = [
+    ['per-write flushing', (r) => { r.results[0].cold.projection['revision-delta'] = 64; }],
+    ['V-wide enrollment', (r) => { r.results[0].cold.projection.enrolled = 100; }],
+    ['stable-parent fan-out', (r) => { r.results[0].cold.projection['cold-leaf'] = 92; }],
+    ['multiple root commits', (r) => { r.results[0].cold.projection['root-commits'] = 8; }],
+  ];
+  const red = mutations.map(([label, mutate]) => {
+    const changed = JSON.parse(JSON.stringify(result));
+    mutate(changed);
+    return expectMutationFailure(label, () => assertDevResult(changed));
+  });
+  const release = classifyReleaseBundle(PROD);
+  red.push(expectMutationFailure('production instrumentation leak', () => {
+    assertNoProductionSentinels(`${release.blob}\n${SENTINELS[0]}`);
+  }));
+  return red;
+}
+
 function writeReport(report) {
   fs.mkdirSync(OUT, { recursive: true });
   fs.writeFileSync(REPORT, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
@@ -179,6 +210,7 @@ async function main() {
   const cleanup = createHarnessCleanup();
   cleanup.installSignalHandlers();
   let browser;
+  let tearingDown = false;
   try {
     shadow('compile', 'ui-g13');
     shadow('release', 'ui-g13-prod');
@@ -191,10 +223,12 @@ async function main() {
     const httpServerBin = resolveBin('http-server/bin/http-server');
     const devServer = await startLocalHttpServer({
       cleanup, httpServerBin, root: DEV, port: devPort, cwd: IMPL,
+      suppressExitDiagnostic: () => tearingDown,
     });
     if (!devServer.ready) fail('development server did not prove owned readiness');
     const prodServer = await startLocalHttpServer({
       cleanup, httpServerBin, root: PROD, port: prodPort, cwd: IMPL,
+      suppressExitDiagnostic: () => tearingDown,
     });
     if (!prodServer.ready) fail('advanced server did not prove owned readiness');
 
@@ -215,6 +249,7 @@ async function main() {
     if (devState.error) fail(devState.error);
     if (pageErrors.length) fail(`development page errors:\n${pageErrors.join('\n')}`);
     assertDevResult(devState.result);
+    const mutationTeeth = assertMutationTeeth(devState.result);
 
     const prod = await browser.newPage();
     const prodErrors = [];
@@ -242,6 +277,7 @@ async function main() {
       status: 'pass',
       correctness: 'exact counts; one post-drain root commit',
       timing: 'evidence-only; no threshold',
+      mutationTeeth,
       development: devState.result,
       advanced: { bundles, dom: prodState },
     };
@@ -252,6 +288,7 @@ async function main() {
     writeReport({ gate: 'G-13', status: 'fail', error: error.stack || String(error) });
     throw error;
   } finally {
+    tearingDown = true;
     if (browser) await browser.close();
     await cleanup.cleanup();
   }
@@ -261,4 +298,3 @@ main().catch((error) => {
   console.error(error.stack || String(error));
   process.exitCode = 1;
 });
-

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -103,6 +103,7 @@ function expectedProjection() {
     advances: 8,
     'revision-delta': 8,
     'hot-renders': 8,
+    'hot-renders-by-index': [1, 1, 1, 1, 1, 1, 1, 1],
     'cold-renders': 0,
     'root-commits': 1,
     'hot-base': 8,
@@ -171,6 +172,9 @@ function assertMutationTeeth(result) {
     ['V-wide enrollment', (r) => { r.results[0].cold.projection.enrolled = 100; }],
     ['stable-parent fan-out', (r) => { r.results[0].cold.projection['cold-leaf'] = 92; }],
     ['multiple root commits', (r) => { r.results[0].cold.projection['root-commits'] = 8; }],
+    ['same-total uneven hot distribution', (r) => {
+      r.results[0].cold.projection['hot-renders-by-index'] = [2, 0, 1, 1, 1, 1, 1, 1];
+    }],
   ];
   const red = mutations.map(([label, mutate]) => {
     const changed = JSON.parse(JSON.stringify(result));

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -147,6 +147,9 @@
                 ;; (npm run test:ui-g1); nothing under a production
                 ;; build or another test build :requires it.
                 "ui/bench"
+                ;; rf2-vxgfnd.12.3 — isolated G-13 browser push-economics
+                ;; fixture + advanced instrumentation-elision companion.
+                "ui/g13"
                 ;; rf2-3cfvt — adversarial-property SECURITY tier. A small
                 ;; cross-artefact test tree probing the three security
                 ;; boundaries the pin-and-assert regime missed: SSR escaping
@@ -768,6 +771,30 @@
    ;; The load-bearing pass/digest hook is inherited from :build-defaults.
    :compiler-options {:optimizations :advanced
                       :infer-externs :auto}}
+
+  ;; rf2-vxgfnd.12.3 — G-13 exact push-work browser gate. The development
+  ;; build retains gate-local evidence; its advanced companion compiles the
+  ;; SAME view fixture with all instrumentation closed and goog.DEBUG=false.
+  :ui-g13
+  {:target :browser
+   :output-dir "out/ui-g13"
+   :asset-path "."
+   :modules {:main {:entries [re-frame.ui.g13.dev]
+                    :init-fn re-frame.ui.g13.dev/-main}}
+   :compiler-options
+   {:closure-defines {re-frame.ui.g13.fixture/instrumentation? true}}}
+
+  :ui-g13-prod
+  {:target :browser
+   :output-dir "out/ui-g13-prod"
+   :asset-path "."
+   :modules {:main {:entries [re-frame.ui.g13.prod]
+                    :init-fn re-frame.ui.g13.prod/-main}}
+   :compiler-options
+   {:optimizations :advanced
+    :infer-externs :auto
+    :closure-defines {goog.DEBUG false
+                      re-frame.ui.g13.fixture/instrumentation? false}}}
 
   ;; rf2-2hrj8 — `:browser-test` is narrowed to DOM-dependent tests only.
   ;; The ns-regexp `-dom-cljs-test$` matches files whose namespace ends in

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -69,19 +69,23 @@
                               :advances (count (filter #(= 1 %) hot-deltas))
                               :revision-delta (reduce + (deltas all before))
                               :hot-renders (:hot-body counters)
+                              :hot-renders-by-index (:hot-body-by-index counters)
                               :cold-renders (:cold-body counters)
                               :root-commits (:commits counters)
                               :hot-base (:hot-base counters)
                               :stable-parent (:stable-parent counters)
                               :cold-leaf (:cold-leaf counters)}
                  expected    {:enrolled 8 :advances 8 :revision-delta 8
-                              :hot-renders 8 :cold-renders 0 :root-commits 1
+                              :hot-renders 8
+                              :hot-renders-by-index (vec (repeat 8 1))
+                              :cold-renders 0 :root-commits 1
                               :hot-base 8 :stable-parent 8 :cold-leaf 0}]
              (ensure! (= {:pending 8 :hot-dirty 8 :cold-dirty 0
                           :revision-delta 0
                           :evidence-counts (vec (repeat 8 8))
                           :counters {:writes 8 :hot-base 8 :stable-parent 8
                                      :cold-leaf 0 :hot-body 0 :cold-body 0
+                                     :hot-body-by-index (vec (repeat 8 0))
                                      :commits 0}}
                          @pre)
                       "write side did not coalesce before the read side"
@@ -92,11 +96,16 @@
                       {:v v :label label :cold-deltas cold-deltas})
              (ensure! (zero? (reactive/pending-cell-count))
                       "dirty registry did not drain" {:v v :label label})
-             (ensure! (= (str (:hot (rf/app-db-value frame)))
-                         (.-textContent
-                          (uit/query root "[data-g13-kind='hot']")))
-                      "DOM did not reflect the eighth queued write"
-                      {:v v :label label})
+             (let [published (str (:hot (rf/app-db-value frame)))]
+               (doseq [i (range fixture/hot-count)]
+                 (ensure! (= published
+                             (.-textContent
+                              (uit/query
+                               root
+                               (str "[data-g13-kind='hot'][data-g13-index='"
+                                    i "']"))))
+                          "a hot DOM row did not publish the eighth queued write"
+                          {:v v :label label :index i :expected published})))
              (ensure! (= (str "cold-" (dec v))
                          (.-textContent
                           (uit/query root (str "[data-g13-index='" (dec v) "']"))))

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -44,25 +44,25 @@
 (defn- sample! [root frame v label]
   (let [{:keys [all hot cold]} (split-cells v)
         before (into {} (map (juxt identity reactive/revision)) all)
-        pre    (atom nil)
-        started (js/performance.now)]
+        pre    (atom nil)]
     (fixture/reset-counters!)
-    (-> (uit/flush!
-         (fn []
-           ;; dispatch! completes all eight write epochs synchronously. The
-           ;; read side has not run until flush!'s returned Promise advances.
-           (uit/dispatch! frame [::fixture/step fixture/queued-writes])
-           (reset! pre
-                   {:pending (reactive/pending-cell-count)
-                    :hot-dirty (count (filter reactive/dirty? hot))
-                    :cold-dirty (count (filter reactive/dirty? cold))
-                    :revision-delta (reduce + (deltas all before))
-                    :evidence-counts
-                    (mapv #(get (reactive/pending-evidence %) :count) hot)
-                    :counters (fixture/counter-snapshot)})))
-        (.then
-         (fn []
-           (let [hot-deltas  (deltas hot before)
+    (let [started (js/performance.now)]
+      (-> (uit/flush!
+           (fn []
+             ;; dispatch! completes all eight write epochs synchronously. The
+             ;; read side has not run until flush!'s returned Promise advances.
+             (uit/dispatch! frame [::fixture/step fixture/queued-writes])
+             (reset! pre
+                     {:pending (reactive/pending-cell-count)
+                      :hot-dirty (count (filter reactive/dirty? hot))
+                      :cold-dirty (count (filter reactive/dirty? cold))
+                      :revision-delta (reduce + (deltas all before))
+                      :evidence-counts
+                      (mapv #(get (reactive/pending-evidence %) :count) hot)
+                      :counters (fixture/counter-snapshot)})))
+          (.then
+           (fn []
+             (let [hot-deltas  (deltas hot before)
                  cold-deltas (deltas cold before)
                  counters    (fixture/counter-snapshot)
                  projection  {:enrolled (:pending @pre)
@@ -97,9 +97,14 @@
                           (uit/query root "[data-g13-kind='hot']")))
                       "DOM did not reflect the eighth queued write"
                       {:v v :label label})
+             (ensure! (= (str "cold-" (dec v))
+                         (.-textContent
+                          (uit/query root (str "[data-g13-index='" (dec v) "']"))))
+                      "cold DOM changed during a hot-only drain"
+                      {:v v :label label})
              {:label label
               :elapsed-ms (- (js/performance.now) started)
-              :projection projection}))))))
+              :projection projection})))))))
 
 (defn- percentile [xs p]
   (let [sorted (vec (sort xs))]

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -1,0 +1,177 @@
+(ns re-frame.ui.g13.dev
+  "Development-half of G-13: exact push-work counts plus timing evidence.
+  Timing is descriptive only; correctness rests entirely on deterministic
+  counts before and after the single read/render commit."
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui]
+            [re-frame.ui.g13.fixture :as fixture]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(def sizes [100 500])
+(def warmups 3)
+(def recorded-samples 9)
+
+(defn- fail! [message data]
+  (throw (ex-info (str "G-13: " message) data)))
+
+(defn- ensure! [pred message data]
+  (when-not pred (fail! message data)))
+
+(defn- cell-query [cell]
+  (some (fn [[kind _frame-id query]]
+          (when (= :sub kind) query))
+        (reactive/committed-target-keys cell)))
+
+(defn- split-cells [v]
+  (let [cells (vec (reactive/current-live-cells))
+        hot   (filterv #(= [::fixture/hot] (cell-query %)) cells)
+        cold  (filterv #(let [q (cell-query %)]
+                          (and (vector? q) (= ::fixture/cold (first q))))
+                       cells)]
+    (ensure! (= v (count cells)) "mounted ViewCell cardinality drift"
+             {:v v :cells (count cells)})
+    (ensure! (= fixture/hot-count (count hot)) "hot ViewCell cardinality drift"
+             {:v v :hot (count hot)})
+    (ensure! (= (- v fixture/hot-count) (count cold))
+             "cold ViewCell cardinality drift"
+             {:v v :cold (count cold)})
+    {:all cells :hot hot :cold cold}))
+
+(defn- deltas [cells before]
+  (mapv #(- (reactive/revision %) (get before %)) cells))
+
+(defn- sample! [root frame v label]
+  (let [{:keys [all hot cold]} (split-cells v)
+        before (into {} (map (juxt identity reactive/revision)) all)
+        pre    (atom nil)
+        started (js/performance.now)]
+    (fixture/reset-counters!)
+    (-> (uit/flush!
+         (fn []
+           ;; dispatch! completes all eight write epochs synchronously. The
+           ;; read side has not run until flush!'s returned Promise advances.
+           (uit/dispatch! frame [::fixture/step fixture/queued-writes])
+           (reset! pre
+                   {:pending (reactive/pending-cell-count)
+                    :hot-dirty (count (filter reactive/dirty? hot))
+                    :cold-dirty (count (filter reactive/dirty? cold))
+                    :revision-delta (reduce + (deltas all before))
+                    :evidence-counts
+                    (mapv #(get (reactive/pending-evidence %) :count) hot)
+                    :counters (fixture/counter-snapshot)})))
+        (.then
+         (fn []
+           (let [hot-deltas  (deltas hot before)
+                 cold-deltas (deltas cold before)
+                 counters    (fixture/counter-snapshot)
+                 projection  {:enrolled (:pending @pre)
+                              :advances (count (filter #(= 1 %) hot-deltas))
+                              :revision-delta (reduce + (deltas all before))
+                              :hot-renders (:hot-body counters)
+                              :cold-renders (:cold-body counters)
+                              :root-commits (:commits counters)
+                              :hot-base (:hot-base counters)
+                              :stable-parent (:stable-parent counters)
+                              :cold-leaf (:cold-leaf counters)}
+                 expected    {:enrolled 8 :advances 8 :revision-delta 8
+                              :hot-renders 8 :cold-renders 0 :root-commits 1
+                              :hot-base 8 :stable-parent 8 :cold-leaf 0}]
+             (ensure! (= {:pending 8 :hot-dirty 8 :cold-dirty 0
+                          :revision-delta 0
+                          :evidence-counts (vec (repeat 8 8))
+                          :counters {:writes 8 :hot-base 8 :stable-parent 8
+                                     :cold-leaf 0 :hot-body 0 :cold-body 0
+                                     :commits 0}}
+                         @pre)
+                      "write side did not coalesce before the read side"
+                      {:v v :label label :pre @pre})
+             (ensure! (= expected projection) "post-drain work projection drift"
+                      {:v v :label label :expected expected :actual projection})
+             (ensure! (every? zero? cold-deltas) "a cold ViewCell advanced"
+                      {:v v :label label :cold-deltas cold-deltas})
+             (ensure! (zero? (reactive/pending-cell-count))
+                      "dirty registry did not drain" {:v v :label label})
+             (ensure! (= (str (* 8 fixture/queued-writes))
+                         (.-textContent
+                          (uit/query root "[data-g13-kind='hot']")))
+                      "DOM did not reflect the eighth queued write"
+                      {:v v :label label})
+             {:label label
+              :elapsed-ms (- (js/performance.now) started)
+              :projection projection}))))))
+
+(defn- percentile [xs p]
+  (let [sorted (vec (sort xs))]
+    (nth sorted (js/Math.floor (* p (dec (count sorted)))))))
+
+(defn- run-size! [v]
+  (let [frame (uit/frame {:app-db (fixture/seed v)})
+        cold* (atom nil)]
+    (-> (uit/with-root [root [ui/frame-provider {:frame frame}
+                              [fixture/app {:v v}]]]
+          (-> (sample! root frame v "cold")
+              (.then
+               (fn [cold]
+                 (reset! cold* cold)
+                 (reduce (fn [p i]
+                           (.then p (fn [xs]
+                                      (-> (sample! root frame v (str "warmup-" i))
+                                          (.then #(conj xs %))))))
+                         (js/Promise.resolve [])
+                         (range warmups))))
+              (.then
+               (fn [_]
+                 (reduce (fn [p i]
+                           (.then p (fn [xs]
+                                      (-> (sample! root frame v (str "sample-" i))
+                                          (.then #(conj xs %))))))
+                         (js/Promise.resolve [])
+                         (range recorded-samples))))
+              (.then
+               (fn [samples]
+                 (let [raw (mapv :elapsed-ms samples)]
+                   {:v v
+                    :cold @cold*
+                    :warm {:raw-ms raw
+                           :p50-ms (percentile raw 0.50)
+                           :p95-ms (percentile raw 0.95)}
+                    :samples samples})))))
+        (.then (fn [result]
+                 (rf/destroy-frame! frame)
+                 result)
+               (fn [e]
+                 (rf/destroy-frame! frame)
+                 (throw e))))))
+
+(defn- execute! []
+  (fixture/register!)
+  (rf/init! ui/adapter)
+  (-> (reduce (fn [p v]
+                (.then p (fn [xs]
+                           (-> (run-size! v) (.then #(conj xs %))))))
+              (js/Promise.resolve [])
+              sizes)
+      (.then
+       (fn [results]
+         (let [projections (mapv #(get-in % [:cold :projection]) results)]
+           (ensure! (apply = projections)
+                    "count projection depends on V"
+                    {:projections projections})
+           {:gate "G-13"
+            :status "pass"
+            :sizes sizes
+            :queued-writes fixture/queued-writes
+            :affected-viewcells fixture/hot-count
+            :timing-posture "evidence-only; no threshold"
+            :results results})))))
+
+(defn -main []
+  (-> (execute!)
+      (.then (fn [result]
+               (unchecked-set js/globalThis
+                              "__RF2_G13_RESULT_SENTINEL__"
+                              (clj->js result))))
+      (.catch (fn [e]
+                (unchecked-set js/globalThis "__RF2_G13_ERROR__"
+                               (or (.-stack e) (str e)))))))

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -92,7 +92,7 @@
                       {:v v :label label :cold-deltas cold-deltas})
              (ensure! (zero? (reactive/pending-cell-count))
                       "dirty registry did not drain" {:v v :label label})
-             (ensure! (= (str (* 8 fixture/queued-writes))
+             (ensure! (= (str (:hot (rf/app-db-value frame)))
                          (.-textContent
                           (uit/query root "[data-g13-kind='hot']")))
                       "DOM did not reflect the eighth queued write"

--- a/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
@@ -1,0 +1,92 @@
+(ns re-frame.ui.g13.fixture
+  "Shared G-13 push-economics fixture. The dev build retains gate-local
+  evidence; the :advanced companion compiles the same view shape with every
+  counter and Profiler branch closed. Nothing here instruments production
+  re-frame.ui runtime code."
+  (:require ["react" :as React]
+            [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview]]))
+
+(goog-define ^boolean instrumentation? false)
+
+(def hot-count 8)
+(def queued-writes 8)
+(def counters (atom {}))
+
+(defn reset-counters! []
+  (reset! counters {:writes 0
+                    :hot-base 0
+                    :stable-parent 0
+                    :cold-leaf 0
+                    :hot-body 0
+                    :cold-body 0
+                    :commits 0}))
+
+(defn counter-snapshot [] @counters)
+
+(defn- count! [k]
+  (when instrumentation?
+    (swap! counters update k (fnil inc 0))))
+
+(defn register! []
+  ;; Literal sentinels are the non-vacuity control for the advanced scan.
+  ;; With instrumentation? false Closure must remove this entire branch.
+  (when instrumentation?
+    (.debug js/console
+            "RF2_G13_COUNTER_SENTINEL"
+            "RF2_G13_PROFILER_SENTINEL"
+            "RF2_G13_DEBUG_EVIDENCE_SENTINEL"))
+  (rf/reg-sub ::hot
+              (fn [db _]
+                (count! :hot-base)
+                (:hot db)))
+  (rf/reg-sub ::stable-parent
+              (fn [db _]
+                (count! :stable-parent)
+                (:cold db)))
+  (rf/reg-sub ::cold
+              :<- [::stable-parent]
+              (fn [cold [_ i]]
+                (count! :cold-leaf)
+                (nth cold i)))
+  (rf/reg-event ::step
+                (fn [{:keys [db]} [_ remaining]]
+                  (count! :writes)
+                  (cond-> {:db (update db :hot inc)}
+                    (> remaining 1)
+                    (assoc :fx [[:dispatch [::step (dec remaining)]]]))))
+  nil)
+
+(defn seed [v]
+  {:hot 0
+   :cold (mapv #(str "cold-" %) (range v))})
+
+(defview hot-row [{:keys [index]}]
+  (let [_ (count! :hot-body)]
+    [:output {:data-g13-kind "hot" :data-g13-index index}
+     (str (ui/sub [::hot]))]))
+
+(defview cold-row [{:keys [index]}]
+  (let [_ (count! :cold-body)]
+    [:output {:data-g13-kind "cold" :data-g13-index index}
+     (ui/sub [::cold index])]))
+
+(defview table [{:keys [v]}]
+  [:section {:data-g13-ready "true" :data-g13-v v}
+   (for [i (range hot-count)]
+     [hot-row {:key i :index i}])
+   (for [i (range hot-count v)]
+     [cold-row {:key i :index i}])])
+
+(defn- profiled [^js props]
+  (React/createElement
+   (.-Profiler React)
+   #js {:id "g13-root"
+        :onRender (fn [& _]
+                    (count! :commits))}
+   (React/createElement table #js {:v (.-v props)})))
+
+(defview app [{:keys [v]}]
+  (if instrumentation?
+    (ui/raw (React/createElement profiled #js {:v v}))
+    [table {:v v}]))

--- a/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
@@ -19,6 +19,7 @@
                     :stable-parent 0
                     :cold-leaf 0
                     :hot-body 0
+                    :hot-body-by-index (vec (repeat hot-count 0))
                     :cold-body 0
                     :commits 0}))
 
@@ -62,7 +63,9 @@
    :cold (mapv #(str "cold-" %) (range v))})
 
 (defview hot-row [{:keys [index]}]
-  (let [_ (count! :hot-body)]
+  (let [_ (count! :hot-body)
+        _ (when instrumentation?
+            (swap! counters update-in [:hot-body-by-index index] inc))]
     [:output {:data-g13-kind "hot" :data-g13-index index}
      (str (ui/sub [::hot]))]))
 

--- a/implementation/ui/g13/re_frame/ui/g13/prod.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/prod.cljs
@@ -14,4 +14,3 @@
                [fixture/app {:v 100}]]
               host
               {:root-id :g13/advanced-companion})))
-

--- a/implementation/ui/g13/re_frame/ui/g13/prod.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/prod.cljs
@@ -1,0 +1,17 @@
+(ns re-frame.ui.g13.prod
+  "Advanced-build companion: ordinary public mount of the shared view shape.
+  No ui.test or gate instrumentation is reachable from this entry point."
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui]
+            [re-frame.ui.g13.fixture :as fixture]))
+
+(defn -main []
+  (fixture/register!)
+  (rf/init! ui/adapter)
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed 100)]]})
+        host  (.getElementById js/document "app")]
+    (ui/mount [ui/frame-provider {:frame frame}
+               [fixture/app {:v 100}]]
+              host
+              {:root-id :g13/advanced-companion})))
+


### PR DESCRIPTION
## Summary

- add the isolated G-13 mounted browser fixture for V=100/500, C=8 affected ViewCells, and Q=8 queued writes
- gate exact post-drain work: 8 enrollments/advances/revisions/renders, zero cold work, and one React root commit
- retain cold/warm raw timing plus p50/p95 as evidence only, with no timing threshold
- add a same-shape `:advanced`, `goog.DEBUG=false` companion and prove counter/Profiler/result/debug sentinels elide while its ordinary DOM renders correctly
- wire the new gate to `ui_gates`, required-check aggregation, always-uploaded JSON evidence, and CI summary output

## Contract

Implements `rf2-vxgfnd.12.3` without UIx/Helix, production runtime counters, emitter/runtime edits, or changes to the G-1 runner. This stacked slice was based exactly on approved PR #5808 head `2fb15ff412455b80af2b3866f70493989039bf3a`.

Eight epochs remain write-side causal evidence. All eight queued events drain before one read/render phase; the gate explicitly rejects an epoch-equals-render interpretation.

## Validation

- `npm run test:ui-g13` (green: dev exact counts at both V values; advanced elision + DOM proof)
- `npm run test:script-policy` (green)
- `shadow-cljs compile ui-g13` (green, zero warnings)
- G-13 validator mutation teeth red for per-write flushing, V-wide enrollment, stable-parent fan-out, multiple commits, and production instrumentation leakage