### PR TITLE
fix(ui): reactive-core correctness cluster — capture scoping, listener containment, cell retention, banner honesty (rf2-mc62sp/owwbyl/1llvoh/4kkc5r)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -896,26 +896,46 @@
   (atom #{}))
 
 (defonce ^:private root-cells
-  ;; ROOT-INCARNATION OWNERSHIP: `incarnation -> #{owned cells}`. Every ViewCell
-  ;; attached to a root (`attach-root!`, the mount seam) enrols here under its
-  ;; root's incarnation and STAYS enrolled across a transient Activity hide — a
-  ;; hide removes the cell from `live-cells` (it holds no committed deps) but NOT
-  ;; from its root membership. This is the piece `teardown-collector` alone cannot
-  ;; supply: a cell hidden by React Activity BEFORE the root's teardown window is
-  ;; armed already left `:fresh`/`:connected`, so its cleanup can never enrol it in
-  ;; the window, and it would otherwise linger `:disconnected {:reason :unknown}`
-  ;; and RECONNECTABLE after its root is gone (rf2-vxgfnd.85). `teardown-root!`
-  ;; consults this registry to reap those already-hidden cells alongside the ones
-  ;; the window captures. Membership is bounded to CURRENTLY-retained cells: a cell
-  ;; leaves on final `teardown!` (`detach-root!`), and an incarnation's entry is
-  ;; dropped the moment its last cell leaves — so repeated mount/hide/unmount
-  ;; cycles never grow a historical registry. The incarnation is a FRESH per-mount
-  ;; identity (`make-root-incarnation`), NOT the reusable root-id, so a stale
-  ;; teardown can never reap the cells of a replacement root mounted under the same
-  ;; root-id. `defonce` (module-lived); `reset-scheduler!` clears it between
-  ;; fixtures. Frame teardown also consults its still-disconnected members,
-  ;; whose retained subscription targets and resource-incarnation pins name
-  ;; their last published frames.
+  ;; ROOT-INCARNATION OWNERSHIP: `incarnation -> <weak membership set>`. Every
+  ;; ViewCell attached to a root (`attach-root!`, the mount seam) enrols here
+  ;; under its root's incarnation and STAYS enrolled across a transient Activity
+  ;; hide — a hide removes the cell from `live-cells` (it holds no committed
+  ;; deps) but NOT from its root membership. This is the piece
+  ;; `teardown-collector` alone cannot supply: a cell hidden by React Activity
+  ;; BEFORE the root's teardown window is armed already left
+  ;; `:fresh`/`:connected`, so its cleanup can never enrol it in the window, and
+  ;; it would otherwise linger `:disconnected {:reason :unknown}` and
+  ;; RECONNECTABLE after its root is gone (rf2-vxgfnd.85). `teardown-root!`
+  ;; consults this registry to reap those already-hidden cells alongside the
+  ;; ones the window captures.
+  ;;
+  ;; Membership is WEAK (rf2-mc62sp): an ordinary React reconciliation unmount
+  ;; (conditional subtree, route change, keyed-list eviction) runs only the
+  ;; effect cleanup → `disconnect!`, which deliberately never detaches (hide vs
+  ;; unmount are indistinguishable there — 03 §4), so a STRONG registry would
+  ;; pin every ordinarily-unmounted cell — with its retained committed site
+  ;; values — for the root's whole lifetime: unbounded production memory growth
+  ;; per UI churn. Weak membership keeps both consumers exactly correct: a
+  ;; genuinely HIDDEN cell is strongly reachable from React's retained fiber
+  ;; (the `useRef` in `use-cell`), so its entry lives precisely as long as
+  ;; Activity retention and stays discoverable for `teardown-root!` /
+  ;; `teardown-frame!`; a reconciliation-unmounted cell becomes unreachable
+  ;; (its leases were already released at `disconnect!`, and nothing can ever
+  ;; reconnect a cell nothing references), so it collects and its entry clears
+  ;; — the teardown scans lose nothing, per 03 §4 "the cell is garbage". The
+  ;; per-host weak plumbing (`make-weak-member-set` etc.) lives beside
+  ;; `attach-root!`; `detach-root!` on final `teardown!` stays the
+  ;; DETERMINISTIC fast path, and an incarnation's entry is dropped the moment
+  ;; its last cell deterministically leaves (or, on CLJS, when the
+  ;; finalization reaper clears the last collected member) — repeated
+  ;; mount/hide/unmount cycles never grow a historical registry. The
+  ;; incarnation is a FRESH per-mount identity (`make-root-incarnation`), NOT
+  ;; the reusable root-id, so a stale teardown can never reap the cells of a
+  ;; replacement root mounted under the same root-id. `defonce`
+  ;; (module-lived); `reset-scheduler!` clears it between fixtures. Frame
+  ;; teardown also consults its still-disconnected members, whose retained
+  ;; subscription targets and resource-incarnation pins name their last
+  ;; published frames.
   (atom {}))
 
 (defonce ^:private teardown-collector
@@ -2044,9 +2064,11 @@
 ;; survive an Activity hide. Root teardown needs an ownership association that
 ;; DOES survive a transient hide: the `root-cells` registry keyed by a per-mount
 ;; root incarnation. `attach-root!` (the mount seam) enrols a cell under its
-;; root's incarnation; the cell stays enrolled across a hide and leaves only
-;; when it is proven dead (`detach-root!` from `teardown!`). `teardown-root!`
-;; reaps a root's already-hidden cells through this registry.
+;; root's incarnation; the cell stays enrolled across a hide and leaves
+;; deterministically when it is proven dead (`detach-root!` from `teardown!`) —
+;; or, because membership is WEAK (rf2-mc62sp), simply by being collected after
+;; an ordinary reconciliation unmount dropped the last strong reference.
+;; `teardown-root!` reaps a root's already-hidden cells through this registry.
 
 (defn make-root-incarnation
   "Mint a FRESH, opaque root-incarnation token — a per-mount identity with no
@@ -2058,26 +2080,153 @@
   []
   #?(:clj (Object.) :cljs (js-obj)))
 
-(defn- forget-root-cell!
-  "Remove `cell` from `incarnation`'s membership set, DROPPING the incarnation
-  entry entirely when its last cell leaves — so repeated mount/hide/unmount
-  cycles never grow a historical registry (rf2-vxgfnd.85 AC5)."
-  [^ViewCell cell incarnation]
-  (when (some? incarnation)
+;; ---- weak root membership (rf2-mc62sp) --------------------------------------
+;;
+;; The registry must survive an Activity hide (React gives no hide-vs-unmount
+;; signal at cleanup), yet an ordinary reconciliation unmount runs ONLY that
+;; same cleanup — so a strong set would pin every ordinarily-unmounted cell
+;; (with its retained committed site values) until the whole root tears down.
+;; Membership is therefore WEAK, per host idiom (mirroring the observation
+;; port's weak node-record table): a hidden cell is strongly reachable from
+;; React's retained fiber, so its entry lives exactly as long as Activity
+;; retention; an unmounted cell becomes unreachable — nothing can ever
+;; reconnect it — collects, and its entry clears with it.
+;;
+;;   - JVM: a synchronized `WeakHashMap`-backed keyset (the
+;;     `re-frame.interop` weak-registry idiom) — stale entries expunge on
+;;     every access, iteration under the wrapper's own lock.
+;;   - CLJS: a `js/Set` of `js/WeakRef` plus an ephemeron `js/WeakMap`
+;;     (cell -> its ref) for O(1) removal; a module `FinalizationRegistry`
+;;     reaper prunes a collected cell's ref and drops the incarnation entry
+;;     when its last member clears (where the host lacks the registry, husks
+;;     are compacted opportunistically on iteration instead).
+
+(defn- make-weak-member-set
+  []
+  #?(:clj  (java.util.Collections/synchronizedSet
+            (java.util.Collections/newSetFromMap (java.util.WeakHashMap.)))
+     :cljs {:refs (js/Set.) :by-cell (js/WeakMap.)}))
+
+(defn- weak-empty?
+  [members]
+  #?(:clj  (.isEmpty ^java.util.Set members)
+     :cljs (zero? (.-size ^js (:refs members)))))
+
+(defn- drop-root-entry-if-empty!
+  "Drop `incarnation`'s registry entry when its membership set has emptied —
+  guarded so a concurrent re-attach (which installs or repopulates the entry)
+  is never clobbered. Retry-safe inside `swap!`: the emptiness read is
+  idempotent."
+  [incarnation members]
+  (when (weak-empty? members)
     (swap! root-cells
            (fn [m]
-             (let [s (disj (get m incarnation #{}) cell)]
-               (if (empty? s) (dissoc m incarnation) (assoc m incarnation s)))))))
+             (let [s (get m incarnation)]
+               (if (and (identical? s members) (weak-empty? s))
+                 (dissoc m incarnation)
+                 m))))))
+
+#?(:cljs
+   (defonce ^:private root-cells-reaper
+     ;; Finalization hook: when a member cell is collected, remove its cleared
+     ;; WeakRef husk from its incarnation's set and drop the entry when that
+     ;; was the last member — so GC-driven departure is as bounded as the
+     ;; deterministic `detach-root!` path. Guarded: an exotic host without
+     ;; FinalizationRegistry just leaves husks to iteration-time compaction.
+     (when (exists? js/FinalizationRegistry)
+       (js/FinalizationRegistry.
+        (fn [held]
+          (let [{:keys [incarnation ref]} held
+                members (get @root-cells incarnation)]
+            (when (some? members)
+              (.delete ^js (:refs members) ref)
+              (drop-root-entry-if-empty! incarnation members))))))))
+
+(defn- weak-add!
+  [members incarnation ^ViewCell cell]
+  #?(:clj  (.add ^java.util.Set members cell)
+     :cljs (let [by-cell ^js (:by-cell members)]
+             (when-not (.has by-cell cell)
+               (let [ref (js/WeakRef. cell)]
+                 (.set by-cell cell ref)
+                 (.add ^js (:refs members) ref)
+                 (when (some? root-cells-reaper)
+                   (.register root-cells-reaper cell
+                              {:incarnation incarnation :ref ref}
+                              ref)))))))
+
+(defn- weak-remove!
+  [members ^ViewCell cell]
+  #?(:clj  (.remove ^java.util.Set members cell)
+     :cljs (let [by-cell ^js (:by-cell members)]
+             (when-some [ref (.get by-cell cell)]
+               (.delete by-cell cell)
+               (.delete ^js (:refs members) ref)
+               (when (some? root-cells-reaper)
+                 (.unregister root-cells-reaper ref))))))
+
+(defn- weak-live
+  "Snapshot the still-LIVE cells of one incarnation's weak membership set
+  (nil-safe — an absent entry is no members). The teardown-discovery read:
+  a cleared ref is a collected — therefore unreachable, therefore never
+  reconnectable — cell with nothing left to reap; on CLJS its husk is
+  compacted away as it is encountered."
+  [members]
+  (if (nil? members)
+    []
+    #?(:clj  (locking members (into [] members))
+       :cljs (let [refs ^js (:refs members)
+                   out  (array)]
+               (.forEach refs
+                         (fn [ref _ _]
+                           (if-some [cell (.deref ^js ref)]
+                             (.push out cell)
+                             (.delete refs ref))))
+               (vec out)))))
+
+(defn- weak-live-count
+  [members]
+  (if (nil? members)
+    0
+    #?(:clj  (.size ^java.util.Set members)
+       :cljs (count (weak-live members)))))
+
+(defn- forget-root-cell!
+  "Remove `cell` from `incarnation`'s weak membership set, DROPPING the
+  incarnation entry entirely when its last cell leaves — so repeated
+  mount/hide/unmount cycles never grow a historical registry
+  (rf2-vxgfnd.85 AC5)."
+  [^ViewCell cell incarnation]
+  (when (some? incarnation)
+    (when-some [members (get @root-cells incarnation)]
+      (weak-remove! members cell)
+      (drop-root-entry-if-empty! incarnation members))))
+
+(defn- enrol-root-cell!
+  "Add `cell` to `incarnation`'s WEAK membership set, installing the set on
+  first use. Loops to self-heal the (concurrent-JVM, test-shaped) race where
+  a simultaneous last-member removal drops the incarnation entry between the
+  install and the add — the re-check guarantees the added cell is reachable
+  through the CURRENT registry entry."
+  [^ViewCell cell incarnation]
+  (let [members (or (get @root-cells incarnation)
+                    (let [fresh (make-weak-member-set)]
+                      (-> (swap! root-cells update incarnation #(or % fresh))
+                          (get incarnation))))]
+    (weak-add! members incarnation cell)
+    (when-not (identical? members (get @root-cells incarnation))
+      (recur cell incarnation))))
 
 (defn attach-root!
   "Mount seam: associate `cell` with root `incarnation` — the per-mount ownership
   token (`make-root-incarnation`) that SURVIVES a transient Activity disconnect
   and lets `teardown-root!` reap a cell already Activity-hidden BEFORE the host
   unmount window (rf2-vxgfnd.85). Enrols the cell in `root-cells` under
-  `incarnation` (idempotent — a set); re-attaching to a DIFFERENT incarnation
-  first drops the old membership, so a cell can never straddle two roots. An
-  Activity hide (which removes the cell from `live-cells`) does NOT drop this
-  membership — that is the whole point. Returns the cell."
+  `incarnation` (idempotent, and WEAK — membership never keeps an unmounted
+  cell alive, rf2-mc62sp); re-attaching to a DIFFERENT incarnation first drops
+  the old membership, so a cell can never straddle two roots. An Activity hide
+  (which removes the cell from `live-cells`) does NOT drop this membership —
+  that is the whole point. Returns the cell."
   [^ViewCell cell incarnation]
   (let [st  (state cell)
         old (:root @st)]
@@ -2088,13 +2237,14 @@
       (when (and (some? old) (not (identical? old incarnation)))
         (forget-root-cell! cell old))
       (swap! st assoc :root incarnation)
-      (swap! root-cells update incarnation (fnil conj #{}) cell)))
+      (enrol-root-cell! cell incarnation)))
   cell)
 
 (defn- detach-root!
   "Drop `cell`'s root-incarnation membership on FINAL teardown — the cell is
-  proven dead, so it leaves the registry (membership is bounded to
-  currently-retained cells). Idempotent; a no-op when the cell owns no root."
+  proven dead, so it leaves the registry deterministically (the fast path;
+  weak membership is the backstop for cells that were never proven dead).
+  Idempotent; a no-op when the cell owns no root."
   [^ViewCell cell]
   (let [st  (state cell)
         inc (:root @st)]
@@ -2109,11 +2259,12 @@
 
 (defn root-cell-count
   "The number of root incarnations currently tracked, or — with `incarnation` —
-  the number of cells owned by it (tool/test read). Proves the ownership registry
-  is bounded to retained/mounted cells and drops empty incarnations on final
-  teardown (rf2-vxgfnd.85 AC5)."
+  the number of LIVE cells its weak membership currently retains (tool/test
+  read). Proves the ownership registry is bounded to retained/mounted cells:
+  empty incarnations drop on final teardown (rf2-vxgfnd.85 AC5), and a
+  collected member simply stops counting (rf2-mc62sp)."
   ([] (count @root-cells))
-  ([incarnation] (count (get @root-cells incarnation))))
+  ([incarnation] (weak-live-count (get @root-cells incarnation))))
 
 (defn- release-committed!
   "Release every live lexical-site lease and retain each exact query/target/
@@ -2319,7 +2470,7 @@
         connected (filter #(cell-retained-frame? % frame-id frame-token)
                           @live-cells)
         hidden    (into #{}
-                        (comp (mapcat val)
+                        (comp (mapcat (comp weak-live val))
                               (filter #(= :disconnected (lifecycle %)))
                               (filter #(cell-retained-frame?
                                         % frame-id frame-token)))
@@ -2410,16 +2561,19 @@
          incs      (cond-> (into #{} (keep cell-root) collected)
                      (some? root-incarnation) (conj root-incarnation))
          ;; already-Activity-hidden owned cells the window could NOT capture —
-         ;; still `:disconnected`, belonging to a torn-down incarnation.
+         ;; still `:disconnected`, belonging to a torn-down incarnation. A
+         ;; hidden-but-alive cell is pinned by React's retained fiber, so weak
+         ;; membership still discovers it; only collected (unreachable, never
+         ;; reconnectable) cells are absent — nothing to reap (rf2-mc62sp).
          hidden    (into #{}
-                         (comp (mapcat #(get @root-cells %))
+                         (comp (mapcat #(weak-live (get @root-cells %)))
                                (filter #(= :disconnected (lifecycle %))))
                          incs)
          victims   (if (and @host-error (some? root-incarnation))
                      ;; The host handle is consumed/released even on this path.
                      ;; Fail closed over the EXACT root generation, including
                      ;; cells still connected because React ran no cleanup.
-                     (into collected (get @root-cells root-incarnation))
+                     (into collected (weak-live (get @root-cells root-incarnation)))
                      (into collected hidden))]
      (doseq [cell victims]
        (teardown! cell))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -260,13 +260,19 @@
 ;; ---------------------------------------------------------------------------
 ;; Ambient render capture
 ;;
-;; Single-threaded on both hosts within one synchronous render; a compiled
+;; Single-threaded on both hosts WITHIN one synchronous render; a compiled
 ;; view's children are ELEMENTS (rendered later by the host), never
-;; synchronously nested calls, so renders never nest — a save/restore cell
-;; is sufficient and re-entrancy-robust.
+;; synchronously nested calls, so renders never nest on one thread. ACROSS
+;; threads the JVM Tier-1 host gives no such guarantee (parallel test
+;; runners, fixture futures), so the slot is a DYNAMIC var — thread-local
+;; under `binding`, exactly like every neighbouring render-path scope
+;; (`*sub-overrides*`, `frame/*current-frame*`) — and two concurrent renders
+;; can neither cross-record sites into each other's captures nor false-throw
+;; the duplicate-sid guard (rf2-1llvoh). On single-threaded CLJS `binding`
+;; compiles to the same save/restore the old atom hand-rolled.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private ambient (atom nil)) ;; {:cell <cell> :capture <volatile>} | nil
+(def ^:private ^:dynamic *ambient* nil) ;; {:cell <cell> :capture <volatile>} | nil
 
 (defn- fresh-capture
   [generation]
@@ -681,7 +687,7 @@
   Fail-loud rides the port: `:rf.error/no-such-sub` on an unknown entry
   sub, `:rf.error/frame-destroyed` against a destroyed frame."
   ([query]
-   (if (some? (:cell @ambient))
+   (if (some? (:cell *ambient*))
      (error/throw-error!
        :rf.error/ui-tree-malformed
        're-frame.ui.reactive/sub-read
@@ -690,7 +696,7 @@
        {:extra {:query query}})
      (sub-read nil query)))
   ([sid query]
-   (let [{:keys [cell capture]} @ambient
+   (let [{:keys [cell capture]} *ambient*
          _ (when (and (some? cell) (nil? sid))
              (error/throw-error!
                :rf.error/ui-tree-malformed
@@ -751,7 +757,7 @@
   capture, and the later passive resource reconciler alone changes ownership."
   [sid descriptor]
   (let [descriptor (ui-lease/validate-descriptor! descriptor)
-        {:keys [cell capture]} @ambient]
+        {:keys [cell capture]} *ambient*]
     (when (or (nil? cell) (nil? capture) (nil? sid))
       (error/throw-error!
        :rf.error/ui-tree-malformed
@@ -789,16 +795,16 @@
   speculative render therefore cannot replace the input of an earlier render
   that React actually commits. StrictMode's effect mount→cleanup→remount reuses
   the selected effect closure, so both mounts reconcile the same immutable
-  capture without a shared slot."
+  capture without a shared slot.
+
+  The ambient slot is a dynamic var: `binding` gives the save/restore for
+  free on single-threaded CLJS and THREAD-LOCAL isolation on the JVM, so two
+  concurrent Tier-1 renders own disjoint captures (rf2-1llvoh)."
   [^ViewCell cell thunk]
-  (let [cap  (volatile! (fresh-capture (:generation @(state cell))))
-        prev @ambient]
-    (reset! ambient {:cell cell :capture cap})
-    (try
+  (let [cap (volatile! (fresh-capture (:generation @(state cell))))]
+    (binding [*ambient* {:cell cell :capture cap}]
       (let [el (thunk)]
-        [el @cap])
-      (finally
-        (reset! ambient prev)))))
+        [el @cap]))))
 
 ;; ---- useSyncExternalStore contract ------------------------------------------
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -831,9 +831,22 @@
   (count (:listeners @(state cell))))
 
 (defn- notify-listeners!
+  "Deliver the revision notification to EVERY listener of `cell`. Each
+  listener is contained in its own try/catch so one throwing consumer cannot
+  starve its sibling listeners on the same cell (mirroring the observation
+  port's per-lease disposal containment); the FIRST escape is rethrown AFTER
+  every listener has been delivered — surfaced, never starving (rf2-owwbyl)."
   [^ViewCell cell]
-  (doseq [f (vals (:listeners @(state cell)))]
-    (f)))
+  (let [escape (reduce (fn [acc f]
+                         (try
+                           (f)
+                           acc
+                           (catch #?(:clj Throwable :cljs :default) e
+                             (or acc e))))
+                       nil
+                       (vals (:listeners @(state cell))))]
+    (when (some? escape)
+      (throw escape))))
 
 (defn- advance-revision!
   "Advance the cell's revision and notify subscribers — the host re-reads
@@ -1181,24 +1194,44 @@
   listener fires synchronously within this flush) and, in DEV, hand the captured
   `ev` to the installed `evidence-sink` (Xray; rf2-vxgfnd.46) inside a guard.
 
-  A THROWING sink is a broken DEBUG tool, never an authority over the render
-  correction: its throw is CONTAINED here (caught and returned to the batch core
-  for one bounded diagnostic) so it can neither strand a cell nor abort the
-  batch's remaining cells (rf2-vxgfnd.73). Because completion already finished for
-  the whole batch, a re-entrant sink/listener that re-marks this (or ANY) cell
-  enrols a FRESH pending window rather than losing the notification. The sink
-  still receives the exact pre-clear bounded summary once per flushed cell.
-  Returns `{:cell cell :error e}` on a contained sink escape (DEV only), else nil;
-  the whole evidence/containment path DCEs under `goog.DEBUG=false`."
+  BOTH consumer families are contained here, because neither is an authority
+  over the render correction (the rf2-vxgfnd.73 doctrine):
+
+    - a THROWING LISTENER (the PRODUCTION surface — rf2-owwbyl) is caught and
+      returned to the batch core, so it can neither strand this cell nor abort
+      the batch's remaining cells' deliveries: phase 1 already cleared every
+      drained cell's dirty flag and registry membership, so an aborted phase 2
+      would LOSE the undelivered sibling notifications outright — stale UI
+      until unrelated movement re-marks them. The batch core rethrows the
+      FIRST listener escape AFTER the whole batch has delivered — surfaced,
+      never silent, never starving (the same drain-then-rethrow shape as the
+      observation port's `drain-pending-disposals!`).
+    - a THROWING sink is a broken DEBUG tool: contained exactly as before
+      (rf2-vxgfnd.73) and reported via ONE bounded diagnostic (never rethrown,
+      never through the sink). The sink still receives the exact pre-clear
+      bounded summary once per flushed cell.
+
+  Because completion already finished for the whole batch, a re-entrant
+  sink/listener that re-marks this (or ANY) cell enrols a FRESH pending window
+  rather than losing the notification. Returns nil, or a map carrying the
+  contained `:listener` and/or `:sink` escape as `{:cell cell :error e}`; the
+  evidence/sink half DCEs under `goog.DEBUG=false`."
   [^ViewCell cell ev]
-  (notify-listeners! cell)
-  (when interop/debug-enabled?
-    (when-some [sink @evidence-sink]
-      (try
-        (sink cell ev)
-        nil
-        (catch #?(:clj Throwable :cljs :default) e
-          {:cell cell :error e})))))
+  (let [listener-escape (try
+                          (notify-listeners! cell)
+                          nil
+                          (catch #?(:clj Throwable :cljs :default) e
+                            {:cell cell :error e}))
+        sink-escape     (when interop/debug-enabled?
+                          (when-some [sink @evidence-sink]
+                            (try
+                              (sink cell ev)
+                              nil
+                              (catch #?(:clj Throwable :cljs :default) e
+                                {:cell cell :error e}))))]
+    (cond-> nil
+      (some? listener-escape) (assoc :listener listener-escape)
+      (some? sink-escape)     (assoc :sink sink-escape))))
 
 (defn- run-flush-batch!
   "The two-phase batch-flush CORE over an explicit ordered `cells` seq
@@ -1206,26 +1239,35 @@
   scheduler state — with no user code — so the whole batch is complete before
   PHASE 2 (`deliver-flush!`) runs any listener or evidence-sink. A re-entrant
   re-mark in phase 2 therefore always sees a fully-completed batch and opens the
-  NEXT window, regardless of iteration order. Preserves the DEV containment:
-  each `deliver-flush!` contains a throwing sink, the batch captures the FIRST
-  escape and emits ONE bounded diagnostic (never through the sink), and the whole
-  DEBUG branch DCEs under `goog.DEBUG=false`. Returns the count actually flushed."
+  NEXT window, regardless of iteration order.
+
+  Phase 2 delivers EVERY cell regardless of consumer behaviour — each
+  `deliver-flush!` contains its cell's throwing listener AND (in DEV) a
+  throwing sink per-cell, so neither can abort the remaining cells' deliveries
+  (rf2-owwbyl / rf2-vxgfnd.73). Evaluate the delivery FIRST (never inside a
+  short-circuiting form), keep the FIRST escape of each family across the
+  batch, then: emit ONE bounded sink diagnostic (never through the sink; the
+  sink half DCEs under `goog.DEBUG=false`) and RETHROW the first listener
+  escape AFTER the whole batch delivered — a production consumer bug is
+  surfaced to the flush caller, never silent, and never costs a sibling cell
+  its notification. Returns the count actually flushed."
   [cells]
-  (let [completed (into [] (keep complete-flush!) cells)]
-    (if interop/debug-enabled?
-      ;; deliver EVERY cell regardless of tool behaviour — a throwing sink is
-      ;; contained per-cell (returns the escape, never propagates). Evaluate the
-      ;; delivery FIRST (never inside `or`, which would short-circuit the rest of
-      ;; the batch after the first escape), keep the FIRST escape, emit ONE
-      ;; bounded diagnostic — never through the sink.
-      (let [escape (reduce (fn [acc [cell ev]]
-                             (let [e (deliver-flush! cell ev)] (or acc e)))
-                           nil
-                           completed)]
-        (when (some? escape)
-          (report-sink-escape! escape)))
-      (doseq [[cell _] completed]
-        (deliver-flush! cell nil)))
+  (let [completed (into [] (keep complete-flush!) cells)
+        escapes   (reduce (fn [acc [cell ev]]
+                            (let [e (deliver-flush! cell ev)]
+                              (cond-> acc
+                                (and (:listener e) (nil? (:listener acc)))
+                                (assoc :listener (:listener e))
+
+                                (and (:sink e) (nil? (:sink acc)))
+                                (assoc :sink (:sink e)))))
+                          {}
+                          completed)]
+    (when interop/debug-enabled?
+      (when-some [se (:sink escapes)]
+        (report-sink-escape! se)))
+    (when-some [le (:listener escapes)]
+      (throw (:error le)))
     (count completed)))
 
 (defn flush-scope!

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -154,11 +154,20 @@
 ;; N lexical (sub …) sites in a view share ONE ViewCell (one
 ;; useSyncExternalStore hook). The render body runs ONCE for all N sites, the
 ;; commit acquires N REAL leases (deduped by target identity), and when all N
-;; sites move in ONE drain the cell coalesces to ONE notification — the
+;; sites fan in during ONE drain the cell coalesces to ONE notification — the
 ;; notification count per drain is INVARIANT to the site count. Fully against
-;; the real port + plain-atom cache: the one-drain fan-in is a REAL app-db move
-;; caught at the headless commit evidence comparison (step 5/8), which advances
-;; the cell's revision AT MOST ONCE per commit — no scheduler seam, no mock.
+;; the real port + plain-atom cache — no scheduler seam, no mock — but be
+;; honest about WHICH invalidation channel drives the fan-in: each sub is
+;; RE-REGISTERED (reg-sub again), so the port disposes its canonical node and
+;; fires every committed lease's REAL :hmr-cause on-change, caught at
+;; mark-dirty! (constant-work enrolment) and advanced once by the coalesced
+;; flush. This is NOT the app-db value-movement channel: on plain-atom a
+;; value move has no watch and is caught at the commit evidence comparison
+;; (step 5/8) — that path is pinned by the reconcile suite's moved-evidence
+;; fixtures (re-frame.ui.reactive-reconcile-cljs-test), and the end-to-end
+;; app-db-movement G-3 proof on the watchable adapter is the MOUNTED
+;; counterpart (re-frame.ui.mounted-g3-cardinality-dom-cljs-test) — do not
+;; deprioritise it on the strength of this headless gate.
 
 (defn- g3-scaling-case
   "One G-3 case at `n` sites: render a cell with n distinct sub sites, commit,

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -631,3 +631,83 @@
         (render+commit! cell [[:r/nan]]))
       (is (= 0 (reactive/revision cell))
           "stable NaN evidence causes zero corrective revisions"))))
+
+;; ===========================================================================
+;; Concurrent JVM Tier-1 renders own DISJOINT ambient captures (rf2-1llvoh)
+;; ===========================================================================
+;;
+;; The ambient render-capture slot is a DYNAMIC var (thread-local under
+;; `binding`), matching every neighbouring render-path scope. These fixtures
+;; force the adversarial cross-thread interleave A-enter → B-enter → A-read →
+;; B-read → B-exit → A-exit and prove each render's returned capture contains
+;; EXACTLY its own sites — with a module-global slot, A's read lands in B's
+;; still-open capture (silent wrong ownership) or false-throws the
+;; duplicate-sid guard on an sid collision. JVM-only: CLJS is single-threaded
+;; and `binding` compiles to the same save/restore the slot always had.
+
+#?(:clj
+   (defn- interleaved-renders!
+     "Run two concurrent Tier-1 renders with a latch-forced interleave: A is
+     mid-capture when B enters and reads. Returns
+     {:a {:value v :sites by-site} :b {...}}; rethrows a thread's escape."
+     [sid-a q-a sid-b q-b]
+     (let [a-entered   (promise)
+           b-entered   (promise)
+           a-read-done (promise)
+           b-read-done (promise)
+           fut-a (future
+                   (rf/with-frame fid
+                     (reactive/with-capture (reactive/make-cell ::amb-a)
+                       (fn []
+                         (deliver a-entered true)
+                         (deref b-entered 5000 ::timeout)
+                         (let [v (reactive/sub-read sid-a q-a)]
+                           (deliver a-read-done true)
+                           ;; hold A's capture OPEN until B has read, so the
+                           ;; interleave is deterministic in both directions
+                           (deref b-read-done 5000 ::timeout)
+                           v)))))
+           fut-b (future
+                   (deref a-entered 5000 ::timeout)
+                   (rf/with-frame fid
+                     (reactive/with-capture (reactive/make-cell ::amb-b)
+                       (fn []
+                         (deliver b-entered true)
+                         (deref a-read-done 5000 ::timeout)
+                         (let [v (reactive/sub-read sid-b q-b)]
+                           (deliver b-read-done true)
+                           v)))))
+           [va cap-a] @fut-a
+           [vb cap-b] @fut-b]
+       {:a {:value va :sites (reactive/site-records cap-a)}
+        :b {:value vb :sites (reactive/site-records cap-b)}})))
+
+#?(:clj
+   (deftest concurrent-renders-record-only-their-own-sites
+     (rf/reg-sub :amb/a (fn [db _] (:a db)))
+     (rf/reg-sub :amb/b (fn [db _] (:b db)))
+     (seed! {:a :va :b :vb})
+     (let [{:keys [a b]} (interleaved-renders!
+                          [:amb :site-a] [:amb/a]
+                          [:amb :site-b] [:amb/b])]
+       (testing "each thread's capture holds EXACTLY its own site + value"
+         (is (= #{[:amb :site-a]} (set (keys (:sites a))))
+             "A's capture records A's site — not lost to B's open capture")
+         (is (= #{[:amb :site-b]} (set (keys (:sites b))))
+             "B's capture records B's site only — no cross-thread pollution")
+         (is (= :va (:value a) (get-in a [:sites [:amb :site-a] :value])))
+         (is (= :vb (:value b) (get-in b [:sites [:amb :site-b] :value])))))))
+
+#?(:clj
+   (deftest concurrent-renders-share-an-sid-without-false-duplicate-throw
+     ;; Site ids are per-CAPTURE ownership keys; the same compiler sid on two
+     ;; concurrent threads is two different renders, never a duplicate site.
+     (rf/reg-sub :amb/a (fn [db _] (:a db)))
+     (rf/reg-sub :amb/b (fn [db _] (:b db)))
+     (seed! {:a :va :b :vb})
+     (let [{:keys [a b]} (interleaved-renders!
+                          [:amb :shared] [:amb/a]
+                          [:amb :shared] [:amb/b])]
+       (testing "no false :rf.error/ui-tree-malformed; each side owns its record"
+         (is (= :va (get-in a [:sites [:amb :shared] :value])))
+         (is (= :vb (get-in b [:sites [:amb :shared] :value])))))))

--- a/implementation/ui/test/re_frame/ui/reactive_reentrant_flush_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reentrant_flush_cljs_test.cljc
@@ -189,3 +189,86 @@
       (is (= 55 (:b-epoch fwd)))
       (is (= 1 (:pending-count fwd)))
       (is (true? (:escape-a? fwd)) "the escape names the offending cell — not silent"))))
+
+;; ===========================================================================
+;; A THROWING LISTENER must not strand completed sibling deliveries
+;; (rf2-owwbyl — the rf2-vxgfnd.73 bug class one layer down, on the
+;; PRODUCTION notification path)
+;; ===========================================================================
+;;
+;; Phase 1 clears every drained cell's dirty flag + registry membership BEFORE
+;; phase 2 runs any listener. An uncontained listener throw therefore did not
+;; defer the sibling notifications — it LOST them: the sibling was no longer
+;; dirty, no longer registered, its listeners never invoked — stale UI until
+;; unrelated movement. The fix contains per listener AND per cell, completes
+;; the whole batch, then rethrows the FIRST escape so the bug is surfaced.
+
+(defn- run-throwing-listener-scenario
+  "Batch {A,B}; A's first listener throws; A carries a second listener and B
+  carries one. Flush in `order-fn`'s order; capture the surfaced escape.
+  Returns the full observable outcome."
+  [order-fn]
+  (reactive/reset-scheduler!)
+  (let [ha2    (atom 0)
+        hb     (atom 0)
+        cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)]
+    (reactive/subscribe cell-a (fn [] (throw (ex-info "listener boom" {:cell :a}))))
+    (reactive/subscribe cell-a (fn [] (swap! ha2 inc)))
+    (reactive/subscribe cell-b (fn [] (swap! hb inc)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [escape (try
+                   (reactive/flush-batch-in-order! (order-fn [cell-a cell-b]))
+                   nil
+                   (catch #?(:clj Throwable :cljs :default) e e))]
+      {:escape-msg    (some-> escape ex-message)
+       :rev-a         (reactive/revision cell-a)
+       :rev-b         (reactive/revision cell-b)
+       :hits-a2       @ha2
+       :hits-b        @hb
+       :a-dirty?      (reactive/dirty? cell-a)
+       :b-dirty?      (reactive/dirty? cell-b)
+       :pending-count (reactive/pending-cell-count)})))
+
+(deftest throwing-listener-cannot-strand-sibling-cells-either-order
+  (let [fwd (run-throwing-listener-scenario identity)              ;; A then B
+        rev (run-throwing-listener-scenario (fn [[a b]] [b a]))]   ;; B then A
+    (testing "both iteration orders yield the IDENTICAL contained outcome"
+      (is (= fwd rev)))
+    (testing "cells 2..N still deliver — the sibling's notification is not lost"
+      (is (= 1 (:hits-b fwd))
+          "B's listener fired despite A's listener throwing (the rf2-owwbyl
+           regression: B was permanently stranded — cleared but undelivered)")
+      (is (= 1 (:hits-a2 fwd))
+          "A's OWN second listener fired too — containment is per listener")
+      (is (= 1 (:rev-a fwd)) "A completed")
+      (is (= 1 (:rev-b fwd)) "B completed")
+      (is (false? (:a-dirty? fwd)))
+      (is (false? (:b-dirty? fwd)))
+      (is (= 0 (:pending-count fwd)) "nothing lingers in the registry"))
+    (testing "the escape is SURFACED to the flush caller — never silent"
+      (is (= "listener boom" (:escape-msg fwd))
+          "the first listener escape is rethrown after the batch delivered"))))
+
+(deftest throwing-listener-through-the-real-flush-pending-primitive
+  (reactive/reset-scheduler!)
+  (let [hb     (atom 0)
+        cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)]
+    (reactive/subscribe cell-a (fn [] (throw (ex-info "listener boom" {}))))
+    (reactive/subscribe cell-b (fn [] (swap! hb inc)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [escape (try (reactive/flush-pending!) nil
+                      (catch #?(:clj Throwable :cljs :default) e e))]
+      (is (some? escape) "the escape surfaces through flush-scope! too")
+      (is (= 1 @hb) "…after the whole drained batch delivered"))
+    (testing "the scheduler is fully settled — a later movement flows normally"
+      (is (= 0 (reactive/pending-cell-count)))
+      (reactive/mark-dirty! cell-b 3)
+      (is (= 1 (try (reactive/flush-pending!)
+                    (catch #?(:clj Throwable :cljs :default) _ ::rethrew))
+          )
+          "the next drain flushes B cleanly (A has no pending window)")
+      (is (= 2 @hb)))))

--- a/implementation/ui/test/re_frame/ui/reactive_root_retention_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_retention_cljs_test.cljc
@@ -1,0 +1,163 @@
+(ns re-frame.ui.reactive-root-retention-cljs-test
+  "rf2-mc62sp — root-incarnation membership must not RETAIN ordinarily-
+  unmounted ViewCells.
+
+  An ordinary React reconciliation unmount (conditional subtree, route
+  change, keyed-list eviction) runs only the effect cleanup → `disconnect!`,
+  which deliberately never detaches (hide vs unmount are indistinguishable
+  there — 03 §4). A STRONG `root-cells` set therefore pinned every such cell —
+  with its retained committed site values — until the whole root tore down:
+  unbounded production memory growth per UI churn, contradicting 03 §4's
+  ':disconnected … if React does not reconnect the cell, the cell is garbage'.
+
+  Membership is now WEAK (WeakHashMap keyset on the JVM; js/WeakRef set +
+  FinalizationRegistry reaper on CLJS), preserving BOTH registry consumers:
+
+    - lease/root/frame TEARDOWN DISCOVERY of hidden cells — a genuinely
+      Activity-hidden cell is strongly reachable from React's retained fiber
+      (`use-cell`'s useRef), so its weak entry lives exactly as long as
+      Activity retention and `teardown-root!`/`teardown-frame!` still find it
+      (rf2-vxgfnd.85);
+    - the Xray EVIDENCE PROJECTION (rf2-vxgfnd.75), which reads the per-cell
+      `:root` field (`reactive/cell-root`) — never this registry — and is
+      structurally unaffected (its own suite pins that).
+
+  The leak proof forces GC on the JVM (the graft-checked host where weak
+  clearing is deterministic under System/gc); the cross-host fixtures pin the
+  survive-hide / deterministic-teardown semantics of the weak rewrite on both
+  hosts. `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
+  (`clojure -M:test`)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.test-support         :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- render+commit! [cell fid queries]
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:ret/site i] q))
+                                        (range) queries))))]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- mount!
+  "Graft analogue of a real mount UNDER a root: mint a cell, attach it to
+  `incarnation`, commit it connected under `fid` observing `queries`."
+  [vid incarnation fid queries]
+  (let [cell (reactive/make-cell vid)]
+    (reactive/attach-root! cell incarnation)
+    (render+commit! cell fid queries)))
+
+;; ===========================================================================
+;; Weak membership keeps the rf2-vxgfnd.85 semantics: survives a hide,
+;; deterministic departure on teardown!, entry dropped with the last member
+;; ===========================================================================
+
+(deftest membership-survives-hide-and-drops-deterministically-on-teardown
+  (rf/reg-sub :ret/a (fn [db _] (:a db)))
+  (let [fid         (make-frame! :ret/frame {:a 1})
+        incarnation (reactive/make-root-incarnation)
+        base        (reactive/root-cell-count)
+        cell        (mount! ::v incarnation fid [[:ret/a]])]
+    (testing "attached: one live member under the incarnation"
+      (is (= 1 (reactive/root-cell-count incarnation)))
+      (is (identical? incarnation (reactive/cell-root cell))
+          "the projection's per-cell :root read is untouched by weak membership"))
+    (testing "an Activity hide does NOT drop membership (the whole point)"
+      (reactive/disconnect! cell)
+      (is (= :disconnected (reactive/lifecycle cell)))
+      (is (= 1 (reactive/root-cell-count incarnation))
+          "the hidden cell — strongly retained by its fiber/test handle —
+           stays discoverable through the weak registry"))
+    (testing "final teardown! leaves deterministically (the fast path)"
+      (reactive/teardown! cell)
+      (is (= 0 (reactive/root-cell-count incarnation)))
+      (is (= base (reactive/root-cell-count))
+          "the incarnation entry dropped with its last member (AC5)"))))
+
+(deftest hidden-cells-stay-discoverable-for-root-teardown
+  (rf/reg-sub :ret/a (fn [db _] (:a db)))
+  (let [fid         (make-frame! :ret/frame {:a 1})
+        incarnation (reactive/make-root-incarnation)
+        hidden      (mount! ::hidden incarnation fid [[:ret/a]])]
+    ;; Hidden BEFORE any teardown window exists — the .85 shape. The test
+    ;; handle stands in for React's retained fiber (Activity keeps the fiber,
+    ;; so a real hidden cell is strongly reachable exactly like this).
+    (reactive/disconnect! hidden)
+    (is (= :disconnected (reactive/lifecycle hidden)))
+    (testing "root teardown still reaps the hidden cell through weak membership"
+      (reactive/teardown-root! incarnation (fn [] nil))
+      (is (= :dead (reactive/lifecycle hidden))
+          "lease-teardown discovery of hidden-but-alive cells is preserved")
+      (is (= 0 (reactive/root-cell-count incarnation))))))
+
+;; ===========================================================================
+;; The leak fixture (JVM — deterministic weak clearing under System/gc):
+;; ordinary reconciliation unmounts must leave COLLECTABLE cells, while a
+;; hidden sibling under the same root stays retained + reapable
+;; ===========================================================================
+
+#?(:clj
+   (defn- gc-until
+     "Hint GC (bounded retries) until `pred` returns true; returns its final
+     value. Weakly-reachable objects clear on the first full GC in practice."
+     [pred]
+     (loop [i 0]
+       (cond
+         (pred)     true
+         (>= i 100) (pred)
+         :else      (do (System/gc)
+                        (Thread/sleep 10)
+                        (recur (inc i)))))))
+
+#?(:clj
+   (deftest reconciliation-unmounted-cells-are-garbage-not-root-retained
+     (rf/reg-sub :ret/a (fn [db _] (:a db)))
+     (let [fid         (make-frame! :ret/frame {:a 1})
+           incarnation (reactive/make-root-incarnation)
+           n           32
+           ;; one genuinely hidden sibling under the SAME root — must survive
+           hidden      (doto (mount! ::hidden incarnation fid [[:ret/a]])
+                         (reactive/disconnect!))
+           ;; churn: mount + ordinary reconciliation unmount, keyed-list
+           ;; style. Hold each churned cell only WEAKLY once its cycle ends —
+           ;; React drops the fiber, so nothing else references it (its
+           ;; leases were already released at disconnect!).
+           refs        (mapv (fn [i]
+                               (let [cell (mount! (keyword "ret" (str "row-" i))
+                                                  incarnation fid [[:ret/a]])]
+                                 (reactive/disconnect! cell)
+                                 (java.lang.ref.WeakReference. cell)))
+                             (range n))]
+       (is (= (+ n 1) (reactive/root-cell-count incarnation))
+           "precondition: every churned cell is (weakly) enrolled pre-GC")
+       (testing "the churned population is GARBAGE — collectable, not pinned
+                 by root ownership (rf2-mc62sp; red under strong membership)"
+         (is (true? (gc-until #(every? (fn [^java.lang.ref.WeakReference r]
+                                         (nil? (.get r)))
+                                       refs)))
+             "every reconciliation-unmounted cell was collected — root-cells
+              no longer strongly retains the ordinary-unmount population")
+         (is (= 1 (reactive/root-cell-count incarnation))
+             "membership returned to baseline: exactly the hidden sibling"))
+       (testing "…while the hidden sibling stayed reapable for lease teardown"
+         (is (= :disconnected (reactive/lifecycle hidden)))
+         (reactive/teardown-root! incarnation (fn [] nil))
+         (is (= :dead (reactive/lifecycle hidden)))
+         (is (= 0 (reactive/root-cell-count incarnation)))))))


### PR DESCRIPTION
Four-bead same-surface correctness cluster from the S2-audit stream, all centred on `implementation/ui/src/re_frame/ui/reactive.cljc`. Every finding was RE-VERIFIED against post-#5818/#5828/#5829 main before fixing — all four still reproduced (red-proofs below were run against the pre-fix tree in this branch's history).

## rf2-4kkc5r — G-3 headless banner honesty (comment-only)

**Re-verified:** the banner at `reactive_epoch_cljs_test.cljc` still claimed "a REAL app-db move caught at the headless commit evidence comparison (step 5/8)" while the fixture drives sub RE-REGISTRATION → the port's `:hmr`-cause `on-change` → `mark-dirty!` → coalesced flush.

**Fix:** banner now names the actual channel, drops the app-db-move/step-5 claim (that description belongs to the reconcile suite's moved-evidence fixtures), and cross-references `mounted-g3-cardinality-dom-cljs-test` as the real app-db-movement G-3 proof with an explicit "do not deprioritise the mounted counterpart" note. No assertion changes.

## rf2-1llvoh — ambient render-capture slot: dynamic var, thread-local on the JVM

**Re-verified:** `ambient` was still a module-global atom with hand-rolled `reset!`/`finally` save-restore while every neighbouring render-path scope (`*sub-overrides*`, `frame/*current-frame*`, `subs-cache/*disposal-cause*`) is a dynamic var.

**Fix:** `^:private ^:dynamic *ambient*` + `binding` in `with-capture` — thread-local on the JVM, identical save/restore semantics on single-threaded CLJS.

**Proof:** two latch-forced interleaved concurrent JVM renders (A mid-capture while B enters and reads) assert each returned capture contains exactly its own sites — both the distinct-sid (ownership) and shared-sid (no false duplicate-sid throw) shapes. **Red pre-fix:** A's site landed in B's open capture and vanished from A's own (`(not (= :va :va nil))`).

Note: `slice-memo*` (the bead's "optional" sibling) was deliberately left as a module holder — its lifecycle (installed at first probe, released on next tick) has no enclosing lexical scope for `binding`, and its tag guard already prevents wrong values; it is an economy the commit corrects regardless.

## rf2-owwbyl — flush phase-2 listener containment

**Re-verified:** `deliver-flush!` contained only the DEBUG evidence-sink throw; `notify-listeners!` was bare in both the DEBUG reduce and the production doseq. Phase 1 clears every drained cell's dirty flag + registry membership before phase 2 runs, so a throwing listener LOST (not deferred) the undelivered sibling notifications — stale UI until unrelated movement.

**Fix:** containment mirrors the observation port's `drain-pending-disposals!` shape at both granularities — per LISTENER inside `notify-listeners!` (one throwing consumer cannot starve same-cell siblings; first escape rethrown after all delivered) and per CELL inside `deliver-flush!`/`run-flush-batch!` (batch keeps the first escape of each family, delivers EVERY cell, reports the sink diagnostic, then rethrows the first listener escape). Surfaced, never silent, never starving. Sink half stays DEBUG-gated and DCEs in production.

**Proof:** throwing-listener fixtures in `[A B]` and `[B A]` orders — cells 2..N still deliver, A's own second listener still fires, nothing lingers pending, escape rethrows with original identity; plus the same through the real `flush-pending!` primitive with a clean follow-up drain. **Red pre-fix:** `hits-b 0` in `[A B]` order (stranded) and the two orders diverged.

## rf2-mc62sp — weak `root-cells` membership

**Re-verified against the lease (#5828) + evidence-projection (#5829) merges** by walking every current `root-cells` consumer: `attach-root!`/`forget-root-cell!`/`detach-root!` (writes), `root-cell-count` (tool/test read), `teardown-frame!` (hidden-cell discovery), `teardown-root!` (hidden reap + fail-closed exact-generation reap), `reset-scheduler!`. The evidence projection reads the per-cell `:root` field (`reactive/cell-root`) — never the registry — so it is structurally outside the change. The leak reproduced: only `teardown!` pruned; an ordinary reconciliation unmount (`disconnect!` only) pinned the cell + its last committed sub values for the root's lifetime.

**Design (three sentences):** membership becomes weak per host idiom, mirroring the observation port's weak node-record table — a synchronized `WeakHashMap`-backed keyset on the JVM, a `js/Set` of `js/WeakRef` + ephemeron `js/WeakMap` (O(1) removal) + `FinalizationRegistry` reaper on CLJS. A genuinely hidden cell is strongly reachable from React's retained fiber (`use-cell`'s `useRef`), so its weak entry lives exactly as long as Activity retention and both teardown discovery paths still find it; a reconciliation-unmounted cell becomes unreachable — hence never reconnectable — so it collects and its entry clears with nothing left to reap. `detach-root!` from `teardown!` remains the deterministic fast path, and empty incarnation entries still drop deterministically on last departure (plus via the CLJS reaper on GC-driven departure).

**Proof:** (a) JVM churn fixture — 32 keyed mount/unmount cycles + one hidden sibling under the same root: every unmounted cell collects under forced GC and membership returns to exactly the hidden sibling (**red pre-fix:** refs never clear, count stuck at 33); (b) the hidden sibling stays discoverable and `teardown-root!` reaps it to `:dead`; (c) cross-host fixtures pin survive-hide semantics, deterministic teardown departure, and the AC5 entry-drop; the existing rf2-vxgfnd.85 Activity/root/frame teardown suites and the `tool.evidence` projection suite stay green on both hosts.

**Follow-up worth noting (not fixed here, DEBUG-only):** the `re-frame.ui.tool.evidence` projection's own `entries*` registry prunes only `:dead` cells, so in a DEV session with the projection installed an ordinarily-unmounted (`:disconnected`, never torn down) cell stays pinned by the tool — the same bug class one layer up, in the DEBUG plane. Candidate for a small follow-up bead.

No spec prose ripple required: Spec 006/03 §4 already states the unmounted cell is garbage — this PR makes the implementation conform to it; the registry semantics documented in `reactive.cljc` docstrings were updated in place.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **438 tests / 5495 assertions, 0 failures, 0 errors**
- `npm run test:ui` (focused CLJS node + adapter-isolation): **445 tests / 2249 assertions, 0 failures** (isolation PASS, 255 compiler-selected imports)
- `npm run test:browser` (mounted/DOM paths over the touched reconciler): **342 tests / 1848 assertions, 0 failures**
- `sh scripts/test-fast-pr.sh` (lockstep, skill gates, core JVM, full `test:cljs`, per-ns isolation, policy gates): **PASS** — full CLJS node suite **9226 tests / 43636 assertions, 0 failures, 0 errors**

Red-proofs for each behavioural bead were run locally by reverting `reactive.cljc` to the pre-fix commit and re-running the new fixtures (details per bead above).
