### PR TITLE
fix(ui): bind commits to exact render captures

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -32,9 +32,10 @@
   the layout commit acquires the CAPTURED targets. Abandoned renders
   (StrictMode double-render, time-sliced tear-off) acquire NO OWNERSHIP —
   the 10k-abandoned-renders-retain-zero-OWNERSHIP property is structural,
-  mirroring the port's S-3 §5 cold-probe exit criterion. (They do retain
-  their single `:latest-capture` of values until the next render overwrites
-  it — at most one, never accumulating; see `with-capture`.)
+  mirroring the port's S-3 §5 cold-probe exit criterion. Each finished render
+  returns its immutable capture beside the host element; an abandoned render's
+  pair becomes unreachable instead of publishing speculative state to the
+  ViewCell.
 
   ## The render capture
 
@@ -353,7 +354,6 @@
   ;;    :evidence  ev|nil        ; DEBUG-only bounded causal evidence for the
   ;;                             ;   pending window (see `fold-evidence`); nil
   ;;                             ;   in production (elided) + between flushes
-  ;;    :latest-capture cap|nil  ; last finished render capture (commit input)
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]}   ; lifecycle facts (dev/tool; 03 §4)
   )
@@ -382,7 +382,6 @@
             :revision       0
             :dirty?         false
             :evidence       nil
-            :latest-capture nil
             :listeners      {}
             :intervals      []}))))
 
@@ -447,12 +446,11 @@
   (get-in @view-generations [view-id :generation] 0))
 
 (defn advance-generation!
-  "Advance a LIVE `cell`'s view-body generation to `generation` — the same-shell
-  HMR seam (03 §10). A same-signature reload bumps a mounted cell's generation
-  so any in-flight capture rendered under the PRIOR body is stale-rejected at the
-  next commit (step 1); the next render runs the new body and the commit
-  reconciles the changed `sub` sites — STATE PRESERVED (the same cell, its
-  committed dependency set carried forward). Monotone: a no-op unless
+  "Advance a LIVE `cell`'s view-body generation to `generation` — the
+  changed-signature HMR/remount seam (03 §10). A generation bump makes any
+  in-flight capture rendered under the PRIOR body stale at the next commit
+  (step 1). Same-signature reloads preserve the generation and never call this
+  seam. Monotone: a no-op unless
   `generation` exceeds the cell's current generation. Returns the cell."
   [^ViewCell cell generation]
   (let [st (state cell)]
@@ -500,30 +498,25 @@
       v)))
 
 (defn with-capture
-  "Run `thunk` (a compiled view body) under a fresh ambient capture, stash the
-  finished capture on `cell` as the layout commit's input, and return the
-  thunk's value (the host element).
+  "Run `thunk` (a compiled view body) under a fresh ambient capture and return
+  `[host-element capture]`.
 
   Ownership-free: the render acquires NO ref-count, watch, or cache node, so an
   abandoned render (a thunk whose result the host discards — StrictMode
-  double-render, time-sliced tear-off) leaks ZERO ownership. It does, however,
-  RETAIN its capture: the finished capture (its targets + probe evidence +
-  values, possibly a large probed collection) is stashed on the cell as
-  `:latest-capture` and stays there until the NEXT render overwrites it. The
-  honest bound is therefore AT MOST ONE capture retained per cell — never
-  accumulating, never ownership — not zero. That retention is REQUIRED, not a
-  leak: the layout commit reads `:latest-capture` in a later effect, and
-  StrictMode's effect mount→cleanup→remount re-commits the SAME capture with no
-  intervening render, so clearing it here would break the reacquire
-  (rf2-vxgfnd.44)."
+  double-render, time-sliced tear-off) leaks ZERO ownership and publishes ZERO
+  shared capture state. React retains the pair only on the selected finished
+  Fiber: its layout-effect closure commits that exact render's capture. A later
+  speculative render therefore cannot replace the input of an earlier render
+  that React actually commits. StrictMode's effect mount→cleanup→remount reuses
+  the selected effect closure, so both mounts reconcile the same immutable
+  capture without a shared slot."
   [^ViewCell cell thunk]
   (let [cap  (volatile! (fresh-capture (:generation @(state cell))))
         prev @ambient]
     (reset! ambient {:cell cell :capture cap})
     (try
       (let [el (thunk)]
-        (swap! (state cell) assoc :latest-capture @cap)
-        el)
+        [el @cap])
       (finally
         (reset! ambient prev)))))
 
@@ -1568,8 +1561,9 @@
   nil)
 
 (defn commit!
-  "Run the 8-step layout commit for `cell` against its latest render
-  capture. Idempotent: an unchanged committed set + capture reconciles to a
+  "Run the 8-step layout commit for `cell` against the exact immutable
+  `capture` returned beside the committed host element by `with-capture`.
+  Idempotent: an unchanged committed set + capture reconciles to a
   no-op (kept-check retains every lease untouched), so StrictMode's
   release/reacquire replay is naturally balanced.
 
@@ -1596,16 +1590,11 @@
   8. If any evidence moved in the render→commit gap, advance the revision
      and notify — React corrects BEFORE paint.
 
-  Returns `cell` on a normal commit, `:stale` on a rejected generation, or
-  `:no-capture` when nothing has been rendered yet."
-  [^ViewCell cell]
+  Returns `cell` on a normal commit or `:stale` on a rejected generation."
+  [^ViewCell cell cap]
   (let [st  (state cell)
-        st0 @st
-        cap (:latest-capture st0)]
+        st0 @st]
     (cond
-      (nil? cap)
-      :no-capture
-
       ;; step 1 — stale generation
       (not= (:generation cap) (:generation st0))
       :stale
@@ -1791,14 +1780,6 @@
   "The installed lease for target key `tk` (tool/test read), or nil."
   [^ViewCell cell tk]
   (get (:committed @(state cell)) tk))
-
-(defn latest-capture
-  "The cell's last finished render capture — the layout commit's input, and the
-  single capture a cell retains between renders (tool/test read; nil before the
-  first render). See `with-capture`: a render retains AT MOST this one capture,
-  overwritten by the next render, never accumulating (rf2-vxgfnd.44)."
-  [^ViewCell cell]
-  (:latest-capture @(state cell)))
 
 (defn revision
   "The cell's current revision integer (tool/test read)."

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -15,11 +15,10 @@
       channel, distinct from the prop-driven one memo gates).
     - render RESOLVES + PROBES without ownership (via `reactive/with-capture`
       → `sub` → the observation port's `resolve-target`/`probe`); the
-      LAYOUT commit acquires the CAPTURED targets. Abandoned renders
-      (StrictMode double-render, time-sliced tear-off) acquire no ownership;
-      they retain only their one `:latest-capture` of values until the next
-      render overwrites it (at most one, never accumulating — see
-      `reactive/with-capture`).
+      LAYOUT commit acquires the CAPTURED targets. Each render's effect closes
+      over that render's exact immutable capture. Abandoned renders (StrictMode
+      double-render, time-sliced tear-off) acquire no ownership and publish no
+      speculative capture state to the ViewCell.
     - the reconcile layout effect runs after EVERY committed render and is
       idempotent (kept-check retains unchanged leases untouched); the
       lifecycle layout effect (empty deps) owns connect/disconnect, so
@@ -97,14 +96,15 @@
                                   (fn [] (reactive/get-snapshot cell))
                                   (fn [] 0))
       ;; render-phase: resolve + probe every executed site into a fresh
-      ;; ownership-free capture, stashed on the cell for the layout commit.
-      (let [element (reactive/with-capture cell thunk)]
+      ;; ownership-free capture. The selected Fiber's effect closes over this
+      ;; exact value; speculative sibling renders cannot replace it.
+      (let [[element capture] (reactive/with-capture cell thunk)]
         ;; reconcile — after EVERY committed render; no cleanup (leases are
         ;; owned by the cell and reconciled by the kept-check, never torn
         ;; down between renders — that would churn shared nodes).
         (react/useLayoutEffect
           (fn reconcile []
-            (reactive/commit! cell)
+            (reactive/commit! cell capture)
             js/undefined))
         ;; lifecycle — connect implicitly via the reconcile above; the cleanup
         ;; releases owners on React unmount AND Activity hide (indistinguishable

--- a/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
@@ -1,0 +1,176 @@
+(ns re-frame.ui.exact-render-capture-dom-cljs-test
+  "rf2-vxgfnd.105 — a real React concurrent-render proof for exact capture
+  ownership.
+
+  React renders sibling A, then a Suspense child performs a later B capture on
+  A's exact ViewCell and suspends forever. React commits A plus the fallback
+  and abandons B. The selected A Fiber's layout effect must commit A's immutable
+  capture, never speculative state published by B. StrictMode makes render and
+  effect replay hostile without scheduler mocks."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            ["react" :as React]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.viewcell :as viewcell]))
+
+(def ^:private frame-id :exact-capture/frame)
+
+(defn- browser? [] (exists? js/document))
+
+(use-fixtures
+ :each
+ (test-support/make-reset-runtime-fixture
+  {:adapter ui/adapter :ambient-frame nil :async? true}))
+
+(defn- act-promise [thunk]
+  (try
+    (js/Promise.resolve
+     (React/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- unexpected! [done label e]
+  (is false (str label ": " e))
+  (done))
+
+(defn- observed-component [props]
+  (let [renders (unchecked-get props "renders")]
+    (viewcell/render
+     ::observed
+     (fn []
+       (let [value (reactive/sub-read [::a])]
+         (swap! renders inc)
+         (React/createElement "output" #js {:data-capture "a"}
+                              (str value)))))))
+
+(defn- poison-component [props]
+  (let [cell    (unchecked-get props "cell")
+        blocker (unchecked-get props "blocker")]
+    ;; This is a complete ownership-free render B on A's exact cell. It runs
+    ;; after observed-component captured A, then the stable Promise abandons B.
+    ;; The returned [element capture] pair is deliberately unreachable.
+    (reactive/with-capture cell #(reactive/sub-read [::b]))
+    (throw blocker)))
+
+(defn- hostile-tree [props]
+  (let [poison? (unchecked-get props "poison")
+        cell    (unchecked-get props "cell")
+        renders (unchecked-get props "renders")
+        blocker (unchecked-get props "blocker")]
+    (React/createElement
+     React/Fragment nil
+     (React/createElement observed-component #js {:renders renders})
+     (when poison?
+       (React/createElement
+        React/Suspense
+        #js {:fallback (React/createElement "span"
+                                            #js {:data-capture "fallback"}
+                                            "waiting")}
+        (React/createElement poison-component
+                             #js {:cell cell :blocker blocker}))))))
+
+(defview hostile-root [{:keys [poison? cell renders blocker]}]
+  (ui/raw
+   (React/createElement
+    (.-StrictMode React) nil
+    (React/createElement hostile-tree
+                         #js {:poison poison?
+                              :cell cell
+                              :renders renders
+                              :blocker blocker}))))
+
+(defn- root-form [root poison? cell renders blocker]
+  (ui/render! root
+    [frame-provider {:frame frame-id}
+     [hostile-root {:poison? poison?
+                    :cell cell
+                    :renders renders
+                    :blocker blocker}]]))
+
+(defn- target-key [query]
+  [:sub frame-id query])
+
+(deftest committed-fiber-owns-its-exact-capture-not-later-abandoned-work
+  (if-not (browser?)
+    (is true ":node — the browser gate runs the real Suspense/StrictMode body")
+    (async done
+      (rf/reg-sub ::a (fn [db _] (:a db)))
+      (rf/reg-sub ::b (fn [db _] (:b db)))
+      (rf/make-frame {:id frame-id :doc "exact render capture proof"})
+      (frame/replace-app-db! frame-id {:a 1 :b 10})
+      (let [container  (js/document.createElement "div")
+            roots-base (client/live-root-ids)
+            cells-base (reactive/current-live-cells)
+            root       (ui/create-root container {:root-id :exact-capture/root})
+            renders    (atom 0)
+            blocker    (js/Promise. (fn [_resolve _reject]))
+            mounted    (atom nil)]
+        (.appendChild (.-body js/document) container)
+        (-> (act-promise #(root-form root false nil renders blocker))
+            (.then
+             (fn []
+               (let [cells (set (remove cells-base
+                                        (reactive/current-live-cells)))]
+                 (is (= 1 (count cells))
+                     "the mounted observed component owns one live ViewCell")
+                 (reset! mounted (first cells))
+                 (is (= "1" (.-textContent
+                              (.querySelector container "[data-capture=a]"))))
+                 ;; Update order is A first, then B+throw. Suspense commits the
+                 ;; fallback while A's selected effect must retain capture A.
+                 (act-promise
+                  #(root-form root true @mounted renders blocker)))))
+            (.then
+             (fn []
+               (let [cell @mounted]
+                 (testing "React committed A plus fallback, never B"
+                   (is (= "1" (.-textContent
+                                (.querySelector container "[data-capture=a]"))))
+                   (is (= "waiting" (.-textContent
+                                      (.querySelector container
+                                                      "[data-capture=fallback]"))))
+                   (is (= #{(target-key [::a])}
+                          (reactive/committed-target-keys cell)))
+                   (is (= {(target-key [::a]) 1}
+                          (reactive/committed-values cell)))
+                   (is (nil? (get @(:sub-cache (frame/frame frame-id)) [::b]))
+                       "abandoned B materialised no cache node and owns nothing"))
+                 (let [before-b @renders]
+                   (-> (act-promise
+                        #(frame/replace-app-db! frame-id {:a 1 :b 11}))
+                       (.then
+                        (fn []
+                          (is (= before-b @renders)
+                              "moving abandoned B cannot render the selected view")
+                          (let [before-a @renders]
+                            (-> (act-promise
+                                 #(frame/replace-app-db! frame-id {:a 2 :b 11}))
+                                (.then
+                                 (fn []
+                                   (is (> @renders before-a)
+                                       "moving committed A does render")
+                                   (is (= "2" (.-textContent
+                                               (.querySelector
+                                                container "[data-capture=a]")))))))))))))))
+            (.then
+             (fn []
+               (act-promise #(ui/unmount! root))))
+            (.then
+             (fn []
+               (.remove container)
+               (is (= cells-base (reactive/current-live-cells))
+                   "unmount restores the live-cell baseline")
+               (is (= roots-base (client/live-root-ids))
+                   "unmount restores the public-root baseline")
+               (is (nil? (get @(:sub-cache (frame/frame frame-id)) [::a]))
+                   "unmount releases A's final observation owner")
+               (done)))
+            (.catch
+             (fn [e]
+               (try (ui/unmount! root) (catch :default _ nil))
+               (.remove container)
+               (unexpected! done "exact-capture browser proof rejected" e))))))))

--- a/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
@@ -42,7 +42,8 @@
 ;; frame/require-current-frame! → the :adapter/current-frame hook), recorded
 ;; into a live cell's capture. NOT a direct sub-read.
 (defn- render-cell! [cell queries]
-  (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
+  (first (reactive/with-capture
+          cell (fn [] (mapv reactive/sub-read queries)))))
 
 (deftest reader-is-published-under-plain-atom
   (is (some? (late-bind/get-fn :adapter/current-frame))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
@@ -48,9 +48,10 @@
   id)
 
 (defn- render+commit! [cell fid queries]
-  (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  (reactive/commit! cell)
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv reactive/sub-read queries))))]
+    (reactive/commit! cell capture))
   cell)
 
 ;; ===========================================================================
@@ -84,10 +85,10 @@
                    ;; Commit the fresh cell against the STILL-LIVE frame — it
                    ;; acquires a lease and enrols into the live-cell registry
                    ;; AFTER the sweep already snapshotted.
-                   (rf/with-frame fid
-                     (reactive/with-capture new-cell
-                       (fn [] (reactive/sub-read [:race/a]))))
-                   (reactive/commit! new-cell)
+                   (let [[_ capture] (rf/with-frame fid
+                                       (reactive/with-capture new-cell
+                                         (fn [] (reactive/sub-read [:race/a]))))]
+                     (reactive/commit! new-cell capture))
                    (.countDown committed))]
         ;; Drive the destroy on this thread — it blocks in the wrapped hook
         ;; until the racing commit releases `committed`, then resumes (flip +
@@ -134,10 +135,10 @@
       (let [race (future
                    (.await swept 5 TimeUnit/SECONDS)
                    ;; A commit onto the UNRELATED live frame B, mid-destroy of A.
-                   (rf/with-frame fb
-                     (reactive/with-capture cell-b
-                       (fn [] (reactive/sub-read [:race/a]))))
-                   (reactive/commit! cell-b)
+                   (let [[_ capture] (rf/with-frame fb
+                                       (reactive/with-capture cell-b
+                                         (fn [] (reactive/sub-read [:race/a]))))]
+                     (reactive/commit! cell-b capture))
                    (.countDown committed))]
         (frame/destroy-frame! fa)
         (deref race 5000 ::timeout))
@@ -146,9 +147,9 @@
             "a commit onto a disjoint live frame is untouched by frame A's
              teardown — frame-closing? is false for B, so no global serialization")
         (is (reactive/cell-observes-frame? cell-b fb))
-        (is (= 2 (rf/with-frame fb
-                   (reactive/with-capture cell-b
-                     (fn [] (reactive/sub-read [:race/a])))))
+        (is (= 2 (first (rf/with-frame fb
+                          (reactive/with-capture cell-b
+                            (fn [] (reactive/sub-read [:race/a]))))))
             "frame B reads live after A was destroyed"))
       (testing "frame A's own cell died with A"
         (is (= :dead (reactive/lifecycle cell-a))))

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -68,9 +68,10 @@
   "Render (probe) `queries` under frame `id`, then commit — the cell ends
   observing `id`."
   [cell id queries]
-  (rf/with-frame id
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  (reactive/commit! cell)
+  (let [[_ capture] (rf/with-frame id
+                      (reactive/with-capture
+                       cell (fn [] (mapv reactive/sub-read queries))))]
+    (reactive/commit! cell capture))
   cell)
 
 ;; ===========================================================================
@@ -171,10 +172,13 @@
     (seed! fid (into {} (map (fn [i] [i i])) (range n)))
     (let [cell (reactive/make-cell (keyword (str "g3-cell-" n)))]
       ;; ONE render body invocation drives all n sites (one ViewCell, one hook)
-      (rf/with-frame fid
-        (reactive/with-capture cell
-          (fn [] (swap! body-runs inc) (mapv reactive/sub-read queries))))
-      (reactive/commit! cell)
+      (let [[_ capture] (rf/with-frame fid
+                          (reactive/with-capture
+                           cell
+                           (fn []
+                             (swap! body-runs inc)
+                             (mapv reactive/sub-read queries))))]
+        (reactive/commit! cell capture))
       (is (= 1 @body-runs)
           (str n " sites → ONE body invocation (one shared ViewCell, not " n ")"))
       (is (= n (count (reactive/committed-target-keys cell)))
@@ -374,7 +378,7 @@
                  (reactive/with-capture cell
                    (fn [] [(reactive/sub-read [:s/a])
                            (reactive/sub-read [:s/b])])))]
-      (is (= [[:a 5] [:b 5]] out))
+      (is (= [[:a 5] [:b 5]] (first out)))
       (is (= 1 @parent-runs)
           "sibling cold probes in ONE render compute the shared parent ONCE
            via the slice-scoped memo threaded through sub-read")

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -45,9 +45,10 @@
   (:ref-count (get @(:sub-cache (frame/frame fid)) q)))
 
 (defn- render+commit! [cell fid queries]
-  (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  (reactive/commit! cell)
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv reactive/sub-read queries))))]
+    (reactive/commit! cell capture))
   cell)
 
 (defn- throws-id [thunk]
@@ -179,9 +180,10 @@
               being caught in that throw"
       (is (= :dead (reactive/lifecycle cell))))
     (testing "a :dead cell still fails loudly on re-commit — no resume (03 §4)"
-      (rf/with-frame fid
-        (reactive/with-capture cell (fn [] nil)))
-      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))))))
+      (let [[_ capture] (rf/with-frame fid
+                          (reactive/with-capture cell (fn [] nil)))]
+        (is (= :rf.error/frame-destroyed
+               (throws-id #(reactive/commit! cell capture))))))))
 
 ;; ===========================================================================
 ;; The sweep is frame-scoped — a sibling frame's cells are untouched
@@ -204,6 +206,6 @@
           "the sibling frame's lease is neither released nor churned")
       (is (reactive/cell-observes-frame? cell-b fb)))
     (testing "the sibling frame still reads live"
-      (is (= 2 (rf/with-frame fb
-                 (reactive/with-capture cell-b
-                   (fn [] (reactive/sub-read [:td/a])))))))))
+      (is (= 2 (first (rf/with-frame fb
+                        (reactive/with-capture cell-b
+                          (fn [] (reactive/sub-read [:td/a]))))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -175,6 +175,24 @@
     (reactive/advance-generation! cell 5)
     (is (= 5 (reactive/generation cell)))))
 
+(deftest same-generation-selected-capture-survives-later-abandoned-capture
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
+        lease-a (reactive/committed-lease cell (tk [:r/a]))
+        [_ cap-a] (render! cell [[:r/a]])
+        [_ cap-b] (render! cell [[:r/b]])]
+    (is (= 0 (:generation cap-a) (:generation cap-b))
+        "same-signature/same-generation work needs no generation fence")
+    ;; Model React selecting A while the later B Fiber is abandoned. The exact
+    ;; effect closure commits A; B cannot redirect the same-generation commit.
+    (reactive/commit! cell cap-a)
+    (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell)))
+    (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
+        "same-signature A preserves the exact live lease")
+    (is (nil? (entry [:r/b])) "abandoned B owns and materialises nothing")))
+
 ;; ===========================================================================
 ;; Cell 3 — site identity survives edits (target identity, not position)
 ;; ===========================================================================

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -68,12 +68,11 @@
 
 (defn- render! [cell queries]
   (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  cell)
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries)))))
 
 (defn- render+commit! [cell queries]
-  (render! cell queries)
-  (reactive/commit! cell)
+  (let [[_ capture] (render! cell queries)]
+    (reactive/commit! cell capture))
   cell)
 
 ;; ===========================================================================
@@ -145,7 +144,7 @@
           "the remounted shell is a FRESH cell — no committed deps (fresh state)"))))
 
 ;; ===========================================================================
-;; Cell 2 — stale-cell rejection at commit (step 1): the same-shell reload
+;; Cell 2 — stale-capture rejection at commit (step 1): generation remount seam
 ;; ===========================================================================
 
 (deftest stale-generation-capture-rejected-at-commit-step-1
@@ -154,21 +153,20 @@
   (let [cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
         lease0 (reactive/committed-lease cell (tk [:r/a]))]
     (is (= 1 (ref-count [:r/a])) "precondition: committed at generation 0")
-    (testing "a reload BUMPS the live cell's body generation; its in-flight
+    (testing "a changed-signature remount BUMPS the cell generation; its in-flight
               capture (rendered under the prior body) is now stale"
-      (render! cell [[:r/a]])                       ; capture at generation 0
-      (reactive/advance-generation! cell 1)         ; the same-shell reload bump
-      (is (= 1 (reactive/generation cell)))
-      (is (= :stale (reactive/commit! cell))
-          "commit step 1 REJECTS the stale-generation capture (the host re-renders)"))
+      (let [[_ capture] (render! cell [[:r/a]])]    ; capture at generation 0
+        (reactive/advance-generation! cell 1)       ; changed-signature remount
+        (is (= 1 (reactive/generation cell)))
+        (is (= :stale (reactive/commit! cell capture))
+            "commit step 1 REJECTS the stale-generation capture (the host re-renders)")))
     (testing "no ownership was touched — the prior committed set stays installed"
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a]))))
       (is (= 1 (ref-count [:r/a])) "no acquire, no release on a stale rejection"))
-    (testing "the re-render under the new body commits normally — state preserved"
+    (testing "a fresh render under the new generation commits normally"
       (render+commit! cell [[:r/a]])
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
-          "the same lease is retained across the reload — the committed dep set
-           is carried forward (a same-signature preserve)"))))
+          "the same live target retains its lease across the explicit generation seam"))))
 
 (deftest advance-generation-is-monotone
   (let [cell (reactive/make-cell ::v 2)]

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -66,8 +66,9 @@
         token-a (frame/frame-incarnation-token fid)
         cell    (reactive/make-cell ::v)]
     ;; render probes incarnation A (ownership-free)
-    (rf/with-frame fid
-      (reactive/with-capture cell (fn [] (reactive/sub-read [:ic/a]))))
+    (let [[_ capture] (rf/with-frame fid
+                        (reactive/with-capture
+                         cell (fn [] (reactive/sub-read [:ic/a]))))]
     ;; commit: step 4 acquires A's lease + step 5 reads it (A still live), THEN
     ;; the :post-acquire seam fully destroys A and recreates B under the same id
     ;; BEFORE the publish. The incarnation-safe revalidation must join THIS commit
@@ -77,7 +78,7 @@
                 (when (= :post-acquire phase)
                   (frame/destroy-frame! fid)     ;; A fully destroyed (marker cleared)
                   (make-frame! fid {:a 99})))]    ;; B — a DISTINCT incarnation, new state
-      (reactive/commit! cell))
+      (reactive/commit! cell capture)))
     (testing "precondition — B is a distinct incarnation under the reused id"
       (is (not (identical? token-a (frame/frame-incarnation-token fid)))
           "destroy + recreate minted a fresh incarnation token")
@@ -96,9 +97,10 @@
       ;; it isolates B's OWN read. The dead cell already left every registry.
       (reactive/reset-scheduler!)
       (let [cell-b (reactive/make-cell ::b)]
-        (rf/with-frame fid
-          (reactive/with-capture cell-b (fn [] (reactive/sub-read [:ic/a]))))
-        (reactive/commit! cell-b)
+        (let [[_ capture] (rf/with-frame fid
+                            (reactive/with-capture
+                             cell-b (fn [] (reactive/sub-read [:ic/a]))))]
+          (reactive/commit! cell-b capture))
         (is (= :connected (reactive/lifecycle cell-b)) "B's own cell connects")
         (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys cell-b))
             "B's cell owns B's node")
@@ -118,9 +120,10 @@
   (rf/reg-sub :ic/a (fn [db _] (:a db)))
   (let [fid  (make-frame! :ic/frame2 {:a 1})
         cell (reactive/make-cell ::v)]
-    (rf/with-frame fid
-      (reactive/with-capture cell (fn [] (reactive/sub-read [:ic/a]))))
-    (reactive/commit! cell)
+    (let [[_ capture] (rf/with-frame fid
+                        (reactive/with-capture
+                         cell (fn [] (reactive/sub-read [:ic/a]))))]
+      (reactive/commit! cell capture))
     (is (= :connected (reactive/lifecycle cell))
         "no supersede, no close ⇒ ordinary connected commit (incarnation check is false)")
     (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys cell)))))

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
@@ -97,9 +97,10 @@
         ;; Commit B's cell IN the window. The incarnation-scoped revalidation must
         ;; resolve against B's acquired token, NOT A's stale bare-id marker.
         (try
-          (rf/with-frame fid
-            (reactive/with-capture b-cell (fn [] (reactive/sub-read [:ic/a]))))
-          (reactive/commit! b-cell)
+          (let [[_ capture] (rf/with-frame fid
+                              (reactive/with-capture
+                               b-cell (fn [] (reactive/sub-read [:ic/a]))))]
+            (reactive/commit! b-cell capture))
           (catch Throwable e (reset! b-error e)))
         (.countDown b-done)
         (is (nil? (deref destroy 5000 ::timeout)) "A's destroy completes cleanly"))

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -52,15 +52,14 @@
 
 (defn- render!
   "Simulate one render pass: run the site probes into a fresh capture under
-  the ambient frame. Returns the cell."
+  the ambient frame. Returns `[render-value immutable-capture]`."
   [cell queries]
   (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  cell)
+    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries)))))
 
 (defn- render+commit! [cell queries]
-  (render! cell queries)
-  (reactive/commit! cell)
+  (let [[_ capture] (render! cell queries)]
+    (reactive/commit! cell capture))
   cell)
 
 (defn- throws-id [thunk]
@@ -87,34 +86,28 @@
       (is (nil? (entry [:r/b]))
           "the 10k-abandoned-renders-retain-zero property holds at the cell"))))
 
-(deftest abandoned-render-retains-at-most-one-capture
-  ;; rf2-vxgfnd.44 (finding b) — an abandoned render acquires no OWNERSHIP
-  ;; (proven above), but it DOES stash its one `:latest-capture` of values, which
-  ;; lingers until the next render overwrites it. The honest bound is AT MOST ONE
-  ;; capture retained per cell — never accumulating. (`with-capture` cannot clear
-  ;; on abandon: StrictMode's effect replay re-commits the SAME capture with no
-  ;; intervening render, so the stash is REQUIRED, not a leak — hence the
-  ;; docstring is the fix, not a clear.)
+(deftest commit-is-bound-to-the-exact-render-capture
+  ;; rf2-vxgfnd.105 — React retains the selected render's effect closure. A
+  ;; later speculative render of the same cell must not replace that closure's
+  ;; commit input through shared ViewCell state.
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (rf/reg-sub :r/b (fn [db _] (:b db)))
   (seed! {:a 1 :b 2})
   (let [cell (reactive/make-cell ::v)]
-    (is (nil? (reactive/latest-capture cell)) "no capture before the first render")
-    ;; an abandoned render (never committed) stashes exactly its one capture
-    (render! cell [[:r/a]])
-    (let [cap1 (reactive/latest-capture cell)]
-      (is (some? cap1) "the abandoned render retained its capture")
-      (is (= [(tk [:r/a])] (:order cap1)) "the capture holds this render's site")
-      ;; the NEXT render OVERWRITES it — captures never accumulate
-      (render! cell [[:r/b]])
-      (let [cap2 (reactive/latest-capture cell)]
-        (is (not (identical? cap1 cap2)) "the next render replaced the capture")
-        (is (= [(tk [:r/b])] (:order cap2))
-            "exactly ONE capture retained — the latest; the prior is gone")))
-    ;; N further abandoned renders still leave exactly ONE capture, not N
-    (dotimes [_ 1000] (render! cell [[:r/a]]))
-    (is (= [(tk [:r/a])] (:order (reactive/latest-capture cell)))
-        "1000 abandoned renders retain ONE capture (the last) — never accumulate")))
+    (let [[a-value cap-a] (render! cell [[:r/a]])
+          [b-value cap-b] (render! cell [[:r/b]])]
+      (is (= [1] a-value))
+      (is (= [2] b-value))
+      (is (= [(tk [:r/a])] (:order cap-a))
+          "A remains immutable after the later speculative B capture")
+      (is (= [(tk [:r/b])] (:order cap-b)))
+      ;; Model React selecting A and abandoning B: only A's effect closure runs.
+      (reactive/commit! cell cap-a)
+      (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell))
+          "the selected render commits its own capture, never the later B")
+      (is (= 1 (ref-count [:r/a])))
+      (is (nil? (entry [:r/b]))
+          "the abandoned capture materialises no node and owns nothing"))))
 
 ;; ===========================================================================
 ;; commit installs + reads; kept-check retains untouched
@@ -159,15 +152,15 @@
   (rf/reg-sub :r/b (fn [db _] (:b db)))
   (rf/reg-sub :r/c (fn [db _] (:c db)))
   (seed! {:a 1 :b 2 :c 3})
-  (let [cell (reactive/make-cell ::v)]
+  (let [cell (reactive/make-cell ::v)
+        [_ capture] (render! cell [[:r/a] [:r/b] [:r/c]])]
     ;; probe all three (all registered, all cold — no cache nodes yet)
-    (render! cell [[:r/a] [:r/b] [:r/c]])
     ;; make the THIRD acquire throw: unregister :r/c between render and commit
     (subs/clear-sub :r/c)
     (testing "the k-th acquisition failure rolls the staged leases back and
               leaves the prior (empty) committed set installed"
       (is (= :rf.error/no-such-sub
-             (throws-id #(reactive/commit! cell)))
+             (throws-id #(reactive/commit! cell capture)))
           "the acquisition's typed error propagates")
       (is (empty? (reactive/committed-target-keys cell))
           "no lease is installed — the reconcile aborted")
@@ -184,9 +177,10 @@
         lease0 (reactive/committed-lease cell (tk [:r/a]))]
     (is (= 1 (ref-count [:r/a])) ":a committed with one owner")
     ;; new render observes :a (retained) + :b (new) + :c (new); :c will throw
-    (render! cell [[:r/a] [:r/b] [:r/c]])
-    (subs/clear-sub :r/c)
-    (is (= :rf.error/no-such-sub (throws-id #(reactive/commit! cell))))
+    (let [[_ capture] (render! cell [[:r/a] [:r/b] [:r/c]])]
+      (subs/clear-sub :r/c)
+      (is (= :rf.error/no-such-sub
+             (throws-id #(reactive/commit! cell capture)))))
     (testing "the node shared with the prior committed set survives rollback"
       (is (= 1 (ref-count [:r/a])) ":a keeps its prior owner — never re-acquired, never released")
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a]))))
@@ -201,11 +195,11 @@
 (deftest moved-evidence-advances-revision
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
-  (let [cell (reactive/make-cell ::v)]
-    (render! cell [[:r/a]])                 ;; probe observed value 1 (cold)
+  (let [cell (reactive/make-cell ::v)
+        [_ capture] (render! cell [[:r/a]])] ;; probe observed value 1 (cold)
     (is (= 0 (reactive/revision cell)))
     (seed! {:a 2})                          ;; move in the render→commit gap
-    (reactive/commit! cell)                 ;; acquire+read observes 2 ≠ 1
+    (reactive/commit! cell capture)         ;; acquire+read observes 2 ≠ 1
     (is (= 1 (reactive/revision cell))
         "movement between probe and acquire advances the revision (corrects before paint)")))
 
@@ -233,9 +227,9 @@
         lease0 (reactive/committed-lease cell (tk [:r/a]))]
     (is (= 0 (reactive/revision cell)) "precondition: committed, no revision yet")
     (is (= {(tk [:r/a]) 1} (reactive/committed-values cell)))
-    (render! cell [[:r/a]])                 ;; render B probes the live node (value 1)
-    (seed! {:a 2})                          ;; move in the render→commit gap
-    (reactive/commit! cell)                 ;; kept-check RETAINS the lease
+    (let [[_ capture] (render! cell [[:r/a]])] ;; render B probes value 1
+      (seed! {:a 2})                        ;; move in the render→commit gap
+      (reactive/commit! cell capture))      ;; kept-check RETAINS the lease
     (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
         "the site was RETAINED (same lease) — a kept, not staged/retargeted, site")
     (is (= 1 (reactive/revision cell))
@@ -248,9 +242,9 @@
   ;; retained site reads the same version/node-key across the render→commit gap.
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
-  (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])]
-    (render! cell [[:r/a]])                 ;; render B — no seed between probe + commit
-    (reactive/commit! cell)
+  (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])
+        [_ capture] (render! cell [[:r/a]])] ;; render B — no gap movement
+    (reactive/commit! cell capture)
     (is (= 0 (reactive/revision cell))
         "an unchanged retained site reads the same evidence ⇒ no false advance")))
 
@@ -272,25 +266,26 @@
     ;; render probes a LIVE node (hold a subscribe ref so the ownership-free
     ;; probe reads a canonical node — captures node-key K_A at version 0).
     (subs/subscribe [:re/v] {:frame :re/frame})
-    (rf/with-frame :re/frame
-      (reactive/with-capture cell (fn [] (reactive/sub-read [:re/v]))))
-    (is (= 0 (reactive/revision cell)) "precondition: no revision yet")
-    ;; reincarnate in the gap: identical construction + a single replace-app-db!
-    ;; makes node-version + frame/registry epochs COINCIDE with the destroyed
-    ;; incarnation's (dissoc restarts the commit epoch, fresh node ⟹ version 0,
-    ;; no :sub re-registration) — only the FRESH reaction's node-key differs.
-    (frame/destroy-frame! :re/frame)
-    (live-frame/make-frame {:id :re/frame})
-    (frame/replace-app-db! :re/frame {:v 1})
-    ;; commit acquires the FRESH node K_B; read K_B ≠ probe K_A ⟹ moved via the
-    ;; node-key axis alone (version+epoch tie) ⟹ corrective revision advance.
-    (reactive/commit! cell)
-    (is (= 1 (reactive/revision cell))
-        "same-id reincarnation classified MOVED via :node-key — a corrective
-         render before paint (version+epoch alone MISS it — the pre-fix break)")
-    (is (= :connected (reactive/lifecycle cell))
-        "resolved against the LIVE fresh incarnation it acquired — not torn down")
-    (frame/destroy-frame! :re/frame)))
+    (let [[_ capture] (rf/with-frame :re/frame
+                        (reactive/with-capture
+                         cell (fn [] (reactive/sub-read [:re/v]))))]
+      (is (= 0 (reactive/revision cell)) "precondition: no revision yet")
+      ;; reincarnate in the gap: identical construction + a single replace-app-db!
+      ;; makes node-version + frame/registry epochs COINCIDE with the destroyed
+      ;; incarnation's (dissoc restarts the commit epoch, fresh node ⟹ version 0,
+      ;; no :sub re-registration) — only the FRESH reaction's node-key differs.
+      (frame/destroy-frame! :re/frame)
+      (live-frame/make-frame {:id :re/frame})
+      (frame/replace-app-db! :re/frame {:v 1})
+      ;; commit acquires the FRESH node K_B; read K_B ≠ probe K_A ⟹ moved via the
+      ;; node-key axis alone (version+epoch tie) ⟹ corrective revision advance.
+      (reactive/commit! cell capture)
+      (is (= 1 (reactive/revision cell))
+          "same-id reincarnation classified MOVED via :node-key — a corrective
+           render before paint (version+epoch alone MISS it — the pre-fix break)")
+      (is (= :connected (reactive/lifecycle cell))
+          "resolved against the LIVE fresh incarnation it acquired — not torn down")
+      (frame/destroy-frame! :re/frame))))
 
 (deftest unchanged-live-node-across-commit-does-not-false-advance
   ;; The node-key fast-path guard (rf2-vxgfnd.14 AC #4, at the ui layer): a
@@ -302,9 +297,10 @@
   (frame/replace-app-db! :re/frame2 {:v 7})
   (let [cell (reactive/make-cell ::v)]
     (subs/subscribe [:re/v] {:frame :re/frame2})   ;; a live canonical node
-    (rf/with-frame :re/frame2
-      (reactive/with-capture cell (fn [] (reactive/sub-read [:re/v]))))
-    (reactive/commit! cell)                         ;; same live node at commit
+    (let [[_ capture] (rf/with-frame :re/frame2
+                        (reactive/with-capture
+                         cell (fn [] (reactive/sub-read [:re/v]))))]
+      (reactive/commit! cell capture))               ;; same live node at commit
     (is (= 0 (reactive/revision cell))
         "an unchanged live node reads the same node-key — no false movement")
     (frame/destroy-frame! :re/frame2)))
@@ -430,8 +426,9 @@
            (peek (reactive/intervals cell)))
         "an explicit host/root teardown proves the interval ended in unmount")
     (testing "a :dead cell fails loudly on re-commit — no resume"
-      (render! cell [[:r/a]])
-      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))))))
+      (let [[_ capture] (render! cell [[:r/a]])]
+        (is (= :rf.error/frame-destroyed
+               (throws-id #(reactive/commit! cell capture))))))))
 
 (deftest teardown-from-connected-records-unmount
   (rf/reg-sub :r/a (fn [db _] (:a db)))
@@ -456,8 +453,9 @@
     ;; a fresh-but-rf=-equal value on the next render returns the committed
     ;; reference (identical?), so downstream memo sees no change
     (seed! {:coll [1 2 3]})    ;; equal value, different object identity
-    (let [ret (rf/with-frame fid
-                (reactive/with-capture cell (fn [] (reactive/sub-read [:r/coll]))))]
+    (let [[ret _] (rf/with-frame fid
+                    (reactive/with-capture
+                     cell (fn [] (reactive/sub-read [:r/coll]))))]
       (is (identical? committed ret)
           "an rf=-stable read returns the prior exact value (stabilized identity)"))))
 

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -48,9 +48,10 @@
   (:ref-count (get @(:sub-cache (frame/frame fid)) q)))
 
 (defn- render+commit! [cell fid queries]
-  (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-  (reactive/commit! cell)
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv reactive/sub-read queries))))]
+    (reactive/commit! cell capture))
   cell)
 
 (defn- mount!
@@ -107,9 +108,11 @@
     (is (= :dead (reactive/lifecycle cell)))
     (testing "a retained handle recommit fails through the dead-cell lifecycle,
               not by probing a torn-down context (03 §4; commit! step 2)"
-      (rf/with-frame fid
-        (reactive/with-capture cell (fn [] (reactive/sub-read [:rt/a]))))
-      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))))))
+      (let [[_ capture] (rf/with-frame fid
+                          (reactive/with-capture
+                           cell (fn [] (reactive/sub-read [:rt/a]))))]
+        (is (= :rf.error/frame-destroyed
+               (throws-id #(reactive/commit! cell capture))))))))
 
 ;; ===========================================================================
 ;; The Activity-hide transient path is untouched — a hide never goes :dead
@@ -171,10 +174,12 @@
       (is (= 0 (reactive/root-cell-count inc)) "no membership lingers for the incarnation")
       (is (= 0 (reactive/root-cell-count)) "no historical incarnation retained"))
     (testing "the reaped cell fails a recommit through the dead-cell lifecycle"
-      (rf/with-frame fid
-        (reactive/with-capture cell (fn [] (reactive/sub-read [:rt/a]))))
-      (is (= :rf.error/frame-destroyed (throws-id #(reactive/commit! cell)))
-          "a retained handle cannot reconnect after its root is gone"))))
+      (let [[_ capture] (rf/with-frame fid
+                          (reactive/with-capture
+                           cell (fn [] (reactive/sub-read [:rt/a]))))]
+        (is (= :rf.error/frame-destroyed
+               (throws-id #(reactive/commit! cell capture)))
+            "a retained handle cannot reconnect after its root is gone")))))
 
 (deftest a-hide-without-root-teardown-stays-reconnectable
   ;; The discriminator: an Activity hide with NO root teardown must stay
@@ -281,9 +286,9 @@
       (is (= 1 (ref-count fid [:rt/a]))
           "the sibling's lease is neither released nor churned"))
     (testing "the sibling cell still reads live"
-      (is (= 1 (rf/with-frame fid
-                 (reactive/with-capture cell-b
-                   (fn [] (reactive/sub-read [:rt/a])))))))))
+      (is (= 1 (first (rf/with-frame fid
+                        (reactive/with-capture cell-b
+                          (fn [] (reactive/sub-read [:rt/a]))))))))))
 
 ;; ===========================================================================
 ;; A throwing host `.unmount` — generation evidence governs the fail-closed reap

--- a/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
@@ -56,9 +56,10 @@
   [root-id fid queries]
   (let [cell (reactive/make-cell ::v)]
     (reactive/attach-root! cell (root-incarnation root-id))
-    (rf/with-frame fid
-      (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-    (reactive/commit! cell)
+    (let [[_ capture] (rf/with-frame fid
+                        (reactive/with-capture
+                         cell (fn [] (mapv reactive/sub-read queries))))]
+      (reactive/commit! cell capture))
     cell))
 
 (deftest register-mints-a-fresh-incarnation-per-root
@@ -109,9 +110,10 @@
       ;; an unsettled same-commit reconnect is a StrictMode dev replay and must
       ;; NOT be proven a hide (rf2-vxgfnd.44).
       (reactive/settle-disconnect! cell)
-      (rf/with-frame :ri/frame
-        (reactive/with-capture cell (fn [] (reactive/sub-read [:ri/a]))))
-      (reactive/commit! cell)
+      (let [[_ capture] (rf/with-frame :ri/frame
+                          (reactive/with-capture
+                           cell (fn [] (reactive/sub-read [:ri/a]))))]
+        (reactive/commit! cell capture))
       (is (= :connected (reactive/lifecycle cell)))
       (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
              (peek (reactive/intervals cell)))

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -30,9 +30,10 @@
 
 (defn- connected-cell! [fid queries]
   (let [cell (reactive/make-cell ::v)]
-    (rf/with-frame fid
-      (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries))))
-    (reactive/commit! cell)
+    (let [[_ capture] (rf/with-frame fid
+                        (reactive/with-capture
+                         cell (fn [] (mapv reactive/sub-read queries))))]
+      (reactive/commit! cell capture))
     cell))
 
 (defn- register!


### PR DESCRIPTION
## What changed

- bind each ViewCell commit effect to the immutable capture produced by that exact React render
- remove the shared `:latest-capture` handoff that allowed an abandoned render to overwrite a committed render's ownership set
- migrate the internal callers and lifecycle fixtures to the exact-capture contract
- add deterministic real-React Suspense/StrictMode coverage proving abandoned captures cannot acquire ownership

## Why

React may execute a speculative render after the render that ultimately commits. A shared latest-capture slot let that abandoned render replace the subscription/resource set later consumed by the committed effect. This change makes ownership follow React's selected Fiber and closes the concurrency race before `ui/lease` lands.

## Validation

- independent review of the two-commit change was APPROVED on the previous base
- rebased onto PR #5808 head `3d1e1014198ae82256f53a71a9d869cbfe08bb7d`
- `git range-diff` reports both commits patch-equivalent (`=`)
- `git diff --check` passes
- full CI is intentionally running on this ready stacked PR

Bead: `rf2-vxgfnd.105`