### PR TITLE
fix(ui): root preflight evidence finalizes only on a real React commit (rf2-vxgfnd.248); .182 deferred-teardown fence surfaced as remainder

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -51,7 +51,8 @@
   ride the registry in dev only (goog.DEBUG — production carries no
   manifests, I-12); root-id and container ownership are load-bearing
   identity and stay in production."
-  (:require ["react-dom/client" :as rdc]
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
             [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.ui.digest-carrier :as digest-carrier]
@@ -441,10 +442,12 @@
   ns docstring).
 
   Returns the live executor's preflight-attempt RECEIPT (rf2-vxgfnd.139) — the
-  caller passes it to `frames/finalize-preflight-attempt!` once the host render
-  commits, or `frames/abort-preflight-attempt!` if the post-preflight boundary
-  throws. nil when there are no static plans, or when a capture-hook override
-  returns a non-receipt (both are no-ops at the boundary)."
+  caller renders it through the `root-commit-reporter`, which calls
+  `frames/finalize-preflight-attempt!` only when React COMMITS the render
+  (rf2-vxgfnd.248), and `frames/abort-preflight-attempt!` if the post-preflight
+  boundary throws SYNCHRONOUSLY (before React receives the element). nil when
+  there are no static plans, or when a capture-hook override returns a
+  non-receipt (both are no-ops at the boundary)."
   [root-id plans-thunk]
   (when plans-thunk
     (let [plans (plans-thunk)
@@ -471,6 +474,65 @@
     (when (some? on-recoverable)
       (unchecked-set o "onRecoverableError" on-recoverable))
     o))
+
+;; ---------------------------------------------------------------------------
+;; The host-commit reporter — preflight evidence finalizes on a REAL commit
+;; (rf2-vxgfnd.248)
+;; ---------------------------------------------------------------------------
+;;
+;; `ReactDOMRoot.render` SCHEDULES the update and can return BEFORE React lays
+;; out / commits it (react.dev/reference/react-dom/client/createRoot; the pinned
+;; react-dom routes `.render` to `updateContainerImpl`, which enqueues + schedules
+;; without a commit callback). A component that succeeds the element thunk but
+;; then THROWS during React's render is caught by the root's `onUncaughtError`
+;; and the commit is ABORTED — yet `.render` returned normally, so neither the
+;; synchronous mount rollback nor `abort-preflight-attempt!` runs. Finalizing the
+;; preflight attempt immediately after `.render` therefore records a COMMITTED
+;; root scope for a render that never committed (the rf2-vxgfnd.248 defect).
+;;
+;; The fix binds attempt settlement to an AUTHORITATIVE host commit signal, not
+;; the `.render` return: the rendered root element is wrapped in this transparent
+;; reporter, whose sole `useLayoutEffect` calls `frames/finalize-preflight-
+;; attempt!`. Layout effects run ONLY for COMMITTED renders — an ABANDONED render
+;; (StrictMode double-invoke, time-sliced tear-off) publishes no layout effect,
+;; and an ABORTED commit (an uncaught render throw with no error boundary)
+;; discards the whole root tree INCLUDING this reporter, so the effect never
+;; runs. The attempt is thus finalized IFF React actually committed it; a
+;; commit contained by an error boundary (a fallback DID commit) finalizes, as a
+;; committed root scope truthfully exists. `finalize-preflight-attempt!` is itself
+;; REV-GUARDED (frames/finalize-writes!) to the exact install-record revision the
+;; receipt captured, so a stale, duplicated, or replayed commit signal can never
+;; finalize a newer attempt or another root's evidence. No global `flushSync`:
+;; the only cost is one transparent wrapper + one layout effect per root render.
+
+(defn- root-commit-reporter
+  "React function component wrapping a root render (rf2-vxgfnd.248). Renders its
+  `children` unchanged and, in a `useLayoutEffect` keyed to the exact attempt
+  `rfReceipt`, finalizes that attempt at React's REAL commit boundary. Because
+  layout effects fire only for committed renders, an aborted/abandoned render
+  never finalizes; `finalize-preflight-attempt!`'s nil-receipt and rev guards
+  keep a no-plan render and a stale commit signal both harmless."
+  [^js props]
+  (let [receipt (.-rfReceipt props)]
+    (react/useLayoutEffect
+     (fn commit-report []
+       (frames/finalize-preflight-attempt! receipt)
+       js/undefined)
+     #js [receipt]))
+  (.-children props))
+
+(defn- render-attempt-element
+  "The exact element a root's `.render` receives for one attempt: the root
+  incarnation-provided `element` wrapped in the `root-commit-reporter` carrying
+  this attempt's `receipt`, so the preflight attempt finalizes only after React
+  commits this render (rf2-vxgfnd.248), never merely because `.render` returned.
+  `element-thunk` is still evaluated eagerly by the caller, so a synchronous
+  throw from it (a top-region provider naming an absent frame) still propagates
+  into the caller's rollback try/catch unchanged."
+  [receipt incarnation element]
+  (react/createElement root-commit-reporter
+                       #js {:rfReceipt receipt}
+                       (viewcell/provide-root-incarnation incarnation element)))
 
 ;; ---------------------------------------------------------------------------
 ;; The mount surface — runtime halves
@@ -504,12 +566,18 @@
   clobbering the inner root's entry (which the rollback would then delete,
   orphaning the inner root's live tree). Registration still precedes any
   render (contract §7 Layer 3);
-  if that FIRST render (element thunk or host `.render`) throws, the mount
-  rolls back TOTALLY — the exact claim is released and the host root is
-  best-effort unmounted, so a retry starts clean (no phantom live root),
-  and the original error is rethrown even if cleanup also throws. A failed
-  RE-render on an already-live root is the distinct case: the existing
-  root stays registered with its last committed render intact (Q49).
+  if that FIRST render throws SYNCHRONOUSLY (the element thunk, or host
+  `.render` before React receives the element), the mount rolls back TOTALLY
+  — the exact claim is released and the host root is best-effort unmounted, so
+  a retry starts clean (no phantom live root), and the original error is
+  rethrown even if cleanup also throws. Preflight evidence is finalized only
+  when React actually COMMITS the render, through the `root-commit-reporter`
+  wrapper (rf2-vxgfnd.248): a first render whose element thunk succeeds but
+  whose component throws during React's render (onUncaughtError aborts the
+  commit AFTER `.render` returned) is left uncommitted — never a phantom
+  committed root scope. A failed RE-render on an already-live root is the
+  distinct case: the existing root stays registered with its last committed
+  render intact (Q49).
   Returns the Root."
   [{:keys [root-id] :as info} container element-thunk react-opts plans-thunk]
   (require-root-creation-open! 're-frame.ui/mount)
@@ -536,13 +604,15 @@
             ;; never commit, and `.render`ing the stale handle would write into a
             ;; root the replacement now owns. Mirrors the fresh-path re-check.
             (require-live-root! root 're-frame.ui/mount)
+            ;; rf2-vxgfnd.139/.248: wrap the render in the host-commit reporter so
+            ;; the attempt's evidence is finalized (clear stale tags + mark
+            ;; committed) only when React actually COMMITS this render, never
+            ;; merely because `.render` returned. No rollback on this same-root
+            ;; path: the existing root stays registered with its last committed
+            ;; render intact even if this re-render never commits.
             (.render (.-react-root root)
-                     (viewcell/provide-root-incarnation
-                      (root-incarnation-of root-id) (element-thunk)))
-            ;; rf2-vxgfnd.139: the host render COMMITTED — finalize the attempt's
-            ;; evidence (clear stale tags + mark committed). No rollback on this
-            ;; same-root path: the existing root stays registered.
-            (frames/finalize-preflight-attempt! receipt)
+                     (render-attempt-element
+                      receipt (root-incarnation-of root-id) (element-thunk)))
             root
             (catch :default e
               ;; the re-render (or the post-preflight ownership fence) threw AFTER
@@ -592,12 +662,17 @@
               ;; root incarnation the provider below scopes every ViewCell to.
               (register-live-root! info container root)
               (try
+                ;; rf2-vxgfnd.139/.248: wrap the FIRST render in the host-commit
+                ;; reporter so the attempt's evidence binds to React's real
+                ;; COMMIT of this render, not the `.render` return. If the element
+                ;; thunk returns but a component then throws during React's render
+                ;; (onUncaughtError aborts the commit after `.render` returned),
+                ;; the reporter's layout effect never runs, so the fresh install is
+                ;; left uncommitted — never falsely recorded as a committed root
+                ;; scope for a render that never committed.
                 (.render react-root
-                         (viewcell/provide-root-incarnation
-                          (root-incarnation-of root-id) (element-thunk)))
-                ;; rf2-vxgfnd.139: the FIRST host render COMMITTED — bind the
-                ;; attempt's evidence to this boundary (clear + mark committed).
-                (frames/finalize-preflight-attempt! receipt)
+                         (render-attempt-element
+                          receipt (root-incarnation-of root-id) (element-thunk)))
                 root
                 (catch :default e
                   ;; TOTAL rollback of a failed FIRST mount — the element thunk
@@ -650,7 +725,11 @@
   descriptor-base with the Root's identity on the registry entry — the swap
   is IDENTITY-GUARDED to THIS exact Root, never merely the current entry
   under the same id, so it can never write the stale call's descriptor onto
-  a replacement root."
+  a replacement root. Preflight evidence is finalized only when React COMMITS
+  the render, through the `root-commit-reporter` wrapper (rf2-vxgfnd.248): a
+  re-render whose component throws during React's render (the commit aborts
+  after `.render` returned) leaves the prior committed record untouched — the
+  attempt is never falsely marked committed off a `.render` return."
   [^Root root element-thunk plans-thunk descriptor-base]
   (require-live-root! root 're-frame.ui/render!)
   (let [rid     (.-root-id root)
@@ -675,11 +754,13 @@
                                             :root-id rid
                                             :root-id-provenance (:provenance entry))))
                        m))))))
+      ;; rf2-vxgfnd.139/.248: wrap the render in the host-commit reporter so the
+      ;; attempt finalizes at React's real COMMIT of this render, not the
+      ;; `.render` return. A live root's re-render that never commits (an
+      ;; uncaught render throw) leaves its prior committed record untouched.
       (.render (.-react-root root)
-               (viewcell/provide-root-incarnation
-                (root-incarnation-of rid) (element-thunk)))
-      ;; rf2-vxgfnd.139: the host render COMMITTED — finalize the attempt.
-      (frames/finalize-preflight-attempt! receipt)
+               (render-attempt-element
+                receipt (root-incarnation-of rid) (element-thunk)))
       root
       (catch :default e
         ;; the post-preflight ownership fence, element thunk, or host render

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -242,6 +242,60 @@
         (is (nil? (:mount-incomplete entry)) "no incomplete-mount evidence")
         (is (nil? (:preflight-attempt-failed entry)) "no failed-attempt evidence")))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.248 — evidence finalizes only after a REAL React commit. The
+;; element thunk SUCCEEDS (React receives an element), then the component THROWS
+;; during React's initial render; React routes it to `onUncaughtError` and ABORTS
+;; the commit AFTER `.render` returned normally. The RED-BEFORE-FIX shape: the
+;; pre-fix runtime finalized immediately after `.render` returned, recording a
+;; committed root scope for a render that never committed. The commit reporter
+;; (rf2-vxgfnd.248) binds finalization to a real commit, so the aborted render
+;; publishes NO committed evidence. A mutation moving finalization back to
+;; immediately after `.render` deterministically fails this fixture.
+;; ---------------------------------------------------------------------------
+
+(defn- throwing-during-render
+  "A React function component that succeeds construction but THROWS while React
+  renders it — the exact shape `.render` cannot report through its return value."
+  [_props]
+  (throw (ex-info "render-phase boom (rf2-vxgfnd.248)" {:tag :render248})))
+
+(deftest render-abort-after-render-returns-does-not-finalize-committed
+  (when (browser?)
+    (reg-events!)
+    (let [c        (container)
+          captured (atom nil)
+          info     {:root-id :dom248/fresh :provenance :authored}
+          ;; element thunk RETURNS successfully — React receives a real element —
+          ;; whose component then throws during React's render.
+          element-thunk (fn [] (React/createElement throwing-during-render #js {}))
+          plans    (fn [] [{:frame-id :frame/commit248
+                            :config {:initial-events [[:test/set-db {:n 1}]]}
+                            :config-fingerprint "cf1-commit248aaaa"}])
+          ;; our own onUncaughtError REPLACES React's default (reportError), so
+          ;; the deliberate render throw is captured, not surfaced as an uncaught
+          ;; window error the browser runner rejects (rf2-mwx08).
+          opts     (client/root-options
+                    nil (fn [error _info] (reset! captured error)) nil nil)
+          ;; flushSync + act env OFF: React commits synchronously, and the
+          ;; render-phase throw is owned by onUncaughtError (act would surface it).
+          _        (flush-without-act!
+                    #(client/mount* info c element-thunk opts plans))]
+      (is (some? @captured)
+          (str "onUncaughtError fired — the component threw during React's render; "
+               "`.render` returned normally (mount* did not throw)"))
+      (is (some? (frame/frame :frame/commit248))
+          "preflight installed the frame, so an attempt receipt exists to finalize")
+      (let [entry (frames/installed-plan-entry :frame/commit248)]
+        (is (not (:committed entry))
+            (str "the ABORTED render must NOT be recorded as a committed root "
+                 "scope — finalization binds to a real React commit, not the "
+                 "`.render` return (rf2-vxgfnd.248)")))
+      ;; the root stays registered after an aborted commit (rf2-vxgfnd.87) — own
+      ;; and release its claim so no live-root leaks into the next test.
+      (act! #(some-> (:root (client/live-root-entry :dom248/fresh))
+                     client/unmount!*)))))
+
 (deftest committed-root-failed-refresh-preserves-committed-and-marks-attempt-failed
   ;; A genuinely committed root's failed REFRESH/re-render: the prior Root + its
   ;; last committed DOM are preserved (Q49), and only the failed attempt is


### PR DESCRIPTION
Client root lifecycle cluster (rf2-vxgfnd.248 / .182). Re-verified both repros against fresh `origin/main` first — both still reproduced structurally.

## rf2-vxgfnd.248 — preflight evidence finalizes only on a real React commit (DONE)

**Re-verification:** repro still holds on current main — `mount*` (both arms) and `render!*` called `frames/finalize-preflight-attempt!` immediately after `.render` returned. `.render` schedules; it can return before React commits, and a component that succeeds the element thunk but throws during React's render is routed to `onUncaughtError`, which aborts the commit *after* `.render` returned — so the fresh install was recorded `:committed` for a render that never committed.

**Fix:** the rendered root element is wrapped in a transparent `root-commit-reporter` whose sole `useLayoutEffect` calls `finalize-preflight-attempt!`. Layout effects run only for **committed** renders, so:
- a successful commit finalizes (an error-boundary-contained failure commits a fallback and finalizes truthfully);
- an aborted commit (uncaught render throw) or an abandoned render (StrictMode double-invoke, time-sliced tear-off) never finalizes;
- `finalize-preflight-attempt!` is rev-guarded in `frames`, so a stale/duplicated/replayed commit signal cannot finalize a newer attempt or another root's evidence.

No global `flushSync` — one transparent wrapper + one layout effect per root render; the frozen public API is unchanged. The synchronous-throw abort paths (element thunk / top-region provider) are untouched and still call `abort-preflight-attempt!`.

**Red-before-fix fixture:** `render-abort-after-render-returns-does-not-finalize-committed` (preflight_frame_wiring_dom_cljs_test) — a real React root whose element thunk returns then throws during render; proves `.render` returned, `onUncaughtError` fired, and the install record is NOT `:committed`. A mutation moving finalization back to immediately after `.render` deterministically fails it. (The positive commit path stays covered by `successful-mount-commits-the-frame-record`.)

**Spec ripple (follow-up):** Spec 004C §2 / Spec 009 attempt-evidence prose already describes finalization at "the host commit boundary" — now literally a React commit signal, not the `.render` return. No wording change was required, but the `root-commit-reporter` mechanism is a candidate cross-reference for a future Spec 004C editorial pass.

## rf2-vxgfnd.182 — fence ownership through deferred/failed teardown (REMAINDER — needs a reactive.cljc settlement signal)

**Re-verification:** repro still holds on current main. Confirmed against the pinned react-dom 19.2 source: `ReactDOMRoot.unmount` nulls `_internalRoot`, clears the container marker, enqueues a SyncLane teardown, and `flushSyncWork` **no-ops while React is rendering** (`react-dom-client.development.js:27902-27913`, `:16896-16900`) — so a render-phase `unmount!` returns normally with teardown DEFERRED to a microtask React schedules during `.unmount` (`scheduleImmediateRootScheduleTask` → `scheduleMicrotask` = `queueMicrotask`, `:18979-18992`). `unmount!*` currently releases the claim in a `finally`, so a same-stack reentrant mount is admitted, a second root is created on the same container, and the deferred teardown then erases it.

**Why this is not deliverable under a client.cljs-only scope:** a correct fence must **distinguish a DEFERRED teardown from a SYNCHRONOUS one** — because a synchronous unmount completes teardown during `.unmount`, making an immediate same-container remount safe. That legitimate pattern is a ratified, tested behaviour: `unmount-tears-down-and-frees-identity` (root_mount_dom_cljs_test) does a same-stack unmount → remount on the same container/root-id and asserts success. A uniform "fence every unmount for a settlement microtask" approach (prototyped, then reverted) rejects that remount and breaks the test (`act!` does not flush a `js/queueMicrotask` release). The bead's own repro is the SAME shape but must be *rejected* — the only difference is deferred-vs-synchronous.

Deferred-vs-synchronous is observable only at `reactive/teardown-root!`'s collection window (whether each ViewCell's effect-cleanup fired during `.unmount`, or the cells stayed `:connected`) — i.e. in **reactive.cljc**, which is outside this worker's edit scope; my brief mandates STOP-and-report if the fix needs it. Per the scope fence I did not ship a heuristic client-only fence with an unproven release boundary.

**What IS proven and ready for the reactive-aware follow-up:** the settlement boundary itself is reachable — a `js/queueMicrotask` scheduled *after* `.unmount` returns is FIFO-ordered after React's own teardown microtask (queued during `.unmount`), so for a synchronous render-phase unmount the deferred teardown has provably run by the time the fence would release. The missing piece is only the deferred-vs-synchronous discriminator from `reactive/teardown-root!`. Minimal shape: `teardown-root!` reports whether the root's connected cells were reaped synchronously; `unmount!*` releases immediately when they were, else fences (move the claim to a `:tearing-down` registry, reject reentrant `mount*`/`create-root*`/hydrate on the exact root-id/container, release on the settlement microtask). This does NOT re-scope .18's AC4 (the throwing-`.unmount` path keeps its immediate release) and needs no new error id (reuse `:rf.error/root-container-in-use` / `:rf.error/duplicate-root-id` — a new id would need a Spec 009 catalogue row, spec/ being out of scope).

The secondary ACs (AC5 failed-first-mount rollback cleanup-error reporting; AC6 diagnostic honesty re "innerHTML is not React teardown") are client-only but were held to land *with* the core fence in one coherent reactive-aware .182 fix rather than split across PRs.

**Recommendation to the mayor:** re-scope/redispatch .182 to a worker with reactive.cljc in scope, carrying the settlement-boundary + discriminator design above. No AC4 re-scope was triggered.

## Quality gates
- `npm run test:ui` (node runtime): **494 tests / 2479 assertions / 0 failures**
- `npm run test:browser` (Playwright, real react-dom): **352 tests / 1908 assertions / 0 failures** (includes the new .248 fixture)
- `implementation/ui` JVM (`clojure -M:test`): **492 tests / 6335 assertions / 0 failures**
- `scripts/test-fast-pr.sh`: **PASS** (all spine gates green; mkdocs soft-skipped on Windows)
- Build: 0 warnings.
