### PR TITLE
ci: skip push-to-main runs for beads-only commits (paths-ignore .beads/**) (rf2-slylof)

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -23,6 +23,11 @@ name: portability
 on:
   push:
     branches: [main]
+    # Beads checkpoints (.beads-only pushes) are no-op runs that occupy
+    # queue slots; skip them. Mixed code+beads pushes still run (a push is
+    # skipped only when ALL changed files match). PRs stay unfiltered.
+    paths-ignore:
+      - '.beads/**'
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Beads-checkpoint commits to main spawn workflow runs that complete as no-ops but occupy runner queue slots — roughly half the runs on main during mayor sessions (rf2-slylof, operator-requested). This adds `paths-ignore: ['.beads/**']` to the one remaining unfiltered `push: branches: [main]` trigger. GitHub skips a run only when ALL changed files match the ignore list, so mixed code+beads pushes still run everything. `pull_request` / `schedule` / `workflow_dispatch` triggers untouched.

## Workflow enumeration

| Workflow | Action | Why |
| --- | --- | --- |
| `portability.yml` | **edited** | push-to-main trigger had no paths filter |
| `test.yml` | exempt (already done) | push trigger already carries `paths-ignore` with `.beads/**` as its first entry |
| `docs.yml` | exempt | push trigger uses `paths:` (mutually exclusive with `paths-ignore`); `.beads/**` not listed, so beads pushes never trigger it |
| `lint.yml` | exempt | same — `paths:`-filtered push trigger, beads not on the surface |
| `post-merge-playground-freshness.yml` | exempt | same — `paths:`-filtered push trigger |
| `post-merge-workflow-sanity.yml` | exempt | `paths: ['.github/workflows/*.yml']` push trigger; beads pushes never fire it |
| `expensive-tests.yml` | exempt | no push trigger (schedule + workflow_dispatch only) |
| `release.yml` / `release-xray.yml` / `template-release.yml` | exempt | tag-push triggers only, no branch push |

The post-merge-workflow-sanity EXCLUDE entry for `portability.yml` ("already runs on push to main") stays accurate: this PR's own merge commit touches `.github/workflows/`, not `.beads/`, so portability still fires on the merge push.

## Quality gates

- All 10 workflow files parse as valid YAML (PyYAML sweep).
- Structural assertion: `portability.yml` push trigger == `{branches: [main], paths-ignore: ['.beads/**']}`, `pull_request` unchanged, `workflow_dispatch` present; no workflow mixes `paths` and `paths-ignore` on one trigger.
- `actionlint` not available locally; no repo workflow-lint script exists (the sanity gate is the post-merge dispatch canary).
- Real proof is post-merge: the merge commit itself must spawn a portability run (code push → runs), and the next beads checkpoint must spawn zero runs from portability (beads-only push → skipped).