### PR TITLE
feat(ui): preserve state through Fast Refresh

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -816,7 +816,11 @@
 ;; machinery all became unreachable together.
 
 (defview hmr-shell-elision-probe []
-  [:span "production-direct-memo-probe"])
+  ;; A real reactive compiled body roots ViewCell render + commit in both
+  ;; advanced builds. The element is never host-rendered by this grep probe, so
+  ;; no frame is needed at runtime.
+  [:span "production-direct-memo-probe"
+   (ui/sub [:rf.probe/ui-override])])
 
 (defn ^:export touch-ui-hmr-shell! []
   (react/createElement hmr-shell-elision-probe nil))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -44,7 +44,8 @@
   Note the probe does NOT need to assert anything at runtime; it exists
   to root the dead-code-elimination graph at every surface. The grep
   test is the assertion."
-  (:require [re-frame.core         :as rf]
+  (:require ["react" :as react]
+            [re-frame.core         :as rf]
  [re-frame.frame :as frame]
             [re-frame.registrar    :as registrar]
             [re-frame.schemas      :as schemas]
@@ -97,6 +98,7 @@
             ;; the shared validator's " :sub-override value failed schema "
             ;; reason string (reachable ONLY from the two gated override
             ;; consults) must NOT survive.
+            [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.reactive :as ui-reactive]))
 
 ;; ---- trace listener API ---------------------------------------------------
@@ -805,10 +807,25 @@
       (ui-reactive/sub-read [:rf.probe/ui-override]))
     (catch :default _ nil)))
 
+;; ---- rf2-8hf77d: compiled-view Fast Refresh shell DCE ---------------------
+;;
+;; This actual defview roots both emitter arms in the DEBUG=true control build.
+;; In production the explicit goog.DEBUG branch must collapse to the direct
+;; React.memo arm. The `:rf.ui.hmr/*` slot keys are therefore absent only when
+;; the slot, listener store, dynamic descriptor lookup, and extra inner Fiber
+;; machinery all became unreachable together.
+
+(defview hmr-shell-elision-probe []
+  [:span "production-direct-memo-probe"])
+
+(defn ^:export touch-ui-hmr-shell! []
+  (react/createElement hmr-shell-elision-probe nil))
+
 (defn ^:export run []
   (touch-direct-emit-diagnostics!)
   (touch-drain-depth!)
   (touch-ui-sub-overrides!)
+  (touch-ui-hmr-shell!)
   (touch-trace!)
   (touch-schemas!)
   (touch-registrar!)

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -811,7 +811,7 @@
 ;;
 ;; This actual defview roots both emitter arms in the DEBUG=true control build.
 ;; In production the explicit goog.DEBUG branch must collapse to the direct
-;; React.memo arm. The `:rf.ui.hmr/*` slot keys are therefore absent only when
+;; React.memo arm. The private HMR slot keys are therefore absent only when
 ;; the slot, listener store, dynamic descriptor lookup, and extra inner Fiber
 ;; machinery all became unreachable together.
 

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -610,13 +610,13 @@ const DEV_ONLY_SENTINELS = [
   // graph unreachable: revision/remount store, listeners, dynamic descriptor
   // lookup, and the keyed inner Fiber disappear together.
   { source: 're-frame.ui Fast Refresh slot (body revision/listener store)',
-    sentinel: 'rf.ui.hmr/body-revision' },
+    sentinel: 'hmr-body-revision' },
   { source: 're-frame.ui Fast Refresh slot (hook-incompatibility remount key)',
-    sentinel: 'rf.ui.hmr/remount-generation' },
+    sentinel: 'hmr-remount-generation' },
   { source: 're-frame.ui Fast Refresh slot (dynamic descriptor lookup)',
-    sentinel: 'rf.ui.hmr/descriptor' },
+    sentinel: 'hmr-descriptor' },
   { source: 're-frame.ui Fast Refresh slot (stable inner extra Fiber)',
-    sentinel: 'rf.ui.hmr/inner' }
+    sentinel: 'hmr-inner' }
   // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
   // once warning + its emit helper were RETIRED (EP-0002; superseded by
   // the always-on :rf.error/no-frame-context). There is no longer any

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -603,7 +603,20 @@ const DEV_ONLY_SENTINELS = [
   // (DEBUG=true) contains it via that consult. The fragment is the distinctive
   // middle of the reason string, unambiguous under a global grep.
   { source: 're-frame.subs.override-schema/validate-sub-override! (:sub-override schema-failure reason)',
-    sentinel: ' :sub-override value failed schema ' }
+    sentinel: ' :sub-override value failed schema ' },
+  // re-frame.ui Fast Refresh stable shell (rf2-8hf77d). The elision probe
+  // contains a real compiled defview, so DEBUG=true roots the stable shell's
+  // one slot. DEBUG=false must choose direct React.memo and make the whole slot
+  // graph unreachable: revision/remount store, listeners, dynamic descriptor
+  // lookup, and the keyed inner Fiber disappear together.
+  { source: 're-frame.ui Fast Refresh slot (body revision/listener store)',
+    sentinel: 'rf.ui.hmr/body-revision' },
+  { source: 're-frame.ui Fast Refresh slot (hook-incompatibility remount key)',
+    sentinel: 'rf.ui.hmr/remount-generation' },
+  { source: 're-frame.ui Fast Refresh slot (dynamic descriptor lookup)',
+    sentinel: 'rf.ui.hmr/descriptor' },
+  { source: 're-frame.ui Fast Refresh slot (stable inner extra Fiber)',
+    sentinel: 'rf.ui.hmr/inner' }
   // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
   // once warning + its emit helper were RETIRED (EP-0002; superseded by
   // the always-on :rf.error/no-frame-context). There is no longer any

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -124,6 +124,9 @@ function assertDevResult(result) {
   if (result['queued-writes'] !== 8 || result['affected-viewcells'] !== 8) {
     fail('Q/C cardinalities are not 8/8');
   }
+  if (result['fixed-shell-idle-cells'] !== 2) {
+    fail('fixed HMR shell cardinality is not exactly two ownership-empty cells');
+  }
   if (result['timing-posture'] !== 'evidence-only; no threshold') {
     fail('timing evidence grew a threshold posture');
   }
@@ -133,6 +136,9 @@ function assertDevResult(result) {
     if (![100, 500].includes(size.v)) fail(`unexpected V=${size.v}`);
     if (!sameJson(size.cold.projection, expected)) {
       fail(`cold projection drift at V=${size.v}: ${JSON.stringify(size.cold.projection)}`);
+    }
+    if (size.cold['fixed-shell-idle-cells'] !== 2) {
+      fail(`cold sample at V=${size.v} lost the two ownership-empty HMR shells`);
     }
     if (!Array.isArray(size.samples) || size.samples.length !== 9) {
       fail(`V=${size.v} did not retain exactly nine warm samples`);
@@ -148,6 +154,9 @@ function assertDevResult(result) {
     for (const sample of size.samples) {
       if (!sameJson(sample.projection, expected)) {
         fail(`warm projection drift at V=${size.v}/${sample.label}`);
+      }
+      if (sample['fixed-shell-idle-cells'] !== 2) {
+        fail(`warm sample at V=${size.v}/${sample.label} lost the empty HMR shells`);
       }
     }
     projections.push(size.cold.projection);

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -28,21 +28,30 @@
         hot   (filterv #(= [::fixture/hot] (cell-query %)) cells)
         cold  (filterv #(let [q (cell-query %)]
                           (and (vector? q) (= ::fixture/cold (first q))))
-                       cells)]
-    (ensure! (= v (count cells)) "mounted ViewCell cardinality drift"
-             {:v v :cells (count cells)})
+                       cells)
+        idle  (filterv #(empty? (reactive/committed-target-keys %)) cells)
+        owning (into [] (concat hot cold))]
+    (ensure! (= v (count owning)) "ownership-bearing ViewCell cardinality drift"
+             {:v v :owning (count owning) :cells (count cells)})
     (ensure! (= fixture/hot-count (count hot)) "hot ViewCell cardinality drift"
              {:v v :hot (count hot)})
     (ensure! (= (- v fixture/hot-count) (count cold))
              "cold ViewCell cardinality drift"
              {:v v :cold (count cold)})
-    {:all cells :hot hot :cold cold}))
+    (ensure! (= fixture/idle-shell-count (count idle))
+             "fixed-shell empty ViewCell cardinality drift"
+             {:v v :expected fixture/idle-shell-count :idle (count idle)})
+    (ensure! (= (set cells) (set (concat owning idle)))
+             "a mounted ViewCell was neither an owner nor an empty shell"
+             {:v v :cells (count cells) :owning (count owning)
+              :idle (count idle)})
+    {:all cells :owning owning :hot hot :cold cold :idle idle}))
 
 (defn- deltas [cells before]
   (mapv #(- (reactive/revision %) (get before %)) cells))
 
 (defn- sample! [root frame v label]
-  (let [{:keys [all hot cold]} (split-cells v)
+  (let [{:keys [all hot cold idle]} (split-cells v)
         before (into {} (map (juxt identity reactive/revision)) all)
         pre    (atom nil)]
     (fixture/reset-counters!)
@@ -56,6 +65,7 @@
                      {:pending (reactive/pending-cell-count)
                       :hot-dirty (count (filter reactive/dirty? hot))
                       :cold-dirty (count (filter reactive/dirty? cold))
+                      :idle-dirty (count (filter reactive/dirty? idle))
                       :revision-delta (reduce + (deltas all before))
                       :evidence-counts
                       (mapv #(get (reactive/pending-evidence %) :count) hot)
@@ -64,6 +74,7 @@
            (fn []
              (let [hot-deltas  (deltas hot before)
                  cold-deltas (deltas cold before)
+                 idle-deltas (deltas idle before)
                  counters    (fixture/counter-snapshot)
                  projection  {:enrolled (:pending @pre)
                               :advances (count (filter #(= 1 %) hot-deltas))
@@ -80,7 +91,7 @@
                               :hot-renders-by-index (vec (repeat 8 1))
                               :cold-renders 0 :root-commits 1
                               :hot-base 8 :stable-parent 8 :cold-leaf 0}]
-             (ensure! (= {:pending 8 :hot-dirty 8 :cold-dirty 0
+             (ensure! (= {:pending 8 :hot-dirty 8 :cold-dirty 0 :idle-dirty 0
                           :revision-delta 0
                           :evidence-counts (vec (repeat 8 8))
                           :counters {:writes 8 :hot-base 8 :stable-parent 8
@@ -94,6 +105,9 @@
                       {:v v :label label :expected expected :actual projection})
              (ensure! (every? zero? cold-deltas) "a cold ViewCell advanced"
                       {:v v :label label :cold-deltas cold-deltas})
+             (ensure! (every? zero? idle-deltas)
+                      "an ownership-empty fixed-shell ViewCell advanced"
+                      {:v v :label label :idle-deltas idle-deltas})
              (ensure! (zero? (reactive/pending-cell-count))
                       "dirty registry did not drain" {:v v :label label})
              (let [published (str (:hot (rf/app-db-value frame)))]
@@ -113,6 +127,7 @@
                       {:v v :label label})
              {:label label
               :elapsed-ms (- (js/performance.now) started)
+              :fixed-shell-idle-cells (count idle)
               :projection projection})))))))
 
 (defn- percentile [xs p]
@@ -177,6 +192,7 @@
             :sizes sizes
             :queued-writes fixture/queued-writes
             :affected-viewcells fixture/hot-count
+            :fixed-shell-idle-cells fixture/idle-shell-count
             :timing-posture "evidence-only; no threshold"
             :results results})))))
 

--- a/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
@@ -11,6 +11,9 @@
 
 (def hot-count 8)
 (def queued-writes 8)
+;; `table` + `app` are intentionally sub-free defviews. DEV gives each the
+;; fixed HMR-safe ViewCell skeleton; they must stay live but ownership-empty.
+(def idle-shell-count 2)
 (def counters (atom {}))
 
 (defn reset-counters! []

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -444,10 +444,13 @@
        (defn ~render-sym [~props-sym]
          ~render-body)
        (def ~(vary-meta vname merge var-meta)
-         (re-frame.ui.runtime/memo-view
-          ~render-sym
-          ~(comparator-form header slots)
-          ~display-name))
-       (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
-         (re-frame.ui.runtime/register-view! ~view-id ~vname (quote ~manifest)))
+         (let [compare# ~(comparator-form header slots)]
+           (if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+             (re-frame.ui.runtime/register-view!
+              ~view-id ~render-sym compare# ~display-name (quote ~manifest))
+             ;; The production arm is deliberately direct React.memo. Closure
+             ;; folds away the sibling registration arm and with it every HMR
+             ;; slot/listener/dynamic-lookup/extra-Fiber helper.
+             (re-frame.ui.runtime/memo-view
+              ~render-sym compare# ~display-name))))
        ~vname)))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -423,17 +423,14 @@
         body       (emit-node ast st false)
         binds      (vec (header-bindings header))
         render-sym (symbol (str (name vname) "$render"))
-        ;; A view with reactive `(sub …)` sites gets a ViewCell: its render
-        ;; body runs under `re-frame.ui.viewcell/render` (one
-        ;; useSyncExternalStore, render-time probes, layout-commit
-        ;; ownership). Sub-free views are never wrapped — no per-view hook
-        ;; overhead, byte-identical S1 emission (I-15's dev fixed-hook
-        ;; skeleton is an S2e HMR refinement).
+        host-render-sym (symbol (str (name vname) "$host_render"))
+        ;; The raw body is descriptor data in DEV. Stable Inner supplies the
+        ;; fixed ViewCell hook skeleton to EVERY dev view, so adding the first
+        ;; sub is a same-signature edit. Production specializes: a sub-bearing
+        ;; view uses the host wrapper below; a sub-free view goes straight from
+        ;; React.memo to the raw body with zero ViewCell hooks.
         has-subs?  (boolean (seq (:subs (:sites manifest))))
         inner      (if (seq binds) `(let [~@binds] ~body) body)
-        render-body (if has-subs?
-                      `(re-frame.ui.viewcell/render ~view-id (fn [] ~inner))
-                      inner)
         var-meta   (cond-> {:rf.ui/view true
                             :rf.ui/view-id view-id
                             :rf.ui/children? children?}
@@ -442,7 +439,11 @@
     `(do
        ~@(:defs @st)
        (defn ~render-sym [~props-sym]
-         ~render-body)
+         ~inner)
+       ~@(when has-subs?
+           [`(defn ~host-render-sym [~props-sym]
+               (re-frame.ui.viewcell/render
+                ~view-id (fn [] (~render-sym ~props-sym))))])
        (def ~(vary-meta vname merge var-meta)
          (let [compare# ~(comparator-form header slots)]
            (if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
@@ -452,5 +453,6 @@
              ;; folds away the sibling registration arm and with it every HMR
              ;; slot/listener/dynamic-lookup/extra-Fiber helper.
              (re-frame.ui.runtime/memo-view
-              ~render-sym compare# ~display-name))))
+              ~(if has-subs? host-render-sym render-sym)
+              compare# ~display-name))))
        ~vname)))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -386,72 +386,145 @@
             :intervals      []}))))
 
 ;; ---------------------------------------------------------------------------
-;; View-body generation — the HMR hook-signature → preserve/remount decision
-;; (03 §10)
+;; Dev-only view slots — stable shell + exact body revision (03 §10)
 ;; ---------------------------------------------------------------------------
 ;;
-;; The "stable shell + hook-signature hash" contract, realized as a per-view-id
-;; BODY GENERATION. A view re-registration — shadow hot reload OR REPL re-eval,
-;; ONE path (02 §8) — consults the ordered user-hook-site signature hash
-;; (`re-frame.ui.fingerprint/hook-signature-hash`, shipped since S1b — consumed
-;; here, never rebuilt). An UNCHANGED signature KEEPS the generation: mounted
-;; cells preserve their state — their committed captures stay current, the next
-;; render runs the NEW body, and the commit reconciles the changed `sub` sites
-;; (`sub`/`lease`/event sites are EXCLUDED from the signature by the
-;; fingerprint's own contract, so a template edit — or adding your first `sub`
-;; under the dev fixed full hook skeleton, I-15 — is a same-signature edit). A
-;; CHANGED signature BUMPS the generation: the shell deliberately remounts a
-;; fresh cell at the new generation, never a corrupted hook order.
+;; ONE per-view slot is the whole HMR authority.  It owns the stable component
+;; identities, current implementation descriptor, revision store/listeners, and
+;; the hook-signature → remount decision.  There is deliberately no parallel
+;; registrar cache or render-time var lookup.
 ;;
-;; The registry is the ONE authority the runtime's `register-view!` feeds and a
-;; freshly-mounted ViewCell mints against (`view-generation`); a LIVE cell whose
-;; view generation advanced is stale-rejected at its next commit (step 1) via
-;; `advance-generation!`. Host-agnostic, so the decision is graft-checked on both
-;; hosts.
+;; Every successful registration advances BODY REVISION, including a
+;; same-signature edit.  Only a changed hook signature advances REMOUNT
+;; GENERATION.  The stable outer shell observes body revision; its stable inner
+;; body is keyed by remount generation.  Thus a same-signature update runs the
+;; new body on the existing Fiber, while an incompatible hook edit remounts that
+;; Fiber exactly once without changing the public shell identity.
+;;
+;; The slot is dev-only in the CLJS emitter: production takes a literal
+;; `goog.DEBUG=false` branch directly to `React.memo`, leaving this registry and
+;; all listener/dynamic-descriptor machinery unreachable to Closure DCE.
 
 (defonce ^:private view-generations
-  ;; view-id -> {:hook-signature hs :generation g}. `defonce` (module-lived);
-  ;; `reset-scheduler!` clears it between fixtures.
+  ;; view-id -> one atomic :rf.ui.hmr/* slot. `defonce` survives namespace
+  ;; reload; `reset-scheduler!` clears it between fixtures.
   (atom {}))
 
+(defn ensure-view-shells!
+  "Return the stable shell pair for `view-id`, creating it once with
+  `make-shells` when absent. `make-shells` returns `{:outer x :inner y}`.
+
+  The winning pair is published in the SAME per-view slot later used for the
+  descriptor/revisions/listeners. A losing speculative pair is unreachable
+  garbage (possible only under a concurrent JVM test; the CLJS host is
+  single-threaded)."
+  [view-id make-shells]
+  (let [slots (swap! view-generations update view-id
+                     (fn [slot]
+                       (if (:rf.ui.hmr/outer slot)
+                         slot
+                         (let [{:keys [outer inner]} (make-shells)]
+                           (merge {:rf.ui.hmr/registered?       false
+                                   :rf.ui.hmr/body-revision     -1
+                                   :rf.ui.hmr/remount-generation 0
+                                   :rf.ui.hmr/listeners         {}}
+                                  slot
+                                  {:rf.ui.hmr/outer outer
+                                   :rf.ui.hmr/inner inner})))))]
+    (select-keys (get slots view-id)
+                 [:rf.ui.hmr/outer :rf.ui.hmr/inner])))
+
+(defn register-view-descriptor!
+  "Atomically publish one successful dev registration and notify its mounted
+  shells AFTER publication. `descriptor` is the current render/comparator/
+  manifest record.
+
+  Body revision advances on every call. Remount generation advances only when
+  an already-registered slot changes hook signature. Returns the complete
+  published slot snapshot."
+  [view-id hook-signature descriptor]
+  (let [[_ slots]
+        (swap-vals! view-generations update view-id
+                    (fn [slot]
+                      (let [registered? (boolean (:rf.ui.hmr/registered? slot))
+                            changed?    (and registered?
+                                             (not= hook-signature
+                                                   (:rf.ui.hmr/hook-signature slot)))]
+                        (-> (merge {:rf.ui.hmr/body-revision      -1
+                                    :rf.ui.hmr/remount-generation 0
+                                    :rf.ui.hmr/listeners          {}}
+                                   slot)
+                            (assoc :rf.ui.hmr/registered? true
+                                   :rf.ui.hmr/hook-signature hook-signature
+                                   :rf.ui.hmr/descriptor descriptor)
+                            (update :rf.ui.hmr/body-revision inc)
+                            (cond-> changed?
+                              (update :rf.ui.hmr/remount-generation inc))))))
+        published (get slots view-id)]
+    (doseq [listener (vals (:rf.ui.hmr/listeners published))]
+      (listener))
+    published))
+
 (defn register-view-generation!
-  "Consume a view's `hook-signature` at (re-)registration and return its current
-  BODY GENERATION (03 §10). The first registration seeds generation 0. A
-  re-registration carrying the SAME `hook-signature` KEEPS the generation
-  (mounted cells preserve — a template-only edit changes the template
-  fingerprint, never the hook signature); a DIFFERENT `hook-signature` BUMPS it
-  (the shell remounts cleanly). One decision for shadow reload and REPL re-eval
-  (02 §8), so both converge on the same generation. A nil `hook-signature` is a
-  value like any other (a sub/effect-free view never changes signature). Returns
-  the (possibly bumped) generation."
+  "Headless test/JVM seam for the same registration decision as
+  `register-view-descriptor!`. Returns BODY REVISION. It never creates a second
+  authority: the existing descriptor (if any) is republished in the one slot."
   [view-id hook-signature]
-  (-> (swap! view-generations update view-id
-             (fn [prev]
-               (cond
-                 (nil? prev)
-                 {:hook-signature hook-signature :generation 0}
-                 (= hook-signature (:hook-signature prev))
-                 prev
-                 :else
-                 {:hook-signature hook-signature
-                  :generation     (inc (:generation prev))})))
-      (get view-id)
-      :generation))
+  (:rf.ui.hmr/body-revision
+   (register-view-descriptor!
+    view-id hook-signature
+    (get-in @view-generations [view-id :rf.ui.hmr/descriptor]))))
 
 (defn view-generation
-  "The current body generation for `view-id` (0 when never registered) — the
-  generation a freshly-mounted ViewCell for this view is minted at (tool/test
-  read)."
+  "The current BODY REVISION for `view-id` (0 when never registered). Kept
+  under the historical internal name while callers migrate; this is no longer
+  the remount key."
   [view-id]
-  (get-in @view-generations [view-id :generation] 0))
+  (max 0 (get-in @view-generations
+                 [view-id :rf.ui.hmr/body-revision]
+                 0)))
+
+(defn registered-view-revision
+  "The authoritative body revision for a successfully registered `view-id`, or
+  nil when the test/direct-call path has no registered slot."
+  [view-id]
+  (let [slot (get @view-generations view-id)]
+    (when (:rf.ui.hmr/registered? slot)
+      (:rf.ui.hmr/body-revision slot))))
+
+(defn view-remount-generation
+  "The current hook-incompatibility remount key for `view-id` (tool/test read)."
+  [view-id]
+  (get-in @view-generations [view-id :rf.ui.hmr/remount-generation] 0))
+
+(defn view-descriptor
+  "The current implementation descriptor for `view-id` (dev render path)."
+  [view-id]
+  (get-in @view-generations [view-id :rf.ui.hmr/descriptor]))
+
+(defn view-shells
+  "The stable `{:outer :inner}` identities for `view-id` (tool/test read)."
+  [view-id]
+  (let [slot (get @view-generations view-id)]
+    {:outer (:rf.ui.hmr/outer slot)
+     :inner (:rf.ui.hmr/inner slot)}))
+
+(defn subscribe-view!
+  "Subscribe `listener` to successful body publications for `view-id`; return
+  an idempotent unsubscribe thunk. This is the stable shell's minimal
+  useSyncExternalStore store."
+  [view-id listener]
+  (let [k (gensym "rf-ui-hmr-listener")]
+    (swap! view-generations assoc-in
+           [view-id :rf.ui.hmr/listeners k] listener)
+    (fn unsubscribe []
+      (swap! view-generations update-in
+             [view-id :rf.ui.hmr/listeners] dissoc k))))
 
 (defn advance-generation!
-  "Advance a LIVE `cell`'s view-body generation to `generation` — the
-  changed-signature HMR/remount seam (03 §10). A generation bump makes any
-  in-flight capture rendered under the PRIOR body stale at the next commit
-  (step 1). Same-signature reloads preserve the generation and never call this
-  seam. Monotone: a no-op unless
-  `generation` exceeds the cell's current generation. Returns the cell."
+  "Advance a LIVE `cell` to a newer BODY REVISION before capture. A revision
+  bump makes an in-flight capture from the prior body stale at commit step 1.
+  Monotone: a no-op unless `generation` exceeds the cell's current revision."
   [^ViewCell cell generation]
   (let [st (state cell)]
     (when (> generation (:generation @st))
@@ -1595,8 +1668,14 @@
   (let [st  (state cell)
         st0 @st]
     (cond
-      ;; step 1 — stale generation
-      (not= (:generation cap) (:generation st0))
+      ;; step 1 — stale body revision. The cell-local comparison catches an
+      ;; explicit sync/remount. The authoritative slot comparison closes the
+      ;; harder render(old) → registration(new) → layout(old) window even when
+      ;; the cell has not rendered again yet. Direct/headless callers with no
+      ;; registered slot retain the cell-local contract.
+      (or (not= (:generation cap) (:generation st0))
+          (when-some [current (registered-view-revision (:view-id st0))]
+            (not= (:generation cap) current)))
       :stale
 
       :else

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -406,7 +406,7 @@
 ;; all listener/dynamic-descriptor machinery unreachable to Closure DCE.
 
 (defonce ^:private view-generations
-  ;; view-id -> one atomic :rf.ui.hmr/* slot. `defonce` survives namespace
+  ;; view-id -> one atomic private HMR slot. `defonce` survives namespace
   ;; reload. `reset-scheduler!` deliberately NEVER clears it: already-exported
   ;; stable shells retain this slot as their live render authority.
   (atom {}))
@@ -422,18 +422,19 @@
   [view-id make-shells]
   (let [slots (swap! view-generations update view-id
                      (fn [slot]
-                       (if (:rf.ui.hmr/outer slot)
+                       (if (:hmr-outer slot)
                          slot
                          (let [{:keys [outer inner]} (make-shells)]
-                           (merge {:rf.ui.hmr/registered?       false
-                                   :rf.ui.hmr/body-revision     -1
-                                   :rf.ui.hmr/remount-generation 0
-                                   :rf.ui.hmr/listeners         {}}
+                           (merge {:hmr-registered?       false
+                                   :hmr-body-revision     -1
+                                   :hmr-remount-generation 0
+                                   :hmr-listeners         {}}
                                   slot
-                                  {:rf.ui.hmr/outer outer
-                                   :rf.ui.hmr/inner inner})))))]
-    (select-keys (get slots view-id)
-                 [:rf.ui.hmr/outer :rf.ui.hmr/inner])))
+                                  {:hmr-outer outer
+                                   :hmr-inner inner})))))]
+    (let [slot (get slots view-id)]
+      {:outer (:hmr-outer slot)
+       :inner (:hmr-inner slot)})))
 
 (defn prepare-view-descriptor!
   "Prepare a descriptor/revision publication without notifying mounted shells.
@@ -452,21 +453,21 @@
         [old-slots slots]
         (swap-vals! view-generations update view-id
                     (fn [slot]
-                      (let [registered? (boolean (:rf.ui.hmr/registered? slot))
+                      (let [registered? (boolean (:hmr-registered? slot))
                             changed?    (and registered?
                                              (not= hook-signature
-                                                   (:rf.ui.hmr/hook-signature slot)))]
-                        (-> (merge {:rf.ui.hmr/body-revision      -1
-                                    :rf.ui.hmr/remount-generation 0
-                                    :rf.ui.hmr/listeners          {}}
+                                                   (:hmr-hook-signature slot)))]
+                        (-> (merge {:hmr-body-revision      -1
+                                    :hmr-remount-generation 0
+                                    :hmr-listeners          {}}
                                    slot)
-                            (assoc :rf.ui.hmr/registered? true
-                                   :rf.ui.hmr/hook-signature hook-signature
-                                   :rf.ui.hmr/descriptor descriptor
-                                   :rf.ui.hmr/publication-token publication-token)
-                            (update :rf.ui.hmr/body-revision inc)
+                            (assoc :hmr-registered? true
+                                   :hmr-hook-signature hook-signature
+                                   :hmr-descriptor descriptor
+                                   :hmr-publication-token publication-token)
+                            (update :hmr-body-revision inc)
                             (cond-> changed?
-                              (update :rf.ui.hmr/remount-generation inc))))))
+                              (update :hmr-remount-generation inc))))))
         prepared (get slots view-id)]
     {:view-id view-id
      :publication-token publication-token
@@ -484,15 +485,15 @@
         (swap-vals! view-generations update view-id
                     (fn [slot]
                       (if (identical? publication-token
-                                      (:rf.ui.hmr/publication-token slot))
-                        (dissoc slot :rf.ui.hmr/publication-token)
+                                      (:hmr-publication-token slot))
+                        (dissoc slot :hmr-publication-token)
                         slot)))
         current-before (get old-slots view-id)
         committed? (identical? publication-token
-                                (:rf.ui.hmr/publication-token current-before))
+                                (:hmr-publication-token current-before))
         published (get slots view-id)]
     (when committed?
-      (doseq [listener (vals (:rf.ui.hmr/listeners published))]
+      (doseq [listener (vals (:hmr-listeners published))]
         (listener)))
     published))
 
@@ -508,10 +509,10 @@
         (swap! view-generations update view-id
                (fn [slot]
                  (if (identical? publication-token
-                                 (:rf.ui.hmr/publication-token slot))
+                                 (:hmr-publication-token slot))
                    (assoc (or before {})
-                          :rf.ui.hmr/listeners
-                          (:rf.ui.hmr/listeners slot {}))
+                          :hmr-listeners
+                          (:hmr-listeners slot {}))
                    slot)))]
     (get slots view-id)))
 
@@ -530,10 +531,10 @@
   `register-view-descriptor!`. Returns BODY REVISION. It never creates a second
   authority: the existing descriptor (if any) is republished in the one slot."
   [view-id hook-signature]
-  (:rf.ui.hmr/body-revision
+  (:hmr-body-revision
    (register-view-descriptor!
     view-id hook-signature
-    (get-in @view-generations [view-id :rf.ui.hmr/descriptor]))))
+    (get-in @view-generations [view-id :hmr-descriptor]))))
 
 (defn view-generation
   "The current BODY REVISION for `view-id` (0 when never registered). Kept
@@ -541,7 +542,7 @@
   the remount key."
   [view-id]
   (max 0 (get-in @view-generations
-                 [view-id :rf.ui.hmr/body-revision]
+                 [view-id :hmr-body-revision]
                  0)))
 
 (defn registered-view-revision
@@ -549,25 +550,25 @@
   nil when the test/direct-call path has no registered slot."
   [view-id]
   (let [slot (get @view-generations view-id)]
-    (when (:rf.ui.hmr/registered? slot)
-      (:rf.ui.hmr/body-revision slot))))
+    (when (:hmr-registered? slot)
+      (:hmr-body-revision slot))))
 
 (defn view-remount-generation
   "The current hook-incompatibility remount key for `view-id` (tool/test read)."
   [view-id]
-  (get-in @view-generations [view-id :rf.ui.hmr/remount-generation] 0))
+  (get-in @view-generations [view-id :hmr-remount-generation] 0))
 
 (defn view-descriptor
   "The current implementation descriptor for `view-id` (dev render path)."
   [view-id]
-  (get-in @view-generations [view-id :rf.ui.hmr/descriptor]))
+  (get-in @view-generations [view-id :hmr-descriptor]))
 
 (defn view-shells
   "The stable `{:outer :inner}` identities for `view-id` (tool/test read)."
   [view-id]
   (let [slot (get @view-generations view-id)]
-    {:outer (:rf.ui.hmr/outer slot)
-     :inner (:rf.ui.hmr/inner slot)}))
+    {:outer (:hmr-outer slot)
+     :inner (:hmr-inner slot)}))
 
 (defn subscribe-view!
   "Subscribe `listener` to successful body publications for `view-id`; return
@@ -576,10 +577,10 @@
   [view-id listener]
   (let [k (gensym "rf-ui-hmr-listener")]
     (swap! view-generations assoc-in
-           [view-id :rf.ui.hmr/listeners k] listener)
+           [view-id :hmr-listeners k] listener)
     (fn unsubscribe []
       (swap! view-generations update-in
-             [view-id :rf.ui.hmr/listeners] dissoc k))))
+             [view-id :hmr-listeners] dissoc k))))
 
 (defn advance-generation!
   "Advance a LIVE `cell` to a newer BODY REVISION before capture. A revision

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -407,7 +407,8 @@
 
 (defonce ^:private view-generations
   ;; view-id -> one atomic :rf.ui.hmr/* slot. `defonce` survives namespace
-  ;; reload; `reset-scheduler!` clears it between fixtures.
+  ;; reload. `reset-scheduler!` deliberately NEVER clears it: already-exported
+  ;; stable shells retain this slot as their live render authority.
   (atom {}))
 
 (defn ensure-view-shells!
@@ -434,16 +435,21 @@
     (select-keys (get slots view-id)
                  [:rf.ui.hmr/outer :rf.ui.hmr/inner])))
 
-(defn register-view-descriptor!
-  "Atomically publish one successful dev registration and notify its mounted
-  shells AFTER publication. `descriptor` is the current render/comparator/
-  manifest record.
+(defn prepare-view-descriptor!
+  "Prepare a descriptor/revision publication without notifying mounted shells.
 
-  Body revision advances on every call. Remount generation advances only when
-  an already-registered slot changes hook signature. Returns the complete
-  published slot snapshot."
+  This is the first half of the DEV view-registration transaction. It makes
+  the new descriptor and revisions visible BEFORE `registrar/register!` fires
+  its synchronous registration/replacement hooks, so no hook can observe a new
+  manifest paired with an old (or nil) render/comparator. `publication-token`
+  is private transaction identity; listeners may still subscribe while the
+  registrar call is in progress without invalidating the transaction.
+
+  Call `commit-view-descriptor!` after registrar success or
+  `rollback-view-descriptor!` if it throws."
   [view-id hook-signature descriptor]
-  (let [[_ slots]
+  (let [publication-token (atom nil)
+        [old-slots slots]
         (swap-vals! view-generations update view-id
                     (fn [slot]
                       (let [registered? (boolean (:rf.ui.hmr/registered? slot))
@@ -456,14 +462,68 @@
                                    slot)
                             (assoc :rf.ui.hmr/registered? true
                                    :rf.ui.hmr/hook-signature hook-signature
-                                   :rf.ui.hmr/descriptor descriptor)
+                                   :rf.ui.hmr/descriptor descriptor
+                                   :rf.ui.hmr/publication-token publication-token)
                             (update :rf.ui.hmr/body-revision inc)
                             (cond-> changed?
                               (update :rf.ui.hmr/remount-generation inc))))))
+        prepared (get slots view-id)]
+    {:view-id view-id
+     :publication-token publication-token
+     :before (get old-slots view-id)
+     :prepared prepared}))
+
+(defn commit-view-descriptor!
+  "Commit a prepared view publication and notify mounted shells exactly once.
+
+  A re-entrant registration for the same id supersedes an older transaction;
+  only the transaction whose token is still current may notify. Returns the
+  complete current slot snapshot."
+  [{:keys [view-id publication-token]}]
+  (let [[old-slots slots]
+        (swap-vals! view-generations update view-id
+                    (fn [slot]
+                      (if (identical? publication-token
+                                      (:rf.ui.hmr/publication-token slot))
+                        (dissoc slot :rf.ui.hmr/publication-token)
+                        slot)))
+        current-before (get old-slots view-id)
+        committed? (identical? publication-token
+                                (:rf.ui.hmr/publication-token current-before))
         published (get slots view-id)]
-    (doseq [listener (vals (:rf.ui.hmr/listeners published))]
-      (listener))
+    (when committed?
+      (doseq [listener (vals (:rf.ui.hmr/listeners published))]
+        (listener)))
     published))
+
+(defn rollback-view-descriptor!
+  "Roll back a prepared descriptor after registrar failure.
+
+  Rollback is conditional on transaction identity, so it cannot overwrite a
+  newer re-entrant registration. Listener subscriptions made while the
+  registrar call was in flight are retained; descriptor/revision/remount state
+  returns to the exact prior publication. Returns the current slot snapshot."
+  [{:keys [view-id publication-token before]}]
+  (let [slots
+        (swap! view-generations update view-id
+               (fn [slot]
+                 (if (identical? publication-token
+                                 (:rf.ui.hmr/publication-token slot))
+                   (assoc (or before {})
+                          :rf.ui.hmr/listeners
+                          (:rf.ui.hmr/listeners slot {}))
+                   slot)))]
+    (get slots view-id)))
+
+(defn register-view-descriptor!
+  "Publish one descriptor directly through the same prepare/commit path used
+  by the client registrar transaction. This is the headless/JVM test seam.
+
+  Body revision advances on every call. Remount generation advances only when
+  an already-registered slot changes hook signature."
+  [view-id hook-signature descriptor]
+  (-> (prepare-view-descriptor! view-id hook-signature descriptor)
+      (commit-view-descriptor!)))
 
 (defn register-view-generation!
   "Headless test/JVM seam for the same registration decision as

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1154,7 +1154,10 @@
   (reset! teardown-collector nil)
   (reset! evidence-sink nil)
   (reset! last-sink-escape nil)
-  (reset! view-generations {})
+  ;; Do NOT clear `view-generations`: it now owns the stable component shells
+  ;; and descriptors created at namespace load. Clearing it would strand every
+  ;; already-defined defview Var on a shell whose dynamic descriptor vanished.
+  ;; Tests use qualified per-fixture view ids for HMR decisions.
   nil)
 
 (defn- on-change-fn

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1677,8 +1677,9 @@
       ;; the cell has not rendered again yet. Direct/headless callers with no
       ;; registered slot retain the cell-local contract.
       (or (not= (:generation cap) (:generation st0))
-          (when-some [current (registered-view-revision (:view-id st0))]
-            (not= (:generation cap) current)))
+          (and interop/debug-enabled?
+               (when-some [current (registered-view-revision (:view-id st0))]
+                 (not= (:generation cap) current))))
       :stale
 
       :else

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -97,7 +97,7 @@
   registrar success. A registrar throw rolls the prepared slot back, advancing
   neither body revision nor remount generation."
   [id render-fn compare-fn display-name manifest]
-  (let [{:rf.ui.hmr/keys [outer inner]}
+  (let [{:keys [outer inner]}
         (reactive/ensure-view-shells! id #(make-view-shells id))
         descriptor {:render-fn render-fn
                     :compare-fn compare-fn

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -17,7 +17,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.ui.eq :as eq]
             [re-frame.ui.reactive :as reactive]
-            [re-frame.ui.rules :as rules]))
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.viewcell :as viewcell]))
 
 ;; ---------------------------------------------------------------------------
 ;; jsx binding.  Generated templates invoke `.jsx` / `.jsxs` on this module
@@ -62,8 +63,17 @@
                     (reactive/subscribe-view! id listener))
         snapshot  (fn [] (reactive/view-generation id))
         inner     (fn stable-view-body [props]
-                    (let [render-fn (:render-fn (reactive/view-descriptor id))]
-                      (render-fn props)))
+                    ;; The DEV fixed hook skeleton is present from the first
+                    ;; render, even while the body has no sub sites. Adding the
+                    ;; first `sub` is therefore a same-signature body edit, not
+                    ;; a hook-order change. Production specializes sub-free
+                    ;; views to the raw render fn in the emitter.
+                    (viewcell/render
+                     id
+                     (fn []
+                       (let [render-fn (:render-fn
+                                       (reactive/view-descriptor id))]
+                         (render-fn props)))))
         outer-fn  (fn stable-view-shell [props]
                     (react/useSyncExternalStore subscribe snapshot snapshot)
                     ;; React dev freezes the received props object. jsxDEV adds
@@ -81,27 +91,40 @@
 (defn register-view!
   "Register a compiled view in DEV and return its stable public shell.
 
-  Registrar success happens before the one HMR slot publishes the new
-  descriptor. Therefore a failed registration advances neither body revision
-  nor remount generation. Successful publication is atomic; mounted shells are
-  notified only after render/comparator/manifest and both revisions agree."
+  Descriptor/revisions are PREPARED before registrar publication so the
+  registrar's synchronous hooks can never observe a new manifest paired with
+  an old (or nil) render/comparator. Mounted shells are notified only after
+  registrar success. A registrar throw rolls the prepared slot back, advancing
+  neither body revision nor remount generation."
   [id render-fn compare-fn display-name manifest]
   (let [{:rf.ui.hmr/keys [outer inner]}
-        (reactive/ensure-view-shells! id #(make-view-shells id))]
+        (reactive/ensure-view-shells! id #(make-view-shells id))
+        descriptor {:render-fn render-fn
+                    :compare-fn compare-fn
+                    :manifest manifest}
+        old-inner-name (.-displayName inner)
+        old-outer-name (.-displayName outer)]
     (set! (.-displayName render-fn) display-name)
     (set! (.-displayName inner) (str display-name "$Body"))
     (set! (.-displayName outer) display-name)
-    (registrar/register! :view id (cond-> {:rf/id id
-                                           :handler-fn outer
-                                         :rf.ui/compiled? true
-                                         :rf.ui/manifest manifest}
-                                    (:doc manifest) (assoc :doc (:doc manifest))))
-    (reactive/register-view-descriptor!
-     id (:hook-signature manifest)
-     {:render-fn render-fn
-      :compare-fn compare-fn
-      :manifest manifest})
-    outer))
+    (let [publication
+          (reactive/prepare-view-descriptor!
+           id (:hook-signature manifest) descriptor)]
+      (try
+        (registrar/register!
+         :view id
+         (cond-> {:rf/id id
+                  :handler-fn outer
+                  :rf.ui/compiled? true
+                  :rf.ui/manifest manifest}
+           (:doc manifest) (assoc :doc (:doc manifest))))
+        (reactive/commit-view-descriptor! publication)
+        outer
+        (catch :default e
+          (reactive/rollback-view-descriptor! publication)
+          (set! (.-displayName inner) old-inner-name)
+          (set! (.-displayName outer) old-outer-name)
+          (throw e))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dispatch — the S1 seam

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -66,7 +66,11 @@
                       (render-fn props)))
         outer-fn  (fn stable-view-shell [props]
                     (react/useSyncExternalStore subscribe snapshot snapshot)
-                    (jsx3 inner props (reactive/view-remount-generation id)))
+                    ;; React dev freezes the received props object. jsxDEV adds
+                    ;; key diagnostics to the object it receives, so give the
+                    ;; dev-only inner Fiber a shallow carrier of its own.
+                    (jsx3 inner (js/Object.assign (js-obj) props)
+                          (reactive/view-remount-generation id)))
         compare   (fn [prev next]
                     (let [compare-fn (:compare-fn
                                       (reactive/view-descriptor id))]

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -40,7 +40,8 @@
 
 (defn memo-view
   "React.memo over the compiled render fn with the generated `rf=`
-  comparator; displayName in dev."
+  comparator. This is the direct production path: no shell, slot, listener,
+  dynamic render lookup, or extra Fiber."
   [render-fn compare-fn display-name]
   (let [c (react/memo render-fn compare-fn)]
     (when ^boolean js/goog.DEBUG
@@ -48,23 +49,55 @@
       (set! (.-displayName c) display-name))
     c))
 
-(defn register-view!
-  "Registrar `:view` entry for a compiled view (dev builds; the emitted
-  call is goog.DEBUG-gated so production carries no manifests — I-12).
+(defn- make-view-shells
+  "Create the two stable DEV component identities for `id`.
 
-  Also feeds the HMR view-body generation registry (03 §10): a re-registration
-  (shadow hot reload OR REPL re-eval — one path, 02 §8) consults the manifest's
-  hook-signature hash and keeps the generation on a same-signature edit (mounted
-  cells preserve state) or bumps it on a changed signature (the shell remounts).
-  Runs at (re-)registration time, not per render — off the hot path."
-  [id component manifest]
-  (registrar/register! :view id (cond-> {:rf/id id
-                                         :handler-fn component
+  Outer owns the minimal body-revision useSyncExternalStore subscription and
+  delegates prop comparison to the currently-published descriptor. Inner calls
+  the current render function as an ORDINARY function, keeping authored hooks
+  on Inner's stable Fiber. Only its key changes on hook-signature
+  incompatibility."
+  [id]
+  (let [subscribe (fn [listener]
+                    (reactive/subscribe-view! id listener))
+        snapshot  (fn [] (reactive/view-generation id))
+        inner     (fn stable-view-body [props]
+                    (let [render-fn (:render-fn (reactive/view-descriptor id))]
+                      (render-fn props)))
+        outer-fn  (fn stable-view-shell [props]
+                    (react/useSyncExternalStore subscribe snapshot snapshot)
+                    (jsx3 inner props (reactive/view-remount-generation id)))
+        compare   (fn [prev next]
+                    (let [compare-fn (:compare-fn
+                                      (reactive/view-descriptor id))]
+                      (compare-fn prev next)))
+        outer     (react/memo outer-fn compare)]
+    {:outer outer :inner inner}))
+
+(defn register-view!
+  "Register a compiled view in DEV and return its stable public shell.
+
+  Registrar success happens before the one HMR slot publishes the new
+  descriptor. Therefore a failed registration advances neither body revision
+  nor remount generation. Successful publication is atomic; mounted shells are
+  notified only after render/comparator/manifest and both revisions agree."
+  [id render-fn compare-fn display-name manifest]
+  (let [{:rf.ui.hmr/keys [outer inner]}
+        (reactive/ensure-view-shells! id #(make-view-shells id))]
+    (set! (.-displayName render-fn) display-name)
+    (set! (.-displayName inner) (str display-name "$Body"))
+    (set! (.-displayName outer) display-name)
+    (registrar/register! :view id (cond-> {:rf/id id
+                                           :handler-fn outer
                                          :rf.ui/compiled? true
                                          :rf.ui/manifest manifest}
-                                  (:doc manifest) (assoc :doc (:doc manifest))))
-  (reactive/register-view-generation! id (:hook-signature manifest))
-  component)
+                                    (:doc manifest) (assoc :doc (:doc manifest))))
+    (reactive/register-view-descriptor!
+     id (:hook-signature manifest)
+     {:render-fn render-fn
+      :compare-fn compare-fn
+      :manifest manifest})
+    outer))
 
 ;; ---------------------------------------------------------------------------
 ;; Dispatch — the S1 seam

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -81,14 +81,24 @@
   under a fresh render capture, reads its root incarnation from context, and
   wires the reconcile + lifecycle layout commits. Returns the host element."
   [view-id thunk]
-  (let [cell-ref (react/useRef nil)]
+  (let [body-revision (if ^boolean js/goog.DEBUG
+                        (reactive/view-generation view-id)
+                        0)
+        cell-ref (react/useRef nil)]
     (when (nil? (.-current cell-ref))
-      (set! (.-current cell-ref) (reactive/make-cell view-id)))
+      (set! (.-current cell-ref)
+            (reactive/make-cell view-id body-revision)))
     (let [cell             (.-current cell-ref)
           root-incarnation (react/useContext root-incarnation-context)
           subscribe (react/useCallback
                       (fn [listener] (reactive/subscribe cell listener))
                       #js [cell])]
+      ;; Same-signature Fast Refresh keeps this Fiber/ViewCell but advances the
+      ;; body revision. Sync BEFORE capture so the selected render records the
+      ;; exact descriptor revision it executed. Production folds this branch
+      ;; away with the entire HMR slot.
+      (when ^boolean js/goog.DEBUG
+        (reactive/advance-generation! cell body-revision))
       ;; ONE useSyncExternalStore — the cell's scalar revision drives
       ;; sub-invalidation repaints (getServerSnapshot = 0: SSR reads are
       ;; one-shot, no reactive loop).

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -2,10 +2,10 @@
   "React glue for the S2b reactive core — the thin `useRef` /
   `useSyncExternalStore` / `useLayoutEffect` layer that drives
   `re-frame.ui.reactive`'s host-agnostic ViewCell + commit reconciler.
-  The compiled CLJS emitter wraps a sub-bearing view's render body in
-  `render`; sub-free views are never wrapped (no per-view hook overhead,
-  no behaviour change — the dev fixed-hook-skeleton of I-15 is an HMR
-  refinement that lands with S2e).
+  The compiled CLJS emitter wraps a sub-bearing PRODUCTION view's render body
+  in `render`; sub-free production views are never wrapped. In DEV the stable
+  Fast Refresh Inner always calls `render`, providing the fixed hook skeleton
+  before a view gains its first sub site without charging production for it.
 
   The contract, per 03 §3:
 

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -4,10 +4,11 @@
   check. Macro-level, so JVM-hosted — the macro code is host-shared, so
   these pins hold for the CLJS expansion path too."
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
             [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
             [re-frame.ui.compiler.header :as header]))
 
 (defn- expand-error
@@ -171,6 +172,40 @@
       (is (true? (:rf.ui/view (meta def-sym)))
           "the public var carries the Q5 discrimination meta")
       (is (= :app.probe/probe (:rf.ui/view-id (meta def-sym)))))))
+
+(deftest cljs-emission-keeps-dev-hooks-fixed-and-production-specialized
+  (let [args        (fn [vname subs]
+                      {:vname vname
+                       :view-id (keyword "app.probe" (name vname))
+                       :display-name (str "app.probe/" vname)
+                       :docstring nil
+                       :header (header/parse-header [])
+                       :slots []
+                       :ast {:op :text :value "x"}
+                       :manifest {:view-id (keyword "app.probe" (name vname))
+                                  :hook-signature "hs1-fixed"
+                                  :sites {:subs subs}}
+                       :closed-keys nil
+                       :children? false})
+        plain-forms (emit-cljs/emit-defview (args 'plain []))
+        sub-forms   (emit-cljs/emit-defview
+                     (args 'observed [{:query [:value]}]))
+        plain-text  (pr-str plain-forms)
+        sub-text    (pr-str sub-forms)]
+    (testing "sub-free production stays on the raw memo path"
+      (is (not (str/includes? plain-text "re-frame.ui.viewcell/render")))
+      (is (not (str/includes? plain-text "plain$host_render")))
+      (is (re-find #"re-frame.ui.runtime/memo-view plain\$render"
+                   plain-text)))
+    (testing "sub-bearing production gets the ViewCell host wrapper"
+      (is (str/includes? sub-text "observed$host_render"))
+      (is (str/includes? sub-text "re-frame.ui.viewcell/render"))
+      (is (re-find #"re-frame.ui.runtime/register-view! :app.probe/observed observed\$render"
+                   sub-text)
+          "DEV publishes the raw body; stable Inner supplies the invariant skeleton")
+      (is (re-find #"re-frame.ui.runtime/memo-view observed\$host_render"
+                   sub-text)
+          "production memoizes the specialized ViewCell host wrapper"))))
 
 (deftest file-pass-registration-does-not-embed-a-per-view-digest
   (build/begin-build! ::file '#{app.file})

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -157,7 +157,11 @@
     (is (str/includes? text "re-frame.ui.runtime/register-view!")
         "defview emits the registrar :view registration")
     (is (str/includes? text "js/goog.DEBUG")
-        "the registration/manifest emission is dev-gated (I-12)")
+        "the stable-shell registration/manifest emission is dev-gated (I-12)")
+    (is (re-find #"\(if js/goog.DEBUG \(re-frame.ui.runtime/register-view!.*\(re-frame.ui.runtime/memo-view"
+                 text)
+        "golden: DEV registers the stable shell while the sibling production
+         arm is the direct React.memo path — no unconditional HMR residue")
     (is (not (str/includes? text "bd1-"))
         "no-pass REPL expansion may replace the body but never publishes build identity")
     (let [def-sym (some #(when (and (seq? %) (= 'def (first %))

--- a/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
@@ -114,10 +114,17 @@
             (.then
              (fn []
                (let [cells (set (remove cells-base
-                                        (reactive/current-live-cells)))]
-                 (is (= 1 (count cells))
-                     "the mounted observed component owns one live ViewCell")
-                 (reset! mounted (first cells))
+                                        (reactive/current-live-cells)))
+                     owners (filter #(= #{(target-key [::a])}
+                                         (reactive/committed-target-keys %))
+                                    cells)]
+                 ;; DEV's HMR-safe fixed hook skeleton gives every defview a
+                 ;; ViewCell, including the sub-free hostile-root shell. Select
+                 ;; the exact observed cell by committed ownership rather than
+                 ;; assuming there are no empty shell cells in the tree.
+                 (is (= 1 (count owners))
+                     "exactly one mounted cell owns the observed dependency")
+                 (reset! mounted (first owners))
                  (is (= "1" (.-textContent
                               (.querySelector container "[data-capture=a]"))))
                  ;; Update order is A first, then B+throw. Suspense commits the

--- a/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
@@ -73,7 +73,8 @@
             container (js/document.createElement "div")
             root      (ReactDOMClient/createRoot container)
             shell-1   (register! id (stateful-body "v1" probe)
-                                 (fn [_ _] true) hs "PreserveView")]
+                                 (fn [_ _] true) hs "PreserveView")
+            shells-1  (reactive/view-shells id)]
         (.appendChild (.-body js/document) container)
         (-> (act-promise
              #(.render root (React/createElement shell-1 #js {:value "p1"})))
@@ -98,6 +99,9 @@
                (testing "same signature updates in place"
                  (is (identical? shell-1 @shell-2)
                      "public shell identity is stable")
+                 (is (identical? (:inner shells-1)
+                                 (:inner (reactive/view-shells id)))
+                     "the inner component identity is stable too")
                  (is (= 1 (reactive/view-generation id))
                      "body revision advanced")
                  (is (= 0 (reactive/view-remount-generation id))
@@ -158,7 +162,8 @@
             container (js/document.createElement "div")
             root      (ReactDOMClient/createRoot container)
             shell-1   (register! id (effectful-body "v1" probe events false)
-                                 (fn [_ _] true) "hs1-one-hook" "RemountView")]
+                                 (fn [_ _] true) "hs1-one-hook" "RemountView")
+            shells-1  (reactive/view-shells id)]
         (.appendChild (.-body js/document) container)
         (set! (.-error js/console)
               (fn [& xs] (swap! warnings conj (mapv str xs))))
@@ -177,6 +182,9 @@
                (testing "only the stable inner Fiber remounts"
                  (is (identical? shell-1 @shell-2)
                      "the public shell survives an incompatible edit")
+                 (is (identical? (:inner shells-1)
+                                 (:inner (reactive/view-shells id)))
+                     "hook incompatibility changes the key, never Inner's type")
                  (is (= 1 (reactive/view-remount-generation id)))
                  (is (= [:cleanup-v1 :setup-v2] @events)
                      "one cleanup precedes one setup — always/never-key mutations fail")

--- a/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
@@ -12,8 +12,7 @@
             [re-frame.ui :as ui]
             [re-frame.ui.frames :as frames]
             [re-frame.ui.reactive :as reactive]
-            [re-frame.ui.runtime :as runtime]
-            [re-frame.ui.viewcell :as viewcell]))
+            [re-frame.ui.runtime :as runtime]))
 
 (defn- browser? [] (exists? js/document))
 
@@ -48,17 +47,20 @@
     (React/createElement "span" #js {:data-hmr-child "state"}
                          (str n))))
 
-(defn- stateful-body [version probe]
+(defn- stateful-body [version probe read-sub?]
   (fn [props]
     (let [[n set-n] (React/useState 0)
           token (React/useRef (js-obj))
-          prop-v (unchecked-get props "value")]
+          prop-v (unchecked-get props "value")
+          sub-v  (when read-sub?
+                   (reactive/sub-read [::preserve-value]))]
       (swap! probe assoc :parent-n n :set-parent set-n
              :parent-token (.-current token))
       (React/createElement
        "section" #js {:data-hmr-version version}
        (React/createElement "output" #js {:data-hmr-parent "state"}
-                            (str version ":" prop-v ":" n))
+                            (str version ":" prop-v ":" n
+                                 (when read-sub? (str ":" sub-v))))
        (React/createElement child-with-state #js {:probe probe})))))
 
 (deftest same-signature-refresh-preserves-state-and-uses-current-comparator
@@ -66,18 +68,33 @@
     (is true ":node — browser gate runs the mounted Fast Refresh proof")
     (async done
       (let [id        ::preserve
+            fid       :fast-refresh/preserve-frame
             hs        "hs1-preserve"
             probe     (atom {})
             tokens    (atom nil)
             shell-2   (atom nil)
+            shell-3   (atom nil)
+            warnings  (atom [])
+            original-error (.-error js/console)
             container (js/document.createElement "div")
             root      (ReactDOMClient/createRoot container)
-            shell-1   (register! id (stateful-body "v1" probe)
+            cache-entry #(get @(:sub-cache (frame/frame fid))
+                              [::preserve-value])
+            shell-1   (register! id (stateful-body "v1" probe false)
                                  (fn [_ _] true) hs "PreserveView")
             shells-1  (reactive/view-shells id)]
+        (rf/reg-sub ::preserve-value (fn [db _] (:value db)))
+        (rf/make-frame {:id fid :doc "Fast Refresh sub-site mutation proof"})
+        (frame/replace-app-db! fid {:value 42})
         (.appendChild (.-body js/document) container)
+        (set! (.-error js/console)
+              (fn [& xs] (swap! warnings conj (mapv str xs))))
         (-> (act-promise
-             #(.render root (React/createElement shell-1 #js {:value "p1"})))
+             #(.render root
+                       (frames/scope-element
+                        fid
+                        (array (React/createElement
+                                shell-1 #js {:value "p1"})))))
             (.then
              (fn []
                (reset! tokens {:parent (:parent-token @probe)
@@ -88,15 +105,17 @@
             (.then
              (fn []
                ;; No root.render: slot publication + uSES notify is the only
-               ;; update path. v2's false comparator deliberately differs
-               ;; from v1's frozen-true comparator.
+               ;; update path. This edit also adds the first sub site while
+               ;; keeping the authored React-hook signature unchanged. v2's
+               ;; false comparator deliberately differs from v1's frozen-true
+               ;; comparator.
                (act-promise
                 #(reset! shell-2
-                         (register! id (stateful-body "v2" probe)
+                         (register! id (stateful-body "v2" probe true)
                                     (fn [_ _] false) hs "PreserveView")))))
             (.then
              (fn []
-               (testing "same signature updates in place"
+               (testing "same signature and first sub site update in place"
                  (is (identical? shell-1 @shell-2)
                      "public shell identity is stable")
                  (is (identical? (:inner shells-1)
@@ -106,29 +125,63 @@
                      "body revision advanced")
                  (is (= 0 (reactive/view-remount-generation id))
                      "same signature never changes the inner key")
-                 (is (= "v2:p1:7"
+                 (is (= "v2:p1:7:42"
                         (.-textContent
                          (.querySelector container "[data-hmr-parent]")))
-                     "missing-notify / element-invocation mutations fail")
+                     "missing-notify / missing-fixed-skeleton mutations fail")
                  (is (= "19" (.-textContent
                               (.querySelector container "[data-hmr-child]"))))
                  (is (identical? (:parent @tokens) (:parent-token @probe)))
-                 (is (identical? (:child @tokens) (:child-token @probe))))
+                 (is (identical? (:child @tokens) (:child-token @probe)))
+                 (is (= 1 (:ref-count (cache-entry)))
+                     "the newly added sub is owned after the fresh commit"))
+               ;; Remove the sub site again, still without root.render. The
+               ;; fixed dev skeleton remains, state remains, and ownership is
+               ;; reconciled away rather than leaking the old dependency.
+               (act-promise
+                #(reset! shell-3
+                         (register! id (stateful-body "v3" probe false)
+                                    (fn [_ _] false) hs "PreserveView")))))
+            (.then
+             (fn []
+               (testing "same-signature sub removal also updates in place"
+                 (is (identical? shell-1 @shell-3))
+                 (is (= 2 (reactive/view-generation id)))
+                 (is (= 0 (reactive/view-remount-generation id)))
+                 (is (= "v3:p1:7"
+                        (.-textContent
+                         (.querySelector container "[data-hmr-parent]"))))
+                 (is (= "19" (.-textContent
+                              (.querySelector container "[data-hmr-child]"))))
+                 (is (identical? (:parent @tokens) (:parent-token @probe)))
+                 (is (identical? (:child @tokens) (:child-token @probe)))
+                 (is (nil? (cache-entry))
+                     "removing the sub releases the prior ownership")
+                 (is (empty? @warnings)
+                     "adding/removing a sub site produced no hook-order warning"))
                ;; Parent props now move. The currently published v2 comparator
                ;; (false), not v1's frozen comparator (true), must decide.
                (act-promise
                 #(.render root
-                          (React/createElement @shell-2 #js {:value "p2"})))))
+                          (frames/scope-element
+                           fid
+                           (array (React/createElement
+                                   @shell-3 #js {:value "p2"})))))))
             (.then
              (fn []
-               (is (= "v2:p2:7"
+               (is (= "v3:p2:7"
                       (.-textContent
                        (.querySelector container "[data-hmr-parent]")))
                    "the stable memo shell delegates to the current comparator")))
             (.then (fn [] (act-promise #(.unmount root))))
-            (.then (fn [] (.remove container) (done)))
+            (.then
+             (fn []
+               (set! (.-error js/console) original-error)
+               (.remove container)
+               (done)))
             (.catch
              (fn [e]
+               (set! (.-error js/console) original-error)
                (try (.unmount root) (catch :default _ nil))
                (.remove container)
                (is false (str "same-signature browser proof rejected: " e))
@@ -220,24 +273,19 @@
             root      (ReactDOMClient/createRoot container)
             cache-entry #(get @(:sub-cache (frame/frame fid)) [::value])
             render-v2 (fn [_props]
-                        (viewcell/render
-                         id
-                         #(React/createElement
-                           "output" #js {:data-hmr-stale "v2"}
-                           (str (reactive/sub-read [::value])))))
+                        (React/createElement
+                         "output" #js {:data-hmr-stale "v2"}
+                         (str (reactive/sub-read [::value]))))
             render-v1 (fn [_props]
-                        (viewcell/render
-                         id
-                         (fn []
-                           (let [v (reactive/sub-read [::value])]
-                             ;; Move the authoritative body revision after
-                             ;; capture began but before this render's layout
-                             ;; commit. Dependencies remain exactly equal.
-                             (when (compare-and-set! armed true false)
-                               (register! id render-v2 (fn [_ _] true)
-                                          hs "StaleRender"))
-                             (React/createElement
-                              "output" #js {:data-hmr-stale "v1"} (str v))))))
+                        (let [v (reactive/sub-read [::value])]
+                          ;; Move the authoritative body revision after capture
+                          ;; began but before this render's layout commit.
+                          ;; Dependencies remain exactly equal.
+                          (when (compare-and-set! armed true false)
+                            (register! id render-v2 (fn [_ _] true)
+                                       hs "StaleRender"))
+                          (React/createElement
+                           "output" #js {:data-hmr-stale "v1"} (str v))))
             observer  (fn [_props]
                         (React/useLayoutEffect
                          (fn []

--- a/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
@@ -1,0 +1,271 @@
+(ns re-frame.ui.fast-refresh-shell-dom-cljs-test
+  "rf2-8hf77d — real React/browser counterexamples for the dev-only stable
+  component shell. Same-signature registration updates without root.render;
+  incompatible hooks remount only the inner Fiber; a render made stale before
+  layout cannot publish even an equal dependency set."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom/client" :as ReactDOMClient]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.runtime :as runtime]
+            [re-frame.ui.viewcell :as viewcell]))
+
+(defn- browser? [] (exists? js/document))
+
+(use-fixtures
+ :each
+ (test-support/make-reset-runtime-fixture
+  {:adapter ui/adapter :ambient-frame nil :async? true}))
+
+(defn- act-promise [thunk]
+  (try
+    (js/Promise.resolve
+     (React/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- register!
+  [id render-fn compare-fn hook-signature label]
+  (runtime/register-view!
+   id render-fn compare-fn label
+   {:view-id id
+    :display-name label
+    :template-fingerprint (str "tf1-" label)
+    :hook-signature hook-signature
+    :sites {}}))
+
+(defn- child-with-state [props]
+  (let [probe (unchecked-get props "probe")
+        [n set-n] (React/useState 10)
+        token (React/useRef (js-obj))]
+    (swap! probe assoc :child-n n :set-child set-n
+           :child-token (.-current token))
+    (React/createElement "span" #js {:data-hmr-child "state"}
+                         (str n))))
+
+(defn- stateful-body [version probe]
+  (fn [props]
+    (let [[n set-n] (React/useState 0)
+          token (React/useRef (js-obj))
+          prop-v (unchecked-get props "value")]
+      (swap! probe assoc :parent-n n :set-parent set-n
+             :parent-token (.-current token))
+      (React/createElement
+       "section" #js {:data-hmr-version version}
+       (React/createElement "output" #js {:data-hmr-parent "state"}
+                            (str version ":" prop-v ":" n))
+       (React/createElement child-with-state #js {:probe probe})))))
+
+(deftest same-signature-refresh-preserves-state-and-uses-current-comparator
+  (if-not (browser?)
+    (is true ":node — browser gate runs the mounted Fast Refresh proof")
+    (async done
+      (let [id        ::preserve
+            hs        "hs1-preserve"
+            probe     (atom {})
+            tokens    (atom nil)
+            shell-2   (atom nil)
+            container (js/document.createElement "div")
+            root      (ReactDOMClient/createRoot container)
+            shell-1   (register! id (stateful-body "v1" probe)
+                                 (fn [_ _] true) hs "PreserveView")]
+        (.appendChild (.-body js/document) container)
+        (-> (act-promise
+             #(.render root (React/createElement shell-1 #js {:value "p1"})))
+            (.then
+             (fn []
+               (reset! tokens {:parent (:parent-token @probe)
+                               :child (:child-token @probe)})
+               (act-promise
+                #(do ((:set-parent @probe) 7)
+                     ((:set-child @probe) 19)))))
+            (.then
+             (fn []
+               ;; No root.render: slot publication + uSES notify is the only
+               ;; update path. v2's false comparator deliberately differs
+               ;; from v1's frozen-true comparator.
+               (act-promise
+                #(reset! shell-2
+                         (register! id (stateful-body "v2" probe)
+                                    (fn [_ _] false) hs "PreserveView")))))
+            (.then
+             (fn []
+               (testing "same signature updates in place"
+                 (is (identical? shell-1 @shell-2)
+                     "public shell identity is stable")
+                 (is (= 1 (reactive/view-generation id))
+                     "body revision advanced")
+                 (is (= 0 (reactive/view-remount-generation id))
+                     "same signature never changes the inner key")
+                 (is (= "v2:p1:7"
+                        (.-textContent
+                         (.querySelector container "[data-hmr-parent]")))
+                     "missing-notify / element-invocation mutations fail")
+                 (is (= "19" (.-textContent
+                              (.querySelector container "[data-hmr-child]"))))
+                 (is (identical? (:parent @tokens) (:parent-token @probe)))
+                 (is (identical? (:child @tokens) (:child-token @probe))))
+               ;; Parent props now move. The currently published v2 comparator
+               ;; (false), not v1's frozen comparator (true), must decide.
+               (act-promise
+                #(.render root
+                          (React/createElement @shell-2 #js {:value "p2"})))))
+            (.then
+             (fn []
+               (is (= "v2:p2:7"
+                      (.-textContent
+                       (.querySelector container "[data-hmr-parent]")))
+                   "the stable memo shell delegates to the current comparator")))
+            (.then (fn [] (act-promise #(.unmount root))))
+            (.then (fn [] (.remove container) (done)))
+            (.catch
+             (fn [e]
+               (try (.unmount root) (catch :default _ nil))
+               (.remove container)
+               (is false (str "same-signature browser proof rejected: " e))
+               (done))))))))
+
+(defn- effectful-body [version probe events extra-hook?]
+  (fn [_props]
+    (let [[n set-n] (React/useState 0)]
+      (when extra-hook?
+        (React/useRef :new-hook-site))
+      (React/useLayoutEffect
+       (fn []
+         (swap! events conj (keyword (str "setup-" version)))
+         (fn []
+           (swap! events conj (keyword (str "cleanup-" version)))))
+       #js [])
+      (swap! probe assoc :n n :set-n set-n)
+      (React/createElement "output" #js {:data-hmr-effect version}
+                           (str version ":" n)))))
+
+(deftest incompatible-signature-keeps-shell-and-remounts-inner-once
+  (if-not (browser?)
+    (is true ":node — browser gate runs the incompatible-hook proof")
+    (async done
+      (let [id        ::remount
+            probe     (atom {})
+            events    (atom [])
+            warnings  (atom [])
+            shell-2   (atom nil)
+            original-error (.-error js/console)
+            container (js/document.createElement "div")
+            root      (ReactDOMClient/createRoot container)
+            shell-1   (register! id (effectful-body "v1" probe events false)
+                                 (fn [_ _] true) "hs1-one-hook" "RemountView")]
+        (.appendChild (.-body js/document) container)
+        (set! (.-error js/console)
+              (fn [& xs] (swap! warnings conj (mapv str xs))))
+        (-> (act-promise #(.render root (React/createElement shell-1 nil)))
+            (.then (fn [] (act-promise #((:set-n @probe) 7))))
+            (.then
+             (fn []
+               (reset! events [])
+               (act-promise
+                #(reset! shell-2
+                         (register! id (effectful-body "v2" probe events true)
+                                    (fn [_ _] true) "hs1-two-hooks"
+                                    "RemountView")))))
+            (.then
+             (fn []
+               (testing "only the stable inner Fiber remounts"
+                 (is (identical? shell-1 @shell-2)
+                     "the public shell survives an incompatible edit")
+                 (is (= 1 (reactive/view-remount-generation id)))
+                 (is (= [:cleanup-v1 :setup-v2] @events)
+                     "one cleanup precedes one setup — always/never-key mutations fail")
+                 (is (= "v2:0" (.-textContent
+                                 (.querySelector container "[data-hmr-effect]")))
+                     "inner local state reset exactly once")
+                 (is (empty? @warnings)
+                     "the incompatible hook order produced no React warning"))))
+            (.then (fn [] (act-promise #(.unmount root))))
+            (.then
+             (fn []
+               (set! (.-error js/console) original-error)
+               (.remove container)
+               (done)))
+            (.catch
+             (fn [e]
+               (set! (.-error js/console) original-error)
+               (try (.unmount root) (catch :default _ nil))
+               (.remove container)
+               (is false (str "incompatible-signature browser proof rejected: " e))
+               (done))))))))
+
+(deftest stale-equal-deps-render-cannot-own-before-fresh-revision
+  (if-not (browser?)
+    (is true ":node — browser gate runs the render-to-layout revision race")
+    (async done
+      (let [id        ::stale-render
+            fid       :fast-refresh/stale-frame
+            hs        "hs1-stale-equal-deps"
+            armed     (atom true)
+            observed  (atom ::unset)
+            container (js/document.createElement "div")
+            root      (ReactDOMClient/createRoot container)
+            cache-entry #(get @(:sub-cache (frame/frame fid)) [::value])
+            render-v2 (fn [_props]
+                        (viewcell/render
+                         id
+                         #(React/createElement
+                           "output" #js {:data-hmr-stale "v2"}
+                           (str (reactive/sub-read [::value])))))
+            render-v1 (fn [_props]
+                        (viewcell/render
+                         id
+                         (fn []
+                           (let [v (reactive/sub-read [::value])]
+                             ;; Move the authoritative body revision after
+                             ;; capture began but before this render's layout
+                             ;; commit. Dependencies remain exactly equal.
+                             (when (compare-and-set! armed true false)
+                               (register! id render-v2 (fn [_ _] true)
+                                          hs "StaleRender"))
+                             (React/createElement
+                              "output" #js {:data-hmr-stale "v1"} (str v))))))
+            observer  (fn [_props]
+                        (React/useLayoutEffect
+                         (fn []
+                           ;; Runs after the leaf's layout effect in this commit,
+                           ;; before React services the missed-snapshot rerender.
+                           (reset! observed (cache-entry))
+                           js/undefined)
+                         #js [])
+                        nil)
+            shell     (register! id render-v1 (fn [_ _] true)
+                                 hs "StaleRender")]
+        (rf/reg-sub ::value (fn [db _] (:value db)))
+        (rf/make-frame {:id fid :doc "Fast Refresh stale-capture proof"})
+        (frame/replace-app-db! fid {:value 42})
+        (.appendChild (.-body js/document) container)
+        (-> (act-promise
+             #(.render root
+                       (frames/scope-element
+                        fid
+                        (array (React/createElement shell nil)
+                               (React/createElement observer nil)))))
+            (.then
+             (fn []
+               (is (nil? @observed)
+                   "the stale v1 layout acquired nothing; equal-deps cannot bypass revision")
+               (is (= "v2" (.getAttribute
+                             (.querySelector container "[data-hmr-stale]")
+                             "data-hmr-stale"))
+                   "uSES missed-snapshot correction rendered the fresh body")
+               (is (= 1 (:ref-count (cache-entry)))
+                   "only the fresh revision owns the dependency")))
+            (.then (fn [] (act-promise #(.unmount root))))
+            (.then (fn [] (.remove container) (done)))
+            (.catch
+             (fn [e]
+               (try (.unmount root) (catch :default _ nil))
+               (.remove container)
+               (is false (str "stale-revision browser proof rejected: " e))
+               (done))))))))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -12,9 +12,12 @@
             ["react-dom/server" :as rds]
             [re-frame.registrar :as registrar]
             [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]
             [re-frame.ui.runtime :as rt]))
 
 (defn- render [el] (rds/renderToStaticMarkup el))
+(defn- current-render [id] (:render-fn (reactive/view-descriptor id)))
+(defn- current-compare [id] (:compare-fn (reactive/view-descriptor id)))
 
 (defonce dispatches (atom []))
 
@@ -143,7 +146,7 @@
          (render (rt/jsx2 static-tree (js-obj)))))
   ;; the fully-static body hoists to a module constant: the render fn
   ;; returns the IDENTICAL element object across calls
-  (let [rf (.-type static-tree)]
+  (let [rf (current-render ::static-tree)]
     (is (identical? (rf (js-obj)) (rf (js-obj)))
         "static subtree is one hoisted module constant")))
 
@@ -277,7 +280,7 @@
                   :else [ch]))))))
 
 (deftest handler-vector-dispatches-and-splices
-  (let [el      ((.-type counter) (js-obj "n" 3 "locked?" false))
+  (let [el      ((current-render ::counter) (js-obj "n" 3 "locked?" false))
         onClick (find-prop el "onClick")
         onInput (find-prop el "onInput")]
     (is (fn? onClick))
@@ -289,7 +292,7 @@
         ":rf.ui/value splices the event's target.value at dispatch time")))
 
 (deftest checked-placeholder-splices
-  (let [el ((.-type todo-row) (js-obj "todo" {:id 9 :label "x" :done? false
+  (let [el ((current-render ::todo-row) (js-obj "todo" {:id 9 :label "x" :done? false
                                               :priority :low}))
         onChange (find-prop el "onChange")]
     (onChange (js-obj "target" (js-obj "checked" true)))
@@ -297,14 +300,14 @@
 
 (deftest capture-free-handlers-hoist-and-dedupe
   ;; same capture-free vector in two renders -> the same fn object
-  (let [el1 ((.-type counter) (js-obj "n" 1 "locked?" false))
-        el2 ((.-type counter) (js-obj "n" 2 "locked?" false))]
+  (let [el1 ((current-render ::counter) (js-obj "n" 1 "locked?" false))
+        el2 ((current-render ::counter) (js-obj "n" 2 "locked?" false))]
     (is (identical? (find-prop el1 "onClick") (find-prop el2 "onClick"))
         "capture-free literal event vectors hoist to one module callback")))
 
 (deftest unwired-dispatch-throws-loudly
   (rt/set-dispatch-hook! nil)
-  (let [el ((.-type counter) (js-obj "n" 1 "locked?" false))
+  (let [el ((current-render ::counter) (js-obj "n" 1 "locked?" false))
         onClick (find-prop el "onClick")]
     (is (thrown-with-msg? js/Error #"ui-dispatch-unwired"
                           (onClick (js-obj))))))
@@ -314,7 +317,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest memo-comparator-is-the-ruled-rf=
-  (let [cmp (.-compare todo-list)]
+  (let [cmp (current-compare ::todo-list)]
     (is (fn? cmp))
     ;; fresh-but-equal CLJS data => equal (no repaint)
     (is (true? (cmp (js-obj "title" "T" "todos" [{:id 1}])
@@ -342,7 +345,7 @@
                     (js-obj "todos" []))))))
 
 (deftest as-view-generic-comparator
-  (let [cmp (.-compare as-view)]
+  (let [cmp (current-compare ::as-view)]
     (is (true? (cmp (js-obj "a" 1 "b" [1 2]) (js-obj "a" 1 "b" [1 2]))))
     (is (false? (cmp (js-obj "a" 1) (js-obj "a" 1 "c" 3)))
         ":as views compare the UNION of slots (generic comparison)")))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -372,3 +372,48 @@
     (is (true? (:rf.ui/compiled? meta*)))
     (is (= "probe" (:doc meta*)))
     (is (= ::probe-view (get-in meta* [:rf.ui/manifest :view-id])))))
+
+(deftest hmr-slot-publication-is-atomic-and-identities-are-stable
+  (let [id      ::atomic-publication
+        render1 (fn [_props] nil)
+        render2 (fn [_props] nil)
+        cmp1    (fn [_ _] true)
+        cmp2    (fn [_ _] false)
+        shell1  (rt/register-view! id render1 cmp1 "AtomicView"
+                                   {:view-id id :hook-signature "hs1-a"})
+        pair1   (reactive/view-shells id)
+        seen    (atom [])
+        stop    (reactive/subscribe-view!
+                 id
+                 #(swap! seen conj
+                         {:body (reactive/view-generation id)
+                          :remount (reactive/view-remount-generation id)
+                          :descriptor (reactive/view-descriptor id)}))
+        shell2  (rt/register-view! id render2 cmp2 "AtomicView"
+                                   {:view-id id :hook-signature "hs1-b"})]
+    (stop)
+    (is (identical? shell1 shell2) "fresh-shell mutation is rejected")
+    (is (identical? (:inner pair1) (:inner (reactive/view-shells id))))
+    (is (= 1 (count @seen)) "one successful registration emits one notify")
+    (let [{:keys [body remount descriptor]} (first @seen)]
+      (is (= [1 1] [body remount]))
+      (is (identical? render2 (:render-fn descriptor)))
+      (is (identical? cmp2 (:compare-fn descriptor)))
+      (is (= "hs1-b" (get-in descriptor [:manifest :hook-signature]))
+          "listener observes descriptor and both revisions from one publication"))))
+
+(deftest failed-registrar-write-does-not-publish-a-body-revision
+  (let [id ::failed-publication
+        result (try
+                 (with-redefs [registrar/register!
+                               (fn [& _] (throw (js/Error. "registrar boom")))]
+                   (rt/register-view! id (fn [_props] nil) (fn [_ _] true)
+                                      "FailedView"
+                                      {:view-id id :hook-signature "hs1-a"}))
+                 :unexpected-success
+                 (catch :default _ :thrown))]
+    (is (= :thrown result))
+    (is (nil? (reactive/registered-view-revision id))
+        "only a successful registrar write advances body freshness")
+    (is (nil? (reactive/view-descriptor id))
+        "a failed registration cannot become the dynamic render authority")))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -357,8 +357,13 @@
   ;; emitted code calls and assert the entry shape. That defview EMITS
   ;; this call under the goog.DEBUG gate is pinned as an emission-form
   ;; test on the JVM (defview-grammar-jvm-test), where it is order-free.
-  (rt/register-view! ::probe-view todo-list
-                     {:view-id ::probe-view :doc "probe"})
+  (rt/register-view! ::probe-view
+                     (fn [_props] nil)
+                     (fn [_prev _next] true)
+                     "probe-view"
+                     {:view-id ::probe-view
+                      :hook-signature "hs1-probe"
+                      :doc "probe"})
   (let [meta* (registrar/handler-meta :view ::probe-view)]
     (is (some? meta*) "register-view! writes the registrar :view kind")
     (is (true? (:rf.ui/compiled? meta*)))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -232,7 +232,7 @@
 (defn- has-own? [o k]
   (.call (.-hasOwnProperty (.-prototype js/Object)) o k))
 
-(defn- captured-jsx-props [view value]
+(defn- captured-jsx-props [view-id value]
   (let [module   rt/jsx-runtime
         original (.-jsx module)
         captured (atom nil)]
@@ -241,19 +241,19 @@
             (fn [_type props & _]
               (reset! captured props)
               #js {}))
-      ((.-type view) (js-obj "v" value))
+      ((current-render view-id) (js-obj "v" value))
       @captured
       (finally
         (set! (.-jsx module) original)))))
 
 (deftest prototype-setter-key-remains-an-own-prop-on-every-jsx-surface
-  (doseq [[surface view]
-          [[:dom proto-dom]
-           [:custom-element proto-custom]
-           [:view proto-view]
-           [:foreign proto-foreign]]]
+  (doseq [[surface view-id]
+          [[:dom ::proto-dom]
+           [:custom-element ::proto-custom]
+           [:view ::proto-view]
+           [:foreign ::proto-foreign]]]
     (let [value (js-obj "surface" (name surface))
-          props (captured-jsx-props view value)]
+          props (captured-jsx-props view-id value)]
       (is (some? props) (name surface))
       (is (has-own? props "__proto__")
           (str (name surface) " has an own __proto__ data property"))
@@ -373,6 +373,54 @@
     (is (= "probe" (:doc meta*)))
     (is (= ::probe-view (get-in meta* [:rf.ui/manifest :view-id])))))
 
+(deftest registrar-hooks-observe-one-coherent-view-publication
+  (let [id      ::registrar-hook-publication
+        seen    (atom [])
+        body    (fn [label]
+                  (fn [_props]
+                    (rt/jsx2 "output" (js-obj "children" label))))
+        render1 (body "v1")
+        render2 (body "v2")
+        cmp1    (fn [_ _] true)
+        cmp2    (fn [_ _] false)]
+    ;; Registration hooks are process-lived by registrar contract, so this
+    ;; one is permanently inert for every id except its unique fixture id.
+    (registrar/add-registration-hook!
+     (fn [{:keys [kind id now]}]
+       (when (and (= :view kind) (= ::registrar-hook-publication id))
+         (let [descriptor (reactive/view-descriptor id)]
+           (swap! seen conj
+                  (try
+                    {:body-revision (reactive/view-generation id)
+                     :manifest (:rf.ui/manifest now)
+                     :descriptor-manifest (:manifest descriptor)
+                     :render-fn (:render-fn descriptor)
+                     :compare-fn (:compare-fn descriptor)
+                     ;; Counterexample: the synchronous hook renders the
+                     ;; just-published shell. Preparing after register! makes
+                     ;; first load call nil and replacement render old code.
+                     :markup (render (rt/jsx2 (:handler-fn now) (js-obj)))}
+                    (catch :default e
+                      {:error e})))))))
+    (rt/register-view! id render1 cmp1 "HookPublication"
+                       {:view-id id :hook-signature "hs1-hook" :version 1})
+    (rt/register-view! id render2 cmp2 "HookPublication"
+                       {:view-id id :hook-signature "hs1-hook" :version 2})
+    (is (= 2 (count @seen)) "the hook ran on first registration and replacement")
+    (is (every? #(nil? (:error %)) @seen)
+        "the stable shell was renderable during both synchronous hooks")
+    (is (= [0 1] (mapv :body-revision @seen)))
+    (is (= ["<output>v1</output>" "<output>v2</output>"]
+           (mapv :markup @seen))
+        "first load sees a descriptor; reload sees the new body")
+    (is (= [1 2] (mapv #(get-in % [:manifest :version]) @seen)))
+    (is (= (mapv :manifest @seen) (mapv :descriptor-manifest @seen))
+        "registrar manifest and render authority move as one observation")
+    (is (identical? render1 (:render-fn (first @seen))))
+    (is (identical? render2 (:render-fn (second @seen))))
+    (is (identical? cmp1 (:compare-fn (first @seen))))
+    (is (identical? cmp2 (:compare-fn (second @seen))))))
+
 (deftest hmr-slot-publication-is-atomic-and-identities-are-stable
   (let [id      ::atomic-publication
         render1 (fn [_props] nil)
@@ -417,3 +465,58 @@
         "only a successful registrar write advances body freshness")
     (is (nil? (reactive/view-descriptor id))
         "a failed registration cannot become the dynamic render authority")))
+
+(deftest failed-replacement-rolls-back-the-entire-view-publication
+  (let [id      ::failed-replacement
+        render1 (fn [_props] nil)
+        cmp1    (fn [_ _] true)
+        shell1  (rt/register-view! id render1 cmp1 "RollbackV1"
+                                   {:view-id id
+                                    :hook-signature "hs1-a"
+                                    :version 1})
+        before  (reactive/view-descriptor id)
+        pair     (reactive/view-shells id)
+        seen     (atom [])
+        stop     (reactive/subscribe-view! id #(swap! seen conj :notified))
+        result   (try
+                   (with-redefs [registrar/register!
+                                 (fn [& _]
+                                   (is (= 1 (reactive/view-generation id))
+                                       "candidate is prepared for registrar hooks")
+                                   (is (= 2 (get-in (reactive/view-descriptor id)
+                                                    [:manifest :version])))
+                                   (throw (js/Error. "replacement boom")))]
+                     (rt/register-view! id (fn [_props] :v2) (fn [_ _] false)
+                                        "RollbackV2"
+                                        {:view-id id
+                                         :hook-signature "hs1-b"
+                                         :version 2}))
+                   :unexpected-success
+                   (catch :default _ :thrown))]
+    (stop)
+    (is (= :thrown result))
+    (is (= 0 (reactive/view-generation id)))
+    (is (= 0 (reactive/view-remount-generation id)))
+    (is (identical? before (reactive/view-descriptor id))
+        "render/comparator/manifest roll back to the last successful publication")
+    (is (identical? shell1 (:outer (reactive/view-shells id))))
+    (is (identical? (:inner pair) (:inner (reactive/view-shells id))))
+    (is (= "RollbackV1" (.-displayName shell1))
+        "failed candidate display names do not leak")
+    (is (empty? @seen) "a rolled-back candidate never notifies mounted shells")))
+
+(deftest scheduler-reset-never-strands-an-already-loaded-defview
+  (let [shell-before static-tree
+        descriptor-before (reactive/view-descriptor ::static-tree)]
+    (reactive/reset-scheduler!)
+    (is (identical? shell-before static-tree))
+    (is (identical? descriptor-before
+                    (reactive/view-descriptor ::static-tree)))
+    (is (= (str "<div class=\"panel\" id=\"about\" "
+                "style=\"padding:16px;border-top:1px solid #ccc\">"
+                "<h2 class=\"title\">About</h2>"
+                "<p>Static, <em>hoisted</em>.</p>"
+                "<footer aria-label=\"footer\" tabindex=\"0\">"
+                "(c) 2026 &lt;re-frame2&gt;</footer></div>")
+           (render (rt/jsx2 static-tree (js-obj))))
+        "fixture/scheduler cleanup leaves the defview's live authority intact")))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -8,11 +8,10 @@
 
   Every cell exercises the actual substrate primitive — no proxy:
 
-    1. HOOK-SIGNATURE DECIDES PRESERVE vs REMOUNT. `hook-signature-hash`
-       (shipped since S1b, consumed here) keyed through the view-body
-       GENERATION registry: a template edit (same hook signature, moved
-       template fingerprint) KEEPS the generation → mounted cells preserve; a
-       hook edit (moved signature) BUMPS it → the shell remounts a fresh cell.
+    1. HOOK-SIGNATURE DECIDES PRESERVE vs REMOUNT. Every successful
+       registration advances BODY REVISION so mounted shells see the new body.
+       A template edit (same hook signature) KEEPS REMOUNT GENERATION; a hook
+       edit advances it so the stable shell remounts its stable inner Fiber.
        `sub`/`lease`/event sites are excluded from the signature, so adding your
        first `sub` is a same-signature edit.
     2. STALE-CELL REJECTION AT COMMIT (step 1). A live cell whose generation
@@ -104,31 +103,35 @@
               (fp/hook-signature-hash {:locals ['b 'a] :effects []}))
         "hook ORDER is part of the signature (React hook-order safety)")))
 
-(deftest same-signature-reload-keeps-the-view-generation
+(deftest same-signature-reload-advances-body-but-keeps-remount-generation
   (let [vid ::preserve-view
         hs0 (fp/hook-signature-hash {:locals [] :effects []})]
     (is (= 0 (reactive/register-view-generation! vid hs0))
-        "first registration seeds generation 0")
-    (testing "a template-only reload (same hook signature) KEEPS the generation
-              → mounted cells preserve state"
-      (is (= 0 (reactive/register-view-generation! vid hs0)))
-      (is (= 0 (reactive/register-view-generation! vid hs0)))
-      (is (= 0 (reactive/view-generation vid))))))
+        "first successful registration seeds body revision 0")
+    (testing "a template-only reload advances body freshness but never the
+              remount key → mounted state is preserved"
+      (is (= 1 (reactive/register-view-generation! vid hs0)))
+      (is (= 2 (reactive/register-view-generation! vid hs0)))
+      (is (= 2 (reactive/view-generation vid)))
+      (is (= 0 (reactive/view-remount-generation vid))))))
 
-(deftest changed-signature-reload-bumps-the-view-generation
+(deftest changed-signature-reload-bumps-only-the-remount-generation
   (let [vid ::remount-view
         hs0 (fp/hook-signature-hash {:locals [] :effects []})
         hs1 (fp/hook-signature-hash {:locals ['draft] :effects []})
         hs2 (fp/hook-signature-hash {:locals ['draft] :effects ['sync]})]
     (is (= 0 (reactive/register-view-generation! vid hs0)))
-    (testing "a hook edit (moved signature) BUMPS the generation → the shell
-              remounts cleanly"
+    (testing "every registration advances body revision; only hook edits bump
+              the remount key"
       (is (= 1 (reactive/register-view-generation! vid hs1)))
       (is (= 1 (reactive/view-generation vid)))
+      (is (= 1 (reactive/view-remount-generation vid)))
       (is (= 2 (reactive/register-view-generation! vid hs2))
-          "each distinct signature bumps once")
-      (testing "reverting to a prior signature is itself a change (monotone gen)"
-        (is (= 3 (reactive/register-view-generation! vid hs0)))))))
+          "body revision advances once per successful publication")
+      (is (= 2 (reactive/view-remount-generation vid)))
+      (testing "reverting to a prior signature is itself an incompatibility"
+        (is (= 3 (reactive/register-view-generation! vid hs0)))
+        (is (= 3 (reactive/view-remount-generation vid)))))))
 
 (deftest freshly-mounted-cell-mints-at-the-view-generation
   (let [vid ::mint-view
@@ -137,6 +140,7 @@
     (reactive/register-view-generation! vid hs0)
     (reactive/register-view-generation! vid hs1)  ; a changed-signature reload
     (is (= 1 (reactive/view-generation vid)))
+    (is (= 1 (reactive/view-remount-generation vid)))
     (let [cell (reactive/make-cell vid (reactive/view-generation vid))]
       (is (= 1 (reactive/generation cell))
           "a cell mounted after a remount starts at the current view generation")
@@ -147,23 +151,27 @@
 ;; Cell 2 — stale-capture rejection at commit (step 1): generation remount seam
 ;; ===========================================================================
 
-(deftest stale-generation-capture-rejected-at-commit-step-1
+(deftest stale-authoritative-body-revision-rejected-at-commit-step-1
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
-  (let [cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
+  (let [hs   (fp/hook-signature-hash {:locals [] :effects []})
+        _    (reactive/register-view-generation! ::v hs)
+        cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
         lease0 (reactive/committed-lease cell (tk [:r/a]))]
     (is (= 1 (ref-count [:r/a])) "precondition: committed at generation 0")
-    (testing "a changed-signature remount BUMPS the cell generation; its in-flight
-              capture (rendered under the prior body) is now stale"
+    (testing "registration lands after render but before layout: the slot moved
+              while the cell-local revision did not"
       (let [[_ capture] (render! cell [[:r/a]])]    ; capture at generation 0
-        (reactive/advance-generation! cell 1)       ; changed-signature remount
-        (is (= 1 (reactive/generation cell)))
+        (reactive/register-view-generation! ::v hs) ; same-sig body revision 1
+        (is (= 0 (reactive/generation cell))
+            "mutation tooth: cell-local-only checking would accept this capture")
         (is (= :stale (reactive/commit! cell capture))
-            "commit step 1 REJECTS the stale-generation capture (the host re-renders)")))
+            "commit step 1 consults the authoritative slot revision")))
     (testing "no ownership was touched — the prior committed set stays installed"
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a]))))
       (is (= 1 (ref-count [:r/a])) "no acquire, no release on a stale rejection"))
     (testing "a fresh render under the new generation commits normally"
+      (reactive/advance-generation! cell (reactive/view-generation ::v))
       (render+commit! cell [[:r/a]])
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
           "the same live target retains its lease across the explicit generation seam"))))
@@ -292,11 +300,13 @@
         hs1 (fp/hook-signature-hash {:locals ['n] :effects []})
         run (fn [view-id]
               (reactive/register-view-generation! view-id hs0)   ; initial reg
-              [(reactive/register-view-generation! view-id hs0)   ; same-sig reload
-               (reactive/register-view-generation! view-id hs1)   ; changed-sig reload
-               (reactive/register-view-generation! view-id hs0)]) ; changed again
+              {:body [(reactive/register-view-generation! view-id hs0)
+                      (reactive/register-view-generation! view-id hs1)
+                      (reactive/register-view-generation! view-id hs0)]
+               :remount (reactive/view-remount-generation view-id)})
         file-save (run ::via-file-save)
         repl      (run ::via-repl)]
-    (is (= [0 1 2] file-save) "same-sig keeps, each change bumps once")
+    (is (= {:body [1 2 3] :remount 2} file-save)
+        "every body publishes; only the two incompatible transitions remount")
     (is (= file-save repl)
         "a REPL re-eval and a file-save reload take the IDENTICAL generation path")))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -154,15 +154,16 @@
 (deftest stale-authoritative-body-revision-rejected-at-commit-step-1
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
-  (let [hs   (fp/hook-signature-hash {:locals [] :effects []})
-        _    (reactive/register-view-generation! ::v hs)
-        cell (render+commit! (reactive/make-cell ::v 0) [[:r/a]])
+  (let [vid  ::stale-revision-view
+        hs   (fp/hook-signature-hash {:locals [] :effects []})
+        _    (reactive/register-view-generation! vid hs)
+        cell (render+commit! (reactive/make-cell vid 0) [[:r/a]])
         lease0 (reactive/committed-lease cell (tk [:r/a]))]
     (is (= 1 (ref-count [:r/a])) "precondition: committed at generation 0")
     (testing "registration lands after render but before layout: the slot moved
               while the cell-local revision did not"
       (let [[_ capture] (render! cell [[:r/a]])]    ; capture at generation 0
-        (reactive/register-view-generation! ::v hs) ; same-sig body revision 1
+        (reactive/register-view-generation! vid hs) ; same-sig body revision 1
         (is (= 0 (reactive/generation cell))
             "mutation tooth: cell-local-only checking would accept this capture")
         (is (= :stale (reactive/commit! cell capture))
@@ -171,7 +172,7 @@
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a]))))
       (is (= 1 (ref-count [:r/a])) "no acquire, no release on a stale rejection"))
     (testing "a fresh render under the new generation commits normally"
-      (reactive/advance-generation! cell (reactive/view-generation ::v))
+      (reactive/advance-generation! cell (reactive/view-generation vid))
       (render+commit! cell [[:r/a]])
       (is (identical? lease0 (reactive/committed-lease cell (tk [:r/a])))
           "the same live target retains its lease across the explicit generation seam"))))

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -639,8 +639,13 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- reg-view! [id tf hs]
-  (runtime/register-view! id (fn [_])
-                          {:template-fingerprint tf :hook-signature hs}))
+  (runtime/register-view! id
+                          (fn [_props] nil)
+                          (fn [_prev _next] true)
+                          (str id)
+                          {:view-id id
+                           :template-fingerprint tf
+                           :hook-signature hs}))
 
 (deftest client-descriptor-projects-the-build-digest
   (let [published (client/current-build-digest)]


### PR DESCRIPTION
## What changed

- replace the generation-only HMR registry with one dev-only per-view slot holding stable outer/inner identities, current render/comparator/manifest descriptor, body revision, hook-incompatibility remount generation, and the minimal external-store listeners
- give every development defview the invariant ViewCell hook skeleton, so same-signature edits may add or remove `sub` sites safely; retain direct specialized `React.memo` output in production
- publish each view's descriptor/revisions through a prepare → registrar → commit transaction: synchronous registrar hooks see one coherent candidate, mounted shells notify only after success, and registrar failure rolls back
- advance body revision on every successful registration, remount only the inner Fiber when the hook signature changes, and reject render captures against the authoritative current revision
- keep scheduler/test reset separate from process-lived HMR slots so already-exported defviews never lose their render authority
- keep slot keys private, with no new public keyword namespace or spec surface
- remove test-only direct invocation of hook-owning shells in favor of the explicit current-descriptor seam or real React mounting

## Why

Compiled defviews previously created a fresh React component on namespace re-evaluation. The generation registry recorded preserve-versus-remount intent, but the render path could not realize it: every save remounted and lost local state. This change makes the shell identity persistent while keeping hook-incompatible updates safe and production exceptionally lean.

## Proof

- real browser, no `root.render`: same-signature v1 → v2 preserves parent state/ref, stateful-child state/ref, and both shell identities while selecting the current comparator
- same-signature no-sub → sub → no-sub preserves state, emits no hook-order warning, acquires the new observation, then releases it
- changed hook signature preserves the public shell but remounts Inner exactly once with `cleanup-v1` before `setup-v2`
- render(old) → register(new) → layout(old), with equal dependencies, leaves the stale capture ownership-free and lets only the fresh revision own
- synchronous registrar hooks render the stable shell on first registration and replacement and observe matching manifest/render/comparator/revision; failed first/replacement publication rolls back without notification
- compiler golden pins `defview`'s DEV `runtime/register-view!` top-level path and sub-free/sub-bearing production specialization; the real-browser fixture drives that exact registration path. It deliberately does not claim a flaky watch-server source-mutation harness or namespace-wide publication transaction; one synchronous JS reload stack cannot interleave a React commit between top-level registrations
- G13 still proves exactly V ownership-bearing cells and the unchanged 8-view economic projection; it also counts the two sub-free fixed-shell cells explicitly and proves they stay ownership-empty, clean, and revision-idle
- advanced build pins absence of HMR slot, listener store, dynamic descriptor lookup, and extra Inner Fiber

## Validation (head `dfe01fcd6a284b7c484413fdf3f5ba77ed1a1263`)

- `clojure -M:test` from `implementation/ui`: 377 tests, 5,138 assertions, green
- `npm run test:ui`: 384 tests, 1,933 assertions, green
- browser gate: 332 tests, 1,242 assertions, green
- `npm run test:ui-g13`: green, including advanced elision and mutation teeth
- `npm run test:elision`: production 52/52 dev sentinels absent; control 52/52 present
- `python scripts/check_keyword_catalogue_drift.py --verbose`: clean
- `git diff --check`: green
- rebased onto `origin/main` `bd99a17d9350e0022daad7e7f9c6a10121700674`; the original five HMR commits were patch-equivalent under `git range-diff`, followed by two focused CI-gate repairs

## Stage boundary

This S2 change provides the body-revision seam consumed by S3 effects. The S3 `re-frame.ui.react` slice remains responsible for including body revision in effect dependency comparison so an equal authored deps vector cannot suppress refresh cleanup/setup. This PR does not add the not-yet-shipped S3 effect API.

Bead: `rf2-8hf77d`