### PR TITLE
fix(core): incarnation fencing — drain-depth error/halt-commit, flow registry/cache tails (rf2-vxgfnd.154/.155)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -293,6 +293,17 @@
       (write-elision-slot new-runtime-db
                           (get prev-runtime-db :rf.runtime/elision)))))
 
+(defn- apply-elision-transform
+  "Apply the caller's registry transform `f` to the `:rf.runtime/elision` slice
+  of `old-runtime-db`, writing the result back through `write-elision-slot`
+  (which prunes a stranded `:rf.runtime/elision` when the slot clears). The
+  shared read-transform-write body behind both `swap-elision-slot!` arities."
+  [f old-runtime-db]
+  (let [old-runtime-db (or old-runtime-db {})]
+    (write-elision-slot
+      old-runtime-db
+      (f (get-in old-runtime-db [:rf.runtime/elision])))))
+
 (defn ^:no-doc swap-elision-slot!
   "Read-transform-write helper for the per-frame elision registry.
 
@@ -308,15 +319,22 @@
 
   EP-0001: writes through `frame/swap-runtime-db!` (the
   runtime-db partition of the one physical frame-state container) — the
-  elision registry is durable framework state and lives in runtime-db."
-  [frame-id f]
-  (frame/swap-runtime-db! frame-id
-                          (fn [old-runtime-db]
-                            (let [old-runtime-db (or old-runtime-db {})]
-                              (write-elision-slot
-                                old-runtime-db
-                                (f (get-in old-runtime-db [:rf.runtime/elision]))))))
-  nil)
+  elision registry is durable framework state and lives in runtime-db.
+
+  rf2-vxgfnd.155 — the 3-arity is the EXACT-INCARNATION variant the flow
+  lifecycle ops (`clear-flow` / `reg-flow`) issue while an event owns the
+  frame: it routes through `frame/swap-runtime-db-exact!` so a synchronous
+  container watch that destroys A and publishes same-id B during this durable-
+  registry write cannot bump B's commit epoch or write B's runtime-db. The
+  2-arity is the historical bare-id write (EP-0025 classification effects,
+  machine / routing subsystem claims)."
+  ([frame-id f]
+   (frame/swap-runtime-db! frame-id #(apply-elision-transform f %))
+   nil)
+  ([frame-id owner-token f]
+   (frame/swap-runtime-db-exact! frame-id owner-token
+                                 #(apply-elision-transform f %))
+   nil))
 
 ;; ---- EP-0025 commit-plane classification effects -------------------------
 ;;

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1233,17 +1233,56 @@
   `swap-runtime-db!` (runtime-db partition); both differ ONLY by `pk`. Under
   the single-drainer invariant (Spec 002 §Single drainer per frame) the
   read-then-replace is effectively atomic — `commit-frame-transition!` is the
-  only writer during fx drain. INTERNAL."
-  [id pk f args]
-  (when-let [container (frame-state-container id)]
-    (let [current   (adapter/read-container container)
-          new-slice (apply f (get current pk) args)]
-      (adapter/replace-container! container (assoc current pk new-slice))
-      ;; Observation-port evidence counter (Spec 006 §The internal
-      ;; observation port): one bump per physical frame-state install —
-      ;; this is the second (and last) frame-state write chokepoint.
-      (bump-commit-epoch! id)
-      new-slice)))
+  only writer during fx drain. INTERNAL.
+
+  rf2-vxgfnd.155 — the 6-arity is the EXACT-INCARNATION variant used by the
+  callback-bearing flow-registry lifecycle writes (`clear-flow` / `reg-flow`
+  output-mark refresh and path vacation). It resolves the write through
+  `owner-token`'s own frame record (a same-id successor can never redirect it),
+  and — `replace-container!` is a host-adapter callback boundary whose
+  synchronous watch may destroy A and publish same-id B mid-install — rechecks
+  ownership after the callback. A's write that physically linearized in A's
+  captured container before the loss stands (it may legitimately appear in A's
+  halted-destroy snapshot), but the id-keyed commit-epoch bump is FENCED so it
+  never lands on B. Returns the new slice, or nil on owner loss (the caller
+  treats a nil as a no-op and rechecks liveness before its own later actions)."
+  ([id pk f args] (swap-partition! id pk f args nil false))
+  ([id pk f args owner-token exact-owner?]
+   (if-not exact-owner?
+     (when-let [container (frame-state-container id)]
+       (let [current   (adapter/read-container container)
+             new-slice (apply f (get current pk) args)]
+         (adapter/replace-container! container (assoc current pk new-slice))
+         ;; Observation-port evidence counter (Spec 006 §The internal
+         ;; observation port): one bump per physical frame-state install —
+         ;; this is the second (and last) frame-state write chokepoint.
+         (bump-commit-epoch! id)
+         new-slice))
+     ;; Exact-incarnation write (rf2-vxgfnd.155). Resolve the record so the
+     ;; write binds to A's own container; a same-id B cannot redirect it.
+     (when-let [frame-record (frame id)]
+       (when (identical? owner-token (:drain-lock frame-record))
+         (let [container   (:frame-state frame-record)
+               read-result (call-exact-frame-callback
+                             id owner-token true
+                             #(adapter/read-container container))]
+           (when-not (= stale-exact-callback read-result)
+             (let [current   (second read-result)
+                   new-slice (apply f (get current pk) args)]
+               ;; A synchronous watch inside `read-container` may already have
+               ;; lost A; recheck before the physical install.
+               (when (event-continuation-live? id owner-token)
+                 (let [replace-result
+                       (call-exact-frame-callback
+                         id owner-token true
+                         #(adapter/replace-container!
+                            container (assoc current pk new-slice)))]
+                   ;; The install callback's own watch may destroy A. A's write
+                   ;; linearized in A's captured container, but the id-keyed
+                   ;; commit-epoch bump must not attribute to same-id B.
+                   (when-not (= stale-exact-callback replace-result)
+                     (bump-commit-epoch! id)
+                     new-slice)))))))))))
 
 (defn swap-frame-db!
   "Mutate the frame's app-db PARTITION: read the current app-db value,
@@ -1284,6 +1323,24 @@
   is the framework-authority write surface."
   [id f & args]
   (swap-partition! id runtime-partition-key f args))
+
+(defn ^:no-doc swap-frame-db-exact!
+  "Exact-incarnation `swap-frame-db!` (rf2-vxgfnd.155): threads `owner-token`
+  so a synchronous container watch that destroys A and publishes a same-id B
+  during the physical install neither redirects the write into B nor bumps B's
+  commit epoch. A's write that linearized before the loss stands in A's
+  captured container. Used by the callback-bearing flow-registry lifecycle
+  writes. Returns the new app-db slice, or nil on owner loss."
+  [id owner-token f & args]
+  (swap-partition! id app-partition-key f args owner-token true))
+
+(defn ^:no-doc swap-runtime-db-exact!
+  "Exact-incarnation `swap-runtime-db!` (rf2-vxgfnd.155) — the runtime-db
+  sibling of `swap-frame-db-exact!`, used by the exact-aware elision-registry
+  writes the flow lifecycle ops issue. Returns the new runtime-db slice, or
+  nil on owner loss."
+  [id owner-token f & args]
+  (swap-partition! id runtime-partition-key f args owner-token true))
 
 ;; ---- lifecycle-vs-drain serialization -------------------------------------
 ;;

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2859,8 +2859,20 @@
   K settled event-ids, the `run-one-pass!` ring) is the CYCLE EVIDENCE — the
   repeating suffix names the runaway cycle. The record carries ids / counts
   ONLY; the human `:reason` prose stays on the dev-only `trace/emit-error!`
-  path (elided in production), per the elision discipline."
-  [frame-id router depth last-event tail-event-ids]
+  path (elided in production), per the elision discipline.
+
+  rf2-vxgfnd.154 — EXACT-INCARNATION halt fence. `owner-token` is A's captured
+  event-owner token (the frame record's `:drain-lock`). The depth-halt seam runs
+  OUTSIDE the event pipeline's `trace/call-with-continuation-predicate`, so
+  before this fix `trace/continuation-live?` read an always-true predicate: the
+  first `:rf.error/drain-depth-exceeded` listener could destroy A and publish a
+  same-id B, and every later fanout sibling, the frame-owned error route, the
+  dev trace, and the bare-id halt commit then leaked into B. Binding A's exact-
+  owner predicate around all callback-bearing halt work — and threading A's exact
+  token into `commit-halt-record!` — fences B: once the first listener loses A,
+  no later listener, frame route, trace, queue trailer, or halt commit targets B,
+  while evidence already delivered before the loss stands exactly once."
+  [frame-id owner-token router depth last-event tail-event-ids]
   (let [{:keys [queue]} @router
         queue-size      (count queue)
         ;; The halting event — the next one that would have been dequeued.
@@ -2907,6 +2919,17 @@
                          :depth      depth
                          :queue-size queue-size
                          :last-event last-event}]
+    ;; The evidence assembly above is a pure read; A still owns the frame at the
+    ;; halt seam (a halt is a depth trip, not a destroy). Bind A's EXACT-owner
+    ;; continuation predicate around EVERY callback-bearing halt action below
+    ;; (rf2-vxgfnd.154). `trace/continuation-live?` — which the always-on fanout,
+    ;; the frame-owned route, and the dev trace all consult — now reflects A's
+    ;; exact liveness, so the instant the first depth-error listener destroys A
+    ;; and publishes same-id B, every later sibling / route / trace / commit is
+    ;; fenced from B.
+    (trace/call-with-continuation-predicate
+      #(frame/event-continuation-live? frame-id owner-token)
+      (fn []
     ;; Axis 1 — ALWAYS-ON (rf2-fcbrjo). Fan a STRUCTURAL-ONLY non-event union
     ;; record out through the corpus-wide error-emit listener + the frame-owned
     ;; observability sink, so a drain-depth halt surfaces under `goog.DEBUG=
@@ -2958,16 +2981,24 @@
                           ;; are durable. `:rollback? false` reflects that.
                           :rollback?         false
                           :recovery          :no-recovery}))
+    ;; Drop A's runaway queue. The `router` atom is A's incarnation-private drain
+    ;; FSM (`make-frame` builds a fresh one per incarnation), so clearing it never
+    ;; reaches a same-id successor B; it runs unconditionally so A's abandoned
+    ;; queue never lingers even after a listener above lost A.
     (swap! router assoc :queue interop/empty-queue :scheduled? false)
-    (when-let [commit-halt! (late-bind/get-fn-cached :epoch/commit-halt-record!)]
-      ;; The halting event never ran, so the capture buffer is empty and
-      ;; `settle!` would skip; `commit-halt-record!` commits regardless,
-      ;; pinning the halting event's trigger. :frame-state-before equals
-      ;; :frame-state-after — the halting event made no write. rf2-bh56rc:
-      ;; `:committed-at` is the halting event's causal `:rf/time-ms`, not an
-      ;; ambient read.
-      (commit-halt! frame-id fs-now fs-now halting-time-ms :halted-depth halt-reason
-                    halting-event))))
+    ;; The halt commit is A's terminal `:halted-depth` epoch record. Gate it on
+    ;; A's live continuation AND thread A's EXACT owner token: once A is lost the
+    ;; commit neither harvests B's capture buffer nor claims/commits into B's
+    ;; history (rf2-vxgfnd.154). The halting event never ran, so the capture
+    ;; buffer is empty and `settle!` would skip; `commit-halt-record!` commits
+    ;; regardless, pinning the halting event's trigger. :frame-state-before
+    ;; equals :frame-state-after — the halting event made no write. rf2-bh56rc:
+    ;; `:committed-at` is the halting event's causal `:rf/time-ms`, not an
+    ;; ambient read.
+    (when (trace/continuation-live?)
+      (when-let [commit-halt! (late-bind/get-fn-cached :epoch/commit-halt-record!)]
+        (commit-halt! frame-id fs-now fs-now halting-time-ms :halted-depth
+                      halt-reason halting-event owner-token)))))))
 
 (defn- settle-event-epoch!
   "Commit the just-completed event's epoch (Tool-Pair §Time-travel). Per
@@ -3175,7 +3206,12 @@
          tail-ring  []]
     (cond
       (>= depth drain-depth)
-      (do (handle-depth-exceeded! frame-id router depth last-event tail-ring)
+      ;; rf2-vxgfnd.154: thread A's EXACT owner token (`:drain-lock`) so the halt
+      ;; fanout, frame route, dev trace, and terminal commit all bind to A's
+      ;; incarnation and are fenced from a same-id B a depth-error listener may
+      ;; publish.
+      (do (handle-depth-exceeded! frame-id (:drain-lock frame-record) router
+                                  depth last-event tail-ring)
           ::halt)
 
       ;; Per rf2-68kok: destruction-ownership check fires BEFORE the next

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -1110,3 +1110,120 @@
         (late-bind/set-fn! :observability/route-error-record original-route)))
     (is (zero? @sibling-runs) "later union listeners stop on owner loss")
     (is (zero? @route-runs) "the later frame-owned union route is inert")))
+
+;; ---- rf2-vxgfnd.154 — depth-halt fanout + commit exact-incarnation fence ----
+
+(deftest depth-halt-fanout-and-commit-fenced-when-first-listener-loses-a
+  ;; rf2-vxgfnd.154 (red before fix). A runaway cascade trips A's drain-depth
+  ;; limit. `handle-depth-exceeded!` fans the always-on
+  ;; `:rf.error/drain-depth-exceeded` record out through the corpus error-emit
+  ;; registry + the frame-owned error route, THEN commits A's terminal
+  ;; `:halted-depth` epoch record. The FIRST error listener destroys A and
+  ;; publishes a same-id B (with a sentinel in B's capture buffer). Because the
+  ;; depth-halt seam runs OUTSIDE the event pipeline's continuation predicate,
+  ;; before the fix `trace/continuation-live?` was always-true here: later
+  ;; fanout siblings and the frame-owned route ran against B, and the bare-id
+  ;; `commit-halt-record!` harvested B's buffer and committed A's halted-depth
+  ;; trigger into B's history.
+  ;;
+  ;; After the fix the depth-halt binds A's EXACT-owner continuation predicate
+  ;; and threads A's token into the commit: once the first listener loses A, no
+  ;; later sibling, frame route, or halt commit touches B; B's stores stay
+  ;; byte-identical; the evidence the first listener received stands exactly
+  ;; once.
+  (let [id             :drain.incarnation/depth-loss
+        depth-records  (atom [])
+        sibling-runs   (atom 0)
+        frame-routes   (atom 0)
+        b-token        (atom nil)
+        b-sentinel     {:operation :drain.incarnation/b-buffer :tags {:frame id}}
+        original-route (late-bind/get-fn :observability/route-error-record)]
+    (error-emit/clear-error-listeners!)
+    (rf/reg-event :drain.incarnation/loop
+      (fn [_ _] {:fx [[:dispatch [:drain.incarnation/loop]]]}))
+    (rf/make-frame {:id id :drain-depth 4})
+    (try
+      (late-bind/set-fn! :observability/route-error-record
+        (fn [record]
+          (when (= :rf.error/drain-depth-exceeded (:error record))
+            (swap! frame-routes inc))
+          (when original-route (original-route record))))
+      ;; Listener #1 (destroyer) is registered FIRST so the small array-map
+      ;; corpus registry fans it before the sibling: it destroys A, publishes
+      ;; same-id B, and installs a sentinel into B's capture buffer.
+      (rf/register-listener! :errors ::depth-destroyer
+        (fn [record]
+          (when (= :rf.error/drain-depth-exceeded (:error record))
+            (swap! depth-records conj record)
+            (frame/destroy-frame! id)
+            (rf/make-frame {:id id})
+            (reset! b-token (frame/frame-incarnation-token id))
+            (epoch-state/buffer-event! id b-sentinel))))
+      (rf/register-listener! :errors ::depth-sibling
+        (fn [record]
+          (when (= :rf.error/drain-depth-exceeded (:error record))
+            (swap! sibling-runs inc))))
+      (rf/dispatch-sync [:drain.incarnation/loop] {:frame id})
+      (executor-barrier!)
+      (let [token-b @b-token]
+        (is (= 1 (count @depth-records))
+            "the first error listener received the depth record exactly once")
+        (is (some? token-b) "the destroyer published a same-id B")
+        (is (zero? @sibling-runs)
+            "no later corpus error listener runs once the first listener loses A")
+        (is (zero? @frame-routes)
+            "A's depth record never resolves through B's frame-owned error route")
+        (is (identical? token-b (frame/frame-incarnation-token id))
+            "B remains the live incarnation")
+        (is (= {} (frame/frame-app-db-value id))
+            "A's halted-depth commit never mutates B's app-db")
+        (is (empty? (rf/epoch-history id))
+            "no A halted-depth record is committed into B's history")
+        (is (nil? (epoch-state/last-settled-epoch-id id))
+            "A's halt commit never claims B's last-settled anchor")
+        (is (= [b-sentinel] (epoch-state/buffer-for id))
+            "A's halt commit never harvests B's capture buffer"))
+      (finally
+        (rf/unregister-listener! :errors ::depth-destroyer)
+        (rf/unregister-listener! :errors ::depth-sibling)
+        (error-emit/clear-error-listeners!)
+        (late-bind/set-fn! :observability/route-error-record original-route)
+        (when (frame/frame id) (frame/destroy-frame! id))))))
+
+(deftest depth-halt-fans-and-commits-normally-when-a-retains-ownership
+  ;; rf2-vxgfnd.154 mutation tooth. When A stays live through the depth halt the
+  ;; exact-owner continuation predicate must NOT suppress the ordinary
+  ;; behaviour: every corpus error listener still receives the depth record, and
+  ;; A's terminal `:halted-depth` epoch record is still committed into A's own
+  ;; history. A wrongly always-false predicate would silence both.
+  (let [id            :drain.incarnation/depth-live
+        depth-records (atom [])
+        sibling-runs  (atom 0)]
+    (error-emit/clear-error-listeners!)
+    (rf/reg-event :drain.incarnation/live-loop
+      (fn [_ _] {:fx [[:dispatch [:drain.incarnation/live-loop]]]}))
+    (rf/make-frame {:id id :drain-depth 4})
+    (try
+      (rf/register-listener! :errors ::live-a
+        (fn [record]
+          (when (= :rf.error/drain-depth-exceeded (:error record))
+            (swap! depth-records conj record))))
+      (rf/register-listener! :errors ::live-b
+        (fn [record]
+          (when (= :rf.error/drain-depth-exceeded (:error record))
+            (swap! sibling-runs inc))))
+      (rf/dispatch-sync [:drain.incarnation/live-loop] {:frame id})
+      (executor-barrier!)
+      (is (= 1 (count @depth-records))
+          "the always-on depth record fans out when A stays live")
+      (is (= id (:frame (first @depth-records)))
+          "the depth record names the overflowing frame")
+      (is (= 1 @sibling-runs)
+          "every corpus error listener runs when A retains ownership")
+      (is (some #(= :halted-depth (:outcome %)) (rf/epoch-history id))
+          "A's terminal halted-depth record is committed into A's own history")
+      (finally
+        (rf/unregister-listener! :errors ::live-a)
+        (rf/unregister-listener! :errors ::live-b)
+        (error-emit/clear-error-listeners!)
+        (when (frame/frame id) (frame/destroy-frame! id))))))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -294,23 +294,41 @@
   settled record's `:frame-state-after`; the router's live value is only the
   fallback when no record has settled. The snapshots are equal because the
   halted event made no write. Residual capture is cleared before commit, and
-  `committed-at` comes from the halted event's already-stamped envelope."
-  [frame-id frame-state-before frame-state-after committed-at outcome halt-reason trigger-event]
+  `committed-at` comes from the halted event's already-stamped envelope.
+
+  rf2-vxgfnd.154 — EXACT-INCARNATION halt commit. `exact-owner-token` is A's
+  event-owner token (its `:drain-lock`); the router threads it so a depth-error
+  listener that destroyed A and published a same-id B cannot have this terminal
+  commit steal B's stores. The buffer harvest AND the record build/commit are
+  gated on A's live continuation, and `commit-record!` claims A's exact token
+  rather than resolving the current bare-id owner. Once A is lost the commit
+  neither harvests B's capture buffer nor commits into B's history; when A
+  retains ownership (the ordinary depth halt) behaviour is unchanged. A nil
+  token preserves the historical bare-id contract for any non-exact caller.
+  Kept single-arity (not multi-arity) with the `(when interop/debug-enabled? …)`
+  outermost so the epoch's trace-event-projection keyword references stay DCE-
+  able in production (multi-arity perturbed Closure's `:advanced` reachability —
+  the rf2-cprm0q elision trap)."
+  [frame-id frame-state-before frame-state-after committed-at outcome halt-reason
+   trigger-event exact-owner-token]
   (when interop/debug-enabled?
-    (let [events (state/harvest-buffer! frame-id)
-          ;; Source the durable value from the same snapshot restore uses,
-          ;; rather than trusting the router's live re-read. Fall back to
-          ;; the router-passed value when no `:ok` epoch has landed yet
-          ;; (depth-exceed on the first cascade).
-          last-id     (state/last-settled-epoch-id frame-id)
-          last-record (when last-id
-                        (->> (state/history-for frame-id)
-                             (some (fn [r] (when (= last-id (:epoch-id r)) r)))))
-          fs          (if last-record
-                        (:frame-state-after last-record)
-                        frame-state-after)]
-      (commit-record! frame-id fs fs events
-                      committed-at outcome halt-reason trigger-event nil))))
+    (when (or (nil? exact-owner-token)
+              (frame/event-continuation-live? frame-id exact-owner-token))
+      (let [events (state/harvest-buffer! frame-id)
+            ;; Source the durable value from the same snapshot restore uses,
+            ;; rather than trusting the router's live re-read. Fall back to
+            ;; the router-passed value when no `:ok` epoch has landed yet
+            ;; (depth-exceed on the first cascade).
+            last-id     (state/last-settled-epoch-id frame-id)
+            last-record (when last-id
+                          (->> (state/history-for frame-id)
+                               (some (fn [r] (when (= last-id (:epoch-id r)) r)))))
+            fs          (if last-record
+                          (:frame-state-after last-record)
+                          frame-state-after)]
+        (commit-record! frame-id fs fs events
+                        committed-at outcome halt-reason trigger-event
+                        exact-owner-token)))))
 
 ;; ---- restore --------------------------------------------------------------
 ;;

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -467,10 +467,17 @@
         (elision/replace-owner-claims :declarations owner explicit-l))))
 
 (defn- write-flow-output-marks!
-  "Install or refresh one flow's output declarations in its frame."
-  [frame-id flow]
-  (elision/swap-elision-slot! frame-id
-    (fn [reg] (fold-flow-declarations reg flow))))
+  "Install or refresh one flow's output declarations in its frame.
+
+  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
+  incarnation elision write so a synchronous container watch that destroys A
+  mid-write cannot bump same-id B's commit epoch or write B's runtime-db."
+  ([frame-id flow] (write-flow-output-marks! frame-id nil flow))
+  ([frame-id owner-token flow]
+   (let [xf (fn [reg] (fold-flow-declarations reg flow))]
+     (if owner-token
+       (elision/swap-elision-slot! frame-id owner-token xf)
+       (elision/swap-elision-slot! frame-id xf)))))
 
 (defn- clear-flow-output-marks!
   "Remove one flow's declarations while preserving every other declaration
@@ -478,14 +485,21 @@
   axis.
 
   Frame teardown needs no per-flow scrub because the elision registry belongs
-  to the frame-state container that destruction removes."
-  [frame-id flow-id]
-  (let [owner (flow-owner flow-id)]
-    (elision/swap-elision-slot! frame-id
-      (fn [reg]
-        (-> (or reg {})
-            (elision/remove-owner :sensitive-declarations owner)
-            (elision/remove-owner :declarations owner))))))
+  to the frame-state container that destruction removes.
+
+  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
+  incarnation elision write so a synchronous container watch that destroys A
+  mid-write cannot bump same-id B's commit epoch or write B's runtime-db."
+  ([frame-id flow-id] (clear-flow-output-marks! frame-id nil flow-id))
+  ([frame-id owner-token flow-id]
+   (let [owner (flow-owner flow-id)
+         xf    (fn [reg]
+                 (-> (or reg {})
+                     (elision/remove-owner :sensitive-declarations owner)
+                     (elision/remove-owner :declarations owner)))]
+     (if owner-token
+       (elision/swap-elision-slot! frame-id owner-token xf)
+       (elision/swap-elision-slot! frame-id xf)))))
 
 ;; ---- registration --------------------------------------------------------
 
@@ -625,36 +639,48 @@
                         (assoc m frame-id prospective)))))
            ;; A moved output must vacate the old path. Queue the vacation during
            ;; a drain so it is applied to the pending db; otherwise write now.
+           ;; rf2-vxgfnd.155: the direct-path vacation is a callback-bearing
+           ;; app-db write — thread A's pinned incarnation so a watch that loses
+           ;; A cannot bump same-id B's commit epoch or write B's app-db.
            (when-let [prior @prior-on-frame]
              (let [old-path (:output-path prior)]
                (when (not= old-path (:output-path flow))
                  (if (frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id old-path)
-                   (vacate-output-path! frame-id old-path)))))
-           ;; Replacements always refresh marks so removing a declaration also
-           ;; clears the previous one.
-           (when (or (flow-declares-marks? flow)
-                     (some? @prior-on-frame))
-             (write-flow-output-marks! frame-id flow))
-           ;; A replacement invalidates the cache even when inputs are equal.
-           ;; Hot-reload trace dedup uses the derive function as handler identity.
-           (when (some? @prior-on-frame)
-             (drop-frame-flow-row! frame-id flow-id)
-             (when interop/debug-enabled?
-               (let [prior      @prior-on-frame
-                     different? (not= (:derive prior) (:derive flow))
-                     ;; The shared dedup projector expects handler identity under
-                     ;; `:handler-fn`.
-                     shape-meta (assoc flow :handler-fn (:derive flow))
-                     dedup-ok?  (if-let [f (late-bind/get-fn-cached
-                                             :trace.tooling/dedup-allow?)]
-                                  (f :rf.registry/handler-replaced :flow flow-id shape-meta)
-                                  true)]
-                 (when dedup-ok?
-                   (trace/emit! :rf.registry :rf.registry/handler-replaced
-                                {:kind          :flow
-                                 :id            flow-id
-                                 :different-fn? different?})))))))
+                   (vacate-output-path! frame-id pinned-incarnation old-path)))))
+           ;; rf2-vxgfnd.155: postcheck after the (callback-bearing) vacation
+           ;; before the mark write + the bare-id dirty-cache drop + dedup trace.
+           ;; If a container watch destroyed A, abort so no stale A mark / cache /
+           ;; dedup mutation reaches a same-id B.
+           (when (frame/event-continuation-live? frame-id pinned-incarnation)
+             ;; Replacements always refresh marks so removing a declaration also
+             ;; clears the previous one. Exact-incarnation write.
+             (when (or (flow-declares-marks? flow)
+                       (some? @prior-on-frame))
+               (write-flow-output-marks! frame-id pinned-incarnation flow))
+             ;; Postcheck after the output-mark container write before the
+             ;; bare-id dirty-cache drop + dedup trace.
+             (when (frame/event-continuation-live? frame-id pinned-incarnation)
+               ;; A replacement invalidates the cache even when inputs are equal.
+               ;; Hot-reload trace dedup uses the derive function as handler
+               ;; identity.
+               (when (some? @prior-on-frame)
+                 (drop-frame-flow-row! frame-id flow-id)
+                 (when interop/debug-enabled?
+                   (let [prior      @prior-on-frame
+                         different? (not= (:derive prior) (:derive flow))
+                         ;; The shared dedup projector expects handler identity
+                         ;; under `:handler-fn`.
+                         shape-meta (assoc flow :handler-fn (:derive flow))
+                         dedup-ok?  (if-let [f (late-bind/get-fn-cached
+                                                 :trace.tooling/dedup-allow?)]
+                                      (f :rf.registry/handler-replaced :flow flow-id shape-meta)
+                                      true)]
+                     (when dedup-ok?
+                       (trace/emit! :rf.registry :rf.registry/handler-replaced
+                                    {:kind          :flow
+                                     :id            flow-id
+                                     :different-fn? different?})))))))))
        ;; Registration is first-time per frame; replacements use the hot-reload
        ;; trace above.
        (when (and interop/debug-enabled? (nil? @prior-on-frame))
@@ -698,12 +724,19 @@
     (dissoc-in-safe db path)))
 
 (defn- vacate-output-path!
-  "Remove an output path from a frame's app-db, skipping no-op writes."
-  [frame-id path]
-  (when-let [db (frame/frame-app-db-value frame-id)]
-    (let [new-db (vacate-path-in-db db path)]
-      (when-not (identical? new-db db)
-        (frame/swap-frame-db! frame-id (constantly new-db))))))
+  "Remove an output path from a frame's app-db, skipping no-op writes.
+
+  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
+  incarnation app-db write so a synchronous container watch that destroys A
+  mid-vacation cannot bump same-id B's commit epoch or write B's app-db."
+  ([frame-id path] (vacate-output-path! frame-id nil path))
+  ([frame-id owner-token path]
+   (when-let [db (frame/frame-app-db-value frame-id)]
+     (let [new-db (vacate-path-in-db db path)]
+       (when-not (identical? new-db db)
+         (if owner-token
+           (frame/swap-frame-db-exact! frame-id owner-token (constantly new-db))
+           (frame/swap-frame-db! frame-id (constantly new-db))))))))
 
 (defn clear-flow
   "Deregister a flow and remove its output leaf from the selected frame.
@@ -725,20 +758,35 @@
            frame-id
            (fn []
              (when-let [flow (get-in @flows [frame-id id])]
-               (let [path (:output-path flow)]
+               ;; rf2-vxgfnd.155: PIN A's incarnation so the callback-bearing
+               ;; output-mark / path-vacation writes below cannot let a stale A
+               ;; tail dissociate a same-id B's flow row, drop B's dirty-check
+               ;; cache, or bump B's commit epoch. A synchronous container watch
+               ;; may destroy A and publish B mid-write; only A's write that
+               ;; linearized before that loss stands, and every later registry /
+               ;; cache action is fenced by an immediate exact-owner postcheck.
+               (let [pinned (frame/frame-incarnation-token frame-id)
+                     path   (:output-path flow)]
                  ;; In-drain vacation must modify the pending db, not the live
                  ;; app-db that the deferred commit will replace.
                  (if (frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id path)
-                   (vacate-output-path! frame-id path))
-                 (clear-flow-output-marks! frame-id id)
-                 ;; Prune an empty frame row rather than expose `{frame-id {}}`.
-                 (swap! flows (fn [m]
-                                (let [m' (update m frame-id dissoc id)]
-                                  (cond-> m'
-                                    (empty? (get m' frame-id)) (dissoc frame-id)))))
-                 (drop-frame-flow-row! frame-id id)
-                 path))))]
+                   (vacate-output-path! frame-id pinned path))
+                 ;; Postcheck after the (callback-bearing, direct-path) vacation:
+                 ;; if the watch lost A, abort before the mark write and the
+                 ;; bare-id registry / dirty-cache mutations reach B.
+                 (when (frame/event-continuation-live? frame-id pinned)
+                   (clear-flow-output-marks! frame-id pinned id)
+                   ;; Postcheck after the output-mark container write before the
+                   ;; bare-id flow-row dissoc + dirty-cache drop.
+                   (when (frame/event-continuation-live? frame-id pinned)
+                     ;; Prune an empty frame row rather than expose `{frame-id {}}`.
+                     (swap! flows (fn [m]
+                                    (let [m' (update m frame-id dissoc id)]
+                                      (cond-> m'
+                                        (empty? (get m' frame-id)) (dissoc frame-id)))))
+                     (drop-frame-flow-row! frame-id id)
+                     path))))))]
      ;; A no-op clear emits nothing.
      (when (and cleared-path interop/debug-enabled?)
        (trace/emit! :flow :rf.flow/cleared

--- a/implementation/flows/test/re_frame/flows_clear_reg_watch_incarnation_test.clj
+++ b/implementation/flows/test/re_frame/flows_clear_reg_watch_incarnation_test.clj
@@ -1,0 +1,221 @@
+(ns re-frame.flows-clear-reg-watch-incarnation-test
+  "rf2-vxgfnd.155 — exact-incarnation fence for the callback-bearing flow
+  registry lifecycle ops.
+
+  `clear-flow` and `reg-flow` REPLACEMENT each perform callback-bearing
+  container writes (the output-mark refresh via `swap-elision-slot!`, and — in
+  the non-drain path — the app-db path vacation via `swap-frame-db!`) BEFORE
+  their bare-id registry / dirty-check / commit-epoch tail. A synchronous
+  container watch fired during one of those writes can destroy incarnation A
+  and publish a same-id B. Before the fix the stale A tail then dissociated B's
+  flow row, dropped B's dirty-check cache, and bumped B's commit epoch by bare
+  id — while the reserved-fx postcheck only observed the loss AFTER the whole
+  handler returned.
+
+  After the fix each callback-bearing write is exact-incarnation aware (the
+  commit-epoch bump is fenced once A is lost) and each lifecycle op rechecks A's
+  live continuation after the callback, aborting before any bare-id registry /
+  cache / dedup mutation reaches B. Only A's write that physically linearized
+  before the loss stands; B's stores stay byte-identical.
+
+  The watch is driven SYNCHRONOUSLY on the single JVM test thread (the watch
+  destroys A + publishes B reentrantly), so the cross-incarnation ordering is
+  fully deterministic without threads. A one-shot `armed?` CAS makes the watch
+  fire exactly once, during the lifecycle op under test."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.flows :as flows]
+            [re-frame.flows.registry :as registry]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- install-watching-adapter!
+  "Install a plain-atom-backed adapter whose `replace-container!` runs `on-write`
+  (a 0-arg thunk) exactly once, the first time a container write happens while
+  `armed?` holds true. The physical write always lands FIRST so A's write that
+  linearized before the loss stands."
+  [armed? on-write]
+  (let [base-replace (:replace-container! plain-atom/adapter)]
+    (adapter/dispose-adapter!)
+    (reset! frame/frames {})
+    (adapter/install-adapter!
+      (assoc plain-atom/adapter
+             :kind :custom
+             :replace-container!
+             (fn [container value]
+               (base-replace container value)
+               (when (compare-and-set! armed? true false)
+                 (on-write)))))))
+
+(defn- restore-plain-adapter! []
+  (reset! frame/frames {})
+  (adapter/dispose-adapter!)
+  (adapter/install-adapter! plain-atom/adapter))
+
+;; ---------------------------------------------------------------------------
+;; clear-flow — the output-mark write's watch loses A; the stale tail must not
+;; dissociate B's flow row, drop B's dirty-check cache, or bump B's commit epoch.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-output-mark-watch-loss-does-not-corrupt-successor
+  ;; rf2-vxgfnd.155 (red before fix). Clearing A's flow removes its output-mark
+  ;; declaration through a container write; that write's synchronous watch
+  ;; destroys A and publishes same-id B (with B's own flow row + dirty-check
+  ;; cache + output-mark declaration). Before the fix A's stale clear-flow tail
+  ;; then dissociated B's flow row and dropped B's dirty-check cache, and the
+  ;; bare-id mark write bumped B's commit epoch.
+  (let [id            :flow.incarnation/clear-loss
+        armed?        (atom false)
+        b-flow-row    (atom ::unset)
+        b-dirty       (atom ::unset)
+        b-commit      (atom ::unset)
+        b-sensitive   (atom ::unset)
+        b-token       (atom nil)]
+    (install-watching-adapter!
+      armed?
+      (fn []
+        ;; The mark-write watch: destroy A, publish same-id B with its own flow
+        ;; state, and snapshot B's stores for the byte-identical assertions.
+        (frame/destroy-frame! id)
+        (rf/make-frame {:id id})
+        (rf/reg-flow :flow.incarnation/f
+          {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
+          (fn [n] (or n 0)))
+        (registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
+        (reset! b-token (frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (registry/flows-snapshot)
+                                   [id :flow.incarnation/f]))
+        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+        (reset! b-commit (frame/frame-commit-epoch id))
+        (reset! b-sensitive (elision/sensitive-declarations id))))
+    (try
+      (rf/make-frame {:id id})
+      ;; A's flow declares an output classification so clearing it produces a
+      ;; real elision-registry (runtime-db) container write — the watch seam.
+      (rf/reg-flow :flow.incarnation/f
+        {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
+        (fn [n] (or n 0)))
+      (reset! armed? true)
+      (is (nil? (flows/clear-flow :flow.incarnation/f {:frame id}))
+          "clear-flow returns nil; its stale tail is aborted after the watch")
+      (let [token-b @b-token]
+        (is (some? token-b) "the mark-write watch published a same-id B")
+        (is (identical? token-b (frame/frame-incarnation-token id))
+            "B remains the live incarnation")
+        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/f]))
+            "A's stale clear-flow tail never dissociates B's flow row")
+        (is (= @b-dirty
+               (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+            "A's stale clear-flow tail never drops B's dirty-check cache")
+        (is (= @b-commit (frame/frame-commit-epoch id))
+            "A's stale mark write never bumps B's commit epoch")
+        (is (= @b-sensitive (elision/sensitive-declarations id))
+            "A's stale clear-flow tail never rewrites B's output-mark declaration"))
+      (finally
+        (restore-plain-adapter!)))))
+
+;; ---------------------------------------------------------------------------
+;; reg-flow REPLACEMENT — the output-mark refresh write's watch loses A; the
+;; stale post-mark tail (dirty-check drop + dedup trace + commit-epoch bump)
+;; must not reach B.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-replacement-mark-watch-loss-does-not-corrupt-successor
+  ;; rf2-vxgfnd.155 (red before fix). Replacing A's flow refreshes its output
+  ;; marks through a container write; that write's synchronous watch destroys A
+  ;; and publishes same-id B (with B's own flow row + dirty-check cache). Before
+  ;; the fix A's stale post-mark tail then dropped B's dirty-check cache (and
+  ;; emitted a bare-id dedup trace), and the bare-id mark write bumped B's
+  ;; commit epoch.
+  (let [id            :flow.incarnation/reg-loss
+        armed?        (atom false)
+        b-flow-row    (atom ::unset)
+        b-dirty       (atom ::unset)
+        b-commit      (atom ::unset)
+        b-token       (atom nil)]
+    (install-watching-adapter!
+      armed?
+      (fn []
+        (frame/destroy-frame! id)
+        (rf/make-frame {:id id})
+        (rf/reg-flow :flow.incarnation/g
+          {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
+          (fn [n] (or n 0)))
+        (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::b-input])
+        (reset! b-token (frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (registry/flows-snapshot)
+                                   [id :flow.incarnation/g]))
+        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+        (reset! b-commit (frame/frame-commit-epoch id))))
+    (try
+      (rf/make-frame {:id id})
+      (rf/reg-flow :flow.incarnation/g
+        {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
+        (fn [n] (or n 0)))
+      ;; Prime a dirty-check row for A so the (unfixed) stale drop-frame-flow-row!
+      ;; would have something to drop off the successor.
+      (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::a-input])
+      (reset! armed? true)
+      ;; Replacement registration: refreshes marks (the watch seam), then runs
+      ;; the post-mark dirty-cache + dedup tail.
+      (rf/reg-flow :flow.incarnation/g
+        {:frame id :inputs [[:n2]] :output-path [:out] :sensitive [[:out]]}
+        (fn [n] (* 2 (or n 0))))
+      (let [token-b @b-token]
+        (is (some? token-b) "the mark-refresh watch published a same-id B")
+        (is (identical? token-b (frame/frame-incarnation-token id))
+            "B remains the live incarnation")
+        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/g]))
+            "A's stale reg-flow tail never rewrites B's flow row")
+        (is (= @b-dirty
+               (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+            "A's stale post-mark tail never drops B's dirty-check cache")
+        (is (= @b-commit (frame/frame-commit-epoch id))
+            "A's stale mark write never bumps B's commit epoch"))
+      (finally
+        (restore-plain-adapter!)))))
+
+;; ---------------------------------------------------------------------------
+;; Green control — when A retains ownership through a NON-destroying watch, the
+;; ordinary clear-flow behaviour (row removal, cache drop, mark removal, commit-
+;; epoch bump) is preserved. A wrongly-fencing exact path would silently no-op.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-with-live-owner-still-clears-row-cache-and-marks
+  ;; rf2-vxgfnd.155 mutation tooth. The exact-incarnation writes must NOT
+  ;; suppress the normal clear when A stays live: the flow row and dirty-check
+  ;; cache are removed, the output-mark declaration is cleared, and the mark
+  ;; write's commit epoch advances.
+  (let [id          :flow.incarnation/clear-live
+        armed?      (atom false)
+        watch-runs  (atom 0)]
+    (install-watching-adapter!
+      armed?
+      (fn [] (swap! watch-runs inc)))          ; observe only — A stays live
+    (try
+      (rf/make-frame {:id id})
+      (rf/reg-flow :flow.incarnation/h
+        {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
+        (fn [n] (or n 0)))
+      (registry/set-frame-flow-last-inputs! id :flow.incarnation/h [::a-input])
+      (let [epoch-before (frame/frame-commit-epoch id)]
+        (reset! armed? true)
+        (is (nil? (flows/clear-flow :flow.incarnation/h {:frame id}))
+            "clear-flow completes normally against the live owner")
+        (is (= 1 @watch-runs) "the container watch fired on the mark write")
+        (is (nil? (get-in (registry/flows-snapshot) [id :flow.incarnation/h]))
+            "the flow row is removed for the live owner")
+        (is (nil? (registry/get-frame-flow-last-inputs id :flow.incarnation/h))
+            "the dirty-check cache row is dropped for the live owner")
+        (is (empty? (elision/sensitive-declarations id))
+            "the flow's output-mark declaration is cleared for the live owner")
+        (is (> (frame/frame-commit-epoch id) epoch-before)
+            "the mark write advanced the live owner's commit epoch"))
+      (finally
+        (restore-plain-adapter!)))))

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -106,11 +106,14 @@
       ;; via the var-quote (which reads private vars) and restore in finally.
       (alter-var-root vacate-var
                       (constantly
-                        (fn [frame-id path]
+                        ;; Variadic so the patch tolerates both the bare 2-arity
+                        ;; and the rf2-vxgfnd.155 exact-incarnation 3-arity
+                        ;; (`[frame-id owner-token path]`) clear-flow now calls.
+                        (fn [frame-id & args]
                           ;; Real work first (vacate, THEN the registry removal
                           ;; clear-flow does next), then park in the window
                           ;; with the drain-lock held.
-                          (orig-vacate frame-id path)
+                          (apply orig-vacate frame-id args)
                           (.countDown vacated)
                           (await! release "clear-flow release"))))
       (try


### PR DESCRIPTION
Two P1 incarnation-fencing findings on adjacent core modules, run as one serial worker (coupled core module). Both extend the exact-incarnation destroy fence (#5818) and the incarnation pair (#5850) to two callback-bearing seams they did not cover: once a frame incarnation's ownership is lost, framework actions bind to the exact incarnation, never a successor; linearized-before-loss writes stand, only the unentered tail is fenced.

Each finding's repro was re-verified against fresh `origin/main` (with #5818/#5839/#5849/#5850 merged) — both were **still live** at the current head — and each fix carries a red-before-fix fixture demonstrating the leak before, byte-identical successor stores after.

## rf2-vxgfnd.154 — drain-depth error fanout + halt commit

`handle-depth-exceeded!` runs OUTSIDE the event pipeline's `trace/call-with-continuation-predicate`, so `trace/continuation-live?` read an always-true predicate there. A `:rf.error/drain-depth-exceeded` listener that destroyed A and published a same-id B leaked: later fanout siblings and the frame-owned error route ran against B, and the bare-id `commit-halt-record!` harvested B's capture buffer and committed A's halted-depth trigger into B's history (the red run even shows B's sentinel buffer swept into the leaked record's `:trace-events`).

Fix: bind A's exact-owner continuation predicate around all callback-bearing halt work (Axis-1 fanout + frame route, Axis-2 dev trace — which self-fences on `continuing?`), and thread A's exact owner token (`:drain-lock`) into `commit-halt-record!` as a required exact-owner parameter (gates the buffer harvest AND the record build/commit on A's liveness; `commit-record!` claims A's exact token, never a successor's). Ordinary depth halt (A retains ownership) is unchanged. Touches `router.cljc` + `epoch.cljc`.

`commit-halt-record!` is kept SINGLE-arity (not multi-arity) with its `(when interop/debug-enabled? …)` gate outermost: a multi-arity form perturbed Closure's `:advanced` reachability and leaked the epoch's dev-only trace-projection keyword references (`:rf.event/run-start`, `:rf.view/rendered`) into production — the rf2-cprm0q elision trap, caught by the Spec 009 elision probe (`npm run test:elision`), which is green on the final head.

Red-before-fix fixture (`implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj`): **`depth-halt-fanout-and-commit-fenced-when-first-listener-loses-a`** — the first error listener destroys A, publishes same-id B, installs a sentinel in B's buffer; asserts no sibling / frame route / halt commit reaches B and B's token, app-db, history, last-settled anchor, and capture buffer stay byte-identical. Green control: **`depth-halt-fans-and-commits-normally-when-a-retains-ownership`**.

## rf2-vxgfnd.155 — flow registry + cache tails after container callbacks

`clear-flow` and `reg-flow` replacement perform callback-bearing container writes (output-mark refresh via `swap-elision-slot!`; direct-path app-db vacation via `swap-frame-db!`) BEFORE their bare-id registry / dirty-check / commit-epoch tail. A synchronous container watch fired during one of those writes can destroy A and publish same-id B; the stale A tail then dissociated B's flow row, dropped B's dirty-check cache, and bumped B's commit epoch by bare id — the reserved-fx postcheck only observed the loss after the whole handler returned.

Fix: add an exact-incarnation partition write (`swap-partition!` 6-arity + `swap-frame-db-exact!` / `swap-runtime-db-exact!`) that resolves the write through the owner-token's own record and fences the commit-epoch bump once A is lost; give `elision/swap-elision-slot!` and the flow-registry mark/vacation helpers exact-owner arities; and have `clear-flow` / `reg-flow` pin A's incarnation and recheck A's live continuation immediately after each callback-bearing write, aborting before any bare-id registry / cache / dedup mutation reaches B. Only A's write that linearized before the loss stands. Touches `core/elision.cljc`, `core/frame.cljc`, `flows/registry.cljc` (fx.cljc's reserved-fx postcheck is explicitly NOT relied on as an internal transaction boundary).

Red-before-fix fixtures (`implementation/flows/test/re_frame/flows_clear_reg_watch_incarnation_test.clj`): **`clear-flow-output-mark-watch-loss-does-not-corrupt-successor`** and **`reg-flow-replacement-mark-watch-loss-does-not-corrupt-successor`** — a synchronous mark-write watch destroys A, publishes same-id B with its own flow row + dirty-check cache; asserts no stale tail dissociates B's row, drops B's cache, or bumps B's commit epoch (red run: row → nil, cache → nil, commit-epoch 1→2). Green control: **`clear-flow-with-live-owner-still-clears-row-cache-and-marks`**. The drain-race test's private-fn patch was updated to tolerate the new exact-owner arity.

## Quality gates

All foreground, JVM via `clojure -M:test`, plus the CLJS node runtime and the fast-PR spine:

| gate | tests | assertions | result |
| --- | --- | --- | --- |
| core | 1937 | 8841 | 0 fail / 0 err |
| epoch | 388 | 2413 | 0 fail / 0 err |
| flows | 223 | 5926 | 0 fail / 0 err |
| machines conformance | 1024 | 3458 | 0 fail / 0 err |
| CLJS node integration (`test:cljs`) | 9300 | 44069 | 0 fail / 0 err |
| `scripts/test-fast-pr.sh` | — | — | green (incl. production elision probe, bundle isolation) |

The destroyed-reason channel matrix and #5850's frame/epoch fences are intact (machines conformance green).
