### PR TITLE
test(ui)+ci: G-13 gate hardening — causal V-independence, elision, exactly-once, core-change selection (rf2-vxgfnd.209/.210/.211/.212)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -172,6 +172,20 @@ else
         template_expensive=true
         mcp_conformance=true
         mcp_live=true
+        # rf2-vxgfnd.209 — G-13 (cljs-ui-g13) is the end-to-end MOUNTED
+        # falsifier for re-frame.ui push economics (05 §3), and it traverses
+        # core dispatch/drain, the router, frame scheduling, the observation
+        # port, ViewCell enrolment, uSES, compiled bodies, and the React
+        # commit. A change to any implementation/core/* runtime source (the
+        # observation port, router drain, the frame scheduler, …) can introduce
+        # V-wide fan-out or split the write/read batching G-13 exists to catch,
+        # yet the gate ran only under ui_gates — false for a core-only PR — so
+        # the required-check aggregator accepted the skipped job. Arm ui_gates
+        # for the whole core surface (a conservative superset; a narrower
+        # explicit dependency list would be brittle as core evolves) so
+        # cljs-ui-g13 runs for any core runtime change. Docs/spec/tool-only PRs
+        # never reach this case and keep their existing skip.
+        ui_gates=true
         ;;
       implementation/adapters/reagent-slim/*|examples/substrates/reagent_slim/counter/*|implementation/scripts/check-reagent-slim-bundle-isolation.cjs)
         # rf2-8cevm — the examples/ tree is test-free. counter_slim_and_fast

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -160,6 +160,42 @@ test('Core change runs jvm-core + cljs (implementation_jvm + cljs_node_test true
   assert.equal(result.cljs_node_test, 'true');
 });
 
+// rf2-vxgfnd.209 — G-13 (cljs-ui-g13, gated on ui_gates) is the end-to-end
+// MOUNTED falsifier for re-frame.ui push economics; it traverses core
+// dispatch/drain, the router, frame scheduling, and the observation port. Any
+// core runtime change must schedule it, or a V-wide fan-out / split-batching
+// regression reachable only through core merges with the one gate that catches
+// it skipped. Docs/spec/tool-only changes keep their existing skip.
+test('Core observation-port change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)', () => {
+  const result = classify('implementation/core/src/re_frame/substrate/observation.cljc');
+  assert.equal(result.ui_gates, 'true');
+});
+
+test('Core router/drain change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)', () => {
+  const result = classify('implementation/core/src/re_frame/router.cljc');
+  assert.equal(result.ui_gates, 'true');
+});
+
+test('Core frame/scheduler change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)', () => {
+  const result = classify('implementation/core/src/re_frame/frame.cljc');
+  assert.equal(result.ui_gates, 'true');
+});
+
+test('Core facade change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)', () => {
+  const result = classify('implementation/core/src/re_frame/core.cljc');
+  assert.equal(result.ui_gates, 'true');
+});
+
+test('Docs-only change does NOT schedule G-13 (ui_gates false) (rf2-vxgfnd.209)', () => {
+  const result = classify('docs/core/intro.md');
+  assert.equal(result.ui_gates, 'false');
+});
+
+test('Spec-only .md change does NOT schedule G-13 (ui_gates false) (rf2-vxgfnd.209)', () => {
+  const result = classify('spec/006-ReactiveSubstrate.md');
+  assert.equal(result.ui_gates, 'false');
+});
+
 test('Conformance fixture change runs cljs (CLJS corpus runner is in node-test) (rf2-f79t8)', () => {
   const result = classify('spec/conformance/fixtures/dispatch.edn');
   assert.equal(result.implementation_jvm, 'true');

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -243,6 +243,16 @@ function assertDevResult(result) {
   if (result['timing-posture'] !== 'evidence-only; no threshold') {
     fail('timing evidence grew a threshold posture');
   }
+  // rf2-vxgfnd.212 — prove the workload roster is EXACTLY one independently
+  // executed V=100 then one V=500 (each row's V stamped by the mounted fixture,
+  // not synthesized here) BEFORE any projection is compared. A duplicate,
+  // missing, extra, or reordered size — e.g. a V=500 row silently replaced by a
+  // deep copy of the V=100 row — is rejected here; equal-count checks alone
+  // accept it because both rows are individually in the allowed set.
+  const roster = (result.results || []).map((row) => row.v);
+  if (!sameJson(roster, [100, 500])) {
+    fail(`workload roster is not exactly one V=100 then one V=500: ${JSON.stringify(roster)}`);
+  }
   const expected = expectedProjection();
   const projections = [];
   for (const size of result.results || []) {
@@ -305,6 +315,21 @@ function assertMutationTeeth(result) {
     ['fan-out reached a non-affected cell', (r) => {
       r.results[0].cold.projection['fan-out-cells'] = 100;
     }],
+    // rf2-vxgfnd.212 — workload-roster teeth. Each must fail validation, proving
+    // the exact one-to-one V=100/V=500 roster before projections are compared.
+    // 'duplicate V=100' is the bead's exact false-green: the V=500 row silently
+    // replaced by a deep copy of the V=100 row.
+    ['duplicate V=100 (V=500 row copied from V=100)', (r) => { r.results[1].v = 100; }],
+    ['duplicate V=500', (r) => { r.results[0].v = 500; }],
+    ['missing V=500', (r) => { r.results = [r.results[0]]; }],
+    ['missing V=100', (r) => { r.results = [r.results[1]]; }],
+    ['extra size', (r) => {
+      const extra = JSON.parse(JSON.stringify(r.results[0]));
+      extra.v = 250;
+      r.results.push(extra);
+    }],
+    ['swapped roster order', (r) => { r.results.reverse(); }],
+    ['forged metadata-only V=500 row', (r) => { r.results[1] = { v: 500 }; }],
   ];
   const red = mutations.map(([label, mutate]) => {
     const changed = JSON.parse(JSON.stringify(result));

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -215,6 +215,13 @@ function expectedProjection() {
     'hot-base': 8,
     'stable-parent': 8,
     'cold-leaf': 0,
+    // rf2-vxgfnd.210 — the named candidate-work axis. `port-fan-out` is the
+    // observation port's total DELIVERED fan-out for the drain (C*Q=64),
+    // summed over ALL V live cells; `fan-out-cells` is the number of cells
+    // that received any fold (exactly C=8). Both are functions of C and Q,
+    // independent of V.
+    'port-fan-out': 64,
+    'fan-out-cells': 8,
   };
 }
 
@@ -289,6 +296,14 @@ function assertMutationTeeth(result) {
     ['multiple root commits', (r) => { r.results[0].cold.projection['root-commits'] = 8; }],
     ['same-total uneven hot distribution', (r) => {
       r.results[0].cold.projection['hot-renders-by-index'] = [2, 0, 1, 1, 1, 1, 1, 1];
+    }],
+    // rf2-vxgfnd.210 — the candidate-work axis teeth. A V-wide port fan-out
+    // (the observation port delivering to V owners instead of C) inflates the
+    // summed occurrence total; a fan-out that reaches any non-affected cell
+    // grows `fan-out-cells` past C. Both must be rejected.
+    ['V-wide port fan-out', (r) => { r.results[0].cold.projection['port-fan-out'] = 6400; }],
+    ['fan-out reached a non-affected cell', (r) => {
+      r.results[0].cold.projection['fan-out-cells'] = 100;
     }],
   ];
   const red = mutations.map(([label, mutate]) => {

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -177,8 +177,18 @@
                          (range recorded-samples))))
               (.then
                (fn [samples]
-                 (let [raw (mapv :elapsed-ms samples)]
-                   {:v v
+                 (let [raw (mapv :elapsed-ms samples)
+                       ;; rf2-vxgfnd.212 — stamp the ACTUAL mounted graph size
+                       ;; the fixture rendered (`data-g13-v`), never the runner's
+                       ;; expected metadata. A harness bug that mounts one size
+                       ;; twice then reports it as two therefore stamps the same
+                       ;; V twice, and the runner's exact-roster check rejects it
+                       ;; before any projection comparison.
+                       mounted-v (js/parseInt
+                                  (.getAttribute
+                                   (uit/query root "[data-g13-v]") "data-g13-v")
+                                  10)]
+                   {:v mounted-v
                     :cold @cold*
                     :warm {:raw-ms raw
                            :p50-ms (percentile raw 0.50)

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -69,6 +69,20 @@
                       :revision-delta (reduce + (deltas all before))
                       :evidence-counts
                       (mapv #(get (reactive/pending-evidence %) :count) hot)
+                      ;; rf2-vxgfnd.210 — the NAMED candidate-work axis.
+                      ;; Summed over EVERY live cell (all V), `:port-fan-out` is
+                      ;; the observation port's total DELIVERED fan-out for the
+                      ;; drain: one fold per (queued write × affected owner). Its
+                      ;; value is C*Q, and — critically — the V−C non-affected
+                      ;; cells contribute ZERO (`:fan-out-cells` counts the cells
+                      ;; that received ANY fold, and it is exactly C). The number
+                      ;; is therefore causally independent of V: it is not merely
+                      ;; numerically equal across the two runs, it is summed over
+                      ;; all V and provably sourced from only C of them.
+                      :port-fan-out
+                      (reduce + 0 (keep #(:count (reactive/pending-evidence %)) all))
+                      :fan-out-cells
+                      (count (filter #(some? (reactive/pending-evidence %)) all))
                       :counters (fixture/counter-snapshot)})))
           (.then
            (fn []
@@ -85,15 +99,19 @@
                               :root-commits (:commits counters)
                               :hot-base (:hot-base counters)
                               :stable-parent (:stable-parent counters)
-                              :cold-leaf (:cold-leaf counters)}
+                              :cold-leaf (:cold-leaf counters)
+                              :port-fan-out (:port-fan-out @pre)
+                              :fan-out-cells (:fan-out-cells @pre)}
                  expected    {:enrolled 8 :advances 8 :revision-delta 8
                               :hot-renders 8
                               :hot-renders-by-index (vec (repeat 8 1))
                               :cold-renders 0 :root-commits 1
-                              :hot-base 8 :stable-parent 8 :cold-leaf 0}]
+                              :hot-base 8 :stable-parent 8 :cold-leaf 0
+                              :port-fan-out 64 :fan-out-cells 8}]
              (ensure! (= {:pending 8 :hot-dirty 8 :cold-dirty 0 :idle-dirty 0
                           :revision-delta 0
                           :evidence-counts (vec (repeat 8 8))
+                          :port-fan-out 64 :fan-out-cells 8
                           :counters {:writes 8 :hot-base 8 :stable-parent 8
                                      :cold-leaf 0 :hot-body 0 :cold-body 0
                                      :hot-body-by-index (vec (repeat 8 0))
@@ -185,7 +203,7 @@
        (fn [results]
          (let [projections (mapv #(get-in % [:cold :projection]) results)]
            (ensure! (apply = projections)
-                    "count projection depends on V"
+                    "candidate-work projection depends on V"
                     {:projections projections})
            {:gate "G-13"
             :status "pass"
@@ -194,6 +212,20 @@
             :affected-viewcells fixture/hot-count
             :fixed-shell-idle-cells fixture/idle-shell-count
             :timing-posture "evidence-only; no threshold"
+            ;; rf2-vxgfnd.210 — the explicit candidate-work axis plus the HONEST
+            ;; scope of what the counts prove. `port-fan-out` (C*Q, summed over
+            ;; all V live cells with the V−C non-affected cells contributing
+            ;; zero) is the named V-independent candidate-work projection. The
+            ;; counts prove V-independent DELIVERED push work (fan-out
+            ;; occurrences + sub recomputes + renders + one commit). A pure
+            ;; membership SCAN that inspects V candidates but delivers to only C
+            ;; is observable only by a production-side counter at the port's
+            ;; candidate-iteration choke point — out of this gate's reach — and
+            ;; is tracked by timing evidence alone, never asserted by a count
+            ;; nor by a wall-clock threshold.
+            :candidate-work-projection "port-fan-out"
+            :proof-scope
+            "v-independent delivered push work; pure candidate scan is timing-evidence-only"
             :results results})))))
 
 (defn -main []

--- a/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/fixture.cljs
@@ -9,6 +9,34 @@
 
 (goog-define ^boolean instrumentation? false)
 
+;; rf2-vxgfnd.211 — each elision proof token is bound to the EXACT executable
+;; branch it claims is absent. The counter token rides the counter-mutation
+;; path (`count!`), the Profiler token the Profiler wrapper (`profiled`), and
+;; the debug-evidence token the per-index render-evidence path (`hot-row`), so
+;; the advanced scan's biconditional holds CAUSALLY: a token survives the
+;; bundle iff its OWNING branch is reachable. A source mutant that makes any of
+;; these paths unconditional therefore ships its token and the scan goes red —
+;; unlike the prior detached sentinel branch, which stayed elided while the
+;; counter or Profiler code leaked.
+;;
+;; The token is emitted through `witness!` — a `console.debug` SIDE EFFECT
+;; Closure cannot drop from a reachable branch (an unused `let`-binding would be
+;; DCE'd even when its branch is live, breaking the causal bind). A per-token
+;; latch keeps the emit off the timing-measured hot path (at most one call per
+;; token per run). Under `goog.DEBUG=false` + `instrumentation? false` every
+;; owning branch is dead, so `witness!`, the latch, and all three tokens DCE
+;; out together — the ordinary build carries no bookkeeping at all.
+(def ^:private counter-sentinel "RF2_G13_COUNTER_SENTINEL")
+(def ^:private profiler-sentinel "RF2_G13_PROFILER_SENTINEL")
+(def ^:private debug-evidence-sentinel "RF2_G13_DEBUG_EVIDENCE_SENTINEL")
+
+(def ^:private emitted-witnesses (atom #{}))
+
+(defn- witness! [sentinel]
+  (when-not (contains? @emitted-witnesses sentinel)
+    (swap! emitted-witnesses conj sentinel)
+    (.debug js/console sentinel)))
+
 (def hot-count 8)
 (def queued-writes 8)
 ;; `table` + `app` are intentionally sub-free defviews. DEV gives each the
@@ -29,17 +57,17 @@
 (defn counter-snapshot [] @counters)
 
 (defn- count! [k]
+  ;; The counter-mutation path OWNS the counter token: making this branch
+  ;; unconditional ships `counter-sentinel` and reddens the advanced scan.
   (when instrumentation?
+    (witness! counter-sentinel)
     (swap! counters update k (fnil inc 0))))
 
 (defn register! []
-  ;; Literal sentinels are the non-vacuity control for the advanced scan.
-  ;; With instrumentation? false Closure must remove this entire branch.
-  (when instrumentation?
-    (.debug js/console
-            "RF2_G13_COUNTER_SENTINEL"
-            "RF2_G13_PROFILER_SENTINEL"
-            "RF2_G13_DEBUG_EVIDENCE_SENTINEL"))
+  ;; rf2-vxgfnd.211 — the elision tokens no longer live here, detached from the
+  ;; code they claim is absent. Each now rides its OWN executable branch (see
+  ;; `count!`, `hot-row`, `profiled`), so a leak of that branch carries its
+  ;; token into the advanced bundle.
   (rf/reg-sub ::hot
               (fn [db _]
                 (count! :hot-base)
@@ -67,7 +95,9 @@
 
 (defview hot-row [{:keys [index]}]
   (let [_ (count! :hot-body)
+        ;; The per-index render-evidence path OWNS the debug-evidence token.
         _ (when instrumentation?
+            (witness! debug-evidence-sentinel)
             (swap! counters update-in [:hot-body-by-index index] inc))]
     [:output {:data-g13-kind "hot" :data-g13-index index}
      (str (ui/sub [::hot]))]))
@@ -85,6 +115,9 @@
      [cold-row {:key i :index i}])])
 
 (defn- profiled [^js props]
+  ;; The Profiler wrapper OWNS the Profiler token: making `app` always render
+  ;; through `profiled` ships `profiler-sentinel` and reddens the advanced scan.
+  (witness! profiler-sentinel)
   (React/createElement
    (.-Profiler React)
    #js {:id "g13-root"


### PR DESCRIPTION
Hardens the G-13 push-economics gate (landed in #5815, 05 §3) so it can causally prove the claims it makes. One cohesive cluster over `implementation/ui/g13/**`, the G-13 runner, and the CI classifier. G-13 exists to FALSIFY the committed push economics; each finding below closed a hole where a real regression could stay green.

Commit order: .210 → .211 → .212 → .209.

## rf2-vxgfnd.210 — name the V-independent candidate-work axis

The projection counted downstream OUTCOMES (enroll/advance/render/commit) but exposed no explicit candidate-work axis, so equal 8/8/0/1 counts at V=100 vs V=500 asserted numeric equality without proving the work was sourced from only C of the V mounted cells.

- Adds `port-fan-out` — the observation port's total DELIVERED fan-out for the drain (`C*Q = 64`), summed over EVERY live cell (all V) — plus `fan-out-cells` (the number of cells that received any fold, exactly `C = 8`). Both are functions of C and Q, independent of V: the V−C non-affected cells provably contribute zero. Both are in the `projection` compared across V=100/500 by `execute!`.
- **Claim narrowed honestly.** The gate now advertises `:proof-scope "v-independent delivered push work; pure candidate scan is timing-evidence-only"`. A pure membership SCAN that inspects V candidates but delivers to only C is observable only by a production-side counter at the port's candidate-iteration choke point — that seam lives in `core/substrate/observation.cljc`, out of this worktree's scope (a concurrent worker owns it), so per the bead's explicit fallback the stronger total-work property is recorded as unproven rather than pretended-proven by timing. Follow-up bead filed for the production-side pure-scan witness.
- **Red-before-fix:** a real fixture mutant (every `cold-row` also `(ui/sub [::hot])`, so a hot-only movement delivers to all V cells) reddens the gate (exit 1 — trips the V-wide-delivery guards). Runner teeth reject an inflated `port-fan-out` (6400) and a `fan-out-cells` grown past C (100).

## rf2-vxgfnd.211 — bind elision tokens to their real instrumentation branches

The scanned counter/Profiler/debug tokens were colocated in one standalone `register!` branch, detached from the code they claim is absent (counter mutations in `count!`, the Profiler wrapper in `profiled`). Two leaks stayed green: an unconditional `count!` shipped the counter atoms while the detached token stayed elided; an always-rendered Profiler shipped its wrapper while its token stayed folded away.

- Each token now rides the exact branch it owns: `counter-sentinel` in `count!`, `profiler-sentinel` in `profiled`, `debug-evidence-sentinel` in `hot-row`. Emitted via a `witness!` helper — a once-per-token `console.debug` SIDE EFFECT Closure cannot drop from a reachable branch. (An unused `let`-binding is DCE'd by `:advanced` even when its branch is live — verified — so it does NOT bind causally; the first `_sentinel` attempt was discarded for this reason.)
- **Red-before-fix (real source mutants, verified against the compiled `:advanced` bundle):** `unconditional count!` → prod ships only COUNTER; `always-Profiler` → prod ships only PROFILER; `unconditional debug-evidence` → prod ships only DEBUG_EVIDENCE. Each independently reddens `assertNoProductionSentinels`; the clean build ships none, and dev (`:none`) retains all three as the non-vacuity control.

## rf2-vxgfnd.212 — require an exact one-to-one V=100/V=500 roster

The runner validated each row only as a member of `[100,500]` then required two equal projections — never one unique result per size. Replacing the V=500 row with a deep copy of the V=100 row left `sizes:[100,500]`, two individually-allowed rows, and two equal projections, so validation passed while the V=500 scaling arm never ran.

- Validates the roster as exact ordered equality with `[100,500]` BEFORE any projection comparison. Each row's V is now stamped from the fixture's ACTUAL mounted graph size (the rendered `data-g13-v`), never synthesized from the runner's expected metadata.
- **Red-before-fix:** the `duplicate V=100` self-test is the bead's exact false-green (V=500 row copied from V=100) — green under the old validator, red now. Added self-tests: duplicate-100, duplicate-500, missing-100, missing-500, extra-size, swapped-order, forged-metadata-only. All go red.

## rf2-vxgfnd.209 — schedule G-13 for core changes

The changed-surface classifier armed Node/JVM/browser work for `implementation/core/*` but never `ui_gates`, so a PR changing only the observation port, router drain, or frame scheduling skipped G-13 — the one gate meant to falsify V-wide fan-out / split-batching — and the required-check aggregator accepted the skip.

- Arms `ui_gates=true` for the whole `implementation/core/*` surface (a conservative superset; a narrower dependency list would be brittle as core evolves). The `ui_gates → cljs-ui-g13 → all-required-passed` wiring already exists in `test.yml`, so **no workflow change was needed**: a core PR now runs the job (a real G-13 failure blocks merge as a `failure`; no longer a tolerated skip). Docs/spec/tool-only PRs keep their skip.
- **Red-before-fix:** pre-fix vs post-fix classifier on the three representative core paths — `observation.cljc` / `router.cljc` / `frame.cljc` report `ui_gates=false` before, `ui_gates=true` after. Added classifier self-tests for the observation-port, router/drain, frame/scheduler, and core-facade paths (true) and for docs/spec-only paths (false).

## Quality gates

- `npm run test:ui-g13` (G-13 browser + advanced elision): **PASS** — `port-fan-out:64` / `fan-out-cells:8` at both V; 22/22 mutation teeth red; prod bundle token-free; dev non-vacuity control retains all tokens.
- `node scripts/_changed-surfaces.test.cjs`: **144 passed** (incl. 6 new .209 tests).
- `implementation/ui` JVM suite (`clojure -M:test`): **485 tests, 6284 assertions, 0 failures, 0 errors**.
- Real-source-mutant elision matrix (.211): each of the three mutants leaks ONLY its own token into the `:advanced` prod bundle; clean build leaks none.
- Fast-PR spine: the cold-cache CLJS node integration exceeded the local 10-min tooling limit on the fresh worktree; CI runs the full matrix (this PR edits `report-changed-surfaces.sh`, which triggers the `mark_all` matrix).

Scope: `implementation/ui/g13/**` + the G-13 runner + `.github/scripts/report-changed-surfaces.sh` + the classifier test harness. No production API, runtime counter, timing threshold, or UIx/Helix dependency added.
