### PR TITLE
fix(machines): fence post-callback spawn/finalize tails to exact incarnation (rf2-hloj0g); lud4af core-blocked

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -577,56 +577,83 @@
             (teardown/teardown-actor db-after-on-done
                                      {:actor-id  machine-id
                                       :parent-id parent-id
-                                      :invoke-id invoke-id})
-            ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
-            ;; (D6 enrichment) before registrar cleanup.
-            _ (traces/emit-destroyed! {:frame     frame-id
-                                       :actor-id  machine-id
-                                       :system-id released-sid
-                                       :parent-id parent-id
-                                       :invoke-id invoke-id
-                                       :reason    :rf.machine/finished})]
-        ;; (6) Synchronous side effects: abort in-flight HTTP, cancel armed
-        ;; `:after` timers (`:reason :on-destroy`), emit system-id-released trace
-        ;; (when applicable), and clear any registrar entry.
-        (abort-actor-in-flight-http! machine-id)
-        (timer/cancel-actor-timers! frame-id machine-id)
-        ;; Drop this actor's per-instance classification declarations from the
-        ;; per-frame elision registry — the teardown half of
-        ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
-        ;; (which does NOT route through `destroy/teardown-live-actor!`). A spec
-        ;; that declared no classification is a clean no-op, so the registry
-        ;; entry added at spawn dies with the instance (no leak).
-        (classification/drop-at-destroy! frame-id machine-id machine)
-        ;; Forget the finished actor from the per-frame spawn-order channel — the
-        ;; ONE synchronous teardown side-effect the `:final?`-auto-destroy path
-        ;; shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).
-        ;; Without it a finished actor stays recorded → a later stale
-        ;; `[:rf.machine/destroy id]` sees it live → `teardown-live-actor!`
-        ;; RE-RUNS (phantom destroyed trace + re-fired resource release,
-        ;; violating silent-idempotent destroy) and frame-destroy emits a
-        ;; phantom straggler destroy for it.
-        (spawn-order/forget! frame-id machine-id)
-        (traces/emit-system-id-released! frame-id released-sid machine-id)
-        (registrar/unregister! :event machine-id)
-        ;; (7) Per Spec 005 §Final states §`:on-error`: when the child finished
-        ;; via an ERROR leaf AND the spawning parent declares `:spawn :on-error`,
-        ;; dispatch the synthetic reserved failure event into the parent. It
-        ;; resolves natively through the parent's macrostep
-        ;; (`pick-spawn-error-transition`), firing the declarative `:on-error`
-        ;; transition — the XState `invoke onError` control flow. The teardown
-        ;; above already ran (the child auto-destroys on its error leaf, like any
-        ;; `:final?`); this only ROUTES the failure. The dispatched payload is
-        ;; the RAW error (`result`); the parent transition reads it off `:event`.
-        (when on-error?
-          (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
+                                      :invoke-id invoke-id})]
+        ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
+        ;; (D6 enrichment) before registrar cleanup.
+        (traces/emit-destroyed! {:frame     frame-id
+                                 :actor-id  machine-id
+                                 :system-id released-sid
+                                 :parent-id parent-id
+                                 :invoke-id invoke-id
+                                 :reason    :rf.machine/finished})
+        ;; rf2-hloj0g — the teardown tail's callback-bearing hooks — the
+        ;; `:rf.machine/destroyed` trace above, the late-bound HTTP abort hook,
+        ;; and the `:rf.machine/system-id-released` trace — can EACH destroy A /
+        ;; publish same-id B on their own stack. #5856 fenced the earlier
+        ;; completion callbacks (validator / done trace / `:on-done`) with the
+        ;; top-level `owner-gone?` gate, but NOTHING rechecked ownership between
+        ;; these LATER teardown callbacks and the framework-owned actions that
+        ;; follow — so the HTTP/timer cancellation, classification/spawn-order
+        ;; drop, registrar unregister, and `:on-error` dispatch could all run
+        ;; against B (a bare frame-id / machine-id resolves to the CURRENT
+        ;; incarnation). Recheck `owner-gone?` before each next framework action;
+        ;; it is MONOTONIC (once A→B it stays gone), so a per-action guard
+        ;; short-circuits the whole tail. Already-delivered traces/hooks stand —
+        ;; the ruled unwind posture, no rollback.
+        (when-not (owner-gone?)
+          ;; (6) Abort in-flight HTTP (late-bound hook — callback-bearing).
+          (abort-actor-in-flight-http! machine-id))
+        (when-not (owner-gone?)
+          ;; Cancel armed `:after` timers (`:reason :on-destroy`).
+          (timer/cancel-actor-timers! frame-id machine-id)
+          ;; Drop this actor's per-instance classification declarations from the
+          ;; per-frame elision registry — the teardown half of
+          ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
+          ;; (which does NOT route through `destroy/teardown-live-actor!`). A spec
+          ;; that declared no classification is a clean no-op, so the registry
+          ;; entry added at spawn dies with the instance (no leak).
+          (classification/drop-at-destroy! frame-id machine-id machine)
+          ;; Forget the finished actor from the per-frame spawn-order channel — the
+          ;; ONE synchronous teardown side-effect the `:final?`-auto-destroy path
+          ;; shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).
+          ;; Without it a finished actor stays recorded → a later stale
+          ;; `[:rf.machine/destroy id]` sees it live → `teardown-live-actor!`
+          ;; RE-RUNS (phantom destroyed trace + re-fired resource release,
+          ;; violating silent-idempotent destroy) and frame-destroy emits a
+          ;; phantom straggler destroy for it.
+          (spawn-order/forget! frame-id machine-id)
+          ;; The `:rf.machine/system-id-released` trace is callback-bearing and is
+          ;; the LAST action in this group, so the recheck below fences the
+          ;; registrar unregister + `:on-error` dispatch against a B it published.
+          (traces/emit-system-id-released! frame-id released-sid machine-id))
+        (when-not (owner-gone?)
+          (registrar/unregister! :event machine-id)
+          ;; (7) Per Spec 005 §Final states §`:on-error`: when the child finished
+          ;; via an ERROR leaf AND the spawning parent declares `:spawn :on-error`,
+          ;; dispatch the synthetic reserved failure event into the parent. It
+          ;; resolves natively through the parent's macrostep
+          ;; (`pick-spawn-error-transition`), firing the declarative `:on-error`
+          ;; transition — the XState `invoke onError` control flow. The teardown
+          ;; above already ran (the child auto-destroys on its error leaf, like any
+          ;; `:final?`); this only ROUTES the failure. The dispatched payload is
+          ;; the RAW error (`result`); the parent transition reads it off `:event`.
+          (when on-error?
+            (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result)))
+        ;; Publish the teardown runtime-db + fx ONLY if the exact owner survived
+        ;; the WHOLE tail (rf2-hloj0g). If any post-`emit-destroyed!` callback
+        ;; published same-id B, return the inert outcome — the A-derived
+        ;; `db-after-destroy` is DROPPED rather than committed onto B (the
+        ;; router's candidate fence would drop it too; returning inert is the
+        ;; explicit contract, matching the top-level `owner-gone?` branch).
         ;; Machine snapshots are durable runtime-db state (EP-0001): the finalize
         ;; teardown is a runtime-db write, returned under `:rf.db/runtime` (the
         ;; framework-authority partition effect), NOT `:db`. Append the
         ;; destroy-time `:exit` cascade's fx + the resource-lease release for
         ;; this actor's `[:machine machine-id]` owner (nil + filtered out when
         ;; resources is absent — see `resource-release/release-fx-entry`).
-        {:rf.db/runtime db-after-destroy
-         :fx (vec (concat extra-fx exit-fx
-                          (when-let [e (resource-release/release-fx-entry machine-id)]
-                            [e])))})))))
+        (if (owner-gone?)
+          {:rf.db/runtime runtime-db :fx []}
+          {:rf.db/runtime db-after-destroy
+           :fx (vec (concat extra-fx exit-fx
+                            (when-let [e (resource-release/release-fx-entry machine-id)]
+                              [e])))}))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -290,8 +290,17 @@
   "Atomically install the spawned actor's `initial-snap` (with its
   revertible `:rf/machine-type` TYPE reference stamped at the root),
   system-id binding, and runtime-owned spawn registry slot
-  into the frame's runtime-db. Returns `:ok`. Emits the collision and
-  system-id-bound traces when applicable.
+  into the frame's runtime-db. Emits the collision and system-id-bound
+  traces when applicable.
+
+  Returns an EXPLICIT committed/live result (rf2-hloj0g): `:committed`
+  when the runtime-db swap landed, `:skipped` when the exact-owner recheck
+  fenced the swap (a `:rf.error/system-id-collision` listener destroyed A /
+  published same-id B on the trace's own stack). The caller (`spawn-fx*`)
+  runs NO post-install tail (classification / spawn-order /
+  `:rf.machine.lifecycle/spawned` / `:start`) unless install COMMITTED and
+  the exact owner is STILL current — a bare-id `swap-runtime-db!` /
+  `spawn-order/record!` otherwise resolves to the CURRENT incarnation B.
 
   There is NO per-instance handler registration — the
   actor's liveness IS the presence of this snapshot in the (revertible)
@@ -341,22 +350,28 @@
     ;; bare-id `swap-runtime-db!` resolves to the CURRENT incarnation B) or fire
     ;; the `:rf.machine/system-id-bound` trace for it. `continue?` is nil only
     ;; for a hypothetical caller that did not thread it — treated as live.
-    (when (or (nil? continue?) (continue?))
-      (frame/swap-runtime-db! frame-id
-                              (fn [_rt]
-                                (cond-> rt-after-alloc
-                                  spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
-                                  system-id (assoc-in (paths/system-id-path system-id) spawned-id)
-                                  track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
-      (when system-id
-        (trace/emit! :rf.machine :rf.machine/system-id-bound
-                     {:frame      frame-id
-                      :system-id  system-id
-                      ;; The live actor INSTANCE address (the spawned id), not
-                      ;; the registered TYPE; `:machine-id` is reserved for the
-                      ;; type.
-                      :actor-id   spawned-id}))
-      :ok)))
+    ;; rf2-hloj0g — return the swap outcome EXPLICITLY (`:committed` /
+    ;; `:skipped`) so the caller can fence its own post-install tail on it (the
+    ;; earlier `:ok`/nil return was IGNORED, so a `:skipped` install still let
+    ;; classification / spawn-order / lifecycle-spawned run against B).
+    (if (or (nil? continue?) (continue?))
+      (do
+        (frame/swap-runtime-db! frame-id
+                                (fn [_rt]
+                                  (cond-> rt-after-alloc
+                                    spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                                    system-id (assoc-in (paths/system-id-path system-id) spawned-id)
+                                    track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
+        (when system-id
+          (trace/emit! :rf.machine :rf.machine/system-id-bound
+                       {:frame      frame-id
+                        :system-id  system-id
+                        ;; The live actor INSTANCE address (the spawned id), not
+                        ;; the registered TYPE; `:machine-id` is reserved for the
+                        ;; type.
+                        :actor-id   spawned-id}))
+        :committed)
+      :skipped)))
 
 ;; ---- :rf.machine/spawn -----------------------------------------------------
 
@@ -572,13 +587,26 @@
       ;; `install-spawn!` so the callback-bearing `:rf.error/system-id-collision`
       ;; trace it may emit gets a recheck before the runtime-db swap too.
       (when (continue?)
-        (install-spawn! frame-id rt-after-alloc spec'' spawned-id initial-snap
-                        {:system-id system-id
-                         :parent-id parent-id
-                         :invoke-id invoke-id
-                         :track?    track?
-                         :type-ref  type-ref
-                         :continue? continue?})
+        (let [installed (install-spawn! frame-id rt-after-alloc spec'' spawned-id initial-snap
+                                        {:system-id system-id
+                                         :parent-id parent-id
+                                         :invoke-id invoke-id
+                                         :track?    track?
+                                         :type-ref  type-ref
+                                         :continue? continue?})]
+        ;; rf2-hloj0g — `install-spawn!`'s `:rf.error/system-id-collision`
+        ;; (pre-swap → `:skipped`) and `:rf.machine/system-id-bound` (post-swap)
+        ;; traces are callback-bearing: a listener can destroy A / publish
+        ;; same-id B on the trace's own stack. Run the framework-owned tail —
+        ;; per-instance classification, the spawn-order record, and the
+        ;; `:rf.machine.lifecycle/spawned` trace — ONLY when install COMMITTED
+        ;; AND the exact owner is STILL current after those callbacks. Otherwise
+        ;; the bare-id `spawn-order/record!` / classification writes + the
+        ;; lifecycle-spawned trace would commit into B's name. The initial
+        ;; `(continue?)` gate at the cascade top fenced only the earlier
+        ;; `:rf.machine.spawn/spawned` trace-listener callback; this fences the
+        ;; install's own two callbacks that gate ran ahead of.
+        (when (and (= :committed installed) (continue?))
         ;; Lower the machine spec's projection-relative `:sensitive` / `:large`
         ;; `:data` declarations
         ;; into the per-frame elision registry PER ACTOR INSTANCE — re-rooting
@@ -642,7 +670,7 @@
                      :source             :machine-spawn}]
           (if (some? start)
             (dispatch! [spawned-id start] opts)
-            (dispatch! [spawned-id [:rf.machine.spawn/spawned]] opts)))))))
+            (dispatch! [spawned-id [:rf.machine.spawn/spawned]] opts)))))))))
     spawned-id))
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------

--- a/implementation/machines/test/re_frame/machine_post_callback_tail_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_post_callback_tail_fence_test.clj
@@ -1,0 +1,395 @@
+(ns re-frame.machine-post-callback-tail-fence-test
+  "rf2-hloj0g — fence machine SPAWN and FINALIZATION tails after EVERY
+  callback boundary.
+
+  #5856 (rf2-3evq0x) fenced the spawn cascade before install and the
+  completion tail before teardown, but framework-owned tails still crossed
+  LATER callback boundaries the earlier fences ran ahead of:
+
+    - Spawn: `install-spawn!`'s own `:rf.error/system-id-collision` /
+      `:rf.machine/system-id-bound` traces are callback-bearing. A collision
+      listener that destroys A + publishes same-id B makes `install-spawn!`
+      SKIP its swap — yet the caller ignored that outcome and still wrote
+      classification / spawn-order + emitted `:rf.machine.lifecycle/spawned`
+      against B. A `system-id-bound` listener (fired AFTER the swap) has the
+      same shape: install committed against A, but the caller ran its tail
+      against B.
+    - Finalization: after the top-level completion fence, the teardown tail
+      ran the `:rf.machine/destroyed` trace, the late-bound HTTP abort hook,
+      the `:rf.machine/system-id-released` trace, and then HTTP/timer
+      cancellation, classification/spawn-order drop, registrar unregister, and
+      `:on-error` dispatch with NO fresh fence between them. A listener /
+      late-abort hook that published same-id B let A's tail mutate B.
+
+  The ruled policy (rf2-3evq0x, extended here): already-entered authored
+  callbacks may unwind, but loss of exact-incarnation ownership is a TERMINAL
+  fence for EVERY subsequent framework-owned action, rechecked after each
+  callback-bearing trace or hook. These fixtures drive the tails DIRECTLY
+  under a bound event owner (A's dequeue-time token) with a destroyer that
+  publishes same-id B on the callback's / hook's own stack, and assert B
+  stays byte-identical.
+
+  Deterministic + single-threaded — the destroyer runs INSIDE the callback /
+  hook, so the same-id successor B is published on the callback's own stack."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines :as machines]
+            [re-frame.machines.lifecycle-fx.finalize :as finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- spawn-tail fence (install-spawn! callbacks) --------------------------
+;;
+;; `install-spawn!`'s `:rf.error/system-id-collision` (pre-swap) and
+;; `:rf.machine/system-id-bound` (post-swap) traces are callback-bearing. The
+;; caller must run NO tail (classification / spawn-order /
+;; `:rf.machine.lifecycle/spawned` / `:start`) unless install COMMITTED and the
+;; exact owner is STILL current.
+
+(def ^:private spawn-child-type :rf2-hloj0g/spawn-child)
+(def ^:private spawn-child-instance-id (keyword "rf2-hloj0g" "spawn-child#1"))
+
+(defn- run-spawn-tail
+  "Register the child machine, make frame A (optionally pre-seeding a DIFFERENT
+  actor at `pre-existing-sid` so a `:system-id` spawn collides), install a
+  destroyer keyed on `trigger`, then call `spawn-fx` DIRECTLY under A's bound
+  event owner. `trigger` is `:system-id-collision`, `:system-id-bound`, or
+  `:lifecycle-spawned`. Returns the observable post-spawn state on B."
+  [frame-a trigger {:keys [system-id pre-existing-sid]}]
+  (spawn-order/reset-all!)
+  (rf/reg-machine spawn-child-type
+    {:initial :running
+     :states  {:running {:on {:go :done}}
+               :done    {:final? true}}})
+  (rf/make-frame {:id frame-a})
+  (when pre-existing-sid
+    (frame/swap-runtime-db!
+      frame-a
+      (fn [rt] (assoc-in rt [:rf.runtime/machines :system-ids system-id] pre-existing-sid))))
+  (let [token-a          (frame/frame-incarnation-token frame-a)
+        fired?           (atom false)
+        dispatches       (atom [])
+        lifecycle-traces (atom [])
+        b-birth          (atom nil)
+        orig-dispatch!   (late-bind/get-fn :router/dispatch!)
+        destroy+B!       (fn []
+                           (when (compare-and-set! fired? false true)
+                             (frame/destroy-frame! frame-a)   ;; destroy A
+                             (rf/make-frame {:id frame-a})     ;; same-id B
+                             (reset! b-birth (mtest/runtime-db frame-a))))]
+    (trace-tooling/register-listener!
+      ::spawn-tail-fence
+      (fn [ev]
+        (case (:operation ev)
+          :rf.machine.lifecycle/spawned (do (swap! lifecycle-traces conj ev)
+                                            (when (= trigger :lifecycle-spawned) (destroy+B!)))
+          :rf.machine/system-id-bound   (when (= trigger :system-id-bound) (destroy+B!))
+          :rf.error/system-id-collision (when (= trigger :system-id-collision) (destroy+B!))
+          nil)))
+    (try
+      ;; Capture (never route) any dispatch the cascade attempts.
+      (late-bind/set-fn! :router/dispatch!
+                         (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
+      (frame/call-with-event-owner-token frame-a token-a
+        (fn [] (spawn/spawn-fx {:frame frame-a}
+                               (cond-> {:machine-id spawn-child-type :start [:go]}
+                                 system-id (assoc :system-id system-id)))))
+      {:fired?           @fired?
+       :b-birth          @b-birth
+       :b-runtime        (mtest/runtime-db frame-a)
+       :b-snapshot       (mtest/snapshot frame-a spawn-child-instance-id)
+       :spawn-order      (spawn-order/frame-order frame-a)
+       :dispatches       @dispatches
+       :lifecycle-traces @lifecycle-traces}
+      (finally
+        (trace-tooling/unregister-listener! ::spawn-tail-fence)
+        (when orig-dispatch!
+          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+
+(defn- assert-spawn-tail-inert [{:keys [b-birth b-runtime b-snapshot spawn-order
+                                        dispatches lifecycle-traces]}]
+  (is (nil? b-snapshot)
+      "no A-derived child snapshot installed onto same-id B")
+  (is (= b-birth b-runtime)
+      "B's runtime-db is byte-identical to its birth value (no A-derived install)")
+  (is (empty? spawn-order)
+      "no A-derived spawn-order entry recorded against B")
+  (is (empty? lifecycle-traces)
+      "no :rf.machine.lifecycle/spawned emitted against B after the loss")
+  (is (empty? dispatches)
+      "no :start dispatch fired into B after the loss"))
+
+(deftest system-id-collision-loss-fences-spawn-tail
+  (testing "a :rf.error/system-id-collision listener that destroys A + publishes
+            same-id B: install-spawn! SKIPS its swap, and the caller runs NO
+            classification / spawn-order / lifecycle-spawned tail against B.
+            Mutation tooth: ignoring install-spawn!'s :skipped result runs the
+            whole tail against B."
+    (let [frame-a :rf2-hloj0g/collision-frame]
+      (let [result (run-spawn-tail frame-a :system-id-collision
+                                   {:system-id :rf2-hloj0g/the-sid
+                                    :pre-existing-sid :rf2-hloj0g/some-other-actor})]
+        (is (true? (:fired? result)) "the :rf.error/system-id-collision listener ran (fence exercised)")
+        (assert-spawn-tail-inert result)))))
+
+(deftest system-id-bound-loss-fences-spawn-tail
+  (testing "a :rf.machine/system-id-bound listener that destroys A + publishes
+            same-id B (the trace fires AFTER install-spawn!'s swap, so install
+            committed against A): the caller rechecks the exact owner AFTER
+            install and runs NO tail against B. Mutation tooth: without the
+            post-install (continue?) recheck the tail lands on B."
+    (let [frame-a :rf2-hloj0g/bound-frame]
+      (let [result (run-spawn-tail frame-a :system-id-bound
+                                   {:system-id :rf2-hloj0g/fresh-sid})]
+        (is (true? (:fired? result)) "the :rf.machine/system-id-bound listener ran (fence exercised)")
+        (assert-spawn-tail-inert result)))))
+
+(deftest lifecycle-spawned-loss-fences-start
+  (testing "control (regression guard for the existing post-lifecycle-spawned
+            fence): a :rf.machine.lifecycle/spawned listener that destroys A +
+            publishes same-id B fires AFTER install / classification /
+            spawn-order (all against live A), so only the :start dispatch is
+            fenced — B receives no bootstrap dispatch."
+    (let [frame-a :rf2-hloj0g/lifecycle-frame]
+      (let [result (run-spawn-tail frame-a :lifecycle-spawned {})]
+        (is (true? (:fired? result)) "the :rf.machine.lifecycle/spawned listener ran (fence exercised)")
+        (is (= 1 (count (:lifecycle-traces result)))
+            "the lifecycle-spawned trace fired exactly once (it precedes the loss)")
+        (is (empty? (:spawn-order result))
+            "no spawn-order entry survives on same-id B (A's entry died with A)")
+        (is (empty? (:dispatches result))
+            "no :start dispatch fired into B after the lifecycle-spawned loss")))))
+
+(deftest live-owner-spawn-installs-once
+  (testing "control: a spawn whose install fires no destroyer completes exactly
+            once — snapshot installed, system-id bound, spawn-order recorded,
+            lifecycle-spawned emitted, :start dispatched. The fence is scoped to
+            owner-loss only."
+    (spawn-order/reset-all!)
+    (rf/reg-machine spawn-child-type
+      {:initial :running
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a        :rf2-hloj0g/live-spawn-frame
+          dispatches     (atom [])
+          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        (try
+          (late-bind/set-fn! :router/dispatch!
+                             (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-fx {:frame frame-a}
+                                   {:machine-id spawn-child-type
+                                    :system-id  :rf2-hloj0g/live-sid
+                                    :start      [:go]})))
+          (is (some? (mtest/snapshot frame-a spawn-child-instance-id))
+              "the live spawn installed the child snapshot")
+          (is (= spawn-child-instance-id
+                 (get-in (mtest/runtime-db frame-a)
+                         [:rf.runtime/machines :system-ids :rf2-hloj0g/live-sid]))
+              "the live spawn bound the :system-id")
+          (is (= [spawn-child-instance-id] (vec (spawn-order/frame-order frame-a)))
+              "the live spawn recorded exactly one spawn-order entry")
+          (is (= 1 (count @dispatches))
+              "the live spawn dispatched :start exactly once")
+          (finally
+            (when orig-dispatch!
+              (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))
+
+;; ---- finalization-tail fence (teardown callbacks) -------------------------
+;;
+;; After the top-level completion fence, the teardown tail's `:rf.machine/
+;; destroyed` trace, late-bound HTTP abort hook, and `:rf.machine/
+;; system-id-released` trace are each callback-bearing. Ownership is rechecked
+;; after each before the next framework-owned action (HTTP/timer cancellation,
+;; classification/spawn-order drop, registrar unregister, `:on-error`
+;; dispatch, runtime-db/fx publication).
+
+(defn- finishing-machine
+  "A runtime-stamped, finished singleton spec resting on a `:final?` leaf whose
+  `:output-key` designates the completion result."
+  [frame-id]
+  {:initial   :done
+   :rf/frame  frame-id
+   :rf/cofx   {:rf/time-ms 0}
+   :data      {:result 42}
+   :states    {:done {:final? true :output-key :result}}})
+
+(defn- finishing-snapshot [] {:state :done :data {:result 42}})
+
+(defn- seed-finishing+sid!
+  "Install `machine-id`'s finishing snapshot AND a `:system-id` reverse-index
+  binding into `frame-id`'s runtime-db, so the finalize teardown resolves a
+  non-nil released-sid (exercising the `:rf.machine/system-id-released` trace)."
+  [frame-id machine-id sid]
+  (frame/swap-runtime-db!
+    frame-id
+    (fn [rt] (-> rt
+                 (assoc-in [:rf.runtime/machines :snapshots machine-id] (finishing-snapshot))
+                 (assoc-in [:rf.runtime/machines :system-ids sid] machine-id)))))
+
+(defn- run-teardown-tail
+  "Register `machine-id` as a singleton, make frame A, seed its finishing
+  snapshot + `:system-id` binding, install a destroyer keyed on `trigger`, then
+  call `finalize-machine` DIRECTLY under A's bound event owner. `trigger` is
+  `:destroyed-trace`, `:system-id-released`, or `:http-abort`. Returns the
+  observable post-finalize state."
+  [frame-a machine-id sid trigger]
+  (spawn-order/reset-all!)
+  (rf/reg-machine machine-id (finishing-machine frame-a))
+  (rf/make-frame {:id frame-a})
+  (seed-finishing+sid! frame-a machine-id sid)
+  (let [token-a    (frame/frame-incarnation-token frame-a)
+        fired?     (atom false)
+        destroyed  (atom [])
+        released   (atom [])
+        orig-abort (late-bind/get-fn :http/abort-on-actor-destroy)
+        destroy+B! (fn []
+                     (when (compare-and-set! fired? false true)
+                       (frame/destroy-frame! frame-a)   ;; destroy A
+                       (rf/make-frame {:id frame-a})     ;; same-id B
+                       (seed-finishing+sid! frame-a machine-id sid)))]
+    (trace-tooling/register-listener!
+      ::teardown-fence
+      (fn [ev]
+        (case (:operation ev)
+          :rf.machine/destroyed          (do (swap! destroyed conj ev)
+                                             (when (= trigger :destroyed-trace) (destroy+B!)))
+          :rf.machine/system-id-released (do (swap! released conj ev)
+                                             (when (= trigger :system-id-released) (destroy+B!)))
+          nil)))
+    (try
+      (when (= trigger :http-abort)
+        (late-bind/set-fn! :http/abort-on-actor-destroy
+                           (fn [_actor-id] (destroy+B!) nil)))
+      (let [ret (frame/call-with-event-owner-token frame-a token-a
+                  (fn []
+                    (finalize/finalize-machine
+                      (finishing-machine frame-a)
+                      machine-id frame-a (mtest/runtime-db frame-a)
+                      (finishing-snapshot) [:some-completing-event] [])))]
+        {:fired?     @fired?
+         :ret        ret
+         :b-runtime  (mtest/runtime-db frame-a)
+         :b-snapshot (mtest/snapshot frame-a machine-id)
+         :reg-entry  (registrar/lookup :event machine-id)
+         :destroyed  @destroyed
+         :released   @released})
+      (finally
+        (trace-tooling/unregister-listener! ::teardown-fence)
+        (late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)))))
+
+(defn- assert-teardown-inert
+  "Assert the finalize tail was fenced: B kept its snapshot + registrar entry,
+  and finalize returned the inert outcome (runtime-db untouched, no fx)."
+  [{:keys [ret b-runtime b-snapshot reg-entry]}]
+  (is (= {:rf.db/runtime b-runtime :fx []} ret)
+      "finalize returns the inert outcome — the A-derived teardown runtime-db + fx were dropped")
+  (is (some? b-snapshot)
+      "successor B's finishing snapshot survived (no A-derived teardown published)")
+  (is (some? reg-entry)
+      "successor B's registrar entry was NOT unregistered by the A-derived tail"))
+
+(deftest destroyed-trace-loss-fences-teardown-tail
+  (testing "a :rf.machine/destroyed trace LISTENER that destroys A + publishes
+            same-id B: ownership is rechecked AFTER the destroyed trace, so the
+            HTTP abort / timer cancel / classification+spawn-order drop /
+            system-id-released trace / registrar unregister / :on-error / fx
+            tail is fenced. Mutation tooth: without the post-destroyed recheck
+            the whole tail runs against B."
+    (let [frame-a    :rf2-hloj0g/destroyed-frame
+          machine-id :rf2-hloj0g/destroyed-machine]
+      (let [result (run-teardown-tail frame-a machine-id :rf2-hloj0g/destroyed-sid :destroyed-trace)]
+        (is (true? (:fired? result)) "the :rf.machine/destroyed listener ran (fence exercised)")
+        (is (= 1 (count (:destroyed result)))
+            "the destroyed trace fired exactly once (it precedes the loss)")
+        (is (empty? (:released result))
+            "no :rf.machine/system-id-released trace fired after the destroyed-trace loss")
+        (assert-teardown-inert result)))))
+
+(deftest system-id-released-loss-fences-teardown-tail
+  (testing "a :rf.machine/system-id-released trace LISTENER that destroys A +
+            publishes same-id B (the trace fires late in the tail, after HTTP /
+            timer / classification / spawn-order): ownership is rechecked AFTER
+            it, so the registrar unregister + :on-error + fx publication tail is
+            fenced. Mutation tooth: without the post-system-id-released recheck
+            registrar unregister runs against B."
+    (let [frame-a    :rf2-hloj0g/released-frame
+          machine-id :rf2-hloj0g/released-machine]
+      (let [result (run-teardown-tail frame-a machine-id :rf2-hloj0g/released-sid :system-id-released)]
+        (is (true? (:fired? result)) "the :rf.machine/system-id-released listener ran (fence exercised)")
+        (is (= 1 (count (:released result)))
+            "the system-id-released trace fired exactly once (it precedes the loss)")
+        (is (= 1 (count (:destroyed result)))
+            "the destroyed trace fired exactly once earlier in the tail")
+        (assert-teardown-inert result)))))
+
+(deftest http-abort-hook-loss-fences-teardown-tail
+  (testing "the late-bound :http/abort-on-actor-destroy hook destroys A +
+            publishes same-id B: ownership is rechecked AFTER the abort hook, so
+            the timer cancel / classification+spawn-order drop /
+            system-id-released trace / registrar unregister / :on-error / fx
+            tail is fenced. Mutation tooth: without the post-abort recheck the
+            tail runs against B."
+    (let [frame-a    :rf2-hloj0g/abort-frame
+          machine-id :rf2-hloj0g/abort-machine]
+      (let [result (run-teardown-tail frame-a machine-id :rf2-hloj0g/abort-sid :http-abort)]
+        (is (true? (:fired? result)) "the :http/abort-on-actor-destroy hook ran (fence exercised)")
+        (is (= 1 (count (:destroyed result)))
+            "the destroyed trace fired exactly once (it precedes the abort hook)")
+        (is (empty? (:released result))
+            "no :rf.machine/system-id-released trace fired after the abort-hook loss")
+        (assert-teardown-inert result)))))
+
+(deftest live-owner-finalize-tears-down-once
+  (testing "control: a completion whose teardown fires no destroyer tears down
+            fully — the destroyed + system-id-released traces fire and finalize
+            returns a runtime-db effect that dissoc'd the snapshot. The fence is
+            scoped to owner-loss only."
+    (spawn-order/reset-all!)
+    (let [frame-a    :rf2-hloj0g/live-finalize-frame
+          machine-id :rf2-hloj0g/live-finalize-machine
+          sid        :rf2-hloj0g/live-finalize-sid
+          destroyed  (atom [])
+          released   (atom [])]
+      (rf/reg-machine machine-id (finishing-machine frame-a))
+      (rf/make-frame {:id frame-a})
+      (seed-finishing+sid! frame-a machine-id sid)
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        (trace-tooling/register-listener!
+          ::live-finalize
+          (fn [ev] (case (:operation ev)
+                     :rf.machine/destroyed          (swap! destroyed conj ev)
+                     :rf.machine/system-id-released (swap! released conj ev)
+                     nil)))
+        (try
+          (let [ret (frame/call-with-event-owner-token frame-a token-a
+                      (fn []
+                        (finalize/finalize-machine
+                          (finishing-machine frame-a)
+                          machine-id frame-a (mtest/runtime-db frame-a)
+                          (finishing-snapshot) [:some-completing-event] [])))]
+            (is (nil? (get-in (:rf.db/runtime ret)
+                              [:rf.runtime/machines :snapshots machine-id]))
+                "the live completion tore down the actor's snapshot in the returned runtime-db")
+            (is (nil? (get-in (:rf.db/runtime ret)
+                              [:rf.runtime/machines :system-ids sid]))
+                "the live completion released the :system-id binding in the returned runtime-db")
+            (is (= 1 (count @destroyed)) "exactly one :rf.machine/destroyed trace fired")
+            (is (= 1 (count @released)) "exactly one :rf.machine/system-id-released trace fired"))
+          (finally
+            (trace-tooling/unregister-listener! ::live-finalize)))))))


### PR DESCRIPTION
Follow-ups to the merged machines join/spawn lane (#5856). Both are P1 audit
findings on the exact-incarnation fence family. hloj0g is done here; lud4af is
core-blocked and documented as remainder for sequencing.

## rf2-hloj0g — fence post-callback spawn/finalize tails to exact incarnation (DONE)

**Re-verified against current origin/main (372cd0b22f):** both repros still
reproduce. Red-before-fix fixtures fail on unmodified source (12 failing
assertions across 5 loss fixtures), pass after the fix.

**spawn.cljc.** `install-spawn!`'s own `:rf.error/system-id-collision`
(pre-swap) and `:rf.machine/system-id-bound` (post-swap) traces are
callback-bearing. A collision listener that destroys A + publishes same-id B
makes `install-spawn!` SKIP its swap — but the caller ignored that outcome and
still ran classification / `spawn-order/record!` + emitted
`:rf.machine.lifecycle/spawned` against B (a bare-id write resolves to the
current incarnation). A `system-id-bound` listener has the same shape (install
committed against A, caller tail ran against B). Fix: `install-spawn!` returns
an explicit `:committed` / `:skipped` result, and the caller runs the
post-install tail only when install **committed AND** the exact owner is still
current (`(and (= :committed installed) (continue?))`).

**finalize.cljc.** After the top-level completion fence, the teardown tail's
`:rf.machine/destroyed` trace, the late-bound `:http/abort-on-actor-destroy`
hook, and the `:rf.machine/system-id-released` trace are each callback-bearing,
but nothing rechecked ownership between them and the HTTP/timer cancellation,
classification/spawn-order drop, registrar unregister, and `:on-error`
dispatch that follow — so those ran against B. Fix: recheck `owner-gone?`
before each next framework action (it is monotonic, so per-action guards
short-circuit the whole tail), and publish the teardown runtime-db + fx only
if the exact owner survived the whole tail; otherwise return the inert outcome.

Already-delivered callbacks stand (the ruled unwind posture). No rollback
framework, no public API added.

**Red-before-fix fixture:**
`implementation/machines/test/re_frame/machine_post_callback_tail_fence_test.clj`
— drives each tail directly under A's bound event owner with a destroyer that
publishes same-id B on the callback's/hook's own stack. Five loss fixtures
(`system-id-collision`, `system-id-bound`, `machine-destroyed`,
`system-id-released`, `http-abort`) each assert B stays byte-identical; plus a
`lifecycle-spawned` regression guard and live-owner controls that prove the
fence is scoped to owner-loss only. Removing any post-callback exact-owner
fence makes its fixture fail.

## rf2-lud4af — preserve reserved-dispatch semantics in join transport (NOT INCLUDED — core-blocked)

**Re-verified against current origin/main:** the repro reproduces. The
`:rf.machine/join-dispatch` fx (`join.cljc/join-dispatch-fx`) builds a partial
child opts map (`{:frame :source :rf.machine/internal? :rf.cofx}`) and uses a
raw `interop/set-timeout!`, so it bypasses reserved-dispatch semantics exactly
as the bead states: `:fx-overrides` can't capture the completion,
interceptor-overrides / `:trace-id` / `:origin` are lost, per-call
`:rf.cofx/mint-policy :strict` falls back to live minting, and delayed work
uses no frame-owned timer table (no cancellation on frame destroy, no
`:source-detail`).

**This fix genuinely requires `core/fx.cljc` — I stopped per the worktree scope
fence and did NOT edit core.** The three semantics the bead wants preserved all
live in core and are unreachable from a `machines/` regular fx:

1. **Parent-envelope inheritance** (`:fx-overrides` / interceptor-overrides /
   `:trace-id` / `:origin` / `:rf.cofx/mint-policy`) comes from
   `child-dispatch-opts` (private `defn-` in `core/fx.cljc`) and is only passed
   to the **reserved** `:dispatch` / `:dispatch-later` handlers via the
   `(fn [frame-id parent-envelope args])` signature. `:rf.machine/join-dispatch`
   is a regular `reg-fx`, so it never receives the parent envelope.
2. **Frame-owned timer table** (`arm-dispatch-later!` / `dispatch-later-timers`
   / `release-frame!`, cancelled on frame destroy via `:fx/on-frame-destroyed!`)
   is entirely private to `core/fx.cljc`. `machines/` has no hook into it — the
   current transport can only use raw `set-timeout!`.
3. The recordable `:rf.cofx` merge is already available (`router/build-envelope`
   preserves a supplied `:rf.cofx` opt), so **router.cljc likely needs no
   change** — only `core/fx.cljc`.

**Suggested core shape (the bead's "one core child-dispatch implementation"):**
extract a single `child-dispatch!` in `core/fx.cljc` that both the ordinary
`:dispatch` / `:dispatch-later` reserved handlers and a thin
`:rf.machine/join-dispatch` reserved handler call, threading the parent
envelope through `child-dispatch-opts`, routing the delayed path through
`arm-dispatch-later!`, and accepting an optional extra recordable `:rf.cofx`
fact (the join handler supplies `{:rf.machine/join-auth auth}` + `:source
:machine-action`). Promote `:rf.machine/join-dispatch` from a regular `reg-fx`
in `machines.cljc` to that reserved handler. The machines-side
`stamp-fx-entry` / `carrier-auth` contract is unchanged.

**Fixture work that should land WITH the core fix** (per the bead's "also"
clause) — deliberately NOT added here so it can be red-before-fix against the
core change: record a REAL join-child completion → EDN roundtrip → restore →
strict replay (asserting the documented `:dispatch` capture override sees it,
overrides/trace-id/origin/lineage propagate, and per-call `:strict` mint-policy
rejects a missing recorded fact rather than live-minting); add
`wrong-invoke` / `wrong-spawned-id` / `unstamped` / `unknown-child` controls in
the parallel-join shape (these exercise `join.cljc`'s existing exact-authority
selection, which is unchanged).

## Quality gates

- **machines JVM** (`cd implementation/machines && clojure -M:test`):
  1043 tests, 3551 assertions, 0 failures, 0 errors.
  - destroyed-reason channel matrix conformance
    (`destroyed_reason_channel_conformance_test.clj`): 9 tests, 144 assertions,
    green.
  - new `machine_post_callback_tail_fence_test`: 8 tests, 42 assertions, green.
- **core JVM** (`cd implementation/core && clojure -M:test`):
  1958 tests, 8944 assertions, 0 failures, 0 errors.
- **CLJS node integration** (`npm run test:cljs`):
  9352 tests, 44289 assertions, 0 failures, 0 errors.
- **`scripts/test-fast-pr.sh`**: green (all Python drift/guard gates + core JVM
  + CLJS node + per-ns isolation).

## Spec ripples (no spec/** edited)

- Spec 005 §Cancellation cascade / §Final states: the terminal-fence law
  (rf2-3evq0x) now extends past **every** teardown/spawn callback boundary, not
  only the first. Prose note for a follow-up if the maintainers want the
  extended-fence rule spelled out.
- lud4af, when landed, will touch Spec 005 §Spawn-and-join (the transport now
  preserving full reserved-dispatch semantics) and possibly Spec-Schemas
  `:rf/dispatch-envelope` (the `:rf.cofx` join-auth channel).
