### PR TITLE
docs(ui-guide): post-#5823 review cluster — presence order, slug, render cardinality, frame convention (rf2-vxgfnd.127/.128/.129/.130)

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
+++ b/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
@@ -51,11 +51,18 @@ so the single-root common case stays one-liner clean:
    ids derived from `:shop/app` — add `:disambiguator` or author `:root-id`"*. Stripped
    from shipped manifests.
 
-**Root-id slug** (one deterministic function, used by the identifier-prefix default and
-synthesised locators): keyword → `namespace "-" name` (namespace absent → name);
-vector → element slugs joined by `"--"`; any character outside `[A-Za-z0-9_-]`
-normalised to `-`. `:page/shop` → `"page-shop"`; `[:shop/app :left]` →
-`"shop-app--left"`.
+**Root-id slug** (one deterministic, **injective** function, used by the
+identifier-prefix default and synthesised locators — distinct valid root-ids ALWAYS
+yield distinct slugs; the normative algorithm lives in `spec/004C-Roots-and-Mount.md`
+§1): a decodable canonical form over the DOM-safe alphabet `[A-Za-z0-9_-]`, in which
+`_` is the sole metacharacter — every character outside `[A-Za-z0-9-]` (including `_`
+itself) is reversibly escaped `_<lowercase-hex-code-unit>_`, and each structural
+boundary carries an uppercase `_`-tag the escape never emits (`_S` keyword
+namespace/name separator; `_V` vector lead-in; `_K`/`_T`/`_I` a vector element's
+keyword/string/integer type). `:page/shop` → `"page_Sshop"`; `[:shop/app :left]` →
+`"_V_Kshop_Sapp_Kleft"`. (The earlier lossy "normalise every disallowed character to
+`-`" rule aliased distinct root-ids — `:a/b-c` and `:a-b/c` both flattened to `a-b-c`
+— and is retired.)
 
 ## 2. The Root Descriptor v1 — the named, versioned S1 subset
 
@@ -139,7 +146,7 @@ id" is closed here:
 |---|---|---|
 | `:root-id` | identity | authored root-id (§1.1); immutable for the root's lifetime |
 | `:disambiguator` | identity | scalar; only meaningful when `:root-id` is absent (§1.2) |
-| `:identifier-prefix` | rendering | string fed to React's `identifierPrefix` (`use-id`). Default: `"rf2-" + root-id-slug + "-"` (§1) — `:page/shop` → `"rf2-page-shop-"`. (06 §2's `"rf2-shop-"` example is an authored value, not the derived default.) |
+| `:identifier-prefix` | rendering | string fed to React's `identifierPrefix` (`use-id`). Default: `"rf2-" + root-id-slug + "-"` (§1) — `:page/shop` → `"rf2-page_Sshop-"`. (06 §2's `"rf2-shop-"` example is an authored value, not the derived default.) |
 | `:on-uncaught-error` `:on-caught-error` `:on-recoverable-error` | host | plain CLJS fns passed to the React root options. Host-tier option maps are **not** template positions — the §02 §3 handler boundary law does not apply here. Invoked by React outside the re-frame2 commit path; to dispatch they must go through a live frame handle. |
 
 Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) must be **compile-time

--- a/ai/findings/new-substrate-synthesis/drafts/ui-react-interop-contract.md
+++ b/ai/findings/new-substrate-synthesis/drafts/ui-react-interop-contract.md
@@ -147,7 +147,8 @@ foreign interop hands raw JS values through⟩.
 
 Wraps `useId`: a host-generated, tree-positional identifier token, prefixed by the
 root's `identifierPrefix`. Determinism under SSR rides the root contract: the prefix
-default is **`"rf2-" + root-id-slug + "-"`** (`:page/shop` → `"rf2-page-shop-"`), the
+default is **`"rf2-" + root-id-slug + "-"`** (`:page/shop` → `"rf2-page_Sshop-"`, the
+slug's injective typed escape), the
 per-page prefix-uniqueness check makes cross-root collision impossible, and hydrating
 roots MUST take the server's prefix from the manifest — client opts carrying
 `:identifier-prefix` into `hydrate-root` are an error precisely because a divergent

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -89,18 +89,19 @@ Reagent users: home, minus the traps.
 
 When state says an element is gone, React removes it instantly — but toasts slide out,
 modals fade, rows collapse. `ui/presence` owns the gap between *no longer true* and
-*no longer visible*:
+*no longer visible*. Each card reads where it is in that lifetime with `presence-phase`;
+the tray wraps the list in the presence boundary:
 
 ```clojure
-(ui/defview toast-tray []
-  (ui/presence {:timeout-ms 300}
-    (for [t (sub [:toasts/visible])]
-      [toast-card {:key (:id t) :toast t}])))
-
 (ui/defview toast-card [{:keys [toast]}]
   (let [phase (presence-phase)]          ; :mounting | :present | :unmounting
     [:div.toast {:class (name phase)}    ; your CSS does the animating
      (:message toast)]))
+
+(ui/defview toast-tray []
+  (ui/presence {:timeout-ms 300}
+    (for [t (sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
 ```
 
 A child removed from the list keeps rendering as `:unmounting` until its transition ends

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -78,13 +78,13 @@ frame out of the tree:
 `(ui/dispatch-fn)` is one stable function per view instance, bound to the committed frame.
 It fails loudly if called after the view disconnects — which turns a leaked foreign
 listener into an error you see, instead of a dispatch into the void. The fuller ops map is
-`(ui/frame)` (`:frame`, `:dispatch`, `:dispatch-sync`, `:subscribe` — the standard
+`(frame)` (`:frame`, `:dispatch`, `:dispatch-sync`, `:subscribe` — the standard
 `capture-frame` bundle) when you need more than dispatch — say, a bridge that must
 *name* its frame in the payload it sends out of the tree:
 
 ```clojure
 (ui/defview error-reporter []
-  (let [{:keys [frame dispatch]} (ui/frame)]
+  (let [{:keys [frame dispatch]} (frame)]
     (effect :connect
       (let [handler #(dispatch [:errors/reported frame (.-message %)])]
         (js/window.addEventListener "error" handler)

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -74,7 +74,8 @@ author identity the moment a page outgrows that:
   caught at runtime *before any render* — the already-live root is untouched.
 - Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) are compile-time
   literals. `:identifier-prefix` seeds React's generated ids and defaults to
-  `rf2-<root-id-slug>-` (`:page/shop` → `"rf2-page-shop-"`) — author it only when two
+  `rf2-<root-id-slug>-` (`:page/shop` → `"rf2-page_Sshop-"` — the slug escapes the `/`
+  as `_S`, so distinct root-ids can never share a prefix) — author it only when two
   independently built roots could collide.
 - The opts map also carries the host error callbacks (`:on-uncaught-error`,
   `:on-caught-error`, `:on-recoverable-error`) — plain fns handed to the React root,

--- a/ai/findings/new-substrate-synthesis/guide/09-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/09-testing.md
@@ -45,7 +45,12 @@ real registrations, no React:
   states are just app-db values you install or events you dispatch. Stubbing a sub is
   the explicit option:
   `(ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})`.
-- `render` also takes a **literal root form** — the same grammar `mount` accepts:
+- `render` also takes a **literal root form** — the same literal top-region grammar
+  `mount` accepts, deliberately tightened in one way: a test root mounts exactly *one*
+  view, because root identity is that view's id. `mount` will take a multi-view form
+  when you author a `:root-id`; `ui.test/render` won't — a two-view root fails at
+  expansion with `:rf.ui.compile/bad-test-root`. Need a multi-view composition under
+  test? Wrap it in one `defview` and render that.
   `(ui.test/render [ui/frame-root {:id :shop :initial-events [[:shop/boot]]} [app]] {})`
   runs the form's frame plans as preflight ENSURE against the test registrar, minting
   the frames it declares. With a plan-bearing root form, `{:frame …}`/`{:app-db …}` are

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -451,8 +451,11 @@ server in sight (guide 01):
    `{:props p}`. Frames ride `{:frame f}` XOR `{:app-db v}` (test frame minted); with
    neither, structural rendering proceeds and any `sub` raises
    `:rf.error/no-frame-context` — honest, not defaulted.
-2. **A literal root form** — the same grammar `mount` takes, top-region wrappers
-   included. Then:
+2. **A literal root form** — the same literal top-region grammar `mount` takes,
+   wrappers included, tightened to exactly **one mounted view** per test root
+   (§1.1's authored-`:root-id` multi-view allowance does not apply here; two views →
+   `:rf.ui.compile/bad-test-root`, remedy: wrap the composition in one `defview`).
+   Then:
    - `{:props p}` is **rejected** (didactic: props live in the form);
    - the form's `frame-root` plans run preflight ENSURE against the test registrar,
      minting fresh test frames from the plans;


### PR DESCRIPTION
Four post-merge review findings against the re-frame.ui guide tree (all discovered from the #5823 review, unblocked by #5826). One commit per bead; anchors re-located by content on fresh origin/main (post-#5826 line numbers).

## rf2-vxgfnd.130 — bare `frame` convention (guide 05)

The README rules that view body forms, `frame` included, are referred bare — "one convention, every chapter" — yet guide 05 spelled the ops map `(ui/frame)` in two places (the prose introducing the ops map, and the `error-reporter` fence). Both now read `(frame)`, matching the section's own header. Verified: `rg '\(ui/frame\)' ai/findings/new-substrate-synthesis/guide` returns nothing.

## rf2-vxgfnd.127 — presence example resolves every head (guide 02)

The Chapter 02 presence fence defined `toast-tray` before `toast-card` while using `[toast-card …]` inside the tray — the compiler resolves view heads eagerly at `defview` expansion (`:rf.ui.compile/unresolved-head`, `implementation/ui/src/re_frame/ui/compiler/env.cljc`), so the copied fence would fail once `ui/presence` lands at S4. Reordered so `toast-card` comes first (no `declare` ceremony), with a one-clause bridge in the lead-in so the leaf-first order reads as intentional.

## rf2-vxgfnd.129 — `ui.test/render` exact-one-view cardinality (guide 09 + spec 004C §9)

Guide 09 said `render` takes "the same grammar `mount` accepts" — true for the literal top-region grammar, but silent on the deliberate Tier-1 tightening: a test root mounts exactly one view (root identity is that view's id), where `mount` will take a multi-view form under an authored `:root-id`. The guide now states the tightening, names `:rf.ui.compile/bad-test-root`, and gives the one-sentence wrapper-`defview` remedy.

**Spec 004C §9 edit included.** §9 form 2 used the same unqualified shorthand ("the same grammar `mount` takes"). spec/004C is hot-zone, so I checked ownership first: the only open PR (#5818, worker/q4uh2p-destroy-contract) touches spec/002/009/012/Runtime-*/Spec-Schemas but **not** 004C, and no other worker owns it — so the one-sentence qualifier rides here (cross-referencing §1.1's authored-`:root-id` allowance). The public `render` docstring already carries the wording ("exactly ONE mounted view") — no implementation change.

**Executable evidence** (JVM, `implementation/ui`, this branch):

```
(macroexpand '(ui.test/render [:<> [a] [b]] {}))
;; => ex-data {:rf.ui.compile/error :rf.ui.compile/bad-test-root, :view-ids [:evidence3/a :evidence3/b]}
;;    "a root form mounts exactly ONE view — root identity is the mounted view's id; this form has 2.
;;     Keep one mounted view (a fragment of two views has no single identity)"

(defview wrapper [] [:<> [a] [b]])
(macroexpand '(ui.test/render [wrapper] {}))  ;; expands OK
```

## rf2-vxgfnd.128 — retire the non-injective root slug (guide 08 + two drafts)

Guide 08 and the two retained drafts (`drafts/root-identity-and-mount.md` — the copy source — and `drafts/ui-react-interop-contract.md`) still taught the retired lossy default: `:page/shop` → `"rf2-page-shop-"`, "any character outside `[A-Za-z0-9_-]` normalised to `-`". That rule is non-injective (`:a/b-c` and `:a-b/c` both flatten to `a-b-c`), and `identifierPrefix` participates in SSR/hydration identity. All three now teach the injective typed escape normative in spec/004C §1, verified against the actual implementation before writing:

```
(root/root-id-slug :page/shop)                  ;; => "page_Sshop"
(root/root-id-slug [:shop/app :left])            ;; => "_V_Kshop_Sapp_Kleft"
(root/default-identifier-prefix :page/shop)      ;; => "rf2-page_Sshop-"
```

The draft's competing algorithm paragraph is replaced with the normative description plus an explicit pointer to spec/004C §1 (and a note retiring the old rule). Authored `:identifier-prefix` examples (e.g. 06 §2's `"rf2-shop-"`) are untouched — they remain documented as authored values, not derived defaults. Pre-fix sweep and post-fix `grep -rn 'rf2-page-shop|shop-app--left|normalised to \`-\`'` over the synthesis tree: clean.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0.
- `implementation/ui` JVM suite (`clojure -M:test`): 394 tests, 5244 assertions, 0 failures — includes the root slug/injectivity tests (.128 acceptance).
- Docs-only diff (guide + 2 drafts + one spec/004C sentence); no runtime, compiler, or API change.
