### PR TITLE
fix(ui): digest/activation — accepted-generation URLs, final-schedule reconcile, hookless-sentinel reject, preflight generation revalidation (rf2-vxgfnd.237/.194/.205/.199)

### DIFF
--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -226,7 +226,7 @@ function lastPrepareSnapshot() {
   return { version, digest };
 }
 
-async function proveHooklessBuildFailsClosed(shadowRunner, browser, activePage, lkg) {
+async function proveHooklessBuildFailsClosed(shadowRunner, browser) {
   const config = fs.readFileSync(
     path.join(HOOKLESS_CONFIG_ROOT, 'shadow-cljs.edn'), 'utf8',
   );
@@ -284,26 +284,42 @@ async function proveHooklessBuildFailsClosed(shadowRunner, browser, activePage, 
       fail(`hookless runtime produced the wrong diagnostic: ${error.name}: ${error.message}`);
     }
     // Script-loader mode reports the top-level throw as a pageerror, then the
-    // browser may continue loading later independent scripts. If base init ran,
-    // its diagnostic accessor must still expose the unfinalized sentinel —
-    // never a plausible accepted bd1 digest.
-    const unfinalized = await page.evaluate(
+    // browser continues loading later independent scripts and installs the
+    // digest + descriptor accessors. Namespace load is only an EARLY diagnostic;
+    // the enforcement boundary is digest-carrier/current itself, so EVERY later
+    // read must FAIL CLOSED on the unfinalized carrier — the raw sentinel is
+    // never a readable identity (rf2-vxgfnd.205).
+    const laterDigest = await page.evaluate(
       () => typeof globalThis.__rf2ReadDigest === 'function'
         ? globalThis.__rf2ReadDigest()
         : null,
     );
-    if (unfinalized !== DIGEST_SENTINEL) {
-      fail(`hookless runtime exposed a digest after rejection: ${unfinalized}`);
+    if (laterDigest !== null) {
+      fail(`hookless digest read did not fail closed (returned ${JSON.stringify(laterDigest)}); the sentinel must never be a readable identity`);
     }
-
-    const activeDigest = await activePage.evaluate(() => globalThis.__rf2ReadDigest());
-    const stillAccepted = acceptedSnapshot();
-    if (activeDigest !== lkg.digest ||
-        stillAccepted.digest !== lkg.digest ||
-        stillAccepted.version !== lkg.version) {
-      fail('hookless build disturbed the active runtime or accepted JVM snapshot');
+    // Explicit negative assertion over descriptor PUBLICATION: a COMPLETE Root
+    // Descriptor built now stamps :build-digest from current-build-digest, which
+    // is fail-closed — so its :build-digest is null, never the raw sentinel. No
+    // complete descriptor can carry an invalid build identity.
+    const descriptorDigest = await page.evaluate(
+      () => typeof globalThis.__rf2ReadDescriptorDigest === 'function'
+        ? globalThis.__rf2ReadDescriptorDigest()
+        : 'accessor-absent',
+    );
+    if (descriptorDigest !== null) {
+      fail(`hookless complete descriptor published an unfinalized build identity: ${JSON.stringify(descriptorDigest)}`);
     }
-    console.log('ui digest carrier: hookless build rejected before publication (LKG preserved)');
+    // The on-disk carrier still holds only the raw sentinel (asserted above): no
+    // bd1 digest was ever projected, corroborating that nothing published. The
+    // last-known-good of an ACCEPTED build lineage is proven CAUSALLY by the
+    // same-watch-daemon downstream-failure section below; this SEPARATE hookless
+    // config/process is deliberately NOT used as causal LKG proof — its
+    // independent runtime cannot witness an accepted lineage losing its hook
+    // (rf2-vxgfnd.205).
+    console.log(
+      'ui digest carrier: hookless build fails closed at every digest and ' +
+      'descriptor read (no sentinel-stamped identity)',
+    );
   } finally {
     if (page) await page.close();
     tearingDown = true;
@@ -361,11 +377,9 @@ async function main() {
     }
 
     // A separate, real Shadow configuration deliberately omits every build
-    // hook while compiling the same client entry. Its raw sentinel must throw
-    // before base init; the active hooked build remains the LKG witness.
-    await proveHooklessBuildFailsClosed(
-      shadowRunner, browser, page, accepted1,
-    );
+    // hook while compiling the same client entry. Its top-level throw surfaces
+    // as a pageerror, and every later digest/descriptor read must fail closed.
+    await proveHooklessBuildFailsClosed(shadowRunner, browser);
 
     // Warm successful pass: only the unexecuted lazy view changes. The
     // ^:dev/always carrier must be regenerated from its sentinel and reloaded.

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -119,6 +119,46 @@
           "destroy-adapter! finishes and a fresh adapter is installed")
      {:recovery :install-a-fresh-adapter})))
 
+(defn- current-adapter-generation
+  "The opaque token identifying the EXACT installed adapter generation, read
+  from the substrate lifecycle state (nil when none is installed). Minted afresh
+  on every install, so a destroy — or a destroy+reinstall of the SAME adapter
+  spec — yields a different (or nil) token. A fresh public-root mount captures
+  this BEFORE its side-effecting frame preflight and revalidates it AFTER, so a
+  re-entrant preflight that swaps generation A for generation B is distinguished
+  from the generation that admitted the attempt (rf2-vxgfnd.199). Compared only
+  by `identical?`; `adapter-lifecycle-state` is the documented public lifecycle
+  cell owned by the install/dispose pair."
+  []
+  (get-in @substrate-adapter/adapter-lifecycle-state [:installed :generation]))
+
+(defn- require-adapter-generation-open!
+  "Re-assert — AFTER a fresh mount's side-effecting frame preflight and BEFORE
+  any React allocation — that public root creation is still open AND the exact
+  adapter generation that admitted this attempt (`receipt`) is still installed.
+  `run-preflight!` drains `:initial-events` synchronously (arbitrary app /
+  override code) which may terminally destroy the adapter, or destroy generation
+  A and install a replacement generation B. Either fails LOUD with
+  `:rf.error/adapter-disposed` here — before `createRoot`, live-root
+  registration, DOM mutation, ViewCell creation, or observation acquisition — so
+  an attempt admitted under A can never allocate a Root under a disposed A or a B
+  that never admitted it (rf2-vxgfnd.199, the re-entrant-preflight companion to
+  rf2-vxgfnd.104's separate-thread teardown fence). A terminal disposal is caught
+  by `require-root-creation-open!`; a same-breadcrumb replacement (B installed,
+  the disposed breadcrumb already cleared) is caught by the exact-generation
+  compare a boolean recheck cannot see."
+  [where receipt]
+  (require-root-creation-open! where)
+  (when-not (identical? receipt (current-adapter-generation))
+    (error/throw-error!
+     :rf.error/adapter-disposed where
+     (str "the re-frame.ui adapter generation that admitted this mount was "
+          "destroyed or replaced during frame preflight (:initial-events drain) "
+          "— a Root admitted under one adapter generation must not be allocated "
+          "under another. No React root, live-root registration, or DOM was "
+          "created; install a fresh adapter and re-mount")
+     {:recovery :install-a-fresh-adapter})))
+
 ;; ---------------------------------------------------------------------------
 ;; The COMPLETE Root Descriptor v1 — the client read-time projection (dev only)
 ;; ---------------------------------------------------------------------------
@@ -446,10 +486,16 @@
   root is `:rf.error/root-container-in-use`.
 
   ORDER (the Q49 ruling — ns docstring): claim checks, then preflight,
-  then a RE-CHECK of the claim, then `createRoot` + registration + render.
+  then a REVALIDATION of adapter admission (rf2-vxgfnd.199) and a RE-CHECK
+  of the claim, then `createRoot` + registration + render.
   A preflight failure therefore fails the mount loudly with the container
   untouched — no React root, no live-root registration, no render; retry =
-  re-call `mount`. The re-check (rf2-vxgfnd.52) closes the re-entrancy
+  re-call `mount`. Preflight also drains `:initial-events` (arbitrary app
+  code) that may DESTROY or destroy-and-replace the adapter; the exact
+  adapter-generation receipt captured before preflight is revalidated after
+  it (rf2-vxgfnd.199), so an attempt admitted under generation A never
+  allocates a Root under a disposed A or a replacement generation B. The
+  re-check (rf2-vxgfnd.52) closes the re-entrancy
   window that preflight opens: `run-preflight!` drains `:initial-events`
   synchronously (arbitrary app code) and a re-entrant mount can claim this
   root-id / container / identifier-prefix while this mount is still
@@ -511,8 +557,20 @@
         ;; preflight BEFORE any React work (Q49: container untouched on
         ;; failure) — and before registration, so a failed mount leaves
         ;; no registry entry either.
-        (let [receipt (run-preflight! root-id plans-thunk)]
+        ;; rf2-vxgfnd.199: capture the EXACT adapter generation admitting this
+        ;; fresh mount BEFORE the side-effecting preflight, so re-entrant
+        ;; preflight code that destroys (or destroys and replaces) the adapter
+        ;; cannot let this attempt allocate a Root under a generation that never
+        ;; admitted it.
+        (let [adapter-receipt (current-adapter-generation)
+              receipt (run-preflight! root-id plans-thunk)]
           (try
+            ;; REVALIDATE adapter admission FIRST — before the root-claim
+            ;; re-check and any React work (rf2-vxgfnd.199). A terminal disposal
+            ;; or a destroy+reinstall during preflight fails loud before
+            ;; createRoot / registration / DOM; a boolean recheck alone cannot
+            ;; see a same-breadcrumb replacement generation.
+            (require-adapter-generation-open! 're-frame.ui/mount adapter-receipt)
             ;; RE-CHECK the claim AFTER preflight (rf2-vxgfnd.52). run-preflight!
             ;; drains :initial-events SYNCHRONOUSLY — arbitrary app code that may
             ;; itself mount a root for this id or into this container (re-entrancy),

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -3,12 +3,22 @@
 
   Shadow's retained functional build-state is the successful-build authority.
   `:compile-prepare` seeds disposable compiler-env scratch from the incoming
-  accepted snapshot, captures authoritative namespace membership, and
-  pre-touches exactly the CLJS sources Shadow scheduled to compile. That last
-  step makes removing a source's final declaration observable even though no
-  registry macro then runs, while output-present cache hits remain accepted.
-  Macro contributions write only that scratch. `:compile-finish`:
+  accepted snapshot, captures authoritative namespace membership, pre-touches
+  exactly the CLJS sources Shadow scheduled to compile, and records the pass
+  start time. That pre-touch makes removing a source's final declaration
+  observable even though no registry macro then runs, while output-present cache
+  hits remain accepted. Macro contributions write only that scratch.
+  `:compile-finish`:
 
+  0. reconcile against Shadow's FINAL authoritative compile schedule — every
+     CLJS source actually compiled THIS pass (a fresh `:compiled-at` in its
+     output, no earlier than the recorded pass start) is pre-touched too. A
+     later `:compile-prepare` hook (Shadow deep-merges build-local hooks after
+     `:build-defaults` and lets them mutate build state) can force a source to
+     recompile AFTER re-frame.ui observed the schedule; observing the compiled
+     set at finish, not the intermediate prepare snapshot, closes that
+     hook-order gap so a forced recompile that removed a source's final
+     `ui/defview` evicts its accepted row instead of leaving a ghost view;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -85,6 +95,57 @@
            acc)))
      #{}
      build-sources)))
+
+(defn- actually-recompiled-member-nss
+  "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
+  THIS pass, read from the FINAL build-state at `:compile-finish` — after every
+  schedule-mutating `:compile-prepare` hook and after compilation ran. Shadow
+  stamps a fresh `:compiled-at` on a source it compiles this pass
+  (`shadow.build.compiler` sets it to the compile wall-clock); a cache-loaded or
+  cross-pass-retained output keeps an OLDER stamp. Comparing that stamp against
+  `pass-start` (captured when re-frame.ui opened the pass, before any
+  compilation) therefore identifies Shadow's authoritative final compile
+  schedule — immune to the build-local hook merge order re-frame.ui cannot
+  control, and immune to the stale `:cached` marker a retained output carries
+  across passes. Returns the empty set when no pass start was recorded (a
+  non-Shadow/plain-JVM finish), leaving the prepare-time pre-touch as the sole
+  reconciler."
+  [{:keys [build-sources sources output]} pass-start]
+  (if-not (number? pass-start)
+    #{}
+    (let [pass-start (long pass-start)]
+      (reduce
+       (fn [acc resource-id]
+         (let [{:keys [type ns provides]} (get sources resource-id)
+               compiled-at (:compiled-at (get output resource-id))]
+           (if (and (= :cljs type)
+                    (number? compiled-at)
+                    (>= (long compiled-at) pass-start))
+             (into acc (or provides (when ns #{ns})))
+             acc)))
+       #{}
+       build-sources))))
+
+(defn- reconcile-final-schedule
+  "Before deriving the finish candidate, pre-touch every source Shadow actually
+  recompiled this pass but which re-frame.ui did NOT pre-touch at
+  `:compile-prepare` — a source a later prepare hook forced to recompile after
+  re-frame.ui observed the schedule. Pre-touching evicts the accepted row of a
+  source whose successful recompile contributed no re-frame.ui declaration (its
+  final `ui/defview` was removed), closing the ghost-view gap of CLOSED
+  rf2-n7ff9f; a recompiled source that DID re-declare is already touched+staged,
+  so the union is idempotent, and a warm cache hit (no fresh `:compiled-at`)
+  keeps its accepted row. Pure build-state transform."
+  [build-state]
+  (let [pass-start (get-in build-state
+                           [:compiler-env build/scratch-key :pass-start])
+        extra      (actually-recompiled-member-nss build-state pass-start)]
+    (if (and (seq extra)
+             (get-in build-state [:compiler-env build/scratch-key]))
+      (update-in build-state
+                 [:compiler-env build/scratch-key :touched]
+                 (fnil into #{}) extra)
+      build-state)))
 
 (defn- marker-count [^String s ^String marker]
   (loop [from 0 n 0]
@@ -210,15 +271,23 @@
     (do
       (validate-ui-cache-blocker! build-state)
       (let [build-state (reset-cold-ui-consumer-output build-state)]
-        (build/prepare-shadow-build build-state
-                                    build-id
-                                    (member-nss build-state)
-                                    (recompiled-member-nss build-state))))
+        ;; Record the pass start BEFORE any compilation so `:compile-finish` can
+        ;; identify the sources Shadow actually recompiled this pass (fresh
+        ;; `:compiled-at`) — the final authoritative schedule, robust to a later
+        ;; prepare hook mutating it (rf2-vxgfnd.194).
+        (-> (build/prepare-shadow-build build-state
+                                        build-id
+                                        (member-nss build-state)
+                                        (recompiled-member-nss build-state))
+            (assoc-in [:compiler-env build/scratch-key :pass-start]
+                      (System/currentTimeMillis)))))
 
     :compile-finish
-    ;; Projection and candidate carriage are pure build-state transforms. A
-    ;; later Shadow failure discards the returned state transactionally.
-    (let [candidate (build/shadow-finish-candidate
+    ;; Reconcile against Shadow's final compile schedule, then project. All are
+    ;; pure build-state transforms; a later Shadow failure discards the returned
+    ;; state transactionally.
+    (let [build-state (reconcile-final-schedule build-state)
+          candidate (build/shadow-finish-candidate
                      build-state build-id (member-nss build-state))
           projected (if (ui-client-build? build-state)
                       (project-build-digest build-state (:digest candidate))

--- a/implementation/ui/src/re_frame/ui/digest_carrier.cljs
+++ b/implementation/ui/src/re_frame/ui/digest_carrier.cljs
@@ -62,16 +62,32 @@
   (when-not (.-updating cell)
     (set! (.-published cell) compiled-digest)))
 
+(defn- finalized-digest?
+  "True only for a FINALIZED `bd1-` whole-build digest — never the unpatched
+  fixed-width sentinel a hookless or mis-hooked build leaves in the slot.
+  goog.DEBUG-gated so Closure removes this and its callers' guards from advanced
+  production."
+  [d]
+  (and ^boolean js/goog.DEBUG
+       (string? d)
+       (str/starts-with? d "bd1-")))
+
 (defn current
   "Return the compiler-published, fully-activated whole-build digest in dev, nil
   in production. O(1); no registry traversal or client-side digest computation.
-  Fail-closed (nil) while a hot reload is mid-flight, and after a reloaded source
-  threw before its after-load promotion: a read never advertises a candidate the
-  runtime has not finished activating."
+  Fail-closed (nil) while a hot reload is mid-flight, after a reloaded source
+  threw before its after-load promotion — and, crucially, whenever the published
+  slot is NOT a finalized `bd1-` digest. The namespace-load check below is only
+  an early diagnostic; under Shadow `:loader-mode :script` a top-level throw is
+  reported as a `pageerror` and later scripts still install these accessors, so
+  the raw sentinel a hookless build leaves in the slot must be rejected at EVERY
+  read boundary here — never returned as a false build identity, and therefore
+  never stampable into a complete Root Descriptor (rf2-vxgfnd.205)."
   []
   (when ^boolean js/goog.DEBUG
     (when-not (.-updating cell)
-      (.-published cell))))
+      (let [d (.-published cell)]
+        (when (finalized-digest? d) d)))))
 
 (defn ^:dev/before-load before-load
   "Fence the runtime before Shadow swaps reloaded code: digest/descriptor reads

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -9,6 +9,8 @@
 (def ^:private carrier-rid [:cljs "re_frame/ui/digest_carrier.cljs"])
 (def ^:private client-rid [:cljs "re_frame/ui/client.cljs"])
 (def ^:private app-rid [:cljs "app/view.cljs"])
+(def ^:private app-a-rid [:cljs "app/a.cljs"])
+(def ^:private app-b-rid [:cljs "app/b.cljs"])
 
 (defn- shadow-state [build-id js]
   {:shadow.build/build-id build-id
@@ -29,6 +31,31 @@
    :build-modules [{:module-id :base :sources [carrier-rid]}
                    {:module-id :lazy :sources [app-rid]
                     :depends-on #{:base}}]})
+
+(defn- two-source-state
+  "A UI-client build graph with two app sources (app.a, app.b), each declaring a
+  view, plus the digest carrier. `parallel?` toggles Shadow's parallel vs
+  sequential compile-schedule detection (an executor present + parallel build)."
+  [build-id parallel?]
+  (cond-> {:shadow.build/build-id build-id
+           :shadow.build/stage :compile-prepare
+           :compiler-env {}
+           :build-options {:cache-blockers '#{re-frame.ui}}
+           :build-sources [carrier-rid app-a-rid app-b-rid]
+           :sources {carrier-rid {:ns 're-frame.ui.digest-carrier
+                                  :provides #{'re-frame.ui.digest-carrier}
+                                  :type :cljs}
+                     app-a-rid {:ns 'app.a :provides #{'app.a}
+                                :requires '#{re-frame.ui} :type :cljs}
+                     app-b-rid {:ns 'app.b :provides #{'app.b}
+                                :requires '#{re-frame.ui} :type :cljs}}
+           :output {carrier-rid {:resource-id carrier-rid
+                                 :js build-hook/digest-sentinel :cached true}
+                    app-a-rid {:resource-id app-a-rid :js "app.a = {};"}
+                    app-b-rid {:resource-id app-b-rid :js "app.b = {};"}}
+           :build-modules [{:module-id :base
+                            :sources [carrier-rid app-a-rid app-b-rid]}]}
+    parallel? (assoc :executor (Object.))))
 
 (defn- prepare [state]
   (build-hook/hook (assoc state :shadow.build/stage :compile-prepare)))
@@ -183,6 +210,60 @@
         "the rejected candidate remains disposable scratch")
     (is (nil? (get-in compiled [:output carrier-rid]))
         "zero carrier output cannot be mistaken for an accepted publication")))
+
+(deftest later-prepare-hook-forced-recompile-evicts-removed-view
+  ;; rf2-vxgfnd.194: a build-local :compile-prepare hook running AFTER the
+  ;; inherited re-frame.ui hook removes a source's retained output, forcing
+  ;; Shadow to recompile it after re-frame.ui observed the schedule. If that
+  ;; source removed its final ui/defview it contributes nothing, and — pre-fix —
+  ;; its accepted row survived as a ghost view because it was never pre-touched.
+  ;; The :compile-finish reconcile against Shadow's authoritative compiled set
+  ;; (fresh :compiled-at) evicts it. Fails against pre-fix build_hook.clj.
+  (doseq [parallel? [true false]]
+    (testing (str (if parallel? "parallel" "sequential") " compilation")
+      (let [good (-> (two-source-state :ghost parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)]
+        (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
+               (build/accepted-aggregate build/views good))
+            "the accepted build declares both sources' views")
+        ;; Warm pass: app.a + app.b both retain output, so re-frame.ui pre-touches
+        ;; neither. A later prepare hook then removes app.a's output; app.a
+        ;; recompiles this pass (fresh :compiled-at) contributing NO declaration.
+        ;; app.b stays a cache hit (older stamp, no re-declaration).
+        (let [warm-input (-> good
+                             (assoc-in [:output carrier-rid :js]
+                                       build-hook/digest-sentinel)
+                             (assoc-in [:output app-a-rid]
+                                       {:resource-id app-a-rid :js "app.a = {};"
+                                        :cached true})
+                             (assoc-in [:output app-b-rid]
+                                       {:resource-id app-b-rid :js "app.b = {};"
+                                        :cached true}))
+              prepared (prepare warm-input)
+              pass-start (get-in prepared
+                                 [:compiler-env build/scratch-key :pass-start])
+              finished (-> prepared
+                           (assoc-in [:output app-a-rid]
+                                     {:resource-id app-a-rid :js "app.a = {};"
+                                      :compiled-at (inc (long pass-start))
+                                      :cached false})
+                           finish)]
+          (is (not (contains?
+                    (get-in prepared [:compiler-env build/scratch-key :touched])
+                    'app.a))
+              "re-frame.ui does not pre-touch an output-present source at prepare")
+          (is (= {:app/b-view ["tfb-1" "hsb-1"]}
+                 (build/accepted-aggregate build/views finished))
+              "the forced-recompile ghost is evicted; the cache-hit sibling stays")
+          (is (not (contains? (build/accepted-aggregate build/views finished)
+                              :app/a-view))
+              "no ghost view survives the source's zero-declaration recompile")
+          (is (not= (build/accepted-build-digest good)
+                    (build/accepted-build-digest finished))
+              "evicting the ghost changes the accepted whole-build digest"))))))
 
 (deftest interleaved-build-values-carry-isolated-digests
   (let [a (-> (shadow-state :a build-hook/digest-sentinel)

--- a/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
@@ -17,6 +17,21 @@
   ;; require this unrelated base namespace's after-load hook to run.
   (set! (.-__rf2ReadDigest js/globalThis)
         (fn [] (client/current-build-digest)))
+  ;; rf2-vxgfnd.205 — the explicit negative assertion over descriptor
+  ;; PUBLICATION. Register a throwaway static-core live-root entry and read its
+  ;; COMPLETE Root Descriptor: `:build-digest` is stamped at read time from
+  ;; current-build-digest. A fail-closed carrier (hookless / unfinalized slot)
+  ;; must make this nil, never the raw sentinel — so no complete descriptor can
+  ;; publish an invalid build identity. Only the hookless fixture invokes this;
+  ;; the hooked probe installs but never calls it.
+  (set! (.-__rf2ReadDescriptorDigest js/globalThis)
+        (fn []
+          (client/register-live-root!
+           {:root-id ::probe-descriptor :provenance :test
+            :descriptor {:root-template ::probe-descriptor}}
+           (js/Object.)
+           (client/->Root nil (js/Object.) ::probe-descriptor))
+          (:build-digest (client/descriptor ::probe-descriptor))))
   ;; Exact processed-ready witness from pinned Shadow 3.4.10. A WebSocket
   ;; packet arriving is earlier than the client applying :welcome; the runner
   ;; waits on this before its first edit so no HMR update can race registration.

--- a/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
@@ -14,6 +14,7 @@
             ["react" :as react]
             ["react-dom" :as react-dom]
             [re-frame.error :as error]
+            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.ui :as ui :refer [defview frame-root]]
             [re-frame.ui.client :as client]))
 
@@ -477,6 +478,102 @@
           (client/set-preflight-hook! nil)
           (some-> @b-root ui/unmount!)
           (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior))))))
+
+;; ---------------------------------------------------------------------------
+;; adapter-generation admission across re-entrant preflight (rf2-vxgfnd.199)
+;; ---------------------------------------------------------------------------
+;;
+;; A fresh mount admits under the exact adapter generation live BEFORE its
+;; side-effecting preflight. run-preflight! drains :initial-events (arbitrary
+;; app code) which can destroy — or destroy AND replace — the adapter while this
+;; mount holds no React root yet. The exact-generation receipt must fail the
+;; attempt loud before createRoot, so it never allocates a Root under a disposed
+;; generation or a replacement generation B it was never admitted by.
+
+(def ^:private minimal-adapter-a
+  {:kind :custom :dispose-adapter! (fn [] nil)})
+(def ^:private minimal-adapter-b
+  {:kind :custom :dispose-adapter! (fn [] nil)})
+
+(deftest fresh-mount-adapter-destroyed-in-preflight-fails-before-createroot
+  ;; Terminal disposal from a fresh mount's real preflight: createRoot / register
+  ;; / render must NOT run under the disposed adapter. Pre-fix, the post-preflight
+  ;; re-check covered only root-id/container ownership, so the mount proceeded.
+  (when (browser?)
+    (let [c     (container)
+          info  {:root-id :dom-gen/terminal :provenance :authored}
+          prior @substrate-adapter/adapter-lifecycle-state]
+      ;; The shared browser page seats the real ui adapter; clear then install
+      ;; generation A cleanly, and restore the page's adapter in finally.
+      (substrate-adapter/reset-lifecycle-state-for-tests!)
+      (substrate-adapter/install-adapter! minimal-adapter-a)
+      (client/set-preflight-hook!
+       (fn [_root-id _plans]
+         ;; A's :initial-events boot code terminally destroys the adapter and
+         ;; returns normally; no outer React root exists to be torn down yet.
+         (substrate-adapter/dispose-adapter!)))
+      (try
+        (let [{:keys [id data]}
+              (thrown-error
+               #(flush-without-act!
+                 (fn []
+                   (client/mount* info c
+                                  (fn [] (react/createElement "div" nil "boot"))
+                                  nil
+                                  (fn [] [])))))]
+          (is (= :rf.error/adapter-disposed id)
+              "a fresh mount whose preflight destroyed the adapter fails loud before createRoot")
+          (is (= :install-a-fresh-adapter (:recovery data))))
+        (is (= "" (.-innerHTML c))
+            "no React root or DOM was allocated under the disposed adapter")
+        (is (not (contains? (client/live-root-ids) :dom-gen/terminal))
+            "no live-root id, container claim, ViewCell, or observation owner remains")
+        (finally
+          (client/set-preflight-hook! nil)
+          (reset! substrate-adapter/adapter-lifecycle-state prior))))))
+
+(deftest fresh-mount-adapter-replaced-in-preflight-fails-and-leaves-b-untouched
+  ;; Destroy generation A and install a replacement generation B during preflight.
+  ;; disposed? is cleared, so a boolean recheck sees an open adapter — only the
+  ;; exact-generation receipt distinguishes B from the A that admitted the attempt.
+  (when (browser?)
+    (let [c     (container)
+          info  {:root-id :dom-gen/replace :provenance :authored}
+          prior @substrate-adapter/adapter-lifecycle-state]
+      (substrate-adapter/reset-lifecycle-state-for-tests!)
+      (substrate-adapter/install-adapter! minimal-adapter-a)
+      (client/set-preflight-hook!
+       (fn [_root-id _plans]
+         (substrate-adapter/dispose-adapter!)
+         (substrate-adapter/install-adapter! minimal-adapter-b)))
+      (try
+        (let [{:keys [id]}
+              (thrown-error
+               #(flush-without-act!
+                 (fn []
+                   (client/mount* info c
+                                  (fn [] (react/createElement "div" nil "boot"))
+                                  nil
+                                  (fn [] [])))))]
+          (is (= :rf.error/adapter-disposed id)
+              "an A-admitted mount cannot allocate a Root under replacement generation B"))
+        (is (= "" (.-innerHTML c))
+            "the A attempt created no React root — B and the container are untouched")
+        (is (not (contains? (client/live-root-ids) :dom-gen/replace)))
+        (is (identical? minimal-adapter-b
+                        (substrate-adapter/current-adapter-spec))
+            "generation B remains the installed adapter, unaffected by the failed A attempt")
+        ;; A later fresh mount admitted UNDER B succeeds on the same id/container.
+        (client/set-preflight-hook! nil)
+        (let [root (act! #(client/mount* info c
+                                         (fn [] (react/createElement "div" nil "under B"))
+                                         nil nil))]
+          (is (some? root) "a fresh mount admitted under B succeeds")
+          (is (re-find #"under B" (.-innerHTML c)))
+          (act! #(client/unmount!* root)))
+        (finally
+          (client/set-preflight-hook! nil)
+          (reset! substrate-adapter/adapter-lifecycle-state prior))))))
 
 ;; ---------------------------------------------------------------------------
 ;; frame-root: transparent render + the preflight seam


### PR DESCRIPTION
Digest/activation follow-ups descending from the merged activation-transaction work (#5848 / rf2-vxgfnd.193). One cohesive same-surface cluster; each fix reuses #5848's / #5806's transactional last-known-good machinery (functional build-state + digest carrier) rather than forking it.

**Fresh-origin re-verification (mandatory first step):** #5848 (.193 activation transaction), #5806/#5813 (build authority + digest carrier), #5834 (frames preflight), #5808 (root admission) are all merged on `origin/main` (HEAD 81bd66ebc0). Each of the four repros was re-verified against current main before fixing — none had been closed by the ancestor merges.

## rf2-vxgfnd.194 — reconcile against Shadow's final compile schedule

Re-verified: a build-local `:compile-prepare` hook (Shadow deep-merges build-local hooks after `:build-defaults`, letting them mutate build state) can remove a source's retained output *after* the inherited re-frame.ui hook observed the schedule, forcing a recompile. If that source removed its final `ui/defview` it contributes no macro row and — never pre-touched — its accepted row + whole-build digest membership survived as a ghost view.

Fix (`compiler/build_hook.clj`): observe Shadow's **authoritative final compile schedule at `:compile-finish`**, not the intermediate prepare snapshot. Record the pass start when the pass opens; at finish pre-touch every CLJS source Shadow actually recompiled this pass (a fresh `:compiled-at` no earlier than pass start — `shadow.build.compiler` stamps it). A zero-declaration recompile is evicted; a re-declaring recompile is already touched+staged (idempotent); a warm cache hit keeps its accepted row. Robust to hook merge order and to the stale `:cached` marker a retained output carries across passes. The prepare-time pre-touch is kept (load-bearing for during-pass cross-file view-id conflict detection); finish reconcile is additive.

**Red-before-fix fixture:** `later-prepare-hook-forced-recompile-evicts-removed-view` (parallel + sequential) in `compiler_digest_carrier_jvm_test.clj` — 6 failures with the reconcile disabled, green with it.

_Fixture note:_ a functional-state JVM fixture (the established `compiler_digest_carrier_jvm_test` pattern) models Shadow's authoritative final build-state (`:compiled-at` markers) deterministically, avoiding a new hot-zone `shadow-cljs.edn` build-id.

## rf2-vxgfnd.205 — fail every digest-carrier read closed on the hookless sentinel

Re-verified: under Shadow `:loader-mode :script` a hookless build's top-level namespace-load throw is a `pageerror`; later scripts continue and install the accessors, and `digest-carrier/current` returned the raw fixed-width sentinel `__RF2_UI_DIGEST_XX__` as a false identity that `client.cljs` could stamp into a complete Root Descriptor. Namespace load was the sole enforcement boundary.

Fix (`digest_carrier.cljs`): `current` now fails closed at the read boundary — returns the published slot only when it is a finalized `bd1-` digest, else nil. The sentinel is never a readable identity, so no complete descriptor can carry it. The namespace-load check remains an early diagnostic. All guards are `goog.DEBUG`-gated; advanced production is byte/identifier-clean with no added validation cost.

**Red-before-fix fixture** (`scripts/check-ui-digest-carrier.cjs` hookless section, verified end-to-end through the real hookless Shadow build): every later digest read must fail closed (null, never the sentinel), plus an **explicit negative assertion over descriptor publication** via a new `base.cljs` `__rf2ReadDescriptorDigest` accessor (a complete descriptor's `:build-digest` must be null, never the sentinel). The pre-fix carrier returned the readable sentinel. The non-causal cross-process LKG claim is dropped — an independent hookless config/process cannot witness an accepted lineage losing its hook; same-lineage LKG is proven by the same-watch-daemon downstream-failure section.

## rf2-vxgfnd.199 — revalidate exact adapter generation after mount preflight before allocating a root

Re-verified: a fresh `ui/mount` checked adapter admission only *before* its side-effecting preflight. `run-preflight!` drains `:initial-events` synchronously (arbitrary app code) that can destroy the adapter — or destroy generation A and install a replacement B — while the mount holds no React root yet. The post-preflight re-check covered only root-id/container/prefix ownership, so the mount resumed and called `createRoot`/register/render under a disposed or replacement generation.

Fix (`client.cljs`): capture the exact installed adapter generation **before** preflight and revalidate it **after**, before any React allocation. A terminal disposal (admission fence) or a same-breadcrumb replacement generation (exact-generation compare a boolean recheck cannot see) fails loud with `:rf.error/adapter-disposed` before `createRoot`, live-root registration, DOM mutation, ViewCell creation, or observation acquisition. Cleanup aborts only this attempt's preflight evidence (rev-guarded, rf2-vxgfnd.139); generation B and any B-owned root are untouched. Private; no public API change; the generation token is read from the documented public lifecycle cell (no core edit).

**Red-before-fix fixtures:** `fresh-mount-adapter-destroyed-in-preflight-fails-before-createroot` and `fresh-mount-adapter-replaced-in-preflight-fails-and-leaves-b-untouched` in `root_mount_dom_cljs_test.cljs` — 7 failures with the revalidation disabled, green with it (the replace case also asserts a later mount admitted under B succeeds on the same id/container).

## rf2-vxgfnd.237 — artifact generation/activation separation — NOT in this PR (needs hot-zone shadow-cljs.edn)

Re-verified: the gap **fully remains** on current main (the `RF2_PROBE_ACTIVATION_TXN` probe documents `lazy=true, carrier-not-d2=true` — after the failed `:flush`, `/base.js`'s carrier and `/lazy.js` on disk hold rejected candidate d3 while compiler authority is d2; a hard reload / first lazy import would activate d3). #5848 fixed the **active-runtime** LKG (the live browser keeps d2) but not the **on-disk stable-output** separation.

The correction is fundamentally a build-config concern (the bead itself flags it): candidate vs stable output-dir/asset-path, or an activation-indirection module in the top-level `implementation/shadow-cljs.edn` — a **HOT-ZONE** file outside this worker's fence. There is no in-fence lever: on a hard reload the browser reads d3 from disk with no d2 reference, and the only authority that knows d2 is accepted is the JVM compiler whose state rolled back — so the fix must live at the output/flush layer, not the runtime. **Left OPEN for the mayor to sequence a hot-zone build-id change.** The probe continues to document the gap by default (`RF2_PROBE_ACTIVATION_TXN=1` still asserts the fixed behaviour red-before-fix).

## Quality gates

- `implementation/ui` JVM: 486 tests / 6297 assertions, 0 failures (was 485 — +1 test, .194).
- `npm run test:cljs` (node): 9338 tests / 44202 assertions, 0 failures.
- `npm run test:browser`: 349 tests / 1891 assertions, 0 failures (was 1883 — +8 assertions, .199).
- `npm run test:ui-digest-carrier` (real Shadow watch + Chromium): PASS — hookless fails closed at every digest + descriptor read; warm/downstream-failure/recovery/counterexample-2 green; .237 gap documented by default.
- `scripts/test-fast-pr.sh`: PASS (lockstep, skill/MCP + migration cite-integrity, implementor order, eval-docs, per-ns isolation, README/docs anchors, EP status-sync, runtime-subsystem grading, mkdocs --strict) — all green

#5848's / #5806's digest-carrier + build-authority fixtures preserved green.
