### PR TITLE
fix(ui): reactive-core incarnation fencing — slice-memo identity, lease-to-incarnation binding (rf2-vxgfnd.156/.160/.161)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -897,12 +897,16 @@
   Within one synchronous execution slice, cold probes threading the same
   handle share computed derivation parents (N sibling rows probing
   `[:orders/by-id id]` compute shared parents once per slice, not once per
-  row). The table inside is created lazily on first cold probe,
-  belt-and-braces tagged with `(frame, frame-epoch, registry-epoch)` and
-  invalidated on any mismatch, and (CLJS) cleared by `queueMicrotask` so an
-  abandoned slice's table is released. The memo is an ECONOMY, never an
-  authority — the commit evidence comparison (invariant 5) already corrects
-  any staleness before paint. Per Spec 006 §The slice-scoped probe memo."
+  row). The table inside is created lazily on first cold probe, tagged with
+  `(frame, frame-epoch, registry-epoch)` PLUS the exact frame-incarnation
+  token, and invalidated on any mismatch — the token by identity, because the
+  epoch triple can tie across a same-id destroy+recreate (rf2-vxgfnd.160). On
+  CLJS the table is cleared by `queueMicrotask` so an abandoned slice's table
+  is released. The memo is an ECONOMY, never an authority — for a COMMITTING
+  reader the commit evidence comparison (invariant 5) corrects any staleness
+  before paint; the incarnation-complete tag additionally keeps a COMMIT-FREE
+  reader (a Tier-1 probe outside a ViewCell, which has no commit step 5)
+  correct on its own. Per Spec 006 §The slice-scoped probe memo."
   []
   (atom {:tag nil :memo nil}))
 
@@ -913,21 +917,34 @@
 
 (defn- slice-memo-table!
   "Resolve the compute memo atom for a cold probe against `frame-id`:
-  validate the handle's `(frame, frame-epoch, registry-epoch)` tag, reuse
-  the table on a match, else install a fresh one (arming the CLJS microtask
-  clear). A nil handle means no cross-probe sharing — a fresh per-call
-  table."
+  validate the handle's `(frame, frame-epoch, registry-epoch)` tag AND the
+  exact frame-incarnation token (by IDENTITY), reuse the table on a full
+  match, else install a fresh one (arming the CLJS microtask clear). A nil
+  handle means no cross-probe sharing — a fresh per-call table.
+
+  The incarnation token is part of the identity because the
+  (frame, frame-epoch, registry-epoch) triple can TIE across a same-id
+  destroy+recreate: `frame/dissoc-frame!` restarts the commit epoch, so a
+  fresh incarnation B can present the EXACT epochs a destroyed incarnation A
+  did. Without the token, a COMMIT-FREE consumer (a Tier-1 `ui.test/render`
+  outside any ViewCell) would receive A's memoized parent for B — and there is
+  no commit step 5 to correct a commit-free read. The memo remains an ECONOMY
+  for a COMMITTING reader, but its tag is itself incarnation-complete so the
+  commit-free path is correct on its own (rf2-vxgfnd.160)."
   [handle frame-id]
   (if (nil? handle)
     (seed-observation-opts! (atom {}) frame-id)
-    (let [tag [frame-id
-               (frame/frame-commit-epoch frame-id)
-               @registry-epoch*]
-          {existing-tag :tag existing :memo} @handle]
-      (if (and existing (= existing-tag tag))
+    (let [token (frame/frame-incarnation-token frame-id)
+          tag   [frame-id
+                 (frame/frame-commit-epoch frame-id)
+                 @registry-epoch*]
+          {existing-tag :tag existing-token :token existing :memo} @handle]
+      (if (and existing
+               (= existing-tag tag)
+               (identical? existing-token token))
         existing
         (let [fresh (seed-observation-opts! (atom {}) frame-id)]
-          (reset! handle {:tag tag :memo fresh})
+          (reset! handle {:tag tag :token token :memo fresh})
           #?(:cljs
              (when (exists? js/queueMicrotask)
                (js/queueMicrotask
@@ -935,7 +952,7 @@
                    ;; Release only OUR table — a later slice may have
                    ;; installed a fresh one already.
                    (when (identical? fresh (:memo @handle))
-                     (reset! handle {:tag nil :memo nil}))))))
+                     (reset! handle {:tag nil :token nil :memo nil}))))))
           fresh)))))
 
 ;; ---- resolve-target -----------------------------------------------------------

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -19,6 +19,7 @@
             [re-frame.core                  :as rf]
             [re-frame.error-emit            :as error-emit]
             [re-frame.frame                 :as frame]
+            [re-frame.live-frame            :as live-frame]
             [re-frame.interop               :as interop]
             [re-frame.source-coords         :as source-coords]
             [re-frame.subs                  :as subs]
@@ -1607,6 +1608,44 @@
           (let [ev (obs/probe (obs/resolve-target {:frame fid :query-v [:obs/a]}) memo)]
             (is (= [:a 6] (:value ev)) "no stale memoized value served")
             (is (> @parent-runs runs-before) "the parent recomputed")))))))
+
+(deftest slice-memo-tag-includes-the-exact-frame-incarnation
+  ;; rf2-vxgfnd.160 — the shared cold-probe memo must NOT serve a DESTROYED
+  ;; incarnation's value to a COMMIT-FREE consumer. The
+  ;; (frame, frame-epoch, registry-epoch) triple TIES across a same-id
+  ;; destroy+recreate (frame/dissoc-frame! restarts the commit epoch, and no new
+  ;; :sub registration bumps the registry epoch), so without the exact
+  ;; incarnation token in the tag a Tier-1 probe outside any ViewCell reuses A's
+  ;; memoized parent for B — and there is NO commit step 5 to correct a
+  ;; commit-free read.
+  (let [mfid   :memo/frame]
+    (rf/reg-sub :memo/parent (fn [db _] (:value db)))
+    (rf/reg-sub :memo/value :<- [:memo/parent] (fn [v _] v))
+    (let [target (fn [] (obs/resolve-target {:frame mfid :query-v [:memo/value]}))]
+      ;; incarnation A — seed {:value :A}, ONE state commit
+      (live-frame/make-frame {:id mfid})
+      (frame/replace-app-db! mfid {:value :A})
+      (let [memo    (obs/make-slice-memo)              ;; the shared module handle
+            token-a (frame/frame-incarnation-token mfid)
+            fe-a    (frame/frame-commit-epoch mfid)
+            ev-a    (obs/probe (target) memo)]         ;; seeds A's parent into the memo
+        (is (= :A (:value ev-a)) "A's value seeds the memo")
+        ;; destroy A; recreate same-id B with an EQUAL-epoch commit
+        (frame/destroy-frame! mfid)
+        (live-frame/make-frame {:id mfid})
+        (frame/replace-app-db! mfid {:value :B})
+        (let [token-b (frame/frame-incarnation-token mfid)]
+          (testing "precondition — B ties A on the (frame, frame-epoch, registry-epoch) tag"
+            (is (not (identical? token-a token-b)) "B is a DISTINCT incarnation")
+            (is (= fe-a (frame/frame-commit-epoch mfid))
+                "frame-commit-epoch ties across the reincarnation (epoch restarted)"))
+          ;; the SECOND probe reuses the SAME memo handle — no reset-scheduler!
+          (let [ev-b (obs/probe (target) memo)]
+            (is (= (:registry-epoch ev-a) (:registry-epoch ev-b))
+                "registry-epoch ties too — the whole pre-token tag is identical")
+            (is (= :B (:value ev-b))
+                "the commit-free re-probe returns B's value — the incarnation token
+                 in the memo tag prevents A's stale parent from being reused")))))))
 
 ;; ===========================================================================
 ;; the leak fixture — 10k cold probes retain zero

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2657,17 +2657,23 @@
          collected  @captured
          explicit?  (some? root-incarnation)
          ;; When an explicit root incarnation is named it is AUTHORITATIVE: this
-         ;; teardown owns EXACTLY the cells of that generation (rf2-vxgfnd.156). A
+         ;; teardown owns the cells of that generation (rf2-vxgfnd.156). A
          ;; re-entrant cleanup can disconnect a SIBLING root's cell INSIDE this
          ;; window — a resource-lifecycle `on-disconnect` or a router trace
          ;; listener firing during root A's `.unmount` — and such a captured
-         ;; sibling is NOT ours to reap: filter the captured set by identity with
-         ;; each cell's own `cell-root`, leaving a sibling reconnectable. The
-         ;; legacy one-arity path has no explicit generation, so it trusts every
-         ;; window-captured cell (a real host `.unmount` sweeps EXACTLY its own
-         ;; root's tree — sibling roots are structurally isolated, 03 §4).
+         ;; sibling, owned by a DIFFERENT incarnation, is NOT ours to reap: drop
+         ;; only cells whose `cell-root` is a KNOWN-DIFFERENT incarnation, leaving
+         ;; the sibling reconnectable. A captured cell with NO root ownership
+         ;; (`cell-root` nil — a bare/test mount that never went through a
+         ;; root-incarnation provider) is KEPT: the host `.unmount` sweep is
+         ;; structural (it fires EXACTLY this root's tree, 03 §4), so an
+         ;; unattached captured cell is this root's own. The legacy one-arity
+         ;; path has no explicit generation, so it trusts every captured cell.
          owned     (if explicit?
-                     (into #{} (filter #(identical? root-incarnation (cell-root %)))
+                     (into #{}
+                           (remove (fn [c]
+                                     (when-some [r (cell-root c)]
+                                       (not (identical? root-incarnation r)))))
                            collected)
                      collected)
          ;; the incarnations whose hidden cells this teardown owns. Explicit:

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2597,19 +2597,29 @@
   `:disconnected {:reason :unknown}` and RECONNECTABLE after its root is gone. So
   teardown ALSO consults the `root-cells` ownership registry: after the window
   closes it reaps every still-`:disconnected` cell owned by a torn-down root
-  incarnation. Two incarnation sources, unioned:
+  incarnation. Which incarnation(s) that registry sweep — and the captured set
+  itself — is scoped to depends ON THE ARITY (rf2-vxgfnd.156):
 
-    - `root-incarnation` — the explicit incarnation the caller (the mount/root
-      layer) names for the root being unmounted. This is the deterministic path:
-      it reaps a root's hidden cells even when the window captured NONE (the whole
-      root hidden, or a single already-hidden cell).
-    - the incarnations of every WINDOW-CAPTURED cell — a captured cell names its
-      own root's incarnation, so its still-hidden siblings under the same root are
-      reaped too, even when no explicit incarnation is supplied.
+    - `[root-incarnation unmount-thunk]` — the explicit incarnation is
+      AUTHORITATIVE. It alone derives the hidden-cell victims (the deterministic
+      path: it reaps a root's hidden cells even when the window captured NONE —
+      the whole root hidden, or a single already-hidden cell), AND the
+      window-captured set is FILTERED to cells belonging to that exact identity.
+      A re-entrant cleanup that disconnects a SIBLING root's cell inside the
+      window (a resource-lifecycle / trace listener) therefore neither dies nor
+      expands the sweep onto its root — sibling isolation holds even when the
+      structural host guarantee does not (the cleanup was app-driven, not a
+      React sweep of A's tree).
+    - `[unmount-thunk]` — no explicit generation, so the incarnations of every
+      WINDOW-CAPTURED cell govern: a captured cell names its own root's
+      incarnation, so its still-hidden same-root siblings are reaped too. This is
+      sound because a real host `.unmount` sweeps EXACTLY its own root's tree, so
+      the captured set is precisely that root's cells.
 
-  Only `:disconnected` owned cells are reaped; a still-`:connected` cell of a
-  SIBLING root's incarnation is never in the set, and an incarnation is a fresh
-  per-mount identity, so a replacement root under the same root-id is untouched.
+  Only `:disconnected` owned cells are reaped through the registry; a
+  still-`:connected` cell of a SIBLING root's incarnation is never in the set,
+  and an incarnation is a fresh per-mount identity, so a replacement root under
+  the same root-id is untouched.
 
   Ordering-robust and re-entrancy-safe by save/restore. If `unmount-thunk`
   THROWS, the original host error still propagates, but an EXPLICIT
@@ -2641,10 +2651,28 @@
                           (vreset! captured @teardown-collector)
                           (reset! teardown-collector prev))))
          collected  @captured
-         ;; the incarnations whose hidden cells this teardown owns: the explicit
-         ;; one plus every window-captured cell's own incarnation.
-         incs      (cond-> (into #{} (keep cell-root) collected)
-                     (some? root-incarnation) (conj root-incarnation))
+         explicit?  (some? root-incarnation)
+         ;; When an explicit root incarnation is named it is AUTHORITATIVE: this
+         ;; teardown owns EXACTLY the cells of that generation (rf2-vxgfnd.156). A
+         ;; re-entrant cleanup can disconnect a SIBLING root's cell INSIDE this
+         ;; window — a resource-lifecycle `on-disconnect` or a router trace
+         ;; listener firing during root A's `.unmount` — and such a captured
+         ;; sibling is NOT ours to reap: filter the captured set by identity with
+         ;; each cell's own `cell-root`, leaving a sibling reconnectable. The
+         ;; legacy one-arity path has no explicit generation, so it trusts every
+         ;; window-captured cell (a real host `.unmount` sweeps EXACTLY its own
+         ;; root's tree — sibling roots are structurally isolated, 03 §4).
+         owned     (if explicit?
+                     (into #{} (filter #(identical? root-incarnation (cell-root %)))
+                           collected)
+                     collected)
+         ;; the incarnations whose hidden cells this teardown owns. Explicit:
+         ;; EXACTLY the named token — a captured sibling's token must NOT expand
+         ;; the hidden-cell sweep onto that sibling's root. Legacy: inferred from
+         ;; every captured cell's own root (its still-hidden same-root siblings).
+         incs      (if explicit?
+                     #{root-incarnation}
+                     (into #{} (keep cell-root) collected))
          ;; already-Activity-hidden owned cells the window could NOT capture —
          ;; still `:disconnected`, belonging to a torn-down incarnation. A
          ;; hidden-but-alive cell is pinned by React's retained fiber, so weak
@@ -2654,12 +2682,12 @@
                          (comp (mapcat #(weak-live (get @root-cells %)))
                                (filter #(= :disconnected (lifecycle %))))
                          incs)
-         victims   (if (and @host-error (some? root-incarnation))
+         victims   (if (and @host-error explicit?)
                      ;; The host handle is consumed/released even on this path.
                      ;; Fail closed over the EXACT root generation, including
                      ;; cells still connected because React ran no cleanup.
-                     (into collected (weak-live (get @root-cells root-incarnation)))
-                     (into collected hidden))]
+                     (into owned (weak-live (get @root-cells root-incarnation)))
+                     (into owned hidden))]
      (doseq [cell victims]
        (teardown! cell))
      (if @host-error

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -349,10 +349,14 @@
   synchronous render pass; GC hygiene only, not a before-paint boundary).
   On the JVM `next-tick` is a concurrent executor, not a microtask, so a
   timer-driven clear would race a synchronous render; there the handle is
-  invalidated by the memo's own `(frame, frame-epoch, registry-epoch)` tag
-  on the next epoch (`slice-memo-table!`) and cleared between fixtures by
-  `reset-scheduler!`. The memo is an ECONOMY — commit step 5 corrects any
-  staleness before paint — so the coarser JVM lifetime is harmless."
+  invalidated by the memo's own `(frame, frame-epoch, registry-epoch)` tag —
+  PLUS the exact frame-incarnation token, which distinguishes a same-id
+  destroy+recreate whose epochs tie (rf2-vxgfnd.160) — on the next
+  slice (`slice-memo-table!`) and cleared between fixtures by
+  `reset-scheduler!`. The memo is an ECONOMY — for a committing reader commit
+  step 5 corrects any staleness before paint, and the incarnation-complete tag
+  keeps a commit-free reader correct on its own — so the coarser JVM lifetime
+  is harmless."
   []
   (or @slice-memo*
       (let [h (obs/make-slice-memo)]

--- a/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_incarnation_close_cljs_test.cljc
@@ -123,11 +123,12 @@
       (is (empty? (reactive/committed-target-keys cell))
           "A's stale lease is released — no old ownership survives on the replacement id"))
     (testing "the replacement incarnation B is wholly untouched and commits cleanly"
-      ;; Clear the slice PROBE MEMO first: a cold probe caches its computed value
-      ;; under a `(frame, frame-epoch, registry-epoch)` tag, and those tie across
-      ;; the reincarnation by construction — so a stale A-tagged entry would be
-      ;; reused. The memo is an economy (commit corrects before paint); resetting
-      ;; it isolates B's OWN read. The dead cell already left every registry.
+      ;; Reset the slice PROBE MEMO for clean isolation. A cold probe caches its
+      ;; computed value under a `(frame, frame-epoch, registry-epoch)` tag whose
+      ;; epochs tie across this reincarnation by construction — but the tag ALSO
+      ;; carries the exact frame-incarnation token (rf2-vxgfnd.160), so B's probe
+      ;; would already miss A's stale entry by identity. The reset simply pins B's
+      ;; OWN read unambiguously. The dead cell already left every registry.
       (reactive/reset-scheduler!)
       (let [cell-b (reactive/make-cell ::b)]
         (let [[_ capture] (rf/with-frame fid

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -269,6 +269,92 @@
       (is (= 1 (reactive/root-cell-count inc-2))))))
 
 ;; ===========================================================================
+;; rf2-vxgfnd.156 — an EXPLICIT root incarnation is authoritative: a re-entrant
+;; cleanup that disconnects a SIBLING root's cell inside the window neither dies
+;; nor expands the hidden-cell sweep onto that sibling's root
+;; ===========================================================================
+
+(deftest explicit-teardown-does-not-reap-a-captured-sibling-cell
+  ;; The A/B graft: root A's explicit teardown window is armed; a re-entrant
+  ;; cleanup (a resource-lifecycle / trace listener, modelled here by the thunk)
+  ;; disconnects sibling root B's cell too. Pre-fix, `teardown-root!` trusted
+  ;; EVERY captured cell, so B's cell was force-dead and B's token expanded the
+  ;; sweep. The explicit incarnation A must be authoritative: only A's captured
+  ;; cell is reaped; B's captured cell stays reconnectable and retains B ownership.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        inc-a  (reactive/make-root-incarnation)
+        inc-b  (reactive/make-root-incarnation)
+        cell-a (mount! ::a inc-a fid [[:rt/a]])
+        cell-b (mount! ::b inc-b fid [[:rt/a]])]
+    (is (= :connected (reactive/lifecycle cell-a)))
+    (is (= :connected (reactive/lifecycle cell-b)))
+    (is (= 1 (reactive/teardown-root!
+              inc-a
+              (fn []
+                (reactive/disconnect! cell-a)
+                ;; re-entrant: a sibling root B cell disconnects inside A's window
+                (reactive/disconnect! cell-b))))
+        "exactly ONE cell reaped — A's — not the captured sibling B cell")
+    (is (= :dead (reactive/lifecycle cell-a)) "root A's cell dies")
+    (testing "B's captured cell is NOT force-dead — reconnectable, B ownership retained"
+      (is (not= :dead (reactive/lifecycle cell-b))
+          "the explicit A teardown must not kill a captured sibling B cell")
+      (is (= :disconnected (reactive/lifecycle cell-b)) "left a plain reconnectable hide")
+      (is (identical? inc-b (reactive/cell-root cell-b)) "B ownership retained")
+      (is (= 1 (reactive/root-cell-count inc-b)) "…still owned by B"))
+    (testing "a reveal reconnects B's cell cleanly through the real observation port"
+      (reactive/settle-disconnect! cell-b)
+      (render+commit! cell-b fid [[:rt/a]])
+      (is (= :connected (reactive/lifecycle cell-b)))
+      (let [v (first (rf/with-frame fid
+                       (reactive/with-capture cell-b
+                         (fn [] (reactive/sub-read ::site [:rt/a])))))]
+        (is (= 1 v) "B's reconnected cell reads live")))))
+
+(deftest explicit-teardown-does-not-sweep-a-hidden-B-sibling-via-a-captured-B-token
+  ;; rf2-vxgfnd.156 step 4 — a captured B cell's token must NOT expand the
+  ;; hidden-cell reap. Only the explicit A token derives hidden victims; a B
+  ;; sibling hidden BEFORE the window stays reconnectable even though a B cell
+  ;; was captured inside A's window.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid      (make-frame! :rt/frame {:a 1})
+        inc-a    (reactive/make-root-incarnation)
+        inc-b    (reactive/make-root-incarnation)
+        cell-a   (mount! ::a inc-a fid [[:rt/a]])
+        cell-b   (mount! ::b inc-b fid [[:rt/a]])
+        hidden-b (mount! ::hb inc-b fid [[:rt/a]])]
+    (reactive/disconnect! hidden-b)                     ;; B sibling hidden BEFORE the window
+    (is (= :disconnected (reactive/lifecycle hidden-b)))
+    (reactive/teardown-root!
+     inc-a
+     (fn []
+       (reactive/disconnect! cell-a)
+       (reactive/disconnect! cell-b)))                  ;; re-entrant B capture
+    (is (= :dead (reactive/lifecycle cell-a)) "root A's cell dies")
+    (testing "neither the captured B cell nor the pre-hidden B sibling is reaped"
+      (is (not= :dead (reactive/lifecycle cell-b)) "captured B cell survives")
+      (is (= :disconnected (reactive/lifecycle hidden-b))
+          "B's pre-hidden sibling is NOT swept by A's explicit teardown")
+      (is (= 2 (reactive/root-cell-count inc-b))
+          "both B cells still owned by B — A's teardown claimed neither"))))
+
+(deftest legacy-one-arity-still-reaps-siblings-via-captured-incarnation
+  ;; The one-arity path is UNCHANGED (rf2-vxgfnd.85): with no explicit
+  ;; incarnation, a window-captured cell's own incarnation still reaps its
+  ;; still-hidden same-root siblings. (Regression guard on the arity split.)
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        inc    (reactive/make-root-incarnation)
+        shown  (mount! ::shown inc fid [[:rt/a]])
+        hidden (mount! ::hidden inc fid [[:rt/a]])]
+    (reactive/disconnect! hidden)
+    (is (= 2 (reactive/teardown-root! (fn [] (reactive/disconnect! shown))))
+        "one-arity still reaps the captured cell + its same-root hidden sibling")
+    (is (= :dead (reactive/lifecycle shown)))
+    (is (= :dead (reactive/lifecycle hidden)))))
+
+;; ===========================================================================
 ;; Root isolation — a teardown only claims the cells its own unmount disconnects
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/reactive_slice_memo_incarnation_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_slice_memo_incarnation_cljs_test.cljc
@@ -1,0 +1,74 @@
+(ns re-frame.ui.reactive-slice-memo-incarnation-cljs-test
+  "rf2-vxgfnd.160 — the module-wide slice probe memo (`current-slice-memo`) must
+  carry the EXACT frame incarnation, so a COMMIT-FREE reader never receives a
+  destroyed incarnation's memoized value.
+
+  `re-frame.ui.reactive/sub-read` outside a live cell is a one-shot headless
+  read: it probes ownership-free through the module slice memo (the same handle
+  a Tier-1 `ui.test/render` seeds — 03 §3). Outside a ViewCell there is NO
+  commit step 5 to correct a stale memo hit. The
+  `(frame, frame-epoch, registry-epoch)` tag TIES across a same-id
+  destroy+recreate (the commit epoch restarts), so the memo tag must ALSO carry
+  the incarnation token — validated by identity — for the commit-free path.
+
+  `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
+  (`clojure -M:test`), so the module memo's incarnation-completeness is
+  graft-checked on both hosts against the REAL observation port. The core-port
+  primitive counterpart lives in `re-frame.observation-port-cljs-test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(deftest commit-free-sub-read-does-not-serve-a-destroyed-incarnations-memo
+  ;; The exact commit-free repro: seed A into the module memo with one headless
+  ;; sub-read, reincarnate to same-id B with epochs that tie, then read again
+  ;; WITHOUT resetting the scheduler. The second read must return B — the module
+  ;; memo's incarnation-complete tag is what prevents A's stale parent hit.
+  (rf/reg-sub :sm/parent (fn [db _] (:value db)))
+  (rf/reg-sub :sm/value :<- [:sm/parent] (fn [v _] v))
+  (let [mfid :sm/frame]
+    ;; incarnation A — one state commit
+    (live-frame/make-frame {:id mfid})
+    (frame/replace-app-db! mfid {:value :A})
+    (let [token-a (frame/frame-incarnation-token mfid)
+          fe-a    (frame/frame-commit-epoch mfid)
+          ;; a commit-free headless read seeds A into the MODULE slice memo
+          va      (rf/with-frame mfid (reactive/sub-read [:sm/value]))]
+      (is (= :A va) "A's value seeds the module memo")
+      ;; destroy A; recreate same-id B with an EQUAL-epoch commit
+      (frame/destroy-frame! mfid)
+      (live-frame/make-frame {:id mfid})
+      (frame/replace-app-db! mfid {:value :B})
+      (testing "precondition — B ties A on the pre-token tag"
+        (is (not (identical? token-a (frame/frame-incarnation-token mfid)))
+            "B is a DISTINCT incarnation")
+        (is (= fe-a (frame/frame-commit-epoch mfid))
+            "frame-commit-epoch ties across the reincarnation"))
+      ;; NO reset-scheduler! — the module handle persists (JVM) / is reused
+      (let [vb (rf/with-frame mfid (reactive/sub-read [:sm/value]))]
+        (is (= :B vb)
+            "the commit-free re-read returns B — never A's stale memoized parent")))))
+
+(deftest same-incarnation-commit-free-reads-are-unaffected
+  ;; The economy still holds within ONE incarnation: repeated commit-free reads
+  ;; against the same live incarnation return the live value and share the memo.
+  (rf/reg-sub :sm/parent (fn [db _] (:value db)))
+  (rf/reg-sub :sm/value :<- [:sm/parent] (fn [v _] v))
+  (let [mfid :sm/frame2]
+    (live-frame/make-frame {:id mfid})
+    (frame/replace-app-db! mfid {:value :one})
+    (is (= :one (rf/with-frame mfid (reactive/sub-read [:sm/value]))))
+    (frame/replace-app-db! mfid {:value :two})
+    (is (= :two (rf/with-frame mfid (reactive/sub-read [:sm/value])))
+        "a live-incarnation state commit still moves the value (tag epoch bumps)")))

--- a/implementation/ui/test/re_frame/ui/reactive_stale_lease_capture_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_stale_lease_capture_cljs_test.cljc
@@ -1,0 +1,121 @@
+(ns re-frame.ui.reactive-stale-lease-capture-cljs-test
+  "rf2-vxgfnd.161 — a ViewCell commit must never CONNECT while retaining a lease
+  from a SUPERSEDED frame incarnation.
+
+  RE-VERIFICATION (2026-07): the bead was filed against PR #5787's head, which
+  PRE-DATES the lexical-site commit rewrite (#5821) that introduced the
+  `candidate-current?` gate in `commit*`. At that head, a two-site capture
+  could acquire lease 1 from incarnation A, lose A, acquire lease 2 from a fresh
+  same-id B, and CONNECT while retaining the stale A lease — because commit
+  incarnation evidence was derived from a LATER bare-id registry read
+  (`committed-frame-incarnations` → `frame/frame-incarnation-token`), which by
+  then read B's token, so `incarnation-superseded?` and
+  `frame-incarnation-closing?` both passed.
+
+  On CURRENT main that symptom is UNREACHABLE, so the bead's required
+  lease-carried-token machinery would be REDUNDANT fencing. The reason:
+  destroying incarnation A disposes A's sub-cache, so any lease acquired from A
+  is no longer CANONICAL — `obs/current?` reads false for it
+  (`node-still-canonical?` compares the lease's reaction against the frame's
+  CURRENT sub-cache, which is now B's). `commit*`'s `candidate-current?` gate
+  rejects the WHOLE commit if ANY candidate lease is non-current, rolling back
+  every staged lease and synchronously invalidating (no connect, no retained
+  stale lease) — strictly BEFORE the incarnation-token revalidation runs. A
+  mixed capture therefore cannot connect: lease 1 (owner A destroyed) is always
+  non-current at the gate.
+
+  These fixtures PIN that fencing so a future weakening of `candidate-current?`
+  re-opens .161 as a red test. `.cljc` ending `-cljs-test` graft-checks on node
+  (`test:cljs`) AND JVM (`clojure -M:test`) against the REAL observation port +
+  sub-cache. The `:post-acquire`-window incarnation revalidation (destruction
+  AFTER the gate) is pinned separately by
+  `re-frame.ui.reactive-incarnation-close-cljs-test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.live-frame            :as live-frame]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.frames]
+            [re-frame.ui.reactive           :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+;; ---- THE LINCHPIN: a superseded incarnation's lease is non-current -----------
+(deftest a-superseded-incarnations-lease-is-non-current
+  ;; This is WHY the mixed capture cannot connect: the instant A is destroyed
+  ;; (and a same-id B replaces it), the A-owned lease stops being the frame's
+  ;; canonical node, so `obs/current?` — the exact predicate `commit*`'s
+  ;; candidate-current? gate uses — reads false for it.
+  (rf/reg-sub :sl/a (fn [db _] (:a db)))
+  (let [fid    :sl/frame
+        _      (make-frame! fid {:a 1})
+        target (rf/with-frame fid (obs/resolve-target {:query-v [:sl/a]}))
+        lease  (rf/with-frame fid (obs/acquire! target (fn [_] nil)))]
+    (is (obs/current? lease target) "the A lease is current while A is live")
+    (frame/destroy-frame! fid)
+    (make-frame! fid {:a 99})                           ;; same-id B
+    (is (not (obs/current? lease target))
+        "after same-id B replaces A the A lease is NON-CURRENT — its node was disposed")
+    (obs/release! lease)))
+
+;; ---- the two-site stale capture is rejected, never connected -----------------
+(deftest a-two-site-capture-with-a-superseded-incarnation-does-not-connect
+  ;; Two sites acquire from A, then A is destroyed and same-id B created in the
+  ;; acquire→snapshot window (:post-stage-acquire). Both A leases go non-current,
+  ;; so the candidate-current? gate rejects the whole commit BEFORE any
+  ;; incarnation-token revalidation — the cell never connects and retains no
+  ;; stale lease. (Pre-#5821 this connected with stale A leases; removing
+  ;; candidate-current? would restore that failure.)
+  (rf/reg-sub :sl/a (fn [db _] (:a db)))
+  (rf/reg-sub :sl/b (fn [db _] (:b db)))
+  (let [fid     :sl/frame2
+        _       (make-frame! fid {:a 1 :b 2})
+        token-a (frame/frame-incarnation-token fid)
+        cell    (reactive/make-cell ::two)
+        [_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn []
+                              (reactive/sub-read ::s1 [:sl/a])
+                              (reactive/sub-read ::s2 [:sl/b]))))]
+    (binding [reactive/*commit-barrier*
+              (fn [phase _]
+                (when (= :post-stage-acquire phase)
+                  (frame/destroy-frame! fid)
+                  (make-frame! fid {:a 99 :b 88})))]
+      (reactive/commit! cell capture))
+    (is (not (identical? token-a (frame/frame-incarnation-token fid)))
+        "B is a distinct incarnation under the reused id")
+    (testing "the stale capture is rejected — no connect, no retained lease"
+      (is (not= :connected (reactive/lifecycle cell))
+          "a commit whose incarnation was superseded before the snapshot never connects")
+      (is (empty? (reactive/committed-sites cell)) "no committed sites — nothing retained")
+      (is (nil? (:ref-count (get @(:sub-cache (frame/frame fid)) [:sl/a])))
+          "B's replacement cache is untouched — the rejected staging released cleanly"))))
+
+;; ---- ordinary same-incarnation multi-site commit is unaffected ---------------
+(deftest ordinary-same-incarnation-multi-site-commit-connects
+  (rf/reg-sub :sl/a (fn [db _] (:a db)))
+  (rf/reg-sub :sl/b (fn [db _] (:b db)))
+  (let [fid  (make-frame! :sl/frame3 {:a 1 :b 2})
+        cell (reactive/make-cell ::ok)
+        [_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn []
+                              (reactive/sub-read ::s1 [:sl/a])
+                              (reactive/sub-read ::s2 [:sl/b]))))]
+    (reactive/commit! cell capture)
+    (is (= :connected (reactive/lifecycle cell))
+        "a live, unchanged incarnation commits normally — no false rejection")
+    (is (= 2 (count (reactive/committed-sites cell))))))


### PR DESCRIPTION
## Summary

Reactive-core incarnation fencing across the compiled-view substrate. Three P1 findings, all touching `implementation/ui/src/re_frame/ui/reactive.cljc`, worked as one serial worker / one PR. Each was re-verified against fresh `origin/main` before implementing; one of the three (.161) proved **already fenced** by a change merged after the bead's audited head.

Discipline: pre-alpha, no back-compat shims — once a frame incarnation's ownership is lost, framework state binds to the exact incarnation, never a successor (the merged destroy-contract + lease-slice discipline).

## rf2-vxgfnd.156 — Scope explicit root-incarnation teardown to the named root (STILL LIVE, fixed)

`teardown-root!`'s explicit `[root-incarnation unmount-thunk]` arity trusted **every** window-captured cell and unioned every captured cell's token into the hidden-cell sweep. A re-entrant cleanup inside root A's teardown window — a resource-lifecycle `on-disconnect` or a router trace listener firing during A's `.unmount` — can disconnect a **sibling** root B's cell; that captured B cell was force-deaded and B's token expanded the sweep onto B's root.

**Fix:** with an explicit incarnation, treat that identity as authoritative — filter the captured set by `cell-root` identity, and derive hidden victims from the named token alone. The legacy one-arity path (no explicit generation) is unchanged: it still trusts every captured cell, sound because a real host `.unmount` sweeps exactly its own root's tree.

**Red-before-fix fixtures** (`reactive-root-teardown-cljs-test`, node + JVM, real observation port):
- `explicit-teardown-does-not-reap-a-captured-sibling-cell` — the A/B graft: only A's cell is reaped; B's captured cell stays reconnectable, retains B ownership, and reconnects cleanly.
- `explicit-teardown-does-not-sweep-a-hidden-B-sibling-via-a-captured-B-token` — a captured B token must not expand the hidden-cell reap.
- `legacy-one-arity-still-reaps-siblings-via-captured-incarnation` — arity-split regression guard.

Verified red-before-fix: reverting the `owned`/`incs` logic → 8 failures + 1 error.

*AC4 note (DOM re-entrant fixture):* a re-entrant sibling disconnect is an app-callback path (resource-lifecycle / trace listener), **not** React's tree sweep — the existing `real-root-unmount-isolates-a-sibling-root` DOM test already covers structural isolation, and the `.cljc` graft fixtures (which run on the node runtime via `test:cljs` against the real observation port) are the faithful direct model of the re-entrant callback. A bespoke DOM harness reaching across roots to force the disconnect would be over-engineering without adding fidelity.

## rf2-vxgfnd.160 — Include exact frame incarnation in slice-memo identity (STILL LIVE, fixed)

The shared cold-probe memo tagged a table only with `(frame, frame-epoch, registry-epoch)`. That triple **ties** across a same-id destroy+recreate — `frame/dissoc-frame!` restarts the commit epoch and no new `:sub` registration bumps the registry epoch — so a **commit-free** consumer (a Tier-1 `ui.test/render` or a headless `reactive/sub-read` outside any ViewCell) could be served a destroyed incarnation A's memoized parent for a fresh same-id B. There is no commit step 5 to correct a commit-free read.

**Fix:** `slice-memo-table!` now carries the exact `frame-incarnation-token`, compared by identity. Docstrings (`make-slice-memo`, `current-slice-memo`) state the incarnation-complete tag rather than claiming commit correction protects commit-free reads. Same-incarnation slice sharing / the economy is retained.

**Red-before-fix fixtures** (node + JVM, real observation port):
- `re-frame.observation-port-cljs-test/slice-memo-tag-includes-the-exact-frame-incarnation` (port primitive).
- `re-frame.ui.reactive-slice-memo-incarnation-cljs-test/commit-free-sub-read-does-not-serve-a-destroyed-incarnations-memo` (the module `current-slice-memo` carrier + `same-incarnation-commit-free-reads-are-unaffected`).

Verified red-before-fix on both fixtures: without the token the re-probe returns `:A` (stale).

**Coordination note (spec worker):** Spec 006 §The slice-scoped probe memo prose is owned by the spec worker this wave; its incarnation-complete-tag update (and dropping the "commit correction protects commit-free reads" claim) is flagged here rather than edited, per the hot-zone / scope fence.

## rf2-vxgfnd.161 — Bind each acquired ViewCell lease to its exact frame incarnation (ALREADY FENCED — proof added, no redundant fencing)

**Re-verification finding:** the .161 symptom (a two-site capture connecting while retaining a lease from a superseded same-id incarnation) is **unreachable on current main**. The bead was filed against PR #5787's head, which pre-dates the #5821 lexical-site commit rewrite that added the `candidate-current?` gate to `commit*`.

Destroying incarnation A disposes A's sub-cache, so any lease acquired from A is no longer canonical — `obs/current?` reads false for it (`node-still-canonical?` compares the lease's reaction against the frame's *current* sub-cache, now B's). `candidate-current?` rejects the whole commit (rolling back staged leases + synchronous invalidate) **before** the incarnation-token revalidation runs. A mixed capture therefore can never connect: lease 1 (owner A destroyed) is always non-current at the gate. Empirically confirmed with a throwaway mid-acquire barrier driving the exact `site1=A / site2=B` interleave — also rejected. (Production has no yield between synchronous acquires, so that interleave is test-only.)

Per the wave's instruction — *prove no-repro rather than add redundant fencing* — the bead's lease-carried-token machinery was **not** implemented (`committed-frame-incarnations`, the observation lease, and `test.cljc` are unchanged). Instead a kept regression test pins the existing fence so a future weakening of `candidate-current?` re-opens .161 as a red test:
- `re-frame.ui.reactive-stale-lease-capture-cljs-test`: `a-superseded-incarnations-lease-is-non-current` (the linchpin), `a-two-site-capture-with-a-superseded-incarnation-does-not-connect`, `ordinary-same-incarnation-multi-site-commit-connects`.

## Invariants preserved

- The two-guard rule (I-4), the merged weak-root-cells (rf2-mc62sp) and generation-fencing (rf2-vxgfnd.88/.94) contracts are intact.
- No observation cache node, owner, watch, or public port API added (.160 is a tag-identity change; .161 adds nothing to source).
- No touch to `frames.cljc`, `core/frame.cljc`, epoch, or `spec/**` (scope fences honored).

All run in the worktree; foreground/captured to file (never `tail`-truncated for the summary).

| Gate | Result |
| --- | --- |
| `implementation/core` JVM (`clojure -M:test`) | 1936 tests, 8831 assertions — **0 failures, 0 errors** |
| `implementation/ui` JVM (`clojure -M:test`) | 482 tests, 6260 assertions — **0 failures, 0 errors** |
| node CLJS (`npm run test:cljs`) | 9309 tests, 44106 assertions — **0 failures, 0 errors** |
| browser (`npm run test:browser`) | 343 tests, 1854 assertions — **0 failures, 0 errors** |
| fast PR spine (`scripts/test-fast-pr.sh`) | **PASS** — all gates green (lockstep, skill/MCP drift, retired-spelling, thrown-error-message, ambient-durable-read, JS harness policy, per-ns isolation, markdown link/anchor; `mkdocs --strict` soft-skipped locally, runs in CI) |

### Regression caught + fixed mid-review

The first node-suite run surfaced **2 failures** in `root-teardown-wiring-cljs-test/unmount-drives-the-cell-to-dead-and-releases-the-claim` (a `.cljs` wiring test I did not author). Root cause: the initial strict `.156` filter `(identical? root-incarnation (cell-root %))` dropped a window-captured cell that was never `attach-root!`'d (the wiring fixture commits a bare cell with `cell-root` = nil). Since the host `.unmount` sweep is structural (fires exactly this root's tree), an unattached captured cell IS this root's own — so the filter was refined to drop only **known-different** incarnations (non-nil, non-identical), keeping identical-owned and unattached cells. Sibling isolation is unchanged (a real sibling-root cell is attached to its own incarnation via `client/mount!`'s provider). Full node + ui-JVM suites re-run green after the fix.
