### PR TITLE
docs(ui-guide): make the guide stage-honest and fixture-claim exact (rf2-vxgfnd.114)

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md
+++ b/ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md
@@ -1,11 +1,15 @@
 # DRAFT — Guide → docs move plan (S6, W2/W3): landing shape, transforms, PR sequencing
 
-> **Status: DRAFT · 2026-07-12.** The concrete migration plan for moving the re-frame.ui
-> user guide (11 files, ⟨guide/⟩ — completeness + correctness passed 2026-07-12) out of
-> the gitignored `ai/` tree into the repo's human-facing docs at S6, per
-> ⟨11 W2/W3⟩ and ⟨12 §3 S6 epic⟩. The fixture pipeline
-> (⟨drafts/guide-fixture-pipeline.md⟩) depends on this landing shape for its S6 phase;
-> §3 below is the handshake. Open items are tagged **[S6-CONFIRM]**.
+> **Status: DRAFT · 2026-07-12 · re-based 2026-07-13.** The concrete migration plan for
+> moving the re-frame.ui user guide (11 files, ⟨guide/⟩ — completeness + correctness
+> passed 2026-07-12) out of the synthesis tree into the repo's human-facing docs at S6,
+> per ⟨11 W2/W3⟩ and ⟨12 §3 S6 epic⟩. Note the tree's tracking state: the synthesis
+> subtree has been **force-tracked in git since #5800** (the surrounding `ai/` tree
+> stays local-only), so the pages are already in-repo and CI-readable — the S6 move is
+> about giving them their `docs/` home and reader-facing shape, not about making them
+> visible. The fixture pipeline (⟨drafts/guide-fixture-pipeline.md⟩) depends on this
+> landing shape for its S6 phase; §3 below is the handshake. Open items are tagged
+> **[S6-CONFIRM]**.
 
 ## 0. Facts the plan stands on
 
@@ -37,8 +41,9 @@
    one prose reference points outside ("design rationale lives one directory up",
    ⟨guide/README ¶1⟩); ~18 inline stage markers + 8 stage notes (correctness-pass
    re-census — the completeness pass added chapter-top notes) + the README
-   stage-honesty paragraph; **zero** `;; guide:*` fence markers exist yet; zero images
-   ⟨guide/ greps 2026-07-12⟩.
+   stage-honesty paragraph; the **five mandatory `;; guide:no-fixture` markers** exist
+   on the pages (added 2026-07-13 with the stage-truth reconciliation — the §2.4 set);
+   zero images ⟨guide/ greps 2026-07-12/13⟩.
 
 ## 1. Landing location + nav
 
@@ -128,7 +133,7 @@ input. Every transform below happens in it, once.
 |---|---|
 | Intra-guide chapter links (`[02](02-views.md)` — ~30 sites, all same-dir relative) | **Keep unchanged**; README→index rename doesn't affect them (no chapter links back to README) |
 | ⟨guide/README ¶1⟩ "design rationale lives one directory up" | **Remove the clause.** The synthesis suite does not move; docs never link `spec/` ⟨AUTHORING §2⟩. The sentence becomes "This guide teaches the library as a user." |
-| ⟨guide/README ¶1⟩ the CI-fixture promise | **Keep as-is at move time** — by S6 the promise is carried by the bridge fixtures (S1–S5 chapters all active per the stage forcer). The "except fences marked `guide:no-fixture`" amendment lands with the extractor PR, not the move ⟨guide-fixture-pipeline §2 README amendment⟩ |
+| ⟨guide/README ¶1⟩ the fixture-coverage statement | **Update to the move-time truth.** Since 2026-07-13 the README states exact coverage (guide 09's fixture today, growing per stage); by S6 all S1–S5 chapters are active per the stage forcer, so the sentence becomes the full every-example promise. The "except fences marked `guide:no-fixture`" amendment lands with the extractor PR, not the move ⟨guide-fixture-pipeline §2 README amendment⟩ |
 | ⟨10-migration doc⟩ links to `drafts/reagent-compat-boundary.md` (×3) | **Replace with inline prose.** The draft doesn't move; its normative content promotes spec-side (004A at S7), and docs never link `spec/`. The page inlines what the reader needs: the three co-mount granularities and the ownership/teardown one-liners it currently cites |
 | ⟨10-migration doc⟩ synthesis-suite citations ("08 §2", "12 §2", "02 §3 table", "06 §1", "guide 03") | **Rewrite or drop.** "02 §3 table" → link `04-events.md` (the decision table's guide home); "guide 03" → `03-state.md`; "06 §1 subset check" → `08-ssr.md`; stage-plumbing citations ("08 §2", "12 §2", delta numbers) → **drop** — program management is not reader content |
 | Provenance parentheticals: "Blessed-table verdict; qualifier added 2026-07-12" ⟨guide/02 L73–74⟩, "delta #2, ruled 2026-07-12; 12 §2" ⟨10-migration⟩, "(an Xray addition staged behind its integration review)" ⟨guide/06 L32⟩, the migration doc's **Status:** line | **Strip.** "No bead ids in prose. Pages state current truth" ⟨AUTHORING §Honesty⟩. The *facts* stay (wave-2 status, S7 freeze); the ruling ledger goes |
@@ -192,16 +197,17 @@ template → **docs/guide + skills** → CI → benchmarks ⟨12 §3 S6⟩), S1�
 
 ### 2.4 Fence markers: add the mandatory ones now, freeze the fences
 
-The pages carry **zero** `;; guide:*` markers today ⟨grep 2026-07-12⟩. The pipeline's
+The five mandatory markers are **already on the pages** (added 2026-07-13 with the
+stage-truth reconciliation), so the extractor PR touches zero pages. The pipeline's
 fence contract makes unmarked elisions and unmarked wave-2 fences an extractor *error*
-⟨guide-fixture-pipeline §2⟩. **The move PR adds the mandatory markers** so the
-extractor PR touches zero pages:
+⟨guide-fixture-pipeline §2⟩. **The move PR verifies the census** — any fence added
+since must carry its marker; the set as of 2026-07-13:
 
-| Fence | Marker added |
+| Fence | Marker |
 |---|---|
 | 01 `deps.edn` stub (`{…}`) | `;; guide:no-fixture — install stub, elided coordinates` |
 | 03 conditional-read one-liner (`… ✓`) | `;; guide:no-fixture — illustrative fragment` |
-| 05 `media-bridge` body (`…)`) | `;; guide:no-fixture — illustrative fragment` |
+| 05 `media-bridge` body (`…)`) | `;; guide:no-fixture — illustrative fragment, elided body` |
 | 08 `render-static` call (`{…}`) | `;; guide:no-fixture — illustrative fragment` |
 | 02 `data/render` | `;; guide:no-fixture — wave-2, does not ship in v1` |
 
@@ -312,8 +318,9 @@ scripts/ touches. Well inside single-worker sizing; no bundling.
    stranded-worker rule.
 2. CI: the `Docs required` aggregator green (docs.yml detect will light
    `docs_surface` on this diff).
-3. **No gitignored-tree references survive:** grep over `docs/ui/` for
-   `new-substrate-synthesis`, `findings/`, `drafts/`, `⟨`, `ai/` → zero hits.
+3. **No synthesis-tree references survive** (the tree is tracked but is not
+   reader-facing docs): grep over `docs/ui/` for `new-substrate-synthesis`,
+   `findings/`, `drafts/`, `⟨`, `ai/` → zero hits.
 4. **No shipped-stage markers survive:** grep `\(lands S[1-5]` and `Stage note` over
    `docs/ui/` → zero; wave-2 qualifiers preserved (grep `wave-2` ≥ 4 hits).
 5. **Fence bodies byte-identical** to the source pages modulo the added `;; guide:*`

--- a/ai/findings/new-substrate-synthesis/drafts/guide-fixture-pipeline.md
+++ b/ai/findings/new-substrate-synthesis/drafts/guide-fixture-pipeline.md
@@ -1,8 +1,11 @@
 # DRAFT — The guide-fixture pipeline (making the README promise real at scale)
 
-> **Status: DRAFT · 2026-07-12.** Design for the promise in ⟨guide/README ¶1⟩: *"Every
-> example on these pages compiles and runs as a CI fixture — if a guide example needs
-> internals explained, that's an API bug."* The normative sources are
+> **Status: DRAFT · 2026-07-12 · re-based 2026-07-13** to two changed facts: the
+> synthesis tree (guide pages included) has been **force-tracked in git since #5800**,
+> so "CI cannot read the pages" is no longer true; and ⟨guide/README ¶1⟩ now states
+> *exact* fixture coverage (guide 09 Tier-1 today, growing with the stages) rather
+> than a universal claim. The universal every-example-runs promise is this pipeline's
+> **target**, not the current state. The normative sources are
 > ⟨07-testing §7 — the guide as a test surface⟩ and the G-14 honest remainder
 > (⟨implementation/ui/test/re_frame/ui/g14_compile_budget_jvm_test.clj docstring⟩:
 > *"guide-fixtures CI cost needs the guide-examples corpus (08 §3)"*, landed via #5703).
@@ -18,12 +21,16 @@
 Three facts shape everything below; any model that ignores one of them is wrong for
 this repo.
 
-1. **The guide is gitignored until S6.** It lives under `ai/findings/…/guide/` — the
-   local-only `ai/` tree ⟨CLAUDE.md §Local working files⟩ — until the S6 docs
-   workstream (W2/W3) moves it into the repo ⟨12 §3 S6 epic⟩. **No CI job can read the
-   pages before then.** Any pipeline that *derives* fixtures from the pages cannot be a
-   CI gate until S6. Whatever runs in CI during S2–S5 must be checked-in test source
-   that CI can see without the pages.
+1. **The guide is tracked working material, not yet docs.** It lives under
+   `ai/findings/…/guide/`, and since #5800 that synthesis subtree is **force-tracked in
+   git** (⟨.gitignore⟩ carries the temporary exception; the surrounding `ai/` tree
+   stays local-only ⟨CLAUDE.md §Local working files⟩), so CI *can* read the pages
+   today. What has not happened is the S6 docs move (W2/W3) ⟨12 §3 S6 epic⟩: the pages
+   are a working artefact that dissolves into `docs/` at S6 and no extractor exists —
+   building one before S6 is speculative machinery the program has declined. So during
+   S2–S5, what runs in CI stays checked-in test source; the tracked pages are available
+   to any local script (and to a future gate) but nothing derives fixtures from them
+   yet.
 2. **Fences come in dialects.** Census (originally 52/51 on 2026-07-12; re-censused
    after the guide completeness pass the same day and re-verified by the correctness
    pass — the elided and wave-2 sets below unchanged): **51 fences across the 11
@@ -34,7 +41,9 @@ this repo.
    08's `render-static` call (`{…}`) — and one (guide 02's `data/render`) names a
    **wave-2** artefact that does not exist in v1 ⟨12 §2 blessed table⟩. "Every example
    compiles" cannot naively mean "every fence compiles"; the contract must make the
-   exceptions *visible on the page* or the promise rots silently.
+   exceptions *visible on the page* or the promise rots silently. (As of 2026-07-13
+   those five fences carry their `;; guide:no-fixture` markers on the page — the §2
+   mandatory set, added ahead of the S6 move.)
 3. **Stage markers are load-bearing.** The README's stage-honesty convention —
    unmarked = Stage 1, `*(lands S2 — reactive subs)*` etc. — annotates whole chapters
    (stage notes), sections (header markers), and single bullets ⟨guide/README §Stage
@@ -52,9 +61,9 @@ Three candidate models, one recommendation.
 
 | Model | Mechanism | Strengths | Why it fails as the *whole* answer here |
 |---|---|---|---|
-| **(A) Literate extraction** | a script parses guide `.md` fences into generated test namespaces | single source of truth; page↔fixture drift impossible by construction | cannot run in CI until the guide enters the repo at S6 (constraint 1); a bare fence lacks everything the S1d worker had to invent — ns preamble, requires, the fixture app surface (`fixture-catalog`, event registrations, the reset-runtime fixture), and assertions for non-test fences — so "parse fences" alone under-specifies the pipeline |
-| **(B) Mirrored fixtures** | hand-maintained fixture files 1:1 with chapters, drift-checked against the page | works **today**, on gitignored pages, with human judgment for stage adaptation — this is exactly the S1d precedent | at guide scale (51 fences and growing) hand-mirroring is a standing tax; the drift gate is structurally weak while adaptations are legitimate (an adapted fixture *should* differ from its fence, so byte-comparison either fails spuriously or gets normalised into meaninglessness); and CI can't compare against a page it can't read anyway |
-| **(C) Annotation-driven extraction** | fence-level markers (eligibility, stage, target, fixture id) drive a generator; per-chapter scaffolds supply context; assertions live in companion files | keeps the page the source of truth **and** makes the exceptions visible in the page source; stage markers become machine-readable; the manifest falls out for free | still gated on the guide entering the repo (constraint 1); needs marker + scaffold conventions defined up front or the completeness pass authors fences the extractor can't consume |
+| **(A) Literate extraction** | a script parses guide `.md` fences into generated test namespaces | single source of truth; page↔fixture drift impossible by construction | the extractor is S6 work by plan (constraint 1 — the pages are CI-readable, but no extractor exists before the docs move); a bare fence lacks everything the S1d worker had to invent — ns preamble, requires, the fixture app surface (`fixture-catalog`, event registrations, the reset-runtime fixture), and assertions for non-test fences — so "parse fences" alone under-specifies the pipeline |
+| **(B) Mirrored fixtures** | hand-maintained fixture files 1:1 with chapters, drift-checked against the page | works **today**, needing nothing beyond the tracked pages, with human judgment for stage adaptation — this is exactly the S1d precedent | at guide scale (51 fences and growing) hand-mirroring is a standing tax; the drift gate is structurally weak while adaptations are legitimate (an adapted fixture *should* differ from its fence, so byte-comparison either fails spuriously or gets normalised into meaninglessness); and no comparison harness exists before S6 to make the check mechanical |
+| **(C) Annotation-driven extraction** | fence-level markers (eligibility, stage, target, fixture id) drive a generator; per-chapter scaffolds supply context; assertions live in companion files | keeps the page the source of truth **and** makes the exceptions visible in the page source; stage markers become machine-readable; the manifest falls out for free | still lands at S6 with the docs move (constraint 1); needs marker + scaffold conventions defined up front or the completeness pass authors fences the extractor can't consume |
 
 **Recommendation: (C) annotation-driven extraction is the pipeline, landing at S6 with
 W2/W3 — with (B) hand-mirrored fixtures as the S2–S5 bridge, per the S1d precedent.**
@@ -71,10 +80,11 @@ at gate time — there is no second copy to drift (§5) — and the standing mir
 disappears exactly when the guide's growth rate is highest (post-completeness-pass,
 post-adoption).
 
-Why the bridge must exist at all: constraint 1. The alternative — hold all guide
-fixtures until S6 — breaks the per-stage proof column of ⟨12 §2b⟩ (surface rows name
-guide-shaped fixtures as their stage proof) and abandons the S1d precedent that already
-ships. The bridge fixtures are the stage proofs; the S6 pipeline is the scale answer.
+Why the bridge must exist at all: constraint 1 — the extractor is S6 work, and the
+alternative of holding all guide fixtures until S6 breaks the per-stage proof column of
+⟨12 §2b⟩ (surface rows name guide-shaped fixtures as their stage proof) and abandons
+the S1d precedent that already ships. The bridge fixtures are the stage proofs; the S6
+pipeline is the scale answer.
 
 **Authoring rule for the completeness pass, effective now:** write new fences as if the
 extractor already existed — complete forms, marker comments where §2 requires them,
@@ -124,10 +134,12 @@ bridge fixtures may keep doing so — but they are not counted, not manifest row
 their absence is not a promise violation. Trying to extract inline spans is how
 literate pipelines drown.
 
-**README amendment at S6** (one sentence, honesty): the promise gains "— except the
-handful marked `guide:no-fixture` on the page, each with its reason", plus the marker
-convention in the stage-honesty paragraph. Until then the bridge-era promise is carried
-by the manifest (§3), which counts waived fences per chapter.
+**README amendment at S6** (one sentence, honesty): once every chapter is active, the
+README's exact-coverage statement (re-based 2026-07-13 — it names guide 09's fixture as
+the only one live today) becomes the full promise, gaining "— except the handful marked
+`guide:no-fixture` on the page, each with its reason", plus the marker convention in
+the stage-honesty paragraph. Until then coverage is stated exactly on the README and
+counted per chapter by the manifest (§3).
 
 ## 3. Stage gating: activate with the stage, park loudly before it
 
@@ -167,9 +179,9 @@ cognitect runner — zero new CI wiring) asserts:
    guide 09 is `:active` at S1 but its two adaptations park on S2);
 4. every guide chapter has a row (the completeness pass adds chapters; a chapter with
    no row is red). Bridge-era source for "every chapter": the manifest itself carries
-   the chapter list — CI cannot see the gitignored pages, so during S2–S5 the list is
-   maintained by hand and verified against the pages by the local drift script (§5);
-   from S6 the extractor generates it.
+   the chapter list — the tracked pages are CI-readable, but with no extractor before
+   S6 the list is maintained by hand and verified against the pages by the local drift
+   script (§5); from S6 the extractor generates it.
 
 **Skipped-not-silent under the quiet-tests policy.** Green output stays quiet
 ⟨docs/quiet-tests.md via TESTING.md⟩, so the "N fixtures parked per stage" report is
@@ -250,8 +262,10 @@ Residual drift surfaces and their gates:
    Token-level or whitespace-insensitive comparison is rejected — it licenses cosmetic
    divergence, and cosmetic divergence is how "the page is the contract" dies.
 
-**Bridge era (S2–S5): procedural + local-script, honestly not a CI gate.** CI cannot
-read the pages (constraint 1), so page↔fixture comparison cannot gate a PR. Instead:
+**Bridge era (S2–S5): procedural + local-script, honestly not a CI gate.** The tracked
+pages are CI-readable, but no extraction/comparison harness exists before S6
+(constraint 1), so page↔fixture comparison does not gate a PR during the bridge — the
+check stays procedural. Instead:
 
 - every bridge fixture carries the `guide:begin/end` delimiters and the manifest's
   `:lifted` date + `:adapted` ledger from day one (S1d's docstring, promoted to the

--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -3,13 +3,17 @@
 ## Install
 
 ```clojure
+;; guide:no-fixture — install stub, elided coordinates
 ;; deps.edn
 {:deps {day8/re-frame2    {…}
         day8/re-frame2-ui {…}}}
 ```
 
-`package.json` carries `react` and `react-dom` (19.2.4+) — nothing else. No Reagent, no
-UIx, no Helix.
+`package.json` carries `react` and `react-dom` — nothing else. No Reagent, no UIx, no
+Helix. The published artifact's peer floor is planned as React 19.2.4+; the reference
+implementation today builds and tests against a 19.2.0 pin
+(`implementation/package.json`), and the floor takes effect when the artifact's peer
+contract ships with it.
 
 The compiler owns one whole-build view digest. For Shadow 3.4.10, configure its two
 load-bearing settings once (not once per build):

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -69,6 +69,7 @@ Reagent users: home, minus the traps.
   definitions) uses the explicit interpreter artifact:
 
 ```clojure
+;; guide:no-fixture — wave-2, does not ship in v1
 (require '[re-frame.ui.data :as data])
 (data/render tree-from-server)     ; opt-in; its cost is visible and attributable
 ```

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -28,6 +28,7 @@ lives in app-db where events, time-travel, Story, and Xray can see it.
 - **Conditional reads are legal.** `sub` is not a hook:
 
 ```clojure
+;; guide:no-fixture — illustrative fragment
 (let [details (when expanded? (sub [:orders/details id]))] …)   ; ✓
 ```
 

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -42,16 +42,19 @@ Mixing them up fails loudly with a did-you-mean: `frame-root` given `:frame`, or
 Frames are **isolated**. A page can mount several:
 
 ```clojure
-[:body
- [ui/frame-root {:id :shop   :initial-events [[:shop/init]]}   [shop-app]]
- [ui/frame-root {:id :assist :initial-events [[:assist/init]]} [assistant]]]
+(ui/mount [:div.page
+           [ui/frame-root {:id :shop   :initial-events [[:shop/init]]}   [shop-app]]
+           [ui/frame-root {:id :assist :initial-events [[:assist/init]]} [assistant]]]
+          page-el
+          {:root-id :page/home})
 ```
 
 Each subtree's `sub` and handlers bind to *its* frame and only its frame — there is no
 spelling for a cross-frame read in application code. Events in `:shop` cannot re-render
 `:assist`. (One detail worth knowing: a root form that mounts two views, as this one
 does, must author its `:root-id` — the derived default only exists when there is
-exactly one mounted view. [08](08-ssr.md) has the full identity story.) Frames also pair naturally with server rendering — a page is N hydration
+exactly one mounted view, which is why the mount above spells out `:page/home`.
+[08](08-ssr.md) has the full identity story.) Frames also pair naturally with server rendering — a page is N hydration
 *roots* referencing whichever frames they need, several roots can share one frame, and
 each root fails or hydrates independently ([08](08-ssr.md)). And you can mount one app N
 times side-by-side (each instance its own frame universe) for comparison demos and tests.
@@ -63,6 +66,7 @@ imperative need — an effect that dispatches later, an interop callback that mu
 frame out of the tree:
 
 ```clojure
+;; guide:no-fixture — illustrative fragment, elided body
 (ui/defview media-bridge [{:keys [stream-id]}]
   (let [dispatch! (ui/dispatch-fn)]
     (effect [stream-id]

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -6,18 +6,23 @@ server output are **structurally equivalent** (verified by fingerprint and a gen
 parity suite), so they cannot drift apart.
 
 *(Stage note: the JVM emitter, structural parity, root identity, and the client host
-tier are Stage 1 — shipped, and Tier-1 tests ride them today. Hydration, root
-manifests, `render-static`, and the `client-only` phase flip land S5 — SSR roots.)*
+tier are Stage 1 — shipped, and Tier-1 tests ride them today; headless `sub` resolution
+rides the S2 snapshot path, also shipped. The host-fallback rules below are the ruled
+contract for features that land later — `local`, `effect`, `client-only`, and error
+boundaries at S3; presence at S4. Hydration, root manifests, `render-static`, and the
+`client-only` phase flip land S5 — SSR roots.)*
 
 ## What renders on the server
 
 Structure, props, subscriptions (via the pure snapshot path), branches, lists, event
-intent, and `ui/html` — full semantics. Host-bearing features have honest fallbacks:
-`local` contributes its initial value; effects don't run; refs are absent;
-`client-only` renders its declared fallback (`ui/portal` — wave-2 — will follow the same
-rule when it ships); presence renders as `:present`; and error boundaries don't catch
-here — a server-side throw follows the server failure policy (project the error, or
-fail the response), because catching and retrying is client recovery.
+intent, and `ui/html` — full semantics. Host-bearing features have honest fallbacks,
+each fixed now as the ruled contract and landing with its feature's stage: `local`
+contributes its initial value and effects don't run *(both land S3)*; refs are absent;
+`client-only` renders its declared fallback *(lands S3; `ui/portal` — wave-2 — will
+follow the same rule if it ever ships)*; presence renders as `:present` *(lands S4)*;
+and error boundaries don't catch here *(the component lands S3)* — a server-side throw
+follows the server failure policy (project the error, or fail the response), because
+catching and retrying is client recovery.
 Views that *are* their host behavior (a canvas chart) wrap the leaf in `client-only` and
 keep the shared markup outside.
 
@@ -36,6 +41,9 @@ state world. A page can have several of each, and they mix freely:
  [:div#shop-root]      ; root :page/shop   → view [shop-app],   frames :shop + :session
  [:div#assist-root]]   ; root :page/assist → view [assistant],  frames :assist + :session
 ```
+
+*(The rest of this section is the hydration contract — ruled now; it lands S5 with SSR
+roots.)*
 
 Each root ships a small manifest (its id, view, props, referenced frame payload ids,
 fingerprint). **Frame payloads install idempotently** — here both roots reference
@@ -107,6 +115,7 @@ A root with no client capabilities *can* ship as inert HTML — no payload, no h
 but only when you say so:
 
 ```clojure
+;; guide:no-fixture — illustrative fragment
 (ui/render-static [site-footer {…}])   ; host declares it; compiler proves it
 ```
 
@@ -131,7 +140,8 @@ an SSR path without a fallback is a build error.
 
 Handlers-as-data pays off here twice: the JVM tree retains event vectors as data, so
 headless tests assert intent server-side; and Xray's static interaction surface reads
-them without executing anything. On the client they become ordinary React handlers.
+them without executing anything. On the client they become ordinary React handlers
+*(the committed client wiring lands S3)*.
 (Pre-hydration interaction capture — queueing clicks before the bundle arrives — is a
 research track, not a shipped feature; the data property that would enable it is already
 here.)

--- a/ai/findings/new-substrate-synthesis/guide/09-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/09-testing.md
@@ -55,11 +55,12 @@ real registrations, no React:
   on the JVM here — the standard re-frame discipline anyway). And Tier 1 renders the
   *structural subset*: `local` shows its initial value (calling its setter is a typed
   error pointing at Tier 3), effects don't run, refs are absent — state transitions and
-  host behavior are Tier-3 subjects by design.
+  host behavior are Tier-3 subjects by design. *(The `local` and `effect` forms
+  themselves land S3; the subset rule here is their ruled Tier-1 contract.)*
 - These run in your JVM watch loop in milliseconds and never flake on timing. They're
   also exactly how the library tests itself, so the shapes are first-class.
 - *(Stage note: the Tier-1 core — `render`, `find`, `find-all`, `text`, `attrs`,
-  `frame`, `dispatch!` — shipped at Stage 1. Tier-1 `sub` snapshots and the mounted
+  `frame` — shipped at Stage 1. `dispatch!`, Tier-1 `sub` snapshots, and the mounted
   Tier-3 `with-root` / native-CSS `query` / Promise-backed `flush!` surface shipped at
   Stage 2. `flush-presence!` lands at Stage 4.)*
 
@@ -130,11 +131,13 @@ genuinely DOM-shaped checks. Scenes mount by **view id** from the registry.
 
 ## What you can trust without testing it yourself
 
-The library's own CI pins, per release: ownership correctness under concurrent React
-(abandoned renders retain nothing; StrictMode settles to one owner; Activity hide/reveal
-releases and reacquires), JVM/browser emitter parity (generative, from your props
-schemas), dev/prod behavioral equivalence, bundle absence rosters, and the performance
-gates. Your tests get to assume the substrate; they only need to cover your app.
+The library's own CI builds toward a pinned release set, each gate wiring in with the
+stage that ships its feature: ownership correctness under concurrent React (abandoned
+renders retain nothing; StrictMode settles to one owner; Activity hide/reveal releases
+and reacquires), JVM/browser emitter parity (generative, from your props schemas),
+dev/prod behavioural equivalence, bundle absence rosters, and the performance gates.
+The S1/S2 slices — parity and the ownership fixtures — are wired today; the rest land
+with S3–S6. Your tests get to assume the substrate; they only need to cover your app.
 
 ## Rules of thumb
 

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -3,8 +3,14 @@
 re-frame2 UI is the view layer for re-frame2: views are hiccup, handlers are event
 vectors, and the compiler ships code with no interpreter, no hooks ceremony, and no manual
 memoization. This guide teaches the library as a user; design rationale lives one
-directory up. Every example on these pages compiles and runs as a CI fixture — if a guide
-example needs internals explained, that's an API bug, not a documentation problem.
+directory up. The examples are written to run as CI fixtures, and coverage grows with
+the stages. Today one chapter is covered: guide 09's Tier-1 examples run in the
+library's JVM suite as `implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`;
+the remaining chapters are lifted as their stages land, per the fixture-pipeline draft
+one directory up (`drafts/guide-fixture-pipeline.md`). A fence that is deliberately
+schematic — an elided fragment, or a wave-2 surface — says so in a `;; guide:no-fixture`
+comment on the fence itself. The bar does not move with the coverage: if a guide example
+needs internals explained, that's an API bug, not a documentation problem.
 
 | Chapter | You'll learn |
 |---|---|


### PR DESCRIPTION
Post-merge audit of #5823 (rf2-vxgfnd.114) found five stage-truth defects in the tracked `re-frame.ui` guide. This docs-only slice resolves all five against the frozen surface matrix (`12-implementation-plan.md` §2b), current main, and `implementation/package.json`.

**1. Guide 08/09 taught unmarked S3–S5 behaviour.** `guide/08-ssr.md`'s top stage note now governs the host-fallback rules explicitly (`local`/`effect`/`client-only`/error boundaries S3, presence S4, hydration/manifests/`render-static`/phase-flip S5), the fallback list carries inline markers, the hydration-contract paragraphs get an unmissable governing marker, and the "event vectors become ordinary React handlers" claim is marked S3. `guide/09-testing.md`'s structural-subset rule now states that `local`/`effect` themselves land S3, and the "what you can trust" section says which CI slices are wired today (S1 parity, S2 ownership) versus landing with S3–S6.

**2. The every-example-is-a-CI-fixture claim was false.** `guide/README.md` now states exact coverage: one fixture exists today (`implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`, guide 09 Tier 1), coverage grows per stage, and deliberately schematic fences carry `;; guide:no-fixture` markers — the five mandatory markers (01 install stub, 02 wave-2 `data/render`, 03 conditional-read fragment, 05 `media-bridge` fragment, 08 `render-static` fragment) are now on the pages. Both pipeline drafts are re-based to the tracked-tree reality: the synthesis tree is force-tracked since #5800, so "CI cannot read the pages" is gone; the S6 extractor boundary is now stated as the plan decision it is, not a physical impossibility.

**3. Guide 05's multi-frame example failed its own prose.** The two-view root now shows the complete `ui/mount` call with an authored `:root-id :page/home`, so following the example cannot trip the no-single-mounted-view fence; the prose points at the authored id.

**4. `ui.test/dispatch!` was attributed to Stage 1.** The guide 09 stage note now places it at Stage 2 with the mounted semantics, matching the frozen matrix row for `re-frame.ui.test/*`.

**5. React 19.2.4+ vs the 19.2.0 pin.** `guide/01-getting-started.md` now names both honestly: the published artifact's planned peer floor is 19.2.4+, the reference implementation currently pins 19.2.0 (`implementation/package.json`). No dependency version changed.

Verification sweeps: no guide or draft still claims the tree is gitignored or CI-blind; no universal fixture promise exceeds executable coverage; chapters 01/04/05/06/07/08/10 carry governing stage notes and 09's list-note is corrected; `ui.test` source confirms `dispatch!`/`with-root`/`flush!`/`:sub-overrides` are shipped as the guide states.

## Quality gates

docs-only; CI classifier decides. Ran locally: `python scripts/check_doc_slugs.py` (green, exit 0).
