### PR TITLE
fix(ui): reject reactive vars escaping into computed callee value flow (rf2-vxgfnd.252)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -308,6 +308,20 @@
       (coll? x) (some #(bare-reactive-reference-kind e % locals) x)
       :else nil)))
 
+(defn- reactive-authoring-var-kind
+  "Return :sub/:lease/:frame when `sym` is an unquoted, unshadowed reference to
+  a public reactive authoring var. Such a var is sound ONLY as a compiler-owned
+  DIRECT CALL HEAD — the rewriter consumes those heads (and lowers them to an
+  indexed runtime site) before this leaf check runs — so a bare reference that
+  reaches any other, value-flow, position has escaped the manifest. `env` must
+  already carry the ambient lexical locals so a local shadow resolves to nil."
+  [env sym]
+  (let [{:keys [fqn]} (env/resolve-sym env sym)]
+    (cond
+      (contains? sub-fqns fqn)   :sub
+      (contains? lease-fqns fqn) :lease
+      (contains? frame-fqns fqn) :frame)))
+
 (defn reject-reactive-binding!
   "Reject executable sub/lease calls embedded in a binding pattern/default.
   Destructuring forms are consumed by the host compiler, not expression
@@ -613,7 +627,38 @@
                  (into (empty f)
                        (map #(rw % locals (conj p :set (map-path-token %))))
                        f))
-               :else f))]
+
+               ;; A BARE reactive authoring var reaching this leaf is a
+               ;; value-flow escape. Every SOUND reactive site is consumed above
+               ;; as a direct call head (`(sub q)`/`(lease d)`/`(frame)` → an
+               ;; indexed runtime site) or rejected pre-expansion under a macro.
+               ;; A bare `sub`/`lease`/`frame` symbol here instead flows as a
+               ;; VALUE — into a computed callee `((if p sub inc) q)`, a let
+               ;; alias `(let [f sub] (f q))`, an argument, or a collection —
+               ;; where the analyzer cannot own a lexical render site, so the
+               ;; manifest under-declares and the optimized build elides the
+               ;; ViewCell, leaving the read to go stale / escape ownership.
+               ;; Reject it loudly. Lexical shadows resolve to nil here and pass
+               ;; through; quoted data was returned by the `quote` branch above.
+               :else
+               (if-let [kind (and (symbol? f) (not (contains? locals f))
+                                  (reactive-authoring-var-kind
+                                   (update e :locals into locals) f))]
+                 (env/fail! e :rf.ui.compile/unsupported-form
+                            (str "bare " (name kind) " reference — re-frame.ui/"
+                                 (name kind) " is a reactive authoring var, sound "
+                                 "ONLY as a compiler-owned direct call head ("
+                                 (if (= :frame kind) "(frame)"
+                                     (str "(" (name kind) " query)"))
+                                 "). Here it flows as a VALUE (into a computed "
+                                 "callee, let-binding, argument, or collection) "
+                                 "where the compiler cannot own a lexical render "
+                                 "site, so the manifest would under-declare and "
+                                 "the optimized build would elide the read. Keep "
+                                 "the read at a visible " (name kind)
+                                 " call site, or make the boundary its own defview")
+                            {:form f :reactive-kind kind})
+                 f)))]
      (rw form (cond-> #{}
                 (deferred-expr-root? expr-root) (conj deferred-scope))
          (vec expr-root)))))

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -235,6 +235,26 @@
       (is (not (some #{:callee} (:expr-path site)))
           "a symbol head is preserved verbatim — no :callee token is minted"))))
 
+(deftest legitimate-value-flow-still-compiles
+  ;; rf2-vxgfnd.252 — the escape guard rejects ONLY bare reactive authoring
+  ;; vars (sub/lease/frame). Ordinary NON-reactive value flow through a computed
+  ;; callee, a let alias, or an argument stays legal and mints no reactive site,
+  ;; and a DIRECT reactive call passed as a value still lowers to one site.
+  (testing "a non-reactive computed callee is ordinary value flow (no site)"
+    (let [{:keys [ast sites]} (ana-full '[:div {:title ((if p inc dec) 1)}])]
+      (is (empty? (:subs sites)))
+      (is (= '((if p inc dec) 1) (get-in ast [:props :attrs 0 :value]))
+          "the non-reactive callee is preserved verbatim")))
+  (testing "a let-bound non-reactive alias is ordinary value flow (no site)"
+    (let [{:keys [ast sites]} (ana-full '[:div {:title (let [f inc] (f 1))}])]
+      (is (empty? (:subs sites)))
+      (is (= '(let [f inc] (f 1)) (get-in ast [:props :attrs 0 :value])))))
+  (testing "a DIRECT reactive call passed as an argument still lowers to a site"
+    (let [{:keys [sites]} (ana-full '[:div {:title (str (sub [:n]))}])]
+      (is (= 1 (count (:subs sites)))
+          "the direct (sub …) is a compiler-owned call head, not an escaping var")
+      (is (= [[:n]] (map :query (:subs sites)))))))
+
 (deftest lexical-site-id-is-portable-stable-and-query-independent
   (let [template-a [:div (located-sub 102 8 [:item/by-id 'id])]
         template-b [:div (located-sub 202 8 [:item/by-id 'id])]

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -110,6 +110,42 @@
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (lease {:a 1} {:b 2})}]))))
 
+(deftest computed-callee-value-escape
+  ;; rf2-vxgfnd.252 — a reactive authoring var (sub/lease/frame) is sound ONLY
+  ;; as a compiler-owned DIRECT CALL HEAD, which the rewriter lowers to an
+  ;; indexed runtime site. A BARE reactive var that instead flows as a VALUE —
+  ;; into a computed callee, a let alias, an argument, or a collection — leaves
+  ;; the manifest under-declaring while a public authoring var survives; the
+  ;; optimized build then elides the ViewCell and the read escapes ownership.
+  ;; This is the escape #5855/.217 (direct calls in computed callees) did not
+  ;; close. Removing the leaf guard makes every reject row below fail (they
+  ;; silently re-accept), so this deftest is the mutation fixture too.
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title ((if p sub inc) [:q])}]))
+      "bare sub in a computed (if …) callee — the .252 counterexample")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title ((identity sub) [:q])}]))
+      "bare sub through a computed-callee wrapper escapes identically")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [f sub] (f [:q]))}]))
+      "a let-bound sub alias becomes an unindexed invocation target")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (str sub)}]))
+      "a bare sub passed as an argument is value flow, not a render site")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title ((if p lease inc) {:resource :r})}]))
+      "bare lease escapes into a computed callee identically")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [g frame] (g))}]))
+      "bare frame escapes through a let alias identically")
+  ;; The soundness rule does not touch the legal forms:
+  (is (nil? (reject-id '[:div {:title ((if (sub [:op]) inc dec) 1)}]))
+      "a DIRECT (sub …) in the computed callee is still one indexed site (.217)")
+  (is (nil? (reject-id '[:div {:title (let [sub identity] (sub query))}]))
+      "a local shadowing sub is an ordinary call, never a reactive site")
+  (is (nil? (reject-id '[:div {:title '((if p sub inc) [:q])}]))
+      "quoted data is inert — never an invocation target"))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -250,6 +250,11 @@
    [:rf.ui.compile/frame-in-loop
     '[:button {:on-click (fn [_] (do-send! (:dispatch (frame))))} "x"]
     ["finite render-time site"]]
+   ;; rf2-vxgfnd.252 — a bare reactive authoring var escaping into computed
+   ;; callee / value flow (distinct throw site: the leaf value-flow guard).
+   [:rf.ui.compile/unsupported-form
+    '[:div {:title ((if p sub inc) [:q])}]
+    ["direct call head" "defview"]]
    ;; handlers
    [:rf.ui.compile/loop-capturing-handler
     '(for [t ts] [:li {:key (:id t) :on-click [::open (:id t)]} "x"])


### PR DESCRIPTION
Closes rf2-vxgfnd.252. Extends the inline-sub soundness family (#5821 lexical site identity, #5855/.217 computed-position rewrite) to close the last value-flow escape they left open.

## The escape (re-verified live on origin/main @ 18d909eefb)

`#5855`/`.217` recursively lower genuine reactive **calls** inside a computed callee, but a bare reactive **authoring var** could still flow as a plain value and never reach a compiler-owned site. Confirmed still-live before the fix (empty subs manifest, bare `sub` surviving in the AST):

```clojure
((if p sub inc) [:q])        ; subs manifest: 0 — bare `sub` survives
((identity sub) [:q])        ; subs manifest: 0
(let [f sub] (f [:q]))       ; subs manifest: 0 — let-bound alias
((if p lease inc) {:resource :r})   ; same for lease
(let [g frame] (g))                 ; same for frame
```

If the reactive branch is selected at runtime, production either picks a sub-free component shape or calls the public `re-frame.ui/sub` placeholder (which throws, since the compiler never lowered it) — and because the manifest under-declares, the optimized build elides the ViewCell entirely, so the read goes stale / escapes ownership. This is exactly the compiler-soundness invariant "a reactive read must never escape the manifest/ViewCell."

## The fix

One leaf rule in the analyzer's expression rewriter (`compiler/analyze.cljc`, `rewrite-expr`): a bare, unquoted, **unshadowed** symbol resolving to `re-frame.ui/sub`|`lease`|`frame` is legal **only** as a compiler-owned direct call head — the rewriter consumes and indexes those heads *above* this check. Any bare reactive var reaching a value-flow leaf (computed callee, let alias, argument, collection) is rejected with a stable typed diagnostic (`:rf.ui.compile/unsupported-form`, the established id for this soundness family — no new id, no frozen-roster contract change).

Because every value-flow path funnels bare symbols through `rewrite-expr`, the single leaf rule closes the computed-callee, `identity`-wrapper, and let-alias escapes uniformly. Quoted data (`quote` branch) and lexical shadows (resolve to nil once locals are merged) pass through untouched; direct `(sub …)` calls nested in a computed callee still lower to one indexed site (`.217` behaviour preserved).

### Didactic reject message

> bare sub reference — re-frame.ui/sub is a reactive authoring var, sound ONLY as a compiler-owned direct call head ((sub query)). Here it flows as a VALUE (into a computed callee, let-binding, argument, or collection) where the compiler cannot own a lexical render site, so the manifest would under-declare and the optimized build would elide the read. Keep the read at a visible sub call site, or make the boundary its own defview

(name is `lease`/`frame` and the call-head spelling `(lease query)`/`(frame)` for those variants.)

## Quality gates (all run in the FOREGROUND, green)

- **`analyze_reject_cljs_test` — new `computed-callee-value-escape` deftest** (red-before-fix; also the mutation fixture): the six escape forms above now reject with `:rf.ui.compile/unsupported-form`; the direct-call `.217` form, the lexical shadow, and quoted data still accept.
- **`analyze_accept_cljs_test` — new `legitimate-value-flow-still-compiles` deftest**: non-reactive value flow through a computed callee / let alias compiles and mints no site; a direct `(sub …)` passed as an argument still lowers to exactly one indexed site.
- **`error_roster_cljs_test`**: added a roster row for the new throw site (existing `unsupported-form` id — the frozen roster and its completeness check are unchanged); message names the escape (`direct call head`, `defview`).
- `cd implementation/ui && clojure -M:test` → **494 tests, 6365 assertions, 0 failures, 0 errors** (includes analyze_reject/accept + error_roster + defview_grammar + the g14 compile-budget gate — no perf regression).
- `cd implementation && npm run test:cljs` → **9357 tests, 44331 assertions, 0 failures, 0 errors** (analyzer runs on both hosts; CLJS path confirmed).

## Follow-ups (not in scope here)

- **Spec 004 grammar prose**: the "a reactive authoring var is legal only as a compiler-owned direct call head" rule should be spelled out in the Template-grammar §; coordinate wording with open rf2-vxgfnd.224 (not treated as owner of this defect). Prose-only ripple — compile-diagnostic ids stay out of the Spec 009 catalogue (S1e roster precedent).
- **Narrow sibling gap**: a bare reactive var used as a destructuring `:or` default value (`(let [{:keys [x] :or {x sub}} v] …)`) is a different path (the pattern, not a rewritten expression) — the existing `reject-reactive-binding!` catches the *call* form there but not a bare ref, and a naive bare-ref scan of a binding pattern would false-positive on legitimate shadowing (`(fn [sub] …)`). Left for a dedicated, binding-position-aware fix.
