### PR TITLE
feat(ui): project bounded ViewCell invalidation evidence to Xray (rf2-vxgfnd.75)

### DIFF
--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -63,4 +63,30 @@ for (const forbidden of [
   }
 }
 
+/*
+ * rf2-vxgfnd.75 — the tool-tier invalidation-evidence projection.
+ *
+ * The elision companion test requires re-frame.ui.tool.evidence into this
+ * exact bundle, so these are positive proofs of erasure (the namespace is
+ * present; its debug-gated projection is not), not absence-by-omission.
+ * Source positive controls first: the sentinels still name the debug-only
+ * accumulation (`:dropped-exact?` — the rf2-vxgfnd.74 honest-loss keyword,
+ * minted only inside debug-gated folds in reactive.cljc + the projection)
+ * and the projection's rejected-install diagnostic string.
+ */
+const TOOL_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui', 'tool',
+                              'evidence.cljc');
+const toolSource = fs.readFileSync(TOOL_SOURCE, 'utf8');
+for (const expected of ['dropped-exact', 'invalidation-evidence projection']) {
+  if (!toolSource.includes(expected)) {
+    fail(`tool-evidence source positive-control sentinel is absent: ${expected}`);
+  }
+}
+
+for (const forbidden of ['dropped-exact', 'invalidation-evidence projection']) {
+  if (bundle.includes(forbidden)) {
+    fail(`invalidation-evidence projection survived advanced output: ${forbidden}`);
+  }
+}
+
 process.stdout.write('ui mounted production elision: PASS\n');

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -996,7 +996,12 @@
   intended `re-frame.ui.tool`/Xray projection point; the flush's call is gated
   on `interop/debug-enabled?`, so it is a no-op in production. A THROWING sink
   is contained by the flush (see `flush-one!` / `report-sink-escape!`) and can
-  never strand a cell or abort the render batch. Returns nil."
+  never strand a cell or abort the render batch. Returns nil.
+
+  This is the RAW last-write-wins slot (the test seam). First-party tools
+  install through the identity-owned, HMR-safe lifecycle over it —
+  `re-frame.ui.tool.evidence/install!` / `uninstall!` (rf2-vxgfnd.75) — which
+  rejects a second owner instead of silently clearing the first."
   [f]
   (reset! evidence-sink f)
   nil)
@@ -2070,6 +2075,13 @@
   "The cell's current revision integer (tool/test read)."
   [^ViewCell cell]
   (:revision @(state cell)))
+
+(defn cell-view-id
+  "The view id `cell` was minted for (tool/test read) — the stable authoring
+  identity axis the `re-frame.ui.tool.evidence` projection keys a
+  developer-facing row on, alongside the owning root (rf2-vxgfnd.75)."
+  [^ViewCell cell]
+  (:view-id @(state cell)))
 
 (defn current-live-cells
   "The set of currently-CONNECTED ViewCells (tool/test read) — the live-cell

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -1,0 +1,310 @@
+(ns re-frame.ui.tool.evidence
+  "The first-party tool projection over the ViewCell DEBUG
+  invalidation-evidence plane (rf2-vxgfnd.75) — the `re-frame.ui.tool`/Xray
+  consumer the reactive scheduler's `set-evidence-sink!` seam was built for
+  (rf2-vxgfnd.46).
+
+  WHAT IT PROJECTS. Each flushed render batch delivers one BOUNDED causal
+  summary per pending cell (`re-frame.ui.reactive/fold-evidence` — first/latest
+  frame-epoch, occurrence `:count`, the cause set, a capped shown-target
+  sample, and the honest `:dropped`/`:dropped-exact?` loss account from
+  rf2-vxgfnd.74). This namespace ACCRETES those per-batch records into one
+  bounded per-cell accumulator keyed by stable identity — a projection ordinal
+  (`:cell-id`), the authoring view (`:view-id`), and the owning client root
+  (`:root-id`, resolved through the live-root registry at read time) — so a
+  tool (Xray) can attribute coalesced renders to their contributing movement
+  across the cell's whole observed life WITHOUT retaining any event payload.
+
+  LIFECYCLE — IDENTITY-OWNED, NEVER CLOBBERING. The reactive seam is a raw
+  last-write-wins slot; this tier makes it safe for tool coexistence + HMR:
+  `install!` claims the projection for an owner id, a SECOND owner's install
+  is REJECTED (returns false, warns — the first registration is never
+  silently cleared), a same-owner re-install is an idempotent re-arm (the
+  `:after-load` / Fast Refresh path — accumulated evidence survives), and
+  `uninstall!` (owner-checked) releases the sink callback and every retained
+  entry. A tool absent or uninstalled retains ZERO ViewCells/evidence.
+
+  OBSERVATIONAL ONLY. The scheduler stays authoritative: delivery runs inside
+  the flush's containment (rf2-vxgfnd.73 — a throwing consumer can neither
+  strand a cell nor abort a batch), the projection never acquires/releases or
+  computes, and dead (torn-down) cells are PRUNED at delivery and at read so
+  abandoned cells disappear from the projection. The whole operative surface
+  is gated on `interop/debug-enabled?` and DCEs out of `:advanced` +
+  goog.DEBUG=false production output (Spec 006 §The internal observation
+  port; 03 §3)."
+  (:require [re-frame.interop     :as interop]
+            [re-frame.ui.reactive :as reactive]
+            #?(:cljs [re-frame.ui.client :as client])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the bounded per-cell accumulator ---------------------------------------
+;;
+;; The SAME honesty discipline as the per-window fold (rf2-vxgfnd.74), applied
+;; at the cumulative tier: a bounded SHOWN sample of distinct moving targets,
+;; overflow recorded by IDENTITY in a bounded loss set, saturation flagged
+;; (never silently lost), everything constant-size per cell.
+
+(def ^:private ^:const target-cap
+  ;; Distinct moving targets SHOWN per cell accumulator — mirrors the
+  ;; per-window shown-sample cap so a one-batch cell projects verbatim.
+  8)
+
+(def ^:private ^:const dropped-cap
+  ;; Distinct OMITTED target keys tracked before the cumulative loss account
+  ;; itself saturates (`:dropped-exact?` flips false; `(count :dropped)`
+  ;; becomes a LOWER bound) — mirrors the per-window loss-set cap.
+  64)
+
+(def ^:private empty-accrual
+  ;; The zero accumulator — also the normalization for a (defensive) nil or
+  ;; partial delivered batch, which folds as empty.
+  {:first-epoch    nil
+   :latest-epoch   nil
+   :count          0
+   :causes         #{}
+   :targets        []
+   :dropped        #{}
+   :dropped-exact? true})
+
+(defn- fold-target
+  "Fold ONE distinct target key `tk` from a delivered batch into the
+  cumulative shown-sample/loss-set pair. First classification is stable: a
+  target already shown (or already recorded as an omission) folds as known —
+  re-delivery across batches can never inflate the loss (the cross-batch
+  restatement of the rf2-vxgfnd.74 honesty fix)."
+  [acc tk]
+  (let [known? (or (some #(= tk %) (:targets acc))
+                   (contains? (:dropped acc) tk))]
+    (cond
+      known?                                 acc
+      (< (count (:targets acc)) target-cap)  (update acc :targets conj tk)
+      (< (count (:dropped acc)) dropped-cap) (update acc :dropped conj tk)
+      :else                                  (assoc acc :dropped-exact? false))))
+
+(defn- accrete-evidence
+  "Fold one flushed batch's bounded evidence record `ev` into the cell's
+  cumulative accumulator `acc` (nil = first delivery). Returns a BOUNDED,
+  constant-size record — `empty-accrual`'s keys plus `:batches`:
+
+    :first-epoch    — the anchor of the FIRST delivered window (set once,
+                      never rewritten — nil stays nil when that window
+                      carried no epoch evidence, mirroring the window fold)
+    :latest-epoch   — the most recent window's latest movement
+    :count          — total invalidation OCCURRENCES across every batch
+    :batches        — how many flushed batches delivered evidence
+    :causes         — the union cause set (:value/:hmr/:disposed — ≤3)
+    :targets        — bounded shown sample of distinct moving targets
+    :dropped        — bounded loss SET of distinct omitted targets; its
+                      count is the honest cumulative fan-out loss
+    :dropped-exact? — false once EITHER a delivered window or the
+                      cumulative loss set saturated (a floor, never a lie)
+
+  Never retains `ev` itself, a payload, or anything scaling with the
+  invalidation count."
+  [acc ev]
+  (let [ev  (merge empty-accrual ev)
+        acc (or acc (assoc empty-accrual
+                           :first-epoch (:first-epoch ev)
+                           :batches 0))]
+    (-> acc
+        (update :batches inc)
+        (assoc :latest-epoch (:latest-epoch ev))
+        (update :count + (:count ev))
+        (update :causes into (:causes ev))
+        (as-> a (reduce fold-target a (concat (:targets ev) (:dropped ev))))
+        (cond-> (false? (:dropped-exact? ev)) (assoc :dropped-exact? false)))))
+
+;; ---- projection state --------------------------------------------------------
+
+(defonce ^:private owner*
+  ;; The identity that currently owns the projection (any comparable value —
+  ;; a namespaced keyword by convention), or nil when uninstalled. `defonce`
+  ;; so the ownership survives namespace reload (HMR) — a same-owner
+  ;; re-install is the idempotent re-arm path.
+  (atom nil))
+
+(defonce ^:private entries*
+  ;; `ViewCell -> {:cell-id ord :view-id vid :evidence accrual}` — the whole
+  ;; retained projection. Keyed by cell identity (the scheduler's own dedup
+  ;; axis); dead cells are pruned at every delivery and read, and the map is
+  ;; cleared on uninstall, so a tool absent or closed retains ZERO cells.
+  (atom {}))
+
+(defonce ^:private cell-ordinal*
+  ;; Monotonic mint for `:cell-id` — a stable, developer-facing instance
+  ;; ordinal (two mounts of one view are two cells; the ordinal keeps their
+  ;; rows apart and stable across batches). Never reset while installed.
+  (atom 0))
+
+(defn- prune-dead
+  "Drop every entry whose cell has been torn down (`:dead` — root/frame
+  teardown, rf2-vxgfnd.85). A disconnected (Activity-hidden) cell is still
+  retained and reconnectable, so its accumulated evidence stays."
+  [entries]
+  (reduce-kv (fn [m cell _]
+               (if (= :dead (reactive/lifecycle cell)) (dissoc m cell) m))
+             entries entries))
+
+(defn- project-batch!
+  "The installed evidence-sink `(fn [cell ev] …)`: accrete one flushed
+  batch's bounded record into `cell`'s accumulator and sweep dead cells.
+  Runs inside the flush's rf2-vxgfnd.73 containment; constant-work per
+  delivery (the record is already bounded). Never called in production
+  (the flush's sink call is debug-gated); belt-gated here regardless."
+  [cell ev]
+  (when interop/debug-enabled?
+    (when-not (= :dead (reactive/lifecycle cell))
+      ;; Mint the ordinal outside the swap (pure retry body). The CLJS host
+      ;; is single-threaded; a concurrent JVM fixture could at worst waste
+      ;; an ordinal, never corrupt an entry.
+      (let [ord (when-not (contains? @entries* cell)
+                  (swap! cell-ordinal* inc))]
+        (swap! entries*
+               (fn [entries]
+                 (let [entries (prune-dead entries)
+                       entry   (or (get entries cell)
+                                   {:cell-id  ord
+                                    :view-id  (reactive/cell-view-id cell)
+                                    :evidence nil})]
+                   (assoc entries cell
+                          (update entry :evidence accrete-evidence ev)))))))
+    nil))
+
+;; ---- lifecycle (identity-owned install/uninstall) ---------------------------
+
+(defn- warn-rejected-install!
+  "A rejected install must not be SILENT (the caller also gets false):
+  emit one host diagnostic naming both owners. Debug-gated at the caller,
+  so the whole branch DCEs out of production."
+  [current rejected]
+  #?(:cljs
+     (when (exists? js/console)
+       (.warn js/console
+              (str "[re-frame.ui] the invalidation-evidence projection is "
+                   "already owned by " (pr-str current) " — the install for "
+                   (pr-str rejected) " was REJECTED (one tool cannot "
+                   "silently clear another owner's registration). Uninstall "
+                   "the current owner first (uninstall!), or coordinate on "
+                   "one owner id.")))
+     :clj nil))
+
+(defn install!
+  "Claim the invalidation-evidence projection for `owner-id` (any comparable
+  non-nil value; a namespaced keyword by convention) and arm the reactive
+  seam (`reactive/set-evidence-sink!`) with this namespace's accretor.
+
+  Identity-owned, HMR-safe:
+    - unowned            → installs fresh (empty projection); returns true.
+    - owned by owner-id  → idempotent RE-ARM (the `:after-load`/Fast-Refresh
+                           path, and the recovery after a test-fixture
+                           `reset-scheduler!` cleared the raw slot) —
+                           accumulated evidence is KEPT; returns true.
+    - owned by another   → REJECTED: nothing changes, the current owner's
+                           registration stands, one console diagnostic is
+                           emitted (never silent); returns false.
+
+  Production (`goog.DEBUG=false` / `-Dre-frame.debug=false`): a no-op
+  returning false — the debug evidence plane does not exist there, and the
+  whole projection DCEs out of `:advanced` output.
+
+  While installed, the raw `set-evidence-sink!` slot belongs to this tier;
+  bypassing it directly is the test seam only."
+  [owner-id]
+  (if-not interop/debug-enabled?
+    false
+    (do
+      (assert (some? owner-id) "install! requires a non-nil owner id")
+      (let [[old new] (swap-vals! owner*
+                                  (fn [cur]
+                                    (if (or (nil? cur) (= cur owner-id))
+                                      owner-id
+                                      cur)))]
+        (cond
+          (nil? old)
+          (do (reset! entries* {})
+              (reactive/set-evidence-sink! project-batch!)
+              true)
+
+          (= old owner-id)
+          (do (reactive/set-evidence-sink! project-batch!)
+              true)
+
+          :else
+          (do (warn-rejected-install! new owner-id)
+              false))))))
+
+(defn uninstall!
+  "Release the projection iff `owner-id` owns it: clear the reactive sink
+  slot, drop EVERY retained entry (cells + accumulated evidence), and free
+  the ownership — teardown releases all callbacks/references, so a closed
+  tool retains nothing. Returns true when released; false (nothing changes)
+  when `owner-id` is not the current owner. Production: no-op, false."
+  [owner-id]
+  (if-not interop/debug-enabled?
+    false
+    (let [[old _] (swap-vals! owner* (fn [cur] (if (= cur owner-id) nil cur)))]
+      (if (= old owner-id)
+        (do (reactive/set-evidence-sink! nil)
+            (reset! entries* {})
+            true)
+        false))))
+
+(defn force-release!
+  "Test support: release the projection REGARDLESS of owner — sink slot
+  cleared, every entry dropped, ownership freed. The fixture-reset door
+  (pair it with `reactive/reset-scheduler!` between fixtures); production
+  tools use the owner-checked `uninstall!`. Returns nil."
+  []
+  (reset! owner* nil)
+  (reset! entries* {})
+  (when interop/debug-enabled?
+    (reactive/set-evidence-sink! nil))
+  nil)
+
+(defn installed-owner
+  "The identity currently owning the projection, or nil (tool/test read)."
+  []
+  @owner*)
+
+;; ---- the projection read -----------------------------------------------------
+
+(defn- root-id-index
+  "incarnation -> root-id over the CLJS client live-root registry — the
+  developer-facing name for the opaque per-mount incarnation a cell enrols
+  under (rf2-vxgfnd.85). Empty on the JVM host (no client registry; Tier-1
+  cells attach to raw incarnations, which have no authored name)."
+  []
+  #?(:cljs (into {}
+                 (keep (fn [rid]
+                         (when-some [i (:root-incarnation
+                                        (client/live-root-entry rid))]
+                           [i rid])))
+                 (client/live-root-ids))
+     :clj  {}))
+
+(defn projection
+  "The current Xray-usable invalidation-evidence projection: a vector of
+  per-cell records in stable `:cell-id` order —
+
+    {:cell-id  ord      ; stable projection ordinal for this cell instance
+     :view-id  vid      ; the authoring view (defview identity)
+     :root-id  rid|nil  ; the owning LIVE client root (nil when the cell is
+                        ;   not under a live client root — e.g. Tier-1/JVM)
+     :evidence accrual} ; the bounded cumulative record (`accrete-evidence`)
+
+  Dead cells are pruned before the read, so abandoned/unmounted cells never
+  appear; an uninstalled (or never-installed) projection is empty. nil in a
+  production build, where the debug evidence plane is elided (tool read)."
+  []
+  (when interop/debug-enabled?
+    (let [entries (swap! entries* prune-dead)
+          roots   (root-id-index)]
+      (->> entries
+           (map (fn [[cell {:keys [cell-id view-id evidence]}]]
+                  {:cell-id  cell-id
+                   :view-id  view-id
+                   :root-id  (get roots (reactive/cell-root cell))
+                   :evidence evidence}))
+           (sort-by :cell-id)
+           (into [])))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -1,0 +1,271 @@
+(ns re-frame.ui.tool-evidence-cljs-test
+  "rf2-vxgfnd.75 — the first-party tool projection over the ViewCell DEBUG
+  invalidation-evidence plane (`re-frame.ui.tool.evidence`).
+
+  The rows:
+
+    - IDENTITY-OWNED LIFECYCLE — install claims the projection for an owner;
+      a second owner's install is REJECTED (the first registration is never
+      silently cleared); uninstall is owner-checked and releases the sink
+      callback plus every retained entry (zero retention when closed);
+    - HMR-SAFE — a same-owner re-install is an idempotent re-arm that keeps
+      the accumulated evidence (the `:after-load` path), including recovery
+      after a fixture `reset-scheduler!` cleared the raw slot;
+    - BATCH EVIDENCE, STABLY KEYED — each flushed batch's bounded record
+      accretes into one per-cell accumulator carrying first/latest epoch,
+      total occurrence count, batch count, the cause union, the bounded
+      shown-target sample, and the honest rf2-vxgfnd.74 loss account — keyed
+      by a stable projection ordinal + view id, with NO payload retention;
+    - CROSS-BATCH LOSS HONESTY — re-delivering the same overflow targets
+      across batches never inflates the distinct-omission loss;
+    - PRUNING — dead (torn-down) cells disappear from the projection;
+    - OBSERVATIONAL — the scheduler's revisions/notifications are untouched
+      and no sink escape is recorded (rf2-vxgfnd.73's containment applies).
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` / `test:ui` (node)
+  AND `clojure -M:test` (JVM), so the projection is graft-checked on both."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.reactive           :as reactive]
+            [re-frame.ui.tool.evidence      :as evidence]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- tk [id q] [:sub id q])
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- rc!
+  "Render (probe) `queries` under the default frame, then commit — the cell
+  ends observing it (the reactive-epoch-test technique for driving REAL
+  observation-port fan-out at this tier)."
+  [cell queries]
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:tool-ev/site i] q))
+                                        (range) queries))))]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- entry-for
+  "The projection row for view id `vid`, or nil."
+  [vid]
+  (some #(when (= vid (:view-id %)) %) (evidence/projection)))
+
+(def ^:private bounded-evidence-keys
+  #{:batches :first-epoch :latest-epoch :count :causes :targets
+    :dropped :dropped-exact?})
+
+;; ===========================================================================
+;; Identity-owned lifecycle — never clobbers, releases everything
+;; ===========================================================================
+
+(deftest install-is-identity-owned-and-never-clobbers
+  (is (nil? (evidence/installed-owner)) "unowned at rest")
+  (is (true? (evidence/install! ::tool-a)) "a fresh install claims the projection")
+  (is (= ::tool-a (evidence/installed-owner)))
+
+  (testing "a SECOND owner's install is rejected — nothing changes (AC3)"
+    (is (false? (evidence/install! ::tool-b)))
+    (is (= ::tool-a (evidence/installed-owner)) "the first owner still holds it"))
+
+  (testing "…and the first owner's projection is STILL live, not clobbered"
+    (let [cell (reactive/make-cell ::v)]
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (some? (entry-for ::v)) "the batch reached tool-a's projection")))
+
+  (testing "a non-owner uninstall is refused and releases nothing"
+    (is (false? (evidence/uninstall! ::tool-b)))
+    (is (= ::tool-a (evidence/installed-owner)))
+    (is (some? (entry-for ::v)) "tool-a's accumulated evidence survives"))
+
+  (testing "the owner's uninstall releases the sink AND every entry (AC4)"
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (evidence/projection)) "zero retained cells/evidence")
+    ;; the raw slot is free: a flush while uninstalled projects nothing…
+    (let [cell (reactive/make-cell ::w)]
+      (reactive/mark-dirty! cell 2)
+      (reactive/flush-pending!)
+      (is (= [] (evidence/projection)) "nothing delivered while uninstalled"))
+    ;; …and a different tool can now claim it
+    (is (true? (evidence/install! ::tool-b)) "the freed slot is claimable")
+    (is (= ::tool-b (evidence/installed-owner)))
+    (is (= [] (evidence/projection)) "the new owner starts empty")))
+
+(deftest same-owner-reinstall-is-an-idempotent-rearm-that-keeps-evidence
+  ;; The HMR path: `:after-load` re-runs the installing namespace. The
+  ;; re-install must neither error, nor clobber, nor lose the accumulation.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell (reactive/make-cell ::v)]
+    (doseq [e [1 2 3]] (reactive/mark-dirty! cell e))
+    (reactive/flush-pending!)
+    (is (= 3 (get-in (entry-for ::v) [:evidence :count])))
+
+    (testing "re-install: true, same owner, evidence KEPT"
+      (is (true? (evidence/install! ::tool-a)))
+      (is (= ::tool-a (evidence/installed-owner)))
+      (is (= 3 (get-in (entry-for ::v) [:evidence :count]))
+          "the accumulated evidence survives the re-install"))
+
+    (testing "re-install RE-ARMS after a fixture reset cleared the raw slot"
+      ;; `reset-scheduler!` (the test-fixture clean slate) drops the raw
+      ;; evidence-sink underneath the tool tier. A same-owner install is the
+      ;; documented recovery: it re-arms delivery without losing ownership.
+      (reactive/reset-scheduler!)
+      (is (true? (evidence/install! ::tool-a)))
+      (reactive/mark-dirty! cell 4)
+      (reactive/flush-pending!)
+      (is (= 4 (get-in (entry-for ::v) [:evidence :count]))
+          "delivery resumed into the SAME accumulator (batches accrete)")
+      (is (= 2 (get-in (entry-for ::v) [:evidence :batches]))))))
+
+;; ===========================================================================
+;; Batch evidence content — stable identity, bounded record, no payloads
+;; ===========================================================================
+
+(deftest the-projection-carries-batch-evidence-with-stable-identity
+  (is (true? (evidence/install! ::xray)))
+  (let [cell-a (reactive/make-cell ::va)
+        cell-b (reactive/make-cell ::vb)
+        hits-a (atom 0)]
+    (reactive/subscribe cell-a (fn [] (swap! hits-a inc)))
+    (doseq [e (range 1 9)] (reactive/mark-dirty! cell-a e))
+    (reactive/mark-dirty! cell-b 9)
+    (reactive/flush-pending!)
+
+    (testing "one row per cell, in stable ordinal order"
+      (let [rows (evidence/projection)]
+        (is (= 2 (count rows)))
+        (is (= [(:cell-id (first rows)) (:cell-id (second rows))]
+               (sort [(:cell-id (first rows)) (:cell-id (second rows))]))
+            "rows sort by the stable projection ordinal")
+        (is (= #{::va ::vb} (into #{} (map :view-id) rows))
+            "each row names its authoring view")))
+
+    (testing "the accumulator exposes the full bounded batch summary (AC2)"
+      (let [{:keys [evidence root-id]} (entry-for ::va)]
+        (is (= 1 (:first-epoch evidence)) "anchored to the FIRST movement")
+        (is (= 8 (:latest-epoch evidence)) "…tracking the LATEST")
+        (is (= 8 (:count evidence)) "every occurrence counted")
+        (is (= 1 (:batches evidence)) "one flushed batch so far")
+        (is (= #{} (:causes evidence)) "epoch-only marks carry no cause")
+        (is (= [] (:targets evidence)))
+        (is (= #{} (:dropped evidence)) "the rf2-vxgfnd.74 loss field, empty")
+        (is (true? (:dropped-exact? evidence)) "…and exact")
+        (is (nil? root-id) "no live client root owns a Tier-1 cell")))
+
+    (testing "no payload retention — exactly the bounded keys (AC2)"
+      (is (= bounded-evidence-keys
+             (set (keys (:evidence (entry-for ::va)))))))
+
+    (testing "a later batch ACCRETES under the SAME identity"
+      (let [id-before (:cell-id (entry-for ::va))]
+        (doseq [e (range 9 13)] (reactive/mark-dirty! cell-a e))
+        (reactive/flush-pending!)
+        (let [{:keys [cell-id evidence]} (entry-for ::va)]
+          (is (= id-before cell-id) "the projection ordinal is stable")
+          (is (= 1 (:first-epoch evidence)) "the anchor never rewrites")
+          (is (= 12 (:latest-epoch evidence)))
+          (is (= 12 (:count evidence)))
+          (is (= 2 (:batches evidence))))
+        (is (= 1 (get-in (entry-for ::vb) [:evidence :count]))
+            "the sibling row is untouched")))
+
+    (testing "the projection is OBSERVATIONAL (rf2-vxgfnd.73 containment seam)"
+      (is (= 2 (reactive/revision cell-a)) "two batches → two advances, as ever")
+      (is (= 2 @hits-a) "…and two notifications — scheduling untouched")
+      (is (nil? (reactive/last-evidence-sink-escape)) "no contained escape"))))
+
+(deftest real-port-fanout-projects-cause-and-target
+  ;; End-to-end through the REAL observation-port fan-out at this tier: an
+  ;; HMR re-registration fires each committed site's live lease `on-change`
+  ;; with its rich payload; the projection must surface the cause + target.
+  (rf/reg-sub :tool-ev/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (is (true? (evidence/install! ::xray)))
+  (let [cell (rc! (reactive/make-cell ::v) [[:tool-ev/a]])]
+    (rf/reg-sub :tool-ev/a (fn [db _] (:a db)))   ;; re-register → real :hmr fan-out
+    (reactive/flush-pending!)
+    (let [{:keys [evidence]} (entry-for ::v)]
+      (is (= #{:hmr} (:causes evidence)) "the real cause is projected")
+      (is (= [(tk fid [:tool-ev/a])] (:targets evidence))
+          "…with the moving target key")
+      (is (= 1 (:count evidence))))))
+
+;; ===========================================================================
+;; Cross-batch loss honesty (the rf2-vxgfnd.74 axis, cumulative tier)
+;; ===========================================================================
+
+(deftest cross-batch-loss-stays-honest
+  ;; 10 distinct targets overflow the shown cap (8) in ONE window: 2 distinct
+  ;; omissions. Re-delivering the SAME 10 in a SECOND batch must not inflate
+  ;; the cumulative loss — omission identity is already recorded.
+  (let [n       10
+        ids     (mapv (fn [i] (keyword "tool-ev" (str "s" i))) (range n))
+        queries (mapv vector ids)]
+    (doseq [i (range n)]
+      (rf/reg-sub (ids i) (fn [db _] (get db i))))
+    (seed! (into {} (map (fn [i] [i i])) (range n)))
+    (is (true? (evidence/install! ::xray)))
+    (let [cell (rc! (reactive/make-cell ::v) queries)]
+      (doseq [i (range n)]                  ;; batch 1: 10 distinct :hmr targets
+        (rf/reg-sub (ids i) (fn [db _] (get db i))))
+      (reactive/flush-pending!)
+      (let [{:keys [evidence]} (entry-for ::v)]
+        (is (= 10 (:count evidence)))
+        (is (= 8 (count (:targets evidence))) "shown sample capped")
+        (is (= 2 (count (:dropped evidence))) "two distinct omissions")
+        (is (true? (:dropped-exact? evidence))))
+
+      ;; a real re-render re-acquires fresh leases on the re-registered
+      ;; nodes before any further movement can fan out to this cell
+      (rc! cell queries)
+      (doseq [i (range n)]                  ;; batch 2: the SAME 10 targets
+        (rf/reg-sub (ids i) (fn [db _] (get db i))))
+      (reactive/flush-pending!)
+      (let [{:keys [evidence]} (entry-for ::v)]
+        (is (= 20 (:count evidence)) "occurrences keep counting")
+        (is (= 2 (:batches evidence)))
+        (is (= 8 (count (:targets evidence))) "the shown sample is stable")
+        (is (= 2 (count (:dropped evidence)))
+            "re-delivered omissions do NOT inflate the distinct loss (not 4)")
+        (is (true? (:dropped-exact? evidence))
+            "…and the account stays exact")))))
+
+;; ===========================================================================
+;; Pruning — dead cells disappear; nothing survives teardown
+;; ===========================================================================
+
+(deftest dead-cells-disappear-from-the-projection
+  (is (true? (evidence/install! ::xray)))
+  (let [cell-a (reactive/make-cell ::va)
+        cell-b (reactive/make-cell ::vb)]
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (reactive/flush-pending!)
+    (is (= 2 (count (evidence/projection))) "both cells project")
+
+    (reactive/teardown! cell-a)             ;; host/root teardown → :dead
+    (let [rows (evidence/projection)]
+      (is (= 1 (count rows)) "the dead cell disappeared (AC4)")
+      (is (= ::vb (:view-id (first rows)))))
+
+    (testing "uninstall then releases the survivor too — zero retention"
+      (is (true? (evidence/uninstall! ::xray)))
+      (is (= [] (evidence/projection))))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
@@ -1,0 +1,97 @@
+(ns re-frame.ui.tool-evidence-dom-cljs-test
+  "rf2-vxgfnd.75 — mounted proof for the tool-tier invalidation-evidence
+  projection (`re-frame.ui.tool.evidence`).
+
+  A REAL first-party ViewCell under a live client root: a dispatched event
+  moves the sub, the observation port's `on-change` fires, the ViewCell
+  flush delivers the coalesced bounded evidence into the installed
+  projection — never a direct sink call (the AC's integration axis). The
+  projection row carries the developer-facing identity (view id + the LIVE
+  root's root-id) and the bounded accumulator; tearing the root down removes
+  the cell from the projection, and uninstalling releases everything."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]
+            [re-frame.ui.tool.evidence :as evidence]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn (fn []
+               (reactive/reset-scheduler!)
+               (evidence/force-release!))}))
+
+(defview evidence-probe []
+  [:output {:data-role "evidence-probe"}
+   (str (ui/sub [::value]))])
+
+(defn- probe-row []
+  (some #(when (= ::evidence-probe (:view-id %)) %) (evidence/projection)))
+
+(deftest a-real-invalidation-flows-through-the-flush-into-the-projection
+  (when (browser?)
+    (rf/reg-sub ::value (fn [db _] (:value db)))
+    (rf/reg-event ::set-value
+                  (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)}))
+    (let [f (uit/frame {:app-db {:value 0}})]
+      (is (true? (evidence/install! ::xray-panel)))
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f}
+                                  [evidence-probe]]]
+              (testing "mount alone projects nothing — no invalidation yet"
+                (is (= "0" (.-textContent
+                            (uit/query root "[data-role='evidence-probe']"))))
+                (is (nil? (probe-row))))
+              (-> (uit/flush! #(uit/dispatch! f [::set-value 1]))
+                  (.then
+                   (fn []
+                     (testing "the port movement rendered…"
+                       (is (= "1" (.-textContent
+                                   (uit/query root
+                                              "[data-role='evidence-probe']")))))
+                     (testing "…and the flush projected the bounded evidence
+                               with developer-facing identity (AC1/AC2/AC6)"
+                       (let [{:keys [cell-id view-id root-id evidence]}
+                             (probe-row)]
+                         (is (some? cell-id) "a stable projection ordinal")
+                         (is (= ::evidence-probe view-id))
+                         (is (keyword? root-id) "the LIVE root's root-id")
+                         (is (= "rf.ui.test.root" (namespace root-id))
+                             "…the with-root-minted client root")
+                         (is (pos? (:count evidence)))
+                         (is (= 1 (:batches evidence)) "one coalesced flush")
+                         (is (contains? (:causes evidence) :value)
+                             "the port's real :value cause")
+                         (is (some #(= [::value] (nth % 2)) (:targets evidence))
+                             "the moving sub is a shown target")
+                         (is (some? (:latest-epoch evidence))
+                             "epoch attribution rode the port payload")
+                         (is (= #{} (:dropped evidence))
+                             "one target — the honest loss field is empty")
+                         (is (true? (:dropped-exact? evidence)))))
+                     (testing "the scheduler stayed authoritative — no escape"
+                       (is (nil? (reactive/last-evidence-sink-escape))))))))
+            (.then
+             (fn []
+               (testing "root teardown removed the cell from the projection (AC4)"
+                 (is (nil? (probe-row)))
+                 (is (= [] (evidence/projection))))
+               (testing "uninstall releases the registration"
+                 (is (true? (evidence/uninstall! ::xray-panel)))
+                 (is (nil? (evidence/installed-owner))))
+               (rf/destroy-frame! f)
+               (done)))
+            (.catch
+             (fn [e]
+               (evidence/force-release!)
+               (rf/destroy-frame! f)
+               (is false (str "unexpected rejection: " e))
+               (done))))))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_elision_prod_test.cljs
@@ -1,0 +1,48 @@
+(ns re-frame.ui.tool-evidence-elision-prod-test
+  "Advanced-production control for the tool-tier invalidation-evidence
+  projection (rf2-vxgfnd.75).
+
+  This namespace runs ONLY in `:browser-test-prod-elision` (`:advanced`,
+  goog.DEBUG=false). Requiring `re-frame.ui.tool.evidence` here pulls the
+  projection into the exact release bundle the companion gate
+  (scripts/check-ui-mounted-prod-elision.cjs) greps, so the bundle
+  assertion — no evidence-accumulation or projection-diagnostic sentinels
+  survive — is a positive proof of erasure rather than absence-by-omission.
+
+  Behaviourally: in production the debug evidence plane does not exist, so
+  the projection is inert — install is a refused no-op, nothing is owned,
+  nothing is retained, and a driven scheduler flush accrues no evidence.
+
+  The normal DEBUG-build counterparts (tool-evidence-cljs-test /
+  tool-evidence-dom-cljs-test) supply the positive controls: the same calls
+  there install, project, and accumulate."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.tool.evidence :as evidence]))
+
+(use-fixtures :each
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+(deftest advanced-production-elides-the-invalidation-evidence-projection
+  (testing "the lifecycle is an inert no-op — nothing installs, nothing owns"
+    (is (false? (evidence/install! ::probe)))
+    (is (nil? (evidence/installed-owner)))
+    (is (nil? (evidence/projection)) "the projection read is nil in production")
+    (is (false? (evidence/uninstall! ::probe))))
+
+  (testing "a driven flush accrues NO evidence anywhere"
+    (let [cell (reactive/make-cell ::v)
+          hits (atom 0)]
+      (reactive/subscribe cell (fn [] (swap! hits inc)))
+      (reactive/mark-dirty! cell 1)
+      (is (nil? (reactive/pending-evidence cell))
+          "the debug evidence plane itself is elided")
+      (reactive/flush-pending!)
+      (is (= 1 (reactive/revision cell)) "…while scheduling works as ever")
+      (is (= 1 @hits))
+      (is (nil? (evidence/projection)) "and the projection retained nothing"))))


### PR DESCRIPTION
Closes rf2-vxgfnd.75. Builds on the merged rf2-vxgfnd.73 (throwing-sink isolation) and rf2-vxgfnd.74 (honest loss accounting).

## What

PR #5742 (rf2-vxgfnd.46) preserved bounded ViewCell invalidation evidence across a coalesced render batch and added a bare process-global `set-evidence-sink!` — but no first-party consumer existed, so the evidence still stopped at an implementation seam, and the raw last-write-wins slot was not a tooling lifecycle (a second observer silently replaced the first; a scheduler reset dropped the sink; nothing tied a flushed cell to developer-facing identity).

This PR adds **`re-frame.ui.tool.evidence`** — the smallest first-party tool projection that turns each flushed batch's bounded evidence into Xray-usable evidence.

### The projection

- Each delivered batch record — first/latest frame-epoch, occurrence `:count`, the cause set, the capped shown-target sample, and the finalized rf2-vxgfnd.74 honest loss account (`:dropped` distinct-omission set + `:dropped-exact?` floor flag) — **accretes into one bounded per-cell accumulator** (plus `:batches`). No event payload is ever retained; the record stays constant-size per cell.
- **Stable identity**: each row carries a stable projection ordinal (`:cell-id`), the authoring view (`:view-id`, via a new `reactive/cell-view-id` tool read), and the owning **live client root's `:root-id`** (the cell's opaque root incarnation resolved through the client live-root registry at read time).
- **Cross-batch honesty**: omission identity is recorded once, so re-delivering the same overflow targets across batches never inflates the distinct loss; saturation propagates as an explicit floor (`:dropped-exact? false`), never a lie.

### The lifecycle (identity-owned, HMR-safe)

- `install!` claims the projection for an owner id and arms the reactive seam. A **second owner's install is rejected** (returns false + one console diagnostic — the first registration is never silently cleared). A **same-owner re-install is the idempotent re-arm** (the `:after-load`/Fast-Refresh path — accumulated evidence kept; also the documented recovery after a fixture `reset-scheduler!` cleared the raw slot).
- `uninstall!` is owner-checked and **releases everything** — the sink callback and every retained entry. A tool absent or closed retains zero ViewCells/evidence. `force-release!` is the fixture door.
- The scheduler stays authoritative and the tool observational: delivery rides the rf2-vxgfnd.73 flush containment, and **dead (torn-down) cells are pruned** at delivery and at read, so abandoned/unmounted cells disappear from the projection.

### Production erasure

The whole operative surface is gated on `interop/debug-enabled?` and DCEs out of `:advanced` + `goog.DEBUG=false`. Proven, not assumed: the new `tool-evidence-elision-prod-test` requires the namespace into the exact release bundle `scripts/check-ui-mounted-prod-elision.cjs` greps, and the gate now also forbids the `dropped-exact` evidence-accumulation sentinel and the projection's `invalidation-evidence projection` diagnostic string (with source positive controls) — so the bundle assertion is a positive proof of erasure rather than absence-by-omission. Behaviourally, the prod control asserts install/uninstall/projection are inert and a driven flush accrues nothing while scheduling works as ever.

### Acceptance criteria → where proven

| AC | Proof |
| --- | --- |
| Real consumer receives each flushed batch's evidence with stable root/view/cell identity | `tool_evidence_cljs_test` (JVM+node) + `tool_evidence_dom_cljs_test` (browser: real root-id + view-id) |
| first/latest epoch, count, causes, bounded targets, honest .74 loss field; no payload retention | `the-projection-carries-batch-evidence-with-stable-identity` (exact bounded key set), `real-port-fanout-projects-cause-and-target`, `cross-batch-loss-stays-honest` |
| Identity-owned, HMR-safe install/uninstall; no silent clobber; teardown releases all | `install-is-identity-owned-and-never-clobbers`, `same-owner-reinstall-is-an-idempotent-rearm-that-keeps-evidence` |
| Tool absent/closed → zero retention; abandoned cells disappear | `dead-cells-disappear-from-the-projection` + DOM test's post-teardown/uninstall asserts |
| Consumer exceptions isolated per .73; scheduling untouched | delivery rides the contained sink seam (`.73` fixtures) + observational asserts (revisions/notifications/`last-evidence-sink-escape` nil) |
| Browser coverage drives a REAL observation-port invalidation through flush into the projection | `tool_evidence_dom_cljs_test` — `uit/dispatch!` → port `on-change` → coalesced flush → projection (never a direct sink call) |
| Advanced production contains no projection/evidence/diagnostic keywords | extended `check-ui-mounted-prod-elision.cjs` + `tool_evidence_elision_prod_test` |

### Surface notes

- **reactive.cljc footprint is minimal and additive** (+14/-1): the `cell-view-id` tool read next to `revision`, and a `set-evidence-sink!` docstring pointer naming the owned lifecycle over the raw test seam. No scheduler behaviour change.
- **tools/xray untouched** — the projection is the ui artefact's tool seam Xray will consume when its re-frame.ui integration lands; **spec unchanged because no tools/xray files changed** and no new error ids / trace ops / reserved keywords are minted (keyword catalogue drift gate: clean).
- **Named follow-up** (spec hot zone owned by another in-flight branch): the S3 "View identity and the instrumentation surface" stage (Spec 004 §Staging) should formalize this projection's evidence schema when the instrumentation surface lands; no Spec 009 catalogue rows are required by this PR (no new `:rf.error`/`:rf.warning` ids, no trace ops).
- No compatibility plumbing to UIx/Helix/reagent-slim (scheduled for removal).

## Quality gates

- `implementation/ui` `clojure -M:test` (JVM): **400 tests / 5311 assertions / 0 failures** (new ns alone: 6 tests / 67 assertions)
- `implementation` `npm run test:ui` (node, incl. ui-adapter-isolation): **412 tests / 2103 assertions / 0 failures** (isolation PASS, 223 compiler-selected imports)
- `implementation` `npm run test:browser` (Playwright): **339 tests / 1825 assertions / 0 failures**
- `implementation` `npm run test:browser-prod-elision` (`:advanced`, goog.DEBUG=false): **elision gate PASS + 80 tests / 261 assertions / 0 failures**
- `python scripts/check_keyword_catalogue_drift.py`: **clean** (289 files, 0 findings)
- `sh scripts/test-fast-pr.sh` (full spine): **PASS** — incl. core JVM **1901 tests / 8577 assertions / 0 failures**, CLJS node integration (`npm run test:cljs`) **9193 tests / 43490 assertions / 0 failures**, per-ns isolation (15/15 standalone), lockstep/skill/retired-spelling/thrown-error/ambient-durable gates, markdown link/anchor gates (mkdocs soft-skipped locally; CI runs it)
