### PR TITLE
fix(core): keep predecessor terminal facts out of successor trace ring (rf2-vxgfnd.244)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -3493,32 +3493,6 @@
         (safe-call-hook! :fx/on-frame-destroyed! id)
         ;; The shipped subsystems tear down via the named ordered hooks above.
         (emit-frame-destroyed-trace! id)
-        ;; Per Spec 009 §Per-frame trace rings:
-        ;; release the destroyed frame's event-keyed ring so no
-        ;; residual trace events leak across the frame lifecycle. Fired
-        ;; AFTER `:rf.frame/destroyed` emits so the destroyed trace
-        ;; itself (which is frameless and bypasses the ring anyway)
-        ;; still flows through the live stream cleanly. Routed via
-        ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
-        ;; Serialize teardown's two clears with successful upsert publication.
-        ;; The frame is already lifecycle-dead, so a delayed publisher that
-        ;; enters afterwards fails its live-token predicate; a publisher that
-        ;; entered before the flip completes first and these clears win last.
-        ;; No interleaving can repopulate either auxiliary store after cleanup.
-        (serialize-frame-trace-policy!
-         (fn []
-           (safe-call-hook! :trace.tooling/release-frame-ring! id)
-           ;; rf2-zcl055: release the destroyed frame's trace-emission gate
-           ;; flag — the teardown counterpart to construction's
-           ;; `trace/set-frame-no-emit!`. A tool / inspector frame registered
-           ;; with `:rf.trace/frame-no-emit? true` (e.g. `:rf/xray`) otherwise
-           ;; leaves a permanent entry in trace.cljc's process-global
-           ;; `trace-disabled-frames` set (the ring IS freed above; the flag
-           ;; was not — a teardown asymmetry). Called directly (not via a
-           ;; tooling hook) because `trace.cljc` is always loaded — the set +
-           ;; predicate live on the core trace surface, same as construction.
-           ;; Idempotent no-op for application frames (the common case).
-           (trace/clear-frame-no-emit-for! id)))
         ;; EP-0024: there is ONE `frames` registry, and `dissoc-frame!` below IS
         ;; the forget. The frame's resolved generation rides the record's
         ;; `:generation` slot, so dropping the record drops it too — no separate
@@ -3529,8 +3503,42 @@
         ;; and claim (dropping) those stores. The bundle is bound lexically to
         ;; A's exact destroy recipe and published by the post-dissoc epoch hook
         ;; regardless of whether A still owns the stores when it fires.
+        ;; rf2-vxgfnd.244: the snapshot is taken BEFORE the ring release below.
+        ;; The snapshot itself emits no trace on the happy path, but a snapshot-
+        ;; hook FAILURE emits `:rf.warning/teardown-hook-exception` under
+        ;; ordinary (non-structural) delivery — carrying A's bare frame id — so
+        ;; it would push onto A's ring. Ordering it before `release-frame-ring!`
+        ;; means A's normal ring release clears that push instead of the warning
+        ;; recreating an already-released ring. No same-id B can exist yet (this
+        ;; is still pre-dissoc), so ordinary delivery is correct here.
         (let [terminal-evidence (snapshot-epoch-terminal-evidence!
                                   id run-fs-before fs-at-destroy run-time-ms)]
+          ;; Per Spec 009 §Per-frame trace rings:
+          ;; release the destroyed frame's event-keyed ring so no
+          ;; residual trace events leak across the frame lifecycle. Fired
+          ;; AFTER `:rf.frame/destroyed` emits so the destroyed trace
+          ;; itself (which is frameless and bypasses the ring anyway)
+          ;; still flows through the live stream cleanly. Routed via
+          ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
+          ;; Serialize teardown's two clears with successful upsert publication.
+          ;; The frame is already lifecycle-dead, so a delayed publisher that
+          ;; enters afterwards fails its live-token predicate; a publisher that
+          ;; entered before the flip completes first and these clears win last.
+          ;; No interleaving can repopulate either auxiliary store after cleanup.
+          (serialize-frame-trace-policy!
+           (fn []
+             (safe-call-hook! :trace.tooling/release-frame-ring! id)
+             ;; rf2-zcl055: release the destroyed frame's trace-emission gate
+             ;; flag — the teardown counterpart to construction's
+             ;; `trace/set-frame-no-emit!`. A tool / inspector frame registered
+             ;; with `:rf.trace/frame-no-emit? true` (e.g. `:rf/xray`) otherwise
+             ;; leaves a permanent entry in trace.cljc's process-global
+             ;; `trace-disabled-frames` set (the ring IS freed above; the flag
+             ;; was not — a teardown asymmetry). Called directly (not via a
+             ;; tooling hook) because `trace.cljc` is always loaded — the set +
+             ;; predicate live on the core trace surface, same as construction.
+             ;; Idempotent no-op for application frames (the common case).
+             (trace/clear-frame-no-emit-for! id)))
           (dissoc-frame! id)
           (notify-epoch-listeners! id expected-incarnation-token
                                    terminal-evidence))

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -71,6 +71,13 @@
 (def ^:dynamic ^:private *continuation-predicate* nil)
 (def ^:dynamic ^:private *epoch-capture-enabled?* true)
 (def ^:dynamic ^:private *frame-policy-enabled?* true)
+;; Retentionless structural delivery (rf2-vxgfnd.244). When false, an emitted
+;; event still streams live to every registered trace listener but is NOT
+;; pushed onto any per-frame trace ring. `call-with-structural-delivery` binds
+;; it false so an obsolete incarnation A's terminal facts — which carry A's
+;; inherited dispatch-id and A's bare frame id — cannot be retained by the
+;; ring that id now names (a same-id successor B's ring once B is installed).
+(def ^:dynamic ^:private *ring-retention-enabled?* true)
 
 (defn ^:no-doc call-with-continuation-predicate
   "Run `f` with an internal exact-owner predicate guarding the distinct
@@ -104,14 +111,21 @@
   (continuing?))
 
 (defn ^:no-doc call-with-structural-delivery
-  "Deliver a structural trace without bare-id epoch/policy attribution.
+  "Deliver a structural trace without bare-id epoch/policy attribution and
+  without any per-frame ring retention.
 
   Used when an obsolete incarnation must report a lifecycle fact after its
   registry slot may already belong to a same-id successor. The successor's
-  frame-no-emit policy cannot suppress the predecessor's required fact."
+  frame-no-emit policy cannot suppress the predecessor's required fact, its
+  epoch capture cannot buffer it, and — per rf2-vxgfnd.244 — no per-frame ring
+  (the successor's included, since predecessor and successor share the bare
+  frame id) may retain it. The fact still streams live to every registered
+  trace listener exactly once. This is the whole of `retentionless structural
+  delivery`: global live delivery, zero durable per-frame residue."
   [f]
-  (binding [*epoch-capture-enabled?* false
-            *frame-policy-enabled?* false]
+  (binding [*epoch-capture-enabled?*   false
+            *frame-policy-enabled?*    false
+            *ring-retention-enabled?*  false]
     (f)))
 
 (defn trigger-handler-from-meta
@@ -544,7 +558,10 @@
   (when (continuing?)
     (when-let [deliver-tooling (late-bind/get-fn-cached :trace.tooling/deliver!)]
       (try
-        (deliver-tooling event continuing?)
+        ;; `*ring-retention-enabled?*` rides through so the tooling hook
+        ;; skips the per-frame ring push under retentionless structural
+        ;; delivery while still fanning out to live listeners (rf2-vxgfnd.244).
+        (deliver-tooling event continuing? *ring-retention-enabled?*)
         (catch #?(:clj Throwable :cljs :default) e
           (when (continuing?) (throw e)))))))
 

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -684,17 +684,28 @@
   "Push `event` onto its in-flight frame's run-keyed ring (when the
   run has a `:dispatch-id` and a `:frame`; frameless emits skip the
   ring per the B3 ruling), then fan out to every registered listener.
-  Listener throws are isolated. No-op in production."
-  [event continue?]
-  (push-to-ring! event)
-  (loop [entries (seq @listeners)]
-    (when (and entries (continue?))
-      (let [[_ f] (first entries)]
-        (try
-          (f event)
-          (catch #?(:clj Throwable :cljs :default) _ nil))
-        (when (continue?)
-          (recur (next entries)))))))
+  Listener throws are isolated. No-op in production.
+
+  `retain?` (rf2-vxgfnd.244) gates ONLY the ring push. Under retentionless
+  structural delivery (`re-frame.trace/call-with-structural-delivery`) it is
+  false: an obsolete incarnation's terminal fact still streams live to every
+  listener, but no per-frame ring retains it — the fact carries the bare frame
+  id a same-id successor now shares, so a ring push would leak predecessor
+  evidence into the successor's ring. The default `true` arity preserves the
+  ordinary emit path. Retention is the ONLY thing gated; listener fan-out is
+  unconditional so the required terminal fact reaches live consumers exactly
+  once either way."
+  ([event continue?] (deliver-to-tooling! event continue? true))
+  ([event continue? retain?]
+   (when retain? (push-to-ring! event))
+   (loop [entries (seq @listeners)]
+     (when (and entries (continue?))
+       (let [[_ f] (first entries)]
+         (try
+           (f event)
+           (catch #?(:clj Throwable :cljs :default) _ nil))
+         (when (continue?)
+           (recur (next entries))))))))
 
 (late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)
 

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -1,6 +1,7 @@
 (ns re-frame.frame-destroy-incarnation-jvm-test
   "Deterministic JVM barriers for incarnation-owned frame teardown."
-  (:require [clojure.test :refer [deftest is use-fixtures]]
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
             [re-frame.epoch]
@@ -575,6 +576,187 @@
     (is (empty? (filter #(= :rf.warning/teardown-hook-exception (:operation %))
                         (:b-buffer suppressed)))
         "A's teardown warning never enters B's epoch capture buffer")))
+
+;; ---- rf2-vxgfnd.244 — predecessor terminal facts out of successor RING ------
+;;
+;; The extension #5850's epoch-only fence missed. #5850 made A's terminal facts
+;; bypass B's epoch CAPTURE and B's no-emit POLICY (structural delivery), and
+;; its fixtures assert B's epoch buffer / history — but NOT B's per-frame trace
+;; RING. Under structural delivery A's terminal facts still carried A's inherited
+;; dispatch-id and A's bare frame id, so `trace/tooling.cljc` pushed them into
+;; the CURRENT ring for that id — B's, once B is installed. The fix makes
+;; structural delivery RETENTIONLESS: global listeners get each terminal fact
+;; exactly once, but no ring retains it. These fixtures assert the RING.
+
+(deftest predecessor-terminal-facts-never-retained-in-successor-ring
+  ;; rf2-vxgfnd.244 (red before fix). A is destroyed mid-drain and paused at its
+  ;; POST-DISSOC epoch hook. Same-id B is then installed and SETTLES an ordinary
+  ;; event, populating B's per-frame trace RING with a legitimate sentinel run.
+  ;; When A resumes it publishes its terminal facts (:rf.epoch/snapshotted /
+  ;; :rf.epoch/outcome, plus :rf.epoch.cb/silenced-on-frame-destroy for the
+  ;; observer A accrued) under retentionless structural delivery: each carries
+  ;; A's inherited dispatch-id and A's bare frame id (== B's id). B's public flat
+  ;; trace buffer must stay byte-identical, no ring must be recreated for
+  ;; destroyed A, and every A terminal fact must still reach the global live
+  ;; trace listener exactly once.
+  ;;
+  ;; Before the fix `deliver-to-tooling!` pushed unconditionally, so A's
+  ;; :halted-destroy snapshotted / :blocked outcome / silencing landed under a
+  ;; new (A-dispatch-id) run slot in B's ring — B's flat buffer grew.
+  (let [id             :destroy/ring-evidence-overlap
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        a-observer     ::ring-a-observer
+        global-facts   (atom [])
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :destroy/ring-a-settle
+      (fn [{:keys [db]} _] {:db (assoc db :a-settled true)}))
+    (rf/reg-event :destroy/ring-a
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/reg-event :destroy/ring-b-settle
+      (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
+    (rf/make-frame {:id id})
+    ;; A accrues an observer by settling one ordinary event, so its destroy
+    ;; fans a :rf.epoch.cb/silenced-on-frame-destroy terminal fact too.
+    (rf/register-listener! :epoch a-observer (fn [_] nil))
+    (rf/dispatch-sync [:destroy/ring-a-settle] {:frame id})
+    ;; Global live trace listener — captures A's frame-tagged terminal facts.
+    (rf/register-listener! :trace ::ring-global-facts
+      (fn [ev]
+        (when (and (= id (get-in ev [:tags :frame]))
+                   (contains? #{:rf.epoch/snapshotted :rf.epoch/outcome
+                                :rf.epoch.cb/silenced-on-frame-destroy}
+                              (:operation ev)))
+          (swap! global-facts conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:destroy/ring-a] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A is paused at its post-dissoc epoch hook")
+        ;; Same-id B: install and settle an ordinary event so B's RING holds a
+        ;; legitimate sentinel run before A publishes its terminal facts.
+        (rf/make-frame {:id id})
+        (rf/dispatch-sync [:destroy/ring-b-settle] {:frame id})
+        (let [token-b       (frame/frame-incarnation-token id)
+              b-ring-before (rf/trace-buffer id {:flat true})
+              b-bundles-before (rf/trace-buffer id)]
+          (is (seq b-ring-before)
+              "B's ring holds its own settle sentinel before A resumes")
+          ;; A resumes and publishes its terminal facts while B owns the id.
+          (.countDown release-a)
+          (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+              "A's terminal recipe completes")
+          (executor-barrier!)
+
+          ;; THE RING BOUNDARY: B's public flat buffer is byte-identical.
+          (is (= b-ring-before (rf/trace-buffer id {:flat true}))
+              "B's flat trace ring is byte-identical after A's terminal fan-out")
+          (is (= b-bundles-before (rf/trace-buffer id))
+              "B's event-bundle ring view is unchanged too")
+          ;; None of A's terminal operations reach B's ring.
+          (is (empty? (filter #(contains? #{:rf.epoch/snapshotted :rf.epoch/outcome
+                                            :rf.epoch.cb/silenced-on-frame-destroy}
+                                          (:operation %))
+                              (rf/trace-buffer id {:flat true})))
+              "no A terminal operation is retained in B's ring")
+          ;; A's inherited dispatch-id never appears as a run slot in B's ring.
+          (let [a-dispatch-ids (into #{}
+                                     (comp (map #(get-in % [:tags :rf.trace/dispatch-id]))
+                                           (remove nil?))
+                                     @global-facts)
+                b-ring-dispatch-ids (into #{}
+                                          (comp (map #(get-in % [:tags :rf.trace/dispatch-id]))
+                                                (remove nil?))
+                                          (rf/trace-buffer id {:flat true}))]
+            (is (empty? (set/intersection a-dispatch-ids b-ring-dispatch-ids))
+                "A's dispatch-id is never retained as a run slot in B's ring"))
+
+          ;; GLOBAL DELIVERY still fires: each A terminal fact reaches the live
+          ;; listener exactly once (scoped to A's terminal outcomes).
+          (is (= 1 (count (filter #(and (= :rf.epoch/snapshotted (:operation %))
+                                        (= :halted-destroy (get-in % [:tags :outcome])))
+                                  @global-facts)))
+              "A's :halted-destroy snapshotted reaches the global listener once")
+          (is (= 1 (count (filter #(and (= :rf.epoch/outcome (:operation %))
+                                        (= :blocked (get-in % [:tags :outcome])))
+                                  @global-facts)))
+              "A's :blocked outcome reaches the global listener once")
+          (is (= 1 (count (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                           (:operation %))
+                                        (= a-observer (get-in % [:tags :cb-id])))
+                                  @global-facts)))
+              "A's silencing fact for its observer reaches the global listener once")
+
+          ;; B stays live and keeps settling normally.
+          (is (identical? token-b (frame/frame-incarnation-token id))
+              "B remains the current incarnation")
+          (rf/dispatch-sync [:destroy/ring-b-settle] {:frame id})
+          (is (< (count b-ring-before)
+                 (count (rf/trace-buffer id {:flat true})))
+              "B's own subsequent event does grow B's ring (ring is live, not frozen)")))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch a-observer)
+        (rf/unregister-listener! :trace ::ring-global-facts)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
+(deftest snapshot-hook-failure-leaves-no-residual-ring
+  ;; rf2-vxgfnd.244 (red before fix). A throwing `:epoch/snapshot-frame-destroyed`
+  ;; during a mid-run destroy emits `:rf.warning/teardown-hook-exception` under
+  ;; ORDINARY (non-structural) delivery, carrying A's bare frame id. Ordering the
+  ;; snapshot BEFORE A's ring release means that warning's ring push is cleared
+  ;; by A's normal ring release — no residual per-frame ring survives for the
+  ;; destroyed frame — while the required global diagnostic still fires.
+  ;;
+  ;; Before the fix the snapshot ran AFTER release-frame-ring!, so the warning
+  ;; RECREATED A's already-released ring, leaving a residual ring keyed by the
+  ;; destroyed id.
+  (let [id           :destroy/ring-snapshot-fail
+        warnings     (atom [])
+        original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+    (rf/reg-event :destroy/ring-snap-a
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/make-frame {:id id})
+    (rf/register-listener! :trace ::ring-snap-warn
+      (fn [ev]
+        (when (and (= id (get-in ev [:tags :frame]))
+                   (= :rf.warning/teardown-hook-exception (:operation ev)))
+          (swap! warnings conj ev))))
+    (try
+      ;; Fail the pre-dissoc snapshot hook for this mid-run destroy.
+      (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+        (fn [& args]
+          (if (= id (first args))
+            (throw (ex-info "snapshot blew" {}))
+            (when original-snap (apply original-snap args)))))
+      (rf/dispatch-sync [:destroy/ring-snap-a] {:frame id})
+      (executor-barrier!)
+      ;; The required global diagnostic fired.
+      (is (= 1 (count @warnings))
+          "the snapshot-failure teardown-hook warning reaches the global listener")
+      (is (= :epoch/snapshot-frame-destroyed
+             (get-in (first @warnings) [:tags :hook]))
+          "the warning names the failing snapshot hook")
+      ;; No residual ring survives for the destroyed frame.
+      (is (empty? (rf/trace-buffer id {:flat true}))
+          "no residual per-frame trace ring survives destroyed A")
+      (is (empty? (rf/trace-buffer id))
+          "no residual event-bundle ring survives destroyed A either")
+      (is (nil? (frame/frame-incarnation-token id))
+          "the frame is fully destroyed")
+      (finally
+        (rf/unregister-listener! :trace ::ring-snap-warn)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)))))
 
 (deftest owner-loss-unwinds-only-entered-authored-afters
   ;; Mutation tooth: removing execute-chain's continuation predicate would run

--- a/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
@@ -1,0 +1,121 @@
+(ns re-frame.trace.structural-retention-cljs-test
+  "Synchronous retention-boundary coverage for retentionless structural
+  delivery (rf2-vxgfnd.244) — the extension #5850's epoch-only fence missed.
+
+  #5850 made an obsolete incarnation A's terminal facts bypass a same-id
+  successor B's epoch CAPTURE and B's no-emit POLICY (via
+  `re-frame.trace/call-with-structural-delivery`). But the per-frame trace
+  RING was still written: A's terminal facts carry A's inherited dispatch-id
+  and A's bare frame id, so `re-frame.trace.tooling/push-to-ring!` appended
+  them onto the CURRENT ring for that id — which is B's ring once B is
+  installed under the shared id.
+
+  The fix makes structural delivery RETENTIONLESS: the fact still streams live
+  to every registered trace listener exactly once, but no per-frame ring
+  retains it. This suite pins that boundary directly and synchronously (no
+  threads), on BOTH JVM and CLJS — the ring + emit substrate is
+  platform-agnostic. The deterministic same-id A→B pause/resume scenario lives
+  in the JVM `frame-destroy-incarnation-jvm-test`.
+
+  Per Spec 009 §Per-frame trace rings and §Listener invocation rules."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(defn- flat [frame-id]
+  (trace-tooling/trace-buffer frame-id {:flat true}))
+
+(deftest ordinary-emit-is-retained-structural-emit-is-not
+  (testing "ring retention is gated ONLY by structural delivery; live delivery is not"
+    (let [fid  :rf2-244/sync-frame
+          did  :rf2-244/run-1
+          live (atom [])]
+      (trace/clear-listeners!)
+      (trace-tooling/clear-trace-rings!)
+      (trace/register-listener! ::retention-live (fn [ev] (swap! live conj ev)))
+      (try
+        ;; Control: an ordinary (non-structural) emit carrying a frame id + a
+        ;; dispatch-id IS retained in that frame's ring.
+        (trace/emit! :test :rf2-244/ordinary
+                     {:frame fid :rf.trace/dispatch-id did})
+        (is (= 1 (count (flat fid)))
+            "an ordinary emit is retained in the frame's ring")
+        (is (= 1 (count @live))
+            "and the ordinary emit reached the live listener")
+
+        ;; Boundary: a structural emit of the SAME shape reaches the live
+        ;; listener but is NOT retained in the ring.
+        (let [ring-before (flat fid)
+              live-before (count @live)]
+          (trace/call-with-structural-delivery
+            #(trace/emit! :test :rf2-244/structural
+                          {:frame fid :rf.trace/dispatch-id did}))
+          (is (= (inc live-before) (count @live))
+              "the structural emit still reaches the live listener exactly once")
+          (is (= :rf2-244/structural (:operation (last @live)))
+              "the live listener saw the structural event")
+          (is (= ring-before (flat fid))
+              "the structural emit is NOT retained in the frame's ring")
+          (is (empty? (filter #(= :rf2-244/structural (:operation %)) (flat fid)))
+              "the structural operation never appears in the ring"))
+        (finally
+          (trace/unregister-listener! ::retention-live)
+          (trace-tooling/clear-trace-rings!)
+          (trace/clear-listeners!))))))
+
+(deftest structural-emit-never-allocates-a-successor-ring
+  (testing "a structural emit tagged with a never-emitted frame id creates no ring"
+    ;; This is the same-id-successor case in miniature: `fid` stands in for B's
+    ;; freshly-installed id, which has emitted nothing of its own yet. A's
+    ;; terminal fact — carrying that bare id under structural delivery — must
+    ;; not conjure a ring keyed by it. Before the fix the push allocated one.
+    (let [fid  :rf2-244/fresh-successor
+          did  :rf2-244/a-inherited
+          live (atom [])]
+      (trace/clear-listeners!)
+      (trace-tooling/clear-trace-rings!)
+      (trace/register-listener! ::fresh-live (fn [ev] (swap! live conj ev)))
+      (try
+        (is (empty? (flat fid))
+            "no ring exists for the fresh successor id yet")
+        (trace/call-with-structural-delivery
+          #(trace/emit! :test :rf2-244/a-terminal
+                        {:frame fid :rf.trace/dispatch-id did}))
+        (is (= 1 (count @live))
+            "A's terminal fact still reaches the live listener exactly once")
+        (is (empty? (flat fid))
+            "no ring is allocated for the successor id by A's structural fact")
+        (finally
+          (trace/unregister-listener! ::fresh-live)
+          (trace-tooling/clear-trace-rings!)
+          (trace/clear-listeners!))))))
+
+(deftest error-emit-under-structural-delivery-is-also-retentionless
+  (testing "emit-error! honours the retentionless boundary too (terminal diagnostics)"
+    ;; A's terminal diagnostics (`:rf.epoch.cb/listener-exception`,
+    ;; `:rf.warning/teardown-hook-exception`) travel through `emit-error!`
+    ;; under structural delivery. They must reach listeners but never a ring.
+    (let [fid  :rf2-244/err-frame
+          did  :rf2-244/err-run
+          live (atom [])]
+      (trace/clear-listeners!)
+      (trace-tooling/clear-trace-rings!)
+      (trace/register-listener! ::err-live (fn [ev] (swap! live conj ev)))
+      (try
+        ;; Control: an ordinary error emit is retained.
+        (trace/emit-error! :rf2-244/ordinary-error
+                           {:frame fid :rf.trace/dispatch-id did})
+        (is (= 1 (count (flat fid)))
+            "an ordinary error emit is retained in the ring")
+        (let [ring-before (flat fid)]
+          (trace/call-with-structural-delivery
+            #(trace/emit-error! :rf2-244/structural-error
+                                {:frame fid :rf.trace/dispatch-id did}))
+          (is (= 2 (count @live))
+              "the structural error still reaches the live listener")
+          (is (= ring-before (flat fid))
+              "the structural error is NOT retained in the ring"))
+        (finally
+          (trace/unregister-listener! ::err-live)
+          (trace-tooling/clear-trace-rings!)
+          (trace/clear-listeners!))))))


### PR DESCRIPTION
Closes rf2-vxgfnd.244. The precise extension of the merged incarnation pair (#5850) that its epoch-only fence missed.

## The gap (exact path)

#5850's `call-with-structural-delivery` made an obsolete incarnation A's terminal facts bypass a same-id successor B's **epoch capture** and B's **frame-no-emit policy** — but NOT B's per-frame trace **RING**:

- `frame.cljc` released A's trace ring *before* the snapshot/publication sequence.
- `epoch/listeners.cljc` emitted A's `:rf.epoch/snapshotted` / `:rf.epoch/outcome` / silencing / listener-exception under `call-with-structural-delivery`, and `frame.cljc` emitted the post-dissoc teardown-hook-exception the same way — each still carrying A's inherited handler `dispatch-id` and A's bare frame id.
- `trace.cljc`'s structural scope disabled epoch capture + frame no-emit but left ring retention on, so `deliver!` still called the tooling hook.
- `trace/tooling.cljc`'s `push-to-ring!` routed an event carrying a dispatch id + bare frame id into the **current** ring for that id — B's ring once B is installed. A snapshot-hook failure could similarly recreate A's already-released ring.

Result: a public `(rf/trace-buffer B {:flat true})` contained predecessor A's terminal facts. The merged #5850 fixtures assert B's epoch buffer/history, **not** the ring, so CI stayed green despite the leak.

## The fix (retentionless structural delivery)

The smallest local notion of retentionless structural delivery — global live trace listeners still receive each required terminal fact exactly once, but **no** current/future frame ring retains it.

- `trace.cljc`: new private `*ring-retention-enabled?*` dynamic (default true). `call-with-structural-delivery` now binds it false alongside the existing epoch/policy flags, and `deliver!` threads it to the tooling hook. This automatically covers all five existing structural-delivery call sites (three in `epoch/listeners.cljc`, one in `frame.cljc`, one in `router.cljc`) — every one a stale-incarnation terminal fact where retentionlessness is exactly correct. No edit to `listeners.cljc` was needed.
- `trace/tooling.cljc`: `deliver-to-tooling!` gains a `retain?` arg gating **only** `push-to-ring!`; listener fan-out stays unconditional so the terminal fact reaches live consumers exactly once either way.
- `frame.cljc`: the pre-dissoc `snapshot-epoch-terminal-evidence!` call now runs **before** the ring release (not after). A snapshot-hook failure emits its `:rf.warning/teardown-hook-exception` under ordinary (non-structural) delivery, so ordering it before `release-frame-ring!` means A's normal ring release clears that push instead of the warning recreating an already-released ring. No same-id B can exist yet (still pre-dissoc), so ordinary delivery stays correct there.

Per the bead guidance, the fix does **no** post-dissoc bare-id ring clear (that could erase B's legitimate evidence) — it prevents retention in the first place.

## Quality gates

Red-before-fix was proven by temporarily reverting each half of the fix and observing the new RING fixtures fail, then restored:

- **`predecessor-terminal-facts-never-retained-in-successor-ring`** (JVM, `frame_destroy_incarnation_jvm_test.clj`) — the red-before-fix RING fixture. Pauses A after dissociation, installs same-id B with an ordinary retained-ring sentinel (B settles an event), resumes A, and asserts B's public flat trace buffer stays **byte-identical**; none of A's terminal operations or inherited dispatch-id appear in B's ring; and each A terminal fact (`:rf.epoch/snapshotted` `:halted-destroy`, `:rf.epoch/outcome` `:blocked`, `:rf.epoch.cb/silenced-on-frame-destroy`) still reaches the global live listener exactly once. Reverting the tooling retention gate makes B's ring grow with A's `:halted-destroy` slot (confirmed red).
- **`snapshot-hook-failure-leaves-no-residual-ring`** (JVM) — A throwing `:epoch/snapshot-frame-destroyed` during a mid-run destroy leaves no residual per-frame ring while still producing the required global diagnostic. Reverting the snapshot-before-release ordering leaves a residual `:rf.warning/teardown-hook-exception` ring (confirmed red).
- **`re-frame.trace.structural-retention-cljs-test`** (`.cljc`, CLJ + synchronous CLJS) — pins the retention boundary directly: an ordinary emit is retained; a structural emit of the same shape reaches the live listener but is not retained and allocates no successor ring; `emit-error!` under structural delivery is likewise retentionless.

Foreground suites (all green):
- `implementation/core` JVM — 1955 tests / 8916 assertions, 0 failures.
- `implementation/epoch` JVM — 388 tests / 2413 assertions, 0 failures.
- `implementation/machines` JVM (destroyed-reason matrix) — 1035 tests / 3509 assertions, 0 failures.
- `npm run test:cljs` node integration — 9339 tests / 44214 assertions, 0 failures (includes the new synchronous `.cljc` suite).

## Spec 009 follow-up (not in this PR)

The Spec 009 trace-contract prose for §Per-frame trace rings / structural delivery does not yet name the retention boundary explicitly. This PR keeps the behavioural contract self-documented in code; a doc ripple to state "structural (obsolete-incarnation) terminal facts stream live but are never ring-retained" can follow as a separate spec-prose bead.
