### PR TITLE
ci: enforce publishable artefacts in the release workflow (rf2-vxgfnd.173)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -258,6 +258,107 @@ while IFS= read -r deps_file; do
   fi
 done < <(find "${REPO_ROOT}/implementation" -mindepth 2 -maxdepth 3 -name deps.edn)
 
+# ─────────────────────────────────────────────────────────────────────
+# rf2-vxgfnd.173 — release-inventory cross-check (executable coupling).
+#
+# The inventory-drift guard ABOVE proves every publishable
+# implementation/*/deps.edn appears in THIS script's ARTEFACTS list. That
+# is necessary but NOT sufficient: an artefact can sit in the lockstep
+# inventory and still be silently absent from the release TRAIN — no
+# pre-deploy JVM test, no deploy-leaf matrix row, no GitHub-release
+# artefact line. PR #5792's release.yml comment claimed this guard also
+# enforced the release-matrix half; it did not — the guard never read
+# release.yml (its only release.yml mention was advice in an error
+# string). This section makes that coupling executable: every discovered
+# publishable artefact must be present in ALL THREE required release.yml
+# inventories or the build fails — in ordinary PR CI (test.yml invokes
+# this script) and in the tag/release path before any Clojars upload.
+#
+# The three required surfaces, per the release DAG in release.yml:
+#   1. Pre-deploy test — a `working-directory: implementation/<sub>` step
+#      running `clojure -M:test` in the `test` job.
+#   2. Deploy topology — core deploys via the deploy-core job; every leaf
+#      via a `directory: implementation/<sub>` deploy-leaf matrix row.
+#   3. GitHub-release  — a `- `<coordinate>`` row in the release body.
+#
+# The published coordinate is read from each artefact's :clein/build :lib
+# (so day8/reagent-slim's non-uniform coordinate is cross-checked as-is,
+# not guessed from the directory name). That :lib is the canonical
+# manifest the bead permits: one source consumed by both the lockstep
+# arrays above and this cross-check.
+RELEASE_YML="${REPO_ROOT}/.github/workflows/release.yml"
+if [[ ! -f "${RELEASE_YML}" ]]; then
+  echo "::error file=.github/workflows/release.yml::release workflow missing — cannot cross-check the publishable-artefact release inventory (rf2-vxgfnd.173)"
+  errors=$((errors + 1))
+else
+  # Build the three required release inventories once, as newline-set
+  # strings. Step boundaries (`- name:`) reset the tracked
+  # working-directory so a `run:` line only picks up its own step's
+  # directory. Trailing whitespace (incl. a CRLF \r on Windows checkouts)
+  # is stripped — [:space:] covers \r.
+
+  # (1) pre-deploy test subpaths: `working-directory: implementation/<sub>`
+  #     steps whose command is `clojure -M:test` (the `test` job).
+  release_test_subpaths="$(awk '
+    /^[[:space:]]*-[[:space:]]+name:/ { wd="" }
+    /^[[:space:]]*working-directory:[[:space:]]*implementation\// { line=$0; sub(/^.*working-directory:[[:space:]]*/,"",line); gsub(/[[:space:]]+$/,"",line); wd=line }
+    /^[[:space:]]*run:[[:space:]]*clojure -M:test/ { if (wd!="") print wd }
+  ' "${RELEASE_YML}" | sort -u)"
+
+  # (2) deploy-topology subpaths: the deploy-core job (working-directory +
+  #     `clojure -M:clein deploy`) for core, plus every `directory:`
+  #     deploy-leaf matrix row for the leaves.
+  release_deploy_subpaths="$(awk '
+    /^[[:space:]]*-[[:space:]]+name:/ { wd="" }
+    /^[[:space:]]*working-directory:[[:space:]]*implementation\// { line=$0; sub(/^.*working-directory:[[:space:]]*/,"",line); gsub(/[[:space:]]+$/,"",line); wd=line }
+    /^[[:space:]]*run:[[:space:]]*clojure -M:clein deploy/ { if (wd!="") print wd }
+    /^[[:space:]]*directory:[[:space:]]*implementation\// { line=$0; sub(/^.*directory:[[:space:]]*/,"",line); gsub(/[[:space:]]+$/,"",line); print line }
+  ' "${RELEASE_YML}" | sort -u)"
+
+  # (3) github-release body coordinates: backtick-wrapped `day8/…` tokens
+  #     on release-notes list rows (`- `day8/…``). Anchored to list-item
+  #     lines so a prose/comment mention of a backticked coordinate is
+  #     NOT miscounted as a release-notes row.
+  release_body_coords="$(awk '
+    /^[[:space:]]*-[[:space:]]+`day8\// { s=$0; while (match(s, /`day8\/[^`]+`/)) { print substr(s, RSTART+1, RLENGTH-2); s=substr(s, RSTART+RLENGTH) } }
+  ' "${RELEASE_YML}" | sort -u)"
+
+  in_release_set() { grep -qxF -- "$1" <<< "$2"; }
+
+  while IFS= read -r deps_file; do
+    [[ -f "${deps_file}" ]] || continue
+    stripped="$(sed 's/;;.*$//' "${deps_file}")"
+    grep -qF ':clein/build' <<< "${stripped}" || continue
+
+    subpath="${deps_file#"${REPO_ROOT}/implementation/"}"
+    subpath="${subpath%/deps.edn}"
+    impl_sub="implementation/${subpath}"
+
+    # Published coordinate from :clein/build :lib (canonical manifest).
+    lib="$(grep -oE ':lib[[:space:]]+day8/[^[:space:]]+' <<< "${stripped}" | head -n1 | sed -E 's/^:lib[[:space:]]+//')"
+    if [[ -z "${lib}" ]]; then
+      echo "::error file=${impl_sub}/deps.edn::${impl_sub} declares a :clein/build alias but no :lib coordinate could be read — cannot cross-check the release inventory (rf2-vxgfnd.173)"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    if ! in_release_set "${impl_sub}" "${release_test_subpaths}"; then
+      echo "::error file=.github/workflows/release.yml::publishable artefact '${lib}' (${impl_sub}) has NO pre-deploy JVM test step ('working-directory: ${impl_sub}' + 'clojure -M:test') in the release 'test' job — a declared-publishable artefact must be gated before deploy (rf2-vxgfnd.173)"
+      errors=$((errors + 1))
+    fi
+
+    if ! in_release_set "${impl_sub}" "${release_deploy_subpaths}"; then
+      echo "::error file=.github/workflows/release.yml::publishable artefact '${lib}' (${impl_sub}) has NO deploy step — expected the deploy-core job (core) or a 'directory: ${impl_sub}' deploy-leaf matrix row — so it would never ship in the release train (rf2-vxgfnd.173)"
+      errors=$((errors + 1))
+    fi
+
+    if ! in_release_set "${lib}" "${release_body_coords}"; then
+      echo "::error file=.github/workflows/release.yml::publishable artefact '${lib}' (${impl_sub}) has NO GitHub-release artefact row (a '- \`${lib}\`' line in the github-release body) — the release notes would omit it (rf2-vxgfnd.173)"
+      errors=$((errors + 1))
+    fi
+  done < <(find "${REPO_ROOT}/implementation" -mindepth 2 -maxdepth 3 -name deps.edn)
+fi
+
 # Tools/* deployable jars (rf2-lwtke). Each tools/<name>/deps.edn that
 # carries a :clein/build alias publishes to Clojars at the same lockstep
 # version as the framework artefacts above — every consumer that pins
@@ -349,4 +450,5 @@ fi
 
 total_count=$((${#ARTEFACTS[@]} + ${#TOOLS[@]}))
 echo "lockstep version verification PASSED — all ${total_count} artefacts (${#ARTEFACTS[@]} implementation/ + ${#TOOLS[@]} tools/) pinned to repo-root VERSION ${VERSION}"
+echo "release-inventory cross-check PASSED — every publishable implementation artefact is present in release.yml's pre-deploy test, deploy-leaf topology, and github-release inventories (rf2-vxgfnd.173)"
 exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,24 @@
 # not an omission. The publishing wiring (a jvm-ui pre-deploy step + a
 # deploy leaf after deploy-core + a verify-version-lockstep.sh inventory
 # entry + a release-notes line) lands in the SAME change that first gives
-# ui a :clein/build. That coupling is enforced, not merely documented:
-# verify-version-lockstep.sh's inventory guard (rf2-qmhysc) FAILS the
-# build the instant any implementation/*/deps.edn gains a :clein/build
-# without a matching lockstep-inventory + release-matrix entry — so ui
-# can neither be published nor silently omitted-once-publishable behind
-# the release train's back.
+# ui a :clein/build. That coupling is enforced, not merely documented —
+# verify-version-lockstep.sh runs TWO guards over every
+# implementation/*/deps.edn that carries a :clein/build alias:
+#   (1) the lockstep-inventory guard (rf2-qmhysc): the artefact must
+#       appear in the script's ARTEFACTS / ARTEFACT_PATHS inventory; and
+#   (2) the release-inventory cross-check (rf2-vxgfnd.173): the artefact
+#       must ALSO be present in ALL THREE required release.yml
+#       inventories — a pre-deploy `clojure -M:test` step in the `test`
+#       job, a deploy (the deploy-core job for core / a `directory:`
+#       deploy-leaf matrix row for a leaf), and a `- `<coordinate>``
+#       github-release body line.
+# Before rf2-vxgfnd.173 only guard (1) was executable and this comment
+# overclaimed; guard (2) now reads release.yml so the release-matrix half
+# is genuinely enforced, not merely asserted in an error string. Both
+# guards run in ordinary PR CI (test.yml invokes this script) AND in the
+# tag/release path before any Clojars upload, so ui can neither be
+# published nor silently omitted-once-publishable behind the release
+# train's back.
 #
 # # Lockstep versioning policy through 1.0
 #


### PR DESCRIPTION
## The gap

`.github/scripts/verify-version-lockstep.sh` discovers every publishable
`implementation/*/deps.edn` (those carrying a `:clein/build` alias) and cross-checked it
only against the script's own `ARTEFACTS`/`ARTEFACT_PATHS` shell arrays. It never read
`.github/workflows/release.yml` — the only `release.yml` mention was advice in an error
string. So the release train's three real inventories (pre-deploy JVM test, deploy-core /
deploy-leaf topology, and the GitHub-release artefact rows) were independent lists.

PR #5792 added a `release.yml` comment claiming the lockstep guard "FAILS the build the
instant any `implementation/*/deps.edn` gains a `:clein/build` without a matching
lockstep-inventory + release-matrix entry." Only the lockstep-inventory half was
executable — the release-matrix half was not. A publishable artefact could pass the guard
while being silently absent from the release train (no pre-deploy test, no deploy leaf, no
release-notes row), so a broken/incomplete release could be tagged.

Follow-up to closed rf2-qmhysc and rf2-pc479y (whose close reason relied on the coupling
that was never implemented).

## The enforcement

Extended `verify-version-lockstep.sh` with a **release-inventory cross-check** that runs
beside the existing version guard. For every discovered publishable implementation
artefact it asserts presence in all three required `release.yml` inventories:

1. **Pre-deploy test** — a `working-directory: implementation/<sub>` step running
   `clojure -M:test` in the `test` job.
2. **Deploy topology** — core deploys via the `deploy-core` job; every leaf via a
   `directory: implementation/<sub>` `deploy-leaf` matrix row.
3. **GitHub-release** — a `` - `<coordinate>` `` row in the release body.

The published coordinate is read from each artefact's `:clein/build :lib` (the canonical
manifest the bead permits — one source consumed by both the lockstep arrays and this
cross-check), so `day8/reagent-slim`'s non-uniform coordinate is cross-checked as-is
rather than guessed from the directory name. The three inventories are extracted from
`release.yml` once via `awk` (step-boundary aware; trailing `\r` from Windows/CRLF
checkouts trimmed; release-body extraction anchored to list-item rows so a prose/comment
mention of a backticked coordinate is not miscounted). Any missing surface emits a
`::error file=.github/workflows/release.yml::…` line and fails the gate.

Because `test.yml` already invokes this script at PR time and `release.yml` invokes it in
the pre-deploy gate, the cross-check runs in **ordinary PR CI and the tag/release path
before any Clojars upload** — no `test.yml` change needed. Scope stayed inside
`release.yml` + the lockstep verifier only.

#5792's `release.yml` comment is rewritten to state only what the executable gates now
enforce (two guards: lockstep-inventory + release-inventory cross-check).

The current pre-publication `implementation/ui` (no `:clein/build`) continues to pass —
nothing pretends UI is publishable.

## Red-before-fix demo

Synthetic scenario per the bead's repro: make `implementation/ui` publishable
(`:clein/build`, `:lib day8/re-frame2-ui`), add it **only** to the script's shell/lockstep
inventory arrays, and leave `release.yml` untouched.

- **Pre-fix** (`origin/main` verifier): `lockstep version verification PASSED — all 19
  artefacts …`, exit 0. The bug: a declared-publishable artefact with no release wiring
  passes the gate.
- **Post-fix** (this PR's verifier): exit 1 with one `::error::` per missing surface —
  no pre-deploy test step, no deploy leaf, no GitHub-release row for `day8/re-frame2-ui`.

Each acceptance criterion exercised:
- Current pre-publication tree passes (18 artefacts + cross-check green).
- `:clein/build` present but no lockstep entry → fails (4 errors: inventory guard + 3 release surfaces).
- Added only to the shell/lockstep inventory, deploy row absent → fails (3 errors).
- Partial wiring (test + deploy present, GitHub-release row omitted) → fails on exactly that surface (1 error).
- Fully wired into all three release surfaces → passes (19 artefacts + cross-check green).

## Quality gates

- `bash .github/scripts/verify-version-lockstep.sh` on the current tree: **PASS** (green
  baseline — 18 artefacts + release-inventory cross-check).
- Red-before-fix + all acceptance-criteria scenarios: as above (pre-fix passes the broken
  scenario, post-fix fails it; fully-wired passes).
- `bash -n` syntax check: clean.
- `scripts/test-fast-pr.sh`: the lockstep/release verifier gate (the surface this PR
  modifies) is green, as are all JVM + Python skill/doc/policy gates. The final
  CLJS-node step is an environment-only skip in the fresh worktree (`shadow-cljs` not
  installed — no `npm ci`); this diff touches zero CLJS. CI runs the full CLJS suite.
- `actionlint` / `shellcheck`: not installed locally; CI runs them.
