### PR TITLE
rf2-vxgfnd.111: preserve inline sub runtime metadata

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -2174,16 +2174,17 @@
 (defn lower-inline-sub
   "Lower an inline `:reg-sub` descriptor's raw computation fn into the runnable
   layer-1 (`:input-kind :db`) sub slots `reg-sub` installs (`:handler-fn` +
-  `:input-kind :db` + empty `:input-signals`). `_meta` is the inline entry's
-  metadata map (unused — the descriptor already carries the inline `:metadata`,
-  and an inline tuple cannot express the `:<-` chain that would change the
-  input kind); `impl` is the raw `(fn [db query-v] …)` computation. Returns
-  ONLY the runnable slots so image-assembly merges them onto the descriptor,
-  preserving `:impl` + provenance."
-  [_meta impl]
-  {:handler-fn    impl
-   :input-kind    :db
-   :input-signals []})
+  `:input-kind :db` + empty `:input-signals`). `metadata` is also projected
+  onto the runnable descriptor's top level, matching the shape `reg-sub`
+  installs and making runtime consumers such as return-schema validation read
+  the same slots regardless of registration path. Image assembly still keeps
+  the original nested `:metadata` plus `:impl` and provenance for inspection.
+  Runtime-owned runnable slots win over metadata."
+  [metadata impl]
+  (assoc metadata
+         :handler-fn    impl
+         :input-kind    :db
+         :input-signals []))
 
 (late-bind/set-fn! :image/lower-inline-sub lower-inline-sub)
 

--- a/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
@@ -113,13 +113,40 @@
             (a static :<- / parametric input-fn sub is NOT expressible inline and
             stays namespace-authored)"
     (let [body (fn [db _] (:counter/value db))
-          d    (runnable {:reg-sub [[:counter/value body]]})]
+          meta {:schema        :counter/int
+                :doc           "Image-owned counter value."
+                ;; Authored metadata must never replace runnable ownership.
+                :handler-fn    ::hostile-handler
+                :input-kind    :parametric
+                :input-signals [[:hostile/input]]}
+          d    (runnable {:reg-sub [[:counter/value meta body]]})]
       (is (= :sub (:kind d)))
       (is (= :counter/value (:id d)))
       (is (= body (:impl d)))
-      (is (= body (:handler-fn d)) "the db-reader is the runnable :handler-fn")
-      (is (= :db (:input-kind d)) "inline subs are layer-1 db-readers ONLY")
-      (is (= [] (:input-signals d)) "a layer-1 db-reader has no input signals"))))
+      (is (= meta (:metadata d))
+          "the authored metadata remains nested for provenance/introspection")
+      (is (= :counter/int (:schema d))
+          "runtime metadata is also flat, matching reg-sub's runnable shape")
+      (is (= "Image-owned counter value." (:doc d)))
+      (is (= body (:handler-fn d))
+          "the runtime handler wins over a hostile metadata slot")
+      (is (= :db (:input-kind d))
+          "the fixed layer-1 input kind wins over hostile metadata")
+      (is (= [] (:input-signals d))
+          "the fixed empty signal list wins over hostile metadata")))
+  (testing "omitted metadata and an explicitly nil schema stay distinguishable"
+    (let [body     (fn [_ _] nil)
+          omitted (runnable {:reg-sub [[:counter/omitted body]]})
+          explicit (runnable {:reg-sub [[:counter/explicit
+                                         {:schema nil}
+                                         body]]})]
+      (is (not (contains? omitted :schema))
+          "omitting metadata does not invent a top-level schema slot")
+      (is (contains? explicit :schema)
+          "an explicitly nil schema remains present in the runnable metadata")
+      (is (nil? (:schema explicit)))
+      (is (= {:schema nil} (:metadata explicit))
+          "the exact authored nil metadata remains nested for inspection"))))
 
 (deftest inline-fx-lowers-to-the-runnable-fx-slot
   (testing "inline :reg-fx lowers via the LIVE :image/lower-inline-fx into the

--- a/implementation/core/test/re_frame/live_run_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_run_frame_resolution_cljs_test.cljc
@@ -46,8 +46,10 @@
             [re-frame.image          :as image]
             [re-frame.registrar      :as registrar]
             [re-frame.live-frame     :as lf]
+            [re-frame.schemas        :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support   :as test-support]))
+            [re-frame.test-support   :as test-support]
+            [re-frame.trace.tooling  :as trace-tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixture: install the plain-atom adapter (so frames are runnable), opt OUT of
@@ -95,6 +97,37 @@
    :id               id
    :input-kind       :db
    :handler-fn       compute-fn})
+
+(defn- with-inline-sub-schema-port
+  "Install a deterministic schema port for one body and restore the process
+  bundle afterwards. The two deliberately conflicting schema ids make it
+  observable whether a frame resolved the image or global registration."
+  [calls body]
+  (let [snapshot (schemas/snapshot-schema-fns)]
+    (schemas/set-schema-fns!
+      {:validate (fn [schema value]
+                   (swap! calls conj [schema value])
+                   (case schema
+                     :image/int     (int? value)
+                     :global/string (string? value)
+                     true))
+       :explain  (fn [schema value]
+                   {:schema schema :value value})})
+    (try (body)
+         (finally (schemas/restore-schema-fns! snapshot)))))
+
+(defn- collect-error-events
+  "Run `body` while collecting typed error trace events."
+  [body]
+  (let [seen (atom [])
+        id   ::inline-sub-schema-errors]
+    (trace-tooling/register-listener! id
+      (fn [event]
+        (when (= :error (:op-type event))
+          (swap! seen conj event))))
+    (try (body)
+         (finally (trace-tooling/unregister-listener! id)))
+    @seen))
 
 ;; ===========================================================================
 ;; 1. THE ACCEPTANCE — a REAL frame-targeted dispatch resolves the event
@@ -455,6 +488,59 @@
            global sub")
       (is (nil? registrar/*generation*)
           "the generation binding did NOT leak past the build"))))
+
+(deftest inline-sub-schema-is-authoritative-for-ordinary-subscribe
+  (testing "a real inline image sub validates its return with the image schema,
+            not a conflicting global registration's schema"
+    (let [invalid-q :inline.schema/invalid
+          valid-q   :inline.schema/valid
+          calls     (atom [])]
+      ;; If generation resolution or metadata lowering is wrong, these global
+      ;; schemas produce the exact opposite outcome from the image schemas.
+      (rf/reg-sub invalid-q {:schema :global/string} (fn [_ _] ::global))
+      (rf/reg-sub valid-q   {:schema :global/string} (fn [_ _] ::global))
+      (let [img (image/image
+                  {:id :inline/schema
+                   :registrations
+                   {:reg-sub
+                    [[invalid-q {:schema :image/int}
+                      (fn [_ _] "accepted-only-by-global")]
+                     [valid-q {:schema :image/int}
+                      (fn [_ _] 7)]]}})
+            _   (lf/make-frame {:id :inline/schema-frame :images [img]} [])
+            result (atom ::unset)
+            errors (with-inline-sub-schema-port calls
+                     #(collect-error-events
+                        (fn []
+                          (reset! result
+                            [(rf/subscribe-once [invalid-q]
+                               {:frame :inline/schema-frame})
+                             (rf/subscribe-once [valid-q]
+                               {:frame :inline/schema-frame})]))))
+            failure (first
+                      (filter #(= :rf.error/schema-validation-failure
+                                  (:operation %))
+                              errors))]
+        (is (= [nil 7] @result)
+            "invalid image return recovers to nil; valid image return survives")
+        (is (= [[:image/int "accepted-only-by-global"]
+                [:image/int 7]]
+               @calls)
+            "both reads consult the image schema and never the global schema")
+        (is (some? failure) "invalid image return emits typed failure evidence")
+        (is (= :sub-return (-> failure :tags :where)))
+        (is (= :inline/schema-frame (-> failure :tags :frame)))
+        (is (= invalid-q (-> failure :tags :rf.sub/id)))
+        (is (= invalid-q (-> failure :tags :failing-id)))
+        (is (= [invalid-q] (-> failure :tags :rf.sub/query-v)))
+        (is (= invalid-q (-> failure :tags :schema-id)))
+        (is (= "accepted-only-by-global" (-> failure :tags :received)))
+        (is (= "accepted-only-by-global" (-> failure :tags :value)))
+        (is (= {:schema :image/int :value "accepted-only-by-global"}
+               (-> failure :tags :explain)))
+        (is (and (string? (-> failure :tags :reason))
+                 (re-find #":image/int" (-> failure :tags :reason)))
+            "failure reason names the authoritative image schema")))))
 
 (deftest inline-registrations-fx-fn-body-runs-through-pipeline
   (testing "an image built from INLINE :registrations with a REAL fx fn body

--- a/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
@@ -35,11 +35,21 @@
   Saves + restores the prior hook so the consolidated node-test bundle's real
   Malli validator is untouched for sibling tests."
   [test-fn]
-  (let [prior (late-bind/get-fn :schemas/validate-with-registered-fn)]
+  (let [prior-validator (late-bind/get-fn :schemas/validate-with-registered-fn)
+        prior-explainer (late-bind/get-fn :schemas/explain-with-registered-fn)]
     (late-bind/set-fn! :schemas/validate-with-registered-fn
-      (fn [schema value] (if (= schema :int) (int? value) true)))
+      (fn [schema value]
+        (case schema
+          :int           (int? value)
+          :image/int     (int? value)
+          :global/string (string? value)
+          true)))
+    (late-bind/set-fn! :schemas/explain-with-registered-fn
+      (fn [schema value] {:schema schema :value value}))
     (try (test-fn)
-         (finally (late-bind/set-fn! :schemas/validate-with-registered-fn prior)))))
+         (finally
+           (late-bind/set-fn! :schemas/validate-with-registered-fn prior-validator)
+           (late-bind/set-fn! :schemas/explain-with-registered-fn prior-explainer)))))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
@@ -49,10 +59,12 @@
   "Read `query` as a compiled-view site with `overrides` bound (the explicit
   override door). Outside a ViewCell, `sub-read` returns the freshly resolved
   value — for a HIT, the schema-validated pinned value."
-  [overrides query]
-  (rf/with-frame fid
-    (binding [reactive/*sub-overrides* overrides]
-      (reactive/sub-read query))))
+  ([overrides query]
+   (read-override fid overrides query))
+  ([frame-id overrides query]
+   (rf/with-frame frame-id
+     (binding [reactive/*sub-overrides* overrides]
+       (reactive/sub-read query)))))
 
 (defn- collect-errors
   "Run `thunk` capturing every `:rf.error/*` trace event. Returns the vector
@@ -115,6 +127,55 @@
           "any value surfaces when the sub declares no schema")
       (is (not-any? #(= :rf.error/schema-validation-failure (:operation %)) errors)
           "no validation runs when the sub has no :schema"))))
+
+(deftest inline-image-schema-is-authoritative-for-overrides
+  (testing "compiled-view overrides resolve schema metadata from the target
+            frame's real inline image, not a conflicting global registration"
+    (let [frame-id  :inline.schema/ui-frame
+          invalid-q :inline.schema/override-invalid
+          valid-q   :inline.schema/override-valid]
+      ;; These schemas deliberately produce the opposite answers. A global
+      ;; lookup would accept the string and reject the integer.
+      (rf/reg-sub invalid-q {:schema :global/string} (fn [_ _] ::global))
+      (rf/reg-sub valid-q   {:schema :global/string} (fn [_ _] ::global))
+      (rf/make-frame
+        {:id frame-id
+         :images
+         [(rf/image
+            {:id :inline.schema/ui-image
+             :registrations
+             {:reg-sub
+              [[invalid-q {:schema :image/int} (fn [_ _] 1)]
+               [valid-q   {:schema :image/int} (fn [_ _] 2)]]}})]})
+      (let [result (atom ::unset)
+            errors (collect-errors
+                     (fn []
+                       (reset! result
+                         [(read-override frame-id
+                            {[invalid-q] "accepted-only-by-global"}
+                            [invalid-q])
+                          (read-override frame-id {[valid-q] 7} [valid-q])])))]
+        (is (= [nil 7] @result)
+            "image-invalid override recovers to nil; image-valid override survives")
+        (let [failures (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               errors)
+              failure  (first failures)]
+          (is (= 1 (count failures))
+              "only the image-invalid override emits a failure")
+          (is (= :sub-override (-> failure :tags :where)))
+          (is (= frame-id (-> failure :tags :frame)))
+          (is (= invalid-q (-> failure :tags :rf.sub/id)))
+          (is (= invalid-q (-> failure :tags :failing-id)))
+          (is (= [invalid-q] (-> failure :tags :rf.sub/query-v)))
+          (is (= invalid-q (-> failure :tags :schema-id)))
+          (is (= "accepted-only-by-global" (-> failure :tags :received)))
+          (is (= "accepted-only-by-global" (-> failure :tags :value)))
+          (is (= {:schema :image/int :value "accepted-only-by-global"}
+                 (-> failure :tags :explain)))
+          (is (and (string? (-> failure :tags :reason))
+                   (re-find #":image/int" (-> failure :tags :reason)))
+              "typed failure evidence names the authoritative image schema"))))))
 
 ;; ---- HIT vs MISS distinction ---------------------------------------------
 


### PR DESCRIPTION
## Summary
- project inline reg-sub metadata onto the canonical runnable descriptor shape while retaining the nested metadata, implementation, and provenance descriptor
- keep runtime-owned handler and input slots authoritative over authored metadata
- prove ordinary subscriptions and re-frame.ui overrides both use the target frame image schema rather than a conflicting global schema

## Root cause
Inline sub lowering discarded metadata from the runnable top level. Image assembly retained it only under the nested metadata key, while both ordinary return validation and compiled-view override validation read the top-level schema slot.

## Proof
- core focused JVM: 22 tests, 117 assertions, green
- ui focused JVM: 6 tests, 24 assertions, green
- clj-kondo: 0 errors; one existing unused-require warning in re-frame.subs
- mutation: restoring the old runnable-only lowerer makes the structural, ordinary subscription, and compiled override witnesses fail