### PR TITLE
fix(core): incarnation fencing — halted-destroy snapshot, terminal-callback trailer across successor no-emit (rf2-vxgfnd.151/.152)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -3062,9 +3062,25 @@
 
   `terminal-evidence` is the bundle `snapshot-epoch-terminal-evidence!` captured
   BEFORE dissoc (rf2-vxgfnd.151) — the epoch surface publishes A's terminal
-  facts from it rather than re-reading the now-shared id-keyed stores."
+  facts from it rather than re-reading the now-shared id-keyed stores.
+
+  This is the ONLY teardown step that runs AFTER `dissoc-frame!`, so a same-id
+  successor B may already own the registry key when it fires. A throw here is
+  predecessor A's terminal diagnostic: it is recorded on both Spec 009 channels
+  like every other teardown step, but the dev-only
+  `:rf.warning/teardown-hook-exception` trace is delivered under STRUCTURAL
+  delivery so a same-id B's `:rf.trace/frame-no-emit?` policy can neither
+  suppress nor capture it (rf2-vxgfnd.152). Every PRE-dissoc teardown hook keeps
+  ordinary bare-id policy — no same-id B can exist before dissoc, so their
+  attribution is A's unambiguously."
   [id owner-token terminal-evidence]
-  (safe-call-hook! :epoch/on-frame-destroyed id owner-token terminal-evidence))
+  (when-let [f (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (try
+      (f id owner-token terminal-evidence)
+      (catch #?(:clj Throwable :cljs :default) ex
+        (trace/call-with-structural-delivery
+          #(record-teardown-failure! :epoch/on-frame-destroyed
+                                     :safe-call-hook! ex))))))
 
 (defn- snapshot-epoch-terminal-evidence!
   "rf2-vxgfnd.151 — snapshot the destroyed incarnation's terminal halted-destroy

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -3058,10 +3058,32 @@
 
   `owner-token` is the destroyed frame's stable incarnation identity. The epoch
   artefact uses it to compare-clean only this incarnation's id-keyed state if a
-  fresh same-id frame has already published between registry dissoc and step 11."
-  [id owner-token fs-before fs-after committed-at]
-  (safe-call-hook! :epoch/on-frame-destroyed
-                   id owner-token fs-before fs-after committed-at))
+  fresh same-id frame has already published between registry dissoc and step 11.
+
+  `terminal-evidence` is the bundle `snapshot-epoch-terminal-evidence!` captured
+  BEFORE dissoc (rf2-vxgfnd.151) — the epoch surface publishes A's terminal
+  facts from it rather than re-reading the now-shared id-keyed stores."
+  [id owner-token terminal-evidence]
+  (safe-call-hook! :epoch/on-frame-destroyed id owner-token terminal-evidence))
+
+(defn- snapshot-epoch-terminal-evidence!
+  "rf2-vxgfnd.151 — snapshot the destroyed incarnation's terminal halted-destroy
+  evidence (its `:halted-destroy` record + listener/silencing snapshot) while it
+  is still the sole owner of its id-keyed epoch stores, i.e. BEFORE
+  `dissoc-frame!`. A same-id successor can only be constructed after that dissoc,
+  so it can never claim (and drop) the buffer / observation ledger out from under
+  this snapshot. Returns the evidence bundle threaded to `notify-epoch-
+  listeners!` (or nil when no epoch layer participates / the frame was not
+  mid-drain). Guarded like the best-effort teardown steps: a throw here is
+  recorded on both Spec 009 channels and swallowed so teardown still completes."
+  [id fs-before fs-after committed-at]
+  (when-let [snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+    (try
+      (snap id fs-before fs-after committed-at)
+      (catch #?(:clj Throwable :cljs :default) ex
+        (record-teardown-failure! :epoch/snapshot-frame-destroyed
+                                  :safe-call-hook! ex)
+        nil))))
 
 (defn destroy-frame!
   "Tear down a frame. Per Spec 002 §Destroy, the ordered steps are:
@@ -3428,9 +3450,17 @@
         ;; the forget. The frame's resolved generation rides the record's
         ;; `:generation` slot, so dropping the record drops it too — no separate
         ;; forget hook is needed.
-        (dissoc-frame! id)
-        (notify-epoch-listeners! id expected-incarnation-token
-                                 run-fs-before fs-at-destroy run-time-ms)
+        ;; rf2-vxgfnd.151: snapshot A's terminal halted-destroy evidence while A
+        ;; is STILL the sole owner of its id-keyed epoch stores — before
+        ;; dissoc-frame!, after which a same-id successor B can be constructed
+        ;; and claim (dropping) those stores. The bundle is bound lexically to
+        ;; A's exact destroy recipe and published by the post-dissoc epoch hook
+        ;; regardless of whether A still owns the stores when it fires.
+        (let [terminal-evidence (snapshot-epoch-terminal-evidence!
+                                  id run-fs-before fs-at-destroy run-time-ms)]
+          (dissoc-frame! id)
+          (notify-epoch-listeners! id expected-incarnation-token
+                                   terminal-evidence))
         nil)
         (finally
           ;; EP-0008 R1 — FINALLY-shaped flush of the always-on

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -821,9 +821,13 @@
    {:key         :epoch/clear-epoch-listeners!
     :producer-ns 're-frame.epoch
     :description "Clear every registered epoch-settled callback (test isolation)."}
+   {:key         :epoch/snapshot-frame-destroyed
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-vxgfnd.151"
+    :description "Snapshot the destroyed incarnation's terminal halted-destroy evidence BEFORE dissoc-frame!, while it is still the sole owner of its id-keyed epoch stores. Invoked as (f frame-id fs-before fs-after committed-at): fs-before is the in-flight event's pre-run frame-state snapshot, fs-after the destroy-time frame-state value captured before teardown, committed-at the destroying event's causal time (each nil where no in-flight run supplied it). Returns the {:record :listener-snapshot :silenced-cbs} bundle threaded to :epoch/on-frame-destroyed — binding A's terminal record + silencing fan to A's exact incarnation before a same-id successor B (constructable only after dissoc) can claim and drop those stores."}
    {:key         :epoch/on-frame-destroyed
     :producer-ns 're-frame.epoch
-    :description "Tear down a frame's epoch state when the frame is destroyed. Invoked as (f frame-id owner-token fs-before fs-after committed-at): owner-token is the destroyed incarnation's stable identity and compare-guards the final post-dissoc cleanup against a fresh same-id replacement; fs-before is the in-flight event's pre-run frame-state snapshot, fs-after the destroy-time frame-state value captured before teardown, and committed-at the destroying event's causal time. The snapshots are the real :frame-state-before/:frame-state-after slots (and :db-* projections) a mid-drain :halted-destroy record carries. Snapshot/time values are nil where no in-flight run supplied them."}
+    :description "Publish a destroyed frame's terminal epoch evidence and drop its id-keyed stores AFTER dissoc-frame!. Invoked as (f frame-id owner-token terminal-evidence): owner-token is the destroyed incarnation's stable identity and compare-guards the id-keyed store DROP against a fresh same-id replacement (stale A can never erase B); terminal-evidence is the bundle :epoch/snapshot-frame-destroyed captured before dissoc. Publication of A's :halted-destroy record, its structural :rf.epoch/snapshotted+outcome trailers, and its silencing fan is INDEPENDENT of winning that compare-cleanup, so a same-id B claiming the stores cannot lose A's terminal evidence (rf2-vxgfnd.151). A direct-seam arity (f frame-id owner-token fs-before fs-after committed-at) snapshots at call time for tools / unit pins where no same-id successor races the stores."}
    {:key         :epoch/projected-record
     :producer-ns 're-frame.epoch
     :design-bead "rf2-mrsck"

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -176,13 +176,14 @@
         (late-bind/set-fn! :flows/teardown-on-frame-destroy!
                            (fn [_id]
                              (swap! other-hooks-called conj :flows-ran)))
-        ;; rf2-9neiq: the :epoch/on-frame-destroyed hook takes
-        ;; (frame-id owner-token db-before db-after committed-at) — exact
-        ;; incarnation ownership plus the two snapshots
-        ;; destroy-frame! threads for the :halted-destroy record plus the
-        ;; destroying event's causal :time-ms (rf2-bh56rc).
+        ;; rf2-vxgfnd.151: the post-dissoc :epoch/on-frame-destroyed hook takes
+        ;; (frame-id owner-token terminal-evidence) — exact incarnation
+        ;; ownership plus the pre-dissoc terminal-evidence bundle
+        ;; :epoch/snapshot-frame-destroyed captured for the :halted-destroy
+        ;; record. (The two frame-state snapshots + causal :time-ms now reach
+        ;; the epoch layer via that pre-dissoc snapshot hook.)
         (late-bind/set-fn! :epoch/on-frame-destroyed
-                           (fn [_id _owner-token _db-before _db-after _committed-at]
+                           (fn [_id _owner-token _terminal-evidence]
                              (swap! other-hooks-called conj :epoch-ran)))
 
         ;; Destroy must not re-throw.

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -310,6 +310,122 @@
         (rf/unregister-listener! :trace ::event-tail-overlap)
         (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
 
+(deftest predecessor-halted-destroy-evidence-survives-successor-epoch-claim
+  ;; rf2-vxgfnd.151 (red before fix). A is destroyed mid-drain and paused at its
+  ;; POST-DISSOC epoch hook. Same-id B is then created and SETTLES an ordinary
+  ;; event, claiming the id-keyed epoch stores (which drops A's buffer and
+  ;; observation ledger). When A resumes it must STILL publish its terminal
+  ;; halted-destroy evidence: the record was snapshotted BEFORE dissoc, and its
+  ;; publication is decoupled from winning the compare-cleanup. B's stores stay
+  ;; byte-identical.
+  ;;
+  ;; Before the fix the unfixed path read the buffer AFTER dissoc (B had already
+  ;; dropped it → no record) AND gated publication on winning the cleanup
+  ;; comparison (B owned → nil → no publication): zero A records, zero trailers.
+  (let [id             :destroy/halted-evidence-overlap
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        a-records      (atom [])
+        traces         (atom [])
+        b-observer     ::b-halted-observer
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :destroy/halted-a
+      (fn [_ _]
+        (frame/destroy-frame! id)
+        {:db {:owner :a-tail}}))
+    (rf/reg-event :destroy/halted-b-settle
+      (fn [{:keys [db]} _]
+        {:db (assoc db :owner :b)}))
+    (rf/make-frame {:id id})
+    ;; Capture A's terminal epoch record + its structural trailer pair.
+    (rf/register-listener! :epoch ::a-epoch-watch
+      (fn [r] (when (= :halted-destroy (:outcome r)) (swap! a-records conj r))))
+    (rf/register-listener! :trace ::halted-evidence-overlap
+      (fn [ev]
+        (when (and (= id (get-in ev [:tags :frame]))
+                   (contains? #{:rf.epoch/snapshotted :rf.epoch/outcome}
+                              (:operation ev)))
+          (swap! traces conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          ;; The post-dissoc publish hook. Hold only A's first (halted) call.
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:destroy/halted-a] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A is paused at its post-dissoc epoch hook (evidence already
+             snapshotted before dissoc)")
+        ;; Same-id B, with its own observer, SETTLES an ordinary event — its
+        ;; first captured event claims the id-keyed epoch stores, dropping A's
+        ;; buffer + observation ledger.
+        (rf/make-frame {:id id})
+        (epoch-state/put-listener! b-observer (fn [_] nil))
+        (rf/dispatch-sync [:destroy/halted-b-settle] {:frame id})
+        (let [token-b      (frame/frame-incarnation-token id)
+              b-history    (rf/epoch-history id)
+              b-buffer     (epoch-state/buffer-for id)
+              b-last-epoch (epoch-state/last-settled-epoch-id id)
+              b-db         (frame/frame-app-db-value id)]
+          (is (= 1 (count b-history))
+              "B settled one ordinary event and now owns the id-keyed stores")
+          (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
+              "B's observer is armed before A resumes")
+
+          ;; A resumes and reaches its terminal publish while B owns the stores.
+          (.countDown release-a)
+          (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+              "A's terminal recipe completes")
+          (executor-barrier!)
+
+          ;; A's terminal evidence is published DESPITE B owning the stores.
+          (is (= 1 (count @a-records))
+              "exactly one A :halted-destroy record reaches epoch listeners")
+          (is (= :destroy/halted-a (:event-id (first @a-records)))
+              "the terminal record is A's destroying event")
+          ;; B's ordinary settle also emits :ok trailers on the same frame id;
+          ;; scope to A's TERMINAL outcomes (B's are :ok, A's are
+          ;; :halted-destroy / :blocked).
+          (let [by-op (group-by :operation @traces)]
+            (is (= 1 (count (filter #(= :halted-destroy (get-in % [:tags :outcome]))
+                                    (get by-op :rf.epoch/snapshotted))))
+                "exactly one A :halted-destroy :rf.epoch/snapshotted is published")
+            (is (= 1 (count (filter #(= :blocked (get-in % [:tags :outcome]))
+                                    (get by-op :rf.epoch/outcome))))
+                "exactly one A blocked :rf.epoch/outcome is published"))
+
+          ;; B's stores are byte-identical: A's compare-cleanup no-op'd.
+          (is (identical? token-b (frame/frame-incarnation-token id))
+              "B remains the current incarnation")
+          (is (= {:owner :b} b-db)
+              "A's inert returned tail never mutated B's state")
+          (is (= {:owner :b} (frame/frame-app-db-value id))
+              "B's state is unchanged after A resumes")
+          (is (= b-history (rf/epoch-history id))
+              "B's history is untouched by A's terminal cleanup")
+          (is (= b-buffer (epoch-state/buffer-for id))
+              "B's capture buffer is untouched")
+          (is (= b-last-epoch (epoch-state/last-settled-epoch-id id))
+              "B's last-settled anchor is untouched")
+          (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
+              "B's listener observation survives A's terminal cleanup")
+
+          ;; B keeps settling normally.
+          (rf/dispatch-sync [:destroy/halted-b-settle] {:frame id})
+          (is (= 2 (count (rf/epoch-history id)))
+              "B settles subsequent events normally after A resumes")))
+      (finally
+        (.countDown release-a)
+        (epoch-state/drop-listener! b-observer)
+        (rf/unregister-listener! :epoch ::a-epoch-watch)
+        (rf/unregister-listener! :trace ::halted-evidence-overlap)
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
 (deftest owner-loss-unwinds-only-entered-authored-afters
   ;; Mutation tooth: removing execute-chain's continuation predicate would run
   ;; :never/before and the handler after :killer/before destroys A. Removing

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -426,6 +426,156 @@
         (rf/unregister-listener! :trace ::halted-evidence-overlap)
         (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
 
+;; ---- rf2-vxgfnd.152 — predecessor terminal diagnostics across B no-emit -----
+
+(defn- run-terminal-listener-exception-scenario
+  "Destroy A mid-drain and pause at its post-dissoc epoch hook; install same-id
+  B (with the given `no-emit?` policy) during the pause; on resume a terminal
+  epoch listener throws while receiving A's halted record. Returns the captured
+  `:rf.epoch.cb/listener-exception` traces plus B state. A's terminal
+  listener-exception must be delivered structurally regardless of B's policy
+  (rf2-vxgfnd.152).
+
+  B is installed on the main thread during the pause (not re-entrantly from the
+  listener) so a same-id B is unambiguously live when the diagnostic emits."
+  [id no-emit?]
+  (let [a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        exceptions     (atom [])
+        thrower        (keyword "rf2-152" (str "lx-thrower-" (name id)))
+        trace-key      (keyword "rf2-152" (str "lx-trace-" (name id)))
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :rf2-152/lx-destroy-self
+      (fn [_ _] (frame/destroy-frame! id) {}))
+    (rf/make-frame {:id id})
+    ;; Terminal listener that throws while receiving A's halted record.
+    (rf/register-listener! :epoch thrower
+      (fn [r]
+        (when (= :halted-destroy (:outcome r))
+          (throw (ex-info "terminal listener blew" {})))))
+    (rf/register-listener! :trace trace-key
+      (fn [ev]
+        (when (and (= id (get-in ev [:tags :frame]))
+                   (= :rf.epoch.cb/listener-exception (:operation ev)))
+          (swap! exceptions conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:rf2-152/lx-destroy-self] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A paused at its post-dissoc epoch hook")
+        (rf/make-frame {:id id :rf.trace/frame-no-emit? no-emit?})
+        (let [token-b (frame/frame-incarnation-token id)]
+          (.countDown release-a)
+          (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+              "A's terminal recipe completes")
+          (executor-barrier!)
+          {:exceptions   @exceptions
+           :thrower      thrower
+           :b-token-ok?  (identical? token-b (frame/frame-incarnation-token id))
+           :b-buffer     (epoch-state/buffer-for id)
+           :b-history    (rf/epoch-history id)}))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch thrower)
+        (rf/unregister-listener! :trace trace-key)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
+(deftest terminal-listener-exception-crosses-successor-no-emit
+  ;; rf2-vxgfnd.152 (red before fix). A terminal halted-destroy listener that
+  ;; throws while a same-id B is live must still yield exactly one A
+  ;; :rf.epoch.cb/listener-exception — whether or not B enabled no-emit — and
+  ;; that diagnostic must not enter B's epoch capture. Before the fix the
+  ;; diagnostic was resolved through B's bare-id policy, so a no-emit B
+  ;; suppressed it to zero.
+  (let [suppressed (run-terminal-listener-exception-scenario
+                     :rf2-152/lx-noemit true)
+        control    (run-terminal-listener-exception-scenario
+                     :rf2-152/lx-plain false)]
+    (is (= 1 (count (:exceptions suppressed)))
+        "A's terminal listener-exception is delivered despite same-id B no-emit")
+    (is (= (:thrower suppressed)
+           (get-in (first (:exceptions suppressed)) [:tags :cb-id]))
+        "the diagnostic names the failing terminal listener")
+    (is (= 1 (count (:exceptions control)))
+        "the control (B no-emit disabled) also yields exactly one diagnostic")
+    (is (true? (:b-token-ok? suppressed))
+        "same-id B remains the live incarnation through A's terminal fan-out")
+    (is (empty? (filter #(= :rf.epoch.cb/listener-exception (:operation %))
+                        (:b-buffer suppressed)))
+        "A's diagnostic never enters B's epoch capture buffer")
+    (is (empty? (:b-history suppressed))
+        "no A diagnostic is recorded into B's history")))
+
+(defn- run-terminal-teardown-hook-exception-scenario
+  "Destroy A; its post-dissoc epoch teardown hook installs same-id B (with the
+  given `no-emit?` policy) then throws. Returns the captured
+  `:rf.warning/teardown-hook-exception` traces plus B state. A's post-dissoc
+  teardown-hook warning must be delivered structurally regardless of B's policy
+  (rf2-vxgfnd.152)."
+  [id no-emit?]
+  (let [warnings    (atom [])
+        trace-key   (keyword "rf2-152" (str "tdtrace-" (name id)))
+        original-ep (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/make-frame {:id id})
+    (rf/register-listener! :trace trace-key
+      (fn [ev]
+        (when (and (= id (get-in ev [:tags :frame]))
+                   (= :rf.warning/teardown-hook-exception (:operation ev)))
+          (swap! warnings conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (if (= id (first args))
+            (do
+              ;; Install same-id B, then fail the post-dissoc epoch hook: B's
+              ;; no-emit policy must not suppress A's teardown-hook warning.
+              (rf/make-frame {:id id :rf.trace/frame-no-emit? no-emit?})
+              (throw (ex-info "epoch teardown blew" {})))
+            (when original-ep (apply original-ep args)))))
+      (frame/destroy-frame! id)
+      (executor-barrier!)
+      {:warnings  @warnings
+       :b-live?   (some? (frame/frame-incarnation-token id))
+       :b-buffer  (epoch-state/buffer-for id)}
+      (finally
+        ;; Restore the real hook BEFORE destroying B so B's teardown does not
+        ;; re-enter the throwing wrapper.
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-ep)
+        (rf/unregister-listener! :trace trace-key)
+        (when (frame/frame id) (frame/destroy-frame! id))))))
+
+(deftest terminal-teardown-hook-exception-crosses-successor-no-emit
+  ;; rf2-vxgfnd.152 (red before fix). A throwing POST-DISSOC epoch teardown hook
+  ;; must still yield exactly one A :rf.warning/teardown-hook-exception — whether
+  ;; or not the same-id successor B enabled no-emit — and it must not enter B's
+  ;; epoch capture. Before the fix the warning went through the ordinary bare-id
+  ;; policy path, so a no-emit B suppressed it to zero.
+  (let [suppressed (run-terminal-teardown-hook-exception-scenario
+                     :rf2-152/td-noemit true)
+        control    (run-terminal-teardown-hook-exception-scenario
+                     :rf2-152/td-plain false)]
+    (is (= 1 (count (:warnings suppressed)))
+        "A's post-dissoc teardown-hook warning is delivered despite B no-emit")
+    (is (= :epoch/on-frame-destroyed
+           (get-in (first (:warnings suppressed)) [:tags :hook]))
+        "the warning names the failing epoch teardown hook")
+    (is (= 1 (count (:warnings control)))
+        "the control (B no-emit disabled) also yields exactly one warning")
+    (is (true? (:b-live? suppressed))
+        "same-id B remains live after A's teardown hook fails")
+    (is (empty? (filter #(= :rf.warning/teardown-hook-exception (:operation %))
+                        (:b-buffer suppressed)))
+        "A's teardown warning never enters B's epoch capture buffer")))
+
 (deftest owner-loss-unwinds-only-entered-authored-afters
   ;; Mutation tooth: removing execute-chain's continuation predicate would run
   ;; :never/before and the handler after :killer/before destroys A. Removing

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -319,11 +319,14 @@
 ;; warn-once cache, so the compatibility hook bought nothing.)
 
 (def ^:private destroy-frame-hook-keys
-  "The destroy-frame! cleanup-hook keys. Each fires through
-  `frame/safe-call-hook!` (rf2-ggkay) inside the destroy cascade.
-  Mirrored here so the assertion visits each by name."
+  "The destroy-frame! cleanup-hook keys. `:ssr` / `:machines` fire through
+  `frame/safe-call-hook!` (rf2-ggkay) inside the destroy cascade; the two epoch
+  keys fire directly (`:epoch/snapshot-frame-destroyed` BEFORE dissoc,
+  `:epoch/on-frame-destroyed` AFTER — rf2-vxgfnd.151). Mirrored here so the
+  assertion visits each by name."
   [:ssr/on-frame-destroyed
    :machines/on-frame-destroyed!
+   :epoch/snapshot-frame-destroyed
    :epoch/on-frame-destroyed])
 
 (deftest destroy-frame-fires-every-cleanup-hook-exactly-once
@@ -351,31 +354,45 @@
 (deftest destroy-frame-cleanup-hooks-receive-frame-id
   (testing "cleanup hooks that take the destroyed frame's id receive it
             correctly — :ssr / :machines / :epoch all pass the id"
-    ;; :ssr / :machines take the destroyed id. :epoch/on-frame-destroyed
-    ;; takes (id owner-token db-before db-after committed-at): exact frame
-    ;; ownership plus rf2-9neiq's two
-    ;; snapshots for the :halted-destroy record) + rf2-bh56rc (the
-    ;; destroying event's causal :time-ms). Pin each arg shape so a future
-    ;; refactor that swaps positional → varargs (or drops the id) breaks
-    ;; loudly.
+    ;; :ssr / :machines take the destroyed id. rf2-vxgfnd.151 split the epoch
+    ;; teardown across two hooks: the PRE-dissoc :epoch/snapshot-frame-destroyed
+    ;; takes (id db-before db-after committed-at) — rf2-9neiq's two snapshots
+    ;; for the :halted-destroy record + rf2-bh56rc's destroying-event causal
+    ;; :time-ms — and the POST-dissoc :epoch/on-frame-destroyed takes
+    ;; (id owner-token terminal-evidence) — exact frame ownership plus the
+    ;; pre-dissoc bundle. Pin each arg shape so a future refactor that swaps
+    ;; positional → varargs (or drops the id) breaks loudly.
     (let [snapshot   @late-bind/hooks
-          captured-args (atom {})]
+          captured-args (atom {})
+          original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
       (try
         (doseq [k [:ssr/on-frame-destroyed
                    :machines/on-frame-destroyed!]]
           (late-bind/set-fn! k (fn [id]
                                  (swap! captured-args assoc k id))))
-        ;; The epoch hook's five-arg shape — record the id, exact incarnation
-        ;; owner, and that the snapshot args + committed-at arrive (all nil
-        ;; here: an out-of-cascade destroy carries no pre-cascade snapshot
-        ;; and no in-flight causal token).
+        ;; The pre-dissoc snapshot hook's four-arg shape — record the id and
+        ;; that the two snapshot args + committed-at arrive (all nil here save
+        ;; fs-after: an out-of-cascade destroy carries no pre-cascade snapshot
+        ;; and no in-flight causal token). Delegate to the real hook so the
+        ;; downstream :epoch/on-frame-destroyed still receives a live bundle.
+        (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+                           (fn [id db-before db-after committed-at]
+                             (swap! captured-args assoc
+                                    :epoch/snapshot-frame-destroyed id
+                                    :epoch/snapshot-args [db-before db-after]
+                                    :epoch/committed-at committed-at)
+                             (when original-snap
+                               (original-snap id db-before db-after committed-at))))
+        ;; The post-dissoc hook's three-arg shape — record the id, exact
+        ;; incarnation owner, and that the terminal-evidence bundle arrives.
         (late-bind/set-fn! :epoch/on-frame-destroyed
-                           (fn [id owner-token db-before db-after committed-at]
+                           (fn [id owner-token terminal-evidence]
                              (swap! captured-args assoc
                                     :epoch/on-frame-destroyed id
                                     :epoch/owner-token owner-token
-                                    :epoch/snapshot-args [db-before db-after]
-                                    :epoch/committed-at committed-at)))
+                                    :epoch/terminal-evidence-arrived?
+                                    (contains? @captured-args
+                                               :epoch/snapshot-frame-destroyed))))
         (rf/make-frame {:id :rf2-j9phb/arg-target})
         (frame/destroy-frame! :rf2-j9phb/arg-target)
 
@@ -386,20 +403,26 @@
                (get @captured-args :machines/on-frame-destroyed!))
             "machines hook receives the destroyed frame id")
         (is (= :rf2-j9phb/arg-target
+               (get @captured-args :epoch/snapshot-frame-destroyed))
+            "pre-dissoc snapshot hook receives the destroyed frame id")
+        (is (= :rf2-j9phb/arg-target
                (get @captured-args :epoch/on-frame-destroyed))
-            "epoch hook receives the destroyed frame id")
+            "post-dissoc epoch hook receives the destroyed frame id")
         (is (some? (get @captured-args :epoch/owner-token))
             "epoch hook receives the destroyed incarnation's stable owner token")
+        (is (true? (get @captured-args :epoch/terminal-evidence-arrived?))
+            "the post-dissoc hook runs AFTER the pre-dissoc snapshot hook —
+             the terminal-evidence bundle it publishes was captured first")
         ;; rf2-9neiq / rf2-3aizt1: for this OUT-OF-RUN destroy, fs-before
         ;; (the pre-run snapshot from frame/*run-frame-state-before*)
         ;; is nil (no in-flight run), while fs-after is the live
         ;; frame-state value read at destroy-time — the frame's initial empty
         ;; two-partition frame-state. EP-0001 (rf2-3aizt1, decision #2): the
-        ;; destroy hook now threads the whole frame-state (both partitions),
+        ;; snapshot hook now threads the whole frame-state (both partitions),
         ;; not app-db alone.
         (is (= [nil {:rf.db/app {} :rf.db/runtime {}}]
                (get @captured-args :epoch/snapshot-args))
-            "epoch hook receives (fs-before fs-after): nil pre-run
+            "snapshot hook receives (fs-before fs-after): nil pre-run
              (out-of-run destroy) + the destroy-time frame-state
              {:rf.db/app {} :rf.db/runtime {}} (rf2-9neiq / rf2-3aizt1)")
         ;; rf2-bh56rc: an out-of-run destroy has no in-flight causal
@@ -408,7 +431,7 @@
         ;; on this path, so the value is moot — the assertion pins the arg
         ;; shape, not a committed timestamp.)
         (is (contains? @captured-args :epoch/committed-at)
-            "epoch hook receives the terminal committed-at arg (rf2-bh56rc)")
+            "snapshot hook receives the terminal committed-at arg (rf2-bh56rc)")
         (is (nil? (get @captured-args :epoch/committed-at))
             "committed-at is nil for an out-of-cascade destroy (no token)")
         (finally

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -555,6 +555,11 @@
    ;; capture seam. Back-fills it into the causing (most-recently-settled)
    ;; epoch's `:trace-events`, where Xray's VIEWS step surfaces it.
    :epoch/record-unmount!     listeners/record-unmount!
+   ;; rf2-vxgfnd.151: `destroy-frame!` fires this BEFORE dissoc to bind the
+   ;; dying incarnation's terminal halted-destroy evidence to a bundle while it
+   ;; still solely owns its id-keyed epoch stores; the bundle is threaded to the
+   ;; post-dissoc `:epoch/on-frame-destroyed` hook.
+   :epoch/snapshot-frame-destroyed listeners/snapshot-terminal-destroy-evidence!
    :epoch/on-frame-destroyed  listeners/on-frame-destroyed!
 
    ;; ---- introspection + Tool-Pair write surface --------------------

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -10,18 +10,28 @@
        failing cb emits `:rf.epoch.cb/listener-exception` so devtools
        can surface the broken consumer.
 
-    2. `on-frame-destroyed!` — the late-bind hook
+    2. `snapshot-terminal-destroy-evidence!` — the late-bind hook
        `re-frame.frame/destroy-frame!` invokes against the
-       `:epoch/on-frame-destroyed` slot. Coordinates the four-step
-       destroy contract:
+       `:epoch/snapshot-frame-destroyed` slot BEFORE dissoc, binding the
+       dying incarnation's terminal evidence (halted record + silencing
+       fan) to a bundle while it still solely owns its id-keyed stores.
 
-         (a) mid-drain destroy detection → commit a `:halted-destroy`
+    3. `on-frame-destroyed!` — the late-bind hook
+       `re-frame.frame/destroy-frame!` invokes against the
+       `:epoch/on-frame-destroyed` slot AFTER dissoc. Coordinates the
+       four-step destroy contract against the pre-dissoc bundle:
+
+         (a) mid-drain destroy detection → deliver the `:halted-destroy`
              partial record (carrying the real pre-cascade `:db-before`
               and destroy-time snapshots) to listeners, not the ring.
          (b) emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb
              whose observed-frames set contained `frame-id`.
          (c) drop the per-frame ring buffer.
          (d) drop the in-flight capture buffer.
+
+       Publication of (a)/(b) is independent of the compare-owned store
+       drop (c)/(d), so a same-id successor claiming the stores cannot lose
+       predecessor A's terminal evidence (rf2-vxgfnd.151).
 
   Listener registry and observation bookkeeping live in
   `re-frame.epoch.state`."
@@ -242,73 +252,110 @@
     (state/drop-render-key-mount-attribution!
       frame-id (-> event :tags :rf.view/render-key))))
 
-(defn on-frame-destroyed!
-  "Handle epoch state when a frame is destroyed.
+(defn snapshot-terminal-destroy-evidence!
+  "Snapshot a destroyed incarnation's terminal halted-destroy evidence while it
+  is STILL the sole owner of its id-keyed epoch stores.
 
-  If a run-start is still buffered, listeners receive a raw
-  `:halted-destroy` record containing the pre-run and destroy-time whole-frame
-  snapshots plus the destroying event's causal time. The record is not stored:
-  destroyed frames have empty history, so listener delivery is the only channel
-  for this terminal partial record.
+  `re-frame.frame/destroy-frame!` calls this (via `:epoch/snapshot-frame-
+  destroyed`) BEFORE `dissoc-frame!`. A same-id successor B can only be
+  constructed after that dissoc, so it can never claim — and thereby drop — the
+  buffer / observation ledger out from under this snapshot (rf2-vxgfnd.151).
 
-  `owner-token` is the destroyed frame's stable incarnation token. Each
-  listener whose CURRENT generation observed the frame receives one
-  silencing trace (a stale observation from a since-replaced same-id generation
-  is skipped — `state/cbs-observing-frame` scopes the fan to the live
-  generation). The observation, history, capture, last-settled, and
-  mount-attribution entries are then removed so a same-keyed replacement frame
-  starts clean. Owner comparison and cleanup are serialised with fresh
-  same-id epoch publication: stale A cleanup no-ops after B has claimed these
-  id-keyed stores. Repeated destroys are idempotent."
-  [frame-id owner-token fs-before fs-after committed-at]
+  Returns the evidence bundle `{:record :listener-snapshot :silenced-cbs}`
+  consumed by `on-frame-destroyed!`, or nil when no epoch layer participates
+  (production / debug disabled). `:record` is the `:halted-destroy` partial
+  record when the frame was mid-drain (a `:rf.event/run-start` is buffered),
+  else nil; the silencing fan is derived either way from the observers the
+  exact incarnation accrued. Schema digesting is intentionally omitted: A's
+  schemas are already torn down and a bare-id digest could only resolve absent
+  state or a same-id B."
+  [frame-id fs-before fs-after committed-at]
   (when interop/debug-enabled?
-    ;; Snapshot and assemble terminal evidence BEFORE entering the exact-owner
-    ;; cleanup transaction. In particular, schema digesting is late-bound and
-    ;; callback-bearing; running it under the re-entrant owner monitor allowed
-    ;; the callback to publish same-id B and then let stale A erase B's stores.
     (let [buffered-events   (state/buffer-for frame-id)
-          in-flight?       (some #(= :rf.event/run-start (:operation %))
-                                 buffered-events)
-          record           (when in-flight?
-                             (assembly/build-record
-                               frame-id fs-before fs-after buffered-events
-                               committed-at :halted-destroy
-                               {:operation :rf.frame/destroyed-mid-drain}
-                               ;; A's schemas were already torn down before the
-                               ;; terminal epoch hook. A bare-id digest here
-                               ;; could only resolve absent state or same-id B;
-                               ;; terminal partial records therefore omit it.
-                               nil))
+          in-flight?        (some #(= :rf.event/run-start (:operation %))
+                                  buffered-events)
+          record            (when in-flight?
+                              (assembly/build-record
+                                frame-id fs-before fs-after buffered-events
+                                committed-at :halted-destroy
+                                {:operation :rf.frame/destroyed-mid-drain}
+                                nil))
           listener-snapshot (if record (state/listeners-snapshot) {})
           silenced-cbs      (into (set (state/cbs-observing-frame frame-id))
                                   (keys listener-snapshot))]
-      (when-let [{:keys [record listener-snapshot silenced-cbs]}
-                 (state/cleanup-frame-owner!
-                   frame-id owner-token
-                   (fn []
-                     ;; Data-only exact-owner transaction: no external callback
-                     ;; may run between owner comparison and the complete drop.
-                     (state/drop-frame-observation! frame-id)
-                     (state/drop-frame-history! frame-id)
-                     (state/drop-frame-buffer! frame-id)
-                     (state/drop-last-settled-epoch! frame-id)
-                     (state/drop-frame-mount-attribution! frame-id)
-                     {:record            record
-                      :listener-snapshot listener-snapshot
-                      :silenced-cbs      silenced-cbs}))]
-      (when record
-        ;; Use the same detailed/coarse trailer pair as normal commits. These
-        ;; terminal emits are explicitly excluded from capture ownership.
-        ;; A has already been dissociated, so a same-id B may now own the
-        ;; registry key. Deliver A's terminal facts without consulting B's
-        ;; frame-no-emit policy or entering B's epoch capture buffer.
-        (trace/call-with-structural-delivery
-          #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
-                                               (:event-id record) :halted-destroy))
-        (deliver-listener-snapshot! record listener-snapshot))
-      (doseq [cb-id silenced-cbs]
-        ;; The silencing fact belongs to destroyed A too; never let a same-id
-        ;; successor's trace policy suppress or capture it.
-        (trace/call-with-structural-delivery
-          #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                        {:frame frame-id :cb-id cb-id})))))))
+      {:record            record
+       :listener-snapshot listener-snapshot
+       :silenced-cbs      silenced-cbs})))
+
+(defn on-frame-destroyed!
+  "Publish a destroyed frame's terminal epoch evidence and drop its id-keyed
+  stores.
+
+  Two arities:
+
+    * `[frame-id owner-token terminal-evidence]` — the destroy-recipe arity.
+      `terminal-evidence` is the bundle `snapshot-terminal-destroy-evidence!`
+      captured BEFORE dissoc; publishing that snapshot (rather than re-reading
+      the now-shared id-keyed stores) is what keeps predecessor A's evidence
+      intact after a same-id successor B has claimed those stores
+      (rf2-vxgfnd.151).
+
+    * `[frame-id owner-token fs-before fs-after committed-at]` — the direct-seam
+      arity for tools / unit pins, where no same-id successor can race the
+      stores: it snapshots at call time and delegates to the arity above.
+
+  If a run-start was buffered, listeners receive a raw `:halted-destroy` record
+  (pre-run + destroy-time whole-frame snapshots plus the destroying event's
+  causal time). The record is not stored: destroyed frames have empty history,
+  so listener delivery is the only channel for this terminal partial record.
+
+  Each listener whose CURRENT generation observed the frame receives one
+  silencing trace (a stale observation from a since-replaced same-id generation
+  is skipped — `state/cbs-observing-frame` scopes the fan to the live
+  generation).
+
+  The id-keyed store DROP is compare-owned (`state/cleanup-frame-owner!`): it
+  runs only while `owner-token` still owns the stores, so stale A can never
+  erase a fresh same-id B. PUBLICATION of A's already-snapshotted terminal
+  record, its structural trailers, and its silencing fan is INDEPENDENT of
+  winning that comparison — the evidence was bound to A's exact incarnation
+  before dissoc and is A's to deliver whether or not A still owns the stores
+  (rf2-vxgfnd.151). All terminal emits use structural delivery so a same-id B's
+  frame-no-emit policy can neither suppress nor capture them. Repeated destroys
+  are idempotent."
+  ([frame-id owner-token fs-before fs-after committed-at]
+   (on-frame-destroyed! frame-id owner-token
+                       (snapshot-terminal-destroy-evidence!
+                         frame-id fs-before fs-after committed-at)))
+  ([frame-id owner-token terminal-evidence]
+   (when interop/debug-enabled?
+     (let [{:keys [record listener-snapshot silenced-cbs]} terminal-evidence]
+       ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
+       ;; same-id B has already claimed them, this no-ops and leaves B untouched.
+       (state/cleanup-frame-owner!
+         frame-id owner-token
+         (fn []
+           ;; Data-only exact-owner transaction: no external callback runs
+           ;; between owner comparison and the complete drop.
+           (state/drop-frame-observation! frame-id)
+           (state/drop-frame-history! frame-id)
+           (state/drop-frame-buffer! frame-id)
+           (state/drop-last-settled-epoch! frame-id)
+           (state/drop-frame-mount-attribution! frame-id)
+           true))
+       ;; Publish A's terminal facts regardless of the cleanup comparison — the
+       ;; evidence was snapshotted before dissoc and belongs to A's incarnation.
+       (when record
+         ;; Same detailed/coarse trailer pair as normal commits, delivered
+         ;; structurally: excluded from capture ownership and immune to a same-id
+         ;; B's frame-no-emit policy.
+         (trace/call-with-structural-delivery
+           #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
+                                                (:event-id record) :halted-destroy))
+         (deliver-listener-snapshot! record listener-snapshot))
+       (doseq [cb-id silenced-cbs]
+         ;; The silencing fact belongs to destroyed A too; never let a same-id
+         ;; successor's trace policy suppress or capture it.
+         (trace/call-with-structural-delivery
+           #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                         {:frame frame-id :cb-id cb-id})))))))

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -46,13 +46,32 @@
 
   Observation stamping belongs to the caller: ordinary fan-out stamps before
   delivery; terminal destroy fan-out snapshots the silencing set and removes
-  the dying incarnation's observation state atomically before delivery."
+  the dying incarnation's observation state atomically before delivery.
+
+  `terminal?` marks the destroy fan-out of predecessor A's `:halted-destroy`
+  record. A's registry slot may already belong to a same-id successor B by the
+  time a listener throws (a terminal listener can itself install B), so A's
+  `:rf.epoch.cb/listener-exception` diagnostic is delivered STRUCTURALLY —
+  bypassing B's `:rf.trace/frame-no-emit?` policy and B's epoch capture — rather
+  than resolved through B's bare-id policy (rf2-vxgfnd.152). Ordinary
+  (non-terminal) fan-out keeps the live frame's no-emit policy."
   ([record listener-snapshot]
    ;; Terminal destroy delivery already removed observation ownership and must
    ;; not recreate it while fanning out the halted record.
-   (deliver-listener-snapshot! record listener-snapshot (constantly true) false))
+   (deliver-listener-snapshot! record listener-snapshot (constantly true) false true))
   ([record listener-snapshot continue? record-observation?]
-   (let [frame-id (:frame record)]
+   (deliver-listener-snapshot! record listener-snapshot continue? record-observation? false))
+  ([record listener-snapshot continue? record-observation? terminal?]
+   (let [frame-id (:frame record)
+         emit-listener-exception!
+         (fn [id ex]
+           (trace/emit-error! :rf.epoch.cb/listener-exception
+                              {:frame       frame-id
+                               :cb-id       id
+                               :rf.epoch/id (:epoch-id record)
+                               :message     #?(:clj  (.getMessage ^Throwable ex)
+                                               :cljs (.-message ex))
+                               :recovery    :no-recovery}))]
      (loop [entries (seq listener-snapshot)]
        (when (and entries (continue?))
           (let [[id {:keys [callback generation]}] (first entries)]
@@ -66,13 +85,13 @@
                ;; A callback that destroyed the exact owner has an inert throw;
                ;; never emit its failure diagnostic against same-id B.
                (when (continue?)
-                 (trace/emit-error! :rf.epoch.cb/listener-exception
-                                    {:frame       frame-id
-                                     :cb-id       id
-                                     :rf.epoch/id (:epoch-id record)
-                                     :message     #?(:clj  (.getMessage ^Throwable ex)
-                                                     :cljs (.-message ex))
-                                     :recovery    :no-recovery}))))
+                 (if terminal?
+                   ;; A's terminal callback fault is A's own diagnostic. A same-id
+                   ;; B that a listener just installed (possibly no-emit) must not
+                   ;; suppress or capture it (rf2-vxgfnd.152).
+                   (trace/call-with-structural-delivery
+                     #(emit-listener-exception! id ex))
+                   (emit-listener-exception! id ex)))))
            (recur (next entries))))))))
 
 (defn notify-listeners!


### PR DESCRIPTION
Tight incarnation-fencing pair across the epoch + trace boundary. Two review findings on predecessor/successor frame-incarnation fencing, both against PR #5818's merged destroy contract. One serial lane (shared `frame.cljc` + epoch listeners), sequential commits `.151` → `.152`.

Both were re-verified still-live against current `main` (post #5818 / #5836 / #5838): #5818's fence covers A's `:rf.epoch/snapshotted` + blocked `:rf.epoch/outcome` structural trailers, but not the two gaps below.

## rf2-vxgfnd.151 — snapshot predecessor halted-destroy evidence before successor epoch claims

**Still live.** At the audited head the terminal halted-destroy evidence was snapshotted *inside* the post-dissoc epoch hook and all terminal publication was gated on winning the compare-owned cleanup. A same-id successor B that settled one ordinary event between dissoc and that hook claimed the id-keyed epoch stores first — dropping A's buffer + observation ledger and taking ownership — so A read an empty buffer (no record) **and** lost the cleanup comparison (no publication): zero halted-destroy record, zero `:rf.epoch/snapshotted`, zero blocked `:rf.epoch/outcome`.

**Fix.** Bind A's terminal evidence to A's exact incarnation *before* dissoc, while A is still the sole owner of its id-keyed stores (a same-id B can only be constructed after dissoc): `destroy-frame!` fires a new `:epoch/snapshot-frame-destroyed` hook that builds the halted record + listener/silencing snapshot and threads the bundle to the post-dissoc `:epoch/on-frame-destroyed` hook. Publication of that bundle is now **decoupled** from the compare-owned store DROP — A delivers its terminal facts whether or not it still owns the stores, while the drop stays compare-owned so stale A can never erase B. All terminal emits stay structural (immune to B's frame-no-emit policy + capture).

The post-dissoc hook signature becomes `(frame-id owner-token terminal-evidence)`; a direct-seam arity `(frame-id owner-token fs-before fs-after committed-at)` preserves tool/unit callers. Late-bind directory + the two arg-shape pins updated.

**Red-before-fix fixture:** `frame_destroy_incarnation_jvm_test/predecessor-halted-destroy-evidence-survives-successor-epoch-claim` (latch-coordinated: A paused at its post-dissoc epoch hook; same-id B settles + claims the stores; A resumes and still publishes exactly one halted-destroy record + `:rf.epoch/snapshotted` + blocked `:rf.epoch/outcome`; B's history, buffer, last-settled anchor, state, and observation stay byte-identical, and B keeps settling normally). Verified red against unfixed `origin/main` (0 A records, 0 trailers).

## rf2-vxgfnd.152 — deliver predecessor terminal callback diagnostics across successor no-emit

**Still live.** Two terminal diagnostics raised while tearing down predecessor A were resolved through the *current* same-id B's bare-id trace policy, so a B registered with `:rf.trace/frame-no-emit? true` silently erased diagnostics that belong to dissociated A:

1. A terminal halted-destroy listener throw emitted `:rf.epoch.cb/listener-exception` via the ordinary policy path.
2. A throwing **post-dissoc** epoch teardown hook emitted `:rf.warning/teardown-hook-exception` via the ordinary policy path.

**Fix.** Both now use structural delivery — mirroring the `.117` structural-trailer seam #5818 already landed for A's `:rf.epoch/snapshotted` + blocked `:rf.epoch/outcome`. The bypass is scoped narrowly to these two terminal sites: `deliver-listener-snapshot!`'s terminal fan-out (a new `terminal?` flag wraps only the listener-exception emit in `call-with-structural-delivery`) and `notify-epoch-listeners!` (the sole post-dissoc teardown step wraps only its teardown-hook-exception diagnostic). Ordinary listener failures and every pre-dissoc teardown hook keep the live frame's no-emit policy — no same-id B can exist before dissoc — and no A diagnostic enters B capture.

**Red-before-fix fixtures** (both deterministic; each paired with a no-emit-disabled control that stays green):
- `terminal-listener-exception-crosses-successor-no-emit`
- `terminal-teardown-hook-exception-crosses-successor-no-emit`

Verified red against the `.151`-fixed / `.152`-unfixed tree: each suppressed case yields zero diagnostics; the fix restores exactly one, uncaptured by B. Controls green in both trees.

## Scope / non-overlap

Surface is `implementation/core/src/re_frame/{frame.cljc,trace.cljc}` + `implementation/epoch/**` + their tests (plus the `late_bind/directory.cljc` entry for the new epoch hook, required by the drift gate). `trace.cljc` was read but needed no change — the `call-with-structural-delivery` / `*frame-policy-enabled?*` / `*epoch-capture-enabled?*` seam it already exposes is exactly what both fixes reuse. No `machines/**`, no `observation.cljc`, no `reactive.cljc`, no spec/guide edits. The destroyed-reason channel matrix (`destroyed_reason_channel_conformance_test`) is unaffected.

## Quality gates

- `implementation/core` JVM — 1926 tests / 8765 assertions, 0 failures 0 errors
- `implementation/epoch` JVM — 388 tests / 2413 assertions, 0 failures 0 errors
- `implementation/machines` JVM (reason matrix conformance) — 987 tests / 3273 assertions, 0 failures 0 errors
- `scripts/test-fast-pr.sh` — PASS (CLJS node integration 9246 tests / 43749 assertions, 0 failures 0 errors; per-ns isolation 15/15; README/docs/EP/retired-spelling/thrown-error/ambient-durable/runtime-grading gates all green; `mkdocs --strict` soft-skipped locally — no mkdocs on PATH, CI runs it)
