### PR TITLE
fix(core): opaque, channel-aware observation error provenance (rf2-w55bh0)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -170,6 +170,90 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+;; ---- opaque, channel-aware emission provenance (rf2-w55bh0) ------------------
+;;
+;; Several fail-loud port surfaces EMIT their category's canonical record and
+;; THEN throw the matching typed error (the emit-then-throw idiom): the ABI
+;; guard, the shared `emit-and-throw!` sites (frame-destroyed / no-such-sub /
+;; retry-exhausted), and two `throw-acquire-recovery!` arms whose category the
+;; sub BUILD already surfaced. A containment drain that CATCHES such a throwable
+;; to keep notifying siblings (the disposal-notification drain below) must decide
+;; whether PRODUCTION observability (the always-on error-emit axis) is already
+;; covered for that one runtime error, so it neither double-reports an
+;; already-fanned failure (Spec 009's one-runtime-error law) nor lets a
+;; production-elided failure go silent.
+;;
+;; The attestation is CHANNEL-AWARE and OPAQUE:
+;;
+;;   - CHANNEL-AWARE — it records WHICH error channel(s) the source actually
+;;     emitted on, never a single "fanned" Boolean. A source that fanned through
+;;     `error-emit/emit-error-both!` covered `#{:always-on :trace}`; a source
+;;     whose only emission was the sub build's DIAGNOSTIC `:rf.error/sub-cycle`
+;;     trace covered `#{:trace}` — production-elided, so the always-on axis is
+;;     NOT covered. Collapsing the two to one Boolean is exactly the bug that made
+;;     a cyclic-acquire callback failure vanish under `goog.DEBUG=false`: the
+;;     drain mistook trace coverage for full coverage and emitted nothing.
+;;   - OPAQUE / NON-FORGEABLE — the token is an [[EmissionProvenance]] host
+;;     object (an opaque deftype identity token, like `ObservationLease`), minted
+;;     ONLY here and never exported. An application `on-change` callback that
+;;     throws an ex-info can copy any keyword or literal into ex-data, but it
+;;     cannot construct this type, so a public-looking marker, a reconstructed
+;;     `{:channels …}` map, or a spoofed / imitated `:rf.error/id` all fail the
+;;     `instance?` gate and can neither inject a category nor suppress reporting.
+;;     This REPLACES the reconstructible `error-emit/fanned-at-source-key`
+;;     (a public namespaced key whose literal value was `true`) and the
+;;     `:rf.error/id`-plus-`:reason` shape test the drain used to trust.
+;;
+;; Carried in the thrown ex-data under a framework-internal key (the KEY may be
+;; known, but the VALUE is unforgeable). The drain reads it through
+;; [[source-covered-always-on?]]; a throwable with NO token — a diagnostic-only
+;; thrown category (`:rf.error/observation-malformed-target` / `…-malformed-lease`
+;; / `:rf.error/reentrant-graph-op`), a raw untyped consumer bug, or an
+;; application spoof — reads FALSE, so the drain owns always-on coverage and
+;; wraps it in the stable `:rf.error/observation-on-change-failed`, NEVER
+;; promoting a diagnostic-only category onto the always-on axis.
+
+;; The opaque channel-aware attestation token. A host object compared by
+;; `instance?` and read only through a private accessor — an application ex-data
+;; map cannot construct one (mirrors the `ObservationLease` opaque-identity
+;; idiom). `channels` is the set of axes the source already covered
+;; (`#{:always-on :trace}` / `#{:trace}`).
+(deftype EmissionProvenance [channels])
+
+(def ^:private emission-provenance-key
+  "Framework-internal ex-data slot carrying an [[EmissionProvenance]] token — the
+  opaque, channel-aware attestation of which error channel(s) an emit-then-throw
+  site already fanned this failure's canonical record on (rf2-w55bh0). Consulted
+  only through [[source-covered-always-on?]]; never part of the public
+  thrown-error shape."
+  ::emission-provenance)
+
+(def ^:private provenance-both-channels
+  "Provenance for a source that fanned through `error-emit/emit-error-both!` —
+  the always-on record AND the dev trace event both covered."
+  (->EmissionProvenance #{:always-on :trace}))
+
+(def ^:private provenance-trace-only
+  "Provenance for a source whose only emission rode the DIAGNOSTIC trace axis
+  (the sub build's `:rf.error/sub-cycle`) — production-elided, so the always-on
+  axis is NOT covered and a containment drain still owes production a record."
+  (->EmissionProvenance #{:trace}))
+
+(defn- source-covered-always-on?
+  "True when caught throwable `t` carries observation's opaque, channel-aware
+  [[EmissionProvenance]] token attesting its canonical record was ALREADY fanned
+  on the ALWAYS-ON axis at the source (with the source's own attribution), so a
+  containment drain must add nothing there. Non-forgeable — an application ex-data
+  map cannot construct an [[EmissionProvenance]], so a public-looking marker, a
+  reconstructed map shape, or a spoofed `:rf.error/id` all read false.
+  Channel-aware — a source that emitted ONLY on the diagnostic trace axis reads
+  false, so trace coverage is never mistaken for always-on coverage
+  (rf2-w55bh0)."
+  [t]
+  (let [prov (get (ex-data t) emission-provenance-key)]
+    (and (instance? EmissionProvenance prov)
+         (contains? (.-channels ^EmissionProvenance prov) :always-on))))
+
 ;; ---- ABI version guard -----------------------------------------------------
 
 (def port-abi-version
@@ -212,9 +296,10 @@
         reason
         {:extra {:expected expected
                  :actual   port-abi-version
-                 ;; First-emission provenance (rf2-wbkjk9): the record above
-                 ;; is the exactly-once emission.
-                 error-emit/fanned-at-source-key true}})))
+                 ;; Opaque, channel-aware emission provenance (rf2-w55bh0): the
+                 ;; emit-error-both! record above covered BOTH axes, so a
+                 ;; containment drain sees always-on coverage and re-fans nothing.
+                 emission-provenance-key provenance-both-channels}})))
   nil)
 
 ;; ---- registry epoch ---------------------------------------------------------
@@ -381,13 +466,15 @@
   (error/throw-error! error-id where reason
                       {:extra (merge {:frame          frame-id
                                       :rf.sub/query-v query-v
-                                      ;; First-emission provenance (rf2-wbkjk9):
-                                      ;; the record above IS this failure's
-                                      ;; exactly-once emission — a containment
-                                      ;; drain catching this throw (an on-change
-                                      ;; that called a port op) must not re-fan
-                                      ;; it on either channel.
-                                      error-emit/fanned-at-source-key true}
+                                      ;; Opaque, channel-aware emission
+                                      ;; provenance (rf2-w55bh0): the
+                                      ;; emit-error-both! record above IS this
+                                      ;; failure's exactly-once emission on BOTH
+                                      ;; axes — a containment drain catching this
+                                      ;; throw (an on-change that called a port
+                                      ;; op) sees always-on coverage and re-fans
+                                      ;; it on neither channel.
+                                      emission-provenance-key provenance-both-channels}
                                      extra)}))
 
 (defn- throw-frame-destroyed!
@@ -530,12 +617,17 @@
        :extra    {:frame          frame-id
                   :rf.sub/query-v query-v
                   :cycle          (:cycle result)
-                  ;; First-emission provenance (rf2-wbkjk9): the build already
-                  ;; surfaced :rf.error/sub-cycle per its channel contract
-                  ;; (diagnostic trace); a containment drain must not
-                  ;; re-emit — and in particular must not PROMOTE the
-                  ;; diagnostic category onto the always-on axis.
-                  error-emit/fanned-at-source-key true}})
+                  ;; Opaque, channel-aware emission provenance (rf2-w55bh0): the
+                  ;; build surfaced :rf.error/sub-cycle on the DIAGNOSTIC TRACE
+                  ;; axis ONLY (it is production-elided) — so this attests
+                  ;; `#{:trace}`, NOT full coverage. A containment drain must not
+                  ;; re-emit the diagnostic sub-cycle (nor promote it onto the
+                  ;; always-on axis), but production observability is NOT yet
+                  ;; covered, so the drain still adds the stable always-on
+                  ;; callback-failure record. Stamping a channel-blind Boolean
+                  ;; here is the bug that silenced a cyclic-acquire callback
+                  ;; failure under goog.DEBUG=false.
+                  emission-provenance-key provenance-trace-only}})
 
     (:input-fn-exception :input-fn-bad-return)
     (error/throw-error!
@@ -549,10 +641,12 @@
       {:recovery :no-recovery
        :extra    {:frame          frame-id
                   :rf.sub/query-v query-v
-                  ;; First-emission provenance (rf2-wbkjk9): the build ALREADY
-                  ;; fanned the always-on :rf.error/sub-input-fn-* record (one
-                  ;; record, one throw); a containment drain must not re-fan.
-                  error-emit/fanned-at-source-key true}})
+                  ;; Opaque, channel-aware emission provenance (rf2-w55bh0): the
+                  ;; build ALREADY fanned the always-on :rf.error/sub-input-fn-*
+                  ;; record on both axes (one record, one throw), so this attests
+                  ;; `#{:always-on :trace}` and a containment drain re-fans
+                  ;; nothing.
+                  emission-provenance-key provenance-both-channels}})
 
     ;; :frame-destroyed and any unexpected classification — fan + throw typed.
     (throw-frame-destroyed! 're-frame.substrate.observation/acquire!
@@ -721,63 +815,62 @@
   (registrar isolates replacement-hook failures — `re-frame.registrar`), and
   the `:disposed` drain rides `interop/next-tick` (a JVM Future whose result
   is never inspected); either boundary would otherwise make the escape
-  invisible exactly where it matters — so NEITHER a typed NOR an untyped
-  `on-change` failure may depend on the rethrow being observed.
+  invisible exactly where it matters — so no `on-change` failure may depend on
+  the rethrow being observed.
 
-  Classification is by FIRST-EMISSION PROVENANCE plus the canonical
-  thrown-error SHAPE — never by `:rf.error/id` truthiness (rf2-wbkjk9), and
-  never a global seen-error registry:
+  Classification is CHANNEL-AWARE and by OPAQUE PROVENANCE (rf2-w55bh0) —
+  never by a channel-blind `fanned` Boolean, never by `:rf.error/id`
+  truthiness / reconstructible ex-data shape, and never a global seen-error
+  registry. The drain owns PRODUCTION (always-on) coverage for this one
+  callback failure UNLESS [[source-covered-always-on?]] proves the source
+  already fanned an always-on record:
 
-    - ALREADY FANNED AT SOURCE (`error-emit/fanned-at-source?` — the port's
-      own emit-then-throw surfaces stamp it: `read` on a released lease,
-      probe/acquire fail-loud throws, the ABI guard, and the acquire-recovery
-      throws whose category the sub BUILD already surfaced): the source's
-      record IS the exactly-once emission, carrying the SOURCE's correct
-      frame/query attribution. Re-fanning here would double-report the one
-      runtime error and overwrite that attribution with the NOTIFYING owner's
-      context. Nothing more is emitted, on either channel.
-    - UNFANNED CANONICAL TYPED (`error-emit/canonical-typed-error?` without
-      the provenance stamp — a plain framework throw with no fan of its own):
-      re-surfaced exactly once under its OWN id, attributed to the notifying
-      former owner. The dev `:rf.error/reentrant-graph-op` assert — an
-      `on-change` mutating graph ownership mid-notification — is the
-      motivating case: this IS its only always-on appearance, and it exists
-      TO BE SEEN (Spec 009).
-    - EVERYTHING ELSE — untyped (a raw consumer-callback bug from
-      re-frame.ui's `on-change`: a `TypeError` / `AssertionError` / host
-      `RuntimeException`), a missing or MALFORMED `:rf.error/id`
-      (non-keyword), or an id outside the reserved `rf.error` namespace (an
-      application ex-info must not SPOOF a canonical framework category) —
-      is wrapped exactly once in the stable catalogued
-      `:rf.error/observation-on-change-failed`, carrying the original
-      throwable as the record's `:exception` cause.
+    - ALREADY COVERED ON THE ALWAYS-ON AXIS — the port's own emit-then-throw
+      surfaces that fanned through `error-emit/emit-error-both!` (`read` on a
+      released lease, the probe/acquire fail-loud throws, the ABI guard, the
+      retry-exhausted throw, and the acquire-recovery input-fn arms whose
+      always-on record the sub BUILD fanned) stamp the opaque
+      `#{:always-on :trace}` provenance. Their record IS the exactly-once
+      emission, carrying the SOURCE's correct frame/query attribution. Adding
+      anything here would double-report the one runtime error and overwrite
+      that attribution with the NOTIFYING owner's context, so nothing more is
+      emitted on either channel.
+    - NOT COVERED ON THE ALWAYS-ON AXIS — a source that emitted ONLY on the
+      diagnostic trace axis (the build's production-elided `:rf.error/sub-cycle`,
+      provenance `#{:trace}`), a DIAGNOSTIC-ONLY thrown category with no fan
+      of its own (`:rf.error/observation-malformed-target` / `…-malformed-lease`
+      / the dev `:rf.error/reentrant-graph-op` assert), a raw untyped
+      consumer-callback bug (a `TypeError` / `AssertionError` / host
+      `RuntimeException`), or an application ex-info trying to SPOOF a framework
+      category (a reserved-but-uncatalogued or imitated `:rf.error/id`, a
+      reconstructed provenance shape, or a copy of a public marker) — all read
+      FALSE. Production observability is still owed, so the drain adds EXACTLY
+      ONE stable catalogued `:rf.error/observation-on-change-failed` record,
+      carrying the original throwable as the record's `:exception` cause. The
+      escape's own diagnostic category is NEVER promoted onto the always-on
+      axis; its detail rides as the wrapper's cause.
 
-  When the drain owns the first emission it rides the shared TWO-CHANNEL
-  fan-out (`error-emit/emit-error-both!`, rf2-q3fmqm): the always-on record
-  for off-box shippers PLUS the dev diagnostic-trace event Xray's
-  trace-tooling listener consumes — the registrar/next-tick boundaries
-  swallow the rethrow, so without the trace leg a real HMR/disposed callback
-  failure was invisible in the primary debugging surface. The
-  category-specific trace tags carry the disposal `cause` (`:hmr` /
-  `:disposed`), the former owner's entry-sub coordinates
-  (`:rf.sub/id` / `:rf.sub/query-v`), and the original throwable. In
-  advanced production the trace leg is DCE'd inside `trace/emit-error!`
-  while the always-on record survives. The record's `:event-id` carries the
-  ENTRY SUB id, and `error-emit` classifies the wrapper category
-  subscription-owned, so `:source-coord` resolves under `[:sub id]` — a
-  macro-registered sub yields its exact coordinate, a programmatic one
-  omits the slot, and a same-id event registration cannot steal
-  attribution."
+  The drain-owned wrapper rides the shared TWO-CHANNEL fan-out
+  (`error-emit/emit-error-both!`, rf2-q3fmqm): the always-on record for off-box
+  shippers PLUS the dev diagnostic-trace event Xray's trace-tooling listener
+  consumes — the registrar/next-tick boundaries swallow the rethrow, so without
+  the trace leg a real HMR/disposed callback failure was invisible in the
+  primary debugging surface. The category-specific trace tags carry the disposal
+  `cause` (`:hmr` / `:disposed`), the former owner's entry-sub coordinates
+  (`:rf.sub/id` / `:rf.sub/query-v`), and the original throwable. In advanced
+  production the trace leg is DCE'd inside `trace/emit-error!` while the
+  always-on record survives. The record's `:event-id` carries the ENTRY SUB id,
+  and `error-emit` classifies the wrapper category subscription-owned, so
+  `:source-coord` resolves under `[:sub id]` — a macro-registered sub yields its
+  exact coordinate, a programmatic one omits the slot, and a same-id event
+  registration cannot steal attribution."
   [lease cause exception]
-  (when-not (error-emit/fanned-at-source? exception)
+  (when-not (source-covered-always-on? exception)
     (let [{:keys [frame-id query-v]} @(lease-state lease)
-          sub-id   (first query-v)
-          typed?   (error-emit/canonical-typed-error? exception)
-          error-id (if typed?
-                     (:rf.error/id (ex-data exception))
-                     :rf.error/observation-on-change-failed)]
+          sub-id (first query-v)]
       (error-emit/emit-error-both!
-        error-id query-v sub-id frame-id exception 0 (interop/now-ms)
+        :rf.error/observation-on-change-failed
+        query-v sub-id frame-id exception 0 (interop/now-ms)
         {:rf.sub/id         sub-id
          :rf.sub/query-v    query-v
          :where             're-frame.substrate.observation/drain-pending-disposals!
@@ -785,20 +878,17 @@
          :cause             cause
          :exception         exception
          :exception-message (error/ex-message-safe exception)
-         :reason            (if typed?
-                              (str "a former-owner on-change callback for "
-                                   (pr-str sub-id) " escaped with the typed "
-                                   (pr-str error-id) " during the " cause
-                                   " disposal-notification drain; surfaced here "
-                                   "exactly once because the drain boundary "
-                                   "swallows the rethrow.")
-                              (str "a former-owner on-change callback for "
-                                   (pr-str sub-id) " threw during the " cause
-                                   " disposal-notification drain; the escape is "
-                                   "contained (siblings still notified) and "
-                                   "surfaced here before the boundary swallows "
-                                   "the rethrow — the underlying on-change "
-                                   "consumer bug is a re-frame.ui defect to fix."))
+         :reason            (str "a former-owner on-change callback for "
+                                 (pr-str sub-id) " failed during the " cause
+                                 " disposal-notification drain; surfaced here on "
+                                 "the always-on axis exactly once because the "
+                                 "drain boundary swallows the rethrow and the "
+                                 "failure's source did not already cover "
+                                 "production observability. The escape is "
+                                 "contained (siblings still notified) and rides "
+                                 "as this record's :exception cause — the "
+                                 "underlying on-change consumer bug is a "
+                                 "re-frame.ui defect to fix.")
          :recovery          :no-recovery}))))
 
 (defn ^:no-doc drain-pending-disposals!
@@ -822,16 +912,17 @@
   one uncontained fan-out; it mirrors registrar's per-hook and subs.cache's
   per-reaction dispose containment). Every sibling is notified; EVERY escape is
   surfaced EXACTLY ONCE so it survives a swallowing boundary without violating
-  Spec 009's one-runtime-error law (rf2-6ui49w + rf2-wbkjk9: an escape whose
-  source already fanned its record is left with its source's exactly-once
-  emission; an unfanned canonical typed escape keeps its catalogue id; an
-  untyped / malformed-id / non-catalogued-id consumer-callback bug is wrapped
-  in `:rf.error/observation-on-change-failed` — see
-  [[report-disposal-notify-escape!]]); then the first escape is re-thrown AFTER
-  the whole drain for any DIRECT caller, with its identity/cause intact, but
-  correctness never depends on the registrar / next-tick boundary observing
-  that rethrow — the surfaced record IS the visibility. Never silent, never
-  starving, never double-reported."
+  Spec 009's one-runtime-error law (rf2-6ui49w + rf2-wbkjk9 + rf2-w55bh0: the
+  drain owns PRODUCTION coverage unless the escape's OPAQUE, channel-aware
+  provenance proves the source already fanned an always-on record; an escape
+  whose source covered only the diagnostic trace axis, a diagnostic-only thrown
+  category, a raw untyped consumer bug, or an application spoof is wrapped once
+  in `:rf.error/observation-on-change-failed` WITHOUT promoting its own category
+  onto the always-on axis — see [[report-disposal-notify-escape!]]); then the
+  first escape is re-thrown AFTER the whole drain for any DIRECT caller, with its
+  identity/cause intact, but correctness never depends on the registrar /
+  next-tick boundary observing that rethrow — the surfaced record IS the
+  visibility. Never silent, never starving, never double-reported."
   [cause]
   (let [[old _new] (swap-vals! pending-disposals
                                (fn [pending]
@@ -848,12 +939,15 @@
                          (catch #?(:clj Throwable :cljs :default) t
                            ;; Surface EVERY escape EXACTLY ONCE before the
                            ;; boundary swallows the rethrow (rf2-6ui49w +
-                           ;; rf2-wbkjk9): an already-fanned typed escape keeps
-                           ;; its source's emission; a drain-owned first
-                           ;; emission rides the two-channel fan-out
-                           ;; (rf2-q3fmqm) — typed under its own catalogue id,
-                           ;; untyped/malformed/non-catalogued wrapped in
-                           ;; :rf.error/observation-on-change-failed.
+                           ;; rf2-wbkjk9 + rf2-w55bh0): channel-aware, opaque
+                           ;; provenance decides. An escape whose source already
+                           ;; covered the always-on axis keeps its source's
+                           ;; emission; everything else (trace-only coverage, a
+                           ;; diagnostic-only thrown category, an untyped bug, a
+                           ;; spoof) is wrapped once in the always-on
+                           ;; :rf.error/observation-on-change-failed via the
+                           ;; two-channel fan-out (rf2-q3fmqm), never promoting
+                           ;; its own category onto the always-on axis.
                            (report-disposal-notify-escape! lease cause t)
                            (conj acc t))))
                      []
@@ -1659,13 +1753,14 @@
               reason
               {:extra {:frame          (:frame-id st)
                        :rf.sub/query-v (:query-v st)
-                       ;; First-emission provenance (rf2-wbkjk9): the record
-                       ;; above is the exactly-once emission, attributed to
-                       ;; THIS released lease's own frame/query — a
-                       ;; containment drain catching this throw (an on-change
-                       ;; reading a released lease) must not re-fan it under
-                       ;; the notifying owner's context.
-                       error-emit/fanned-at-source-key true}})))
+                       ;; Opaque, channel-aware emission provenance (rf2-w55bh0):
+                       ;; the emit-error-both! record above is the exactly-once
+                       ;; emission on BOTH axes, attributed to THIS released
+                       ;; lease's own frame/query — a containment drain catching
+                       ;; this throw (an on-change reading a released lease) sees
+                       ;; always-on coverage and must not re-fan it under the
+                       ;; notifying owner's context.
+                       emission-provenance-key provenance-both-channels}})))
         ;; Resolve the JVM WeakReference ONCE and hold the result strongly across
         ;; the canonicality check + deref. A GC between two lookups could clear
         ;; the second lookup even after the first proved the node canonical.

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -1012,9 +1012,12 @@
 ;; drain runs inside the registrar replacement hook, whose per-hook catch DROPS
 ;; the throw (no log/trace/record), swallowing even the dev
 ;; :rf.error/reentrant-graph-op assert exactly where it matters. The fix wraps
-;; each lease's notify in its own try/catch (siblings never starve), fans a
-;; TYPED escape onto the always-on axis (SEEN through the registrar's swallow),
-;; and re-throws after the whole drain (never silent).
+;; each lease's notify in its own try/catch (siblings never starve), surfaces the
+;; callback failure on the always-on axis (SEEN through the registrar's swallow)
+;; via the stable :rf.error/observation-on-change-failed wrapper — the
+;; diagnostic-only reentrant-graph-op is NEVER promoted onto the always-on axis
+;; under its own id (rf2-w55bh0), it rides as the wrapper's cause — and re-throws
+;; after the whole drain (never silent).
 ;; ===========================================================================
 
 (deftest disposal-drain-contains-a-throwing-owner-and-surfaces-the-escape
@@ -1042,9 +1045,19 @@
         (is (= 1 (count @notes-b)))
         (is (= :hmr (:cause (first @notes-b)))))
       (testing "the escape is SEEN on the always-on axis despite the registrar's
-                per-hook swallow (rf2-vxgfnd.28 — reentrant-graph-op exists to be seen)"
-        (is (some #(= :rf.error/reentrant-graph-op (:error %)) records)
-            "the swallowed reentrant-graph-op reached the always-on error surface"))
+                per-hook swallow — the diagnostic-only reentrant-graph-op is
+                wrapped in the stable :rf.error/observation-on-change-failed
+                (never promoted onto the always-on axis under its own diagnostic
+                id — rf2-w55bh0), carrying the reentrant assert as its cause"
+        (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                               records)]
+          (is (= 1 (count wrapped))
+              "the swallowed callback failure reached the always-on error surface")
+          (is (= :rf.error/reentrant-graph-op
+                 (error-id (:exception (first wrapped))))
+              "the diagnostic reentrant-graph-op rides as the wrapper's cause"))
+        (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
+            "the diagnostic category is NOT promoted onto the always-on axis"))
       (testing "reg-items! returned normally — the registrar isolates the hook"
         (is (= :ok outcome))))
     ;; Owner A's release! never completed (it threw); both are cleanly releasable
@@ -1895,17 +1908,21 @@
 ;;      bare imitation of a canonical id) was re-dispatched as though it
 ;;      were a catalogued framework category.
 ;;
-;; The fix is explicit FIRST-EMISSION PROVENANCE on the throwable (the
-;; port's emit-then-throw sites stamp `error-emit/fanned-at-source-key`
-;; into the thrown ex-data) plus the canonical thrown-error SHAPE check
-;; (`error-emit/canonical-typed-error?`) — never :rf.error/id truthiness,
-;; never a global seen-error registry:
+;; The fix is OPAQUE, CHANNEL-AWARE emission PROVENANCE on the throwable
+;; (rf2-w55bh0 supersedes the reconstructible `error-emit/fanned-at-source-key`
+;; + `:rf.error/id`-shape scheme): the port's emit-then-throw sites stamp an
+;; unforgeable `EmissionProvenance` token recording WHICH channel(s) the source
+;; covered, and the drain consults `source-covered-always-on?` — never
+;; :rf.error/id truthiness, never a reconstructible ex-data shape, never a global
+;; seen-error registry. Two buckets:
 ;;
-;;   - already-fanned typed  → nothing more (the source's record IS the
-;;     exactly-once record, attribution intact);
-;;   - unfanned canonical typed → exactly once under its ORIGINAL id;
-;;   - untyped / malformed-id / non-catalogued id → exactly one stable
-;;     :rf.error/observation-on-change-failed wrapper.
+;;   - source already covered the ALWAYS-ON axis → nothing more (the source's
+;;     record IS the exactly-once record, attribution intact);
+;;   - NOT covered on the always-on axis (trace-only coverage, a diagnostic-only
+;;     thrown category, an untyped bug, a malformed/imitated id, a spoofed
+;;     public marker) → exactly one stable :rf.error/observation-on-change-failed
+;;     wrapper, the escape riding as its cause — never promoting the escape's own
+;;     category onto the always-on axis.
 ;;
 ;; Red-before-fix: with the provenance/choke-point repair reverted, the
 ;; released-lease fixtures below observe TWO read-after-release records
@@ -1992,30 +2009,38 @@
       (obs/release! lb)
       (obs/release! lc))))
 
-(deftest disposed-drain-surfaces-an-unfanned-typed-escape-exactly-once-under-its-own-id
+(deftest disposed-drain-wraps-a-diagnostic-only-typed-escape-without-promoting-it
   (reg-items!)
   (seed-items! [:a])
   (with-redefs [interop/next-tick (fn [_f] nil)]
     (let [bad (atom nil)
-          ;; The motivating unfanned canonical typed case: a forbidden
-          ;; reentrant release! from inside the fan-out throws the dev
-          ;; :rf.error/reentrant-graph-op assert — a plain typed throw with
-          ;; NO always-on fan of its own; the drain owns its first (and
-          ;; only) emission.
+          ;; A DIAGNOSTIC-ONLY typed escape: a forbidden reentrant release! from
+          ;; inside the fan-out throws the dev :rf.error/reentrant-graph-op assert
+          ;; (Spec 009: diagnostic channel — a plain typed throw with NO always-on
+          ;; fan of its own). rf2-w55bh0: the drain owns the callback failure's
+          ;; always-on coverage and must NOT promote the diagnostic category onto
+          ;; the always-on axis under its own id — it wraps it in the stable
+          ;; :rf.error/observation-on-change-failed, the reentrant assert riding as
+          ;; the cause.
           la  (obs/acquire! (items-target) (fn [_n] (obs/release! @bad)))]
       (reset! bad la)
       (force-dispose-node! [:obs/items])
       (let [[[outcome thrown] records]
             (with-error-records #(obs/drain-pending-disposals! :disposed))]
-        (let [rg (filterv #(= :rf.error/reentrant-graph-op (:error %)) records)]
-          (testing "visible EXACTLY once under its ORIGINAL id"
-            (is (= 1 (count rg))))
-          (testing "attributed to the notifying former owner's entry sub and
-                    carrying the escape as the record's cause"
-            (is (= :obs/items (:event-id (first rg))))
-            (is (identical? thrown (:exception (first rg))))))
-        (testing "a canonical typed escape is never wrapped"
-          (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:error %))
+        (testing "the callback failure surfaces EXACTLY once, wrapped in the
+                  stable always-on :rf.error/observation-on-change-failed"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)]
+            (is (= 1 (count wrapped)))
+            (testing "attributed to the notifying former owner's entry sub, with
+                      the diagnostic reentrant assert riding as the record's cause"
+              (is (= :obs/items (:event-id (first wrapped))))
+              (is (identical? thrown (:exception (first wrapped))))
+              (is (= :rf.error/reentrant-graph-op
+                     (error-id (:exception (first wrapped))))))))
+        (testing "the diagnostic-only category is NEVER promoted onto the
+                  always-on axis under its own id (rf2-w55bh0)"
+          (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %))
                                records))))
         (is (= :threw outcome))
         (is (= :rf.error/reentrant-graph-op (error-id thrown)))))))
@@ -2186,10 +2211,12 @@
             "no wrapper trace event for a typed escape"))
       (obs/release! live))))
 
-(deftest disposed-drain-fans-an-unfanned-typed-escape-on-both-channels
-  ;; When the drain owns the first emission of a CANONICAL TYPED escape (the
-  ;; dev reentrant assert), the same two-channel fan-out applies: one
-  ;; always-on record AND one trace event under the ORIGINAL id.
+(deftest disposed-drain-wraps-a-diagnostic-only-typed-escape-on-both-channels
+  ;; When the drain owns the callback failure's coverage for a DIAGNOSTIC-ONLY
+  ;; typed escape (the dev reentrant assert), the two-channel fan-out applies to
+  ;; the stable WRAPPER: one always-on record AND one trace event under
+  ;; :rf.error/observation-on-change-failed — the diagnostic category is never
+  ;; promoted onto the always-on axis under its own id (rf2-w55bh0).
   (reg-items!)
   (seed-items! [:a])
   (with-redefs [interop/next-tick (fn [_f] nil)]
@@ -2200,10 +2227,15 @@
       (let [[[outcome _] records traces]
             (with-both-channels #(obs/drain-pending-disposals! :disposed))]
         (is (= :threw outcome))
-        (is (= 1 (count (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))))
-        (let [tev (filterv #(= :rf.error/reentrant-graph-op (:operation %)) traces)]
+        (is (= 1 (count (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)))
+            "exactly one always-on wrapper record")
+        (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
+            "the diagnostic category is NOT promoted onto the always-on axis")
+        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                           traces)]
           (is (= 1 (count tev))
-              "the drain-owned first emission reaches the trace channel too")
+              "the drain-owned wrapper reaches the trace channel too")
           (is (= :disposed (:cause (:tags (first tev))))))))))
 
 (deftest collision-event-registration-cannot-steal-sub-attribution
@@ -2231,6 +2263,183 @@
               "a programmatic sub omits the slot; the same-id EVENT
                registration's coordinate is NOT stolen")))
       (obs/release! la))))
+
+;; ===========================================================================
+;; rf2-w55bh0 — the drain's emission provenance is OPAQUE and CHANNEL-AWARE
+;;
+;; The rf2-wbkjk9 scheme (a public `error-emit/fanned-at-source-key` truthy
+;; marker + a `:rf.error/id`-plus-`:reason` SHAPE test) was both CHANNEL-BLIND
+;; and RECONSTRUCTIBLE. Three defects the fixtures below pin:
+;;
+;;   1. CHANNEL-BLIND SUPPRESSION — a source that fanned ONLY the diagnostic
+;;      trace axis (the production-elided :rf.error/sub-cycle) was stamped with
+;;      the same Boolean "fanned" marker as a source that covered the always-on
+;;      axis, so the drain mistook trace coverage for full coverage and emitted
+;;      NOTHING. An HMR/disposed callback reaching a cyclic acquire went silent
+;;      in production.
+;;   2. DIAGNOSTIC-CATEGORY PROMOTION — an unfanned diagnostic-only thrown
+;;      category (:rf.error/observation-malformed-target, the dev
+;;      :rf.error/reentrant-graph-op assert) was dynamically re-fanned through
+;;      emit-error-both! under its OWN id, promoting a category Spec 009
+;;      EXCLUDES from the always-on axis.
+;;   3. FORGEABLE PROVENANCE — an application ex-info could copy the public
+;;      marker (to SUPPRESS reporting) or carry a reserved / imitated
+;;      `:rf.error/id` + `:reason` (to INJECT a framework category).
+;;
+;; The fix: observation stamps an OPAQUE, unforgeable `EmissionProvenance` token
+;; recording WHICH channel(s) the source covered, and the drain asks
+;; `source-covered-always-on?`. A source that did not cover the always-on axis
+;; (trace-only, a diagnostic-only thrown category, an untyped bug, or a spoof)
+;; gets exactly one stable :rf.error/observation-on-change-failed wrapper — the
+;; escape riding as its cause — never promoting its own category. Red-before-fix
+;; is noted per fixture; the fixtures ALSO fail if channel coverage is collapsed
+;; back to a Boolean or the opaque token is replaced with a reconstructible map
+;; shape.
+;; ===========================================================================
+
+(deftest disposed-drain-adds-always-on-callback-failure-when-source-covered-only-trace
+  ;; CHANNEL-BLIND SUPPRESSION. A former-owner on-change callback that reaches a
+  ;; CYCLIC acquire throws the diagnostic-only :rf.error/sub-cycle, whose only
+  ;; emission is the sub build's production-elided TRACE event. In advanced
+  ;; production, where the dev reentrancy guard is DCE'd, the on-change's own
+  ;; synchronous cyclic acquire throws exactly this; we model that in this debug
+  ;; test by acquiring the cyclic target to obtain the REAL observation sub-cycle
+  ;; throw (trace-only provenance) and re-raising it from the on-change. Pre-fix
+  ;; the port stamped it with a channel-BLIND Boolean, so the drain suppressed
+  ;; everything — production got no record. The channel-AWARE fix adds exactly one
+  ;; always-on callback-failure record WITHOUT promoting sub-cycle.
+  ;; Red-before-fix / channel-collapse-to-Boolean: wrapped count 0.
+  (reg-items!)
+  (rf/reg-sub :obs/wcyc1 :<- [:obs/wcyc2] (fn [v _] v))
+  (rf/reg-sub :obs/wcyc2 :<- [:obs/wcyc1] (fn [v _] v))
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [cyclic       (obs/resolve-target {:frame fid :query-v [:obs/wcyc1]})
+          sub-cycle-ex (try (obs/acquire! cyclic (fn [_]))
+                            (catch #?(:clj Throwable :cljs :default) e e))
+          notes        (atom [])
+          la (obs/acquire! (items-target) (fn [_n] (throw sub-cycle-ex)))
+          lb (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+      (is (= :rf.error/sub-cycle (error-id sub-cycle-ex))
+          "the fixture carries a REAL observation sub-cycle throw")
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome thrown] records]
+            (with-error-records #(obs/drain-pending-disposals! :disposed))]
+        (testing "the healthy sibling still drained"
+          (is (= 1 (count @notes))))
+        (testing "exactly one production-survivable callback-failure record —
+                  trace coverage of the diagnostic sub-cycle is NOT full coverage
+                  (pre-fix / channel-collapse-to-Boolean: zero)"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)]
+            (is (= 1 (count wrapped)))
+            (is (identical? sub-cycle-ex (:exception (first wrapped)))
+                "the diagnostic sub-cycle throw rides as the wrapper's cause")
+            (is (= :obs/items (:event-id (first wrapped))))))
+        (testing "the diagnostic-only sub-cycle category is NEVER promoted onto
+                  the always-on axis"
+          (is (empty? (filterv #(= :rf.error/sub-cycle (:error %)) records))))
+        (testing "the first escape is rethrown to the direct caller with the
+                  sub-cycle identity intact"
+          (is (= :threw outcome))
+          (is (identical? sub-cycle-ex thrown))
+          (is (= :rf.error/sub-cycle (error-id thrown)))))
+      (obs/release! la)
+      (obs/release! lb))))
+
+(deftest disposed-drain-wraps-a-diagnostic-only-malformed-target-escape-without-promoting-it
+  ;; DIAGNOSTIC-CATEGORY PROMOTION. A former-owner on-change that probes a
+  ;; malformed target throws the diagnostic-only
+  ;; :rf.error/observation-malformed-target (probe carries no reentrancy guard, so
+  ;; it reaches the closed-target grammar gate). Pre-fix the drain trusted the
+  ;; canonical thrown-error SHAPE and dynamically re-fanned malformed-target
+  ;; through emit-error-both!, promoting a category Spec 009 EXCLUDES from the
+  ;; always-on axis. Red-before-fix: :rf.error/observation-malformed-target
+  ;; appears among the always-on records (and the wrapper is absent).
+  (reg-items!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [notes (atom [])
+          la (obs/acquire! (items-target) (fn [_n] (obs/probe {:kind :bogus})))
+          lb (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+      (force-dispose-node! [:obs/items])
+      (let [[[outcome thrown] records]
+            (with-error-records #(obs/drain-pending-disposals! :disposed))]
+        (is (= 1 (count @notes)) "the healthy sibling still drained")
+        (testing "the callback failure is wrapped exactly once on the always-on
+                  axis, carrying the malformed-target throw as its cause"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)]
+            (is (= 1 (count wrapped)))
+            (is (= :rf.error/observation-malformed-target
+                   (error-id (:exception (first wrapped)))))))
+        (testing "the diagnostic-only malformed-target category is NEVER promoted
+                  onto the always-on axis"
+          (is (empty? (filterv #(= :rf.error/observation-malformed-target (:error %))
+                               records))))
+        (is (= :threw outcome))
+        (is (= :rf.error/observation-malformed-target (error-id thrown))))
+      (obs/release! la)
+      (obs/release! lb))))
+
+(deftest disposed-drain-cannot-be-suppressed-or-spoofed-by-forged-provenance
+  ;; FORGEABLE PROVENANCE. An application on-change can copy any keyword or
+  ;; literal into its thrown ex-data, but it cannot construct the
+  ;; framework-internal EmissionProvenance token — so no forgery can SUPPRESS the
+  ;; always-on callback-failure record or INJECT a category. Red-before-fix: the
+  ;; public marker suppressed the drain (wrapped absent) and the reserved /
+  ;; imitated ids were fanned as framework categories.
+  (reg-items!)
+  (seed-items! [:a])
+  (with-redefs [interop/next-tick (fn [_f] nil)]
+    (let [;; (1) a copy of the OLD public "already-fanned" marker — pre-fix this
+          ;;     suppressed the drain entirely (fanned-at-source? true).
+          public-marker (ex-info "forged public marker"
+                                 {error-emit/fanned-at-source-key true})
+          ;; (2) a RECONSTRUCTED provenance-shaped map under the (guessable)
+          ;;     framework key — fails the instance? gate; this ALSO fails if the
+          ;;     opaque token is replaced with a reconstructible map shape.
+          shape-forgery (ex-info "forged provenance shape"
+                                 {:re-frame.substrate.observation/emission-provenance
+                                  {:channels #{:always-on :trace}}})
+          ;; (3) a reserved-but-UNCATALOGUED id + plausible :reason — pre-fix
+          ;;     canonical-typed-error? trusted the shape and INJECTED it.
+          reserved-boom (ex-info "reserved uncatalogued"
+                                 {:rf.error/id :rf.error/not-in-catalogue
+                                  :reason      "a plausible framework sentence"})
+          ;; (4) an IMITATED existing catalogued id + plausible :reason — pre-fix
+          ;;     this SPOOFED :rf.error/frame-destroyed onto the axis.
+          imitation     (ex-info "imitated existing id"
+                                 {:rf.error/id :rf.error/frame-destroyed
+                                  :reason      "a plausible framework sentence"})
+          notes (atom [])
+          la (obs/acquire! (items-target) (fn [_n] (throw public-marker)))
+          lb (obs/acquire! (items-target) (fn [_n] (throw shape-forgery)))
+          lc (obs/acquire! (items-target) (fn [_n] (throw reserved-boom)))
+          ld (obs/acquire! (items-target) (fn [_n] (throw imitation)))
+          le (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+      (force-dispose-node! [:obs/items])
+      (let [[[_ _] records]
+            (with-error-records #(obs/drain-pending-disposals! :disposed))]
+        (testing "the healthy sibling was still notified"
+          (is (= 1 (count @notes))))
+        (testing "no forged marker can SUPPRESS the always-on callback-failure —
+                  each forgery yields exactly one stable wrapper carrying its
+                  original throwable as the cause"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)
+                causes  (set (map :exception wrapped))]
+            (is (= 4 (count wrapped)))
+            (is (contains? causes public-marker))
+            (is (contains? causes shape-forgery))
+            (is (contains? causes reserved-boom))
+            (is (contains? causes imitation))
+            (is (every? #(= :obs/items (:event-id %)) wrapped))))
+        (testing "no forged id is INJECTED onto the always-on axis"
+          (is (empty? (filterv #(= :rf.error/not-in-catalogue (:error %)) records)))
+          (is (empty? (filterv #(= :rf.error/frame-destroyed (:error %)) records)))))
+      (obs/release! la) (obs/release! lb) (obs/release! lc)
+      (obs/release! ld) (obs/release! le))))
 
 ;; ===========================================================================
 ;; ABI guard


### PR DESCRIPTION
Closes rf2-w55bh0.

## Repro

The observation-port disposal-notify escape drain (`report-disposal-notify-escape!`) classified escaping `on-change` failures by a **channel-blind Boolean** marker (`error-emit/fanned-at-source-key`, a public namespaced key whose literal value was `true`) plus a **reconstructible** `:rf.error/id`-plus-`:reason` shape test (`error-emit/canonical-typed-error?`). Two independent exact-head audits reproduced:

- **Channel-blind suppression.** `throw-acquire-recovery!` stamped `:rf.error/sub-cycle` with the same "fanned" Boolean as an always-on emission, but the sub build surfaces `sub-cycle` on the **diagnostic trace axis only** (it is production-elided). A former-owner `on-change` reaching a cyclic acquire during an HMR / disposed drain therefore left the drain mistaking trace coverage for full coverage — it emitted **nothing**, and the swallowing drain boundary (registrar per-hook `catch` / unobserved `next-tick`) hid the rethrow, so production received no always-on record.
- **Diagnostic-category promotion.** An unfanned diagnostic-only thrown category — `:rf.error/observation-malformed-target` (and the dev `:rf.error/reentrant-graph-op` assert) — was re-fanned through `emit-error-both!` under its **own id**, promoting a category Spec 009 marks `diagnostic` onto the always-on axis.
- **Reconstructible provenance.** An application `on-change` ex-info could copy the public `fanned-at-source` marker to **suppress** reporting, or carry a reserved-uncatalogued / imitated `:rf.error/id` + `:reason` to **inject** a framework category.

## Fix (entirely inside `observation.cljc`)

- A new opaque, unforgeable `EmissionProvenance` deftype token (mirrors the `ObservationLease` opaque-identity idiom) records **which channel(s)** a source actually covered — `#{:always-on :trace}` for the `emit-error-both!` emit-then-throw sites, `#{:trace}` for the sub build's diagnostic `sub-cycle`. The emit seams stamp it under a framework-internal ex-data key; the drain asks `source-covered-always-on?` (an `instance?` gate + channel-set membership).
- A source that did **not** cover the always-on axis (trace-only coverage, a diagnostic-only thrown category, a raw untyped consumer bug, or an application spoof) gets **exactly one** stable `:rf.error/observation-on-change-failed` wrapper, the escape riding as its `:exception` cause — its own diagnostic category is **never promoted** onto the always-on axis.
- Legitimate already-emitted always-on failures (`read`-after-release, frame-destroyed, no-such-sub, sub-input-fn-*, retry-exhausted, port-version-mismatch) stay **exact-once with the source's own attribution** — the drain adds nothing.
- Non-forgeable by construction: a public-looking marker, a reconstructed `{:channels …}` map, or a spoofed `:rf.error/id` all fail the `instance?` gate; no application ex-data can inject or suppress a category.

No `error_emit.cljc` change (the held rf2-xakb4p lane owns that file), no new error category, no public API, no global dedupe registry, no compatibility branch.

### Typed ids

- Emit-seam provenance stamps now channel-aware: `:rf.error/observation-port-version-mismatch`, `:rf.error/frame-destroyed`, `:rf.error/no-such-sub`, `:rf.error/observation-retry-exhausted`, `:rf.error/read-after-release`, `:rf.error/sub-input-fn-exception`, `:rf.error/sub-input-fn-bad-return` → `#{:always-on :trace}`; `:rf.error/sub-cycle` → `#{:trace}`.
- Drain wrapper: `:rf.error/observation-on-change-failed` (unchanged category, unchanged tags — Channel stays `always-on`).
- Diagnostic-only thrown categories now wrapped (not promoted) when they escape the drain: `:rf.error/sub-cycle`, `:rf.error/observation-malformed-target`, `:rf.error/observation-malformed-lease`, `:rf.error/reentrant-graph-op`.

### Behaviour change

Per the Spec 009 catalogue Channel column, `:rf.error/reentrant-graph-op` is **diagnostic**. The prior drain promoted it onto the always-on axis under its own id ("exists to be seen"); the channel-aware fix wraps it in `:rf.error/observation-on-change-failed` (the reentrant assert riding as the cause), consistent with the bead's "never promote a diagnostic-only category" mandate. Three existing fixtures that pinned the promotion were updated to assert the wrapped behaviour.

## Follow-ups (not in this PR)

- **Spec 009 prose.** No new id/row is needed (scope-fenced out of this PR), but the existing `:rf.error/observation-on-change-failed` row prose ("a TYPED escape keeps its own catalogue id") should be refined to note that a *diagnostic-only* typed escape is now wrapped, not promoted. Prose-only; the conformance gate is unaffected (Channel/tags unchanged, and the source now only ever fans the static always-on category through `emit-error-both!`).
- `error_emit.cljc` retains `fanned-at-source-key` / `fanned-at-source?` / `canonical-typed-error?` — now unused by observation. Removing them belongs to the held rf2-xakb4p lane (owns `error_emit.cljc`).

## Quality gates

Red-before-fix confirmed: with the src reverted to `origin/main` (test file kept), the three new fixtures fail; restored, all green.

- **`disposed-drain-adds-always-on-callback-failure-when-source-covered-only-trace`** — the channel-blind suppression fixture (also fails if channel coverage is collapsed back to a Boolean). Red-before-fix: wrapped count 0.
- **`disposed-drain-wraps-a-diagnostic-only-malformed-target-escape-without-promoting-it`** — diagnostic-category promotion. Red-before-fix: `:rf.error/observation-malformed-target` appears on the always-on records.
- **`disposed-drain-cannot-be-suppressed-or-spoofed-by-forged-provenance`** — opacity/forgeability (public marker + reconstructed-map-shape + reserved/imitated id). Also fails if the opaque token is replaced with a reconstructible map shape.

Green (CLJ + CLJS, debug):

- core JVM (`clojure -M:test`): 1951 tests, 8898 assertions, 0 failures (incl. the error-catalogue channel-conformance gate).
- ui JVM (ViewCell consumer, `clojure -M:test`): 483 tests, 6278 assertions, 0 failures.
- CLJS node (`npm run test:cljs`): 9338 tests, 44229 assertions, 0 failures (both-host coverage for the deftype/provenance).
- `scripts/test-fast-pr.sh`: PASS.
