### PR TITLE
rf2-vxgfnd.106: implement the frozen S2 ui/lease ownership contract

### DIFF
--- a/implementation/core/src/re_frame/adapter/resource_lease.cljs
+++ b/implementation/core/src/re_frame/adapter/resource_lease.cljs
@@ -61,6 +61,7 @@
     settles to exactly one held lease, matching the committed instance."
   (:require ["react" :as React]
             [re-frame.frame  :as frame]
+            [re-frame.resource-lease-owner :as lease-owner]
             [re-frame.router :as router]))
 
 ;; ============================================================================
@@ -80,23 +81,16 @@
 ;; family's still-live resource. A single source of owner identity removes the
 ;; collision by construction.
 
-(defonce ^:private lease-owner-counter
-  ;; Monotone per-runtime counter minting a globally-unique lease token — the
-  ;; SOLE lease-owner counter in the framework (mirrors the spine's
-  ;; `unmount-instance-counter`). Two components leasing the same resource+scope
-  ;; hold INDEPENDENT leases (releasing one never drops the other), AND two
-  ;; components from DIFFERENT adapter families can never collide on one owner.
-  (atom 0))
-
 (defn mint-lease-owner!
   "Mint a fresh, process-unique resource-lease OWNER in the framework-canonical
   `[:lease <n>]` shape (Spec 016 §Active owners). THE single owner mint for
   every adapter family (rf2-qdkt8y): two owners minted anywhere in one process
   are always distinct, so a mixed-adapter process can never collide two
   families' leases on one owner. Framework-internal — not part of the public
-  adapter surface."
+  adapter surface. Kept as the legacy helper's internal seam; the neutral mint
+  is owned by `re-frame.resource-lease-owner`."
   []
-  [:lease (swap! lease-owner-counter inc)])
+  (lease-owner/mint!))
 
 ;; ============================================================================
 ;; Shared ensure / release dispatch (one implementation, all families)

--- a/implementation/core/src/re_frame/resource_lease_owner.cljc
+++ b/implementation/core/src/re_frame/resource_lease_owner.cljc
@@ -13,7 +13,18 @@
   ;; reconciler prove the same ownership protocol headlessly on the JVM.
   (atom 0))
 
+(def ^:private mint-provenance
+  "RF2_RESOURCE_LEASE_OWNER_MINT_SENTINEL")
+
 (defn mint!
   "Mint a fresh process-unique framework resource owner `[:lease n]`."
   []
-  [:lease (swap! owner-counter inc)])
+  (let [n (swap! owner-counter inc)]
+    #?(:cljs
+       (when-not (and (pos? n) (js/Number.isSafeInteger n))
+         ;; Preserve the protocol's process-unique guarantee instead of
+         ;; silently minting duplicate IEEE-754 integers after precision loss.
+         ;; The stable message is also the compiled-positive/DCE provenance
+         ;; control for the lease-free advanced companion.
+         (throw (js/Error. mint-provenance))))
+    [:lease n]))

--- a/implementation/core/src/re_frame/resource_lease_owner.cljc
+++ b/implementation/core/src/re_frame/resource_lease_owner.cljc
@@ -7,9 +7,10 @@
   optional Resources artefact.")
 
 (defonce ^:private owner-counter
-  ;; One monotone source for the whole CLJS runtime. The canonical vector is
+  ;; One monotone source for the whole runtime process. The canonical vector is
   ;; public protocol data (Spec 016); the counter and this namespace are not a
-  ;; public application API.
+  ;; public application API. A .cljc home lets the host-agnostic ViewCell
+  ;; reconciler prove the same ownership protocol headlessly on the JVM.
   (atom 0))
 
 (defn mint!

--- a/implementation/core/src/re_frame/resource_lease_owner.cljs
+++ b/implementation/core/src/re_frame/resource_lease_owner.cljs
@@ -1,0 +1,18 @@
+(ns re-frame.resource-lease-owner
+  "Process-wide identity for framework-minted resource lease owners.
+
+  This namespace deliberately owns only identity. It has no React, adapter,
+  router, or Resources dependency, so every view family can share one mint
+  without coupling the first-party UI substrate to a legacy adapter or to the
+  optional Resources artefact.")
+
+(defonce ^:private owner-counter
+  ;; One monotone source for the whole CLJS runtime. The canonical vector is
+  ;; public protocol data (Spec 016); the counter and this namespace are not a
+  ;; public application API.
+  (atom 0))
+
+(defn mint!
+  "Mint a fresh process-unique framework resource owner `[:lease n]`."
+  []
+  [:lease (swap! owner-counter inc)])

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -24,6 +24,7 @@
             [re-frame.source-coord-dom-elision-prod-test]
             [re-frame.adapter.uix-source-coord-dom-elision-prod-test]
             [re-frame.adapter.helix-source-coord-dom-elision-prod-test]
+            [re-frame.ui.resource-lease-hook-matrix-elision-prod-test]
             [re-frame.on-error-elision-prod-test]
             ;; Per rf2-9pxj70 — the three EP-0008-promoted always-on
             ;; teardown / write-race rows

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -22,14 +22,34 @@ const IMPL = path.resolve(__dirname, '..');
 const OUT = path.join(IMPL, 'out');
 const DEV = path.join(OUT, 'ui-g13');
 const PROD = path.join(OUT, 'ui-g13-prod');
+const MINT_CONTROL = path.join(OUT, 'ui-g13-mint-control');
+const PROD_MANIFEST = path.join(PROD, 'manifest.edn');
 const REPORT = path.join(OUT, 'ui-g13.json');
 const TIMEOUT = 90000;
 const SENTINELS = [
   'RF2_G13_COUNTER_SENTINEL',
   'RF2_G13_PROFILER_SENTINEL',
   'RF2_G13_DEBUG_EVIDENCE_SENTINEL',
+  'RF2_UI_RESOURCE_LEASE_EVIDENCE_SENTINEL',
   '__RF2_G13_RESULT_SENTINEL__',
 ];
+const LEASE_FREE_FORBIDDEN = [
+  'rf.resource/ensure',
+  'rf.resource/release-owner',
+  'RF2_UI_RESOURCE_LEASE_EVIDENCE_SENTINEL',
+  'resources/reg-resource',
+];
+const RESOURCE_BOOKKEEPING_FORBIDDEN = [
+  'resource-order',
+  'resource-by-site',
+  'resource-desired',
+  'resource-capture',
+  'resource-reservations',
+  'resource-held-order',
+  'resource-lifecycle',
+];
+const OWNER_MINT_SENTINEL = 'RF2_RESOURCE_LEASE_OWNER_MINT_SENTINEL';
+const OPTIONAL_RESOURCES_SENTINEL = 'rf.resource.internal/page-succeeded';
 
 function fail(message) {
   throw new Error(`G-13 FAIL: ${message}`);
@@ -87,13 +107,99 @@ function assertBundleElision() {
   if (release.status !== 'ok') {
     fail(`advanced companion bundle is ${release.status}, not inspectable`);
   }
+  const mintControl = classifyReleaseBundle(MINT_CONTROL);
+  if (mintControl.status !== 'ok') {
+    fail(`advanced mint control bundle is ${mintControl.status}, not inspectable`);
+  }
+  const prodManifest = fs.readFileSync(PROD_MANIFEST, 'utf8');
   assertNoProductionSentinels(release.blob);
-  return { devSentinelsPresent: SENTINELS, advancedSentinelsAbsent: SENTINELS };
+  assertLeaseFreeAdvanced(release.blob, null, mintControl.blob);
+  assertOptionalResourcesManifest(prodManifest);
+  return {
+    devSentinelsPresent: SENTINELS,
+    advancedSentinelsAbsent: SENTINELS,
+    leaseFreeAdvancedBytes: Buffer.byteLength(release.blob, 'utf8'),
+    ownerMintAdvancedControlBytes: Buffer.byteLength(mintControl.blob, 'utf8'),
+    leaseFreeForbiddenAbsent: LEASE_FREE_FORBIDDEN,
+    resourceBookkeepingAbsent: RESOURCE_BOOKKEEPING_FORBIDDEN,
+    ownerMintAdvancedControlPresent: OWNER_MINT_SENTINEL,
+    ownerMintSentinelAbsent: OWNER_MINT_SENTINEL,
+    optionalResourcesSentinelAbsent: OPTIONAL_RESOURCES_SENTINEL,
+    optionalResourcesManifestAbsent: 're_frame/resources.cljc and re_frame/resources/**',
+    uiDependencyBoundary: 'day8/re-frame2 present; day8/re-frame2-resources absent',
+  };
+}
+
+function assertOptionalResourcesManifest(manifest) {
+  if (!manifest.includes('re_frame/core_resources.cljc')) {
+    fail('advanced source manifest omitted core Resources façade positive control');
+  }
+  const optionalSource = manifest.match(/re_frame\/resources(?:\.cljc|\/)[^"\s]*/);
+  if (optionalSource) {
+    fail(`advanced source graph retained optional Resources source ${optionalSource[0]}`);
+  }
 }
 
 function assertNoProductionSentinels(blob) {
   for (const sentinel of SENTINELS) {
     if (blob.includes(sentinel)) fail(`advanced companion leaked ${sentinel}`);
+  }
+}
+
+function assertLeaseFreeAdvanced(blob, uiDepsOverride = null, mintControlBlob = null) {
+  const reactiveSource = fs.readFileSync(
+    path.join(IMPL, 'ui', 'src', 're_frame', 'ui', 'reactive.cljc'), 'utf8');
+  const ownerSource = fs.readFileSync(
+    path.join(IMPL, 'core', 'src', 're_frame', 'resource_lease_owner.cljc'), 'utf8');
+  const featuresSource = fs.readFileSync(
+    path.join(IMPL, 'core', 'src', 're_frame', 'features.cljc'), 'utf8');
+  const resourcesSource = fs.readFileSync(
+    path.join(IMPL, 'resources', 'src', 're_frame', 'resources.cljc'), 'utf8');
+  const uiDeps = uiDepsOverride || fs.readFileSync(
+    path.join(IMPL, 'ui', 'deps.edn'), 'utf8');
+  const source = `${reactiveSource}\n${featuresSource}`;
+  for (const token of LEASE_FREE_FORBIDDEN) {
+    if (!source.includes(token)) {
+      fail(`lease-free DCE positive-control source omitted ${token}`);
+    }
+    if (blob.includes(token)) {
+      fail(`lease-free advanced companion retained ${token}`);
+    }
+  }
+  for (const token of RESOURCE_BOOKKEEPING_FORBIDDEN) {
+    if (!reactiveSource.includes(token)) {
+      fail(`resource-bookkeeping positive-control source omitted ${token}`);
+    }
+    if (blob.includes(token)) {
+      fail(`lease-free advanced companion retained resource bookkeeping ${token}`);
+    }
+  }
+  for (const token of [
+    '(ns re-frame.resource-lease-owner',
+    '(defn mint!',
+    OWNER_MINT_SENTINEL,
+  ]) {
+    if (!ownerSource.includes(token)) {
+      fail(`owner-mint positive-control source omitted ${token}`);
+    }
+  }
+  if (!mintControlBlob || !mintControlBlob.includes(OWNER_MINT_SENTINEL)) {
+    fail(`advanced owner-mint control omitted sentinel ${OWNER_MINT_SENTINEL}`);
+  }
+  if (blob.includes(OWNER_MINT_SENTINEL)) {
+    fail(`lease-free advanced companion retained owner mint sentinel ${OWNER_MINT_SENTINEL}`);
+  }
+  if (!resourcesSource.includes(OPTIONAL_RESOURCES_SENTINEL)) {
+    fail(`optional Resources positive-control source omitted ${OPTIONAL_RESOURCES_SENTINEL}`);
+  }
+  if (blob.includes(OPTIONAL_RESOURCES_SENTINEL)) {
+    fail(`lease-free advanced companion retained optional Resources sentinel ${OPTIONAL_RESOURCES_SENTINEL}`);
+  }
+  if (!/day8\/re-frame2\s+\{/.test(uiDeps)) {
+    fail('UI dependency positive control omitted day8/re-frame2');
+  }
+  if (/day8\/re-frame2-resources\s+\{/.test(uiDeps)) {
+    fail('UI artefact dependency boundary retained day8/re-frame2-resources');
   }
 }
 
@@ -191,8 +297,42 @@ function assertMutationTeeth(result) {
     return expectMutationFailure(label, () => assertDevResult(changed));
   });
   const release = classifyReleaseBundle(PROD);
+  const mintControl = classifyReleaseBundle(MINT_CONTROL);
+  const prodManifest = fs.readFileSync(PROD_MANIFEST, 'utf8');
   red.push(expectMutationFailure('production instrumentation leak', () => {
     assertNoProductionSentinels(`${release.blob}\n${SENTINELS[0]}`);
+  }));
+  red.push(expectMutationFailure('lease-free resource reachability leak', () => {
+    assertLeaseFreeAdvanced(`${release.blob}\n${LEASE_FREE_FORBIDDEN[0]}`, null, mintControl.blob);
+  }));
+  red.push(expectMutationFailure('lease-free resource bookkeeping leak', () => {
+    assertLeaseFreeAdvanced(`${release.blob}\n${RESOURCE_BOOKKEEPING_FORBIDDEN[2]}`, null, mintControl.blob);
+  }));
+  red.push(expectMutationFailure('lease-free neutral owner mint reachability', () => {
+    assertLeaseFreeAdvanced(`${release.blob}\n${OWNER_MINT_SENTINEL}`, null, mintControl.blob);
+  }));
+  red.push(expectMutationFailure('owner mint advanced-control non-vacuity', () => {
+    assertLeaseFreeAdvanced(
+      release.blob,
+      null,
+      mintControl.blob.split(OWNER_MINT_SENTINEL).join('owner_control_removed'),
+    );
+  }));
+  red.push(expectMutationFailure('optional Resources runtime reachability', () => {
+    assertLeaseFreeAdvanced(`${release.blob}\n${OPTIONAL_RESOURCES_SENTINEL}`, null, mintControl.blob);
+  }));
+  const uiDeps = fs.readFileSync(path.join(IMPL, 'ui', 'deps.edn'), 'utf8');
+  red.push(expectMutationFailure('optional Resources dependency leak', () => {
+    assertLeaseFreeAdvanced(
+      release.blob,
+      `${uiDeps}\nday8/re-frame2-resources {:local/root "../resources"}`,
+      mintControl.blob,
+    );
+  }));
+  red.push(expectMutationFailure('optional Resources source-graph leak', () => {
+    assertOptionalResourcesManifest(
+      `${prodManifest}\n"re_frame/resources/internal/runtime.cljs"`,
+    );
   }));
   return red;
 }
@@ -226,7 +366,7 @@ async function main() {
   let tearingDown = false;
   try {
     shadow('compile', 'ui-g13');
-    shadow('release', 'ui-g13-prod');
+    shadow('release', 'ui-g13-prod', 'ui-g13-mint-control');
     writePage(DEV);
     writePage(PROD);
     const bundles = assertBundleElision();

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -796,6 +796,21 @@
     :closure-defines {goog.DEBUG false
                       re-frame.ui.g13.fixture/instrumentation? false}}}
 
+  ;; Compiled non-vacuity control for G-13's neutral owner-mint DCE proof.
+  ;; It uses the exact advanced options above but directly invokes mint!, so
+  ;; the scanner first proves the retained implementation's stable provenance
+  ;; sentinel before requiring it absent from the lease-free companion.
+  :ui-g13-mint-control
+  {:target :browser
+   :output-dir "out/ui-g13-mint-control"
+   :asset-path "."
+   :modules {:main {:entries [re-frame.resource-lease-owner]
+                    :init-fn re-frame.resource-lease-owner/mint!}}
+   :compiler-options
+   {:optimizations :advanced
+    :infer-externs :auto
+    :closure-defines {goog.DEBUG false}}}
+
   ;; rf2-2hrj8 — `:browser-test` is narrowed to DOM-dependent tests only.
   ;; The ns-regexp `-dom-cljs-test$` matches files whose namespace ends in
   ;; `-dom-cljs-test` (i.e. files named `*_dom_cljs_test.cljs`). The

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -51,6 +51,7 @@
   #?(:cljs (:require-macros [re-frame.ui]))
   (:refer-clojure :exclude [spread])
   (:require [re-frame.error :as error]
+            [re-frame.ui.lease]
             [re-frame.ui.reactive :as reactive]
             #?@(:clj  [[re-frame.ui.compiler :as compiler]
                        [re-frame.ui.compiler.root :as root]
@@ -264,15 +265,21 @@
    {:extra {:query query}}))
 
 (defn lease
-  "(lease descriptor) — declares resource liveness at a view site.
-  Grammar-only at S1; lands with the S2 observation slice."
+  "Compiler-owned `(lease descriptor)` authoring form.
+
+  Accepted direct leading declarations in `defview` lower to a compact
+  site-bearing internal capture on CLJS and pure descriptor validation on the
+  JVM. This var exists for symbol resolution only. A direct call—including a
+  helper or macro-hidden call the view compiler cannot index—fails loudly; the
+  runtime never invents an invisible dynamic ownership site."
   [descriptor]
-  #?(:clj  (error/throw-error!
-            :rf.error/ui-lease-unavailable 're-frame.ui/lease
-            (str "(lease " (pr-str descriptor) ") — leases land with the S2 "
-                 "observation slice")
-            {:extra {:descriptor descriptor}})
-     :cljs (runtime/lease* descriptor)))
+  (error/throw-error!
+   :rf.error/ui-tree-malformed 're-frame.ui/lease
+   (str "(ui/lease " (pr-str descriptor)
+        ") executed outside compiler lowering — ui/lease is a lexical "
+        "defview declaration, not a callable ownership helper. Put the direct "
+        "lease form before the view's final template")
+   {:extra {:descriptor descriptor :recovery :use-leading-lease-declaration}}))
 
 ;; ---------------------------------------------------------------------------
 ;; Interop compile forms — recognized by the analyzer in templates; the

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -51,7 +51,7 @@
   #?(:cljs (:require-macros [re-frame.ui]))
   (:refer-clojure :exclude [spread])
   (:require [re-frame.error :as error]
-            [re-frame.ui.lease]
+            [re-frame.ui.lease-descriptor]
             [re-frame.ui.reactive :as reactive]
             #?@(:clj  [[re-frame.ui.compiler :as compiler]
                        [re-frame.ui.compiler.root :as root]
@@ -275,11 +275,11 @@
   [descriptor]
   (error/throw-error!
    :rf.error/ui-tree-malformed 're-frame.ui/lease
-   (str "(ui/lease " (pr-str descriptor)
-        ") executed outside compiler lowering — ui/lease is a lexical "
+   (str "ui/lease executed outside compiler lowering — it is a lexical "
         "defview declaration, not a callable ownership helper. Put the direct "
         "lease form before the view's final template")
-   {:extra {:descriptor descriptor :recovery :use-leading-lease-declaration}}))
+   {:recovery :use-leading-lease-declaration
+    :extra {:descriptor-summary (error/diag-value-summary descriptor)}}))
 
 ;; ---------------------------------------------------------------------------
 ;; Interop compile forms — recognized by the analyzer in templates; the

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -56,7 +56,8 @@
   ([id msg data] (throw (env/compile-error id msg data))))
 
 (defn- parse-defview-forms
-  "[docstring? opts-map? argv template] with exactly one template form."
+  "Parse `[docstring? opts-map? argv & body]`. The body is partitioned after
+  symbol resolution into a leading lease-declaration prefix plus one template."
   [vname forms]
   (let [[docstring forms] (if (string? (first forms))
                             [(first forms) (rest forms)]
@@ -78,13 +79,6 @@
                  "template, but the argument vector is missing — write "
                  "(defview " vname " [] " (pr-str argv) ") for a zero-prop view")
             {:view vname}))
-    (when (not= 1 (count body))
-      (fail :rf.ui.compile/multi-form-body
-            (str "defview " vname ": the body is exactly ONE template form "
-                 "(got " (count body) ") — a view is a pure (props) -> "
-                 "template; siblings wrap in [:<> ...], computation goes in "
-                 "(let ...)")
-            {:view vname}))
     (let [unknown (remove defview-option-keys (keys opts))]
       (when (seq unknown)
         (fail :rf.ui.compile/unknown-option
@@ -102,7 +96,37 @@
               (str "defview " vname ": :id override must be a qualified "
                    "keyword; got " (pr-str id))
               {:view vname :id id})))
-    {:docstring docstring :opts opts :argv argv :template (first body)}))
+    {:docstring docstring :opts opts :argv argv :body body}))
+
+(defn- split-defview-body
+  "Return `[lease-forms template]` for the closed v1 body grammar:
+
+      direct-resolved-lease* final-template
+
+  A conditional lease keeps the declaration direct and makes its descriptor
+  conditional. No arbitrary statement body is opened."
+  [e vname body]
+  (loop [leases [] forms (seq body)]
+    (cond
+      (nil? forms)
+      (fail :rf.ui.compile/multi-form-body
+            (str "defview " vname ": leading lease declarations must be "
+                 "followed by exactly ONE template form")
+            {:view vname})
+
+      (ana/lease-declaration-form? e (first forms))
+      (recur (conj leases (first forms)) (next forms))
+
+      (next forms)
+      (fail :rf.ui.compile/multi-form-body
+            (str "defview " vname ": after zero or more direct leading "
+                 "(lease descriptor) declarations, the body has exactly ONE "
+                 "template form (got " (count forms) " remaining). Conditional "
+                 "liveness is (lease (when p descriptor)); siblings wrap in "
+                 "[:<> ...], computation goes in (let ...)")
+            {:view vname})
+
+      :else [leases (first forms)])))
 
 (defn- capabilities [ast]
   (let [caps (volatile! #{})]
@@ -157,7 +181,7 @@
           {:view vname}))
   (let [cljs?   (some? (:ns menv))
         ns-sym  (if cljs? (-> menv :ns :name) (ns-name *ns*))
-        {:keys [docstring opts argv template]} (parse-defview-forms vname forms)
+        {:keys [docstring opts argv body]} (parse-defview-forms vname forms)
         view-id (or (:id opts) (keyword (str ns-sym) (str vname)))
         hdr     (header/parse-header argv)
         schema-keys (header/props-schema-keys (:props opts))
@@ -192,19 +216,29 @@
                                     ;; reacquires instead of transferring an
                                     ;; ordinal to another lexical site.
                                     :template-anchor
-                                    (fingerprint/digest "sta1-" template)})
+                                    (fingerprint/digest "sta1-" body)})
                     (assoc :self-children? children?
                            :self-closed-keys closed-keys))
         _       (ana/reject-reactive-binding! e0 argv)
         e       (env/with-locals e0 header-syms)
+        [lease-forms template] (split-defview-body e vname body)
+        lease-declarations
+        (mapv #(ana/analyze-lease-declaration e %1 %2)
+              (range) lease-forms)
         ast     (ana/analyze e template)
         _       (doseq [w @(:warnings e)]
                   (binding [*out* *err*]
                     (println (str "WARNING re-frame.ui [" view-id "] "
                                   (:id w) ": " (:msg w)))))
         sites   @(:sites e)
+        ast-projection (ana/template-fingerprint-projection ast)
         tf      (fingerprint/template-fingerprint
-                 (ana/template-fingerprint-projection ast))
+                 (if (seq lease-declarations)
+                   {:leases (mapv (comp ana/template-fingerprint-projection
+                                        :descriptor)
+                                  lease-declarations)
+                    :template ast-projection}
+                   ast-projection))
         hs      (fingerprint/hook-signature-hash {:locals [] :effects []})
         manifest {:view-id view-id
                   :display-name display-name
@@ -224,7 +258,8 @@
                   :as? (= :as (:mode hdr))
                   :template-fingerprint tf
                   :hook-signature hs
-                  :capabilities (capabilities ast)
+                  :capabilities (cond-> (capabilities ast)
+                                  (seq lease-declarations) (conj :lease))
                   :sites sites}
         args    {:vname vname
                  :view-id view-id
@@ -232,6 +267,7 @@
                  :docstring docstring
                  :header hdr
                  :slots slots
+                 :lease-declarations lease-declarations
                  :ast ast
                  :manifest manifest
                  :closed-keys closed-keys

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -258,8 +258,7 @@
                   :as? (= :as (:mode hdr))
                   :template-fingerprint tf
                   :hook-signature hs
-                  :capabilities (cond-> (capabilities ast)
-                                  (seq lease-declarations) (conj :lease))
+                  :capabilities (capabilities ast)
                   :sites sites}
         args    {:vname vname
                  :view-id view-id

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -151,6 +151,80 @@
    [1 (:self-id e) kind (relative-source-anchor e form)
     (:path e) (vec expr-path)]))
 
+(declare rewrite-expr)
+
+(defn lease-declaration-form?
+  "True when `form` is a direct, unshadowed call resolving to public
+  `re-frame.ui/lease`. Only such forms may occupy defview's leading lease
+  declaration prefix; helper calls and macro-produced calls are never granted
+  an invisible ownership site."
+  [e form]
+  (and (seq? form)
+       (symbol? (first form))
+       (not (contains? (:locals e) (first form)))
+       (env/resolves-to? e (first form) lease-fqns)))
+
+(defn- compile-time-lease-descriptor!
+  "Validate the statically knowable portion of one descriptor. Dynamic
+  expressions defer to the host-neutral runtime validator; literal map keys
+  and literal resource ids fail at compile time."
+  [e descriptor]
+  (cond
+    (nil? descriptor) nil
+
+    (map? descriptor)
+    (let [allowed  #{:resource :scope :params}
+          unknown  (seq (sort-by pr-str (remove allowed (keys descriptor))))
+          resource (:resource descriptor)
+          dynamic-resource? (or (symbol? resource) (seq? resource))]
+      (when unknown
+        (env/fail! e :rf.ui.compile/unsupported-form
+                   (str "a lease descriptor contains unknown key"
+                        (when (next unknown) "s") " " (pr-str (vec unknown))
+                        " — the v1 map is closed to :resource, :scope, and :params")
+                   {:form descriptor :unknown (vec unknown)}))
+      (when-not (contains? descriptor :resource)
+        (env/fail! e :rf.ui.compile/unsupported-form
+                   "a lease descriptor requires :resource"
+                   {:form descriptor}))
+      (when (and (not dynamic-resource?)
+                 (not (and (keyword? resource) (namespace resource))))
+        (env/fail! e :rf.ui.compile/unsupported-form
+                   (str "a lease descriptor's :resource must be a qualified "
+                        "keyword; got " (pr-str resource))
+                   {:form descriptor :resource resource})))
+
+    ;; A symbol/call may evaluate to nil or a descriptor at render time.
+    (or (symbol? descriptor) (seq? descriptor)) nil
+
+    :else
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "a lease descriptor must evaluate to nil or a closed map; "
+                    "the literal " (pr-str descriptor) " cannot")
+               {:form descriptor}))
+  descriptor)
+
+(defn analyze-lease-declaration
+  "Analyze one direct leading `(lease descriptor)` declaration. Returns the
+  compact emitted site record; also appends the tool-rich manifest row.
+  Descriptor expression rewriting is evaluation-order/shadowing aware, so a
+  finite nested `sub` receives its own independent sid while any nested lease
+  is rejected by the ordinary expression rewriter."
+  [e index form]
+  (when-not (= 2 (count form))
+    (env/fail! e :rf.ui.compile/unsupported-form
+               "(lease descriptor) takes exactly one descriptor argument"
+               {:form form}))
+  (let [descriptor (compile-time-lease-descriptor! e (second form))
+        expr-path  [:lease-declarations index]
+        sid        (lexical-site-id e :lease form expr-path)
+        descriptor* (rewrite-expr e (conj expr-path :descriptor) descriptor)]
+    (env/add-site! e :leases {:sid sid
+                              :descriptor descriptor
+                              :path (:path e)
+                              :expr-path expr-path})
+    {:sid sid :descriptor descriptor*}))
+
 (defn- map-path-token [x]
   (fingerprint/digest "ep1-" x))
 
@@ -425,26 +499,21 @@
                         (env/fail! e :rf.ui.compile/unsupported-form
                                    "(lease descriptor) takes exactly one descriptor argument"
                                    {:form f}))
-                      (when (or (nil? (:self-id e))
-                                (:in-loop? e)
-                                (contains? locals deferred-scope))
+                      (if (or (nil? (:self-id e))
+                              (:in-loop? e)
+                              (contains? locals deferred-scope))
                         (env/fail! e :rf.ui.compile/lease-in-loop
                                    (str "(lease ...) must be a finite render-time site in "
                                         "a defview — it cannot run in a loop, deferred "
                                         "callback, raw-fn/ref body, or root expression. "
-                                        "Hoist the lease into the view body; for rows, "
+                                        "Move it into the leading lease declaration prefix; for rows, "
                                         "extract a keyed child view")
-                                   {:form f}))
-                     (let [sid (lexical-site-id e :lease f p)]
-                       (env/add-site! e :leases {:sid sid :descriptor (second f)
-                                                 :path (:path e) :expr-path (vec p)})
-                       ;; Runtime lease lowering belongs to .106. Rebuild now so
-                       ;; sub sites nested in its descriptor still lower.
-                       (with-same-meta
-                         f
-                          (apply list head
-                                 (map-indexed #(rw %2 locals (conj p (inc %1)))
-                                             (rest f))))))
+                                   {:form f})
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   (str "(lease ...) is a declaration, not an expression — "
+                                        "put direct lease forms before the view's one final "
+                                        "template; conditional liveness is (lease (when p descriptor))")
+                                   {:form f})))
 
                    (fn-form? f) (rw-fn f locals p)
                    (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -448,10 +448,13 @@
 
 (defn emit-defview
   [{:keys [vname view-id display-name docstring header slots ast manifest
-           closed-keys children?]}]
+           closed-keys children? lease-declarations]}]
   (let [st         (new-state vname)
         body       (->> (emit-node ast st false)
                         (hoist-literal-sub-queries st))
+        leases     (mapv #(update % :descriptor
+                                  (partial hoist-literal-sub-queries st))
+                          lease-declarations)
         binds      (vec (header-bindings header))
         render-sym (symbol (str (name vname) "$render"))
         host-render-sym (symbol (str (name vname) "$host_render"))
@@ -461,7 +464,22 @@
         ;; view uses the host wrapper below; a sub-free view goes straight from
         ;; React.memo to the raw body with zero ViewCell hooks.
         has-subs?  (boolean (seq (:subs (:sites manifest))))
-        inner      (if (seq binds) `(let [~@binds] ~body) body)
+        has-leases? (boolean (seq leases))
+        lease-binds (vec
+                     (mapcat (fn [{:keys [sid descriptor]}]
+                               [(gensym "lease")
+                                `(re-frame.ui.reactive/lease-site
+                                  ~sid ~descriptor)])
+                             leases))
+        rendered   (if (seq lease-binds)
+                     `(let [~@lease-binds] ~body)
+                     body)
+        inner      (if (seq binds) `(let [~@binds] ~rendered) rendered)
+        host-render (cond
+                      (and has-subs? has-leases?)
+                      're-frame.ui.viewcell/render-subs-and-leases
+                      has-subs? 're-frame.ui.viewcell/render-subs
+                      has-leases? 're-frame.ui.viewcell/render-leases)
         var-meta   (cond-> {:rf.ui/view true
                             :rf.ui/view-id view-id
                             :rf.ui/children? children?}
@@ -471,9 +489,9 @@
        ~@(:defs @st)
        (defn ~render-sym [~props-sym]
          ~inner)
-       ~@(when has-subs?
+       ~@(when host-render
            [`(defn ~host-render-sym [~props-sym]
-               (re-frame.ui.viewcell/render
+               (~host-render
                 ~view-id (fn [] (~render-sym ~props-sym))))])
        (def ~(vary-meta vname merge var-meta)
          (let [compare# ~(comparator-form header slots)]
@@ -484,6 +502,6 @@
              ;; folds away the sibling registration arm and with it every HMR
              ;; slot/listener/dynamic-lookup/extra-Fiber helper.
              (re-frame.ui.runtime/memo-view
-              ~(if has-subs? host-render-sym render-sym)
+              ~(if host-render host-render-sym render-sym)
               compare# ~display-name))))
        ~vname)))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -240,7 +240,7 @@
         (vec
          (mapcat (fn [{:keys [descriptor]}]
                    [(gensym "lease")
-                    `(re-frame.ui.lease/validate-descriptor! ~descriptor)])
+                    `(re-frame.ui.lease-descriptor/validate-descriptor! ~descriptor)])
                  lease-declarations))
         rendered (if (seq lease-binds)
                    `(let [~@lease-binds] ~body)

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -232,9 +232,19 @@
 ;; ---------------------------------------------------------------------------
 
 (defn emit-defview
-  [{:keys [vname view-id docstring header ast manifest closed-keys children?]}]
+  [{:keys [vname view-id docstring header ast manifest closed-keys children?
+           lease-declarations]}]
   (let [body     (emit-node ast)
         bind     (:binding-form header)
+        lease-binds
+        (vec
+         (mapcat (fn [{:keys [descriptor]}]
+                   [(gensym "lease")
+                    `(re-frame.ui.lease/validate-descriptor! ~descriptor)])
+                 lease-declarations))
+        rendered (if (seq lease-binds)
+                   `(let [~@lease-binds] ~body)
+                   body)
         var-meta (cond-> {:rf.ui/view true
                           :rf.ui/view-id view-id
                           :rf.ui/children? children?}
@@ -245,6 +255,6 @@
          (re-frame.ui.tree/view-boundary
           ~view-id
           ~props-sym
-          ~(if bind `(let [~bind ~props-sym] ~body) body)))
+          ~(if bind `(let [~bind ~props-sym] ~rendered) rendered)))
        (re-frame.ui.tree/register-view! ~view-id ~vname (quote ~manifest))
        (var ~vname))))

--- a/implementation/ui/src/re_frame/ui/lease.cljc
+++ b/implementation/ui/src/re_frame/ui/lease.cljc
@@ -1,0 +1,61 @@
+(ns re-frame.ui.lease
+  "Internal descriptor grammar for compiled `ui/lease` sites.
+
+  Validation is host-neutral and side-effect-free: the JVM emitter evaluates
+  and validates declarations but never acquires a resource, while the CLJS
+  capture path validates before it records a desired site."
+  (:require [re-frame.error :as error]))
+
+(def descriptor-keys
+  "The closed v1 descriptor vocabulary. Internal compiler/test seam."
+  #{:resource :scope :params})
+
+(defn valid-resource-id?
+  [x]
+  (and (keyword? x) (some? (namespace x))))
+
+(defn validate-descriptor!
+  "Return `descriptor` unchanged when it is nil (inactive) or a valid closed
+  resource descriptor. Fail loudly before capture/dispatch otherwise.
+
+  Optional key presence is deliberately preserved: omitted `:params` and
+  explicit `:params nil` are distinct payloads."
+  [descriptor]
+  (cond
+    (nil? descriptor) nil
+
+    (not (map? descriptor))
+    (error/throw-error!
+     :rf.error/ui-tree-malformed 're-frame.ui/lease
+     (str "a lease descriptor must be nil or a map; got "
+          (pr-str descriptor))
+     {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+
+    :else
+    (let [unknown (seq (remove descriptor-keys (keys descriptor)))
+          resource (:resource descriptor)]
+      (cond
+        unknown
+        (error/throw-error!
+         :rf.error/ui-tree-malformed 're-frame.ui/lease
+         (str "a lease descriptor contains unknown key"
+              (when (next unknown) "s") " " (pr-str (vec unknown))
+              "; the v1 map is closed to :resource, :scope, and :params")
+         {:extra {:descriptor descriptor
+                  :unknown (vec unknown)
+                  :recovery :fix-lease-descriptor}})
+
+        (not (contains? descriptor :resource))
+        (error/throw-error!
+         :rf.error/ui-tree-malformed 're-frame.ui/lease
+         "a lease descriptor requires :resource"
+         {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+
+        (not (valid-resource-id? resource))
+        (error/throw-error!
+         :rf.error/ui-tree-malformed 're-frame.ui/lease
+         (str "a lease descriptor's :resource must be a qualified keyword; got "
+              (pr-str resource))
+         {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+
+        :else descriptor))))

--- a/implementation/ui/src/re_frame/ui/lease_descriptor.cljc
+++ b/implementation/ui/src/re_frame/ui/lease_descriptor.cljc
@@ -1,9 +1,11 @@
-(ns re-frame.ui.lease
+(ns re-frame.ui.lease-descriptor
   "Internal descriptor grammar for compiled `ui/lease` sites.
 
   Validation is host-neutral and side-effect-free: the JVM emitter evaluates
   and validates declarations but never acquires a resource, while the CLJS
-  capture path validates before it records a desired site."
+  capture path validates before it records a desired site. The namespace name
+  deliberately differs from the public `re-frame.ui/lease` var so their CLJS
+  names cannot occupy the same generated JavaScript property."
   (:require [re-frame.error :as error]))
 
 (def descriptor-keys
@@ -27,12 +29,13 @@
     (not (map? descriptor))
     (error/throw-error!
      :rf.error/ui-tree-malformed 're-frame.ui/lease
-     (str "a lease descriptor must be nil or a map; got "
-          (pr-str descriptor))
-     {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+     "a lease descriptor must be nil or a closed map"
+     {:recovery :fix-lease-descriptor
+      :extra {:descriptor-summary (error/diag-value-summary descriptor)}})
 
     :else
-    (let [unknown (seq (remove descriptor-keys (keys descriptor)))
+    (let [unknown (seq (sort-by pr-str
+                                (remove descriptor-keys (keys descriptor))))
           resource (:resource descriptor)]
       (cond
         unknown
@@ -41,21 +44,23 @@
          (str "a lease descriptor contains unknown key"
               (when (next unknown) "s") " " (pr-str (vec unknown))
               "; the v1 map is closed to :resource, :scope, and :params")
-         {:extra {:descriptor descriptor
-                  :unknown (vec unknown)
-                  :recovery :fix-lease-descriptor}})
+         {:recovery :fix-lease-descriptor
+          :extra {:descriptor-keys (-> descriptor error/diag-value-summary :keys)
+                  :unknown (vec unknown)}})
 
         (not (contains? descriptor :resource))
         (error/throw-error!
          :rf.error/ui-tree-malformed 're-frame.ui/lease
          "a lease descriptor requires :resource"
-         {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+         {:recovery :fix-lease-descriptor
+          :extra {:descriptor-keys (-> descriptor error/diag-value-summary :keys)}})
 
         (not (valid-resource-id? resource))
         (error/throw-error!
          :rf.error/ui-tree-malformed 're-frame.ui/lease
-         (str "a lease descriptor's :resource must be a qualified keyword; got "
-              (pr-str resource))
-         {:extra {:descriptor descriptor :recovery :fix-lease-descriptor}})
+         "a lease descriptor's :resource must be a qualified keyword"
+         {:recovery :fix-lease-descriptor
+          :extra {:descriptor-keys (-> descriptor error/diag-value-summary :keys)
+                  :resource-summary (error/diag-value-summary resource)}})
 
         :else descriptor))))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -127,13 +127,17 @@
   unreachable garbage. The memo is an ECONOMY, never an authority — the commit
   evidence comparison (step 5) corrects any staleness before paint."
   (:require [re-frame.error :as error]
+            [re-frame.features :as features]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
             [re-frame.registrar :as registrar]
+            [re-frame.resource-lease-owner :as lease-owner]
+            [re-frame.router :as router]
             [re-frame.substrate.observation :as obs]
             [re-frame.subs.override-schema :as override-schema]
-            [re-frame.ui.eq :as eq]))
+            [re-frame.ui.eq :as eq]
+            [re-frame.ui.lease-descriptor :as ui-lease]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -265,7 +269,9 @@
 
 (defn- fresh-capture
   [generation]
-  {:generation generation :order [] :by-site {}})
+  {:generation generation
+   :order []
+   :by-site {}})
 
 (defn- target-key
   [target]
@@ -368,6 +374,13 @@
   ;;                             ; disconnect for exact query/value reuse and
   ;;                             ; hidden-cell frame attribution; absence means
   ;;                             ; the site was conditional/dropped
+  ;;    :resources {...}        ; ABSENT on no-lease cells. Lease-capable
+  ;;                             ; wrappers install one lazy nested state map
+  ;;                             ; carrying desired/capture/reservations/held
+  ;;    :extra-frame-incarnations {frame-id #{token ...}}
+  ;;                             ; ABSENT on no-lease cells; generic frame
+  ;;                             ; teardown index maintained with :resources
+  ;;    :on-teardown fn         ; ABSENT on no-lease cells; capability cleanup
   ;;    :revision  int           ; get-snapshot returns this (useSyncExternalStore)
   ;;    :dirty?    bool          ; pending-notification flag (drain coalescing)
   ;;    :evidence  ev|nil        ; DEBUG-only bounded causal evidence for the
@@ -391,17 +404,18 @@
   ([view-id] (make-cell view-id 0))
   ([view-id generation]
    (->ViewCell
-     (atom {:view-id        view-id
-            :generation     generation
-            :lifecycle      :fresh
-            :root           nil
-            :disconnect-provisional? false
-            :committed      {}
-            :revision       0
-            :dirty?         false
-            :evidence       nil
-            :listeners      {}
-            :intervals      []}))))
+     (atom
+      (cond-> {:view-id        view-id
+               :generation     generation
+               :lifecycle      :fresh
+               :root           nil
+               :disconnect-provisional? false
+               :committed      {}
+               :revision       0
+               :dirty?         false
+               :evidence       nil
+               :listeners      {}
+               :intervals      []})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dev-only view slots — stable shell + exact body revision (03 §10)
@@ -705,6 +719,62 @@
          (vswap! capture record-site sid query* target ev v*)
          v*)
        v))))
+
+(defn- record-resource-site
+  "Record one active compiler-indexed resource declaration in `cap`.
+  Resource ownership is lexical-site keyed: equal descriptors at two sites
+  deliberately remain two independent owners."
+  [cap sid record]
+  (if (or (contains? (:resource-by-site cap) sid)
+          (contains? (:by-site cap) sid))
+    (error/throw-error!
+     :rf.error/ui-tree-malformed
+     're-frame.ui.reactive/lease-site
+     (str "compiler lexical site id " (pr-str sid)
+          " executed more than once in one render capture")
+     {:extra {:site-id sid
+              :descriptor-keys (-> record :descriptor
+                                   error/diag-value-summary :keys)
+              :resource-id (get-in record [:descriptor :resource])}})
+    (-> cap
+        (update :resource-order (fnil conj []) sid)
+        (assoc-in [:resource-by-site sid] record))))
+
+(defn lease-site
+  "Compiler-only render bridge for `(ui/lease descriptor)`.
+
+  Validates the closed descriptor before recording anything. `nil` is an
+  inactive declaration and records no desired ownership. An active site pins
+  the ambient frame's exact incarnation in the immutable render capture; it
+  never mints an owner or dispatches. Layout commit accepts/rejects that exact
+  capture, and the later passive resource reconciler alone changes ownership."
+  [sid descriptor]
+  (let [descriptor (ui-lease/validate-descriptor! descriptor)
+        {:keys [cell capture]} @ambient]
+    (when (or (nil? cell) (nil? capture) (nil? sid))
+      (error/throw-error!
+       :rf.error/ui-tree-malformed
+       're-frame.ui.reactive/lease-site
+       "compiled lease-site must execute once with a non-nil lexical id inside its ViewCell capture"
+       {:extra {:site-id sid
+                :descriptor-summary (error/diag-value-summary descriptor)}}))
+    (when (some? descriptor)
+      (let [frame-id    (frame/require-current-frame!
+                         :lease {:where 're-frame.ui/lease})
+            frame-token (frame/frame-incarnation-token frame-id)]
+        (when (or (nil? frame-token)
+                  (frame/frame-incarnation-closing? frame-id frame-token))
+          (error/throw-error!
+           :rf.error/frame-destroyed
+           're-frame.ui.reactive/lease-site
+           (str "resource lease site targeted absent or closing frame "
+                (pr-str frame-id))
+           {:extra {:frame frame-id :site-id sid}}))
+        (vswap! capture record-resource-site sid
+                {:descriptor descriptor
+                 :frame-id frame-id
+                 :frame-token frame-token})))
+    nil))
 
 (defn with-capture
   "Run `thunk` (a compiled view body) under a fresh ambient capture and return
@@ -1182,6 +1252,10 @@
 (defn- cell-frames
   "The set of frame-ids `cell`'s committed subscription sites observe.
 
+  Resource leases are liveness ownership, not read observation. Their exact
+  frame-incarnation index participates in teardown discovery only; it must not
+  put a resource-only frame into `flush-frame!` scope.
+
   Only records with a live lease are currently observed. A static Story-
   override target names NO frame (the pinned value IS the
   resolution — there is no node and no observed frame), so an OVERRIDE-ONLY
@@ -1207,12 +1281,20 @@
   "True when `cell`'s last published lexical site records name `frame-id`.
   Records survive an Activity disconnect with `:lease nil`, providing bounded
   exact query/value history plus frame attribution for hidden root-owned cells."
-  [^ViewCell cell frame-id]
-  (boolean
-    (some (fn [{:keys [target]}]
-            (and (= :subscription (:kind target))
-                 (= frame-id (:frame-id target))))
-          (vals (:committed @(state cell))))))
+  ([^ViewCell cell frame-id]
+   (cell-retained-frame? cell frame-id ::any-incarnation))
+  ([^ViewCell cell frame-id frame-token]
+   (let [st @(state cell)
+         observation?
+         (some (fn [{:keys [target]}]
+                 (and (= :subscription (:kind target))
+                      (= frame-id (:frame-id target))))
+               (vals (:committed st)))
+         extra-tokens (get (:extra-frame-incarnations st) frame-id)
+         extra? (and (seq extra-tokens)
+                     (or (= ::any-incarnation frame-token)
+                         (some #(identical? frame-token %) extra-tokens)))]
+     (boolean (or observation? extra?)))))
 
 (defn flush-frame!
   "The FRAME arity of `flush!` — flush every pending cell observing frame
@@ -1319,6 +1401,386 @@
       (record-evidence! cell payload))
     (enrol-dirty! cell)))
 
+;; ---- resource ownership family -------------------------------------------
+;;
+;; Resource leases share the ViewCell/exact render capture and lifecycle with
+;; observation leases, but deliberately do NOT participate in the observation
+;; port's acquire transaction. Layout accepts an ownership-free desired plan;
+;; one passive effect prevalidates the COMPLETE plan and queues ordinary
+;; resource events. There is no cross-frame handler rollback or sync dispatch.
+
+(defn- resource-frame-index
+  "Generic teardown index for every desired/reserved/held resource record.
+  Kept outside the base ViewCell shape: no-lease cells have no index key."
+  [{:keys [resource-desired resource-reservations resource-held]}]
+  (reduce (fn [out {:keys [frame-id frame-token]}]
+            (update out frame-id (fnil conj #{}) frame-token))
+          {}
+          (concat (vals (:by-site resource-desired))
+                  (vals resource-reservations)
+                  (vals resource-held))))
+
+(defn- install-resource-state
+  [m resources]
+  (assoc m
+         :resources resources
+         :extra-frame-incarnations (resource-frame-index resources)))
+
+(defn- resource-capture-current?
+  [st cap]
+  (let [resources (:resources st)]
+    (and (= :connected (:lifecycle st))
+         (= (:generation cap) (:generation st))
+         (identical? cap (:resource-capture resources)))))
+
+(defn- validate-resource-frame!
+  [{:keys [frame-id frame-token sid]}]
+  (when (or (not (identical? frame-token
+                             (frame/frame-incarnation-token frame-id)))
+            (frame/frame-incarnation-closing? frame-id frame-token))
+    (error/throw-error!
+     :rf.error/frame-destroyed
+     're-frame.ui/lease
+     (str "resource lease site " (pr-str sid)
+          " no longer targets the live frame incarnation it captured")
+     {:extra {:frame frame-id :site-id sid}})))
+
+(defn- resolved-registration
+  "Resolve `(kind,id)` through the desired frame's exact image generation."
+  [frame-id kind id]
+  (live-frame/call-with-frame-resolution
+   (live-frame/frame-resolution-target frame-id)
+   #(registrar/lookup kind id)))
+
+(defn- require-resource-registration!
+  [{:keys [descriptor frame-id]}]
+  (let [resource-id (:resource descriptor)]
+    (when-not (resolved-registration frame-id :resource resource-id)
+      (error/throw-error!
+       :rf.error/resource-not-registered
+       're-frame.ui/lease
+       (str "no resource is registered under " (pr-str resource-id)
+            " in frame " (pr-str frame-id)
+            " — call rf/reg-resource before leasing it")
+       {:recovery :fix-registration
+        :extra {:resource-id resource-id}}))))
+
+(defn- prevalidate-resource-plan!
+  "Validate the complete desired plan before minting or dispatching anything."
+  [{:keys [order by-site]} prior-held prior-held-order]
+  (let [records (mapv #(assoc (get by-site %) :sid %) order)
+        held-records (keep prior-held prior-held-order)]
+    (when (or (seq records) (seq held-records))
+      ;; The canonical optional-feature probe. This check is first so an absent
+      ;; artefact reports the copy-pasteable coordinate/require fix instead of
+      ;; a secondary registrar miss. A dev shell with zero current/prior lease
+      ;; sites is a true no-op: it keeps the fixed passive hook but does not
+      ;; require the optional feature merely by mounting.
+      (features/require-feature! :resources)
+      (doseq [record records]
+        (validate-resource-frame! record)
+        (ui-lease/validate-descriptor! (:descriptor record))
+        (require-resource-registration! record))
+      (doseq [record held-records]
+        (validate-resource-frame! record)))
+    records))
+
+(defn- same-resource-reservation?
+  [prior desired]
+  (and prior
+       (= (:frame-id prior) (:frame-id desired))
+       (identical? (:frame-token prior) (:frame-token desired))
+       (eq/rf= (:descriptor prior) (:descriptor desired))))
+
+(defn- ensure-event
+  [view-id {:keys [sid descriptor frame-id owner commit-id]}]
+  [:rf.resource/ensure
+   (cond-> {:resource (:resource descriptor)
+            :owner owner}
+     (contains? descriptor :scope)  (assoc :scope (:scope descriptor))
+     (contains? descriptor :params) (assoc :params (:params descriptor))
+     interop/debug-enabled?
+     (assoc :cause {:rf.ui/view view-id
+                    :rf.ui/commit commit-id
+                    :rf.ui/site sid
+                    :frame frame-id
+                    :owner owner}))])
+
+(defn- enqueue-ensure!
+  [view-id {:keys [frame-id] :as record}]
+  (router/dispatch! (ensure-event view-id record) {:frame frame-id}))
+
+(defn- enqueue-release!
+  [{:keys [frame-id owner]}]
+  (router/dispatch! [:rf.resource/release-owner {:owner owner}]
+                    {:frame frame-id}))
+
+(defn- attempt-resource-releases!
+  "Attempt every release in order. Never short-circuits; returns the first
+  escape and the records whose release could not be queued."
+  [records]
+  (reduce (fn [{:keys [error failed]} record]
+            (try
+              (enqueue-release! record)
+              {:error error :failed failed}
+              (catch #?(:clj Throwable :cljs :default) e
+                {:error (or error e) :failed (conj failed record)})))
+          {:error nil :failed []}
+          records))
+
+(defn- release-held-resources!
+  "Lifecycle cleanup: attempt every held release, then clear held ownership
+  regardless of a host/router escape. Reservations are retained only when
+  `retain-reservations?` (Activity/StrictMode disconnect). Returns the first
+  contained dispatch escape, if any."
+  [^ViewCell cell retain-reservations?]
+  (let [st      (state cell)
+        before @st
+        resources (:resources before)
+        held   (:resource-held resources)
+        records (keep held (:resource-held-order resources))
+        result  (attempt-resource-releases! records)]
+    (swap! st (fn [m]
+                (install-resource-state
+                 m
+                 (cond-> (assoc (:resources m)
+                                :resource-held {}
+                                :resource-held-order [])
+                   (not retain-reservations?)
+                   (assoc :resource-desired {:order [] :by-site {}}
+                          :resource-capture nil
+                          :resource-reservations {})))))
+    (:error result)))
+
+(def ^:private resource-lifecycle-ops
+  ;; This map and every function it reaches are referenced only by
+  ;; enable-resource-lifecycle!. A production view with no lease sites never
+  ;; reaches that installer, allowing Closure to erase the full resource
+  ;; ownership family (including release event ids and the neutral owner mint).
+  {:disconnect (fn [cell] (release-held-resources! cell true))
+   :teardown   (fn [cell] (release-held-resources! cell false))})
+
+(defn enable-resource-lifecycle!
+  "Install the resource cleanup family on a lease-capable ViewCell. Idempotent
+  and ownership-free: render may install these function pointers, but only the
+  accepted passive capture can mint/ensure an owner. Production sub-only cells
+  never call this function, preserving structural lease-free DCE."
+  [^ViewCell cell]
+  (swap! (state cell)
+         (fn [m]
+           (if (:resources m)
+             m
+             (let [resources
+                   (cond-> {:resource-desired {:order [] :by-site {}}
+                            :resource-capture nil
+                            :resource-reservations {}
+                            :resource-held {}
+                            :resource-held-order []
+                            :resource-lifecycle resource-lifecycle-ops}
+                     interop/debug-enabled? (assoc :resource-commit 0))]
+               (assoc (install-resource-state m resources)
+                      :on-teardown (:teardown resource-lifecycle-ops))))))
+  cell)
+
+(defn- run-resource-lifecycle!
+  [^ViewCell cell phase]
+  (when-let [f (get-in @(state cell) [:resources :resource-lifecycle phase])]
+    (f cell)))
+
+(defn reconcile-resource-leases!
+  "Passive-effect resource reconciliation for the exact layout-accepted
+  `capture`. Stale/abandoned effects are inert. The full desired set validates
+  before owner mint or dispatch; same-site `rf=` descriptors on the same frame
+  incarnation retain their exact owner. Every fresh ensure is queued in lexical
+  order before any old owner release is attempted."
+  [^ViewCell cell cap]
+  (let [st  (state cell)
+        st0 @st
+        resources0 (:resources st0)]
+    (when (resource-capture-current? st0 cap)
+      (let [desired (:resource-desired resources0)
+            records (prevalidate-resource-plan!
+                     desired
+                     (:resource-held resources0)
+                     (:resource-held-order resources0))]
+        ;; A feature hook/registrar lookup can synchronously run user tooling.
+        ;; Recheck selected-capture identity before any irreversible mint.
+        (when (resource-capture-current? @st cap)
+          (let [resources         (:resources @st)
+                prior-reservations (:resource-reservations resources)
+                prior-held        (:resource-held resources)
+                prior-held-order  (:resource-held-order resources)
+                commit-id         (:resource-commit resources)
+                reservations
+                (persistent!
+                 (reduce (fn [out {:keys [sid] :as desired-record}]
+                           (let [prior (get prior-reservations sid)
+                                 record
+                                 (cond->
+                                  (if (same-resource-reservation? prior desired-record)
+                                    ;; Preserve the exact prior descriptor
+                                    ;; object and owner on an rf=-equal render.
+                                    (assoc desired-record
+                                           :descriptor (:descriptor prior)
+                                           :owner (:owner prior))
+                                    (assoc desired-record
+                                           :owner (lease-owner/mint!)))
+                                   interop/debug-enabled?
+                                   (assoc :commit-id commit-id))]
+                             (assoc! out sid record)))
+                         (transient {})
+                         records))
+                desired-records (mapv reservations (:order desired))
+                desired-owners  (into #{} (map :owner) desired-records)
+                ensures         (filterv #(not (contains? prior-held (:owner %)))
+                                         desired-records)
+                releases        (into []
+                                      (comp (keep prior-held)
+                                            (remove #(contains? desired-owners
+                                                                (:owner %))))
+                                      prior-held-order)
+                staged-held     (reduce (fn [m record]
+                                          (assoc m (:owner record) record))
+                                        prior-held ensures)
+                staged-order    (into (vec prior-held-order)
+                                      (comp (map :owner)
+                                            (remove #(contains? prior-held %)))
+                                      ensures)
+                view-id         (:view-id @st)]
+            ;; Publish candidate cleanup reachability before the first enqueue.
+            (swap! st
+                   (fn [m]
+                     (install-resource-state
+                      m
+                      (assoc (:resources m)
+                             :resource-reservations reservations
+                             :resource-held staged-held
+                             :resource-held-order staged-order))))
+            (let [ensure-error
+                  (try
+                    (doseq [record ensures]
+                      (enqueue-ensure! view-id record))
+                    nil
+                    (catch #?(:clj Throwable :cljs :default) e e))]
+              (if ensure-error
+                (let [{failed-comp :failed}
+                      ;; Conservatively release every staged candidate. The
+                      ;; throwing dispatch may have enqueued before escaping;
+                      ;; release-owner is safe for a fresh owner that did not.
+                      (attempt-resource-releases! ensures)
+                      failed-by-owner
+                      (into {} (map (juxt :owner identity)) failed-comp)
+                      failed-order (mapv :owner failed-comp)]
+                  ;; Restore the prior authoritative state. A compensation
+                  ;; release that itself failed remains cleanup-reachable even
+                  ;; though its candidate reservation is abandoned.
+                  (swap! st
+                         (fn [m]
+                           (install-resource-state
+                            m
+                            (assoc (:resources m)
+                                   :resource-reservations prior-reservations
+                                   :resource-held (merge prior-held failed-by-owner)
+                                   :resource-held-order
+                                   (into (vec prior-held-order) failed-order)))))
+                  (throw ensure-error))
+                (let [release-result (attempt-resource-releases! releases)
+                      failed-release (:failed release-result)
+                      final-held (reduce (fn [m record]
+                                           (assoc m (:owner record) record))
+                                         (into {} (map (juxt :owner identity))
+                                               desired-records)
+                                         failed-release)
+                      final-order (into (mapv :owner desired-records)
+                                        (map :owner) failed-release)]
+                  (swap! st
+                         (fn [m]
+                           (install-resource-state
+                            m
+                            (assoc (:resources m)
+                                   :resource-reservations reservations
+                                   :resource-held final-held
+                                   :resource-held-order final-order))))
+                  (when-let [e (:error release-result)]
+                    (throw e))))))))))
+  nil)
+
+(defn resource-reservations
+  "Canonical site-keyed resource owner reservations (internal tool/test read)."
+  [^ViewCell cell]
+  (get-in @(state cell) [:resources :resource-reservations]))
+
+(defn resource-held
+  "Currently-held resource owners keyed by owner token (internal tool/test read)."
+  [^ViewCell cell]
+  (get-in @(state cell) [:resources :resource-held]))
+
+(defn resource-state-installed?
+  "True only for a ViewCell whose lease-capable wrapper installed lazy state
+  (internal structural-erasure inspection seam)."
+  [^ViewCell cell]
+  (contains? @(state cell) :resources))
+
+(defn resource-frame-incarnation-count
+  "Distinct retained incarnation tokens for `frame-id` in a lease-capable
+  cell's teardown index (internal compactness inspection seam)."
+  [^ViewCell cell frame-id]
+  (count (get (:extra-frame-incarnations @(state cell)) frame-id)))
+
+(def ^:private resource-evidence-sentinel
+  ;; Stable non-vacuity marker for the actual advanced DCE gate. Simple/dev
+  ;; output retains this private debug-plane binding; goog.DEBUG=false removes
+  ;; it together with resource-lease-evidence's body.
+  "RF2_UI_RESOURCE_LEASE_EVIDENCE_SENTINEL")
+
+(defn resource-lease-evidence
+  "Dev-only bounded Xray join rows for the accepted resource plan. Carries
+  view/commit/site/frame/owner identity and deliberately no descriptor, scope,
+  or params. Returns nil in production."
+  [^ViewCell cell]
+  (when interop/debug-enabled?
+    (let [_sentinel resource-evidence-sentinel
+          st @(state cell)
+          resources (:resources st)]
+      (into []
+            (keep (fn [sid]
+                    (when-let [{:keys [frame-id owner commit-id]}
+                               (get (:resource-reservations resources) sid)]
+                      {:rf.ui/view (:view-id st)
+                       :rf.ui/commit commit-id
+                       :rf.ui/site sid
+                       :frame frame-id
+                       :owner owner})))
+            (get-in resources [:resource-desired :order])))))
+
+(def ^:private conflicting-resource-incarnations
+  ::conflicting-resource-incarnations)
+
+(defn- resource-capture-incarnations
+  [cap]
+  (reduce (fn [out {:keys [frame-id frame-token]}]
+            (if (contains? out frame-id)
+              (if (identical? (get out frame-id) frame-token)
+                out
+                (reduced conflicting-resource-incarnations))
+              (assoc out frame-id frame-token)))
+          {}
+          (vals (:resource-by-site cap))))
+
+(defn- accept-resource-capture
+  [m cap]
+  (let [desired {:order (or (:resource-order cap) [])
+                 :by-site (or (:resource-by-site cap) {})}
+        resources
+        (cond-> (assoc (:resources m)
+                       :resource-desired desired
+                       ;; Exact identity closes selected-layout A vs abandoned
+                       ;; passive B: only this accepted capture may reconcile.
+                       :resource-capture cap)
+          interop/debug-enabled?
+          (update :resource-commit (fnil inc 0)))]
+    (install-resource-state m resources)))
+
 ;; ---- lifecycle (03 §4) ------------------------------------------------------
 ;;
 ;; Three OBSERVABLE runtime states. The fact emitted at cleanup is always
@@ -1393,10 +1855,14 @@
   [^ViewCell cell incarnation]
   (let [st  (state cell)
         old (:root @st)]
-    (when (and (some? old) (not (identical? old incarnation)))
-      (forget-root-cell! cell old))
-    (swap! st assoc :root incarnation)
-    (swap! root-cells update incarnation (fnil conj #{}) cell))
+    ;; A resource/frame pin can reject and tear down the cell in the preceding
+    ;; layout effect. The later lifecycle effect must not resurrect that dead
+    ;; cell into root ownership.
+    (when-not (= :dead (:lifecycle @st))
+      (when (and (some? old) (not (identical? old incarnation)))
+        (forget-root-cell! cell old))
+      (swap! st assoc :root incarnation)
+      (swap! root-cells update incarnation (fnil conj #{}) cell)))
   cell)
 
 (defn- detach-root!
@@ -1504,7 +1970,7 @@
     ;; sweep can find this cell while it observes a live committed dep set.
     (swap! live-cells conj cell)))
 
-(defn disconnect!
+(defn- disconnect*
   "Effects-cleanup transition (React unmount OR Activity hide —
   indistinguishable at this moment): release lease owners (hidden UI must
   not poll) and emit `:disconnected {:reason :unknown}`. The cell is
@@ -1519,10 +1985,12 @@
   indistinguishable here, 03 §4); the upgrade to `:unmounted` happens later, in
   `teardown-root!`. With the window unarmed (an Activity hide) nothing is
   captured and the cell stays reconnectable."
-  [^ViewCell cell]
+  [^ViewCell cell on-disconnect]
   (let [st (state cell)]
     (when (contains? #{:fresh :connected} (:lifecycle @st))
       (release-committed! cell)
+      (when on-disconnect
+        (on-disconnect cell))
       (discard-pending! cell)
       ;; Leave the live-cell registry: a disconnected cell holds no committed
       ;; deps, so it observes no frame — and an unmounted cell must not linger.
@@ -1544,6 +2012,19 @@
         (swap! teardown-collector conj cell)))
     cell))
 
+(defn disconnect!
+  "No-capability effects cleanup. Production views with only subscription
+  sites call this path, so resource lifecycle code remains unreachable."
+  [^ViewCell cell]
+  (disconnect* cell nil))
+
+(defn disconnect-resources!
+  "Lease-capable effects cleanup. Hidden UI must not poll: every held owner is
+  released while its reservation remains reusable for StrictMode/Activity
+  reconnect."
+  [^ViewCell cell]
+  (disconnect* cell #(run-resource-lifecycle! % :disconnect)))
+
 (defn teardown!
   "Explicit host/root teardown (root unmount, parent teardown, frame
   destroy): the frame/adapter/root is destroyed under this cell's handle —
@@ -1560,8 +2041,16 @@
         (swap! st update :intervals conj
                {:state :unmounted :reason :unmounted :proof :host-teardown}))
       (release-committed! cell)
+      ;; Final teardown drops both held ownership and reusable reservations.
+      ;; Dispatch escapes are contained here so one bad owner cannot prevent
+      ;; later cells or root-membership cleanup from becoming total.
+      (when-some [on-teardown (:on-teardown @st)]
+        (on-teardown cell))
       (discard-pending! cell)
-      (swap! st assoc :lifecycle :dead :committed {})
+      (swap! st assoc
+             :lifecycle :dead
+             :committed {})
+      (swap! st dissoc :on-teardown :extra-frame-incarnations)
       (swap! live-cells disj cell)
       ;; leave the root-incarnation registry — a dead cell is no longer
       ;; retained, so it must not linger as reapable ownership (rf2-vxgfnd.85).
@@ -1587,11 +2076,17 @@
   snapshots, so the per-cell `teardown!` de-enrol is safe. Returns the count
   torn down."
   [frame-id]
-  (let [connected (filter #(cell-observes-frame? % frame-id) @live-cells)
+  (let [frame-token (frame/frame-incarnation-token frame-id)
+        ;; Observation ownership retains its historical bare-id discovery;
+        ;; resource ownership additionally requires the exact render-captured
+        ;; incarnation so A's teardown cannot reap a same-id B reservation.
+        connected (filter #(cell-retained-frame? % frame-id frame-token)
+                          @live-cells)
         hidden    (into #{}
                         (comp (mapcat val)
                               (filter #(= :disconnected (lifecycle %)))
-                              (filter #(cell-retained-frame? % frame-id)))
+                              (filter #(cell-retained-frame?
+                                        % frame-id frame-token)))
                         @root-cells)
         victims   (into hidden connected)]
     (doseq [cell victims]
@@ -1741,20 +2236,17 @@
 
 (defn- committed-frame-incarnations
   "Post-acquire snapshot `{frame-id -> incarnation-token}` for every frame the
-  candidate committed map observes. `commit!` immediately validates every
-  candidate lease with `current?`; together those operations close the window
-  in which a lease acquired from A could otherwise be paired with a snapshot
-  of a replacement same-id incarnation B. A frame absent/destroyed reads nil.
-  O(observed frames)."
+  candidate observation map observes. Capability-specific callers may merge
+  additional render-time pins before the common close revalidation."
   [committed]
   (persistent!
-    (reduce (fn [acc {:keys [target lease]}]
-              (if (and lease (= :subscription (:kind target)))
-                (let [fid (:frame-id target)]
-                  (assoc! acc fid (frame/frame-incarnation-token fid)))
-                acc))
-            (transient {})
-            (vals committed))))
+   (reduce (fn [acc {:keys [target lease]}]
+             (if (and lease (= :subscription (:kind target)))
+               (let [fid (:frame-id target)]
+                 (assoc! acc fid (frame/frame-incarnation-token fid)))
+               acc))
+           (transient {})
+           (vals committed))))
 
 (defn- incarnation-superseded?
   "True when ANY frame in the acquire-time `incarnations` snapshot is no longer
@@ -1791,7 +2283,7 @@
                      replacement id (rf2-vxgfnd.88)."
   nil)
 
-(defn commit!
+(defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable
   `capture` returned beside the committed host element by `with-capture`.
   Idempotent: an unchanged committed set + capture reconciles to a
@@ -1822,7 +2314,7 @@
      and notify — React corrects BEFORE paint.
 
   Returns `cell` on a normal commit or `:stale` on a rejected generation."
-  [^ViewCell cell cap]
+  [^ViewCell cell cap extra-incarnations accept-capture]
   (let [st  (state cell)
         st0 @st]
     (cond
@@ -1913,7 +2405,10 @@
               ;; the formerly-uncovered acquire→snapshot window.
               _ (when-some [barrier *commit-barrier*]
                   (barrier :post-stage-acquire cell))
-              incarnations (committed-frame-incarnations candidate)
+              observed-incarnations (committed-frame-incarnations candidate)
+              incarnations (if (seq extra-incarnations)
+                             (merge observed-incarnations extra-incarnations)
+                             observed-incarnations)
               candidate-current?
               (every? (fn [[sid record]]
                         (obs/current? (:lease record) (:target (new-by sid))))
@@ -1960,7 +2455,12 @@
           ;; replacement id (rf2-vxgfnd.88).
           (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
           ;; step 6 — publish exact per-site query/value + dependency set
-          (swap! st assoc :committed new-committed)
+          (swap! st
+                 (fn [m]
+                   (let [m* (assoc m :committed new-committed)]
+                     (if accept-capture
+                       (accept-capture m* cap)
+                       m*))))
           ;; step 7 — release dropped + retargeted prior leases
           (doseq [[_ record] to-release]
             (obs/release! (:lease record)))
@@ -2024,6 +2524,24 @@
                       (and retained-moved? (not (dirty? cell))))
               (advance-revision! cell)))
               cell)))))))
+
+(defn commit!
+  "Commit an observation-only capture without installing or copying resource
+  state. This is the production path for the 0/0 and 1/0 capability shapes."
+  [^ViewCell cell cap]
+  (commit* cell cap nil nil))
+
+(defn commit-resources!
+  "Commit a lease-capable capture with its exact render-time frame pins and
+  ownership-free desired plan. Owner minting remains passive."
+  [^ViewCell cell cap]
+  (let [incarnations (resource-capture-incarnations cap)]
+    (if (= conflicting-resource-incarnations incarnations)
+      ;; One render cannot coherently target two incarnations of the same frame
+      ;; id. Reject before generic commit publishes/connects; passive reconcile
+      ;; then sees a dead cell and cannot mint or dispatch.
+      (teardown! cell)
+      (commit* cell cap incarnations accept-resource-capture))))
 
 ;; ---- test/inspection reads --------------------------------------------------
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -40,21 +40,22 @@
   ## The render capture
 
   A render pass records each executed site's resolved target + probe
-  evidence + value into a per-pass CAPTURE (ownership-free). Sites dedup by
-  target identity, so N reads of one query share one committed lease and a
-  shared node can never fall through its zero-owner disposal edge. The
-  latest finished capture is stashed on the cell; the layout commit
-  reconciles the committed dependency set against it — idempotently, so
-  StrictMode's mount→unmount→mount effect replay is naturally balanced.
+  evidence + value into a per-pass CAPTURE (ownership-free), keyed by the
+  compiler-issued lexical site id. Equal queries at distinct sites therefore
+  own distinct balanced leases while still sharing the subscription node.
+  The exact immutable capture travels beside its host element into the
+  selected layout/passive effect closure; it is never published speculatively
+  by render. Layout reconciles the committed dependency set against that
+  selected capture — idempotently, so StrictMode's mount→unmount→mount effect
+  replay is naturally balanced.
 
   ## `sub` value stabilization (03 §2, I-8)
 
-  A site returns the PRIOR EXACT value (identical reference) when the new
-  read is `rf=` to the last committed value for its target — so an
-  `rf=`-stable read does not repaint downstream. Stabilization here is
-  keyed by target identity `(frame, stabilized query)`; per-site query-
-  object reuse (the parametric-args case) needs compile-site identity and
-  lands with the HMR site-identity slice (S2e).
+  A site returns its PRIOR EXACT value (identical reference) when the new read
+  is `rf=` to that lexical site's last committed value — so an `rf=`-stable
+  read does not repaint downstream. Query-object reuse is likewise per-site:
+  a parametric read may retain its exact prior query object without collapsing
+  an equal query executed at another compiler-issued site.
 
   ## Drain coalescing + `flush!` scope (S2d — 03 §3 invariant 6; Spec 006
   §Epoch finalization)
@@ -865,15 +866,14 @@
 (defonce ^:private live-cells
   ;; The set of currently-CONNECTED ViewCells — the connected input to a
   ;; frame-destroy sweep (`teardown-frame!`). A cell enrols on `connect!`,
-  ;; when it starts observing a frame) and leaves on `disconnect!` (React
-  ;; unmount / Activity hide, when it releases its committed dependency set) or
-  ;; `teardown!` (it goes :dead). Membership therefore tracks EXACTLY the cells
-  ;; carrying a live committed dependency set, so a destroyed frame can find the
-  ;; connected cells observing it and transition them to :dead (03 §4) rather
-  ;; than leave them live to throw `:rf.error/frame-destroyed` on their next
-  ;; read. Because a disconnected cell leaves the set, an unmounted cell never
-  ;; lingers here (no retention leak). `defonce` (module-lived); tests clear it
-  ;; via `reset-scheduler!`.
+  ;; when it starts observing subscriptions and/or publishing resource-liveness
+  ;; pins, and leaves on `disconnect!` (React unmount / Activity hide, when both
+  ;; ownership families release) or `teardown!` (it goes :dead). The exact
+  ;; membership test remains family-specific: committed subscription leases
+  ;; define reactive observation/flush scope, while desired/reserved/held
+  ;; resource incarnation pins provide teardown discovery only. A disconnected
+  ;; cell leaves the set, so an unmounted cell never lingers here (no retention
+  ;; leak). `defonce` (module-lived); tests clear it via `reset-scheduler!`.
   (atom #{}))
 
 (defonce ^:private root-cells
@@ -895,7 +895,8 @@
   ;; teardown can never reap the cells of a replacement root mounted under the same
   ;; root-id. `defonce` (module-lived); `reset-scheduler!` clears it between
   ;; fixtures. Frame teardown also consults its still-disconnected members,
-  ;; whose retained `:values` keys name their last published frames.
+  ;; whose retained subscription targets and resource-incarnation pins name
+  ;; their last published frames.
   (atom {}))
 
 (defonce ^:private teardown-collector
@@ -1528,29 +1529,130 @@
           {:error nil :failed []}
           records))
 
+(defn- stage-resource-held!
+  "Make exactly one about-to-be-enqueued owner lifecycle-cleanup reachable.
+  The desired plan already indexes its exact frame pin, so this deliberately
+  updates held/order only (no whole-plan index rebuild per owner). Returns true
+  only while `cap` still owns connected reconciliation authority."
+  [st cap {:keys [owner] :as record}]
+  (swap! st
+         (fn [m]
+           (if (resource-capture-current? m cap)
+             (-> m
+                 (assoc-in [:resources :resource-held owner] record)
+                 (update-in [:resources :resource-held-order]
+                            (fn [order]
+                              (if (some #(= owner %) order)
+                                order
+                                (conj (vec order) owner)))))
+             m)))
+  (let [m @st]
+    (and (resource-capture-current? m cap)
+         (identical? record
+                     (get-in m [:resources :resource-held owner])))))
+
+(defn- forget-exact-held!
+  "Forget successfully released records only while the held owner still names
+  the exact record this reconciliation staged/read. A newer reentrant passive
+  may have installed a different record under the same reusable owner; that
+  newer authority is never overwritten. Rebuilds the canonical frame index
+  once after the batch."
+  [st records]
+  (when (seq records)
+    (swap! st
+           (fn [m]
+             (if-let [resources (:resources m)]
+               (let [[held removed]
+                     (reduce
+                      (fn [[held removed] {:keys [owner] :as record}]
+                        (if (identical? record (get held owner))
+                          [(dissoc held owner) (conj removed owner)]
+                          [held removed]))
+                      [(:resource-held resources) #{}]
+                      records)]
+                 (if (seq removed)
+                   (install-resource-state
+                    m
+                    (assoc resources
+                           :resource-held held
+                           :resource-held-order
+                           (into [] (remove removed)
+                                 (:resource-held-order resources))))
+                   m))
+               m))))
+  nil)
+
+(defn- compensate-resource-ensures!
+  "Conservatively release the ensures this reconciliation actually attempted
+  and still exactly owns. Future lexical candidates were never staged or
+  enqueued. A record whose held entry a reentrant authority (a newer passive
+  reconcile or a lifecycle cleanup) replaced or already released is skipped —
+  compensating it here would double-release an owner someone else now
+  accounts for. Successfully compensated exact records leave held state;
+  failed compensation stays cleanup-reachable."
+  [st records]
+  (let [held          (get-in @st [:resources :resource-held])
+        mine          (filterv #(identical? % (get held (:owner %))) records)
+        result        (attempt-resource-releases! mine)
+        failed-owners (into #{} (map :owner) (:failed result))
+        successful    (into [] (remove #(contains? failed-owners (:owner %)))
+                            mine)]
+    (forget-exact-held! st successful)
+    result))
+
 (defn- release-held-resources!
-  "Lifecycle cleanup: attempt every held release, then clear held ownership
-  regardless of a host/router escape. Reservations are retained only when
-  `retain-reservations?` (Activity/StrictMode disconnect). Returns the first
-  contained dispatch escape, if any."
+  "Lifecycle cleanup: park held ownership before attempting every release.
+  A disconnect also parks reusable reservations behind a unique cleanup token:
+  it restores them only if no synchronous release listener reconnected,
+  recommitted, or tore down the cell. Final teardown forgets reservations.
+  Returns the first contained dispatch escape, if any."
   [^ViewCell cell retain-reservations?]
   (let [st      (state cell)
         before @st
         resources (:resources before)
         held   (:resource-held resources)
         records (keep held (:resource-held-order resources))
-        result  (attempt-resource-releases! records)]
+        reservations (:resource-reservations resources)
+        cleanup-token (when retain-reservations?
+                        #?(:clj (Object.) :cljs (js-obj)))]
+    ;; Publish the complete cleanup state BEFORE dispatch: trace listeners run
+    ;; synchronously and may reconnect or teardown this cell. In particular,
+    ;; hide owner1's reservation so a reconnect during release(owner1) mints a
+    ;; distinct owner instead of ensuring owner1 immediately before the outer
+    ;; dispatch drops it.
     (swap! st (fn [m]
                 (install-resource-state
                  m
                  (cond-> (assoc (:resources m)
+                                :resource-reservations {}
                                 :resource-held {}
                                 :resource-held-order [])
+                   retain-reservations?
+                   (assoc :resource-disconnect-token cleanup-token)
+
                    (not retain-reservations?)
-                   (assoc :resource-desired {:order [] :by-site {}}
-                          :resource-capture nil
-                          :resource-reservations {})))))
-    (:error result)))
+                   (-> (assoc :resource-desired {:order [] :by-site {}}
+                              :resource-capture nil)
+                       (dissoc :resource-disconnect-token))))))
+    (let [result (attempt-resource-releases! records)]
+      (when retain-reservations?
+        ;; Normal StrictMode/Activity cleanup retains owner identity. Any
+        ;; synchronous reconnect/commit clears the token in
+        ;; `accept-resource-capture`, and teardown clears it above, so this
+        ;; conditional restore cannot overwrite newer/dead authority.
+        (swap! st
+               (fn [m]
+                 (let [current (:resources m)]
+                   (if (and (= :disconnected (:lifecycle m))
+                            (identical? cleanup-token
+                                        (:resource-disconnect-token current)))
+                     (install-resource-state
+                      m
+                      (-> current
+                          (assoc :resource-reservations reservations)
+                          (dissoc :resource-disconnect-token)))
+                     m)))))
+      (:error result))))
 
 (def ^:private resource-lifecycle-ops
   ;; This map and every function it reaches are referenced only by
@@ -1592,7 +1694,12 @@
   `capture`. Stale/abandoned effects are inert. The full desired set validates
   before owner mint or dispatch; same-site `rf=` descriptors on the same frame
   incarnation retain their exact owner. Every fresh ensure is queued in lexical
-  order before any old owner release is attempted."
+  order before any old owner release is attempted. Because dispatch trace
+  listeners run synchronously, each owner becomes cleanup-reachable immediately
+  before its own enqueue and exact capture/lifecycle authority is fenced after
+  every ensure and release. Future lexical owners are never staged early, and
+  final publication is conditional on the same accepted capture still owning a
+  connected cell."
   [^ViewCell cell cap]
   (let [st  (state cell)
         st0 @st
@@ -1639,70 +1746,131 @@
                                             (remove #(contains? desired-owners
                                                                 (:owner %))))
                                       prior-held-order)
-                staged-held     (reduce (fn [m record]
-                                          (assoc m (:owner record) record))
-                                        prior-held ensures)
-                staged-order    (into (vec prior-held-order)
-                                      (comp (map :owner)
-                                            (remove #(contains? prior-held %)))
-                                      ensures)
                 view-id         (:view-id @st)]
-            ;; Publish candidate cleanup reachability before the first enqueue.
-            (swap! st
-                   (fn [m]
-                     (install-resource-state
-                      m
-                      (assoc (:resources m)
-                             :resource-reservations reservations
-                             :resource-held staged-held
-                             :resource-held-order staged-order))))
-            (let [ensure-error
-                  (try
-                    (doseq [record ensures]
-                      (enqueue-ensure! view-id record))
-                    nil
-                    (catch #?(:clj Throwable :cljs :default) e e))]
-              (if ensure-error
-                (let [{failed-comp :failed}
-                      ;; Conservatively release every staged candidate. The
-                      ;; throwing dispatch may have enqueued before escaping;
-                      ;; release-owner is safe for a fresh owner that did not.
-                      (attempt-resource-releases! ensures)
-                      failed-by-owner
-                      (into {} (map (juxt :owner identity)) failed-comp)
-                      failed-order (mapv :owner failed-comp)]
-                  ;; Restore the prior authoritative state. A compensation
-                  ;; release that itself failed remains cleanup-reachable even
-                  ;; though its candidate reservation is abandoned.
-                  (swap! st
-                         (fn [m]
-                           (install-resource-state
-                            m
-                            (assoc (:resources m)
-                                   :resource-reservations prior-reservations
-                                   :resource-held (merge prior-held failed-by-owner)
-                                   :resource-held-order
-                                   (into (vec prior-held-order) failed-order)))))
-                  (throw ensure-error))
-                (let [release-result (attempt-resource-releases! releases)
-                      failed-release (:failed release-result)
-                      final-held (reduce (fn [m record]
-                                           (assoc m (:owner record) record))
-                                         (into {} (map (juxt :owner identity))
-                                               desired-records)
-                                         failed-release)
-                      final-order (into (mapv :owner desired-records)
-                                        (map :owner) failed-release)]
-                  (swap! st
-                         (fn [m]
-                           (install-resource-state
-                            m
-                            (assoc (:resources m)
-                                   :resource-reservations reservations
-                                   :resource-held final-held
-                                   :resource-held-order final-order))))
-                  (when-let [e (:error release-result)]
-                    (throw e))))))))))
+            ;; Candidate reservations remain LOCAL until every ensure succeeds.
+            ;; Stage only the owner whose dispatch is about to run, then fence
+            ;; the exact accepted capture immediately after the synchronous
+            ;; trace/listener surface returns.
+            (let [ensure-result
+                  (loop [remaining ensures
+                         attempted []]
+                    (if-some [record (first remaining)]
+                      (if-not (stage-resource-held! st cap record)
+                        {:status :lost :attempted attempted}
+                        (let [attempted' (conj attempted record)
+                              escape
+                              (try
+                                (enqueue-ensure! view-id record)
+                                nil
+                                (catch #?(:clj Throwable :cljs :default) e e))]
+                          (cond
+                            (not (resource-capture-current? @st cap))
+                            {:status :lost
+                             :attempted attempted'
+                             :error escape}
+
+                            escape
+                            {:status :error
+                             :attempted attempted'
+                             :error escape}
+
+                            :else
+                            (recur (next remaining) attempted'))))
+                      {:status :ok :attempted attempted}))]
+              (if-not (= :ok (:status ensure-result))
+                (let [compensation
+                      ;; A lifecycle transition published cleanup before its
+                      ;; resource dispatch and already released/cleared staged
+                      ;; owners. A connected capture supersession did not, so
+                      ;; compensate exactly the attempted prefix while preserving
+                      ;; all newer desired/capture authority.
+                      (when (= :connected (:lifecycle @st))
+                        (compensate-resource-ensures!
+                         st (:attempted ensure-result)))]
+                  (when-let [e (or (:error ensure-result)
+                                   (:error compensation))]
+                    (throw e)))
+                (let [release-result
+                      ;; Old releases retain their held records until enqueue
+                      ;; succeeds. Continue across ordinary release escapes for
+                      ;; total cleanup, but stop immediately when synchronous
+                      ;; reentrancy loses exact authority.
+                      (loop [remaining releases
+                             released  []
+                             failed    []
+                             error     nil]
+                        (if-some [record (first remaining)]
+                          (if-not (resource-capture-current? @st cap)
+                            {:status :lost
+                             :released released
+                             :failed failed
+                             :error error}
+                            (let [escape
+                                  (try
+                                    (enqueue-release! record)
+                                    nil
+                                    (catch #?(:clj Throwable :cljs :default) e e))
+                                  current? (resource-capture-current? @st cap)
+                                  released' (cond-> released (nil? escape)
+                                              (conj record))
+                                  failed'   (cond-> failed escape (conj record))
+                                  error'    (or error escape)]
+                              (if current?
+                                (recur (next remaining)
+                                       released' failed' error')
+                                {:status :lost
+                                 :released released'
+                                 :failed failed'
+                                 :error error'})))
+                          {:status :ok
+                           :released released
+                           :failed failed
+                           :error error}))]
+                  (if-not (= :ok (:status release-result))
+                    (let [compensation
+                          (when (= :connected (:lifecycle @st))
+                            (compensate-resource-ensures!
+                             st (:attempted ensure-result)))]
+                      (when (= :connected (:lifecycle @st))
+                        (forget-exact-held! st (:released release-result)))
+                      (when-let [e (or (:error release-result)
+                                       (:error compensation))]
+                        (throw e)))
+                    (let [failed-release (:failed release-result)
+                          final-held
+                          (reduce (fn [m record]
+                                    (assoc m (:owner record) record))
+                                  (into {} (map (juxt :owner identity))
+                                        desired-records)
+                                  failed-release)
+                          final-order
+                          (into (mapv :owner desired-records)
+                                (map :owner) failed-release)]
+                      ;; Never overwrite a dead/disconnected cell or a newer
+                      ;; selected capture. This swap has no user-code edge; the
+                      ;; post-check covers a concurrent authority loss as well.
+                      (swap! st
+                             (fn [m]
+                               (if (resource-capture-current? m cap)
+                                 (install-resource-state
+                                  m
+                                  (assoc (:resources m)
+                                         :resource-reservations reservations
+                                         :resource-held final-held
+                                         :resource-held-order final-order))
+                                 m)))
+                      (if (resource-capture-current? @st cap)
+                        (when-let [e (:error release-result)]
+                          (throw e))
+                        (let [compensation
+                              (when (= :connected (:lifecycle @st))
+                                (compensate-resource-ensures!
+                                 st (:attempted ensure-result)))]
+                          (when (= :connected (:lifecycle @st))
+                            (forget-exact-held! st (:released release-result)))
+                          (when-let [e (or (:error release-result)
+                                           (:error compensation))]
+                            (throw e))))))))))))))
   nil)
 
 (defn resource-reservations
@@ -1772,11 +1940,14 @@
   (let [desired {:order (or (:resource-order cap) [])
                  :by-site (or (:resource-by-site cap) {})}
         resources
-        (cond-> (assoc (:resources m)
-                       :resource-desired desired
-                       ;; Exact identity closes selected-layout A vs abandoned
-                       ;; passive B: only this accepted capture may reconcile.
-                       :resource-capture cap)
+        (cond-> (-> (:resources m)
+                    (assoc :resource-desired desired
+                           ;; Exact identity closes selected-layout A vs abandoned
+                           ;; passive B: only this accepted capture may reconcile.
+                           :resource-capture cap)
+                    ;; Reconnect/commit supersedes any in-flight disconnect
+                    ;; reservation-restore authority.
+                    (dissoc :resource-disconnect-token))
           interop/debug-enabled?
           (update :resource-commit (fnil inc 0)))]
     (install-resource-state m resources)))
@@ -1813,14 +1984,16 @@
 
 ;; ---- root-incarnation ownership (03 §4; rf2-vxgfnd.85) ----------------------
 ;;
-;; A ViewCell's committed dependency set (`live-cells`) is the discoverability
-;; surface a FRAME-destroy sweep consults, but it is dropped the instant the cell
-;; disconnects — so it cannot survive an Activity hide. Root teardown needs an
-;; ownership association that DOES survive a transient hide: the `root-cells`
-;; registry keyed by a per-mount root incarnation. `attach-root!` (the mount seam)
-;; enrols a cell under its root's incarnation; the cell stays enrolled across a
-;; hide and leaves only when it is proven dead (`detach-root!` from `teardown!`).
-;; `teardown-root!` reaps a root's already-hidden cells through this registry.
+;; `live-cells` is the connected discoverability surface a FRAME-destroy sweep
+;; consults: subscription leases contribute reactive-observation frames and
+;; resource desired/reserved/held records contribute exact teardown-only pins.
+;; The membership is dropped the instant the cell disconnects, so it cannot
+;; survive an Activity hide. Root teardown needs an ownership association that
+;; DOES survive a transient hide: the `root-cells` registry keyed by a per-mount
+;; root incarnation. `attach-root!` (the mount seam) enrols a cell under its
+;; root's incarnation; the cell stays enrolled across a hide and leaves only
+;; when it is proven dead (`detach-root!` from `teardown!`). `teardown-root!`
+;; reaps a root's already-hidden cells through this registry.
 
 (defn make-root-incarnation
   "Mint a FRESH, opaque root-incarnation token — a per-mount identity with no
@@ -1989,8 +2162,6 @@
   (let [st (state cell)]
     (when (contains? #{:fresh :connected} (:lifecycle @st))
       (release-committed! cell)
-      (when on-disconnect
-        (on-disconnect cell))
       (discard-pending! cell)
       ;; Leave the live-cell registry: a disconnected cell holds no committed
       ;; deps, so it observes no frame — and an unmounted cell must not linger.
@@ -2009,7 +2180,12 @@
         (arm-disconnect-settle! cell))
       ;; Host/root teardown in flight: attribute this cell to it (03 §4).
       (when (some? @teardown-collector)
-        (swap! teardown-collector conj cell)))
+        (swap! teardown-collector conj cell))
+      ;; Resource dispatch is deliberately LAST. Router trace listeners run
+      ;; synchronously; a listener may reconnect or teardown, and this outer
+      ;; disconnect must perform no stale lifecycle/registry write afterward.
+      (when on-disconnect
+        (on-disconnect cell)))
     cell))
 
 (defn disconnect!
@@ -2041,20 +2217,25 @@
         (swap! st update :intervals conj
                {:state :unmounted :reason :unmounted :proof :host-teardown}))
       (release-committed! cell)
-      ;; Final teardown drops both held ownership and reusable reservations.
-      ;; Dispatch escapes are contained here so one bad owner cannot prevent
-      ;; later cells or root-membership cleanup from becoming total.
-      (when-some [on-teardown (:on-teardown @st)]
-        (on-teardown cell))
-      (discard-pending! cell)
-      (swap! st assoc
-             :lifecycle :dead
-             :committed {})
-      (swap! st dissoc :on-teardown :extra-frame-incarnations)
-      (swap! live-cells disj cell)
-      ;; leave the root-incarnation registry — a dead cell is no longer
-      ;; retained, so it must not linger as reapable ownership (rf2-vxgfnd.85).
-      (detach-root! cell))
+      (let [on-teardown (:on-teardown @st)]
+        (discard-pending! cell)
+        ;; Terminalize and clear every generic registry BEFORE resource release
+        ;; dispatch. A synchronous trace listener that re-enters teardown now
+        ;; observes :dead and no-ops instead of recursively releasing forever.
+        (swap! st (fn [m]
+                    (-> m
+                        (assoc :lifecycle :dead :committed {})
+                        (dissoc :on-teardown :extra-frame-incarnations))))
+        (swap! live-cells disj cell)
+        ;; leave the root-incarnation registry — a dead cell is no longer
+        ;; retained, so it must not linger as reapable ownership (rf2-vxgfnd.85).
+        (detach-root! cell)
+        ;; Final teardown drops both held ownership and reusable reservations.
+        ;; Dispatch escapes are contained here so one bad owner cannot prevent
+        ;; later cells or root-membership cleanup from becoming total. This is
+        ;; the final reentrant step; no outer authoritative write follows it.
+        (when on-teardown
+          (on-teardown cell))))
     cell))
 
 (defn teardown-frame!
@@ -2069,12 +2250,14 @@
   `:ui/on-frame-destroyed!` late-bind hook wired in `re-frame.ui.frames`;
   the sweep runs while the frame is still live, so each cell releases its
   leases against the live sub-cache (symmetric with `disconnect!`). The
-  connected membership test rides the committed dependency set
-  (`cell-observes-frame?`). An Activity-hidden cell holds no committed deps, so
-  its bounded root ownership plus retained `:values` target keys supply the
-  corresponding discoverability without another global registry. Iterates
-  snapshots, so the per-cell `teardown!` de-enrol is safe. Returns the count
-  torn down."
+  connected membership test uses `cell-retained-frame?`: committed
+  subscription targets provide observation attribution, while resource
+  desired/reservation/held records contribute exact incarnation tokens through
+  `:extra-frame-incarnations`. An Activity-hidden cell holds no live
+  subscription/resource owners, so its bounded root ownership plus retained
+  subscription targets and resource reservations supply corresponding
+  discoverability without another global registry. Iterates snapshots, so the
+  per-cell `teardown!` de-enrol is safe. Returns the count torn down."
   [frame-id]
   (let [frame-token (frame/frame-incarnation-token frame-id)
         ;; Observation ownership retains its historical bare-id discovery;

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -68,7 +68,7 @@
                     ;; first `sub` is therefore a same-signature body edit, not
                     ;; a hook-order change. Production specializes sub-free
                     ;; views to the raw render fn in the emitter.
-                    (viewcell/render
+                    (viewcell/render-dev
                      id
                      (fn []
                        (let [render-fn (:render-fn
@@ -198,19 +198,6 @@
      (str "a dynamic handler expression produced " (pr-str v) " — handlers "
           "classify by type: event vector, options map, handler fn, or nil")
      {:extra {:value v}})))
-
-;; ---------------------------------------------------------------------------
-;; lease — S2 declaration surface stub (grammar compiles; leases land with
-;; the resource-lease slice — 03 §7's aggregated post-commit effect)
-;; ---------------------------------------------------------------------------
-
-(defn lease*
-  [descriptor]
-  (error/throw-error!
-   :rf.error/ui-lease-unavailable 're-frame.ui/lease
-   (str "(lease " (pr-str descriptor) ") — leases land with the S2 "
-        "observation slice")
-   {:extra {:descriptor descriptor}}))
 
 ;; ---------------------------------------------------------------------------
 ;; Dev checks (goog.DEBUG-stripped in production)

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -132,7 +132,7 @@
     (reactive/with-capture cell thunk)))
 
 (defn- use-commit-and-lifecycle!
-  "Publish the selected render capture and own React visibility lifecycle."
+  "Publish an observation-only capture and own React visibility lifecycle."
   [cell root-incarnation capture]
   ;; Reconcile after every committed render. There is deliberately no cleanup:
   ;; retained observation/resource owners live on the cell, not on a render.
@@ -150,6 +150,20 @@
       (fn cleanup [] (reactive/disconnect! cell)))
     #js [root-incarnation]))
 
+(defn- use-resource-commit-and-lifecycle!
+  "Publish a lease-capable capture and own its specialized visibility cleanup."
+  [cell root-incarnation capture]
+  (react/useLayoutEffect
+    (fn reconcile []
+      (reactive/commit-resources! cell capture)
+      js/undefined))
+  (react/useLayoutEffect
+    (fn lifecycle []
+      (when (some? root-incarnation)
+        (reactive/attach-root! cell root-incarnation))
+      (fn cleanup [] (reactive/disconnect-resources! cell)))
+    #js [root-incarnation]))
+
 (defn- use-resource-reconcile!
   "Reconcile resource ownership after the layout commit accepted `capture`.
 
@@ -157,6 +171,9 @@
   desired plan; queued ensure/release events are write-side work for the next
   drain.  A stale/abandoned capture is rejected by `reactive`."
   [cell capture]
+  ;; Pure capability installation, not ownership: abandoned renders may set a
+  ;; function pointer but cannot mint, ensure, or publish a desired plan.
+  (reactive/enable-resource-lifecycle! cell)
   (react/useEffect
     (fn reconcile-resources []
       (reactive/reconcile-resource-leases! cell capture)
@@ -178,7 +195,7 @@
   [view-id thunk]
   (let [[cell root-incarnation] (use-cell view-id)
         [element capture]      (capture-plain cell thunk)]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-commit-and-lifecycle! cell root-incarnation capture)
     (use-resource-reconcile! cell capture)
     element))
 
@@ -188,7 +205,7 @@
   (let [[cell root-incarnation] (use-cell view-id)
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides cell overrides thunk)]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-commit-and-lifecycle! cell root-incarnation capture)
     (use-resource-reconcile! cell capture)
     element))
 
@@ -199,7 +216,7 @@
   (let [[cell root-incarnation] (use-cell view-id)
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides cell overrides thunk)]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-commit-and-lifecycle! cell root-incarnation capture)
     (use-resource-reconcile! cell capture)
     element))
 

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -2,10 +2,11 @@
   "React glue for the S2b reactive core — the thin `useRef` /
   `useSyncExternalStore` / `useLayoutEffect` layer that drives
   `re-frame.ui.reactive`'s host-agnostic ViewCell + commit reconciler.
-  The compiled CLJS emitter wraps a sub-bearing PRODUCTION view's render body
-  in `render`; sub-free production views are never wrapped. In DEV the stable
-  Fast Refresh Inner always calls `render`, providing the fixed hook skeleton
-  before a view gains its first sub site without charging production for it.
+  The compiled CLJS emitter selects one exact PRODUCTION wrapper:
+  `render-subs`, `render-leases`, or `render-subs-and-leases`; a view with
+  neither capability is not wrapped. In DEV the stable Fast Refresh Inner
+  always calls `render-dev`, providing the fixed superset hook skeleton before
+  a view gains or loses either capability without charging production for it.
 
   The contract, per 03 §3:
 
@@ -76,13 +77,13 @@
                        #js {:value incarnation}
                        element))
 
-(defn render
-  "Wrap a compiled view's render `thunk` (a zero-arg fn returning the host
-  element) in its ViewCell. Establishes the cell (stable per React
-  instance), subscribes the component to the cell's revision, runs the body
-  under a fresh render capture, reads its root incarnation from context, and
-  wires the reconcile + lifecycle layout commits. Returns the host element."
-  [view-id thunk]
+(defn- use-cell
+  "Create/read this component instance's ViewCell and root-incarnation.
+
+  This is the common two-hook prefix shared by every wrapped production shape
+  and the stable dev shell.  Keeping the capability-specific hooks out of this
+  helper makes their absence structural in advanced output."
+  [view-id]
   (let [body-revision (if ^boolean js/goog.DEBUG
                         (reactive/view-generation view-id)
                         0)
@@ -91,74 +92,118 @@
       (set! (.-current cell-ref)
             (reactive/make-cell view-id body-revision)))
     (let [cell             (.-current cell-ref)
-          root-incarnation (react/useContext root-incarnation-context)
-          ;; Story's mounted override scope is React context, not a dynamic
-          ;; binding: descendants render after their provider's caller has
-          ;; returned.  Read it in THIS compiled view and bind the portable
-          ;; override door only around THIS view body.  `use-current` folds to
-          ;; nil/no-hook in production, alongside resolve-override's existing
-          ;; debug gate.
-          overrides        (sub-overrides/use-current)
-          subscribe (react/useCallback
-                      (fn [listener] (reactive/subscribe cell listener))
-                      #js [cell])]
+          root-incarnation (react/useContext root-incarnation-context)]
       ;; Same-signature Fast Refresh keeps this Fiber/ViewCell but advances the
       ;; body revision. Sync BEFORE capture so the selected render records the
       ;; exact descriptor revision it executed. Production folds this branch
       ;; away with the entire HMR slot.
       (when ^boolean js/goog.DEBUG
         (reactive/advance-generation! cell body-revision))
-      ;; ONE useSyncExternalStore — the cell's scalar revision drives
-      ;; sub-invalidation repaints (getServerSnapshot = 0: SSR reads are
-      ;; one-shot, no reactive loop).
-      (react/useSyncExternalStore subscribe
-                                  (fn [] (reactive/get-snapshot cell))
-                                  (fn [] 0))
-      ;; render-phase: resolve + probe every executed site into a fresh
-      ;; ownership-free capture. The selected Fiber's effect closes over this
-      ;; exact value; speculative sibling renders cannot replace it. Story's
-      ;; override door is scoped to THIS capture/body only.
-      (let [[element capture]
-            (if interop/debug-enabled?
-              ;; Binding is intentionally inside the constant DEBUG branch:
-              ;; advanced production output must contain no push/set/restore
-              ;; machinery for Story's override door.
-              (do
-                ;; Stable bundle sentinel: the advanced production gate
-                ;; asserts this whole debug branch is absent.
-                (when (and (some? overrides) (not (map? overrides)))
-                  (throw
-                   (js/Error.
-                    "rf-ui-mounted-override-binding expects a map")))
-                (binding [reactive/*sub-overrides* overrides]
-                  (reactive/with-capture cell thunk)))
-              (reactive/with-capture cell thunk))]
-        ;; reconcile — after EVERY committed render; no cleanup (leases are
-        ;; owned by the cell and reconciled by the kept-check, never torn
-        ;; down between renders — that would churn shared nodes).
-        (react/useLayoutEffect
-          (fn reconcile []
-            (reactive/commit! cell capture)
-            js/undefined))
-        ;; lifecycle — connect implicitly via the reconcile above; the cleanup
-        ;; releases owners on React unmount AND Activity hide (indistinguishable
-        ;; here — 03 §4). Reveal re-mounts this effect and the reconcile
-        ;; reacquires + corrects before paint. In DEV, React StrictMode
-        ;; double-invokes this effect (mount→cleanup→remount in one commit), so
-        ;; every sub node churns through a zero-owner dispose/rebuild — an
-        ;; inherent dev cost, balanced by the idempotent reconcile; the
-        ;; same-commit reconnect is NOT a hide and `reactive/connect!` does not
-        ;; log an Activity-hide proof for it (rf2-vxgfnd.44). On mount the cell ENROLS under its
-        ;; root incarnation (`attach-root!`, rf2-vxgfnd.85/.92) — an ownership that
-        ;; SURVIVES the hide-cleanup, so root teardown reaps a cell hidden before
-        ;; its unmount window. Keyed on the incarnation identity, so a re-mount
-        ;; under a fresh root re-enrols. `attach-root!` is idempotent; the cleanup
-        ;; NEVER detaches the root (that is `teardown!`'s job — the hide must stay
-        ;; reapable-by-its-root).
-        (react/useLayoutEffect
-          (fn lifecycle []
-            (when (some? root-incarnation)
-              (reactive/attach-root! cell root-incarnation))
-            (fn cleanup [] (reactive/disconnect! cell)))
-          #js [root-incarnation])
-        element))))
+      [cell root-incarnation])))
+
+(defn- use-sub-revision!
+  "Install the one aggregated subscription hook and return Story overrides."
+  [cell]
+  (let [overrides (sub-overrides/use-current)
+        subscribe (react/useCallback
+                    (fn [listener] (reactive/subscribe cell listener))
+                    #js [cell])]
+    (react/useSyncExternalStore subscribe
+                                (fn [] (reactive/get-snapshot cell))
+                                (fn [] 0))
+    overrides))
+
+(defn- capture-plain
+  [cell thunk]
+  (reactive/with-capture cell thunk))
+
+(defn- capture-with-overrides
+  "Capture a sub-bearing body under Story's dev-only mounted override door."
+  [cell overrides thunk]
+  (if interop/debug-enabled?
+    (do
+      ;; Stable bundle sentinel: the advanced production gate asserts this
+      ;; whole debug branch is absent.
+      (when (and (some? overrides) (not (map? overrides)))
+        (throw
+         (js/Error. "rf-ui-mounted-override-binding expects a map")))
+      (binding [reactive/*sub-overrides* overrides]
+        (reactive/with-capture cell thunk)))
+    (reactive/with-capture cell thunk)))
+
+(defn- use-commit-and-lifecycle!
+  "Publish the selected render capture and own React visibility lifecycle."
+  [cell root-incarnation capture]
+  ;; Reconcile after every committed render. There is deliberately no cleanup:
+  ;; retained observation/resource owners live on the cell, not on a render.
+  (react/useLayoutEffect
+    (fn reconcile []
+      (reactive/commit! cell capture)
+      js/undefined))
+  ;; Connect via commit above; cleanup releases ownership on both unmount and
+  ;; Activity hide. Root enrolment deliberately survives hide so root teardown
+  ;; can reap an entirely-hidden subtree.
+  (react/useLayoutEffect
+    (fn lifecycle []
+      (when (some? root-incarnation)
+        (reactive/attach-root! cell root-incarnation))
+      (fn cleanup [] (reactive/disconnect! cell)))
+    #js [root-incarnation]))
+
+(defn- use-resource-reconcile!
+  "Reconcile resource ownership after the layout commit accepted `capture`.
+
+  This is a passive effect: render and layout publish only an ownership-free
+  desired plan; queued ensure/release events are write-side work for the next
+  drain.  A stale/abandoned capture is rejected by `reactive`."
+  [cell capture]
+  (react/useEffect
+    (fn reconcile-resources []
+      (reactive/reconcile-resource-leases! cell capture)
+      js/undefined)))
+
+(defn render-subs
+  "Production wrapper for a view with sub sites and no resource leases."
+  [view-id thunk]
+  (let [[cell root-incarnation] (use-cell view-id)
+        overrides              (use-sub-revision! cell)
+        [element capture]      (capture-with-overrides cell overrides thunk)]
+    (use-commit-and-lifecycle! cell root-incarnation capture)
+    element))
+
+(defn render-leases
+  "Production wrapper for a view with resource leases and no sub sites.
+
+  Structurally contains zero `useSyncExternalStore` calls."
+  [view-id thunk]
+  (let [[cell root-incarnation] (use-cell view-id)
+        [element capture]      (capture-plain cell thunk)]
+    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-reconcile! cell capture)
+    element))
+
+(defn render-subs-and-leases
+  "Production wrapper for a view containing both sub and resource sites."
+  [view-id thunk]
+  (let [[cell root-incarnation] (use-cell view-id)
+        overrides              (use-sub-revision! cell)
+        [element capture]      (capture-with-overrides cell overrides thunk)]
+    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-reconcile! cell capture)
+    element))
+
+(defn render-dev
+  "Stable Fast Refresh wrapper: the full hook superset regardless of the
+  currently-compiled body capabilities."
+  [view-id thunk]
+  (let [[cell root-incarnation] (use-cell view-id)
+        overrides              (use-sub-revision! cell)
+        [element capture]      (capture-with-overrides cell overrides thunk)]
+    (use-commit-and-lifecycle! cell root-incarnation capture)
+    (use-resource-reconcile! cell capture)
+    element))
+
+(def render
+  "Internal compatibility alias for pre-S2b direct-render fixtures. New
+  compiled output names its exact capability wrapper."
+  render-subs)

--- a/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
@@ -1,0 +1,80 @@
+(ns re-frame.ui.lease-compiler-jvm-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.registrar :as registrar]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.tree :as tree]))
+
+(def descriptor* (atom {:resource :feed/items}))
+(def evaluations* (atom 0))
+
+(defview dynamic-lease-view []
+  (ui/lease (do (swap! evaluations* inc) @descriptor*))
+  [:div "leased"])
+
+(defview two-lease-sites []
+  (ui/lease {:resource :feed/items})
+  (ui/lease {:resource :feed/items})
+  [:div "two"])
+
+(defn- expand-error [form]
+  (try
+    (macroexpand-1 form)
+    nil
+    (catch clojure.lang.ExceptionInfo ex ex)
+    (catch Exception ex
+      (let [cause (.getCause ex)]
+        (when (instance? clojure.lang.ExceptionInfo cause) cause)))))
+
+(deftest leading-declarations-evaluate-once-and-render-no-node
+  (reset! descriptor* {:resource :feed/items})
+  (reset! evaluations* 0)
+  (let [rendered (tree/render dynamic-lease-view {})]
+    (is (= 1 @evaluations*))
+    (is (= :div (get-in rendered [:children 0 :tag])))
+    (is (= ["leased"] (get-in rendered [:children 0 :children]))))
+  (testing "dynamic validation happens before structural publication"
+    (reset! descriptor* {:resource :unqualified})
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (ex-data
+                          (try (tree/render dynamic-lease-view {})
+                               (catch clojure.lang.ExceptionInfo ex ex))))))))
+
+(deftest manifest-records-distinct-lexical-sites
+  (let [leases (get-in (registrar/lookup :view ::two-lease-sites)
+                       [:rf.ui/manifest :sites :leases])]
+    (is (= 2 (count leases)))
+    (is (= 2 (count (set (map :sid leases)))))
+    (is (every? #(= {:resource :feed/items} (:descriptor %)) leases))
+    (is (contains? (get-in (registrar/lookup :view ::two-lease-sites)
+                           [:rf.ui/manifest :capabilities])
+                   :lease))))
+
+(deftest body-grammar-is-a-closed-prefix
+  (doseq [[form id]
+          [['(re-frame.ui/defview v []
+               (re-frame.ui/lease {:resource :feed/items}))
+            :rf.ui.compile/multi-form-body]
+           ['(re-frame.ui/defview v []
+               (when active? (re-frame.ui/lease {:resource :feed/items}))
+               [:div])
+            :rf.ui.compile/multi-form-body]
+           ['(re-frame.ui/defview v []
+               [:div (re-frame.ui/lease {:resource :feed/items})])
+            :rf.ui.compile/unsupported-form]
+           ['(re-frame.ui/defview v []
+               (re-frame.ui/lease {:resource :feed/items :unknown true})
+               [:div])
+            :rf.ui.compile/unsupported-form]
+           ['(re-frame.ui/defview v []
+               (re-frame.ui/lease {:resource :unqualified})
+               [:div])
+            :rf.ui.compile/unsupported-form]]]
+    (let [ex (expand-error form)]
+      (is (= id (:rf.ui.compile/error (ex-data ex))) (pr-str form)))))
+
+(deftest public-lease-is-never-a-dynamic-helper
+  (is (= :rf.error/ui-tree-malformed
+         (:rf.error/id
+          (ex-data
+           (try (ui/lease {:resource :feed/items})
+                (catch clojure.lang.ExceptionInfo ex ex)))))))

--- a/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
@@ -48,9 +48,10 @@
     (is (= 2 (count leases)))
     (is (= 2 (count (set (map :sid leases)))))
     (is (every? #(= {:resource :feed/items} (:descriptor %)) leases))
-    (is (contains? (get-in (registrar/lookup :view ::two-lease-sites)
-                           [:rf.ui/manifest :capabilities])
-                   :lease))))
+    (is (not (contains? (get-in (registrar/lookup :view ::two-lease-sites)
+                                [:rf.ui/manifest :capabilities])
+                        :lease))
+        "reactive sites live under :sites; they do not grow capability bits")))
 
 (deftest body-grammar-is-a-closed-prefix
   (doseq [[form id]

--- a/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj
@@ -1,7 +1,10 @@
 (ns re-frame.ui.lease-compiler-jvm-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [re-frame.registrar :as registrar]
             [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.header :as header]
             [re-frame.ui.tree :as tree]))
 
 (def descriptor* (atom {:resource :feed/items}))
@@ -78,3 +81,34 @@
           (ex-data
            (try (ui/lease {:resource :feed/items})
                 (catch clojure.lang.ExceptionInfo ex ex)))))))
+
+(defn- emitted-capability-shape [vname subs leases]
+  (pr-str
+   (emit-cljs/emit-defview
+    {:vname vname
+     :view-id (keyword "lease.matrix" (name vname))
+     :display-name (str "lease.matrix/" vname)
+     :header (header/parse-header [])
+     :slots []
+     :ast {:op :text :value "x"}
+     :lease-declarations leases
+     :manifest {:view-id (keyword "lease.matrix" (name vname))
+                :hook-signature "hs1-fixed"
+                :sites {:subs subs :leases leases}}
+     :children? false})))
+
+(deftest cljs-production-wrapper-is-specialized-by-capability
+  (let [lease-row {:sid "lease-site" :descriptor {:resource :feed/items}}
+        neither (emitted-capability-shape 'neither [] [])
+        subs    (emitted-capability-shape 'subs [{:sid "sub-site"}] [])
+        leases  (emitted-capability-shape 'leases [] [lease-row])
+        both    (emitted-capability-shape 'both [{:sid "sub-site"}] [lease-row])]
+    (is (not (str/includes? neither "re-frame.ui.viewcell/render-"))
+        "neither capability is direct React.memo with no ViewCell")
+    (is (str/includes? subs "re-frame.ui.viewcell/render-subs"))
+    (is (not (str/includes? subs "render-subs-and-leases")))
+    (is (str/includes? leases "re-frame.ui.viewcell/render-leases"))
+    (is (not (str/includes? leases "render-subs-and-leases")))
+    (is (str/includes? both "re-frame.ui.viewcell/render-subs-and-leases"))
+    (is (= 1 (count (re-seq #"re-frame.ui.reactive/lease-site" leases)))
+        "one declaration lowers to one compact render capture call")))

--- a/implementation/ui/test/re_frame/ui/lease_descriptor_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/lease_descriptor_jvm_test.clj
@@ -1,0 +1,35 @@
+(ns re-frame.ui.lease-descriptor-jvm-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.lease :as lease]))
+
+(defn- error-id [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo ex
+      (:rf.error/id (ex-data ex)))))
+
+(deftest descriptor-grammar-is-closed-and-preserves-presence
+  (testing "nil is the inactive descriptor"
+    (is (nil? (lease/validate-descriptor! nil))))
+  (testing "valid maps are returned without normalization"
+    (doseq [descriptor [{:resource :feed/items}
+                        {:resource :feed/items :params nil}
+                        {:resource :feed/items :scope :rf.scope/global
+                         :params {:page 1}}]]
+      (is (identical? descriptor (lease/validate-descriptor! descriptor))))
+    (is (not (contains? (lease/validate-descriptor! {:resource :feed/items})
+                        :params)))
+    (is (contains? (lease/validate-descriptor!
+                    {:resource :feed/items :params nil})
+                   :params)))
+  (testing "malformed dynamic values fail before capture"
+    (doseq [descriptor [42
+                        [:feed/items]
+                        {}
+                        {:resource :unqualified}
+                        {:resource "feed/items"}
+                        {:resource :feed/items :extra true}]]
+      (is (= :rf.error/ui-tree-malformed
+             (error-id #(lease/validate-descriptor! descriptor)))
+          (pr-str descriptor)))))

--- a/implementation/ui/test/re_frame/ui/lease_descriptor_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/lease_descriptor_jvm_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.ui.lease-descriptor-jvm-test
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.lease :as lease]))
+            [re-frame.ui.lease-descriptor :as lease]))
 
 (defn- error-id [f]
   (try

--- a/implementation/ui/test/re_frame/ui/resource_lease_hook_matrix_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/resource_lease_hook_matrix_elision_prod_test.cljs
@@ -1,0 +1,114 @@
+(ns re-frame.ui.resource-lease-hook-matrix-elision-prod-test
+  "rf2-vxgfnd.106 — actual :advanced/goog.DEBUG=false mounted proof of the
+  frozen production hook matrix: neither 0/0, sub 1/0, lease 0/1, both 1/1
+  for useSyncExternalStore/resource-passive respectively."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            ["react" :as React]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.resources]
+            [re-frame.resources.test-support]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+(def ^:private this-ns
+  "re-frame.ui.resource-lease-hook-matrix-elision-prod-test")
+
+(defview matrix-neither []
+  [:output {:data-matrix "neither"} "plain"])
+
+(defview matrix-sub []
+  [:output {:data-matrix "sub"} (str (ui/sub [::value]))])
+
+(defview matrix-lease []
+  (ui/lease {:resource ::feed :params {}})
+  [:output {:data-matrix "lease"} "lease"])
+
+(defview matrix-both []
+  (ui/lease {:resource ::feed :params {}})
+  [:output {:data-matrix "both"} (str (ui/sub [::value]))])
+
+(defn- install-matrix-registrations!
+  []
+  (rf/reg-sub ::value (fn [db _] (:value db)))
+  (rf/reg-resource ::feed
+                   {:scope :rf.scope/global
+                    :params-schema [:map]}
+                   (fn [_ _]
+                     {:request {:method :get :url "/ui-lease-matrix"}}))
+  (rf/reg-event :rf.resource/ensure (fn [{:keys [db]} _] {:db db}))
+  (rf/reg-event :rf.resource/release-owner (fn [{:keys [db]} _] {:db db})))
+
+(defn- matrix-frame []
+  (rf/make-frame
+   {:id :ui.lease/prod-matrix
+    :images [(rf/image {:id ::base
+                        :select-ns {:include ["**"]
+                                    :exclude [this-ns]}})
+             (rf/image {:id ::overrides
+                        :select-ns {:include [this-ns]}})]
+    :initial-events [[:rf/set-db {:value 7}]]}))
+
+(defn- measure-hooks!
+  [f component label]
+  (let [container (js/document.createElement "div")
+        root      (volatile! nil)
+        counts    (atom {:uses 0 :passive 0})
+        original-uses (.-useSyncExternalStore React)
+        original-effect (.-useEffect React)]
+    (.appendChild js/document.body container)
+    (vreset! root (ui/create-root container {:root-id :ui.lease/matrix}))
+    (set! (.-useSyncExternalStore React)
+          (fn [& args]
+            (swap! counts update :uses inc)
+            (.apply original-uses nil (to-array args))))
+    (set! (.-useEffect React)
+          (fn [& args]
+            (swap! counts update :passive inc)
+            (.apply original-effect nil (to-array args))))
+    (try
+      (ReactDOM/flushSync
+       #(ui/render! @root
+                    [ui/frame-provider {:frame f}
+                     (ui/raw (React/createElement component nil))]))
+      @counts
+      (finally
+        (set! (.-useSyncExternalStore React) original-uses)
+        (set! (.-useEffect React) original-effect)
+        (when @root
+          (ReactDOM/flushSync #(ui/unmount! @root)))
+        (.remove container)))))
+
+(def ^:private expected-matrix
+  {:neither {:uses 0 :passive 0}
+   :sub     {:uses 1 :passive 0}
+   :lease   {:uses 0 :passive 1}
+   :both    {:uses 1 :passive 1}})
+
+(defn- valid-matrix? [m] (= expected-matrix m))
+
+(deftest advanced-mounted-capability-matrix-has-exact-hook-cardinality
+  (install-matrix-registrations!)
+  (let [f (matrix-frame)
+        observed {:neither (measure-hooks! f matrix-neither :neither)
+                  :sub     (measure-hooks! f matrix-sub :sub)
+                  :lease   (measure-hooks! f matrix-lease :lease)
+                  :both    (measure-hooks! f matrix-both :both)}]
+    (js/console.log
+     (str "RF2_UI_RESOURCE_LEASE_HOOK_MATRIX observed=" (pr-str observed)))
+    (is (valid-matrix? observed))
+    ;; Mutation teeth: each historically-dangerous shape change makes the
+    ;; exact production gate red, including charging lease-only for uSES and
+    ;; leaking the resource passive into sub-only/neither.
+    (doseq [mutated [(assoc-in observed [:lease :uses] 1)
+                     (assoc-in observed [:sub :passive] 1)
+                     (assoc-in observed [:neither :passive] 1)
+                     (assoc-in observed [:both :uses] 0)]]
+      (is (not (valid-matrix? mutated))))
+    (rf/destroy-frame! f)))

--- a/implementation/ui/test/re_frame/ui/resource_lease_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/resource_lease_lifecycle_dom_cljs_test.cljs
@@ -1,0 +1,304 @@
+(ns re-frame.ui.resource-lease-lifecycle-dom-cljs-test
+  "rf2-vxgfnd.106 — mounted React proof for the resource-ownership family:
+  lease-only StrictMode/Activity/unmount, same-signature HMR retention/removal,
+  and eight queued ensure writes settling before one subscribed read render."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom/client" :as ReactDOMClient]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.resources]
+            [re-frame.resources.test-support]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.runtime :as runtime]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+(def ^:private Activity React/Activity)
+(defonce ^:private resource-events (atom []))
+(defonce ^:private batch-evidence (atom {:ensures 0 :read-bodies 0}))
+(def ^:private this-ns
+  "re-frame.ui.resource-lease-lifecycle-dom-cljs-test")
+
+(defn- install-resource-control!
+  []
+  (reset! resource-events [])
+  (rf/reg-resource ::feed
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:n {:optional true} :int]]}
+                   (fn [_params _ctx]
+                     {:request {:method :get :url "/ui-lease-proof"}}))
+  ;; Keep the proof about ui/lease ownership and ordinary FIFO drains. The
+  ;; Resources artefact is genuinely loaded (the feature probe is real), while
+  ;; deterministic handlers avoid transport/network work.
+  (rf/reg-event :rf.resource/ensure
+                (fn [{:keys [db]} [_ payload]]
+                  (swap! resource-events conj [:ensure payload])
+                  {:db db}))
+  (rf/reg-event :rf.resource/release-owner
+                (fn [{:keys [db]} [_ payload]]
+                  (swap! resource-events conj [:release payload])
+                  {:db db})))
+
+(defn- make-test-frame
+  [id app-db]
+  ;; The resource artefact owns the standard handlers in the base image. This
+  ;; test's deterministic handlers are an intentional later-image override,
+  ;; never an ambiguous same-image duplicate.
+  (rf/make-frame
+   {:id id
+    :images [(rf/image {:id ::base
+                        :select-ns {:include ["**"]
+                                    :exclude [this-ns]}})
+             (rf/image {:id ::lease-test-overrides
+                        :select-ns {:include [this-ns]}})]
+    :initial-events [[:rf/set-db app-db]]}))
+
+(defn- settle!
+  []
+  (-> (uit/flush!)
+      (.then (fn [] (uit/flush!)))))
+
+(defn- lease-cell
+  []
+  (some #(when (seq (reactive/resource-reservations %)) %)
+        (reactive/current-live-cells)))
+
+(defview mounted-lease-leaf []
+  (ui/lease {:resource ::feed :params {}})
+  [:output {:data-role "mounted-lease-leaf"} "leased"])
+
+(defview mounted-lease-activity []
+  [Activity {:mode (if (ui/sub [::hidden?]) "hidden" "visible")}
+   [mounted-lease-leaf]])
+
+(defview strict-mounted-lease-activity []
+  (ui/raw
+   (React/createElement (.-StrictMode React) nil
+                        (React/createElement mounted-lease-activity nil))))
+
+(deftest lease-only-strictmode-activity-and-unmount-own-exactly-one-token
+  (if-not (browser?)
+    (is true ":node — browser gate runs mounted lease lifecycle")
+    (do
+      (install-resource-control!)
+      (rf/reg-sub ::hidden? (fn [db _] (:hidden? db)))
+      (rf/reg-event ::hide (fn [{:keys [db]} _]
+                             {:db (assoc db :hidden? true)}))
+      (rf/reg-event ::show (fn [{:keys [db]} _]
+                             {:db (assoc db :hidden? false)}))
+      (let [f    (make-test-frame :ui.lease/lifecycle-frame
+                                  {:hidden? false})
+            cell* (atom nil)
+            owner* (atom nil)]
+        (async done
+          (->
+           (uit/with-root [root [ui/frame-provider {:frame f}
+                                 [strict-mounted-lease-activity]]]
+             (-> (settle!)
+                 (.then
+                  (fn []
+                    (let [cell  (lease-cell)
+                          owner (-> (reactive/resource-reservations cell)
+                                    vals first :owner)]
+                      (reset! cell* cell)
+                      (reset! owner* owner)
+                      (is (some? cell))
+                      (is (= :connected (reactive/lifecycle cell)))
+                      (is (= #{owner} (set (keys (reactive/resource-held cell)))))
+                      (is (= "leased"
+                             (.-textContent
+                              (uit/query root "[data-role='mounted-lease-leaf']"))))
+                      (uit/flush! #(uit/dispatch! f [::hide])))))
+                 (.then (fn [] (settle!)))
+                 (.then
+                  (fn []
+                    (testing "Activity hide releases but preserves reservation"
+                      (is (= :disconnected (reactive/lifecycle @cell*)))
+                      (is (empty? (reactive/resource-held @cell*)))
+                      (is (= @owner* (-> (reactive/resource-reservations @cell*)
+                                         vals first :owner))))
+                    (uit/flush! #(uit/dispatch! f [::show]))))
+                 (.then (fn [] (settle!)))
+                 (.then
+                  (fn []
+                    (testing "reveal reuses the exact owner under StrictMode"
+                      (is (identical? @cell* (lease-cell)))
+                      (is (= :connected (reactive/lifecycle @cell*)))
+                      (is (= #{@owner*}
+                             (set (keys (reactive/resource-held @cell*)))))
+                      (is (= @owner* (-> (reactive/resource-reservations @cell*)
+                                         vals first :owner))))))))
+           (.then
+            (fn []
+              (testing "final root unmount releases and forgets reservation"
+                (is (= :dead (reactive/lifecycle @cell*)))
+                (is (empty? (reactive/resource-held @cell*)))
+                (is (empty? (reactive/resource-reservations @cell*))))
+              (rf/destroy-frame! f)
+              (done))
+            (fn [e]
+              (rf/destroy-frame! f)
+              (is false (str "mounted lease lifecycle rejected: " e))
+              (done)))))))))
+
+(defn- act-promise [thunk]
+  (try
+    (js/Promise.resolve
+     (React/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- register-hmr-lease!
+  [id descriptor]
+  (runtime/register-view!
+   id
+   (fn [_props]
+     (reactive/lease-site "sid1-hmr-lease" descriptor)
+     (React/createElement "output" #js {:data-hmr-lease true}
+                          (if descriptor "leased" "plain")))
+   (fn [_ _] true)
+   "HmrLease"
+   {:view-id id
+    :display-name "HmrLease"
+    :template-fingerprint "tf1-hmr-lease"
+    :hook-signature "hs1-hmr-lease"
+    :sites {"sid1-hmr-lease" {:kind :lease}}}))
+
+(deftest same-signature-hmr-retains-equal-owner-and-releases-removed-site
+  (if-not (browser?)
+    (is true ":node — browser gate runs mounted lease HMR")
+    (do
+      (install-resource-control!)
+      (let [id        ::hmr-lease
+            fid       :ui.lease/hmr-frame
+            descriptor {:resource ::feed :params {}}
+            container (js/document.createElement "div")
+            root      (ReactDOMClient/createRoot container)
+            shell     (register-hmr-lease! id descriptor)
+            cell*     (atom nil)
+            owner*    (atom nil)]
+        (make-test-frame fid {})
+        (.appendChild js/document.body container)
+        (async done
+          (-> (act-promise
+               #(.render root
+                         (frames/scope-element
+                          fid (array (React/createElement shell nil)))))
+              (.then
+               (fn []
+                 (let [cell  (lease-cell)
+                       owner (-> (reactive/resource-reservations cell)
+                                 vals first :owner)]
+                   (reset! cell* cell)
+                   (reset! owner* owner)
+                   (act-promise #(register-hmr-lease! id (into {} descriptor))))))
+              (.then
+               (fn []
+                 (testing "rf=-equal same-site refresh keeps the exact owner"
+                   (is (identical? @cell* (lease-cell)))
+                   (is (= @owner* (-> (reactive/resource-reservations @cell*)
+                                      vals first :owner))))
+                 (act-promise #(register-hmr-lease! id nil))))
+              (.then
+               (fn []
+                 (testing "removing the lease in place releases and forgets it"
+                   (is (= "plain"
+                          (.-textContent
+                           (.querySelector container "[data-hmr-lease]"))))
+                   (is (empty? (reactive/resource-held @cell*)))
+                   (is (empty? (reactive/resource-reservations @cell*))))))
+              (.then (fn [] (act-promise #(.unmount root))))
+              (.then
+               (fn []
+                 (.remove container)
+                 (rf/destroy-frame! fid)
+                 (done)))
+              (.catch
+               (fn [e]
+                 (try (.unmount root) (catch :default _ nil))
+                 (.remove container)
+                 (rf/destroy-frame! fid)
+                 (is false (str "mounted lease HMR rejected: " e))
+                 (done)))))))))
+
+(defview lease-write-batch []
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 0}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 1}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 2}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 3}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 4}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 5}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 6}}))
+  (ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {:n 7}}))
+  [:span {:data-role "lease-batch-owner"} "owner"])
+
+(defview lease-write-reader []
+  (let [_ (swap! batch-evidence update :read-bodies inc)]
+    [:output {:data-role "lease-write-count"}
+     (str (ui/sub [::write-count]))]))
+
+(defview lease-write-app []
+  [:section [lease-write-batch] [lease-write-reader]])
+
+(deftest one-lease-passive-batch-drains-eight-writes-before-one-read-render
+  (if-not (browser?)
+    (is true ":node — browser gate runs one-drain/one-render proof")
+    (do
+      (install-resource-control!)
+      (rf/reg-sub ::activate? (fn [db _] (:activate? db)))
+      (rf/reg-sub ::write-count (fn [db _] (:writes db)))
+      (rf/reg-event ::activate (fn [{:keys [db]} _]
+                                 {:db (assoc db :activate? true)}))
+      ;; Replace only the deterministic ensure handler: all eight ordinary
+      ;; queued events write in one run-to-completion drain.
+      (rf/reg-event :rf.resource/ensure
+                    (fn [{:keys [db]} [_ payload]]
+                      (swap! batch-evidence update :ensures inc)
+                      {:db (update db :writes inc)}))
+      (let [f       (make-test-frame :ui.lease/batch-frame
+                                     {:activate? false :writes 0})
+            frame-id (frame/frame-target->id f)
+            read-key [:sub frame-id [::write-count]]]
+        (async done
+          (->
+           (uit/with-root [root [ui/frame-provider {:frame f}
+                                 [lease-write-app]]]
+             (let [reader-cell (some #(when (contains?
+                                                   (reactive/committed-target-keys %)
+                                                   read-key)
+                                                %)
+                                     (reactive/current-live-cells))
+                   revision0 (reactive/revision reader-cell)]
+               (reset! batch-evidence {:ensures 0 :read-bodies 0})
+               (-> (uit/flush! #(uit/dispatch! f [::activate]))
+                   (.then (fn [] (settle!)))
+                   (.then
+                    (fn []
+                      (is (= 8 (:ensures @batch-evidence)))
+                      (is (= "8"
+                             (.-textContent
+                              (uit/query root "[data-role='lease-write-count']"))))
+                      (is (= 1 (:read-bodies @batch-evidence))
+                          "eight write-side epochs settle before one read body")
+                      (is (= (inc revision0) (reactive/revision reader-cell))
+                          "the aggregate ViewCell revision advances once"))))))
+           (.then (fn []
+                    (rf/destroy-frame! f)
+                    (done))
+                  (fn [e]
+                    (rf/destroy-frame! f)
+                    (is false (str "lease batch/render proof rejected: " e))
+                    (done)))))))))

--- a/implementation/ui/test/re_frame/ui/resource_lease_owner_mixed_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/resource_lease_owner_mixed_cljs_test.cljs
@@ -1,0 +1,51 @@
+(ns re-frame.ui.resource-lease-owner-mixed-cljs-test
+  "rf2-vxgfnd.106 — wiring-sensitive proof that the frozen stock-Reagent
+  helper and the actual re-frame.ui reconciler draw owner identities through
+  the same neutral process-global mint."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.adapter.resource-lease :as adapter-lease]
+            [re-frame.core :as rf]
+            [re-frame.features :as features]
+            [re-frame.registrar :as registrar]
+            [re-frame.resource-lease-owner :as lease-owner]
+            [re-frame.router :as router]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.reactive :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- silent-dispatch
+  ([] (silent-dispatch nil))
+  ([_event] nil)
+  ([_event _opts] nil))
+
+(deftest stock-reagent-and-ui-reconcile-share-the-neutral-mint
+  (registrar/register! :resource ::feed {:rf/resource {}})
+  (let [cell  (reactive/make-cell ::ui-owner)
+        calls (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! silent-dispatch
+                  ;; The controlled neutral source makes this a wiring test,
+                  ;; not a coincidence test. A private UI counter would leave
+                  ;; calls=1 and cannot manufacture [:shared 2].
+                  lease-owner/mint! (fn [] [:shared (swap! calls inc)])]
+      (let [stock-owner (adapter-lease/mint-lease-owner!)
+            [_ cap] (rf/with-frame :rf/default
+                      (reactive/with-capture
+                       cell
+                       #(do (reactive/lease-site
+                             ::site {:resource ::feed})
+                            :element)))]
+        (reactive/commit-resources! cell cap)
+        (reactive/reconcile-resource-leases! cell cap)
+        (let [ui-owner (-> (reactive/resource-reservations cell)
+                           vals first :owner)]
+          (is (= 2 @calls))
+          (is (= [:shared 1] stock-owner))
+          (is (= [:shared 2] ui-owner))
+          (is (not= stock-owner ui-owner)))))))

--- a/implementation/ui/test/re_frame/ui/resource_lease_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/resource_lease_reconcile_cljs_test.cljc
@@ -1,0 +1,558 @@
+(ns re-frame.ui.resource-lease-reconcile-cljs-test
+  "rf2-vxgfnd.106 — headless proof of the resource ownership family inside
+  the exact ViewCell capture/lifecycle.  Runs on node and JVM without loading
+  the optional Resources artefact; registrar-shaped feature rows and the
+  router enqueue seam are sufficient to prove planning and ownership."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.features :as features]
+            [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.resource-lease-owner :as lease-owner]
+            [re-frame.router :as router]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.reactive :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- register-feature! [& resources]
+  (doseq [resource resources]
+    (registrar/register! :resource resource {:rf/resource {}})))
+
+(defn- capture-leases
+  ([cell sites] (capture-leases cell fid sites))
+  ([cell frame-id sites]
+   (reactive/enable-resource-lifecycle! cell)
+   (rf/with-frame frame-id
+     (reactive/with-capture
+      cell
+      (fn []
+        (doseq [[sid descriptor] sites]
+          (reactive/lease-site sid descriptor))
+        :element)))))
+
+(defn- commit-leases! [cell sites]
+  (let [[_ capture] (capture-leases cell sites)]
+    (reactive/commit-resources! cell capture)
+    capture))
+
+(defn- throws-id [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+(defn- dispatch-standin
+  "Redefine router/dispatch! without breaking compiler-optimized CLJS arity
+  calls. A single-body CLJS fn has no invoke$arity$2 property."
+  [f]
+  (fn capture
+    ([event] (capture event nil))
+    ([event opts] (f event opts))))
+
+(defn- collecting-dispatch [calls]
+  (dispatch-standin (fn [event opts]
+                      (swap! calls conj [event opts]))))
+
+(deftest lease-free-capture-and-cell-lifecycle-omit-resource-state
+  (let [cell (reactive/make-cell ::lease-free)
+        [_ cap] (reactive/with-capture cell (constantly :plain))
+        lease-free-capture? #(and (not (contains? % :resource-order))
+                                  (not (contains? % :resource-by-site)))]
+    (is (lease-free-capture? cap))
+    (is (not (lease-free-capture? (assoc cap :resource-order [])))
+        "mutation tooth: adding resource capture state makes the shape fail")
+    (is (false? (reactive/resource-state-installed? cell)))
+    (reactive/commit! cell cap)
+    (is (false? (reactive/resource-state-installed? cell)))
+    (reactive/disconnect! cell)
+    (is (false? (reactive/resource-state-installed? cell)))
+    (reactive/teardown! cell)
+    (is (false? (reactive/resource-state-installed? cell)))))
+
+(deftest resource-lease-frame-does-not-expand-observation-flush-scope
+  (let [resource-frame :lease/flush-scope
+        _              (live-frame/make-frame {:id resource-frame})
+        cell           (reactive/make-cell ::flush-scope)]
+    (try
+      (rf/reg-sub ::flush-value (fn [db _] (:value db)))
+      (frame/replace-app-db! fid {:value 1})
+      (reactive/enable-resource-lifecycle! cell)
+      (let [[_ cap]
+            (reactive/with-capture
+             cell
+             (fn []
+               (rf/with-frame fid
+                 (reactive/sub-read ::sub [::flush-value]))
+               (rf/with-frame resource-frame
+                 (reactive/lease-site ::lease {:resource :feed/items}))
+               :element))]
+        (reactive/commit-resources! cell cap))
+      (reactive/mark-dirty! cell)
+      (let [before (reactive/revision cell)]
+        (is (zero? (reactive/flush-frame! resource-frame))
+            "a B resource lease is liveness, not B read observation")
+        (is (= before (reactive/revision cell))
+            "flushing resource-only B leaves the A-dirty cell pending")
+        (is (= 1 (reactive/flush-frame! fid)))
+        (is (= (inc before) (reactive/revision cell))
+            "flushing observed subscription frame A advances exactly once"))
+      (finally
+        (frame/destroy-frame! resource-frame)))))
+
+(deftest render-and-abandon-own-nothing
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::abandoned)
+        calls (atom [])
+        mints (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (dotimes [_ 100]
+        (capture-leases cell [[::site {:resource :feed/items}]]))
+      (is (zero? @mints))
+      (is (empty? @calls))
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest site-id-loss-mutation-fails-before-commit-or-owner-mint
+  (let [cell  (reactive/make-cell ::site-id-loss)
+        mints (atom 0)]
+    (with-redefs [lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (is (= :rf.error/ui-tree-malformed
+             (throws-id
+              #(rf/with-frame fid
+                 (reactive/with-capture
+                  cell
+                  (fn []
+                    ;; Models a compiler mutation that aliases two lexical
+                    ;; declarations onto one sid.
+                    (reactive/lease-site ::lost {:resource :feed/items})
+                    (reactive/lease-site ::lost {:resource :feed/items})))))))
+      (is (zero? @mints))
+      (is (empty? (reactive/resource-reservations cell))))))
+
+(deftest equal-sites-own-independently-and-rf-equal-rerender-does-not-churn
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::equal-sites)
+        calls (atom [])
+        mints (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (let [cap (commit-leases!
+                 cell [[::a {:resource :feed/items}]
+                       [::b {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (let [ensures (mapv first @calls)
+            owners  (mapv (comp :owner second) ensures)
+            evidence (reactive/resource-lease-evidence cell)]
+        (is (= [:rf.resource/ensure :rf.resource/ensure]
+               (mapv first ensures)))
+        (is (= 2 (count (set owners)))
+            "equal descriptors at distinct lexical sites have distinct owners")
+        (is (every? #(not (contains? (second %) :params)) ensures)
+            "omitted params stay omitted in every ensure payload")
+        (is (= 2 (count evidence)))
+        (is (every? #(= #{:rf.ui/view :rf.ui/commit :rf.ui/site :frame :owner}
+                        (set (keys %)))
+                    evidence)
+            "Xray join evidence is bounded identity, never descriptor data"))
+      (reset! calls [])
+      (let [cap (commit-leases!
+                 cell [[::a (into {} {:resource :feed/items})]
+                       [::b (into {} {:resource :feed/items})]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (is (= 2 @mints) "rf=-equal same-site descriptors retain owners")
+      (is (empty? @calls) "equal re-render queues neither ensure nor release"))))
+
+(deftest retarget-queues-all-ensures-before-releases-and-preserves-explicit-nil
+  (register-feature! :feed/items :feed/new)
+  (let [cell  (reactive/make-cell ::retarget)
+        calls (atom [])
+        mints (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (let [cap (commit-leases!
+                 cell [[::a {:resource :feed/items}]
+                       [::b {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (let [owners-before (set (keys (reactive/resource-held cell)))]
+        (reset! calls [])
+        (let [cap (commit-leases!
+                   cell [[::a {:resource :feed/new :scope nil :params nil}]])]
+          (reactive/reconcile-resource-leases! cell cap))
+        (let [events (mapv first @calls)
+              ensure (first events)
+              payload (second ensure)]
+          (is (= [:rf.resource/ensure
+                  :rf.resource/release-owner
+                  :rf.resource/release-owner]
+                 (mapv first events)))
+          (is (contains? payload :scope))
+          (is (contains? payload :params))
+          (is (nil? (:scope payload)))
+          (is (nil? (:params payload)))
+          (is (not (contains? owners-before (:owner payload)))
+              "retarget mints a fresh owner"))))))
+
+(deftest disconnect-releases-held-but-reveal-reuses-reservation
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::activity)
+        calls (atom [])
+        mints (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (let [owner (-> (reactive/resource-reservations cell) vals first :owner)]
+        (reset! calls [])
+        (reactive/disconnect-resources! cell)
+        (is (= [:rf.resource/release-owner]
+               (mapv (comp first first) @calls)))
+        (is (empty? (reactive/resource-held cell)))
+        (is (= owner (-> (reactive/resource-reservations cell) vals first :owner)))
+        (reset! calls [])
+        (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+          (reactive/reconcile-resource-leases! cell cap))
+        (is (= [:rf.resource/ensure]
+               (mapv (comp first first) @calls)))
+        (is (= owner (-> @calls first first second :owner)))
+        (is (= 1 @mints) "StrictMode/Activity replay reuses its reservation")))))
+
+(deftest missing-optional-feature-fails-before-owner-mint-or-dispatch
+  (registrar/register! :resource :feed/items {:rf/resource {}})
+  (let [cell  (reactive/make-cell ::missing-feature)
+        calls (atom [])
+        mints (atom 0)
+        cap   (commit-leases! cell [[::a {:resource :feed/items}]])]
+    (with-redefs [features/require-feature!
+                  (fn [_]
+                    (throw (ex-info "missing" {:rf.error/id
+                                                :rf.error/feature-not-loaded})))
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (is (= :rf.error/feature-not-loaded
+             (throws-id #(reactive/reconcile-resource-leases! cell cap))))
+      (is (zero? @mints))
+      (is (empty? @calls))
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest full-plan-prevalidation-rejects-one-missing-resource-before-any-work
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::missing-resource)
+        calls (atom [])
+        mints (atom 0)
+        cap   (commit-leases!
+               cell [[::valid {:resource :feed/items}]
+                     [::bad {:resource :feed/not-registered}]])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (is (= :rf.error/resource-not-registered
+             (throws-id #(reactive/reconcile-resource-leases! cell cap))))
+      (is (zero? @mints)
+          "a valid earlier site does not mint before the complete plan validates")
+      (is (empty? @calls))
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest ensure-enqueue-escape-compensates-every-staged-owner
+  (register-feature! :feed/items)
+  (let [cell (reactive/make-cell ::ensure-escape)
+        calls (atom [])
+        ensure-attempt (atom 0)
+        cap (commit-leases!
+             cell [[::a {:resource :feed/items}]
+                   [::b {:resource :feed/items}]
+                   [::c {:resource :feed/items}]])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (= :rf.resource/ensure (first event))
+                       (when (= 2 (swap! ensure-attempt inc))
+                         (throw (ex-info "injected ensure enqueue escape" {}))))))]
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                      :cljs cljs.core/ExceptionInfo)
+                   (reactive/reconcile-resource-leases! cell cap)))
+      (is (= [:rf.resource/ensure :rf.resource/ensure
+              :rf.resource/release-owner :rf.resource/release-owner
+              :rf.resource/release-owner]
+             (mapv (comp first first) @calls))
+          "all staged owners are conservatively compensated, including the
+           possibly-enqueued throwing record and the not-yet-ensured tail")
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest passive-reconcile-is-bound-to-the-exact-accepted-capture
+  (register-feature! :feed/items :feed/new)
+  (let [cell  (reactive/make-cell ::exact-passive)
+        calls (atom [])
+        mints (atom 0)
+        [_ old-cap] (capture-leases cell [[::a {:resource :feed/items}]])
+        new-cap (commit-leases! cell [[::a {:resource :feed/new}]])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (reactive/reconcile-resource-leases! cell old-cap)
+      (is (zero? @mints) "a passive effect from an unselected capture is inert")
+      (is (empty? @calls))
+      (reactive/reconcile-resource-leases! cell new-cap)
+      (is (= [:rf.resource/ensure]
+             (mapv (comp first first) @calls)))
+      (is (= :feed/new (-> @calls first first second :resource))))))
+
+(deftest hmr-generation-advance-invalidates-an-older-accepted-passive-closure
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::hmr-stale 0)
+        calls (atom [])
+        mints (atom 0)
+        cap   (commit-leases! cell [[::a {:resource :feed/items}]])]
+    ;; Model registration advancing authority before the replacement render is
+    ;; selected (or when that render is later abandoned).
+    (reactive/advance-generation! cell 1)
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (reactive/reconcile-resource-leases! cell cap)
+      (is (zero? @mints))
+      (is (empty? @calls))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest hmr-removing-the-last-lease-releases-and-forgets-its-owner
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::hmr-remove 0)
+        calls (atom [])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)]
+      (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (is (= 1 (count (reactive/resource-held cell))))
+      (reset! calls [])
+      (reactive/advance-generation! cell 1)
+      (let [cap (commit-leases! cell [])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (is (= [:rf.resource/release-owner]
+             (mapv (comp first first) @calls)))
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest ownership-empty-dev-shell-does-not-probe-the-optional-feature
+  (let [cell   (reactive/make-cell ::empty-dev-shell)
+        probes (atom 0)
+        [_ cap] (reactive/with-capture cell (constantly :element))]
+    (reactive/commit-resources! cell cap)
+    (with-redefs [features/require-feature!
+                  (fn [_]
+                    (swap! probes inc)
+                    (throw (ex-info "must not probe" {})))]
+      (reactive/reconcile-resource-leases! cell cap)
+      (is (zero? @probes))
+      (is (empty? (reactive/resource-held cell))))))
+
+(deftest cross-frame-retarget-prevalidates-then-ensures-all-before-any-release
+  (register-feature! :feed/items :feed/new)
+  (let [frame-a (live-frame/make-frame {:id :lease/frame-a})
+        frame-b (live-frame/make-frame {:id :lease/frame-b})
+        cell    (reactive/make-cell ::cross-frame)
+        calls   (atom [])
+        mints   (atom 0)
+        capture (fn [rows]
+                  (reactive/with-capture
+                   cell
+                   (fn []
+                     (doseq [[frame-id sid descriptor] rows]
+                       (rf/with-frame frame-id
+                         (reactive/lease-site sid descriptor)))
+                     :element)))]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])]
+      (let [[_ cap] (capture [[frame-a ::a {:resource :feed/items}]
+                              [frame-b ::b {:resource :feed/items}]])]
+        (reactive/commit-resources! cell cap)
+        (reactive/reconcile-resource-leases! cell cap))
+      (reset! calls [])
+      ;; Both lexical sites change exact frame incarnation and descriptor.
+      ;; The desired lexical order deliberately crosses the two frame queues.
+      (let [[_ cap] (capture [[frame-b ::a {:resource :feed/new}]
+                              [frame-a ::b {:resource :feed/new}]])]
+        (reactive/commit-resources! cell cap)
+        (reactive/reconcile-resource-leases! cell cap))
+      (is (= [:rf.resource/ensure :rf.resource/ensure
+              :rf.resource/release-owner :rf.resource/release-owner]
+             (mapv (comp first first) @calls)))
+      (is (= [:lease/frame-b :lease/frame-a :lease/frame-a :lease/frame-b]
+             (mapv (comp :frame second) @calls))
+          "desired lexical ensures precede deterministic prior-owner releases")
+      (is (= 4 @mints) "each cross-frame retarget mints a fresh owner"))
+    (frame/destroy-frame! frame-a)
+    (frame/destroy-frame! frame-b)))
+
+(deftest resource-only-cells-are-discoverable-while-connected-and-hidden
+  (register-feature! :feed/items)
+  (let [frame-id :lease/discovery
+        _        (live-frame/make-frame {:id frame-id})
+        connected (reactive/make-cell ::connected)
+        hidden    (reactive/make-cell ::hidden)
+        root      (reactive/make-root-incarnation)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (dispatch-standin (fn [_ _] nil))]
+      (doseq [cell [connected hidden]]
+        (let [[_ cap] (capture-leases cell frame-id
+                                      [[::a {:resource :feed/items}]])]
+          (reactive/commit-resources! cell cap)
+          (reactive/reconcile-resource-leases! cell cap)))
+      (is (= 1 (reactive/resource-frame-incarnation-count connected frame-id))
+          "desired/reserved/held copies dedupe to one exact frame token")
+      (reactive/attach-root! hidden root)
+      (reactive/disconnect-resources! hidden)
+      (is (= :disconnected (reactive/lifecycle hidden)))
+      (is (= 2 (reactive/teardown-frame! frame-id))
+          "frame discovery unions connected desired state and hidden reservations")
+      (is (= :dead (reactive/lifecycle connected)))
+      (is (= :dead (reactive/lifecycle hidden)))
+      (is (empty? (reactive/resource-reservations connected)))
+      (is (empty? (reactive/resource-reservations hidden))))
+    (frame/destroy-frame! frame-id)))
+
+(deftest transient-same-id-incarnations-remain-distinct-in-frame-index
+  (register-feature! :feed/items)
+  (let [frame-id :lease/transient-index
+        _        (live-frame/make-frame {:id frame-id})
+        token-a  (reactive/make-root-incarnation)
+        token-b  (reactive/make-root-incarnation)
+        current  (atom token-a)
+        cell     (reactive/make-cell ::transient-index)]
+    (with-redefs [features/require-feature! (constantly true)
+                  frame/frame-incarnation-token (fn [_] @current)
+                  frame/frame-incarnation-closing? (fn [_ _] false)
+                  router/dispatch! (dispatch-standin (fn [_ _] nil))]
+      (let [[_ cap-a] (capture-leases cell frame-id
+                                      [[::a {:resource :feed/items}]])]
+        (reactive/commit-resources! cell cap-a)
+        (reactive/reconcile-resource-leases! cell cap-a))
+      (reset! current token-b)
+      (let [[_ cap-b] (capture-leases cell frame-id
+                                      [[::a {:resource :feed/items}]])]
+        (reactive/commit-resources! cell cap-b))
+      (is (= 2 (reactive/resource-frame-incarnation-count cell frame-id))
+          "old held/reserved A and accepted desired B do not collapse")
+      ;; Model A's exact teardown callback before passive B reconciliation.
+      ;; Discovery must retain A even though desired state already names B.
+      (reset! current token-a)
+      (is (= 1 (reactive/teardown-frame! frame-id)))
+      (is (= :dead (reactive/lifecycle cell))))
+    (frame/destroy-frame! frame-id)))
+
+(deftest layout-rejects-resource-capture-from-a-superseded-frame-incarnation
+  (register-feature! :feed/items)
+  (let [frame-id :lease/reincarnation
+        _        (live-frame/make-frame {:id frame-id})
+        cell     (reactive/make-cell ::reincarnation)
+        [_ cap]  (capture-leases cell frame-id
+                                 [[::a {:resource :feed/items}]])]
+    (frame/destroy-frame! frame-id)
+    (live-frame/make-frame {:id frame-id})
+    (reactive/commit-resources! cell cap)
+    (is (= :dead (reactive/lifecycle cell))
+        "lease-only layout joins A teardown instead of silently targeting B")
+    (is (empty? (reactive/resource-reservations cell)))
+    (is (empty? (reactive/resource-held cell)))
+    (frame/destroy-frame! frame-id)))
+
+(deftest layout-rejects-mixed-same-id-incarnations-before-publish
+  (let [frame-id :lease/mixed-incarnations
+        _        (live-frame/make-frame {:id frame-id})
+        cell     (reactive/make-cell ::mixed-incarnations)
+        calls    (atom [])
+        mints    (atom 0)
+        phases   (atom [])
+        root     (reactive/make-root-incarnation)
+        [_ cap]
+        (do
+          (reactive/enable-resource-lifecycle! cell)
+          (rf/with-frame frame-id
+            (reactive/with-capture
+             cell
+             (fn []
+               (reactive/lease-site ::a {:resource :feed/items})
+               (frame/destroy-frame! frame-id)
+               (live-frame/make-frame {:id frame-id})
+               (reactive/lease-site ::b {:resource :feed/items})
+               :element))))]
+    (with-redefs [lease-owner/mint! (fn [] [:lease (swap! mints inc)])
+                  router/dispatch! (collecting-dispatch calls)]
+      (binding [reactive/*commit-barrier*
+                (fn [phase _] (swap! phases conj phase))]
+        (reactive/commit-resources! cell cap))
+      (reactive/reconcile-resource-leases! cell cap))
+    (is (= :dead (reactive/lifecycle cell)))
+    (is (empty? @phases)
+        "conflicting pins reject before the generic commit can publish/connect")
+    (is (zero? @mints))
+    (is (empty? @calls))
+    (is (empty? (reactive/resource-reservations cell)))
+    (is (empty? (reactive/resource-held cell)))
+    (reactive/attach-root! cell root)
+    (is (nil? (reactive/cell-root cell)))
+    (is (zero? (reactive/root-cell-count root))
+        "the later layout hook cannot reattach a rejected dead cell")
+    (frame/destroy-frame! frame-id)))
+
+(deftest final-teardown-releases-and-forgets-reservation
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::final-teardown)
+        calls (atom [])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)]
+      (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap))
+      (reset! calls [])
+      (reactive/teardown! cell)
+      (is (= [:rf.resource/release-owner]
+             (mapv (comp first first) @calls)))
+      (is (empty? (reactive/resource-reservations cell)))
+      (is (empty? (reactive/resource-held cell)))
+      (is (= :dead (reactive/lifecycle cell))))))
+
+(deftest throwing-host-cleanup-attempts-every-owner-and-cell-and-clears-state
+  (register-feature! :feed/items)
+  (let [a (reactive/make-cell ::cleanup-a)
+        b (reactive/make-cell ::cleanup-b)
+        calls (atom [])
+        release-attempt (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (= :rf.resource/release-owner (first event))
+                       (when (= 1 (swap! release-attempt inc))
+                         (throw (ex-info "injected first release escape" {}))))))]
+      (doseq [cell [a b]]
+        (let [cap (commit-leases!
+                   cell [[::x {:resource :feed/items}]
+                         [::y {:resource :feed/items}]])]
+          (reactive/reconcile-resource-leases! cell cap)))
+      (reset! calls [])
+      (is (= 2 (reactive/teardown-frame! fid)))
+      (is (= 4 @release-attempt)
+          "the first throwing owner cannot short-circuit later owners/cells")
+      (doseq [cell [a b]]
+        (is (= :dead (reactive/lifecycle cell)))
+        (is (empty? (reactive/resource-reservations cell)))
+        (is (empty? (reactive/resource-held cell)))))))

--- a/implementation/ui/test/re_frame/ui/resource_lease_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/resource_lease_reconcile_cljs_test.cljc
@@ -268,7 +268,7 @@
       (is (empty? (reactive/resource-reservations cell)))
       (is (empty? (reactive/resource-held cell))))))
 
-(deftest ensure-enqueue-escape-compensates-every-staged-owner
+(deftest ensure-enqueue-escape-compensates-exactly-the-attempted-prefix
   (register-feature! :feed/items)
   (let [cell (reactive/make-cell ::ensure-escape)
         calls (atom [])
@@ -289,13 +289,156 @@
                       :cljs cljs.core/ExceptionInfo)
                    (reactive/reconcile-resource-leases! cell cap)))
       (is (= [:rf.resource/ensure :rf.resource/ensure
-              :rf.resource/release-owner :rf.resource/release-owner
-              :rf.resource/release-owner]
+              :rf.resource/release-owner :rf.resource/release-owner]
              (mapv (comp first first) @calls))
-          "all staged owners are conservatively compensated, including the
-           possibly-enqueued throwing record and the not-yet-ensured tail")
+          "exactly the attempted prefix is compensated — the possibly-enqueued
+           throwing record included; the never-staged lexical tail was never
+           dispatched, so a reentrant cleanup can neither see nor leak it")
       (is (empty? (reactive/resource-reservations cell)))
       (is (empty? (reactive/resource-held cell))))))
+
+(deftest teardown-during-first-ensure-terminates-the-reconcile
+  ;; rf2-vxgfnd.124 blocker 2 — resource dispatch runs its trace listeners
+  ;; synchronously, so ensure(A) can tear the cell down mid-reconcile. The
+  ;; reconcile must observe the terminal lifecycle after the dispatch returns
+  ;; and stop: no release-B/ensure-B continuation, and no stale
+  ;; held/reservation republication onto the dead cell. Pre-fix the staged
+  ;; candidates were prepublished and the loop continued, producing
+  ;; ensure-A, release-A, release-B, ensure-B — leaking B forever.
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::ensure-teardown)
+        calls (atom [])
+        cap   (commit-leases!
+               cell [[::a {:resource :feed/items}]
+                     [::b {:resource :feed/items}]])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (= :rf.resource/ensure (first event))
+                       (reactive/teardown! cell))))]
+      (reactive/reconcile-resource-leases! cell cap)
+      (is (= [:rf.resource/ensure :rf.resource/release-owner]
+             (mapv (comp first first) @calls))
+          "ensure-A, teardown's release-A — and nothing after")
+      (is (= (get-in (first @calls) [0 1 :owner])
+             (get-in (second @calls) [0 1 :owner]))
+          "teardown releases exactly the one staged/ensured owner")
+      (is (= :dead (reactive/lifecycle cell)))
+      (is (empty? (reactive/resource-reservations cell))
+          "the terminated reconcile publishes no reservation onto the dead cell")
+      (is (empty? (reactive/resource-held cell))
+          "the terminated reconcile publishes no held state onto the dead cell")
+      (is (zero? (reactive/resource-frame-incarnation-count cell fid))
+          "no dead frame pin lingers in the teardown index"))))
+
+(deftest reentrant-teardown-during-release-is-terminal-and-idempotent
+  ;; rf2-vxgfnd.124 blocker 3 — teardown! publishes :dead and clears every
+  ;; generic registry BEFORE dispatching resource cleanup, so a synchronous
+  ;; release listener re-entering teardown! observes the terminal state and
+  ;; no-ops. Pre-fix the nested call saw a still-connected cell and recursed
+  ;; without bound (the entry guard below fails the test deterministically
+  ;; instead of blowing the stack).
+  (register-feature! :feed/items)
+  (let [cell    (reactive/make-cell ::teardown-recursion)
+        calls   (atom [])
+        entries (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)]
+      (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap)))
+    (reset! calls [])
+    (with-redefs [router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (= :rf.resource/release-owner (first event))
+                       (when (< 3 (swap! entries inc))
+                         (throw (ex-info "unbounded reentrant teardown" {})))
+                       (reactive/teardown! cell))))]
+      (reactive/teardown! cell)
+      (is (= [:rf.resource/release-owner]
+             (mapv (comp first first) @calls))
+          "one owner, one release — the nested teardown observes :dead and no-ops")
+      (is (= :dead (reactive/lifecycle cell)))
+      (reactive/teardown! cell)
+      (is (= 1 (count @calls))
+          "an explicit later teardown is a dispatch-free no-op"))))
+
+(deftest nested-teardown-during-disconnect-release-stays-terminal
+  ;; rf2-vxgfnd.124 blocker 4 — disconnect publishes :disconnected and parks
+  ;; the reusable reservations behind a unique cleanup token BEFORE
+  ;; dispatching releases. A release listener that tears the cell down must
+  ;; leave it :dead: the outer disconnect performs no unconditional lifecycle
+  ;; write after its reentrant cleanup and cannot restore reservations over
+  ;; the terminal state. Pre-fix the outer disconnect overwrote :dead with
+  ;; :disconnected and resurrected the reservation on a dead cell.
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::disconnect-overwrite)
+        calls (atom [])]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch! (collecting-dispatch calls)]
+      (let [cap (commit-leases! cell [[::a {:resource :feed/items}]])]
+        (reactive/reconcile-resource-leases! cell cap)))
+    (reset! calls [])
+    (with-redefs [router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (= :rf.resource/release-owner (first event))
+                       (reactive/teardown! cell))))]
+      (reactive/disconnect-resources! cell))
+    (is (= [:rf.resource/release-owner]
+           (mapv (comp first first) @calls))
+        "the nested teardown finds no remaining held owner to re-release")
+    (is (= :dead (reactive/lifecycle cell))
+        "the outer disconnect never overwrites the nested terminal state")
+    (is (empty? (reactive/resource-reservations cell))
+        "no reservation is restored onto the dead cell")
+    (is (empty? (reactive/resource-held cell)))))
+
+(deftest capture-supersession-during-ensure-stops-the-stale-reconcile
+  ;; A synchronous listener committing a NEW capture mid-ensure replaces
+  ;; reconciliation authority. The superseded loop must stop after the
+  ;; in-flight dispatch (no stale ensure-B), and its compensation must skip
+  ;; any owner the newer passive already accounted for — releasing that owner
+  ;; again would double-release a lease the live capture rightfully holds.
+  (register-feature! :feed/items)
+  (let [cell  (reactive/make-cell ::supersession)
+        calls (atom [])
+        mints (atom 0)
+        fired (atom false)
+        cap1  (commit-leases!
+               cell [[::a {:resource :feed/items}]
+                     [::b {:resource :feed/items}]])]
+    (with-redefs [features/require-feature! (constantly true)
+                  lease-owner/mint! (fn [] [:lease (swap! mints inc)])
+                  router/dispatch!
+                  (dispatch-standin
+                   (fn [event opts]
+                     (swap! calls conj [event opts])
+                     (when (and (= :rf.resource/ensure (first event))
+                                (compare-and-set! fired false true))
+                       (let [cap2 (commit-leases!
+                                   cell [[::a {:resource :feed/items}]])]
+                         (reactive/reconcile-resource-leases! cell cap2)))))]
+      (reactive/reconcile-resource-leases! cell cap1)
+      (let [events   @calls
+            owner-of #(get-in % [0 1 :owner])]
+        (is (= [:rf.resource/ensure :rf.resource/ensure
+                :rf.resource/release-owner]
+               (mapv (comp first first) events))
+            "ensure-A1, nested ensure-A2, nested release-A1 — no stale ensure-B
+             and no compensating double release-A1 afterwards")
+        (is (= (owner-of (first events)) (owner-of (nth events 2)))
+            "the nested passive releases exactly the superseded staged owner")
+        (is (= [(owner-of (second events))]
+               (vec (keys (reactive/resource-held cell))))
+            "the newer capture's owner is the only held owner")
+        (is (= (owner-of (second events))
+               (-> (reactive/resource-reservations cell) (get ::a) :owner))
+            "the newer reservation is never clobbered by the stale loop")))))
 
 (deftest passive-reconcile-is-bound-to-the-exact-accepted-capture
   (register-feature! :feed/items :feed/new)


### PR DESCRIPTION
Implements the frozen S2 `ui/lease` ownership contract (rf2-vxgfnd.106) and closes out the audited blockers tracked by rf2-vxgfnd.124.

## The frozen contract

- Public `ui/lease` accepts only `nil` or the closed descriptor `{:resource qualified-keyword, optional :scope, optional :params}`; missing `:params` stays distinct from explicit `nil`.
- Compiler-authoritative lexical site identity is shared with `sub` — no render-order counter, no second identity system.
- Render and abandoned renders own nothing: exact layout acceptance publishes the desired resource plan; one passive reconciliation owns ensures/releases.
- Resource ownership is not observation. Lease frame pins feed the exact teardown/liveness index only and never enlarge subscription/flush scope.
- `rf=`-equal same-site descriptors retain their exact owner; retargets mint fresh owners. The complete desired plan prevalidates, all ensures enqueue before releases in deterministic per-frame order, and ordinary FIFO drain-to-quiescence is followed by one read/render batch. No global coordinator, no cross-frame rollback.
- Lease-only views use the fixed ViewCell/lifecycle skeleton with zero `useSyncExternalStore`; sub+lease views share one cell and one subscription hook.
- StrictMode, Activity, unmount, root/frame destroy, throwing cleanup, and HMR retain/release exact ownership with no leak and no resurrection.
- Lease-free advanced output erases the resource ownership family, mint/debug strings, and the optional Resources artefact/dependency sources. The neutral process-global owner mint is shared with stock Reagent; no adapter dependency, no frozen API-table delta.

## Audited blocker fixes (rf2-vxgfnd.124)

1. **Reactive flush scope contamination** — `cell-frames` (the `flush-frame!` scope test) keys on committed subscription sites only; resource lease pins live in the exact `:extra-frame-incarnations` teardown index consulted solely by `cell-retained-frame?`/`teardown-frame!`. Proof: `resource-lease-frame-does-not-expand-observation-flush-scope` (flushing lease-only frame B flushes nothing and leaves the A-dirty cell pending; flushing observed frame A advances exactly once).
2. **Passive ensure reentrancy** — candidate reservations stay local until every ensure succeeds; each owner becomes cleanup-reachable immediately before its own enqueue, and exact capture/lifecycle authority is fenced after every synchronous ensure/release dispatch. A teardown during `ensure(A)` now terminates the reconcile (`ensure-A, release-A` — nothing after) instead of the pre-fix `ensure-A, release-A, release-B, ensure-B` leak, and a terminated reconcile never republishes held/reservation state onto a dead cell. Proofs: `teardown-during-first-ensure-terminates-the-reconcile`, `capture-supersession-during-ensure-stops-the-stale-reconcile`, `ensure-enqueue-escape-compensates-exactly-the-attempted-prefix`.
3. **Teardown release recursion** — `teardown!` publishes `:dead` and clears every generic registry before dispatching resource cleanup, so a synchronous release listener re-entering `teardown!` observes the terminal state and no-ops instead of recursing. Proof: `reentrant-teardown-during-release-is-terminal-and-idempotent`.
4. **Disconnect overwrite** — disconnect publishes `:disconnected` and parks reusable reservations behind a unique cleanup token before dispatching releases; a nested teardown stays terminal — no unconditional lifecycle write follows the reentrant cleanup, and the conditional reservation restore cannot fire over `:dead` or newer commit authority. Proof: `nested-teardown-during-disconnect-release-stays-terminal`.
5. **Source-doc honesty** — the `reactive.cljc` namespace documentation now describes the landed per-site identity / selected-capture behavior (post rf2-vxgfnd.100/.105) with no staging/future claims for shipped behavior.

Additional defect found and fixed during close-out: superseded-ensure compensation releases only records still identically owned in held state, so an owner a newer passive reconcile already accounts for is never double-released.

## Riding beads

- **rf2-vxgfnd.116** — mixed same-id A/B resource incarnation pins reject before layout publication (`layout-rejects-mixed-same-id-incarnations-before-publish`).
- **rf2-vxgfnd.119** — the real owner mint and the 0/0, 1/0, 0/1, 1/1 hook matrix production proof are non-vacuous and visibly executed (mounted prod-elision suite + G-13 mint-control non-vacuity teeth).
- **rf2-vxgfnd.120** — a terminally dead ViewCell is not reattached by the second layout effect (`attach-root!` on a dead cell is a no-op; asserted in the mixed-incarnation rejection proof).
- **rf2-vxgfnd.122** — the steady-state teardown index dedupes repeated exact tokens while transient A+B incarnations for one frame id stay distinct (`resource-only-cells-are-discoverable-while-connected-and-hidden`, `transient-same-id-incarnations-remain-distinct-in-frame-index`).

These beads stay open until this PR merges.

## Quality gates

All run locally in foreground. The final head's `implementation/` tree is hash-identical to the tree every gate below ran on (the rebase picked up beads/guide-doc commits only); JVM UI and Node UI additionally re-ran on the exact final head.

| Gate | Command | Result |
| --- | --- | --- |
| JVM UI (exact final head) | `implementation/ui: clojure -M:test` | PASS — 425 tests / 5393 assertions, 0 failures 0 errors |
| Node UI + adapter isolation (exact final head) | `npm run test:ui` | PASS — 434 tests / 2159 assertions, 0 failures 0 errors; ui-adapter-isolation PASS (251 compiler-selected imports) |
| Browser DOM | `npm run test:browser` | PASS — 341 tests / 1828 assertions, 0 failures 0 errors |
| Advanced prod-elision (mounted) | `npm run test:browser-prod-elision` | PASS — 80 tests / 258 assertions, 0 failures 0 errors; ui mounted production elision PASS |
| G-13 incl. all 13 mutation teeth | `npm run test:ui-g13` | PASS — lease-free advanced bundle 620,014 B; owner-mint advanced control 92,434 B; mint sentinel present only in control; optional Resources runtime/dependency/source-manifest absent |
| Fast PR spine | `scripts/test-fast-pr.sh` | PASS — core JVM 1901 / 8577 (0 failures), CLJS node integration 9215 / 43546 (0 failures), per-ns isolation 15/15, script policy/self-test and markdown gates PASS (`mkdocs --strict` soft-skip, CI-owned) |

Beads: rf2-vxgfnd.106 (owning), rf2-vxgfnd.124 (close-out), riding rf2-vxgfnd.116 / .119 / .120 / .122.
