### PR TITLE
fix(ui): fence ViewCell publication against HMR authority change during commit (rf2-vxgfnd.214)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2796,6 +2796,28 @@
                      replacement id (rf2-vxgfnd.88)."
   nil)
 
+(defn- stale-body-authority?
+  "DEV/HMR body-authority check (rf2-vxgfnd.214): true when `cap`'s captured
+  body generation no longer matches the cell's CURRENT authority — either the
+  cell-local revision `state-gen` (a FRESH read) or the authoritative registered
+  slot revision for `view-id`. A direct/headless caller with no registered slot
+  falls back to the cell-local contract (`registered-view-revision` nil ⇒ that
+  half no-ops).
+
+  The commit's step-1 gate samples this authority ONCE, before the callback-
+  capable staging window; `commit*` re-consults it at the final publication
+  boundary so a re-registration landing mid-commit cannot publish under a stale
+  body. Callers gate the ENTIRE consult behind `interop/debug-enabled?`, so
+  production — where `use-cell` mints every cell at body revision 0 and never
+  advances it (the whole HMR slot is dev-only) — performs no registry lookup and
+  this predicate constant-folds away under goog.DEBUG=false."
+  [cap state-gen view-id]
+  (let [cap-gen (:generation cap)]
+    (or (not= cap-gen state-gen)
+        (boolean
+          (when-some [current (registered-view-revision view-id)]
+            (not= cap-gen current))))))
+
 (defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable
   `capture` returned beside the committed host element by `with-capture`.
@@ -2967,76 +2989,99 @@
           ;; joins this commit to the acquired incarnation's teardown, not the
           ;; replacement id (rf2-vxgfnd.88).
           (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
-          ;; step 6 — publish exact per-site query/value + dependency set
-          (swap! st
-                 (fn [m]
-                   (let [m* (assoc m :committed new-committed)]
-                     (if accept-capture
-                       (accept-capture m* cap)
-                       m*))))
-          ;; step 7 — release dropped + retargeted prior leases
-          (doseq [[_ record] to-release]
-            (obs/release! (:lease record)))
-          ;; lifecycle: connect (reconnect annotation when re-committing a
-          ;; hidden cell). This ENROLS the cell into the live-cell registry —
-          ;; the discoverability publish a frame-destroy sweep consults.
-          (connect! cell)
-          ;; INCARNATION-SAFE frame-close revalidation (rf2-vxgfnd.88, extending
-          ;; rf2-vxgfnd.61). Two reasons this commit must JOIN a teardown instead
-          ;; of publishing `:connected`, checked against the ACQUIRE-time
-          ;; incarnation snapshot rather than the bare frame-id:
-          ;;
-          ;;   (a) `incarnation-superseded?` — a frame this commit acquired from
-          ;;       is no longer live under the SAME incarnation token: it was
-          ;;       destroyed, OR a fresh same-id incarnation replaced it in the
-          ;;       render→commit gap. The bare-id `frame-closing?` MISSES this once
-          ;;       the old incarnation's teardown completed and cleared its marker
-          ;;       while a replacement went live under the id — so an old lease
-          ;;       would otherwise survive on the replacement id (rf2-vxgfnd.88).
-          ;;       Token identity (`frame/frame-incarnation-token`, the record's
-          ;;       `:drain-lock`, distinct per incarnation) resolves the commit to
-          ;;       exactly the incarnation it targeted.
-          ;;
-          ;;   (b) `frame-incarnation-closing?` — the ACQUIRED incarnation is
-          ;;       IN-FLIGHT closing (rf2-vxgfnd.61, scoped to the incarnation by
-          ;;       rf2-vxgfnd.94). #5731 wires destroy to a SNAPSHOT sweep of the
-          ;;       live cells that runs while the frame is still LIVE (pre-flip),
-          ;;       then flips liveness. A commit that acquires + enrols between the
-          ;;       sweep snapshot and the flip is MISSED by the sweep, and its
-          ;;       incarnation token is UNCHANGED (the frame is still live pre-flip)
-          ;;       — so `incarnation-superseded?` alone would not catch it. But
-          ;;       `destroying-frames` is populated at the TOP of `destroy-frame!`,
-          ;;       so the marker is continuously present across the whole teardown
-          ;;       window: the enrolled cell observes the close and joins the
-          ;;       teardown against the still-releasable cache. Scoping to the
-          ;;       ACQUIRE-time token (not the bare id) is what closes .88's
-          ;;       reciprocal Failure-2: in the JVM window where an OLD incarnation
-          ;;       A's marker is still set (post-`dissoc-frame!`, pre-`finally`)
-          ;;       while a fresh same-id incarnation B is already live, a commit
-          ;;       that acquired B reads FALSE here (B's token ≠ A's marker token),
-          ;;       so A's stale close authority cannot tear down a cell that owns B
-          ;;       (rf2-vxgfnd.94). The bare-id `frame/frame-closing?` would read
-          ;;       true for the reused id and wrongly reap B's cell.
-          ;;
-          ;; A live, not-closing frame under an unchanged incarnation (incl. a
-          ;; committed fresh same-id incarnation this commit legitimately acquired)
-          ;; makes both checks false — disjoint frames commit/destroy concurrently,
-          ;; and the single-threaded CLJS host (destroy runs to completion without
-          ;; yielding to a commit) never sees either true.
-          (if (or (incarnation-superseded? incarnations)
-                  (some (fn [[fid token]]
-                          (frame/frame-incarnation-closing? fid token))
-                        incarnations))
-            (teardown! cell)
-            ;; step 8 — moved evidence corrects before paint. The staged catch
-            ;; always advances synchronously; a RETAINED catch advances only when
-            ;; no live watch already caught the move — a pending (`dirty?`) cell is
-            ;; a watchable host whose scheduled flush already corrects before paint,
-            ;; so advancing here too would add a redundant render (rf2-vxgfnd.39).
-            (when (or staged-moved?
-                      (and retained-moved? (not (dirty? cell))))
-              (advance-revision! cell)))
-              cell)))))))
+          ;; FINAL HMR-authority fence (rf2-vxgfnd.214). Step 1 samples the body
+          ;; authority ONCE — before the :pre-acquire barrier, the acquire/cache
+          ;; callbacks, and the :post-acquire barrier, EVERY one of which can
+          ;; synchronously advance the authoritative body revision (a same-shell
+          ;; re-registration landing in the render→commit gap). Re-read the
+          ;; authority at the narrowest publication boundary — after all
+          ;; callback-capable work, with nothing callback-capable between here and
+          ;; the step-6 publish — and refuse to publish a stale-authority capture:
+          ;; release ONLY the newly staged leases in reverse acquisition order,
+          ;; leave the prior committed set / values / lifecycle untouched, and
+          ;; return :stale exactly as step 1 does (the re-registration already
+          ;; notified the shell, so a fresh render at the new body is inbound;
+          ;; unlike the candidate-current? incarnation path this needs no
+          ;; advance-revision!). DEV/HMR-only: production mints every cell at body
+          ;; revision 0 and never advances it, so the whole fence DCEs under
+          ;; goog.DEBUG=false — no registry lookup, no hot-path bookkeeping.
+          (if (and interop/debug-enabled?
+                   (stale-body-authority? cap (:generation @st) (:view-id st0)))
+            (do
+              (doseq [[_ record] (rseq staged)]
+                (obs/release! (:lease record)))
+              :stale)
+            (do
+              ;; step 6 — publish exact per-site query/value + dependency set
+              (swap! st
+                     (fn [m]
+                       (let [m* (assoc m :committed new-committed)]
+                         (if accept-capture
+                           (accept-capture m* cap)
+                           m*))))
+              ;; step 7 — release dropped + retargeted prior leases
+              (doseq [[_ record] to-release]
+                (obs/release! (:lease record)))
+              ;; lifecycle: connect (reconnect annotation when re-committing a
+              ;; hidden cell). This ENROLS the cell into the live-cell registry —
+              ;; the discoverability publish a frame-destroy sweep consults.
+              (connect! cell)
+              ;; INCARNATION-SAFE frame-close revalidation (rf2-vxgfnd.88, extending
+              ;; rf2-vxgfnd.61). Two reasons this commit must JOIN a teardown instead
+              ;; of publishing `:connected`, checked against the ACQUIRE-time
+              ;; incarnation snapshot rather than the bare frame-id:
+              ;;
+              ;;   (a) `incarnation-superseded?` — a frame this commit acquired from
+              ;;       is no longer live under the SAME incarnation token: it was
+              ;;       destroyed, OR a fresh same-id incarnation replaced it in the
+              ;;       render→commit gap. The bare-id `frame-closing?` MISSES this once
+              ;;       the old incarnation's teardown completed and cleared its marker
+              ;;       while a replacement went live under the id — so an old lease
+              ;;       would otherwise survive on the replacement id (rf2-vxgfnd.88).
+              ;;       Token identity (`frame/frame-incarnation-token`, the record's
+              ;;       `:drain-lock`, distinct per incarnation) resolves the commit to
+              ;;       exactly the incarnation it targeted.
+              ;;
+              ;;   (b) `frame-incarnation-closing?` — the ACQUIRED incarnation is
+              ;;       IN-FLIGHT closing (rf2-vxgfnd.61, scoped to the incarnation by
+              ;;       rf2-vxgfnd.94). #5731 wires destroy to a SNAPSHOT sweep of the
+              ;;       live cells that runs while the frame is still LIVE (pre-flip),
+              ;;       then flips liveness. A commit that acquires + enrols between the
+              ;;       sweep snapshot and the flip is MISSED by the sweep, and its
+              ;;       incarnation token is UNCHANGED (the frame is still live pre-flip)
+              ;;       — so `incarnation-superseded?` alone would not catch it. But
+              ;;       `destroying-frames` is populated at the TOP of `destroy-frame!`,
+              ;;       so the marker is continuously present across the whole teardown
+              ;;       window: the enrolled cell observes the close and joins the
+              ;;       teardown against the still-releasable cache. Scoping to the
+              ;;       ACQUIRE-time token (not the bare id) is what closes .88's
+              ;;       reciprocal Failure-2: in the JVM window where an OLD incarnation
+              ;;       A's marker is still set (post-`dissoc-frame!`, pre-`finally`)
+              ;;       while a fresh same-id incarnation B is already live, a commit
+              ;;       that acquired B reads FALSE here (B's token ≠ A's marker token),
+              ;;       so A's stale close authority cannot tear down a cell that owns B
+              ;;       (rf2-vxgfnd.94). The bare-id `frame/frame-closing?` would read
+              ;;       true for the reused id and wrongly reap B's cell.
+              ;;
+              ;; A live, not-closing frame under an unchanged incarnation (incl. a
+              ;; committed fresh same-id incarnation this commit legitimately acquired)
+              ;; makes both checks false — disjoint frames commit/destroy concurrently,
+              ;; and the single-threaded CLJS host (destroy runs to completion without
+              ;; yielding to a commit) never sees either true.
+              (if (or (incarnation-superseded? incarnations)
+                      (some (fn [[fid token]]
+                              (frame/frame-incarnation-closing? fid token))
+                            incarnations))
+                (teardown! cell)
+                ;; step 8 — moved evidence corrects before paint. The staged catch
+                ;; always advances synchronously; a RETAINED catch advances only when
+                ;; no live watch already caught the move — a pending (`dirty?`) cell is
+                ;; a watchable host whose scheduled flush already corrects before paint,
+                ;; so advancing here too would add a redundant render (rf2-vxgfnd.39).
+                (when (or staged-moved?
+                          (and retained-moved? (not (dirty? cell))))
+                  (advance-revision! cell)))
+              cell)))))))))
 
 (defn commit!
   "Commit an observation-only capture without installing or copying resource

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
@@ -1,0 +1,186 @@
+(ns re-frame.ui.reactive-hmr-authority-fence-cljs-test
+  "rf2-vxgfnd.214 — the ViewCell commit fences PUBLICATION against an HMR
+  body-authority change that lands DURING the commit.
+
+  #5817 made `commit!` reject a capture whose authoritative body revision was
+  already stale at step 1. But step 1 samples the authority ONCE, before the
+  callback-capable staging window: the `:pre-acquire` barrier, `obs/acquire!` +
+  sub-cache construction, and the `:post-acquire` barrier can each SYNCHRONOUSLY
+  register a newer body revision (a same-shell re-registration in the
+  render→commit gap). Before this bead the revision-0 capture published anyway,
+  so the stale render temporarily OWNED dependencies — violating the HMR
+  contract (03 §10) that a stale capture obtains no ownership.
+
+  The fix is one FINAL authority fence at the narrowest publication boundary —
+  after all staging, evidence reads, and callback-capable hooks, immediately
+  before the state publication, with nothing callback-capable between the fence
+  and the publish. If the body authority moved, only the newly staged leases are
+  released (reverse acquisition order), the prior committed set / values /
+  revision / lifecycle stay untouched, and the commit returns `:stale` exactly
+  as step 1 does.
+
+  Staging is deterministic and host-agnostic via the `reactive/*commit-barrier*`
+  test seam, which fires synchronously INSIDE `commit!` at `:pre-acquire`,
+  `:post-stage-acquire` (the acquisition/cache-callback window), and
+  `:post-acquire`. The fixtures re-register the same view at each of those
+  points, so no threads are needed; `.cljc` ending `-cljs-test` graft-checks on
+  node (`test:cljs`) AND JVM (`clojure -M:test`) against the REAL observation
+  port + sub-cache (plain-atom adapter).
+
+  MUTATION TOOTH: every fence case asserts `commit!` returned `:stale` and that
+  NO staged ownership survived. Deleting or moving the final fence (so the
+  revision-0 capture publishes) flips each such assertion red — the fence is the
+  sole thing standing between a mid-commit re-registration and a stale publish."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.fingerprint        :as fp]
+            [re-frame.ui.reactive           :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    (reactive/reset-scheduler!)
+    (try (t) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+(def ^:private hs0 (fp/hook-signature-hash {:locals [] :effects []}))
+(def ^:private hs1 (fp/hook-signature-hash {:locals ['draft] :effects []}))
+
+(defn- sub-cache [] (:sub-cache (frame/frame fid)))
+(defn- entry [q] (get @(sub-cache) q))
+(defn- ref-count [q] (:ref-count (entry q)))
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- tk [q] [:sub fid q])
+
+(defn- capture-of
+  "A fresh render capture for `sites` (a vector of [sid query]) at the cell's
+  current generation — ownership-free, exactly what React would carry into the
+  layout effect."
+  [cell sites]
+  (second
+    (rf/with-frame fid
+      (reactive/with-capture
+        cell (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))))
+
+(defn- reregister-barrier
+  "A `*commit-barrier*` that, at `at-phase`, re-registers `vid` at `hook-sig`
+  (advancing the authoritative body revision under the running commit)."
+  [vid at-phase hook-sig]
+  (fn [phase _cell]
+    (when (= phase at-phase)
+      (reactive/register-view-generation! vid hook-sig))))
+
+;; ===========================================================================
+;; A mid-commit re-registration at EACH callback-capable phase is fenced
+;; ===========================================================================
+
+(defn- fences-at-phase
+  "Register `vid` at revision 0, render a revision-0 capture with one sub site,
+  then re-register at `at-phase` (with `hook-sig`) during the commit. The commit
+  must return `:stale` and touch no ownership."
+  [at-phase hook-sig]
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::fence-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)
+        cap  (capture-of cell [[::site [:r/a]]])]
+    (is (= 0 (:generation cap)) "capture formed at body revision 0")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [result (binding [reactive/*commit-barrier*
+                           (reregister-barrier vid at-phase hook-sig)]
+                   (reactive/commit! cell cap))]
+      (is (= :stale result)
+          (str "a re-registration at " at-phase " fences the stale-body publish"))
+      (is (= :fresh (reactive/lifecycle cell))
+          "a fenced candidate never connects")
+      (is (empty? (reactive/committed-sites cell))
+          "no dependency set published")
+      (is (nil? (entry [:r/a]))
+          "the staged lease was released — the node has zero owners (disposed)")
+      (is (= 0 (reactive/revision cell))
+          "no revision advance — the shell's re-registration drives the re-render"))))
+
+(deftest reregistration-at-pre-acquire-is-fenced
+  (testing "same-signature body replacement at :pre-acquire"
+    (fences-at-phase :pre-acquire hs0)))
+
+(deftest reregistration-during-acquisition-is-fenced
+  (testing "same-signature body replacement in the acquisition/cache window"
+    (fences-at-phase :post-stage-acquire hs0)))
+
+(deftest reregistration-at-post-acquire-is-fenced
+  (testing "same-signature body replacement at :post-acquire (the last hook)"
+    (fences-at-phase :post-acquire hs0)))
+
+(deftest changed-signature-remount-registration-is-fenced
+  (testing "a CHANGED hook signature (remount generation) still advances body
+            revision, so its mid-commit registration is fenced too"
+    (fences-at-phase :post-acquire hs1)))
+
+;; ===========================================================================
+;; The fence preserves the prior committed state and releases ONLY the staged
+;; leases (reverse order, exactly once)
+;; ===========================================================================
+
+(deftest fence-preserves-prior-committed-and-releases-only-staged
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (rf/reg-sub :r/c (fn [db _] (:c db)))
+  (seed! {:a 1 :b 2 :c 3})
+  (let [vid  ::preserve-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    ;; A clean revision-0 commit installs the prior committed set (site :a).
+    (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))
+    (let [lease-a (reactive/committed-lease cell (tk [:r/a]))
+          rev0    (reactive/revision cell)]
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= 1 (ref-count [:r/a])) "prior committed lease installed")
+      (testing "a later same-generation render retains :a and stages :b + :c,
+                then a re-registration fences the publish"
+        (let [cap    (capture-of cell [[::a [:r/a]] [::b [:r/b]] [::c [:r/c]]])
+              result (binding [reactive/*commit-barrier*
+                               (reregister-barrier vid :post-acquire hs0)]
+                       (reactive/commit! cell cap))]
+          (is (= :stale result) "the stale-body publish is fenced")
+          (testing "prior committed :a is wholly untouched"
+            (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
+                "the retained lease keeps its exact identity")
+            (is (= 1 (ref-count [:r/a])) ":a never re-acquired or released")
+            (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell))
+                "the published dependency set is unchanged — no staged site leaked")
+            (is (= :connected (reactive/lifecycle cell)) "lifecycle unchanged")
+            (is (= rev0 (reactive/revision cell)) "revision unchanged"))
+          (testing "BOTH staged leases (:b, :c) were released exactly once"
+            (is (nil? (entry [:r/b])) ":b staged then released → zero-owner node")
+            (is (nil? (entry [:r/c])) ":c staged then released → zero-owner node")))))))
+
+;; ===========================================================================
+;; The ordinary unchanged-authority commit is unaffected — it publishes once
+;; ===========================================================================
+
+(deftest unchanged-authority-commit-publishes-once
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::normal-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    (testing "no mid-commit re-registration ⇒ the capture publishes and connects"
+      (let [result (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))]
+        (is (identical? cell result) "a clean commit returns the cell, not :stale")
+        (is (= :connected (reactive/lifecycle cell)))
+        (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell)))
+        (is (= 1 (ref-count [:r/a])) "exactly one owner acquired")
+        (is (= 1 (:value (reactive/committed-site cell ::a)))))
+      (let [lease-a (reactive/committed-lease cell (tk [:r/a]))]
+        (testing "a second unchanged-authority render retains the exact lease"
+          (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))
+          (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
+              "acquire-before-release kept the live lease untouched")
+          (is (= 1 (ref-count [:r/a])) "no churn on a no-op reconcile"))))))


### PR DESCRIPTION
## Repro (re-verified live on origin/main `81bd66ebc0`)

`commit*` (`implementation/ui/src/re_frame/ui/reactive.cljc`) samples the HMR body authority **once**, at step 1 — the cell-local `:generation` and, in DEV, `registered-view-revision`. It then runs the `:pre-acquire` barrier, `obs/acquire!` + sub-cache construction, step-5 evidence reads, and the `:post-acquire` barrier. Every one of those points is callback-capable and can synchronously register a **newer** body revision (a same-shell re-registration landing in the render→commit gap). The pre-fix code published the stale revision-0 capture anyway, so the stale render temporarily **owned** dependencies — violating the 03 §10 HMR contract that a stale capture obtains no ownership.

`#5854`'s `candidate-current?` fence only catches frame-**incarnation** movement (node/frame identity), not a change to the view's HMR **body** authority, so the gap was still live. Confirmed by extending the existing `*commit-barrier*` seam to re-register the view mid-commit: pre-fix the commit published and connected; the new fixtures are red without the fence.

## Fix

One final DEV/HMR-only authority fence at the narrowest publication boundary — immediately after the `:post-acquire` barrier and immediately before the step-6 publish `swap!`, with nothing callback-capable between the check and the publish:

- New private predicate `stale-body-authority?` re-reads the cell-local generation (`(:generation @st)`, fresh) and the authoritative `registered-view-revision` and compares both to the capture's generation — the same dual authority step 1 uses, but freshly sampled.
- If either moved: release **only** the newly staged leases in reverse acquisition order (`(rseq staged)`), leave the prior committed set / values / revision / lifecycle untouched, and return `:stale` exactly as step 1 does. No `advance-revision!` — the re-registration already notified the shell, so a fresh render at the new body is inbound (unlike the `candidate-current?` incarnation path which has no other re-render trigger).
- The whole fence is gated behind `interop/debug-enabled?`, so it constant-folds away under `:advanced` + `goog.DEBUG=false`: production mints every cell at body revision 0 and never advances it (`use-cell` is `js/goog.DEBUG`-gated), so there is no HMR registry lookup or hot-path bookkeeping in advanced output.

The incarnation/`candidate-current?` path and the normal unchanged-authority commit are untouched.

## Quality gates

New deterministic fixtures in `implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc` (`.cljc` → runs on **both** node `test:cljs` and JVM `clojure -M:test`), the **red-before-fix** coverage:

- `reregistration-at-pre-acquire-is-fenced`
- `reregistration-during-acquisition-is-fenced` (`:post-stage-acquire`, the acquisition/cache-callback window)
- `reregistration-at-post-acquire-is-fenced`
- `changed-signature-remount-registration-is-fenced` (changed hook signature / remount generation)
- `fence-preserves-prior-committed-and-releases-only-staged` (prior lease/value/revision/lifecycle intact; both staged leases released exactly once, reverse order)
- `unchanged-authority-commit-publishes-once` (normal path unaffected; acquire-before-release retained)

Each fence case asserts `:stale` + zero staged ownership survived — the **mutation tooth**: deleting/moving the final fence flips them red.

Gates run (all green, foreground):
- `cd implementation/ui && clojure -M:test` — 491 tests, 0 failures
- `cd implementation && npm run test:ui` (node) — 491 tests, 0 failures
- `cd implementation && npm run test:browser` — 347 tests, 0 failures
- `sh scripts/test-fast-pr.sh` — PASS

### Browser fixture note

The mid-commit re-registration is only reproducible **deterministically** via the `reactive/*commit-barrier*` seam (synchronous interleaving between `:post-acquire` and the publish `swap!`); a mounted browser DOM mount cannot deterministically hit that window (the same reason `reactive-incarnation-close-cljs-test` states "no threads are needed"). The existing HMR-matrix coverage this mirrors is itself headless `.cljc`. `test:browser` was run as a non-regression gate (green); no flaky browser fixture was added, consistent with the "testbeds are clean feature surfaces / no low-value smoke tests" posture.

## Spec follow-ups (not in this PR)

Spec 006 (§The internal observation port / epoch finalization) and Spec 004/003 §10 (the HMR contract) describe the render→commit staleness rejection at step 1; they do not yet name the **final** publication-boundary authority fence. Worth a prose ripple noting the two-point authority check (entry + publication boundary). Filing as a follow-up bead rather than touching the hot-zone spec files here.
