### PR TITLE
fix(core): structural-delivery scope must not taint listener-triggered work; honest delayed epoch fan-out after same-id rearm (rf2-vf2qke/vxgfnd.245)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -549,7 +549,23 @@
   `:trace.tooling/deliver!` hook published by `re-frame.trace.tooling`.
   The tooling hook is unregistered in production (the tooling sibling
   ns is not loaded) — the lookup returns nil and the fan-out is
-  skipped. Per Spec 009 §Listener invocation rules and rf2-qwm0a."
+  skipped. Per Spec 009 §Listener invocation rules and rf2-qwm0a.
+
+  Structural-delivery scope is a property of the CURRENT outer envelope,
+  NOT ambient authority for the external callbacks it fans out to
+  (rf2-vf2qke). By the time the public tooling listener fan-out runs, every
+  structural decision has already been consumed against THIS envelope:
+  epoch capture was gated above, frame-no-emit was gated in `emit!` /
+  `emit-error!`, and the outer ring-retention decision is captured here into
+  `retain?` and passed explicitly to the tooling hook for the outer ring
+  push. So the fan-out restores ordinary delivery defaults: a listener that
+  reacts to A's structural terminal fact by dispatching or emitting its OWN
+  legitimate nested work into a same-id successor B or an unrelated frame C
+  must run that work under NORMAL scope — normal epoch capture, its own
+  frame-no-emit policy, and normal per-frame ring retention — rather than
+  inheriting A's retentionless/no-capture/no-policy scope. A listener that
+  explicitly re-requests structural semantics via
+  `call-with-structural-delivery` re-binds the flags false and is honoured."
   [event]
   (when (and *epoch-capture-enabled?* (continuing?))
     (deliver-to-epoch-capture! event))
@@ -557,13 +573,21 @@
   ;; A, do not deliver the same stale event into tooling/rings/listeners.
   (when (continuing?)
     (when-let [deliver-tooling (late-bind/get-fn-cached :trace.tooling/deliver!)]
-      (try
-        ;; `*ring-retention-enabled?*` rides through so the tooling hook
-        ;; skips the per-frame ring push under retentionless structural
-        ;; delivery while still fanning out to live listeners (rf2-vxgfnd.244).
-        (deliver-tooling event continuing? *ring-retention-enabled?*)
-        (catch #?(:clj Throwable :cljs :default) e
-          (when (continuing?) (throw e)))))))
+      ;; Capture the outer envelope's ring-retention decision BEFORE restoring
+      ;; ordinary defaults, then pass it explicitly for the outer ring push. The
+      ;; tooling hook (in the sibling ns, which cannot see these vars) reads
+      ;; `retain?` from the argument, not the dynamic var — so restoring the
+      ;; flags to their ordinary defaults around the whole call leaves the outer
+      ;; ring push governed by the captured structural decision while any
+      ;; listener-triggered nested emit runs under normal scope (rf2-vf2qke).
+      (let [retain? *ring-retention-enabled?*]
+        (binding [*epoch-capture-enabled?*  true
+                  *frame-policy-enabled?*   true
+                  *ring-retention-enabled?* true]
+          (try
+            (deliver-tooling event continuing? retain?)
+            (catch #?(:clj Throwable :cljs :default) e
+              (when (continuing?) (throw e)))))))))
 
 (defn- hoist-projected-sensitive
   "Hoist a classification-projection-stamped `[:tags :sensitive?]` up to

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -758,6 +758,125 @@
         (when (frame/frame id) (frame/destroy-frame! id))
         (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)))))
 
+;; ---- rf2-vf2qke — structural scope must not taint listener-triggered work ----
+;;
+;; #5865 binds the structural-delivery flags (epoch-capture / frame-policy /
+;; ring-retention all false) around the WHOLE synchronous outer emit, and the
+;; public tooling listener fan-out runs INSIDE that scope. A listener reacting to
+;; A's real structural terminal fact that dispatches its OWN legitimate work into
+;; unrelated frame C (or a same-id successor B) had that nested cascade INHERIT
+;; A's retentionless/no-capture/no-policy scope: it streamed live but bypassed
+;; C's epoch capture, C's own ring retention, and C's frame-no-emit policy. The
+;; fix restores ordinary delivery defaults around the fan-out while the outer
+;; ring push keeps the captured structural retention decision. Merged fixtures
+;; used PASSIVE atom listeners and missed this; these use DISPATCHING listeners.
+
+(deftest listener-dispatch-during-structural-terminal-fact-runs-under-normal-scope
+  ;; rf2-vf2qke (red before fix). Idle frame A (observed by an epoch listener) is
+  ;; destroyed at TOP LEVEL — emitting its terminal
+  ;; :rf.epoch.cb/silenced-on-frame-destroy fact under retentionless structural
+  ;; delivery, with no drain on the stack so the fan-out is live (continuing?
+  ;; true). A public trace listener reacts to that fact by dispatching a
+  ;; legitimate ordinary event into UNRELATED frame C. Before the fix C's cascade
+  ;; ran under A's inherited structural scope: C's epoch capture was disabled (no
+  ;; record) and C's ring retention was off (empty ring), even though C's db
+  ;; still committed and its events streamed live. After the fix C's nested work
+  ;; is captured and retained normally.
+  ;;
+  ;; Mutation tooth: NOT restoring ordinary defaults around the fan-out (leaving
+  ;; the ambient structural bindings in force for the callbacks) empties C's epoch
+  ;; history and trace ring and fails this fixture.
+  (let [a-id   :vf2qke/terminal-a
+        c-id   :vf2qke/nested-c
+        fired? (atom false)
+        c-live (atom [])]
+    (rf/make-frame {:id c-id})
+    (rf/reg-event :vf2qke/c-event
+      (fn [{:keys [db]} _] {:db (assoc db :c :ran)}))
+    (rf/make-frame {:id a-id})
+    (rf/reg-event :vf2qke/seed (fn [_ _] {:db {:n 0}}))
+    ;; An epoch observer so A's destroy fans a real structural terminal fact.
+    (rf/register-listener! :epoch ::vf2qke-a-obs (fn [_] nil))
+    (rf/dispatch-sync [:vf2qke/seed] {:frame a-id})
+    ;; The dispatching public listener: on A's structural terminal fact, run
+    ;; ordinary nested work into unrelated C exactly once.
+    (rf/register-listener! :trace ::vf2qke-dispatcher
+      (fn [ev]
+        (when (and (= a-id (get-in ev [:tags :frame]))
+                   (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                   (compare-and-set! fired? false true))
+          (rf/dispatch-sync [:vf2qke/c-event] {:frame c-id}))))
+    ;; A raw trace listener capturing C's own run events (proves live delivery).
+    (rf/register-listener! :trace ::vf2qke-c-live
+      (fn [ev]
+        (when (= c-id (get-in ev [:tags :frame]))
+          (swap! c-live conj ev))))
+    (try
+      (rf/destroy-frame! a-id)
+      (executor-barrier!)
+      (is (true? @fired?)
+          "the listener saw A's structural terminal fact and dispatched")
+      ;; UNRELATED C: nested work captured into C's epoch history + retained in
+      ;; C's ring, and it actually ran and streamed live.
+      (is (= 1 (count (rf/epoch-history c-id)))
+          "C's listener-triggered cascade is captured into C's epoch history")
+      (is (= {:c :ran} (frame/frame-app-db-value c-id))
+          "C's nested event actually ran and committed")
+      (is (seq (rf/trace-buffer c-id {:flat true}))
+          "C's listener-triggered cascade is retained in C's per-frame ring")
+      (is (seq @c-live) "C's nested events streamed live to listeners")
+      (finally
+        (rf/unregister-listener! :epoch ::vf2qke-a-obs)
+        (rf/unregister-listener! :trace ::vf2qke-dispatcher)
+        (rf/unregister-listener! :trace ::vf2qke-c-live)
+        (when (frame/frame a-id) (frame/destroy-frame! a-id))
+        (when (frame/frame c-id) (frame/destroy-frame! c-id))))))
+
+(deftest listener-triggered-work-obeys-nested-frame-no-emit-policy
+  ;; rf2-vf2qke (red before fix). A listener reacting to A's structural terminal
+  ;; fact dispatches into a nested frame D that declared its OWN
+  ;; :rf.trace/frame-no-emit? policy. That policy must apply to D's nested work:
+  ;; before the fix the ambient structural scope disabled frame-policy for the
+  ;; callback, so D's events leaked to listeners despite D's no-emit policy.
+  (let [a-id   :vf2qke/policy-a
+        d-id   :vf2qke/nested-noemit-d
+        fired? (atom false)
+        d-live (atom [])]
+    (rf/make-frame {:id d-id :rf.trace/frame-no-emit? true})
+    (rf/reg-event :vf2qke/d-event
+      (fn [{:keys [db]} _] {:db (assoc db :d :ran)}))
+    (rf/make-frame {:id a-id})
+    (rf/reg-event :vf2qke/policy-seed (fn [_ _] {:db {:n 0}}))
+    (rf/register-listener! :epoch ::vf2qke-policy-obs (fn [_] nil))
+    (rf/dispatch-sync [:vf2qke/policy-seed] {:frame a-id})
+    (rf/register-listener! :trace ::vf2qke-policy-dispatcher
+      (fn [ev]
+        (when (and (= a-id (get-in ev [:tags :frame]))
+                   (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                   (compare-and-set! fired? false true))
+          (rf/dispatch-sync [:vf2qke/d-event] {:frame d-id}))))
+    (rf/register-listener! :trace ::vf2qke-d-live
+      (fn [ev]
+        (when (= d-id (get-in ev [:tags :frame]))
+          (swap! d-live conj ev))))
+    (try
+      (rf/destroy-frame! a-id)
+      (executor-barrier!)
+      (is (true? @fired?) "the listener dispatched into the no-emit frame D")
+      (is (= {:d :ran} (frame/frame-app-db-value d-id))
+          "D's nested event ran and committed (no-emit suppresses TRACE, not work)")
+      ;; D's own no-emit policy applies to the nested work: no D traces leak.
+      (is (empty? @d-live)
+          "D's frame-no-emit policy suppresses its nested trace — no leak to listeners")
+      (is (empty? (rf/trace-buffer d-id {:flat true}))
+          "no D trace is retained under D's own no-emit policy")
+      (finally
+        (rf/unregister-listener! :epoch ::vf2qke-policy-obs)
+        (rf/unregister-listener! :trace ::vf2qke-policy-dispatcher)
+        (rf/unregister-listener! :trace ::vf2qke-d-live)
+        (when (frame/frame a-id) (frame/destroy-frame! a-id))
+        (when (frame/frame d-id) (frame/destroy-frame! d-id))))))
+
 (deftest owner-loss-unwinds-only-entered-authored-afters
   ;; Mutation tooth: removing execute-chain's continuation predicate would run
   ;; :never/before and the handler after :killer/before destroys A. Removing

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -617,8 +617,13 @@
     (rf/reg-event :destroy/ring-b-settle
       (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
     (rf/make-frame {:id id})
-    ;; A accrues an observer by settling one ordinary event, so its destroy
-    ;; fans a :rf.epoch.cb/silenced-on-frame-destroy terminal fact too.
+    ;; A accrues an observer by settling one ordinary event. Because same-id B
+    ;; then SETTLES (claiming the id-keyed stores and re-arming this observer with
+    ;; B's record), A's silencing fan for the observer is honestly SUPPRESSED
+    ;; under rf2-vxgfnd.245 — the observer is live on B, so B silences it on B's
+    ;; own destroy, not A. A's :rf.epoch/snapshotted / :rf.epoch/outcome trailers
+    ;; still fire (they are A's unconditional terminal evidence) and pin the RING
+    ;; boundary this #5865 fixture exists for.
     (rf/register-listener! :epoch a-observer (fn [_] nil))
     (rf/dispatch-sync [:destroy/ring-a-settle] {:frame id})
     ;; Global live trace listener — captures A's frame-tagged terminal facts.
@@ -689,11 +694,17 @@
                                         (= :blocked (get-in % [:tags :outcome])))
                                   @global-facts)))
               "A's :blocked outcome reaches the global listener once")
-          (is (= 1 (count (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
-                                           (:operation %))
-                                        (= a-observer (get-in % [:tags :cb-id])))
-                                  @global-facts)))
-              "A's silencing fact for its observer reaches the global listener once")
+          ;; rf2-vxgfnd.245: A's silencing fan for its observer is SUPPRESSED —
+          ;; same-id B claimed the id and re-armed the observer with B's record,
+          ;; so the observer is live on B (B silences it on B's own destroy). A
+          ;; publishing a bare silencing here would falsely claim the observer
+          ;; went silent. A's other terminal facts (snapshotted / outcome) still
+          ;; fire above and demonstrate the retentionless-vs-global boundary.
+          (is (empty? (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                        (:operation %))
+                                    (= a-observer (get-in % [:tags :cb-id])))
+                              @global-facts))
+              "A's silencing for its observer is suppressed after B re-armed it (rf2-vxgfnd.245)")
 
           ;; B stays live and keeps settling normally.
           (is (identical? token-b (frame/frame-incarnation-token id))
@@ -757,6 +768,171 @@
         (rf/unregister-listener! :trace ::ring-snap-warn)
         (when (frame/frame id) (frame/destroy-frame! id))
         (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)))))
+
+;; ---- rf2-vxgfnd.245 — honest delayed epoch fan-out after same-id rearm -------
+;;
+;; #5850 snapshots predecessor A's `silenced-cbs` before dissoc and later
+;; PUBLISHES that saved set UNCONDITIONALLY — even when a same-id B has claimed
+;; the epoch stores and the same current listener generation has already received
+;; B's newer record and been re-armed. That makes A emit a bare
+;; :rf.epoch.cb/silenced-on-frame-destroy claiming a callback went silent when it
+;; is in fact live on B (and B re-emits the identical unqualified signal on its
+;; own later destroy). The fix gates A's silencing fan on A still winning its
+;; compare-owned cleanup — equivalently, on no successor having re-armed the
+;; id-keyed observation state. A's required halted record/trailers stay
+;; unconditional (rf2-vxgfnd.151); only the silencing fan is gated.
+
+(deftest predecessor-silencing-fan-suppressed-after-successor-rearm
+  ;; rf2-vxgfnd.245 (red before fix). A settles (cb observes A + A claims the
+  ;; id-keyed stores), A self-destroys mid-drain and pauses at its POST-DISSOC
+  ;; epoch hook (silenced-cbs — including cb — already snapshotted before dissoc).
+  ;; Same-id B is created and SETTLES an ordinary event: B claims the stores and
+  ;; the unchanged cb generation receives B's :ok record, re-arming it for the
+  ;; reused id. When A resumes, its silencing fan for cb must be SUPPRESSED (B
+  ;; owns the id; cb is live on B). The listener keeps receiving B's records, and
+  ;; when B later destroys, exactly ONE truthful silencing for cb fires.
+  ;;
+  ;; Before the fix A published its stale snapshot unconditionally: a bare A
+  ;; silencing for cb fired even though cb is live on B (and B's later destroy
+  ;; fired a second identical one).
+  (let [id             :vxgfnd245/rearm
+        cb             ::vxgfnd245-cb
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        received       (atom [])
+        silencings     (atom [])
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :vxgfnd245/a-settle
+      (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :vxgfnd245/a-destroy
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/reg-event :vxgfnd245/b-settle
+      (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
+    (rf/make-frame {:id id})
+    ;; cb observes A by settling one ordinary event; A claims the id-keyed stores.
+    (rf/register-listener! :epoch cb (fn [r] (swap! received conj r)))
+    (rf/dispatch-sync [:vxgfnd245/a-settle] {:frame id})
+    (rf/register-listener! :trace ::vxgfnd245-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:vxgfnd245/a-destroy] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A is paused at its post-dissoc epoch hook (silenced-cbs already
+             snapshotted incl cb)")
+        ;; Same-id B settles: claims stores + re-arms cb for the reused id.
+        (rf/make-frame {:id id})
+        (rf/dispatch-sync [:vxgfnd245/b-settle] {:frame id})
+        (is (= 2 (count @received))
+            "cb received A's settle and B's settle — re-armed for the reused id")
+        ;; A resumes and reaches its terminal publish while B owns the stores.
+        (.countDown release-a)
+        (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+            "A's terminal recipe completes")
+        (executor-barrier!)
+        ;; THE FIX: A's silencing fan for cb is suppressed — cb is live on B.
+        (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
+            "no bare A silencing for cb after B claimed the id and re-armed it")
+        ;; A's HISTORICAL halted-destroy record is still delivered to cb — the
+        ;; .151 record-delivery contract is unchanged by .245 (only the silencing
+        ;; fan is gated). cb remains live on B: an extra B settle reaches it.
+        (let [before-extra (count @received)]
+          (rf/dispatch-sync [:vxgfnd245/b-settle] {:frame id})
+          (is (= (inc before-extra) (count @received))
+              "cb continues to receive B's records after A resumed — it is live on B"))
+        ;; When B (where cb IS live) destroys, exactly one truthful silencing.
+        (rf/destroy-frame! id)
+        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+            "exactly one truthful silencing for cb — fired by B's own destroy"))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd245-silencing)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
+(deftest predecessor-silencing-honours-new-generation-registered-in-gap
+  ;; rf2-vxgfnd.245 (red before fix). The re-register-in-the-gap case: cb observes
+  ;; A, A self-destroys mid-drain and pauses; during the pause cb is REPLACED by a
+  ;; NEW generation and same-id B settles (the new cb generation receives B's
+  ;; record and is re-armed). A's stale snapshot silencing must not fire against
+  ;; the reused id: cb is live (new generation) on B. B's later destroy emits
+  ;; exactly one truthful silencing for the new generation.
+  (let [id             :vxgfnd245/regen
+        cb             ::vxgfnd245-regen-cb
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        old-received   (atom 0)
+        new-received   (atom 0)
+        silencings     (atom [])
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :vxgfnd245/regen-a-settle
+      (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :vxgfnd245/regen-a-destroy
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/reg-event :vxgfnd245/regen-b-settle
+      (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
+    (rf/make-frame {:id id})
+    (rf/register-listener! :epoch cb (fn [_] (swap! old-received inc)))
+    (rf/dispatch-sync [:vxgfnd245/regen-a-settle] {:frame id})
+    (rf/register-listener! :trace ::vxgfnd245-regen-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:vxgfnd245/regen-a-destroy] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A paused post-dissoc")
+        ;; Replace cb with a NEW generation in the gap, then B settles.
+        (rf/register-listener! :epoch cb (fn [_] (swap! new-received inc)))
+        (rf/make-frame {:id id})
+        (rf/dispatch-sync [:vxgfnd245/regen-b-settle] {:frame id})
+        (is (= 1 @new-received)
+            "the NEW cb generation received B's settled record")
+        (.countDown release-a)
+        (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+            "A's terminal recipe completes")
+        (executor-barrier!)
+        (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
+            "A's stale snapshot never silences the reused id after a gap re-register")
+        ;; A delivers its HISTORICAL halted record to its OWN snapshot generation
+        ;; (the old callback captured pre-dissoc), NOT the new one. So the old
+        ;; callback saw A-settle + A's halted record; the new generation was
+        ;; invoked only by B — A never invokes the new generation (rf2-vxgfnd.245
+        ;; pins old/new behaviour).
+        (is (= 2 @old-received)
+            "the old cb generation received A's settle + A's historical halted record")
+        (is (= 1 @new-received)
+            "A never invoked the new cb generation — only B's settle reached it")
+        ;; B destroys → exactly one truthful silencing for the live new generation.
+        (rf/destroy-frame! id)
+        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+            "exactly one truthful silencing for the new generation on B's destroy"))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd245-regen-silencing)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
 
 ;; ---- rf2-vf2qke — structural scope must not taint listener-triggered work ----
 ;;

--- a/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
@@ -90,6 +90,112 @@
           (trace-tooling/clear-trace-rings!)
           (trace/clear-listeners!))))))
 
+;; ---- rf2-vf2qke — structural scope must not taint listener-triggered work ----
+;;
+;; #5865 binds the structural-delivery flags (epoch-capture / frame-policy /
+;; ring-retention all false) around the ENTIRE synchronous outer emit — but the
+;; public tooling listener fan-out runs INSIDE that dynamic scope. A listener
+;; reacting to A's structural terminal fact that performs its own legitimate
+;; nested emission (a direct `emit!` or a `dispatch`) into another frame C or
+;; same-id successor B had that nested work INHERIT A's retentionless scope: it
+;; streamed live but was never retained in C's own ring, never captured, and
+;; bypassed C's own frame-no-emit policy. The merged fixtures above use PASSIVE
+;; atom listeners and miss this — the taint only manifests when a listener EMITS.
+;;
+;; The fix captures the outer envelope's structural decisions BEFORE the listener
+;; fan-out (the outer ring push already received the captured retain?), then
+;; restores ordinary delivery defaults while invoking the public tooling
+;; listeners, so a listener's own emitted work runs under normal scope. An
+;; explicitly nested `call-with-structural-delivery` can still re-request
+;; structural semantics.
+
+(deftest listener-triggered-nested-emit-runs-under-normal-scope
+  (testing "a public listener reacting to A's structural terminal fact that emits
+            legitimate nested work into unrelated frame C: the nested emit gets
+            NORMAL ring retention, not A's outer retentionless scope (rf2-vf2qke)"
+    ;; Mutation tooth: restoring the ambient structural bindings during the
+    ;; listener fan-out (i.e. NOT restoring ordinary defaults) leaves C's nested
+    ;; emit retentionless and this fixture fails — C's ring stays empty.
+    (let [a-fid :rf2-vf2qke/a-frame
+          a-did :rf2-vf2qke/a-run
+          c-fid :rf2-vf2qke/c-frame
+          c-did :rf2-vf2qke/c-run
+          live  (atom [])
+          fired? (atom false)]
+      (trace/clear-listeners!)
+      (trace-tooling/clear-trace-rings!)
+      ;; A public tooling listener that, on seeing A's structural terminal fact,
+      ;; performs legitimate nested work: a direct public emit! into UNRELATED
+      ;; frame C carrying C's own dispatch-id. That nested emit is ordinary work,
+      ;; not part of A's structural delivery, so it must land in C's ring.
+      (trace/register-listener! ::vf2qke-dispatcher
+        (fn [ev]
+          (swap! live conj ev)
+          (when (and (= :rf2-vf2qke/a-structural (:operation ev))
+                     (compare-and-set! fired? false true))
+            (trace/emit! :test :rf2-vf2qke/c-nested
+                         {:frame c-fid :rf.trace/dispatch-id c-did}))))
+      (try
+        (is (empty? (flat c-fid)) "C has no ring before A's terminal fact")
+        ;; A emits its terminal fact under retentionless structural delivery.
+        (trace/call-with-structural-delivery
+          #(trace/emit! :test :rf2-vf2qke/a-structural
+                        {:frame a-fid :rf.trace/dispatch-id a-did}))
+        ;; A's structural fact reached listeners once and is never retained.
+        (is (= 1 (count (filter #(= :rf2-vf2qke/a-structural (:operation %)) @live)))
+            "A's structural fact reached the listener exactly once")
+        (is (empty? (filter #(= :rf2-vf2qke/a-structural (:operation %)) (flat a-fid)))
+            "A's structural fact is NOT retained in A's ring")
+        ;; THE FIX: C's listener-triggered nested emit IS retained in C's ring —
+        ;; legitimate nested work runs under normal (non-structural) scope.
+        (is (= 1 (count (flat c-fid)))
+            "C's listener-triggered nested emit is retained in C's ring")
+        (is (= :rf2-vf2qke/c-nested (:operation (first (flat c-fid))))
+            "C's ring holds exactly the nested emit")
+        ;; And the nested emit reached the live stream too.
+        (is (some #(= :rf2-vf2qke/c-nested (:operation %)) @live)
+            "the nested emit also streamed live")
+        (finally
+          (trace/unregister-listener! ::vf2qke-dispatcher)
+          (trace-tooling/clear-trace-rings!)
+          (trace/clear-listeners!))))))
+
+(deftest explicitly-nested-structural-delivery-stays-retentionless
+  (testing "a listener that itself re-requests structural delivery for its nested
+            emit keeps retentionless semantics — restoring ordinary defaults for
+            the fan-out does not defeat an explicit nested request (rf2-vf2qke)"
+    (let [a-fid :rf2-vf2qke/a2-frame
+          a-did :rf2-vf2qke/a2-run
+          c-fid :rf2-vf2qke/c2-frame
+          c-did :rf2-vf2qke/c2-run
+          live  (atom [])
+          fired? (atom false)]
+      (trace/clear-listeners!)
+      (trace-tooling/clear-trace-rings!)
+      (trace/register-listener! ::vf2qke-structural-dispatcher
+        (fn [ev]
+          (swap! live conj ev)
+          (when (and (= :rf2-vf2qke/a2-structural (:operation ev))
+                     (compare-and-set! fired? false true))
+            ;; The listener EXPLICITLY requests structural delivery for its own
+            ;; nested emit — which must stay retentionless despite the fan-out
+            ;; running under restored ordinary defaults.
+            (trace/call-with-structural-delivery
+              #(trace/emit! :test :rf2-vf2qke/c2-nested
+                            {:frame c-fid :rf.trace/dispatch-id c-did})))))
+      (try
+        (trace/call-with-structural-delivery
+          #(trace/emit! :test :rf2-vf2qke/a2-structural
+                        {:frame a-fid :rf.trace/dispatch-id a-did}))
+        (is (some #(= :rf2-vf2qke/c2-nested (:operation %)) @live)
+            "the explicitly-structural nested emit still streamed live")
+        (is (empty? (flat c-fid))
+            "the explicitly-nested structural emit is NOT retained in C's ring")
+        (finally
+          (trace/unregister-listener! ::vf2qke-structural-dispatcher)
+          (trace-tooling/clear-trace-rings!)
+          (trace/clear-listeners!))))))
+
 (deftest error-emit-under-structural-delivery-is-also-retentionless
   (testing "emit-error! honours the retentionless boundary too (terminal diagnostics)"
     ;; A's terminal diagnostics (`:rf.epoch.cb/listener-exception`,

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -348,22 +348,35 @@
                          frame-id fs-before fs-after committed-at)))
   ([frame-id owner-token terminal-evidence]
    (when interop/debug-enabled?
-     (let [{:keys [record listener-snapshot silenced-cbs]} terminal-evidence]
-       ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
-       ;; same-id B has already claimed them, this no-ops and leaves B untouched.
-       (state/cleanup-frame-owner!
-         frame-id owner-token
-         (fn []
-           ;; Data-only exact-owner transaction: no external callback runs
-           ;; between owner comparison and the complete drop.
-           (state/drop-frame-observation! frame-id)
-           (state/drop-frame-history! frame-id)
-           (state/drop-frame-buffer! frame-id)
-           (state/drop-last-settled-epoch! frame-id)
-           (state/drop-frame-mount-attribution! frame-id)
-           true))
-       ;; Publish A's terminal facts regardless of the cleanup comparison — the
-       ;; evidence was snapshotted before dissoc and belongs to A's incarnation.
+     (let [{:keys [record listener-snapshot silenced-cbs]} terminal-evidence
+           ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If
+           ;; a same-id B has already claimed them, this no-ops and leaves B
+           ;; untouched. The return value records whether A STILL WON its
+           ;; compare-owned cleanup: `cleanup-fn` returns true when A owned the
+           ;; stores (or no epoch state was ever claimed), nil when a successor B
+           ;; has already claimed them. That truth is exactly "no successor has
+           ;; re-armed the id-keyed observation state" (a successor claims by
+           ;; SETTLING, which fans its record to — and thereby re-arms — every
+           ;; live-generation observer of the reused id), so it gates A's
+           ;; silencing fan below (rf2-vxgfnd.245).
+           a-won-cleanup?
+           (state/cleanup-frame-owner!
+             frame-id owner-token
+             (fn []
+               ;; Data-only exact-owner transaction: no external callback runs
+               ;; between owner comparison and the complete drop.
+               (state/drop-frame-observation! frame-id)
+               (state/drop-frame-history! frame-id)
+               (state/drop-frame-buffer! frame-id)
+               (state/drop-last-settled-epoch! frame-id)
+               (state/drop-frame-mount-attribution! frame-id)
+               true))]
+       ;; Publish A's terminal RECORD + trailers regardless of the cleanup
+       ;; comparison — the evidence was snapshotted before dissoc and belongs to
+       ;; A's incarnation (rf2-vxgfnd.151). A late predecessor terminal record may
+       ;; arrive after a newer same-id epoch; it is HISTORICAL and consumers must
+       ;; not treat it as the successor's current ring/focus (Spec 009 / Tool-Pair
+       ;; late-record consumer rule).
        (when record
          ;; Same detailed/coarse trailer pair as normal commits, delivered
          ;; structurally: excluded from capture ownership and immune to a same-id
@@ -372,9 +385,19 @@
            #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                                 (:event-id record) :halted-destroy))
          (deliver-listener-snapshot! record listener-snapshot))
-       (doseq [cb-id silenced-cbs]
-         ;; The silencing fact belongs to destroyed A too; never let a same-id
-         ;; successor's trace policy suppress or capture it.
-         (trace/call-with-structural-delivery
-           #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                         {:frame frame-id :cb-id cb-id})))))))
+       ;; The SILENCING fan is HONEST only when A still wins its compare-owned
+       ;; cleanup. If a same-id successor B has claimed the id-keyed stores, the
+       ;; same current listener generation already received B's newer record and
+       ;; is re-armed — so a bare A `:silenced-on-frame-destroy` would falsely
+       ;; claim a callback that is LIVE on B went silent (and B's own later
+       ;; destroy re-emits the identical unqualified signal). Gating on
+       ;; `a-won-cleanup?` republishes A's silencing ONLY when no successor
+       ;; re-armed the observation state; B silences those callbacks itself when B
+       ;; is destroyed (rf2-vxgfnd.245).
+       (when a-won-cleanup?
+         (doseq [cb-id silenced-cbs]
+           ;; The silencing fact belongs to destroyed A too; never let a same-id
+           ;; successor's trace policy suppress or capture it.
+           (trace/call-with-structural-delivery
+             #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                           {:frame frame-id :cb-id cb-id}))))))))

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -45,6 +45,10 @@
             [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
+            ;; rf2-vxgfnd.245 — the reentrant CLJS fail-before fixture wraps the
+            ;; `:epoch/on-frame-destroyed` late-bind hook to install + settle a
+            ;; same-id successor synchronously inside A's terminal publish.
+            [re-frame.late-bind :as late-bind]
             ;; rf2-lo28u — schemas + the Malli adapter so a `:schema`-bearing
             ;; reg-event's `:where :event` violation actually fires (without
             ;; the adapter the default validator soft-passes).
@@ -424,3 +428,60 @@
               "exactly one silencing trace for the live generation")))
       (trace-tooling/unregister-listener! ::rec)
       (rf/unregister-listener! :epoch ::probe))))
+
+;; ---- 8. rf2-vxgfnd.245 — honest delayed silencing after same-id rearm ------
+
+(deftest predecessor-silencing-suppressed-after-reentrant-successor-rearm-cljs
+  (testing "rf2-vxgfnd.245 (synchronous/reentrant CLJS, red before fix) — A's
+            post-dissoc epoch hook re-entrantly installs a same-id successor B and
+            settles it, claiming the id-keyed stores and re-arming the unchanged
+            cb generation with B's record. A must NOT then republish its stale
+            snapshot silencing for cb (cb is live on B); B silences cb on B's own
+            destroy exactly once. Before the fix A published its silencing
+            unconditionally, so cb was falsely silenced and B re-emitted an
+            identical unqualified signal."
+    (let [id         :rf2-245/frame
+          cb         ::rf2-245-cljs-cb
+          received   (atom [])
+          silencings (atom [])
+          armed?     (atom true)
+          original   (late-bind/get-fn :epoch/on-frame-destroyed)]
+      (rf/reg-event :rf2-245/seed     (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :rf2-245/b-settle (fn [{:keys [db]} _] {:db {:owner :b}}))
+      (rf/make-frame {:id id})
+      ;; cb observes A by settling one ordinary event; A claims the id-keyed stores.
+      (rf/register-listener! :epoch cb (fn [r] (swap! received conj r)))
+      (rf/dispatch-sync [:rf2-245/seed] {:frame id})
+      (rf/register-listener! :trace ::rf2-245-cljs-silencing
+        (fn [ev]
+          (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+            (swap! silencings conj ev))))
+      (try
+        (late-bind/set-fn! :epoch/on-frame-destroyed
+          (fn [& args]
+            ;; On A's FIRST post-dissoc hook, re-entrantly install same-id B and
+            ;; settle it: B claims the id-keyed stores and re-arms cb with B's
+            ;; record — synchronously, no threads. The idle top-level destroy runs
+            ;; this hook with no drain on the stack (continuing? true), so the
+            ;; reentrant settle commits normally.
+            (when (and (= id (first args)) (compare-and-set! armed? true false))
+              (rf/make-frame {:id id})
+              (rf/dispatch-sync [:rf2-245/b-settle] {:frame id}))
+            (when original (apply original args))))
+        (rf/destroy-frame! id)
+        ;; THE FIX: A's silencing fan for cb is suppressed — cb is live on B.
+        (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
+            "no bare A silencing for cb after reentrant B claimed + re-armed it")
+        ;; cb is live on B: another B settle reaches it.
+        (let [before (count @received)]
+          (rf/dispatch-sync [:rf2-245/b-settle] {:frame id})
+          (is (= (inc before) (count @received))
+              "cb continues to receive B's records — it is live on B"))
+        ;; B destroy → exactly one truthful silencing for cb.
+        (rf/destroy-frame! id)
+        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+            "exactly one truthful silencing for cb — fired by B's own destroy")
+        (finally
+          (late-bind/set-fn! :epoch/on-frame-destroyed original)
+          (rf/unregister-listener! :epoch cb)
+          (rf/unregister-listener! :trace ::rf2-245-cljs-silencing))))))


### PR DESCRIPTION
Two P1 follow-ups to the merged trace-ring (#5865 / rf2-vxgfnd.244) and incarnation-pair (#5850) work, on the shared core trace + epoch terminal-fan-out surface. One PR, commits in order vf2qke -> .245. Each fix carries its red-before-fix fixture; #5865's RING fixtures and #5850's fences stay green. Pre-alpha: no back-compat shims; no scheduler / second event bus / opaque owner token introduced.

Both repros were re-verified RED against fresh `origin/main` before fixing.

## rf2-vf2qke - structural-delivery scope must not taint listener-triggered work

**Problem.** `#5865` binds the structural-delivery flags (epoch-capture / frame-policy / ring-retention all false) around the *entire* synchronous outer trace emit, but the public tooling listener fan-out (`deliver-to-tooling!`) runs *inside* that dynamic scope. A public listener that reacts to obsolete incarnation A's structural terminal fact and dispatches (or directly `emit!`s) its own legitimate nested work into a same-id successor B or an unrelated frame C had that nested work **inherit A's retentionless scope**: it committed and streamed live but bypassed its own epoch capture, its own per-frame ring retention, and its own frame-no-emit policy. The merged `#5865` fixtures use *passive atom* listeners and miss this - the taint only manifests when a listener **emits**.

**Fix (`implementation/core/src/re_frame/trace.cljc`, `deliver!`).** Make the structural flags a property of the *current outer envelope*, not ambient authority for external callbacks. By the time the tooling fan-out runs, every structural decision has already been consumed against this envelope - epoch capture was gated, frame-no-emit was gated in `emit!`/`emit-error!`, and the outer ring-retention decision is captured here into `retain?` and passed explicitly to the tooling hook for the outer ring push. `deliver!` then restores ordinary delivery defaults around the fan-out, so a listener's own nested work runs under normal scope. An explicitly nested `call-with-structural-delivery` re-binds the flags false and is still honoured. The tooling sibling reads `retain?` from its argument (it cannot see these private vars), so wrapping the whole call leaves the outer ring push governed by the captured structural decision.

**Red-before-fix fixtures (DISPATCHING listeners):**
- `implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc` - `listener-triggered-nested-emit-runs-under-normal-scope` (sync, JVM + CLJS): a listener's direct nested `emit!` into unrelated frame C is retained in C's ring; `explicitly-nested-structural-delivery-stays-retentionless` pins the escape hatch.
- `implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj` - `listener-dispatch-during-structural-terminal-fact-runs-under-normal-scope`: a listener reacting to A's real `:rf.epoch.cb/silenced-on-frame-destroy` terminal fact dispatches into unrelated C - C's cascade is captured into C's epoch history and retained in C's ring. `listener-triggered-work-obeys-nested-frame-no-emit-policy`: dispatch into a no-emit frame D obeys D's own policy (no leak).

Verified RED with the restore removed: C's epoch history empty (0), C's ring empty, D's no-emit trace leaked to listeners.

## rf2-vxgfnd.245 - honest delayed epoch fan-out after same-id listener rearm

**Problem.** `#5850` snapshots predecessor A's `silenced-cbs` before dissoc and later publishes that saved set **unconditionally** - even when a same-id B has claimed the epoch stores and the same current listener generation already received B's newer record and was re-armed. A then emits a bare `:rf.epoch.cb/silenced-on-frame-destroy` claiming a callback went silent when it is in fact *live on B*, and B re-emits the identical unqualified signal on its own later destroy.

**Fix (`implementation/epoch/src/re_frame/epoch/listeners.cljc`, `on-frame-destroyed!`).** Gate A's silencing fan on A still winning its compare-owned cleanup. `cleanup-frame-owner!` returns truthy only when A still owns the id-keyed stores (or none were ever claimed) - which is exactly *"no successor has re-armed the id-keyed observation state"* (a successor claims by settling, which fans its record to and re-arms every live-generation observer of the reused id). When B has claimed, A's silencing is suppressed; B silences those callbacks itself on B's own destroy. A's required halted record + structural trailers stay **unconditional** (rf2-vxgfnd.151) - a late predecessor terminal record is historical and must not be treated as the successor's current focus. Only the silencing fan is gated.

**Red-before-fix fixtures:**
- `implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj` - `predecessor-silencing-fan-suppressed-after-successor-rearm` (CLJ threaded pause): A settles (cb observes A), A self-destroys mid-drain and pauses post-dissoc; same-id B settles (claims stores, re-arms cb); A resumes -> no bare A silencing; B's destroy -> exactly one truthful silencing. `predecessor-silencing-honours-new-generation-registered-in-gap` pins the re-register-new-generation case (A never invokes/silences the new generation; A's historical halted record still reaches its own snapshot generation).
- `implementation/epoch/test/re_frame/epoch_cljs_test.cljs` - `predecessor-silencing-suppressed-after-reentrant-successor-rearm-cljs` (synchronous/reentrant CLJS): A's post-dissoc hook re-entrantly installs + settles same-id B; A's silencing is suppressed; B silences once.

Verified RED (unfixed): A published a bare stale silencing for the observer even though B claimed the id, producing **two** identical unqualified signals (A's stale + B's legit).

**Incidental assertion flip.** `predecessor-terminal-facts-never-retained-in-successor-ring` (the #5865/.244 RING fixture) set up its observer to be re-armed by B, so under .245 A's silencing for it is now honestly suppressed - its one silencing-count assertion flips to expect 0. **The RING boundary assertions (#5865's actual fix - B's flat ring byte-identical, no A terminal op retained, dispatch-id isolation) are unchanged and green.**

## Spec 009 trace-contract ripples (follow-ups; spec/** out of scope for this PR)

- Spec 009 / Tool-Pair should document the **late-record consumer rule** made explicit here: a predecessor terminal `:halted-destroy` record may arrive after a newer same-id epoch, is historical, and must not be treated as the successor's current ring/focus.
- Spec 009 / Tool-Pair should note that `:rf.epoch.cb/silenced-on-frame-destroy` is suppressed for a callback re-armed by a same-id successor (the successor emits it on its own destroy).

These are parent-epic-owned spec surfaces; filing as PR-body follow-ups rather than touching the hot-zone spec files in this cluster.

## Quality gates

All run in the foreground, all green:

| Gate | Result |
|------|--------|
| core JVM (`clojure -M:test`) | 1962 tests, 8963 assertions, 0 failures, 0 errors |
| epoch (`clojure -M:test`) | 388 tests, 2413 assertions, 0 failures, 0 errors |
| machines conformance (`clojure -M:test`) | 1035 tests, 3509 assertions, 0 failures, 0 errors |
| CLJS node (`npm run test:cljs`) | 9355 tests, 44300 assertions, 0 failures, 0 errors |

`scripts/test-fast-pr.sh` (superset of the above + JS harness helpers) was also run; CI re-confirms.
