### PR TITLE
docs(ui-guide): stage-truth pass against the landed S2 reactive core (rf2-drhien)

### DIFF
--- a/ai/findings/new-substrate-synthesis/README.md
+++ b/ai/findings/new-substrate-synthesis/README.md
@@ -39,7 +39,7 @@ benchmark hope.
 | [11-adoption-workstreams.md](11-adoption-workstreams.md) | Everything beyond the library — migrator, docs, tools, CI, deletion wave — as stage epics |
 | [12-implementation-plan.md](12-implementation-plan.md) | Where the artifact lands, the **blessed** public API table + demand-bar audit, the stage→bead plan |
 | [drafts/](drafts/) | Diff-ready spec amendment drafts (004 interim + rewrite, 006 observation port, `ui.test` selector grammar) |
-| [guide/](guide/README.md) | The user manual (9 chapters; every example a CI fixture by policy) |
+| [guide/](guide/README.md) | The user manual (10 chapters; every example a CI fixture by policy) |
 | [reviews/](reviews/) | The review archive |
 
 ## Naming

--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -78,10 +78,12 @@ Three things carry the whole model:
    edits. No provider → `sub` raises `:rf.error/no-frame-context`; the runtime never
    guesses.
 
-> **Stage note.** The compiled template, the props model, and the mount grammar above
-> are shipped (Stage 1, on main today); the live reactive loop — `sub` re-rendering the
-> view, `frame-root`'s runtime ENSURE, the `ui/adapter` you hand `rf/init!` — *(lands
-> S2 — reactive subs)*. Same source either way: what you write today is the contract.
+> **Stage note.** The compiled template, the props model, and the mount grammar are
+> Stage 1; the reactive read loop — `sub` re-rendering the view, `frame-root`'s runtime
+> ENSURE, the `ui/adapter` you hand `rf/init!` — shipped with the S2 reactive core. All
+> of it is on main today. What's left is the button: committed dispatch from compiled
+> handler sites *(lands S3 — committed handlers)* — until then the vector is data you
+> can read and assert, and tests drive state with `ui.test/dispatch!`.
 
 One more default worth knowing: this single-root page needed no root identity — the
 root id derives from the mounted view. When a page mounts the same view twice, or you
@@ -108,8 +110,8 @@ needs no DOM, no browser, no flake — it runs on the JVM in your watch loop:
 Two ground rules, both cheap: the events/subs a view touches must be `.cljc` (they run
 on the JVM here — standard re-frame discipline anyway), and attribute reads go through
 `ui.test/attrs`, never keyword lookup on the node. The full testing story is
-[09](09-testing.md). *(The test harness core is Stage 1; a Tier-1 render that crosses a
-`sub` site — as this one does — lands S2. A subless view tests today.)*
+[09](09-testing.md). This test — `sub` site included — runs on main today: the Tier-1
+core is Stage 1 and the `sub` snapshot path shipped with the S2 reactive core.
 
 ## Hot reload
 

--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -110,8 +110,9 @@ needs no DOM, no browser, no flake — it runs on the JVM in your watch loop:
 Two ground rules, both cheap: the events/subs a view touches must be `.cljc` (they run
 on the JVM here — standard re-frame discipline anyway), and attribute reads go through
 `ui.test/attrs`, never keyword lookup on the node. The full testing story is
-[09](09-testing.md). This test — `sub` site included — runs on main today: the Tier-1
-core is Stage 1 and the `sub` snapshot path shipped with the S2 reactive core.
+[09](09-testing.md). This test runs on main today, `sub` site included — the Tier-1
+harness shipped at Stage 1, and the snapshot path that lets a headless render resolve
+subscriptions arrived with the S2 reactive core.
 
 ## Hot reload
 

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -36,9 +36,9 @@ construction.
   It catches render/lifecycle throws below it (not event-handler or async errors — those
   have their own paths), dispatches `:on-error` after the failing commit, renders the
   fallback, and retries when `:reset-key` changes. The fallback view receives `:error`
-  plus the boundary's declared props and cannot itself dispatch during render; on the
-  server there is no boundary recovery — a throw follows the server failure policy
-  ([08](08-ssr.md)) — boundaries are a client mechanism.
+  alongside the boundary's declared props, and it cannot dispatch during its own render.
+  On the server there is no boundary recovery at all: a throw follows the server failure
+  policy ([08](08-ssr.md)), because catching and retrying is a client mechanism.
 - Views call views by symbol: `[product-card {:product p}]`. Children arrive as
   `:children` — declaring that binding is what opts a view into accepting them (passing
   children to a view that declares none is a compile error). **`:key` is reserved**

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -91,9 +91,10 @@ modals fade, rows collapse. `ui/presence` owns the gap between *no longer true* 
 *no longer visible*:
 
 ```clojure
-(ui/presence {:timeout-ms 300}
-  (for [t (sub [:toasts/visible])]
-    [toast-card {:key (:id t) :toast t}]))
+(ui/defview toast-tray []
+  (ui/presence {:timeout-ms 300}
+    (for [t (sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
 
 (ui/defview toast-card [{:keys [toast]}]
   (let [phase (presence-phase)]          ; :mounting | :present | :unmounting

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -35,7 +35,10 @@ construction.
 
   It catches render/lifecycle throws below it (not event-handler or async errors — those
   have their own paths), dispatches `:on-error` after the failing commit, renders the
-  fallback, and retries when `:reset-key` changes.
+  fallback, and retries when `:reset-key` changes. The fallback view receives `:error`
+  plus the boundary's declared props and cannot itself dispatch during render; on the
+  server there is no boundary recovery — a throw follows the server failure policy
+  ([08](08-ssr.md)) — boundaries are a client mechanism.
 - Views call views by symbol: `[product-card {:product p}]`. Children arrive as
   `:children` — declaring that binding is what opts a view into accepting them (passing
   children to a view that declares none is a compile error). **`:key` is reserved**

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -117,8 +117,9 @@ called after the view disconnects (it catches leaked listeners for you). Dispatc
 `lease` declares *interest*: while this view is mounted and visible, keep the resource
 alive. First lease in → the resource is ensured (fetch starts, or an in-flight one is
 joined); last lease out → it can wind down. **Lease never returns data and never fetches
-during render**; reading is always the passive `(sub [:rf/resource …])`. Like `sub`, a
-conditional `lease` is legal (`(when live? (lease …))` — a hidden tile holds nothing)
-and a `lease` inside a loop is a compile error — extract a keyed child view. Rule of thumb:
+during render**; reading is always the passive `(sub [:rf/resource …])`. Conditional
+leases follow the same rule as conditional reads: `(when live? (lease …))` is legal —
+a hidden tile holds nothing alive — while a `lease` inside a loop is a compile error,
+with the same fix (extract a keyed child view). Rule of thumb:
 loading that belongs to navigation or workflow rides route/event resource plans; `lease`
 is for liveness that genuinely follows visible UI — dashboard tiles, hover cards, modals.

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -12,7 +12,7 @@ A view has four inputs, each with one spelling:
 There is no fifth. No ratoms, cursors, reactions, or external stores — state that matters
 lives in app-db where events, time-travel, Story, and Xray can see it.
 
-## Subscriptions: `sub` *(lands S2 — reactive subs)*
+## Subscriptions: `sub`
 
 ```clojure
 (ui/defview order-summary [{:keys [order-id]}]

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -117,6 +117,8 @@ called after the view disconnects (it catches leaked listeners for you). Dispatc
 `lease` declares *interest*: while this view is mounted and visible, keep the resource
 alive. First lease in → the resource is ensured (fetch starts, or an in-flight one is
 joined); last lease out → it can wind down. **Lease never returns data and never fetches
-during render**; reading is always the passive `(sub [:rf/resource …])`. Rule of thumb:
+during render**; reading is always the passive `(sub [:rf/resource …])`. Like `sub`, a
+conditional `lease` is legal (`(when live? (lease …))` — a hidden tile holds nothing)
+and a `lease` inside a loop is a compile error — extract a keyed child view. Rule of thumb:
 loading that belongs to navigation or workflow rides route/event resource plans; `lease`
 is for liveness that genuinely follows visible UI — dashboard tiles, hover cards, modals.

--- a/ai/findings/new-substrate-synthesis/guide/04-events.md
+++ b/ai/findings/new-substrate-synthesis/guide/04-events.md
@@ -34,8 +34,11 @@ splicing, the sync door, `ui/event`/`ui/handler` semantics — lands S3.)*
 [:div   {:on-key-down [:editor/key :rf.ui/key]}]        ; "Enter", "a", …
 ```
 
-`:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key` — that's the whole vocabulary, spliced at
-dispatch time. **Placeholders work in literal vectors only** (the compiler recognizes
+`:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key` — that's the whole vocabulary: a closed
+set of three scalars, spliced at dispatch time. There is deliberately no `:rf.ui/event`
+and no `:rf.ui/form-data` — a raw event is a host object and form payloads carry
+duplicate keys and files (not EDN); both cases are exactly what `ui/event` (below)
+exists for. **Placeholders work in literal vectors only** (the compiler recognizes
 them at the call site); a vector forwarded through props dispatches its contents as-is,
 and dev warns if it spots a placeholder keyword riding one.
 

--- a/ai/findings/new-substrate-synthesis/guide/04-events.md
+++ b/ai/findings/new-substrate-synthesis/guide/04-events.md
@@ -130,7 +130,8 @@ testable:
            (-> tree (ui.test/find :select) ui.test/attrs :on-change)))))
 ```
 
-*(This test runs on main today — Tier-1 renders resolve `sub` sites against the frame.)*
+*(This test runs on main today — a Tier-1 render resolves its `sub` sites against the
+frame you minted.)*
 
 **When the door applies — honestly.** The compiler proves an element controlled by
 seeing a literal `:value`/`:checked` prop co-present with the vector-handler site —

--- a/ai/findings/new-substrate-synthesis/guide/04-events.md
+++ b/ai/findings/new-substrate-synthesis/guide/04-events.md
@@ -127,7 +127,7 @@ testable:
            (-> tree (ui.test/find :select) ui.test/attrs :on-change)))))
 ```
 
-*(This render crosses `sub` sites, so it runs fully once S2's Tier-1 sub path lands.)*
+*(This test runs on main today — Tier-1 renders resolve `sub` sites against the frame.)*
 
 **When the door applies — honestly.** The compiler proves an element controlled by
 seeing a literal `:value`/`:checked` prop co-present with the vector-handler site —

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -49,8 +49,9 @@ Frames are **isolated**. A page can mount several:
 
 Each subtree's `sub` and handlers bind to *its* frame and only its frame — there is no
 spelling for a cross-frame read in application code. Events in `:shop` cannot re-render
-`:assist`. (A root form mounting two views like this authors its `:root-id` — the
-derived default needs exactly one mounted view; [08](08-ssr.md).) Frames also pair naturally with server rendering — a page is N hydration
+`:assist`. (One detail worth knowing: a root form that mounts two views, as this one
+does, must author its `:root-id` — the derived default only exists when there is
+exactly one mounted view. [08](08-ssr.md) has the full identity story.) Frames also pair naturally with server rendering — a page is N hydration
 *roots* referencing whichever frames they need, several roots can share one frame, and
 each root fails or hydrates independently ([08](08-ssr.md)). And you can mount one app N
 times side-by-side (each instance its own frame universe) for comparison demos and tests.

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -49,7 +49,8 @@ Frames are **isolated**. A page can mount several:
 
 Each subtree's `sub` and handlers bind to *its* frame and only its frame — there is no
 spelling for a cross-frame read in application code. Events in `:shop` cannot re-render
-`:assist`. Frames also pair naturally with server rendering — a page is N hydration
+`:assist`. (A root form mounting two views like this authors its `:root-id` — the
+derived default needs exactly one mounted view; [08](08-ssr.md).) Frames also pair naturally with server rendering — a page is N hydration
 *roots* referencing whichever frames they need, several roots can share one frame, and
 each root fails or hydrates independently ([08](08-ssr.md)). And you can mount one app N
 times side-by-side (each instance its own frame universe) for comparison demos and tests.

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -4,9 +4,10 @@ A frame is a running re-frame2 universe: app-db, subscriptions, event queue, epo
 history. Views live *inside* one. Two components manage that relationship, and their names
 say which verb they perform.
 
-*(Stage note: the mount grammar and frame-plan extraction compile today — Stage 1. The
-runtime on this page — ENSURE preflight, provider scoping, `(frame)` — lands S2;
-`ui/dispatch-fn` and `effect` land S3.)*
+*(Stage note: the mount grammar and frame-plan extraction are Stage 1; runtime ENSURE
+preflight and provider scoping shipped with the S2 reactive core — all on main today.
+The `(frame)` ops map *(lands S2)* is the remaining S2 piece; `ui/dispatch-fn` and
+`effect` land S3.)*
 
 ## `frame-root` — ensure
 

--- a/ai/findings/new-substrate-synthesis/guide/07-performance.md
+++ b/ai/findings/new-substrate-synthesis/guide/07-performance.md
@@ -3,9 +3,10 @@
 The performance model is mostly a list of things you *don't* do. The compiler emits what a
 meticulous React engineer writes by hand — every view, every time.
 
-*(Stage note: the compiled output and memo comparators are Stage 1; the reactive
-economics below ride S2, and the CI gates that prove the production claims — bundle
-absence, size budget, output shape — wire in across S3–S6.)*
+*(Stage note: the compiled output and memo comparators are Stage 1, and the reactive
+economics below ride the S2 core — both on main today, with the push-economics gate
+(G-13) already wired. The CI gates that prove the production claims — bundle absence,
+size budget, output shape — wire in across S3–S6.)*
 
 ## What you never write
 
@@ -55,10 +56,10 @@ exists to confirm this, not to negotiate with it.
 ## What production builds contain
 
 No dev checks, no source coords, no causes/manifests/histories, no interpreter, no wrapper
-components — the runtime is ~4 KB gzipped over React, and each component carries only the
-machinery its source implies (a props-only view is a memoized function and direct element
-calls, full stop). These are CI gates — bundle scan, size budget, output-shape diff — not
-intentions.
+components — the kernel budget is ≤ 4 KB gzipped over React, and each component carries
+only the machinery its source implies (a props-only view is a memoized function and direct
+element calls, full stop). These are CI gates — bundle scan, size budget, output-shape
+diff — not intentions.
 
 ## Measuring
 

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -15,7 +15,9 @@ Structure, props, subscriptions (via the pure snapshot path), branches, lists, e
 intent, and `ui/html` — full semantics. Host-bearing features have honest fallbacks:
 `local` contributes its initial value; effects don't run; refs are absent;
 `client-only` renders its declared fallback (`ui/portal` — wave-2 — will follow the same
-rule when it ships); presence renders as `:present`.
+rule when it ships); presence renders as `:present`; error boundaries don't catch — a
+server-side throw follows the server failure policy (project the error, or fail the
+response), because boundaries are a client recovery mechanism.
 Views that *are* their host behavior (a canvas chart) wrap the leaf in `client-only` and
 keep the shared markup outside.
 

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -15,9 +15,9 @@ Structure, props, subscriptions (via the pure snapshot path), branches, lists, e
 intent, and `ui/html` — full semantics. Host-bearing features have honest fallbacks:
 `local` contributes its initial value; effects don't run; refs are absent;
 `client-only` renders its declared fallback (`ui/portal` — wave-2 — will follow the same
-rule when it ships); presence renders as `:present`; error boundaries don't catch — a
-server-side throw follows the server failure policy (project the error, or fail the
-response), because boundaries are a client recovery mechanism.
+rule when it ships); presence renders as `:present`; and error boundaries don't catch
+here — a server-side throw follows the server failure policy (project the error, or
+fail the response), because catching and retrying is client recovery.
 Views that *are* their host behavior (a canvas chart) wrap the leaf in `client-only` and
 keep the shared markup outside.
 

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -63,8 +63,9 @@ author identity the moment a page outgrows that:
   fix in the message ("add `:disambiguator` or author `:root-id`"). Duplicates are also
   caught at runtime *before any render* — the already-live root is untouched.
 - Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) are compile-time
-  literals. `:identifier-prefix` seeds React's generated ids and defaults to a slug of
-  the root-id — author it only when two independently built roots could collide.
+  literals. `:identifier-prefix` seeds React's generated ids and defaults to
+  `rf2-<root-id-slug>-` (`:page/shop` → `"rf2-page-shop-"`) — author it only when two
+  independently built roots could collide.
 - The opts map also carries the host error callbacks (`:on-uncaught-error`,
   `:on-caught-error`, `:on-recoverable-error`) — plain fns handed to the React root,
   invoked outside the commit path.

--- a/ai/findings/new-substrate-synthesis/guide/09-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/09-testing.md
@@ -39,12 +39,18 @@ real registrations, no React:
   `(ui.test/text node)`. Never keyword-look-up an attribute on a node: attrs and events
   live behind the projection, so `(:on-click node)` reads a node *field* that isn't
   there and silently misses.
-- Drive state with real events: `(ui.test/dispatch! frame [:cart/add 42])` — shipped
-  today: real dispatch plus a drain to fixed point — then re-render and
-  assert the button now reads "Remove" *(a re-render that reads `sub` sites rides S2's
-  snapshot path)*. Loading and error states are just app-db values
-  you install or events you dispatch. Stubbing a sub is the explicit option:
+- Drive state with real events: `(ui.test/dispatch! frame [:cart/add 42])` — real
+  dispatch plus a drain to fixed point — then re-render and assert the button now reads
+  "Remove". The whole loop, `sub` reads included, runs on main today. Loading and error
+  states are just app-db values you install or events you dispatch. Stubbing a sub is
+  the explicit option:
   `(ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})`.
+- `render` also takes a **literal root form** — the same grammar `mount` accepts:
+  `(ui.test/render [ui/frame-root {:id :shop :initial-events [[:shop/boot]]} [app]] {})`
+  runs the form's frame plans as preflight ENSURE against the test registrar, minting
+  the frames it declares. With a plan-bearing root form, `{:frame …}`/`{:app-db …}` are
+  rejected (the root form owns its frames — pass a bare view to control the frame), and
+  `{:props …}` belongs to the bare-view form only.
 - **Two Tier-1 ground rules.** The events/subs your view touches must be `.cljc` (they run
   on the JVM here — the standard re-frame discipline anyway). And Tier 1 renders the
   *structural subset*: `local` shows its initial value (calling its setter is a typed

--- a/ai/findings/new-substrate-synthesis/guide/10-worked-app.md
+++ b/ai/findings/new-substrate-synthesis/guide/10-worked-app.md
@@ -6,10 +6,11 @@ proves itself: the counter shows the loop; the dashboard shows the loop *scaling
 without new concepts. Nothing here is repo-specific; it's the shape of any consumer
 app.
 
-*(Stage note: everything compiles and Tier-1-renders under Stage 1, and `dispatch!` in
-tests is shipped today. The live loop — `sub`-driven repaints, the `ui/adapter`
-reactive wiring — lands S2; dispatch behaviour and the error boundary land S3. Markers
-below flag each.)*
+*(Stage note: everything on this page compiles, Tier-1-renders — `sub` reads
+included — and test-drives with `dispatch!` on main today; the live loop (`sub`-driven
+repaints, the `ui/adapter` reactive wiring) shipped with the S2 core. Committed
+dispatch from compiled handler sites, the error boundary, and `lease` liveness are
+still to land — markers below flag each.)*
 
 ## The state shape first
 
@@ -53,7 +54,7 @@ One namespace, `.cljc` (the JVM tests will thank you), dataflow before views:
 Note where the computation went: filtering and sorting live in `:metric/ids` —
 shared, cached, Xray-visible, JVM-testable. Views below do presentation only.
 
-## One tile, narrow reads *(lands S2 — reactive subs)*
+## One tile, narrow reads
 
 ```clojure
 (defview metric-tile [{:keys [id]}]
@@ -157,8 +158,7 @@ nothing re-seeds.
 ## Tests, headless
 
 The tile's whole contract — what it shows, what it dispatches — asserts on the JVM
-tree, no browser *(these renders cross `sub` sites, so they run fully once S2's Tier-1
-sub path lands; `dispatch!` itself is shipped today)*:
+tree, no browser; both tests run on main today (`sub` reads and `dispatch!` alike):
 
 ```clojure
 (ns dash.app-test

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -31,6 +31,11 @@ contract either way. *(lands S2)* now marks only the S2 remainder still to land 
 `lease` and the `(frame)` ops map. Wave-2 names (`ui/element`, `ui/view`, `ui/portal`,
 `re-frame.ui.data/render`) are not v1 and only ever appear with that qualifier.
 
+**Reading the examples.** Code on these pages assumes
+`(:require [re-frame.core :as rf] [re-frame.ui :as ui :refer [defview sub]])`, with the
+other body forms (`local`, `effect`, `lease`, `frame`, `presence-phase`) referred bare
+the same way — one convention, every chapter.
+
 **Coming from Reagent?** Your hiccup transfers whole. Reads are `(sub [:q])` — a value,
 nothing to deref. Handlers are usually vectors, not closures. One component form, no
 ratoms: app state lives in app-db, keystroke ephemera in `local`.

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -20,16 +20,17 @@ example needs internals explained, that's an API bug, not a documentation proble
 | [10 — A worked app](10-worked-app.md) | The counter grown into a dashboard: state shape, tiles, narrow subs, a live tile, tests |
 
 **Stage honesty.** The library ships in stages (S1–S7). Everything unmarked on these
-pages is shipped on main today: the Stage-1 compiler slice — compiled templates, props,
-roots and mounting, `ui/raw` / `ui/html` / `ui/spread`, the Tier-1 test core — plus the
-landed Stage-2 reactive core — `sub`-driven repaints, Tier-1 `sub` reads, `frame-root`'s
-runtime ENSURE preflight, the `ui/adapter` you hand `rf/init!`, and the mounted Tier-3
-test surface (`with-root`, `query`, `flush!`). A compact marker like
-*(lands S3 — committed handlers)* flags a surface whose contract is final but whose
-implementation lands in a later stage; the spelling and semantics shown are the ruled
-contract either way. *(lands S2)* now marks only the S2 remainder still to land —
-`lease` and the `(frame)` ops map. Wave-2 names (`ui/element`, `ui/view`, `ui/portal`,
-`re-frame.ui.data/render`) are not v1 and only ever appear with that qualifier.
+pages is shipped on main today. That covers the Stage-1 compiler slice (compiled
+templates, props, roots and mounting, `ui/raw` / `ui/html` / `ui/spread`, the Tier-1
+test core) and the Stage-2 reactive core that has since landed: `sub`-driven repaints,
+Tier-1 `sub` reads, `frame-root`'s runtime ENSURE preflight, the `ui/adapter` you hand
+`rf/init!`, and the mounted Tier-3 test surface (`with-root`, `query`, `flush!`). A
+compact marker like *(lands S3 — committed handlers)* flags a surface whose contract is
+final but whose implementation lands in a later stage; the spelling and semantics shown
+are the ruled contract either way. The *(lands S2)* marker survives on just two
+stragglers — `lease` and the `(frame)` ops map. Wave-2 names (`ui/element`, `ui/view`,
+`ui/portal`, `re-frame.ui.data/render`) are not v1 and only ever appear with that
+qualifier.
 
 **Reading the examples.** Code on these pages assumes
 `(:require [re-frame.core :as rf] [re-frame.ui :as ui :refer [defview sub]])`, with the

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -20,11 +20,15 @@ example needs internals explained, that's an API bug, not a documentation proble
 | [10 — A worked app](10-worked-app.md) | The counter grown into a dashboard: state shape, tiles, narrow subs, a live tile, tests |
 
 **Stage honesty.** The library ships in stages (S1–S7). Everything unmarked on these
-pages is Stage 1 — compiled templates, props, roots and mounting, `ui/raw` / `ui/html` /
-`ui/spread`, the Tier-1 test core — shipped today. A compact marker like
-*(lands S2 — reactive subs)* flags a surface whose contract is final but whose
+pages is shipped on main today: the Stage-1 compiler slice — compiled templates, props,
+roots and mounting, `ui/raw` / `ui/html` / `ui/spread`, the Tier-1 test core — plus the
+landed Stage-2 reactive core — `sub`-driven repaints, Tier-1 `sub` reads, `frame-root`'s
+runtime ENSURE preflight, the `ui/adapter` you hand `rf/init!`, and the mounted Tier-3
+test surface (`with-root`, `query`, `flush!`). A compact marker like
+*(lands S3 — committed handlers)* flags a surface whose contract is final but whose
 implementation lands in a later stage; the spelling and semantics shown are the ruled
-contract either way. Wave-2 names (`ui/element`, `ui/view`, `ui/portal`,
+contract either way. *(lands S2)* now marks only the S2 remainder still to land —
+`lease` and the `(frame)` ops map. Wave-2 names (`ui/element`, `ui/view`, `ui/portal`,
 `re-frame.ui.data/render`) are not v1 and only ever appear with that qualifier.
 
 **Coming from Reagent?** Your hiccup transfers whole. Reads are `(sub [:q])` — a value,


### PR DESCRIPTION
## What

Correctness + completeness pass over the re-frame2.ui user guide (`ai/findings/new-substrate-synthesis/guide/`, tracked), reviewed against the ratified synthesis suite (01–12 + drafts + the blessed 12 §2 API table) and verified line-by-line against the implementation on `main`.

## Why now

The guide's stage annotations predate the S2 landings. On `main` today: `sub`-driven repaints (ViewCell + `useSyncExternalStore`), Tier-1 JVM `sub` reads (`test_render_jvm_test.clj` `sub-read-against-a-frame`), runtime ENSURE preflight (`frames/execute-frame-plans!`), `ui/adapter` consumed by `rf/init!`, and the mounted Tier-3 test surface (`with-root`/`query`/`flush!`). Several chapters still said these "land S2".

## Changes

- **Stage honesty (guide README + 01/03/05/07/09/10):** unmarked = shipped on main (S1 slice + landed S2 reactive core); `*(lands S2)*` now marks only the S2 remainder — `lease` (stubbed, `:rf.error/ui-lease-unavailable`) and the `(frame)` ops map. Committed dispatch from compiled handler sites stays S3 (`:rf.error/ui-dispatch-unwired` on main), now stated explicitly in 01/10 instead of implied.
- **Stale notes removed** (01, 04 §forms test, 09 §Tier-1, 10 §tests): "runs fully once S2's Tier-1 sub path lands" — it runs today.
- **09 completeness:** documented `ui.test/render`'s literal-root-form arity (plan-bearing preflight ENSURE against the test registrar; `{:frame}`/`{:app-db}` rejected alongside a plan-bearing form; `{:props}` bare-view only) — per `drafts/root-identity-and-mount.md` §9, implemented on main (`literal-root-form-renders`).
- **02 error-boundary:** fallback receives `:error` + declared props and cannot dispatch during render; no server-side boundary recovery (02 §6 / 06 §1 alignment).
- **07:** `~4 KB` runtime claim restated as the gated budget (≤ 4 KB gz, G-10); G-13 noted as wired (#5815). **08:** `:identifier-prefix` default named precisely (`rf2-<root-id-slug>-`).
- **Parent README:** guide chapter count 9 → 10.

## Verified, deliberately unchanged

- React "19.2.4+" (05 §5 pins the spec floor; repo currently pins 19.2.0 — spec wins in the guide).
- Shadow 3.4.10 config claims (`:cache-blockers`, `:build-defaults` hook) — match `implementation/shadow-cljs.edn:406-407` exactly.
- `:passive`/`:once` "rejects loudly today" (04) — matches `analyze.cljc:626`.
- All error/warning ids, placeholder vocabulary, selector grammar, `reg-event`/`reg-sub` spellings, mount/host-tier signatures — match implementation.

Docs-only; no hot-zone files. Bead: rf2-drhien.