### PR TITLE
fix(ui): serialize execute-frame-plans! decide+record (rf2-vxgfnd.35)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -101,6 +101,20 @@
   multi-plan rollback by destroying seeded frames would not un-fire their
   effects.
 
+  On the JVM, whole runs are additionally SERIALIZED under one process-wide
+  monitor (rf2-vxgfnd.35): phase 1 decides against `installed-plans` and
+  phase 2 records into it, so two concurrent `execute-frame-plans!` calls
+  could otherwise BOTH decide `:install` for one frame-id — the second
+  `make-frame` would surgically overwrite the first and the last record
+  would win, silently missing the cross-root conflict this table exists to
+  catch (or misreading a half-installed frame as boot-authoritative). The
+  monitor makes each decide+record run atomic with respect to other runs.
+  It is the OUTERMOST lock — taken at host preflight, before `make-frame`'s
+  synchronous drain or any per-frame drain serialization; nothing below this
+  entry point acquires it — and JVM monitors are reentrant, so a nested
+  same-thread preflight still enters. CLJS is single-threaded: no lock
+  exists there and the call is direct.
+
   ## Q49 RULING (ENSURE retry-after-preflight-failure; pinned here)
 
   A preflight failure FAILS THE MOUNT LOUDLY; the container is untouched
@@ -349,27 +363,9 @@
                                        :preflight-attempt-failed))))
                          m frame-ids))))
 
-(defn execute-frame-plans!
-  "Execute a root's static frame plans (the LIVE preflight ENSURE — see
-  the ns docstring for the full disposition table and the Q49 ruling).
-  `plans` are the evaluated `[{:frame-id … :config-fingerprint …
-  :config {…}} …]` in document order; `root-id` is the arriving root.
-
-  Phase 1 VALIDATES every plan (pure — cross-root fingerprint conflicts
-  AND config-bearing-vs-boot-authority conflicts throw
-  `:rf.error/frame-payload-conflict` before ANY install). Phase 2
-  installs/adopts/refreshes in document order: `make-frame` creates the
-  frame if absent and drains `:initial-events` synchronously before
-  returning (EP-0027); its install record is published only if that
-  incarnation remains live; a found-live same-fingerprint plan is a pure no-op
-  (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
-  met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
-  config/generation untouched, only the fingerprint recorded
-  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run labels the
-  siblings it already wrote by provenance: a FRESH install →
-  `:mount-incomplete`; an ALREADY-LIVE refresh/adopt →
-  `:preflight-attempt-failed` (the live root persists, Q49 — rf2-vxgfnd.30
-  (b), rf2-vxgfnd.72). Returns nil."
+(defn- execute-frame-plans*
+  "The unserialized decide+record run behind [[execute-frame-plans!]] — see
+  that docstring. JVM callers MUST hold `preflight-run-lock` (rf2-vxgfnd.35)."
   [root-id plans]
   (let [decided
         (mapv (fn [{:keys [frame-id config config-fingerprint] :as plan}]
@@ -479,6 +475,50 @@
            (into [] (comp (filter #(= :live (second %))) (map first)) w)))
         (throw e)))
     nil))
+
+#?(:clj
+   (defonce ^:private preflight-run-lock
+     ;; rf2-vxgfnd.35: the ONE process-wide monitor `execute-frame-plans!`
+     ;; serializes under on the JVM — see the ns docstring (§Atomicity
+     ;; posture) for the decide/record race it closes. OUTERMOST in the lock
+     ;; order (taken at host preflight, before any per-frame drain
+     ;; serialization) and reentrant, so a nested same-thread preflight (an
+     ;; `:initial-events` handler that mounts) still enters.
+     (Object.)))
+
+(defn execute-frame-plans!
+  "Execute a root's static frame plans (the LIVE preflight ENSURE — see
+  the ns docstring for the full disposition table and the Q49 ruling).
+  `plans` are the evaluated `[{:frame-id … :config-fingerprint …
+  :config {…}} …]` in document order; `root-id` is the arriving root.
+
+  Phase 1 VALIDATES every plan (pure — cross-root fingerprint conflicts
+  AND config-bearing-vs-boot-authority conflicts throw
+  `:rf.error/frame-payload-conflict` before ANY install). Phase 2
+  installs/adopts/refreshes in document order: `make-frame` creates the
+  frame if absent and drains `:initial-events` synchronously before
+  returning (EP-0027); its install record is published only if that
+  incarnation remains live; a found-live same-fingerprint plan is a pure no-op
+  (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
+  met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
+  config/generation untouched, only the fingerprint recorded
+  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run labels the
+  siblings it already wrote by provenance: a FRESH install →
+  `:mount-incomplete`; an ALREADY-LIVE refresh/adopt →
+  `:preflight-attempt-failed` (the live root persists, Q49 — rf2-vxgfnd.30
+  (b), rf2-vxgfnd.72). Returns nil.
+
+  Concurrency (rf2-vxgfnd.35): on the JVM the whole decide+record run is
+  serialized under one process-wide monitor, so two concurrent callers can
+  never both decide `:install` for one frame-id (the silent
+  last-record-wins overwrite); the loser instead observes the winner's
+  completed record and surfaces the ratified
+  `:rf.error/frame-payload-conflict`. CLJS is single-threaded — the call
+  is direct and lock-free (see the ns docstring §Atomicity posture)."
+  [root-id plans]
+  #?(:clj  (locking preflight-run-lock
+             (execute-frame-plans* root-id plans))
+     :cljs (execute-frame-plans* root-id plans)))
 
 ;; ---------------------------------------------------------------------------
 ;; frame-provider scope validation (shared by both hosts)

--- a/implementation/ui/test/re_frame/ui/frame_plan_preflight_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_plan_preflight_race_jvm_test.clj
@@ -1,0 +1,147 @@
+(ns re-frame.ui.frame-plan-preflight-race-jvm-test
+  "JVM preflight-executor race coverage (rf2-vxgfnd.35).
+
+  `execute-frame-plans!` decides in phase 1 (reads `installed-plans` + frame
+  liveness) and records in phase 2. Before rf2-vxgfnd.35 nothing serialized
+  two concurrent JVM runs: both could decide `:install` for one frame-id, the
+  second `make-frame` surgically overwrote the first, and the last record won
+  — the cross-root `:rf.error/frame-payload-conflict` the disposition table
+  exists to raise was silently missed (and a run arriving mid-install could
+  misread the half-installed frame as boot-authoritative). Since #5720
+  `ui.test/render` drives this executor on the JVM, so parallel JVM test
+  execution reaches the window.
+
+  Two arms, mirroring `frame-plan-publication-race-jvm-test`'s latch shape —
+  no sleeps or scheduler guesses on the deterministic arm:
+
+  - LATCH arm: root A pauses INSIDE its install (an `:initial-events` handler
+    blocks on a CountDownLatch — after `make-frame` made the frame live,
+    before A's record publishes: exactly the decide/record window). Root B
+    arrives mid-run; B must be serialized BEHIND A's whole run and then
+    surface the ratified cross-root conflict naming root A's COMPLETED
+    install — never an adopt / boot-authority misdiagnosis of the
+    half-installed frame, never a silent overwrite.
+  - BARRIER stress arm: both threads release from one CyclicBarrier straight
+    into `execute-frame-plans!` for the same fresh frame-id with differing
+    fingerprints, sweeping real scheduler interleavings. Every rep: exactly
+    one winner; the loser conflicts against the WINNER'S record; the
+    surviving record is the winner's.
+
+  CLJS cannot interleave two synchronous preflights (single-threaded — the
+  serialization is JVM-only by construction), so this fixture is JVM-only."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.frames :as frames])
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil})
+  (fn [t] (frames/reset-installed-plans!) (t) (frames/reset-installed-plans!)))
+
+(defn- plan [frame-id fingerprint config]
+  {:frame-id frame-id :config config :config-fingerprint fingerprint})
+
+(defn- run-plan
+  "Run one root's single-plan preflight: `::won` on success, the thrown
+  ex-data map on the canonical conflict."
+  [root-id p]
+  (try
+    (frames/execute-frame-plans! root-id [p])
+    ::won
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
+;; ---------------------------------------------------------------------------
+;; LATCH arm — deterministic: root B arrives while root A is mid-install
+;; ---------------------------------------------------------------------------
+
+(deftest concurrent-install-serializes-and-the-loser-sees-the-winners-record
+  (let [fid     :preflight-race/frame
+        entered (CountDownLatch. 1)
+        release (CountDownLatch. 1)]
+    ;; Pause root A INSIDE phase 2: `make-frame` has made the frame LIVE and
+    ;; is draining `:initial-events` synchronously; A's install record is NOT
+    ;; yet published. This holds A's whole decide+record run open.
+    (rf/reg-event ::pause
+      (fn [{:keys [db]} _]
+        (.countDown entered)
+        (.await release 10 TimeUnit/SECONDS)
+        {:db db}))
+    (try
+      (let [a (future (run-plan :root/a
+                                (plan fid "cf1-aaaaaaaa"
+                                      {:initial-events [[::pause]]})))]
+        (is (.await entered 10 TimeUnit/SECONDS)
+            "root A is paused mid-install (frame live, record unpublished)")
+        (let [b (future (run-plan :root/b
+                                  (plan fid "cf1-bbbbbbbb"
+                                        {:initial-events
+                                         [[:rf/set-db {:from :b}]]})))]
+          ;; Serialization probe: B must be BLOCKED behind A's in-flight run.
+          ;; Unserialized, B returns promptly here — it sees A's live frame
+          ;; with no record and misdiagnoses it as boot-authoritative.
+          (is (= ::pending (deref b 250 ::pending))
+              "root B is serialized behind root A's open decide+record run")
+          (.countDown release)
+          (is (= ::won (deref a 10000 ::timeout))
+              "root A's install completes and wins")
+          (let [outcome (deref b 10000 ::timeout)]
+            (is (map? outcome)
+                "root B fails loud — never a silent overwrite")
+            (is (= :rf.error/frame-payload-conflict (:rf.error/id outcome))
+                "the loser surfaces the ratified conflict outcome")
+            (is (= :root/a (get-in outcome [:installed :installed-by]))
+                (str "the conflict names root A's COMPLETED install — not a "
+                     "boot-authority misdiagnosis of the half-installed frame"))
+            (is (= "cf1-aaaaaaaa"
+                   (get-in outcome [:installed :config-fingerprint]))
+                "the conflict carries the winner's recorded fingerprint")
+            (is (= :root/b (get-in outcome [:arriving :root-id]))
+                "the conflict scopes the failure to the arriving root"))
+          (is (= {:config-fingerprint "cf1-aaaaaaaa" :installed-by :root/a}
+                 (frames/installed-plan-entry fid))
+              "exactly one install wins — the surviving record is root A's")
+          (is (some? (frame/frame fid))
+              "the winner's frame is live and untouched (06 §2 failure scoping)")))
+      (finally
+        ;; Never strand root A's drain if an assertion or setup step fails.
+        (.countDown release)))))
+
+;; ---------------------------------------------------------------------------
+;; BARRIER stress arm — scheduler-swept: exactly one winner per frame-id
+;; ---------------------------------------------------------------------------
+
+(deftest install-race-stress-exactly-one-winner-never-a-silent-overwrite
+  (dotimes [i 50]
+    (let [fid     (keyword "preflight-race" (str "stress-" i))
+          barrier (CyclicBarrier. 2)
+          run     (fn [root-id fingerprint]
+                    (future
+                      (.await barrier 10 TimeUnit/SECONDS)
+                      (run-plan root-id (plan fid fingerprint {}))))
+          a       (run :root/a "cf1-aaaaaaaa")
+          b       (run :root/b "cf1-bbbbbbbb")
+          ra      (deref a 10000 ::timeout)
+          rb      (deref b 10000 ::timeout)
+          [winner-root winner-fp winner-res loser-res]
+          (if (= ::won ra)
+            [:root/a "cf1-aaaaaaaa" ra rb]
+            [:root/b "cf1-bbbbbbbb" rb ra])]
+      (is (= ::won winner-res)
+          (str "rep " i ": one thread's install wins"))
+      (is (map? loser-res)
+          (str "rep " i ": the loser fails loud — two silent wins is the "
+               "last-record-wins clobber"))
+      (is (= :rf.error/frame-payload-conflict (:rf.error/id loser-res))
+          (str "rep " i ": the loser surfaces the ratified conflict"))
+      (is (= winner-root (get-in loser-res [:installed :installed-by]))
+          (str "rep " i ": the loser conflicts against the WINNER'S completed "
+               "record — never an adopt/boot-authority misread of a mid-run "
+               "install"))
+      (is (= {:config-fingerprint winner-fp :installed-by winner-root}
+             (frames/installed-plan-entry fid))
+          (str "rep " i ": the surviving record is the winner's, unclobbered")))))


### PR DESCRIPTION
Closes rf2-vxgfnd.35 (pulled forward from its S5 gate: since #5720, `ui.test/render` drives `frames/execute-frame-plans!` on the JVM, so the non-atomicity is reachable by parallel JVM test execution today).

## The race

`execute-frame-plans!` decides in phase 1 (reads `installed-plans` + frame liveness per plan) and records in phase 2 (`make-frame` then `publish-plan-for-live-incarnation!`). Nothing serialized two concurrent JVM runs, so for one frame-id with differing config fingerprints:

- **Silent overwrite**: two threads both see "no record, no frame" and both decide `:install`; the second `make-frame` surgically overwrites the first's config and the last record wins — the cross-root `:rf.error/frame-payload-conflict` the disposition table exists to raise is silently missed.
- **Boot-authority misdiagnosis**: a run arriving while the other is mid-install (frame live, record not yet published) misreads the half-installed frame as boot-authoritative (`:installed nil`, "created outside the plan registry — a boot rf/make-frame"), or — config-less — silently ADOPTS it, clobbering the winner's install record with a non-owning adopt record.

**Re-verified post-#5818** (which reworked the INSTALL/ADOPT/REFRESH disposition but added no serialization): running the new race test against unmodified `frames.cljc` fails 174 of 260 assertions, exhibiting both arms above — including stress reps where BOTH threads returned success and the surviving record was the loser's (`{:config-fingerprint "cf1-bbbbbbbb", :installed-by :root/b}` over root A's completed install). The race was NOT incidentally closed by #5818.

`publish-plan-for-live-incarnation!`'s per-frame drain serialization doesn't cover this: it only guards publication against a concurrent destroy, and in the `:install` case the frame doesn't exist yet, so `call-serialized-with-drain!` runs the thunk directly.

## The fix — chosen shape and why

The bead names two acceptable shapes: a lock, or a single-swap decide+record. A single swap cannot hold `make-frame`'s side effects (frame creation + the synchronous `:initial-events` drain) inside a `swap!`, so it would need a claim/reservation protocol with throw-path cleanup — more machinery for the same guarantee. The chosen shape is the simplest fully-correct one: **one process-wide JVM monitor around the whole decide+record run**.

- The `execute-frame-plans!` body moves to a private `execute-frame-plans*`; the public entry wraps it in `#?(:clj (locking preflight-run-lock ...) :cljs ...)`.
- The monitor is OUTERMOST in the lock order — taken at host preflight, before `make-frame`'s drain or any per-frame drain serialization; nothing below this entry point acquires it, so no inversion. JVM monitors are reentrant, so a nested same-thread preflight (an `:initial-events` handler that mounts) still enters.
- **CLJS is provably unchanged**: the `:cljs` branch is a direct call to the impl — no lock exists there, zero cost, single-threaded by construction.
- The loser of a race now runs strictly after the winner's completed record and surfaces the ratified `:rf.error/frame-payload-conflict` naming the winner's install — never a silent overwrite, never the boot-authority misdiagnosis.

No disposition-table change, no coordination framework; the ns docstring (§Atomicity posture) documents the serialization.

## Proof

New `implementation/ui/test/re_frame/ui/frame_plan_preflight_race_jvm_test.clj` (mirrors `frame_plan_publication_race_jvm_test.clj`'s latch shape — no sleeps as coordination):

- **Latch arm (deterministic)**: root A pauses INSIDE its install via a CountDownLatch-blocking `:initial-events` handler (frame live, record unpublished — exactly the window); root B arrives mid-run, must be serialized behind A's open run, then surfaces the cross-root conflict naming root A's COMPLETED install (`:installed {:installed-by :root/a}`), with A's record surviving unclobbered.
- **Barrier stress arm**: 50 reps of two CyclicBarrier-released threads racing fresh frame-ids with differing fingerprints — every rep: exactly one winner, the loser conflicts against the WINNER'S record, and the surviving record is the winner's.

Spec note: no Spec 006/002 prose change included (spec surfaces are fenced to other live workers). If the JVM whole-run serialization guarantee wants a 006 / 03 §8 prose ripple, that is a follow-up.

## Quality gates

- `implementation/ui`: `clojure -M:test` — 433 tests / 5720 assertions, 0 failures, 0 errors (includes the 2 new race tests, 260 assertions; the same suite against unmodified source fails 174 of them)
- `implementation`: `npm run test:ui` — 441 tests / 2226 assertions, 0 failures, 0 errors
- `scripts/test-fast-pr.sh` — PASS (exit 0; mkdocs arm soft-skipped locally, CI runs it)
