### PR TITLE
S2: compile lexical reactive site identity

### DIFF
--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -15,6 +15,8 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui', 'viewcell.cljs');
+const ANALYZER_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui',
+                                  'compiler', 'analyze.cljc');
 const BUNDLE = path.join(ROOT, 'out', 'browser-test-prod-elision', 'js', 'test.js');
 const SENTINEL = 'rf-ui-mounted-override-binding expects a map';
 
@@ -33,9 +35,32 @@ if (occurrences !== 1) {
   fail(`expected exactly one source sentinel, found ${occurrences}`);
 }
 
+const analyzerSource = fs.readFileSync(ANALYZER_SOURCE, 'utf8');
+for (const expected of ['sid1-', ':expr-path']) {
+  if (!analyzerSource.includes(expected)) {
+    fail(`compiler source positive-control sentinel is absent: ${expected}`);
+  }
+}
+
 const bundle = fs.readFileSync(BUNDLE, 'utf8');
 if (bundle.includes(SENTINEL)) {
   fail('DEBUG-only override binding branch survived in the advanced bundle');
+}
+
+if (!/sid1-[A-Za-z0-9_-]+/.test(bundle)) {
+  fail('compact compiler lexical site id is absent from the advanced hot path');
+}
+
+for (const forbidden of [
+  'expr-path',
+  'hmr-body-revision',
+  'hmr-remount-generation',
+  'hmr-descriptor',
+  'hmr-inner'
+]) {
+  if (bundle.includes(forbidden)) {
+    fail(`development site/HMR diagnostic survived advanced output: ${forbidden}`);
+  }
 }
 
 process.stdout.write('ui mounted production elision: PASS\n');

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -248,16 +248,20 @@
 ;; ---------------------------------------------------------------------------
 
 (defn sub
-  "(sub [:query ...]) — returns the subscription's value at a compile-
-  indexed view site. In a live CLJS view the read is reactive: all of a
-  view's sites share one ViewCell (one `useSyncExternalStore`), the render
-  probes ownership-free, and the layout commit acquires the captured
-  target (`re-frame.ui.reactive` / `re-frame.ui.viewcell`). On the JVM
-  Tier-1 render it is a one-shot headless read honouring the explicit
-  override door (`ui.test/render {:sub-overrides …}`). Fail-loud rides the
-  observation port: `:rf.error/no-such-sub` / `:rf.error/frame-destroyed`."
+  "(sub [:query ...]) is a compiler-owned authoring form for a lexical view
+  site. Accepted template occurrences lower to the internal two-argument
+  site-bearing read on BOTH hosts. This var exists for symbol resolution only;
+  a direct call (including from a helper the view compiler cannot inspect)
+  fails loudly rather than becoming a nonreactive one-shot read. Pass values
+  into helpers, or make the helper a defview. Explicit headless probing belongs
+  to the test/observation seam."
   [query]
-  (reactive/sub-read query))
+  (error/throw-error!
+   :rf.error/ui-tree-malformed 're-frame.ui/sub
+   (str "(ui/sub " (pr-str query) ") executed outside compiler lowering — "
+        "ui/sub is a lexical defview form, not a callable subscription helper. "
+        "Pass the read value into the helper or extract a defview")
+   {:extra {:query query}}))
 
 (defn lease
   "(lease descriptor) — declares resource liveness at a view site.

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -178,11 +178,21 @@
         header-syms (into (set (mapcat env/binding-syms
                                        (keep :pattern (:entries hdr))))
                           (when (:as-sym hdr) [(:as-sym hdr)]))
+        src     (source-coords form cljs?)
         e       (-> (env/make-env {:host (if cljs? :cljs :clj)
-                                   :cljs-env menv
-                                   :ns-sym ns-sym
-                                   :self vname
-                                   :self-id view-id})
+                                    :cljs-env menv
+                                    :ns-sym ns-sym
+                                    :self vname
+                                    :self-id view-id
+                                    :source src
+                                    ;; Reader metadata is not guaranteed (macro-
+                                    ;; generated templates). In that case every
+                                    ;; site incorporates this whole-template
+                                    ;; semantic anchor, so an edit safely
+                                    ;; reacquires instead of transferring an
+                                    ;; ordinal to another lexical site.
+                                    :template-anchor
+                                    (fingerprint/digest "sta1-" template)})
                     (assoc :self-children? children?
                            :self-closed-keys closed-keys)
                     (env/with-locals header-syms))
@@ -192,9 +202,9 @@
                     (println (str "WARNING re-frame.ui [" view-id "] "
                                   (:id w) ": " (:msg w)))))
         sites   @(:sites e)
-        tf      (fingerprint/template-fingerprint ast)
+        tf      (fingerprint/template-fingerprint
+                 (ana/template-fingerprint-projection ast))
         hs      (fingerprint/hook-signature-hash {:locals [] :effects []})
-        src     (source-coords form cljs?)
         manifest {:view-id view-id
                   :display-name display-name
                   :doc docstring

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -179,7 +179,7 @@
                                        (keep :pattern (:entries hdr))))
                           (when (:as-sym hdr) [(:as-sym hdr)]))
         src     (source-coords form cljs?)
-        e       (-> (env/make-env {:host (if cljs? :cljs :clj)
+        e0      (-> (env/make-env {:host (if cljs? :cljs :clj)
                                     :cljs-env menv
                                     :ns-sym ns-sym
                                     :self vname
@@ -194,8 +194,9 @@
                                     :template-anchor
                                     (fingerprint/digest "sta1-" template)})
                     (assoc :self-children? children?
-                           :self-closed-keys closed-keys)
-                    (env/with-locals header-syms))
+                           :self-closed-keys closed-keys))
+        _       (ana/reject-reactive-binding! e0 argv)
+        e       (env/with-locals e0 header-syms)
         ast     (ana/analyze e template)
         _       (doseq [w @(:warnings e)]
                   (binding [*out* *err*]

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -84,13 +84,22 @@
 
 (def ^:private runtime-sub-fqn 're-frame.ui.reactive/sub-read)
 (def ^:private deferred-scope ::deferred-scope)
+(def ^:private transparent-macro-fqns
+  "Closed macro set whose arguments are host-independent expression slots,
+  with no user-authored binders. Preserve their spelling while recursively
+  lowering explicit sub/lease calls."
+  (into #{}
+        (mapcat (fn [s] [(symbol "clojure.core" (name s))
+                         (symbol "cljs.core" (name s))]))
+        '[or and when when-not cond -> ->> some-> some->> cond-> cond->>]))
 
 (defn- deferred-expr-root?
   "Expression roots whose value is evaluated by a later host callback, not by
   the view's render capture. `sub`/`lease` below these roots would be
   phase-divergent between the JVM data host and React."
   [expr-root]
-  (or (= :handler (first expr-root))
+  (or (and (= :handler (first expr-root))
+           (= :event-arg (nth expr-root 2 nil)))
       (some #{:raw-fn} expr-root)))
 
 (defn runtime-sub-form?
@@ -145,6 +154,83 @@
 (defn- map-path-token [x]
   (fingerprint/digest "ep1-" x))
 
+(defn- reactive-call-kind
+  "Return :sub/:lease when `x` contains an unshadowed resolved reactive CALL.
+  Quoted data is never executable. This scanner is deliberately about calls,
+  not bare symbols, so a binding pattern may still introduce a local named
+  `sub` or `lease`."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (seq? x)
+      (or (let [h (first x)]
+            (when (and (symbol? h) (not (contains? locals h)))
+              (cond
+                (env/resolves-to? e* h sub-fqns) :sub
+                (env/resolves-to? e* h lease-fqns) :lease)))
+          (some #(reactive-call-kind e % locals) (rest x)))
+      (map? x) (or (some #(reactive-call-kind e % locals) (keys x))
+                   (some #(reactive-call-kind e % locals) (vals x)))
+      (coll? x) (some #(reactive-call-kind e % locals) x)
+      :else nil)))
+
+(defn- reactive-macro-reference-kind
+  "Like `reactive-call-kind`, plus unquoted bare references. Opaque macros may
+  turn a bare `sub` argument into a call (`->` is the canonical example), so
+  only macro expansion could prove such a reference harmless."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (and (symbol? x) (not (contains? locals x)))
+      (cond
+        (env/resolves-to? e* x sub-fqns) :sub
+        (env/resolves-to? e* x lease-fqns) :lease)
+      (map? x) (or (some #(reactive-macro-reference-kind e % locals) (keys x))
+                   (some #(reactive-macro-reference-kind e % locals) (vals x)))
+      (coll? x) (some #(reactive-macro-reference-kind e % locals) x)
+      :else nil)))
+
+(defn- bare-reactive-reference-kind
+  "Return :sub/:lease for an unquoted BARE reactive var reference. A direct
+  `(sub ...)`/`(lease ...)` head is not bare—the rewriter owns it—but a
+  threading step such as `(-> query sub)` would become an unindexed call only
+  after macro expansion and must fail loudly."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (and (symbol? x) (not (contains? locals x)))
+      (cond
+        (env/resolves-to? e* x sub-fqns) :sub
+        (env/resolves-to? e* x lease-fqns) :lease)
+      (seq? x)
+      (let [h (first x)
+            direct? (and (symbol? h) (not (contains? locals h))
+                         (or (env/resolves-to? e* h sub-fqns)
+                             (env/resolves-to? e* h lease-fqns)))]
+        (some #(bare-reactive-reference-kind e % locals)
+              (if direct? (rest x) x)))
+      (map? x) (or (some #(bare-reactive-reference-kind e % locals) (keys x))
+                   (some #(bare-reactive-reference-kind e % locals) (vals x)))
+      (coll? x) (some #(bare-reactive-reference-kind e % locals) x)
+      :else nil)))
+
+(defn reject-reactive-binding!
+  "Reject executable sub/lease calls embedded in a binding pattern/default.
+  Destructuring forms are consumed by the host compiler, not expression
+  rewriting; allowing a call there would bypass lexical site ownership."
+  [e binding-form]
+  (when-let [kind (reactive-call-kind e binding-form #{})]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "(" (name kind) " ...) cannot appear in a binding pattern "
+                    "or destructuring :or default — that position cannot own "
+                    "a lexical render site. Hoist the read into the view body "
+                    "and bind/destructure its value there")
+               {:form binding-form :reactive-kind kind}))
+  binding-form)
+
 (defn rewrite-expr
   "Rewrite an opaque expression, lowering resolved unshadowed `(sub q)` calls
   to the serialized two-argument runtime shape and recording stable lexical
@@ -160,6 +246,7 @@
               (with-meta x (meta old)))
            (rw-fn-arity [arity locals p]
              (let [[argv & body] arity
+                   _ (reject-reactive-binding! (update e :locals into locals) argv)
                    body-locals (-> locals
                                    (into (env/binding-syms argv))
                                    (conj deferred-scope))]
@@ -177,6 +264,7 @@
                    rewritten
                    (if (vector? (first tail))
                      (let [[argv & body] tail
+                            _ (reject-reactive-binding! (update e :locals into locals*) argv)
                             body-locals (-> locals*
                                             (into (env/binding-syms argv))
                                             (conj deferred-scope))]
@@ -198,9 +286,11 @@
                               out []
                               scope locals]
                          (if-let [[pat init] (first pairs)]
-                           (recur (rest pairs) (inc i)
+                           (do
+                             (reject-reactive-binding! (update e :locals into scope) pat)
+                             (recur (rest pairs) (inc i)
                                   (conj out pat (rw init scope (conj p :binding i)))
-                                  (into scope (env/binding-syms pat)))
+                                  (into scope (env/binding-syms pat))))
                            [(with-same-meta bindings (vec out)) scope]))]
                    (with-same-meta
                      f
@@ -276,29 +366,10 @@
                                      (rw v locals (conj p :map-value t)))))
                           (empty m)
                           m)))
-           (contains-reactive-call? [x locals]
-             ;; An unresolved/unknown binder macro cannot be traversed safely.
-             ;; This conservative scan deliberately treats a macro-local name
-             ;; that shadows `sub` as reactive: only macro expansion could
-             ;; prove the shadow, so failing is preferable to mis-lowering it.
-             (let [e* (update e :locals into locals)]
-               (cond
-                 (and (seq? x) (= 'quote (first x))) false
-                 (seq? x)
-                 (or (let [h (first x)]
-                       (and (symbol? h)
-                            (not (contains? locals h))
-                            (or (env/resolves-to? e* h sub-fqns)
-                                (env/resolves-to? e* h lease-fqns))))
-                     (some #(contains-reactive-call? % locals) (rest x)))
-                 (map? x) (or (some #(contains-reactive-call? % locals) (keys x))
-                              (some #(contains-reactive-call? % locals) (vals x)))
-                 (coll? x) (some #(contains-reactive-call? % locals) x)
-                 :else false)))
-           (macro-call? [e* head locals]
-             (and (symbol? head)
-                  (not (contains? locals head))
-                  (true? (-> (env/resolve-sym e* head) :meta :macro))))
+           (macro-info [e* head locals]
+             (when (and (symbol? head) (not (contains? locals head)))
+               (let [info (env/resolve-sym e* head)]
+                 (when (true? (-> info :meta :macro)) info))))
            (rw [f locals p]
              (cond
                (and (seq? f) (= 'quote (first f))) f
@@ -364,8 +435,24 @@
                    (contains? #{'letfn 'letfn*} head) (rw-letfn f locals p)
                    (= 'try head) (rw-try f locals p)
 
-                   (macro-call? e* head locals)
-                   (if (contains-reactive-call? (rest f) locals)
+                   (and (macro-info e* head locals)
+                        (contains? transparent-macro-fqns
+                                   (:fqn (macro-info e* head locals))))
+                   (if-let [kind (bare-reactive-reference-kind e (rest f) locals)]
+                     (env/fail! e :rf.ui.compile/unsupported-form
+                                (str "bare " (name kind) " reference below macro "
+                                     head " would become an unindexed reactive "
+                                     "call after expansion. Write the explicit "
+                                     "(" (name kind) " query) call")
+                                {:form f :macro head})
+                     (with-same-meta
+                       f
+                       (apply list head
+                              (map-indexed #(rw %2 locals (conj p (inc %1)))
+                                           (rest f)))))
+
+                   (macro-info e* head locals)
+                   (if (reactive-macro-reference-kind e (rest f) locals)
                      (env/fail! e :rf.ui.compile/unsupported-form
                                 (str "(sub ...)/(lease ...) below macro " head
                                      " cannot be assigned a sound lexical site "
@@ -1200,6 +1287,7 @@
     (let [pairs (partition 2 bindings)
           [e* rewritten]
           (reduce (fn [[acc out] [i [pat init]]]
+                    (reject-reactive-binding! acc pat)
                     [(env/with-locals acc (env/binding-syms pat))
                      (conj out pat
                            (walk-expr acc [:let :binding i] init))])
@@ -1255,6 +1343,7 @@
                                  {:form form}))
                     (let [[scope* binds*]
                           (reduce (fn [[s xs] [j [pat init]]]
+                                    (reject-reactive-binding! s pat)
                                     [(env/with-loop s (env/binding-syms pat))
                                      (conj xs pat
                                            (walk-expr (assoc s :in-loop? true)
@@ -1277,7 +1366,8 @@
                              {:form form})
 
                   :else
-                  (let [r* (walk-expr (if first-coll?
+                  (let [_  (reject-reactive-binding! scope l)
+                        r* (walk-expr (if first-coll?
                                         scope
                                         (assoc scope :in-loop? true))
                                       [:for i :collection] r)]

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -154,6 +154,8 @@
 (defn- map-path-token [x]
   (fingerprint/digest "ep1-" x))
 
+(declare reactive-macro-reference-kind)
+
 (defn- reactive-call-kind
   "Return :sub/:lease when `x` contains an unshadowed resolved reactive CALL.
   Quoted data is never executable. This scanner is deliberately about calls,
@@ -168,7 +170,12 @@
             (when (and (symbol? h) (not (contains? locals h)))
               (cond
                 (env/resolves-to? e* h sub-fqns) :sub
-                (env/resolves-to? e* h lease-fqns) :lease)))
+                (env/resolves-to? e* h lease-fqns) :lease
+                ;; A macro can manufacture a call from a bare reactive var
+                ;; (`(-> query sub)`). Binding/default forms never pass through
+                ;; the rewriter later, so fence that escape here too.
+                (true? (-> (env/resolve-sym e* h) :meta :macro))
+                (reactive-macro-reference-kind e (rest x) locals))))
           (some #(reactive-call-kind e % locals) (rest x)))
       (map? x) (or (some #(reactive-call-kind e % locals) (keys x))
                    (some #(reactive-call-kind e % locals) (vals x)))

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -14,6 +14,7 @@
   (:require [clojure.string :as str]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.fingerprint :as fingerprint]
             [re-frame.ui.rules :as rules]))
 
 (def node-ops
@@ -78,66 +79,328 @@
 (defn- spread-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-spread-fqns)))
 
 ;; ---------------------------------------------------------------------------
-;; Expression walking — sub/lease site indexing + loop finiteness
+;; Expression rewriting — lexical site indexing + loop finiteness
 ;; ---------------------------------------------------------------------------
 
-(defn walk-expr
-  "Walk an opaque expression: index (sub ...)/(lease ...) sites and
-  enforce the finite-sites law — a sub/lease site anywhere it may
-  evaluate more than once per render (`:in-loop?`) is a compile error."
-  [e form]
-  (letfn [(walk [f locals]
+(def ^:private runtime-sub-fqn 're-frame.ui.reactive/sub-read)
+(def ^:private deferred-scope ::deferred-scope)
+
+(defn- deferred-expr-root?
+  "Expression roots whose value is evaluated by a later host callback, not by
+  the view's render capture. `sub`/`lease` below these roots would be
+  phase-divergent between the JVM data host and React."
+  [expr-root]
+  (or (= :handler (first expr-root))
+      (some #{:raw-fn} expr-root)))
+
+(defn runtime-sub-form?
+  "True for the compiler's serialized internal lowering of a lexical sub.
+  Public only within the compiler family (fingerprint/emitter tests use it)."
+  [x]
+  (and (seq? x) (= runtime-sub-fqn (first x)) (= 3 (count x))))
+
+(defn template-fingerprint-projection
+  "Remove compiler-owned lexical site ids from an analyzed AST while retaining
+  the semantic sub query. This makes source-anchor/path movement irrelevant to
+  template/build identity without making the query invisible."
+  [ast]
+  (letfn [(project [x]
             (cond
-              (and (seq? f) (= 'quote (first f))) nil
+              (runtime-sub-form? x)
+              (with-meta (list 're-frame.ui/sub (project (nth x 2))) (meta x))
 
-              (seq? f)
-              (let [head (first f)]
-                (when (and (symbol? head) (not (contains? locals head)))
-                  (let [e* (update e :locals into locals)]
-                    (cond
-                      (env/resolves-to? e* head sub-fqns)
-                      (do (when (:in-loop? e)
-                            (env/fail! e :rf.ui.compile/sub-in-loop
-                                       (str "(sub ...) inside a loop — subscription sites "
-                                            "must be finite. Extract a keyed child view and "
-                                            "read the sub there")
-                                       {:form f}))
-                          (env/add-site! e :subs {:query (second f) :path (:path e)}))
+              (map? x)
+              (with-meta (into (empty x) (map (fn [[k v]] [(project k) (project v)])) x)
+                         (meta x))
 
-                      (env/resolves-to? e* head lease-fqns)
-                      (do (when (:in-loop? e)
-                            (env/fail! e :rf.ui.compile/lease-in-loop
-                                       (str "(lease ...) inside a loop — lease sites must "
-                                            "be finite. Extract a keyed child view")
-                                       {:form f}))
-                          (env/add-site! e :leases {:descriptor (second f) :path (:path e)}))
-                      :else nil)))
-                ;; collect locals introduced by fn*/let* inside opaque exprs
-                ;; (best-effort shadow tracking)
-                (let [locals' (cond
-                                (fn-form? f)
-                                (into locals (mapcat env/binding-syms
-                                                     (filter vector? (flatten1-argvs f))))
-                                (and (contains? #{'let 'let* 'loop 'loop*} head)
-                                     (vector? (second f)))
-                                (into locals (mapcat env/binding-syms
-                                                     (take-nth 2 (second f))))
-                                :else locals)]
-                  (doseq [x (rest f)] (walk x locals'))))
+              (vector? x) (with-meta (mapv project x) (meta x))
+              (set? x)    (with-meta (into (empty x) (map project) x) (meta x))
+              (seq? x)    (with-meta (apply list (map project x)) (meta x))
+              :else x))]
+    (project ast)))
 
-              (coll? f)
-              (doseq [x f] (walk x locals))
+(defn- relative-source-anchor
+  [e form]
+  (let [m    (meta form)
+        base (:source e)
+        line (:line m)
+        col  (:column m)]
+    (if (and (integer? line) (integer? (:line base)))
+      ;; Reader end coordinates are not host-common (and have changed across
+      ;; reader versions). Start coordinates are the portable lexical anchor.
+      [:relative (- line (:line base)) (or col 0)]
+      ;; No reader anchor means no attempt to history-match sites. The whole
+      ;; template anchor changes all such ids on an edit: safe reacquisition,
+      ;; never ordinal transfer to a different lexical site.
+      [:template (or (:template-anchor e)
+                     (fingerprint/digest "sta1-" form))])))
 
-              :else nil))
-          (flatten1-argvs [f]
-            ;; fn forms: (fn name? [args] ...) or (fn ([a] ..) ([a b] ..))
-            (let [tail (drop 1 f)
-                  tail (if (symbol? (first tail)) (rest tail) tail)]
-              (if (vector? (first tail))
-                [(first tail)]
-                (map first (filter seq? tail)))))]
-    (walk form #{})
-    form))
+(defn- lexical-site-id
+  [e kind form expr-path]
+  (fingerprint/digest
+   "sid1-"
+   [1 (:self-id e) kind (relative-source-anchor e form)
+    (:path e) (vec expr-path)]))
+
+(defn- map-path-token [x]
+  (fingerprint/digest "ep1-" x))
+
+(defn rewrite-expr
+  "Rewrite an opaque expression, lowering resolved unshadowed `(sub q)` calls
+  to the serialized two-argument runtime shape and recording stable lexical
+  sub/lease ids. The returned form MUST be threaded into the AST.
+
+  `expr-root` names the containing AST slot; recursive paths then distinguish
+  every nested expression without a fragile global/preorder ordinal. Binding
+  scopes follow evaluation order for fn/let/loop/letfn and all metadata and
+  collection kinds are preserved."
+  ([e form] (rewrite-expr e [:expr] form))
+  ([e expr-root form]
+   (letfn [(with-same-meta [old x]
+              (with-meta x (meta old)))
+           (rw-fn-arity [arity locals p]
+             (let [[argv & body] arity
+                   body-locals (-> locals
+                                   (into (env/binding-syms argv))
+                                   (conj deferred-scope))]
+               (with-same-meta
+                 arity
+                 (apply list argv
+                        (map-indexed #(rw %2 body-locals (conj p :body %1)) body)))))
+           (rw-fn [f locals p]
+             (let [head (first f)
+                   tail (rest f)
+                   named? (symbol? (first tail))
+                   fname (when named? (first tail))
+                   tail (if named? (rest tail) tail)
+                   locals* (cond-> locals fname (conj fname))
+                   rewritten
+                   (if (vector? (first tail))
+                     (let [[argv & body] tail
+                            body-locals (-> locals*
+                                            (into (env/binding-syms argv))
+                                            (conj deferred-scope))]
+                       (concat [head] (when fname [fname]) [argv]
+                               (map-indexed #(rw %2 body-locals (conj p :body %1)) body)))
+                     (concat [head] (when fname [fname])
+                             (map-indexed #(rw-fn-arity %2 locals* (conj p :arity %1))
+                                          tail)))]
+               (with-same-meta f (apply list rewritten))))
+           (rw-let [f locals p]
+             (let [head (first f)
+                   bindings (second f)]
+               (if-not (vector? bindings)
+                 (with-same-meta f
+                   (apply list (map-indexed #(rw %2 locals (conj p %1)) f)))
+                 (let [[bindings* locals*]
+                       (loop [pairs (partition 2 bindings)
+                              i 0
+                              out []
+                              scope locals]
+                         (if-let [[pat init] (first pairs)]
+                           (recur (rest pairs) (inc i)
+                                  (conj out pat (rw init scope (conj p :binding i)))
+                                  (into scope (env/binding-syms pat)))
+                           [(with-same-meta bindings (vec out)) scope]))]
+                   (with-same-meta
+                     f
+                     (apply list head bindings*
+                             (map-indexed #(rw %2 (cond-> locals*
+                                                   (contains? #{'loop 'loop*} head)
+                                                   (conj deferred-scope))
+                                               (conj p :body %1))
+                                          (drop 2 f))))))))
+           (rw-letfn [f locals p]
+             (let [specs (second f)]
+               (if-not (vector? specs)
+                 (with-same-meta f
+                   (apply list (map-indexed #(rw %2 locals (conj p %1)) f)))
+                 (let [names (into #{} (keep #(when (seq? %) (first %))) specs)
+                       scope (into locals names)
+                       specs* (with-same-meta
+                                specs
+                                (mapv (fn [i spec]
+                                        (if (and (seq? spec) (symbol? (first spec)))
+                                          (let [[name & arities] spec
+                                                fake (with-meta (apply list 'fn name arities)
+                                                                (meta spec))
+                                                [_ _ & rewritten] (rw-fn fake scope
+                                                                          (conj p :spec i))]
+                                            (with-same-meta spec (apply list name rewritten)))
+                                          (rw spec scope (conj p :spec i))))
+                                      (range) specs))]
+                   (with-same-meta
+                     f
+                     (apply list (first f) specs*
+                            (map-indexed #(rw %2 scope (conj p :body %1))
+                                         (drop 2 f))))))))
+           (rw-try [f locals p]
+             ;; `catch` introduces a local, so it cannot go through generic
+             ;; traversal. `finally` does not. Preserve the marker/type slots
+             ;; verbatim and rewrite only evaluated bodies.
+             (with-same-meta
+               f
+               (apply list
+                      (first f)
+                      (map-indexed
+                       (fn [i clause]
+                         (cond
+                           (and (seq? clause) (= 'catch (first clause))
+                                (symbol? (nth clause 2 nil)))
+                           (let [[marker type binding & body] clause]
+                             (with-same-meta
+                               clause
+                               (apply list marker type binding
+                                      (map-indexed
+                                       #(rw %2 (conj locals binding)
+                                            (conj p :catch i :body %1))
+                                       body))))
+
+                           (and (seq? clause) (= 'finally (first clause)))
+                           (with-same-meta
+                             clause
+                             (apply list 'finally
+                                    (map-indexed
+                                     #(rw %2 locals (conj p :finally :body %1))
+                                     (rest clause))))
+
+                           :else (rw clause locals (conj p :body i))))
+                       (rest f)))))
+           (rw-map [m locals p]
+             (with-same-meta
+               m
+               (reduce-kv (fn [out k v]
+                            (let [t (map-path-token k)]
+                              (assoc out
+                                     (rw k locals (conj p :map-key t))
+                                     (rw v locals (conj p :map-value t)))))
+                          (empty m)
+                          m)))
+           (contains-reactive-call? [x locals]
+             ;; An unresolved/unknown binder macro cannot be traversed safely.
+             ;; This conservative scan deliberately treats a macro-local name
+             ;; that shadows `sub` as reactive: only macro expansion could
+             ;; prove the shadow, so failing is preferable to mis-lowering it.
+             (let [e* (update e :locals into locals)]
+               (cond
+                 (and (seq? x) (= 'quote (first x))) false
+                 (seq? x)
+                 (or (let [h (first x)]
+                       (and (symbol? h)
+                            (not (contains? locals h))
+                            (or (env/resolves-to? e* h sub-fqns)
+                                (env/resolves-to? e* h lease-fqns))))
+                     (some #(contains-reactive-call? % locals) (rest x)))
+                 (map? x) (or (some #(contains-reactive-call? % locals) (keys x))
+                              (some #(contains-reactive-call? % locals) (vals x)))
+                 (coll? x) (some #(contains-reactive-call? % locals) x)
+                 :else false)))
+           (macro-call? [e* head locals]
+             (and (symbol? head)
+                  (not (contains? locals head))
+                  (true? (-> (env/resolve-sym e* head) :meta :macro))))
+           (rw [f locals p]
+             (cond
+               (and (seq? f) (= 'quote (first f))) f
+
+               (seq? f)
+               (let [head (first f)
+                     e*   (update e :locals into locals)]
+                 (cond
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head sub-fqns))
+                    (do
+                      (when-not (= 2 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   "(sub query) takes exactly one query argument"
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope))
+                        (env/fail! e :rf.ui.compile/sub-in-loop
+                                   (str "(sub ...) must be a finite render-time site in a "
+                                        "defview — it cannot run in a loop, deferred "
+                                        "callback, raw-fn/ref body, or root expression. "
+                                        "Hoist the read into the view body and let the "
+                                        "callback capture its committed value; for rows, "
+                                        "extract a keyed child view")
+                                   {:form f}))
+                     (let [sid   (lexical-site-id e :sub f p)
+                           query (rw (second f) locals (conj p :query))]
+                       (env/add-site! e :subs {:sid sid :query (second f)
+                                               :path (:path e) :expr-path (vec p)})
+                       (with-same-meta f (list runtime-sub-fqn sid query))))
+
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head lease-fqns))
+                    (do
+                      (when-not (= 2 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   "(lease descriptor) takes exactly one descriptor argument"
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope))
+                        (env/fail! e :rf.ui.compile/lease-in-loop
+                                   (str "(lease ...) must be a finite render-time site in "
+                                        "a defview — it cannot run in a loop, deferred "
+                                        "callback, raw-fn/ref body, or root expression. "
+                                        "Hoist the lease into the view body; for rows, "
+                                        "extract a keyed child view")
+                                   {:form f}))
+                     (let [sid (lexical-site-id e :lease f p)]
+                       (env/add-site! e :leases {:sid sid :descriptor (second f)
+                                                 :path (:path e) :expr-path (vec p)})
+                       ;; Runtime lease lowering belongs to .106. Rebuild now so
+                       ;; sub sites nested in its descriptor still lower.
+                       (with-same-meta
+                         f
+                          (apply list head
+                                 (map-indexed #(rw %2 locals (conj p (inc %1)))
+                                             (rest f))))))
+
+                   (fn-form? f) (rw-fn f locals p)
+                   (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)
+                   (contains? #{'letfn 'letfn*} head) (rw-letfn f locals p)
+                   (= 'try head) (rw-try f locals p)
+
+                   (macro-call? e* head locals)
+                   (if (contains-reactive-call? (rest f) locals)
+                     (env/fail! e :rf.ui.compile/unsupported-form
+                                (str "(sub ...)/(lease ...) below macro " head
+                                     " cannot be assigned a sound lexical site "
+                                     "before macro expansion. Hoist the read into "
+                                     "a surrounding let, then pass the value to "
+                                     "the macro expression")
+                                {:form f :macro head})
+                     f)
+
+                   :else
+                   (with-same-meta
+                     f
+                     ;; The call head is not an evaluated argument and cannot
+                     ;; itself contain a reactive site. Preserve it verbatim.
+                     (apply list head
+                            (map-indexed #(rw %2 locals (conj p (inc %1)))
+                                         (rest f))))))
+
+               (map? f) (rw-map f locals p)
+               (vector? f)
+               (with-same-meta f (mapv #(rw %2 locals (conj p %1)) (range) f))
+               (set? f)
+               (with-same-meta
+                 f
+                 (into (empty f)
+                       (map #(rw % locals (conj p :set (map-path-token %))))
+                       f))
+               :else f))]
+     (rw form (cond-> #{}
+                (deferred-expr-root? expr-root) (conj deferred-scope))
+         (vec expr-root)))))
+
+;; Transitional internal name used throughout the analyzer. Unlike its former
+;; side-effect-only implementation it returns the rewritten expression.
+(def walk-expr rewrite-expr)
 
 ;; ---------------------------------------------------------------------------
 ;; Tag sugar — :div.cls#id / :div#id.cls (both orders)
@@ -213,7 +476,12 @@
                {:prop k :form form}))
   (check-loop-capture! e (str "event vector " (pr-str form) " at " k) form)
   (check-placeholders! e form)
-  (doseq [x (rest form)] (walk-expr e x)))
+  (with-meta
+    (into [(first form)]
+          (map-indexed (fn [i x]
+                         (walk-expr e [:handler k :event-arg i] x)))
+          (rest form))
+    (meta form)))
 
 (defn analyze-handler
   "Classify one :on-* entry. -> {:k kw :name str :classification
@@ -223,11 +491,11 @@
   (let [nm (name k)]
     (cond
       (vector? form)
-      (do (analyze-event-vector! e k form)
-          (env/add-site! e :events {:prop k :handler form :path (:path e)
+      (let [form* (analyze-event-vector! e k form)]
+          (env/add-site! e :events {:prop k :handler form* :path (:path e)
                                     :classification :vector :serializable? true})
-          {:k k :name nm :classification :vector :form form :capture? false
-           :hoistable? (every? #(or (literal-scalar? %) (contains? rules/placeholders %)) form)
+          {:k k :name nm :classification :vector :form form* :capture? false
+           :hoistable? (every? #(or (literal-scalar? %) (contains? rules/placeholders %)) form*)
            :serializable? true})
 
       (map? form)
@@ -260,14 +528,16 @@
                           "them as element props; S1 rejects rather than "
                           "silently dropping them. Remove the option for now")
                      {:prop k :form form}))
-        (analyze-event-vector! e k (:event form))
-        (env/add-site! e :events {:prop k :handler form :path (:path e)
-                                  :classification :options :serializable? true})
-        {:k k :name nm :classification :options :form form
-         :capture? (boolean (:capture form))
-         :hoistable? (every? #(or (literal-scalar? %) (contains? rules/placeholders %))
-                             (:event form))
-         :serializable? true})
+        (let [event* (analyze-event-vector! e k (:event form))
+              form*  (assoc form :event event*)]
+          (env/add-site! e :events {:prop k :handler form* :path (:path e)
+                                    :classification :options :serializable? true})
+          {:k k :name nm :classification :options :form form*
+           :capture? (boolean (:capture form))
+           :hoistable? (every? #(or (literal-scalar? %)
+                                     (contains? rules/placeholders %))
+                                event*)
+           :serializable? true}))
 
       (fn-form? form)
       (do (when (:in-loop? e)
@@ -277,19 +547,19 @@
                                     "the data idiom; prefer an event vector or a "
                                     "keyed child view")
                           :form form}))
-          (walk-expr e form)
-          (env/add-site! e :events {:prop k :handler :opaque :path (:path e)
-                                    :classification :fn :serializable? false})
-          {:k k :name nm :classification :fn :form form :capture? false
-           :hoistable? false :serializable? false})
+          (let [form* (walk-expr e [:handler k :fn] form)]
+            (env/add-site! e :events {:prop k :handler :opaque :path (:path e)
+                                      :classification :fn :serializable? false})
+            {:k k :name nm :classification :fn :form form* :capture? false
+             :hoistable? false :serializable? false}))
 
       :else
-      (do (walk-expr e form)
-          (check-loop-capture! e (str "dynamic handler at " k) form)
-          (env/add-site! e :events {:prop k :handler :opaque :path (:path e)
-                                    :classification :dynamic :serializable? false})
-          {:k k :name nm :classification :dynamic :form form :capture? false
-           :hoistable? false :serializable? false}))))
+      (let [form* (walk-expr e [:handler k :dynamic] form)]
+        (check-loop-capture! e (str "dynamic handler at " k) form)
+        (env/add-site! e :events {:prop k :handler :opaque :path (:path e)
+                                  :classification :dynamic :serializable? false})
+        {:k k :name nm :classification :dynamic :form form* :capture? false
+         :hoistable? false :serializable? false}))))
 
 ;; ---------------------------------------------------------------------------
 ;; :class / :style
@@ -326,21 +596,28 @@
                                 (->> consts
                                      (keep (fn [[k v]] (when v (if (keyword? k) (name k) k))))
                                      sort))
-              flags (->> exprs
-                         (map (fn [[k v]] [(if (keyword? k) (name k) k) v]))
-                         (sort-by first)
-                         vec)]
-          (doseq [[_ v] flags] (walk-expr e v))
+               flags (->> exprs
+                          (map (fn [[k v]]
+                                 [(if (keyword? k) (name k) k)
+                                  (walk-expr e [:class :flag k] v)]))
+                          (sort-by first)
+                          vec)]
           {:base-str (str/join " " const-names) :flags flags :dyn nil
            :static? (empty? flags)}))
 
       (vector? form) ; mixed literal/expr vector — runtime join in vector order
-      (do (doseq [x form] (when-not (literal-scalar? x) (walk-expr e x)))
-          {:base-str (str/join " " base) :flags [] :dyn form :static? false})
+      (let [form* (with-meta
+                    (mapv (fn [i x]
+                            (if (literal-scalar? x)
+                              x
+                              (walk-expr e [:class :vector i] x)))
+                          (range) form)
+                    (meta form))]
+        {:base-str (str/join " " base) :flags [] :dyn form* :static? false})
 
       :else
-      (do (walk-expr e form)
-          {:base-str (str/join " " base) :flags [] :dyn form :static? false}))))
+      {:base-str (str/join " " base) :flags []
+       :dyn (walk-expr e [:class :dynamic] form) :static? false})))
 
 (defn analyze-style
   "-> {:entries [{:css-name str :value form :literal? bool}] :static? bool}
@@ -356,14 +633,16 @@
                                             "pass the whole :style value as "
                                             "one dynamic expression")
                                        {:key k :form form}))
-                          (when-not (literal-scalar? v) (walk-expr e v))
-                          {:css-name (name k) :value v :literal? (literal-scalar? v)})
-                        form)]
+                           {:css-name (name k)
+                            :value (if (literal-scalar? v)
+                                     v
+                                     (walk-expr e [:style k] v))
+                            :literal? (literal-scalar? v)})
+                         form)]
       {:entries entries :static? (every? :literal? entries)})
 
     :else
-    (do (walk-expr e form)
-        {:dyn form :static? false})))
+    {:dyn (walk-expr e [:style :dynamic] form) :static? false}))
 
 ;; ---------------------------------------------------------------------------
 ;; Element props
@@ -387,9 +666,9 @@
                       "be explicit: (ui/raw-fn f); object refs are preferred")
                  {:form form})
       (raw-fn-form? e form)
-      {:form (second form) :raw-fn? true}
+      {:form (walk-expr e [:ref :raw-fn] (second form)) :raw-fn? true}
       :else
-      (do (walk-expr e form) {:form form :raw-fn? false}))
+      {:form (walk-expr e [:ref :element] form) :raw-fn? false})
     :view
     (env/fail! e :rf.ui.compile/ref-on-view-s1
                (str ":ref at an internal-view call site — internal views "
@@ -397,7 +676,7 @@
                     "forwarding lands S3. (Conservative S1 pin.)")
                {:form form})
     :foreign
-    (do (walk-expr e form) {:form form :raw-fn? false})))
+    {:form (walk-expr e [:ref :foreign] form) :raw-fn? false}))
 
 (defn analyze-element-props
   "Analyze a DOM/custom element's props position (literal map or
@@ -426,12 +705,13 @@
           (env/fail! e :rf.ui.compile/bad-spread
                      "(ui/spread base) or (ui/spread base overrides)"
                      {:form props-form}))
-        (walk-expr e base)
-        (when overrides (walk-expr e overrides))
+        (let [base*      (walk-expr e [:spread :base] base)
+              overrides* (when overrides
+                           (walk-expr e [:spread :overrides] overrides))]
         {:key {:present? false} :class (analyze-class e (:classes tag-info) nil)
          :style nil :attrs [] :events []
-         :spread {:base base :overrides overrides}
-         :ref nil :property-props #{} :static? false})
+         :spread {:base base* :overrides overrides*}
+         :ref nil :property-props #{} :static? false}))
       (let [m (or props-form {})]
         (doseq [k (keys m)]
           (when-not (keyword? k)
@@ -453,11 +733,12 @@
               attr-ks    (remove on? (keys m*))
               events     (mapv #(analyze-handler e % (get m* %)) handler-ks)
               attrs      (mapv (fn [k]
-                                 (let [v (get m* k)
-                                       n (name k)
-                                       property? (boolean (and properties (properties k)))]
-                                   (when-not (literal-scalar? v)
-                                     (walk-expr e v))
+                                  (let [v (get m* k)
+                                        n (name k)
+                                        property? (boolean (and properties (properties k)))
+                                        v* (if (literal-scalar? v)
+                                             v
+                                             (walk-expr e [:prop k] v))]
                                    ;; literal collection VALUES only — seq forms
                                    ;; are dynamic expressions (runtime-normalized)
                                    (when (and (or (vector? v) (map? v) (set? v))
@@ -482,8 +763,8 @@
                                                   (rules/custom-element-property-name n)
                                                   (rules/react-prop-name n))
                                     :kind (if property? :property :attr)
-                                    :value v
-                                    :literal? (literal-scalar? v)}))
+                                     :value v*
+                                     :literal? (literal-scalar? v)}))
                                attr-ks)
               sugar-id   (:id tag-info)
               attrs      (into (if sugar-id
@@ -495,9 +776,12 @@
                            (analyze-class e (:classes tag-info) (get m :class)))
               style-a    (when (contains? m :style)
                            (analyze-style e (get m :style)))
-              ref-a      (when (contains? m :ref) (analyze-ref e ref-form :element))]
-          (when-not (literal-scalar? key-form) (when (contains? m :key) (walk-expr e key-form)))
-          {:key   {:present? (contains? m :key) :expr key-form
+               ref-a      (when (contains? m :ref) (analyze-ref e ref-form :element))
+               key-form*  (if (and (contains? m :key)
+                                    (not (literal-scalar? key-form)))
+                            (walk-expr e [:key] key-form)
+                            key-form)]
+          {:key   {:present? (contains? m :key) :expr key-form*
                    :literal? (literal-scalar? key-form)}
            :class class-a
            :style style-a
@@ -560,18 +844,20 @@
                          (env/fail! e :rf.ui.compile/bad-html
                                     "(ui/html x) requires a string"
                                     {:form (first child-fs)}))
-                       (when-not (string? s) (walk-expr e s))
+                       (let [s* (if (string? s)
+                                  s
+                                  (walk-expr e [:html] s))]
                        ;; Record the trusted-markup site in the compiler
                        ;; manifest (profile row `ui/html` — "manifest site
                        ;; recording"): the visible bypass carries source/
                        ;; template path so tools can list every place escaping
                        ;; is bypassed. `:serializable?` is false for a dynamic
                        ;; string expression, true for a literal.
-                       (env/add-site! e :htmls {:form s
+                       (env/add-site! e :htmls {:form s*
                                                 :static? (string? s)
                                                 :serializable? (string? s)
                                                 :path (:path e)})
-                       {:op :html :form s :static? (string? s)}))]
+                       {:op :html :form s* :static? (string? s)})))]
       {:op :element
        :tag tag
        :custom? custom?
@@ -632,21 +918,28 @@
                            ;; passing row data into a keyed child view is exactly
                            ;; the extract-a-keyed-child-view fix; only HANDLER
                            ;; sites are capture-checked.
-                           (let [raw?    (raw-form? e v)
-                                 raw-fn? (raw-fn-form? e v)]
-                             (when-not (literal-scalar? v) (walk-expr e v))
-                             {:k k
-                              :slot (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k))
-                              :value (cond raw? (second v) raw-fn? (second v) :else v)
-                              :marker (cond raw? :foreign raw-fn? :ui/raw-fn :else nil)
-                              :literal? (literal-scalar? v)}))
-                         m*)]
-      (when (and (contains? m :key) (not (literal-scalar? key-form)))
-        (walk-expr e key-form))
-      {:key {:present? (contains? m :key) :expr key-form
+                            (let [raw?    (raw-form? e v)
+                                  raw-fn? (raw-fn-form? e v)
+                                  v*      (cond
+                                            raw? (walk-expr e [:component-prop k :raw]
+                                                            (second v))
+                                            raw-fn? (walk-expr e [:component-prop k :raw-fn]
+                                                               (second v))
+                                            (literal-scalar? v) v
+                                            :else (walk-expr e [:component-prop k] v))]
+                              {:k k
+                               :slot (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k))
+                               :value v*
+                               :marker (cond raw? :foreign raw-fn? :ui/raw-fn :else nil)
+                               :literal? (literal-scalar? v)}))
+                          m*)]
+      (let [key-form* (if (and (contains? m :key) (not (literal-scalar? key-form)))
+                        (walk-expr e [:component-key] key-form)
+                        key-form)]
+      {:key {:present? (contains? m :key) :expr key-form*
              :literal? (literal-scalar? key-form)}
        :entries entries
-       :ref ref-a})))
+       :ref ref-a}))))
 
 (defn- analyze-component [e form]
   (let [head      (nth form 0)
@@ -747,13 +1040,19 @@
                         "keyword — plans are static identity; got "
                         (pr-str id))
                    {:form form :id id}))
-      (let [config (not-empty (dissoc props :id))]
+      (let [config (not-empty (dissoc props :id))
+            config* (when config
+                      (with-meta
+                        (into (empty config)
+                              (map (fn [[k v]]
+                                     [k (walk-expr e [:frame-root :config k] v)]))
+                              config)
+                        (meta config)))]
         ;; config values are opaque runtime expressions (evaluated at
         ;; preflight) — walk them for sub/lease site indexing only
-        (doseq [[_k v] config] (walk-expr e v))
         {:op :frame-root
          :frame-id id
-         :config config
+         :config config*
          :children (analyze-children e (vec (drop 2 form)))
          :static? false
          :path (:path e)}))))
@@ -805,12 +1104,14 @@
                         (str/join ", " (map pr-str (keys extra)))
                         " — providers only scope (roots ensure)")
                    {:form form})))
-    (let [target (:frame props)]
+    (let [target (:frame props)
+          target* (if (literal-scalar? target)
+                    target
+                    (walk-expr e [:frame-provider :frame] target))]
       ;; the :frame target is a runtime expression — walk it for sub/lease
       ;; site indexing (a sub in the target expression is still a site)
-      (when-not (literal-scalar? target) (walk-expr e target))
       {:op :frame-provider
-       :frame target
+       :frame target*
        ;; children keep whatever region flag `e` carries: preserved in a
        ;; root form's top region (nested frame-root plans still extract),
        ;; absent in a defview template
@@ -829,10 +1130,12 @@
                                         (str/join ", " (map pr-str (keys extra))))
                                    {:form form}))))
         key-form  (when has-props (get second* :key))
+        key-form* (if (and has-props (not (literal-scalar? key-form)))
+                    (walk-expr e [:fragment :key] key-form)
+                    key-form)
         children  (analyze-children e (vec (if has-props (drop 2 form) (drop 1 form))))]
-    (when (and has-props (not (literal-scalar? key-form))) (walk-expr e key-form))
     {:op :fragment
-     :key {:present? has-props :expr key-form :literal? (literal-scalar? key-form)}
+     :key {:present? has-props :expr key-form* :literal? (literal-scalar? key-form)}
      :children children
      :static? (and (not has-props) (every? node-static? children))
      :path (:path e)}))
@@ -851,8 +1154,7 @@
   (first body))
 
 (defn- analyze-if [e test then else form]
-  (walk-expr e test)
-  {:op :if :test test
+  {:op :if :test (walk-expr e [:if :test] test)
    :then (analyze (update e :path conj :then) then)
    :else (if (some? else)
            (analyze (update e :path conj :else) else)
@@ -875,12 +1177,11 @@
 
 (defn- analyze-case [e form]
   (let [[_ expr & clauses] form]
-    (walk-expr e expr)
     (let [default? (odd? (count clauses))
           pairs    (partition 2 (if default? (butlast clauses) clauses))
           default  (when default? (last clauses))]
       {:op :case
-       :expr expr
+       :expr (walk-expr e [:case :expr] expr)
        :clauses (into []
                       (map-indexed (fn [i [test branch]]
                                      [test (analyze (update e :path conj [:case i]) branch)]))
@@ -897,12 +1198,16 @@
       (env/fail! e :rf.ui.compile/bad-let
                  (str head " needs an even bindings vector") {:form form}))
     (let [pairs (partition 2 bindings)
-          e*    (reduce (fn [acc [pat init]]
-                          (walk-expr acc init)
-                          (env/with-locals acc (env/binding-syms pat)))
-                        e pairs)
+          [e* rewritten]
+          (reduce (fn [[acc out] [i [pat init]]]
+                    [(env/with-locals acc (env/binding-syms pat))
+                     (conj out pat
+                           (walk-expr acc [:let :binding i] init))])
+                  [e []]
+                  (map-indexed vector pairs))
+          bindings* (with-meta (vec rewritten) (meta bindings))
           body-form (single-body! e (str head) body form)]
-      {:op :let :bindings bindings
+      {:op :let :bindings bindings*
        :body (analyze (update e* :path conj :body) body-form)
        :static? false :path (:path e)})))
 
@@ -911,10 +1216,14 @@
     (when-not (vector? fnspecs)
       (env/fail! e :rf.ui.compile/bad-let "letfn needs a fnspecs vector" {:form form}))
     (let [names (map first fnspecs)
-          e*    (env/with-locals e names)]
-      (doseq [spec fnspecs] (walk-expr e* spec))
+          e*    (env/with-locals e names)
+          ;; Reuse the opaque rewriter's exact letfn scoping (all names in
+          ;; scope for every body; each argv shadows vars within its arity).
+          fnspecs* (second
+                     (walk-expr e [:letfn :bindings]
+                                (list 'letfn fnspecs nil)))]
       (let [body-form (single-body! e "letfn" body form)]
-        {:op :letfn :fnspecs fnspecs
+        {:op :letfn :fnspecs fnspecs*
          :body (analyze (update e* :path conj :body) body-form)
          :static? false :path (:path e)}))))
 
@@ -928,43 +1237,55 @@
       (when (keyword? (ffirst pairs))
         (env/fail! e :rf.ui.compile/bad-for
                    "for needs a binding pair before modifiers" {:form form}))
-      ;; walk seq-exprs: first coll evaluates once per render (sub legal
-      ;; there); every later coll/modifier expr is per-row (in-loop)
-      (loop [e* e, first-coll? true, ps pairs, bound []]
-        (when-let [[l r] (first ps)]
-          (cond
-            (= :let l)
-            (do (when-not (vector? r)
-                  (env/fail! e :rf.ui.compile/bad-for ":let modifier needs a bindings vector"
-                             {:form form}))
-                (doseq [[_pat init] (partition 2 r)]
-                  (walk-expr (assoc e* :in-loop? true) init))
-                (recur (env/with-loop e* (mapcat env/binding-syms (take-nth 2 r)))
-                       false (rest ps) bound))
+      ;; Rewrite in evaluation order. The first collection evaluates once per
+      ;; view render; after its binding every later collection/modifier is
+      ;; row-scoped and therefore rejects sub/lease sites.
+      (let [[e-final rewritten]
+            (loop [scope e
+                   first-coll? true
+                   ps (seq (map-indexed vector pairs))
+                   out []]
+              (if-let [[i [l r]] (first ps)]
+                (cond
+                  (= :let l)
+                  (do
+                    (when-not (and (vector? r) (even? (count r)))
+                      (env/fail! e :rf.ui.compile/bad-for
+                                 ":let modifier needs an even bindings vector"
+                                 {:form form}))
+                    (let [[scope* binds*]
+                          (reduce (fn [[s xs] [j [pat init]]]
+                                    [(env/with-loop s (env/binding-syms pat))
+                                     (conj xs pat
+                                           (walk-expr (assoc s :in-loop? true)
+                                                      [:for i :let j] init))])
+                                  [scope []]
+                                  (map-indexed vector (partition 2 r)))]
+                      (recur scope* false (next ps)
+                             (conj out l (with-meta (vec binds*) (meta r))))))
 
-            (contains? #{:when :while} l)
-            (do (walk-expr (assoc e* :in-loop? true) r)
-                (recur e* false (rest ps) bound))
+                  (contains? #{:when :while} l)
+                  (recur scope false (next ps)
+                         (conj out l
+                               (walk-expr (assoc scope :in-loop? true)
+                                          [:for i l] r)))
 
-            (keyword? l)
-            (env/fail! e :rf.ui.compile/bad-for
-                       (str "unknown for modifier " l " — the subgrammar is "
-                            ":let / :when / :while (Q6 pin)")
-                       {:form form})
+                  (keyword? l)
+                  (env/fail! e :rf.ui.compile/bad-for
+                             (str "unknown for modifier " l " — the subgrammar is "
+                                  ":let / :when / :while (Q6 pin)")
+                             {:form form})
 
-            :else
-            (do (walk-expr (if first-coll? e* (assoc e* :in-loop? true)) r)
-                (recur (env/with-loop e* (env/binding-syms l))
-                       false (rest ps) bound)))))
-      (let [all-bound (into []
-                            (comp (partition-all 2)
-                                  (mapcat (fn [[l r]]
-                                            (cond
-                                              (= :let l) (mapcat env/binding-syms (take-nth 2 r))
-                                              (keyword? l) []
-                                              :else (env/binding-syms l)))))
-                            seq-exprs)
-            e-body    (update (env/with-loop e all-bound) :path conj :for)
+                  :else
+                  (let [r* (walk-expr (if first-coll?
+                                        scope
+                                        (assoc scope :in-loop? true))
+                                      [:for i :collection] r)]
+                    (recur (env/with-loop scope (env/binding-syms l))
+                           false (next ps) (conj out l r*))))
+                [scope out]))
+            seq-exprs* (with-meta (vec rewritten) (meta seq-exprs))
+            e-body    (update e-final :path conj :for)
             body-form (single-body! e "for" (vec body) form)
             _         (when (and (seq? body-form) (= 'for (first body-form)))
                         (env/fail! e :rf.ui.compile/nested-for-body
@@ -994,7 +1315,7 @@
                             "duplicates). Key on row data: {:key (:id x)}")
                        {:form form})))
         {:op :for
-         :seq-exprs seq-exprs
+         :seq-exprs seq-exprs*
          :body body-ast
          :static? false
          :path (:path e)}))))
@@ -1033,8 +1354,8 @@
           (when (or (nil? x) (seq extra))
             (env/fail! e :rf.ui.compile/bad-raw "(ui/raw react-element) takes one argument"
                        {:form form}))
-          (walk-expr e x)
-          {:op :raw :form x :static? false :path (:path e)})
+          {:op :raw :form (walk-expr e [:raw] x)
+           :static? false :path (:path e)})
 
         (html-form? e form)
         (env/fail! e :rf.ui.compile/html-not-sole-child
@@ -1072,8 +1393,8 @@
                    {:form form})
 
         :else
-        (do (walk-expr e form)
-            {:op :expr :form form :static? false :path (:path e)})))))
+        {:op :expr :form (walk-expr e [:expr] form)
+         :static? false :path (:path e)}))))
 
 (defn analyze
   "Template form -> AST node."
@@ -1105,8 +1426,8 @@
                    {:form form})))
     ;; a control form / opaque expression ends the static top region (S1c)
     (seq? form)     (analyze-list (dissoc e :top-region?) form)
-    (symbol? form)  (do (walk-expr e form)
-                        {:op :expr :form form :static? false :path (:path e)})
+    (symbol? form)  {:op :expr :form (walk-expr e [:expr] form)
+                     :static? false :path (:path e)}
     :else
     (env/fail! e :rf.ui.compile/unsupported-form
                (str "unsupported template form " (pr-str form) " of type "

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -168,14 +168,18 @@
       (seq? x)
       (or (let [h (first x)]
             (when (and (symbol? h) (not (contains? locals h)))
-              (cond
-                (env/resolves-to? e* h sub-fqns) :sub
-                (env/resolves-to? e* h lease-fqns) :lease
-                ;; A macro can manufacture a call from a bare reactive var
-                ;; (`(-> query sub)`). Binding/default forms never pass through
-                ;; the rewriter later, so fence that escape here too.
-                (true? (-> (env/resolve-sym e* h) :meta :macro))
-                (reactive-macro-reference-kind e (rest x) locals))))
+              (let [info (env/resolve-sym e* h)]
+                (cond
+                  (contains? sub-fqns (:fqn info)) :sub
+                  (contains? lease-fqns (:fqn info)) :lease
+                  ;; Binding/default forms never pass through rewriting later.
+                  ;; An unaudited macro can inject a reactive call even when its
+                  ;; invocation carries no visible sub token, so reject it.
+                  (and (true? (-> info :meta :macro))
+                       (not (contains? transparent-macro-fqns (:fqn info))))
+                  :opaque-macro
+                  (true? (-> info :meta :macro))
+                  (reactive-macro-reference-kind e (rest x) locals)))))
           (some #(reactive-call-kind e % locals) (rest x)))
       (map? x) (or (some #(reactive-call-kind e % locals) (keys x))
                    (some #(reactive-call-kind e % locals) (vals x)))
@@ -231,10 +235,15 @@
   [e binding-form]
   (when-let [kind (reactive-call-kind e binding-form #{})]
     (env/fail! e :rf.ui.compile/unsupported-form
-               (str "(" (name kind) " ...) cannot appear in a binding pattern "
-                    "or destructuring :or default — that position cannot own "
-                    "a lexical render site. Hoist the read into the view body "
-                    "and bind/destructure its value there")
+               (if (= :opaque-macro kind)
+                 (str "an unaudited macro cannot appear in a binding pattern "
+                      "or destructuring :or default — macro expansion could "
+                      "inject a reactive call after lexical site analysis. "
+                      "Compute the default in the view body instead")
+                 (str "(" (name kind) " ...) cannot appear in a binding pattern "
+                      "or destructuring :or default — that position cannot own "
+                      "a lexical render site. Hoist the read into the view body "
+                      "and bind/destructure its value there"))
                {:form binding-form :reactive-kind kind}))
   binding-form)
 
@@ -459,15 +468,14 @@
                                            (rest f)))))
 
                    (macro-info e* head locals)
-                   (if (reactive-macro-reference-kind e (rest f) locals)
-                     (env/fail! e :rf.ui.compile/unsupported-form
-                                (str "(sub ...)/(lease ...) below macro " head
-                                     " cannot be assigned a sound lexical site "
-                                     "before macro expansion. Hoist the read into "
-                                     "a surrounding let, then pass the value to "
-                                     "the macro expression")
-                                {:form f :macro head})
-                     f)
+                   (env/fail! e :rf.ui.compile/unsupported-form
+                              (str "macro " head " is outside the compiler's "
+                                   "audited expression set and could inject, "
+                                   "duplicate, or defer a reactive call after "
+                                   "lexical site analysis. Rewrite it with "
+                                   "ordinary functions/control forms, or hoist "
+                                   "the computation around the view template")
+                              {:form f :macro head})
 
                    :else
                    (with-same-meta

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -16,6 +16,7 @@
   This namespace only RUNS on the JVM (macro expansion) but is .cljc so
   both hosts' test suites can golden the emission as data."
   (:require [clojure.string :as str]
+            [clojure.walk :as walk]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.rules :as rules]))
 
@@ -23,13 +24,42 @@
 (def ^:private event-sym 'rf-ui-evt)
 
 (defn- new-state [view-name]
-  (atom {:defs [] :n 0 :handlers {} :view-name (name view-name)}))
+  (atom {:defs [] :n 0 :handlers {} :sub-queries {}
+         :view-name (name view-name)}))
 
 (defn- hoist! [st kind form]
   (let [{:keys [n view-name]} @st
         sym (symbol (str view-name "$" (name kind) "$" n))]
     (swap! st #(-> % (update :n inc) (update :defs conj `(def ~sym ~form))))
     sym))
+
+(defn- literal-data?
+  "True for self-evaluating/collection data that CLJS would otherwise rebuild
+  inside the render function. Lists and symbols remain runtime expressions."
+  [x]
+  (cond
+    (ana/literal-scalar? x) true
+    (vector? x) (every? literal-data? x)
+    (map? x) (every? (fn [[k v]] (and (literal-data? k) (literal-data? v))) x)
+    (set? x) (every? literal-data? x)
+    :else false))
+
+(defn- hoist-literal-sub-queries
+  [st form]
+  (walk/postwalk
+   (fn [x]
+     (if (ana/runtime-sub-form? x)
+       (let [[runtime sid query] x]
+         (if (literal-data? query)
+           (let [query-sym
+                 (or (get-in @st [:sub-queries query])
+                     (let [sym (hoist! st :query query)]
+                       (swap! st assoc-in [:sub-queries query] sym)
+                       sym))]
+             (with-meta (list runtime sid query-sym) (meta x)))
+           x))
+       x))
+   form))
 
 ;; ---------------------------------------------------------------------------
 ;; Handlers
@@ -420,7 +450,8 @@
   [{:keys [vname view-id display-name docstring header slots ast manifest
            closed-keys children?]}]
   (let [st         (new-state vname)
-        body       (emit-node ast st false)
+        body       (->> (emit-node ast st false)
+                        (hoist-literal-sub-queries st))
         binds      (vec (header-bindings header))
         render-sym (symbol (str (name vname) "$render"))
         host-render-sym (symbol (str (name vname) "$host_render"))

--- a/implementation/ui/src/re_frame/ui/compiler/env.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/env.cljc
@@ -33,13 +33,19 @@
   self = the view symbol being compiled (nil outside defview);
   self-id = its view id. `resolver` (tests only) overrides host
   resolution: (fn [sym]) -> {:fqn sym :meta {..}} | nil."
-  [{:keys [host cljs-env ns-sym self self-id resolver]}]
+  [{:keys [host cljs-env ns-sym self self-id resolver source template-anchor]}]
   {:host      host
    :cljs-env  cljs-env
    :ns        ns-sym
    :self      self
    :self-id   self-id
    :resolver  resolver
+   ;; Compiler-owned lexical-site identity inputs. `source` is the defview
+   ;; declaration anchor (only relative line/column deltas are consumed) and
+   ;; `template-anchor` is a semantic whole-template fallback for reader forms
+   ;; that carry no usable source metadata. Neither reaches emitted code.
+   :source    source
+   :template-anchor template-anchor
    :locals    #{}
    :loop-syms #{}
    :in-loop?  false

--- a/implementation/ui/src/re_frame/ui/compiler/env.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/env.cljc
@@ -84,7 +84,13 @@
        (let [resolve* (requiring-resolve 'cljs.analyzer.api/resolve)
              info     (resolve* (:cljs-env env) sym)]
          (when (and info (not (:local info)) (:name info) (symbol? (:name info)))
-           {:fqn (:name info) :meta (:meta info)}))
+           ;; CLJS analyzer macro authority is a TOP-LEVEL `:macro` flag on
+           ;; the resolved info map (not reliably duplicated in `:meta`).
+           ;; Normalize it into the metadata shape shared with CLJ resolution
+           ;; so expression rewriting cannot traverse an opaque binder macro.
+           {:fqn (:name info)
+            :meta (cond-> (or (:meta info) {})
+                    (:macro info) (assoc :macro true))}))
        (catch Exception _ nil))))
 
 #?(:clj

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -519,20 +519,49 @@
   "Roll back a prepared descriptor after registrar failure.
 
   Rollback is conditional on transaction identity, so it cannot overwrite a
-  newer re-entrant registration. Listener subscriptions made while the
-  registrar call was in flight are retained; descriptor/revision/remount state
-  returns to the exact prior publication. Returns the current slot snapshot."
+  newer re-entrant registration. Revisions are globally monotone even across
+  failure: restore the prior descriptor at a fresh body revision and notify
+  once, making every render of the provisional descriptor stale. If the failed
+  candidate exposed a different hook shape, restoration advances remount
+  generation again. A failed first registration becomes an unavailable
+  tombstone at a fresh revision. Listener subscriptions made in flight are
+  retained. Returns the current slot snapshot."
   [{:keys [view-id publication-token before]}]
-  (let [slots
-        (swap! view-generations update view-id
-               (fn [slot]
-                 (if (identical? publication-token
-                                 (:hmr-publication-token slot))
-                   (assoc (or before {})
-                          :hmr-listeners
-                          (:hmr-listeners slot {}))
-                   slot)))]
-    (get slots view-id)))
+  (let [[old-slots slots]
+        (swap-vals!
+         view-generations update view-id
+         (fn [slot]
+           (if (identical? publication-token
+                           (:hmr-publication-token slot))
+             (let [prior (or before {})
+                   prior-registered? (boolean (:hmr-registered? prior))
+                   shape-observed?
+                   (or (not prior-registered?)
+                       (not= (:hmr-hook-signature prior)
+                             (:hmr-hook-signature slot)))
+                   restored
+                   (-> prior
+                       (assoc :hmr-listeners (:hmr-listeners slot {})
+                              :hmr-body-revision
+                              (inc (:hmr-body-revision slot))
+                              :hmr-remount-generation
+                              (cond-> (:hmr-remount-generation slot)
+                                shape-observed? inc)))]
+               (if prior-registered?
+                 restored
+                 (assoc restored
+                        :hmr-registered? false
+                        :hmr-hook-signature nil
+                        :hmr-descriptor nil)))
+             slot)))
+        current-before (get old-slots view-id)
+        rolled-back? (identical? publication-token
+                                  (:hmr-publication-token current-before))
+        restored (get slots view-id)]
+    (when rolled-back?
+      (doseq [listener (vals (:hmr-listeners restored))]
+        (listener)))
+    restored))
 
 (defn register-view-descriptor!
   "Publish one descriptor directly through the same prepare/commit path used

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -276,11 +276,18 @@
 (defn- record-site
   "Add one compiler-indexed lexical site to `cap`. Site identity—not target
   equality—is the ownership key, so two equal queries remain two owners. A
-  repeated execution of one sid in a render is a compiler-contract violation;
-  the first observation wins defensively."
+  repeated execution of one sid in a render is a compiler-contract violation
+  and fails loudly: rendering a later value while committing the first target
+  would otherwise create an incoherent dependency."
   [cap sid query target ev value]
   (if (contains? (:by-site cap) sid)
-    cap
+    (error/throw-error!
+      :rf.error/ui-tree-malformed
+      're-frame.ui.reactive/sub-read
+      (str "compiler lexical site id " (pr-str sid)
+           " executed more than once in one render capture — each finite "
+           "reactive occurrence must have a distinct stable id")
+      {:extra {:site-id sid :query query}})
     (-> cap
         (update :order conj sid)
         (assoc-in [:by-site sid] {:query query
@@ -639,6 +646,13 @@
      (sub-read nil query)))
   ([sid query]
    (let [{:keys [cell capture]} @ambient
+         _ (when (and (some? cell) (nil? sid))
+             (error/throw-error!
+               :rf.error/ui-tree-malformed
+               're-frame.ui.reactive/sub-read
+               (str "nil lexical site id reached an active ViewCell capture — "
+                    "compiled render reads must carry a non-nil site id")
+               {:extra {:query query}}))
          prior-record (when (some? cell)
                         (get (:committed @(state cell)) sid))
          prior-query  (:query prior-record)
@@ -1689,10 +1703,12 @@
 ;; token unchanged — the marker is the only signal there).
 
 (defn- committed-frame-incarnations
-  "Snapshot `{frame-id -> incarnation-token}` for every frame the committed map
-  `committed` observes — captured at ACQUIRE time so the frame-close revalidation
-  compares each frame's LIVE incarnation against the one this commit acquired from
-  (rf2-vxgfnd.88). A frame absent/destroyed reads nil. O(observed frames)."
+  "Post-acquire snapshot `{frame-id -> incarnation-token}` for every frame the
+  candidate committed map observes. `commit!` immediately validates every
+  candidate lease with `current?`; together those operations close the window
+  in which a lease acquired from A could otherwise be paired with a snapshot
+  of a replacement same-id incarnation B. A frame absent/destroyed reads nil.
+  O(observed frames)."
   [committed]
   (persistent!
     (reduce (fn [acc {:keys [target lease]}]
@@ -1729,7 +1745,9 @@
                      commit ACQUIRE the FRESH incarnation while the render probed
                      the destroyed one — the `:node-key` reincarnation
                      `evidence-moved?` must correct before paint (rf2-vxgfnd.93).
-    :post-acquire  — after stage-acquire + the evidence read, BEFORE the publish.
+    :post-stage-acquire — after leases are acquired, BEFORE the incarnation
+                     snapshot/current validation.
+    :post-acquire  — after validation + the evidence read, BEFORE the publish.
                      A full destroy of the ACQUIRED incarnation + a fresh same-id
                      incarnation here proves the frame-close revalidation joins the
                      commit to the acquired incarnation's teardown, not the
@@ -1853,11 +1871,28 @@
                                                                      [:query :target :value])
                                                         :lease lease)])))))
               staged-map (into {} staged)
-              ;; ACQUIRE-time incarnation snapshot for the frame-close
-              ;; revalidation (rf2-vxgfnd.88): the exact incarnation each lease
-              ;; was acquired from, so a same-id reincarnation before publish is
-              ;; caught by token identity, not merely the reused frame-id.
-              incarnations (committed-frame-incarnations (merge retained staged-map))
+              candidate (merge retained staged-map)
+              ;; A JVM fixture can destroy/recreate the just-acquired frame in
+              ;; the formerly-uncovered acquire→snapshot window.
+              _ (when-some [barrier *commit-barrier*]
+                  (barrier :post-stage-acquire cell))
+              incarnations (committed-frame-incarnations candidate)
+              candidate-current?
+              (every? (fn [[sid record]]
+                        (obs/current? (:lease record) (:target (new-by sid))))
+                      candidate)]
+          (if-not candidate-current?
+            (do
+              ;; One of the acquired/retained leases belonged to an incarnation
+              ;; that vanished before a trustworthy snapshot could be paired
+              ;; with it. Roll back only newly staged ownership, preserve the
+              ;; prior committed set, and synchronously invalidate so the host
+              ;; re-probes the current incarnation before paint.
+              (doseq [[_ record] (rseq staged)]
+                (obs/release! (:lease record)))
+              (advance-revision! cell)
+              cell)
+            (let [
               ;; step 5 — evidence comparison: read EACH acquired node (staged AND
               ;; retained) against the render's probe evidence, so movement in the
               ;; render→commit gap is caught before paint (invariant 5).
@@ -1881,7 +1916,7 @@
                                            (:evidence (new-by sid))))
               staged-moved?   (boolean (some moved-in? staged))
               retained-moved? (boolean (some moved-in? retained))
-              new-committed (merge retained staged-map)]
+              new-committed candidate]
           ;; :post-acquire test seam — a fixture may destroy the ACQUIRED
           ;; incarnation + recreate the id here to prove the revalidation below
           ;; joins this commit to the acquired incarnation's teardown, not the
@@ -1951,7 +1986,7 @@
             (when (or staged-moved?
                       (and retained-moved? (not (dirty? cell))))
               (advance-revision! cell)))
-          cell)))))
+              cell)))))))
 
 ;; ---- test/inspection reads --------------------------------------------------
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -525,7 +525,8 @@
   candidate exposed a different hook shape, restoration advances remount
   generation again. A failed first registration becomes an unavailable
   tombstone at a fresh revision. Listener subscriptions made in flight are
-  retained. Returns the current slot snapshot."
+  retained. Returns true only when this publication performed the compensation;
+  a stale publication returns false."
   [{:keys [view-id publication-token before]}]
   (let [[old-slots slots]
         (swap-vals!
@@ -561,7 +562,7 @@
     (when rolled-back?
       (doseq [listener (vals (:hmr-listeners restored))]
         (listener)))
-    restored))
+    rolled-back?))
 
 (defn register-view-descriptor!
   "Publish one descriptor directly through the same prepare/commit path used

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -265,7 +265,7 @@
 
 (defn- fresh-capture
   [generation]
-  {:generation generation :order [] :by-key {}})
+  {:generation generation :order [] :by-site {}})
 
 (defn- target-key
   [target]
@@ -274,14 +274,25 @@
     :story-override [:override (:override-id target)]))
 
 (defn- record-site
-  "Add a site's observation to `cap`, deduped by target identity (the first
-  observation of a target within a pass fixes its order + evidence)."
-  [cap tk target ev value]
-  (if (contains? (:by-key cap) tk)
+  "Add one compiler-indexed lexical site to `cap`. Site identity—not target
+  equality—is the ownership key, so two equal queries remain two owners. A
+  repeated execution of one sid in a render is a compiler-contract violation;
+  the first observation wins defensively."
+  [cap sid query target ev value]
+  (if (contains? (:by-site cap) sid)
     cap
     (-> cap
-        (update :order conj tk)
-        (assoc-in [:by-key tk] {:target target :evidence ev :value value}))))
+        (update :order conj sid)
+        (assoc-in [:by-site sid] {:query query
+                                  :target target
+                                  :evidence ev
+                                  :value value}))))
+
+(defn site-records
+  "The immutable `{sid -> render observation}` in capture `cap` (internal
+  compiler/runtime/test seam)."
+  [cap]
+  (:by-site cap))
 
 ;; ---------------------------------------------------------------------------
 ;; The slice-scoped probe memo (S2d item 3; 03 §3)
@@ -344,11 +355,12 @@
   ;;                             ;   same-tick StrictMode dev replay (no hide);
   ;;                             ;   `settle-disconnect!` clears it. false/absent
   ;;                             ;   in production (no StrictMode double-invoke)
-  ;;    :committed {tk -> lease} ; installed dependency set
-  ;;    :values    {tk -> value} ; last published site values (stabilization
-  ;;                             ;   + revision evidence); retained across a
-  ;;                             ;   disconnect, so frame teardown can identify
-  ;;                             ;   an Activity-hidden cell's last frames
+  ;;    :committed {sid -> {:query exact-query :target target :value value
+  ;;                        :lease lease|nil}}
+  ;;                             ; lexical site records. `:lease nil` survives
+  ;;                             ; disconnect for exact query/value reuse and
+  ;;                             ; hidden-cell frame attribution; absence means
+  ;;                             ; the site was conditional/dropped
   ;;    :revision  int           ; get-snapshot returns this (useSyncExternalStore)
   ;;    :dirty?    bool          ; pending-notification flag (drain coalescing)
   ;;    :evidence  ev|nil        ; DEBUG-only bounded causal evidence for the
@@ -378,7 +390,6 @@
             :root           nil
             :disconnect-provisional? false
             :committed      {}
-            :values         {}
             :revision       0
             :dirty?         false
             :evidence       nil
@@ -600,36 +611,56 @@
 ;; ---- read + query stabilization ---------------------------------------------
 
 (defn sub-read
-  "The one bridge `(sub query)` lowers to on both hosts. Resolves the
-  site's target (override door → ambient frame), probes ownership-free, and
-  returns the value:
+  "The one bridge `(sub query)` lowers to on both hosts. The compiler calls
+  `(sub-read sid query)`; `sid` is the stable lexical ownership key. Resolves
+  the site's target (override door → ambient frame), probes ownership-free,
+  and returns the value:
 
     - Inside a live cell render (ambient capture present), RECORDS the site
-      (target + evidence) into the capture and returns the `rf=`-stabilized
-      value (the prior committed reference when the read is `rf=`).
-    - Outside a cell (the JVM `ui.test/render` one-shot headless read, or a
-      defensive direct call), returns the freshly probed value — no
-      ownership, no capture.
+      by sid. A fresh candidate query that is `rf=` to that same site's prior
+      query is replaced by the PRIOR EXACT query object BEFORE override/target
+      resolution. The value is then stabilized against the same site's prior
+      exact value.
+    - Outside a cell, either arity is a one-shot headless read: freshly probe,
+      with no ownership/capture. The legacy one-argument arity is deliberately
+      illegal under an ambient capture so a compiler/test cannot silently lose
+      lexical identity.
 
   Fail-loud rides the port: `:rf.error/no-such-sub` on an unknown entry
   sub, `:rf.error/frame-destroyed` against a destroyed frame."
-  [query]
-  (let [override (resolve-override query)
-        site-ctx (cond-> {:query-v query}
-                   (some? override) (assoc :override override))
-        target   (obs/resolve-target site-ctx)
-        ev       (obs/probe target (current-slice-memo))
-        v        (:value ev)
-        {:keys [cell capture]} @ambient]
-    (if (some? cell)
-      (let [tk    (target-key target)
-            prior (get (:values @(state cell)) tk ::none)
-            v*    (if (and (not (identical? ::none prior)) (eq/rf= v prior))
-                    prior
-                    v)]
-        (vswap! capture record-site tk target ev v*)
-        v*)
-      v)))
+  ([query]
+   (if (some? (:cell @ambient))
+     (error/throw-error!
+       :rf.error/ui-tree-malformed
+       're-frame.ui.reactive/sub-read
+       (str "one-argument sub-read reached an active ViewCell capture — "
+            "compiled render reads must carry their lexical site id")
+       {:extra {:query query}})
+     (sub-read nil query)))
+  ([sid query]
+   (let [{:keys [cell capture]} @ambient
+         prior-record (when (some? cell)
+                        (get (:committed @(state cell)) sid))
+         prior-query  (:query prior-record)
+         query*       (if (and prior-record (eq/rf= query prior-query))
+                        prior-query
+                        query)
+         ;; Query stabilization MUST precede both the override door and target
+         ;; resolution: adapters may key their caches by exact query identity.
+         override     (resolve-override query*)
+         site-ctx     (cond-> {:query-v query*}
+                        (some? override) (assoc :override override))
+         target       (obs/resolve-target site-ctx)
+         ev           (obs/probe target (current-slice-memo))
+         v            (:value ev)]
+     (if (some? cell)
+       (let [prior-value (:value prior-record)
+             v*          (if (and prior-record (eq/rf= v prior-value))
+                           prior-value
+                           v)]
+         (vswap! capture record-site sid query* target ev v*)
+         v*)
+       v))))
 
 (defn with-capture
   "Run `thunk` (a compiled view body) under a fresh ambient capture and return
@@ -1100,8 +1131,8 @@
 (defn- cell-frames
   "The set of frame-ids `cell`'s committed subscription sites observe.
 
-  Keyed on `:sub` target keys ONLY. A static Story-override site commits an
-  `[:override id]` key that names NO frame (the pinned value IS the
+  Only records with a live lease are currently observed. A static Story-
+  override target names NO frame (the pinned value IS the
   resolution — there is no node and no observed frame), so an OVERRIDE-ONLY
   cell observes no frame and this returns `#{}`. The frame-scope membership
   test (`cell-observes-frame?`) is therefore false for such a cell against
@@ -1110,8 +1141,10 @@
   mixing `sub` and override sites observes exactly its `sub` sites' frames."
   [^ViewCell cell]
   (into #{}
-        (keep (fn [tk] (when (= :sub (nth tk 0)) (nth tk 1))))
-        (keys (:committed @(state cell)))))
+        (keep (fn [{:keys [target lease]}]
+                (when (and lease (= :subscription (:kind target)))
+                  (:frame-id target))))
+        (vals (:committed @(state cell)))))
 
 (defn cell-observes-frame?
   "True when `cell`'s committed dependency set includes a site in frame
@@ -1120,15 +1153,15 @@
   (contains? (cell-frames cell) frame-id))
 
 (defn- cell-retained-frame?
-  "True when `cell`'s last published site values name `frame-id`. Unlike the
-  live committed set, `:values` survives an Activity disconnect for value
-  stabilization, so this is the bounded history a frame-destroy sweep uses for
-  still-disconnected, root-owned cells."
+  "True when `cell`'s last published lexical site records name `frame-id`.
+  Records survive an Activity disconnect with `:lease nil`, providing bounded
+  exact query/value history plus frame attribution for hidden root-owned cells."
   [^ViewCell cell frame-id]
   (boolean
-    (some (fn [tk]
-            (and (= :sub (nth tk 0)) (= frame-id (nth tk 1))))
-          (keys (:values @(state cell))))))
+    (some (fn [{:keys [target]}]
+            (and (= :subscription (:kind target))
+                 (= frame-id (:frame-id target))))
+          (vals (:committed @(state cell))))))
 
 (defn flush-frame!
   "The FRAME arity of `flush!` — flush every pending cell observing frame
@@ -1340,14 +1373,19 @@
   ([incarnation] (count (get @root-cells incarnation))))
 
 (defn- release-committed!
-  "Release every lease in the committed dependency set and clear it —
-  acquire-before-release is not needed here (this is a full teardown, not a
-  reconcile). Idempotent via the port's own release! idempotence."
+  "Release every live lexical-site lease and retain each exact query/target/
+  value record with `:lease nil`. A disconnect therefore owns nothing while a
+  reconnect can still stabilize exact objects per site. Idempotent."
   [^ViewCell cell]
   (let [st (state cell)]
-    (doseq [lease (vals (:committed @st))]
-      (obs/release! lease))
-    (swap! st assoc :committed {})))
+    (doseq [{:keys [lease]} (vals (:committed @st))]
+      (when lease (obs/release! lease)))
+    (swap! st update :committed
+           (fn [sites]
+             (reduce-kv (fn [out sid record]
+                          (assoc out sid (assoc record :lease nil)))
+                        (empty sites)
+                        sites)))))
 
 (defn- annotate-open-disconnect!
   "Upgrade the still-open `:disconnected {:reason :unknown}` interval's
@@ -1472,7 +1510,7 @@
                {:state :unmounted :reason :unmounted :proof :host-teardown}))
       (release-committed! cell)
       (discard-pending! cell)
-      (swap! st assoc :lifecycle :dead)
+      (swap! st assoc :lifecycle :dead :committed {})
       (swap! live-cells disj cell)
       ;; leave the root-incarnation registry — a dead cell is no longer
       ;; retained, so it must not linger as reapable ownership (rf2-vxgfnd.85).
@@ -1657,12 +1695,13 @@
   (rf2-vxgfnd.88). A frame absent/destroyed reads nil. O(observed frames)."
   [committed]
   (persistent!
-    (reduce (fn [acc tk]
-              (if (= :sub (nth tk 0))
-                (assoc! acc (nth tk 1) (frame/frame-incarnation-token (nth tk 1)))
+    (reduce (fn [acc {:keys [target lease]}]
+              (if (and lease (= :subscription (:kind target)))
+                (let [fid (:frame-id target)]
+                  (assoc! acc fid (frame/frame-incarnation-token fid)))
                 acc))
             (transient {})
-            (keys committed))))
+            (vals committed))))
 
 (defn- incarnation-superseded?
   "True when ANY frame in the acquire-time `incarnations` snapshot is no longer
@@ -1760,25 +1799,33 @@
         ;; render→commit gap here so the stage-acquire below binds the FRESH
         ;; incarnation while the render probed the destroyed one (rf2-vxgfnd.93).
         (when-some [barrier *commit-barrier*] (barrier :pre-acquire cell))
-        (let [committed  (:committed st0)          ;; tk -> lease
-              new-order  (:order cap)              ;; tk, render order
-              new-by     (:by-key cap)
+        (let [committed  (:committed st0)          ;; sid -> site record
+              new-order  (:order cap)              ;; sid, render order
+              new-by     (:by-site cap)
               new-set    (set new-order)
               ;; step 3 — kept-check
               retained   (persistent!
                            (reduce
-                             (fn [acc [tk lease]]
-                               (if (and (contains? new-set tk)
-                                        (obs/current? lease (:target (new-by tk))))
-                                 (assoc! acc tk lease)
-                                 acc))
+                             (fn [acc [sid prior]]
+                               (let [lease (:lease prior)]
+                                 (if (and lease
+                                          (contains? new-set sid)
+                                          (obs/current? lease
+                                                        (:target (new-by sid))))
+                                   (assoc! acc sid
+                                           (assoc (select-keys (new-by sid)
+                                                               [:query :target :value])
+                                                  :lease lease))
+                                 acc)))
                              (transient {})
                              committed))
-              retained?  (fn [tk] (contains? retained tk))
+              retained?  (fn [sid] (contains? retained sid))
               to-release (persistent!
                            (reduce
-                             (fn [acc [tk lease]]
-                               (if (retained? tk) acc (assoc! acc tk lease)))
+                             (fn [acc [sid record]]
+                               (if (or (retained? sid) (nil? (:lease record)))
+                                 acc
+                                 (assoc! acc sid record)))
                              (transient {})
                              committed))
               to-acquire (into [] (remove retained?) new-order)
@@ -1788,8 +1835,8 @@
                                 acc    []]
                            (if (empty? ks)
                              acc
-                             (let [tk     (first ks)
-                                   target (:target (new-by tk))
+                             (let [sid    (first ks)
+                                   target (:target (new-by sid))
                                    lease  (try
                                             (obs/acquire! target on-change)
                                             (catch #?(:clj Throwable :cljs :default) e
@@ -1797,10 +1844,14 @@
                                               ;; REVERSE acquisition order; the
                                               ;; prior committed set stays
                                               ;; installed; propagate the throw.
-                                              (doseq [[_ l] (rseq acc)]
-                                                (obs/release! l))
+                                              (doseq [[_ record] (rseq acc)]
+                                                (obs/release! (:lease record)))
                                               (throw e)))]
-                               (recur (rest ks) (conj acc [tk lease])))))
+                               (recur (rest ks)
+                                      (conj acc
+                                            [sid (assoc (select-keys (new-by sid)
+                                                                     [:query :target :value])
+                                                        :lease lease)])))))
               staged-map (into {} staged)
               ;; ACQUIRE-time incarnation snapshot for the frame-close
               ;; revalidation (rf2-vxgfnd.88): the exact incarnation each lease
@@ -1825,28 +1876,22 @@
               ;; `read` recomputes the plain-atom node on deref, so a headless move
               ;; is observed here; the two catches are kept distinct because the
               ;; step-8 advance treats them differently (see below).
-              moved-in? (fn [[tk lease]]
-                          (evidence-moved? (obs/read lease)
-                                           (:evidence (new-by tk))))
+              moved-in? (fn [[sid record]]
+                          (evidence-moved? (obs/read (:lease record))
+                                           (:evidence (new-by sid))))
               staged-moved?   (boolean (some moved-in? staged))
               retained-moved? (boolean (some moved-in? retained))
-              new-values (persistent!
-                           (reduce (fn [acc tk]
-                                     (assoc! acc tk (:value (new-by tk))))
-                                   (transient {})
-                                   new-order))]
+              new-committed (merge retained staged-map)]
           ;; :post-acquire test seam — a fixture may destroy the ACQUIRED
           ;; incarnation + recreate the id here to prove the revalidation below
           ;; joins this commit to the acquired incarnation's teardown, not the
           ;; replacement id (rf2-vxgfnd.88).
           (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
-          ;; step 6 — publish (committed values + dependency set)
-          (swap! st assoc
-                 :committed (merge retained staged-map)
-                 :values    new-values)
+          ;; step 6 — publish exact per-site query/value + dependency set
+          (swap! st assoc :committed new-committed)
           ;; step 7 — release dropped + retargeted prior leases
-          (doseq [[_ lease] to-release]
-            (obs/release! lease))
+          (doseq [[_ record] to-release]
+            (obs/release! (:lease record)))
           ;; lifecycle: connect (reconnect annotation when re-committing a
           ;; hidden cell). This ENROLS the cell into the live-cell registry —
           ;; the discoverability publish a frame-destroy sweep consults.
@@ -1911,19 +1956,43 @@
 ;; ---- test/inspection reads --------------------------------------------------
 
 (defn committed-target-keys
-  "The target keys of the cell's installed dependency set (tool/test read)."
+  "Legacy target projection of the cell's LIVE installed dependency set.
+  Equal-query lexical sites intentionally collapse in this compatibility view;
+  use `committed-sites` to inspect ownership identity."
   [^ViewCell cell]
-  (set (keys (:committed @(state cell)))))
+  (into #{}
+        (comp (filter :lease) (map (comp target-key :target)))
+        (vals (:committed @(state cell)))))
 
 (defn committed-values
-  "The cell's last-published site values, keyed by target (tool/test read)."
+  "Legacy target-keyed value projection. Equal targets collapse here by
+  definition; canonical state is `committed-sites`."
   [^ViewCell cell]
-  (:values @(state cell)))
+  (persistent!
+    (reduce (fn [out {:keys [target value]}]
+              (assoc! out (target-key target) value))
+            (transient {})
+            (vals (:committed @(state cell))))))
 
 (defn committed-lease
-  "The installed lease for target key `tk` (tool/test read), or nil."
+  "Legacy target-keyed installed lease projection, or nil. If two sites share
+  a target this returns one of their distinct leases; use `committed-site`."
   [^ViewCell cell tk]
-  (get (:committed @(state cell)) tk))
+  (some (fn [{:keys [target lease]}]
+          (when (= tk (target-key target)) lease))
+        (vals (:committed @(state cell)))))
+
+(defn committed-sites
+  "The canonical `{sid -> {:query :target :value :lease}}` lexical ownership
+  map for `cell` (internal tool/test seam). Disconnected records remain with
+  `:lease nil`; conditionally absent sites are not present."
+  [^ViewCell cell]
+  (:committed @(state cell)))
+
+(defn committed-site
+  "The canonical committed record for lexical `sid`, or nil."
+  [^ViewCell cell sid]
+  (get (:committed @(state cell)) sid))
 
 (defn revision
   "The cell's current revision integer (tool/test read)."

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -94,8 +94,10 @@
   Descriptor/revisions are PREPARED before registrar publication so the
   registrar's synchronous hooks can never observe a new manifest paired with
   an old (or nil) render/comparator. Mounted shells are notified only after
-  registrar success. A registrar throw rolls the prepared slot back, advancing
-  neither body revision nor remount generation."
+  registrar success. A registrar throw compensates monotonically: the prior
+  descriptor (or an unavailable first-load tombstone) is republished at a fresh
+  revision and mounted shells are notified once, so no provisional render can
+  commit or strand a cell on a revision that moved backwards."
   [id render-fn compare-fn display-name manifest]
   (let [{:keys [outer inner]}
         (reactive/ensure-view-shells! id #(make-view-shells id))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -123,9 +123,12 @@
         (reactive/commit-view-descriptor! publication)
         outer
         (catch :default e
-          (reactive/rollback-view-descriptor! publication)
-          (set! (.-displayName inner) old-inner-name)
-          (set! (.-displayName outer) old-outer-name)
+          ;; A registrar hook may have synchronously published a newer winner.
+          ;; Restore diagnostic names only when this transaction also restored
+          ;; its descriptor; a stale failure must not clobber the winner.
+          (when (reactive/rollback-view-descriptor! publication)
+            (set! (.-displayName inner) old-inner-name)
+            (set! (.-displayName outer) old-outer-name))
           (throw e))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -20,6 +20,7 @@
       html        {:fqn 're-frame.ui/html :meta {}}
       raw-fn      {:fqn 're-frame.ui/raw-fn :meta {}}
       spread      {:fqn 're-frame.ui/spread :meta {}}
+      if-let      {:fqn 'clojure.core/if-let :meta {:macro true}}
       frame-provider {:fqn 're-frame.ui/frame-provider :meta {}}
       child-view  {:fqn 'app.views/child-view
                    :meta {:rf.ui/view true :rf.ui/children? true}}
@@ -173,6 +174,19 @@
                                     [:p {:data-n (sub [:count])} "x"]])]
     (is (= 2 (count (:subs sites))))
     (is (= [[:title]] (map :query (take 1 (:subs sites)))))))
+
+(deftest lexical-shadowing-never-mints-a-reactive-site
+  (testing "a local named sub is an ordinary call, not re-frame.ui/sub"
+    (let [{:keys [ast sites]}
+          (ana-full '[:div {:title (let [sub identity] (sub query))}])]
+      (is (empty? (:subs sites)))
+      (is (= '(let [sub identity] (sub query))
+             (get-in ast [:props :attrs 0 :value])))))
+  (testing "catch bindings receive the same lexical-shadow treatment"
+    (let [{:keys [sites]}
+          (ana-full '[:div {:title (try value
+                                    (catch Exception sub (sub query)))}])]
+      (is (empty? (:subs sites))))))
 
 (deftest html-sites-index
   (testing "ui/html records a manifest site — the profile row's 'manifest

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -7,7 +7,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             #?(:clj [clojure.edn :as edn] :cljs [cljs.reader :as edn])
             [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.env :as env]))
+            [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.fingerprint :as fingerprint]))
 
 (def resolver
   "Injected Q5 resolution stub — fqn + var meta per symbol."
@@ -21,6 +22,7 @@
       raw-fn      {:fqn 're-frame.ui/raw-fn :meta {}}
       spread      {:fqn 're-frame.ui/spread :meta {}}
       if-let      {:fqn 'clojure.core/if-let :meta {:macro true}}
+      ->          {:fqn 'clojure.core/-> :meta {:macro true}}
       frame-provider {:fqn 're-frame.ui/frame-provider :meta {}}
       child-view  {:fqn 'app.views/child-view
                    :meta {:rf.ui/view true :rf.ui/children? true}}
@@ -50,6 +52,21 @@
   (let [e (mk-env)
         ast (ana/analyze e form)]
     {:ast ast :warnings @(:warnings e) :sites @(:sites e)}))
+
+(defn- analyze-site-fixture [host source template]
+  (let [e (-> (env/make-env {:host host :ns-sym 'app.test
+                              :self 'self-view :self-id :app.test/self-view
+                              :source source
+                              :template-anchor
+                              (fingerprint/digest "sta1-" template)
+                              :resolver resolver})
+              (assoc :self-children? false :self-closed-keys nil))
+        ast (ana/analyze e template)]
+    {:ast ast :sites @(:sites e)}))
+
+(defn- located-sub [line column query]
+  (with-meta (list 'sub query)
+    {:line line :column column :end-line (+ line 10) :end-column 99}))
 
 ;; ---------------------------------------------------------------------------
 ;; Scalars + basics
@@ -156,7 +173,12 @@
     (is (= :fn (:classification (first (get-in el [:props :events]))))
         "bare fns are legal in known native event properties"))
   (let [el (ana* '[:button {:on-click (if a [:x/a] [:x/b])} "x"])]
-    (is (= :dynamic (:classification (first (get-in el [:props :events])))))))
+    (is (= :dynamic (:classification (first (get-in el [:props :events]))))))
+  (let [{:keys [ast sites]}
+        (ana-full '[:button {:on-click (if (sub [:enabled?]) [:x/go] nil)} "x"])]
+    (is (= :dynamic (:classification (first (get-in ast [:props :events])))))
+    (is (= 1 (count (:subs sites)))
+        "dynamic handler classification runs at render, so its sub is finite")))
 
 (deftest event-sites-index-into-the-manifest
   (let [{:keys [sites]} (ana-full '[:div
@@ -175,6 +197,47 @@
     (is (= 2 (count (:subs sites))))
     (is (= [[:title]] (map :query (take 1 (:subs sites)))))))
 
+(deftest lexical-site-id-is-portable-stable-and-query-independent
+  (let [template-a [:div (located-sub 102 8 [:item/by-id 'id])]
+        template-b [:div (located-sub 202 8 [:item/by-id 'id])]
+        clj-a (analyze-site-fixture :clj {:line 100 :column 1} template-a)
+        cljs-a (analyze-site-fixture :cljs {:line 100 :column 1} template-a)
+        moved (analyze-site-fixture :clj {:line 200 :column 1} template-b)
+        changed-query
+        (analyze-site-fixture
+         :clj {:line 100 :column 1}
+         [:div (located-sub 102 8 [:item/by-id 'other-id])])
+        sid #(get-in % [:sites :subs 0 :sid])]
+    (is (= (sid clj-a) (sid cljs-a))
+        "host is not part of lexical identity")
+    (is (= (sid clj-a) (sid moved))
+        "moving the whole declaration preserves relative source identity")
+    (is (= (sid clj-a) (sid changed-query))
+        "the query value is destination data, never ownership identity")
+    (is (= (fingerprint/template-fingerprint
+            (ana/template-fingerprint-projection (:ast clj-a)))
+           (fingerprint/template-fingerprint
+            (ana/template-fingerprint-projection (:ast moved))))
+        "source/site movement does not perturb semantic template identity")
+    (is (not=
+         (fingerprint/template-fingerprint
+          (ana/template-fingerprint-projection (:ast clj-a)))
+         (fingerprint/template-fingerprint
+          (ana/template-fingerprint-projection (:ast changed-query))))
+        "site id is projected out, but the semantic query remains")))
+
+(deftest metadata-loss-reacquires-safely-instead-of-transferring-an-ordinal
+  (let [old (analyze-site-fixture :clj {:line 1} '[:div (sub [:a])])
+        edited (analyze-site-fixture
+                :clj {:line 1} '[:div (sub [:b]) (sub [:a])])
+        old-sid (get-in old [:sites :subs 0 :sid])
+        new-sids (mapv :sid (get-in edited [:sites :subs]))]
+    (is (= 2 (count (distinct new-sids)))
+        "equal/different destinations never collapse distinct lexical paths")
+    (is (not (some #{old-sid} new-sids))
+        "without reader anchors the whole-template fallback changes all ids;
+         no bare preorder ordinal can transfer A's ownership to inserted B")))
+
 (deftest lexical-shadowing-never-mints-a-reactive-site
   (testing "a local named sub is an ordinary call, not re-frame.ui/sub"
     (let [{:keys [ast sites]}
@@ -187,6 +250,12 @@
           (ana-full '[:div {:title (try value
                                     (catch Exception sub (sub query)))}])]
       (is (empty? (:subs sites))))))
+
+(deftest ordinary-destructuring-defaults-remain-legal
+  (let [{:keys [sites]}
+        (ana-full '(let [{:keys [x] :or {x (str "fallback")}} value]
+                     [:div x]))]
+    (is (empty? (:subs sites)))))
 
 (deftest html-sites-index
   (testing "ui/html records a manifest site — the profile row's 'manifest

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -84,6 +84,9 @@
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '(let [{:keys [x] :or {x (sub [:q])}} value] [:div x]))))
   (is (= :rf.ui.compile/unsupported-form
+         (reject-id '(let [{:keys [x] :or {x (-> [:q] sub)}} value]
+                       [:div x]))))
+  (is (= :rf.ui.compile/unsupported-form
          (reject-id '(for [{:keys [x] :or {x (sub [:q])}} xs]
                        [:div {:key x} x]))))
   (is (= :rf.ui.compile/unsupported-form

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -60,7 +60,32 @@
   (is (= :rf.ui.compile/sub-in-loop
          (reject-id '(for [x xs :let [v (sub [:q x])]] [:li {:key x} v]))))
   (is (= :rf.ui.compile/lease-in-loop
-         (reject-id '(for [x xs] [:li {:key x} (str (lease {:resource x}))])))))
+         (reject-id '(for [x xs] [:li {:key x} (str (lease {:resource x}))]))))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:button {:on-click [::open (sub [:q])]} "x"])))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:button {:on-click {:event [::open (sub [:q])]}} "x"])))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:button {:on-click (fn [_] (sub [:q]))} "x"])))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:div {:ref (raw-fn (fn [_] (sub [:q])))}])))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:div {:title (mapv (fn [x] (sub [:q x])) xs)}])))
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:div {:title (loop [x 0] (sub [:q x]))}])))
+  (is (= :rf.ui.compile/lease-in-loop
+         (reject-id '[:button {:on-click (fn [_] (lease {:resource :x}))} "x"])))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (if-let [x maybe] (sub [:q x]) nil)}]))
+      "opaque binder macros fail loudly instead of receiving an unsound rewrite")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (sub)}])))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (sub [:a] [:b])}])))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (lease)}])))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (lease {:a 1} {:b 2})}]))))
 
 (deftest loop-captured-handlers
   (is (= :rf.ui.compile/loop-capturing-handler

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -79,6 +79,17 @@
          (reject-id '[:div {:title (if-let [x maybe] (sub [:q x]) nil)}]))
       "opaque binder macros fail loudly instead of receiving an unsound rewrite")
   (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (-> [:q] sub)}]))
+      "a macro cannot turn a bare resolved sub reference into an unindexed call")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '(let [{:keys [x] :or {x (sub [:q])}} value] [:div x]))))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '(for [{:keys [x] :or {x (sub [:q])}} xs]
+                       [:div {:key x} x]))))
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:button {:on-click
+                               (fn [{:keys [x] :or {x (sub [:q])}}] x)}])))
+  (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (sub)}])))
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (sub [:a] [:b])}])))

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -1,0 +1,79 @@
+(ns re-frame.ui.compiler-macro-resolution-jvm-test
+  "Real CLJS-analyzer resolution proofs for the expression macro barrier."
+  (:require [cljs.analyzer :as cljs-analyzer]
+            [cljs.analyzer.api :as cljs-api]
+            [cljs.core]
+            [cljs.env :as cljs-env]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.compiler.analyze :as analyze]
+            [re-frame.ui.compiler.env :as env]))
+
+(defmacro user-binder
+  [[binding init] then else]
+  `(let [~binding ~init] (if ~binding ~then ~else)))
+
+(defn- compile-error-id [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e
+         (:rf.ui.compile/error (ex-data e)))))
+
+(defn- with-real-cljs-env [f]
+  (binding [cljs-env/*compiler* (cljs-env/default-compiler-env)]
+    ;; A real CLJS compile interns core/user macros into analyzer state. Build
+    ;; that exact authority rather than injecting a synthetic :macro flag.
+    (cljs-analyzer/intern-macros 'cljs.core)
+    (cljs-analyzer/intern-macros
+     're-frame.ui.compiler-macro-resolution-jvm-test)
+    (let [cljs-e (cljs-api/empty-env)]
+      (cljs-api/analyze cljs-e '(def ordinary-call (fn [x] x)))
+      (let [base (env/make-env {:host :cljs :cljs-env cljs-e
+                                :ns-sym 'cljs.user})
+            resolve* (fn [sym]
+                       (case sym
+                         sub   {:fqn 're-frame.ui/sub :meta {}}
+                         lease {:fqn 're-frame.ui/lease :meta {}}
+                         (env/resolve-sym base sym)))
+            e (env/make-env {:host :cljs :cljs-env cljs-e
+                             :ns-sym 'cljs.user
+                             :self 'probe :self-id :cljs.user/probe
+                             :resolver resolve*})]
+        (f base e)))))
+
+(deftest real-cljs-analyzer-macro-authority-is-preserved
+  (with-real-cljs-env
+    (fn [base _]
+      (testing "core and user binder macros carry the analyzer's top-level flag"
+        (is (true? (get-in (env/resolve-sym base 'if-let) [:meta :macro])))
+        (is (true?
+             (get-in
+              (env/resolve-sym
+               base
+               're-frame.ui.compiler-macro-resolution-jvm-test/user-binder)
+              [:meta :macro]))))
+      (testing "a real analyzed ordinary function is not over-classified"
+        (is (not (true? (get-in (env/resolve-sym base 'ordinary-call)
+                                [:meta :macro]))))))))
+
+(deftest real-cljs-binder-macros-fail-while-transparent-expressions-lower
+  (with-real-cljs-env
+    (fn [_ e]
+      (doseq [form
+              ['[:div {:title (if-let [x maybe] (sub [:q x]) nil)}]
+               '[:div {:title
+                       (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder
+                        [x maybe] (sub [:q x]) nil)}]
+               '[:div {:title (-> [:q] sub)}]]]
+        (is (= :rf.ui.compile/unsupported-form
+               (compile-error-id #(analyze/analyze e form)))
+            (pr-str form)))
+      (doseq [form
+              ['[:div {:title (ordinary-call (sub [:q]))}]
+               '[:div {:title (or (sub [:q]) "")}]
+               '[:div {:title (when (sub [:q]) "ready")}]
+               '[:div {:title (cond (sub [:q]) "ready" :else "waiting")}]
+               '[:div {:title (-> (sub [:q]) ordinary-call)}]]]
+        (let [e*  (assoc e :sites (atom {:events [] :subs [] :leases [] :htmls []}))
+              ast (analyze/analyze e* form)]
+          (is (= 1 (count (:subs @(:sites e*)))) (pr-str form))
+          (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+              (pr-str form)))))))

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -66,6 +66,11 @@
         (is (= :rf.ui.compile/unsupported-form
                (compile-error-id #(analyze/analyze e form)))
             (pr-str form)))
+      (is (= :rf.ui.compile/unsupported-form
+             (compile-error-id
+              #(analyze/reject-reactive-binding!
+                e '[{:keys [x] :or {x (-> [:q] sub)}}])))
+          "real CLJS macro resolution fences a manufactured default call")
       (doseq [form
               ['[:div {:title (ordinary-call (sub [:q]))}]
                '[:div {:title (or (sub [:q]) "")}]

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -68,6 +68,12 @@
             (pr-str form)))
       (is (= :rf.ui.compile/unsupported-form
              (compile-error-id
+              #(analyze/analyze
+                e '[:div {:title
+                           (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder)}])))
+          "an opaque zero-arg invocation cannot inject an invisible site")
+      (is (= :rf.ui.compile/unsupported-form
+             (compile-error-id
               #(analyze/reject-reactive-binding!
                 e '[{:keys [x] :or {x (-> [:q] sub)}}])))
           "real CLJS macro resolution fences a manufactured default call")

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -28,6 +28,9 @@
             (when (instance? clojure.lang.ExceptionInfo c)
               (:rf.ui.compile/error (ex-data c))))))))
 
+(defmacro injected-sub []
+  '(re-frame.ui/sub [:injected]))
+
 ;; ---------------------------------------------------------------------------
 ;; Arities + options
 ;; ---------------------------------------------------------------------------
@@ -68,6 +71,13 @@
                :or {x (-> [:fallback] re-frame.ui/sub)}}]
              [:div x])))
       "a header macro cannot manufacture a one-arity read after site analysis")
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error
+          '(re-frame.ui/defview opaque-macro-header
+             [{:keys [x]
+               :or {x (re-frame.ui.defview-grammar-jvm-test/injected-sub)}}]
+             [:div x])))
+      "even an invocation with no visible sub token is fenced")
   (is (nil? (expand-error
              '(re-frame.ui/defview ordinary-header
                 [{:keys [x] :or {x (str "fallback")}}]
@@ -76,6 +86,13 @@
   (is (nil? (expand-error
              '(re-frame.ui/defview shadowing-header [{:keys [sub]}] [:div sub])))
       "the header local shadows re-frame.ui/sub only in the body"))
+
+(deftest an-opaque-macro-cannot-inject-an-unmanifested-template-site
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error
+          '(re-frame.ui/defview injected-template []
+             [:div (re-frame.ui.defview-grammar-jvm-test/injected-sub)])))
+      "sub-free production selection cannot be fooled by later macroexpansion"))
 
 (deftest options-map-is-closed
   (is (= :rf.ui.compile/unknown-option

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -9,6 +9,7 @@
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.emit-jvm :as emit-jvm]
             [re-frame.ui.compiler.header :as header]))
 
 (defn- expand-error
@@ -22,9 +23,10 @@
       (:rf.ui.compile/error (ex-data ex)))
     (catch Exception ex
       ;; macroexpansion wraps in CompilerException in some paths
-      (let [c (.getCause ex)]
-        (when (instance? clojure.lang.ExceptionInfo c)
-          (:rf.ui.compile/error (ex-data c)))))))
+      (or (:rf.ui.compile/error (ex-data ex))
+          (let [c (.getCause ex)]
+            (when (instance? clojure.lang.ExceptionInfo c)
+              (:rf.ui.compile/error (ex-data c))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Arities + options
@@ -51,6 +53,22 @@
   (is (= :rf.ui.compile/bad-defview-args
          (expand-error '(re-frame.ui/defview v ["not-a-binding"] [:div "x"])))
       "the one argument is a map-destructuring form or a symbol"))
+
+(deftest reactive-header-defaults-are-rejected-before-host-lowering
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error
+          '(re-frame.ui/defview reactive-header
+             [{:keys [sub] :or {sub (re-frame.ui/sub [:fallback])}}]
+             [:div sub])))
+      "a header default cannot bypass site indexing and select sub-free render")
+  (is (nil? (expand-error
+             '(re-frame.ui/defview ordinary-header
+                [{:keys [x] :or {x (str "fallback")}}]
+                [:div x])))
+      "ordinary pure defaults keep the documented header ergonomics")
+  (is (nil? (expand-error
+             '(re-frame.ui/defview shadowing-header [{:keys [sub]}] [:div sub])))
+      "the header local shadows re-frame.ui/sub only in the body"))
 
 (deftest options-map-is-closed
   (is (= :rf.ui.compile/unknown-option
@@ -206,6 +224,47 @@
       (is (re-find #"re-frame.ui.runtime/memo-view observed\$host_render"
                    sub-text)
           "production memoizes the specialized ViewCell host wrapper"))))
+
+(deftest both-host-forms-carry-only-the-compact-site-id-and-literals-hoist
+  (let [args (fn [vname query]
+               {:vname vname
+                :view-id (keyword "app.probe" (name vname))
+                :display-name (str "app.probe/" vname)
+                :docstring nil
+                :header (header/parse-header [])
+                :slots []
+                :ast {:op :expr
+                      :form (list 're-frame.ui.reactive/sub-read
+                                  "sid1-fixture" query)}
+                :manifest {:view-id (keyword "app.probe" (name vname))
+                           :hook-signature "hs1-fixed"
+                           :sites {:subs [{:sid "sid1-fixture"
+                                          :query query
+                                          :path [:child 0]
+                                          :expr-path [:expr]}]}}
+                :closed-keys nil
+                :children? false})
+        literal-cljs (pr-str (emit-cljs/emit-defview
+                              (args 'literal-site [:item/by-id 1])))
+        dynamic-cljs (pr-str (emit-cljs/emit-defview
+                              (args 'dynamic-site [:item/by-id 'id])))
+        jvm-text (pr-str (emit-jvm/emit-defview
+                          (args 'jvm-site [:item/by-id 1])))]
+    (is (re-find #"literal-site\$query\$0 \[:item/by-id 1\]" literal-cljs)
+        "literal queries are module constants, not per-render allocations")
+    (is (re-find #"sub-read \"sid1-fixture\" literal-site\$query\$0"
+                 literal-cljs))
+    (is (re-find #"sub-read \"sid1-fixture\" \[:item/by-id id\]"
+                 dynamic-cljs)
+        "parametric queries remain direct runtime expressions")
+    (is (re-find #"sub-read \"sid1-fixture\" \[:item/by-id 1\]" jvm-text)
+        "the JVM structural host receives the same compiler site id")
+    (is (str/includes? literal-cljs ":expr-path")
+        "source/structural diagnostics remain available in the dev manifest")
+    (is (= 1 (count (re-seq
+                     #"sub-read \"sid1-fixture\" literal-site\$query\$0"
+                     literal-cljs)))
+        "the hot call itself carries only scalar sid + query")))
 
 (deftest file-pass-registration-does-not-embed-a-per-view-digest
   (build/begin-build! ::file '#{app.file})

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -61,6 +61,13 @@
              [{:keys [sub] :or {sub (re-frame.ui/sub [:fallback])}}]
              [:div sub])))
       "a header default cannot bypass site indexing and select sub-free render")
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error
+          '(re-frame.ui/defview threaded-reactive-header
+             [{:keys [x]
+               :or {x (-> [:fallback] re-frame.ui/sub)}}]
+             [:div x])))
+      "a header macro cannot manufacture a one-arity read after site analysis")
   (is (nil? (expand-error
              '(re-frame.ui/defview ordinary-header
                 [{:keys [x] :or {x (str "fallback")}}]

--- a/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
@@ -42,7 +42,7 @@
     (viewcell/render
      ::observed
      (fn []
-       (let [value (reactive/sub-read [::a])]
+       (let [value (reactive/sub-read ::site [::a])]
          (swap! renders inc)
          (React/createElement "output" #js {:data-capture "a"}
                               (str value)))))))
@@ -53,7 +53,7 @@
     ;; This is a complete ownership-free render B on A's exact cell. It runs
     ;; after observed-component captured A, then the stable Promise abandons B.
     ;; The returned [element capture] pair is deliberately unreachable.
-    (reactive/with-capture cell #(reactive/sub-read [::b]))
+    (reactive/with-capture cell #(reactive/sub-read ::site [::b]))
     (throw blocker)))
 
 (defn- hostile-tree [props]

--- a/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
@@ -53,7 +53,7 @@
           token (React/useRef (js-obj))
           prop-v (unchecked-get props "value")
           sub-v  (when read-sub?
-                   (reactive/sub-read [::preserve-value]))]
+                   (reactive/sub-read ::preserve-site [::preserve-value]))]
       (swap! probe assoc :parent-n n :set-parent set-n
              :parent-token (.-current token))
       (React/createElement
@@ -275,9 +275,9 @@
             render-v2 (fn [_props]
                         (React/createElement
                          "output" #js {:data-hmr-stale "v2"}
-                         (str (reactive/sub-read [::value]))))
+                         (str (reactive/sub-read ::value-site [::value]))))
             render-v1 (fn [_props]
-                        (let [v (reactive/sub-read [::value])]
+                        (let [v (reactive/sub-read ::value-site [::value])]
                           ;; Move the authoritative body revision after capture
                           ;; began but before this render's layout commit.
                           ;; Dependencies remain exactly equal.

--- a/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_context_hook_cljs_test.cljs
@@ -43,7 +43,9 @@
 ;; into a live cell's capture. NOT a direct sub-read.
 (defn- render-cell! [cell queries]
   (first (reactive/with-capture
-          cell (fn [] (mapv reactive/sub-read queries)))))
+          cell (fn [] (mapv (fn [i q]
+                              (reactive/sub-read [:context/site i] q))
+                            (range) queries)))))
 
 (deftest reader-is-published-under-plain-atom
   (is (some? (late-bind/get-fn :adapter/current-frame))

--- a/implementation/ui/test/re_frame/ui/hidden_sub_macros.clj
+++ b/implementation/ui/test/re_frame/ui/hidden_sub_macros.clj
@@ -1,0 +1,4 @@
+(ns re-frame.ui.hidden-sub-macros)
+
+(defmacro hidden-public-sub []
+  '(re-frame.ui/sub [:hidden/macro-helper]))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -450,25 +450,38 @@
       (is (= "hs1-b" (get-in descriptor [:manifest :hook-signature]))
           "listener observes descriptor and both revisions from one publication"))))
 
-(deftest failed-registrar-write-does-not-publish-a-body-revision
+(deftest failed-first-registration-publishes-unavailable-compensation
   (let [id ::failed-publication
+        seen (atom [])
+        stop (volatile! nil)
         result (try
                  (with-redefs [registrar/register!
-                               (fn [& _] (throw (js/Error. "registrar boom")))]
+                               (fn [& _]
+                                 (vreset! stop
+                                          (reactive/subscribe-view!
+                                           id
+                                           #(swap! seen conj
+                                                   [(reactive/view-generation id)
+                                                    (reactive/view-remount-generation id)
+                                                    (reactive/view-descriptor id)])))
+                                 (throw (js/Error. "registrar boom")))]
                    (rt/register-view! id (fn [_props] nil) (fn [_ _] true)
                                       "FailedView"
                                       {:view-id id :hook-signature "hs1-a"}))
                  :unexpected-success
                  (catch :default _ :thrown))]
+    (when @stop (@stop))
     (is (= :thrown result))
     (is (nil? (reactive/registered-view-revision id))
-        "only a successful registrar write advances body freshness")
+        "the failed first load is unavailable, never registered")
     (is (nil? (reactive/view-descriptor id))
-        "a failed registration cannot become the dynamic render authority")))
+        "a failed registration cannot become the dynamic render authority")
+    (is (= [[1 1 nil]] @seen)
+        "the provisional first-load shape is compensated by one fresh tombstone")))
 
 (deftest failed-replacement-rolls-back-the-entire-view-publication
   (let [id      ::failed-replacement
-        render1 (fn [_props] nil)
+        render1 (fn [_props] :v1)
         cmp1    (fn [_ _] true)
         shell1  (rt/register-view! id render1 cmp1 "RollbackV1"
                                    {:view-id id
@@ -477,7 +490,12 @@
         before  (reactive/view-descriptor id)
         pair     (reactive/view-shells id)
         seen     (atom [])
-        stop     (reactive/subscribe-view! id #(swap! seen conj :notified))
+        cell     (reactive/make-cell id 0)
+        provisional-capture (atom nil)
+        stop     (reactive/subscribe-view!
+                  id #(swap! seen conj
+                             [(reactive/view-generation id)
+                              (reactive/view-remount-generation id)]))
         result   (try
                    (with-redefs [registrar/register!
                                  (fn [& _]
@@ -485,6 +503,14 @@
                                        "candidate is prepared for registrar hooks")
                                    (is (= 2 (get-in (reactive/view-descriptor id)
                                                     [:manifest :version])))
+                                   ;; Model the synchronous registrar callback
+                                   ;; re-entering the stable shell before failure.
+                                   (reactive/advance-generation!
+                                    cell (reactive/view-generation id))
+                                   (reset! provisional-capture
+                                           (second
+                                            (reactive/with-capture
+                                             cell (fn [] :provisional))))
                                    (throw (js/Error. "replacement boom")))]
                      (rt/register-view! id (fn [_props] :v2) (fn [_ _] false)
                                         "RollbackV2"
@@ -495,15 +521,97 @@
                    (catch :default _ :thrown))]
     (stop)
     (is (= :thrown result))
-    (is (= 0 (reactive/view-generation id)))
-    (is (= 0 (reactive/view-remount-generation id)))
+    (is (= 2 (reactive/view-generation id))
+        "rollback never decrements past the observed provisional revision")
+    (is (= 2 (reactive/view-remount-generation id))
+        "changed candidate g+1 is restored to the old shape at fresh g+2")
     (is (identical? before (reactive/view-descriptor id))
-        "render/comparator/manifest roll back to the last successful publication")
+        "the fresh compensating publication restores the last good descriptor")
     (is (identical? shell1 (:outer (reactive/view-shells id))))
     (is (identical? (:inner pair) (:inner (reactive/view-shells id))))
     (is (= "RollbackV1" (.-displayName shell1))
         "failed candidate display names do not leak")
-    (is (empty? @seen) "a rolled-back candidate never notifies mounted shells")))
+    (is (= [[2 2]] @seen) "restoration notifies mounted shells exactly once")
+    (is (= :stale (reactive/commit! cell @provisional-capture))
+        "a capture of the provisional descriptor can never commit after rollback")
+    (is (= 1 (reactive/generation cell))
+        "the cell observed n+1 but was never forced backwards")
+    (reactive/advance-generation! cell (reactive/view-generation id))
+    (let [[value capture]
+          (reactive/with-capture
+           cell (fn [] ((:render-fn (reactive/view-descriptor id)) nil)))]
+      (is (= :v1 value))
+      (is (identical? cell (reactive/commit! cell capture)))
+      (is (= 2 (reactive/generation cell))
+          "the restored descriptor advances and commits; the cell is not stuck"))))
+
+(deftest rollback-same-hook-shape-advances-body-only-and-stale-token-is-a-no-op
+  (let [id ::rollback-same-shape
+        descriptor {:render-fn identity :compare-fn =
+                    :manifest {:hook-signature "hs1-a"}}
+        _ (reactive/register-view-descriptor! id "hs1-a" descriptor)
+        seen (atom 0)
+        stop (reactive/subscribe-view! id #(swap! seen inc))
+        publication
+        (reactive/prepare-view-descriptor! id "hs1-a" (assoc descriptor :v 1))]
+    (reactive/rollback-view-descriptor! publication)
+    (stop)
+    (is (= 2 (reactive/view-generation id))
+        "restoration is a fresh monotone body publication")
+    (is (= 0 (reactive/view-remount-generation id))
+        "same hook shape does not remount")
+    (is (identical? descriptor (reactive/view-descriptor id)))
+    (is (= 1 @seen)))
+  (let [id ::stale-rollback-token
+        descriptor {:render-fn identity :compare-fn =
+                    :manifest {:hook-signature "hs1-a"}}
+        _ (reactive/register-view-descriptor! id "hs1-a" descriptor)
+        stale (reactive/prepare-view-descriptor! id "hs1-a"
+                                                 (assoc descriptor :v :stale))
+        winner (reactive/prepare-view-descriptor! id "hs1-a"
+                                                  (assoc descriptor :v :winner))
+        _ (reactive/commit-view-descriptor! winner)
+        seen (atom 0)
+        stop (reactive/subscribe-view! id #(swap! seen inc))]
+    (reactive/rollback-view-descriptor! stale)
+    (stop)
+    (is (= 2 (reactive/view-generation id)))
+    (is (= :winner (:v (reactive/view-descriptor id))))
+    (is (= 0 @seen) "a stale rollback token is a complete no-op")))
+
+(deftest nested-failed-publications-restore-parent-transaction-authority
+  (let [id ::nested-rollback
+        d0 {:v 0} d1 {:v 1} d2 {:v 2}
+        _ (reactive/register-view-descriptor! id "hs0" d0)
+        cell (reactive/make-cell id 0)
+        p1 (reactive/prepare-view-descriptor! id "hs1" d1)
+        _ (reactive/advance-generation! cell 1)
+        [_ cap1] (reactive/with-capture cell (fn [] :p1))
+        p2 (reactive/prepare-view-descriptor! id "hs2" d2)
+        _ (reactive/advance-generation! cell 2)
+        [_ cap2] (reactive/with-capture cell (fn [] :p2))]
+    (reactive/rollback-view-descriptor! p2)
+    (is (= 1 (:v (reactive/view-descriptor id)))
+        "nested failure restores the parent provisional descriptor")
+    (is (= 3 (reactive/view-generation id)))
+    (reactive/rollback-view-descriptor! p1)
+    (is (= 0 (:v (reactive/view-descriptor id)))
+        "the still-authoritative parent can compensate to last-known-good")
+    (is (= 4 (reactive/view-generation id)))
+    (is (= 4 (reactive/view-remount-generation id)))
+    (is (= :stale (reactive/commit! cell cap1)))
+    (is (= :stale (reactive/commit! cell cap2))))
+  (let [id ::nested-child-fails-parent-succeeds
+        d0 {:v 0} d1 {:v 1} d2 {:v 2}
+        _ (reactive/register-view-descriptor! id "hs0" d0)
+        p1 (reactive/prepare-view-descriptor! id "hs1" d1)
+        p2 (reactive/prepare-view-descriptor! id "hs2" d2)]
+    (reactive/rollback-view-descriptor! p2)
+    (reactive/commit-view-descriptor! p1)
+    (is (= 1 (:v (reactive/view-descriptor id))))
+    (is (= 3 (reactive/registered-view-revision id))
+        "parent success commits the fresh compensating revision")
+    (is (= 3 (reactive/view-remount-generation id)))))
 
 (deftest scheduler-reset-never-strands-an-already-loaded-defview
   (let [shell-before static-tree

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -545,6 +545,41 @@
       (is (= 2 (reactive/generation cell))
           "the restored descriptor advances and commits; the cell is not stuck"))))
 
+(deftest stale-failure-cannot-clobber-a-reentrant-winners-debug-name
+  (let [id       ::reentrant-name-winner
+        shell    (rt/register-view! id (fn [_props] :v1) (fn [_ _] true)
+                                    "NameV1"
+                                    {:view-id id
+                                     :hook-signature "hs-name"
+                                     :version 1})
+        reentered? (atom false)
+        result   (try
+                   (with-redefs [registrar/register!
+                                 (fn [& _]
+                                   (when (compare-and-set! reentered? false true)
+                                     (rt/register-view!
+                                      id (fn [_props] :v3) (fn [_ _] false)
+                                      "NameV3"
+                                      {:view-id id
+                                       :hook-signature "hs-name"
+                                       :version 3})
+                                     (throw (js/Error. "stale v2 failure"))))]
+                     (rt/register-view! id (fn [_props] :v2) (fn [_ _] false)
+                                        "NameV2"
+                                        {:view-id id
+                                         :hook-signature "hs-name"
+                                         :version 2}))
+                   :unexpected-success
+                   (catch :default _ :thrown))]
+    (is (= :thrown result))
+    (is (= 3 (get-in (reactive/view-descriptor id) [:manifest :version]))
+        "the reentrant registration remains the descriptor authority")
+    (is (= "NameV3" (.-displayName shell))
+        "the stale outer failure cannot restore its pre-publication name")
+    (is (= "NameV3$Body"
+           (.-displayName (:inner (reactive/view-shells id))))
+        "the winning inner shell name is fenced by the same publication token")))
+
 (deftest rollback-same-hook-shape-advances-body-only-and-stale-token-is-a-no-op
   (let [id ::rollback-same-shape
         descriptor {:render-fn identity :compare-fn =

--- a/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_destroy_race_jvm_test.clj
@@ -50,7 +50,9 @@
 (defn- render+commit! [cell fid queries]
   (let [[_ capture] (rf/with-frame fid
                       (reactive/with-capture
-                       cell (fn [] (mapv reactive/sub-read queries))))]
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:race/site i] q))
+                                        (range) queries))))]
     (reactive/commit! cell capture))
   cell)
 
@@ -87,7 +89,7 @@
                    ;; AFTER the sweep already snapshotted.
                    (let [[_ capture] (rf/with-frame fid
                                        (reactive/with-capture new-cell
-                                         (fn [] (reactive/sub-read [:race/a]))))]
+                                         (fn [] (reactive/sub-read ::site [:race/a]))))]
                      (reactive/commit! new-cell capture))
                    (.countDown committed))]
         ;; Drive the destroy on this thread — it blocks in the wrapped hook
@@ -137,7 +139,7 @@
                    ;; A commit onto the UNRELATED live frame B, mid-destroy of A.
                    (let [[_ capture] (rf/with-frame fb
                                        (reactive/with-capture cell-b
-                                         (fn [] (reactive/sub-read [:race/a]))))]
+                                         (fn [] (reactive/sub-read ::site [:race/a]))))]
                      (reactive/commit! cell-b capture))
                    (.countDown committed))]
         (frame/destroy-frame! fa)
@@ -149,7 +151,7 @@
         (is (reactive/cell-observes-frame? cell-b fb))
         (is (= 2 (first (rf/with-frame fb
                           (reactive/with-capture cell-b
-                            (fn [] (reactive/sub-read [:race/a]))))))
+                            (fn [] (reactive/sub-read ::site [:race/a]))))))
             "frame B reads live after A was destroyed"))
       (testing "frame A's own cell died with A"
         (is (= :dead (reactive/lifecycle cell-a))))

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -70,7 +70,9 @@
   [cell id queries]
   (let [[_ capture] (rf/with-frame id
                       (reactive/with-capture
-                       cell (fn [] (mapv reactive/sub-read queries))))]
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:epoch/site i] q))
+                                        (range) queries))))]
     (reactive/commit! cell capture))
   cell)
 
@@ -177,7 +179,9 @@
                            cell
                            (fn []
                              (swap! body-runs inc)
-                             (mapv reactive/sub-read queries))))]
+                             (mapv (fn [i q]
+                                     (reactive/sub-read [:epoch/site i] q))
+                                   (range) queries))))]
         (reactive/commit! cell capture))
       (is (= 1 @body-runs)
           (str n " sites → ONE body invocation (one shared ViewCell, not " n ")"))
@@ -376,8 +380,8 @@
     (let [cell (reactive/make-cell ::v)
           out  (rf/with-frame fid
                  (reactive/with-capture cell
-                   (fn [] [(reactive/sub-read [:s/a])
-                           (reactive/sub-read [:s/b])])))]
+                   (fn [] [(reactive/sub-read ::site-a [:s/a])
+                           (reactive/sub-read ::site-b [:s/b])])))]
       (is (= [[:a 5] [:b 5]] (first out)))
       (is (= 1 @parent-runs)
           "sibling cold probes in ONE render compute the shared parent ONCE

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -47,7 +47,9 @@
 (defn- render+commit! [cell fid queries]
   (let [[_ capture] (rf/with-frame fid
                       (reactive/with-capture
-                       cell (fn [] (mapv reactive/sub-read queries))))]
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:teardown/site i] q))
+                                        (range) queries))))]
     (reactive/commit! cell capture))
   cell)
 
@@ -208,4 +210,4 @@
     (testing "the sibling frame still reads live"
       (is (= 2 (first (rf/with-frame fb
                         (reactive/with-capture cell-b
-                          (fn [] (reactive/sub-read [:td/a]))))))))))
+                          (fn [] (reactive/sub-read ::site [:td/a]))))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -17,8 +17,8 @@
     2. STALE-CELL REJECTION AT COMMIT (step 1). A live cell whose generation
        advanced past its in-flight capture is stale-rejected (`:stale`) with no
        ownership touched — the same-shell reload's mark-stale-then-re-render.
-    3. SITE IDENTITY survives edits. Sites are keyed by target IDENTITY
-       `(frame, query)`: a sibling site added above a lease never retargets it;
+    3. SITE IDENTITY survives edits. Sites are keyed by compiler-minted lexical
+       identity: a sibling site added above a lease never retargets it;
        a site whose query moves retargets (kept-check fails → release + acquire)
        and a shared node never churns.
     4. SUB REPLACEMENT via lease `current?`. A committed ViewCell lease whose
@@ -67,10 +67,21 @@
 
 (defn- render! [cell queries]
   (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries)))))
+    (reactive/with-capture cell
+      (fn [] (mapv (fn [i q]
+                     (reactive/sub-read [:hmr/site i] q))
+                   (range) queries)))))
 
 (defn- render+commit! [cell queries]
   (let [[_ capture] (render! cell queries)]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- render-sites+commit! [cell sites]
+  (let [[_ capture]
+        (rf/with-frame fid
+          (reactive/with-capture cell
+            (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))]
     (reactive/commit! cell capture))
   cell)
 
@@ -203,18 +214,21 @@
     (is (nil? (entry [:r/b])) "abandoned B owns and materialises nothing")))
 
 ;; ===========================================================================
-;; Cell 3 — site identity survives edits (target identity, not position)
+;; Cell 3 — compiler site identity survives edits (not query or position)
 ;; ===========================================================================
 
 (deftest sibling-site-added-above-never-retargets-an-existing-lease
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (rf/reg-sub :r/b (fn [db _] (:b db)))
   (seed! {:a 1 :b 2})
-  (let [cell   (render+commit! (reactive/make-cell ::v) [[:r/a]])
+  (let [site-a ::site-a
+        site-b ::site-b
+        cell   (render-sites+commit! (reactive/make-cell ::v)
+                                     [[site-a [:r/a]]])
         lease-a (reactive/committed-lease cell (tk [:r/a]))]
-    (testing "an edit inserts a NEW sibling site ABOVE :a; :a's lease is keyed by
-              target identity (frame,query), never by position"
-      (render+commit! cell [[:r/b] [:r/a]])
+    (testing "an edit inserts a NEW compiler site ABOVE :a; :a keeps its
+              lexical identity even though its traversal position moved"
+      (render-sites+commit! cell [[site-b [:r/b]] [site-a [:r/a]]])
       (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
           ":a keeps the SAME lease — the prepended :b did not shift its owner")
       (is (= #{(tk [:r/a]) (tk [:r/b])} (reactive/committed-target-keys cell)))

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -68,7 +68,7 @@
     ;; render probes incarnation A (ownership-free)
     (let [[_ capture] (rf/with-frame fid
                         (reactive/with-capture
-                         cell (fn [] (reactive/sub-read [:ic/a]))))]
+                         cell (fn [] (reactive/sub-read ::site [:ic/a]))))]
     ;; commit: step 4 acquires A's lease + step 5 reads it (A still live), THEN
     ;; the :post-acquire seam fully destroys A and recreates B under the same id
     ;; BEFORE the publish. The incarnation-safe revalidation must join THIS commit
@@ -99,7 +99,7 @@
       (let [cell-b (reactive/make-cell ::b)]
         (let [[_ capture] (rf/with-frame fid
                             (reactive/with-capture
-                             cell-b (fn [] (reactive/sub-read [:ic/a]))))]
+                             cell-b (fn [] (reactive/sub-read ::site [:ic/a]))))]
           (reactive/commit! cell-b capture))
         (is (= :connected (reactive/lifecycle cell-b)) "B's own cell connects")
         (is (= #{(tk fid [:ic/a])} (reactive/committed-target-keys cell-b))
@@ -122,7 +122,7 @@
         cell (reactive/make-cell ::v)]
     (let [[_ capture] (rf/with-frame fid
                         (reactive/with-capture
-                         cell (fn [] (reactive/sub-read [:ic/a]))))]
+                         cell (fn [] (reactive/sub-read ::site [:ic/a]))))]
       (reactive/commit! cell capture))
     (is (= :connected (reactive/lifecycle cell))
         "no supersede, no close ⇒ ordinary connected commit (incarnation check is false)")

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -59,6 +59,39 @@
 ;; Failure-1: an old-incarnation commit must NOT survive on the replacement id
 ;; ===========================================================================
 
+(deftest acquire-before-incarnation-snapshot-cannot-pair-a-lease-from-a-with-token-b
+  (rf/reg-sub :ic/a (fn [db _] (:a db)))
+  (let [fid     :ic/acquire-snapshot
+        _       (make-frame! fid {:a 1})
+        token-a (frame/frame-incarnation-token fid)
+        cell    (reactive/make-cell ::acquire-snapshot)
+        [_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (reactive/sub-read ::site [:ic/a]))))]
+    (binding [reactive/*commit-barrier*
+              (fn [phase _]
+                (when (= :post-stage-acquire phase)
+                  ;; The lease now belongs to A, but the subsequent frame-id
+                  ;; lookup would see B. `current?` must reject that pairing.
+                  (frame/destroy-frame! fid)
+                  (make-frame! fid {:a 99})))]
+      (reactive/commit! cell capture))
+    (is (not (identical? token-a (frame/frame-incarnation-token fid))))
+    (is (= :fresh (reactive/lifecycle cell))
+        "a rejected candidate never publishes/connects")
+    (is (empty? (reactive/committed-sites cell)))
+    (is (= 1 (reactive/revision cell))
+        "the host is synchronously invalidated to probe B before paint")
+    (is (nil? (get @(:sub-cache (frame/frame fid)) [:ic/a]))
+        "rolling back A cannot materialize or decrement B's cache")
+    (reactive/reset-scheduler!)
+    (let [[_ capture-b] (rf/with-frame fid
+                          (reactive/with-capture
+                           cell (fn [] (reactive/sub-read ::site [:ic/a]))))]
+      (reactive/commit! cell capture-b))
+    (is (= :connected (reactive/lifecycle cell)))
+    (is (= 99 (:value (reactive/committed-site cell ::site))))))
+
 (deftest commit-of-a-superseded-incarnation-joins-its-teardown-not-the-replacement
   (rf/reg-sub :ic/a (fn [db _] (:a db)))
   (let [fid     :ic/frame

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_race_jvm_test.clj
@@ -99,7 +99,7 @@
         (try
           (let [[_ capture] (rf/with-frame fid
                               (reactive/with-capture
-                               b-cell (fn [] (reactive/sub-read [:ic/a]))))]
+                               b-cell (fn [] (reactive/sub-read ::site [:ic/a]))))]
             (reactive/commit! b-cell capture))
           (catch Throwable e (reset! b-error e)))
         (.countDown b-done)

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -55,7 +55,10 @@
   the ambient frame. Returns `[render-value immutable-capture]`."
   [cell queries]
   (rf/with-frame fid
-    (reactive/with-capture cell (fn [] (mapv reactive/sub-read queries)))))
+    (reactive/with-capture cell
+      (fn [] (mapv (fn [i q]
+                     (reactive/sub-read [:reconcile/site i] q))
+                   (range) queries)))))
 
 (defn- render+commit! [cell queries]
   (let [[_ capture] (render! cell queries)]
@@ -98,9 +101,10 @@
           [b-value cap-b] (render! cell [[:r/b]])]
       (is (= [1] a-value))
       (is (= [2] b-value))
-      (is (= [(tk [:r/a])] (:order cap-a))
+      (is (= [[:reconcile/site 0]] (:order cap-a))
           "A remains immutable after the later speculative B capture")
-      (is (= [(tk [:r/b])] (:order cap-b)))
+      (is (= [[:reconcile/site 0]] (:order cap-b))
+          "the same lexical site may carry a different query in a later capture")
       ;; Model React selecting A and abandoning B: only A's effect closure runs.
       (reactive/commit! cell cap-a)
       (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell))
@@ -268,7 +272,7 @@
     (subs/subscribe [:re/v] {:frame :re/frame})
     (let [[_ capture] (rf/with-frame :re/frame
                         (reactive/with-capture
-                         cell (fn [] (reactive/sub-read [:re/v]))))]
+                         cell (fn [] (reactive/sub-read ::site [:re/v]))))]
       (is (= 0 (reactive/revision cell)) "precondition: no revision yet")
       ;; reincarnate in the gap: identical construction + a single replace-app-db!
       ;; makes node-version + frame/registry epochs COINCIDE with the destroyed
@@ -299,7 +303,7 @@
     (subs/subscribe [:re/v] {:frame :re/frame2})   ;; a live canonical node
     (let [[_ capture] (rf/with-frame :re/frame2
                         (reactive/with-capture
-                         cell (fn [] (reactive/sub-read [:re/v]))))]
+                         cell (fn [] (reactive/sub-read ::site [:re/v]))))]
       (reactive/commit! cell capture))               ;; same live node at commit
     (is (= 0 (reactive/revision cell))
         "an unchanged live node reads the same node-key — no false movement")
@@ -455,7 +459,7 @@
     (seed! {:coll [1 2 3]})    ;; equal value, different object identity
     (let [[ret _] (rf/with-frame fid
                     (reactive/with-capture
-                     cell (fn [] (reactive/sub-read [:r/coll]))))]
+                     cell (fn [] (reactive/sub-read ::site [:r/coll]))))]
       (is (identical? committed ret)
           "an rf=-stable read returns the prior exact value (stabilized identity)"))))
 

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -65,6 +65,17 @@
     (reactive/commit! cell capture))
   cell)
 
+(defn- render-sites! [cell sites]
+  (rf/with-frame fid
+    (reactive/with-capture
+     cell
+     (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites)))))
+
+(defn- render-sites+commit! [cell sites]
+  (let [[_ capture] (render-sites! cell sites)]
+    (reactive/commit! cell capture))
+  cell)
+
 (defn- throws-id [thunk]
   (try (thunk) nil
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
@@ -144,6 +155,87 @@
     (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell)))
     (is (= 1 (ref-count [:r/a])) "one owner installed at commit")
     (is (= {(tk [:r/a]) 1} (reactive/committed-values cell)))))
+
+(deftest same-site-rf-equal-query-preserves-exact-object-before-resolution
+  (rf/reg-sub :r/p (fn [db [_ k]] (get db k)))
+  (seed! {:x 10})
+  (let [sid ::parametric-site
+        q1  (mapv identity [:r/p :x])
+        q2  (mapv identity [:r/p :x])
+        cell (render-sites+commit! (reactive/make-cell ::parametric)
+                                   [[sid q1]])
+        lease1 (:lease (reactive/committed-site cell sid))
+        resolve* obs/resolve-target
+        resolved-query (atom nil)
+        [_ capture]
+        (with-redefs [obs/resolve-target
+                      (fn [site-ctx]
+                        (reset! resolved-query (:query-v site-ctx))
+                        (resolve* site-ctx))]
+          (render-sites! cell [[sid q2]]))]
+    (is (= q1 q2))
+    (is (not (identical? q1 q2)) "the rerender really rebuilt the query")
+    (is (identical? q1 @resolved-query)
+        "stabilization happens before override/target resolution")
+    (is (identical? q1 (get-in (reactive/site-records capture) [sid :query])))
+    (reactive/commit! cell capture)
+    (is (identical? q1 (:query (reactive/committed-site cell sid))))
+    (is (identical? lease1 (:lease (reactive/committed-site cell sid)))
+        "rf=-equal rerender neither retargets nor churns ownership")
+    (dotimes [_ 10000]
+      (render-sites! cell [[sid (mapv identity [:r/p :x])]]))
+    (is (identical? q1 (:query (reactive/committed-site cell sid)))
+        "abandoned candidates never become the published preservation object")))
+
+(deftest equal-query-lexical-sites-are-distinct-owners
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [q1 (mapv identity [:r/a])
+        q2 (mapv identity [:r/a])
+        cell (render-sites+commit! (reactive/make-cell ::equal-sites)
+                                   [[::site-a q1] [::site-b q2]])
+        a (reactive/committed-site cell ::site-a)
+        b (reactive/committed-site cell ::site-b)]
+    (is (= #{::site-a ::site-b} (set (keys (reactive/committed-sites cell)))))
+    (is (not (identical? (:lease a) (:lease b)))
+        "target equality never collapses lexical owner tokens")
+    (is (identical? q1 (:query a)))
+    (is (identical? q2 (:query b)))
+    (is (= 2 (ref-count [:r/a]))
+        "the shared cache node has one reference per lexical owner")
+    (let [lease-b (:lease b)
+          q2-next (mapv identity [:r/a])]
+      (render-sites+commit! cell [[::site-b q2-next]])
+      (is (= #{::site-b} (set (keys (reactive/committed-sites cell))))
+          "conditional disappearance removes only the absent sid")
+      (is (identical? lease-b
+                      (:lease (reactive/committed-site cell ::site-b))))
+      (is (identical? q2 (:query (reactive/committed-site cell ::site-b))))
+      (is (= 1 (ref-count [:r/a]))))))
+
+(deftest changed-query-at-one-site-acquires-before-releasing
+  (rf/reg-sub :r/p (fn [db [_ k]] (get db k)))
+  (seed! {:x 10 :y 20})
+  (let [sid ::retarget-site
+        cell (render-sites+commit! (reactive/make-cell ::retarget)
+                                   [[sid [:r/p :x]]])
+        acquire* obs/acquire!
+        release* obs/release!
+        operations (atom [])]
+    (with-redefs [obs/acquire!
+                  (fn [target on-change]
+                    (swap! operations conj [:acquire (:query target)])
+                    (acquire* target on-change))
+                  obs/release!
+                  (fn [lease]
+                    (swap! operations conj [:release])
+                    (release* lease))]
+      (render-sites+commit! cell [[sid [:r/p :y]]]))
+    (is (= [[:acquire [:r/p :y]] [:release]] @operations)
+        "retarget stages the new owner before dropping the prior owner")
+    (is (= [:r/p :y] (:query (reactive/committed-site cell sid))))
+    (is (nil? (entry [:r/p :x])))
+    (is (= 1 (ref-count [:r/p :y])))))
 
 (deftest recommit-retains-lease-untouched
   (rf/reg-sub :r/a (fn [db _] (:a db)))

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -89,6 +89,26 @@
       (is (nil? (entry [:r/b]))
           "the 10k-abandoned-renders-retain-zero property holds at the cell"))))
 
+(deftest missing-or-duplicate-compiler-site-identity-fails-loudly
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [cell (reactive/make-cell ::site-contract)]
+    (is (= :rf.error/ui-tree-malformed
+           (throws-id #(reactive/with-capture
+                         cell
+                         (fn [] (reactive/sub-read nil [:r/a])))))
+        "the explicit two-arity path cannot smuggle a missing sid")
+    (is (= :rf.error/ui-tree-malformed
+           (throws-id #(reactive/with-capture
+                         cell
+                         (fn [] [(reactive/sub-read ::same-site [:r/a])
+                                 (reactive/sub-read ::same-site [:r/b])]))))
+        "a colliding sid never renders one target while committing another")
+    (is (empty? (reactive/committed-sites cell)))
+    (is (nil? (entry [:r/a])))
+    (is (nil? (entry [:r/b])))))
+
 (deftest commit-is-bound-to-the-exact-render-capture
   ;; rf2-vxgfnd.105 — React retains the selected render's effect closure. A
   ;; later speculative render of the same cell must not replace that closure's

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -50,7 +50,9 @@
 (defn- render+commit! [cell fid queries]
   (let [[_ capture] (rf/with-frame fid
                       (reactive/with-capture
-                       cell (fn [] (mapv reactive/sub-read queries))))]
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:root/site i] q))
+                                        (range) queries))))]
     (reactive/commit! cell capture))
   cell)
 
@@ -110,7 +112,7 @@
               not by probing a torn-down context (03 §4; commit! step 2)"
       (let [[_ capture] (rf/with-frame fid
                           (reactive/with-capture
-                           cell (fn [] (reactive/sub-read [:rt/a]))))]
+                           cell (fn [] (reactive/sub-read ::site [:rt/a]))))]
         (is (= :rf.error/frame-destroyed
                (throws-id #(reactive/commit! cell capture))))))))
 
@@ -176,7 +178,7 @@
     (testing "the reaped cell fails a recommit through the dead-cell lifecycle"
       (let [[_ capture] (rf/with-frame fid
                           (reactive/with-capture
-                           cell (fn [] (reactive/sub-read [:rt/a]))))]
+                           cell (fn [] (reactive/sub-read ::site [:rt/a]))))]
         (is (= :rf.error/frame-destroyed
                (throws-id #(reactive/commit! cell capture)))
             "a retained handle cannot reconnect after its root is gone")))))
@@ -288,7 +290,7 @@
     (testing "the sibling cell still reads live"
       (is (= 1 (first (rf/with-frame fid
                         (reactive/with-capture cell-b
-                          (fn [] (reactive/sub-read [:rt/a]))))))))))
+                          (fn [] (reactive/sub-read ::site [:rt/a]))))))))))
 
 ;; ===========================================================================
 ;; A throwing host `.unmount` — generation evidence governs the fail-closed reap

--- a/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_sub_override_schema_cljs_test.cljc
@@ -23,6 +23,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support         :as test-support]
             [re-frame.trace.tooling        :as trace-tooling]
+            [re-frame.ui                   :as ui]
             [re-frame.ui.reactive          :as reactive]))
 
 (def ^:private fid :rf/default)
@@ -64,6 +65,17 @@
       (fn [ev] (when (= :error (:op-type ev)) (swap! seen conj ev))))
     (try (thunk) (finally (trace-tooling/unregister-listener! lid)))
     @seen))
+
+(defn- hidden-public-sub-helper []
+  (ui/sub [:hidden/helper]))
+
+(deftest public-sub-cannot-hide-an-unmanifested-read-in-a-helper
+  (is (= :rf.error/ui-tree-malformed
+         (try (hidden-public-sub-helper) nil
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core/ExceptionInfo) e
+                (:rf.error/id (ex-data e)))))
+      "unlowered public ui/sub is symmetrically fail-loud on JVM and CLJS"))
 
 ;; ---- the schema-validation fold-in (parity with the Reagent path) --------
 

--- a/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc
@@ -47,6 +47,12 @@
           :msg (ex-message e)
           :data (ex-data e)})))
 
+(deftest reactive-sites-are-rejected-at-a-root-expression
+  (is (= :rf.ui.compile/sub-in-loop
+         (compile-error-id
+          #(analyze-root* '[:div {:title (sub [:root/query])}])))
+      "a mount/root has no ViewCell and therefore cannot own a sub site"))
+
 ;; ---------------------------------------------------------------------------
 ;; Root-id: authored shapes + derivation + slug + prefix (contract §1, §3)
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
@@ -58,7 +58,9 @@
     (reactive/attach-root! cell (root-incarnation root-id))
     (let [[_ capture] (rf/with-frame fid
                         (reactive/with-capture
-                         cell (fn [] (mapv reactive/sub-read queries))))]
+                         cell (fn [] (mapv (fn [i q]
+                                            (reactive/sub-read [:incarnation/site i] q))
+                                          (range) queries))))]
       (reactive/commit! cell capture))
     cell))
 
@@ -112,7 +114,7 @@
       (reactive/settle-disconnect! cell)
       (let [[_ capture] (rf/with-frame :ri/frame
                           (reactive/with-capture
-                           cell (fn [] (reactive/sub-read [:ri/a]))))]
+                           cell (fn [] (reactive/sub-read ::site [:ri/a]))))]
         (reactive/commit! cell capture))
       (is (= :connected (reactive/lifecycle cell)))
       (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -32,7 +32,9 @@
   (let [cell (reactive/make-cell ::v)]
     (let [[_ capture] (rf/with-frame fid
                         (reactive/with-capture
-                         cell (fn [] (mapv reactive/sub-read queries))))]
+                         cell (fn [] (mapv (fn [i q]
+                                            (reactive/sub-read [:wiring/site i] q))
+                                          (range) queries))))]
       (reactive/commit! cell capture))
     cell))
 

--- a/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
@@ -24,7 +24,9 @@
             [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.sub-overrides :as sub-overrides]
-            [re-frame.ui.test :as uit]))
+            [re-frame.ui.test :as uit])
+  (:require-macros [re-frame.ui.hidden-sub-macros
+                    :refer [hidden-public-sub]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -37,10 +39,25 @@
 (defn prod-provider-tree []
   (sub-overrides/provider-element
    {[::prod-value] "forbidden-override"}
-   (React/createElement prod-sub-value nil)))
+   (React/createElement React/Fragment nil
+                        (React/createElement prod-sub-value nil)
+                        (React/createElement prod-sub-value nil))))
 
 (defview prod-mounted-tree []
   (ui/raw (React/createElement prod-provider-tree nil)))
+
+(defn hidden-ordinary-helper []
+  (ui/sub [:hidden/ordinary-helper]))
+
+(defn hidden-macro-helper []
+  (hidden-public-sub))
+
+(deftest advanced-production-hidden-reads-fail-instead-of-going-nonreactive
+  (doseq [helper [hidden-ordinary-helper hidden-macro-helper]]
+    (is (= :rf.error/ui-tree-malformed
+           (try (helper) nil
+                (catch :default e (:rf.error/id (ex-data e)))))
+        "advanced production preserves fail-loud public authoring semantics")))
 
 (deftest mounted-viewcell-provider-carriage-elides-in-production
   (rf/reg-sub ::prod-value (fn [db _] (:prod-value db)))
@@ -66,12 +83,27 @@
           (is (= "ordinary"
                  (.-textContent
                   (.querySelector container "[data-role='prod-sub-value']"))))
-          (let [cells (reactive/current-live-cells)]
-            (is (= 1 (count cells)))
-            (is (= #{sub-key}
-                   (reactive/committed-target-keys (first cells))))
-            (is (some? (get @(:sub-cache (frame/frame frame-id))
-                            [::prod-value])))))
+          (let [cells   (vec (reactive/current-live-cells))
+                records (mapv #(first (vals (reactive/committed-sites %))) cells)
+                sids    (mapv #(first (keys (reactive/committed-sites %))) cells)]
+            (is (= 2 (count cells)))
+            (is (= 2 (.-length
+                      (.querySelectorAll container
+                                         "[data-role='prod-sub-value']"))))
+            (is (every? #(= #{sub-key}
+                            (reactive/committed-target-keys %))
+                        cells))
+            (is (= 1 (count (distinct sids)))
+                "both view instances execute the same compiler lexical site")
+            (is (.startsWith (first sids) "sid1-")
+                "the advanced hot call retains the compact versioned sid")
+            (is (identical? (:query (first records))
+                            (:query (second records)))
+                "the literal query is one module constant, not rebuilt per render")
+            (is (= 2 (:ref-count
+                      (get @(:sub-cache (frame/frame frame-id))
+                           [::prod-value])))
+                "each lexical view instance remains an independent owner")))
         (catch :default e
           (is false (str "advanced mounted override-elision control rejected: " e)))
         (finally


### PR DESCRIPTION
Closes rf2-vxgfnd.100.

Carries deterministic compiler-owned lexical site IDs into both host call shapes and reconciles ViewCell ownership by site rather than target. Preserves exact rf=-equal query objects before target resolution, keeps equal-query sites as distinct owners, and retains transactional acquire-before-release semantics.

Also hardens expression lowering across lexical scopes and host macros, rejects deferred/root/ambiguous sites, hoists literal CLJS queries, and adds compiler/runtime/incarnation-race proofs.

Current evidence: implementation/ui clojure -M:test — 388 tests, 5208 assertions, 0 failures/errors.