### PR TITLE
fix(machines): join/spawn exact-authority lane (rf2-3phait/nvxehu/s2bsmw/ir4t5v)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -69,6 +69,27 @@
   []
   (frame/make-anon-frame-record! {:initial-events [[:work/flow [:reset]]]}))
 
+(defn- synth-child-done!
+  "Synthesise one child's :on-child-done arrival, carrying the SAME
+   exact-authority stamp the member child's own handler boundary would
+   have stamped (rf2-nvxehu). The join interceptor authenticates every
+   completion carrier to the exact join attempt — parent/invoke identity,
+   logical child id, exact current actor id, exact per-attempt token — so
+   a bare hand-dispatched carrier is suppressed as :attempt-unverified.
+   A headless test that bypasses the live children (dispatch-sync fires
+   no :after timers) therefore reads the runtime-owned join state and
+   presents the equivalent `:rf/join-auth` metadata."
+  [f shard]
+  (let [js (join-state f)]
+    (rf/dispatch-sync
+      [:work/flow (with-meta [:work/child-done shard]
+                    {:rf/join-auth {:parent-id  :work/flow
+                                    :invoke-id  [:working]
+                                    :child-id   shard
+                                    :spawned-id (get-in js [:children shard])
+                                    :attempt    (:rf/attempt js)}})]
+      {:frame f})))
+
 ;; ============================================================================
 ;; (1) SPAWN CASCADE — :start spawns 3 children
 ;; ============================================================================
@@ -111,12 +132,13 @@
     ;; via :after-yield loops and dispatch :work/child-done on entry
     ;; to their terminal state. dispatch-sync doesn't fire :after
     ;; timers, so for the headless test we synthesise the
-    ;; child-done events directly. The runtime's intercept logic
-    ;; (intercept-invoke-all-event in re-frame.machines) treats
-    ;; them identically — the events arrive at the parent's
-    ;; handler boundary either way.
+    ;; child-done events directly — carrying the exact-authority
+    ;; stamp the member child's boundary would have stamped
+    ;; (rf2-nvxehu; see synth-child-done!). With the stamp, the
+    ;; runtime's join interceptor treats them identically to live
+    ;; child completions.
 
-    (rf/dispatch-sync [:work/flow [:work/child-done :s1]] {:frame f})
+    (synth-child-done! f :s1)
     ;; After the first :work/child-done, the join state's :done
     ;; carries :s1; the join condition (:all of 3) hasn't resolved
     ;; yet so :resolved? stays false and the parent is still :working.
@@ -126,7 +148,7 @@
       (is (= #{:s1}     (:done js)))
       (is (false?       (:resolved? js))))
 
-    (rf/dispatch-sync [:work/flow [:work/child-done :s2]] {:frame f})
+    (synth-child-done! f :s2)
     (is (= #{:s1 :s2} (:done (join-state f))))
     (is (= :working   (:state (snapshot f))))
 
@@ -135,7 +157,7 @@
     ;; this was the last child), and dispatches [:work/flow
     ;; [:work/all-done]]. The parent's :working :on table catches
     ;; :work/all-done → :complete (with :stamp-outcome action).
-    (rf/dispatch-sync [:work/flow [:work/child-done :s3]] {:frame f})
+    (synth-child-done! f :s3)
     (let [snap (snapshot f)]
       (is (= :complete (:state snap)))
       (is (= :complete (-> snap :data :outcome)))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -98,8 +98,10 @@
   `finalize-machine`. See Spec 005 §Destroy is silent-idempotent
   for the normative paragraph.
 
-  The tracked-slot signal the tracked form additionally consults is
-  resolved-actor-id agnostic and so stays local to that call site."
+  This is the ONE liveness probe every destroy shape consults
+  (rf2-s2bsmw). The tracked form pairs it with the exact-incarnation
+  predicate (`slot-owned-incarnation?`); tracked-slot PRESENCE is
+  ownership bookkeeping, never a liveness signal."
   [frame-id actor-id runtime-db]
   (and actor-id
        (or (some? (registrar/lookup :event actor-id))
@@ -317,33 +319,19 @@
   The liveness probe must distinguish *already-destroyed* (the actor was
   alive and the teardown projection ran) from *not-yet-materialised-snapshot*
   (the actor IS alive in this drain — a spawn + destroy back-to-back in the
-  same `:fx` vector, before the snapshot swap landed). `live?` is true iff
-  ANY of the following hold:
+  same `:fx` vector, before the snapshot swap landed). Liveness is the
+  shared `actor-live?` probe — registrar entry / snapshot / spawn-order,
+  identical for every shape (rf2-s2bsmw dropped the tracked form's
+  slot-presence override: a tracked slot naming a dead actor is STALE
+  OWNERSHIP BOOKKEEPING, pruned by `destroy-tracked!` without re-running
+  lifecycle teardown, never a liveness signal).
 
-    - **Registrar entry present** at `actor-id`. Normal spawned actors have no
-      per-instance entry, but teardown recognises stale or externally installed
-      entries.
-    - **Snapshot present** at `[:rf.runtime/machines :snapshots actor-id]`. Covers the
-      narrow window where a singleton's handler has been replaced
-      mid-drain but the snapshot still lives, plus belt-and-braces
-      for hand-crafted call sites.
-    - **Spawn-order entry present** for `actor-id` in the per-frame
-      spawn-order channel. `spawn-order/record!` runs unconditionally
-      on spawn; `spawn-order/forget!` runs unconditionally on destroy —
-      so the entry's presence/absence is the most reliable
-      \"alive-or-gone\" bit, covering the back-to-back spawn-then-destroy
-      window before the snapshot swap lands.
-    - **`slot-live?`** — the tracked-form belt-and-braces liveness hint (the
-      `[:rf.runtime/machines :spawned parent-id invoke-id]` slot's presence),
-      passed true ONLY by the tracked-`:spawn` shape; false for the keyword
-      and reap shapes.
-
-  A truly-already-destroyed actor has ALL of these gone — the unified
-  teardown projection, registrar cleanup, and `spawn-order/forget!`
+  A truly-already-destroyed actor has ALL the probe's signals gone — the
+  unified teardown projection, registrar cleanup, and `spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
   See Spec 005 §Destroy is silent-idempotent for the normative paragraph."
-  [frame-id actor-id reason parent-id invoke-id old-db slot-live?]
-  (when (or (actor-live? frame-id actor-id old-db) slot-live?)
+  [frame-id actor-id reason parent-id invoke-id old-db]
+  (when (actor-live? frame-id actor-id old-db)
     ;; Shared ordered teardown pipeline (see `teardown-live-actor!`). The
     ;; `:exit` cascade runs BEFORE the `:rf.machine/destroyed` trace:
     ;; per Spec 005 §Declarative `:spawn` §Composition with explicit `:entry`
@@ -455,7 +443,7 @@
       ;; teardown slot keys). `parent-id` / `invoke-id` / `child-id` were used
       ;; ABOVE only to READ + verify the join state.
       (destroy-resolved! frame-id actor-id :rf.machine/join-reaped
-                         nil nil old-db false))))
+                         nil nil old-db))))
 
 ;; ---- the closed map-form grammar (rf2-3phait) ------------------------------
 ;;
@@ -486,18 +474,73 @@
   (and (keyword? (:rf/parent-id args))
        (vector?  (:rf/invoke-id args))))
 
+(defn- slot-owned-incarnation?
+  "The exact-incarnation half of the tracked form's shared
+  liveness/incarnation predicate (rf2-s2bsmw). True iff the actor at
+  `actor-id` is the incarnation THIS `[:spawned parent-id invoke-id]` slot
+  owns: its snapshot's `:data` carries the framework-reserved
+  `:rf/parent-id` + `:rf/invoke-id` ownership stamps (written by
+  `stamp-framework-data` at spawn — the same reserved keys the
+  spawn-`:on-error` routing reads) matching the slot coordinates exactly.
+
+  A same-id REPLACEMENT actor spawned through another path (a hand-emitted
+  `:fixed-actor-id` re-spawn, a different parent) carries different — or
+  no — ownership stamps, so a STALE slot can never destroy it: exact
+  incarnation identity is respected. A snapshot-less-but-live edge (the
+  back-to-back spawn-then-destroy window where only the spawn-order signal
+  is up) has no stamps to contradict the slot, so it counts as owned —
+  the tracked destroy retains its pre-existing behaviour there."
+  [runtime-db actor-id parent-id invoke-id]
+  (let [snap (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))]
+    (if (map? snap)
+      (let [d (:data snap)]
+        (and (= parent-id (:rf/parent-id d))
+             (= invoke-id (:rf/invoke-id d))))
+      true)))
+
+(defn- prune-tracked-slot!
+  "Stale ownership-slot cleanup, SEPARATED from actor lifecycle teardown
+  (rf2-s2bsmw): clear the `[:spawned parent-id invoke-id]` slot and the
+  parent snapshot's mirroring `[:data :rf/spawned <invoke-id>]` entry via
+  the unified projection (slot-only: nil actor-id), WITHOUT re-running exit
+  handlers, child cascades, timer/resource cleanup, terminal replies, or a
+  `:rf.machine/destroyed` trace — the actor the slot names is either
+  already dead for this incarnation (its own destroy ran the full pipeline
+  once) or a live replacement this slot does not own."
+  [frame-id parent-id invoke-id]
+  (frame/swap-runtime-db! frame-id
+                          (fn [runtime-db]
+                            (first (teardown/teardown-actor
+                                     runtime-db {:parent-id parent-id
+                                                 :invoke-id invoke-id}))))
+  nil)
+
 (defn- destroy-tracked!
   "The tracked single-`:spawn` exit-cascade form `{:rf/parent-id p
   :rf/invoke-id i}` (already shape-validated by `destroy-machine-fx`).
-  Resolves the actor id from the `[:spawned p i]` slot; the teardown is
-  `:explicit`.
+  Resolves the actor id from the `[:spawned p i]` slot; a live owned
+  child's teardown is `:explicit`.
 
   Slot-shape fence (rf2-3phait): the tracked form is admitted only when the
   resolved slot is an actor-id KEYWORD. A `:spawn-all` join-state MAP at the
   slot means the tracked form was mis-addressed — consuming it as an actor id
   would clear the join slot and orphan every live child — so it fails loud
   (`:cause :slot-shape-mismatch`) with zero mutation. A nil slot (already
-  cleared — a repeat exit) stays a silent no-op."
+  cleared — a repeat exit) stays a silent no-op.
+
+  Stale-slot fence (rf2-s2bsmw): slot presence is OWNERSHIP BOOKKEEPING,
+  never liveness. An imperative keyword destroy tears the actor down but
+  leaves the tracked slot naming the now-dead id (its teardown-args carry
+  no parent/invoke); the later declarative exit must therefore split on the
+  shared liveness/incarnation predicate (`actor-live?` +
+  `slot-owned-incarnation?`):
+
+    - dead for this incarnation → `prune-tracked-slot!` (slot + parent
+      mirror only; NO second exit cascade / teardown / destroyed trace —
+      Spec 005's silent-idempotent destroy law);
+    - live but a same-id REPLACEMENT this slot does not own → prune the
+      stale slot only, leaving the replacement untouched;
+    - live and owned → the normal exact-incarnation `:explicit` destroy."
   [frame-id args old-db]
   (let [parent-id (:rf/parent-id args)
         invoke-id (:rf/invoke-id args)
@@ -506,12 +549,15 @@
       (nil? slot-id)
       nil
 
-      (keyword? slot-id)
-      (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db
-                         true)
+      (not (keyword? slot-id))
+      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
+
+      (and (actor-live? frame-id slot-id old-db)
+           (slot-owned-incarnation? old-db slot-id parent-id invoke-id))
+      (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db)
 
       :else
-      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args))))
+      (prune-tracked-slot! frame-id parent-id invoke-id))))
 
 (defn destroy-machine-fx
   "fx handler for `:rf.machine/destroy`. Parses the CLOSED destroy grammar
@@ -543,7 +589,7 @@
       ;; Imperative form — the actor-id IS the arg; a live in-progress
       ;; teardown is ALWAYS an `:explicit` cancellation.
       (keyword? args)
-      (destroy-resolved! frame-id args :explicit nil nil old-db false)
+      (destroy-resolved! frame-id args :explicit nil nil old-db)
 
       (map? args)
       (let [shape (set (keys args))]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -39,9 +39,20 @@
   is AUTHENTICATED against the live join state before being honoured — the
   reason and the reaped actor-id are runtime-derived from durable join state,
   never caller-supplied, so the form cannot be forged at the public
-  reserved-fx boundary (rf2-3lyqzu). See `destroy-join-reap!`. Any map that
-  matches none of these shapes fails loud with
-  `:rf.error/machine-destroy-bad-arg` and performs no teardown.
+  reserved-fx boundary (rf2-3lyqzu). See `destroy-join-reap!`.
+
+  The map grammar is a CLOSED discriminated union (rf2-3phait). PRESENCE of
+  a discriminator key (`:rf/reap` / `:rf/spawn-all`) SELECTS that shape —
+  never its truthiness — and the selected shape then requires the
+  discriminator's value to be exactly `true` plus the exact coordinate
+  key-set and types (`:rf/parent-id` keyword, `:rf/invoke-id` path vector,
+  `:rf/child-id` keyword). The tracked single-`:spawn` form is admitted only
+  for its exact two-key shape, and only when the resolved slot is an actor-id
+  KEYWORD — never a `:spawn-all` join-state map. Every malformed, overlapping,
+  or unknown shape fails loud with `:rf.error/machine-destroy-bad-arg` and
+  performs ZERO mutation — no slot, actor, child, trace, terminal-reply, or
+  ownership change. There is no permissive coercion, no truthy alias, and no
+  compatibility fallback.
 
   The actor-teardown runtime-db dance lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
@@ -63,7 +74,8 @@
 
 (defn- actor-live?
   "The silent-idempotent liveness probe, shared by the
-  keyword/tracked `destroy-single!` path and the per-actor
+  keyword/tracked destroy paths (`destroy-machine-fx` /
+  `destroy-tracked!`) and the per-actor
   `destroy-single-actor!` path. An actor with a resolved
   `actor-id` is live iff ANY of the following survive:
 
@@ -82,11 +94,11 @@
 
   A truly-already-destroyed actor has all three gone — the unified
   teardown projection, registrar cleanup, and `spawn-order/forget!`
-  run atomically per `destroy-single-actor!` / `destroy-single!` /
+  run atomically per `destroy-single-actor!` / `destroy-resolved!` /
   `finalize-machine`. See Spec 005 §Destroy is silent-idempotent
   for the normative paragraph.
 
-  The tracked-slot signal `destroy-single!` additionally consults is
+  The tracked-slot signal the tracked form additionally consults is
   resolved-actor-id agnostic and so stays local to that call site."
   [frame-id actor-id runtime-db]
   (and actor-id
@@ -98,7 +110,7 @@
 (defn- teardown-live-actor!
   "The shared ordered teardown pipeline for a LIVE actor (the caller has
   already confirmed liveness). Both destroy entry-points — the per-actor
-  `destroy-single-actor!` and the keyword/tracked `destroy-single!` — run
+  `destroy-single-actor!` and the keyword/tracked `destroy-resolved!` — run
   this IDENTICAL ordered sequence; they differ only in actor-id resolution
   (done in the caller) and whether they emit the `:rf.machine/destroyed`
   trace (passed as `emit-destroyed!-fn`).
@@ -121,7 +133,7 @@
        projection prunes (`{:actor-id …}` for the per-actor form; the
        tracked map adds `:parent-id` / `:invoke-id`);
     6. emit `:rf.machine/destroyed` via the optional `emit-destroyed!-fn`
-       (called with the released sid) — `destroy-single!` emits here so the
+       (called with the released sid) — `destroy-resolved!` emits here so the
        trace lands after `:exit`; `destroy-single-actor!`'s
        callers own the emit, so they pass nil;
     7. forget the actor from the per-frame spawn-order channel
@@ -137,7 +149,7 @@
        refetching/polling) past the actor's death. Fired LAST, once the actor
        is gone; guarded on resources being loaded (machines never depends on
        resources), so a no-resources app is a clean no-op. Runs on BOTH explicit
-       destroy (`destroy-single!`) and the frame-destroy cascade
+       destroy (`destroy-resolved!`) and the frame-destroy cascade
        (`destroy-single-actor!`) since both route through here.
 
   Returns the `db-swapped?` flag from the teardown projection."
@@ -195,7 +207,7 @@
   `:rf.http/managed` requests, emit the
   `:system-id-released` trace, clear any registrar entry, and
   forget the actor from the per-frame spawn-order channel.
-  The ordered teardown pipeline is shared with `destroy-single!` via
+  The ordered teardown pipeline is shared with `destroy-resolved!` via
   `teardown-live-actor!`.
 
   Used by `destroy-machine-fx` for the keyword-form imperative
@@ -214,7 +226,7 @@
   can gate their `:rf.machine/destroyed` emit on the truthy live-and-torn-down
   return, preventing a double-destroyed trace for join-cancelled survivors
   the resolution cascade already tore down. Mirrors the `live?` gate
-  `destroy-single!` carries."
+  `destroy-resolved!` carries."
   [frame-id actor-id]
   (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
     ;; This site does NOT emit `:rf.machine/destroyed` — its callers
@@ -228,16 +240,34 @@
     ;; an already-destroyed actor (silent no-op).
     true))
 
+(declare destroy-spawn-all-children!*)
+
 (defn- destroy-spawn-all-children!
   "The declarative-`:spawn-all` exit-cascade form.
   Resolves the children map from `[:rf.runtime/machines :spawned parent-id invoke-id]`,
   tears each child down via `destroy-single-actor!`, then clears the
   join-state slot via the unified teardown projection (slot-prune only:
-  nil actor-id)."
-  [frame-id parent-id invoke-id]
+  nil actor-id).
+
+  Slot-shape fence (rf2-3phait, the mirror of the tracked-form fence): the
+  addressed slot must hold a `:spawn-all` JOIN-STATE MAP (or nothing — a
+  repeat exit against an already-cleared slot is a silent no-op). A slot
+  holding a single-`:spawn` actor-id KEYWORD means the spawn-all form was
+  mis-addressed; clearing it would orphan the live tracked child without
+  teardown, so the form fails loud (`:cause :slot-shape-mismatch`) and
+  mutates nothing."
+  [frame-id parent-id invoke-id args]
   (let [join-state (get-in (frame/frame-runtime-db-value frame-id)
-                           (paths/spawned-path parent-id invoke-id))
-        children   (when (map? join-state) (:children join-state))]
+                           (paths/spawned-path parent-id invoke-id))]
+    (if-not (or (nil? join-state) (map? join-state))
+      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
+      (destroy-spawn-all-children!* frame-id parent-id invoke-id join-state))))
+
+(defn- destroy-spawn-all-children!*
+  "The verified body of `destroy-spawn-all-children!` — `join-state` is
+  known to be a join-state map (or nil, the repeat-exit no-op)."
+  [frame-id parent-id invoke-id join-state]
+  (let [children (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
       ;; `destroy-single-actor!` runs the child's `:exit`
       ;; cascade before teardown; we fire `:rf.machine/destroyed` AFTER it
@@ -273,7 +303,8 @@
     nil))
 
 (defn- destroy-resolved!
-  "Shared tail of every `destroy-single!` shape: run the liveness-gated
+  "Shared tail of the keyword / tracked-`:spawn` / verified-reap shapes:
+  run the liveness-gated
   ordered teardown for an ALREADY-RESOLVED `actor-id` and emit its
   `:rf.machine/destroyed` trace with `reason`. The keyword / tracked-`:spawn`
   / verified-reap shapes differ ONLY in how they resolve `actor-id` +
@@ -403,64 +434,122 @@
                          nil nil old-db false)
       (traces/emit-destroy-bad-arg! frame-id :unverified-reap args))))
 
-(defn- destroy-single!
-  "Dispatch the single-actor `:rf.machine/destroy` shapes to the shared
-  teardown tail (`destroy-resolved!`), resolving `actor-id` + `reason` per
-  shape. See the ns docstring for the form grammar.
+;; ---- the closed map-form grammar (rf2-3phait) ------------------------------
+;;
+;; Each map shape is admitted by its EXACT key-set — presence of a
+;; discriminator key selects the shape (never its truthiness), and the
+;; selected shape then requires the discriminator value to be exactly `true`
+;; plus exact coordinate types. Anything else fails loud with
+;; `:rf.error/machine-destroy-bad-arg` and performs zero mutation. No
+;; permissive coercion, no truthy aliases, no compatibility fallback.
 
-    - Keyword (imperative) form `[:rf.machine/destroy actor-id]` — the actor-id
-      IS the arg; a live in-progress teardown is ALWAYS an `:explicit`
-      cancellation.
-    - VERIFIED reap form `{:rf/reap true …}` — the sole selector of
-      `:rf.machine/join-reaped`, authenticated against live join state by
-      `destroy-join-reap!`.
-    - Tracked single-`:spawn` exit-cascade form `{:rf/parent-id p
-      :rf/invoke-id i}` — resolve actor-id from the `[:spawned p i]` slot;
-      the teardown is `:explicit`.
-    - UNKNOWN / malformed map shape — e.g. the pre-auth forgery
-      `{:rf/actor-id … :rf/reason …}` — fails loud
-      (`:rf.error/machine-destroy-bad-arg`, `:cause :unknown-shape`) with no
-      teardown, so an app action can never mint a caller-chosen destroyed
-      reason at the public reserved-fx boundary (rf2-3lyqzu).
+(def ^:private reap-form-keys
+  "The VERIFIED reap shape's exact key-set."
+  #{:rf/reap :rf/parent-id :rf/invoke-id :rf/child-id})
 
-  (The `:rf/spawn-all` form is routed to `destroy-spawn-all-children!` by
-  `destroy-machine-fx` before this fn is reached.)"
-  [frame-id args]
-  (let [old-db (frame/frame-runtime-db-value frame-id)]
+(def ^:private spawn-all-form-keys
+  "The declarative-`:spawn-all` exit-cascade shape's exact key-set."
+  #{:rf/spawn-all :rf/parent-id :rf/invoke-id})
+
+(def ^:private tracked-form-keys
+  "The tracked single-`:spawn` exit-cascade shape's exact key-set."
+  #{:rf/parent-id :rf/invoke-id})
+
+(defn- join-coordinates-ok?
+  "Exact coordinate types shared by every map form: `:rf/parent-id` is an
+  actor-id keyword; `:rf/invoke-id` is the declaring-path vector the
+  transition reducer stamps (`(vec prefix)`)."
+  [args]
+  (and (keyword? (:rf/parent-id args))
+       (vector?  (:rf/invoke-id args))))
+
+(defn- destroy-tracked!
+  "The tracked single-`:spawn` exit-cascade form `{:rf/parent-id p
+  :rf/invoke-id i}` (already shape-validated by `destroy-machine-fx`).
+  Resolves the actor id from the `[:spawned p i]` slot; the teardown is
+  `:explicit`.
+
+  Slot-shape fence (rf2-3phait): the tracked form is admitted only when the
+  resolved slot is an actor-id KEYWORD. A `:spawn-all` join-state MAP at the
+  slot means the tracked form was mis-addressed — consuming it as an actor id
+  would clear the join slot and orphan every live child — so it fails loud
+  (`:cause :slot-shape-mismatch`) with zero mutation. A nil slot (already
+  cleared — a repeat exit) stays a silent no-op."
+  [frame-id args old-db]
+  (let [parent-id (:rf/parent-id args)
+        invoke-id (:rf/invoke-id args)
+        slot-id   (when old-db (get-in old-db (paths/spawned-path parent-id invoke-id)))]
     (cond
-      (not (map? args))
-      (destroy-resolved! frame-id args :explicit nil nil old-db false)
+      (nil? slot-id)
+      nil
 
-      (:rf/reap args)
-      (destroy-join-reap! frame-id args old-db)
-
-      (and (contains? args :rf/parent-id) (contains? args :rf/invoke-id))
-      (let [parent-id (:rf/parent-id args)
-            invoke-id (:rf/invoke-id args)
-            slot-id   (when old-db (get-in old-db (paths/spawned-path parent-id invoke-id)))]
-        (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db
-                           (some? slot-id)))
+      (keyword? slot-id)
+      (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db
+                         true)
 
       :else
-      (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))))
+      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args))))
 
 (defn destroy-machine-fx
-  "fx handler for `:rf.machine/destroy`. Dispatches to the keyword-form
-  / single-`:spawn` teardown (`destroy-single!`) or the
-  `:spawn-all` children-iteration teardown
-  (`destroy-spawn-all-children!`) per the `args` shape. See the ns
-  docstring for the form semantics."
+  "fx handler for `:rf.machine/destroy`. Parses the CLOSED destroy grammar
+  (see the ns docstring, rf2-3phait) and dispatches:
+
+    - keyword `actor-id` — the imperative form (`:explicit` cancellation);
+    - `{:rf/reap true :rf/parent-id p :rf/invoke-id i :rf/child-id c}` —
+      the VERIFIED reap, authenticated against live join state by
+      `destroy-join-reap!`;
+    - `{:rf/spawn-all true :rf/parent-id p :rf/invoke-id i}` — the
+      `:spawn-all` children-iteration teardown;
+    - `{:rf/parent-id p :rf/invoke-id i}` — the tracked single-`:spawn`
+      exit-cascade teardown;
+    - anything else — `:rf.error/machine-destroy-bad-arg` (`:cause
+      :unknown-shape`) with ZERO mutation. Notably the pre-auth forgery
+      `{:rf/actor-id … :rf/reason …}` (rf2-3lyqzu), false-valued / wrong-typed
+      discriminators, missing or wrongly-typed coordinates, and overlapping
+      discriminator sets (rf2-3phait)."
   [{frame-id :frame} args]
   (let [;; EP-0002 carried invariant — the cascade envelope frame is the
         ;; fx-context `:frame`; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id   (frame/require-frame-stamp!
-                     frame-id :rf.machine/destroy
-                     {:where 'rf.machine/destroy
-                      :event-id (when (map? args) (:rf/parent-id args))})
-        spawn-all? (and (map? args) (true? (:rf/spawn-all args)))]
-    (if spawn-all?
-      (destroy-spawn-all-children! frame-id
-                                   (:rf/parent-id args)
-                                   (:rf/invoke-id args))
-      (destroy-single! frame-id args))))
+        frame-id (frame/require-frame-stamp!
+                   frame-id :rf.machine/destroy
+                   {:where 'rf.machine/destroy
+                    :event-id (when (map? args) (:rf/parent-id args))})
+        old-db   (frame/frame-runtime-db-value frame-id)]
+    (cond
+      ;; Imperative form — the actor-id IS the arg; a live in-progress
+      ;; teardown is ALWAYS an `:explicit` cancellation.
+      (keyword? args)
+      (destroy-resolved! frame-id args :explicit nil nil old-db false)
+
+      (map? args)
+      (let [shape (set (keys args))]
+        (cond
+          (contains? args :rf/reap)
+          (if (and (= shape reap-form-keys)
+                   (true? (:rf/reap args))
+                   (join-coordinates-ok? args)
+                   (keyword? (:rf/child-id args)))
+            (destroy-join-reap! frame-id args old-db)
+            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+
+          (contains? args :rf/spawn-all)
+          (if (and (= shape spawn-all-form-keys)
+                   (true? (:rf/spawn-all args))
+                   (join-coordinates-ok? args))
+            (destroy-spawn-all-children! frame-id
+                                         (:rf/parent-id args)
+                                         (:rf/invoke-id args)
+                                         args)
+            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+
+          (= shape tracked-form-keys)
+          (if (join-coordinates-ok? args)
+            (destroy-tracked! frame-id args old-db)
+            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+
+          :else
+          (traces/emit-destroy-bad-arg! frame-id :unknown-shape args)))
+
+      :else
+      (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -395,13 +395,21 @@
   the reap against DURABLE join state before honouring it — the fix for the
   forgeable pre-auth `{:rf/actor-id … :rf/reason …}` shape (rf2-3lyqzu). The
   named `:spawn-all` join at `[:spawned p i]` MUST exist, OWN `child-id`,
-  and have folded `child-id` into `:done ∪ :failed`. The actor-id is then
-  RESOLVED from the live join state (`(get-in join-state [:children
-  child-id])`), never carried by the caller — so the reap can neither point
+  have folded `child-id` into `:done ∪ :failed`, AND have its `:resolved?`
+  latch flipped (rf2-nvxehu): reaping is a POST-RESOLUTION act, so a
+  completed child of a still-waiting `:all` join can never be reaped early
+  through the public reserved-fx boundary. Because the fold side binds every
+  `:done` / `:failed` entry to the exact current child attempt (the
+  `:rf/join-auth` gate in `join.cljc`), membership in `:done ∪ :failed` IS
+  proof the terminal belongs to this attempt. The actor-id is then RESOLVED
+  from the live join state (`(get-in join-state [:children child-id])`),
+  never carried by the caller — so the reap can neither point
   post-completion teardown at an arbitrary victim NOR suppress the
   cancellation of an in-progress (not-yet-completed) actor. An unverifiable
   reap FAILS LOUD (`:rf.error/machine-destroy-bad-arg`, `:cause
-  :unverified-reap`) and performs no teardown.
+  :unverified-reap` for a claim the join state cannot substantiate, `:cause
+  :unresolved-join` for a substantiated terminal ahead of the `:resolved?`
+  latch) and performs no teardown.
 
   Verification against join state is INDEPENDENT of the liveness guard in
   `destroy-resolved!`: the composed final-child case (a child that reached a
@@ -420,7 +428,23 @@
         completed? (and (some? actor-id)
                         (or (contains? (:done   join-state) child-id)
                             (contains? (:failed join-state) child-id)))]
-    (if completed?
+    (cond
+      ;; The join state cannot substantiate the claim at all — no live join,
+      ;; foreign child-id, or an in-progress (never-completed) child.
+      (not completed?)
+      (traces/emit-destroy-bad-arg! frame-id :unverified-reap args)
+
+      ;; Substantiated terminal, but the join attempt has NOT resolved
+      ;; (rf2-nvxehu): a non-decisive completed child of a still-waiting
+      ;; `:all` join may not be reaped early — the cancellation-suppressing
+      ;; reap is authorized only after this exact attempt's `:resolved?`
+      ;; latch flipped. (The internal resolution-cascade reaps always run
+      ;; against the post-resolution join state — the `:rf.db/runtime` write
+      ;; commits before the `:fx` drain — so genuine reaps see `true` here.)
+      (not (true? (:resolved? join-state)))
+      (traces/emit-destroy-bad-arg! frame-id :unresolved-join args)
+
+      :else
       ;; Tear down ONLY the child actor — pass NIL parent/invoke so
       ;; `teardown-actor` does NOT prune the `[:spawned parent invoke]` slot,
       ;; which for a `:spawn-all` holds the WHOLE join-state map (every
@@ -431,8 +455,7 @@
       ;; teardown slot keys). `parent-id` / `invoke-id` / `child-id` were used
       ;; ABOVE only to READ + verify the join state.
       (destroy-resolved! frame-id actor-id :rf.machine/join-reaped
-                         nil nil old-db false)
-      (traces/emit-destroy-bad-arg! frame-id :unverified-reap args))))
+                         nil nil old-db false))))
 
 ;; ---- the closed map-form grammar (rf2-3phait) ------------------------------
 ;;

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -14,6 +14,12 @@
       children. Forged / unknown ids are rejected with the
       `:rf.error/machine-spawn-all-bad-child-id` error trace and a
       no-op fx (the join state is NOT mutated).
+   3b. Authenticates the carrier to the EXACT join attempt (rf2-nvxehu):
+      the `:rf/join-auth` metadata the member child's own handler boundary
+      stamped must match the current join's parent/invoke identity, logical
+      child id, exact current actor id, and exact attempt token. Unstamped
+      / superseded / duplicate carriers are suppressed stale
+      (`:rf.machine.spawn-all/stale-completion`) with zero mutation.
    4. Adds `<child-id>` to `:done` or `:failed`.
    5. If `:resolved?` is already true, this is a post-resolution
       late-completion (it fires NO further parent event — the
@@ -47,6 +53,163 @@
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; The verified fold body is defined below the interceptor for reading
+;; order (gates first, fold second); forward-declared so the interceptor
+;; can reference it.
+(declare intercept-fold)
+
+;; ---------------------------------------------------------------------------
+;; Attempt authentication (rf2-nvxehu).
+;;
+;; A `:spawn-all` child's completion carrier is the PUBLIC event shape
+;; `[<parent-id> [<done-kw> <child-id> & extra]]` — it carries no actor or
+;; attempt identity, so after parent re-entry / child respawn a STALE carrier
+;; from a prior attempt is indistinguishable from a live one by value. The
+;; runtime therefore authenticates carriers through the existing PRIVATE
+;; lifecycle path: at spawn, each child's `:data` gets the framework-reserved
+;; `:rf/join-child` membership record (parent/invoke identity, logical child
+;; id, its own spawned instance address, the join's completion event
+;; keywords, and the opaque per-attempt token `spawn-all-init-fx` minted into
+;; the join state). When the child's own handler emits a matching completion
+;; dispatch, `stamp-join-completion-fx` (called at the handler-return
+;; boundary in `registration.cljc`) stamps that record onto the INNER event
+;; vector's METADATA under `:rf/join-auth` — the public event value is
+;; untouched, no application-facing surface is added, and only a dispatch
+;; that flowed through the member child's own boundary can carry the stamp.
+;;
+;; The interceptor's fold branch then requires the stamp to match
+;; runtime-owned join state EXACTLY — parent/invoke identity, logical child
+;; id, exact current actor id, exact attempt token — before a `:done` /
+;; `:failed` fold. Unstamped, superseded (prior attempt / wrong actor), and
+;; duplicate carriers are classified stale and perform ZERO mutation (no
+;; fold, no terminal publication, no resolution, no reap).
+;; ---------------------------------------------------------------------------
+
+(defn- join-completion-event?
+  "True iff `event` (a `[:dispatch …]` fx's event vector) IS this join
+  child's own completion carrier: exactly `[<parent-id> [<done-kw-or-
+  error-kw> <child-id> & extra]]` for the membership record `rec`. Only the
+  2-element outer shape is stampable — extra outer args are rebuilt by
+  `route-inner-event` at the parent (metadata would be lost) and no child
+  emits them for its own completion."
+  [event {:keys [parent-id child-id done-kw error-kw]}]
+  (and (vector? event)
+       (= 2 (count event))
+       (= parent-id (first event))
+       (let [inner (second event)]
+         (and (vector? inner)
+              (or (= done-kw (first inner))
+                  (= error-kw (first inner)))
+              (= child-id (second inner))))))
+
+(defn- stamp-completion-event
+  "Stamp the `:rf/join-auth` attempt-authentication metadata onto the INNER
+  event vector of a matching completion carrier. The stamped facts are the
+  exact-authority tuple the interceptor verifies: parent/invoke identity,
+  logical child id, the child's own spawned instance address, and the
+  opaque per-attempt token."
+  [event rec]
+  (let [inner (second event)
+        auth  (select-keys rec [:parent-id :invoke-id :child-id
+                                :spawned-id :attempt])]
+    (assoc event 1 (vary-meta inner assoc :rf/join-auth auth))))
+
+(defn- stamp-fx-entry
+  "Stamp one fx-vector entry when it dispatches this child's own completion
+  (`:dispatch` and `:dispatch-n` forms); every other entry rides through
+  untouched."
+  [fx-entry rec]
+  (if (and (vector? fx-entry) (>= (count fx-entry) 2))
+    (let [[fx-id arg] fx-entry]
+      (cond
+        (and (= :dispatch fx-id) (join-completion-event? arg rec))
+        (assoc fx-entry 1 (stamp-completion-event arg rec))
+
+        (and (= :dispatch-n fx-id) (sequential? arg))
+        (assoc fx-entry 1 (mapv #(if (join-completion-event? % rec)
+                                   (stamp-completion-event % rec)
+                                   %)
+                                arg))
+
+        :else fx-entry))
+    fx-entry))
+
+(defn stamp-join-completion-fx
+  "The child-boundary half of the exact-authority contract (rf2-nvxehu).
+  Given the effects map a `:spawn-all` child's handler is about to return
+  and the child's `:rf/join-child` membership record (nil for every
+  non-join-child actor — the common case, a no-op), stamp the
+  `:rf/join-auth` metadata onto each outbound completion carrier in `:fx`
+  targeting this child's own join. Called from the machine-handler return
+  boundary (`registration.cljc/commit-or-finalize`), so it covers action
+  fx, bootstrap-entry fx, and the finalize path uniformly — the existing
+  private lifecycle path, no new application-facing surface."
+  [effects join-child]
+  (if (and join-child
+           (map? effects)
+           (seq (:fx effects)))
+    (update effects :fx (fn [fxs] (mapv #(stamp-fx-entry % join-child) fxs)))
+    effects))
+
+(defn- join-auth-current?
+  "True iff the carrier's `:rf/join-auth` stamp matches the CURRENT join
+  attempt exactly: same parent/invoke identity, same logical child id, the
+  stamped actor is the actor CURRENTLY mapped to that child, and the
+  stamped attempt token equals the live join state's `:rf/attempt`. Every
+  clause is verified against runtime-owned state — nothing is trusted from
+  the carrier beyond equality with what the runtime already knows."
+  [auth parent-id invoke-id child-id join-state]
+  (and (map? auth)
+       (= parent-id (:parent-id auth))
+       (= invoke-id (:invoke-id auth))
+       (= child-id  (:child-id auth))
+       (some? (:attempt auth))
+       (= (:rf/attempt join-state) (:attempt auth))
+       (= (get-in join-state [:children child-id]) (:spawned-id auth))))
+
+(defn- suppress-stale-completion!
+  "Fail-closed suppression of a completion carrier that may NOT fold
+  (rf2-nvxehu): emit one `:rf.machine.spawn-all/stale-completion` trace
+  carrying the `:status :stale` / `:rf.reply/work-status :suppressed`
+  reply facts with the precise `stale-reason`
+  (`:rf.machine.spawn-all/attempt-unverified` — no runtime stamp;
+  `:rf.machine.spawn-all/attempt-superseded` — prior attempt / wrong
+  actor / mis-routed join; `:rf.machine.spawn-all/duplicate-completion` —
+  exact re-completion of an already-folded child), and return the no-op
+  effect map. ZERO mutation: no fold, no terminal publication, no
+  resolution, no reap. The post-resolution `:resolved?` branch keeps its
+  own `:rf.machine.spawn-all/late-completion` trace — this op covers the
+  PRE-resolution suppression classes."
+  [frame-id parent-id invoke-id join-state child-id kind completed-at
+   runtime-db stale-reason]
+  (let [spawned-id  (get-in join-state [:children child-id])
+        stale-reply (m-reply/stale-join-child-reply
+                      {:parent-id    parent-id
+                       :invoke-id    invoke-id
+                       :child-id     child-id
+                       :spawned-id   spawned-id
+                       :frame        frame-id
+                       :completed-at completed-at}
+                      kind stale-reason)
+        summary     (m-reply/trace-reply stale-reply {:frame frame-id})]
+    (trace/emit! :rf.machine :rf.machine.spawn-all/stale-completion
+                 (cond-> {:actor-id  parent-id
+                          :invoke-id invoke-id
+                          :child-id  child-id
+                          :kind      kind
+                          :frame     frame-id
+                          ;; reply-envelope vocabulary (Managed-Effects §9)
+                          :rf.reply/work-kind    (:rf.reply/work-kind summary)
+                          :rf.reply/status       (:status summary)
+                          :rf.reply/work-id      (:rf.reply/work-id summary)
+                          :rf.reply/work-status  (:rf.reply/work-status summary)
+                          :rf.reply/stale-reason (:rf.reply/stale-reason summary)
+                          :rf.reply/correlation  (:correlation summary)}
+                   (some? (:completed-at summary))
+                   (assoc :rf.reply/completed-at (:completed-at summary))))
+    {:rf.db/runtime runtime-db
+     :fx []}))
 
 (defn- find-active-spawn-all-in-tree
   "Helper for `find-active-spawn-alls`. Given a machine-like map with
@@ -543,45 +706,92 @@
               {:rf.db/runtime runtime-db :fx []})
 
           :else
-          ;; Read 'compute resolution; emit traces; build fx; write back':
-          ;; the body is now three named acts plus an assoc-in.
-          (let [join-state' (case kind
-                              :done   (update join-state :done   (fnil conj #{}) child-id)
-                              :failed (update join-state :failed (fnil conj #{}) child-id))
-                resolution   (compute-resolution spec join-state' kind)
-                join-state'' (assoc join-state' :resolved? (:resolved? resolution))]
-            ;; Surface a join that just became UNSATISFIABLE.
-            ;; When a child FAILS and the spec has no `:on-any-failed`, the
-            ;; failure folds into `:failed` without resolving; once enough
-            ;; children have failed that the success condition is unreachable
-            ;; the join hangs forever, silently. Emit a one-shot advisory on
-            ;; the fold that FIRST makes the join unsatisfiable (it was
-            ;; satisfiable before this fold, and this fold did not resolve) so
-            ;; the operator sees the dead join + the likely fix (declare
-            ;; `:on-any-failed`). Advisory severity: the request is not
-            ;; recovered, but the actor is not crashed — this is a config
-            ;; footgun nudge, the dev-advisory family (`:on-spawn-return-
-            ;; ignored`, the cofx lints), not an operation-recovery emit.
-            (when (and (not (:resolved? resolution))
-                       (join-unsatisfiable? spec join-state')
-                       (not (join-unsatisfiable? spec join-state)))
-              (trace/emit! :warning :rf.warning/spawn-all-join-unsatisfiable
-                           {:actor-id  parent-id
-                            :invoke-id invoke-id
-                            :join      (:join spec :all)
-                            :done      (:done   join-state')
-                            :failed    (:failed join-state')
-                            :total     (count (:children spec))
-                            :frame     frame-id
-                            :recovery  :join-hangs
-                            :reason    (str "A :spawn-all join can no longer be "
-                                            "satisfied — too many children have failed "
-                                            "and no :on-any-failed transition is declared, "
-                                            "so the join will hang forever. Declare "
-                                            ":on-any-failed to handle child failures.")}))
-            (emit-resolution-traces! frame-id parent-id invoke-id spec join-state''
-                                     child-id child-extra completed-at resolution)
-            (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
-                                          child-id child-extra resolution)]
-              {:rf.db/runtime (assoc-in runtime-db (paths/spawned-path parent-id invoke-id) join-state'')
-               :fx fx})))))))
+          ;; Exact-authority fold gate (rf2-nvxehu). Before ANY fold, the
+          ;; carrier must prove it belongs to THIS join attempt: the
+          ;; `:rf/join-auth` metadata the member child's own handler
+          ;; boundary stamped (`stamp-join-completion-fx`) must match the
+          ;; current join's parent/invoke identity, logical child id, exact
+          ;; current actor id, and exact attempt token. An UNSTAMPED carrier
+          ;; (a hand-crafted dispatch that never flowed through the member
+          ;; child's boundary) and a SUPERSEDED one (a prior attempt's
+          ;; straggler after parent re-entry / child respawn — including a
+          ;; `:fixed-actor-id` respawn where the actor id alone cannot
+          ;; discriminate attempts) are classified stale and fold NOTHING;
+          ;; a DUPLICATE exact completion of an already-folded child is
+          ;; likewise suppressed so one child attempt can never publish two
+          ;; terminals (rf2-ir4t5v). All three suppressions are
+          ;; zero-mutation fail-closed drops with stable typed evidence
+          ;; (`:rf.reply/stale-reason` on the stale-completion trace).
+          (let [auth (:rf/join-auth (meta inner-event))]
+            (cond
+              (nil? auth)
+              (suppress-stale-completion!
+                frame-id parent-id invoke-id join-state child-id kind
+                completed-at runtime-db
+                :rf.machine.spawn-all/attempt-unverified)
+
+              (not (join-auth-current? auth parent-id invoke-id child-id join-state))
+              (suppress-stale-completion!
+                frame-id parent-id invoke-id join-state child-id kind
+                completed-at runtime-db
+                :rf.machine.spawn-all/attempt-superseded)
+
+              (or (contains? (:done   join-state) child-id)
+                  (contains? (:failed join-state) child-id))
+              (suppress-stale-completion!
+                frame-id parent-id invoke-id join-state child-id kind
+                completed-at runtime-db
+                :rf.machine.spawn-all/duplicate-completion)
+
+              :else
+              (intercept-fold frame-id parent-id invoke-id spec join-state
+                              child-id kind child-extra completed-at
+                              runtime-db))))))))
+
+(defn- intercept-fold
+  "The verified fold body of `intercept-spawn-all-event` — the carrier has
+  passed the live-join / child-ownership / exact-authority gates. Read
+  'compute resolution; emit traces; build fx; write back': three named
+  acts plus an assoc-in."
+  [frame-id parent-id invoke-id spec join-state child-id kind child-extra
+   completed-at runtime-db]
+  (let [join-state'  (case kind
+                       :done   (update join-state :done   (fnil conj #{}) child-id)
+                       :failed (update join-state :failed (fnil conj #{}) child-id))
+        resolution   (compute-resolution spec join-state' kind)
+        join-state'' (assoc join-state' :resolved? (:resolved? resolution))]
+    ;; Surface a join that just became UNSATISFIABLE.
+    ;; When a child FAILS and the spec has no `:on-any-failed`, the
+    ;; failure folds into `:failed` without resolving; once enough
+    ;; children have failed that the success condition is unreachable
+    ;; the join hangs forever, silently. Emit a one-shot advisory on
+    ;; the fold that FIRST makes the join unsatisfiable (it was
+    ;; satisfiable before this fold, and this fold did not resolve) so
+    ;; the operator sees the dead join + the likely fix (declare
+    ;; `:on-any-failed`). Advisory severity: the request is not
+    ;; recovered, but the actor is not crashed — this is a config
+    ;; footgun nudge, the dev-advisory family (`:on-spawn-return-
+    ;; ignored`, the cofx lints), not an operation-recovery emit.
+    (when (and (not (:resolved? resolution))
+               (join-unsatisfiable? spec join-state')
+               (not (join-unsatisfiable? spec join-state)))
+      (trace/emit! :warning :rf.warning/spawn-all-join-unsatisfiable
+                   {:actor-id  parent-id
+                    :invoke-id invoke-id
+                    :join      (:join spec :all)
+                    :done      (:done   join-state')
+                    :failed    (:failed join-state')
+                    :total     (count (:children spec))
+                    :frame     frame-id
+                    :recovery  :join-hangs
+                    :reason    (str "A :spawn-all join can no longer be "
+                                    "satisfied — too many children have failed "
+                                    "and no :on-any-failed transition is declared, "
+                                    "so the join will hang forever. Declare "
+                                    ":on-any-failed to handle child failures.")}))
+    (emit-resolution-traces! frame-id parent-id invoke-id spec join-state''
+                             child-id child-extra completed-at resolution)
+    (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
+                                  child-id child-extra resolution)]
+      {:rf.db/runtime (assoc-in runtime-db (paths/spawned-path parent-id invoke-id) join-state'')
+       :fx fx})))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -20,7 +20,11 @@
       child id, exact current actor id, and exact attempt token. Unstamped
       / superseded / duplicate carriers are suppressed stale
       (`:rf.machine.spawn-all/stale-completion`) with zero mutation.
-   4. Adds `<child-id>` to `:done` or `:failed`.
+   4. Adds `<child-id>` to `:done` or `:failed`. A NON-DECISIVE fold (the
+      join does not resolve on it) publishes the child's canonical work
+      terminal at fold time via `:rf.machine.spawn-all/child-completed`
+      (rf2-ir4t5v); the DECISIVE fold's terminal rides the resolution
+      trace instead — one terminal authority per child.
    5. If `:resolved?` is already true, this is a post-resolution
       late-completion (it fires NO further parent event — the
       `:resolved?` latch already flipped). Surviving siblings are
@@ -365,17 +369,22 @@
      :resolution-event resolution-event
      :join-event-kw    join-event-kw}))
 
-(defn- decisive-child-reply-facts
-  "Build the reply-envelope facts for the DECISIVE child completion that
-  drove a `:spawn-all` join resolution, ready to ride
-  ADDITIVELY on the resolution trace (Managed-Effects §Tracing /
-  §Status taxonomy). The decisive child's completion IS the managed-async
-  completion that resolved the join, so it lowers through the shared
-  `join-child-reply` (`:status :ok` for the `:done`-side resolutions,
-  `:status :error` for the `:on-any-failed` resolution) — the same uniform
-  vocabulary the single-`:spawn` `:rf.machine/done` reply carries. Returns
-  a tag-map fragment `{:rf.reply/work-id … :rf.reply/status … …}` to merge into the
-  resolution trace, or `{}` when no decisive child is resolvable.
+(defn- child-completion-reply-facts
+  "Build the reply-envelope facts for ONE accepted child completion —
+  the canonical `:completed` / `:failed` terminal for that child's work
+  attempt, lowered through the shared `join-child-reply` (`:status :ok`
+  for a `:done` fold, `:status :error` for a `:failed` fold) — the same
+  uniform vocabulary the single-`:spawn` `:rf.machine/done` reply carries.
+  Returns a tag-map fragment `{:rf.reply/work-id … :rf.reply/status … …}`.
+
+  ONE AUTHORITY PER CHILD (rf2-ir4t5v): these facts ride EXACTLY ONE trace
+  per accepted fold — the `:rf.machine.spawn-all/child-completed` fold
+  trace for a NON-DECISIVE fold (the join did not resolve), or ADDITIVELY
+  on the resolution trace for the DECISIVE fold (the join resolved). The
+  two emits sit on opposite arms of the fold's `(:resolved? resolution)`
+  split (`intercept-fold`), so a child attempt can never publish its
+  terminal twice; duplicate pre-resolution signals are suppressed upstream
+  by the exact-authority gate, and post-resolution arrivals stay `:stale`.
 
   `kind` is the arriving child's fold kind (`:done` / `:failed`);
   `child-extra` is its forwarded payload (the `:value` for a `:done`,
@@ -398,6 +407,39 @@
              :rf.reply/correlation (:correlation summary)}
       (some? (:completed-at summary))
       (assoc :rf.reply/completed-at (:completed-at summary)))))
+
+(defn- emit-child-fold-terminal!
+  "Fire the `:rf.machine.spawn-all/child-completed` trace for a
+  NON-DECISIVE accepted fold (rf2-ir4t5v) — the canonical `:completed` /
+  `:failed` work terminal for a child whose first valid completion folded
+  into a join that did NOT resolve on it. Without this, a non-decisive
+  child's work attempt ended with NO terminal status at all: the join
+  machinery published terminals only through the final resolution trace,
+  so in an `:all` join every child but the decisive one was folded
+  silently, then reaped without cancellation — stranding
+  work-ledger/Xray projections on an open attempt.
+
+  The DECISIVE fold's terminal rides the resolution trace instead
+  (`emit-resolution-traces!`); the two emits sit on opposite arms of the
+  fold's `(:resolved? resolution)` split, so each child attempt has
+  exactly ONE terminal authority. Duplicate pre-resolution signals never
+  reach here (suppressed by the exact-authority gate) and post-resolution
+  arrivals stay `:stale` — one terminal per work attempt, closed."
+  [frame-id parent-id invoke-id join-state'' child-id kind child-extra
+   completed-at]
+  (let [spawned-id (get-in join-state'' [:children child-id])]
+    (trace/emit! :rf.machine :rf.machine.spawn-all/child-completed
+                 (merge {:actor-id   parent-id
+                         :invoke-id  invoke-id
+                         :child-id   child-id
+                         :spawned-id spawned-id
+                         :kind       kind
+                         :done       (:done   join-state'')
+                         :failed     (:failed join-state'')
+                         :frame      frame-id}
+                        (child-completion-reply-facts
+                          frame-id parent-id invoke-id join-state''
+                          child-id kind child-extra completed-at)))))
 
 (defn- emit-resolution-traces!
   "Fire the post-resolution observability traces in order: any-failed,
@@ -428,11 +470,11 @@
                          :failed     (:failed join-state'')
                          :done       (:done   join-state'')
                          :frame      frame-id}
-                        (decisive-child-reply-facts
+                        (child-completion-reply-facts
                           frame-id parent-id invoke-id join-state''
                           child-id :failed child-extra completed-at))))
   (when success-fired?
-    (let [reply-facts (decisive-child-reply-facts
+    (let [reply-facts (child-completion-reply-facts
                         frame-id parent-id invoke-id join-state''
                         child-id :done child-extra completed-at)]
       (if (= :all (:join spec :all))
@@ -789,8 +831,14 @@
                                     "and no :on-any-failed transition is declared, "
                                     "so the join will hang forever. Declare "
                                     ":on-any-failed to handle child failures.")}))
-    (emit-resolution-traces! frame-id parent-id invoke-id spec join-state''
-                             child-id child-extra completed-at resolution)
+    ;; ONE terminal authority per child (rf2-ir4t5v): a DECISIVE fold's
+    ;; terminal rides the resolution trace; a NON-DECISIVE fold publishes
+    ;; its canonical terminal HERE, at first valid fold — never both.
+    (if (:resolved? resolution)
+      (emit-resolution-traces! frame-id parent-id invoke-id spec join-state''
+                               child-id child-extra completed-at resolution)
+      (emit-child-fold-terminal! frame-id parent-id invoke-id join-state''
+                                 child-id kind child-extra completed-at))
     (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
                                   child-id child-extra resolution)]
       {:rf.db/runtime (assoc-in runtime-db (paths/spawned-path parent-id invoke-id) join-state'')

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -739,11 +739,22 @@
                       :before     snapshot
                       :after      next-snapshot
                       :frame      frame-id}))
-      (if finished?
-        (finalize/finalize-machine machine machine-id frame-id
-                                   new-runtime-db next-snapshot inner-event merged-fx)
-        {:rf.db/runtime new-runtime-db
-         :fx            merged-fx}))))
+      ;; Exact-authority stamping (rf2-nvxehu): when THIS actor is a
+      ;; `:spawn-all` join child (its `:data` carries the framework-reserved
+      ;; `:rf/join-child` membership record the spawn stamped), stamp the
+      ;; `:rf/join-auth` attempt-authentication metadata onto each outbound
+      ;; completion carrier in the returned `:fx` — action fx, bootstrap-entry
+      ;; fx, and the finalize path all flow through this single return seam.
+      ;; A non-join-child actor (record nil — the common case) rides through
+      ;; untouched. The parent's join interceptor refuses to fold any carrier
+      ;; that did not pass through its member child's own boundary here.
+      (join/stamp-join-completion-fx
+        (if finished?
+          (finalize/finalize-machine machine machine-id frame-id
+                                     new-runtime-db next-snapshot inner-event merged-fx)
+          {:rf.db/runtime new-runtime-db
+           :fx            merged-fx})
+        (get-in snapshot [:data :rf/join-child])))))
 
 (defn- reject-internal-event-external-dispatch
   "The public/private `:internal-events` boundary, checked at

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -204,14 +204,52 @@
   "Stamp framework-reserved keys into the spawned actor's
   initial `:data` so the actor knows its own address (`:rf/self-id`)
   and, for declarative-`:spawn` spawns, its parent's address +
-  invoke-id."
-  [spec spawned-id parent-id invoke-id]
+  invoke-id. `join-child` (a `:spawn-all` child's private join-membership
+  record — see `join-child-record`) rides under `:rf/join-child` when
+  present."
+  [spec spawned-id parent-id invoke-id join-child]
   (when spec
     (let [base-data (or (:data spec) {})
           data'     (cond-> (assoc base-data :rf/self-id spawned-id)
-                      parent-id (assoc :rf/parent-id parent-id)
-                      invoke-id (assoc :rf/invoke-id invoke-id))]
+                      parent-id  (assoc :rf/parent-id parent-id)
+                      invoke-id  (assoc :rf/invoke-id invoke-id)
+                      join-child (assoc :rf/join-child join-child))]
       (assoc spec :data data'))))
+
+(defn- join-child-record
+  "Build the PRIVATE join-membership record the runtime stamps into a
+  `:spawn-all` child's `:data` under `:rf/join-child` (rf2-nvxehu). It
+  carries the exact coordinates of the join ATTEMPT this child instance
+  belongs to — the parent/invoke identity, the logical child id, the
+  child's own spawned instance address, the join's completion event
+  keywords, and the opaque per-attempt token the seeding
+  `spawn-all-init-fx` minted into the join state. The child's
+  machine-handler boundary reads it to stamp outbound completion carriers
+  with the attempt authentication the parent's join interceptor verifies
+  (`join/stamp-join-completion-fx` / `intercept-spawn-all-event`), so a
+  stale completion from a PRIOR attempt / prior actor incarnation can
+  never fold into a successor join. Framework-reserved, never
+  application-facing.
+
+  Returns nil for non-`:spawn-all` spawns and for a rejected invoke (the
+  reject sentinel carries no `:children`).
+
+  Ordering note: `spawn-all-init-fx` is the FIRST fx in the entry vector,
+  ahead of every per-child `:rf.machine/spawn`, so the per-attempt token is
+  ALWAYS in runtime-db by the time this reads it (the same ordering
+  `spawn-all-invoke-rejected?` relies on)."
+  [runtime-db args spawned-id]
+  (when-let [invoke-id (:rf/spawn-all-id args)]
+    (let [parent-id  (:rf/parent-id args)
+          join-state (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
+      (when (and (map? join-state) (contains? join-state :children))
+        {:parent-id  parent-id
+         :invoke-id  invoke-id
+         :child-id   (:rf/spawn-all-child-id args)
+         :spawned-id spawned-id
+         :done-kw    (get-in join-state [:spec :on-child-done])
+         :error-kw   (get-in join-state [:spec :on-child-error])
+         :attempt    (:rf/attempt join-state)}))))
 
 ;; The spawned actor's initial snapshot is built by
 ;; `parallel/build-initial-snapshot` — the single source of truth shared
@@ -426,7 +464,8 @@
           (and old-rt machine-id-for-alloc)
                         (allocate-actor-id-in-runtime-db old-rt machine-id-for-alloc)
           :else         [old-rt nil])
-        spec''     (stamp-framework-data spec' spawned-id parent-id invoke-id)
+        spec''     (stamp-framework-data spec' spawned-id parent-id invoke-id
+                                         (join-child-record old-rt args spawned-id))
         ;; Build the initial snapshot ONCE here so the schema-rejection
         ;; decision can gate every side effect below; `install-spawn!`
         ;; threads the same value rather than re-building it.
@@ -553,6 +592,22 @@
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------
 
+(defonce ^:private join-attempt-counter
+  ;; Monotonic per-seed attempt-token source (rf2-nvxehu; mirrors
+  ;; `timer/after-attempt-counter`). Every LIVE `:spawn-all` seed mints one
+  ;; opaque token into the join state under `:rf/attempt`, and the same token
+  ;; is stamped into each child's private `:rf/join-child` membership record —
+  ;; so the parent's join interceptor can bind every completion carrier to the
+  ;; exact join ATTEMPT that spawned it. Actor ids alone cannot discriminate a
+  ;; re-entry respawn (`:fixed-actor-id` children reuse the SAME id across
+  ;; attempts; `actor-generation` is always 1 for them), hence the token.
+  ;; Uniqueness is per-session accident-gating (the machines security stance:
+  ;; trust the explicit invoker, gate accidents), not cryptographic.
+  (atom 0))
+
+(defn- next-join-attempt-token []
+  (swap! join-attempt-counter inc))
+
 (defn spawn-all-init-fx
   "fx handler for `:rf.machine/spawn-all-init`. Per Spec 005
   §Spawn-and-join via `:spawn-all`, on entry to a `:spawn-all`-bearing
@@ -560,11 +615,12 @@
   fxs) to seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in
   the frame's runtime-db. The seed map shape is:
 
-    {:children {<child-id> <spawned-id>, ...}
-     :done      #{}
-     :failed    #{}
-     :resolved? false
-     :spec      <invoke-all-spec>}
+    {:children   {<child-id> <spawned-id>, ...}
+     :done       #{}
+     :failed     #{}
+     :resolved?  false
+     :spec       <invoke-all-spec>
+     :rf/attempt <opaque-attempt-token>}   ;; minted HERE per live seed (rf2-nvxehu)
 
   Subsequent `:on-child-done` / `:on-child-error` events arrive at the
   parent's `make-machine-handler` boundary and are intercepted by
@@ -631,7 +687,14 @@
                                   (paths/spawned-path parent-id invoke-id)
                                   spawn-all-reject-sentinel)
           nil)
-      (do
+      (let [;; Mint the opaque per-attempt token (rf2-nvxehu). One LIVE seed =
+            ;; one join ATTEMPT; the token rides the join state AND each
+            ;; child's `:rf/join-child` membership record (stamped by the
+            ;; per-child spawn fxs that run AFTER this fx in the same entry
+            ;; vector), binding every completion carrier to this exact
+            ;; attempt. The reject sentinel branch above mints NO token —
+            ;; a rejected invoke has no attempt to authenticate against.
+            join-state (assoc join-state :rf/attempt (next-join-attempt-token))]
         ;; Machine spawn-registry state is durable runtime-db state.
         (frame/swap-runtime-db! frame-id assoc-in
                                 (paths/spawned-path parent-id invoke-id) join-state)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -100,7 +100,7 @@
   trace fires — the fx refuses rather than silently choosing a semantic
   reason (rf2-3lyqzu).
 
-  Two `cause`s:
+  The closed `cause` vocabulary:
 
     - `:unverified-reap` — a `{:rf/reap true :rf/parent-id p :rf/invoke-id i
       :rf/child-id c}` reap request whose claim does NOT match the live join
@@ -111,13 +111,28 @@
       the named actor is the completed / failed child of the named join —
       an in-progress actor's teardown is always an `:explicit` cancellation.
 
+    - `:unresolved-join` — a reap whose terminal claim the join state DOES
+      substantiate, arriving AHEAD of the join attempt's `:resolved?` latch
+      (rf2-nvxehu). Reaping is a post-resolution act: a non-decisive
+      completed child of a still-waiting `:all` join cannot be reaped early
+      through the public reserved-fx boundary.
+
+    - `:slot-shape-mismatch` — a well-formed tracked / spawn-all form whose
+      addressed `[:spawned p i]` slot holds the OTHER form's shape
+      (rf2-3phait): the tracked single-`:spawn` form resolving a `:spawn-all`
+      join-state MAP (consuming it as an actor id would clear the join slot
+      and orphan every live child), or the spawn-all form resolving an
+      actor-id KEYWORD.
+
     - `:unknown-shape` — a map matching NONE of the known destroy shapes
       (the keyword `actor-id` form, the tracked `{:rf/parent-id :rf/invoke-id}`
       `:spawn` exit-cascade form, the `:rf/spawn-all` form, or the verified
       reap). Notably this is the pre-auth forgery
       `{:rf/actor-id … :rf/reason …}`, which used to mint a CALLER-chosen
       destroyed reason and thereby suppress the cancellation terminal of an
-      in-progress actor at the public reserved-fx boundary.
+      in-progress actor at the public reserved-fx boundary — and every
+      false-valued / wrong-typed discriminator, missing or wrongly-typed
+      coordinate, and overlapping discriminator set (rf2-3phait).
 
   Diagnostic channel (DCE'd in production), matching the sibling forgery
   guard `:rf.error/machine-spawn-all-bad-child-id`: the SAFE behaviour (no

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -408,14 +408,27 @@
   in-region prefix-path. To keep the
   runtime-owned `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot unique
   per-region (and per-region `:after` epoch tracking distinct from sibling
-  regions), prepend the region name onto the `:rf/invoke-id`."
-  [region-name fx]
-  (let [[fx-id args] fx]
-    (cond
-      (and (map? args) (contains? args :rf/invoke-id))
-      [fx-id (update args :rf/invoke-id #(vec (cons region-name %)))]
+  regions), prepend the region name onto the `:rf/invoke-id`.
 
-      :else fx)))
+  A `:spawn-all` PER-CHILD spawn fx carries the same invocation path under
+  `:rf/spawn-all-id` (its join-slot key — deliberately NOT `:rf/invoke-id`,
+  which would make `spawn-fx` track the child in a per-child slot). It must
+  be region-prefixed IDENTICALLY, or the child-side join reads
+  (`spawn-all-invoke-rejected?`, the `:rf/join-child` membership record —
+  rf2-nvxehu) address a slot the region's `spawn-all-init-fx` never seeded."
+  [region-name fx]
+  (let [[fx-id args] fx
+        prefix-path  #(vec (cons region-name %))]
+    (if (and (map? args)
+             (or (contains? args :rf/invoke-id)
+                 (contains? args :rf/spawn-all-id)))
+      [fx-id (cond-> args
+               (contains? args :rf/invoke-id)
+               (update :rf/invoke-id prefix-path)
+
+               (contains? args :rf/spawn-all-id)
+               (update :rf/spawn-all-id prefix-path))]
+      fx)))
 
 ;; ---- initial-state entry cascade ------------------------------------------
 ;;

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -332,22 +332,30 @@
 
 (defn stale-join-child-reply
   "Build the `:status :stale` reply for a `:spawn-all` join-child
-  completion that arrived AFTER the join already resolved (the
-  post-resolution late-completion branch). Per Managed-Effects §Stale
-  suppression the late completion MUST NOT mutate the join (the join is
-  latched `:resolved?`); this reply carries NO `:value` and represents the
-  drop the reply-envelope way — `:rf.reply/stale-reason
-  :rf.machine.spawn-all/join-resolved`, `:rf.reply/work-status :suppressed`.
+  completion that the runtime SUPPRESSED. The 2-arity is the
+  post-resolution late-completion (`:rf.reply/stale-reason
+  :rf.machine.spawn-all/join-resolved` — the join is latched `:resolved?`);
+  the 3-arity threads an explicit `stale-reason` for the other suppression
+  classes (rf2-nvxehu): `:rf.machine.spawn-all/attempt-unverified` (a
+  completion carrier with no runtime attempt authentication),
+  `:rf.machine.spawn-all/attempt-superseded` (a carrier bound to a PRIOR
+  child attempt / wrong actor after respawn or re-entry), and
+  `:rf.machine.spawn-all/duplicate-completion` (an exact re-completion of an
+  already-folded child). Per Managed-Effects §Stale suppression the
+  suppressed completion MUST NOT mutate the join; this reply carries NO
+  `:value`, `:rf.reply/work-status :suppressed`.
 
-  Work-id matches `join-child-reply`'s so the suppressed late completion
-  joins the same uniform work/reply row as the child's earlier (decisive
-  or non-decisive) fold. `ctx` keys mirror `join-child-reply`'s; `kind`
+  Work-id matches `join-child-reply`'s so the suppressed completion joins
+  the same uniform work/reply row as the child's earlier (decisive or
+  non-decisive) fold. `ctx` keys mirror `join-child-reply`'s; `kind`
   (`:done` / `:failed`) rides under `:correlation` as the would-be fold
   kind. Optional facts omitted when absent."
-  [{:keys [parent-id invoke-id child-id spawned-id frame completed-at]} kind]
-  (cond-> {:status       :stale
+  ([ctx kind]
+   (stale-join-child-reply ctx kind :rf.machine.spawn-all/join-resolved))
+  ([{:keys [parent-id invoke-id child-id spawned-id frame completed-at]} kind stale-reason]
+   (cond-> {:status       :stale
            :stale?       true
-           :rf.reply/stale-reason :rf.machine.spawn-all/join-resolved
+           :rf.reply/stale-reason stale-reason
            :rf.reply/work-id      (spawn-work-id spawned-id invoke-id)
            :rf.reply/work-kind    :machine
            :rf.reply/work-status  :suppressed
@@ -357,8 +365,8 @@
                            (some? child-id)   (assoc :child-id child-id)
                            (some? spawned-id) (assoc :spawned-id spawned-id)
                            (some? kind)       (assoc :kind kind))}
-    (some? frame)        (assoc :rf.frame/id frame)
-    (some? completed-at) (assoc :completed-at completed-at)))
+     (some? frame)        (assoc :rf.frame/id frame)
+     (some? completed-at) (assoc :completed-at completed-at))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:after` timer — the existing specialized stale-gated reply instance

--- a/implementation/machines/test/re_frame/destroy_closed_grammar_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_closed_grammar_cljs_test.cljc
@@ -1,0 +1,287 @@
+(ns re-frame.destroy-closed-grammar-cljs-test
+  "rf2-3phait — the `:rf.machine/destroy` map-form grammar is a CLOSED
+  discriminated union. Presence of a discriminator key (`:rf/reap` /
+  `:rf/spawn-all`) SELECTS that shape; the shape then requires the value
+  exactly `true` plus the exact coordinate fields/types. Any malformed,
+  overlapping, or unknown map shape emits exactly one
+  `:rf.error/machine-destroy-bad-arg` and performs ZERO mutation — no slot,
+  actor, child, trace, terminal-reply, or ownership change.
+
+  The pre-fix defect: the map-shape dispatch tested TRUTHINESS of
+  `(:rf/reap args)`, so `{:rf/reap false :rf/parent-id p :rf/invoke-id i
+  :rf/child-id c}` fell through to the tracked single-`:spawn` branch. With
+  a `:spawn-all` join at the addressed slot, that branch read the WHOLE
+  join-state map as the slot's actor id, cleared the join slot, left the
+  real children live and orphaned, and emitted a bogus
+  `:rf.machine/destroyed` trace whose actor id was the join-state map — and
+  no bad-arg error. (`destroy-machine-fx`'s `:rf/spawn-all` routing had the
+  same truthy-fall-through: `{:rf/spawn-all false …}` reached the tracked
+  branch too.)
+
+  The file is named `*-cljs-test.cljc` so it's discovered by both
+  cognitect-style JVM runs and shadow-cljs (`cljs-test$` ns-regexp)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load the machines artefact so its fx handlers + late-bind hooks are
+   ;; installed when this ns runs in isolation.
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- destroyed-traces []
+  (mtest/events-of :rf.machine/destroyed))
+
+(defn- bad-arg-traces []
+  (mtest/events-of :rf.error/machine-destroy-bad-arg))
+
+(defn- join-state [parent-id invoke-id]
+  (get-in (mtest/runtime-db)
+          [:rf.runtime/machines :spawned parent-id invoke-id]))
+
+;; A child that stays LIVE (its states are not :final?) and never
+;; auto-dispatches back — so join state stays pristine while we throw
+;; malformed destroy carriers at it.
+(def ^:private inert-child
+  {:initial :running
+   :data    {}
+   :states  {:running {}}})
+
+(defn- reg-join-parent!
+  "Register a two-child :spawn-all parent + inert children and start it.
+  Returns the seeded join-state map."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine child-a-kw inert-child)
+  (rf/reg-machine child-b-kw inert-child)
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw}
+                                           {:id :b :machine-id child-b-kw}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}}}})
+  (rf/dispatch-sync [parent-kw [:start]])
+  (join-state parent-kw [:racing]))
+
+(defn- destroy-with!
+  "Fire one `[:rf.machine/destroy args]` through an ordinary app event."
+  [args]
+  (rf/reg-event ::fire-destroy
+    (fn [_ [_ a]] {:fx [[:rf.machine/destroy a]]}))
+  (rf/dispatch-sync [::fire-destroy args]))
+
+(defn- assert-zero-mutation!
+  "The load-bearing zero-mutation assertion set: join slot intact (same
+  value), both children still live, no destroyed trace."
+  [parent-kw pre-join]
+  (let [post-join (join-state parent-kw [:racing])
+        children  (:children pre-join)]
+    (is (= pre-join post-join)
+        "the join slot is byte-identical — no slot mutation")
+    (doseq [[cid spawned-id] children]
+      (is (some? (mtest/snapshot spawned-id))
+          (str "child " cid " (" spawned-id ") is still live")))
+    (is (empty? (destroyed-traces))
+        (str "no :rf.machine/destroyed fired; saw "
+             (mapv :tags (destroyed-traces))))))
+
+;; ---- the P1 corruption repro: {:rf/reap false …} ---------------------------
+
+(deftest reap-false-carrier-fails-closed
+  (testing "rf2-3phait — {:rf/reap false + exact coordinates} is a MALFORMED
+            reap carrier: it must emit exactly one
+            :rf.error/machine-destroy-bad-arg and mutate NOTHING. Pre-fix it
+            fell through to the tracked branch, read the join-state map as an
+            actor id, cleared the join slot, orphaned both live children, and
+            emitted a bogus destroyed trace with zero bad-arg errors."
+    (let [pre-join (reg-join-parent! :dcg/p1 :dcg/p1a :dcg/p1b)]
+      (is (map? (:children pre-join)) "live two-child join seeded")
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      false
+                      :rf/parent-id :dcg/p1
+                      :rf/invoke-id [:racing]
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces)))
+          "exactly one :rf.error/machine-destroy-bad-arg fired")
+      (is (keyword? (:cause (:tags (first (bad-arg-traces)))))
+          "the bad-arg error carries stable typed :cause evidence")
+      (assert-zero-mutation! :dcg/p1 pre-join))))
+
+;; ---- nil / wrong-typed :rf/reap values -------------------------------------
+
+(deftest reap-nil-value-fails-closed
+  (testing "rf2-3phait — {:rf/reap nil …}: presence of :rf/reap selects the
+            reap shape; a nil value is malformed (fail closed, zero mutation)"
+    (let [pre-join (reg-join-parent! :dcg/p2 :dcg/p2a :dcg/p2b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      nil
+                      :rf/parent-id :dcg/p2
+                      :rf/invoke-id [:racing]
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p2 pre-join))))
+
+(deftest reap-wrong-type-value-fails-closed
+  (testing "rf2-3phait — {:rf/reap \"true\" …}: only the exact value true is
+            the reap discriminator; truthy aliases are malformed"
+    (let [pre-join (reg-join-parent! :dcg/p3 :dcg/p3a :dcg/p3b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      "true"
+                      :rf/parent-id :dcg/p3
+                      :rf/invoke-id [:racing]
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p3 pre-join))))
+
+;; ---- missing / wrongly-typed coordinates -----------------------------------
+
+(deftest reap-missing-coordinate-fails-closed
+  (testing "rf2-3phait — a reap missing :rf/invoke-id is malformed"
+    (let [pre-join (reg-join-parent! :dcg/p4 :dcg/p4a :dcg/p4b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      true
+                      :rf/parent-id :dcg/p4
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p4 pre-join))))
+
+(deftest reap-wrongly-typed-coordinate-fails-closed
+  (testing "rf2-3phait — a reap whose :rf/invoke-id is not a path vector is
+            malformed (exact coordinate types, no permissive coercion)"
+    (let [pre-join (reg-join-parent! :dcg/p5 :dcg/p5a :dcg/p5b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      true
+                      :rf/parent-id :dcg/p5
+                      :rf/invoke-id :racing
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p5 pre-join))))
+
+;; ---- overlapping discriminators / unknown keys -----------------------------
+
+(deftest overlapping-discriminators-fail-closed
+  (testing "rf2-3phait — a carrier declaring BOTH :rf/reap and :rf/spawn-all
+            is an overlapping shape: fail closed, zero mutation"
+    (let [pre-join (reg-join-parent! :dcg/p6 :dcg/p6a :dcg/p6b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      true
+                      :rf/spawn-all true
+                      :rf/parent-id :dcg/p6
+                      :rf/invoke-id [:racing]
+                      :rf/child-id  :a})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p6 pre-join))))
+
+(deftest spawn-all-false-carrier-fails-closed
+  (testing "rf2-3phait — {:rf/spawn-all false …} is malformed (presence
+            selects the spawn-all shape; the value must be exactly true).
+            Pre-fix it fell through destroy-machine-fx's truthy routing into
+            the tracked branch and corrupted the join slot"
+    (let [pre-join (reg-join-parent! :dcg/p7 :dcg/p7a :dcg/p7b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/spawn-all false
+                      :rf/parent-id :dcg/p7
+                      :rf/invoke-id [:racing]})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p7 pre-join))))
+
+(deftest unknown-extra-key-fails-closed
+  (testing "rf2-3phait — a well-discriminated reap carrying an EXTRA unknown
+            key is outside the closed grammar: fail closed"
+    (let [pre-join (reg-join-parent! :dcg/p8 :dcg/p8a :dcg/p8b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/reap      true
+                      :rf/parent-id :dcg/p8
+                      :rf/invoke-id [:racing]
+                      :rf/child-id  :a
+                      :rf/extra     1})
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p8 pre-join))))
+
+;; ---- tracked form pointed at a spawn-all join slot -------------------------
+
+(deftest tracked-form-at-spawn-all-slot-fails-closed
+  (testing "rf2-3phait — the tracked single-:spawn form {:rf/parent-id
+            :rf/invoke-id} resolving a slot that holds a spawn-all JOIN-STATE
+            MAP must fail closed: the tracked branch can never consume a
+            join-state map as an actor id"
+    (let [pre-join (reg-join-parent! :dcg/p9 :dcg/p9a :dcg/p9b)]
+      (mtest/reset-captured!)
+      (destroy-with! {:rf/parent-id :dcg/p9
+                      :rf/invoke-id [:racing]})
+      (is (= 1 (count (bad-arg-traces)))
+          "the tracked form addressed at a join slot fails loud")
+      (assert-zero-mutation! :dcg/p9 pre-join))))
+
+;; ---- non-map, non-keyword args ---------------------------------------------
+
+(deftest non-keyword-non-map-arg-fails-closed
+  (testing "rf2-3phait — the imperative form requires a keyword actor id;
+            any other non-map arg is outside the closed grammar"
+    (let [pre-join (reg-join-parent! :dcg/p10 :dcg/p10a :dcg/p10b)]
+      (mtest/reset-captured!)
+      (destroy-with! "not-an-actor-id")
+      (is (= 1 (count (bad-arg-traces))))
+      (assert-zero-mutation! :dcg/p10 pre-join))))
+
+;; ---- genuine forms stay green ----------------------------------------------
+
+(deftest genuine-tracked-destroy-stays-green
+  (testing "rf2-3phait — the genuine tracked single-:spawn exit-cascade
+            destroy still tears the tracked child down exactly once"
+    (rf/reg-machine :dcg/live-child inert-child)
+    (rf/reg-machine :dcg/tracked-parent
+      {:initial :idle
+       :states  {:idle    {:on {:start :working}}
+                 :working {:spawn {:machine-id :dcg/live-child}
+                           :on    {:stop :idle}}}})
+    (rf/dispatch-sync [:dcg/tracked-parent [:start]])
+    (let [child-id (get-in (mtest/runtime-db)
+                           [:rf.runtime/machines :spawned :dcg/tracked-parent [:working]])]
+      (is (keyword? child-id) "single tracked :spawn child live")
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [:dcg/tracked-parent [:stop]])
+      (is (nil? (mtest/snapshot child-id)) "tracked child torn down on exit")
+      (is (= 1 (count (filterv #(= child-id (:actor-id (:tags %)))
+                               (destroyed-traces))))
+          "exactly one destroyed trace for the tracked child")
+      (is (empty? (bad-arg-traces))
+          "no bad-arg error for the genuine tracked form"))))
+
+(deftest genuine-spawn-all-exit-stays-green
+  (testing "rf2-3phait — the genuine {:rf/spawn-all true} exit-cascade form
+            still tears every child down and clears the slot"
+    (rf/reg-machine :dcg/sa-child inert-child)
+    (rf/reg-machine :dcg/sa-parent
+      {:initial :idle
+       :states  {:idle    {:on {:start :racing}}
+                 :racing  {:spawn-all
+                           {:children        [{:id :a :machine-id :dcg/sa-child}
+                                              {:id :b :machine-id :dcg/sa-child}]
+                            :join            :all
+                            :on-child-done   :child/done
+                            :on-child-error  :child/failed
+                            :on-all-complete [:all/done]}
+                           :on {:abort :idle}}}})
+    (rf/dispatch-sync [:dcg/sa-parent [:start]])
+    (let [children (:children (join-state :dcg/sa-parent [:racing]))]
+      (is (= 2 (count children)))
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [:dcg/sa-parent [:abort]])
+      (is (nil? (join-state :dcg/sa-parent [:racing])) "join slot cleared")
+      (doseq [[cid spawned-id] children]
+        (is (nil? (mtest/snapshot spawned-id))
+            (str "child " cid " torn down on exit")))
+      (is (empty? (bad-arg-traces))
+          "no bad-arg error for the genuine spawn-all exit form"))))

--- a/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
@@ -1,0 +1,263 @@
+(ns re-frame.join-child-terminal-cljs-test
+  "rf2-ir4t5v — every non-decisive `:spawn-all` child publishes exactly one
+  canonical work terminal.
+
+  Pre-fix, the join machinery emitted terminal work-reply facts ONLY
+  through the final resolution trace. In an `:all` join, a child completing
+  before the decisive child was folded into `:done` silently — it never
+  received a canonical `:completed` reply — and was later reaped without
+  cancellation, so its work attempt ended with NO terminal status at all
+  (first child A statuses `[]`, decisive child B `[:completed]`). Failed
+  non-decisive folds had the analogous missing `:failed` fact. That
+  contradicts the closed one-terminal-per-work-attempt contract and
+  strands work-ledger/Xray projections.
+
+  Post-fix, the canonical terminal is published exactly once at the FIRST
+  valid fold via `:rf.machine.spawn-all/child-completed` when the fold is
+  non-decisive, while the decisive child's terminal continues to ride the
+  resolution trace — the two emits sit on opposite arms of the fold's
+  `(:resolved? resolution)` split, so no child is double-published.
+  Duplicate pre-resolution signals are suppressed by the exact-authority
+  gate (rf2-nvxehu); post-resolution arrivals remain `:stale`; survivors
+  cancelled by `:any`/failure resolution still close exactly once as
+  `:cancelled`.
+
+  The file is named `*-cljs-test.cljc` so it's discovered by both
+  cognitect-style JVM runs and shadow-cljs (`cljs-test$` ns-regexp)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load the machines artefact so its fx handlers + late-bind hooks are
+   ;; installed when this ns runs in isolation.
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(def ^:private terminal-work-statuses
+  "The closed TERMINAL work-status set — a child attempt closes on exactly
+  one of these (`:suppressed` is the stale/duplicate non-terminal drop)."
+  #{:completed :failed :cancelled})
+
+(defn- work-statuses-for
+  "Every `:rf.reply/work-status` carried by a captured trace whose
+  `:rf.reply/work-id` names `spawned-id` (its 2nd element — the child's
+  spawned instance address), across ALL trace ops — how a durable
+  work-ledger / Xray projection groups one child attempt's reply facts."
+  [spawned-id]
+  (into []
+        (comp (map :tags)
+              (filter #(= spawned-id (second (:rf.reply/work-id %))))
+              (keep :rf.reply/work-status))
+        (or (mtest/captured-events) [])))
+
+(defn- terminals-for [spawned-id]
+  (filterv terminal-work-statuses (work-statuses-for spawned-id)))
+
+(defn- child-completed-traces []
+  (mtest/events-of :rf.machine.spawn-all/child-completed))
+
+(defn- join-state [parent-id]
+  (get-in (mtest/runtime-db)
+          [:rf.runtime/machines :spawned parent-id [:racing]]))
+
+(defn- mk-child [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}]
+                              {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})
+             :dispatch-err  (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/failed (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-err}}}
+             :done   {}
+             :failed {}}})
+
+(defn- reg-join-parent!
+  "Register a two-child join parent (join mode + resolution keys via
+  `spawn-all-extra`) + dispatching children and start it. The parent stays
+  on `:racing` at resolution (no `:on` for the resolution events). Returns
+  the seeded join state."
+  [parent-kw child-a-kw child-b-kw spawn-all-extra]
+  (rf/reg-machine child-a-kw (mk-child parent-kw))
+  (rf/reg-machine child-b-kw (mk-child parent-kw))
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        (merge
+                          {:children       [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                            {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                           :on-child-done  :child/done
+                           :on-child-error :child/failed}
+                          spawn-all-extra)}}})
+  (rf/dispatch-sync [parent-kw [:start]])
+  (join-state parent-kw))
+
+;; ---------------------------------------------------------------------------
+;; the P2 repro — two-child :all success
+;; ---------------------------------------------------------------------------
+
+(deftest non-decisive-completed-child-gets-exactly-one-completed-terminal
+  (testing "rf2-ir4t5v — two-child :all success: the NON-DECISIVE first
+            child A closes exactly one :completed work terminal at fold
+            time; the DECISIVE child B closes exactly one :completed via
+            the resolution trace; neither is double-published and neither
+            is ever :cancelled. Pre-fix A's statuses were [] (no terminal)."
+    (let [j (reg-join-parent! :jct/p1 :jct/p1a :jct/p1b
+                              {:join :all :on-all-complete [:all/done]})
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      ;; A folds first — non-decisive in a 2-child :all.
+      (rf/dispatch-sync [a [:go]])
+      (is (= [:completed] (terminals-for a))
+          (str "non-decisive child A closes exactly one :completed at fold "
+               "time (pre-fix: []); saw " (work-statuses-for a)))
+      (let [fold-traces (child-completed-traces)]
+        (is (= 1 (count fold-traces)) "one child-completed fold trace for A")
+        (let [tags (:tags (first fold-traces))]
+          (is (= :a (:child-id tags)))
+          (is (= a (:spawned-id tags)))
+          (is (= :done (:kind tags)))
+          (is (= :ok (:rf.reply/status tags)) "canonical :ok reply facts")
+          (is (= :completed (:rf.reply/work-status tags)))
+          (is (some? (:rf.reply/work-id tags)))))
+      ;; B resolves — decisive; its terminal rides the resolution trace only.
+      (rf/dispatch-sync [b [:go]])
+      (is (true? (:resolved? (join-state :jct/p1))))
+      (is (= [:completed] (terminals-for a))
+          "A's terminal count is STILL one after resolution (reap adds none)")
+      (is (= [:completed] (terminals-for b))
+          "decisive child B closes exactly one :completed (resolution authority)")
+      (is (= 1 (count (child-completed-traces)))
+          "NO fold-time child-completed for the decisive child — one authority per child")
+      (is (not-any? #{:cancelled} (work-statuses-for a))
+          "completed child A is never cancelled")
+      (is (not-any? #{:cancelled} (work-statuses-for b))))))
+
+;; ---------------------------------------------------------------------------
+;; non-decisive failure
+;; ---------------------------------------------------------------------------
+
+(deftest non-decisive-failed-child-gets-exactly-one-failed-terminal
+  (testing "rf2-ir4t5v — an :all join with NO :on-any-failed folds a failure
+            without resolving: the failed child closes exactly one :failed
+            terminal at fold time (the analogous missing-:failed fact)"
+    (let [j (reg-join-parent! :jct/p2 :jct/p2a :jct/p2b
+                              {:join :all :on-all-complete [:all/done]})
+          a (get-in j [:children :a])]
+      (rf/dispatch-sync [a [:fail]])
+      (is (false? (:resolved? (join-state :jct/p2)))
+          "the failure fold did not resolve (no :on-any-failed)")
+      (is (= [:failed] (terminals-for a))
+          (str "non-decisive failed child closes exactly one :failed; saw "
+               (work-statuses-for a)))
+      (let [tags (:tags (first (child-completed-traces)))]
+        (is (= :failed (:kind tags)))
+        (is (= :error (:rf.reply/status tags)) "canonical :error reply facts")
+        (is (= :failed (:rf.reply/work-status tags)))))))
+
+;; ---------------------------------------------------------------------------
+;; decisive success / decisive failure — resolution authority unchanged
+;; ---------------------------------------------------------------------------
+
+(deftest decisive-folds-keep-the-resolution-authority
+  (testing "rf2-ir4t5v — decisive folds publish through the resolution trace
+            ONLY: an :any success and an :on-any-failed failure each close
+            the decisive child exactly once, with NO fold-time
+            child-completed trace"
+    ;; :any success — the first completion is decisive.
+    (let [j (reg-join-parent! :jct/p3 :jct/p3a :jct/p3b
+                              {:join :any :on-some-complete [:race/won]})
+          a (get-in j [:children :a])]
+      (rf/dispatch-sync [a [:go]])
+      (is (true? (:resolved? (join-state :jct/p3))))
+      (is (= [:completed] (terminals-for a))
+          "decisive :any child closes exactly one :completed")
+      (is (empty? (child-completed-traces))
+          "no fold-time trace for a decisive fold"))
+    (mtest/reset-captured!)
+    ;; :on-any-failed failure — the first failure is decisive.
+    (let [j (reg-join-parent! :jct/p4 :jct/p4a :jct/p4b
+                              {:join :all :on-all-complete [:all/done]
+                               :on-any-failed [:all/failed]})
+          a (get-in j [:children :a])]
+      (rf/dispatch-sync [a [:fail]])
+      (is (true? (:resolved? (join-state :jct/p4))))
+      (is (= [:failed] (terminals-for a))
+          "decisive failed child closes exactly one :failed")
+      (is (empty? (child-completed-traces))
+          "no fold-time trace for the decisive failure either"))))
+
+;; ---------------------------------------------------------------------------
+;; duplicates and post-resolution stragglers add no terminals
+;; ---------------------------------------------------------------------------
+
+(deftest duplicate-and-post-resolution-signals-add-no-terminals
+  (testing "rf2-ir4t5v — a duplicate pre-resolution completion (suppressed
+            :duplicate-completion) and a post-resolution straggler
+            (:stale late-completion) leave the child's terminal count at
+            exactly one"
+    (let [j (reg-join-parent! :jct/p5 :jct/p5a :jct/p5b
+                              {:join :all :on-all-complete [:all/done]})
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      (rf/dispatch-sync [a [:go]])
+      (is (= [:completed] (terminals-for a)))
+      ;; Authenticated duplicate, pre-resolution.
+      (rf/dispatch-sync
+        [:jct/p5 (with-meta [:child/done :a]
+                   {:rf/join-auth {:parent-id  :jct/p5
+                                   :invoke-id  [:racing]
+                                   :child-id   :a
+                                   :spawned-id a
+                                   :attempt    (:rf/attempt (join-state :jct/p5))}})])
+      (is (= [:completed] (terminals-for a))
+          "the duplicate added NO second terminal (suppressed, not re-published)")
+      ;; Resolve, then a post-resolution straggler for :a.
+      (rf/dispatch-sync [b [:go]])
+      (is (true? (:resolved? (join-state :jct/p5))))
+      (rf/dispatch-sync [:jct/p5 [:child/done :a]])
+      (is (= [:completed] (terminals-for a))
+          "the post-resolution straggler stayed :stale — still one terminal")
+      (is (some #(= :stale (:rf.reply/status (:tags %)))
+                (mtest/events-of :rf.machine.spawn-all/late-completion))
+          "the straggler was classified through the stale late-completion path"))))
+
+;; ---------------------------------------------------------------------------
+;; survivors still close exactly once as :cancelled
+;; ---------------------------------------------------------------------------
+
+(deftest any-resolution-survivor-still-closes-exactly-once-cancelled
+  (testing "rf2-ir4t5v — an :any resolution's surviving sibling closes
+            exactly one :cancelled terminal; the decisive completed child
+            closes exactly one :completed and is never cancelled"
+    (let [j (reg-join-parent! :jct/p6 :jct/p6a :jct/p6b
+                              {:join :any :on-some-complete [:race/won]})
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      (rf/dispatch-sync [a [:go]])
+      (is (true? (:resolved? (join-state :jct/p6))))
+      (is (= [:completed] (terminals-for a))
+          "decisive child: exactly one :completed, no cancellation")
+      ;; The survivor's single :cancelled closure is deliberately carried on
+      ;; TWO attribution traces — the join-resolution attribution
+      ;; (`:rf.machine.spawn-all/…cancelled-on-join-resolution`) AND its own
+      ;; `:rf.machine/destroyed` cancelled reply (see `build-resolution-fx`).
+      ;; Both rows carry the SAME work-id and the SAME `:cancelled` status —
+      ;; one closed outcome, never a contradictory second terminal kind.
+      (is (= #{:cancelled} (set (terminals-for b)))
+          (str "survivor closes as :cancelled and ONLY :cancelled; saw "
+               (work-statuses-for b)))
+      (is (not-any? #{:completed :failed} (work-statuses-for b))
+          "the survivor never reports a completion/failure terminal"))))

--- a/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
@@ -1,0 +1,333 @@
+(ns re-frame.join-exact-auth-cljs-test
+  "rf2-nvxehu — join folds and reaps are authenticated to the EXACT child
+  attempt and resolved join.
+
+  The completion carrier `[<parent> [<done-kw> <child-id> & extra]]` carries
+  no actor or attempt identity, so pre-fix a STALE completion from a prior
+  attempt (parent re-entry / child respawn) folded into the successor join
+  and could make the CURRENT child appear completed — after which the
+  \"verified\" reap derived the current actor from `:children` and destroyed
+  it with the cancellation-suppressing `:rf.machine/join-reaped` even though
+  it never completed. Separately, the public reserved-fx reap accepted any
+  folded child while the join's `:resolved?` latch was still false, so an
+  app could invoke the internal cancellation-suppressing reap early during a
+  still-waiting `:all` join.
+
+  The fix is ONE exact-authority contract:
+
+    - fold side — a carrier folds only when the `:rf/join-auth` metadata the
+      member child's own handler boundary stamped
+      (`join/stamp-join-completion-fx`) matches the current join's
+      parent/invoke identity, logical child id, exact current actor id, and
+      exact per-attempt token (minted by `spawn-all-init-fx`). Unstamped /
+      superseded / duplicate carriers are suppressed stale
+      (`:rf.machine.spawn-all/stale-completion`) with zero mutation.
+    - reap side — the cancellation-suppressing reap additionally requires
+      the exact join attempt's `:resolved?` latch (`:cause :unresolved-join`
+      refusal ahead of it).
+
+  The file is named `*-cljs-test.cljc` so it's discovered by both
+  cognitect-style JVM runs and shadow-cljs (`cljs-test$` ns-regexp)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load the machines artefact so its fx handlers + late-bind hooks are
+   ;; installed when this ns runs in isolation.
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- join-state [parent-id]
+  (get-in (mtest/runtime-db)
+          [:rf.runtime/machines :spawned parent-id [:racing]]))
+
+(defn- stale-completions []
+  (mtest/events-of :rf.machine.spawn-all/stale-completion))
+
+(defn- stale-reasons []
+  (mapv (comp :rf.reply/stale-reason :tags) (stale-completions)))
+
+(defn- destroyed-for [actor-id]
+  (filterv #(= actor-id (:actor-id (:tags %)))
+           (mtest/events-of :rf.machine/destroyed)))
+
+(defn- bad-arg-causes []
+  (mapv (comp :cause :tags) (mtest/events-of :rf.error/machine-destroy-bad-arg)))
+
+(defn- mk-child
+  "A dispatching child: on `:go` / `:fail` it transitions to a PLAIN
+  (non-`:final?`) terminal and dispatches its completion back to
+  `parent-id` — through its OWN handler boundary, so the runtime stamps the
+  `:rf/join-auth` attempt authentication."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}]
+                              {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})
+             :dispatch-err  (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/failed (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-err}}}
+             :done   {}
+             :failed {}}})
+
+(defn- reg-join-parent!
+  "Register a re-enterable two-child `:all` join parent + dispatching
+  children and start it. The parent stays on `:racing` at resolution (no
+  `:on` for `:all/done`) so the join slot survives for post-resolution
+  probes; `:abort` exits `:racing` (tearing the attempt down) and `:start`
+  re-enters it (seeding a NEW attempt). Returns the seeded join state."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine child-a-kw (mk-child parent-kw))
+  (rf/reg-machine child-b-kw (mk-child parent-kw))
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}})
+  (rf/dispatch-sync [parent-kw [:start]])
+  (join-state parent-kw))
+
+(defn- dispatch-forged!
+  "Hand-dispatch a completion carrier with a CRAFTED `:rf/join-auth` stamp
+  (nil `auth` dispatches the bare, unstamped public carrier)."
+  [parent-kw inner auth]
+  (rf/dispatch-sync
+    [parent-kw (if auth
+                 (with-meta inner {:rf/join-auth auth})
+                 inner)]))
+
+;; ---------------------------------------------------------------------------
+;; the P1 counterexample — stale prior-attempt completion after re-entry
+;; ---------------------------------------------------------------------------
+
+(deftest stale-prior-attempt-completion-cannot-fold-into-successor-join
+  (testing "rf2-nvxehu — after parent re-entry (attempt 2), a carrier bound
+            to attempt 1 (old actor id + old attempt token) is classified
+            stale (:attempt-superseded) and folds NOTHING: no :done fold, no
+            resolution, no terminal, and the current child is NEVER reaped.
+            Pre-fix this folded :a into the successor join's :done."
+    (let [j1     (reg-join-parent! :jea/p1 :jea/p1a :jea/p1b)
+          token1 (:rf/attempt j1)
+          a1     (get-in j1 [:children :a])]
+      (is (some? token1) "attempt 1 minted an opaque token")
+      (is (keyword? a1) "attempt 1 spawned :a")
+      ;; Tear attempt 1 down (exit :racing), then re-enter (attempt 2).
+      (rf/dispatch-sync [:jea/p1 [:abort]])
+      (rf/dispatch-sync [:jea/p1 [:start]])
+      (let [j2     (join-state :jea/p1)
+            token2 (:rf/attempt j2)
+            a2     (get-in j2 [:children :a])]
+        (is (some? token2) "attempt 2 minted its own token")
+        (is (not= token1 token2) "per-attempt tokens are distinct")
+        (mtest/reset-captured!)
+        ;; The stale straggler: attempt 1's exact carrier.
+        (dispatch-forged! :jea/p1 [:child/done :a]
+                          {:parent-id  :jea/p1
+                           :invoke-id  [:racing]
+                           :child-id   :a
+                           :spawned-id a1
+                           :attempt    token1})
+        (let [j2' (join-state :jea/p1)]
+          (is (= #{} (:done j2'))
+              "the stale carrier folded NOTHING into the successor join")
+          (is (false? (:resolved? j2')) "the successor join did not resolve"))
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
+            "exactly one stale-completion with :attempt-superseded evidence")
+        (is (some? (mtest/snapshot a2)) "current child :a (A2) is untouched")
+        (is (empty? (destroyed-for a2)) "A2 was never reaped or destroyed")))))
+
+(deftest old-token-with-current-actor-id-is-superseded
+  (testing "rf2-nvxehu — the attempt token discriminates INDEPENDENTLY of
+            actor identity (the :fixed-actor-id-respawn pin, where actor ids
+            are equal across attempts): a carrier naming the CURRENT actor
+            but a PRIOR attempt token is stale (:attempt-superseded)"
+    (let [j1     (reg-join-parent! :jea/p2 :jea/p2a :jea/p2b)
+          token1 (:rf/attempt j1)]
+      (rf/dispatch-sync [:jea/p2 [:abort]])
+      (rf/dispatch-sync [:jea/p2 [:start]])
+      (let [j2 (join-state :jea/p2)
+            a2 (get-in j2 [:children :a])]
+        (mtest/reset-captured!)
+        (dispatch-forged! :jea/p2 [:child/done :a]
+                          {:parent-id  :jea/p2
+                           :invoke-id  [:racing]
+                           :child-id   :a
+                           :spawned-id a2       ;; CURRENT actor id
+                           :attempt    token1}) ;; PRIOR attempt token
+        (is (= #{} (:done (join-state :jea/p2)))
+            "an old-token carrier cannot fold even when the actor id matches")
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons)))))))
+
+;; ---------------------------------------------------------------------------
+;; unstamped / wrong-actor / wrong-child / wrong-invoke carriers
+;; ---------------------------------------------------------------------------
+
+(deftest unstamped-carrier-is-suppressed-unverified
+  (testing "rf2-nvxehu — a bare hand-dispatched completion (never flowed
+            through the member child's boundary, so no runtime stamp) is
+            classified :attempt-unverified and folds nothing"
+    (reg-join-parent! :jea/p3 :jea/p3a :jea/p3b)
+    (mtest/reset-captured!)
+    (dispatch-forged! :jea/p3 [:child/done :a] nil)
+    (is (= #{} (:done (join-state :jea/p3))) "no fold")
+    (is (false? (:resolved? (join-state :jea/p3))) "no resolution")
+    (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+        "stable typed evidence: :attempt-unverified")))
+
+(deftest wrong-actor-for-correct-child-is-superseded
+  (testing "rf2-nvxehu — a carrier naming the correct child but the WRONG
+            actor (sibling :b's id, current token) fails the exact
+            actor-identity clause"
+    (let [j (reg-join-parent! :jea/p4 :jea/p4a :jea/p4b)]
+      (mtest/reset-captured!)
+      (dispatch-forged! :jea/p4 [:child/done :a]
+                        {:parent-id  :jea/p4
+                         :invoke-id  [:racing]
+                         :child-id   :a
+                         :spawned-id (get-in j [:children :b]) ;; WRONG actor
+                         :attempt    (:rf/attempt j)})
+      (is (= #{} (:done (join-state :jea/p4))))
+      (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))))))
+
+(deftest wrong-child-for-correct-actor-is-superseded
+  (testing "rf2-nvxehu — a carrier claiming child :b with an auth record
+            minted for child :a (correct actor A, correct token) fails the
+            logical-child-id clause"
+    (let [j (reg-join-parent! :jea/p5 :jea/p5a :jea/p5b)]
+      (mtest/reset-captured!)
+      (dispatch-forged! :jea/p5 [:child/done :b]
+                        {:parent-id  :jea/p5
+                         :invoke-id  [:racing]
+                         :child-id   :a                        ;; record's child
+                         :spawned-id (get-in j [:children :a])
+                         :attempt    (:rf/attempt j)})
+      (is (= #{} (:done (join-state :jea/p5))))
+      (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))))))
+
+(deftest wrong-invoke-identity-is-superseded
+  (testing "rf2-nvxehu — a carrier stamped for a DIFFERENT invoke path fails
+            the parent/invoke identity clause"
+    (let [j (reg-join-parent! :jea/p6 :jea/p6a :jea/p6b)]
+      (mtest/reset-captured!)
+      (dispatch-forged! :jea/p6 [:child/done :a]
+                        {:parent-id  :jea/p6
+                         :invoke-id  [:other-invoke]           ;; WRONG invoke
+                         :child-id   :a
+                         :spawned-id (get-in j [:children :a])
+                         :attempt    (:rf/attempt j)})
+      (is (= #{} (:done (join-state :jea/p6))))
+      (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))))))
+
+;; ---------------------------------------------------------------------------
+;; duplicate exact completion
+;; ---------------------------------------------------------------------------
+
+(deftest duplicate-exact-completion-is-suppressed
+  (testing "rf2-nvxehu / rf2-ir4t5v — an exact re-completion of an
+            already-folded child (correct actor, correct token) is suppressed
+            (:duplicate-completion): the fold stays as-is and no second
+            terminal can publish; the join still resolves normally afterwards"
+    (let [j (reg-join-parent! :jea/p7 :jea/p7a :jea/p7b)
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      ;; Legit fold of :a (non-decisive in a 2-child :all).
+      (rf/dispatch-sync [a [:go]])
+      (is (= #{:a} (:done (join-state :jea/p7))) ":a folded")
+      (mtest/reset-captured!)
+      ;; Exact duplicate, correctly authenticated for the CURRENT attempt.
+      (dispatch-forged! :jea/p7 [:child/done :a]
+                        {:parent-id  :jea/p7
+                         :invoke-id  [:racing]
+                         :child-id   :a
+                         :spawned-id a
+                         :attempt    (:rf/attempt (join-state :jea/p7))})
+      (is (= #{:a} (:done (join-state :jea/p7))) "the fold record is unchanged")
+      (is (false? (:resolved? (join-state :jea/p7))) "no premature resolution")
+      (is (= [:rf.machine.spawn-all/duplicate-completion] (stale-reasons))
+          "stable typed evidence: :duplicate-completion")
+      ;; The join still resolves on the genuine decisive completion.
+      (rf/dispatch-sync [b [:go]])
+      (is (true? (:resolved? (join-state :jea/p7)))
+          "the genuine decisive completion still resolves the join"))))
+
+;; ---------------------------------------------------------------------------
+;; the reap-side latch — no early reap through the public fx boundary
+;; ---------------------------------------------------------------------------
+
+(deftest completed-child-in-unresolved-join-cannot-be-reaped
+  (testing "rf2-nvxehu — a folded (completed) child of a STILL-WAITING :all
+            join cannot be reaped through the public reserved-fx boundary:
+            the reap is refused with :cause :unresolved-join and no teardown;
+            after genuine resolution the same child IS reaped
+            (:rf.machine/join-reaped) exactly once. Pre-fix the early reap
+            succeeded (membership in :done was the only proof)."
+    (rf/reg-event ::forge-reap
+      (fn [_ [_ p invoke child-id]]
+        {:fx [[:rf.machine/destroy {:rf/reap      true
+                                    :rf/parent-id p
+                                    :rf/invoke-id invoke
+                                    :rf/child-id  child-id}]]}))
+    (let [j (reg-join-parent! :jea/p8 :jea/p8a :jea/p8b)
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      ;; :a folds; the 2-child :all join is NOT resolved.
+      (rf/dispatch-sync [a [:go]])
+      (is (= #{:a} (:done (join-state :jea/p8))))
+      (is (false? (:resolved? (join-state :jea/p8))))
+      (mtest/reset-captured!)
+      ;; The early reap — refused ahead of the :resolved? latch.
+      (rf/dispatch-sync [::forge-reap :jea/p8 [:racing] :a])
+      (is (= [:unresolved-join] (bad-arg-causes))
+          "refused with the distinct :unresolved-join cause")
+      (is (some? (mtest/snapshot a)) "the folded child stays live — no teardown")
+      (is (empty? (destroyed-for a)) "no destroyed trace for the refused reap")
+      ;; Genuine resolution: :b completes, the join resolves, and the
+      ;; resolution cascade reaps BOTH completed children with the
+      ;; non-cancellation reason.
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [b [:go]])
+      (is (true? (:resolved? (join-state :jea/p8))))
+      (is (nil? (mtest/snapshot a)) "post-resolution, :a is reaped")
+      (is (= [:rf.machine/join-reaped]
+             (mapv (comp :reason :tags) (destroyed-for a)))
+          "exactly one destroyed trace for :a — the genuine post-resolution reap"))))
+
+;; ---------------------------------------------------------------------------
+;; the genuine flow stays green through the stamp machinery
+;; ---------------------------------------------------------------------------
+
+(deftest genuine-child-completions-still-fold-and-resolve
+  (testing "rf2-nvxehu — real member children completing through their own
+            handler boundary still fold and resolve the join (the stamp path
+            end-to-end), across BOTH attempts of a re-entered parent"
+    (let [j1 (reg-join-parent! :jea/p9 :jea/p9a :jea/p9b)]
+      ;; Attempt 1 resolves normally.
+      (rf/dispatch-sync [(get-in j1 [:children :a]) [:go]])
+      (rf/dispatch-sync [(get-in j1 [:children :b]) [:go]])
+      (is (true? (:resolved? (join-state :jea/p9))) "attempt 1 resolved")
+      ;; Re-enter; attempt 2 resolves normally too (fresh token, fresh stamps).
+      (rf/dispatch-sync [:jea/p9 [:abort]])
+      (rf/dispatch-sync [:jea/p9 [:start]])
+      (let [j2 (join-state :jea/p9)]
+        (is (false? (:resolved? j2)))
+        (rf/dispatch-sync [(get-in j2 [:children :a]) [:go]])
+        (rf/dispatch-sync [(get-in j2 [:children :b]) [:go]])
+        (is (true? (:resolved? (join-state :jea/p9))) "attempt 2 resolved")))))

--- a/implementation/machines/test/re_frame/tracked_slot_prune_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/tracked_slot_prune_cljs_test.cljc
@@ -1,0 +1,199 @@
+(ns re-frame.tracked-slot-prune-cljs-test
+  "rf2-s2bsmw — the tracked single-`:spawn` exit prunes DEAD slots without
+  double-destroying actors.
+
+  The pre-fix defect: an imperative keyword destroy tears the tracked child
+  down but leaves the parent's `[:spawned p i]` slot naming the now-dead
+  actor (its teardown-args carry no parent/invoke). The later declarative
+  parent exit treated slot PRESENCE as liveness (`destroy-resolved!`'s
+  `slot-live?` override), re-ran the whole teardown pipeline against the
+  dead actor — a second `:exit` cascade, a second `:rf.machine/destroyed`
+  trace, destroyed reasons `[:explicit :explicit]` — violating Spec 005's
+  silent-idempotent destroy law and risking duplicate exit cascades,
+  resource releases, and terminal/diagnostic evidence.
+
+  The fix separates stale ownership-slot cleanup from actor lifecycle
+  teardown: a slot naming an actor that is dead FOR THAT EXACT INCARNATION
+  is pruned (slot + parent `:rf/spawned` mirror only — `prune-tracked-slot!`)
+  with no second teardown; a live same-id REPLACEMENT the slot does not own
+  (`slot-owned-incarnation?` reads the snapshot's framework-reserved
+  `:rf/parent-id` / `:rf/invoke-id` ownership stamps) is likewise left
+  untouched; only a live, owned child takes the normal exact-incarnation
+  `:explicit` destroy.
+
+  Fixtures instrument lifecycle traces AND side effects (the child's
+  `:exit` action bumps a counter), not just final registry state — mutating
+  the tracked branch back to slot-presence liveness fires two traces and
+  two `:exit` runs.
+
+  The file is named `*-cljs-test.cljc` so it's discovered by both
+  cognitect-style JVM runs and shadow-cljs (`cljs-test$` ns-regexp)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load the machines artefact so its fx handlers + late-bind hooks are
+   ;; installed when this ns runs in isolation.
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- destroyed-reasons-for [actor-id]
+  (into []
+        (comp (filter #(= actor-id (:actor-id (:tags %))))
+              (map (comp :reason :tags)))
+        (mtest/events-of :rf.machine/destroyed)))
+
+(defn- tracked-slot [parent-id]
+  (get-in (mtest/runtime-db)
+          [:rf.runtime/machines :spawned parent-id [:working]]))
+
+(defn- parent-mirror [parent-id]
+  (get-in (mtest/snapshot parent-id) [:data :rf/spawned [:working]]))
+
+(defn- destroy-imperatively!
+  "Fire one imperative keyword destroy through an ordinary app event."
+  [actor-id]
+  (rf/reg-event ::imperative-destroy
+    (fn [_ [_ a]] {:fx [[:rf.machine/destroy a]]}))
+  (rf/dispatch-sync [::imperative-destroy actor-id]))
+
+(defn- reg-tracked-parent!
+  "Register a single tracked-`:spawn` parent whose child's `:exit` bumps
+  `exit-count` (side-effect instrumentation). `spawn-spec` is the parent's
+  `:spawn` map. Starts the parent into `:working` and returns the tracked
+  child's actor id."
+  [parent-kw child-kw spawn-spec exit-count]
+  (rf/reg-machine child-kw
+    {:initial :running
+     :data    {}
+     :states  {:running {:exit (fn [_] (swap! exit-count inc) {})}}})
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle    {:on {:start :working}}
+               :working {:spawn spawn-spec
+                         :on    {:stop :idle}}}})
+  (rf/dispatch-sync [parent-kw [:start]])
+  (tracked-slot parent-kw))
+
+;; ---------------------------------------------------------------------------
+;; the P2 repro — imperative destroy, then declarative parent exit
+;; ---------------------------------------------------------------------------
+
+(deftest imperative-destroy-then-parent-exit-tears-down-exactly-once
+  (testing "rf2-s2bsmw — direct keyword destroy followed by the parent's
+            declarative exit yields EXACTLY ONE stopped transition: one
+            :rf.machine/destroyed trace, one :exit cascade run; the later
+            tracked exit removes the stale slot + parent mirror WITHOUT
+            re-running lifecycle teardown. Pre-fix: reasons
+            [:explicit :explicit] and a second :exit run."
+    (let [exit-count (atom 0)
+          child-id   (reg-tracked-parent! :tsp/p1 :tsp/p1-child
+                                          {:machine-id :tsp/p1-child}
+                                          exit-count)]
+      (is (keyword? child-id) "tracked child spawned")
+      (is (some? (parent-mirror :tsp/p1)) "parent :rf/spawned mirror bound")
+      ;; Imperative destroy: full teardown ONCE; the tracked slot survives
+      ;; (its teardown-args carry no parent/invoke) — the bug's precondition.
+      (destroy-imperatively! child-id)
+      (is (nil? (mtest/snapshot child-id)) "actor dead after imperative destroy")
+      (is (= child-id (tracked-slot :tsp/p1))
+          "precondition: the tracked slot still names the now-dead actor")
+      (is (= [:explicit] (destroyed-reasons-for child-id))
+          "one destroyed trace from the imperative destroy")
+      (is (= 1 @exit-count) "one :exit run from the imperative destroy")
+      ;; Declarative parent exit: stale-slot cleanup only.
+      (rf/dispatch-sync [:tsp/p1 [:stop]])
+      (is (nil? (tracked-slot :tsp/p1)) "the stale slot is pruned")
+      (is (nil? (parent-mirror :tsp/p1)) "the parent :rf/spawned mirror is pruned")
+      (is (= [:explicit] (destroyed-reasons-for child-id))
+          (str "NO second destroyed trace — Spec 005 silent-idempotent "
+               "destroy law; saw " (destroyed-reasons-for child-id)))
+      (is (= 1 @exit-count)
+          "NO second :exit cascade for the already-dead incarnation"))))
+
+(deftest repeated-tracked-exit-is-silent-idempotent
+  (testing "rf2-s2bsmw — re-firing the tracked destroy form against the
+            already-pruned slot is a silent no-op (no trace, no error)"
+    (let [exit-count (atom 0)
+          child-id   (reg-tracked-parent! :tsp/p2 :tsp/p2-child
+                                          {:machine-id :tsp/p2-child}
+                                          exit-count)]
+      (destroy-imperatively! child-id)
+      (rf/dispatch-sync [:tsp/p2 [:stop]])
+      (mtest/reset-captured!)
+      ;; Hand-fire the tracked form again — the slot is already gone.
+      (rf/reg-event ::refire-tracked
+        (fn [_ _] {:fx [[:rf.machine/destroy {:rf/parent-id :tsp/p2
+                                              :rf/invoke-id [:working]}]]}))
+      (rf/dispatch-sync [::refire-tracked])
+      (is (empty? (mtest/events-of :rf.machine/destroyed))
+          "repeat exit emits no destroyed trace")
+      (is (empty? (mtest/events-of :rf.error/machine-destroy-bad-arg))
+          "repeat exit raises no error — silent idempotence")
+      (is (= 1 @exit-count) "no further :exit runs"))))
+
+;; ---------------------------------------------------------------------------
+;; exact incarnation identity — same-id replacement survives the stale slot
+;; ---------------------------------------------------------------------------
+
+(deftest stale-slot-cannot-destroy-same-id-replacement
+  (testing "rf2-s2bsmw — destroy → same-id replacement (spawned through a
+            DIFFERENT path, so it carries different ownership stamps) → old
+            parent exit: the stale slot is pruned but the live replacement
+            is NOT destroyed — exact incarnation identity is respected"
+    (let [exit-count (atom 0)]
+      (reg-tracked-parent! :tsp/p3 :tsp/p3-child
+                           {:machine-id     :tsp/p3-child
+                            :fixed-actor-id :tsp/fixed-3}
+                           exit-count)
+      (is (= :tsp/fixed-3 (tracked-slot :tsp/p3)))
+      ;; Kill the tracked incarnation.
+      (destroy-imperatively! :tsp/fixed-3)
+      (is (nil? (mtest/snapshot :tsp/fixed-3)))
+      ;; Hand-emit a same-id REPLACEMENT through the imperative spawn path —
+      ;; no :rf/parent-id / :rf/invoke-id args, so its :data carries no
+      ;; ownership stamps for the old slot.
+      (rf/reg-event ::respawn-fixed
+        (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :tsp/p3-child
+                                            :fixed-actor-id :tsp/fixed-3}]]}))
+      (rf/dispatch-sync [::respawn-fixed])
+      (is (some? (mtest/snapshot :tsp/fixed-3)) "replacement incarnation live")
+      (is (= :tsp/fixed-3 (tracked-slot :tsp/p3))
+          "precondition: the STALE slot still names the (reused) id")
+      (mtest/reset-captured!)
+      ;; Old parent exits: the stale slot may prune itself, never the
+      ;; replacement.
+      (rf/dispatch-sync [:tsp/p3 [:stop]])
+      (is (nil? (tracked-slot :tsp/p3)) "the stale slot is pruned")
+      (is (some? (mtest/snapshot :tsp/fixed-3))
+          "the same-id replacement incarnation SURVIVES the old parent's exit")
+      (is (empty? (mtest/events-of :rf.machine/destroyed))
+          "no destroyed trace fired against the replacement"))))
+
+;; ---------------------------------------------------------------------------
+;; ordinary live tracked exit — unchanged
+;; ---------------------------------------------------------------------------
+
+(deftest live-owned-tracked-exit-keeps-full-teardown
+  (testing "rf2-s2bsmw — the ordinary declarative exit of a still-live owned
+            child retains the full teardown: one :exit run, one :explicit
+            destroyed trace, slot + mirror cleared"
+    (let [exit-count (atom 0)
+          child-id   (reg-tracked-parent! :tsp/p4 :tsp/p4-child
+                                          {:machine-id :tsp/p4-child}
+                                          exit-count)]
+      (rf/dispatch-sync [:tsp/p4 [:stop]])
+      (is (nil? (mtest/snapshot child-id)) "live child torn down on exit")
+      (is (= [:explicit] (destroyed-reasons-for child-id))
+          "exactly one :explicit destroyed trace")
+      (is (= 1 @exit-count) "exactly one :exit cascade run")
+      (is (nil? (tracked-slot :tsp/p4)) "slot cleared")
+      (is (nil? (parent-mirror :tsp/p4)) "parent mirror cleared"))))


### PR DESCRIPTION
Four-bead correctness lane on the `:spawn-all` join/spawn machinery, resuming the session-limit-killed worker's branch. Each fix carries its red-before-fix fixture (CLJ+CLJS `.cljc`), mutation-proven.

## rf2-3phait — closed discriminated destroy map-form grammar (P1)

Presence of `:rf/reap` / `:rf/spawn-all` now SELECTS its shape (never truthiness); the selected shape requires the discriminator to be exactly `true` plus the exact coordinate key-set/types. Every malformed, false-valued, wrongly-typed, overlapping, or unknown map shape emits one `:rf.error/machine-destroy-bad-arg` and performs zero mutation. The tracked single-`:spawn` branch can no longer consume a spawn-all join-state map as an actor id (`:cause :slot-shape-mismatch`) — pre-fix, `{:rf/reap false …}` cleared the join slot, orphaned both live children, and emitted a bogus destroyed trace naming the join-state map. Fixture: `destroy_closed_grammar_cljs_test.cljc` (10 tests). (Committed by the prior worker; verified green on the rebase over current main.)

## rf2-nvxehu — exact-authority join folds and reaps (P1)

The completion carrier `[parent [done-kw child-id & extra]]` carries no actor/attempt identity, so a stale straggler from a prior attempt could fold into the successor join and get the CURRENT child reaped without ever completing; separately the public reserved-fx reap accepted any folded child while `:resolved?` was still false.

One exact-authority contract now closes both:

- `spawn-all-init-fx` mints an opaque per-attempt token (`:rf/attempt`, monotonic counter — the timer attempt-token pattern) into each live join seed; each child's `:data` carries the framework-reserved `:rf/join-child` membership record (parent/invoke identity, logical child id, own spawned id, completion kws, token).
- The child's own handler-return boundary (`commit-or-finalize`) stamps matching outbound completion carriers with `:rf/join-auth` METADATA on the inner event vector (`join/stamp-join-completion-fx`) — the existing private lifecycle path; the public event value is untouched, no new app-facing surface.
- The parent's fold branch requires the stamp to match runtime-owned state exactly (parent/invoke + logical child id + exact current actor id + exact attempt token) before any fold. Unstamped (`:attempt-unverified`), superseded (`:attempt-superseded` — prior attempt / wrong actor / wrong invoke, incl. the `:fixed-actor-id` respawn case actor ids cannot discriminate), and duplicate (`:duplicate-completion`) carriers are suppressed stale via the new `:rf.machine.spawn-all/stale-completion` trace: zero mutation — no fold, no terminal, no resolution, no reap.
- `destroy-join-reap!` additionally requires the exact attempt's `:resolved?` latch (`:cause :unresolved-join`); actor id/reason stay runtime-owned; membership in `:done ∪ :failed` is attempt-exact by the fold gate. Genuine post-resolution reaps and silent idempotence for already-auto-destroyed exact actors unchanged (rf2-evejwu suite green).
- `prefix-region-invoke-id` now region-prefixes `:rf/spawn-all-id` alongside `:rf/invoke-id`, so per-region spawn-all children address the region's actual join slot (also fixes the region-blind `spawn-all-invoke-rejected?` read).

Fixture: `join_exact_auth_cljs_test.cljc` (9 tests). Mutation-proof: reverting the fold gate fails 7 fixtures (13 assertions); reverting the resolved latch distinctly fails the early-reap fixture (4 assertions). One test-only ripple: `long_running_work_cljs_test.cljs`'s headless synthesised completions now present the same `:rf/join-auth` stamp a member child's boundary would stamp.

## rf2-s2bsmw — stale tracked-slot prune without double destroy (P2)

Imperative keyword destroy + later declarative parent exit no longer double-destroys: `destroy-tracked!` splits on the shared liveness/incarnation predicate (`actor-live?` + the new `slot-owned-incarnation?`, which matches the snapshot's reserved `:rf/parent-id`/`:rf/invoke-id` ownership stamps against the slot coordinates). Dead-for-that-incarnation slot ⇒ `prune-tracked-slot!` (slot + parent `:rf/spawned` mirror only, no second exit cascade/teardown/trace); live same-id replacement the slot does not own ⇒ prune only, replacement untouched; live owned child ⇒ normal exact-incarnation `:explicit` destroy. `destroy-resolved!` loses the `slot-live?` override entirely. Fixture: `tracked_slot_prune_cljs_test.cljc` (4 tests, instrumenting destroyed traces AND `:exit` side-effect counters). Mutation-proof: restoring slot-presence liveness fails the double-destroy and replacement-kill fixtures.

## rf2-ir4t5v — one canonical terminal per spawn-all child (P2)

Non-decisive children's work attempts no longer end with no terminal at all (pre-fix: two-child `:all` gave A `[]`, B `[:completed]`). The canonical `:completed`/`:failed` terminal publishes exactly once at each child's FIRST valid fold via the new `:rf.machine.spawn-all/child-completed` trace when the fold is non-decisive; the decisive child's terminal keeps riding the resolution trace. The two emits sit on opposite arms of the fold's `(:resolved? resolution)` split — one terminal authority per child, structurally proven (no double emission possible). Duplicates are suppressed upstream by the nvxehu gate; post-resolution arrivals stay `:stale`; `:any`/failure survivors close as `:cancelled` only (their single closure deliberately rides the two same-status attribution traces `build-resolution-fx` documents). Lifecycle reaping stays separate from work-terminal publication; reap reasons unchanged — the destroyed-reason channel matrix conformance suite is green. Fixture: `join_child_terminal_cljs_test.cljc` (5 tests). Mutation-proof: reverting to resolution-only authority fails the non-decisive success/failure fixtures with empty terminal vectors.

## Spec ripples (follow-up notes — spec docs are owned by live docs lanes)

- Spec 009 §`:op-type` vocabulary: two new `:rf.machine` trace ops — `:rf.machine.spawn-all/stale-completion` (pre-resolution suppression evidence; `:rf.reply/stale-reason` one of `:rf.machine.spawn-all/attempt-unverified` / `attempt-superseded` / `duplicate-completion`) and `:rf.machine.spawn-all/child-completed` (non-decisive fold terminal). No new error ids; no new destroyed reasons (the channel/reason matrix is untouched).
- Spec 005 §Spawn-and-join: the seeded join-state map now carries `:rf/attempt` (opaque per-attempt token); spawned `:spawn-all` children carry the framework-reserved `:rf/join-child` record in `:data`; the child-completion protocol is authenticated at the parent boundary (hand-dispatched carriers no longer fold); the reap form is authorized only post-`:resolved?`.
- Spec 009 §Error event catalogue: `:rf.error/machine-destroy-bad-arg` gains the `:cause :unresolved-join` value (same error id).

## Quality gates

- `implementation/machines` JVM suite: **1017 tests / 3429 assertions, 0 failures** (run per commit, foreground).
- `npm run test:cljs` (node CLJS integration): **9256 tests / 43792 assertions, 0 failures**.
- `scripts/test-fast-pr.sh` full spine: **PASS** (core JVM 1914 tests / 8664 assertions; script policy/helpers; per-ns isolation; markdown/link gates; all static gates).
- Mutation proofs run per bead (fold gate, resolved latch, slot-presence liveness, resolution-only authority) — each fails its own fixtures distinctly.
