### PR TITLE
fix(ui): bind preflight evidence to exact root attempt + host commit boundary (rf2-vxgfnd.139)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -398,13 +398,18 @@
   here — at preflight, before any React work (03 §8). Routes to the
   installed override hook when one is set, else the live executor. A
   throw propagates to the mount/render! caller (the Q49 ruling — see the
-  ns docstring)."
+  ns docstring).
+
+  Returns the live executor's preflight-attempt RECEIPT (rf2-vxgfnd.139) — the
+  caller passes it to `frames/finalize-preflight-attempt!` once the host render
+  commits, or `frames/abort-preflight-attempt!` if the post-preflight boundary
+  throws. nil when there are no static plans, or when a capture-hook override
+  returns a non-receipt (both are no-ops at the boundary)."
   [root-id plans-thunk]
   (when plans-thunk
     (let [plans (plans-thunk)
           f     (or @preflight-hook frames/execute-frame-plans!)]
-      (f root-id plans)))
-  nil)
+      (f root-id plans))))
 
 ;; ---------------------------------------------------------------------------
 ;; React root options
@@ -476,59 +481,85 @@
          (:identifier-prefix info) (:identifier-prefix existing))
         ;; re-preflight BEFORE the re-render: a failure leaves the live
         ;; root and its last committed render untouched (Q49).
-        (run-preflight! root-id plans-thunk)
-        ;; rf2-vxgfnd.69: run-preflight! drained :initial-events SYNCHRONOUSLY
-        ;; (arbitrary app code) that may have unmount!ed this root and mounted
-        ;; a replacement under the same id/container. Revalidate ownership of
-        ;; the CAPTURED handle before the re-render — a superseded root must
-        ;; never commit, and `.render`ing the stale handle would write into a
-        ;; root the replacement now owns. Mirrors the fresh-path re-check.
-        (require-live-root! root 're-frame.ui/mount)
-        (.render (.-react-root root)
-                 (viewcell/provide-root-incarnation
-                  (root-incarnation-of root-id) (element-thunk)))
-        root)
+        (let [receipt (run-preflight! root-id plans-thunk)]
+          (try
+            ;; rf2-vxgfnd.69: run-preflight! drained :initial-events SYNCHRONOUSLY
+            ;; (arbitrary app code) that may have unmount!ed this root and mounted
+            ;; a replacement under the same id/container. Revalidate ownership of
+            ;; the CAPTURED handle before the re-render — a superseded root must
+            ;; never commit, and `.render`ing the stale handle would write into a
+            ;; root the replacement now owns. Mirrors the fresh-path re-check.
+            (require-live-root! root 're-frame.ui/mount)
+            (.render (.-react-root root)
+                     (viewcell/provide-root-incarnation
+                      (root-incarnation-of root-id) (element-thunk)))
+            ;; rf2-vxgfnd.139: the host render COMMITTED — finalize the attempt's
+            ;; evidence (clear stale tags + mark committed). No rollback on this
+            ;; same-root path: the existing root stays registered.
+            (frames/finalize-preflight-attempt! receipt)
+            root
+            (catch :default e
+              ;; the re-render (or the post-preflight ownership fence) threw AFTER
+              ;; preflight completed. The existing live root + its last committed
+              ;; render are untouched (Q49); record only the FAILED ATTEMPT — an
+              ;; already-committed refresh stays :committed + :preflight-attempt-
+              ;; failed, never falsely mount-incomplete (rf2-vxgfnd.139).
+              (frames/abort-preflight-attempt! receipt)
+              (throw e)))))
       (do
         (check-root-claim! 're-frame.ui/mount info container)
         ;; preflight BEFORE any React work (Q49: container untouched on
         ;; failure) — and before registration, so a failed mount leaves
         ;; no registry entry either.
-        (run-preflight! root-id plans-thunk)
-        ;; RE-CHECK the claim AFTER preflight (rf2-vxgfnd.52). run-preflight!
-        ;; drains :initial-events SYNCHRONOUSLY — arbitrary app code that may
-        ;; itself mount a root for this id or into this container (re-entrancy),
-        ;; registering it while THIS mount is still unregistered. The
-        ;; pre-preflight claim is now stale; re-running it BEFORE createRoot and
-        ;; the UNCONDITIONAL register means a re-entrant mount that took
-        ;; ownership fails this mount loud (duplicate-root-id /
-        ;; root-container-in-use / duplicate-identifier-prefix) rather than
-        ;; createRoot-ing a container the inner root owns and clobbering its
-        ;; registry entry — which the failed-first-render rollback below would
-        ;; then match on THIS root and delete, orphaning the inner root's live
-        ;; React tree. No user code runs between this re-check and register
-        ;; (createRoot is React-internal, register is a swap!), so the window
-        ;; is closed.
-        (check-root-claim! 're-frame.ui/mount info container)
-        (let [react-root (rdc/createRoot container react-opts)
-              root       (Root. react-root container root-id)]
-          ;; register BEFORE any render (contract §7 Layer 3) — this MINTS the
-          ;; root incarnation the provider below scopes every ViewCell to.
-          (register-live-root! info container root)
+        (let [receipt (run-preflight! root-id plans-thunk)]
           (try
-            (.render react-root
-                     (viewcell/provide-root-incarnation
-                      (root-incarnation-of root-id) (element-thunk)))
-            root
+            ;; RE-CHECK the claim AFTER preflight (rf2-vxgfnd.52). run-preflight!
+            ;; drains :initial-events SYNCHRONOUSLY — arbitrary app code that may
+            ;; itself mount a root for this id or into this container (re-entrancy),
+            ;; registering it while THIS mount is still unregistered. The
+            ;; pre-preflight claim is now stale; re-running it BEFORE createRoot and
+            ;; the UNCONDITIONAL register means a re-entrant mount that took
+            ;; ownership fails this mount loud (duplicate-root-id /
+            ;; root-container-in-use / duplicate-identifier-prefix) rather than
+            ;; createRoot-ing a container the inner root owns and clobbering its
+            ;; registry entry — which the failed-first-render rollback below would
+            ;; then match on THIS root and delete, orphaning the inner root's live
+            ;; React tree. No user code runs between this re-check and register
+            ;; (createRoot is React-internal, register is a swap!), so the window
+            ;; is closed.
+            (check-root-claim! 're-frame.ui/mount info container)
+            (let [react-root (rdc/createRoot container react-opts)
+                  root       (Root. react-root container root-id)]
+              ;; register BEFORE any render (contract §7 Layer 3) — this MINTS the
+              ;; root incarnation the provider below scopes every ViewCell to.
+              (register-live-root! info container root)
+              (try
+                (.render react-root
+                         (viewcell/provide-root-incarnation
+                          (root-incarnation-of root-id) (element-thunk)))
+                ;; rf2-vxgfnd.139: the FIRST host render COMMITTED — bind the
+                ;; attempt's evidence to this boundary (clear + mark committed).
+                (frames/finalize-preflight-attempt! receipt)
+                root
+                (catch :default e
+                  ;; TOTAL rollback of a failed FIRST mount — the element thunk
+                  ;; or the synchronous host render threw. Release this exact
+                  ;; claim (identity-guarded: a stale handle never evicts a
+                  ;; newer root) and best-effort unmount the host root so a
+                  ;; retry starts clean, with no phantom live root and no host
+                  ;; root residue. Rethrow the ORIGINAL mount error even if the
+                  ;; host cleanup also throws (cleanup never masks it).
+                  (release-root! root-id root)
+                  (try (.unmount react-root) (catch :default _ nil))
+                  (throw e))))
             (catch :default e
-              ;; TOTAL rollback of a failed FIRST mount — the element thunk
-              ;; or the synchronous host render threw. Release this exact
-              ;; claim (identity-guarded: a stale handle never evicts a
-              ;; newer root) and best-effort unmount the host root so a
-              ;; retry starts clean, with no phantom live root and no host
-              ;; root residue. Rethrow the ORIGINAL mount error even if the
-              ;; host cleanup also throws (cleanup never masks it).
-              (release-root! root-id root)
-              (try (.unmount react-root) (catch :default _ nil))
+              ;; rf2-vxgfnd.139: preflight completed but the post-preflight
+              ;; boundary threw (the re-entrancy re-check, or the first-render
+              ;; rollback above rethrowing). A fresh install whose host mount
+              ;; never committed is :mount-incomplete — no root scopes it — never
+              ;; a phantom completed installer. Rev-guarded: a re-entrant root
+              ;; that took ownership of the same frame is untouched.
+              (frames/abort-preflight-attempt! receipt)
               (throw e))))))))
 
 (defn create-root*
@@ -564,31 +595,42 @@
   a replacement root."
   [^Root root element-thunk plans-thunk descriptor-base]
   (require-live-root! root 're-frame.ui/render!)
-  (let [rid (.-root-id root)]
-    (run-preflight! rid plans-thunk)
-    ;; rf2-vxgfnd.69: revalidate ownership AFTER the side-effecting preflight
-    ;; (which may have unmount!ed this root and mounted a replacement under
-    ;; the same id) and BEFORE the descriptor write / .render — a superseded
-    ;; handle fails loud, leaving the replacement root untouched.
-    (require-live-root! root 're-frame.ui/render!)
-    (when ^boolean js/goog.DEBUG
-      (when descriptor-base
-        (swap! live-roots
-               (fn [m]
-                 ;; identity-guarded to THIS exact Root (rf2-vxgfnd.69): never
-                 ;; write the descriptor onto a root that merely shares the id.
-                 (let [entry (get m rid)]
-                   (if (identical? (:root entry) root)
-                     (assoc m rid
-                            (assoc entry :descriptor
-                                   (assoc descriptor-base
-                                          :root-id rid
-                                          :root-id-provenance (:provenance entry))))
-                     m))))))
-    (.render (.-react-root root)
-             (viewcell/provide-root-incarnation
-              (root-incarnation-of rid) (element-thunk)))
-    root))
+  (let [rid     (.-root-id root)
+        receipt (run-preflight! rid plans-thunk)]
+    (try
+      ;; rf2-vxgfnd.69: revalidate ownership AFTER the side-effecting preflight
+      ;; (which may have unmount!ed this root and mounted a replacement under
+      ;; the same id) and BEFORE the descriptor write / .render — a superseded
+      ;; handle fails loud, leaving the replacement root untouched.
+      (require-live-root! root 're-frame.ui/render!)
+      (when ^boolean js/goog.DEBUG
+        (when descriptor-base
+          (swap! live-roots
+                 (fn [m]
+                   ;; identity-guarded to THIS exact Root (rf2-vxgfnd.69): never
+                   ;; write the descriptor onto a root that merely shares the id.
+                   (let [entry (get m rid)]
+                     (if (identical? (:root entry) root)
+                       (assoc m rid
+                              (assoc entry :descriptor
+                                     (assoc descriptor-base
+                                            :root-id rid
+                                            :root-id-provenance (:provenance entry))))
+                       m))))))
+      (.render (.-react-root root)
+               (viewcell/provide-root-incarnation
+                (root-incarnation-of rid) (element-thunk)))
+      ;; rf2-vxgfnd.139: the host render COMMITTED — finalize the attempt.
+      (frames/finalize-preflight-attempt! receipt)
+      root
+      (catch :default e
+        ;; the post-preflight ownership fence, element thunk, or host render
+        ;; threw AFTER preflight completed. A live root's failed re-render leaves
+        ;; its last committed render untouched (Q49); record only the failed
+        ;; ATTEMPT (rf2-vxgfnd.139) — rev-guarded, never falsely mount-incomplete
+        ;; on an already-committed root, never clobbering a superseding root.
+        (frames/abort-preflight-attempt! receipt)
+        (throw e)))))
 
 (defn hydrate-root*
   "Runtime half of `ui/hydrate-root`. Hydrating mounts read identity FROM

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -76,16 +76,40 @@
   re-add the dead lifetime's record after the hook prunes it. A later plan
   for the same id is a genuinely new frame lifetime — created fresh,
   `:initial-events` REPLAYED (the opt-in destroy-then-reseat composition,
-  rf2-lxwpob). A plan that throws mid-run
-  labels the siblings it already wrote by PROVENANCE (rf2-vxgfnd.30 (b),
-  rf2-vxgfnd.72): a sibling that this run FRESH-installed is tagged
-  `:mount-incomplete` — its mount never completed and no root yet scopes
-  it. A sibling that was ALREADY LIVE (a refresh of an installed root, or
-  an adopt of a boot frame) keeps its live-root state and carries neutral
-  `:preflight-attempt-failed` evidence instead: the frame and its scoping
-  root PERSIST (Q49), only the re-preflight ATTEMPT failed. So a later
-  conflict names an incomplete FRESH mount without ever claiming that a
-  still-live root does not scope its refreshed frame.
+  rf2-lxwpob).
+
+  ## Attempt evidence, bound to the host commit boundary (rf2-vxgfnd.139)
+
+  An install record proves plan AUTHORITY, not a COMMITTED React root. Attempt
+  evidence therefore binds to two axes the plan action alone cannot see:
+
+    - the EXACT write — every install/refresh/adopt mints a monotone `:rev`
+      (the install-record revision). Mark/clear acts only while the current
+      record still carries that rev, so an overtaking overwrite, a destroyed-
+      then-recreated frame, or an unrelated equal-plan root can never mark or
+      clear another attempt's evidence.
+    - the COMMITTED ROOT SCOPE — `:committed` is set at the client's host-commit
+      boundary (`finalize-preflight-attempt!`), never by plan execution, and
+      carried forward across a same-owner refresh. It distinguishes a genuinely
+      committed live root from a fresh/uncommitted install or a retry of an
+      incomplete mount.
+
+  A plan that throws MID-RUN labels the siblings it already wrote by PROVENANCE,
+  where provenance is a committed-scope fact (rf2-vxgfnd.30 (b), rf2-vxgfnd.72,
+  rf2-vxgfnd.139): a FRESH / never-committed install is tagged
+  `:mount-incomplete` — its mount never completed and no root scopes it. An
+  already-COMMITTED refresh, or an adopt of a live BOOT frame, keeps its
+  committed/boot state and carries neutral `:preflight-attempt-failed` evidence:
+  the committed scope / boot frame PERSISTS (Q49), only the ATTEMPT failed.
+
+  The COMPLEMENTARY boundary is the host render. When a run's plans all succeed
+  but the client's post-preflight ownership fence, element thunk, or first host
+  render then throws, the client calls `abort-preflight-attempt!` with the same
+  provenance rule — so a fresh install whose host render failed reads as an
+  incomplete mount (no root scopes it), never a phantom completed installer. A
+  committed live root's failed re-render keeps its prior Root/DOM and records
+  only the failed attempt. Evidence is finalized (cleared + `:committed`) only
+  after that host boundary succeeds.
 
   ## Atomicity posture (the rf2-ktmto9 mirror)
 
@@ -175,19 +199,51 @@
 (defonce ^:private installed-plans
   ;; frame-id -> ONE of two records, discriminated by authority:
   ;;   INSTALLED (this root OWNS the frame lifetime — refresh rights):
-  ;;     {:config-fingerprint "cf1-…" :installed-by root-id}
+  ;;     {:config-fingerprint "cf1-…" :installed-by root-id :rev N}
   ;;   ADOPTED (a boot / external frame this root merely SCOPES — NO refresh
   ;;     rights; boot config stays authoritative):
-  ;;     {:config-fingerprint "cf1-…" :adopted-by root-id :adopted true}
-  ;; A failed run labels the surviving records it wrote by provenance
-  ;; (rf2-vxgfnd.30 (b), rf2-vxgfnd.72): a FRESH install → `:mount-incomplete
-  ;; true` (mount never completed, no root scopes it); an ALREADY-LIVE refresh
-  ;; or adopt → `:preflight-attempt-failed true` (neutral attempt evidence —
-  ;; the live frame + its scoping root persist, Q49). Records are
-  ;; PRUNED on `frame/destroy-frame!` (rf2-vxgfnd.30 (a)) — the destroy hook
-  ;; dissocs the id, so a re-created same-id frame is a genuinely new
-  ;; lifetime rather than a resurrected dead-lifetime record.
+  ;;     {:config-fingerprint "cf1-…" :adopted-by root-id :adopted true :rev N}
+  ;;
+  ;; `:rev` (rf2-vxgfnd.139) is a globally-monotone identity minted at EVERY
+  ;; install/refresh/adopt write — the "install record revision". It binds
+  ;; attempt evidence to the EXACT write: a mark/clear from a stale attempt (an
+  ;; overtaking overwrite, a destroyed-then-recreated frame, an unrelated equal-
+  ;; plan root) can never match a newer record's rev. It is INTERNAL plumbing —
+  ;; `installed-plan-entry` strips it from the tool/test projection.
+  ;;
+  ;; `:committed true` (rf2-vxgfnd.139) means a host render for the owning /
+  ;; scoping root has COMMITTED — set by `finalize-preflight-attempt!` at the
+  ;; client's host-commit boundary (never by plan execution alone), carried
+  ;; forward across a same-owner refresh. Frame/boot AUTHORITY (an install
+  ;; record) is distinct from a COMMITTED ROOT SCOPE (`:committed`): an install
+  ;; record proves plan authority, not a committed React root.
+  ;;
+  ;; A failed ATTEMPT labels the surviving records it wrote by provenance
+  ;; (rf2-vxgfnd.30 (b), rf2-vxgfnd.72, rf2-vxgfnd.139) — where provenance is a
+  ;; COMMITTED-scope fact, NOT a :refresh/:adopt action:
+  ;;   FRESH / never-committed install (no `:committed` before) → `:mount-
+  ;;     incomplete true` (mount never completed, no root scopes it);
+  ;;   already-COMMITTED refresh, or an adopt of a live BOOT frame →
+  ;;     `:preflight-attempt-failed true` (neutral attempt evidence — the
+  ;;     committed root scope / boot frame persists, Q49).
+  ;; Records are PRUNED on `frame/destroy-frame!` (rf2-vxgfnd.30 (a)) — the
+  ;; destroy hook dissocs the id, so a re-created same-id frame is a genuinely
+  ;; new lifetime rather than a resurrected dead-lifetime record.
   (atom {}))
+
+(defonce ^:private plan-rev
+  ;; The globally-monotone install-record revision counter (rf2-vxgfnd.139).
+  ;; A single atom shared across all frame-ids: each install/refresh/adopt write
+  ;; mints a fresh rev, so a rev uniquely identifies one exact write across all
+  ;; frames and time.
+  (atom 0))
+
+(defn- next-plan-rev! [] (swap! plan-rev inc))
+
+;; The rev counter is deliberately NEVER reset (not even by
+;; `reset-installed-plans!`): monotonicity across a wiped registry is the safety
+;; property — a receipt captured before a reset can never collide with a record
+;; minted after it.
 
 (defn- adopted-record?
   "True when `record` marks a boot/external frame this root merely SCOPES
@@ -195,15 +251,26 @@
   [record]
   (true? (:adopted record)))
 
-(defn installed-plan-entry
-  "The recorded install/adoption for `frame-id` (tool/test read):
-  `{:config-fingerprint … :installed-by root-id}` (installed) or
-  `{:config-fingerprint … :adopted-by root-id :adopted true}` (adopted), or
-  nil. Records are pruned on destroy; the extra live-guard keeps a
-  never-hooked path from surfacing a stale record as an install."
+(defn- installed-record
+  "INTERNAL raw record for `frame-id` (carries `:rev` + `:committed`), guarded
+  by frame liveness so a never-hooked dead record never surfaces as an install.
+  `installed-plan-entry` is the tool/test projection of this (rev stripped)."
   [frame-id]
   (when (some? (frame/frame frame-id))
     (get @installed-plans frame-id)))
+
+(defn installed-plan-entry
+  "The recorded install/adoption for `frame-id` (tool/test read):
+  `{:config-fingerprint … :installed-by root-id}` (installed) or
+  `{:config-fingerprint … :adopted-by root-id :adopted true}` (adopted),
+  optionally carrying `:committed` (a committed root scope, rf2-vxgfnd.139) or
+  a failed-attempt tag (`:mount-incomplete` / `:preflight-attempt-failed`), or
+  nil. The internal `:rev` (install-record revision) is STRIPPED — it is
+  identity plumbing, not part of the projection. Records are pruned on destroy;
+  the extra live-guard keeps a never-hooked path from surfacing a stale record
+  as an install."
+  [frame-id]
+  (some-> (installed-record frame-id) (dissoc :rev)))
 
 (defn reset-installed-plans!
   "Test support: wipe the plan-install registry. Does NOT destroy frames —
@@ -279,7 +346,7 @@
         "failed before any install")
    {:recovery :align-frame-plan-config
     :extra {:frame-id  frame-id
-            :installed installed
+            :installed (dissoc installed :rev)   ; :rev is internal identity
             :arriving  {:config-fingerprint config-fingerprint
                         :root-id root-id}}}))
 
@@ -313,64 +380,73 @@
         "failed before any install")
    {:recovery :scope-config-less-or-own-the-lifetime
     :extra {:frame-id  frame-id
-            :installed installed
+            :installed (dissoc installed :rev)   ; :rev is internal identity
             :arriving  {:config-fingerprint config-fingerprint
                         :root-id root-id}}}))
 
-(defn- mark-mount-incomplete!
-  "Tag the surviving FRESH-installed records `frame-ids` (siblings this run
-  created for the first time before a later plan threw) `:mount-incomplete
-  true`, so a later conflict never presents their root as a completed owner
-  it never became — their mount did not complete and no root scopes them yet."
-  [frame-ids]
-  (when (seq frame-ids)
-    (swap! installed-plans
-           (fn [m] (reduce (fn [m id]
-                             (cond-> m
-                               (contains? m id) (assoc-in [id :mount-incomplete] true)))
-                           m frame-ids)))))
+;; `written` (and a preflight receipt's `:writes`) is a vector of
+;; `{:frame-id :rev :provenance}` entries — one per record this attempt wrote or
+;; found-live, in document order. `:rev` binds the entry to the EXACT record
+;; written; `:provenance` is a COMMITTED-scope fact (rf2-vxgfnd.139), not an
+;; action:
+;;   :fresh      — an install, or a refresh of a NEVER-committed record; on
+;;                 abort → :mount-incomplete (no committed root scopes it).
+;;   :live       — a refresh of an already-COMMITTED record, or an adopt of a
+;;                 live BOOT frame; on abort → :preflight-attempt-failed (the
+;;                 committed scope / boot frame persists, Q49).
+;;   :found-live — the ratified same-fingerprint no-op; never marked on abort,
+;;                 only committed / cleared on a successful host boundary.
 
-(defn- mark-preflight-attempt-failed!
-  "Tag the surviving ALREADY-LIVE records `frame-ids` (a refresh of an
-  installed root, or an adopt of a boot frame, that this run wrote before a
-  later plan threw) `:preflight-attempt-failed true` (rf2-vxgfnd.72). Neutral
-  attempt evidence: the frame and its scoping root PERSIST (Q49), so this
-  records that the re-preflight ATTEMPT did not complete WITHOUT overwriting
-  the live root's completed-mount state with a mount-incomplete claim."
-  [frame-ids]
-  (when (seq frame-ids)
+(defn- abort-writes!
+  "Mark the surviving records of an aborted attempt, REV-GUARDED to the exact
+  write: only a record still carrying this entry's `:rev` is touched, so an
+  overtaking overwrite, a destroyed-then-recreated frame, or an unrelated
+  equal-plan root is never clobbered. :fresh → `:mount-incomplete`; :live →
+  `:preflight-attempt-failed`; :found-live is left untouched."
+  [writes]
+  (when (seq writes)
     (swap! installed-plans
-           (fn [m] (reduce (fn [m id]
-                             (cond-> m
-                               (contains? m id)
-                               (assoc-in [id :preflight-attempt-failed] true)))
-                           m frame-ids)))))
+           (fn [m]
+             (reduce (fn [m {:keys [frame-id rev provenance]}]
+                       (let [rec (get m frame-id)]
+                         (if (and rec (= rev (:rev rec)))
+                           (case provenance
+                             :fresh (assoc-in m [frame-id :mount-incomplete] true)
+                             :live  (assoc-in m [frame-id :preflight-attempt-failed] true)
+                             m)
+                           m)))
+                     m writes)))))
 
-(defn- clear-run-incomplete-evidence!
-  "A run completed: every frame it touched is backed by a completed mount, so
-  drop any stale failed-run evidence an earlier throwing run left — both the
-  fresh-mount `:mount-incomplete` tag and the live-root
-  `:preflight-attempt-failed` attempt tag. Only entries that carry a tag are
-  rewritten (the found-live no-op path stays write-free in the common,
-  unmarked case)."
-  [frame-ids]
-  (swap! installed-plans
-         (fn [m] (reduce (fn [m id]
-                           (let [rec (get m id)]
-                             (cond-> m
-                               (or (:mount-incomplete rec)
-                                   (:preflight-attempt-failed rec))
-                               (update id dissoc :mount-incomplete
-                                       :preflight-attempt-failed))))
-                         m frame-ids))))
+(defn- finalize-writes!
+  "A host boundary COMMITTED: mark every record this attempt still owns
+  `:committed` and clear its stale failed-attempt evidence. REV-GUARDED — a
+  record overwritten or pruned since this attempt wrote it is skipped, so a
+  stale receipt can never finalize a newer record."
+  [writes]
+  (when (seq writes)
+    (swap! installed-plans
+           (fn [m]
+             (reduce (fn [m {:keys [frame-id rev]}]
+                       (let [rec (get m frame-id)]
+                         (if (and rec (= rev (:rev rec)))
+                           (assoc m frame-id
+                                  (-> rec
+                                      (assoc :committed true)
+                                      (dissoc :mount-incomplete
+                                              :preflight-attempt-failed)))
+                           m)))
+                     m writes)))))
 
 (defn- execute-frame-plans*
   "The unserialized decide+record run behind [[execute-frame-plans!]] — see
-  that docstring. JVM callers MUST hold `preflight-run-lock` (rf2-vxgfnd.35)."
+  that docstring. JVM callers MUST hold `preflight-run-lock` (rf2-vxgfnd.35).
+  Returns the preflight-attempt receipt `{:root-id … :writes […]}` on success."
   [root-id plans]
   (let [decided
         (mapv (fn [{:keys [frame-id config config-fingerprint] :as plan}]
-                (let [installed       (installed-plan-entry frame-id)
+                ;; `installed` is the RAW record (carries :rev + :committed);
+                ;; conflict payloads strip :rev inside the throw fns.
+                (let [installed       (installed-record frame-id)
                       config-bearing? (boolean (seq config))]
                   (cond
                     ;; a recorded plan/adoption already governs this LIVE frame
@@ -382,14 +458,14 @@
                       ;; (rf2-vxgfnd.56 — adoption never grants refresh rights).
                       (if config-bearing?
                         (throw-boot-authority-conflict! root-id plan installed)
-                        (assoc plan ::action :found-live))
+                        (assoc plan ::action :found-live ::prior installed))
                       ;; INSTALLED = this-or-another root OWNS the lifetime.
                       (cond
                         (= (:config-fingerprint installed) config-fingerprint)
-                        (assoc plan ::action :found-live)
+                        (assoc plan ::action :found-live ::prior installed)
 
                         (= (:installed-by installed) root-id)
-                        (assoc plan ::action :refresh)
+                        (assoc plan ::action :refresh ::prior installed)
 
                         :else
                         (throw-plan-conflict! root-id plan installed)))
@@ -410,21 +486,20 @@
                     :else
                     (assoc plan ::action :install))))
               plans)
-        ;; frame-ids whose record THIS run writes, each tagged by PROVENANCE
-        ;; so a mid-run throw can label it honestly (rf2-vxgfnd.30 (b),
-        ;; rf2-vxgfnd.72):
-        ;;   :fresh — an :install that created the frame this run. On a later
-        ;;     throw its mount never completed and no root yet scopes it.
-        ;;   :live  — a :refresh of an already-live installed root, or an
-        ;;     :adopt of an already-live boot frame. On a later throw the frame
-        ;;     and its scoping root PERSIST (Q49); only the ATTEMPT failed.
-        ;; Accumulated in document order.
+        ;; The receipt's write log (rf2-vxgfnd.139): one `{:frame-id :rev
+        ;; :provenance}` per record this run wrote or found-live, in document
+        ;; order — see the `abort-writes!` / `finalize-writes!` comment for the
+        ;; provenance vocabulary. Bound to the host boundary by the receipt.
         written (volatile! [])]
     (try
       (doseq [{:keys [frame-id config config-fingerprint] :as plan} decided]
         (case (::action plan)
-          ;; the ratified idempotent no-op: no re-seed, no record churn.
-          :found-live nil
+          ;; the ratified idempotent no-op: no re-seed, no record churn. It
+          ;; STILL rides the receipt (by the found-live record's current rev)
+          ;; so a successful host boundary clears any stale evidence + commits.
+          :found-live
+          (when-let [rev (:rev (::prior plan))]
+            (vswap! written conj {:frame-id frame-id :rev rev :provenance :found-live}))
 
           ;; a live plan-less (boot-created) frame: create-if-absent means
           ;; create NOTHING. Record only the plan's fingerprint under an
@@ -432,50 +507,57 @@
           ;; conflict-scoped — the boot frame's config/generation/`:images`
           ;; are left entirely untouched (rf2-vxgfnd.26), and the record can
           ;; never enter a root-owned refresh path (rf2-vxgfnd.56). The boot
-          ;; frame was already LIVE, so a later throw is an attempt failure,
-          ;; not a mount-incomplete over never-mounted state.
-          :adopt (when (publish-plan-for-live-incarnation!
-                        frame-id
-                        {:config-fingerprint config-fingerprint
-                         :adopted-by root-id
-                         :adopted true})
-                   (vswap! written conj [frame-id :live]))
+          ;; frame is already LIVE, so an aborted adoption is a :live attempt
+          ;; failure (boot frame persists), never a mount-incomplete claim
+          ;; over never-mounted state — but the ADOPTING root's SCOPE is not
+          ;; committed until the host boundary succeeds.
+          :adopt
+          (let [rev (next-plan-rev!)]
+            (when (publish-plan-for-live-incarnation!
+                   frame-id
+                   {:config-fingerprint config-fingerprint
+                    :adopted-by root-id
+                    :adopted true
+                    :rev rev})
+              (vswap! written conj {:frame-id frame-id :rev rev :provenance :live})))
 
           ;; :install / :refresh — create-if-absent / surgical refresh;
           ;; :initial-events drain synchronously inside the engine, in
           ;; document order across plans. The record lands only AFTER a
           ;; successful install AND only while that incarnation is still live,
           ;; so a throwing or self-destroying setup leaves no install record.
-          ;; An :install is FRESH (nothing scoped this id before); a :refresh
-          ;; acts on an ALREADY-LIVE installed root (its prior mount + render
-          ;; persist).
-          (do
+          ;; PROVENANCE is a COMMITTED-scope fact, NOT the action: a refresh of
+          ;; an already-`:committed` record is :live (its prior render persists,
+          ;; and the record carries `:committed` FORWARD); a fresh install, or a
+          ;; refresh of a never-committed record (a retry of an incomplete
+          ;; mount), is :fresh — no root has committed a scope (rf2-vxgfnd.139).
+          (let [committed? (boolean (:committed (::prior plan)))
+                rev        (next-plan-rev!)
+                record     (cond-> {:config-fingerprint config-fingerprint
+                                    :installed-by root-id
+                                    :rev rev}
+                             committed? (assoc :committed true))]
             (live-frame/make-frame (assoc (or config {}) :id frame-id))
-            (when (publish-plan-for-live-incarnation!
-                   frame-id
-                   {:config-fingerprint config-fingerprint
-                    :installed-by root-id})
+            (when (publish-plan-for-live-incarnation! frame-id record)
               (vswap! written conj
-                      [frame-id (if (= :install (::action plan)) :fresh :live)])))))
-      ;; The whole run completed. Drop stale failed-run evidence from records
-      ;; that survived; a self-destroying setup has neither a live frame nor a
-      ;; published record here, so the missing id is a no-op.
-      (clear-run-incomplete-evidence! (map :frame-id decided))
+                      {:frame-id frame-id :rev rev
+                       :provenance (if committed? :live :fresh)})))))
+      ;; The whole plan run completed. Do NOT finalize here — evidence is bound
+      ;; to the host commit boundary (rf2-vxgfnd.139): the client calls
+      ;; `finalize-preflight-attempt!` only AFTER its post-preflight ownership
+      ;; fence + synchronous host render succeed, and `abort-preflight-attempt!`
+      ;; if that boundary throws. Return the receipt.
+      {:root-id root-id :writes @written}
       (catch #?(:clj Throwable :cljs :default) e
-        ;; a plan threw mid-run: the siblings this run wrote stay live
-        ;; (irreversible :initial-events — the atomicity posture). Label each
-        ;; by provenance (rf2-vxgfnd.72): a FRESH install whose mount never
-        ;; completed is :mount-incomplete + "no root scopes"; an already-LIVE
-        ;; refresh/adopt keeps its live-root state and carries neutral
-        ;; :preflight-attempt-failed evidence instead — its live root and last
-        ;; committed render are untouched (Q49).
-        (let [w @written]
-          (mark-mount-incomplete!
-           (into [] (comp (filter #(= :fresh (second %))) (map first)) w))
-          (mark-preflight-attempt-failed!
-           (into [] (comp (filter #(= :live (second %))) (map first)) w)))
-        (throw e)))
-    nil))
+        ;; a plan threw MID-RUN: the siblings this run wrote stay live
+        ;; (irreversible :initial-events — the atomicity posture). This throw
+        ;; propagates out of preflight, so the mount fails BEFORE the host
+        ;; boundary; mark the writes here (the client never sees the receipt).
+        ;; :fresh → :mount-incomplete (no root scopes); :live → neutral
+        ;; :preflight-attempt-failed (committed scope / boot frame persists,
+        ;; Q49). Rev-guarded — never clobbers an overtaking write.
+        (abort-writes! @written)
+        (throw e)))))
 
 #?(:clj
    (defonce ^:private preflight-run-lock
@@ -503,11 +585,21 @@
   (no re-seed — the HMR guarantee); a live plan-less (boot-created) frame
   met by a CONFIG-LESS plan is ADOPTED under a non-owning record — its
   config/generation untouched, only the fingerprint recorded
-  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws mid-run labels the
-  siblings it already wrote by provenance: a FRESH install →
-  `:mount-incomplete`; an ALREADY-LIVE refresh/adopt →
-  `:preflight-attempt-failed` (the live root persists, Q49 — rf2-vxgfnd.30
-  (b), rf2-vxgfnd.72). Returns nil.
+  (rf2-vxgfnd.26, rf2-vxgfnd.56). A plan that throws MID-RUN (the mount fails
+  before the host boundary) labels the siblings it already wrote by provenance:
+  a FRESH / never-committed install → `:mount-incomplete`; an already-COMMITTED
+  refresh or an adopt of a live boot frame → `:preflight-attempt-failed` (the
+  committed scope / boot frame persists, Q49 — rf2-vxgfnd.30 (b), rf2-vxgfnd.72,
+  rf2-vxgfnd.139).
+
+  Evidence is BOUND to the host commit boundary (rf2-vxgfnd.139): a run that
+  completes its plans does NOT finalize here. It returns a preflight-attempt
+  RECEIPT `{:root-id … :writes [{:frame-id :rev :provenance} …]}`; the client
+  (`re-frame.ui.client/mount*` / `render!*`) calls `finalize-preflight-attempt!`
+  only after its post-preflight ownership fence + synchronous host render
+  succeed, and `abort-preflight-attempt!` if that boundary throws. So a run whose
+  plans all succeed but whose host render fails leaves phase-correct evidence
+  (a fresh install → `:mount-incomplete`), never a phantom completed installer.
 
   Concurrency (rf2-vxgfnd.35): on the JVM the whole decide+record run is
   serialized under one process-wide monitor, so two concurrent callers can
@@ -520,6 +612,35 @@
   #?(:clj  (locking preflight-run-lock
              (execute-frame-plans* root-id plans))
      :cljs (execute-frame-plans* root-id plans)))
+
+(defn finalize-preflight-attempt!
+  "The client's HOST-COMMIT-BOUNDARY hook (rf2-vxgfnd.139). Called by
+  `re-frame.ui.client` AFTER a preflight `receipt`'s root has passed the
+  post-preflight ownership fence AND its synchronous host render has COMMITTED:
+  mark every record this exact attempt still owns `:committed` and clear its
+  stale failed-attempt evidence. REV-GUARDED to the exact write — a record
+  overwritten (an overtaking root), pruned (a destroy), or reincarnated since is
+  skipped, so a stale receipt can never finalize a newer attempt or a
+  post-commit boundary. A nil receipt (no static plans, or a capture-hook
+  override) is a no-op. Returns nil."
+  [receipt]
+  (when-let [writes (:writes receipt)]
+    (finalize-writes! writes))
+  nil)
+
+(defn abort-preflight-attempt!
+  "The client's HOST-COMMIT-BOUNDARY hook (rf2-vxgfnd.139) for the failure arm:
+  called when the post-preflight ownership fence, the element thunk, or the
+  first synchronous host render throws AFTER preflight completed (so the client
+  holds the receipt). Mark this attempt's :fresh writes `:mount-incomplete` and
+  its :live writes `:preflight-attempt-failed` (a fresh install whose host
+  render failed reads as never-scoped; an already-committed refresh / adopted
+  boot frame keeps its committed scope). REV-GUARDED — never clobbers an
+  overtaking write. A nil receipt is a no-op. Returns nil."
+  [receipt]
+  (when-let [writes (:writes receipt)]
+    (abort-writes! writes))
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; frame-provider scope validation (shared by both hosts)

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_cljs_test.cljs
@@ -369,13 +369,16 @@
                            "cf1-bad2222222222222")]))
   (is (true? (:mount-incomplete (frames/installed-plan-entry :frame/ok)))
       "sanity: the failed mount tagged the surviving record")
-  ;; A retries WITHOUT the bad plan -> the mount completes -> the tag clears.
-  (frames/execute-frame-plans!
-   :root/a [(plan :frame/ok {:initial-events [[:test/set-db {:n 1}]]}
-                  "cf1-ok22222222222222")])
+  ;; A retries WITHOUT the bad plan AND its host render commits — evidence is
+  ;; cleared only at the host boundary (rf2-vxgfnd.139).
+  (frames/finalize-preflight-attempt!
+   (frames/execute-frame-plans!
+    :root/a [(plan :frame/ok {:initial-events [[:test/set-db {:n 1}]]}
+                   "cf1-ok22222222222222")]))
   (let [entry (frames/installed-plan-entry :frame/ok)]
     (is (nil? (:mount-incomplete entry))
-        "a completed run clears the stale :mount-incomplete tag")
+        "a committed run clears the stale :mount-incomplete tag")
+    (is (true? (:committed entry)) "…and records the committed root scope")
     (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
 
 ;; ---- rf2-vxgfnd.72: a failed RE-preflight of an ALREADY-LIVE root --------
@@ -389,11 +392,16 @@
 
 (deftest failed-re-preflight-of-a-live-root-keeps-live-state-not-mount-incomplete
   (reg-events!)
-  ;; root A mounts :frame/live and COMPLETES — a genuinely live, scoped root.
-  (frames/execute-frame-plans!
-   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 5}]]}
-                  "cf1-live1111111111")])
+  ;; root A mounts :frame/live and its host render COMMITS — a genuinely
+  ;; committed, scoped root (rf2-vxgfnd.139: a refresh's failure is a live-root
+  ;; attempt failure ONLY because the prior mount committed a host boundary).
+  (frames/finalize-preflight-attempt!
+   (frames/execute-frame-plans!
+    :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 5}]]}
+                   "cf1-live1111111111")]))
   (is (some? (frame/frame :frame/live)) "the frame is live after the first mount")
+  (is (true? (:committed (frames/installed-plan-entry :frame/live)))
+      "sanity: the committed host boundary recorded a committed root scope")
   (rf/dispatch-sync [:test/inc] {:frame :frame/live})
   (is (= 6 (:n (rf/app-db-value :frame/live)))
       "durable state = 6 (the last committed render's state)")
@@ -416,6 +424,8 @@
     (is (= :root/a (:installed-by entry)) "root A still OWNS + scopes the frame")
     (is (nil? (:mount-incomplete entry))
         "the live root is NOT falsely tagged :mount-incomplete (rf2-vxgfnd.72)")
+    (is (true? (:committed entry))
+        "the committed root scope is PRESERVED — the prior render persists (Q49)")
     (is (true? (:preflight-attempt-failed entry))
         "instead the record carries neutral failed-attempt evidence"))
   ;; a later cross-root config conflict on :frame/live must NOT claim the frame
@@ -435,10 +445,11 @@
 
 (deftest completed-retry-clears-the-preflight-attempt-failed-tag
   (reg-events!)
-  ;; A mounts + completes, then a re-preflight refresh fails on a later plan.
-  (frames/execute-frame-plans!
-   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 1}]]}
-                  "cf1-r1aaaaaaaaaaaa")])
+  ;; A mounts + COMMITS, then a re-preflight refresh fails on a later plan.
+  (frames/finalize-preflight-attempt!
+   (frames/execute-frame-plans!
+    :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 1}]]}
+                   "cf1-r1aaaaaaaaaaaa")]))
   (err-id #(frames/execute-frame-plans!
             :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 2}]]}
                            "cf1-r2bbbbbbbbbbbb")
@@ -446,14 +457,153 @@
                            "cf1-badrrrrrrrrrr")]))
   (is (true? (:preflight-attempt-failed (frames/installed-plan-entry :frame/live)))
       "sanity: the failed re-preflight tagged the live record")
-  ;; A retries WITHOUT the bad plan -> the run completes -> the tag clears.
-  (frames/execute-frame-plans!
-   :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 2}]]}
-                  "cf1-r2bbbbbbbbbbbb")])
+  ;; A retries WITHOUT the bad plan AND its host render commits -> the tag clears.
+  (frames/finalize-preflight-attempt!
+   (frames/execute-frame-plans!
+    :root/a [(plan :frame/live {:initial-events [[:test/set-db {:n 2}]]}
+                   "cf1-r2bbbbbbbbbbbb")]))
   (let [entry (frames/installed-plan-entry :frame/live)]
     (is (nil? (:preflight-attempt-failed entry))
-        "a completed run clears the stale :preflight-attempt-failed tag")
+        "a committed run clears the stale :preflight-attempt-failed tag")
+    (is (true? (:committed entry)) "…and the committed root scope stays recorded")
     (is (= :root/a (:installed-by entry)) "the ownership record is intact")))
+
+;; ---- rf2-vxgfnd.139: liveness is a COMMITTED-ROOT fact, not a :refresh fact
+;; A never-committed fresh mount that is RETRIED (same root, changed config)
+;; must NOT be relabelled from the truthful :mount-incomplete to the
+;; :preflight-attempt-failed "still LIVE and scoped" evidence: an install record
+;; proves plan authority, not a committed React root. Counterexample 1.
+
+(deftest retry-after-uncommitted-fresh-mount-stays-mount-incomplete-not-live
+  (reg-events!)
+  ;; attempt 1: a fresh install of :frame/retry then a later plan throws — the
+  ;; mount never completed, so :frame/retry is :mount-incomplete (no root scopes).
+  (err-id #(frames/execute-frame-plans!
+            :root/a [(plan :frame/retry {:initial-events [[:test/set-db {:n 1}]]}
+                           "cf1-retryv1aaaaaaa")
+                     (plan :frame/bad {:initial-events [:not-a-vector]}
+                           "cf1-retrybad11111a")]))
+  (is (true? (:mount-incomplete (frames/installed-plan-entry :frame/retry)))
+      "sanity: the fresh mount that never completed is :mount-incomplete")
+  ;; attempt 2: the SAME root RETRIES with a CHANGED config and throws again.
+  ;; Because :installed-by equals root A this decides :refresh — but A never
+  ;; committed a root, so the evidence must stay :mount-incomplete, NOT flip to
+  ;; the live-root attempt-failed claim.
+  (err-id #(frames/execute-frame-plans!
+            :root/a [(plan :frame/retry {:initial-events [[:test/set-db {:n 2}]]}
+                           "cf1-retryv2bbbbbbb")
+                     (plan :frame/bad {:initial-events [:not-a-vector]}
+                           "cf1-retrybad22222b")]))
+  (let [entry (frames/installed-plan-entry :frame/retry)]
+    (is (true? (:mount-incomplete entry))
+        "a changed-config retry of a NEVER-committed mount stays :mount-incomplete")
+    (is (not (:preflight-attempt-failed entry))
+        "it never becomes the live-root 'attempt-failed' evidence (rf2-vxgfnd.139)"))
+  ;; a cross-root conflict must flag the never-committed mount, never claim a
+  ;; live scoping root with a prior render.
+  (let [msg (try (frames/execute-frame-plans!
+                  :root/c [(plan :frame/retry {} "cf1-retryccccccccc")])
+                 nil (catch cljs.core/ExceptionInfo e (ex-message e)))]
+    (is (some? msg) "the cross-root arrival still fails loud")
+    (is (some? (re-find #"no root actually scopes it" msg))
+        "the conflict flags the never-committed mount")
+    (is (nil? (re-find #"still LIVE and scoped by root" msg))
+        "it never claims a never-mounted root is still live + scoped")))
+
+(deftest committed-mount-then-failed-refresh-is-attempt-failed-not-mount-incomplete
+  ;; The SOUND counterpart of the counterexample above: once a mount's host
+  ;; boundary COMMITS (finalize), a later refresh that fails IS a live-root
+  ;; attempt failure — the committed scope persists. This is the distinction the
+  ;; runtime binds via :committed, not via the :refresh action.
+  (reg-events!)
+  (frames/finalize-preflight-attempt!
+   (frames/execute-frame-plans!
+    :root/a [(plan :frame/c {:initial-events [[:test/set-db {:n 1}]]}
+                   "cf1-committedv1aaa")]))
+  (is (true? (:committed (frames/installed-plan-entry :frame/c)))
+      "sanity: the host boundary committed a root scope")
+  ;; a refresh (changed config) whose later sibling throws
+  (err-id #(frames/execute-frame-plans!
+            :root/a [(plan :frame/c {:initial-events [[:test/set-db {:n 2}]]}
+                           "cf1-committedv2bbb")
+                     (plan :frame/bad {:initial-events [:not-a-vector]}
+                           "cf1-committedbad11")]))
+  (let [entry (frames/installed-plan-entry :frame/c)]
+    (is (nil? (:mount-incomplete entry))
+        "a COMMITTED root's failed refresh is never mount-incomplete")
+    (is (true? (:committed entry)) "the committed scope PERSISTS (Q49)")
+    (is (true? (:preflight-attempt-failed entry))
+        "only the failed refresh ATTEMPT is recorded")))
+
+(deftest execute-frame-plans-returns-a-receipt-bound-to-the-host-boundary
+  ;; The receipt threads plan bookkeeping to the client's host-commit boundary.
+  (reg-events!)
+  (let [receipt (frames/execute-frame-plans!
+                 :root/r [(plan :frame/rcpt {:initial-events [[:test/set-db {:n 1}]]}
+                                "cf1-receipt1111111")])]
+    (is (= :root/r (:root-id receipt)) "the receipt names the arriving root")
+    (is (= [:frame/rcpt] (mapv :frame-id (:writes receipt)))
+        "…and logs the frames this attempt wrote")
+    (is (= :fresh (:provenance (first (:writes receipt))))
+        "a fresh install has :fresh provenance")
+    ;; before finalize the fresh install is NOT yet a committed scope
+    (is (not (:committed (frames/installed-plan-entry :frame/rcpt)))
+        "plan completion alone does NOT commit a root scope")
+    (frames/finalize-preflight-attempt! receipt)
+    (is (true? (:committed (frames/installed-plan-entry :frame/rcpt)))
+        "the host-boundary finalize records the committed scope")))
+
+;; ---- rf2-vxgfnd.139 identity guards: the receipt rev has TEETH -------------
+;; These fail if the rev identity check is mutated away (mark/clear keyed on
+;; bare frame-id): a stale attempt would then clobber a newer record.
+
+(deftest stale-abort-receipt-cannot-mark-a-newer-committed-record
+  (reg-events!)
+  ;; A installs + commits F, then A refreshes + commits F AGAIN (a new rev).
+  (let [r1 (frames/execute-frame-plans!
+            :root/a [(plan :frame/f {:initial-events [[:test/set-db {:n 1}]]}
+                           "cf1-teeth1aaaaaaaa")])]
+    (frames/finalize-preflight-attempt! r1)
+    (frames/finalize-preflight-attempt!
+     (frames/execute-frame-plans!
+      :root/a [(plan :frame/f {:initial-events [[:test/set-db {:n 2}]]}
+                     "cf1-teeth2bbbbbbbb")]))
+    ;; the record is now at a NEWER rev than r1. A STALE abort of r1 must NOT
+    ;; mark the current committed record :mount-incomplete.
+    (frames/abort-preflight-attempt! r1)
+    (let [entry (frames/installed-plan-entry :frame/f)]
+      (is (true? (:committed entry)) "the newer committed record is untouched")
+      (is (nil? (:mount-incomplete entry))
+          "a stale abort receipt (older rev) cannot mark the newer record")
+      (is (nil? (:preflight-attempt-failed entry))
+          "…nor tag it attempt-failed"))))
+
+(deftest stale-finalize-receipt-cannot-clear-a-reincarnated-records-evidence
+  (reg-events!)
+  ;; A installs F (rev N).
+  (let [rA (frames/execute-frame-plans!
+            :root/a [(plan :frame/g {:initial-events [[:test/set-db {:n 1}]]}
+                           "cf1-reinc1aaaaaaaa")])]
+    ;; F is DESTROYED (record pruned) then re-created as a boot frame.
+    (frame/destroy-frame! :frame/g)
+    (is (nil? (frames/installed-plan-entry :frame/g)) "sanity: the record is pruned")
+    (rf/make-frame {:id :frame/g :doc "reincarnation"})
+    ;; root B adopts the reincarnation, then a later plan throws -> B's adopt
+    ;; record carries :preflight-attempt-failed at a NEW rev (M != N).
+    (err-id #(frames/execute-frame-plans!
+              :root/b [(plan :frame/g {} "cf1-reinc2bbbbbbbb")
+                       (plan :frame/badx {:initial-events [:not-a-vector]}
+                             "cf1-reincbad111111")]))
+    (is (true? (:preflight-attempt-failed (frames/installed-plan-entry :frame/g)))
+        "sanity: B's reincarnation adopt is attempt-failed")
+    ;; A STALE finalize of rA (rev N) must NOT clear B's evidence or commit it.
+    (frames/finalize-preflight-attempt! rA)
+    (let [entry (frames/installed-plan-entry :frame/g)]
+      (is (= :root/b (:adopted-by entry)) "the reincarnation's real adopter is intact")
+      (is (true? (:preflight-attempt-failed entry))
+          "a stale finalize receipt (dead lifetime's rev) cannot clear newer evidence")
+      (is (nil? (:committed entry))
+          "…nor falsely mark the reincarnation committed"))))
 
 (deftest failed-run-after-adopt-marks-attempt-failed-not-mount-incomplete
   (reg-events!)

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -183,6 +183,106 @@
           "root A's install survives; retry = the host re-calls mount"))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.139 — evidence bound to the exact root attempt + host commit
+;; boundary. These use a REAL live-root registry + React root (what the node
+;; executor twin cannot fake): a fresh install whose HOST render fails must not
+;; read as a completed install, and a committed root's failed refresh must
+;; preserve its prior committed Root/DOM.
+;; ---------------------------------------------------------------------------
+
+(deftest fresh-mount-host-failure-marks-mount-incomplete-not-committed
+  ;; Counterexample 2: preflight INSTALLS :frame/installed139 (create +
+  ;; :initial-events drain), then the host boundary (element thunk) throws. The
+  ;; mount rolls back — NO live root survives — yet the record must not read as
+  ;; a completed install. It is :mount-incomplete: no root scopes it.
+  (when (browser?)
+    (reg-events!)
+    (let [c     (container)
+          info  {:root-id :dom139/fresh :provenance :authored}
+          boom  (fn [] (throw (ex-info "host render boom" {:tag :host})))
+          plans (fn [] [{:frame-id :frame/installed139
+                         :config {:initial-events [[:test/set-db {:n 1}]]}
+                         :config-fingerprint "cf1-installed13911"}])
+          threw (try (flush-without-act!
+                      #(client/mount* info c boom
+                                      (client/root-options nil nil nil nil) plans))
+                     false (catch :default _ true))]
+      (is threw "the host render throw propagated out of mount*")
+      (is (some? (frame/frame :frame/installed139))
+          "the frame is live — its :initial-events fired at preflight (irreversible)")
+      (is (not (contains? (client/live-root-ids) :dom139/fresh))
+          "the fresh mount rolled back — NO live root survives")
+      (is (true? (:mount-incomplete (frames/installed-plan-entry :frame/installed139)))
+          "a fresh install whose host render failed is :mount-incomplete — no root scopes it")
+      (is (not (:committed (frames/installed-plan-entry :frame/installed139)))
+          "and it is NOT recorded as a committed root scope")
+      ;; a later conflicting root must be told the mount is incomplete.
+      (let [msg (try (frames/execute-frame-plans!
+                      :dom139/other [{:frame-id :frame/installed139 :config {}
+                                      :config-fingerprint "cf1-other139222222"}])
+                     nil (catch cljs.core/ExceptionInfo e (ex-message e)))]
+        (is (some? (re-find #"did NOT complete" msg))
+            "the conflict flags the phantom installer's incomplete mount")))))
+
+(deftest successful-mount-commits-the-frame-record
+  ;; The happy path: a real ui/mount whose host render commits records the
+  ;; committed root scope (:committed), with no failed-attempt evidence.
+  (when (browser?)
+    (reg-events!)
+    (let [c (container)]
+      (act!
+       #(ui/mount [frame-root {:id :frame/committed139
+                               :initial-events [[:test/set-db {:n 7}]]}
+                   [mini {:label "ok"}]]
+                  c {:root-id :dom139/ok}))
+      (is (re-find #"ok" (.-innerHTML c)) "sanity: the render committed")
+      (let [entry (frames/installed-plan-entry :frame/committed139)]
+        (is (true? (:committed entry))
+            "a successful mount's host render commits the record (rf2-vxgfnd.139)")
+        (is (nil? (:mount-incomplete entry)) "no incomplete-mount evidence")
+        (is (nil? (:preflight-attempt-failed entry)) "no failed-attempt evidence")))))
+
+(deftest committed-root-failed-refresh-preserves-committed-and-marks-attempt-failed
+  ;; A genuinely committed root's failed REFRESH/re-render: the prior Root + its
+  ;; last committed DOM are preserved (Q49), and only the failed attempt is
+  ;; recorded — the committed scope is NEVER relabelled :mount-incomplete.
+  (when (browser?)
+    (reg-events!)
+    (let [c    (container)
+          info {:root-id :dom139/live :provenance :authored}
+          ok   (fn [] (React/createElement "div" #js {:className "live139"} "live"))
+          boom (fn [] (throw (ex-info "rerender boom" {})))
+          v1   (fn [] [{:frame-id :frame/live139
+                        :config {:initial-events [[:test/set-db {:n 1}]]}
+                        :config-fingerprint "cf1-live139v1aaaa"}])
+          v2   (fn [] [{:frame-id :frame/live139
+                        :config {:initial-events [[:test/set-db {:n 2}]]}
+                        :config-fingerprint "cf1-live139v2bbbb"}])]
+      ;; first mount COMMITS the frame + root
+      (act! #(client/mount* info c ok (client/root-options nil nil nil nil) v1))
+      (is (true? (:committed (frames/installed-plan-entry :frame/live139)))
+          "sanity: the first mount committed a root scope")
+      (is (re-find #"live" (.-innerHTML c)) "sanity: the committed render is in the DOM")
+      ;; a re-mount REFRESHES the frame (v2) but its re-render throws
+      (let [threw (try (flush-without-act!
+                        #(client/mount* info c boom
+                                        (client/root-options nil nil nil nil) v2))
+                       false (catch :default _ true))]
+        (is threw "the failed re-render throws"))
+      ;; Q49: the existing root stays registered + its last committed DOM intact
+      (is (contains? (client/live-root-ids) :dom139/live)
+          "the committed root stays registered on a failed re-render")
+      (is (re-find #"live" (.-innerHTML c))
+          "its last committed render / DOM is UNTOUCHED (Q49)")
+      (let [entry (frames/installed-plan-entry :frame/live139)]
+        (is (true? (:committed entry)) "the committed root scope is PRESERVED")
+        (is (nil? (:mount-incomplete entry))
+            "a committed root's failed refresh is NEVER mount-incomplete")
+        (is (true? (:preflight-attempt-failed entry))
+            "only the failed refresh ATTEMPT is recorded (rf2-vxgfnd.139)"))
+      (act! #(client/unmount!* (:root (client/live-root-entry :dom139/live)))))))
+
+;; ---------------------------------------------------------------------------
 ;; frame-provider — scope a live frame through the compiled template
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-vxgfnd.139.

## Repro (still live on origin/main after #5834 + #5850)

Re-verified against fresh `origin/main` (`3af2e07`): both counterexamples reproduce.

The runtime derived root-lifecycle truth solely from the frame-plan action and finalized evidence before the host operation succeeded:

- **Counterexample 1 — failed fresh-mount retry mislabeled live.** A fresh mount installs F then a later plan throws → F `:mount-incomplete`. The same root retries with a changed config → because `:installed-by` equals the root, it decides `:refresh`, classified `:live`, and the truthful `:mount-incomplete` is replaced by `:preflight-attempt-failed` ("still LIVE and scoped by root A with a prior render") — while `live-root-ids` contains no A. An install record proves plan authority, not a committed React root.
- **Counterexample 2 — successful preflight followed by host failure.** `execute-frame-plans!` cleared failed-attempt evidence as soon as all plans returned, *before* `client.cljs` created/rendered the host root. A synchronous first-render failure rolled the root back but left a frame record that reads as a completed installer, with no live root.

Marker ownership was also keyed by bare frame-id, so a stale attempt or a destroyed/recreated frame could mark or clear another attempt's evidence.

## Fix (internal bookkeeping only — no public API / frozen-table change)

One small identity-guarded preflight-attempt receipt, shared by `frames` and the client boundary:

- **`:rev`** — a globally-monotone install-record revision minted at every install/refresh/adopt write. Mark/clear act only while the current record still carries that rev, so an overtaking overwrite, a destroyed-then-recreated frame, or an unrelated equal-plan root can never touch another attempt's evidence. Internal — `installed-plan-entry` strips it from the tool/test projection.
- **`:committed`** — set only at the client's host-commit boundary (`finalize-preflight-attempt!`), carried forward across a same-owner refresh. Distinguishes frame/boot authority from a committed root scope.
- **Provenance is a committed-scope fact, not the `:refresh`/`:adopt` action.** A fresh or never-committed install aborts to `:mount-incomplete`; an already-committed refresh or an adopt of a live boot frame aborts to `:preflight-attempt-failed` (prior Root/DOM preserved, Q49).
- **`execute-frame-plans!` returns a receipt** and no longer finalizes; `client.cljs` `mount*`/`render!*` call `finalize-preflight-attempt!` only after their post-preflight ownership fence + synchronous host render succeed, and `abort-preflight-attempt!` if that boundary throws.

Irreversible sibling effects and initial events remain committed per Q49. No rollback/destroy-reseed, no second coordinator.

Scope: `implementation/ui/src/re_frame/ui/frames.cljc` (the receipt + evidence rules) and `client.cljs` (the host-commit-boundary binding — genuinely required for counterexample 2), plus their tests. Contract reconciliation (Spec 004C record variants, Spec 009 projection) is a required follow-up (spec/** is out of this worker's scope).

## Quality gates

Red-before-fix fixtures (both demonstrated failing on origin/main, green after):
- `retry-after-uncommitted-fresh-mount-stays-mount-incomplete-not-live` (executor, counterexample 1) — node lane.
- `fresh-mount-host-failure-marks-mount-incomplete-not-committed` (real live-root registry + React root, counterexample 2) — browser lane.

Additional coverage: `committed-mount-then-failed-refresh-is-attempt-failed-not-mount-incomplete`, `execute-frame-plans-returns-a-receipt-bound-to-the-host-boundary`, and two identity-guard **teeth** tests (`stale-abort-receipt-cannot-mark-a-newer-committed-record`, `stale-finalize-receipt-cannot-clear-a-reincarnated-records-evidence` — fail if the rev check is mutated away); DOM `successful-mount-commits-the-frame-record` and `committed-root-failed-refresh-preserves-committed-and-marks-attempt-failed`.

- `cd implementation/ui && clojure -M:test` — 474 tests, 6232 assertions, 0 failures/0 errors.
- `cd implementation && npm run test:ui` — 473 tests, 2386 assertions, 0 failures/0 errors.
- `cd implementation && npm run test:browser` — 346 tests, 1872 assertions, 0 failures/0 errors (client.cljs mount paths touched).
- `sh scripts/test-fast-pr.sh` — PASS (CLJS node integration 9308 tests, 44096 assertions, 0 failures/0 errors; isolation, mkdocs --strict, all gates green).
