### PR TITLE
fix(core): observation on-change failure contract — exact-once provenance, two-channel fan-out, frozen schema (rf2-wbkjk9/q3fmqm/gg3om8)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -109,13 +109,19 @@
   "Categories whose `:event-id` slot carries a SUB id — their source
   coords live under `[:sub sub-id]` in the always-on registry, so
   `dispatch-on-error!` resolves them there rather than under the
-  `[:event …]` default. Covers the parametric input-fn failures and
-  the reactive sub-exception, so the always-on production error records
+  `[:event …]` default. Covers the parametric input-fn failures, the
+  reactive sub-exception, and the observation port's on-change-failure
+  wrapper (whose `:event-id` carries the former owner's ENTRY SUB id —
+  rf2-q3fmqm: `[:sub …]` is the ONLY lookup realm, so a macro-registered
+  sub resolves its exact coordinate and a same-id EVENT registration can
+  never steal attribution; a programmatic sub registration resolves nil
+  and the slot stays absent), so the always-on production error records
   carry the failing sub's `:source-coord`."
   #{:rf.error/sub-input-fn-exception
     :rf.error/sub-input-fn-bad-return
     :rf.error/sub-exception
-    :rf.error/no-such-sub})
+    :rf.error/no-such-sub
+    :rf.error/observation-on-change-failed})
 
 (defn- error-source-coord
   "Resolve the `{:ns :file :line}` source-coord for the failing `id` of an

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -360,6 +360,80 @@
      (trace/emit-error! category trace-tags))
    nil))
 
+;; ---- first-emission provenance (exact-once at containment drains) ---------
+;;
+;; Several fail-loud sites EMIT their category's canonical record (through
+;; [[emit-error-both!]] / [[dispatch-on-error!]]) and THEN throw the matching
+;; canonical typed error — e.g. the observation port's `read` on a released
+;; lease. A boundary that CATCHES such a throwable to keep draining siblings
+;; (a containment drain, e.g. the port's disposal-notification drain) cannot
+;; otherwise tell a throwable whose category is ALREADY visible from one that
+;; has never been fanned: re-dispatching every caught typed throwable
+;; double-emits the already-fanned ones — TWO always-on records for ONE
+;; runtime error, the second able to overwrite the source's correct
+;; frame/query attribution with the catching context's — while never
+;; re-dispatching silently loses the unfanned ones at a swallowing boundary
+;; (rf2-wbkjk9; Spec 009's one-runtime-error law).
+;;
+;; The repair is explicit provenance ON THE THROWABLE — never a global
+;; seen-error registry (process-global dedup state would suppress genuinely
+;; distinct recurrences of the same category and leak across frames/tests):
+;; an emit-then-throw site stamps [[fanned-at-source-key]] into the ex-data
+;; it throws (via the canonical builder's `:extra`), and a containment drain
+;; consults [[fanned-at-source?]] — already-fanned ⇒ exactly-once is ALREADY
+;; satisfied at the source with the source's own attribution, nothing more on
+;; either channel; unfanned ⇒ the drain owns the first (and only) emission.
+;;
+;; [[canonical-typed-error?]] is the drain-side companion: STRUCTURAL
+;; provenance that a caught throwable was built by the canonical thrown-error
+;; builder (`re-frame.error/thrown-ex-info` — the single chokepoint every
+;; framework throw routes through) under the RESERVED `rf.error` catalogue
+;; namespace. It replaces `:rf.error/id`-truthiness classification: an
+;; application ex-info carrying `{:rf.error/id :app/x}` (non-reserved
+;; namespace), a malformed id (non-keyword), or a bare imitation of a
+;; canonical id without the builder's required `:reason` sentence all
+;; classify FALSE — a drain wraps them in its own stable catalogued category
+;; instead of fanning them as though they were canonical framework
+;; categories. Framework emissions under the reserved namespace are pinned
+;; to catalogue rows at build time by the Spec 009 catalogue source-scan
+;; gate (`error-catalogue-channel-conformance-test`), so the reserved-shape
+;; check IS the runtime spelling of catalogue membership.
+
+(def fanned-at-source-key
+  "Ex-data slot carrying FIRST-EMISSION PROVENANCE (rf2-wbkjk9): `true` when
+  the throwing site had ALREADY fanned this failure's canonical record per
+  its category's channel contract before throwing (the emit-then-throw
+  idiom), so a downstream containment drain must NOT re-emit it on either
+  channel. Stamped by the throwing site via the canonical builder's `:extra`
+  (e.g. `re-frame.substrate.observation`'s fail-loud surfaces); consulted
+  through [[fanned-at-source?]]. Framework-internal — never part of the
+  public thrown-error shape contract."
+  ::fanned-at-source)
+
+(defn fanned-at-source?
+  "True when caught throwable `t` carries [[fanned-at-source-key]] — its
+  failure was already surfaced by its source's own emission, with the
+  source's own attribution, so exactly-once is already satisfied."
+  [t]
+  (true? (get (ex-data t) fanned-at-source-key)))
+
+(defn canonical-typed-error?
+  "True when caught throwable `t` carries the canonical framework
+  thrown-error shape (Spec 009 §The thrown-error shape) under the RESERVED
+  `rf.error` catalogue namespace: a keyword `:rf.error/id` whose namespace is
+  `\"rf.error\"` AND the builder's required `:reason` human sentence. This is
+  structural provenance of `re-frame.error/thrown-ex-info` — NOT an
+  id-truthiness test (rf2-wbkjk9): a non-reserved application id, a
+  malformed non-keyword id, or a bare canonical-id imitation without the
+  builder shape all classify false, so a containment drain wraps them
+  rather than letting them spoof a canonical category."
+  [t]
+  (let [data (ex-data t)
+        id   (:rf.error/id data)]
+    (and (keyword? id)
+         (= "rf.error" (namespace id))
+         (string? (:reason data)))))
+
 ;; ---- general non-event always-on record (EP-0008 union shape) -------------
 ;;
 ;; `dispatch-on-error!` (above) is the EVENT-centric always-on path: it takes

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -652,15 +652,56 @@
       application ex-info must not SPOOF a canonical framework category) —
       is wrapped exactly once in the stable catalogued
       `:rf.error/observation-on-change-failed`, carrying the original
-      throwable as the record's `:exception` cause."
-  [lease exception]
+      throwable as the record's `:exception` cause.
+
+  When the drain owns the first emission it rides the shared TWO-CHANNEL
+  fan-out (`error-emit/emit-error-both!`, rf2-q3fmqm): the always-on record
+  for off-box shippers PLUS the dev diagnostic-trace event Xray's
+  trace-tooling listener consumes — the registrar/next-tick boundaries
+  swallow the rethrow, so without the trace leg a real HMR/disposed callback
+  failure was invisible in the primary debugging surface. The
+  category-specific trace tags carry the disposal `cause` (`:hmr` /
+  `:disposed`), the former owner's entry-sub coordinates
+  (`:rf.sub/id` / `:rf.sub/query-v`), and the original throwable. In
+  advanced production the trace leg is DCE'd inside `trace/emit-error!`
+  while the always-on record survives. The record's `:event-id` carries the
+  ENTRY SUB id, and `error-emit` classifies the wrapper category
+  subscription-owned, so `:source-coord` resolves under `[:sub id]` — a
+  macro-registered sub yields its exact coordinate, a programmatic one
+  omits the slot, and a same-id event registration cannot steal
+  attribution."
+  [lease cause exception]
   (when-not (error-emit/fanned-at-source? exception)
     (let [{:keys [frame-id query-v]} @(lease-state lease)
-          error-id (if (error-emit/canonical-typed-error? exception)
+          sub-id   (first query-v)
+          typed?   (error-emit/canonical-typed-error? exception)
+          error-id (if typed?
                      (:rf.error/id (ex-data exception))
                      :rf.error/observation-on-change-failed)]
-      (error-emit/dispatch-on-error!
-        error-id query-v (first query-v) frame-id exception 0 (interop/now-ms)))))
+      (error-emit/emit-error-both!
+        error-id query-v sub-id frame-id exception 0 (interop/now-ms)
+        {:rf.sub/id         sub-id
+         :rf.sub/query-v    query-v
+         :where             're-frame.substrate.observation/drain-pending-disposals!
+         :frame             frame-id
+         :cause             cause
+         :exception         exception
+         :exception-message (error/ex-message-safe exception)
+         :reason            (if typed?
+                              (str "a former-owner on-change callback for "
+                                   (pr-str sub-id) " escaped with the typed "
+                                   (pr-str error-id) " during the " cause
+                                   " disposal-notification drain; surfaced here "
+                                   "exactly once because the drain boundary "
+                                   "swallows the rethrow.")
+                              (str "a former-owner on-change callback for "
+                                   (pr-str sub-id) " threw during the " cause
+                                   " disposal-notification drain; the escape is "
+                                   "contained (siblings still notified) and "
+                                   "surfaced here before the boundary swallows "
+                                   "the rethrow — the underlying on-change "
+                                   "consumer bug is a re-frame.ui defect to fix."))
+         :recovery          :no-recovery}))))
 
 (defn ^:no-doc drain-pending-disposals!
   "Drain the queued node-disposed notifications whose INTRINSIC cause is
@@ -707,13 +748,15 @@
                          (notify-disposal! lease cause)
                          acc
                          (catch #?(:clj Throwable :cljs :default) t
-                           ;; Surface EVERY escape on the always-on axis BEFORE
-                           ;; the boundary swallows the rethrow — typed under its
-                           ;; own catalogue id, untyped wrapped in
-                           ;; :rf.error/observation-on-change-failed — so an
-                           ;; untyped consumer on-change bug is never silently
-                           ;; lost at a disposal drain (rf2-6ui49w).
-                           (report-disposal-notify-escape! lease t)
+                           ;; Surface EVERY escape EXACTLY ONCE before the
+                           ;; boundary swallows the rethrow (rf2-6ui49w +
+                           ;; rf2-wbkjk9): an already-fanned typed escape keeps
+                           ;; its source's emission; a drain-owned first
+                           ;; emission rides the two-channel fan-out
+                           ;; (rf2-q3fmqm) — typed under its own catalogue id,
+                           ;; untyped/malformed/non-catalogued wrapped in
+                           ;; :rf.error/observation-on-change-failed.
+                           (report-disposal-notify-escape! lease cause t)
                            (conj acc t))))
                      []
                      taken)]

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -211,7 +211,10 @@
         're-frame.substrate.observation/assert-port-abi-version!
         reason
         {:extra {:expected expected
-                 :actual   port-abi-version}})))
+                 :actual   port-abi-version
+                 ;; First-emission provenance (rf2-wbkjk9): the record above
+                 ;; is the exactly-once emission.
+                 error-emit/fanned-at-source-key true}})))
   nil)
 
 ;; ---- registry epoch ---------------------------------------------------------
@@ -377,7 +380,14 @@
            extra))
   (error/throw-error! error-id where reason
                       {:extra (merge {:frame          frame-id
-                                      :rf.sub/query-v query-v}
+                                      :rf.sub/query-v query-v
+                                      ;; First-emission provenance (rf2-wbkjk9):
+                                      ;; the record above IS this failure's
+                                      ;; exactly-once emission — a containment
+                                      ;; drain catching this throw (an on-change
+                                      ;; that called a port op) must not re-fan
+                                      ;; it on either channel.
+                                      error-emit/fanned-at-source-key true}
                                      extra)}))
 
 (defn- throw-frame-destroyed!
@@ -460,7 +470,13 @@
       {:recovery :no-recovery
        :extra    {:frame          frame-id
                   :rf.sub/query-v query-v
-                  :cycle          (:cycle result)}})
+                  :cycle          (:cycle result)
+                  ;; First-emission provenance (rf2-wbkjk9): the build already
+                  ;; surfaced :rf.error/sub-cycle per its channel contract
+                  ;; (diagnostic trace); a containment drain must not
+                  ;; re-emit — and in particular must not PROMOTE the
+                  ;; diagnostic category onto the always-on axis.
+                  error-emit/fanned-at-source-key true}})
 
     (:input-fn-exception :input-fn-bad-return)
     (error/throw-error!
@@ -473,7 +489,11 @@
            (:reason result))
       {:recovery :no-recovery
        :extra    {:frame          frame-id
-                  :rf.sub/query-v query-v}})
+                  :rf.sub/query-v query-v
+                  ;; First-emission provenance (rf2-wbkjk9): the build ALREADY
+                  ;; fanned the always-on :rf.error/sub-input-fn-* record (one
+                  ;; record, one throw); a containment drain must not re-fan.
+                  error-emit/fanned-at-source-key true}})
 
     ;; :frame-destroyed and any unexpected classification — fan + throw typed.
     (throw-frame-destroyed! 're-frame.substrate.observation/acquire!
@@ -596,41 +616,51 @@
                    :registry-epoch @registry-epoch*})))))
 
 (defn- report-disposal-notify-escape!
-  "Fan an escaping former-owner `on-change` failure onto the ALWAYS-ON
-  error-emit axis (surface #4) so it is SEEN even when the drain boundary
-  swallows the propagated throw. The `:hmr` drain runs INSIDE the registrar
-  replacement hook, whose per-hook `try/catch` DROPS the throw (registrar
-  isolates replacement-hook failures — `re-frame.registrar`), and the
-  `:disposed` drain rides `interop/next-tick` (a JVM Future whose result is
-  never inspected); either boundary would otherwise make the escape invisible
-  exactly where it matters — so NEITHER a typed NOR an untyped `on-change`
-  failure may depend on the rethrow being observed.
+  "Surface an escaping former-owner `on-change` failure EXACTLY ONCE per
+  runtime error (Spec 009's one-runtime-error law) even though the drain
+  boundary swallows the propagated throw. The `:hmr` drain runs INSIDE the
+  registrar replacement hook, whose per-hook `try/catch` DROPS the throw
+  (registrar isolates replacement-hook failures — `re-frame.registrar`), and
+  the `:disposed` drain rides `interop/next-tick` (a JVM Future whose result
+  is never inspected); either boundary would otherwise make the escape
+  invisible exactly where it matters — so NEITHER a typed NOR an untyped
+  `on-change` failure may depend on the rethrow being observed.
 
-  BOTH escape kinds are surfaced, so a former-owner `on-change` bug is NEVER
-  silently lost at a disposal boundary (rf2-6ui49w) — only the catalogue id
-  differs:
+  Classification is by FIRST-EMISSION PROVENANCE plus the canonical
+  thrown-error SHAPE — never by `:rf.error/id` truthiness (rf2-wbkjk9), and
+  never a global seen-error registry:
 
-    - a TYPED re-frame escape (its `ex-data` carries a catalogued
-      `:rf.error/id`) is re-surfaced under its OWN id, so its identity is
-      preserved. The dev `:rf.error/reentrant-graph-op` assert — an `on-change`
-      mutating graph ownership mid-notification — is the motivating case: it is
-      a plain dev throw with no axis-1 fan of its own, so this IS its only
-      always-on appearance, and it exists TO BE SEEN (Spec 009).
-    - an UNTYPED escape (a raw consumer-callback bug from re-frame.ui's
-      `on-change` — a `TypeError` / `AssertionError` / host `RuntimeException`,
-      or a defect before any typed wrapping) is wrapped in the stable
-      catalogued `:rf.error/observation-on-change-failed`, carrying the original
-      throwable as the record's `:exception` cause.
-
-  Exactly ONE always-on record per escape: the typed-vs-untyped choice is the
-  SOLE id (a typed error is never ALSO fanned under the untyped wrapper), so
-  typed errors keep their catalogue identity and are not double-reported."
+    - ALREADY FANNED AT SOURCE (`error-emit/fanned-at-source?` — the port's
+      own emit-then-throw surfaces stamp it: `read` on a released lease,
+      probe/acquire fail-loud throws, the ABI guard, and the acquire-recovery
+      throws whose category the sub BUILD already surfaced): the source's
+      record IS the exactly-once emission, carrying the SOURCE's correct
+      frame/query attribution. Re-fanning here would double-report the one
+      runtime error and overwrite that attribution with the NOTIFYING owner's
+      context. Nothing more is emitted, on either channel.
+    - UNFANNED CANONICAL TYPED (`error-emit/canonical-typed-error?` without
+      the provenance stamp — a plain framework throw with no fan of its own):
+      re-surfaced exactly once under its OWN id, attributed to the notifying
+      former owner. The dev `:rf.error/reentrant-graph-op` assert — an
+      `on-change` mutating graph ownership mid-notification — is the
+      motivating case: this IS its only always-on appearance, and it exists
+      TO BE SEEN (Spec 009).
+    - EVERYTHING ELSE — untyped (a raw consumer-callback bug from
+      re-frame.ui's `on-change`: a `TypeError` / `AssertionError` / host
+      `RuntimeException`), a missing or MALFORMED `:rf.error/id`
+      (non-keyword), or an id outside the reserved `rf.error` namespace (an
+      application ex-info must not SPOOF a canonical framework category) —
+      is wrapped exactly once in the stable catalogued
+      `:rf.error/observation-on-change-failed`, carrying the original
+      throwable as the record's `:exception` cause."
   [lease exception]
-  (let [{:keys [frame-id query-v]} @(lease-state lease)
-        error-id (or (:rf.error/id (ex-data exception))
+  (when-not (error-emit/fanned-at-source? exception)
+    (let [{:keys [frame-id query-v]} @(lease-state lease)
+          error-id (if (error-emit/canonical-typed-error? exception)
+                     (:rf.error/id (ex-data exception))
                      :rf.error/observation-on-change-failed)]
-    (error-emit/dispatch-on-error!
-      error-id query-v (first query-v) frame-id exception 0 (interop/now-ms))))
+      (error-emit/dispatch-on-error!
+        error-id query-v (first query-v) frame-id exception 0 (interop/now-ms)))))
 
 (defn ^:no-doc drain-pending-disposals!
   "Drain the queued node-disposed notifications whose INTRINSIC cause is
@@ -651,15 +681,18 @@
   Each lease's notification is CONTAINED in its own `try/catch` so one owner's
   throwing `on-change` cannot starve its siblings (rf2-vxgfnd.28 — this was the
   one uncontained fan-out; it mirrors registrar's per-hook and subs.cache's
-  per-reaction dispose containment). Every sibling is notified; EVERY escape —
-  typed OR untyped — is fanned onto the always-on axis so it survives a
-  swallowing boundary (rf2-6ui49w: a typed escape keeps its catalogue id, an
-  untyped consumer-callback bug is wrapped in
-  `:rf.error/observation-on-change-failed`; see
+  per-reaction dispose containment). Every sibling is notified; EVERY escape is
+  surfaced EXACTLY ONCE so it survives a swallowing boundary without violating
+  Spec 009's one-runtime-error law (rf2-6ui49w + rf2-wbkjk9: an escape whose
+  source already fanned its record is left with its source's exactly-once
+  emission; an unfanned canonical typed escape keeps its catalogue id; an
+  untyped / malformed-id / non-catalogued-id consumer-callback bug is wrapped
+  in `:rf.error/observation-on-change-failed` — see
   [[report-disposal-notify-escape!]]); then the first escape is re-thrown AFTER
-  the whole drain for any DIRECT caller, but correctness never depends on the
-  registrar / next-tick boundary observing that rethrow — the always-on fan IS
-  the visibility. Never silent, never starving."
+  the whole drain for any DIRECT caller, with its identity/cause intact, but
+  correctness never depends on the registrar / next-tick boundary observing
+  that rethrow — the surfaced record IS the visibility. Never silent, never
+  starving, never double-reported."
   [cause]
   (let [[old _new] (swap-vals! pending-disposals
                                (fn [pending]
@@ -1449,7 +1482,14 @@
               're-frame.substrate.observation/read
               reason
               {:extra {:frame          (:frame-id st)
-                       :rf.sub/query-v (:query-v st)}})))
+                       :rf.sub/query-v (:query-v st)
+                       ;; First-emission provenance (rf2-wbkjk9): the record
+                       ;; above is the exactly-once emission, attributed to
+                       ;; THIS released lease's own frame/query — a
+                       ;; containment drain catching this throw (an on-change
+                       ;; reading a released lease) must not re-fan it under
+                       ;; the notifying owner's context.
+                       error-emit/fanned-at-source-key true}})))
         ;; Resolve the JVM WeakReference ONCE and hold the result strongly across
         ;; the canonicality check + deref. A GC between two lookups could clear
         ;; the second lookup even after the first proved the node canonical.

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -20,6 +20,7 @@
             [re-frame.error-emit            :as error-emit]
             [re-frame.frame                 :as frame]
             [re-frame.interop               :as interop]
+            [re-frame.source-coords         :as source-coords]
             [re-frame.subs                  :as subs]
             [re-frame.subs.cache            :as subs-cache]
             [re-frame.substrate.observation :as obs]
@@ -1876,6 +1877,176 @@
     (obs/release! lb)
     (obs/release! lc)
     (obs/release! ld)))
+
+;; ===========================================================================
+;; rf2-q3fmqm — drain-owned first emissions ride the shared TWO-CHANNEL
+;; fan-out (visible to Xray's trace listener) and resolve SUBSCRIPTION
+;; source coordinates
+;;
+;; The rf2-6ui49w emission called error-emit/dispatch-on-error! directly: it
+;; reached the always-on production axis but never the dev diagnostic trace
+;; — Xray installs a TRACE-tooling listener, not an always-on error
+;; listener, so a real HMR/disposed callback failure produced one always-on
+;; record and ZERO trace events (and the registrar swallows the drain's
+;; rethrow on :hmr, leaving no alternate diagnostic). The record also
+;; mis-resolved source coordinates: its :event-id slot carries the former
+;; owner's ENTRY SUB id, but error_emit.cljc did not classify the category
+;; subscription-owned, so lookup consulted [:event id] — a same-id EVENT
+;; registration could steal attribution, and a macro-registered sub with no
+;; colliding event got NO coordinate at all.
+;;
+;; The fix: when the drain owns the first emission (per rf2-wbkjk9's
+;; provenance — an already-fanned typed escape is NOT fanned again on
+;; either channel), it uses the shared emit-error-both! two-channel fan-out
+;; with category-specific trace tags, and error_emit classifies
+;; :rf.error/observation-on-change-failed among the sub-error categories so
+;; [:sub id] is the ONLY lookup realm. Red-before-fix: trace count zero,
+;; coordinate missing (macro sub) / stolen (event collision).
+;; ===========================================================================
+
+(defn- with-both-channels
+  "Run `thunk` capturing BOTH error channels: the always-on error-emit
+  records AND the dev diagnostic-trace `:op-type :error` events (the surface
+  Xray's trace collector consumes). Returns
+  `[result-or-thrown records trace-errors]`."
+  [thunk]
+  (let [records (atom [])
+        traces  (atom [])]
+    (error-emit/register-error-listener!
+      ::records (fn [record] (swap! records conj record)))
+    (rf/register-listener! :trace ::traces (fn [ev] (swap! traces conj ev)))
+    (try
+      (let [result (try [:ok (thunk)]
+                        (catch #?(:clj Throwable :cljs :default) e
+                          [:threw e]))]
+        [result @records (filterv #(= :error (:op-type %)) @traces)])
+      (finally
+        (rf/unregister-listener! :trace ::traces)
+        (error-emit/unregister-error-listener! ::records)))))
+
+(deftest hmr-drain-fans-the-wrapper-on-both-channels-with-the-sub-source-coordinate
+  (reg-items!)                       ;; MACRO-registered → coords under [:sub :obs/items]
+  (seed-items! [:a])
+  (let [boom (ex-info "untyped on-change boom" {::boom true})
+        la   (obs/acquire! (items-target) (fn [_n] (throw boom)))]
+    ;; A REAL HMR failure: the sub re-registration drains the :hmr boundary
+    ;; inside the registrar replacement hook (which swallows the rethrow), and
+    ;; the former owner's on-change throws the raw untyped bug.
+    (let [[[outcome _] records traces] (with-both-channels #(reg-items!))]
+      (is (= :ok outcome) "the registrar isolates the replacement hook")
+      (testing "exactly ONE always-on record — the production axis is unchanged"
+        (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records)]
+          (is (= 1 (count wrapped)))
+          (is (identical? boom (:exception (first wrapped))))
+          (testing "…and it resolves the EXACT macro-registered [:sub id]
+                    source coordinate (pre-fix: the slot was absent — lookup
+                    consulted [:event :obs/items])"
+            (let [coord (source-coords/error-coords-for :sub :obs/items)]
+              (is (some? coord) "the macro registration captured coords")
+              (is (= coord (:source-coord (first wrapped))))))))
+      (testing "exactly ONE dev diagnostic-trace event for the same logical
+                failure — Xray's trace collector sees it without registering
+                an always-on listener (pre-fix: zero trace events)"
+        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                           traces)]
+          (is (= 1 (count tev)))
+          (let [tags (:tags (first tev))]
+            (is (identical? boom (:exception tags))
+                "the trace tags carry the original throwable")
+            (is (= :hmr (:cause tags))
+                "the category-specific tags carry the disposal cause")
+            (is (= :obs/items (:rf.sub/id tags)))
+            (is (= [:obs/items] (:rf.sub/query-v tags)))
+            (is (= fid (:frame tags)))))))
+    (obs/release! la)))
+
+(deftest disposed-drain-fans-the-wrapper-on-both-channels
+  (reg-items!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [boom (ex-info "untyped on-change boom" {::boom true})
+          la   (obs/acquire! (items-target) (fn [_n] (throw boom)))]
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome thrown] records traces]
+            (with-both-channels #(obs/drain-pending-disposals! :disposed))]
+        (is (= :threw outcome))
+        (is (identical? boom thrown))
+        (is (= 1 (count (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)))
+            "exactly one always-on record at the :disposed boundary")
+        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                           traces)]
+          (is (= 1 (count tev)) "exactly one trace event at the :disposed boundary")
+          (is (= :disposed (:cause (:tags (first tev)))))))
+      (obs/release! la))))
+
+(deftest drain-two-channel-fanout-composes-with-first-emission-provenance
+  ;; An ALREADY-FANNED typed escape (the released-lease read) gains neither a
+  ;; second always-on record NOR a second trace event from the drain: the
+  ;; source's own emit-error-both! is the one two-channel emission.
+  (reg-items!)
+  (reg-other!)
+  (seed-items! [:a])
+  (let [released (obs/acquire! (other-target) (fn [_]))]
+    (obs/release! released)
+    (let [live (obs/acquire! (items-target) (fn [_n] (obs/read released)))]
+      (let [[[outcome _] records traces] (with-both-channels #(reg-items!))]
+        (is (= :ok outcome))
+        (is (= 1 (count (filterv #(= :rf.error/read-after-release (:error %)) records)))
+            "one always-on record — the source's")
+        (is (= 1 (count (filterv #(= :rf.error/read-after-release (:operation %)) traces)))
+            "one trace event — the source's; the drain adds none")
+        (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                             traces))
+            "no wrapper trace event for a typed escape"))
+      (obs/release! live))))
+
+(deftest disposed-drain-fans-an-unfanned-typed-escape-on-both-channels
+  ;; When the drain owns the first emission of a CANONICAL TYPED escape (the
+  ;; dev reentrant assert), the same two-channel fan-out applies: one
+  ;; always-on record AND one trace event under the ORIGINAL id.
+  (reg-items!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [bad (atom nil)
+          la  (obs/acquire! (items-target) (fn [_n] (obs/release! @bad)))]
+      (reset! bad la)
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome _] records traces]
+            (with-both-channels #(obs/drain-pending-disposals! :disposed))]
+        (is (= :threw outcome))
+        (is (= 1 (count (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))))
+        (let [tev (filterv #(= :rf.error/reentrant-graph-op (:operation %)) traces)]
+          (is (= 1 (count tev))
+              "the drain-owned first emission reaches the trace channel too")
+          (is (= :disposed (:cause (:tags (first tev))))))))))
+
+(deftest collision-event-registration-cannot-steal-sub-attribution
+  ;; PROGRAMMATIC sub registration (no [:sub id] coords) + MACRO event
+  ;; registration under the SAME keyword ([:event id] coords present). The
+  ;; record must OMIT :source-coord — never steal the event's coordinate.
+  (subs/reg-sub :obs/collide (fn [db _] (:items db)))
+  (rf/reg-event :obs/collide (fn [_cofx _event] {}))
+  (seed-items! [:a])
+  (is (nil? (source-coords/error-coords-for :sub :obs/collide))
+      "the programmatic sub registration captured NO coords")
+  (is (some? (source-coords/error-coords-for :event :obs/collide))
+      "the macro event registration DID capture coords under [:event id]")
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [boom   (ex-info "untyped on-change boom" {::boom true})
+          target (obs/resolve-target {:frame fid :query-v [:obs/collide]})
+          la     (obs/acquire! target (fn [_n] (throw boom)))]
+      (force-dispose-node! [:obs/collide])
+      (let [[[_outcome _] records _traces]
+            (with-both-channels #(obs/drain-pending-disposals! :disposed))]
+        (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records)]
+          (is (= 1 (count wrapped)))
+          (is (not (contains? (first wrapped) :source-coord))
+              "a programmatic sub omits the slot; the same-id EVENT
+               registration's coordinate is NOT stolen")))
+      (obs/release! la))))
 
 ;; ===========================================================================
 ;; ABI guard

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -1692,6 +1692,192 @@
              "the abandoned lease was reclaimed once its node record's weak key died")))))
 
 ;; ===========================================================================
+;; rf2-wbkjk9 — exact-once first-emission provenance in the disposal-notify
+;; escape drain: no double emission, no category spoofing
+;;
+;; #5782 (rf2-6ui49w) made swallowed on-change failures visible, but
+;; report-disposal-notify-escape! re-dispatched EVERY throwable carrying a
+;; truthy :rf.error/id. Two defects:
+;;
+;;   1. DOUBLE EMISSION — a callback that calls an observation op which
+;;      emits-then-throws (obs/read on a released lease) got its category
+;;      fanned TWICE: once at the source (with the source's correct
+;;      frame/query attribution) and once by the drain (with the NOTIFYING
+;;      owner's context overwriting it). Two always-on records for one
+;;      runtime error — a Spec 009 one-runtime-error-law violation.
+;;   2. CATEGORY SPOOFING — an application ex-info carrying any truthy
+;;      :rf.error/id (`:app/not-catalogued`, a malformed non-keyword, or a
+;;      bare imitation of a canonical id) was re-dispatched as though it
+;;      were a catalogued framework category.
+;;
+;; The fix is explicit FIRST-EMISSION PROVENANCE on the throwable (the
+;; port's emit-then-throw sites stamp `error-emit/fanned-at-source-key`
+;; into the thrown ex-data) plus the canonical thrown-error SHAPE check
+;; (`error-emit/canonical-typed-error?`) — never :rf.error/id truthiness,
+;; never a global seen-error registry:
+;;
+;;   - already-fanned typed  → nothing more (the source's record IS the
+;;     exactly-once record, attribution intact);
+;;   - unfanned canonical typed → exactly once under its ORIGINAL id;
+;;   - untyped / malformed-id / non-catalogued id → exactly one stable
+;;     :rf.error/observation-on-change-failed wrapper.
+;;
+;; Red-before-fix: with the provenance/choke-point repair reverted, the
+;; released-lease fixtures below observe TWO read-after-release records
+;; (the second with stolen attribution) and the spoof fixtures observe the
+;; application id fanned as a framework category.
+;; ===========================================================================
+
+(defn- reg-other! []
+  (rf/reg-sub :obs/other (fn [db _] (:items db))))
+
+(defn- other-target []
+  (obs/resolve-target {:frame fid :query-v [:obs/other]}))
+
+(deftest hmr-drain-does-not-double-emit-an-already-fanned-typed-escape
+  (reg-items!)
+  (reg-other!)
+  (seed-items! [:a])
+  ;; A lease on a DIFFERENT sub, already released — reading it is the
+  ;; deterministic emit-then-throw composition: obs/read first fans
+  ;; :rf.error/read-after-release (with the RELEASED lease's own
+  ;; [:obs/other] attribution), then throws the marked typed error.
+  (let [released (obs/acquire! (other-target) (fn [_]))]
+    (obs/release! released)
+    (let [live (obs/acquire! (items-target) (fn [_n] (obs/read released)))]
+      ;; HMR re-registration of :obs/items drains the :hmr boundary; the
+      ;; live owner's on-change reads the released lease.
+      (let [[[outcome _] records] (with-error-records #(reg-items!))]
+        (is (= :ok outcome) "the registrar isolates the replacement hook")
+        (let [rar (filterv #(= :rf.error/read-after-release (:error %)) records)]
+          (testing "EXACTLY one always-on record for the one runtime error —
+                    the source's own emission; the drain does not re-fan an
+                    already-fanned typed escape (rf2-wbkjk9)"
+            (is (= 1 (count rar))))
+          (testing "the surviving record keeps the SOURCE's attribution (the
+                    released lease's own sub), never the notifying owner's
+                    [:obs/items] context"
+            (is (= :obs/other (:event-id (first rar))))
+            (is (= [:obs/other] (:event (first rar))))))
+        (testing "a typed escape is never ALSO wrapped"
+          (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records)))))
+      (obs/release! live))))
+
+(deftest disposed-drain-classifies-mixed-escapes-exactly-once-each
+  (reg-items!)
+  (reg-other!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [released (obs/acquire! (other-target) (fn [_]))
+          _        (obs/release! released)
+          boom     (ex-info "untyped on-change boom" {::boom true})
+          notes    (atom [])
+          ;; Owner A — already-fanned typed: reads the released lease.
+          la (obs/acquire! (items-target) (fn [_n] (obs/read released)))
+          ;; Owner B — untyped consumer bug.
+          lb (obs/acquire! (items-target) (fn [_n] (throw boom)))
+          ;; Owner C — healthy sibling that MUST still be notified.
+          lc (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+      (is (= 3 (obs/active-owner-count (:reaction (entry [:obs/items])))))
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome thrown] records]
+            (with-error-records #(obs/drain-pending-disposals! :disposed))]
+        (testing "the COMPLETE sibling drain ran despite two throwing owners"
+          (is (= 1 (count @notes)))
+          (is (= :disposed (:cause (first @notes)))))
+        (testing "the already-fanned typed escape appears EXACTLY once, with
+                  its source attribution"
+          (let [rar (filterv #(= :rf.error/read-after-release (:error %)) records)]
+            (is (= 1 (count rar)))
+            (is (= :obs/other (:event-id (first rar))))))
+        (testing "the untyped escape appears EXACTLY once, wrapped, carrying
+                  the original throwable"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)]
+            (is (= 1 (count wrapped)))
+            (is (identical? boom (:exception (first wrapped))))))
+        (testing "the FIRST escape is rethrown to the direct caller with
+                  identity/cause intact (owner-set order is unordered, so it
+                  is ONE of the two originals — never a re-wrap)"
+          (is (= :threw outcome))
+          (is (or (identical? boom thrown)
+                  (= :rf.error/read-after-release (error-id thrown))))))
+      (obs/release! la)
+      (obs/release! lb)
+      (obs/release! lc))))
+
+(deftest disposed-drain-surfaces-an-unfanned-typed-escape-exactly-once-under-its-own-id
+  (reg-items!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [bad (atom nil)
+          ;; The motivating unfanned canonical typed case: a forbidden
+          ;; reentrant release! from inside the fan-out throws the dev
+          ;; :rf.error/reentrant-graph-op assert — a plain typed throw with
+          ;; NO always-on fan of its own; the drain owns its first (and
+          ;; only) emission.
+          la  (obs/acquire! (items-target) (fn [_n] (obs/release! @bad)))]
+      (reset! bad la)
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome thrown] records]
+            (with-error-records #(obs/drain-pending-disposals! :disposed))]
+        (let [rg (filterv #(= :rf.error/reentrant-graph-op (:error %)) records)]
+          (testing "visible EXACTLY once under its ORIGINAL id"
+            (is (= 1 (count rg))))
+          (testing "attributed to the notifying former owner's entry sub and
+                    carrying the escape as the record's cause"
+            (is (= :obs/items (:event-id (first rg))))
+            (is (identical? thrown (:exception (first rg))))))
+        (testing "a canonical typed escape is never wrapped"
+          (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records))))
+        (is (= :threw outcome))
+        (is (= :rf.error/reentrant-graph-op (error-id thrown)))))))
+
+(deftest hmr-drain-wraps-spoofed-and-malformed-ids-instead-of-fanning-them
+  (reg-items!)
+  (seed-items! [:a])
+  (let [;; A non-catalogued APPLICATION id — must not ride the always-on
+        ;; axis as though it were a canonical framework category.
+        app-boom       (ex-info "app boom" {:rf.error/id :app/not-catalogued})
+        ;; A MALFORMED id (non-keyword) — same wrapper arm.
+        malformed-boom (ex-info "malformed boom" {:rf.error/id "not-a-keyword"})
+        ;; A bare IMITATION of a canonical id (reserved namespace but not
+        ;; the canonical thrown-error shape — no :reason sentence): id
+        ;; truthiness alone must not spoof the category.
+        imitation-boom (ex-info "imitation boom"
+                                {:rf.error/id :rf.error/handler-exception})
+        notes  (atom [])
+        la (obs/acquire! (items-target) (fn [_n] (throw app-boom)))
+        lb (obs/acquire! (items-target) (fn [_n] (throw malformed-boom)))
+        lc (obs/acquire! (items-target) (fn [_n] (throw imitation-boom)))
+        ld (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+    (let [[[outcome _] records] (with-error-records #(reg-items!))]
+      (is (= :ok outcome))
+      (testing "the healthy sibling was still notified"
+        (is (= 1 (count @notes)))
+        (is (= :hmr (:cause (first @notes)))))
+      (testing "no spoofed category reaches the always-on axis"
+        (is (empty? (filterv #(= :app/not-catalogued (:error %)) records)))
+        (is (empty? (filterv #(= "not-a-keyword" (:error %)) records)))
+        (is (empty? (filterv #(= :rf.error/handler-exception (:error %)) records))))
+      (testing "each throwable produced EXACTLY one stable wrapper record,
+                carrying its original throwable as the cause"
+        (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records)
+              causes  (set (map :exception wrapped))]
+          (is (= 3 (count wrapped)))
+          (is (contains? causes app-boom))
+          (is (contains? causes malformed-boom))
+          (is (contains? causes imitation-boom))
+          (is (every? #(= :obs/items (:event-id %)) wrapped)))))
+    (obs/release! la)
+    (obs/release! lb)
+    (obs/release! lc)
+    (obs/release! ld)))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 


### PR DESCRIPTION
One coupled surface — the observation port's on-change failure drains, their error fan-out, and the frozen contract — shipped as two runtime commits in dependency order. The third bead (rf2-gg3om8, the spec/schema slice) is **deliberately not shipped here**: its hard gate requires the Spec-Schemas/006 lease-and-override PR from `worker/spec-followup-113-115-126` to have MERGED first, and at ship time that branch has no PR open, so per the dispatch brief this PR stops at the two runtime beads and the mayor routes the schema slice.

## rf2-wbkjk9 — exact-once first-emission provenance (commit 1)

**Re-verified on fresh main (red-before-fix):** `report-disposal-notify-escape!` re-dispatched every throwable carrying a truthy `:rf.error/id`. The bead's composed released-lease repro produced **two** always-on `:rf.error/read-after-release` records for one runtime error — the second overwriting the source's correct `[:obs/other]` attribution with the notifying owner's `[:obs/items]` context — at BOTH the `:hmr` and `:disposed` boundaries; and application ex-infos with `{:rf.error/id :app/not-catalogued}`, a malformed non-keyword id, and a bare `:rf.error/handler-exception` imitation were all fanned as though they were canonical framework categories.

**Fix — provenance, not truthiness:**

- `re-frame.error-emit/fanned-at-source-key` + `fanned-at-source?`: first-emission provenance stamped ON THE THROWABLE by the port's emit-then-throw surfaces (`emit-and-throw!` → frame-destroyed / no-such-sub / retry-exhausted, the released-lease `read`, the ABI guard, and the acquire-recovery `:cycle` / input-fn arms whose category the sub build already surfaced). No global seen-error registry; no source-record suppression.
- `re-frame.error-emit/canonical-typed-error?`: structural provenance of the canonical thrown-error builder (keyword `:rf.error/id` under the reserved `rf.error` namespace + the builder's required `:reason` sentence) — the runtime spelling of catalogue membership (framework emissions under the reserved namespace are pinned to catalogue rows at build time by the Spec 009 source-scan gate).
- The drain's three arms: already-fanned → nothing more on either channel (the source's record IS the exactly-once record, attribution intact); unfanned canonical typed → exactly once under its original id (the dev reentrant-graph-op case remains visible — it exists to be seen); untyped / malformed-id / non-catalogued-id → exactly one stable `:rf.error/observation-on-change-failed` wrapper carrying the original throwable as `:exception`. Sibling drain completes; the first escape is rethrown after the drain with identity/cause intact.

## rf2-q3fmqm — two-channel fan-out + subscription source coordinates (commit 2)

**Re-verified on fresh main (red-before-fix):** a REAL HMR callback failure (macro-registered sub, former owner's on-change throwing a raw untyped bug, drained inside the registrar replacement hook) produced one always-on record and **zero** trace events — invisible to Xray's trace-tooling listener — and the record's `:source-coord` was **absent** (lookup consulted `[:event :obs/items]`); with a same-id event registration and a programmatic sub, the record **stole** the event's coordinate.

**Fix:**

- When the drain owns the first emission (composed with commit 1's provenance — an already-fanned typed escape gains a second record on NEITHER channel), it rides the shared `emit-error-both!` two-channel fan-out with category-specific trace tags: `:cause` (`:hmr`/`:disposed`), `:rf.sub/id`, `:rf.sub/query-v`, `:frame`, the original throwable + `:exception-message`, `:reason`, `:recovery :no-recovery`. Advanced production keeps the always-on record while the trace leg DCEs inside `trace/emit-error!`.
- `:rf.error/observation-on-change-failed` joins `error-emit`'s `sub-error-categories`, so `[:sub id]` is the ONLY source-coord lookup realm: macro-registered subs resolve their exact coordinate, programmatic subs omit the slot, and same-id event registrations cannot steal attribution. The `:event-id` realm name is **kept** (no rename): it matches the established sub-* precedent — the slot holds a sub id for every subscription-owned category — so the closed record shape is unchanged and no consumer migration is needed.

Proof is on the ACTUAL emit sites (real HMR re-registration and the `:disposed` drain boundary), with both a trace and an always-on listener registered — not a synthetic `dispatch-on-error!` conformance table.

## rf2-gg3om8 — STOPPED (hard gate not met)

The frozen-contract slice (canonical `:rf.error/observation-on-change-failed` schema row in `spec/Spec-Schemas.md` + Spec 006 observation callback/disposal amendments + Spec 009 reconciliation) is gated on the `worker/spec-followup-113-115-126` PR merging first — both lanes own clauses in the same hot-zone spec files. At ship time that branch exists on origin but **no PR has been opened from it**, so it cannot have merged. Per the dispatch brief this PR ships the two runtime beads and stops; rf2-gg3om8 stays open for the mayor to route after the spec-followup PR merges. (Known interim drift, for the gg3om8 author: the Spec 009 wrapper-category row still says the emission rides `dispatch-on-error!` — commit 2 moved it to `emit-error-both!`; the row also predates the drain's typed-escape arms. Both belong to the gg3om8 reconciliation.)

Note for reviewers: `reactive.cljc` is untouched; the seam edits are confined to `substrate/observation.cljc` and `error_emit.cljc` (the emit/classification seam), plus the port's own test file.

## Quality gates

- `implementation/core` JVM: `clojure -M:test` — 1923 tests / 8723 assertions, 0 failures, 0 errors (post-commit-2 tree).
- `implementation` CLJS node: `npm run test:cljs` — 9235 tests / 43695 assertions, 0 failures, 0 errors (post-commit-2 tree; the new `.cljc` fixtures run on both hosts).
- `sh scripts/test-fast-pr.sh` — PASS (all python contract gates, core JVM 1923/8723, JS harness helpers, CLJS node integration 9235/43695, per-ns isolation 15/15; markdown gates skipped — no .md changes in this diff).
- Red-before-fix runs recorded per bead: 9 failing assertions pre-commit-1 (double emission at both boundaries + all three spoof shapes fanned), 12 failing assertions pre-commit-2 (trace count zero at both boundaries + missing/stolen coordinates).
