### PR TITLE
fix(ui): frame-ops — linearize cache publication across reincarnation, frame-only views as React context consumers (rf2-vxgfnd.229/.228)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -465,6 +465,14 @@
         ;; React.memo to the raw body with zero ViewCell hooks.
         has-subs?  (boolean (seq (:subs (:sites manifest))))
         has-leases? (boolean (seq leases))
+        ;; rf2-vxgfnd.228: a `(frame)` site resolves the AMBIENT committed frame
+        ;; (the form takes no arguments — always ambient, never an explicit pin),
+        ;; so a frame-ops-bearing view MUST become a real React frame-context
+        ;; CONSUMER or a provider retarget (A→B) memo-bails the non-consumer
+        ;; child and its held ops stay locked to the old frame. Frame-ops joins
+        ;; subs + leases in the wrapper-selection taxonomy; a view with NONE of
+        ;; the three stays on the inert direct React.memo path.
+        has-frame-ops? (boolean (seq (:frame-ops (:sites manifest))))
         lease-binds (vec
                      (mapcat (fn [{:keys [sid descriptor]}]
                                [(gensym "lease")
@@ -476,10 +484,17 @@
                      body)
         inner      (if (seq binds) `(let [~@binds] ~rendered) rendered)
         host-render (cond
+                      (and has-subs? has-leases? has-frame-ops?)
+                      're-frame.ui.viewcell/render-subs-and-leases-frame
                       (and has-subs? has-leases?)
                       're-frame.ui.viewcell/render-subs-and-leases
+                      (and has-subs? has-frame-ops?)
+                      're-frame.ui.viewcell/render-subs-frame
                       has-subs? 're-frame.ui.viewcell/render-subs
-                      has-leases? 're-frame.ui.viewcell/render-leases)
+                      (and has-leases? has-frame-ops?)
+                      're-frame.ui.viewcell/render-leases-frame
+                      has-leases? 're-frame.ui.viewcell/render-leases
+                      has-frame-ops? 're-frame.ui.viewcell/render-frame)
         var-meta   (cond-> {:rf.ui/view true
                             :rf.ui/view-id view-id
                             :rf.ui/children? children?}

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -743,6 +743,34 @@
   []
   (reset! frame-ops-cache {}))
 
+(def ^:dynamic ^:no-doc *frame-ops-publish-barrier*
+  "JVM linearization TEST SEAM — nil in production (one nil check on the SLOW
+  publish path only, zero cost on the fast cache-hit path), NEVER bound off a
+  test path (the `reactive/*commit-barrier*` idiom). Bound to a
+  `(fn [frame-id token] …)`, `frame-ops` calls it AFTER its initial liveness
+  check and BEFORE the drain-serialized publish, so a fixture can interleave a
+  same-id destroy + reincarnation between a stale reader's liveness check and
+  its cache publication (rf2-vxgfnd.229). Nil-safe on both hosts; CLJS never
+  interleaves a second publisher, so only JVM fixtures bind it."
+  nil)
+
+(defn- throw-frame-ops-destroyed!
+  "The ambient frame a `(frame)` read resolved has no live incarnation to
+  publish against — it is absent, destroyed, closing, or a same-id
+  reincarnation overtook the read between resolve and publish. Fail loud
+  through the canonical destroyed-frame path rather than returning (or
+  displacing) a dead-incarnation bundle."
+  [frame-id]
+  (error/throw-error!
+   :rf.error/frame-destroyed 're-frame.ui/frame
+   (str "(frame) resolved the ambient frame " (pr-str frame-id)
+        " but no live incarnation of it exists — the frame is absent,"
+        " destroyed, or closing (a same-id frame may have been destroyed and"
+        " re-created since the read began). The scope named a frame that no"
+        " longer runs; create/ensure the frame before rendering views scoped"
+        " to it")
+   {:extra {:frame frame-id}}))
+
 (defn- throw-frame-ops-stale!
   [frame-id op]
   (error/throw-error!
@@ -790,6 +818,45 @@
      :dispatch-sync (fence-op-2 frame-id token :dispatch-sync (:dispatch-sync base))
      :subscribe     (fence-op-1 frame-id token :subscribe (:subscribe base))}))
 
+(defn- publish-frame-ops!
+  "Mint and publish the `(frame)` bundle for the incarnation `token` of
+  `frame-id`, LINEARIZED against a same-id destroy/reincarnation through the
+  frame's drain serialization — the SAME seam `publish-plan-for-live-
+  incarnation!` uses (rf2-vxgfnd.229). Returns the published (or the
+  concurrently-published) bundle.
+
+  The captured `token` is REVALIDATED as the still-live incarnation INSIDE the
+  critical section, so publication and `destroy-frame!`'s liveness flip (which
+  runs under the same `:drain-lock`) linearize. The incarnation-scoped closing
+  check also covers `destroy-frame!`'s pre-liveness-flip window (its close
+  marker is set — and the destroy hook has already PRUNED this cache entry —
+  while `frame/frame` still returns the dying record). If a destroy/recreate
+  overtook the read, the captured token is no longer live: we neither publish a
+  dead-incarnation bundle nor displace the live incarnation's (a newer B's)
+  cache entry — we fail loud through the canonical destroyed-frame path. Under
+  the lock only ONE reader mints per incarnation, so a concurrent same-token
+  first read observes the published entry and shares its identity.
+
+  The publishing `swap!` is an unconditional `assoc`: the drain-serialized
+  revalidation is what prevents an older-token reader from overwriting a newer
+  entry, NOT a check-then-swap over the cache atom (which is exactly the torn
+  check-then-independent-publish this fix removes)."
+  [frame-id token]
+  (or
+   (frame/call-serialized-with-drain!
+    frame-id
+    (fn []
+      (when (and (identical? token (frame/frame-incarnation-token frame-id))
+                 (not (frame/frame-incarnation-closing? frame-id token)))
+        (let [entry (get @frame-ops-cache frame-id)]
+          (if (and entry (identical? token (:token entry)))
+            (:bundle entry)
+            (-> (swap! frame-ops-cache assoc frame-id
+                       {:token token :bundle (mint-frame-ops frame-id token)})
+                (get frame-id)
+                :bundle))))))
+   (throw-frame-ops-destroyed! frame-id)))
+
 (defn frame-ops
   "The runtime bridge `(frame)` lowers to (compiler-owned; the public
   authoring form is `re-frame.ui/frame`). Resolve the committed frame via
@@ -805,30 +872,27 @@
 
   Identity is STABLE for one live frame incarnation (cached by incarnation
   token); ops are incarnation-fenced so a stale bundle fails loud instead
-  of retargeting a same-id replacement frame."
+  of retargeting a same-id replacement frame. A cache MISS mints + publishes
+  through `publish-frame-ops!`, which linearizes the write against a same-id
+  destroy/reincarnation (rf2-vxgfnd.229) so a stale reader can neither displace
+  a newer incarnation's entry nor return a dead-incarnation bundle."
   []
   (let [frame-id (resolve-frame :frame 're-frame.ui/frame)
         token    (frame/frame-incarnation-token frame-id)]
     (when (or (nil? token)
               (frame/frame-incarnation-closing? frame-id token))
-      (error/throw-error!
-       :rf.error/frame-destroyed 're-frame.ui/frame
-       (str "(frame) resolved the ambient frame " (pr-str frame-id)
-            " but no live incarnation of it exists — the frame is absent,"
-            " destroyed, or closing. The scope named a frame that no longer"
-            " runs; create/ensure the frame before rendering views scoped"
-            " to it")
-       {:extra {:frame frame-id}}))
+      (throw-frame-ops-destroyed! frame-id))
     (let [entry (get @frame-ops-cache frame-id)]
       (if (and entry (identical? token (:token entry)))
+        ;; FAST PATH — a pure read of an entry already keyed to the live
+        ;; incarnation token; it publishes nothing and displaces nothing, so it
+        ;; is race-free and needs no serialization (the common per-render read).
         (:bundle entry)
-        (-> (swap! frame-ops-cache update frame-id
-                   (fn [e]
-                     (if (and e (identical? token (:token e)))
-                       e
-                       {:token token :bundle (mint-frame-ops frame-id token)})))
-            (get frame-id)
-            :bundle)))))
+        (do
+          ;; SLOW PATH (cache miss / stale-token entry) — the only writer.
+          (when-some [barrier *frame-ops-publish-barrier*]
+            (barrier frame-id token))
+          (publish-frame-ops! frame-id token))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Scope element builders — the emitted halves

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -47,6 +47,7 @@
   this layout effect (React's commit phase), correcting moved evidence
   before paint without any flush call."
   (:require ["react" :as react]
+            [re-frame.adapter.context :as adapter-context]
             [re-frame.interop :as interop]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.sub-overrides :as sub-overrides]))
@@ -179,6 +180,38 @@
       (reactive/reconcile-resource-leases! cell capture)
       js/undefined)))
 
+(defn- use-frame-context!
+  "Register the calling component as a real React CONSUMER of the shared frame
+  context (rf2-vxgfnd.228).
+
+  A compiled view whose body resolves the AMBIENT frame — any `(frame)` /
+  `frame-ops` site — MUST re-render when an ancestor `frame-provider` RETARGETS
+  its frame (A→B), even when the view's own props stay `rf=`-equal. `frame-ops`
+  reads the context value through `function-component-current-frame`
+  (`_currentValue`), which does NOT subscribe the component to context changes;
+  only `useContext` does. So without this hook React correctly memo-bails the
+  non-consumer child on a pure provider retarget, its body never reruns, and its
+  held ops stay locked to the OLD frame (Spec 004-Views §context-change repaint;
+  the same discipline `re-frame.adapter.use-frame/use-frame` uses).
+
+  The read VALUE is discarded — resolution runs through the carried-invariant
+  chain in `frame-ops`; the SUBSCRIPTION is the entire point. Called as a
+  compile-time-selected LEADING hook, so it is stable in hook order for every
+  render of a given compiled view's component (never conditional at runtime)."
+  []
+  (react/useContext adapter-context/frame-context)
+  nil)
+
+(defn render-frame
+  "Production wrapper for a FRAME-ONLY view: a `(frame)` site but no sub sites
+  and no resource leases (rf2-vxgfnd.228). It observes no reactive source and
+  holds no lease, so it needs no ViewCell — only frame-context CONSUMPTION so a
+  provider retarget re-renders it. Structurally zero `useSyncExternalStore` /
+  passive hooks; one `useContext`."
+  [_view-id thunk]
+  (use-frame-context!)
+  (thunk))
+
 (defn render-subs
   "Production wrapper for a view with sub sites and no resource leases."
   [view-id thunk]
@@ -187,6 +220,14 @@
         [element capture]      (capture-with-overrides cell overrides thunk)]
     (use-commit-and-lifecycle! cell root-incarnation capture)
     element))
+
+(defn render-subs-frame
+  "`render-subs` for a view that ALSO has a `(frame)` site: same ViewCell +
+  sub wiring, plus frame-context consumption so a provider retarget re-renders
+  it (rf2-vxgfnd.228). The leading `use-frame-context!` keeps hook order stable."
+  [view-id thunk]
+  (use-frame-context!)
+  (render-subs view-id thunk))
 
 (defn render-leases
   "Production wrapper for a view with resource leases and no sub sites.
@@ -199,6 +240,13 @@
     (use-resource-reconcile! cell capture)
     element))
 
+(defn render-leases-frame
+  "`render-leases` for a view that ALSO has a `(frame)` site: same ViewCell +
+  lease wiring, plus frame-context consumption (rf2-vxgfnd.228)."
+  [view-id thunk]
+  (use-frame-context!)
+  (render-leases view-id thunk))
+
 (defn render-subs-and-leases
   "Production wrapper for a view containing both sub and resource sites."
   [view-id thunk]
@@ -209,10 +257,22 @@
     (use-resource-reconcile! cell capture)
     element))
 
+(defn render-subs-and-leases-frame
+  "`render-subs-and-leases` for a view that ALSO has a `(frame)` site: same
+  ViewCell + sub + lease wiring, plus frame-context consumption
+  (rf2-vxgfnd.228)."
+  [view-id thunk]
+  (use-frame-context!)
+  (render-subs-and-leases view-id thunk))
+
 (defn render-dev
   "Stable Fast Refresh wrapper: the full hook superset regardless of the
-  currently-compiled body capabilities."
+  currently-compiled body capabilities — including frame-context consumption
+  (rf2-vxgfnd.228), so a body that gains or loses its `(frame)` site across an
+  HMR edit keeps ONE stable hook signature and a dev view always repaints on a
+  provider retarget."
   [view-id thunk]
+  (use-frame-context!)
   (let [[cell root-incarnation] (use-cell view-id)
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides cell overrides thunk)]

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
@@ -1,0 +1,120 @@
+(ns re-frame.ui.frame-ops-provider-retarget-dom-cljs-test
+  "rf2-vxgfnd.228 — a FRAME-ONLY compiled view (a `(frame)` site, NO `sub`, NO
+  lease) must be a real React frame-context CONSUMER, so an ancestor
+  `frame-provider` RETARGET (A→B) re-renders it even when its own props stay
+  `rf=`-equal.
+
+  Before the fix the frame-only view had no ViewCell wrapper and read the
+  ambient frame via `_currentValue` (never `useContext`), so React correctly
+  memo-bailed the non-consumer child on a pure provider retarget: its body never
+  reran and `(frame)` stayed locked to A. This mounted fixture RETARGETS the
+  provider — the gap the rf2-vxgfnd.184 mounted fixture never exercised (it only
+  proved initial resolution).
+
+  DEV build (this `-dom-cljs-test`): the frame-only view runs through
+  `viewcell/render-dev`, whose stable hook superset now consumes the frame
+  context. The PROD wrapper-selection twin — where the emitter routes a
+  frame-only view to `render-frame` and a `(frame)`+`sub` view to
+  `render-subs-frame`, and dropping `:frame-ops` from the selection falls back to
+  the inert direct React.memo path — is `frame-ops-provider-retarget-elision-prod-test`.
+
+  Browser-only bodies — `-dom-cljs-test$` opts this file into `:browser-test`;
+  under `:node-test` the DOM body gates on `(browser?)` and exits early."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+;; Module-level capture seam: a top-level view cannot close over a test's atom,
+;; so each render's resolved ops bundle is handed out here.
+(defonce ^:private captured (atom []))
+(defn- capture! [b] (swap! captured conj b) nil)
+
+(defview retarget-child
+  "Frame-only: a (frame) site, NO sub, NO lease. Renders the resolved ambient
+  frame id so a retarget is observable in the DOM and the capture log."
+  []
+  (let [{:keys [frame] :as bundle} (ui/frame)
+        _ (capture! bundle)]
+    [:output {:data-role "child-frame"} (str frame)]))
+
+(defn- reg! []
+  (rf/reg-event :retarget/set (fn [_ [_ n]] {:db {:n n}}))
+  (rf/reg-sub :retarget/n (fn [db _] (:n db))))
+
+(deftest frame-only-child-rerenders-and-retargets-on-provider-swap
+  (if-not (browser?)
+    (is true "DOM body — runs under :browser-test")
+    (do
+      (reset! captured [])
+      (frames/reset-frame-ops-cache!)
+      (reg!)
+      (let [fa    (uit/frame {:app-db {:n 1}})
+            fb    (uit/frame {:app-db {:n 2}})
+            fa-id (frame/frame-target->id fa)
+            fb-id (frame/frame-target->id fb)
+            container (js/document.createElement "div")]
+        (.appendChild js/document.body container)
+        (let [root (ui/create-root container {:root-id :retarget/root})
+              node #(.querySelector container "[data-role='child-frame']")]
+          (try
+            ;; Mount under provider A.
+            (ReactDOM/flushSync
+             #(ui/render! root [ui/frame-provider {:frame fa} [retarget-child]]))
+            (testing "initial resolution binds to provider A"
+              (is (= fa-id (:frame (last @captured))))
+              (is (= (str fa-id) (.-textContent (node)))))
+
+            (let [renders-after-a (count @captured)
+                  node-a (node)]
+              ;; Retarget A→B. The child element carries the SAME (empty) props,
+              ;; so a non-consumer would memo-bail here.
+              (ReactDOM/flushSync
+               #(ui/render! root [ui/frame-provider {:frame fb} [retarget-child]]))
+              (testing "the frame-only child re-rendered on the provider retarget"
+                (is (> (count @captured) renders-after-a)
+                    "its body reran despite rf=-equal props (real context consumer)")
+                (is (= fb-id (:frame (last @captured)))
+                    "the new render resolved B, not the stale A"))
+              (testing "the retarget updated in place — local/component identity survives"
+                (is (= (str fb-id) (.-textContent node-a))
+                    "the ORIGINAL DOM node was updated in place")
+                (is (identical? node-a (node))
+                    "same DOM node object — reconciled, not remounted"))
+
+              ;; A dispatch through the freshly resolved bundle must drive B and
+              ;; leave A untouched — proof the held ops target B, never A.
+              (testing "imperative work through the post-retarget bundle targets B"
+                (let [b-bundle (last @captured)]
+                  (ReactDOM/flushSync
+                   #((:dispatch-sync b-bundle) [:retarget/set 99]))
+                  (is (= 99 (:n (rf/app-db-value fb)))
+                      "the bundle drove B's frame")
+                  (is (= 1 (:n (rf/app-db-value fa)))
+                      "A's frame is untouched — no stale retarget")))
+
+              ;; Same-provider re-render must add no child render (no needless work).
+              (let [before (count @captured)]
+                (ReactDOM/flushSync
+                 #(ui/render! root [ui/frame-provider {:frame fb} [retarget-child]]))
+                (testing "a same-provider re-render does not re-run the child"
+                  (is (= before (count @captured))
+                      "identical provider value → no context change → memo bail"))))
+            (finally
+              (ReactDOM/flushSync #(ui/unmount! root))
+              (.remove container))))))))

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
@@ -1,0 +1,122 @@
+(ns re-frame.ui.frame-ops-provider-retarget-elision-prod-test
+  "rf2-vxgfnd.228 — the PRODUCTION wrapper-selection twin of
+  `frame-ops-provider-retarget-dom-cljs-test`.
+
+  Runs ONLY in `:browser-test-prod-elision` (`:advanced`, goog.DEBUG=false),
+  where the CLJS emitter's per-view wrapper selection is LIVE (dev collapses
+  every view onto the stable `render-dev` superset, so a dev fixture cannot
+  exercise it). Here:
+
+    - a FRAME-ONLY view (`(frame)`, no sub, no lease) compiles to
+      `viewcell/render-frame` — a real frame-context consumer;
+    - a `(frame)`+`sub` view compiles to `viewcell/render-subs-frame`;
+    - a genuinely frame-INDEPENDENT view compiles to the inert direct
+      `React.memo` path and must NOT re-render on a provider retarget.
+
+  This is the mutation-teeth fixture for the acceptance criterion 'a mutation
+  that removes :frame-ops from context-wrapper selection fails the A-to-B
+  fixture': dropping `:frame-ops` from the emitter's `host-render` cond routes
+  the frame-only and `(frame)`+`sub` views back to the inert path, so they
+  memo-bail the retarget and the B-resolution assertions go red."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+(defonce ^:private frame-only-log (atom []))
+(defonce ^:private frame-sub-log (atom []))
+(defonce ^:private independent-log (atom []))
+
+(defn- log-frame-only! [b] (swap! frame-only-log conj b) nil)
+(defn- log-frame-sub! [b] (swap! frame-sub-log conj b) nil)
+(defn- tick-independent! [] (swap! independent-log conj :render) nil)
+
+(defview prod-frame-only
+  "Frame-only → render-frame."
+  []
+  (let [{:keys [frame] :as bundle} (ui/frame)
+        _ (log-frame-only! bundle)]
+    [:output {:data-role "prod-frame-only"} (str frame)]))
+
+(defview prod-frame-and-sub
+  "(frame) + sub → render-subs-frame."
+  []
+  (let [{:keys [frame] :as bundle} (ui/frame)
+        n (ui/sub [:retarget/n])
+        _ (log-frame-sub! bundle)]
+    [:output {:data-role "prod-frame-sub"} (str frame "=" n)]))
+
+(defview prod-independent
+  "No (frame), no sub, no lease → inert direct React.memo path."
+  []
+  (let [_ (tick-independent!)]
+    [:output {:data-role "prod-independent"} "static"]))
+
+(defn- reg! []
+  (rf/reg-event :retarget/set (fn [_ [_ n]] {:db {:n n}}))
+  (rf/reg-sub :retarget/n (fn [db _] (:n db))))
+
+(defn- text [container sel] (some-> (.querySelector container sel) (.-textContent)))
+
+(deftest prod-frame-ops-views-consume-context-and-independent-stays-inert
+  (reset! frame-only-log [])
+  (reset! frame-sub-log [])
+  (reset! independent-log [])
+  (frames/reset-frame-ops-cache!)
+  (reg!)
+  (let [fa    (uit/frame {:app-db {:n 1}})
+        fb    (uit/frame {:app-db {:n 2}})
+        fa-id (frame/frame-target->id fa)
+        fb-id (frame/frame-target->id fb)
+        container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    (let [root (ui/create-root container {:root-id :retarget/prod-root})]
+      (try
+        (ReactDOM/flushSync
+         #(ui/render! root [ui/frame-provider {:frame fa}
+                            [prod-frame-only] [prod-frame-and-sub] [prod-independent]]))
+        (testing "initial resolution under provider A"
+          (is (= fa-id (:frame (last @frame-only-log))))
+          (is (= fa-id (:frame (last @frame-sub-log))))
+          (is (= (str fa-id) (text container "[data-role='prod-frame-only']")))
+          (is (= (str fa-id "=1") (text container "[data-role='prod-frame-sub']"))))
+
+        (let [fo-before (count @frame-only-log)
+              fs-before (count @frame-sub-log)
+              ind-before (count @independent-log)]
+          ;; Retarget A→B; all three children keep rf=-equal (empty) props.
+          (ReactDOM/flushSync
+           #(ui/render! root [ui/frame-provider {:frame fb}
+                              [prod-frame-only] [prod-frame-and-sub] [prod-independent]]))
+          (testing "render-frame: the frame-only view re-rendered and resolved B"
+            (is (> (count @frame-only-log) fo-before))
+            (is (= fb-id (:frame (last @frame-only-log))))
+            (is (= (str fb-id) (text container "[data-role='prod-frame-only']"))))
+          (testing "render-subs-frame: the (frame)+sub view re-rendered and resolved B"
+            (is (> (count @frame-sub-log) fs-before))
+            (is (= fb-id (:frame (last @frame-sub-log))))
+            (is (= (str fb-id "=2") (text container "[data-role='prod-frame-sub']"))))
+          (testing "the frame-INDEPENDENT view stayed inert (direct memo, no re-render)"
+            (is (= ind-before (count @independent-log))
+                "a genuinely frame-independent view is not charged a context re-render")))
+
+        (testing "a dispatch through the post-retarget frame-only bundle targets B"
+          (ReactDOM/flushSync
+           #((:dispatch-sync (last @frame-only-log)) [:retarget/set 77]))
+          (is (= 77 (:n (rf/app-db-value fb))) "bundle drove B")
+          (is (= 1 (:n (rf/app-db-value fa))) "A untouched"))
+        (finally
+          (ReactDOM/flushSync #(ui/unmount! root))
+          (.remove container))))))

--- a/implementation/ui/test/re_frame/ui/frame_ops_publication_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_ops_publication_race_jvm_test.clj
@@ -1,0 +1,119 @@
+(ns re-frame.ui.frame-ops-publication-race-jvm-test
+  "JVM lifecycle race coverage for the compiled `(frame)` operation-bundle CACHE
+  publication (rf2-vxgfnd.229).
+
+  `re-frame.ui.frames/frame-ops` mints a per-incarnation operation bundle and
+  caches it keyed by the frame's incarnation token. A reader captures token A,
+  passes its liveness check, and later publishes into the cache. If A is
+  destroyed and a same-id replacement incarnation B is created + read BETWEEN
+  that check and the publication, a pre-fix check-then-independent-publish let
+  the paused A reader overwrite B's cache entry and hand back A's already-dead
+  bundle — B then lost its promised stable identity and the read returned a
+  bundle no longer live at return time.
+
+  The fix routes the publish through the frame's drain serialization and
+  REVALIDATES the captured incarnation under the lock (the same seam
+  `publish-plan-for-live-incarnation!` uses), so a stale reader fails loud
+  through the canonical `:rf.error/frame-destroyed` path and never displaces
+  the live incarnation's entry.
+
+  The reader is paused at the deterministic `*frame-ops-publish-barrier*` seam
+  with a CountDownLatch handoff — no sleeps, no scheduler guesses. CLJS cannot
+  interleave a second publisher while synchronous destruction is paused, so this
+  fixture is JVM-only.
+
+  This fixture is also the guard for the acceptance criterion 'a mutation
+  restoring check-then-independent-publish fails deterministically': reverting
+  `publish-frame-ops!` to the pre-fix cache-atom check-then-swap turns both the
+  `:rf.error/frame-destroyed` assertion and the B1/B2 identity assertion red."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.frames            :as frames])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :ambient-frame nil})
+  (fn [test-fn]
+    (frames/reset-frame-ops-cache!)
+    (try (test-fn) (finally (frames/reset-frame-ops-cache!)))))
+
+(defn- read-ops [fid]
+  (binding [frame/*current-frame* fid]
+    (frames/frame-ops)))
+
+(deftest stale-reader-neither-displaces-a-reincarnation-nor-returns-a-dead-bundle
+  (let [fid        :ops-race/frame
+        _          (rf/make-frame {:id fid :doc "incarnation A"})
+        token-a    (frame/frame-incarnation-token fid)
+        at-barrier (CountDownLatch. 1)
+        release    (CountDownLatch. 1)
+        result-a   (atom ::unset)
+        ;; Reader A: capture token A, clear the top-of-`frame-ops` liveness
+        ;; check while A is still live, then PARK at the publish barrier before
+        ;; publishing. The barrier is bound ONLY on this thread — the main
+        ;; thread's reads of B must run without the barrier.
+        reader-a
+        (future
+          (binding [frame/*current-frame* fid
+                    frames/*frame-ops-publish-barrier*
+                    (fn [_fid _tok]
+                      (.countDown at-barrier)
+                      (.await release 10 TimeUnit/SECONDS))]
+            (reset! result-a
+                    (try {:ok (frames/frame-ops)}
+                         (catch clojure.lang.ExceptionInfo e
+                           {:err (:rf.error/id (ex-data e))})))))]
+    (try
+      (is (.await at-barrier 10 TimeUnit/SECONDS)
+          "reader A reached the publish barrier after clearing its liveness check")
+      (is (identical? token-a (frame/frame-incarnation-token fid))
+          "precondition: incarnation A is still the live token while A is parked")
+
+      ;; Destroy A (the :ui/on-frame-destroyed! hook prunes A's cache entry and
+      ;; the destroy flips liveness), then stand up a fresh same-id incarnation
+      ;; B and read it — B mints + publishes its OWN bundle while A is still
+      ;; parked mid-publish.
+      (frame/destroy-frame! fid)
+      (rf/make-frame {:id fid :doc "incarnation B"})
+      (let [token-b (frame/frame-incarnation-token fid)
+            b1      (read-ops fid)]
+        (is (not (identical? token-a token-b))
+            "B is a distinct incarnation of the reused id")
+        (is (= fid (:frame b1)) "B's freshly published bundle is locked to the id")
+
+        ;; Resume A. The fix fails it loud through the destroyed path; the pre-fix
+        ;; independent publish would instead overwrite B's entry and return A's
+        ;; dead bundle.
+        (.countDown release)
+        (is (not= ::timeout (deref reader-a 10000 ::timeout))
+            "reader A resumed and completed")
+        (is (= {:err :rf.error/frame-destroyed} @result-a)
+            "stale reader A fails loud; it never returns a dead-incarnation bundle")
+
+        ;; B's cached identity survived the stale reader entirely.
+        (let [b2 (read-ops fid)]
+          (is (identical? b1 b2)
+              "B1 and B2 are identical — the stale A reader did not displace B's entry")
+          (is (identical? token-b (frame/frame-incarnation-token fid))
+              "B is still the live incarnation after A resumed")))
+      (finally
+        (.countDown release)
+        (deref reader-a 10000 ::timeout)))))
+
+(deftest disjoint-frames-publish-independently-and-same-incarnation-reads-are-stable
+  ;; Companion positive: the drain-serialized publish keeps the ordinary
+  ;; guarantees — disjoint ids make independent progress and repeated
+  ;; same-incarnation reads share one bundle identity.
+  (rf/make-frame {:id :ops-race/x})
+  (rf/make-frame {:id :ops-race/y})
+  (let [x1 (read-ops :ops-race/x)
+        y1 (read-ops :ops-race/y)
+        x2 (read-ops :ops-race/x)]
+    (is (identical? x1 x2) "same-incarnation reads keep stable identity")
+    (is (not (identical? x1 y1)) "disjoint frames get independent bundles")
+    (is (= :ops-race/x (:frame x1)))
+    (is (= :ops-race/y (:frame y1)))))


### PR DESCRIPTION
Two P1 correctness fixes on the compiled `(frame)` operation-bundle / frame-ops surface (from the merged #5838 `(frame)` verb + #5834 preflight-race + #5853 preflight-evidence work). Pre-alpha: no back-compat shims. Both fixes build on #5838's per-incarnation frame-ops cache + incarnation fence and reuse the checked-in machinery. Commit order .229 → .228.

Fresh `origin/main` re-verified before starting: #5838 (`(frame)` form), #5850 (incarnation pair), #5853 (.139 preflight evidence) all merged; both gaps still reproduce on exact head — neither closed nor shifted by the merges.

## rf2-vxgfnd.229 — linearize frame-ops cache publication across same-ID reincarnation

`frame-ops` published the per-incarnation `(frame)` bundle via a bare check-then-independent-swap: a reader captured incarnation token A, cleared its liveness check, then published. If A was destroyed and a same-id replacement B was created + read between that check and the publish, the paused A reader overwrote B's cache entry and returned A's already-dead bundle — B lost its promised stable identity and the read returned a bundle no longer live at return time.

Fix: the slow-path mint+publish now runs through the frame's drain serialization (`frame/call-serialized-with-drain!`) and **revalidates the captured incarnation under the lock** — the exact seam `publish-plan-for-live-incarnation!` already uses. `destroy-frame!`'s liveness flip runs under the same `:drain-lock`, so publication and destruction linearize; the incarnation-scoped closing check covers the pre-liveness-flip window (the destroy hook has already pruned this cache entry while `frame/frame` still returns the dying record). A destroy/recreate that overtook the read makes the captured token no longer live, so the stale reader **fails loud through the canonical `:rf.error/frame-destroyed` path** and never displaces the newer incarnation's entry. The fast cache-hit path is unchanged (pure read, no serialization). #5838's incarnation fence + `:rf.error/frame-destroyed` semantics are untouched.

Red-before-fix fixture: `frame_ops_publication_race_jvm_test` parks reader A at a new `*frame-ops-publish-barrier*` test seam (the `reactive/*commit-barrier*` idiom) via a `CountDownLatch` handoff, destroys A, creates + reads B, then resumes A. Asserts A fails loud (never a dead bundle), B1 ≡ B2, disjoint frames progress independently. Reverting `publish-frame-ops!` to the check-then-independent-publish turns both the destroyed-frame and B1/B2-identity assertions red (2 failures) — the mutation-teeth criterion.

## rf2-vxgfnd.228 — make frame-only compiled views real React context consumers

A compiled view whose only reactive dependency is the ambient frame — a `(frame)` site with no `sub` and no lease — was left on the direct `React.memo` path: the CLJS emitter's wrapper selection keyed only off subscription + lease sites. `frame-ops` resolves the ambient frame through `function-component-current-frame` (a raw `_currentValue` read), which does NOT register the component as a React context consumer, so a pure `frame-provider` retarget (A→B) with `rf=`-equal props memo-bailed the child: its body never reran and its held `(frame)` ops stayed locked to A — contradicting the context-change repaint promise (Spec 004-Views) and violating frame isolation. The #5838 mounted fixture only proved initial provider resolution; it never retargeted.

Fix: `(frame)` takes no arguments — it is always ambient, never an explicit pin — so any `:frame-ops` site charges frame-context consumption. The emitter's `host-render` selection now includes `:frame-ops` alongside subs + leases:

- frame-only → `viewcell/render-frame` (one `useContext`, no ViewCell — nothing observed);
- `(frame)`+subs → `render-subs-frame`; `(frame)`+leases → `render-leases-frame`; `(frame)`+subs+leases → `render-subs-and-leases-frame`;
- none of the three → **unchanged** inert direct `React.memo` path.

Each frame variant adds one leading `React.useContext(frame-context)` via a shared `use-frame-context!` helper — the same subscription mechanism `re-frame.adapter.use-frame/use-frame` uses — so a provider change bypasses memo equality as React intends. `render-dev` consumes the context unconditionally as part of its stable HMR superset (a body gaining/losing its `(frame)` site keeps one hook signature). `useContext` is invisible to the frozen production hook matrix (`useSyncExternalStore` / passive), so the economics gate and mounted prod-elision stay green.

No live-lane file was required: the fix lives entirely in surfaces I own — `compiler/emit_cljs.cljc` + `viewcell.cljs`. It did NOT need `reactive.cljc` or `compiler/analyze.cljc`.

Red-before-fix fixtures:
- `frame_ops_provider_retarget_dom_cljs_test` (DEV, `test:browser`) — mounts a frame-only child under provider A, retargets A→B with `rf=`-equal props, asserts it reran, resolved B, updated its DOM node **in place** (local/component identity survives), a dispatch through the new bundle drove B and left A untouched, and a same-provider re-render adds no work. Reverting `render-dev`'s `useContext` → **5 failures**.
- `frame_ops_provider_retarget_elision_prod_test` (PROD `:advanced`, `test:browser-prod-elision`) — proves `render-frame` + `render-subs-frame` selection under the real production wrapper path and that a frame-independent view stays inert. Dropping `:frame-ops` from the emitter's `host-render` cond → **8 failures** (the mutation teeth).

## Spec ripples (follow-ups, not in this PR)

- Spec 004-Views §context-change repaint / Spec 006 §Frame-provider via React context could note that a compiled `(frame)`-only view is a frame-context consumer (parity with `use-frame`). Non-normative clarification — no contract change. Worth a docs bead.

## Quality gates

- `cd implementation/ui && clojure -M:test` (JVM ui): 476 tests / 6240 assertions, 0 failures (includes new `frame_ops_publication_race_jvm_test`).
- `cd implementation && npm run test:ui` (node ui): 476 tests / 2387 assertions, 0 warnings, 0 failures.
- `cd implementation && npm run test:browser` (DEV mounted): 347 tests / 1881 assertions, 0 failures (includes new `frame_ops_provider_retarget_dom_cljs_test`).
- `cd implementation && npm run test:browser-prod-elision` (PROD `:advanced` mounted): 82 tests / 279 assertions, 0 failures; `ui mounted production elision: PASS` (includes new `frame_ops_provider_retarget_elision_prod_test`).
- `scripts/test-fast-pr.sh`: **PASS fast PR spine** — 9309 tests / 44097 assertions, 0 failures, 0 errors; per-ns isolation all-green.

Red-before-fix confirmed for each fix by the mutation-teeth reverts above (.229: 2 failures; .228 DEV: 5, PROD: 8).
