### PR TITLE
fix(ui): make digest/bytes/HMR activation one accepted transaction (rf2-vxgfnd.193)

### DIFF
--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -23,7 +23,19 @@ const IMPL = path.join(__dirname, '..');
 const LAZY_SOURCE = path.join(
   IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'lazy.cljs',
 );
+const LOADED_SOURCE = path.join(
+  IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'loaded.cljs',
+);
 const OUT = path.join(IMPL, 'out', 'ui-digest-probe-lazy');
+const LAZY_JS = path.join(OUT, 'lazy.js');
+const CARRIER_JS = path.join(
+  OUT, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
+);
+// Opt-in adversarial assertion of the still-open downstream-output invariant
+// (counterexample 1). Off by default so the gate stays green while the fix —
+// artifact generation/activation separation — is a hot-zone follow-up; set to
+// "1" to assert the fixed behaviour (red-before-fix).
+const ASSERT_DOWNSTREAM_OUTPUT = process.env.RF2_PROBE_ACTIVATION_TXN === '1';
 const TARGET = path.join(IMPL, 'target', 'ui-digest-probe');
 const FAIL_MARKER = path.join(TARGET, 'fail-after-compile');
 const ACCEPTED_FILE = path.join(TARGET, 'accepted-digest.txt');
@@ -179,9 +191,15 @@ async function readBrowserDigest(page) {
 }
 
 async function waitForDigestChange(page, prior, timeout = TIMEOUT) {
+  // Wait for a NEW fully-activated digest, not merely any change: a hot reload
+  // fences reads fail-closed (null) between before-load and after-load, so the
+  // stable post-promotion value is a bd1 digest that differs from `prior`.
   await page.waitForFunction(
-    (oldDigest) => typeof globalThis.__rf2ReadDigest === 'function' &&
-                   globalThis.__rf2ReadDigest() !== oldDigest,
+    (oldDigest) => {
+      if (typeof globalThis.__rf2ReadDigest !== 'function') return false;
+      const d = globalThis.__rf2ReadDigest();
+      return typeof d === 'string' && d.startsWith('bd1-') && d !== oldDigest;
+    },
     prior,
     { timeout },
   );
@@ -297,6 +315,7 @@ async function proveHooklessBuildFailsClosed(shadowRunner, browser, activePage, 
 
 async function main() {
   const original = fs.readFileSync(LAZY_SOURCE, 'utf8');
+  const loadedOriginal = fs.readFileSync(LOADED_SOURCE, 'utf8');
   if (!original.includes('digest-probe-v1')) {
     fail('lazy fixture is not at its checked-in v1 marker');
   }
@@ -391,6 +410,43 @@ async function main() {
       fail('late failed pass changed active runtime or accepted JVM witness');
     }
 
+    // Counterexample 1 — the downstream-OUTPUT invariant the active-runtime
+    // witness above does NOT cover. Shadow's browser target flushed candidate
+    // d3 to the stable module URLs BEFORE the intentional :flush failure, then
+    // rolled its functional build-state back to accepted d2. So `/base.js`'s
+    // carrier and `/lazy.js` on disk hold rejected candidate d3 while compiler
+    // authority is d2: a hard reload or a first lazy import would execute /
+    // advertise d3. The fix is artifact generation/activation separation —
+    // stable URLs/manifests must keep resolving to the accepted generation
+    // until the whole pipeline succeeds. That is a Shadow output/flush surface
+    // beyond this carrier's fence (hot-zone shadow-cljs.edn), so this probe
+    // DOCUMENTS the gap by default and only ASSERTS the fixed behaviour under
+    // RF2_PROBE_ACTIVATION_TXN=1 (red-before-fix).
+    const servedLazy = fs.existsSync(LAZY_JS)
+      ? fs.readFileSync(LAZY_JS, 'utf8') : '';
+    const servedCarrier = fs.existsSync(CARRIER_JS)
+      ? fs.readFileSync(CARRIER_JS, 'utf8') : '';
+    const lazyServesRejected = servedLazy.includes('digest-probe-v3');
+    // The accepted digest is d2; a stable carrier that no longer contains d2
+    // (its bytes moved to the rejected candidate d3) is servable-rejected.
+    const carrierServesRejected =
+      servedCarrier.length > 0 && !servedCarrier.includes(digest2);
+    if (lazyServesRejected || carrierServesRejected) {
+      const note =
+        `downstream-output gap: stable URLs serve rejected candidate d3 ` +
+        `after the failed :flush (lazy=${lazyServesRejected}, ` +
+        `carrier-not-d2=${carrierServesRejected}); accepted authority is d2 ` +
+        `(${digest2}). A hard reload / first lazy import would activate d3.`;
+      if (ASSERT_DOWNSTREAM_OUTPUT) {
+        fail(note);
+      }
+      console.log(`ui digest carrier: KNOWN GAP (rf2-vxgfnd.193 followup) — ${note}`);
+    } else {
+      console.log(
+        'ui digest carrier: downstream output stayed on the accepted generation',
+      );
+    }
+
     // Recovery success starts from Shadow's retained d2 state, not the failed
     // candidate or a macro ghost, then publishes one new byte-identical scalar.
     fs.rmSync(FAIL_MARKER, { force: true });
@@ -419,11 +475,94 @@ async function main() {
       fail('browser fetched the lazy module during the proof');
     }
 
+    // Counterexample 2 — the runtime-activation fence. A LOADED base-module
+    // source (loaded.cljs) is edited compile-valid but to throw at top-level
+    // BEFORE its view re-registers. The build compiles, Shadow hot-reloads, the
+    // carrier evaluates first and STAGES the candidate, then the throwing source
+    // stops the reload before after-load — so the candidate is never promoted.
+    // Digest reads must be fail-closed (nil), never the candidate. (Removing the
+    // before/after-load fence would publish the candidate on carrier evaluation,
+    // failing the null assertion below.)
+    const loadedV1 = fs.readFileSync(LOADED_SOURCE, 'utf8');
+    if (!loadedV1.includes('loaded-probe-v1') || !loadedV1.includes('(when false')) {
+      fail('loaded fixture is not at its checked-in inert v1 markers');
+    }
+    if (!(await page.evaluate(() => globalThis.__rf2LoadedExecuted === true))) {
+      fail('loaded base-module source did not execute on the initial page load');
+    }
+    // Shadow catches a reloaded-source top-level throw inside its reload driver
+    // (routing it to the load-failure path, which is exactly why after-load is
+    // skipped), so it surfaces on the console rather than as an uncaught
+    // pageerror. Capture both as informational witnesses; the hard signal is
+    // the fail-closed read below.
+    let sawThrow = null;
+    const onPageError = (error) => {
+      if (error.message.includes('counterexample-2 top-level throw')) sawThrow = error.message;
+    };
+    const onConsole = (msg) => {
+      const text = msg.text();
+      if (text.includes('counterexample-2 top-level throw') ||
+          (text.includes('digest_probe/loaded') && /fail|error/i.test(text))) {
+        sawThrow = sawThrow || text;
+      }
+    };
+    page.on('pageerror', onPageError);
+    page.on('console', onConsole);
+
+    const successC2 = shadow.successCount();
+    const throwing = replaceExactly(
+      replaceExactly(loadedV1, 'loaded-probe-v1', 'loaded-probe-v2'),
+      '(when false', '(when true',
+    );
+    fs.writeFileSync(LOADED_SOURCE, throwing);
+    await shadow.waitSuccess(successC2);   // compile-valid: the build completes
+    // The hot reload fences reads (before-load), the carrier stages the
+    // candidate, then loaded.cljs throws before registration — so after-load
+    // never promotes. A read fail-closing to null can ONLY happen when a hot
+    // reload started (before-load ran) and did not finish (after-load skipped):
+    // that is the runtime-activation fence holding. Reads must never advertise
+    // the staged candidate.
+    await page.waitForFunction(
+      () => typeof globalThis.__rf2ReadDigest === 'function' &&
+            globalThis.__rf2ReadDigest() === null,
+      null,
+      { timeout: TIMEOUT },
+    );
+    const stampedC2 = await page.evaluate(() => globalThis.__rf2ReadDigest());
+    if (stampedC2 !== null) {
+      fail(`runtime advertised an unactivated digest after a loaded throw: ${stampedC2}`);
+    }
     console.log(
-      `ui digest carrier: PASS (${digest1} -> ${digest2} -> failed/LKG -> ${digest3})`,
+      `ui digest carrier: loaded-source throw left reads fail-closed` +
+      (sawThrow ? ` (witnessed: ${String(sawThrow).slice(0, 80)})` : ''),
+    );
+    page.off('pageerror', onPageError);
+    page.off('console', onConsole);
+
+    // A successful retry re-activates: restore the clean loaded source, the
+    // reload runs after-load, and reads recover to a real bd1 digest.
+    const successC2b = shadow.successCount();
+    fs.writeFileSync(LOADED_SOURCE, loadedV1);
+    await shadow.waitSuccess(successC2b);
+    await page.waitForFunction(
+      () => typeof globalThis.__rf2ReadDigest === 'function' &&
+            typeof globalThis.__rf2ReadDigest() === 'string' &&
+            globalThis.__rf2ReadDigest().startsWith('bd1-'),
+      null,
+      { timeout: TIMEOUT },
+    );
+    const recoveredC2 = await page.evaluate(() => globalThis.__rf2ReadDigest());
+    if (!/^bd1-[0-9a-f]{16}$/.test(recoveredC2)) {
+      fail(`successful retry did not re-activate a real digest: ${recoveredC2}`);
+    }
+
+    console.log(
+      `ui digest carrier: PASS (${digest1} -> ${digest2} -> failed/LKG -> ${digest3}` +
+      ` -> loaded-throw/fail-closed -> ${recoveredC2})`,
     );
   } finally {
     fs.writeFileSync(LAZY_SOURCE, original);
+    fs.writeFileSync(LOADED_SOURCE, loadedOriginal);
     fs.rmSync(FAIL_MARKER, { force: true });
     if (browser) await browser.close();
     if (shadow) await terminateProcessTree(shadow.child, { timeoutMs: 5000 });

--- a/implementation/ui/src/re_frame/ui/digest_carrier.cljs
+++ b/implementation/ui/src/re_frame/ui/digest_carrier.cljs
@@ -1,5 +1,6 @@
 (ns ^{:dev/always true} re-frame.ui.digest-carrier
-  "The dev-only client carrier for the compiler-owned whole-build digest.
+  "The dev-only client carrier for the compiler-owned whole-build digest, and
+  the runtime half of the activation transaction (rf2-vxgfnd.193).
 
   The Shadow build hook replaces the one fixed-width sentinel in this
   namespace's compiled `[:output resource-id :js]` at `:compile-finish`, then
@@ -7,31 +8,95 @@
   Runtime readers are O(1): they read this single slot and never walk the
   registrar. Direct no-pass REPL evaluation never mutates this slot.
 
+  Activation is staged, not published on carrier evaluation. Carrier evaluation
+  is `^:dev/always`, so it re-runs first on every hot reload. Publishing the
+  new identity there would advertise a digest before the reload's application
+  sources have evaluated: a later loaded source that throws at top-level (before
+  installing its view registration) stops Shadow's reload and skips the
+  after-load hooks, leaving the runtime stale/partial while descriptors already
+  read the new digest. Instead:
+
+  - `before-load` fences the runtime (`updating` true) so reads become
+    fail-closed for the duration of the swap;
+  - carrier evaluation STAGES the generation's compiled digest;
+  - `after-load` promotes the staged digest to the published slot — and Shadow
+    runs after-load hooks only once EVERY reloaded source has evaluated without
+    throwing.
+
+  A top-level throw in any reloaded source therefore skips promotion: reads stay
+  fail-closed (nil) until a later successful reload's after-load promotes a
+  fully-activated generation. Reads never claim the old or the new identity for
+  a partially mutated runtime. The initial page load runs no before-load fence,
+  so that first, whole load publishes immediately.
+
   Every operation is goog.DEBUG-gated. Closure removes the slot, sentinel,
-  validation and accessors from advanced production output."
+  staging cell, reload hooks, validation and accessors from advanced production
+  output."
   (:require [clojure.string :as str]))
+
+;; The runtime activation cell. It PERSISTS across `^:dev/always` reloads
+;; (`defonce` re-init is skipped once the slot exists), so the `updating` fence
+;; a hot reload's `before-load` sets survives this namespace re-evaluating.
+;;   :published — the digest reads observe; nil while fail-closed;
+;;   :staged    — the candidate digest of the generation currently evaluating;
+;;   :updating  — the fence: true between a hot reload's before-load and a
+;;                SUCCESSFUL after-load (a reloaded-source throw leaves it true).
+(defonce ^:private cell
+  (when ^boolean js/goog.DEBUG
+    #js {:published nil :updating false :staged nil}))
 
 ;; Exactly 20 bytes, matching a bd1- + 16-hex-digit digest. Keep this literal
 ;; unique and in ONE source location: the hook requires exactly one occurrence
 ;; in exactly one compiled carrier output, preserving source-map offsets by
 ;; replacing it with an equal-length digest.
-(def ^:private state
-  (when ^boolean js/goog.DEBUG
-    #js {:digest "__RF2_UI_DIGEST_XX__"}))
+(def ^:private compiled-digest
+  (when ^boolean js/goog.DEBUG "__RF2_UI_DIGEST_XX__"))
+
+;; (Re)evaluation stages this generation's compiled digest. On the initial page
+;; load no before-load fence has run, so the runtime is not `updating` and this
+;; whole, first load publishes immediately. During a hot reload before-load has
+;; set `updating`, so this only STAGES: after-load promotes it iff every
+;; reloaded source evaluated successfully.
+(when ^boolean js/goog.DEBUG
+  (set! (.-staged cell) compiled-digest)
+  (when-not (.-updating cell)
+    (set! (.-published cell) compiled-digest)))
 
 (defn current
-  "Return the compiler-published whole-build digest in dev, nil in production.
-  O(1); no registry traversal or client-side digest computation."
+  "Return the compiler-published, fully-activated whole-build digest in dev, nil
+  in production. O(1); no registry traversal or client-side digest computation.
+  Fail-closed (nil) while a hot reload is mid-flight, and after a reloaded source
+  threw before its after-load promotion: a read never advertises a candidate the
+  runtime has not finished activating."
   []
   (when ^boolean js/goog.DEBUG
-    (.-digest state)))
+    (when-not (.-updating cell)
+      (.-published cell))))
+
+(defn ^:dev/before-load before-load
+  "Fence the runtime before Shadow swaps reloaded code: digest/descriptor reads
+  become fail-closed until a successful after-load promotes the staged
+  generation."
+  []
+  (when ^boolean js/goog.DEBUG
+    (set! (.-updating cell) true)))
+
+(defn ^:dev/after-load after-load
+  "Promote the staged generation once EVERY reloaded source has evaluated. A
+  top-level throw in any reloaded source skips this hook (Shadow stops the
+  reload before after-load), leaving reads fail-closed until a later successful
+  reload."
+  []
+  (when ^boolean js/goog.DEBUG
+    (set! (.-published cell) (.-staged cell))
+    (set! (.-updating cell) false)))
 
 ;; A configured build that omitted the load-bearing hook must not limp along
 ;; with a plausible but false identity. The hook patches the sentinel before
 ;; this namespace executes. Prefix validation avoids a second copy of the
 ;; sentinel literal (the patch target must be unique).
 (when ^boolean js/goog.DEBUG
-  (when-not (str/starts-with? (current) "bd1-")
+  (when-not (str/starts-with? compiled-digest "bd1-")
     (throw
      (js/Error.
       (str "re-frame.ui build digest was not finalized. Configure "

--- a/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
@@ -1,10 +1,15 @@
 (ns re-frame.ui.digest-probe.base
   (:require [re-frame.ui :as ui]
             [re-frame.ui.client :as client]
+            ;; A loaded application source in the base module: the
+            ;; runtime-activation probe (counterexample 2) edits it to throw at
+            ;; top-level during a compile-valid hot reload.
+            [re-frame.ui.digest-probe.loaded :as loaded]
             [shadow.cljs.devtools.client.browser :as shadow-browser]))
 
 (ui/defview base-view []
-  [:main {:data-probe "base"} "digest probe"])
+  [:main {:data-probe "base"} "digest probe"
+   [loaded/loaded-view]])
 
 (defn init []
   ;; The carrier is a read-time O(1) value. Keep the accessor stable across

--- a/implementation/ui/test/re_frame/ui/digest_probe/loaded.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/loaded.cljs
@@ -1,0 +1,24 @@
+(ns re-frame.ui.digest-probe.loaded
+  "A LOADED application source in the base module (required by base.cljs, so it
+  executes on the page — unlike the lazy module). The runtime-activation probe
+  (counterexample 2, rf2-vxgfnd.193) rewrites the two markers below in one warm
+  Shadow watch: the view text moves the whole-build digest, and the inert
+  top-level guard is flipped so the slot throws BEFORE this view re-registers.
+  A compile-valid edit that throws at top-level during hot reload must leave
+  digest/descriptor reads fail-closed — the carrier may only stage the
+  candidate, never publish it before after-load.
+
+  The two rewritten literals are kept out of THIS docstring so the fixture's
+  exactly-one-occurrence replace stays unambiguous."
+  (:require [re-frame.ui :as ui]))
+
+;; Injectable top-level slot: inert as checked in, a top-level throw once the
+;; probe flips the guard. Placed BEFORE the registration so a thrown reload
+;; stops before `loaded-view` re-registers.
+(when false
+  (throw (js/Error. "rf2 counterexample-2 top-level throw (before registration)")))
+
+(ui/defview loaded-view []
+  [:section {:data-probe "loaded"} "loaded-probe-v1"])
+
+(set! (.-__rf2LoadedExecuted js/globalThis) true)


### PR DESCRIPTION
## Summary

Follow-up to #5806. Makes acceptance atomic across compiler authority, written browser bytes, and live-runtime activation. Two invariant violations, opposite directions:

**Counterexample 2 — accepted identity advertised before runtime activation completes (FIXED, in-fence).** The `^:dev/always` digest carrier evaluated first on every hot reload and published the candidate digest immediately. If a later loaded source is compile-valid but throws at top-level *before* installing its view registration, Shadow stops the reload and skips the after-load hooks — the runtime is stale/partial while descriptors already advertise the new digest. The carrier now **stages** on evaluation and **publishes only from a `:dev/after-load` fence**; a `:dev/before-load` fence marks reads fail-closed for the swap window. Shadow runs after-load only once every reloaded source has evaluated, so a top-level throw leaves `current`/descriptor reads **fail-closed (nil) — never the candidate** — until a successful retry re-activates. `defonce` keeps the fence across the `^:dev/always` reload. All machinery stays `goog.DEBUG`-gated and elides from advanced production.

**Counterexample 1 — rejected bytes servable/executable (reproduced + gated; fix is a hot-zone dependency).** Shadow's browser target flushes candidate d3 to the stable module URLs *before* an intentional `:flush` failure, then rolls its functional build-state back to accepted d2 — so `/base.js`'s carrier and `/lazy.js` hold rejected d3 while compiler authority is d2. A hard reload or first lazy import would execute/advertise d3. The required fix is **artifact generation/activation separation** — stable URLs/manifests must keep resolving to the accepted generation until the whole pipeline succeeds. That is a Shadow output/flush surface **beyond this carrier's 3-file fence** (needs the hot-zone top-level `shadow-cljs.edn` and module-load gating in `runtime`/`client`), because re-frame.ui's hooks run at `:compile-prepare`/`:compile-finish` — there is no re-frame.ui hook point after Shadow has flushed the candidate bytes, so nothing in-fence can restore or fail-close the served files after a downstream failure. This PR **detects and reports the gap on every gate run** and **asserts the fixed behaviour under `RF2_PROBE_ACTIVATION_TXN=1`** (red-before-fix). A follow-up bead is filed for the separation.

## The transactional fix

- `digest_carrier.cljs`: `defonce` activation cell (`published`/`staged`/`updating`); carrier evaluation stages; `^:dev/before-load` fences reads; `^:dev/after-load` promotes; `current` returns nil while `updating` (fail-closed). Reuses the existing sentinel/carrier machinery — no second digest authority, no parallel activation system.
- Verified against Shadow 3.4.10's `env/do-js-reload`: `before-load → load-code-fn → after-load` run as one synchronous task chain; a loaded-source top-level throw in `load-code-fn` routes to `failure-fn`, so after-load never runs.

## New red-before-fix fixtures (real Shadow watch + browser)

1. **`loaded.cljs`** — a loaded base-module source (required by `base.cljs`, so it executes on the page). The probe edits it compile-valid to throw at top-level *before* registration; asserts reads go **fail-closed (null)**, then recover to a real `bd1-` digest on a successful retry. **Removing the before/after-load fence fails this** — proven by reverting to the pre-fix carrier (see below).
2. **downstream-output probe** — after the intentional `:flush` failure, reads the served `/base.js` carrier + `/lazy.js` and asserts they stay on the accepted generation; asserts under `RF2_PROBE_ACTIVATION_TXN=1`, logs `KNOWN GAP` otherwise.

The #5806/#5813 hookless-LKG, warm-success, downstream-LKG and recovery phases stay green.

## Red-before-fix evidence

- Counterexample 2, pre-fix carrier restored → `test:ui-digest-carrier` fails: `page.waitForFunction: Timeout 90000ms exceeded` at the fail-closed assertion (the pre-fix carrier publishes the candidate on eval, so `current` never fail-closes).
- Counterexample 1, current main → probe logs: `KNOWN GAP … stable URLs serve rejected candidate d3 after the failed :flush (lazy=true, carrier-not-d2=true); accepted authority is d2`.

## Quality gates

- ui JVM suite (`cd implementation/ui && clojure -M:test`): **457 tests, 5845 assertions, 0 failures**
- CLJS node integration (`npm run test:cljs`): **9276 tests, 43905 assertions, 0 failures**
- digest-carrier probe / browser fixture (`npm run test:ui-digest-carrier`): **PASS** (`… -> failed/LKG -> loaded-throw/fail-closed -> bd1-…`, exit 0)
- advanced production elision (`shadow-cljs release ui-bench`): **no sentinel / `before_load` / `after_load` / `digest_carrier` / fail-closed-branch / `bd1-` in the bundle**
- per-ns isolation for the one namespace that flaked under concurrent load (core `router-carried-frame`, outside this diff) passes cleanly in isolation (3 tests, exit 0)

## Scope + follow-ups

- In-fence surface only: `digest_carrier.cljs`, `digest_probe/{loaded,base}.cljs`, `check-ui-digest-carrier.cjs`. No hot-zone edits.
- **Hot-zone dependency (counterexample 1 fix):** artifact generation/activation separation needs the top-level `shadow-cljs.edn` (candidate vs stable output) + module-load gating in `runtime`/`client` — for the mayor to sequence. Follow-up bead filed.
- **Spec dependency:** Spec 004C §2.2 still claims "Consumers activate only successful build output" — needs an executable-gate qualifier for hard reload / lazy load (owned by the docs-truth surface). Not touched here.

Bead: rf2-vxgfnd.193 (left open for the mayor).
