### PR TITLE
docs(spec): note the two-point ViewCell commit authority check (rf2-h9f6u5)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -628,8 +628,14 @@ HMR is a designed contract with fixtures, not a hope; the REPL path *is* the HMR
 - **The Pair's hot-swap is this same mechanism** invoked over nREPL.
 
 Cell/ownership reconciliation under reload is owned by
-[006](006-ReactiveSubstrate.md); compile budgets (expansion p95, watch-loop rebuild)
-are gated per [008](008-Testing.md) G-14.
+[006](006-ReactiveSubstrate.md) — including the guard that a re-registration landing in a
+cell's render→commit gap never paints the old body: commit checks body authority (the
+cell-local generation *and* the registered view revision) at **both** the render→commit
+boundary and again immediately before publication, releasing any newly-staged leases and
+re-rendering rather than committing a stale capture ([006 §Body authority under hot
+reload](006-ReactiveSubstrate.md#body-authority-under-hot-reload--the-two-point-commit-fence)).
+Compile budgets (expansion p95, watch-loop rebuild) are gated per
+[008](008-Testing.md) G-14.
 
 ## Removed forms — normative absences
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1144,6 +1144,39 @@ attached; nodes created solely by a rolled-back acquisition dispose on their zer
 edge, correctly. A multi-target reconcile-failure fixture at the ViewCell layer is a
 named Stage-2 obligation.
 
+### Body authority under hot reload — the two-point commit fence
+
+Distinct from the value-movement guards (invariant 5, above), a commit also verifies the
+cell's **body authority** — that the body generation the capture was rendered against is
+still current — so an HMR re-registration landing in the render→commit gap can never
+publish a stale body. Authority is **dual** ⟨rf2-vxgfnd.214⟩:
+
+- the cell-local **generation** — bumped on an explicit sync/remount; and
+- the **registered-view-revision** — the authoritative body revision the view registry
+  holds for the view-id, which closes the harder `render(old) → re-registration(new) →
+  layout(old)` window even when the cell has not rendered again. A direct/headless caller
+  with no registered slot falls back to the cell-local half alone (the registry half
+  no-ops).
+
+The capture is rejected as **`:stale`** when either half has advanced past the captured
+generation, checked at **two points**:
+
+1. **Render→commit (step 1).** Commit entry samples the authority once and rejects a
+   stale capture before touching any ownership — the host simply re-renders.
+2. **Final publication boundary.** Step 1 samples *once*, but the staging window between
+   it and publication — the acquire/cache callbacks — can each synchronously advance the
+   authoritative revision (a same-shell re-registration mid-commit). So commit **re-reads**
+   the authority at the narrowest boundary — after all callback-capable work, with nothing
+   callback-capable between it and the publish swap — and refuses to publish a stale
+   capture: it releases **only the newly-staged leases** (reverse acquisition order),
+   leaves the prior committed set, published values, and lifecycle untouched, and returns
+   `:stale`. No revision advances, because the re-registration already notified the shell
+   and a fresh render at the new body is inbound.
+
+The whole fence is **dev/HMR-only**: production mints every cell at body revision 0 and
+never advances it, so both points constant-fold away under `goog.DEBUG=false` — no
+registry lookup on the commit hot path (I-12 production erasure).
+
 ### Callback and reentrancy rules
 
 Spike-validated ⟨S-3 §5, µ⟩:


### PR DESCRIPTION
Docs-only follow-up to the merged HMR-authority fence (PR #5862, rf2-vxgfnd.214). The ViewCell commit's HMR body-authority staleness rejection is now checked at **two points**, not one. This documents that in the spec.

## What changed

**spec/006-ReactiveSubstrate.md** — new subsection `### Body authority under hot reload — the two-point commit fence` (after the transactional multi-acquire staging section). It records:
- the **dual authority** — the cell-local generation *and* the registered-view-revision (with the direct/headless fallback to the cell-local half);
- point 1 — the render→commit (step-1) sample-and-reject;
- point 2 — the NEW final publication-boundary re-read (`stale-body-authority?` before the step-6 publish swap): a mid-commit re-registration releases only the newly-staged leases and returns `:stale` without publishing, no revision advance;
- dev/HMR-only erasure under `goog.DEBUG=false` (I-12).

**spec/004-Views.md** — §Hot reload gains one concise cross-referencing sentence noting the two-point body-authority guard, linking to the new 006 subsection.

Verified against the merged `implementation/ui/src/re_frame/ui/reactive.cljc` (`stale-body-authority?` + `commit*` step-1 gate and the final HMR-authority fence); no implementation touched.

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (validates the new cross-file anchor)
- README link/anchor validator — PASS
- EP status-sync (self-test + live) — PASS
- runtime-subsystem grading (self-test + live) — PASS
- `mkdocs build --strict` — not runnable locally (mkdocs not on PATH; CI runs it)

Docs-only; no code surface, no hot-zone shadow/build files touched.