### PR TITLE
fix(ui)+feat(xray): evidence projection hardened and wired — defonce migration, generation fencing, real Xray consumer (rf2-vxgfnd.168/.147/.146)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -943,7 +943,12 @@
   ;; incarnation is a FRESH per-mount identity (`make-root-incarnation`), NOT
   ;; the reusable root-id, so a stale teardown can never reap the cells of a
   ;; replacement root mounted under the same root-id. `defonce`
-  ;; (module-lived); `reset-scheduler!` clears it between fixtures. Frame
+  ;; (module-lived) — and because `defonce` carries the VALUE across a hot
+  ;; reload, a representation change must migrate the surviving state:
+  ;; `migrate-legacy-root-cells!` (invoked at namespace load, beside the
+  ;; weak helpers) rebuilds any pre-weak persistent-set entries into the
+  ;; current host weak sets (rf2-vxgfnd.168). `reset-scheduler!` clears the
+  ;; registry between fixtures. Frame
   ;; teardown also consults its still-disconnected members, whose retained
   ;; subscription targets and resource-incarnation pins name their last
   ;; published frames.
@@ -2201,6 +2206,75 @@
     0
     #?(:clj  (.size ^java.util.Set members)
        :cljs (count (weak-live members)))))
+
+;; ---- reload migration (rf2-vxgfnd.168) ---------------------------------------
+;;
+;; `root-cells` is `defonce`, so a hot reload (CLJS `:after-load`, JVM
+;; `require :reload`) PRESERVES the pre-weak value — `incarnation ->
+;; #{cell …}` persistent sets (pre-rf2-mc62sp) — while every reloaded
+;; operation assumes the host weak representation. Without migration the
+;; first post-reload root operation crashes mid-lifecycle: on the JVM,
+;; `weak-add!`/`weak-remove!` hit the persistent set's unsupported mutable
+;; ops (`UnsupportedOperationException` inside `teardown!`, AFTER the cell
+;; already went :dead); on CLJS the weak helpers read the missing
+;; `:refs`/`:by-cell` slots (`TypeError`), and the incarnation stays
+;; retained. The load-time call below converges any surviving legacy
+;; entries into the current representation before anything touches them.
+
+(defn migrate-legacy-root-cells!
+  "RELOAD MIGRATION (rf2-vxgfnd.168): rebuild every PRE-WEAK `root-cells`
+  entry — the persistent `#{cell …}` shape a pre-rf2-mc62sp namespace's
+  `defonce` hands a hot reload — into the current host weak membership
+  set. Runs once at namespace load (immediately below, after the weak
+  helpers/reaper exist); re-running is an idempotent no-op, so it is also
+  the tool/test re-run door.
+
+  Identity-preserving: every still-referenced member — INCLUDING an
+  Activity-hidden cell that must stay discoverable for root/frame
+  teardown — is re-enrolled under its incarnation (and, on CLJS,
+  re-registered with the finalization reaper via `weak-add!`). The
+  registry is never cleared: clearing would orphan hidden ownership and
+  leave teardown incomplete. Ordinary reconciliation-unmounted cells
+  become collectible exactly as the weak design intends — the fresh weak
+  set holds them no more strongly than any other member.
+
+  Mixed-state tolerant + convergent: only legacy persistent-set entries
+  convert (`set?` is false for BOTH host weak representations), each
+  entry swap is CAS-guarded on the exact legacy value so a concurrent
+  enrol/forget/migrate can never be clobbered, and the outer loop
+  re-checks until no legacy entry remains (new code never writes the
+  legacy shape, so the loop terminates). Fresh startup pays only the
+  bounded empty-registry check — no compatibility branch remains on the
+  hot read/write paths once migration completes. Returns nil."
+  []
+  (loop []
+    (let [legacy (filter (comp set? val) @root-cells)]
+      (when (seq legacy)
+        (doseq [[incarnation members] legacy]
+          (let [fresh (make-weak-member-set)]
+            (run! (fn [cell] (weak-add! fresh incarnation cell)) members)
+            (swap! root-cells
+                   (fn [m]
+                     (if (identical? (get m incarnation) members)
+                       (assoc m incarnation fresh)
+                       m)))))
+        (recur)))))
+
+(defn seed-legacy-root-cells!
+  "Test seam (rf2-vxgfnd.168): overwrite `incarnation`'s registry entry
+  with the PRE-WEAK persistent-set representation (`#{cell …}`) exactly
+  as a pre-rf2-mc62sp namespace's `defonce` leaves it across a hot
+  reload — the reload-simulation fixture seeds this, runs
+  `migrate-legacy-root-cells!`, and drives teardown/counting through the
+  reloaded code. Never called by production code. Returns nil."
+  [incarnation cells]
+  (swap! root-cells assoc incarnation (into #{} cells))
+  nil)
+
+;; The load-time hook: converge any `defonce`-surviving legacy entries
+;; BEFORE any post-reload root operation can reach them. On a fresh
+;; start `root-cells` is empty and this is one bounded no-op check.
+(migrate-legacy-root-cells!)
 
 (defn- forget-root-cell!
   "Remove `cell` from `incarnation`'s weak membership set, DROPPING the

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -24,6 +24,25 @@
   `uninstall!` (owner-checked) releases the sink callback and every retained
   entry. A tool absent or uninstalled retains ZERO ViewCells/evidence.
 
+  LINEARIZED BY GENERATION (rf2-vxgfnd.147). Owner, generation, the armed
+  sink closure, the entries, and the ordinal mint live in ONE state atom
+  (`state*`), so install/uninstall/publication transitions are single
+  atomic swaps. Every ownership transition through the closed state bumps
+  a monotonically unique GENERATION, the armed sink closure captures the
+  generation current at arm time, and a delivery publishes ONLY while its
+  captured generation exactly matches the current open one — so a delayed
+  callback that raced an uninstall cannot repopulate an ownerless
+  projection, a stale owner-A callback cannot contaminate owner B's fresh
+  projection, and an uninstall/reinstall of the SAME logical owner id is
+  ABA-safe (the old incarnation's callbacks are fenced out by generation,
+  not by owner equality). On the JVM the lifecycle transitions additionally
+  serialize their raw-slot arm/disarm under a tiny transition lock — held
+  only across the swap + slot write, NEVER through a tool/user callback —
+  so a stale A teardown can never disarm B's freshly installed sink. The
+  legal linearization: a publication linearizes at its state swap and takes
+  effect iff the open generation it captured is still current; install and
+  uninstall linearize in transition-lock order.
+
   OBSERVATIONAL ONLY. The scheduler stays authoritative: delivery runs inside
   the flush's containment (rf2-vxgfnd.73 — a throwing consumer can neither
   strand a cell nor abort a batch), the projection never acquires/releases or
@@ -117,25 +136,68 @@
 
 ;; ---- projection state --------------------------------------------------------
 
-(defonce ^:private owner*
-  ;; The identity that currently owns the projection (any comparable value —
-  ;; a namespaced keyword by convention), or nil when uninstalled. `defonce`
-  ;; so the ownership survives namespace reload (HMR) — a same-owner
-  ;; re-install is the idempotent re-arm path.
-  (atom nil))
+(defonce ^:private state*
+  ;; THE ONE AUTHORITATIVE projection state (rf2-vxgfnd.147) — owner,
+  ;; generation, the armed sink closure, the retained entries, and the
+  ;; ordinal mint transition TOGETHER in single atomic swaps, so the
+  ;; lifecycle is linearizable (no second store to race):
+  ;;
+  ;;   :owner        — the identity currently owning the projection (any
+  ;;                   comparable value; a namespaced keyword by
+  ;;                   convention), or nil when uninstalled.
+  ;;   :generation   — monotonically unique ownership-span counter. Bumped
+  ;;                   on every transition through the CLOSED state (fresh
+  ;;                   claim, uninstall, force-release) and NEVER reused,
+  ;;                   so a callback fenced on the generation it captured
+  ;;                   is ABA-safe across uninstall/reinstall of the same
+  ;;                   logical owner id. A same-owner re-arm (the HMR
+  ;;                   path) is the SAME continuous ownership span and
+  ;;                   keeps its generation — accumulated evidence and
+  ;;                   in-flight deliveries stay valid together.
+  ;;   :sink         — the exact closure this tier last armed on the raw
+  ;;                   reactive slot (nil when closed) — kept HERE per the
+  ;;                   one-authoritative-state discipline, and the capture
+  ;;                   door for race fixtures (`installed-sink`).
+  ;;   :entries      — `ViewCell -> {:cell-id ord :view-id vid :evidence
+  ;;                   accrual}` — the whole retained projection. Keyed by
+  ;;                   cell identity (the scheduler's own dedup axis); dead
+  ;;                   cells are pruned at every delivery and read, and the
+  ;;                   map clears atomically WITH the ownership transition
+  ;;                   on uninstall, so a tool absent or closed retains
+  ;;                   ZERO cells.
+  ;;   :next-ordinal — monotonic mint for `:cell-id` (a stable,
+  ;;                   developer-facing instance ordinal: two mounts of one
+  ;;                   view are two cells; the ordinal keeps their rows
+  ;;                   apart and stable across batches). Never reset while
+  ;;                   installed; reset with the entries when the
+  ;;                   projection closes (a closed tool retains no ordinal
+  ;;                   state).
+  ;;
+  ;; `defonce` (module-lived); note the var is NEW with this shape — a hot
+  ;; reload from the pre-.147 multi-atom representation initialises it
+  ;; fresh (the owning tool's `:after-load` re-install re-claims it), so
+  ;; no old-shape value can survive into the new code (the rf2-vxgfnd.168
+  ;; lesson applied at the source).
+  (atom {:owner nil :generation 0 :sink nil :entries {} :next-ordinal 0}))
 
-(defonce ^:private entries*
-  ;; `ViewCell -> {:cell-id ord :view-id vid :evidence accrual}` — the whole
-  ;; retained projection. Keyed by cell identity (the scheduler's own dedup
-  ;; axis); dead cells are pruned at every delivery and read, and the map is
-  ;; cleared on uninstall, so a tool absent or closed retains ZERO cells.
-  (atom {}))
+#?(:clj
+   (defonce ^:private transition-lock
+     ;; Serialises LIFECYCLE transitions (install/uninstall/force-release)
+     ;; with their raw-slot arm/disarm so the pair is one linearization
+     ;; point: a stale A teardown can never disarm B's freshly armed sink.
+     ;; Held ONLY across the state swap + `set-evidence-sink!` write —
+     ;; never through a tool/user callback (`project-batch!` publication
+     ;; does not take it; the generation fence in its swap is its
+     ;; linearization). CLJS is single-threaded: transitions cannot
+     ;; interleave, so no lock exists there.
+     (Object.)))
 
-(defonce ^:private cell-ordinal*
-  ;; Monotonic mint for `:cell-id` — a stable, developer-facing instance
-  ;; ordinal (two mounts of one view are two cells; the ordinal keeps their
-  ;; rows apart and stable across batches). Never reset while installed.
-  (atom 0))
+(defn- transition!
+  "Run lifecycle transition `f` (state swap + raw-slot effect) atomically
+  with respect to other transitions. See `transition-lock`."
+  [f]
+  #?(:clj  (locking transition-lock (f))
+     :cljs (f)))
 
 (defn- prune-dead
   "Drop every entry whose cell has been torn down (`:dead` — root/frame
@@ -147,29 +209,48 @@
              entries entries))
 
 (defn- project-batch!
-  "The installed evidence-sink `(fn [cell ev] …)`: accrete one flushed
-  batch's bounded record into `cell`'s accumulator and sweep dead cells.
+  "One generation-fenced delivery: accrete one flushed batch's bounded
+  record into `cell`'s accumulator and sweep dead cells — IFF `gen`, the
+  generation the armed sink closure captured, is still the current OPEN
+  owner's generation. A callback whose generation has closed (uninstall,
+  force-release, or a later reinstall — even of the same owner id) is a
+  no-op: it can neither repopulate an ownerless projection nor contaminate
+  a successor owner's fresh one (rf2-vxgfnd.147). The fence, the ordinal
+  mint, and the entry write are ONE swap, so publication linearizes at the
+  swap and a concurrent uninstall either precedes it (fence rejects) or
+  follows it (the transition clears the entry it just admitted).
+
   Runs inside the flush's rf2-vxgfnd.73 containment; constant-work per
   delivery (the record is already bounded). Never called in production
   (the flush's sink call is debug-gated); belt-gated here regardless."
-  [cell ev]
+  [gen cell ev]
   (when interop/debug-enabled?
     (when-not (= :dead (reactive/lifecycle cell))
-      ;; Mint the ordinal outside the swap (pure retry body). The CLJS host
-      ;; is single-threaded; a concurrent JVM fixture could at worst waste
-      ;; an ordinal, never corrupt an entry.
-      (let [ord (when-not (contains? @entries* cell)
-                  (swap! cell-ordinal* inc))]
-        (swap! entries*
-               (fn [entries]
-                 (let [entries (prune-dead entries)
-                       entry   (or (get entries cell)
-                                   {:cell-id  ord
-                                    :view-id  (reactive/cell-view-id cell)
-                                    :evidence nil})]
-                   (assoc entries cell
-                          (update entry :evidence accrete-evidence ev)))))))
+      (swap! state*
+             (fn [{:keys [owner generation entries next-ordinal] :as s}]
+               (if-not (and (some? owner) (= gen generation))
+                 s
+                 (let [entries  (prune-dead entries)
+                       existing (get entries cell)
+                       entry    (or existing
+                                    {:cell-id  next-ordinal
+                                     :view-id  (reactive/cell-view-id cell)
+                                     :evidence nil})]
+                   (assoc s
+                          :entries (assoc entries cell
+                                          (update entry :evidence
+                                                  accrete-evidence ev))
+                          :next-ordinal (if existing
+                                          next-ordinal
+                                          (inc next-ordinal))))))))
     nil))
+
+(defn- sink-for
+  "The armed evidence-sink closure for one ownership span: every delivery
+  it performs is fenced on `generation` — the generation current when it
+  was armed (`install!`). Retains nothing beyond that integer."
+  [generation]
+  (fn [cell ev] (project-batch! generation cell ev)))
 
 ;; ---- lifecycle (identity-owned install/uninstall) ---------------------------
 
@@ -209,63 +290,112 @@
   whole projection DCEs out of `:advanced` output.
 
   While installed, the raw `set-evidence-sink!` slot belongs to this tier;
-  bypassing it directly is the test seam only."
+  bypassing it directly is the test seam only.
+
+  Linearization (rf2-vxgfnd.147): the ownership swap + the raw-slot arm are
+  one transition (`transition!`), a FRESH claim opens a NEW generation, and
+  the armed closure captures exactly that generation — deliveries of any
+  earlier generation are fenced out, even for the same owner id (ABA-safe)."
   [owner-id]
   (if-not interop/debug-enabled?
     false
     (do
       (assert (some? owner-id) "install! requires a non-nil owner id")
-      (let [[old new] (swap-vals! owner*
-                                  (fn [cur]
-                                    (if (or (nil? cur) (= cur owner-id))
-                                      owner-id
-                                      cur)))]
-        (cond
-          (nil? old)
-          (do (reset! entries* {})
-              (reactive/set-evidence-sink! project-batch!)
-              true)
-
-          (= old owner-id)
-          (do (reactive/set-evidence-sink! project-batch!)
-              true)
-
-          :else
-          (do (warn-rejected-install! new owner-id)
-              false))))))
+      (transition!
+       (fn []
+         (let [[old new]
+               (swap-vals! state*
+                           (fn [{:keys [owner generation] :as s}]
+                             (cond
+                               ;; fresh claim → NEW generation, fresh fenced
+                               ;; closure, empty projection
+                               (nil? owner)
+                               (let [g (inc generation)]
+                                 (assoc s :owner owner-id
+                                          :generation g
+                                          :sink (sink-for g)
+                                          :entries {}))
+                               ;; same-owner re-arm → the SAME ownership span
+                               ;; (generation kept, evidence kept), fresh
+                               ;; closure for the raw slot
+                               (= owner owner-id)
+                               (assoc s :sink (sink-for generation))
+                               ;; foreign owner → untouched
+                               :else s)))]
+           (if (or (nil? (:owner old)) (= (:owner old) owner-id))
+             ;; Arm the raw slot with the closure the transition minted —
+             ;; both writes sit inside the transition lock, so no stale
+             ;; teardown can interleave between them.
+             (do (reactive/set-evidence-sink! (:sink new))
+                 true)
+             (do (warn-rejected-install! (:owner new) owner-id)
+                 false))))))))
 
 (defn uninstall!
-  "Release the projection iff `owner-id` owns it: clear the reactive sink
-  slot, drop EVERY retained entry (cells + accumulated evidence), and free
-  the ownership — teardown releases all callbacks/references, so a closed
-  tool retains nothing. Returns true when released; false (nothing changes)
-  when `owner-id` is not the current owner. Production: no-op, false."
+  "Release the projection iff `owner-id` owns it: one atomic transition
+  frees the ownership, CLOSES the generation (so every in-flight delivery
+  of this span is fenced out — a delayed callback cannot repopulate the
+  released projection), drops EVERY retained entry (cells + accumulated
+  evidence) and the ordinal state, and disarms the reactive sink slot —
+  teardown releases all callbacks/references, so a closed tool retains
+  nothing. Owner-checked AND transition-serialised: a stale uninstall
+  racing a successor's install either precedes it (releases, then the
+  successor claims fresh) or follows it (sees the successor's ownership
+  and refuses — the successor's sink/state are untouched). Returns true
+  when released; false (nothing changes) when `owner-id` is not the
+  current owner. Production: no-op, false."
   [owner-id]
   (if-not interop/debug-enabled?
     false
-    (let [[old _] (swap-vals! owner* (fn [cur] (if (= cur owner-id) nil cur)))]
-      (if (= old owner-id)
-        (do (reactive/set-evidence-sink! nil)
-            (reset! entries* {})
-            true)
-        false))))
+    (transition!
+     (fn []
+       (let [[old _] (swap-vals! state*
+                                 (fn [{:keys [owner generation] :as s}]
+                                   (if (= owner owner-id)
+                                     {:owner        nil
+                                      :generation   (inc generation)
+                                      :sink         nil
+                                      :entries      {}
+                                      :next-ordinal 0}
+                                     s)))]
+         (if (= (:owner old) owner-id)
+           (do (reactive/set-evidence-sink! nil)
+               true)
+           false))))))
 
 (defn force-release!
   "Test support: release the projection REGARDLESS of owner — sink slot
-  cleared, every entry dropped, ownership freed. The fixture-reset door
-  (pair it with `reactive/reset-scheduler!` between fixtures); production
-  tools use the owner-checked `uninstall!`. Returns nil."
+  cleared, every entry dropped, ownership freed, and the generation CLOSED
+  (an in-flight delivery captured before the reset is fenced out exactly
+  as under an owner-checked uninstall). The fixture-reset door (pair it
+  with `reactive/reset-scheduler!` between fixtures); production tools use
+  the owner-checked `uninstall!`. Returns nil."
   []
-  (reset! owner* nil)
-  (reset! entries* {})
-  (when interop/debug-enabled?
-    (reactive/set-evidence-sink! nil))
-  nil)
+  (transition!
+   (fn []
+     (swap! state* (fn [{:keys [generation]}]
+                     {:owner        nil
+                      :generation   (inc generation)
+                      :sink         nil
+                      :entries      {}
+                      :next-ordinal 0}))
+     (when interop/debug-enabled?
+       (reactive/set-evidence-sink! nil))
+     nil)))
 
 (defn installed-owner
   "The identity currently owning the projection, or nil (tool/test read)."
   []
-  @owner*)
+  (:owner @state*))
+
+(defn installed-sink
+  "The exact sink closure this tier last armed on the reactive slot, or
+  nil when the projection is closed (tool/test read). Race fixtures use it
+  the way `deliver-flush!` does — deref at delivery start, invoke later —
+  to replay a DELAYED delivery against a projection whose generation has
+  since closed and prove the fence holds."
+  []
+  (:sink @state*))
 
 ;; ---- the projection read -----------------------------------------------------
 
@@ -298,7 +428,7 @@
   production build, where the debug evidence plane is elided (tool read)."
   []
   (when interop/debug-enabled?
-    (let [entries (swap! entries* prune-dead)
+    (let [entries (:entries (swap! state* update :entries prune-dead))
           roots   (root-id-index)]
       (->> entries
            (map (fn [[cell {:keys [cell-id view-id evidence]}]]

--- a/implementation/ui/test/re_frame/ui/reactive_root_reload_migration_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_reload_migration_cljs_test.cljc
@@ -1,0 +1,215 @@
+(ns re-frame.ui.reactive-root-reload-migration-cljs-test
+  "rf2-vxgfnd.168 — `root-cells` is `defonce`, and rf2-mc62sp changed its
+  REPRESENTATION from persistent strong sets (`incarnation -> #{cell …}`)
+  to host-specific mutable weak sets. A hot reload (CLJS `:after-load`,
+  JVM `require :reload`) therefore hands the reloaded code the OLD-shape
+  value: without migration the first post-reload root operation crashes
+  mid-lifecycle (JVM `UnsupportedOperationException` inside `teardown!`;
+  CLJS `TypeError` on the missing `:refs`/`:by-cell` slots) and leaves
+  dead cells / incarnations retained.
+
+  The fixture here SIMULATES the reload survivor: cells are mounted
+  through the current code, then `seed-legacy-root-cells!` overwrites the
+  registry entry with the exact pre-weak persistent-set shape, and
+  `migrate-legacy-root-cells!` (the same fn the namespace runs at load)
+  converges it. The proofs:
+
+    - connected AND Activity-hidden cells survive the migration and stay
+      discoverable — root teardown reaps them without host exceptions;
+    - final `teardown!` (the deterministic fast path) works post-migration
+      and drops the incarnation entry with its last member;
+    - the migration is IDEMPOTENT and a MIXED old/new registry converges
+      (already-weak entries untouched — `identical?` preserved);
+    - live-member and tracked-incarnation counts return to zero after
+      teardown on BOTH hosts;
+    - (JVM) ordinary reconciliation-unmounted cells remain COLLECTIBLE
+      after migration — the rebuilt weak set retains no strong edge.
+
+  `.cljc` ending `-cljs-test` runs on node (`test:cljs` / `test:ui`) AND
+  the JVM (`clojure -M:test`), so the migration is graft-checked on both
+  hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.test-support         :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- render+commit! [cell fid queries]
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:mig/site i] q))
+                                        (range) queries))))]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- mount!
+  "Graft analogue of a real mount UNDER a root: mint a cell, attach it to
+  `incarnation`, commit it connected under `fid` observing `queries`."
+  [vid incarnation fid queries]
+  (let [cell (reactive/make-cell vid)]
+    (reactive/attach-root! cell incarnation)
+    (render+commit! cell fid queries)))
+
+;; ===========================================================================
+;; The reload survivor: legacy strong-set entry → migration → full lifecycle
+;; ===========================================================================
+
+(deftest migration-preserves-connected-and-hidden-cells-through-root-teardown
+  (rf/reg-sub :mig/a (fn [db _] (:a db)))
+  (let [fid         (make-frame! :mig/frame {:a 1})
+        incarnation (reactive/make-root-incarnation)
+        base        (reactive/root-cell-count)
+        connected   (mount! ::connected incarnation fid [[:mig/a]])
+        hidden      (doto (mount! ::hidden incarnation fid [[:mig/a]])
+                      (reactive/disconnect!))]
+    ;; Simulate the defonce reload survivor: the pre-rf2-mc62sp namespace
+    ;; left `incarnation -> #{connected hidden}` (a persistent strong set);
+    ;; the reloaded code now runs against it.
+    (reactive/seed-legacy-root-cells! incarnation [connected hidden])
+    (reactive/migrate-legacy-root-cells!)
+
+    (testing "both members survived the representation change"
+      (is (= 2 (reactive/root-cell-count incarnation))
+          "connected + Activity-hidden cells are retained through migration")
+      (is (identical? incarnation (reactive/cell-root connected)))
+      (is (identical? incarnation (reactive/cell-root hidden))))
+
+    (testing "root teardown reaps BOTH through the migrated weak registry —
+              no UnsupportedOperationException (JVM) / TypeError (CLJS)"
+      ;; The unmount thunk is the host React `.unmount` analogue: it sweeps
+      ;; the still-mounted tree's effect cleanups (`disconnect!`), which the
+      ;; armed teardown window captures; the already-hidden sibling is
+      ;; discovered through the (migrated) weak registry.
+      (reactive/teardown-root! incarnation (fn [] (reactive/disconnect! connected)))
+      (is (= :dead (reactive/lifecycle connected)))
+      (is (= :dead (reactive/lifecycle hidden))
+          "the already-hidden cell stayed discoverable across the migration")
+      (is (= 0 (reactive/root-cell-count incarnation)))
+      (is (= base (reactive/root-cell-count))
+          "tracked-incarnation count returned to baseline — no retained
+           incarnation, no partial registry state"))))
+
+(deftest final-teardown-fast-path-works-on-a-migrated-entry
+  (rf/reg-sub :mig/a (fn [db _] (:a db)))
+  (let [fid         (make-frame! :mig/frame {:a 1})
+        incarnation (reactive/make-root-incarnation)
+        base        (reactive/root-cell-count)
+        cell        (mount! ::solo incarnation fid [[:mig/a]])]
+    (reactive/seed-legacy-root-cells! incarnation [cell])
+    (reactive/migrate-legacy-root-cells!)
+    (is (= 1 (reactive/root-cell-count incarnation)))
+    ;; `teardown!` → `detach-root!` → `weak-remove!` — the deterministic
+    ;; departure that crashed on the JVM's persistent set pre-migration.
+    (reactive/teardown! cell)
+    (is (= :dead (reactive/lifecycle cell)))
+    (is (= 0 (reactive/root-cell-count incarnation)))
+    (is (= base (reactive/root-cell-count))
+        "the incarnation entry dropped with its last member (AC5 holds
+         through the migrated representation)")))
+
+;; ===========================================================================
+;; Idempotence + mixed-state convergence
+;; ===========================================================================
+
+(deftest migration-is-idempotent-and-converges-a-mixed-registry
+  (rf/reg-sub :mig/a (fn [db _] (:a db)))
+  (let [fid      (make-frame! :mig/frame {:a 1})
+        base     (reactive/root-cell-count)
+        ;; OLD-shape incarnation: seeded with the legacy persistent set.
+        old-inc  (reactive/make-root-incarnation)
+        old-cell (mount! ::old old-inc fid [[:mig/a]])
+        ;; NEW-shape incarnation: enrolled through the current weak path.
+        new-inc  (reactive/make-root-incarnation)
+        new-cell (mount! ::new new-inc fid [[:mig/a]])]
+    (reactive/seed-legacy-root-cells! old-inc [old-cell])
+
+    (testing "one run converges exactly the legacy entries"
+      (reactive/migrate-legacy-root-cells!)
+      (is (= 1 (reactive/root-cell-count old-inc)))
+      (is (= 1 (reactive/root-cell-count new-inc))
+          "the already-weak entry is untouched"))
+
+    (testing "a re-run is an idempotent no-op — repeated reloads are safe"
+      (reactive/migrate-legacy-root-cells!)
+      (reactive/migrate-legacy-root-cells!)
+      (is (= 1 (reactive/root-cell-count old-inc)))
+      (is (= 1 (reactive/root-cell-count new-inc))))
+
+    (testing "the converged registry drives the full lifecycle on both entries"
+      (reactive/teardown-root! old-inc (fn [] (reactive/disconnect! old-cell)))
+      (reactive/teardown-root! new-inc (fn [] (reactive/disconnect! new-cell)))
+      (is (= :dead (reactive/lifecycle old-cell)))
+      (is (= :dead (reactive/lifecycle new-cell)))
+      (is (= base (reactive/root-cell-count))
+          "live cell + tracked-incarnation counts return to zero"))))
+
+;; ===========================================================================
+;; The weak economy survives migration (JVM — deterministic GC clearing):
+;; a migrated entry must not strongly pin reconciliation-unmounted cells
+;; ===========================================================================
+
+#?(:clj
+   (defn- gc-until
+     "Hint GC (bounded retries) until `pred` returns true; returns its final
+     value. Weakly-reachable objects clear on the first full GC in practice."
+     [pred]
+     (loop [i 0]
+       (cond
+         (pred)     true
+         (>= i 100) (pred)
+         :else      (do (System/gc)
+                        (Thread/sleep 10)
+                        (recur (inc i)))))))
+
+#?(:clj
+   (deftest migrated-members-remain-collectible-not-strongly-pinned
+     (rf/reg-sub :mig/a (fn [db _] (:a db)))
+     (let [fid         (make-frame! :mig/frame {:a 1})
+           incarnation (reactive/make-root-incarnation)
+           n           16
+           hidden      (doto (mount! ::hidden incarnation fid [[:mig/a]])
+                         (reactive/disconnect!))
+           ;; Hold the churned population in an atom so the test can DROP
+           ;; its last strong references deterministically (a bare local
+           ;; would keep them reachable for the whole test body).
+           churned*    (atom (mapv (fn [i]
+                                     (doto (mount! (keyword "mig" (str "row-" i))
+                                                   incarnation fid [[:mig/a]])
+                                       (reactive/disconnect!)))
+                                   (range n)))]
+       ;; The legacy strong set retained the WHOLE churned population; seed
+       ;; it exactly so, migrate, then drop the test's own strong refs.
+       (reactive/seed-legacy-root-cells! incarnation (conj @churned* hidden))
+       (reactive/migrate-legacy-root-cells!)
+       (is (= (+ n 1) (reactive/root-cell-count incarnation))
+           "precondition: every seeded member survived migration")
+       (let [refs (mapv (fn [c] (java.lang.ref.WeakReference. c)) @churned*)]
+         (reset! churned* nil)   ;; the last strong holder lets go
+         (testing "post-migration, the churned population is GARBAGE again"
+           (is (true? (gc-until #(every? (fn [^java.lang.ref.WeakReference r]
+                                           (nil? (.get r)))
+                                         refs)))
+               "the migrated weak set retains no strong edge — the
+                pre-migration strong-set pinning did not survive the rebuild")
+           (is (= 1 (reactive/root-cell-count incarnation))
+               "exactly the hidden sibling remains")))
+       (testing "…and the hidden sibling stays reapable"
+         (is (= :disconnected (reactive/lifecycle hidden)))
+         (reactive/teardown-root! incarnation (fn [] nil))
+         (is (= :dead (reactive/lifecycle hidden)))
+         (is (= 0 (reactive/root-cell-count incarnation)))))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_generation_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_generation_cljs_test.cljc
@@ -1,0 +1,201 @@
+(ns re-frame.ui.tool-evidence-generation-cljs-test
+  "rf2-vxgfnd.147 — generation fencing of the evidence-projection
+  lifecycle, the DETERMINISTIC single-thread half (runs on node AND the
+  JVM; the two-thread latch races live in
+  `tool_evidence_generation_race_jvm_test.clj`).
+
+  The delayed-delivery replay technique: a race fixture captures the
+  armed sink closure exactly the way `deliver-flush!` does (deref at
+  delivery start — here `evidence/installed-sink`), lets the lifecycle
+  move on (uninstall / reinstall / force-release), then invokes the
+  captured closure as the DELAYED callback. Under the pre-.147 multi-atom
+  publication every replay below corrupts the projection (repopulates an
+  ownerless one, contaminates a successor's, or survives an ABA
+  reinstall); under generation fencing each is a proven no-op.
+
+  Also pins the CLJS-reachable reentrant/HMR generation cases: a
+  mid-batch owner change delivers the REMAINING batch through the
+  successor's armed generation (the documented legal linearization), and
+  a same-owner re-arm keeps the span (generation continuity = evidence
+  continuity)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]
+            [re-frame.ui.tool.evidence     :as evidence]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+(defn- entry-for [vid]
+  (some #(when (= vid (:view-id %)) %) (evidence/projection)))
+
+(def ^:private ev-1
+  ;; one bounded batch record, as `fold-evidence` would deliver it
+  {:first-epoch 1 :latest-epoch 1 :count 1
+   :causes #{} :targets [] :dropped #{} :dropped-exact? true})
+
+;; ===========================================================================
+;; Race (a), single-thread replay: a delayed callback after uninstall must
+;; not repopulate the ownerless projection (closed-retains-zero)
+;; ===========================================================================
+
+(deftest delayed-delivery-after-uninstall-is-fenced-out
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell    (reactive/make-cell ::v)
+        delayed (evidence/installed-sink)]   ;; the deliver-flush! deref
+    (is (some? delayed) "the armed closure is captured at delivery start")
+    (is (true? (evidence/uninstall! ::tool-a)))
+    ;; the delayed callback resumes AFTER the uninstall closed the span
+    (delayed cell ev-1)
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (evidence/projection))
+        "the ownerless projection stays EMPTY — the stale generation
+         cannot repopulate it (red under unchecked publication)")))
+
+(deftest delayed-delivery-after-force-release-is-fenced-out
+  ;; the fixture-reset door must fence exactly like an owner uninstall —
+  ;; the HMR/fixture generation case
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell    (reactive/make-cell ::v)
+        delayed (evidence/installed-sink)]
+    (evidence/force-release!)
+    (delayed cell ev-1)
+    (is (= [] (evidence/projection))
+        "force-release! closes the generation; the in-flight delivery
+         publishes nothing")))
+
+;; ===========================================================================
+;; Race (b), single-thread replay: A's late callback cannot contaminate
+;; owner B's fresh projection
+;; ===========================================================================
+
+(deftest stale-owner-a-delivery-cannot-contaminate-owner-b
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell-a  (reactive/make-cell ::va)
+        stale-a (evidence/installed-sink)]
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (is (true? (evidence/install! ::tool-b)))
+    ;; B accretes real evidence through the CURRENT armed path
+    (let [cell-b (reactive/make-cell ::vb)]
+      (reactive/mark-dirty! cell-b 7)
+      (reactive/flush-pending!)
+      (is (= 1 (count (evidence/projection))) "B's fresh projection: one row")
+      ;; A's delayed callback resumes under B's ownership
+      (stale-a cell-a ev-1)
+      (let [rows (evidence/projection)]
+        (is (= 1 (count rows))
+            "B's projection is uncontaminated — no ::va row appeared")
+        (is (= ::vb (:view-id (first rows))))
+        (is (= 1 (get-in (entry-for ::vb) [:evidence :count]))
+            "…and B's own accumulator is untouched")))))
+
+;; ===========================================================================
+;; ABA safety: uninstall + reinstall of the SAME logical owner id is a NEW
+;; generation — owner equality is not a reusable token
+;; ===========================================================================
+
+(deftest same-owner-reinstall-is-a-new-generation-not-an-aba-token
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell-old (reactive/make-cell ::v-old)
+        sink-1   (evidence/installed-sink)]  ;; captured in incarnation 1
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (is (true? (evidence/install! ::tool-a)) "the same logical id re-claims")
+    ;; incarnation 2 accretes real evidence
+    (let [cell-new (reactive/make-cell ::v-new)]
+      (reactive/mark-dirty! cell-new 3)
+      (reactive/flush-pending!)
+      (is (some? (entry-for ::v-new)))
+      ;; incarnation 1's delayed callback replays — SAME owner id, CLOSED
+      ;; generation: bare owner equality would re-admit it (the ABA hole)
+      (sink-1 cell-old ev-1)
+      (is (nil? (entry-for ::v-old))
+          "the first incarnation's delivery is fenced out — generation,
+           not owner equality, is the admission token (ABA-safe)")
+      (is (= 1 (count (evidence/projection)))))))
+
+(deftest same-owner-rearm-keeps-the-span-and-its-inflight-deliveries
+  ;; the OTHER side of the ABA coin: an HMR re-arm (no uninstall) is the
+  ;; SAME continuous ownership span — a delivery captured before the
+  ;; re-arm remains valid, exactly as the accumulated evidence does
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell     (reactive/make-cell ::v)
+        pre-arm  (evidence/installed-sink)]
+    (is (true? (evidence/install! ::tool-a)) "the :after-load re-arm")
+    (pre-arm cell ev-1)
+    (is (= 1 (get-in (entry-for ::v) [:evidence :count]))
+        "the pre-re-arm delivery published — generation continuity is
+         evidence continuity within one ownership span")))
+
+;; ===========================================================================
+;; Stale-teardown protection (the sequential half of race (c)) — the JVM
+;; latch fixture drives the concurrent half
+;; ===========================================================================
+
+(deftest stale-a-uninstall-cannot-release-owner-b
+  (is (true? (evidence/install! ::tool-a)))
+  (is (true? (evidence/uninstall! ::tool-a)))
+  (is (true? (evidence/install! ::tool-b)))
+  (let [cell (reactive/make-cell ::vb)]
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (is (false? (evidence/uninstall! ::tool-a))
+        "A's replayed teardown is refused against B's ownership")
+    (is (= ::tool-b (evidence/installed-owner)) "B's owner token stands")
+    (is (= 1 (count (evidence/projection))) "B's entries stand")
+    ;; …and B's SINK was not disarmed: a further real flush still delivers
+    (reactive/mark-dirty! cell 2)
+    (reactive/flush-pending!)
+    (is (= 2 (get-in (entry-for ::vb) [:evidence :count]))
+        "delivery continues — the stale uninstall touched nothing")))
+
+;; ===========================================================================
+;; Reentrant owner change MID-BATCH: the documented legal linearization —
+;; the remaining batch delivers through the CURRENT armed generation
+;; ===========================================================================
+
+(deftest reentrant-midbatch-uninstall-stops-all-further-delivery
+  ;; a phase-2 listener closes the projection while the batch is
+  ;; mid-delivery: `deliver-flush!` derefs the slot per cell, so every
+  ;; delivery at or after the close finds either a disarmed slot or a
+  ;; closed generation — nothing publishes, nothing is retained
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell-a (reactive/make-cell ::va)
+        cell-b (reactive/make-cell ::vb)]
+    (reactive/subscribe cell-a (fn [] (evidence/uninstall! ::tool-a)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (reactive/flush-batch-in-order! [cell-a cell-b])
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (evidence/projection))
+        "the reentrant close retains zero — no post-close delivery lands")
+    (is (nil? (reactive/last-evidence-sink-escape))
+        "…and the handover raised no contained escape")))
+
+(deftest reentrant-midbatch-owner-change-linearizes-to-the-successor
+  ;; the documented LEGAL linearization of a mid-batch handover:
+  ;; A-close → B-open → every subsequent delivery (including the cell
+  ;; whose own listener performed the handover — its sink deref happens
+  ;; AFTER its listeners ran) publishes through B's armed closure at B's
+  ;; open generation. B owns those rows; A retains nothing.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell-a (reactive/make-cell ::va)
+        cell-b (reactive/make-cell ::vb)]
+    (reactive/subscribe cell-a (fn []
+                                 (evidence/uninstall! ::tool-a)
+                                 (evidence/install! ::tool-b)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (reactive/flush-batch-in-order! [cell-a cell-b])
+    (is (= ::tool-b (evidence/installed-owner)))
+    (is (= #{::va ::vb} (into #{} (map :view-id) (evidence/projection)))
+        "both deliveries linearized AFTER B's install and published into
+         B's projection — no delivery published into the closed A span")
+    (is (nil? (reactive/last-evidence-sink-escape)))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_generation_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_generation_race_jvm_test.clj
@@ -1,0 +1,218 @@
+(ns re-frame.ui.tool-evidence-generation-race-jvm-test
+  "rf2-vxgfnd.147 — the two-thread JVM latch/barrier races over the
+  generation-fenced evidence lifecycle (the deterministic single-thread
+  replays live in `tool_evidence_generation_cljs_test.cljc`).
+
+  The races the bead names, each opened deterministically with a
+  `CountDownLatch` handoff (no sleeps — the barrier makes each a
+  controlled linearization probe, not a stress test):
+
+    1. PAUSED CALLBACK vs UNINSTALL — a delivery thread captures the
+       armed sink (the `deliver-flush!` deref), parks, the owner
+       uninstalls, the delivery resumes: the closed generation fences it
+       out; the ownerless projection stays empty.
+    2. A's LATE CALLBACK vs B's INSTALL — A's parked delivery resumes
+       after B claimed and accreted fresh evidence: B's projection is
+       uncontaminated.
+    3. A-UNINSTALL vs B-INSTALL — raced from two threads under a start
+       barrier, every observed outcome must be one of the two legal
+       linearizations (A-close→B-claim, or B-reject→A-close); in
+       particular an installed B always has a LIVE armed sink (a stale A
+       teardown can never have disarmed it) and a refused B leaves a
+       cleanly closed projection.
+    4. CONCURRENT PROJECT BATCHES — parallel deliveries into own + shared
+       cells commit exactly (occurrence counts, batch counts, distinct
+       stable ordinals): publication is one atomic swap, so concurrency
+       loses nothing and double-mints nothing.
+    5. DELIVERY LOOP vs UNINSTALL — however the in-flight publication
+       interleaves with the closing transition, the closed state retains
+       zero entries (publication-then-clear or fence — both legal)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]
+            [re-frame.ui.tool.evidence     :as evidence])
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+(defn- entry-for [vid]
+  (some #(when (= vid (:view-id %)) %) (evidence/projection)))
+
+(def ^:private ev-1
+  {:first-epoch 1 :latest-epoch 1 :count 1
+   :causes #{} :targets [] :dropped #{} :dropped-exact? true})
+
+;; ===========================================================================
+;; Race 1 — paused callback vs uninstall
+;; ===========================================================================
+
+(deftest paused-delivery-resuming-after-uninstall-is-fenced-out
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell       (reactive/make-cell ::v)
+        captured   (CountDownLatch. 1)   ;; T1 holds the armed sink
+        released   (CountDownLatch. 1)   ;; main finished the uninstall
+        delivered  (CountDownLatch. 1)
+        delivery   (future
+                     (let [sink (evidence/installed-sink)] ;; the flush's deref
+                       (.countDown captured)
+                       (.await released 5 TimeUnit/SECONDS)
+                       ;; the delayed callback resumes AFTER the close
+                       (sink cell ev-1)
+                       (.countDown delivered)))]
+    (.await captured 5 TimeUnit/SECONDS)
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (.countDown released)
+    (is (true? (.await delivered 5 TimeUnit/SECONDS)))
+    (is (nil? (deref delivery 5000 ::timeout)))
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (evidence/projection))
+        "closed-retains-zero: the paused delivery could not repopulate the
+         ownerless projection (red under unchecked multi-atom publication)")))
+
+;; ===========================================================================
+;; Race 2 — A's late callback vs B's fresh projection
+;; ===========================================================================
+
+(deftest late-a-delivery-resuming-under-owner-b-is-fenced-out
+  (is (true? (evidence/install! ::tool-a)))
+  (let [cell-a     (reactive/make-cell ::va)
+        captured   (CountDownLatch. 1)
+        b-ready    (CountDownLatch. 1)   ;; B installed + accreted
+        delivered  (CountDownLatch. 1)
+        delivery   (future
+                     (let [sink (evidence/installed-sink)]
+                       (.countDown captured)
+                       (.await b-ready 5 TimeUnit/SECONDS)
+                       (sink cell-a ev-1)
+                       (.countDown delivered)))]
+    (.await captured 5 TimeUnit/SECONDS)
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (is (true? (evidence/install! ::tool-b)))
+    (let [cell-b (reactive/make-cell ::vb)]
+      (reactive/mark-dirty! cell-b 9)
+      (reactive/flush-pending!)
+      (is (= 1 (count (evidence/projection))) "precondition: B's one row"))
+    (.countDown b-ready)
+    (is (true? (.await delivered 5 TimeUnit/SECONDS)))
+    (is (nil? (deref delivery 5000 ::timeout)))
+    (testing "B's supposedly-fresh projection is actually fresh"
+      (let [rows (evidence/projection)]
+        (is (= [::vb] (mapv :view-id rows))
+            "A's late delivery did not contaminate B (no ::va row)")
+        (is (= 1 (get-in (entry-for ::vb) [:evidence :count])))))))
+
+;; ===========================================================================
+;; Race 3 — A-uninstall vs B-install under a start barrier: every observed
+;; outcome must be a legal linearization, and an installed B always has a
+;; LIVE sink (the pre-fix failure: A's late teardown disarmed B's)
+;; ===========================================================================
+
+(deftest a-uninstall-racing-b-install-always-linearizes-legally
+  (dotimes [round 50]
+    (evidence/force-release!)
+    (reactive/reset-scheduler!)
+    (is (true? (evidence/install! ::tool-a)))
+    (let [barrier   (CyclicBarrier. 2)
+          uninstall (future (.await barrier 5 TimeUnit/SECONDS)
+                            (evidence/uninstall! ::tool-a))
+          install   (future (.await barrier 5 TimeUnit/SECONDS)
+                            (evidence/install! ::tool-b))
+          u-result  (deref uninstall 5000 ::timeout)
+          i-result  (deref install 5000 ::timeout)
+          owner     (evidence/installed-owner)]
+      (is (true? u-result)
+          (str "round " round ": A owned the projection, so A's uninstall
+               released it under EVERY legal order"))
+      (is (contains? #{true false} i-result))
+      (case owner
+        ::tool-b
+        (do (is (true? i-result)
+                (str "round " round ": owner B implies B's install succeeded"))
+            ;; the pre-fix corruption: owner B but sink disarmed by A's
+            ;; late teardown → delivery dead. Prove B's sink is LIVE.
+            (let [cell (reactive/make-cell (keyword "vr" (str round)))]
+              (reactive/mark-dirty! cell 1)
+              (reactive/flush-pending!)
+              (is (= 1 (count (evidence/projection)))
+                  (str "round " round ": an installed B delivers — its sink
+                       and state were never clobbered by the stale A close"))))
+
+        nil
+        (do (is (false? i-result)
+                (str "round " round ": ownerless end-state implies B was
+                     REJECTED while A still owned (legal linearization
+                     B-reject → A-close)"))
+            (is (= [] (evidence/projection))
+                (str "round " round ": the closed projection retains zero"))
+            ;; and delivery is fully disarmed
+            (let [cell (reactive/make-cell (keyword "vr" (str round)))]
+              (reactive/mark-dirty! cell 1)
+              (reactive/flush-pending!)
+              (is (= [] (evidence/projection)))))
+
+        (is false (str "round " round ": ILLEGAL end-state owner " owner))))))
+
+;; ===========================================================================
+;; Race 4 — concurrent project batches commit exactly
+;; ===========================================================================
+
+(deftest concurrent-project-batches-commit-exactly
+  (is (true? (evidence/install! ::tool-a)))
+  (let [m       200
+        cell-1  (reactive/make-cell ::v1)
+        cell-2  (reactive/make-cell ::v2)
+        shared  (reactive/make-cell ::shared)
+        sink    (evidence/installed-sink)
+        barrier (CyclicBarrier. 2)
+        worker  (fn [own]
+                  (future
+                    (.await barrier 5 TimeUnit/SECONDS)
+                    (dotimes [_ m]
+                      (sink own ev-1)
+                      (sink shared ev-1))
+                    true))
+          t1    (worker cell-1)
+          t2    (worker cell-2)]
+    (is (true? (deref t1 10000 ::timeout)))
+    (is (true? (deref t2 10000 ::timeout)))
+    (testing "occurrence + batch counts are exact under contention"
+      (is (= m (get-in (entry-for ::v1) [:evidence :count])))
+      (is (= m (get-in (entry-for ::v1) [:evidence :batches])))
+      (is (= m (get-in (entry-for ::v2) [:evidence :count])))
+      (is (= (* 2 m) (get-in (entry-for ::shared) [:evidence :count])))
+      (is (= (* 2 m) (get-in (entry-for ::shared) [:evidence :batches]))))
+    (testing "ordinals minted once per cell, all distinct and stable"
+      (let [ids (mapv :cell-id (evidence/projection))]
+        (is (= 3 (count ids)))
+        (is (= 3 (count (distinct ids))))))))
+
+;; ===========================================================================
+;; Race 5 — a delivery loop racing the closing transition always ends closed
+;; ===========================================================================
+
+(deftest delivery-loop-racing-uninstall-ends-closed-and-empty
+  (is (true? (evidence/install! ::tool-a)))
+  (let [k        400
+        cell     (reactive/make-cell ::v)
+        sink     (evidence/installed-sink)
+        halfway  (CountDownLatch. 1)
+        delivery (future
+                   (dotimes [i k]
+                     (when (= i (quot k 2)) (.countDown halfway))
+                     (sink cell ev-1))
+                   true)]
+    (.await halfway 5 TimeUnit/SECONDS)
+    (is (true? (evidence/uninstall! ::tool-a)))
+    (is (true? (deref delivery 10000 ::timeout)))
+    (testing "whatever interleaving occurred, the closed state retains zero"
+      (is (nil? (evidence/installed-owner)))
+      (is (= [] (evidence/projection))
+          "publication-then-clear or fence — both linearize to empty"))))

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -41,6 +41,15 @@
          ;; projections; the Machine Inspector reads the runtime slice.
          day8/re-frame2-machines {:local/root "../../implementation/machines"}
 
+         ;; The Views panel's ViewCell Invalidation Evidence section
+         ;; consumes the ui artefact's TOOL tier
+         ;; (`re-frame.ui.tool.evidence` — rf2-vxgfnd.146). The
+         ;; dependency points THIS way only: re-frame.ui never depends
+         ;; on Xray, and production applications never pull Xray
+         ;; (bundle-isolation contract), so the ui artefact reaches
+         ;; production apps solely on its own terms.
+         day8/re-frame2-ui {:local/root "../../implementation/ui"}
+
          ;; Machine charts are owned by machines-viz and embedded here;
          ;; Xray does not maintain a second chart implementation.
          day8/re-frame2-machines-viz {:local/root "../machines-viz"}

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -568,6 +568,13 @@ diff chrome in cascade context, so the Reactive tab's value-listing is duplicate
   sub-id + `no readers remaining` tag; a small `unchanged`/`dim`-tinted swatch). Caption below:
   "Subscriptions cleaned up when their last reader unmounted."
 
+Below the teardown lists sits the **VIEWCELL INVALIDATION EVIDENCE** section (§3.4.1 —
+rf2-vxgfnd.146): the CUMULATIVE per-cell view over the `re-frame.ui` scheduler's bounded
+invalidation-evidence projection. Deliberately NOT epoch-scoped (the one exception on this
+panel): the accumulators span each ViewCell's whole observed life, so the section renders with
+or without a focused event-bundle, and renders its empty placeholder on hosts not running the
+re-frame.ui substrate.
+
 A legend closes the panel ("Views (right) are the focus — each: re-rendered + why (reactive vs
 parent re-render)") with three swatches: `changed (propagates downstream)` · `no change
 (short-circuits)` · `unmounted / destroyed`.
@@ -663,6 +670,58 @@ Rationale: unchanged subs are coverage signal, not signal-of-the-moment.
 Hiding by default keeps the dense view scannable; the toggle preserves
 the "I want to see what DIDN'T fire" affordance.
 
+### §3.4.1 ViewCell invalidation evidence (re-frame.ui substrate · rf2-vxgfnd.146)
+
+Xray is the OWNING native consumer of the `re-frame.ui.tool.evidence`
+projection (framework rf2-vxgfnd.75/.74/.46 — the bounded per-ViewCell
+invalidation-evidence accumulators the reactive scheduler's evidence-sink
+seam was built for). The Views panel renders it as the **VIEWCELL
+INVALIDATION EVIDENCE** section below the teardown lists.
+
+**Ownership + lifecycle.** The preload boot block claims the projection
+under the stable owner identity `:rf.xray/viewcell-evidence`
+(`day8.re-frame2-xray.viewcell-evidence/install!`). A shadow-cljs
+`:after-load` re-runs the same call as the evidence tier's idempotent
+same-owner re-arm — accumulated evidence survives (the HMR path). A
+foreign owner already holding the projection is NEVER clobbered: Xray's
+install is rejected and the section simply projects zero rows.
+`viewcell-evidence/uninstall!` releases exactly Xray's registration —
+generation-fenced downstream (rf2-vxgfnd.147), so an in-flight delivery
+cannot repopulate the released projection and a stale release cannot
+touch a successor owner. A successful install mirrors onto the
+`__day8_re_frame2_xray_viewcell_evidence` global sentinel (the browser
+feature-gate's wiring probe; withdrawn on uninstall).
+
+**Query path.** `:rf.xray/viewcell-evidence` (registered by
+`reactive-panel-subs/install!`) → `viewcell-evidence/rows`: one row per
+live ViewCell instance in stable `:cell-id` order —
+
+    {:cell-id ord :view-id vid :root-id rid|nil
+     :first-epoch e0 :latest-epoch eN :count n :batches b
+     :causes #{:value :hmr :disposed} :targets [tk …]
+     :dropped-count d :dropped-exact? bool}
+
+`:targets` is the bounded shown sample; `:dropped-count` /
+`:dropped-exact?` is the HONEST loss account (`false` ⇒ the count is a
+floor, rendered `≥N dropped`). Dead cells are pruned by the projection
+itself. Freshness rides the `:rf.xray/epoch-history` input (the standing
+epoch-pump axis): the ViewCell flush runs a microtask after drain-settle,
+so a same-epoch read may trail by one pump — the cumulative accumulators
+catch up, never lose.
+
+**Render.** One `list-row` per cell under
+`rf-xray-reactive-viewcell-evidence-section` (rows
+`…-row-<cell-id>`, empty state `…-empty`, caption `…-caption`):
+primary = view name · `cell #<ordinal>` · root-id (when under a live
+client root); trailing tag = occurrences · batches · epoch span
+`e0→eN` · cause union · shown-target count · `[≥]N dropped`.
+
+**Boundary.** tools/xray depends on the ui artefact's tool tier
+(`day8/re-frame2-ui` in deps.edn); `re-frame.ui` never depends on Xray;
+production applications pull neither (the tools/README bundle-isolation
+contract + the debug evidence plane's production elision). Tool absence
+stays zero-cost.
+
 ### §3.5 Queries
 
 | From | Reads |
@@ -670,6 +729,7 @@ the "I want to see what DIDN'T fire" affordance.
 | Focused epoch record | `:rf.sub/run`, `:rf.sub/skipped` (new — §11), `:rf.view/render` / `:rf.view/rendered` — read from the focused epoch record's `:trace-events` (rf2-rly4a — same `focus.epoch-id` scope as Trace, so Reactive + Trace stay correlated) |
 | Registries | Sub metadata (input-paths, signal-fn), view metadata (file:line) |
 | App-db | Seed-path resolution from the epoch's diff (§4) |
+| re-frame.ui evidence projection | `:rf.xray/viewcell-evidence` → `viewcell-evidence/rows` — the CUMULATIVE bounded per-ViewCell invalidation accumulators Xray owns via `re-frame.ui.tool.evidence` (§3.4.1; NOT epoch-scoped) |
 
 Recompute edges resolve from `:rf.sub/run`: **`:rf.sub/cause-sub`** is the sub→sub edge
 (nil ⇒ Level-1, non-nil ⇒ Level-2) and **`:rf.sub/reader-render-key`** is the sub→view edge;

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -104,7 +104,8 @@
   disclosure-toggle state slot. Idempotent."
   (:require [re-frame.core :as rf]
             [re-frame.subs.tooling :as subs-tooling]
-            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
+            [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]))
 
 ;; ---- pure helpers (exposed for test) ------------------------------------
 
@@ -565,5 +566,22 @@
                 :triggered-by (when record (triggered-by record))
                 :seed-paths   (when record (seed-paths record))
                 :has-event-bundle? (some? record)}))))
+
+  ;; -- the ViewCell invalidation-evidence query (rf2-vxgfnd.146) ------
+  ;;
+  ;; The developer-facing query surface over Xray's OWNED
+  ;; `re-frame.ui.tool.evidence` projection (see
+  ;; `day8.re-frame2-xray.viewcell-evidence`). The accumulators are
+  ;; CUMULATIVE per cell (accretion since install), read live at compute
+  ;; time; the `:rf.xray/epoch-history` input is the panel's standing
+  ;; freshness axis — each epoch pump recomputes the read, so newly
+  ;; delivered batches surface on the next recorded epoch (the ViewCell
+  ;; flush runs a microtask AFTER the drain settles, so a same-epoch
+  ;; read may trail by one pump — cumulative rows catch up, never lose).
+  ;; Hosts not running the re-frame.ui substrate project zero rows.
+  (rf/reg-sub :rf.xray/viewcell-evidence
+    :<- [:rf.xray/epoch-history]
+    (fn [_history _query]
+      (viewcell-evidence/rows)))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -456,6 +456,64 @@
 ;; REMOVED — classification no longer propagates input → output, so there is no
 ;; `:rf.egress/output-sensitivity :rf.egress/public` declassify claim to surface.
 
+;; ---- ViewCell invalidation evidence (rf2-vxgfnd.146) --------------------
+
+(defn- causes-label
+  [causes]
+  (when (seq causes)
+    (string/join "/" (map name (sort-by name causes)))))
+
+(defn- evidence-tag
+  "One muted trailing summary per evidence row: occurrences · batches ·
+  epoch span · causes · shown targets · HONEST loss (`≥` when the
+  distinct-omission account saturated — never understated silently)."
+  [{:keys [first-epoch latest-epoch causes targets
+           dropped-count dropped-exact?] :as row}]
+  (let [n (:count row)
+        b (:batches row)]
+    (str n " invalidation" (when (not= 1 n) "s")
+         " · " b " batch" (when (not= 1 b) "es")
+         (when (some? first-epoch)
+           (str " · epochs " first-epoch "→" latest-epoch))
+         (when-some [c (causes-label causes)] (str " · " c))
+         (when (seq targets) (str " · " (count targets) " targets"))
+         (when (pos? (or dropped-count 0))
+           (str " · " (if dropped-exact? "" "≥") dropped-count " dropped")))))
+
+(defn- viewcell-evidence-section
+  "The CUMULATIVE ViewCell invalidation-evidence section — Xray's render
+  path over its owned `re-frame.ui.tool.evidence` projection
+  (rf2-vxgfnd.146). One row per live ViewCell instance, keyed by the
+  stable projection ordinal; unlike the epoch-scoped sections above,
+  the accumulators span the cell's whole observed life (dead cells are
+  pruned by the projection itself). Empty on hosts not running the
+  re-frame.ui substrate."
+  []
+  (let [rows @(rf/subscribe [:rf.xray/viewcell-evidence])]
+    [:section {:data-testid "rf-xray-reactive-viewcell-evidence-section"
+               :style section-margin-top-style}
+     (section-label "viewcell-evidence" "ViewCell Invalidation Evidence")
+     (if (seq rows)
+       (into [:div {:data-testid "rf-xray-reactive-viewcell-evidence-list"
+                    :style list-card-style}]
+             (for [{:keys [cell-id view-id root-id] :as row} rows]
+               ^{:key (str cell-id)}
+               [list-row {:testid (str "rf-xray-reactive-viewcell-evidence-row-"
+                                       cell-id)
+                          :swatch-token :accent
+                          :primary (str (format-id view-id) " · cell #" cell-id
+                                        (when root-id
+                                          (str " · " (format-id root-id))))
+                          :tag (evidence-tag row)}]))
+       [:div {:data-testid "rf-xray-reactive-viewcell-evidence-empty"
+              :style empty-placeholder-style}
+        "(no ViewCell evidence — the host is not running the re-frame.ui
+         substrate, or no invalidations have flushed yet)"])
+     [:p {:data-testid "rf-xray-reactive-viewcell-evidence-caption"
+          :style destroyed-caption-style}
+      "Cumulative per-cell invalidation evidence from the re-frame.ui
+       scheduler (bounded: capped target sample, honest drop account)"]]))
+
 ;; ---- legend ------------------------------------------------------------
 
 (def ^:private legend-swatch-wrapper-style
@@ -532,7 +590,12 @@
       (if (not (:has-event-bundle? data))
         [:div {:data-testid "rf-xray-reactive-pipeline-empty"
                :style {:padding "16px"}}
-         (empty-state data)]
+         (empty-state data)
+         ;; The evidence section is CUMULATIVE (not epoch-scoped), so it
+         ;; renders with or without a focused event-bundle. Plain
+         ;; function call — the subscribe must run inside THIS render's
+         ;; carried :rf/xray frame scope (the panel's delegation idiom).
+         (viewcell-evidence-section)]
         [:div {:data-testid "rf-xray-reactive-pipeline"
                :style {:padding "16px"}}
          [:section {:data-testid "rf-xray-reactive-flow-section"}
@@ -540,4 +603,5 @@
           (flow-graph data)]
          (unmounted-views-section data)
          (destroyed-subs-section data)
+         (viewcell-evidence-section)
          (legend)])]]))

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -53,6 +53,11 @@
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
+            ;; The native ViewCell invalidation-evidence consumer
+            ;; (rf2-vxgfnd.146) — Xray owns the re-frame.ui.tool.evidence
+            ;; projection with a stable identity; load-inert, installed
+            ;; from the boot block below.
+            [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]
             ;; Loading the runtime installs its debug-gated session
             ;; sentinel for agent discovery; no second preload is needed.
             [day8.re-frame2-xray.runtime]))
@@ -100,6 +105,14 @@
   (registry/register-xray-handlers!)
   (install/register-trace-collector!)
   (install/register-epoch-collector!)
+  ;; Claim the re-frame.ui ViewCell invalidation-evidence projection
+  ;; under Xray's stable owner identity (rf2-vxgfnd.146). On
+  ;; `:after-load` this same call is the evidence tier's idempotent
+  ;; same-owner re-arm (accumulated evidence survives); a foreign owner
+  ;; is never clobbered (the install is rejected and Xray projects zero
+  ;; rows). Hosts not running the re-frame.ui substrate simply deliver
+  ;; nothing into the claimed projection.
+  (viewcell-evidence/install!)
   (install/install-browser-api-exports!)
   (keybinding/attach!)
   ;; Apply the persisted CSS-var + theme-class effects. The shell

--- a/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
@@ -1,0 +1,127 @@
+(ns day8.re-frame2-xray.viewcell-evidence
+  "Xray's OWNED consumer of the re-frame.ui ViewCell invalidation-evidence
+  projection (rf2-vxgfnd.146) — the real native runtime the
+  `re-frame.ui.tool.evidence` tier was built for (rf2-vxgfnd.75/.46).
+
+  ## Ownership + lifecycle
+
+  Xray claims the projection under the STABLE identity `owner-id`
+  (`:rf.xray/viewcell-evidence`) from the preload's debug-gated boot
+  block. The evidence tier's identity-owned, generation-fenced lifecycle
+  (rf2-vxgfnd.147) does the rest:
+
+    - first load → `install!` claims the projection; a shadow-cljs
+      `:after-load` re-runs the SAME call as the idempotent same-owner
+      re-arm (accumulated evidence survives — the HMR path);
+    - a foreign owner already holding the projection is NEVER clobbered:
+      Xray's install is rejected (returns false; the evidence tier emits
+      the one console diagnostic) and Xray simply projects zero rows;
+    - `uninstall!` releases exactly Xray's registration — the
+      tool-shutdown/test door. Generation fencing downstream guarantees
+      an in-flight delivery cannot repopulate the released projection,
+      and a stale release cannot touch a successor owner.
+
+  ## Dependency boundary
+
+  tools/xray depends on the ui artefact's TOOL tier (dev-only, exactly
+  like the feature artefacts Xray already reads); `re-frame.ui` does NOT
+  know Xray exists — it exposes the projection, Xray consumes it.
+  Production applications never pull Xray (the tools/README
+  bundle-isolation contract), and tool absence stays zero-cost: this ns
+  loads only from the dev-only preload, and the debug evidence plane
+  itself DCEs out of production builds.
+
+  ## What the developer sees
+
+  `rows` shapes the bounded per-cell accumulators for Xray's query +
+  render path — the `:rf.xray/viewcell-evidence` sub feeding the Views
+  panel's ViewCell Invalidation Evidence section: stable cell/view/root
+  identity plus first/latest frame-epoch, occurrence count, batch count,
+  the cause union, the bounded shown-target sample, and the HONEST loss
+  account (`:dropped-count` / `:dropped-exact?`). A host not running the
+  re-frame.ui substrate simply projects zero rows."
+  (:require [goog.object :as gobj]
+            [re-frame.interop :as interop]
+            [re-frame.ui.tool.evidence :as evidence]))
+
+(def owner-id
+  "Xray's stable evidence-projection owner identity. ONE value for the
+  whole tool lifetime — preload install, `:after-load` re-arm, and
+  shutdown uninstall all name it, so HMR/reinstall and teardown release
+  and re-claim exactly this registration and never another owner's."
+  :rf.xray/viewcell-evidence)
+
+(def ^:private sentinel-key
+  "`js/globalThis` marker mirroring a successful install — the browser
+  feature-gate's cheap 'is the native evidence consumer wired?' probe
+  (parallels the runtime session sentinel in
+  `day8.re-frame2-xray.runtime`)."
+  "__day8_re_frame2_xray_viewcell_evidence")
+
+(defn- sync-sentinel!
+  [installed?]
+  (when (and interop/debug-enabled? (exists? js/globalThis))
+    (if installed?
+      (gobj/set js/globalThis sentinel-key
+                (js-obj "owner" (str owner-id)
+                        "installed" (.now js/Date)))
+      (gobj/remove js/globalThis sentinel-key))))
+
+(defn install!
+  "Claim (or same-owner re-arm) the ViewCell evidence projection for
+  Xray — the preload boot step and the `:after-load` path. Idempotent.
+  Returns the evidence tier's verdict: true installed/re-armed; false
+  rejected (a foreign owner holds the projection — untouched) or
+  production no-op."
+  []
+  (let [ok? (evidence/install! owner-id)]
+    (when ok? (sync-sentinel! true))
+    ok?))
+
+(defn uninstall!
+  "Release exactly Xray's registration (owner-checked here,
+  generation-fenced downstream). Returns true when released; false when
+  Xray was not the current owner (nothing changes)."
+  []
+  (let [ok? (evidence/uninstall! owner-id)]
+    (when ok? (sync-sentinel! false))
+    ok?))
+
+(defn installed?
+  "True when Xray currently owns the projection (query/test read)."
+  []
+  (= owner-id (evidence/installed-owner)))
+
+(defn rows
+  "The developer-facing query projection over Xray's accumulated ViewCell
+  invalidation evidence — a vector, in stable `:cell-id` order:
+
+    {:cell-id        ord      ; stable per-cell-instance ordinal
+     :view-id        vid      ; the authoring view (defview identity)
+     :root-id        rid|nil  ; the owning LIVE client root, or nil
+     :first-epoch    e0       ; anchor of the first delivered window
+     :latest-epoch   eN       ; most recent movement
+     :count          n        ; total invalidation occurrences
+     :batches        b        ; flushed batches that delivered evidence
+     :causes         #{…}     ; union cause set (:value/:hmr/:disposed)
+     :targets        [tk …]   ; bounded shown sample of moving targets
+     :dropped-count  d        ; distinct omitted targets (honest loss)
+     :dropped-exact? bool}    ; false ⇒ d is a lower bound (saturated)
+
+  `[]` when uninstalled, empty, or in a production build (where the
+  debug evidence plane is elided)."
+  []
+  (into []
+        (map (fn [{:keys [cell-id view-id root-id evidence]}]
+               {:cell-id        cell-id
+                :view-id        view-id
+                :root-id        root-id
+                :first-epoch    (:first-epoch evidence)
+                :latest-epoch   (:latest-epoch evidence)
+                :count          (:count evidence)
+                :batches        (:batches evidence)
+                :causes         (:causes evidence)
+                :targets        (:targets evidence)
+                :dropped-count  (count (:dropped evidence))
+                :dropped-exact? (:dropped-exact? evidence)}))
+        (or (evidence/projection) [])))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -472,7 +472,11 @@
    ;; PRs #1728 + #1729 (`:rf.view/rendered`, `:rf.sub/skipped`,
    ;; `:rf.cascade/captured`).
    :rf.xray/reactive-data
-   :rf.xray/reactive-show-unchanged?))
+   :rf.xray/reactive-show-unchanged?
+   ;; rf2-vxgfnd.146 — the ViewCell Invalidation Evidence section's query
+   ;; over Xray's OWNED `re-frame.ui.tool.evidence` projection
+   ;; (spec/021 §3.4.1); registered by `reactive-panel-subs/install!`.
+   :rf.xray/viewcell-evidence))
 
 (def ^:private all-event-names
   "Every Xray-namespaced event registered by `register-xray-handlers!`.

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -1,0 +1,191 @@
+(ns day8.re-frame2-xray.viewcell-evidence-cljs-test
+  "rf2-vxgfnd.146 — the REAL Xray runtime owns the re-frame.ui ViewCell
+  invalidation-evidence projection.
+
+  Requiring `day8.re-frame2-xray.preload` here runs the ACTUAL preload
+  boot block (the same namespace shadow-cljs `:devtools/preloads` loads
+  into every dev host), and `owner-at-load` snapshots the evidence
+  tier's owner IMMEDIATELY after — before any fixture can reset it. If
+  the preload's `viewcell-evidence/install!` wiring is removed, that
+  snapshot is nil and the wiring test goes RED (the mutation probe the
+  bead demands; the browser counterpart lives in the feature-matrix
+  shell sweep, which checks the install sentinel + the rendered Views
+  panel section against the real chrome runtime).
+
+  The end-to-end row test drives a REAL observation-port movement — a
+  committed ViewCell whose subscription lease fans out an `:hmr`
+  invalidation, flushed by the scheduler — and asserts the row surfaces
+  through Xray's query path (`:rf.xray/viewcell-evidence`, subscribed in
+  the `:rf/xray` frame exactly as the Views panel section reads it) with
+  stable identity + the bounded epoch/count/batch/cause/target/loss
+  fields, then that teardown prunes it. Lifecycle tests pin the HMR
+  re-arm (evidence kept), the exact-owner release, and the
+  never-clobber-a-foreign-owner contract."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.tool.evidence :as evidence]
+            [day8.re-frame2-xray.mount :as mount]
+            ;; The REAL preload — its debug-gated boot block runs at load,
+            ;; installing the evidence projection under Xray's identity.
+            [day8.re-frame2-xray.preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]))
+
+;; Snapshotted at NAMESPACE LOAD — i.e. right after the required preload's
+;; boot block ran, before any fixture resets. THE wiring-removal probe.
+(def ^:private owner-at-load (evidence/installed-owner))
+
+(def ^:private sentinel-key "__day8_re_frame2_xray_viewcell_evidence")
+
+(def ^:private sentinel-at-load (aget js/globalThis sentinel-key))
+
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture {})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- boot-xray!
+  "The production init path (mirrors `init_filter_reset_cljs_test`):
+  register the Xray handlers, then `ensure-xray-frame!` — so the
+  `:rf/xray` frame and the `:rf.xray/*` sub graph exist exactly as a
+  real page load builds them."
+  []
+  (registry/register-xray-handlers!)
+  (mount/ensure-xray-frame!))
+
+(defn- rc!
+  "Render (probe) `queries` under the host frame, then commit — the cell
+  ends observing them through REAL subscription leases (the ui
+  tool-evidence-test technique for driving genuine observation-port
+  fan-out)."
+  [cell queries]
+  (let [[_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn [] (mapv (fn [i q]
+                                          (reactive/sub-read [:vce/site i] q))
+                                        (range) queries))))]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- xray-query []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/viewcell-evidence])))
+
+;; ===========================================================================
+;; The preload wiring — no test-only direct install stands in for it
+;; ===========================================================================
+
+(deftest preload-boot-installs-the-projection-under-xrays-stable-identity
+  (is (= viewcell-evidence/owner-id owner-at-load)
+      "the REAL preload boot block claimed the evidence projection —
+       removing the preload install wiring turns this nil (AC: a mutation
+       removing the Xray install must fail)")
+  (is (some? sentinel-at-load)
+      "…and mirrored the install on the browser-probe sentinel")
+  (is (= (str viewcell-evidence/owner-id)
+         (aget sentinel-at-load "owner"))))
+
+;; ===========================================================================
+;; A real observation movement → ViewCell flush → the Xray query row
+;; ===========================================================================
+
+(deftest real-movement-surfaces-in-the-xray-query-row
+  (boot-xray!)
+  (is (true? (viewcell-evidence/install!)))
+  (rf/reg-sub :vce/a (fn [db _] (:a db)))
+  (frame/replace-app-db! fid {:a 1})
+  (let [cell (rc! (reactive/make-cell ::v) [[:vce/a]])]
+    ;; a REAL port fan-out: re-registering the sub fires each committed
+    ;; site's live lease `on-change` with the rich `:hmr` payload
+    (rf/reg-sub :vce/a (fn [db _] (:a db)))
+    (reactive/flush-pending!)
+
+    (testing "the consumer projection carries the bounded row"
+      (let [rows (viewcell-evidence/rows)
+            row  (first rows)]
+        (is (= 1 (count rows)))
+        (is (= ::v (:view-id row)) "stable view identity")
+        (is (number? (:cell-id row)) "stable per-instance ordinal")
+        (is (nil? (:root-id row)) "no live client root owns a graft cell")
+        (is (= 1 (:count row)))
+        (is (= 1 (:batches row)))
+        (is (= #{:hmr} (:causes row)) "the real cause is projected")
+        (is (= [[:sub fid [:vce/a]]] (:targets row))
+            "…with the moving target key")
+        (is (= 0 (:dropped-count row)))
+        (is (true? (:dropped-exact? row)) "the honest loss account")))
+
+    (testing "the SAME row surfaces through Xray's query path — the
+              `:rf.xray/viewcell-evidence` sub the Views panel reads"
+      (let [rows (xray-query)]
+        (is (= (viewcell-evidence/rows) rows))
+        (is (= ::v (:view-id (first rows))))))
+
+    (testing "identity is stable across further batches"
+      (let [id-before (:cell-id (first (viewcell-evidence/rows)))]
+        ;; a real re-render re-acquires fresh leases on the re-registered
+        ;; nodes before any further movement can fan out to this cell
+        (rc! cell [[:vce/a]])
+        (rf/reg-sub :vce/a (fn [db _] (:a db)))
+        (reactive/flush-pending!)
+        (let [row (first (viewcell-evidence/rows))]
+          (is (= id-before (:cell-id row)))
+          (is (= 2 (:count row)))
+          (is (= 2 (:batches row))))))
+
+    (testing "teardown prunes the row — released references, empty query"
+      (reactive/teardown! cell)
+      (is (= [] (viewcell-evidence/rows)))
+      ;; nudge the sub's freshness input (the epoch-pump axis) so a
+      ;; cached composite recomputes before the re-query
+      (frame/replace-app-db! :rf/xray {:epoch-history [::pumped]})
+      (is (= [] (xray-query))))))
+
+;; ===========================================================================
+;; Lifecycle — HMR re-arm, exact-owner release, never clobber
+;; ===========================================================================
+
+(deftest hmr-rearm-keeps-the-accumulated-evidence
+  (is (true? (viewcell-evidence/install!)))
+  (let [cell (reactive/make-cell ::v)]
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (is (= 1 (:count (first (viewcell-evidence/rows)))))
+    ;; the `:after-load` path: the preload boot re-runs → same-owner re-arm
+    (is (true? (viewcell-evidence/install!)))
+    (is (true? (viewcell-evidence/installed?)))
+    (is (= 1 (:count (first (viewcell-evidence/rows))))
+        "accumulated evidence survives the re-arm")
+    (reactive/mark-dirty! cell 2)
+    (reactive/flush-pending!)
+    (is (= 2 (:count (first (viewcell-evidence/rows))))
+        "…and delivery continues into the SAME accumulator")))
+
+(deftest shutdown-releases-the-exact-owner-and-never-clobbers-a-foreign-one
+  (testing "uninstall releases exactly Xray's registration"
+    (is (true? (viewcell-evidence/install!)))
+    (is (some? (aget js/globalThis sentinel-key)))
+    (is (true? (viewcell-evidence/uninstall!)))
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (viewcell-evidence/rows)) "closed retains zero")
+    (is (nil? (aget js/globalThis sentinel-key))
+        "the install sentinel is withdrawn with the registration"))
+
+  (testing "a foreign owner is NEVER clobbered — Xray's install is refused"
+    (is (true? (evidence/install! ::another-tool)))
+    (is (false? (viewcell-evidence/install!)))
+    (is (= ::another-tool (evidence/installed-owner))
+        "the foreign registration stands")
+    (is (false? (viewcell-evidence/installed?)))
+    (is (false? (viewcell-evidence/uninstall!))
+        "…and Xray's uninstall cannot release what it does not own")
+    (is (= ::another-tool (evidence/installed-owner)))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1014,6 +1014,29 @@ async function runShellFeatureSweep(page) {
     (count) => count > 0,
     { timeoutMs: 5000, description: 'epoch-scoped trace feed renders rows' },
   );
+
+  // rf2-vxgfnd.146 — the native ViewCell evidence consumer is wired by
+  // the REAL preload in this chrome runtime: (1) the install sentinel is
+  // present (the preload claimed the re-frame.ui.tool.evidence projection
+  // under Xray's stable owner identity), and (2) the Views panel renders
+  // the cumulative ViewCell Invalidation Evidence section (its EMPTY
+  // state here — the counter surface is Reagent-hosted, so no ViewCells
+  // deliver; the populated-row proof lives in the node suite). Removing
+  // the preload install or the panel consumer wiring fails this sweep.
+  const evidenceInstalled = await page.evaluate(
+    () => !!globalThis.__day8_re_frame2_xray_viewcell_evidence,
+  );
+  if (!evidenceInstalled) {
+    failWithDetails(
+      'rf2-vxgfnd.146 — the Xray preload did not install the native ViewCell evidence projection',
+      { sentinel: '__day8_re_frame2_xray_viewcell_evidence' },
+    );
+  }
+  await clickTab(page, 'views', 'rf-xray-reactive');
+  await expectVisible(
+    page.locator('[data-testid="rf-xray-reactive-viewcell-evidence-section"]'),
+    5000,
+  );
 }
 
 async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {


### PR DESCRIPTION
One coupled family over the `re-frame.ui.tool.evidence` + weak `root-cells` seams — review findings against #5829/#5832. Commit order .168 → .147 → .146.

## rf2-vxgfnd.168 — migrate defonce `root-cells` across the strong→weak representation change

`root-cells` is `defonce`, but #5832 changed its value shape from persistent strong sets (`incarnation -> #{cell …}`) to host-specific mutable weak sets — a hot reload hands the reloaded code the OLD-shape value, and the first post-reload root operation crashed mid-lifecycle (JVM `UnsupportedOperationException` inside `teardown!` after the cell already went `:dead`; CLJS `TypeError` on the missing `:refs`/`:by-cell` slots) while leaving dead cells/incarnations retained.

**Fix** (`implementation/ui/src/re_frame/ui/reactive.cljc`, the root-cells/migration region only): `migrate-legacy-root-cells!` — an identity-preserving, idempotent load-time migration invoked at namespace load right after the weak helpers/reaper. Every legacy persistent-set entry is rebuilt into the current host weak set (members re-enrolled via `weak-add!`, so CLJS re-registers the finalization reaper); each entry swap is CAS-guarded on the exact legacy value; the loop converges over mixed/partially-migrated state; re-running is a no-op; fresh startup pays one bounded empty-registry check; the registry is never cleared (clearing would orphan Activity-hidden ownership). `seed-legacy-root-cells!` is the reload-simulation test seam.

**Proof** (`reactive_root_reload_migration_cljs_test.cljc`, node + JVM): seeds the pre-weak shape, migrates, and proves connected + Activity-hidden cells stay discoverable through root teardown with no host exception; the `teardown!` fast path drops the entry with its last member; idempotence + mixed-registry convergence; counts return to zero on both hosts; and (JVM, GC-forced) migrated members remain collectible — no strong pinning survives the rebuild.

## rf2-vxgfnd.147 — linearize evidence install/publication/teardown by generation

The evidence lifecycle was not linearizable: three atoms, unfenced `project-batch!` publication, separate install/uninstall/clear steps. The bead's three deterministic races all held: (a) a delayed callback after uninstall repopulated an ownerless projection; (b) A's late callback contaminated B's fresh projection; (c) A's late teardown could disarm B's newly installed sink — and bare owner equality was a reusable ABA token.

**Fix** (`implementation/ui/src/re_frame/ui/tool/evidence.cljc`): ONE authoritative state atom (owner + monotonically unique generation + armed sink closure + entries + ordinal mint) so every transition is a single swap. The armed closure captures the generation current at arm time and publishes only while it exactly matches the open generation — fence + ordinal mint + entry write are one swap (the publication's linearization point). Every transition through the closed state bumps the generation (ABA-safe across same-id uninstall/reinstall); a same-owner HMR re-arm keeps its span (generation continuity = evidence continuity). On the JVM a tiny transition lock serializes the state swap with the raw-slot arm/disarm — held only across that pair, never through a tool/user callback — so a stale A teardown can never disarm B's sink. No public API change, no second store, tool exception isolation and scheduler authority untouched; `installed-sink` is the tool/test capture door (mirrors `deliver-flush!`'s deref).

**Proof**: `tool_evidence_generation_cljs_test.cljc` (deterministic replays, node + JVM — delayed delivery after uninstall/force-release, A→B contamination, ABA reinstall, re-arm span continuity, stale-teardown refusal, reentrant mid-batch close + handover linearization) and `tool_evidence_generation_race_jvm_test.clj` (CountDownLatch/CyclicBarrier races — paused callback vs uninstall, late A callback vs B install, A-uninstall vs B-install legal-linearization sweep with a live-sink proof, exact concurrent publication, delivery loop vs close). Mutating the fence away fails 8 tests.

## rf2-vxgfnd.146 — wire the REAL Xray consumer

No runtime installed `evidence/install!`; the integration fixture proved the seam in isolation (rf2-vxgfnd.75 AC1/AC6 materially open). Xray now OWNS the projection end to end:

- **Ownership**: `day8.re-frame2-xray.viewcell-evidence` claims the projection under the stable identity `:rf.xray/viewcell-evidence` from the preload's debug-gated boot block; `:after-load` re-runs the same call as the idempotent same-owner re-arm (evidence survives — the HMR path); a foreign owner is never clobbered; `uninstall!` releases exactly Xray's registration, made safe by .147's generation fencing. Install mirrors onto the `__day8_re_frame2_xray_viewcell_evidence` global sentinel (withdrawn on uninstall).
- **Query path**: `:rf.xray/viewcell-evidence` (registered in `reactive-panel-subs/install!`) → `viewcell-evidence/rows` — stable cell/view/root identity + first/latest epoch, count, batches, causes, bounded targets, honest loss (`:dropped-count`/`:dropped-exact?`), refreshed on the standing epoch-pump axis.
- **Render path**: the Views panel's cumulative **VIEWCELL INVALIDATION EVIDENCE** section (`rf-xray-reactive-viewcell-evidence-*`), rendered with or without a focused event-bundle; empty state on non-ui hosts. Subscribes via plain function-call delegation so the read runs inside the carried `:rf/xray` frame scope (the browser gate caught the child-component frame-context regression; now pinned).
- **Boundary**: `tools/xray/deps.edn` adds `day8/re-frame2-ui` (dev-only tool tier). `re-frame.ui` never depends on Xray; production applications pull neither (release builds strip `:devtools` preloads; the debug evidence plane elides under `:advanced`).
- **Proof**: the node suite requires the REAL preload and snapshots the evidence owner at namespace load — removing the preload install turns the wiring test red; it then drives a genuine observation-port movement through a committed ViewCell flush into the Xray query row (stable identity across batches, teardown pruning, HMR re-arm continuity, exact-owner release / never-clobber). The feature-matrix shell sweep (real chrome runtime, real preload) asserts the install sentinel + the rendered section. The `tools_jvm` / `cljs` / `story_xray_browser` classifier surfaces all fire on this diff.
- **Spec** (standing rule): `tools/xray/spec/021-Dynamic-Panel-Designs.md` — new §3.4.1 (ownership, query schema, render contract, boundary), §3.2 section inventory, §3.5 queries row. Registry snapshot guard updated with the new sub id.

## Quality gates

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | 458 tests / 6160 assertions, 0 failures |
| `npm run test:cljs` (consolidated node) | 9241 tests / 43739 assertions, 0 failures |
| `npm run test:ui` (isolation + focused node) | 456 tests / 2305 assertions, 0 failures; ui-adapter-isolation PASS |
| `npm run test:browser` | 342 tests / 1848 assertions, 0 failures |
| `tools/xray` JVM (`clojure -M:test`) | 1248 tests / 5755 assertions, 0 failures |
| `npm run test:xray-feature-gate:smoke` | 4 scenarios, 0 failures (9 matrix rows) |
| `sh scripts/test-fast-pr.sh` (incl. markdown gates) | PASS |
| Fence-mutation red check | removing the generation fence fails 8 tests |
