### PR TITLE
fix: inline-sub pipeline — computed-position rewrite, registrar normalization, image-local trace projection (rf2-vxgfnd.217/.219/.220)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -590,10 +590,25 @@
 
   EP-0002 (rf2-gjq3ow) — FAIL CLOSED on a nil `frame-id`: subs are frame-scoped,
   so a sub trace with no carried frame is malformed; `:rf.sub/value` (and
-  `:rf.sub/prev-value` when present) are conservatively redacted."
+  `:rf.sub/prev-value` when present) are conservatively redacted.
+
+  rf2-vxgfnd.220 — IMAGE-LOCAL classification: the reactive recompute carries the
+  EXACT classification declaration captured for its reaction under an internal
+  `:rf.sub/classification` slot (the same `sub-meta` the schema validator read).
+  When present it is AUTHORITATIVE — we project from it rather than re-resolving
+  `classification-when :sub sub-id` through the ambient registrar, which after the
+  frame-generation binding unwinds (one-shot deref) or across HMR/incarnation
+  replacement (an ongoing reaction) may see no image metadata or a CONFLICTING
+  same-id global registration. Presence (even an empty captured declaration) wins
+  over any global; the carrier is stripped here so it never egresses. Absence (a
+  trace not stamped by the memo path) falls back to the registrar resolution."
   [tags frame-id]
   (let [sub-id    (:rf.sub/id tags)
-        class     (classification-when :sub sub-id)
+        captured? (contains? tags :rf.sub/classification)
+        class     (if captured?
+                    (normalise-classification (:rf.sub/classification tags))
+                    (classification-when :sub sub-id))
+        tags      (dissoc tags :rf.sub/classification)
         has-prev? (contains? tags :rf.sub/prev-value)]
     (cond
       (nil? frame-id)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -169,6 +169,34 @@
                    "must be the required function(s).")
               (vec remaining))))))
 
+(defn normalize-sub-metadata
+  "The ONE side-effect-free (with respect to the global registrar) subscription-
+  metadata normalization seam, shared by public `reg-sub` and inline-image
+  `lower-inline-sub` (EP-0026 — inline registration follows the SAME registrar
+  contract, neither looser nor stricter). Given the user `meta` map it:
+
+    - validates retired / unknown registration KEYS under the dev/prod policy
+      (`reg-meta/validate-registration-metadata!` — a retired bare `:spec` HARD-
+      errors in dev AND prod naming `:schema`; an unknown bare key warns in dev;
+      namespaced extension keys pass);
+    - validates the `:sensitive` / `:large` CLASSIFICATION declarations fail-loud
+      (`classification/validate-classification!` — a malformed declaration raises
+      `:rf.error/bad-classification`);
+    - strips the production-only pure-documentation fields (`:doc`) exactly as the
+      public registrar does (`registrar/strip-pure-documentation` — a no-op in dev).
+
+  Throws on a retired key or malformed classification; otherwise returns the
+  normalized meta (doc-stripped in production, omitted-vs-explicit-nil and
+  namespaced extension keys preserved). It NEVER writes the global registrar —
+  the runtime-owned runnable slots (`:handler-fn`, `:input-kind`,
+  `:input-signals`) are installed by the caller AFTER normalization, so metadata
+  can never override them. `where-sym` / `id` name the registration in the
+  diagnostics."
+  [where-sym id meta]
+  (reg-meta/validate-registration-metadata! :sub where-sym id meta)
+  (classification/validate-classification! :sub meta)
+  (registrar/strip-pure-documentation meta))
+
 (defn reg-sub
   "Register a subscription under `id`. The sole sub-registration form
   (per Spec 002 §Subscriptions composing).
@@ -241,20 +269,17 @@
                                          :recovery  :no-recovery}))
                    (throw e)))
         {:keys [meta handler-fn input-kind input-signals input-fn]} parsed]
-    ;; rf2-x68lzo — no-silent-swallow on the registration metadata KEYS: a retired
-    ;; bare key (`:spec`) hard-errors, an unknown bare key warns, namespaced/known
-    ;; keys pass. Runs on the user meta before the registrar write.
-    (reg-meta/validate-registration-metadata! :sub 'rf/reg-sub id meta)
-    ;; EP-0025 — VALIDATE the sub's `:sensitive` / `:large` / `:large?`
-    ;; classification declarations fail-loud BEFORE the registrar write. The
-    ;; classification is DERIVED from the registrar meta at read time (no
-    ;; imperative stash). EP-0025 removed sub-output PROPAGATION (no
-    ;; derived-output sensitivity enum, no input→output inheritance), so there
-    ;; is no propagation table to update. The always-on, same-artefact
-    ;; `validate-classification!` is called directly (no late-bind hop).
-    (classification/validate-classification! :sub meta)
+    ;; rf2-vxgfnd.219 — one shared normalization seam validates the retired /
+    ;; unknown registration KEYS (rf2-x68lzo — a retired `:spec` hard-errors,
+    ;; unknown bare keys warn) AND the EP-0025 `:sensitive` / `:large`
+    ;; classification declarations (fail-loud) AND strips production-only `:doc`,
+    ;; so public `reg-sub` and inline-image `lower-inline-sub` accept, reject,
+    ;; and elide identical metadata. Classification is DERIVED from the registrar
+    ;; meta at read time (no imperative stash); the runtime-owned slots below are
+    ;; installed AFTER normalization so metadata cannot override them.
     (registrar/register! :sub id
-      (cond-> (assoc (source-coords/merge-coords meta)
+      (cond-> (assoc (source-coords/merge-coords
+                       (normalize-sub-metadata 'rf/reg-sub id meta))
                      :handler-fn    handler-fn
                      :input-kind    input-kind
                      :input-signals (or input-signals []))
@@ -2174,14 +2199,27 @@
 (defn lower-inline-sub
   "Lower an inline `:reg-sub` descriptor's raw computation fn into the runnable
   layer-1 (`:input-kind :db`) sub slots `reg-sub` installs (`:handler-fn` +
-  `:input-kind :db` + empty `:input-signals`). `metadata` is also projected
-  onto the runnable descriptor's top level, matching the shape `reg-sub`
-  installs and making runtime consumers such as return-schema validation read
-  the same slots regardless of registration path. Image assembly still keeps
-  the original nested `:metadata` plus `:impl` and provenance for inspection.
-  Runtime-owned runnable slots win over metadata."
+  `:input-kind :db` + empty `:input-signals`). `metadata` is NORMALIZED through
+  the SAME `normalize-sub-metadata` seam public `reg-sub` runs (rf2-vxgfnd.219),
+  so an inline registration accepts, rejects, and elides identical metadata: a
+  retired bare `:spec` hard-errors with `:rf.error/retired-registration-key`, a
+  malformed `:sensitive` / `:large` declaration raises
+  `:rf.error/bad-classification`, and production strips `:doc` — neither looser
+  nor stricter than the public path. The normalized meta is projected onto the
+  runnable descriptor's top level, matching the shape `reg-sub` installs so
+  runtime consumers (return-schema validation, classification projection) read
+  the same slots regardless of registration path. Normalization is side-effect-
+  free with respect to the global registrar; the runtime-owned runnable slots
+  are installed AFTER it, so metadata can never override them. Image assembly
+  still keeps the original nested `:metadata` plus `:impl` and provenance for
+  inspection.
+
+  The concrete sub id is not threaded through the image-assembly lowering
+  boundary (`lower` receives only `[metadata impl]`), so a generic
+  `:rf.image/inline-sub` id names the registration in any normalization
+  diagnostic; the error TYPE + named replacement key match the public path."
   [metadata impl]
-  (assoc metadata
+  (assoc (normalize-sub-metadata 'rf/reg-sub :rf.image/inline-sub metadata)
          :handler-fn    impl
          :input-kind    :db
          :input-signals []))

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -340,7 +340,26 @@
                                   ;; `:rf.sub/query-v` / `:rf.sub/cause-sub`
                                   ;; (only computed values are redacted).
                                   :rf.sub/inputs         (vec input-signals)
-                                  :rf.sub/cause-sub      cause-sub}
+                                  :rf.sub/cause-sub      cause-sub
+                                  ;; rf2-vxgfnd.220 — carry the EXACT classification
+                                  ;; declaration captured for THIS reaction (the
+                                  ;; authoritative image-local / global `sub-meta`
+                                  ;; the schema validator above also reads) so the
+                                  ;; `:rf.sub/run` trace chokepoint
+                                  ;; (`re-frame.classification/project-sub-tags`)
+                                  ;; redacts `:rf.sub/value` / `:rf.sub/prev-value`
+                                  ;; from it, INSTEAD of re-resolving classification
+                                  ;; through the ambient registrar by sub-id — which
+                                  ;; is wrong after the frame-generation binding
+                                  ;; unwinds and across HMR/incarnation replacement
+                                  ;; (the trace would see no image metadata, or a
+                                  ;; conflicting same-id global registration). An
+                                  ;; internal carrier: the projector consumes it and
+                                  ;; strips it before egress. `select-keys` on a nil
+                                  ;; `sub-meta` yields `{}` — a captured "no
+                                  ;; classification" that still wins over any global.
+                                  :rf.sub/classification
+                                  (select-keys sub-meta [:sensitive :large :large?])}
                            (some? elapsed-ms)
                            (assoc :rf.sub/elapsed-ms elapsed-ms)
                            reader-rk (assoc :rf.sub/reader-render-key reader-rk)

--- a/implementation/core/test/re_frame/subs_image_local_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_image_local_classification_cljs_test.cljc
@@ -1,0 +1,146 @@
+(ns re-frame.subs-image-local-classification-cljs-test
+  "rf2-vxgfnd.220 — a subscription's `:rf.sub/run` trace projects observability
+  from the EXACT registration classification captured for THAT reaction, not a
+  later/global re-resolution.
+
+  The reactive recompute already captures the authoritative image-local / global
+  `sub-meta` for schema validation; it now also carries that reaction's
+  classification declaration through the `:rf.sub/run` trace chokepoint under an
+  internal `:rf.sub/classification` slot. `project-sub-tags` redacts from the
+  carried declaration instead of re-resolving `classification-when :sub sub-id`
+  through the ambient registrar — which after the frame-generation binding
+  unwinds (one-shot deref) or across HMR/incarnation replacement (an ongoing
+  reaction) sees no image metadata or a CONFLICTING same-id global registration.
+
+  Focused chokepoint fixtures drive `classification/project-trace-event` on
+  `:rf.sub/run` events directly (pure data — the fixtures a mutation restoring
+  ambient re-resolution must fail); an end-to-end leg subscribes to a real
+  sensitive sub and proves the subscriber reads RAW while the projected trace
+  redacts, across an ongoing recompute.
+
+  `.cljc` — runs under both `clojure -M:test` (JVM) and `npm run test:cljs`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.classification :as classification]
+            [re-frame.elision :as elision]
+            [re-frame.privacy :as privacy]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+;; The reset fixture gives each test a clean, isolated runtime (a pinned
+;; :rf/default frame bound as the ambient scope, with registrar snapshot/restore
+;; so sibling namespaces in the shared :node-test bundle survive).
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Focused chokepoint — project-trace-event on :rf.sub/run (pure data)
+;; ---------------------------------------------------------------------------
+
+(defn- project-sub-run
+  "Project a `:rf.sub/run` envelope with the given tags and return the projected
+  tags. `:frame` defaults to :rf/default so the projector does not fail-closed."
+  [tags]
+  (-> (classification/project-trace-event
+        {:operation :rf.sub/run :op-type :rf.sub
+         :tags (merge {:frame :rf/default} tags)})
+      :tags))
+
+(deftest captured-sensitive-declaration-redacts-value-and-prev-value
+  (testing "an image-local sub's captured :sensitive declaration redacts
+            :rf.sub/value and :rf.sub/prev-value — with NO global registration"
+    (let [out (project-sub-run
+                {:rf.sub/id :img/secret
+                 :rf.sub/value      {:token "SECRET" :public 1}
+                 :rf.sub/prev-value {:token "OLD"    :public 0}
+                 :rf.sub/classification {:sensitive [[:token]]}})]
+      (is (= privacy/redacted-sentinel (get-in out [:rf.sub/value :token])))
+      (is (= 1 (get-in out [:rf.sub/value :public])) "unclassified sibling rides raw")
+      (is (= privacy/redacted-sentinel (get-in out [:rf.sub/prev-value :token])))
+      ;; EP-0025: a path-classified sub redacts only its declared paths — there
+      ;; is no whole-output :sensitive? stamp (no sub-output propagation). The
+      ;; captured path redacts exactly as the registrar path would.
+      (is (not (contains? out :rf.sub/classification))
+          "the internal carrier is stripped — it never egresses"))))
+
+(deftest captured-large-declaration-marks-value
+  (testing "a captured :large declaration emits the canonical large marker"
+    (let [out (project-sub-run
+                {:rf.sub/id :img/big
+                 :rf.sub/value {:blob (vec (range 100))}
+                 :rf.sub/classification {:large [[:blob]]}})]
+      (is (elision/marker? (get-in out [:rf.sub/value :blob])))
+      (is (not (contains? out :rf.sub/classification))))))
+
+(deftest conflicting-global-cannot-supply-or-override-captured-classification
+  (testing "a same-id GLOBAL registration with no classification cannot make a
+            captured-sensitive sub leak"
+    (rf/reg-sub :dup/id (fn [db _] db))                 ;; global: no classification
+    (let [out (project-sub-run {:rf.sub/id :dup/id
+                                :rf.sub/value {:token "SECRET"}
+                                :rf.sub/classification {:sensitive [[:token]]}})]
+      (is (= privacy/redacted-sentinel (get-in out [:rf.sub/value :token]))
+          "captured classification wins over the (unclassified) global")))
+  (testing "a captured EMPTY declaration wins over a conflicting SENSITIVE global
+            — presence is authoritative, so the value rides raw"
+    (rf/reg-sub :dup/id2 {:sensitive [[:token]]} (fn [db _] db))  ;; global: sensitive
+    (let [out (project-sub-run {:rf.sub/id :dup/id2
+                                :rf.sub/value {:token "SECRET"}
+                                :rf.sub/classification {}})]      ;; captured: none
+      (is (= "SECRET" (get-in out [:rf.sub/value :token]))
+          "the captured (no-classification) declaration is authoritative"))))
+
+(deftest same-sub-id-different-captured-classifications-stay-isolated
+  (testing "two reactions sharing a sub id but capturing different declarations
+            (two live frames / an HMR successor) project independently"
+    (let [frame-a (project-sub-run {:rf.sub/id :shared/id
+                                    :rf.sub/value {:token "A"}
+                                    :rf.sub/classification {:sensitive [[:token]]}})
+          frame-b (project-sub-run {:rf.sub/id :shared/id
+                                    :rf.sub/value {:token "B"}
+                                    :rf.sub/classification {}})]
+      (is (= privacy/redacted-sentinel (get-in frame-a [:rf.sub/value :token])))
+      (is (= "B" (get-in frame-b [:rf.sub/value :token]))))))
+
+(deftest absent-carrier-falls-back-to-registrar-resolution
+  (testing "a :rf.sub/run trace with NO captured carrier (a non-memo path) still
+            redacts via the registrar — the fallback is preserved"
+    (rf/reg-sub :fallback/s {:sensitive [[:token]]} (fn [db _] db))
+    (let [out (project-sub-run {:rf.sub/id :fallback/s
+                                :rf.sub/value {:token "SECRET"}})]  ;; no carrier
+      (is (= privacy/redacted-sentinel (get-in out [:rf.sub/value :token]))))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end — a real sensitive sub: subscriber RAW, projected trace REDACTED
+;; ---------------------------------------------------------------------------
+
+(defn- captured-sub-runs [recorded sub-id]
+  (filterv (fn [ev] (and (= :rf.sub/run (:operation ev))
+                         (= sub-id (get-in ev [:tags :rf.sub/id]))))
+           @recorded))
+
+(deftest subscriber-reads-raw-while-projected-sub-run-trace-redacts
+  (rf/reg-event :sec/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :token v)}))
+  (rf/reg-sub :sec/read {:sensitive [[:token]]} (fn [db _] {:token (:token db)}))
+  (let [recorded (atom [])]
+    (rf/register-listener! :trace :sec-e2e (fn [ev] (swap! recorded conj ev)))
+    (try
+      (rf/dispatch-sync [:sec/seed "secret-1"])
+      ;; ongoing reactive read #1 — a compute emits :rf.sub/run
+      (is (= {:token "secret-1"} @(rf/subscribe [:sec/read]))
+          "the subscriber derefs the RAW value")
+      ;; ongoing reactive read #2 — value change drives a recompute
+      (rf/dispatch-sync [:sec/seed "secret-2"])
+      (is (= {:token "secret-2"} @(rf/subscribe [:sec/read]))
+          "the recomputed subscriber value is still RAW")
+      (let [runs (captured-sub-runs recorded :sec/read)]
+        (is (seq runs) "at least one :rf.sub/run trace was captured")
+        (doseq [ev runs]
+          (is (= privacy/redacted-sentinel
+                 (get-in ev [:tags :rf.sub/value :token]))
+              "every projected :rf.sub/run redacts the sensitive path")
+          (is (not (contains? (:tags ev) :rf.sub/classification))
+              "the internal carrier never reaches a listener")))
+      (finally
+        (rf/unregister-listener! :trace :sec-e2e)))))

--- a/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
@@ -1,0 +1,103 @@
+(ns re-frame.subs-inline-normalization-cljs-test
+  "rf2-vxgfnd.219 — inline `:reg-sub` metadata is normalized through the SAME
+  registrar contract as public `reg-sub` (EP-0026 — neither looser nor stricter).
+
+  `re-frame.subs/lower-inline-sub` (the `:image/lower-inline-sub` lowering an
+  image's inline `:reg-sub` descriptor runs) previously projected the raw
+  metadata map straight onto the runnable descriptor, bypassing the retired-key
+  guard, the classification validator, and the production `:doc` strip that
+  public `reg-sub` runs. This suite pins the parity: a retired `:spec` key
+  hard-errors on BOTH paths, a malformed `:sensitive` / `:large` declaration
+  raises on BOTH, a valid declaration survives identically, production strips
+  `:doc`, and the runtime-owned runnable slots win over any metadata that names
+  them. A mutation restoring the direct `(assoc metadata …)` fails these rows.
+
+  `.cljc` — the normalizer is host-agnostic, so this runs under both
+  `clojure -M:test` (JVM) and `npm run test:cljs` (node CLJS)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.subs :as subs]
+            [re-frame.registrar :as registrar]
+            [re-frame.interop :as interop]
+            [re-frame.test-support :as test-support]))
+
+(defn- reset-registry [test-fn]
+  (let [snapshot (test-support/snapshot-registrar)]
+    (registrar/clear-all!)
+    (try (test-fn)
+         (finally (test-support/restore-registrar! snapshot)))))
+
+(use-fixtures :each reset-registry)
+
+(defn- caught-ex-data
+  "Run `f`; return the ex-data of an ExceptionInfo it throws, or nil if it
+  returns normally."
+  [f]
+  (try (f) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (ex-data e))))
+
+(def ^:private body (fn [_db _q] :ok))
+
+;; ---- retired bare key (`:spec`) — HARD ERROR on BOTH paths ----------------
+
+(deftest retired-spec-key-hard-errors-on-inline-and-public
+  (testing "public reg-sub and inline lower-inline-sub BOTH reject the retired
+            `:spec` bare key with the same discriminator + named replacement"
+    (let [pub    (caught-ex-data #(subs/reg-sub :norm/pub-retired {:spec [:map]} body))
+          inline (caught-ex-data #(subs/lower-inline-sub {:spec [:map]} body))]
+      (doseq [[label ed] [["public" pub] ["inline" inline]]]
+        (testing label
+          (is (some? ed) "must throw")
+          (is (= :rf.error/retired-registration-key (:rf.error/id ed)))
+          (is (= :spec (:retired-key ed)))
+          (is (= :schema (:replacement ed)) "names the v2 key `:schema`"))))))
+
+;; ---- malformed classification — HARD ERROR on BOTH paths ------------------
+
+(deftest bad-classification-hard-errors-on-inline-and-public
+  (testing "public and inline BOTH reject a malformed `:sensitive` declaration"
+    (let [pub    (caught-ex-data #(subs/reg-sub :norm/pub-badcls {:sensitive :wrong} body))
+          inline (caught-ex-data #(subs/lower-inline-sub {:sensitive :wrong} body))]
+      (doseq [[label ed] [["public" pub] ["inline" inline]]]
+        (testing label
+          (is (some? ed) "must throw")
+          (is (= :rf.error/bad-classification (:rf.error/id ed))))))))
+
+(deftest valid-classification-survives-identically-on-both-paths
+  (testing "a valid `:sensitive` declaration survives on BOTH paths, at the same
+            top-level slot — the descriptor and registrar entry agree"
+    (subs/reg-sub :norm/pub-cls {:sensitive [[:token]]} body)
+    (let [pub-meta   (registrar/handler-meta :sub :norm/pub-cls)
+          inline-desc (subs/lower-inline-sub {:sensitive [[:token]]} body)]
+      (is (= [[:token]] (:sensitive pub-meta)))
+      (is (= [[:token]] (:sensitive inline-desc))
+          "inline descriptor carries the SAME classification declaration"))))
+
+;; ---- production `:doc` strip parity ---------------------------------------
+
+(deftest doc-stripped-in-production-retained-in-dev-on-inline-path
+  (testing "dev (default gate on) retains `:doc` for tooling / agent inspection"
+    (let [desc (subs/lower-inline-sub {:doc "kept in dev"} body)]
+      (is (= "kept in dev" (:doc desc)))))
+  (testing "production (gate off) strips `:doc` from the inline runnable
+            descriptor, exactly as the public registrar does"
+    (with-redefs [interop/debug-enabled? false]
+      (let [desc (subs/lower-inline-sub {:doc "elided in prod" :schema :int} body)]
+        (is (not (contains? desc :doc)) ":doc absent from the inline descriptor in prod")
+        (is (= :int (:schema desc)) "a load-bearing key like :schema is retained")))))
+
+;; ---- runtime-owned slots win + extension keys preserved -------------------
+
+(deftest runtime-owned-slots-win-over-metadata
+  (testing "the runnable slots are installed AFTER normalization, so metadata
+            naming them cannot override the runtime-owned values"
+    (let [desc (subs/lower-inline-sub {:input-kind :parametric :input-signals [:x]} body)]
+      (is (= body (:handler-fn desc)) ":handler-fn is the lowered impl")
+      (is (= :db (:input-kind desc)) ":input-kind is the layer-1 :db, not the metadata's")
+      (is (= [] (:input-signals desc)) ":input-signals is empty, not the metadata's"))))
+
+(deftest namespaced-extension-keys-survive-on-inline-path
+  (testing "namespaced extension keys pass normalization untouched (the open-map
+            carve-out), matching public reg-sub"
+    (let [desc (subs/lower-inline-sub {:myapp/analytics-id 7} body)]
+      (is (= 7 (:myapp/analytics-id desc))))))

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -579,11 +579,28 @@
                               {:form f :macro head})
 
                    :else
+                   ;; A generic invocation. Clojure evaluates the CALLEE before
+                   ;; its arguments, so the callee position is an ordinary
+                   ;; evaluated expression that can host a reactive site:
+                   ;;
+                   ;;   ((if (sub [:op]) inc dec) 1)   ; sub in a computed callee
+                   ;;
+                   ;; A simple symbol/keyword head is not itself an evaluated
+                   ;; expression (a plain fn/special-form name, a keyword lookup
+                   ;; op) and cannot contain a nested site — preserve it verbatim.
+                   ;; A COMPUTED callee (seq/vector/map/set) IS evaluated, so
+                   ;; rewrite it under a stable `:callee` token — BEFORE the
+                   ;; arguments, matching evaluation order — so a visible `(sub …)`
+                   ;; there lowers to its indexed site (or an immediately-invoked
+                   ;; fn / opaque-macro callee is rejected didactically by the
+                   ;; binder/deferred/macro rules `rw` already applies). It must
+                   ;; never survive as a public `ui/sub` with an empty manifest.
                    (with-same-meta
                      f
-                     ;; The call head is not an evaluated argument and cannot
-                     ;; itself contain a reactive site. Preserve it verbatim.
-                     (apply list head
+                     (apply list
+                            (if (or (symbol? head) (keyword? head))
+                              head
+                              (rw head locals (conj p :callee)))
                             (map-indexed #(rw %2 locals (conj p (inc %1)))
                                          (rest f))))))
 

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -198,6 +198,43 @@
     (is (= 2 (count (:subs sites))))
     (is (= [[:title]] (map :query (take 1 (:subs sites)))))))
 
+(deftest computed-callee-subs-index-into-the-manifest
+  ;; rf2-vxgfnd.217 — Clojure evaluates a COMPUTED callee before its arguments,
+  ;; so the function/callee position is an ordinary evaluated expression that can
+  ;; host a finite render-time (sub …). It must be rewritten + indexed under a
+  ;; stable :callee token, never preserved verbatim with an empty manifest (which
+  ;; leaves a public ui/sub as an unlowered call at runtime).
+  (testing "an (if …) computed callee with one sub → exactly one indexed site"
+    (let [{:keys [sites]} (ana-full '[:div {:title ((if (sub [:op]) inc dec) 1)}])
+          site (first (:subs sites))]
+      (is (= 1 (count (:subs sites))))
+      (is (= [:op] (:query site)))
+      (is (some? (:sid site)) "the site carries a deterministic compiler-owned sid")
+      (is (some #{:callee} (:expr-path site))
+          "the site is credited to the callee position, not an argument")))
+  (testing "a str-wrapped computed callee in a child expression indexes too"
+    (let [{:keys [sites]} (ana-full '[:p (str ((if (sub [:operation]) inc dec) 1))])]
+      (is (= 1 (count (:subs sites))))
+      (is (= [[:operation]] (map :query (:subs sites))))))
+  (testing "computed vector / map / set callee expressions index their visible subs"
+    (is (= 1 (count (:subs (:sites (ana-full '[:div {:title ([(sub [:a]) dec] 0)}]))))))
+    (is (= 1 (count (:subs (:sites (ana-full '[:div {:title ({(sub [:k]) :v} :x)}]))))))
+    (is (= 1 (count (:subs (:sites (ana-full '[:div {:title (#{(sub [:s])} 1)}])))))))
+  (testing "the callee-site sid is host-portable (CLJ == CLJS) and finite"
+    (let [tmpl  '[:div {:title ((if (sub [:op]) inc dec) 1)}]
+          clj   (analyze-site-fixture :clj  {:line 10 :column 1} tmpl)
+          cljs  (analyze-site-fixture :cljs {:line 10 :column 1} tmpl)
+          sid   #(get-in % [:sites :subs 0 :sid])]
+      (is (= 1 (count (get-in clj [:sites :subs]))))
+      (is (= (sid clj) (sid cljs))
+          "host is not part of the callee site's lexical identity")))
+  (testing "a plain symbol head keeps its ordinary (non-callee) argument paths"
+    (let [{:keys [sites]} (ana-full '[:div {:title (str (sub [:s]))}])
+          site (first (:subs sites))]
+      (is (= 1 (count (:subs sites))))
+      (is (not (some #{:callee} (:expr-path site)))
+          "a symbol head is preserved verbatim — no :callee token is minted"))))
+
 (deftest lexical-site-id-is-portable-stable-and-query-independent
   (let [template-a [:div (located-sub 102 8 [:item/by-id 'id])]
         template-b [:div (located-sub 202 8 [:item/by-id 'id])]

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -81,6 +81,15 @@
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (-> [:q] sub)}]))
       "a macro cannot turn a bare resolved sub reference into an unindexed call")
+  ;; rf2-vxgfnd.217 — a COMPUTED callee is an evaluated position, so it is
+  ;; analyzed under the same rules; a callee that cannot own a finite site is
+  ;; rejected didactically rather than silently swallowing an invisible read.
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:div {:title ((fn [_] (sub [:q])) 1)}]))
+      "an immediately-invoked fn callee with a reactive body is a deferred site")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title ((-> [:q] sub) 1)}]))
+      "a bare sub reference under a macro in the callee position fails loudly too")
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '(let [{:keys [x] :or {x (sub [:q])}} value] [:div x]))))
   (is (= :rf.ui.compile/unsupported-form

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -191,9 +191,16 @@ expression grammar is therefore **closed**:
   indexed site. A **bare** `sub`/`lease` **reference** below one is rejected: a
   threading step such as `(-> query sub)` would become an unindexed reactive call only
   after expansion, so the explicit `(sub query)` call is required.
-- **Ordinary function calls** — any function. The call head is not an evaluated
-  argument and cannot itself contain a reactive site, so it is preserved verbatim and
-  the arguments are analyzed. Helpers stay helpers: pass reactive **values** in.
+- **Ordinary function calls** — any function. A **simple** symbol/keyword head (a
+  plain fn/special-form name, a keyword lookup op) is not itself an evaluated
+  expression, so it is preserved verbatim and the arguments are analyzed. A
+  **computed callee** — a seq/vector/map/set in head position, e.g.
+  `((if (sub [:op]) inc dec) 1)` — IS evaluated (Clojure evaluates the callee before
+  its arguments), so it is analyzed under the same rules **before** the arguments: a
+  visible `(sub …)` there lowers to its indexed site, and an immediately-invoked-fn /
+  opaque-macro callee that could hide a read is rejected didactically. A visible
+  reactive site is never dropped from the manifest. Helpers stay helpers: pass
+  reactive **values** in.
 - **Every other macro is rejected at compile time** — `:rf.ui.compile/unsupported-form`,
   didactically: *macro X is outside the compiler's audited expression set and could
   inject, duplicate, or defer a reactive call after lexical site analysis; rewrite it


### PR DESCRIPTION
The inline-subscription pipeline cluster — three P1 findings on the path from
the compiler's `(sub …)` rewrite through registrar normalization to trace
projection. Disjoint files, one coherent theme. All three repros re-verified
live on fresh `origin/main` before the fix.

## rf2-vxgfnd.217 — rewrite reactive sites in computed callee positions

`implementation/ui/src/re_frame/ui/compiler/analyze.cljc` preserved a generic
call's head verbatim and rewrote only the arguments, on the premise that a call
head "cannot itself contain a reactive site." Clojure evaluates a **computed
callee** before its arguments, so `((if (sub [:op]) inc dec) 1)` hides a finite
render-time `(sub …)` the compiler dropped from the manifest — emitting no sid
and declaring the view sub-free, leaving a public `ui/sub` as an unlowered
runtime call.

Fix: rewrite the callee under a stable `:callee` token **before** the arguments
when it is a computed seq/vector/map/set; a simple symbol/keyword head stays
verbatim. The recursion reuses the existing binder/deferred/macro rules, so a
visible sub lowers to its indexed site and an IIFE / opaque-macro callee is
rejected didactically (`sub-in-loop` / `unsupported-form`). Also revises
`spec/004-Views.md` §Ordinary function calls, which taught the false evaluation
law (required by the bead NOTES — same causal defect, no separate docs bead).

Red-before-fix fixture: `computed-callee-subs-index-into-the-manifest`
(analyze_accept) — if/vector/map/set callees index exactly one host-portable
sid under a `:callee` path; two `finite-sites` reject rows for the IIFE and
bare-sub-under-macro callees.

## rf2-vxgfnd.219 — normalize inline sub metadata through the registrar contract

`re-frame.subs/lower-inline-sub` projected raw inline metadata straight onto the
runnable descriptor, bypassing public `reg-sub`'s contract: a retired `{:spec …}`
threw on `reg-sub` but assembled inline; a malformed `{:sensitive :wrong}` threw
on `reg-sub` but subscribed inline; and the inline descriptor kept dev-only
`:doc` in production.

Fix: one side-effect-free `normalize-sub-metadata` seam (retired/unknown key
validation + `:sensitive`/`:large` classification validation + the production
`:doc` strip) shared by public `reg-sub` and `lower-inline-sub`. Runtime-owned
slots are installed after normalization, so metadata cannot override them.

Red-before-fix fixture: `subs_inline_normalization_cljs_test` (.cljc, both
hosts) — retired-key + bad-classification parity, valid-classification identical
survival, dev/prod `:doc`, runtime-slots-win, namespaced-extension survival.

## rf2-vxgfnd.220 — project inline sub traces from captured image-local classification

The `:rf.sub/run` trace re-resolved classification through the ambient registrar
by sub-id at projection time. For an image-local sub that registrar had no entry
(or a conflicting same-id global) after the frame-generation binding unwinds
(one-shot deref) or across HMR/incarnation replacement (an ongoing reaction), so
an author-declared `:sensitive` value egressed RAW at `:rf.sub/value`.

Fix: the reaction already captures the authoritative `sub-meta`; carry that
reaction's classification declaration through the trace chokepoint under an
internal `:rf.sub/classification` slot (`re-frame.subs.memo`) and have
`project-sub-tags` (`re-frame.classification`) project from it — authoritative
even when empty, so a conflicting global can neither supply nor override — then
strip the carrier before egress. Absence falls back to the registrar resolution.
Raw values still reach the subscriber; only observability is redacted.

Red-before-fix fixture: `subs_image_local_classification_cljs_test` (.cljc, both
hosts) — image-local sensitive/large redaction with NO global, conflicting
global cannot supply/override (both directions), same-id different-captured
isolation, carrier stripped, absence-fallback, and an end-to-end sensitive-sub
subscription (subscriber RAW, projected `:rf.sub/run` REDACTED across an ongoing
recompute).

## Quality gates

All foreground, all green:

| Gate | Result |
| --- | --- |
| `implementation/core` JVM (`clojure -M:test`) | 1947 tests, 8865 assertions, 0 failures, 0 errors |
| `implementation/ui` JVM (`clojure -M:test`) | 475 tests, 6246 assertions, 0 failures, 0 errors |
| `implementation` CLJS node (`npm run test:cljs`) | 9313 tests, 44123 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` (spine + markdown gates) | PASS (mkdocs soft-skipped locally — not on PATH; CI runs it) |

The ui suite (the inline-sub consumer) and the CLJS reactive/ViewCell path both
stay green, proving the subs-pipeline changes (.219/.220) don't perturb
`reactive.cljc`.
