### PR TITLE
fix(machines): fence lifecycle schema callbacks to exact frame incarnation (rf2-vxgfnd.153)

### DIFF
--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -80,6 +80,46 @@
 ;; vocabulary).
 (def ^:private local-skip-phases #{:spawn :update-snapshot})
 
+;; ---- exact-frame-incarnation continuation ---------------------------------
+;;
+;; A machine schema validator is APPLICATION code (the late-bound
+;; `:schemas/validate-with-registered-fn` adapter running an app-declared
+;; schema). Per the incarnation-fencing family (destroy contract #5818) it can
+;; synchronously destroy the frame incarnation (A) that owns the in-flight
+;; event and publish a same-id successor (B) before returning. Every machine
+;; lifecycle validator therefore threads the router's dequeue-time event-owner
+;; continuation predicate: it is checked AFTER each application callback and
+;; before any subsequent framework-owned write / diagnostic, so a callback
+;; resolved under A can never fire an install, bookkeeping mutation, or trace
+;; against successor B (or a dead frame).
+
+(defn owner-continuation
+  "Build the exact-frame-incarnation continuation predicate for `frame-id`
+  from the router's dequeue-time event-owner binding (`*event-owner*`). Returns
+  a 0-arity predicate: true while `frame-id`'s incarnation that owns the
+  in-flight event may still run framework-owned continuation, false once a
+  synchronous callback has destroyed A / published same-id B. When no event
+  owner is bound (a non-router internal call — e.g. a standalone validator
+  invoke), the predicate is `(constantly true)`, preserving the standalone
+  contract. Shared with `lifecycle-fx.spawn` so the spawn cascade and its
+  `validate-spawn-data!` callback fence against the SAME token."
+  [frame-id]
+  (if-let [owner-token (frame/current-event-owner-token)]
+    #(frame/event-continuation-live? frame-id owner-token)
+    (constantly true)))
+
+(defn- current-owner-continuation
+  "Like `owner-continuation` but derives the frame from the event-owner
+  binding itself — for validators (`validate-update-snapshot-data!`,
+  `validate-completion-output!`) that don't carry the frame-id explicitly:
+  they run inside the owning event's fx drain / finalize cascade, so the
+  dequeue-time event owner IS their frame."
+  []
+  (if-let [owner-token (frame/current-event-owner-token)]
+    (let [owner-frame (frame/current-event-owner-frame-id)]
+      #(frame/event-continuation-live? owner-frame owner-token))
+    (constantly true)))
+
 (defn- emit-failure!
   "Emit `:rf.error/schema-validation-failure` at a machine schema boundary
   (`:where :machine-data` or `:where :machine-output`). `where` names the
@@ -257,10 +297,8 @@
   `(when interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally."
   ([runtime-db event-id frame-id]
-   (if-let [owner-token (frame/current-event-owner-token)]
-     (validate-machine-data! runtime-db event-id frame-id
-                             #(frame/event-continuation-live? frame-id owner-token))
-     (validate-machine-data! runtime-db event-id frame-id (constantly true))))
+   (validate-machine-data! runtime-db event-id frame-id
+                           (owner-continuation frame-id)))
   ([runtime-db _event-id _frame-id continue?]
   ;; `event-id` and `frame-id` are accepted but unused at this boundary
   ;; (the per-snapshot emit already names the machine); the arity matches
@@ -303,16 +341,31 @@
   there is nothing to roll back — `:phase :spawn` emits with
   `:rollback? false`.
 
+  The application schema validator is fenced to the exact frame incarnation
+  via `continue?` (rf2-vxgfnd.153): a validator that destroys the owning frame
+  A and publishes same-id B returns `:rf/stale-incarnation` (via
+  `validate-snapshot-data!`) rather than a schema verdict, and suppresses the
+  failure trace — so the spawn caller (`lifecycle-fx.spawn`) skips the whole
+  install cascade rather than landing A-derived allocation on B. The 3-arity
+  derives the continuation from the router's event-owner binding
+  (`current-owner-continuation`); the spawn caller passes the SAME predicate it
+  fences its post-callback cascade with so both agree on the token.
+
   Per Spec 009 §Production builds the body lives inside a
   `(when interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally — the install proceeds unvalidated
   under `:advanced` + `goog.DEBUG=false`."
-  [spawned-id spec snapshot]
-  (if interop/debug-enabled?
-    (if-let [schema (get-in spec [:schemas :data])]
-      (validate-snapshot-data! spawned-id snapshot schema :spawn)
-      true)
-    true))
+  ([spawned-id spec snapshot]
+   (validate-spawn-data! spawned-id spec snapshot (current-owner-continuation)))
+  ([spawned-id spec snapshot continue?]
+   (if interop/debug-enabled?
+     (if-let [schema (get-in spec [:schemas :data])]
+       ;; Returns true (conform) / false (schema violation, A still owns) /
+       ;; :rf/stale-incarnation (the validator callback lost A). The no-schema
+       ;; branch runs NO callback, so A cannot be lost here — `true`.
+       (validate-snapshot-data! spawned-id snapshot schema :spawn continue?)
+       true)
+     true)))
 
 (defn validate-update-snapshot-data!
   "Sibling validator for the `:rf.machine/update-snapshot` escape-hatch fx.
@@ -333,6 +386,15 @@
   (`machine-meta`) and a spawned actor (`spec-from-snapshot`) so the
   escape hatch is covered uniformly across actor kinds.
 
+  The application schema validator is fenced to the exact frame incarnation
+  (rf2-vxgfnd.153): a validator that destroys the owning frame A and publishes
+  same-id B returns `:rf/stale-incarnation` from `validate-snapshot-data!`,
+  which this fn TRANSLATES to `false` so the escape-hatch fx's
+  `(when (validate-update-snapshot-data! ...) (write))` SKIPS the A-derived
+  merge onto B. The merge is the only post-callback framework action on this
+  path, so skipping it fully fences the escape hatch. The failure trace is
+  suppressed too (the callback lost A), so no diagnostic is attributed to B.
+
   Per Spec 009 §Production builds the body lives inside a
   `(when interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally — the merge proceeds unvalidated under
@@ -340,9 +402,14 @@
   boundaries."
   [machine-id merged-snapshot]
   (if interop/debug-enabled?
-    (if-let [schema (resolve-data-schema machine-id merged-snapshot)]
-      (validate-snapshot-data! machine-id merged-snapshot schema :update-snapshot)
-      true)
+    (let [continue? (current-owner-continuation)]
+      (if-let [schema (resolve-data-schema machine-id merged-snapshot continue?)]
+        (let [result (validate-snapshot-data! machine-id merged-snapshot schema
+                                              :update-snapshot continue?)]
+          ;; Owner-loss (:rf/stale-incarnation) is truthy — collapse it to
+          ;; `false` so the caller's `(when validator (write))` skips the write.
+          (if (= :rf/stale-incarnation result) false result))
+        true))
     true))
 
 (defn validate-completion-output!
@@ -374,6 +441,14 @@
   :machine-data` boundary uses), so an app with no schema adapter pays zero
   cost.
 
+  The application output validator is fenced to the exact frame incarnation
+  (rf2-vxgfnd.153): if the validator callback destroys the owning frame A and
+  publishes same-id B, neither the `:machine-output` failure trace nor the
+  `:rf.error/malformed-schema` trace is emitted — the diagnostic would
+  otherwise be attributed to B, a frame that never ran this completion. The
+  completion still flows (best-effort); only the now-stale diagnostic is
+  suppressed.
+
   Per Spec 009 §Production builds the body lives inside a
   `(when interop/debug-enabled? ...)` gate so production builds return `true`
   unconditionally — the completion proceeds unvalidated under `:advanced` +
@@ -393,27 +468,38 @@
         ;; `:rf.error/malformed-schema :where :machine-output` trace and
         ;; PROCEED (return true), so a schema typo surfaces loudly yet never
         ;; deadlocks a finishing machine.
-        (try
-          (if (validate-fn schema result)
-            true
-            (do (emit-failure! machine-id :machine-output :completion result
-                               schema nil false
-                               (str "Machine " machine-id
-                                    " completion output (the :output-key payload) "
-                                    "failed schema at boundary :where "
-                                    ":machine-output (phase :completion)."))
-                false))
-          (catch #?(:clj Throwable :cljs :default) e
-            (trace/emit-error! :rf.error/malformed-schema
-                               {:where    :machine-output
-                                :reason   (str "Machine " machine-id
-                                               "'s [:schemas :output] schema is malformed — "
-                                               "the registered validator threw: "
-                                               #?(:clj (.getMessage e) :cljs (ex-message e))
-                                               ". The completion proceeds (best-effort).")
-                                :schema   schema
-                                :rollback? false})
-            true))
+        (let [continue? (current-owner-continuation)]
+          (try
+            (let [conforms? (validate-fn schema result)]
+              (cond
+                ;; The validator callback destroyed A / published same-id B —
+                ;; suppress the (now-stale) diagnostic; do not attribute it to B.
+                (not (continue?)) :rf/stale-incarnation
+                conforms?         true
+                :else
+                (do (emit-failure! machine-id :machine-output :completion result
+                                   schema nil false
+                                   (str "Machine " machine-id
+                                        " completion output (the :output-key payload) "
+                                        "failed schema at boundary :where "
+                                        ":machine-output (phase :completion).")
+                                   continue?)
+                    false)))
+            (catch #?(:clj Throwable :cljs :default) e
+              ;; Owner still live → a genuine malformed-schema diagnostic.
+              ;; Owner lost (the callback threw AND destroyed A) → suppress it.
+              (if (continue?)
+                (do (trace/emit-error! :rf.error/malformed-schema
+                                       {:where    :machine-output
+                                        :reason   (str "Machine " machine-id
+                                                       "'s [:schemas :output] schema is malformed — "
+                                                       "the registered validator threw: "
+                                                       #?(:clj (.getMessage e) :cljs (ex-message e))
+                                                       ". The completion proceeds (best-effort).")
+                                        :schema   schema
+                                        :rollback? false})
+                    true)
+                :rf/stale-incarnation))))
         true)
       true)
     true))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -271,11 +271,20 @@
   rejected actor leaves NO half-installed bookkeeping (no registered
   handler, no actor state, no phantom `(rf/machines)` entry).
 
-  Returns `false` for a no-schema / no-validator / conforming spawn."
-  [spec spawned-id initial-snap]
+  `continue?` is A's exact-frame-incarnation continuation predicate
+  (rf2-vxgfnd.153). The schema validator is application code that can destroy
+  A / publish same-id B; when it does, `validate-spawn-data!` returns
+  `:rf/stale-incarnation` (NOT a schema verdict), which is `(false? …)` → this
+  fn returns `false` (not a schema reject) and the ENCLOSING cascade fence in
+  `spawn-fx*` — gated on `(continue?)` — is what suppresses the install. Only a
+  literal `false` (a genuine schema violation while A still owns) is a reject.
+
+  Returns `false` for a no-schema / no-validator / conforming / owner-lost
+  spawn; `true` only on a genuine schema violation."
+  [spec spawned-id initial-snap continue?]
   (and (some? spec)
-       (not (data-validation/validate-spawn-data!
-              spawned-id spec initial-snap))))
+       (false? (data-validation/validate-spawn-data!
+                 spawned-id spec initial-snap continue?))))
 
 (defn- install-spawn!
   "Atomically install the spawned actor's `initial-snap` (with its
@@ -425,7 +434,22 @@
   through. `frame-id` is the resolved (non-nil-stamped) frame; `args` the
   spawn args. Returns the allocated `spawned-id`."
   [frame-id args]
-  (let [;; Prefer the pre-allocated id (declarative :spawn
+  (let [;; A's exact-frame-incarnation continuation predicate (rf2-vxgfnd.153).
+        ;; The `[:schemas :data]` spawn validator (`validate-spawn-data!`, run
+        ;; inside `spawn-rejected?` below) is APPLICATION code that can
+        ;; synchronously destroy this frame incarnation A and publish a same-id
+        ;; successor B before returning. Everything after that callback — the
+        ;; snapshot / system-id / spawn-slot install, per-instance
+        ;; classification lowering, the spawn-order record, the two spawned
+        ;; traces, and the `:start` (or synthetic) dispatch — is framework-owned
+        ;; tail computed from A's already-read runtime-db. Re-checking
+        ;; `(continue?)` at the cascade gate fences that whole tail so no
+        ;; A-derived allocation or bookkeeping lands on B (whose bare-id
+        ;; `swap-runtime-db!` would otherwise resolve to B). Built ONCE here and
+        ;; threaded into `spawn-rejected?` so the callback and the cascade fence
+        ;; against the SAME token.
+        continue?  (data-validation/owner-continuation frame-id)
+        ;; Prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
         ;; no pre-allocated id; the frame's runtime-db spawn-counter slot
@@ -483,19 +507,23 @@
         ;; nothing to runtime-db, so no liveness exists for the rejected actor
         ;; (the strongest form of atomicity: an actor's liveness IS its
         ;; snapshot, and the snapshot was never installed).
-        rejected?  (spawn-rejected? spec'' spawned-id initial-snap)]
+        rejected?  (spawn-rejected? spec'' spawned-id initial-snap continue?)]
     ;; Gate the ENTIRE accepted-spawn cascade — the
     ;; `:rf.machine.spawn/spawned` trace, the snapshot/system-id/spawn-slot
-    ;; install, AND the `:start` (or synthetic) dispatch — on BOTH the spawn
-    ;; being accepted (`not rejected?`) AND the frame being LIVE (`old-rt`).
-    ;; When the frame was destroyed / never existed, `old-rt` is nil and
-    ;; `spawned-id` is nil (the `:else` allocator branch above): firing the
-    ;; spawned trace and dispatching `[nil <start>]` for an actor that was
-    ;; NEVER installed would be an atomicity violation (a phantom spawn
-    ;; signal + a dispatch into the void). A destroyed-frame spawn is a clean
-    ;; no-op — no trace, no install, no dispatch — symmetric with the
-    ;; schema-reject path's atomicity.
-    (when (and (not rejected?) old-rt)
+    ;; install, AND the `:start` (or synthetic) dispatch — on THREE conditions:
+    ;;   (1) the spawn being accepted (`not rejected?` — no schema violation),
+    ;;   (2) the frame being LIVE at read time (`old-rt` non-nil — a
+    ;;       destroyed / never-created frame reads nil and allocates a nil
+    ;;       `spawned-id`; firing a phantom spawned trace + `[nil <start>]`
+    ;;       dispatch would be an atomicity violation), and
+    ;;   (3) the exact frame incarnation that owns the event STILL being live
+    ;;       AFTER the schema callback (`(continue?)` — rf2-vxgfnd.153). A
+    ;;       validator that destroyed A / published same-id B loses the token;
+    ;;       none of the A-derived install / classification / spawn-order /
+    ;;       trace / dispatch tail may land on B.
+    ;; A destroyed-frame or owner-lost spawn is a clean no-op — no trace, no
+    ;; install, no dispatch — symmetric with the schema-reject path's atomicity.
+    (when (and (not rejected?) old-rt (continue?))
       (trace/emit! :rf.machine :rf.machine.spawn/spawned
                    {:frame      frame-id
                     ;; `:machine-id` is the spec-time registered TYPE (xor

--- a/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
@@ -1,0 +1,317 @@
+(ns re-frame.machine-lifecycle-schema-incarnation-fence-test
+  "Fence machine lifecycle SCHEMA callbacks to the exact frame incarnation
+  (rf2-vxgfnd.153 — part of the incarnation-fencing family established by the
+  merged destroy contract #5818).
+
+  A machine schema validator is APPLICATION code (the late-bound
+  `:schemas/validate-with-registered-fn` adapter running an app-declared
+  schema). It can synchronously destroy the frame incarnation A that owns the
+  in-flight event and publish a same-id successor B before returning. The
+  spawn cascade reads A's runtime-db ONCE (`old-rt`), derives an id allocation
+  and initial snapshot from it, then runs the schema validator; every
+  subsequent framework action — the snapshot / system-id / spawn-slot install,
+  per-instance classification lowering, the spawn-order record, the two
+  spawned traces, and the `:start` (or synthetic) dispatch — is A-derived
+  tail. A bare-id `swap-runtime-db!` at install time resolves the CURRENT
+  incarnation (B), so without a fence the A-derived allocation + bookkeeping
+  land on B.
+
+  These fixtures make CONFORMING, FAILING, and THROWING schema callbacks
+  destroy A and publish same-id B, and assert that B's runtime-db, spawn-order,
+  and trace/dispatch state stay byte-identical after the callback loses A. The
+  sibling boundaries — `validate-update-snapshot-data!` (escape-hatch write)
+  and `validate-completion-output!` (finalize diagnostic) — are covered too.
+
+  Deterministic + single-threaded: the destroyer runs INSIDE the validator
+  callback, so no latch coordination is needed (unlike the cross-thread
+  core incarnation barriers) — the same-id successor B is published on the
+  callback's own stack, exactly the synchronous re-entry the fence guards."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines :as machines]
+            [re-frame.machines.data-validation :as data-validation]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.lifecycle-fx.update-snapshot :as update-snapshot]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation (`re-frame.machines` require has side effects).
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; The instance address the fallback allocator mints for the first
+;; hand-emitted `:machine-id` spawn: `<type>#1`. Constructed the way
+;; `allocate-actor-id-in-runtime-db` builds it (avoids `#` in a keyword
+;; literal).
+(def ^:private child-instance-id (keyword "rf2-vxgfnd153" "child#1"))
+(def ^:private live-child-instance-id (keyword "rf2-vxgfnd153" "live-child#1"))
+
+;; ---- spawn cascade fence --------------------------------------------------
+
+(defn- run-destroyer-spawn
+  "Register a schema-bearing child, install a `::child-schema` validator that
+  (on its first call) destroys frame `frame-a` and publishes a same-id
+  successor B, then run `:rf.machine/spawn` for `frame-a` under a bound event
+  owner (A's dequeue-time token). `on-validate` supplies the validator's
+  verdict for the destroyed-A call (returns a boolean, or throws). Returns a
+  map of the observable post-spawn state. Restores every hook/listener.
+
+  Drives `spawn-fx` DIRECTLY under `call-with-event-owner-token` (the pattern
+  `spawn-destroyed-frame-atomicity-test` uses) rather than through
+  `dispatch-sync`: the destroyer publishes same-id B via `rf/make-frame` on the
+  callback's own stack, and a live `dispatch-sync` drain's same-thread guard
+  forbids nested frame creation. The direct call also bypasses the fx-walk's
+  outer owner fence, so the assertions pin the MACHINE-layer fence itself."
+  [frame-a on-validate]
+  (spawn-order/reset-all!)
+  (rf/reg-machine :rf2-vxgfnd153/child
+    {:initial :running
+     :data    {:seed :a}
+     :schemas {:data ::child-schema}
+     :states  {:running {:on {:go :done}}
+               :done    {:final? true}}})
+  (rf/make-frame {:id frame-a})
+  (let [token-a        (frame/frame-incarnation-token frame-a)
+        b-birth        (atom ::unset)
+        fired?         (atom false)
+        threw?         (atom false)
+        spawn-traces   (atom [])
+        fail-traces    (atom [])
+        dispatches     (atom [])
+        orig-validate  (late-bind/get-fn :schemas/validate-with-registered-fn)
+        orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+    (rf/register-listener! :trace ::spawn-fence
+      (fn [ev]
+        (let [op (:operation ev)]
+          (cond
+            (contains? #{:rf.machine.spawn/spawned :rf.machine.lifecycle/spawned} op)
+            (swap! spawn-traces conj ev)
+
+            (and (= :rf.error/schema-validation-failure op)
+                 (= :spawn (get-in ev [:tags :phase])))
+            (swap! fail-traces conj ev)))))
+    (try
+      ;; Capture (never route) any dispatch the spawn cascade attempts — a
+      ;; `[<child> <start>]` for an actor that was never legitimately installed
+      ;; is itself a fence violation.
+      (late-bind/set-fn! :router/dispatch!
+                         (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
+      (late-bind/set-fn! :schemas/validate-with-registered-fn
+        (fn [schema data]
+          (if (and (= schema ::child-schema)
+                   (compare-and-set! fired? false true))
+            (do
+              (frame/destroy-frame! frame-a)     ;; destroy incarnation A
+              (rf/make-frame {:id frame-a})       ;; publish same-id successor B
+              (reset! b-birth (mtest/runtime-db frame-a))
+              (on-validate data))                 ;; verdict / throw
+            true)))
+      (try
+        (frame/call-with-event-owner-token frame-a token-a
+          (fn [] (spawn/spawn-fx {:frame frame-a}
+                                 {:machine-id :rf2-vxgfnd153/child})))
+        (catch Throwable _ (reset! threw? true)))
+      {:b-birth      @b-birth
+       :b-after      (mtest/runtime-db frame-a)
+       :child-snap   (mtest/snapshot frame-a child-instance-id)
+       :spawn-order  (spawn-order/frame-order frame-a)
+       :spawn-traces @spawn-traces
+       :fail-traces  @fail-traces
+       :dispatches   @dispatches
+       :fired?       @fired?
+       :threw?       @threw?}
+      (finally
+        (rf/unregister-listener! :trace ::spawn-fence)
+        (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)
+        (late-bind/set-fn! :router/dispatch! orig-dispatch!)))))
+
+(defn- assert-successor-untouched
+  "Assertions shared by every destroyer variant: the callback ran, and NONE of
+  the A-derived spawn tail landed on successor B."
+  [result]
+  (is (true? (:fired? result))
+      "the schema validator callback ran (the fence boundary was exercised)")
+  (is (false? (:threw? result))
+      "the obsolete callback (even a throwing one) does not escape after A is lost")
+  (is (nil? (:child-snap result))
+      "no A-derived snapshot was installed onto same-id B")
+  (is (= (:b-birth result) (:b-after result))
+      "B's runtime-db is byte-identical to its birth value (no A-derived allocation)")
+  (is (empty? (:spawn-order result))
+      "no A-derived spawn-order entry was recorded against B")
+  (is (empty? (:spawn-traces result))
+      "no :rf.machine.spawn/spawned / :rf.machine.lifecycle/spawned trace fired for B")
+  (is (empty? (:dispatches result))
+      "no :start (or synthetic) dispatch was fired into B"))
+
+(deftest conforming-callback-destroy-does-not-mutate-successor
+  (testing "a CONFORMING (returns true) validator that destroys A + publishes
+            same-id B: the whole install / classification / spawn-order / trace
+            / dispatch cascade is fenced — B stays byte-identical.
+            Mutation tooth: dropping the `(continue?)` cascade gate installs
+            the A-derived snapshot + spawn-counter + spawn-order onto B."
+    (assert-successor-untouched
+      (run-destroyer-spawn :rf2-vxgfnd153/conforming-frame (fn [_] true)))))
+
+(deftest failing-callback-destroy-attributes-no-diagnostic-to-successor
+  (testing "a FAILING (returns false) validator that destroys A: the
+            :rf.error/schema-validation-failure :phase :spawn diagnostic is
+            SUPPRESSED (it would otherwise be attributed to same-id B), and no
+            cascade lands on B. Mutation tooth: leaving `validate-spawn-data!`
+            on the `(constantly true)` continuation emits the failure trace
+            after A was lost."
+    (let [result (run-destroyer-spawn :rf2-vxgfnd153/failing-frame (fn [_] false))]
+      (assert-successor-untouched result)
+      (is (empty? (:fail-traces result))
+          "no schema-validation-failure diagnostic was attributed to B after A lost the callback"))))
+
+(deftest throwing-callback-destroy-is-inert-against-successor
+  (testing "a THROWING validator that destroys A: once A is lost the throw is
+            SWALLOWED at the validator (it belongs to A's dead continuation)
+            and no A-derived tail lands on B. Mutation tooth: leaving
+            `validate-spawn-data!` on the `(constantly true)` continuation
+            re-throws through the machine cascade after A was lost (`:threw?`
+            true)."
+    (assert-successor-untouched
+      (run-destroyer-spawn :rf2-vxgfnd153/throwing-frame
+                           (fn [_] (throw (ex-info "schema validator lost A" {})))))))
+
+(deftest live-owner-spawn-installs-normally
+  (testing "control: a CONFORMING validator that does NOT destroy A leaves the
+            spawn cascade fully intact — the fence is scoped to owner-loss only,
+            so normal successful spawn behavior stays green."
+    (spawn-order/reset-all!)
+    (rf/reg-machine :rf2-vxgfnd153/live-child
+      {:initial :running
+       :data    {:seed :a}
+       :schemas {:data ::live-child-schema}
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (rf/reg-event :rf2-vxgfnd153/live-spawn-event
+      (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id :rf2-vxgfnd153/live-child}]]}))
+    (let [frame-a      :rf2-vxgfnd153/live-frame
+          spawn-traces (atom [])
+          orig         (late-bind/get-fn :schemas/validate-with-registered-fn)]
+      (rf/make-frame {:id frame-a})
+      (rf/register-listener! :trace ::live-spawn
+        (fn [ev] (when (= :rf.machine.spawn/spawned (:operation ev))
+                   (swap! spawn-traces conj ev))))
+      (try
+        (late-bind/set-fn! :schemas/validate-with-registered-fn (fn [_ _] true))
+        (rf/dispatch-sync [:rf2-vxgfnd153/live-spawn-event] {:frame frame-a})
+        (is (some? (mtest/snapshot frame-a live-child-instance-id))
+            "the child snapshot installed (live-owner spawn is unaffected)")
+        (is (seq @spawn-traces)
+            "the :rf.machine.spawn/spawned trace fired for the live-owner spawn")
+        (is (= [live-child-instance-id] (spawn-order/frame-order frame-a))
+            "the spawn-order entry was recorded for the live-owner spawn")
+        (finally
+          (rf/unregister-listener! :trace ::live-spawn)
+          (late-bind/set-fn! :schemas/validate-with-registered-fn orig))))))
+
+;; ---- update-snapshot escape-hatch fence -----------------------------------
+
+(deftest update-snapshot-validator-fences-write-to-successor
+  (testing "the :rf.machine/update-snapshot escape hatch: a validator that
+            destroys A + publishes same-id B (with a distinct sentinel
+            snapshot) must NOT merge the A-derived patch onto B. Mutation
+            tooth: leaving `validate-update-snapshot-data!` on the
+            `(constantly true)` continuation returns truthy, so the caller's
+            `(when validator (write))` merges the A patch onto same-id B."
+    (rf/reg-machine :rf2-vxgfnd153/sing
+      {:initial :running
+       :data    {:v :a-init}
+       :schemas {:data ::sing-schema}
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a :rf2-vxgfnd153/us-frame
+          fired?  (atom false)
+          orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        ;; Seed A's singleton snapshot so the escape hatch has a live target.
+        (frame/swap-runtime-db! frame-a
+          (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd153/sing]
+                             {:state :running :data {:v :a-init}})))
+        (try
+          (late-bind/set-fn! :schemas/validate-with-registered-fn
+            (fn [schema _data]
+              (if (and (= schema ::sing-schema)
+                       (compare-and-set! fired? false true))
+                (do
+                  (frame/destroy-frame! frame-a)      ;; destroy A
+                  (rf/make-frame {:id frame-a})        ;; same-id B
+                  (frame/swap-runtime-db! frame-a
+                    (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd153/sing]
+                                       {:state :running :data {:v :b-sentinel}})))
+                  true)                                ;; conforms → red would write
+                true)))
+          ;; Drive the escape-hatch fx DIRECTLY under A's bound event owner (the
+          ;; destroyer publishes same-id B via make-frame on its own stack).
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (update-snapshot/update-snapshot-fx
+                     {:frame frame-a}
+                     {:rf/machine-id :rf2-vxgfnd153/sing
+                      :rf/patch      {:data {:v :patched}}})))
+          (is (true? @fired?) "the escape-hatch schema validator callback ran")
+          (is (= {:v :b-sentinel}
+                 (:data (mtest/snapshot frame-a :rf2-vxgfnd153/sing)))
+              "B's snapshot :data is untouched — the A-derived patch did not merge onto same-id B")
+          (finally
+            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+
+;; ---- completion-output finalize diagnostic fence --------------------------
+
+(defn- run-completion-validation
+  "Invoke `validate-completion-output!` under a bound event owner (`token-a`
+  for frame `id`) with a validator that reports a violation and — when
+  `destroy?` — first destroys A + publishes same-id B. Returns the count of
+  `:where :machine-output` schema-validation-failure traces emitted."
+  [id destroy?]
+  (rf/make-frame {:id id})
+  (let [token-a (frame/frame-incarnation-token id)
+        traces  (atom [])
+        orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+    (rf/register-listener! :trace ::completion-fence
+      (fn [ev] (when (and (= :rf.error/schema-validation-failure (:operation ev))
+                          (= :machine-output (get-in ev [:tags :where])))
+                 (swap! traces conj ev))))
+    (try
+      (late-bind/set-fn! :schemas/validate-with-registered-fn
+        (fn [schema _result]
+          (when (and destroy? (= schema ::output-schema))
+            (frame/destroy-frame! id)     ;; destroy A
+            (rf/make-frame {:id id}))      ;; same-id B
+          false))                          ;; violation
+      (frame/call-with-event-owner-token id token-a
+        (fn []
+          (data-validation/validate-completion-output!
+            :rf2-vxgfnd153/completion-actor
+            {:schemas {:output ::output-schema}}
+            "bad-output")))
+      (count @traces)
+      (finally
+        (rf/unregister-listener! :trace ::completion-fence)
+        (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))
+
+(deftest completion-output-validator-honors-exact-continuation
+  (testing "a completion-output validator that destroys A + publishes same-id B
+            suppresses the :where :machine-output diagnostic (it would
+            otherwise be attributed to B, a frame that never ran this
+            completion). Mutation tooth: leaving `validate-completion-output!`
+            unfenced emits the boundary trace after A was lost."
+    (is (zero? (run-completion-validation :rf2-vxgfnd153/completion-frame true))
+        "no :machine-output diagnostic is attributed to B after the validator lost A")))
+
+(deftest completion-output-validator-emits-while-owner-live
+  (testing "control: a violation while A STILL owns the completion emits exactly
+            one :machine-output trace — schema error reporting is unaffected by
+            the fence."
+    (is (= 1 (run-completion-validation :rf2-vxgfnd153/completion-live-frame false))
+        "a violation with A live emits exactly one :machine-output diagnostic")))


### PR DESCRIPTION
## rf2-vxgfnd.153 — Fence machine lifecycle schema callbacks to the exact frame incarnation

Part of the incarnation-fencing family established by the merged destroy contract (#5818). A machine schema validator is **application code** (the late-bound `:schemas/validate-with-registered-fn` adapter). It can synchronously destroy the frame incarnation **A** that owns the in-flight event and publish a same-id successor **B** before returning — and the machine lifecycle fx tail did not re-check ownership after that callback.

### Repro (re-verified against current `origin/main`)

Still live after #5818 / #5839 / #5831. #5818's fence protects the **fx-walk** boundaries (`handle-one-fx` pre/post checks), and `validate-machine-data!` (the macrostep walker) was already fenced — but the sibling validators were not:

- **Spawn (the deep bug).** `spawn-fx*` reads A's runtime-db once (`old-rt`), derives an id allocation + initial snapshot from it, then runs `validate-spawn-data!`. A conforming validator that destroys A + publishes same-id B returns `true`; the enclosing cascade (`install-spawn!`'s bare-id `swap-runtime-db!`, `classification/lower-at-spawn!`, `spawn-order/record!`, the two spawned traces, the `:start` dispatch) then lands A-derived allocation + bookkeeping on **B**. `validate-spawn-data!` / `validate-update-snapshot-data!` sat on the legacy `validate-snapshot-data!` arity supplying `(constantly true)`; `validate-completion-output!` was likewise unfenced.
- **Update-snapshot.** The escape-hatch validator's callback could destroy A; the fx then merged the A-derived patch onto same-id B's snapshot.
- **Completion-output.** The output validator's callback could destroy A; the `:machine-output` (or `:rf.error/malformed-schema`) diagnostic was then attributed to B.

### Fix

Thread A's **exact-frame-incarnation continuation** (derived from the router's dequeue-time `*event-owner*` binding — the same token fx.cljc's walk fences with) through all three sibling validators, and fence the enclosing spawn cascade:

- `implementation/machines/src/re_frame/machines/data_validation.cljc`
  - New shared `owner-continuation` / `current-owner-continuation` helpers (the pattern `validate-machine-data!` already used, now DRY'd).
  - `validate-spawn-data!` gains a `continue?` arity → returns `:rf/stale-incarnation` when the callback loses A (suppressing the failure trace).
  - `validate-update-snapshot-data!` self-derives the continuation and **collapses `:rf/stale-incarnation` → `false`** so the escape-hatch fx's existing `(when validator (write))` skips the A-derived merge onto B.
  - `validate-completion-output!` gates both its `:machine-output` failure emit **and** its `:rf.error/malformed-schema` emit on the continuation, so a stale diagnostic is never attributed to B.
- `implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc`
  - `spawn-fx*` builds the continuation once and threads it into `spawn-rejected?`; the accepted-spawn cascade is now gated on `(and (not rejected?) old-rt (continue?))`. Only a literal `false` (a real schema violation while A still owns) is a reject; owner-loss is fenced by the cascade gate.

Writes that physically linearized before ownership loss are **not** rolled back — only the unentered framework-owned tail is fenced (per the ruling). `core/fx.cljc` needed **no change**: the machine layer fences via `frame/*` primitives whose token is identical to fx.cljc's `*exact-frame-owner-token*` (both are the router's dequeue-time `owner-token`; verified via `router.cljc` L1988–1996).

### Quality gates

Red-before-fix fixture: **`implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj`** (JVM, deterministic single-threaded — the destroyer publishes same-id B on the validator callback's own stack). Verified genuinely red on `origin/main` source (**9 failures** across all five destroyer scenarios) and green with the fix:

- Conforming spawn validator destroys A → **no** snapshot / spawn-counter / spawn-order / trace / dispatch lands on B (byte-identical runtime-db).
- Failing spawn validator destroys A → the `:phase :spawn` diagnostic is **not** attributed to B.
- Throwing spawn validator destroys A → the obsolete throw is swallowed (does not escape).
- Update-snapshot validator destroys A → the A-derived patch does **not** merge onto B.
- Completion-output validator destroys A → the `:machine-output` diagnostic is suppressed.
- Two controls (live-owner spawn installs normally; a violation while A still owns emits exactly one `:machine-output` trace) stay green — the fence is scoped to owner-loss only.

All foreground:

- `(cd implementation/machines && clojure -M:test)` → **1024 tests, 3458 assertions, 0 failures** (incl. the destroyed-reason-channel conformance matrix, still green).
- `(cd implementation/core && clojure -M:test)` → **1923 tests, 8723 assertions, 0 failures**.
- `npm run test:cljs` → **9276 tests, 43905 assertions, 0 failures** (the `.cljc` changes compile + behave under CLJS).
- `sh scripts/test-fast-pr.sh` → **PASS fast PR spine** (mkdocs soft-skipped locally; CI runs it).

### Spec follow-up (deferred to the machines-spec worker)

**None required.** The fix reuses existing trace ops / error ids (`:rf.error/schema-validation-failure`, `:rf.error/malformed-schema`) and adds no new trace op or Spec 009 catalogue row — no spec/005/009/Spec-Schemas prose change is needed. Flagging here per the non-overlap protocol in case the machines-spec worker wants to add a one-line cross-reference to the incarnation-fence family under §Schema validation.
