### PR TITLE
fix(ui): fence reentrant resource release until outer ensures enqueued (rf2-vxgfnd.150)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1586,6 +1586,25 @@
        (identical? (:frame-token prior) (:frame-token desired))
        (eq/rf= (:descriptor prior) (:descriptor desired))))
 
+(def ^:private ^:dynamic *resource-release-fence*
+  "The outermost resource ensure-enqueue fence, or nil at rest.
+
+  `router/dispatch!` fires its synchronous `:rf.event/dispatched` trace
+  listeners BEFORE it inserts the envelope and schedules the drain (see
+  `re-frame.router/dispatch!` — the emit-then-enqueue seam). A listener that
+  reentrantly tears down or supersedes this cell can therefore dispatch a
+  cleanup `release-owner` and have it enter FIFO AHEAD of the ensure envelope
+  that is still mid-dispatch — draining `release, ensure` leaks/resurrects the
+  owner (rf2-vxgfnd.150).
+
+  While an ensure is inside that pre-FIFO window this holds a volatile release
+  accumulator: reentrant releases record their intent here instead of
+  dispatching (see `enqueue-release!`), and the outermost ensure flushes them in
+  request order once every ensure has actually entered FIFO (see
+  `fenced-enqueue-ensure!`). Bound on one reconcile thread (JVM) / the single JS
+  thread; never observed at rest."
+  nil)
+
 (defn- ensure-event
   [view-id {:keys [sid descriptor frame-id owner commit-id]}]
   [:rf.resource/ensure
@@ -1604,10 +1623,22 @@
   [view-id {:keys [frame-id] :as record}]
   (router/dispatch! (ensure-event view-id record) {:frame frame-id}))
 
-(defn- enqueue-release!
+(defn- dispatch-release!
   [{:keys [frame-id owner]}]
   (router/dispatch! [:rf.resource/release-owner {:owner owner}]
                     {:frame frame-id}))
+
+(defn- enqueue-release!
+  "Enqueue an owner release — or, while an ensure is inside its pre-FIFO trace
+  window (`*resource-release-fence*` bound), record the release intent so it
+  cannot enter the frame queue before the ensure envelope that triggered it. The
+  outermost ensure flushes deferred releases in request order once every ensure
+  has actually entered FIFO. Outside that window this is the ordinary immediate
+  dispatch."
+  [record]
+  (if-some [fence *resource-release-fence*]
+    (do (vswap! fence conj record) nil)
+    (dispatch-release! record)))
 
 (defn- attempt-resource-releases!
   "Attempt every release in order. Never short-circuits; returns the first
@@ -1621,6 +1652,46 @@
                 {:error (or error e) :failed (conj failed record)})))
           {:error nil :failed []}
           records))
+
+(defn- flush-deferred-releases!
+  "Dispatch the releases deferred during an ensure's pre-FIFO trace window, in
+  request order, now that every nested/outer ensure has actually entered FIFO —
+  so every owner's ensure envelope precedes its cleanup release. Best-effort per
+  release (matching `attempt-resource-releases!`): a single release escape never
+  strands the rest of the batch."
+  [records]
+  (doseq [record records]
+    (try
+      (dispatch-release! record)
+      (catch #?(:clj Throwable :cljs :default) _e nil))))
+
+(defn- fenced-enqueue-ensure!
+  "Enqueue a resource ensure inside the outermost resource-release fence.
+
+  `router/dispatch!` emits its synchronous `:rf.event/dispatched` trace
+  listeners BEFORE it inserts the envelope, so a listener that reentrantly tears
+  down or supersedes this cell would otherwise dispatch a cleanup release into
+  FIFO ahead of the still-mid-dispatch ensure (rf2-vxgfnd.150). The OUTERMOST
+  ensure establishes the fence: reentrant releases fired inside its trace window
+  record intent instead of dispatching (see `enqueue-release!`), while nested
+  ensures dispatched from that window reuse the active fence and enter FIFO
+  immediately. When the outermost ensure returns — every nested/outer ensure now
+  in FIFO — the deferred releases flush in request order, so no cleanup release
+  precedes its owner's ensure envelope. The flush runs on the throw path too
+  (`finally`): an ensure-dispatch failure still compensates the deferred cleanup
+  without pretending the owner was attached, and the fence is already unbound
+  there so the flush dispatches for real rather than re-deferring."
+  [view-id record]
+  (if *resource-release-fence*
+    ;; Nested ensure: reuse the outer fence so this envelope enters FIFO ahead of
+    ;; the deferred releases the outermost frame flushes.
+    (enqueue-ensure! view-id record)
+    (let [fence (volatile! [])]
+      (try
+        (binding [*resource-release-fence* fence]
+          (enqueue-ensure! view-id record))
+        (finally
+          (flush-deferred-releases! @fence))))))
 
 (defn- stage-resource-held!
   "Make exactly one about-to-be-enqueued owner lifecycle-cleanup reachable.
@@ -1788,11 +1859,17 @@
   before owner mint or dispatch; same-site `rf=` descriptors on the same frame
   incarnation retain their exact owner. Every fresh ensure is queued in lexical
   order before any old owner release is attempted. Because dispatch trace
-  listeners run synchronously, each owner becomes cleanup-reachable immediately
-  before its own enqueue and exact capture/lifecycle authority is fenced after
-  every ensure and release. Future lexical owners are never staged early, and
-  final publication is conditional on the same accepted capture still owning a
-  connected cell."
+  listeners run synchronously — and `router/dispatch!` fires them BEFORE it
+  actually enqueues — each ensure runs through `fenced-enqueue-ensure!`: a
+  reentrant teardown/supersession release fired inside that pre-FIFO window is
+  deferred and flushed only once the ensure envelope has really entered the
+  queue, so no cleanup release can precede its owner's ensure (rf2-vxgfnd.150).
+  Each owner becomes cleanup-reachable immediately before its own enqueue and
+  exact capture/lifecycle authority is still fenced after every ensure and
+  release — post-dispatch lifecycle/capture fencing complements, but does not
+  replace, this queue-order fence. Future lexical owners are never staged early,
+  and final publication is conditional on the same accepted capture still owning
+  a connected cell."
   [^ViewCell cell cap]
   (let [st  (state cell)
         st0 @st
@@ -1853,7 +1930,7 @@
                         (let [attempted' (conj attempted record)
                               escape
                               (try
-                                (enqueue-ensure! view-id record)
+                                (fenced-enqueue-ensure! view-id record)
                                 nil
                                 (catch #?(:clj Throwable :cljs :default) e e))]
                           (cond

--- a/implementation/ui/test/re_frame/ui/resource_lease_enqueue_fence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/resource_lease_enqueue_fence_cljs_test.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.ui.resource-lease-enqueue-fence-cljs-test
+  "rf2-vxgfnd.150 — real-router proof that a reentrant resource release cannot
+  enter the frame FIFO before the ensure envelope that triggered it.
+
+  The rf2-vxgfnd.124 stand-in suite (resource-lease-reconcile-cljs-test) replaces
+  `router/dispatch!` with a recorder that appends the event at FUNCTION ENTRY, so
+  its `ensure, release` order proves only handler-ENTRY order. The production
+  router does the opposite at the queue boundary: `router/dispatch!` fires its
+  synchronous `:rf.event/dispatched` trace listeners BEFORE it inserts the
+  envelope and schedules the drain. A listener that tears the cell down (or
+  supersedes its capture) on the first ensure therefore dispatches a cleanup
+  `release-owner` that reaches FIFO AHEAD of the still-mid-dispatch ensure —
+  draining `release, ensure` re-attaches an owner nothing will release (a
+  permanent leak on the dead cell) or resurrects a superseded owner.
+
+  This suite drives the REAL router with real registrar-registered ensure/release
+  handlers modelling an owner registry (ensure attaches, release drops; a release
+  for an unattached owner is a no-op — exactly the leak seam), a real public
+  synchronous `:trace` listener, and a captured `interop/next-tick`. It asserts
+  the actual drained handler order and net owner state. Red before the enqueue
+  fence; green after. Runs on node and JVM without the optional Resources
+  artefact — the observing handlers stand in for its ensure/release owner
+  accounting through the same real router queue."
+  (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.features :as features]
+            [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
+            [re-frame.resource-lease-owner :as lease-owner]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.reactive :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- register-feature! [& resources]
+  (doseq [resource resources]
+    (registrar/register! :resource resource {:rf/resource {}})))
+
+(defn- capture-leases [cell sites]
+  (reactive/enable-resource-lifecycle! cell)
+  (rf/with-frame fid
+    (reactive/with-capture
+     cell
+     (fn []
+       (doseq [[sid descriptor] sites]
+         (reactive/lease-site sid descriptor))
+       :element))))
+
+(defn- commit-leases! [cell sites]
+  (let [[_ capture] (capture-leases cell sites)]
+    (reactive/commit-resources! cell capture)
+    capture))
+
+(defn- install-owner-registry!
+  "Real ensure/release handlers on the REAL router: ensure attaches an owner,
+  release drops it. A release for an unattached owner is a natural no-op — which
+  is precisely why a cleanup release draining ahead of its ensure leaves the
+  owner attached with nothing to release it. Records drained handler order and
+  the live owner set into `order` / `active`."
+  [order active]
+  (rf/reg-event
+   :rf.resource/ensure
+   (fn [{:keys [db]} [_ {:keys [owner]}]]
+     (swap! order conj [:ensure owner])
+     (swap! active conj owner)
+     {:db db}))
+  (rf/reg-event
+   :rf.resource/release-owner
+   (fn [{:keys [db]} [_ {:keys [owner]}]]
+     (swap! order conj [:release owner])
+     (swap! active disj owner)
+     {:db db})))
+
+(defn- drain-ticks!
+  "Run every captured `interop/next-tick` drain callback to quiescence (one
+  same-frame drain). Bounded so a scheduler regression cannot hang the suite."
+  [ticks]
+  (loop [guard 0]
+    (when (and (< guard 1000) (seq @ticks))
+      (let [f (first @ticks)]
+        (swap! ticks #(vec (rest %)))
+        (f)
+        (recur (inc guard))))))
+
+(deftest reentrant-teardown-release-cannot-jump-ahead-of-its-ensure
+  ;; The first ensure's synchronous trace listener tears the cell down. Teardown
+  ;; marks the cell dead, discards its cleanup record, and dispatches
+  ;; release-owner(A). Pre-fix that release reaches FIFO before ensure(A), so the
+  ;; drain runs release-A (no-op — A is not attached yet) then ensure-A (attaches
+  ;; A), leaking A on the dead cell. The enqueue fence defers the reentrant
+  ;; release until ensure(A) is actually queued, so the drain runs ensure-A then
+  ;; release-A and A is clean.
+  (register-feature! :feed/items)
+  (let [cell   (reactive/make-cell ::teardown)
+        order  (atom [])
+        active (atom #{})
+        ticks  (atom [])
+        fired? (atom false)
+        cap    (commit-leases! cell [[::a {:resource :feed/items}]])]
+    (install-owner-registry! order active)
+    (rf/register-listener!
+     :trace ::teardown-on-first-ensure
+     (fn [ev]
+       (when (and (= :rf.event/dispatched (:operation ev))
+                  (= :rf.resource/ensure (first (get-in ev [:tags :rf.event/v])))
+                  (compare-and-set! fired? false true))
+         (reactive/teardown! cell))))
+    (try
+      (with-redefs [features/require-feature! (constantly true)
+                    interop/next-tick (fn [f] (swap! ticks conj f))]
+        (reactive/reconcile-resource-leases! cell cap)
+        (drain-ticks! ticks))
+      (finally
+        (rf/unregister-listener! :trace ::teardown-on-first-ensure)))
+    (is (= :dead (reactive/lifecycle cell))
+        "the reentrant teardown left the cell dead")
+    (is (= [:ensure :release] (mapv first @order))
+        "ensure(A) enters FIFO before its reentrant teardown release — drained
+         handler order is ensure then release, not release then ensure")
+    (is (empty? @active)
+        "owner A is attached then released — it does not leak on the dead cell")
+    (is (empty? (reactive/resource-held cell))
+        "the terminated reconcile publishes no held state onto the dead cell")
+    (is (empty? (reactive/resource-reservations cell))
+        "the terminated reconcile publishes no reservation onto the dead cell")))
+
+(deftest reentrant-supersession-releases-cannot-jump-ahead-of-ensures
+  ;; The first ensure's synchronous trace listener commits a NEW capture and
+  ;; reconciles it, queuing nested ensure(A2) + release(A1) while outer ensure(A1)
+  ;; is still mid-dispatch. Pre-fix FIFO is ensure(A2), release(A1), ensure(A1):
+  ;; the drain resurrects the superseded A1. The fence defers the reentrant
+  ;; release(A1) until every ensure is queued, so FIFO is ensure(A2), ensure(A1),
+  ;; release(A1) and only the latest owner A2 survives.
+  (register-feature! :feed/items)
+  (let [cell   (reactive/make-cell ::supersession)
+        order  (atom [])
+        active (atom #{})
+        ticks  (atom [])
+        mints  (atom 0)
+        fired? (atom false)
+        cap1   (commit-leases! cell [[::a {:resource :feed/items}]])]
+    (install-owner-registry! order active)
+    (rf/register-listener!
+     :trace ::supersede-on-first-ensure
+     (fn [ev]
+       (when (and (= :rf.event/dispatched (:operation ev))
+                  (= :rf.resource/ensure (first (get-in ev [:tags :rf.event/v])))
+                  (compare-and-set! fired? false true))
+         (let [cap2 (commit-leases! cell [[::a {:resource :feed/items}]])]
+           (reactive/reconcile-resource-leases! cell cap2)))))
+    (try
+      (with-redefs [features/require-feature! (constantly true)
+                    lease-owner/mint! (fn [] [:lease (swap! mints inc)])
+                    interop/next-tick (fn [f] (swap! ticks conj f))]
+        (reactive/reconcile-resource-leases! cell cap1)
+        (drain-ticks! ticks))
+      (finally
+        (rf/unregister-listener! :trace ::supersede-on-first-ensure)))
+    (let [kinds          (mapv first @order)
+          release-owners (into [] (comp (filter #(= :release (first %)))
+                                        (map second))
+                               @order)]
+      (is (= [:ensure :ensure :release] kinds)
+          "the nested (A2) and outer (A1) ensures both enter FIFO before the
+           deferred release of the superseded owner")
+      (is (= 1 (count release-owners))
+          "exactly the one superseded owner is released")
+      (is (not (contains? @active (first release-owners)))
+          "the superseded owner A1 is not resurrected after A2 wins")
+      (is (= 1 (count @active))
+          "exactly the latest capture's owner remains active")
+      (is (= @active (set (keys (reactive/resource-held cell))))
+          "the live owner set matches the cell's held owners"))))


### PR DESCRIPTION
## Problem (rf2-vxgfnd.150)

`router/dispatch!` fires its synchronous `:rf.event/dispatched` trace listeners **before** it inserts the envelope and schedules the drain (see `re-frame.router/dispatch!`, the emit-then-enqueue seam). The prior rf2-vxgfnd.124 proof masked this: its dispatch stand-in records each event at *function entry*, so its `ensure, release` assertion proved handler-entry order, not router enqueue/handler order.

In production, if the first resource ensure's trace listener calls `reactive/teardown!`, teardown marks the cell dead, dispatches `release-owner(A)`, and discards its cleanup record **while the outer `ensure(A)` is not yet queued**. The nested release is inserted first; the outer ensure enters FIFO only after the listener returns:

```
actual production FIFO: release-owner(A), ensure(A)
```

One drain-to-quiescence runs `release(A)` as a no-op (A not attached yet), then `ensure(A)` attaches A onto the already-dead cell — a permanent leak. A capture-supersession listener similarly queues nested `ensure(A2), release(A1)` ahead of the outer `ensure(A1)`, resurrecting the superseded A1 after A2 has won.

## Fix

One outermost resource **ensure-enqueue fence** around the real `router/dispatch!` call path, in `implementation/ui/src/re_frame/ui/reactive.cljc`:

- The outermost ensure establishes a dynamic fence (`*resource-release-fence*`) around its `enqueue-ensure!`. While inside that pre-FIFO trace window, reentrant teardown/supersession releases **record their intent** instead of dispatching (`enqueue-release!`); nested ensures reuse the active fence and enter FIFO immediately.
- When the outermost ensure returns — every nested/outer ensure now actually in FIFO — the deferred releases flush in request order (`flush-deferred-releases!`), so no cleanup release can precede its owner's ensure envelope.
- The flush runs on the throw path too (`finally`, fence already unbound): an ensure-dispatch failure still compensates the deferred cleanup without pretending the owner was attached.

Router trace ordering is unchanged; no synchronous resource dispatch, no global transaction coordinator, no per-event render. Post-dispatch lifecycle/capture fencing is retained — it complements, not replaces, this queue-order fence. Every ensure now routes through `fenced-enqueue-ensure!`; every release through the fence-aware `enqueue-release!`.

## Quality gates

**Red-before-fix fixture:** `implementation/ui/test/re_frame/ui/resource_lease_enqueue_fence_cljs_test.cljc` — real router, real registrar-registered ensure/release owner-registry handlers, a real public synchronous `:trace` listener that tears down / supersedes on the first ensure, and a captured `interop/next-tick`. It asserts the actual drained handler order and net owner state.

- `reentrant-teardown-release-cannot-jump-ahead-of-its-ensure` — with the fence mutated away, drains `[:release :ensure]` and leaks owner A on the dead cell; with the fence, drains `[:ensure :release]` and A is clean.
- `reentrant-supersession-releases-cannot-jump-ahead-of-ensures` — with the fence mutated away, drains `[:ensure :release :ensure]` and resurrects A1; with the fence, drains `[:ensure :ensure :release]` and only the latest owner A2 survives.

Mutating the reconcile call site back to the unfenced `enqueue-ensure!` restores the exact failures above (verified).

Gates run green locally:
- `cd implementation/ui && clojure -M:test` — 493 tests, 0 failures (JVM)
- `cd implementation && npm run test:ui` — 493 tests, 0 failures
- `cd implementation && npm run test:cljs` — 9347 tests, 0 failures (node build incl. the real Resources artefact — confirms no id-registration collision)
- retired-spelling / thrown-error-message / ambient-durable-read source gates — clean
