### PR TITLE
test(ui)+docs: Guide 09 reactive fixture + exact coverage claim (rf2-vxgfnd.131)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/09-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/09-testing.md
@@ -41,7 +41,8 @@ real registrations, no React:
   there and silently misses.
 - Drive state with real events: `(ui.test/dispatch! frame [:cart/add 42])` — real
   dispatch plus a drain to fixed point — then re-render and assert the button now reads
-  "Remove". The whole loop, `sub` reads included, runs on main today. Loading and error
+  "Remove". The whole loop — the dispatch, the drain to fixed point, and the re-rendered
+  view's `sub` read of the moved app-db — runs on main today. Loading and error
   states are just app-db values you install or events you dispatch. Stubbing a sub is
   the explicit option:
   `(ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})`.

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -4,10 +4,14 @@ re-frame2 UI is the view layer for re-frame2: views are hiccup, handlers are eve
 vectors, and the compiler ships code with no interpreter, no hooks ceremony, and no manual
 memoization. This guide teaches the library as a user; design rationale lives one
 directory up. The examples are written to run as CI fixtures, and coverage grows with
-the stages. Today one chapter is covered: guide 09's Tier-1 examples run in the
-library's JVM suite as `implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`;
-the remaining chapters are lifted as their stages land, per the fixture-pipeline draft
-one directory up (`drafts/guide-fixture-pipeline.md`). A fence that is deliberately
+the stages. Today one chapter is partly covered: guide 09's Tier-1 code block and the
+dispatch → sub → re-render loop it teaches run as fixtures in the library's JVM suite
+(`implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`) — the verbatim
+render, the intent-through-attrs respelling, the genuine dispatch → sub → re-render
+toggle (membership read through the compiled `sub` path), a seeded-state render, and the
+sub-override door. The chapter's selector-grammar and literal-root fences are not enrolled
+yet, and the remaining chapters are lifted as their stages land, per the fixture-pipeline
+draft one directory up (`drafts/guide-fixture-pipeline.md`). A fence that is deliberately
 schematic — an elided fragment, or a wave-2 surface — says so in a `;; guide:no-fixture`
 comment on the fence itself. The bar does not move with the coverage: if a guide example
 needs internals explained, that's an API bug, not a documentation problem.

--- a/implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj
@@ -5,23 +5,34 @@
   2026-07-12 respelling — the intent assertion reads through the
   ui.test/attrs projection, never direct keyword lookup on the node.
 
-  The 'drive state with real events' Tier-1 prose loop is adapted to the S1
-  structural subset: sub reads land S2, so cart membership arrives as a
-  prop; the dispatch! → re-render → assert shape is the guide's. The mounted
-  S2 example likewise drives state programmatically; compiled browser event
-  dispatch remains explicitly staged at S3."
+  With the S2 reactive core shipped, the 'drive state with real events'
+  Tier-1 loop is lifted for real: `toggle-card` reads its cart membership
+  through the compiled `(sub …)` path — no prop injection, no manual
+  app-db read in the view — so a dispatched write drains, the re-render's
+  subscription observes it, and the rendered tree changes. This is the
+  dispatch → sub → re-render loop the chapter teaches, on the first-party
+  reactive path (the same one the library tests itself with in
+  `test_render_jvm_test.clj` `sub-read-against-a-frame`).
+
+  Enrolled here: the Tier-1 code block (`add-button-carries-intent`), the
+  intent-through-attrs respelling, the dispatch → sub → re-render loop, a
+  seeded-state render, and the sub-override door. The chapter's
+  selector-grammar and literal-root fences and its Tier-2/Tier-3 examples
+  are NOT enrolled by this file (README + guide-fixture-pipeline draft
+  track the exact per-chapter coverage)."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [re-frame.ui :refer [defview]]
+            [re-frame.ui :refer [defview sub]]
             [re-frame.ui.test :as uit]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
-;; Fixture app surface
+;; Fixture app surface — .cljc-honest (the guide's own Tier-1 ground rule):
+;; the sub + events run on the JVM here, so they carry no host-only forms.
 ;; ---------------------------------------------------------------------------
 
 (def fixture-catalog
@@ -29,15 +40,29 @@
 
 (defn product [id] (get fixture-catalog id))
 
+(defn- reg-cart!
+  "Register the cart dataflow the Tier-1 loop drives: membership as a
+  parameterized sub, add/remove as ordinary events. The reset-runtime
+  fixture wipes the registry per test, so each test that reads the sub
+  re-registers first."
+  []
+  (rf/reg-sub :cart/contains?
+    (fn [db [_ id]] (contains? (:cart db) id)))
+  (rf/reg-event :cart/add
+    (fn [{:keys [db]} [_ id]] {:db (update db :cart (fnil conj #{}) id)}))
+  (rf/reg-event :cart/remove
+    (fn [{:keys [db]} [_ id]] {:db (update db :cart disj id)})))
+
 (defview product-card
   [{:keys [product]}]
   [:button {:on-click [:cart/add (:id product)]} "Add to cart"])
 
 (defview toggle-card
-  "The 'assert the button now reads Remove' card — membership is a prop
-  at S1 (the structural subset; sub reads land S2)."
-  [{:keys [product in-cart?]}]
-  (if in-cart?
+  "The 'assert the button now reads Remove' card — membership is read
+  through the compiled `sub` path (03 §3), so a dispatched write to the
+  cart re-renders this button's text and intent. No prop injection."
+  [{:keys [product]}]
+  (if (sub [:cart/contains? (:id product)])
     [:button {:on-click [:cart/remove (:id product)]} "Remove"]
     [:button {:on-click [:cart/add (:id product)]} "Add to cart"]))
 
@@ -61,23 +86,44 @@
         "the tree-contract respelling — same read, prefix form")))
 
 ;; "Drive state with real events: (ui.test/dispatch! frame [:cart/add 42]),
-;; re-render, assert the button now reads 'Remove'."
-(deftest drive-state-with-real-events
-  (rf/reg-event :cart/add
-    (fn [{:keys [db]} [_ id]] {:db (update db :cart conj id)}))
+;; re-render, assert the button now reads 'Remove'. The whole loop, sub reads
+;; included, runs on main today."
+(deftest drive-state-through-the-real-sub
+  (reg-cart!)
   (let [frame (uit/frame {:app-db {:cart #{} :catalog fixture-catalog}})]
+    ;; before: the sub reads an empty cart → the button offers Add
+    (is (= "Add to cart"
+           (-> (uit/render [toggle-card {:product (product 42)}] {:frame frame})
+               (uit/find :button) uit/text))
+        "the compiled (sub …) reads an empty cart on the first render")
     (uit/dispatch! frame [:cart/add 42])
-    (let [in-cart? (contains? (:cart (rf/app-db-value frame)) 42)
-          tree     (uit/render [toggle-card {:product (product 42)
-                                             :in-cart? in-cart?}]
-                               {:frame frame})]
-      (is (= "Remove" (-> tree (uit/find :button) uit/text)))
+    ;; after: the dispatched write has drained; the re-render's subscription
+    ;; observes the new membership and the rendered tree changes.
+    (let [tree (uit/render [toggle-card {:product (product 42)}] {:frame frame})]
+      (is (= "Remove" (-> tree (uit/find :button) uit/text))
+          "dispatch → write drain → (sub …) read → the re-render reads Remove")
       (is (= [:cart/remove 42]
              (-> tree (uit/find :button) uit/attrs :on-click))
-          "the re-rendered button carries the new intent"))))
+          "…and the changed tree carries the new intent"))))
 
-;; "Loading and error states are just app-db values you install."
-(deftest states-are-app-db-values
-  (let [frame (uit/frame {:app-db {:cart #{42}}})]
-    (is (= #{42} (:cart (rf/app-db-value frame)))
-        "install a state, render against it — no mocking layer")))
+;; "Loading and error states are just app-db values you install." — seed the
+;; membership directly (no dispatch); the sub-reading view renders against it.
+(deftest seeded-membership-renders-without-a-dispatch
+  (reg-cart!)
+  (let [frame (uit/frame {:app-db {:cart #{42} :catalog fixture-catalog}})
+        tree  (uit/render [toggle-card {:product (product 42)}] {:frame frame})]
+    (is (= "Remove" (-> tree (uit/find :button) uit/text))
+        "install a state, render against it — the (sub …) reads the seeded
+         cart with no mocking layer and no dispatch")))
+
+;; "Stubbing a sub is the explicit option:
+;;  (ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})."
+(deftest stubbing-a-sub-is-the-explicit-option
+  (reg-cart!)
+  (let [frame (uit/frame {:app-db {:cart #{} :catalog fixture-catalog}})
+        tree  (uit/render [toggle-card {:product (product 42)}]
+                          {:frame frame
+                           :sub-overrides {[:cart/contains? 42] true}})]
+    (is (= "Remove" (-> tree (uit/find :button) uit/text))
+        "the override door pins the membership read — the button reads Remove
+         over an empty real cart, the read never touching app-db")))


### PR DESCRIPTION
Closes rf2-vxgfnd.131.

## The defect

The only executable Guide 09 fixture still identified itself as an **S1 adaptation**: `toggle-card` took cart membership as a **prop**, `drive-state-with-real-events` read app-db by hand and re-rendered on that prop, and the file contained **no `(sub …)`**. Meanwhile `guide/09-testing.md` claimed the complete dispatch → sub → re-render loop runs on main and `guide/README.md` claimed "guide 09's Tier-1 examples run". Since the S2 reactive core shipped (compiled `(sub …)` resolves against a frame on the JVM — proven by `test_render_jvm_test.clj` `sub-read-against-a-frame`), the fixture proved the wrong thing and the coverage wording overclaimed.

## The fixture (two sentences)

`toggle-card` now reads its cart membership through the compiled `(sub [:cart/contains? (:id product)])` path — no prop injection, no manual app-db read in the view — so `drive-state-through-the-real-sub` dispatches a write, drains to fixed point, and the **re-render's subscription** observes the moved app-db and the rendered tree changes ("Add to cart" → "Remove" plus the new `[:cart/remove 42]` intent). The other Tier-1 prose bullets ride the same real sub: a seeded-state render (no dispatch) and the sub-override door.

## Exact enrolled coverage (executable vs prose-only)

Executable fixtures in `implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`:

| Fixture | Guide 09 source it lifts |
|---|---|
| `add-button-carries-intent` | the Tier-1 ` ```clojure ` **code block** (verbatim shape) |
| `intent-assertion-respelled-through-attrs` | the "handlers are event vectors → equality check" prose (read through `ui.test/attrs`) |
| `drive-state-through-the-real-sub` | the "Drive state with real events … the button now reads Remove … the whole loop, sub reads included" prose loop |
| `seeded-membership-renders-without-a-dispatch` | the "Loading and error states are just app-db values you install" prose |
| `stubbing-a-sub-is-the-explicit-option` | the "Stubbing a sub is the explicit option: `:sub-overrides`" prose |

**Not enrolled by this file** (prose/fences that do NOT run as fixtures — stated so in the README, not overclaimed): the selector-grammar fence (`find`/`find-all` spellings), the literal-root-form fence (`ui.test/render [ui/frame-root …]`), and all Tier-2/Tier-3/Story examples. The remaining chapters lift as their stages land, per `drafts/guide-fixture-pipeline.md`.

## Coverage wording settled on

- **README** (was "guide 09's Tier-1 examples run"): now "guide 09's Tier-1 code block and the dispatch → sub → re-render loop it teaches run as fixtures … — the verbatim render, the intent-through-attrs respelling, the genuine dispatch → sub → re-render toggle (membership read through the compiled `sub` path), a seeded-state render, and the sub-override door. **The chapter's selector-grammar and literal-root fences are not enrolled yet**, and the remaining chapters are lifted as their stages land."
- **09-testing.md**: the "runs on main today" line now spells the exact loop the fixture proves — "the dispatch, the drain to fixed point, and the re-rendered view's `sub` read of the moved app-db".

## Proof discipline

Replacing the reactive read (`(sub [:cart/contains? (:id product)])` → `false`) made the fixture fail for the intended reason: `drive-state-through-the-real-sub` (both asserts), `seeded-membership-renders-without-a-dispatch`, and `stubbing-a-sub-is-the-explicit-option` all failed with `"Remove" ≠ "Add to cart"` (4 assertions), while the two subless verbatim tests stayed green. Reverted; the read is load-bearing.

## Quality gates

- **ui JVM suite** (`cd implementation/ui && clojure -M:test`) — **457 tests, 5845 assertions, 0 failures, 0 errors** (includes this fixture: 5 tests, 8 assertions).
- **doc slugs** (`python scripts/check_doc_slugs.py`) — exit 0.
- **Markdown/doc spine guards** (README link/anchor validator, doc-slugs, EP status-sync self-test + live, README inventory ratchet) — all green (the `.md` edits are force-tracked guide pages).
- The fast-PR spine's npm CLJS + core-JVM gates were not run locally: this fresh worktree has no `node_modules`, and the diff is JVM-test + docs-only (no `src/`, no `.cljs`, no deps) so those surfaces are unaffected; CI runs the full spine.
