### PR TITLE
fix(machines): join/completion incarnation fencing — post-loss tails, exact-authority join selection, authority through replay (rf2-3evq0x/wsrtlw/t154jx)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -47,6 +47,7 @@
             [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
+            [re-frame.machines.lifecycle-fx.join :as join]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
@@ -295,6 +296,10 @@
   {:doc "Dispatch an event to a spawned actor addressed by `:system-id`. Emit `[:rf.machine/dispatch-to-system [<system-id> <event-vector>]]` from a machine action's `:fx` vector. No-op when the system-id is unbound. The single named-addressing escape (advanced/parity tier); zero in-repo consumers, retained for XState v6 actor-system parity. Per Spec 005 §Cross-machine messaging by name."}
   dispatch-to-system-fx)
 
+(fx/reg-fx :rf.machine/join-dispatch
+  {:doc "Machine-internal (rf2-t154jx): the recordable transport for a `:spawn-all` child's completion carrier. The runtime rewrites a member child's own outbound `:dispatch` / `:dispatch-later` completion into this fx so the exact-authority tuple rides the recordable `:rf.cofx` `:rf.machine/join-auth` fact (surviving strict replay + delayed dispatch), not event metadata. Not for direct application use. Per Spec 005 §Spawn-and-join via :spawn-all."}
+  join/join-dispatch-fx)
+
 ;; ---- framework-shipped subs -----------------------------------------------
 ;;
 ;; Per Spec 005 §Subscribing to machines via the :rf/machine sub: the
@@ -355,6 +360,7 @@
            [:fx  :rf.machine/after-cancel]
            [:fx  :rf.machine/update-snapshot]
            [:fx  :rf.machine/dispatch-to-system]
+           [:fx  :rf.machine/join-dispatch]
            [:sub :rf/machine]
            [:sub :rf.machine/has-tag?]])))
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -226,7 +226,21 @@
                         ;; shared via `traces/emit-destroy-exit-failure!`.
                         (traces/emit-destroy-exit-failure!
                           machine-id frame-id (result/info exit-result)))]
-  (let [child-data (:data next-snapshot)
+  (let [;; A's exact-frame-incarnation continuation predicate (rf2-3evq0x —
+        ;; the completion-tail half of the incarnation-fencing family
+        ;; established by #5849). The completion-output validator, the
+        ;; `:rf.machine/done` trace fan-out, and the parent `:on-done` callback
+        ;; are all APPLICATION / listener code that can synchronously destroy
+        ;; the frame incarnation A that owns the in-flight event and publish a
+        ;; same-id successor B. Every subsequent framework-owned action —
+        ;; teardown, registrar unregister, HTTP/timer cancellation,
+        ;; classification/spawn-order drop, the `:on-error` dispatch, and the
+        ;; runtime-db / fx publication — is A-derived tail; running it after A
+        ;; is lost erases or mutates B. `owner-continuation` yields
+        ;; `(constantly true)` for a non-router pure-fn / conformance caller
+        ;; (no event owner), so that path stays unaffected.
+        continue?  (data-validation/owner-continuation frame-id)
+        child-data (:data next-snapshot)
         parallel?  (parallel/parallel? machine)
         ;; Resolve the ERROR-classifying leaf. For a PARALLEL
         ;; machine, scan EVERY region's final leaf — a parallel finish is an
@@ -268,7 +282,19 @@
         ;; cascade, so the `[:schemas :output]` schema resolves off it without
         ;; a registrar / snapshot lookup. Production-elided
         ;; (`interop/debug-enabled?`-gated inside the validator).
-        _           (data-validation/validate-completion-output! machine-id machine result)
+        ;; The completion-output validator is APPLICATION code (rf2-3evq0x): a
+        ;; validator that destroys A / publishes same-id B returns
+        ;; `:rf/stale-incarnation` (NOT a schema verdict). Capture it — the
+        ;; original `_` binding dropped the verdict and let the whole finalize
+        ;; tail run against B. A stale return terminally fences every
+        ;; subsequent framework-owned action below (the `owner-gone?` gate).
+        output-validation (data-validation/validate-completion-output! machine-id machine result)
+        stale-output?     (= :rf/stale-incarnation output-validation)
+        ;; Re-checked (live) after each callback-bearing completion trace /
+        ;; fanout and before every framework-owned action: true once the
+        ;; completion-output validator, a `:rf.machine/done` trace listener, or
+        ;; the parent `:on-done` callback has destroyed A / published same-id B.
+        owner-gone?       (fn [] (or stale-output? (not (continue?))))
         ;; Per Spec 005 §Final states §`:on-error` (XState v5 invoke
         ;; `onError`): a `:final?` leaf MAY also declare `:error? true` — a
         ;; designated ERROR terminal. When a `:spawn`-spawned child finishes
@@ -402,7 +428,12 @@
         done-summary (if stale-spawn?
                        (m-reply/stale-spawn-trace reply {:frame frame-id})
                        (m-reply/trace-reply reply {:frame frame-id}))
-        _ (trace/emit! :rf.machine :rf.machine/done
+        ;; The `:rf.machine/done` trace fan-out is callback-bearing
+        ;; (rf2-3evq0x): a listener can destroy A / publish same-id B. Skip it
+        ;; when A is already gone (a stale completion-output validator), and
+        ;; re-check liveness after it before any framework-owned action below.
+        _ (when-not (owner-gone?)
+            (trace/emit! :rf.machine :rf.machine/done
                        ;; `:actor-id` is the finishing actor's
                        ;; live INSTANCE address (singleton: its registration
                        ;; id; spawned: the `<type>#<n>` / fixed instance id).
@@ -434,7 +465,7 @@
                          ;; ADDITIVELY only for a stale late completion, joined
                          ;; to `:rf.reply/work-id` via the shared `:rf.reply/*` facts.
                          stale-spawn? (assoc :rf.reply/stale-reason (:rf.reply/stale-reason done-summary)
-                                             :rf.reply/correlation  (:correlation done-summary))))
+                                             :rf.reply/correlation  (:correlation done-summary)))))
         ;; (3) Apply :on-done to the parent's `:data`. The parent's
         ;; snapshot lives at [:rf.runtime/machines :snapshots <parent-id>]; we read it,
         ;; pass the unified context-map (`{:data :result}`) to
@@ -464,7 +495,11 @@
         ;; the one canonical reply map so the value the trace/ledger see and
         ;; the value the callback receives are the SAME fact.
         db-after-on-done
-        (if (and on-done-fn parent-id (not on-error?) (not stale-spawn?))
+        ;; `:on-done` is an application callback (rf2-3evq0x) — skip it once A
+        ;; is gone (a stale validator or a `:rf.machine/done` listener that
+        ;; destroyed A); its parent-`:data` write must not land under B.
+        (if (and on-done-fn parent-id (not on-error?) (not stale-spawn?)
+                 (not (owner-gone?)))
           (let [parent-data     (:data parent-snap)
                 new-parent-data (try
                                   (on-done-fn {:data parent-data :result (:value reply)})
@@ -514,95 +549,84 @@
             (if (and parent-snap (some? new-parent-data))
               (assoc-in runtime-db (conj parent-path :data) new-parent-data)
               runtime-db))
-          runtime-db)
-        ;; (4) Apply the unified teardown projection:
-        ;; dissoc the child's snapshot, release any `:system-id`
-        ;; reverse-index entry (D8 — after on-done ran), and clear the
-        ;; parent's `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot with
-        ;; the lazy-allocation prune. Returns `[new-db released-sid]`;
-        ;; `released-sid` is resolved against db-after-on-done before
-        ;; the reverse index is mutated.
-        [db-after-destroy released-sid]
-        (teardown/teardown-actor db-after-on-done
-                                 {:actor-id  machine-id
-                                  :parent-id parent-id
-                                  :invoke-id invoke-id})
-        ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
-        ;; (D6 enrichment) before registrar cleanup.
-        _ (traces/emit-destroyed! {:frame     frame-id
-                                   :actor-id  machine-id
-                                   :system-id released-sid
-                                   :parent-id parent-id
-                                   :invoke-id invoke-id
-                                   :reason    :rf.machine/finished})]
-    ;; (6) Synchronous side effects: abort in-flight HTTP, cancel
-    ;; armed `:after` timers (`:reason :on-destroy`), emit
-    ;; system-id-released trace (when applicable), and clear any registrar entry.
-    (abort-actor-in-flight-http! machine-id)
-    (timer/cancel-actor-timers! frame-id machine-id)
-    ;; Drop this actor's per-instance classification declarations from the
-    ;; per-frame elision registry: the
-    ;; teardown half of `classification/lower-at-spawn!`, on the final-state
-    ;; AUTO-DESTROY path (which does NOT route through
-    ;; `destroy/teardown-live-actor!`). `machine` is the finishing actor's
-    ;; runtime-stamped spec; a spec that declared no classification is a clean
-    ;; no-op, so the registry entry added at spawn dies with the instance (no
-    ;; leak).
-    (classification/drop-at-destroy! frame-id machine-id machine)
-    ;; Forget the finished actor from the per-frame spawn-order channel —
-    ;; the ONE synchronous teardown side-effect the `:final?`-auto-destroy
-    ;; path shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).
-    ;; `spawn-order/frame-order` is `actor-live?`'s "most reliable
-    ;; alive-or-gone bit" (destroy.cljc:83); without this call a finished
-    ;; actor stays recorded → a later stale `[:rf.machine/destroy id]` sees
-    ;; it live → `teardown-live-actor!` RE-RUNS (phantom `:rf.machine/destroyed`
-    ;; trace + re-fired resource release, violating silent-idempotent destroy)
-    ;; and frame-destroy emits a phantom straggler destroy for it. Matches the
-    ;; exact `(frame-id actor-id)` args destroy.cljc uses, so the forget! runs
-    ;; atomically per finalize-machine — the invariant destroy.cljc:306-308
-    ;; already documents.
-    (spawn-order/forget! frame-id machine-id)
-    (traces/emit-system-id-released! frame-id released-sid machine-id)
-    (registrar/unregister! :event machine-id)
-    ;; (7) Per Spec 005 §Final states §`:on-error`: when the child
-    ;; finished via an ERROR leaf AND the spawning parent declares
-    ;; `:spawn :on-error`, dispatch the synthetic reserved failure event into
-    ;; the parent. It resolves natively through the parent's macrostep
-    ;; (`pick-spawn-error-transition`), firing the declarative `:on-error`
-    ;; transition (target / guard / actions) with the error payload on
-    ;; `:event` — the XState `invoke onError` control flow. Dispatched (not
-    ;; raised) because the parent is a SEPARATE actor with its own handler /
-    ;; snapshot — symmetric with how the spawn fx dispatches `:start` into the
-    ;; child. The teardown above already ran (the child auto-destroys on its
-    ;; error leaf, like any `:final?`); this only ROUTES the failure.
-    ;;
-    ;; Per EP-0011 §Machine Completion this is the `:status :error` reply
-    ;; driving the `:on-error` transition. The dispatched payload is the RAW
-    ;; error (`result`) — the PUBLIC contract: the parent transition reads it
-    ;; off `:event` (`(nth ev 2)`). The canonical reply map (`reply`, built
-    ;; above) classifies the completion as `:status :error` for the trace /
-    ;; ledger; the parent transition's observable payload is unchanged. The
-    ;; reply's `:error` slot is `{:kind … :value result}` (the family-`:kind`
-    ;; wrapping the reply-map schema requires) — but that wrapping is
-    ;; internal vocabulary, not what the parent transition sees.
-    (when on-error?
-      (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
-    ;; Machine snapshots are durable runtime-db state (EP-0001):
-    ;; the finalize teardown is a runtime-db write, returned under
-    ;; `:rf.db/runtime` (the framework-authority partition effect), NOT `:db`.
-    {:rf.db/runtime db-after-destroy
-     ;; Append the destroy-time `:exit` cascade's fx to
-     ;; the transition's fx vector so any `:exit`-emitted dispatches /
-     ;; HTTP / etc. fire as part of the same epoch.
-     ;;
-     ;; Also append the resource-lease release for this actor's
-     ;; `[:machine machine-id]` owner so the `:final?`-state auto-destroy
-     ;; releases its leases too (the explicit-destroy / spawn-cascade /
-     ;; frame-destroy paths release via `teardown-live-actor!`; finalize is the
-     ;; one teardown that returns an `:fx` vector rather than firing fx
-     ;; imperatively, so it appends the entry here). nil + filtered out when
-     ;; resources is absent (the no-resources guard) — see
-     ;; `resource-release/release-fx-entry`.
-     :fx (vec (concat extra-fx exit-fx
-                      (when-let [e (resource-release/release-fx-entry machine-id)]
-                        [e])))})))
+          runtime-db)]
+    ;; rf2-3evq0x — terminal incarnation fence for the completion tail. If a
+    ;; completion-output validator, a `:rf.machine/done` trace listener, or the
+    ;; parent `:on-done` callback destroyed A / published same-id B, EVERY action
+    ;; below is A-derived framework-owned tail that would erase or mutate B: the
+    ;; teardown projection (dissoc B's snapshot / clear its slot), the
+    ;; `:rf.machine/destroyed` trace, the HTTP/timer cancellation, the
+    ;; classification + spawn-order drop, the registrar unregister, the
+    ;; `:on-error` dispatch, and the runtime-db / fx publication. Return the
+    ;; inert outcome — runtime-db untouched, no fx — before ANY of them.
+    ;; Already-delivered callbacks stand (no rollback); the router's own
+    ;; candidate fence drops the inert runtime-db rather than committing it onto
+    ;; B. (`stale-spawn?` — a child finishing after its PARENT was destroyed — is
+    ;; a DIFFERENT staleness and still tears down normally; `owner-gone?` fires
+    ;; only on A→B frame-incarnation loss.)
+    (if (owner-gone?)
+      {:rf.db/runtime runtime-db :fx []}
+      (let [;; (4) Apply the unified teardown projection: dissoc the child's
+            ;; snapshot, release any `:system-id` reverse-index entry (D8 —
+            ;; after on-done ran), and clear the parent's
+            ;; `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot
+            ;; with the lazy-allocation prune. Returns `[new-db released-sid]`;
+            ;; `released-sid` is resolved against db-after-on-done before the
+            ;; reverse index is mutated.
+            [db-after-destroy released-sid]
+            (teardown/teardown-actor db-after-on-done
+                                     {:actor-id  machine-id
+                                      :parent-id parent-id
+                                      :invoke-id invoke-id})
+            ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
+            ;; (D6 enrichment) before registrar cleanup.
+            _ (traces/emit-destroyed! {:frame     frame-id
+                                       :actor-id  machine-id
+                                       :system-id released-sid
+                                       :parent-id parent-id
+                                       :invoke-id invoke-id
+                                       :reason    :rf.machine/finished})]
+        ;; (6) Synchronous side effects: abort in-flight HTTP, cancel armed
+        ;; `:after` timers (`:reason :on-destroy`), emit system-id-released trace
+        ;; (when applicable), and clear any registrar entry.
+        (abort-actor-in-flight-http! machine-id)
+        (timer/cancel-actor-timers! frame-id machine-id)
+        ;; Drop this actor's per-instance classification declarations from the
+        ;; per-frame elision registry — the teardown half of
+        ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
+        ;; (which does NOT route through `destroy/teardown-live-actor!`). A spec
+        ;; that declared no classification is a clean no-op, so the registry
+        ;; entry added at spawn dies with the instance (no leak).
+        (classification/drop-at-destroy! frame-id machine-id machine)
+        ;; Forget the finished actor from the per-frame spawn-order channel — the
+        ;; ONE synchronous teardown side-effect the `:final?`-auto-destroy path
+        ;; shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).
+        ;; Without it a finished actor stays recorded → a later stale
+        ;; `[:rf.machine/destroy id]` sees it live → `teardown-live-actor!`
+        ;; RE-RUNS (phantom destroyed trace + re-fired resource release,
+        ;; violating silent-idempotent destroy) and frame-destroy emits a
+        ;; phantom straggler destroy for it.
+        (spawn-order/forget! frame-id machine-id)
+        (traces/emit-system-id-released! frame-id released-sid machine-id)
+        (registrar/unregister! :event machine-id)
+        ;; (7) Per Spec 005 §Final states §`:on-error`: when the child finished
+        ;; via an ERROR leaf AND the spawning parent declares `:spawn :on-error`,
+        ;; dispatch the synthetic reserved failure event into the parent. It
+        ;; resolves natively through the parent's macrostep
+        ;; (`pick-spawn-error-transition`), firing the declarative `:on-error`
+        ;; transition — the XState `invoke onError` control flow. The teardown
+        ;; above already ran (the child auto-destroys on its error leaf, like any
+        ;; `:final?`); this only ROUTES the failure. The dispatched payload is
+        ;; the RAW error (`result`); the parent transition reads it off `:event`.
+        (when on-error?
+          (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
+        ;; Machine snapshots are durable runtime-db state (EP-0001): the finalize
+        ;; teardown is a runtime-db write, returned under `:rf.db/runtime` (the
+        ;; framework-authority partition effect), NOT `:db`. Append the
+        ;; destroy-time `:exit` cascade's fx + the resource-lease release for
+        ;; this actor's `[:machine machine-id]` owner (nil + filtered out when
+        ;; resources is absent — see `resource-release/release-fx-entry`).
+        {:rf.db/runtime db-after-destroy
+         :fx (vec (concat extra-fx exit-fx
+                          (when-let [e (resource-release/release-fx-entry machine-id)]
+                            [e])))})))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -49,7 +49,10 @@
   the handler-factory in `re-frame.machines.lifecycle-fx.registration`
   routes every inbound event through it before the machine's normal `:on`
   lookup."
-  (:require [re-frame.machines.parallel :as parallel]
+  (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines.parallel :as parallel]
             [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.reply :as m-reply]
@@ -64,7 +67,7 @@
 (declare intercept-fold)
 
 ;; ---------------------------------------------------------------------------
-;; Attempt authentication (rf2-nvxehu).
+;; Attempt authentication (rf2-nvxehu) + recordable transport (rf2-t154jx).
 ;;
 ;; A `:spawn-all` child's completion carrier is the PUBLIC event shape
 ;; `[<parent-id> [<done-kw> <child-id> & extra]]` — it carries no actor or
@@ -75,19 +78,33 @@
 ;; `:rf/join-child` membership record (parent/invoke identity, logical child
 ;; id, its own spawned instance address, the join's completion event
 ;; keywords, and the opaque per-attempt token `spawn-all-init-fx` minted into
-;; the join state). When the child's own handler emits a matching completion
-;; dispatch, `stamp-join-completion-fx` (called at the handler-return
-;; boundary in `registration.cljc`) stamps that record onto the INNER event
-;; vector's METADATA under `:rf/join-auth` — the public event value is
-;; untouched, no application-facing surface is added, and only a dispatch
-;; that flowed through the member child's own boundary can carry the stamp.
+;; the join state).
+;;
+;; TRANSPORT (rf2-t154jx). When the child's own handler emits a matching
+;; completion dispatch, `stamp-join-completion-fx` (called at the handler-return
+;; boundary in `registration.cljc`) REWRITES that outbound `:dispatch` /
+;; `:dispatch-later` completion into the framework-internal `:rf.machine/
+;; join-dispatch` fx, which re-dispatches the UNCHANGED public completion event
+;; with the exact-authority tuple attached as the RECORDABLE causal-envelope
+;; fact `:rf.machine/join-auth` on the dispatch's `:rf.cofx`. That channel is
+;; part of the event/coeffect recording + strict-replay contract and is
+;; preserved through delayed dispatch — UNLIKE event-vector metadata, which an
+;; EDN round-trip (strict replay) drops and which the retired `:dispatch-n` /
+;; delayed paths never carried. The parent reads the auth back off its `:rf/cofx`
+;; (`carrier-auth`); metadata is accepted only as a test-forged / immediate
+;; internal handoff fallback. The public event value is untouched, no
+;; application control surface is added (a reserved-`:rf.machine/*` fx that
+;; dispatches ONLY the pre-built carrier it was handed — never traversing
+;; arbitrary effects), and only a dispatch that flowed through the member
+;; child's own boundary carries the stamp.
 ;;
 ;; The interceptor's fold branch then requires the stamp to match
 ;; runtime-owned join state EXACTLY — parent/invoke identity, logical child
 ;; id, exact current actor id, exact attempt token — before a `:done` /
-;; `:failed` fold. Unstamped, superseded (prior attempt / wrong actor), and
-;; duplicate carriers are classified stale and perform ZERO mutation (no
-;; fold, no terminal publication, no resolution, no reap).
+;; `:failed` fold. Unstamped, superseded (prior attempt / wrong actor / old
+;; delayed straggler), and duplicate carriers are classified stale and perform
+;; ZERO mutation (no fold, no terminal publication, no resolution, no reap) —
+;; never a silent replay-success no-op.
 ;; ---------------------------------------------------------------------------
 
 (defn- join-completion-event?
@@ -107,48 +124,96 @@
                   (= error-kw (first inner)))
               (= child-id (second inner))))))
 
-(defn- stamp-completion-event
-  "Stamp the `:rf/join-auth` attempt-authentication metadata onto the INNER
-  event vector of a matching completion carrier. The stamped facts are the
-  exact-authority tuple the interceptor verifies: parent/invoke identity,
-  logical child id, the child's own spawned instance address, and the
-  opaque per-attempt token."
-  [event rec]
-  (let [inner (second event)
-        auth  (select-keys rec [:parent-id :invoke-id :child-id
-                                :spawned-id :attempt])]
-    (assoc event 1 (vary-meta inner assoc :rf/join-auth auth))))
+(defn- join-auth-of
+  "The exact-authority tuple the interceptor verifies, projected from a child's
+  `:rf/join-child` membership record `rec`: parent/invoke identity, logical
+  child id, the child's own spawned instance address, and the opaque per-attempt
+  token."
+  [rec]
+  (select-keys rec [:parent-id :invoke-id :child-id :spawned-id :attempt]))
+
+(defn join-dispatch-fx
+  "fx handler for `:rf.machine/join-dispatch` (rf2-t154jx) — the framework-
+  internal transport that carries a `:spawn-all` child's completion carrier to
+  its parent WITH the exact-authority tuple on the RECORDABLE `:rf.cofx`
+  causal-envelope fact `:rf.machine/join-auth`. `stamp-fx-entry` rewrites a
+  member child's OWN outbound `:dispatch` / `:dispatch-later` completion into
+  this fx at the child's handler-return boundary; the parent's join interceptor
+  reads the auth back off its `:rf/cofx` (`carrier-auth`). The authority thus
+  survives BOTH the event/coeffect recording + strict-replay path AND the
+  delayed-dispatch path (event-vector metadata survives neither).
+
+  Not an application control surface — reserved-`:rf.machine/*` internal, it
+  re-dispatches ONLY the pre-built completion carrier it was handed (never
+  traverses arbitrary / custom effect payloads). The completion event VALUE is
+  unchanged; only the private `:rf.machine/join-auth` cofx fact is added.
+
+  args: `{:event <[parent-id inner-event]> :rf/join-auth <auth-tuple>
+          :ms <ms?>}`. A `:ms` (from a `:dispatch-later` completion) that is
+  positive arms a host timer; nil / non-positive dispatches immediately (the
+  same enqueue a direct `:dispatch` completion takes). The completion inherits
+  the machine-internal front-of-queue ordering + `:source :machine-action` the
+  child's original `:dispatch` carried (the emitter is always a machine child)."
+  [{frame-id :frame} {:keys [event ms] auth :rf/join-auth}]
+  (let [frame-id (frame/require-frame-stamp!
+                   frame-id :rf.machine/join-dispatch
+                   {:where 'rf.machine/join-dispatch :event-id (first event)})
+        opts     {:frame                 frame-id
+                  :source                :machine-action
+                  :rf.machine/internal?  true
+                  ;; The recordable causal-envelope fact. `build-envelope`
+                  ;; preserves a supplied `:rf.cofx` map verbatim (extra
+                  ;; owner-qualified keys kept) and fills `:rf/time-ms`, so the
+                  ;; auth rides `:rf.event/cofx` at record time and is
+                  ;; re-presented on strict replay.
+                  :rf.cofx               {:rf.machine/join-auth auth}}
+        fire!    (fn []
+                   (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                     (dispatch! event opts)))]
+    (if (and (number? ms) (pos? ms))
+      (interop/set-timeout! fire! ms)
+      (fire!)))
+  nil)
 
 (defn- stamp-fx-entry
-  "Stamp one fx-vector entry when it dispatches this child's own completion
-  (`:dispatch` and `:dispatch-n` forms); every other entry rides through
-  untouched."
+  "Rewrite one fx-vector entry that dispatches this child's OWN completion
+  carrier into the `:rf.machine/join-dispatch` transport (rf2-t154jx), carrying
+  the exact-authority tuple on the recordable `:rf.cofx` fact rather than event
+  metadata. Handles the direct `:dispatch` form and the reserved
+  `:dispatch-later` `{:ms n :event event}` form (the delayed path #5839's
+  metadata stamp never covered); the retired top-level `:dispatch-n` arm is
+  gone. Every non-completion entry rides through untouched. The public
+  completion event VALUE is preserved verbatim."
   [fx-entry rec]
   (if (and (vector? fx-entry) (>= (count fx-entry) 2))
     (let [[fx-id arg] fx-entry]
       (cond
         (and (= :dispatch fx-id) (join-completion-event? arg rec))
-        (assoc fx-entry 1 (stamp-completion-event arg rec))
+        [:rf.machine/join-dispatch {:event arg :rf/join-auth (join-auth-of rec)}]
 
-        (and (= :dispatch-n fx-id) (sequential? arg))
-        (assoc fx-entry 1 (mapv #(if (join-completion-event? % rec)
-                                   (stamp-completion-event % rec)
-                                   %)
-                                arg))
+        (and (= :dispatch-later fx-id)
+             (map? arg)
+             (join-completion-event? (:event arg) rec))
+        [:rf.machine/join-dispatch {:event        (:event arg)
+                                    :rf/join-auth (join-auth-of rec)
+                                    :ms           (:ms arg)}]
 
         :else fx-entry))
     fx-entry))
 
 (defn stamp-join-completion-fx
-  "The child-boundary half of the exact-authority contract (rf2-nvxehu).
-  Given the effects map a `:spawn-all` child's handler is about to return
-  and the child's `:rf/join-child` membership record (nil for every
-  non-join-child actor — the common case, a no-op), stamp the
-  `:rf/join-auth` metadata onto each outbound completion carrier in `:fx`
-  targeting this child's own join. Called from the machine-handler return
-  boundary (`registration.cljc/commit-or-finalize`), so it covers action
-  fx, bootstrap-entry fx, and the finalize path uniformly — the existing
-  private lifecycle path, no new application-facing surface."
+  "The child-boundary half of the exact-authority contract (rf2-nvxehu /
+  rf2-t154jx). Given the effects map a `:spawn-all` child's handler is about to
+  return and the child's `:rf/join-child` membership record (nil for every
+  non-join-child actor — the common case, a no-op), REWRITE each outbound
+  completion carrier in `:fx` (direct `:dispatch` and reserved `:dispatch-later`
+  forms) targeting this child's own join into the `:rf.machine/join-dispatch`
+  transport, which re-dispatches the unchanged public event with the exact
+  authority attached on the RECORDABLE `:rf.cofx` fact `:rf.machine/join-auth`.
+  Called from the machine-handler return boundary
+  (`registration.cljc/commit-or-finalize`), so it covers action fx,
+  bootstrap-entry fx, and the finalize path uniformly — the existing private
+  lifecycle path, no new application-facing surface."
   [effects join-child]
   (if (and join-child
            (map? effects)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -156,6 +156,23 @@
     (update effects :fx (fn [fxs] (mapv #(stamp-fx-entry % join-child) fxs)))
     effects))
 
+(defn- carrier-auth
+  "The completion carrier's `:rf/join-auth` exact-authority tuple (rf2-nvxehu),
+  read from the recordable transport (rf2-t154jx). The runtime carries it as the
+  framework-owned recordable causal-envelope fact `:rf.machine/join-auth` on the
+  dispatching child's `:rf.cofx` (attached by the `:rf.machine/join-dispatch` fx,
+  threaded onto the machine def's `:rf/cofx` by `prepare-machine-ctx`). That
+  channel survives BOTH the event/coeffect recording + strict-replay path (the
+  event vector's METADATA does NOT — an EDN round-trip drops it) AND the
+  delayed-dispatch path. Event-vector metadata is accepted only as an immediate
+  internal handoff / test-forged fallback. The transport it arrived on is never
+  itself trusted — every clause is validated against runtime-owned join state
+  downstream (`join-auth-current?`), so a forged/tampered/replayed carrier that
+  does not match the live attempt is fail-closed regardless of channel."
+  [machine inner-event]
+  (or (get-in machine [:rf/cofx :rf.machine/join-auth])
+      (:rf/join-auth (meta inner-event))))
+
 (defn- join-auth-current?
   "True iff the carrier's `:rf/join-auth` stamp matches the CURRENT join
   attempt exactly: same parent/invoke identity, same logical child id, the
@@ -628,17 +645,42 @@
   (let [inner-id (first inner-event)
         child-id (second inner-event)
         matches  (find-active-spawn-alls machine snapshot inner-id)
-        ;; When more than one active spawn-all matches the event id (two
-        ;; parallel regions reusing the SAME `:on-child-done`), route to the
-        ;; join whose LIVE join-state `:children` OWNS the arriving child-id —
-        ;; ownership, not declaration order, decides. The owning match is
-        ;; preferred; if none owns the child (genuinely forged), fall back to
-        ;; the first match so the bad-child-id error trace still fires against
-        ;; a real join.
+        ;; The completion carrier's exact-authority tuple, read from the
+        ;; recordable transport (nil for an unstamped / hand-crafted carrier).
+        auth     (carrier-auth machine inner-event)
+        ;; Select the candidate join by EXACT AUTHORITY, BEFORE the fold gate
+        ;; (rf2-wsrtlw). When more than one active `:spawn-all` matches the
+        ;; event id (two parallel regions legitimately reusing the SAME
+        ;; `:on-child-done` AND the SAME logical child id), routing by child-id
+        ;; ownership alone mis-routes an authenticated R2 carrier to R1's join
+        ;; (declaration order), where the fold gate rejects it
+        ;; `:attempt-superseded` and R2 hangs. Instead: for an AUTHENTICATED
+        ;; carrier, select the match whose LIVE join-state IS the exact attempt
+        ;; the auth names — same parent/invoke identity, same `:rf/attempt`
+        ;; token, and child-id mapped to the auth's spawned instance address.
+        ;; This routes the completion to the region whose join actually spawned
+        ;; the child, independent of declaration order or child-id reuse.
+        authoritative?
+        (fn [{invoke-id :invoke-id}]
+          (and (map? auth)
+               (= parent-id (:parent-id auth))
+               (= invoke-id (:invoke-id auth))
+               (some? (:attempt auth))
+               (let [js (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
+                 (and (map? js)
+                      (= (:rf/attempt js) (:attempt auth))
+                      (= (get-in js [:children child-id]) (:spawned-id auth))))))
+        ;; child-id ownership fallback for an UNSTAMPED / malformed / unknown
+        ;; carrier — it routes to a real owning join so the fold gate's
+        ;; fail-closed suppression fires stable typed evidence
+        ;; (`:attempt-unverified`) against it; never guesses an owner. If none
+        ;; owns the child (genuinely forged child-id), fall back to the first
+        ;; match so the bad-child-id error trace still fires against a real join.
         owns?    (fn [{invoke-id :invoke-id}]
                    (let [js (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
                      (and (map? js) (contains? (:children js) child-id))))
-        match    (or (some #(when (owns? %) %) matches)
+        match    (or (some #(when (authoritative? %) %) matches)
+                     (some #(when (owns? %) %) matches)
                      (first matches))
         ;; Resolve the live frame from the runtime-stamped machine
         ;; (registration.cljc/prepare-machine-ctx assoc'd `:rf/frame` before
@@ -750,45 +792,48 @@
           :else
           ;; Exact-authority fold gate (rf2-nvxehu). Before ANY fold, the
           ;; carrier must prove it belongs to THIS join attempt: the
-          ;; `:rf/join-auth` metadata the member child's own handler
-          ;; boundary stamped (`stamp-join-completion-fx`) must match the
-          ;; current join's parent/invoke identity, logical child id, exact
-          ;; current actor id, and exact attempt token. An UNSTAMPED carrier
-          ;; (a hand-crafted dispatch that never flowed through the member
-          ;; child's boundary) and a SUPERSEDED one (a prior attempt's
-          ;; straggler after parent re-entry / child respawn — including a
-          ;; `:fixed-actor-id` respawn where the actor id alone cannot
-          ;; discriminate attempts) are classified stale and fold NOTHING;
-          ;; a DUPLICATE exact completion of an already-folded child is
-          ;; likewise suppressed so one child attempt can never publish two
-          ;; terminals (rf2-ir4t5v). All three suppressions are
+          ;; `:rf/join-auth` tuple the member child's own handler boundary
+          ;; stamped (`stamp-join-completion-fx`) and carried on the recordable
+          ;; `:rf.cofx` transport (rf2-t154jx) — resolved via `carrier-auth`
+          ;; above as `auth` — must match the current join's parent/invoke
+          ;; identity, logical child id, exact current actor id, and exact
+          ;; attempt token. An UNSTAMPED carrier (a hand-crafted dispatch that
+          ;; never flowed through the member child's boundary, OR a strict
+          ;; replay whose recordable authority fact was stripped) and a
+          ;; SUPERSEDED one (a prior attempt's straggler after parent re-entry /
+          ;; child respawn — including a `:fixed-actor-id` respawn where the
+          ;; actor id alone cannot discriminate attempts, and an old-attempt
+          ;; DELAYED completion arriving across re-entry) are classified stale
+          ;; and fold NOTHING; a DUPLICATE exact completion of an already-folded
+          ;; child is likewise suppressed so one child attempt can never publish
+          ;; two terminals (rf2-ir4t5v). All three suppressions are
           ;; zero-mutation fail-closed drops with stable typed evidence
-          ;; (`:rf.reply/stale-reason` on the stale-completion trace).
-          (let [auth (:rf/join-auth (meta inner-event))]
-            (cond
-              (nil? auth)
-              (suppress-stale-completion!
-                frame-id parent-id invoke-id join-state child-id kind
-                completed-at runtime-db
-                :rf.machine.spawn-all/attempt-unverified)
+          ;; (`:rf.reply/stale-reason` on the stale-completion trace) — never a
+          ;; silent replay-success no-op.
+          (cond
+            (nil? auth)
+            (suppress-stale-completion!
+              frame-id parent-id invoke-id join-state child-id kind
+              completed-at runtime-db
+              :rf.machine.spawn-all/attempt-unverified)
 
-              (not (join-auth-current? auth parent-id invoke-id child-id join-state))
-              (suppress-stale-completion!
-                frame-id parent-id invoke-id join-state child-id kind
-                completed-at runtime-db
-                :rf.machine.spawn-all/attempt-superseded)
+            (not (join-auth-current? auth parent-id invoke-id child-id join-state))
+            (suppress-stale-completion!
+              frame-id parent-id invoke-id join-state child-id kind
+              completed-at runtime-db
+              :rf.machine.spawn-all/attempt-superseded)
 
-              (or (contains? (:done   join-state) child-id)
-                  (contains? (:failed join-state) child-id))
-              (suppress-stale-completion!
-                frame-id parent-id invoke-id join-state child-id kind
-                completed-at runtime-db
-                :rf.machine.spawn-all/duplicate-completion)
+            (or (contains? (:done   join-state) child-id)
+                (contains? (:failed join-state) child-id))
+            (suppress-stale-completion!
+              frame-id parent-id invoke-id join-state child-id kind
+              completed-at runtime-db
+              :rf.machine.spawn-all/duplicate-completion)
 
-              :else
-              (intercept-fold frame-id parent-id invoke-id spec join-state
-                              child-id kind child-extra completed-at
-                              runtime-db))))))))
+            :else
+            (intercept-fold frame-id parent-id invoke-id spec join-state
+                            child-id kind child-extra completed-at
+                            runtime-db)))))))
 
 (defn- intercept-fold
   "The verified fold body of `intercept-spawn-all-event` — the carrier has

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -312,7 +312,7 @@
   re-read is value-equal to the snapshot the caller already had. Machine
   snapshots are durable runtime-db state (EP-0001)."
   [frame-id rt-after-alloc spec spawned-id initial-snap
-   {:keys [system-id parent-id invoke-id track? type-ref]}]
+   {:keys [system-id parent-id invoke-id track? type-ref continue?]}]
   (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))
         ;; Stamp the revertible TYPE reference onto the snapshot root so the
         ;; lazy resolver can re-materialise the handler from runtime-db alone. The
@@ -334,21 +334,29 @@
                                                   "; rebinding to " spawned-id
                                                   " (last-write-wins).")
                           :recovery          :warned-and-replaced}))
-    (frame/swap-runtime-db! frame-id
-                            (fn [_rt]
-                              (cond-> rt-after-alloc
-                                spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
-                                system-id (assoc-in (paths/system-id-path system-id) spawned-id)
-                                track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
-    (when system-id
-      (trace/emit! :rf.machine :rf.machine/system-id-bound
-                   {:frame      frame-id
-                    :system-id  system-id
-                    ;; The live actor INSTANCE address (the spawned id), not
-                    ;; the registered TYPE; `:machine-id` is reserved for the
-                    ;; type.
-                    :actor-id   spawned-id}))
-    :ok))
+    ;; rf2-3evq0x — the `:rf.error/system-id-collision` trace above is
+    ;; callback-bearing; recheck the exact-incarnation continuation before the
+    ;; runtime-db swap so a listener that destroyed A / published same-id B
+    ;; cannot land the A-derived snapshot / system-id / spawn-slot install (a
+    ;; bare-id `swap-runtime-db!` resolves to the CURRENT incarnation B) or fire
+    ;; the `:rf.machine/system-id-bound` trace for it. `continue?` is nil only
+    ;; for a hypothetical caller that did not thread it — treated as live.
+    (when (or (nil? continue?) (continue?))
+      (frame/swap-runtime-db! frame-id
+                              (fn [_rt]
+                                (cond-> rt-after-alloc
+                                  spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                                  system-id (assoc-in (paths/system-id-path system-id) spawned-id)
+                                  track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
+      (when system-id
+        (trace/emit! :rf.machine :rf.machine/system-id-bound
+                     {:frame      frame-id
+                      :system-id  system-id
+                      ;; The live actor INSTANCE address (the spawned id), not
+                      ;; the registered TYPE; `:machine-id` is reserved for the
+                      ;; type.
+                      :actor-id   spawned-id}))
+      :ok)))
 
 ;; ---- :rf.machine/spawn -----------------------------------------------------
 
@@ -538,25 +546,39 @@
                     :system-id  system-id
                     :parent-id  parent-id
                     :invoke-id  invoke-id})
-      ;; NO per-instance handler registration. The actor's
-      ;; liveness IS its snapshot's presence in the (revertible) frame
-      ;; value; the snapshot's `:rf/machine-type` (stamped by
-      ;; `install-spawn!`) lets the lazy resolver re-materialise the
-      ;; handler on dispatch. Spawn is a pure runtime-db write.
+      ;; rf2-3evq0x — the `:rf.machine.spawn/spawned` trace above is
+      ;; callback-bearing: a trace LISTENER can synchronously destroy A /
+      ;; publish same-id B before returning. Recheck the exact-incarnation
+      ;; continuation HERE, after the trace fanout and before ANY framework-
+      ;; owned bookkeeping — the install / classification / spawn-order record /
+      ;; `:rf.machine.lifecycle/spawned` trace / `:start` dispatch tail is all
+      ;; A-derived and would otherwise commit into B's name (the bare-id
+      ;; `swap-runtime-db!` resolves to the CURRENT incarnation B). The initial
+      ;; `(continue?)` cascade gate only fenced the SCHEMA-validator callback;
+      ;; this fences the trace-listener callback the earlier gate ran ahead of.
+      ;;
+      ;; NO per-instance handler registration. The actor's liveness IS its
+      ;; snapshot's presence in the (revertible) frame value; the snapshot's
+      ;; `:rf/machine-type` (stamped by `install-spawn!`) lets the lazy resolver
+      ;; re-materialise the handler on dispatch. Spawn is a pure runtime-db
+      ;; write.
       ;;
       ;; (2) Initialise the snapshot + (3) bind :system-id + (4) bind the
       ;; runtime-owned spawn registry (atomically under one runtime-db swap
       ;; so observers see consistent state). When the spawned id was
       ;; allocated from the frame's runtime-db (the hand-emitted-spawn
       ;; fallback path), `rt-after-alloc` already carries the bumped counter —
-      ;; install the snapshot on top of that.
-      (do
+      ;; install the snapshot on top of that. `continue?` is threaded into
+      ;; `install-spawn!` so the callback-bearing `:rf.error/system-id-collision`
+      ;; trace it may emit gets a recheck before the runtime-db swap too.
+      (when (continue?)
         (install-spawn! frame-id rt-after-alloc spec'' spawned-id initial-snap
                         {:system-id system-id
                          :parent-id parent-id
                          :invoke-id invoke-id
                          :track?    track?
-                         :type-ref  type-ref})
+                         :type-ref  type-ref
+                         :continue? continue?})
         ;; Lower the machine spec's projection-relative `:sensitive` / `:large`
         ;; `:data` declarations
         ;; into the per-frame elision registry PER ACTOR INSTANCE — re-rooting
@@ -596,12 +618,17 @@
                       :invoke-id  invoke-id
                       :system-id  system-id
                       :parent-id  parent-id
-                      :state      (:state initial-snap)}))
-      ;; (6) Fire the :start event into the new actor. Spawns that don't
-      ;; supply :start receive a synthetic [:rf.machine.spawn/spawned] so
-      ;; generic child machines can declare their first transition out of an
-      ;; :initial state at spec-write time.
-      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                      :state      (:state initial-snap)})
+      ;; rf2-3evq0x — the `:rf.machine.lifecycle/spawned` trace above is
+      ;; likewise callback-bearing; recheck ownership once more before the
+      ;; `:start` (or synthetic) actor-bootstrap dispatch so a listener that
+      ;; just replaced A with B cannot kick B's bootstrap under A's authority.
+      (when (continue?)
+        ;; (6) Fire the :start event into the new actor. Spawns that don't
+        ;; supply :start receive a synthetic [:rf.machine.spawn/spawned] so
+        ;; generic child machines can declare their first transition out of an
+        ;; :initial state at spec-write time.
+        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
         ;; Stamp `:source :machine-spawn` on the actor-bootstrap dispatch so
         ;; the Epoch panel's DISPATCH step labels it "from machine spawn"
         ;; rather than `:unknown` or `:fx-dispatch` (which would be the value
@@ -615,7 +642,7 @@
                      :source             :machine-spawn}]
           (if (some? start)
             (dispatch! [spawned-id start] opts)
-            (dispatch! [spawned-id [:rf.machine.spawn/spawned]] opts)))))
+            (dispatch! [spawned-id [:rf.machine.spawn/spawned]] opts)))))))
     spawned-id))
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------

--- a/implementation/machines/test/re_frame/join_parallel_authority_select_test.clj
+++ b/implementation/machines/test/re_frame/join_parallel_authority_select_test.clj
@@ -1,0 +1,151 @@
+(ns re-frame.join-parallel-authority-select-test
+  "rf2-wsrtlw — select parallel `:spawn-all` joins by EXACT AUTHORITY before
+  folding.
+
+  #5839's exact-authority check runs AFTER the runtime has selected which
+  active `:spawn-all` join owns an inbound completion. That selection was by
+  child-id ownership (first owning match in declaration order). When two active
+  parallel regions legitimately reuse BOTH the completion event keyword AND the
+  logical child id, a later region's authenticated carrier is mis-routed to the
+  first region's join, rejected there as `:attempt-superseded`, and its own join
+  hangs.
+
+  The fix routes the completion to the region whose LIVE join-state IS the exact
+  attempt the carrier's `:rf/join-auth` names (parent/invoke identity + attempt
+  token + spawned instance), BEFORE the fold gate; child-id ownership is only a
+  fallback for unstamped / unknown carriers (which the fold gate then suppresses
+  fail-closed).
+
+  Two regions `:r1` / `:r2` each declare a `:spawn-all` with the SAME logical
+  child id `:worker` and the SAME `:on-child-done` / `:on-child-error`. The test
+  completes `:r2` first and asserts ONLY `:r2` resolves; `:r1` and its worker are
+  untouched; and no stale/bad-child evidence fires for the legitimate carrier."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+(defn- mk-worker
+  "A worker child that dispatches `done-kw` / `err-kw` back to `parent-id`
+  carrying its own `:worker` logical id — through its OWN handler boundary, so
+  the runtime stamps the exact `:rf/join-auth` for its region's attempt."
+  [parent-id done-kw err-kw]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{d :data e :event}] {:data (assoc d :id (second e))})
+             :dispatch-done (fn [{d :data}] {:fx [[:dispatch [parent-id [done-kw (:id d)]]]]})
+             :dispatch-err  (fn [{d :data}] {:fx [[:dispatch [parent-id [err-kw (:id d)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-err}}}
+             :done   {} :failed {}}})
+
+;; A never-completing helper child so the two-child `:all` join stays OPEN after
+;; the `:worker` folds (a single-child join would RESOLVE + tear the region
+;; down, clearing the join-state we assert on). The helper just sits idle.
+(def ^:private idle-helper
+  {:initial :idle :states {:idle {}}})
+
+(defn- region-spawn-all
+  "A two-child (`:worker` + never-completing `:helper`) `:spawn-all` region
+  sharing `:child/done` / `:child/failed` across regions but resolving to a
+  region-distinct `on-complete` event. The shared `:worker` logical id + shared
+  `:child/done` keyword across regions is exactly the ambiguity the fix routes by
+  exact authority; completing `:worker` alone is NON-DECISIVE (the `:all` join
+  still awaits `:helper`), so the join-state persists to be asserted on."
+  [worker-type on-complete ready-state]
+  {:initial :idle
+   :states  {:idle   {:on {:start :racing}}
+             :racing {:spawn-all {:children       [{:id :worker :machine-id worker-type
+                                                    :start [:set-id :worker]}
+                                                   {:id :helper :machine-id :rf2-wsrtlw/helper}]
+                                  :join           :all
+                                  :on-child-done  :child/done
+                                  :on-child-error :child/failed
+                                  :on-all-complete on-complete}
+                      :on {(first on-complete) ready-state}}
+             ready-state {}}})
+
+(def ^:private parent-kw :rf2-wsrtlw/parent)
+
+(defn- reg-and-start! []
+  (rf/reg-machine :rf2-wsrtlw/wc-r1 (mk-worker parent-kw :child/done :child/failed))
+  (rf/reg-machine :rf2-wsrtlw/wc-r2 (mk-worker parent-kw :child/done :child/failed))
+  (rf/reg-machine :rf2-wsrtlw/helper idle-helper)
+  (rf/reg-machine parent-kw
+    {:type    :parallel
+     :regions {:r1 (region-spawn-all :rf2-wsrtlw/wc-r1 [:r1/done] :r1-ready)
+               :r2 (region-spawn-all :rf2-wsrtlw/wc-r2 [:r2/done] :r2-ready)}})
+  (rf/dispatch-sync [parent-kw [:start]]))
+
+(defn- spawned-joins []
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
+
+(defn- join-for
+  "The join-state whose `:spec` resolves to `on-complete` (region-distinct)."
+  [on-complete]
+  (some (fn [[_invoke js]]
+          (when (= on-complete (get-in js [:spec :on-all-complete])) js))
+        (spawned-joins)))
+
+(deftest later-region-folds-only-itself-by-exact-authority
+  (testing "two active parallel regions reuse child id :worker + event :child/done;
+            completing :r2's worker folds ONLY into :r2 — :r1 and its worker are
+            untouched, and no attempt-superseded / bad-child evidence fires for
+            the legitimate carrier. Mutation tooth: selecting by child-id only
+            routes :r2's carrier to :r1's join, which rejects it superseded, so
+            :r2 never folds (:done stays empty)."
+    (reg-and-start!)
+    (let [r1-join (join-for [:r1/done])
+          r2-join (join-for [:r2/done])]
+      (is (map? r1-join) ":r1 seeded its own join-state")
+      (is (map? r2-join) ":r2 seeded its own join-state")
+      (is (= #{:worker :helper} (set (keys (:children r1-join)))) ":r1 owns logical child :worker")
+      (is (= #{:worker :helper} (set (keys (:children r2-join)))) ":r2 owns logical child :worker")
+      (is (not= (get-in r1-join [:children :worker])
+                (get-in r2-join [:children :worker]))
+          "the two regions spawned DISTINCT worker instances")
+      (is (not= (:rf/attempt r1-join) (:rf/attempt r2-join))
+          "each region minted its own per-attempt token")
+      (mtest/reset-captured!)
+      ;; Complete :r2's worker first — through its own boundary, so its carrier
+      ;; is authenticated for :r2's exact attempt. Non-decisive (the two-child
+      ;; :all join still awaits :helper), so both joins persist to assert on.
+      (rf/dispatch-sync [(get-in r2-join [:children :worker]) [:go]])
+      (let [r1' (join-for [:r1/done])
+            r2' (join-for [:r2/done])]
+        (is (= #{:worker} (:done r2'))
+            ":r2's join folded :worker on its OWN authenticated completion")
+        (is (false? (:resolved? r2')) ":r2 stays open (awaiting :helper)")
+        (is (= #{} (:done r1'))
+            ":r1's join is UNTOUCHED — the completion did not mis-route to it")
+        (is (false? (:resolved? r1')) ":r1 stays open, folded nothing")
+        (is (some? (mtest/snapshot (get-in r1-join [:children :worker])))
+            ":r1's worker actor is still live (never reaped by a mis-routed fold)")
+        (is (empty? (mtest/events-of :rf.machine.spawn-all/stale-completion))
+            "no stale-completion evidence fired for the legitimate carrier")
+        (is (empty? (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+            "no bad-child-id evidence fired for the legitimate carrier")))))
+
+(deftest later-region-failure-folds-only-itself-by-exact-authority
+  (testing "the failure side: completing :r2's worker via :fail routes the error
+            carrier to :r2's join only (:r2 folds :worker into :failed); :r1 is
+            untouched and no mis-route evidence fires."
+    (reg-and-start!)
+    (let [r1-join (join-for [:r1/done])
+          r2-join (join-for [:r2/done])]
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [(get-in r2-join [:children :worker]) [:fail]])
+      (let [r1' (join-for [:r1/done])
+            r2' (join-for [:r2/done])]
+        (is (= #{:worker} (:failed r2')) ":r2 folded :worker into :failed")
+        (is (= #{} (:failed r1')) ":r1 folded no failure (not mis-routed)")
+        (is (empty? (mtest/events-of :rf.machine.spawn-all/stale-completion))
+            "no stale-completion evidence for the legitimate failure carrier")))))

--- a/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
@@ -1,0 +1,240 @@
+(ns re-frame.join-recordable-transport-cljs-test
+  "rf2-t154jx — carry `:spawn-all` join authority through REPLAY and DELAYED
+  dispatch.
+
+  #5839 placed the only exact-attempt credential in METADATA on the inner
+  completion event vector. That authority did not survive two supported delivery
+  paths:
+
+    - Recorded strict replay: event metadata is NOT part of the event/coeffect
+      recording contract; an EDN round-trip drops it, so replaying a real
+      completion silently no-op'd instead of reproducing the fold — violating
+      replay-faithfulness (rf2-nvxehu's exact-authority promise).
+    - Live delayed dispatch: `stamp-fx-entry` handled `:dispatch` /
+      `:dispatch-n` but NOT the reserved `:dispatch-later` `{:ms n :event event}`
+      shape, so a child completing through `:dispatch-later` reached the parent
+      unauthenticated and was suppressed, hanging an `:all` join forever.
+
+  The fix carries the exact authority on the RECORDABLE `:rf.cofx` causal-
+  envelope fact `:rf.machine/join-auth` (via the `:rf.machine/join-dispatch`
+  transport `stamp-fx-entry` rewrites both `:dispatch` and `:dispatch-later`
+  completions into), and reads it back through `carrier-auth`. The public event
+  value and closed grammar are unchanged; missing / tampered authority is
+  validated through the existing typed stale policy, never a silent no-op."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   #?(:clj  [clojure.edn :as edn]
+      :cljs [cljs.reader :as edn])
+   [re-frame.core :as rf]
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- edn-roundtrip
+  "Serialize + re-read `x` through EDN — the same value-only round-trip a
+  Tool-Pair strict replay applies to a recorded event + its causal coeffects.
+  Event-vector METADATA does NOT survive this; `:rf.cofx` map facts DO."
+  [x]
+  (edn/read-string (pr-str x)))
+
+(defn- join-state [parent-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+
+(defn- stale-reasons []
+  (mapv (comp :rf.reply/stale-reason :tags)
+        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+
+(defn- mk-child
+  "A dispatching child: on `:go` transitions to a plain terminal and dispatches
+  its completion back to `parent-id` via `:dispatch` (through its OWN handler
+  boundary, so the runtime attaches the recordable `:rf.machine/join-auth`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- mk-child-delayed
+  "Like `mk-child` but completes through a ZERO-DELAY `:dispatch-later` — the
+  delivery path #5839's metadata stamp never covered."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch-later {:ms 0 :event [parent-id [:child/done (:id data)]]}]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- reg-parent!
+  "A re-enterable two-child `:all` join parent (children `child-a-kw` /
+  `child-b-kw`). Stays on `:racing` at resolution (no `:on` for `:all/done`) so
+  the join slot survives post-resolution probes; `:abort` exits, `:start`
+  re-enters (a fresh attempt)."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}}))
+
+(defn- auth-for
+  "Build the exact-authority tuple a live child :a completion carries, from the
+  live join-state."
+  [parent-kw]
+  (let [j (join-state parent-kw)]
+    {:parent-id  parent-kw
+     :invoke-id  [:racing]
+     :child-id   :a
+     :spawned-id (get-in j [:children :a])
+     :attempt    (:rf/attempt j)}))
+
+;; ---------------------------------------------------------------------------
+;; replay-faithful recordable transport
+;; ---------------------------------------------------------------------------
+
+(deftest recorded-authority-survives-edn-roundtrip-and-folds
+  (testing "rf2-t154jx — the exact authority rides the RECORDABLE :rf.cofx fact
+            :rf.machine/join-auth, so an EDN-roundtripped recorded event + causal
+            coeffects strict-replays into the SAME fold. Removing the recordable
+            authority fact makes the replay a fail-closed stale drop, never a
+            silent replay-success no-op."
+    (rf/reg-machine :jt/ca (mk-child :jt/rp))
+    (rf/reg-machine :jt/cb (mk-child :jt/rp))
+    (reg-parent! :jt/rp :jt/ca :jt/cb)
+    (rf/dispatch-sync [:jt/rp [:start]])
+    (let [auth        (auth-for :jt/rp)
+          rec-event   (edn-roundtrip [:jt/rp [:child/done :a]])
+          rec-cofx    (edn-roundtrip {:rf.machine/join-auth auth})]
+      (mtest/reset-captured!)
+      ;; Strict replay: redispatch the recorded event PLUS its recorded causal
+      ;; coeffects (the `:rf.cofx` map, EDN-roundtripped).
+      (rf/dispatch-sync rec-event {:rf.cofx rec-cofx})
+      (is (= #{:a} (:done (join-state :jt/rp)))
+          "the EDN-roundtripped completion + recorded cofx folded :a (replay-faithful)")
+      (is (empty? (stale-reasons)) "no stale suppression for the faithful replay")
+      ;; Remove the recordable authority fact → fail-closed stale drop.
+      (mtest/reset-captured!)
+      (rf/dispatch-sync (edn-roundtrip [:jt/rp [:child/done :b]])
+                        {:rf.cofx (edn-roundtrip {})})
+      (is (= #{:a} (:done (join-state :jt/rp)))
+          ":b did NOT fold — the completion with its recordable authority removed is suppressed")
+      (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+          "stripping the recordable authority fact is a typed stale drop, not a silent no-op"))))
+
+(deftest metadata-only-carrier-is-dropped-on-replay
+  (testing "rf2-t154jx — a metadata-only carrier (what #5839 produced) does NOT
+            survive the EDN round-trip: replaying it (metadata dropped, no
+            recordable cofx) is suppressed :attempt-unverified rather than
+            silently folding or no-op'ing."
+    (rf/reg-machine :jt/ma (mk-child :jt/mp))
+    (rf/reg-machine :jt/mb (mk-child :jt/mp))
+    (reg-parent! :jt/mp :jt/ma :jt/mb)
+    (rf/dispatch-sync [:jt/mp [:start]])
+    (let [auth        (auth-for :jt/mp)
+          ;; The #5839 wire shape: authority on inner-event METADATA.
+          meta-event  [:jt/mp (with-meta [:child/done :a] {:rf/join-auth auth})]
+          replayed    (edn-roundtrip meta-event)]  ;; EDN drops metadata
+      (mtest/reset-captured!)
+      (rf/dispatch-sync replayed)
+      (is (= #{} (:done (join-state :jt/mp)))
+          "the metadata-stripped replay folded nothing")
+      (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+          "the replay is a fail-closed stale drop"))))
+
+;; ---------------------------------------------------------------------------
+;; live delayed dispatch
+;; ---------------------------------------------------------------------------
+
+(deftest zero-delay-dispatch-later-completion-authenticates-and-folds
+  (testing "rf2-t154jx — a real child completing through a zero-delay
+            :dispatch-later authenticates (the delayed path #5839's metadata
+            stamp never covered) and folds + resolves the join exactly once."
+    (rf/reg-machine :jt/da (mk-child-delayed :jt/dp))
+    (rf/reg-machine :jt/db (mk-child-delayed :jt/dp))
+    (reg-parent! :jt/dp :jt/da :jt/db)
+    (rf/dispatch-sync [:jt/dp [:start]])
+    (let [j (join-state :jt/dp)
+          a (get-in j [:children :a])
+          b (get-in j [:children :b])]
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [a [:go]])
+      (is (= #{:a} (:done (join-state :jt/dp)))
+          ":a folded via the zero-delay :dispatch-later completion")
+      (is (empty? (stale-reasons)) "no stale suppression for the delayed completion")
+      (rf/dispatch-sync [b [:go]])
+      (is (true? (:resolved? (join-state :jt/dp)))
+          "the second delayed completion resolves the :all join"))))
+
+(deftest old-attempt-delayed-completion-across-reentry-is-superseded
+  (testing "rf2-t154jx — an old-attempt completion arriving across re-entry with
+            attempt-1 authority on the recordable cofx is classified
+            :attempt-superseded and cannot fold into the successor join."
+    (rf/reg-machine :jt/oa (mk-child :jt/op))
+    (rf/reg-machine :jt/ob (mk-child :jt/op))
+    (reg-parent! :jt/op :jt/oa :jt/ob)
+    (rf/dispatch-sync [:jt/op [:start]])
+    (let [attempt1-auth (auth-for :jt/op)]
+      ;; Re-enter: attempt 2.
+      (rf/dispatch-sync [:jt/op [:abort]])
+      (rf/dispatch-sync [:jt/op [:start]])
+      (let [j2 (join-state :jt/op)]
+        (is (not= (:attempt attempt1-auth) (:rf/attempt j2)) "attempt 2 minted a new token")
+        (mtest/reset-captured!)
+        ;; The stale straggler delivered with attempt-1 authority on the cofx.
+        (rf/dispatch-sync [:jt/op [:child/done :a]]
+                          {:rf.cofx {:rf.machine/join-auth attempt1-auth}})
+        (is (= #{} (:done (join-state :jt/op)))
+            "the old-attempt delayed completion folded nothing")
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
+            "stable typed evidence: :attempt-superseded")))))
+
+;; ---------------------------------------------------------------------------
+;; scope: only completion :dispatch / :dispatch-later are rewritten
+;; ---------------------------------------------------------------------------
+
+(deftest non-completion-effects-are-not-traversed
+  (testing "rf2-t154jx — the transport rewrites ONLY a member child's own
+            completion :dispatch / :dispatch-later; an arbitrary custom effect a
+            join child also emits is passed through untouched (not traversed /
+            rewritten)."
+    (let [custom-fired (atom [])]
+      (rf/reg-fx :jt/custom-fx (fn [_ payload] (swap! custom-fired conj payload)))
+      (rf/reg-machine :jt/xa
+        {:initial :running
+         :data    {:id nil}
+         :actions {:record-id (fn [{d :data e :event}] {:data (assoc d :id (second e))})
+                   :complete  (fn [{d :data}]
+                                {:fx [[:jt/custom-fx {:hello (:id d)}]
+                                      [:dispatch [:jt/xp [:child/done (:id d)]]]]})}
+         :states  {:running {:on {:set-id {:action :record-id}
+                                  :go     {:target :done :action :complete}}}
+                   :done {}}})
+      (rf/reg-machine :jt/xb (mk-child :jt/xp))
+      (reg-parent! :jt/xp :jt/xa :jt/xb)
+      (rf/dispatch-sync [:jt/xp [:start]])
+      (let [a (get-in (join-state :jt/xp) [:children :a])]
+        (rf/dispatch-sync [a [:go]])
+        (is (= #{:a} (:done (join-state :jt/xp)))
+            "the child's completion :dispatch was rewritten + folded")
+        (is (= [{:hello :a}] @custom-fired)
+            "the child's arbitrary custom effect fired untouched (not traversed)")))))

--- a/implementation/machines/test/re_frame/machine_completion_spawn_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_completion_spawn_incarnation_fence_test.clj
@@ -1,0 +1,255 @@
+(ns re-frame.machine-completion-spawn-incarnation-fence-test
+  "rf2-3evq0x — terminally fence machine COMPLETION and SPAWN tails after
+  incarnation loss.
+
+  #5849 fenced the machine SCHEMA-validator callbacks (spawn-data,
+  update-snapshot, completion-output) to the exact frame incarnation, but two
+  callback-bearing tails still crossed the terminal fence after ownership
+  changed:
+
+    - Completion: `validate-completion-output!` can return
+      `:rf/stale-incarnation`, but `finalize-machine` bound the result to `_`
+      and continued — parent resolution / `:on-done` / done trace / teardown /
+      HTTP+timer cancellation / classification+spawn-order drop / registrar
+      unregister / `:on-error` dispatch / result+fx publication all ran against
+      the successor B. A `:rf.machine/done` trace LISTENER that destroys A +
+      publishes same-id B was likewise unfenced.
+    - Spawn: the accepted spawn cascade checked ownership ONCE (the schema-
+      validator gate), then emitted the callback-bearing `:rf.machine.spawn/
+      spawned` (and `:rf.machine.lifecycle/spawned` / system-id-collision)
+      traces before install / classification / spawn-order / dispatch. A trace
+      LISTENER could replace A with B and the old cascade still committed
+      framework-owned actions into B's name.
+
+  The ruled policy: already-entered authored callbacks may unwind, but loss of
+  exact-incarnation ownership is a TERMINAL fence for every subsequent
+  framework-owned action. These fixtures drive the tails DIRECTLY under a bound
+  event owner (A's dequeue-time token) with a destroyer that publishes same-id
+  B on the callback's / listener's own stack, and assert B stays byte-identical.
+
+  Deterministic + single-threaded — the destroyer runs INSIDE the callback /
+  listener, so no latch coordination is needed (the same-id successor B is
+  published on the callback's own stack)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines :as machines]
+            [re-frame.machines.lifecycle-fx.finalize :as finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- completion-tail fence (finalize-machine) -----------------------------
+
+(defn- finishing-machine
+  "A runtime-stamped, finished singleton spec: rests on a `:final?` leaf whose
+  `:output-key` designates the completion result. `frame-id` is stamped as the
+  live frame; `schema?` toggles the `[:schemas :output]` completion validator."
+  [frame-id schema?]
+  (cond-> {:initial   :done
+           :rf/frame  frame-id
+           :rf/cofx   {:rf/time-ms 0}
+           :data      {:result 42}
+           :states    {:done {:final? true :output-key :result}}}
+    schema? (assoc :schemas {:output ::output-schema})))
+
+(defn- finishing-snapshot []
+  {:state :done :data {:result 42}})
+
+(defn- seed-finishing-runtime-db!
+  "Install `machine-id`'s finishing snapshot into `frame-id`'s runtime-db so
+  the finalize teardown has a live snapshot to (attempt to) reap."
+  [frame-id machine-id]
+  (frame/swap-runtime-db!
+    frame-id
+    (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots machine-id]
+                       (finishing-snapshot)))))
+
+(defn- run-completion-finalize
+  "Register `machine-id` as a singleton, make frame A, seed its finishing
+  snapshot, install a destroyer keyed on `trigger`, then call
+  `finalize-machine` DIRECTLY under A's bound event owner. `trigger` is
+  `:validator` (a completion-output validator that destroys A) or `:done-trace`
+  (a `:rf.machine/done` trace listener that destroys A). Returns the observable
+  post-finalize state."
+  [frame-a machine-id trigger]
+  (spawn-order/reset-all!)
+  (let [schema?   (= trigger :validator)]
+    (rf/reg-machine machine-id (finishing-machine frame-a schema?))
+    (rf/make-frame {:id frame-a})
+    (seed-finishing-runtime-db! frame-a machine-id)
+    (let [token-a        (frame/frame-incarnation-token frame-a)
+          fired?         (atom false)
+          done-traces    (atom [])
+          destroyed      (atom [])
+          orig-validate  (late-bind/get-fn :schemas/validate-with-registered-fn)
+          destroy+B!     (fn []
+                           (when (compare-and-set! fired? false true)
+                             (frame/destroy-frame! frame-a)   ;; destroy A
+                             (rf/make-frame {:id frame-a})     ;; same-id B
+                             (seed-finishing-runtime-db! frame-a machine-id)))]
+      (trace-tooling/register-listener!
+        ::completion-fence
+        (fn [ev]
+          (case (:operation ev)
+            :rf.machine/done      (do (swap! done-traces conj ev)
+                                      (when (= trigger :done-trace) (destroy+B!)))
+            :rf.machine/destroyed (swap! destroyed conj ev)
+            nil)))
+      (try
+        (when (= trigger :validator)
+          (late-bind/set-fn! :schemas/validate-with-registered-fn
+            (fn [schema _result]
+              (when (= schema ::output-schema) (destroy+B!))
+              false)))                                       ;; violation verdict
+        (let [ret (frame/call-with-event-owner-token frame-a token-a
+                    (fn []
+                      (finalize/finalize-machine
+                        (finishing-machine frame-a schema?)
+                        machine-id frame-a (mtest/runtime-db frame-a)
+                        (finishing-snapshot) [:some-completing-event] [])))]
+          {:fired?       @fired?
+           :ret          ret
+           :b-runtime    (mtest/runtime-db frame-a)
+           :b-snapshot   (mtest/snapshot frame-a machine-id)
+           :reg-entry    (registrar/lookup :event machine-id)
+           :spawn-order  (spawn-order/frame-order frame-a)
+           :done-traces  @done-traces
+           :destroyed    @destroyed})
+        (finally
+          (trace-tooling/unregister-listener! ::completion-fence)
+          (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate))))))
+
+(defn- assert-completion-inert [{:keys [ret b-snapshot reg-entry spawn-order destroyed]} frame-a machine-id]
+  (is (= {:rf.db/runtime (mtest/runtime-db frame-a) :fx []} ret)
+      "finalize returns the inert outcome — runtime-db untouched, no fx, before every framework-owned action")
+  (is (some? b-snapshot)
+      "successor B's finishing snapshot was NOT dissoc'd by the A-derived teardown")
+  (is (some? reg-entry)
+      "successor B's registrar entry was NOT unregistered by the A-derived teardown")
+  (is (empty? spawn-order)
+      "no A-derived spawn-order mutation landed on B")
+  (is (empty? destroyed)
+      "no :rf.machine/destroyed trace fired for the A-lost completion"))
+
+(deftest completion-output-validator-loss-fences-teardown
+  (testing "a completion-output validator that destroys A + publishes same-id B:
+            finalize consumes the :rf/stale-incarnation verdict and returns the
+            inert outcome BEFORE teardown / unregister / destroyed trace / fx
+            publication. Mutation tooth: binding the validator result to `_`
+            runs the whole teardown tail against B."
+    (let [frame-a    :rf2-3evq0x/completion-validator-frame
+          machine-id :rf2-3evq0x/completion-validator]
+      (let [result (run-completion-finalize frame-a machine-id :validator)]
+        (is (true? (:fired? result)) "the completion-output validator ran (fence exercised)")
+        (assert-completion-inert result frame-a machine-id)))))
+
+(deftest done-trace-listener-loss-fences-teardown
+  (testing "a :rf.machine/done trace LISTENER that destroys A + publishes same-id
+            B: ownership is rechecked AFTER the callback-bearing done trace, so
+            the teardown / unregister / destroyed trace / fx tail is fenced.
+            Mutation tooth: without the post-trace recheck the teardown reaps B."
+    (let [frame-a    :rf2-3evq0x/done-trace-frame
+          machine-id :rf2-3evq0x/done-trace]
+      (let [result (run-completion-finalize frame-a machine-id :done-trace)]
+        (is (true? (:fired? result)) "the :rf.machine/done trace listener ran (fence exercised)")
+        (is (= 1 (count (:done-traces result)))
+            "the done trace fired exactly once (it precedes the loss)")
+        (assert-completion-inert result frame-a machine-id)))))
+
+(deftest live-owner-completion-tears-down-normally
+  (testing "control: a completion whose validator does NOT destroy A tears down
+            fully — the fence is scoped to owner-loss only."
+    (spawn-order/reset-all!)
+    (let [frame-a    :rf2-3evq0x/live-completion-frame
+          machine-id :rf2-3evq0x/live-completion]
+      (rf/reg-machine machine-id (finishing-machine frame-a false))
+      (rf/make-frame {:id frame-a})
+      (seed-finishing-runtime-db! frame-a machine-id)
+      (let [token-a  (frame/frame-incarnation-token frame-a)
+            destroyed (atom [])]
+        (trace-tooling/register-listener!
+          ::live-completion
+          (fn [ev] (when (= :rf.machine/destroyed (:operation ev))
+                     (swap! destroyed conj ev))))
+        (try
+          (let [ret (frame/call-with-event-owner-token frame-a token-a
+                      (fn []
+                        (finalize/finalize-machine
+                          (finishing-machine frame-a false)
+                          machine-id frame-a (mtest/runtime-db frame-a)
+                          (finishing-snapshot) [:some-completing-event] [])))]
+            ;; finalize returns the teardown as a runtime-db EFFECT (it never
+            ;; imperatively writes the live frame); check the returned value.
+            (is (nil? (get-in (:rf.db/runtime ret)
+                              [:rf.runtime/machines :snapshots machine-id]))
+                "the live-owner completion tore down the actor's snapshot in the returned runtime-db")
+            (is (= 1 (count @destroyed))
+                "exactly one :rf.machine/destroyed trace fired for the live completion")
+            (is (contains? ret :rf.db/runtime)
+                "the live completion returns a runtime-db effect"))
+          (finally
+            (trace-tooling/unregister-listener! ::live-completion)))))))
+
+;; ---- spawn-tail fence (trace listener replaces A with B) -------------------
+
+(def ^:private spawn-child-instance-id (keyword "rf2-3evq0x" "spawn-child#1"))
+
+(deftest spawn-trace-listener-loss-fences-install
+  (testing "a :rf.machine.spawn/spawned trace LISTENER that destroys A +
+            publishes same-id B: ownership is rechecked AFTER the callback-
+            bearing spawned trace, so the install / classification / spawn-order
+            / :start dispatch tail is fenced — B stays byte-identical. Mutation
+            tooth: with only the pre-trace cascade gate the A-derived snapshot +
+            spawn-order + :start dispatch land on B."
+    (spawn-order/reset-all!)
+    (rf/reg-machine :rf2-3evq0x/spawn-child
+      {:initial :running
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a        :rf2-3evq0x/spawn-frame
+          fired?         (atom false)
+          dispatches     (atom [])
+          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)
+            b-birth (atom nil)]
+        (trace-tooling/register-listener!
+          ::spawn-trace-fence
+          (fn [ev]
+            (when (and (= :rf.machine.spawn/spawned (:operation ev))
+                       (compare-and-set! fired? false true))
+              (frame/destroy-frame! frame-a)     ;; destroy A during the spawned trace
+              (rf/make-frame {:id frame-a})       ;; publish same-id B
+              (reset! b-birth (mtest/runtime-db frame-a)))))
+        (try
+          ;; Capture (never route) any dispatch the cascade attempts.
+          (late-bind/set-fn! :router/dispatch!
+                             (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-fx {:frame frame-a}
+                                   {:machine-id :rf2-3evq0x/spawn-child :start [:go]})))
+          (is (true? @fired?) "the :rf.machine.spawn/spawned trace listener ran (fence exercised)")
+          (is (nil? (mtest/snapshot frame-a spawn-child-instance-id))
+              "no A-derived child snapshot installed onto same-id B")
+          (is (= @b-birth (mtest/runtime-db frame-a))
+              "B's runtime-db is byte-identical to its birth value (no A-derived install)")
+          (is (empty? (spawn-order/frame-order frame-a))
+              "no A-derived spawn-order entry recorded against B")
+          (is (empty? @dispatches)
+              "no :start dispatch fired into B after the spawned-trace loss")
+          (finally
+            (trace-tooling/unregister-listener! ::spawn-trace-fence)
+            (when orig-dispatch!
+              (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))


### PR DESCRIPTION
Machines join/completion **incarnation** cluster — three P1 findings on the spawn/join/completion surface #5839's exact-authority lane opened. One serial worker, one PR (shared `join.cljc` / `spawn.cljc`). Each fix carries a red-before-fix fixture; every repro was re-verified LIVE against fresh `origin/main` before fixing.

## rf2-3evq0x — terminally fence completion + spawn tails after incarnation loss

#5849 fenced the machine SCHEMA-validator callbacks to the exact frame incarnation, but two callback-bearing tails still crossed the terminal fence after ownership changed.

- **Completion** (`finalize.cljc`): `validate-completion-output!` can return `:rf/stale-incarnation`, but `finalize-machine` bound the verdict to `_` and continued — parent resolution / `:on-done` / done trace / teardown / HTTP+timer cancel / classification+spawn-order drop / registrar unregister / `:on-error` dispatch / result+fx publication all ran against successor B. The verdict is now captured; an `owner-gone?` gate (re-checked live after the callback-bearing `:rf.machine/done` trace and the `:on-done` callback) returns the inert `{:rf.db/runtime runtime-db :fx []}` outcome before EVERY subsequent framework-owned action. Already-delivered callbacks stand (no rollback). `stale-spawn?` (a child finishing after its PARENT was destroyed) is a different staleness and still tears down normally.
- **Spawn** (`spawn.cljc`): the accepted cascade checked ownership once (the schema gate), then emitted the callback-bearing `:rf.machine.spawn/spawned` / `:rf.machine.lifecycle/spawned` / system-id-collision traces before install / classification / spawn-order / dispatch. `(continue?)` is now re-checked after the spawned trace (before install), after the lifecycle trace (before the `:start` dispatch), and inside `install-spawn!` after the collision trace (before the runtime-db swap).

**Red-before-fix fixture**: `machine_completion_spawn_incarnation_fence_test.clj` — completion-validator loss, `:rf.machine/done` listener loss, spawned-trace listener loss, plus a live-owner control. Reverting the src turns all fence assertions red (teardown reaps B, registrar unregistered, destroyed trace fires).

## rf2-wsrtlw — select parallel spawn-all joins by exact authority before folding

#5839's exact-authority check ran AFTER the runtime selected which active `:spawn-all` join owned an inbound completion, and that selection was by child-id ownership (first owning match in declaration order). When two active parallel regions legitimately reuse BOTH the completion event keyword AND the logical child id, a later region's authenticated carrier was mis-routed to the first region's join, rejected there `:attempt-superseded`, and its own `:all` join hung.

Selection now routes by EXACT AUTHORITY before the fold gate: for an authenticated carrier, pick the match whose LIVE join-state is the exact attempt the `:rf/join-auth` names (parent/invoke identity + `:rf/attempt` token + child-id mapped to the auth's spawned instance). child-id ownership (then first match) remains only as a fallback for unstamped / malformed / unknown carriers, which the fold gate suppresses fail-closed with stable evidence against a real join — never guessing an owner. Adds the `carrier-auth` read seam; the fold gate consumes the single `auth` binding rather than re-reading metadata. No public grammar restriction, no second routing registry, no global child-id uniqueness rule.

**Red-before-fix fixture**: `join_parallel_authority_select_test.clj` — two regions share child id `:worker` + `:child/done`; completing `:r2` first folds ONLY `:r2` (success + failure sides). Reverting to child-id-only selection routes `:r2`'s carrier to `:r1`'s join (`:invoke-id [:r1 :racing]`), fires `:attempt-superseded`, and `:r2` never folds.

## rf2-t154jx — carry spawn-all join authority through replay + delayed dispatch

#5839 placed the only exact-attempt credential in METADATA on the inner completion event vector. That authority survived neither strict replay (event metadata is not part of the event/coeffect recording contract — an EDN round-trip drops it, so a replayed completion silently no-op'd) nor live delayed dispatch (`stamp-fx-entry` handled `:dispatch` / `:dispatch-n` but not the reserved `:dispatch-later` `{:ms n :event event}` shape, so a `:dispatch-later` completion reached the parent unauthenticated and hung an `:all` join).

Fix: carry the exact authority on ONE framework-owned RECORDABLE causal-envelope fact. `stamp-fx-entry` now rewrites BOTH the direct `:dispatch` and the `:dispatch-later` `:event` completion into the new internal `:rf.machine/join-dispatch` transport, which re-dispatches the UNCHANGED public completion event with the authority attached as `:rf.machine/join-auth` on the dispatch's `:rf.cofx`. That channel is preserved through the event/coeffect recording + strict-replay path and through delayed dispatch; the parent reads it back via `carrier-auth` (`:rf/cofx`), with event metadata kept only as a test-forged / immediate-handoff fallback. The retired `:dispatch-n` authentication arm is removed. Missing / tampered / superseded authority routes through the existing typed stale policy (`:attempt-unverified` / `:attempt-superseded`) — never a silent replay no-op. The `:rf.machine/join-dispatch` fx is reserved-namespace internal (registered + added to the runtime re-registration table), dispatches ONLY the pre-built carrier it is handed (no arbitrary-effect traversal), and preserves the machine-internal front-of-queue + `:source :machine-action` ordering the child's original `:dispatch` carried.

**Red-before-fix fixture**: `join_recordable_transport_cljs_test.cljc` — EDN-roundtrip replay folds via the recordable cofx fact (stripping it is a typed stale drop, not a silent no-op); a metadata-only carrier is dropped on replay; a zero-delay `:dispatch-later` completion folds + resolves; an old-attempt delayed completion across re-entry is `:attempt-superseded`; a join child's arbitrary custom effect is not traversed. On `origin/main` these fold nothing / mis-classify.

## Spec follow-ups (not edited here — spec/** out of scope)

No new **trace op** was invented (the stale channel reuses `:rf.machine.spawn-all/stale-completion` with the existing `:attempt-unverified` / `:attempt-superseded` reasons). rf2-t154jx does introduce two new reserved **identifiers** that warrant a spec catalogue entry:

- `:rf.machine/join-dispatch` — new reserved internal **fx-id** -> `spec/Conventions.md` §Reserved fx-ids + Spec 005 §Spawn-and-join child-completion protocol.
- `:rf.machine/join-auth` — new reserved **`:rf.cofx` fact key** -> `spec/Spec-Schemas.md` §`:rf.cofx` (owner-qualified recordable fact) / Conventions §Reserved namespaces.

Minor: an `ms > 0` `:dispatch-later` join completion arms a bare host timer (`interop/set-timeout!`) rather than routing through core's `:dispatch-later` cleanup table — a dispatch into a destroyed frame is a graceful router no-op; a dedicated cleanup hook is a possible follow-up if `ms > 0` join completions into torn-down frames become a concern. The tested (and dominant) path is zero-delay, which dispatches immediately.

## Quality gates (all green)

- `implementation/machines` JVM: **1035 tests / 3509 assertions, 0 failures** — includes the destroyed-reason-channel conformance matrix (kept green).
- `implementation/core` JVM: **1935 tests / 8826 assertions, 0 failures** (verifies core's `:rf.cofx` validation accepts the new `:rf.machine/join-auth` owner-qualified fact).
- CLJS node integration (`npm run test:cljs`): **9305 tests / 44083 assertions, 0 failures** — validates the rf2-t154jx `.cljc` transport fixture on CLJS (resolves on CLJ and CLJS/browser).
- `scripts/test-fast-pr.sh`: all 17 gates green (the one transient `shadow-cljs not found` was a fresh-worktree env gap — resolved by installing node_modules; the CLJS gate then ran green above).
