### PR TITLE
fix(ui): ViewCell — real-slice memo lifetime, positive teardown incarnation evidence, ambient views as frame-context consumers (rf2-vxgfnd.174/.251/.253)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -465,12 +465,16 @@
         ;; React.memo to the raw body with zero ViewCell hooks.
         has-subs?  (boolean (seq (:subs (:sites manifest))))
         has-leases? (boolean (seq leases))
-        ;; rf2-vxgfnd.228: a `(frame)` site resolves the AMBIENT committed frame
-        ;; (the form takes no arguments — always ambient, never an explicit pin),
-        ;; so a frame-ops-bearing view MUST become a real React frame-context
-        ;; CONSUMER or a provider retarget (A→B) memo-bails the non-consumer
-        ;; child and its held ops stay locked to the old frame. Frame-ops joins
-        ;; subs + leases in the wrapper-selection taxonomy; a view with NONE of
+        ;; rf2-vxgfnd.253 (extending .228): a `(frame)` site resolves the AMBIENT
+        ;; committed frame, and so does EVERY sub target and EVERY lease owner (a
+        ;; sub/lease site implicitly captures the ambient frame/incarnation). So
+        ;; any reactive view MUST become a real React frame-context CONSUMER or a
+        ;; provider retarget (A→B) memo-bails the non-consumer child and its held
+        ;; subs/leases/ops stay locked to the old frame. The sub/lease wrappers
+        ;; therefore consume the context unconditionally — frame-ops presence no
+        ;; longer forks the selection, so there are NO separate `-frame` variants.
+        ;; `render-frame` covers a frame-only view (a `(frame)` site but no
+        ;; sub/lease — a context consumer with no ViewCell); a view with NONE of
         ;; the three stays on the inert direct React.memo path.
         has-frame-ops? (boolean (seq (:frame-ops (:sites manifest))))
         lease-binds (vec
@@ -484,15 +488,9 @@
                      body)
         inner      (if (seq binds) `(let [~@binds] ~rendered) rendered)
         host-render (cond
-                      (and has-subs? has-leases? has-frame-ops?)
-                      're-frame.ui.viewcell/render-subs-and-leases-frame
                       (and has-subs? has-leases?)
                       're-frame.ui.viewcell/render-subs-and-leases
-                      (and has-subs? has-frame-ops?)
-                      're-frame.ui.viewcell/render-subs-frame
-                      has-subs? 're-frame.ui.viewcell/render-subs
-                      (and has-leases? has-frame-ops?)
-                      're-frame.ui.viewcell/render-leases-frame
+                      has-subs?  're-frame.ui.viewcell/render-subs
                       has-leases? 're-frame.ui.viewcell/render-leases
                       has-frame-ops? 're-frame.ui.viewcell/render-frame)
         var-meta   (cond-> {:rf.ui/view true

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -120,13 +120,14 @@
 
   `sub-read` threads a SLICE-SCOPED pure memo (`obs/make-slice-memo`)
   into every `probe`, so N sibling rows probing one query compute shared
-  derivation parents once per synchronous execution slice, not once per
-  row (the first-mount fan-out mitigation). The handle is created lazily
-  on the first probe of a slice and cleared on the next event-loop tick
-  (`interop/next-tick` — a MACROTASK, GC hygiene only, not a
-  correctness-before-paint boundary), so an abandoned slice's table is
-  unreachable garbage. The memo is an ECONOMY, never an authority — the commit
-  evidence comparison (step 5) corrects any staleness before paint."
+  derivation parents once per top-level render/execution slice, not once per
+  row (the first-mount fan-out mitigation). The handle is created lazily on the
+  first probe of a slice and DIES WITH ITS SLICE (rf2-vxgfnd.174): the JVM opens
+  a thread-local per-render scope (`with-slice-memo`, discarded on return); CLJS
+  shares the synchronous render pass through a module holder released at the
+  MICROTASK checkpoint (`queue-microtask!`, aligned with the port's own table
+  clear). The memo is an ECONOMY, never an authority — the commit evidence
+  comparison (step 5) corrects any staleness before paint."
   (:require [re-frame.error :as error]
             [re-frame.features :as features]
             [re-frame.frame :as frame]
@@ -326,46 +327,92 @@
   (:by-site cap))
 
 ;; ---------------------------------------------------------------------------
-;; The slice-scoped probe memo (S2d item 3; 03 §3)
+;; The slice-scoped probe memo (S2d item 3; 03 §3; Spec 006 §The slice-scoped
+;; probe memo)
 ;;
-;; ONE memo handle per synchronous execution slice, shared by every probe
-;; in the slice so sibling rows compute shared derivation parents once
-;; (the first-mount fan-out mitigation). Created lazily on the first probe
-;; of a slice; released on the next event-loop tick (`interop/next-tick` —
-;; a macrotask, which is fine here: this is GC hygiene, not a
-;; correctness-before-paint boundary) so an abandoned slice's table is
-;; unreachable garbage. The memo is an ECONOMY only — commit step 5
-;; corrects any staleness before paint — so a single module holder (probes
-;; never nest across slices synchronously) is sufficient.
+;; ONE memo handle per top-level render/execution slice, shared by every probe
+;; in the slice so sibling rows compute shared derivation parents once (the
+;; first-mount fan-out mitigation). The handle DIES WITH ITS SLICE — the prior
+;; slice's table never survives into the next (rf2-vxgfnd.174):
+;;
+;;   - JVM: a THREAD-LOCAL render-slice scope (`*slice*`, opened by
+;;     `with-slice-memo` — the reactive render entry `with-capture` opens one
+;;     around each render, and a Tier-1 render entry may too). The box holds
+;;     this slice's handle; the `binding` discards it on scope exit, so the
+;;     prior table is unreachable with NO `reset-scheduler!`/tag-change
+;;     dependency, two sequential executor tasks never share a table, and
+;;     concurrent renders on distinct threads stay isolated. A bare probe
+;;     outside any render slice gets a fresh per-call handle (no cross-call
+;;     retention).
+;;   - CLJS: a single module holder shares one handle across every probe of a
+;;     synchronous render pass (single-threaded, so no thread-local scope is
+;;     needed), released at the MICROTASK checkpoint (`queue-microtask!`,
+;;     aligned with the port's own table clear — NOT the `interop/next-tick`
+;;     macrotask, which would leave a dead slice's holder live for one more
+;;     host turn) under a CAS guard so a stale clear cannot erase a newer holder.
+;;
+;; The memo is an ECONOMY only — commit step 5 corrects any staleness before
+;; paint, and the incarnation-complete tag (rf2-vxgfnd.160) keeps a commit-free
+;; reader correct on its own — so a single per-slice handle is sufficient.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private slice-memo* (atom nil))
+#?(:cljs (declare queue-microtask!))
+
+(def ^:dynamic ^:private *slice*
+  "When thread-bound (inside a render slice opened by `with-slice-memo`), a
+  volatile box holding THIS slice's probe-memo handle — created lazily, shared
+  by every probe of the slice, and discarded with the `binding` when the scope
+  returns. nil outside a render slice. Effective on the JVM only: the CLJS host
+  shares a synchronous render pass through the module holder below and never
+  binds this var."
+  nil)
+
+(def ^:private slice-memo*
+  "CLJS module holder for the current synchronous render pass's probe-memo
+  handle (the JVM per-render scope is the thread-local `*slice*` above).
+  Released at the microtask checkpoint by `current-slice-memo`."
+  (atom nil))
+
+(defn- with-slice-memo
+  "Open a render/execution slice for `thunk`: every `sub-read`/probe run under
+  it shares ONE slice-memo handle, discarded when `thunk` returns. Re-entrant —
+  a nested call reuses the enclosing slice rather than opening a second one, so a
+  Tier-1 render entry and the `with-capture` inside it share ONE slice. On CLJS
+  this is a passthrough: the single-threaded host shares a synchronous render
+  pass through the module holder (`slice-memo*`), microtask-released, and needs
+  no per-scope binding."
+  [thunk]
+  #?(:clj  (if (thread-bound? #'*slice*)
+             (thunk)
+             (binding [*slice* (volatile! nil)] (thunk)))
+     :cljs (thunk)))
 
 (defn- current-slice-memo
-  "The current slice's probe memo handle — reused across every probe of
-  this synchronous slice, created lazily. On CLJS a fresh slice mints a
-  fresh handle and the old one is released on the next event-loop tick
-  (`interop/next-tick` — `goog.async.nextTick`, a macrotask firing after the
-  synchronous render pass; GC hygiene only, not a before-paint boundary).
-  On the JVM `next-tick` is a concurrent executor, not a microtask, so a
-  timer-driven clear would race a synchronous render; there the handle is
-  invalidated by the memo's own `(frame, frame-epoch, registry-epoch)` tag —
-  PLUS the exact frame-incarnation token, which distinguishes a same-id
-  destroy+recreate whose epochs tie (rf2-vxgfnd.160) — on the next
-  slice (`slice-memo-table!`) and cleared between fixtures by
-  `reset-scheduler!`. The memo is an ECONOMY — for a committing reader commit
-  step 5 corrects any staleness before paint, and the incarnation-complete tag
-  keeps a commit-free reader correct on its own — so the coarser JVM lifetime
-  is harmless."
+  "The current slice's probe-memo handle, reused across every probe of the slice
+  and created lazily. Inside a `with-slice-memo` scope the handle lives in the
+  thread-local `*slice*` box and is discarded when the scope returns
+  (rf2-vxgfnd.174) — so the prior JVM table is unreachable with no reset/tag
+  dependency. Outside any scope: on CLJS the module holder shares the synchronous
+  render pass and a MICROTASK releases it; on the JVM a bare probe gets a fresh
+  per-call handle (no cross-call/cross-render retention). The handle's own
+  `(frame, frame-epoch, registry-epoch)` tag PLUS the exact frame-incarnation
+  token (rf2-vxgfnd.160) still invalidate a stale table within a slice. The memo
+  is an ECONOMY — commit step 5 corrects staleness before paint, and the
+  incarnation-complete tag keeps a commit-free reader correct on its own."
   []
-  (or @slice-memo*
-      (let [h (obs/make-slice-memo)]
-        (reset! slice-memo* h)
-        ;; Release OUR handle at slice end; a later slice may already have
-        ;; installed a newer one, so clear only while ours is still current.
-        #?(:cljs
-           (interop/next-tick (fn [] (compare-and-set! slice-memo* h nil))))
-        h)))
+  (if-some [box *slice*]
+    (or @box (let [h (obs/make-slice-memo)] (vreset! box h) h))
+    #?(:cljs
+       (or @slice-memo*
+           (let [h (obs/make-slice-memo)]
+             (reset! slice-memo* h)
+             ;; Release OUR handle at the microtask checkpoint (aligned with the
+             ;; port's table clear); a later slice may already have installed a
+             ;; newer one, so clear only while ours is still current.
+             (queue-microtask! (fn [] (compare-and-set! slice-memo* h nil)))
+             h))
+       :clj
+       (obs/make-slice-memo))))
 
 ;; ---------------------------------------------------------------------------
 ;; The ViewCell
@@ -814,12 +861,18 @@
 
   The ambient slot is a dynamic var: `binding` gives the save/restore for
   free on single-threaded CLJS and THREAD-LOCAL isolation on the JVM, so two
-  concurrent Tier-1 renders own disjoint captures (rf2-1llvoh)."
+  concurrent Tier-1 renders own disjoint captures (rf2-1llvoh).
+
+  Each render is ALSO a slice-memo scope: on the JVM `with-slice-memo` opens a
+  thread-local per-render slice (discarded on return) so sibling probes share a
+  derivation parent within the render yet a later render recomputes it
+  (rf2-vxgfnd.174); on CLJS this is a passthrough (the module holder owns the
+  synchronous pass), so the hot path allocates nothing extra."
   [^ViewCell cell thunk]
   (let [cap (volatile! (fresh-capture (:generation @(state cell))))]
     (binding [*ambient* {:cell cell :capture cap}]
-      (let [el (thunk)]
-        [el @cap]))))
+      #?(:clj  (with-slice-memo (fn [] (let [el (thunk)] [el @cap])))
+         :cljs (let [el (thunk)] [el @cap])))))
 
 ;; ---- useSyncExternalStore contract ------------------------------------------
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2710,23 +2710,23 @@
          collected  @captured
          explicit?  (some? root-incarnation)
          ;; When an explicit root incarnation is named it is AUTHORITATIVE: this
-         ;; teardown owns the cells of that generation (rf2-vxgfnd.156). A
-         ;; re-entrant cleanup can disconnect a SIBLING root's cell INSIDE this
+         ;; teardown owns EXACTLY the cells of that generation (rf2-vxgfnd.156).
+         ;; A re-entrant cleanup can disconnect an UNRELATED cell INSIDE this
          ;; window — a resource-lifecycle `on-disconnect` or a router trace
-         ;; listener firing during root A's `.unmount` — and such a captured
-         ;; sibling, owned by a DIFFERENT incarnation, is NOT ours to reap: drop
-         ;; only cells whose `cell-root` is a KNOWN-DIFFERENT incarnation, leaving
-         ;; the sibling reconnectable. A captured cell with NO root ownership
-         ;; (`cell-root` nil — a bare/test mount that never went through a
-         ;; root-incarnation provider) is KEPT: the host `.unmount` sweep is
-         ;; structural (it fires EXACTLY this root's tree, 03 §4), so an
-         ;; unattached captured cell is this root's own. The legacy one-arity
-         ;; path has no explicit generation, so it trusts every captured cell.
+         ;; listener firing during root A's `.unmount` may disconnect a sibling
+         ;; root's cell OR a bare/unattached cell — and such a captured cell is
+         ;; NOT ours to reap. Reap ONLY cells whose `cell-root` is IDENTICAL to
+         ;; the named incarnation: POSITIVE ownership evidence, never absence of
+         ;; it (rf2-vxgfnd.251). A captured cell with a different non-nil root, OR
+         ;; with NO root ownership (`cell-root` nil — never attached to this
+         ;; provider), lacks that evidence and is dropped, leaving it
+         ;; reconnectable. The legacy one-arity path has no explicit generation,
+         ;; so it trusts every captured cell (a real host `.unmount` sweeps
+         ;; exactly its own root's tree, 03 §4).
          owned     (if explicit?
                      (into #{}
-                           (remove (fn [c]
-                                     (when-some [r (cell-root c)]
-                                       (not (identical? root-incarnation r)))))
+                           (filter (fn [c]
+                                     (identical? root-incarnation (cell-root c))))
                            collected)
                      collected)
          ;; the incarnations whose hidden cells this teardown owns. Explicit:

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -2,11 +2,15 @@
   "React glue for the S2b reactive core — the thin `useRef` /
   `useSyncExternalStore` / `useLayoutEffect` layer that drives
   `re-frame.ui.reactive`'s host-agnostic ViewCell + commit reconciler.
-  The compiled CLJS emitter selects one exact PRODUCTION wrapper:
-  `render-subs`, `render-leases`, or `render-subs-and-leases`; a view with
-  neither capability is not wrapped. In DEV the stable Fast Refresh Inner
-  always calls `render-dev`, providing the fixed superset hook skeleton before
-  a view gains or loses either capability without charging production for it.
+  The compiled CLJS emitter selects one exact PRODUCTION wrapper by capability:
+  `render-subs`, `render-leases`, or `render-subs-and-leases` for a reactive
+  view (all three ALSO consume the frame context — every sub/lease site is an
+  ambient-frame reader, rf2-vxgfnd.253), `render-frame` for a frame-only view
+  (a `(frame)` site but no sub/lease — a context consumer with no ViewCell), and
+  no wrapper at all for a genuinely inert view (no sub, no lease, no `(frame)`).
+  In DEV the stable Fast Refresh Inner always calls `render-dev`, providing the
+  fixed superset hook skeleton before a view gains or loses any capability
+  without charging production for it.
 
   The contract, per 03 §3:
 
@@ -182,17 +186,21 @@
 
 (defn- use-frame-context!
   "Register the calling component as a real React CONSUMER of the shared frame
-  context (rf2-vxgfnd.228).
+  context (rf2-vxgfnd.228/.253).
 
-  A compiled view whose body resolves the AMBIENT frame — any `(frame)` /
-  `frame-ops` site — MUST re-render when an ancestor `frame-provider` RETARGETS
-  its frame (A→B), even when the view's own props stay `rf=`-equal. `frame-ops`
-  reads the context value through `function-component-current-frame`
-  (`_currentValue`), which does NOT subscribe the component to context changes;
-  only `useContext` does. So without this hook React correctly memo-bails the
-  non-consumer child on a pure provider retarget, its body never reruns, and its
-  held ops stay locked to the OLD frame (Spec 004-Views §context-change repaint;
-  the same discipline `re-frame.adapter.use-frame/use-frame` uses).
+  A compiled view whose body resolves the AMBIENT frame MUST re-render when an
+  ancestor `frame-provider` RETARGETS its frame (A→B), even when the view's own
+  props stay `rf=`-equal. That is EVERY reactive view, not only `(frame)` /
+  `frame-ops` sites: a `sub` target resolves against the ambient frame, and a
+  lease site captures the ambient frame/incarnation as its resource owner
+  (rf2-vxgfnd.253) — so `render-subs`, `render-leases`, and
+  `render-subs-and-leases` all consume this context too. These sites read the
+  context value through the carried-invariant chain / `_currentValue`, which does
+  NOT subscribe the component to context changes; only `useContext` does. So
+  without this hook React correctly memo-bails the non-consumer child on a pure
+  provider retarget, its body never reruns, and its held ops / subscriptions /
+  lease owners stay locked to the OLD frame (Spec 004-Views §context-change
+  repaint; the same discipline `re-frame.adapter.use-frame/use-frame` uses).
 
   The read VALUE is discarded — resolution runs through the carried-invariant
   chain in `frame-ops`; the SUBSCRIPTION is the entire point. Called as a
@@ -213,57 +221,53 @@
   (thunk))
 
 (defn render-subs
-  "Production wrapper for a view with sub sites and no resource leases."
+  "Production wrapper for a view with sub sites and no resource leases.
+
+  Consumes the shared frame context (leading `use-frame-context!`): every sub
+  target resolves against the AMBIENT frame, so an ancestor `frame-provider`
+  RETARGET (A→B) must re-render this view even when its own props stay
+  `rf=`-equal, or `React.memo` bails the non-consumer and the ViewCell stays
+  subscribed to A (rf2-vxgfnd.253, extending .228 from frame-only views to every
+  ambient-frame reader). Any `(frame)` site the body also carries rides the same
+  single subscription — there is no separate `-frame` wrapper."
   [view-id thunk]
+  (use-frame-context!)
   (let [[cell root-incarnation] (use-cell view-id)
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides cell overrides thunk)]
     (use-commit-and-lifecycle! cell root-incarnation capture)
     element))
 
-(defn render-subs-frame
-  "`render-subs` for a view that ALSO has a `(frame)` site: same ViewCell +
-  sub wiring, plus frame-context consumption so a provider retarget re-renders
-  it (rf2-vxgfnd.228). The leading `use-frame-context!` keeps hook order stable."
-  [view-id thunk]
-  (use-frame-context!)
-  (render-subs view-id thunk))
-
 (defn render-leases
   "Production wrapper for a view with resource leases and no sub sites.
 
-  Structurally contains zero `useSyncExternalStore` calls."
+  Consumes the shared frame context (leading `use-frame-context!`): every lease
+  site implicitly captures the AMBIENT frame/incarnation as its resource owner,
+  so a provider retarget (A→B) with `rf=`-equal props must re-render it to ensure
+  B and release A — otherwise `React.memo` bails and the lease stays bound to A's
+  owner (rf2-vxgfnd.253). Structurally contains zero `useSyncExternalStore`
+  calls."
   [view-id thunk]
+  (use-frame-context!)
   (let [[cell root-incarnation] (use-cell view-id)
         [element capture]      (capture-plain cell thunk)]
     (use-resource-commit-and-lifecycle! cell root-incarnation capture)
     (use-resource-reconcile! cell capture)
     element))
 
-(defn render-leases-frame
-  "`render-leases` for a view that ALSO has a `(frame)` site: same ViewCell +
-  lease wiring, plus frame-context consumption (rf2-vxgfnd.228)."
+(defn render-subs-and-leases
+  "Production wrapper for a view containing both sub and resource sites. Consumes
+  the shared frame context (leading `use-frame-context!`) because both its sub
+  targets and its lease owners resolve against the ambient frame — a provider
+  retarget must re-render it (rf2-vxgfnd.253)."
   [view-id thunk]
   (use-frame-context!)
-  (render-leases view-id thunk))
-
-(defn render-subs-and-leases
-  "Production wrapper for a view containing both sub and resource sites."
-  [view-id thunk]
   (let [[cell root-incarnation] (use-cell view-id)
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides cell overrides thunk)]
     (use-resource-commit-and-lifecycle! cell root-incarnation capture)
     (use-resource-reconcile! cell capture)
     element))
-
-(defn render-subs-and-leases-frame
-  "`render-subs-and-leases` for a view that ALSO has a `(frame)` site: same
-  ViewCell + sub + lease wiring, plus frame-context consumption
-  (rf2-vxgfnd.228)."
-  [view-id thunk]
-  (use-frame-context!)
-  (render-subs-and-leases view-id thunk))
 
 (defn render-dev
   "Stable Fast Refresh wrapper: the full hook superset regardless of the

--- a/implementation/ui/test/re_frame/ui/ambient_lease_provider_retarget_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/ambient_lease_provider_retarget_elision_prod_test.cljs
@@ -1,0 +1,226 @@
+(ns re-frame.ui.ambient-lease-provider-retarget-elision-prod-test
+  "rf2-vxgfnd.253 — the PROD (`:advanced`, goog.DEBUG=false) wrapper-selection
+  twin for the LEASE wrappers, alongside the sub twin
+  `frame-ops-provider-retarget-elision-prod-test`.
+
+  A lease site implicitly captures the AMBIENT frame/incarnation as its resource
+  owner, so a lease-bearing view MUST consume the frame context: an ancestor
+  `frame-provider` RETARGET (A→B) with `rf=`-equal props must re-render it, ENSURE
+  B's owner, and RELEASE A's — otherwise `React.memo` bails the non-consumer,
+  the ViewCell keeps A's owner, and B is never ensured.
+
+  Here the emitter's per-view wrapper selection is LIVE (dev collapses every view
+  onto `render-dev`, which always consumes context, so a dev fixture cannot
+  exercise it):
+
+    - a LEASE-ONLY view (a `lease`, no sub, no `(frame)`) compiles to
+      `viewcell/render-leases`;
+    - a SUB+LEASE view compiles to `viewcell/render-subs-and-leases`;
+
+  both now consume the frame context. This is the mutation-teeth fixture: removing
+  the leading `use-frame-context!` from either wrapper memo-bails the retarget, so
+  the re-render / ensure-B / release-A assertions go red.
+
+  Runs ONLY in `:browser-test-prod-elision`."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.resources]
+            [re-frame.resources.test-support]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+(def ^:private this-ns
+  "re-frame.ui.ambient-lease-provider-retarget-elision-prod-test")
+
+(defonce ^:private resource-events (atom []))
+(defonce ^:private lease-renders (atom 0))
+(defonce ^:private sub-lease-renders (atom 0))
+
+(defview prod-lease-only
+  "A `lease`, NO sub, NO `(frame)` → render-leases."
+  []
+  (ui/lease {:resource ::feed :params {}})
+  (let [_ (swap! lease-renders inc)]
+    [:output {:data-role "prod-lease-only"} "leased"]))
+
+(defview prod-sub-and-lease
+  "A `sub` AND a `lease`, no `(frame)` → render-subs-and-leases."
+  []
+  (ui/lease {:resource ::feed :params {}})
+  (let [n (ui/sub [:retarget/n])
+        _ (swap! sub-lease-renders inc)]
+    [:output {:data-role "prod-sub-and-lease"} (str n)]))
+
+(defn- install! []
+  (reset! resource-events [])
+  (rf/reg-sub :retarget/n (fn [db _] (:n db)))
+  (rf/reg-resource ::feed
+                   {:scope :rf.scope/global
+                    :params-schema [:map]}
+                   (fn [_ _] {:request {:method :get :url "/ui-lease-retarget"}}))
+  ;; Deterministic ensure/release handlers that LOG the owner — the resource
+  ;; artefact registers these in the base image; this is a later-image override.
+  (rf/reg-event :rf.resource/ensure
+                (fn [{:keys [db]} [_ payload]]
+                  (swap! resource-events conj [:ensure (:owner payload)])
+                  {:db db}))
+  (rf/reg-event :rf.resource/release-owner
+                (fn [{:keys [db]} [_ payload]]
+                  (swap! resource-events conj [:release (:owner payload)])
+                  {:db db})))
+
+(defn- make-frame* [id n]
+  (rf/make-frame
+   {:id id
+    :images [(rf/image {:id ::base
+                        :select-ns {:include ["**"] :exclude [this-ns]}})
+             (rf/image {:id ::overrides
+                        :select-ns {:include [this-ns]}})]
+    :initial-events [[:rf/set-db {:n n}]]}))
+
+(defn- macrotask []
+  (js/Promise. (fn [resolve] (js/setTimeout resolve 0))))
+
+(defn- settle!
+  "Drain the passive resource reconcile effect + the re-frame router's async
+  ensure/release dispatches. `ui.test/flush!` is unavailable here — it rides
+  React `act`, which is elided from the `:advanced` production React — so this
+  awaits real macrotasks (React flushes passive effects, then the router next-tick
+  drains) instead."
+  []
+  (-> (macrotask) (.then macrotask) (.then macrotask)
+      (.then macrotask) (.then macrotask) (.then macrotask)))
+
+(defn- lease-cell []
+  (some #(when (seq (reactive/resource-reservations %)) %)
+        (reactive/current-live-cells)))
+
+(defn- reservation-owner [cell]
+  (-> (reactive/resource-reservations cell) vals first :owner))
+
+(defn- ensures  [] (filterv #(= :ensure (first %)) @resource-events))
+(defn- releases [] (filterv #(= :release (first %)) @resource-events))
+
+(defn- render-provider! [root frame component]
+  ;; Mount the memo component through `ui/raw` + `React/createElement` (the
+  ;; proven prod-elision pattern from resource-lease-hook-matrix), scoped by a
+  ;; root-template frame-provider whose frame we retarget A→B.
+  (ReactDOM/flushSync
+   #(ui/render! root [ui/frame-provider {:frame frame}
+                      (ui/raw (React/createElement component nil))])))
+
+(deftest lease-only-consumes-context-ensures-b-and-releases-a-on-retarget
+  (install!)
+  (reset! lease-renders 0)
+  (frames/reset-frame-ops-cache!)
+  (let [fa (make-frame* :retarget/lease-a 1)
+        fb (make-frame* :retarget/lease-b 2)
+        container (js/document.createElement "div")
+        owner-a* (atom nil)
+        renders* (atom 0)]
+    (.appendChild js/document.body container)
+    (let [root (ui/create-root container {:root-id :retarget/lease-root})]
+      (async done
+        (-> (js/Promise.resolve)
+            ;; Mount under provider A.
+            (.then (fn [] (render-provider! root fa prod-lease-only) (settle!)))
+            (.then
+             (fn []
+               (let [cell (lease-cell)
+                     owner-a (reservation-owner cell)]
+                 (reset! owner-a* owner-a)
+                 (reset! renders* @lease-renders)
+                 (testing "mount under A ensured exactly A's owner"
+                   (is (some? cell) "the lease-only view minted a resource cell")
+                   (is (some? owner-a))
+                   (is (= 1 (count (ensures))) "one ensure at mount")
+                   (is (= owner-a (second (last (ensures)))) "…for A's owner")
+                   (is (empty? (releases)) "nothing released yet")))
+               ;; Retarget A→B; the child keeps rf=-equal (empty) props.
+               (render-provider! root fb prod-lease-only)
+               (settle!)))
+            (.then
+             (fn []
+               (let [owner-a @owner-a*
+                     owner-b (reservation-owner (lease-cell))]
+                 (testing "render-leases re-rendered on the retarget"
+                   (is (> @lease-renders @renders*)
+                       "the lease-only view reran despite rf=-equal props"))
+                 (testing "ownership moved A→B — ensure B, release A, once each"
+                   (is (not= owner-a owner-b) "a fresh owner was minted for B")
+                   (is (= 2 (count (ensures))) "one further ensure — for B")
+                   (is (= owner-b (second (last (ensures)))) "…B's owner")
+                   (is (= 1 (count (releases))) "A's owner released exactly once")
+                   (is (= owner-a (second (last (releases)))) "…A's owner"))
+                 (testing "ensure B is queued BEFORE release A (correct order)"
+                   (let [events @resource-events
+                         idx-of (fn [pair] (first (keep-indexed
+                                                   (fn [i e] (when (= e pair) i)) events)))
+                         bi (idx-of [:ensure owner-b])
+                         ai (idx-of [:release owner-a])]
+                     (is (and (some? bi) (some? ai) (< bi ai))
+                         "the fresh ensure precedes the old release"))))))
+            (.catch (fn [e] (is false (str "settle failed: " e))))
+            (.finally
+             (fn []
+               (ReactDOM/flushSync #(ui/unmount! root))
+               (.remove container)
+               (rf/destroy-frame! fa)
+               (rf/destroy-frame! fb)
+               (done))))))))
+
+(deftest sub-and-lease-consumes-context-repaints-b-and-moves-ownership
+  (install!)
+  (reset! sub-lease-renders 0)
+  (frames/reset-frame-ops-cache!)
+  (let [fa (make-frame* :retarget/sl-a 10)
+        fb (make-frame* :retarget/sl-b 20)
+        container (js/document.createElement "div")
+        owner-a* (atom nil)
+        renders* (atom 0)
+        text (fn [] (some-> (.querySelector container "[data-role='prod-sub-and-lease']")
+                            (.-textContent)))]
+    (.appendChild js/document.body container)
+    (let [root (ui/create-root container {:root-id :retarget/sl-root})]
+      (async done
+        (-> (js/Promise.resolve)
+            (.then (fn [] (render-provider! root fa prod-sub-and-lease) (settle!)))
+            (.then
+             (fn []
+               (reset! owner-a* (reservation-owner (lease-cell)))
+               (reset! renders* @sub-lease-renders)
+               (testing "mount under A: sub resolves A, lease ensures A"
+                 (is (= "10" (text)) "sub resolved A's :retarget/n")
+                 (is (= 1 (count (ensures)))))
+               (render-provider! root fb prod-sub-and-lease)
+               (settle!)))
+            (.then
+             (fn []
+               (let [owner-a @owner-a*
+                     owner-b (reservation-owner (lease-cell))]
+                 (testing "render-subs-and-leases re-rendered, repainted B, moved ownership"
+                   (is (> @sub-lease-renders @renders*) "the view reran")
+                   (is (= "20" (text)) "sub repainted B's value, not stale A")
+                   (is (not= owner-a owner-b) "lease owner moved A→B")
+                   (is (= 2 (count (ensures))) "B ensured")
+                   (is (= 1 (count (releases))) "A released once")
+                   (is (= owner-a (second (last (releases)))) "…A's owner")))))
+            (.catch (fn [e] (is false (str "settle failed: " e))))
+            (.finally
+             (fn []
+               (ReactDOM/flushSync #(ui/unmount! root))
+               (.remove container)
+               (rf/destroy-frame! fa)
+               (rf/destroy-frame! fb)
+               (done))))))))

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
@@ -14,9 +14,11 @@
   DEV build (this `-dom-cljs-test`): the frame-only view runs through
   `viewcell/render-dev`, whose stable hook superset now consumes the frame
   context. The PROD wrapper-selection twin — where the emitter routes a
-  frame-only view to `render-frame` and a `(frame)`+`sub` view to
-  `render-subs-frame`, and dropping `:frame-ops` from the selection falls back to
-  the inert direct React.memo path — is `frame-ops-provider-retarget-elision-prod-test`.
+  frame-only view to `render-frame` and every sub/lease view to a wrapper that
+  consumes the frame context unconditionally (rf2-vxgfnd.253), while a genuinely
+  inert view falls back to the direct React.memo path — is
+  `frame-ops-provider-retarget-elision-prod-test` (sub wrappers) and
+  `ambient-lease-provider-retarget-elision-prod-test` (lease wrappers).
 
   Browser-only bodies — `-dom-cljs-test$` opts this file into `:browser-test`;
   under `:node-test` the DOM body gates on `(browser?)` and exits early."

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
@@ -9,15 +9,21 @@
 
     - a FRAME-ONLY view (`(frame)`, no sub, no lease) compiles to
       `viewcell/render-frame` — a real frame-context consumer;
-    - a `(frame)`+`sub` view compiles to `viewcell/render-subs-frame`;
+    - a SUB-ONLY view (a `sub`, no `(frame)`, no lease) compiles to
+      `viewcell/render-subs`, which ALSO consumes the frame context because its
+      sub target resolves against the ambient frame (rf2-vxgfnd.253);
+    - a `(frame)`+`sub` view compiles to the SAME `viewcell/render-subs` — the
+      `-frame` variants collapsed once sub/lease wrappers consume context
+      unconditionally;
     - a genuinely frame-INDEPENDENT view compiles to the inert direct
       `React.memo` path and must NOT re-render on a provider retarget.
 
-  This is the mutation-teeth fixture for the acceptance criterion 'a mutation
-  that removes :frame-ops from context-wrapper selection fails the A-to-B
-  fixture': dropping `:frame-ops` from the emitter's `host-render` cond routes
-  the frame-only and `(frame)`+`sub` views back to the inert path, so they
-  memo-bail the retarget and the B-resolution assertions go red."
+  This is the mutation-teeth fixture: dropping `:frame-ops` from the emitter's
+  `host-render` cond routes the frame-only view back to the inert path, and
+  removing the leading `use-frame-context!` from `render-subs` stops the
+  sub-only / `(frame)`+`sub` views consuming context — either way those views
+  memo-bail the retarget and the B-resolution assertions go red. The lease
+  wrappers' twin lives in `ambient-lease-provider-retarget-elision-prod-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             ["react-dom" :as ReactDOM]
             [re-frame.core :as rf]
@@ -37,10 +43,12 @@
 
 (defonce ^:private frame-only-log (atom []))
 (defonce ^:private frame-sub-log (atom []))
+(defonce ^:private sub-only-log (atom []))
 (defonce ^:private independent-log (atom []))
 
 (defn- log-frame-only! [b] (swap! frame-only-log conj b) nil)
 (defn- log-frame-sub! [b] (swap! frame-sub-log conj b) nil)
+(defn- log-sub-only! [n] (swap! sub-only-log conj n) nil)
 (defn- tick-independent! [] (swap! independent-log conj :render) nil)
 
 (defview prod-frame-only
@@ -51,12 +59,21 @@
     [:output {:data-role "prod-frame-only"} (str frame)]))
 
 (defview prod-frame-and-sub
-  "(frame) + sub → render-subs-frame."
+  "(frame) + sub → render-subs (the -frame variant collapsed)."
   []
   (let [{:keys [frame] :as bundle} (ui/frame)
         n (ui/sub [:retarget/n])
         _ (log-frame-sub! bundle)]
     [:output {:data-role "prod-frame-sub"} (str frame "=" n)]))
+
+(defview prod-sub-only
+  "A `sub`, NO `(frame)`, no lease → render-subs. Its sub target resolves
+  against the AMBIENT frame, so a provider retarget must repaint it to B and
+  detach A even though it never names the frame (rf2-vxgfnd.253)."
+  []
+  (let [n (ui/sub [:retarget/n])
+        _ (log-sub-only! n)]
+    [:output {:data-role "prod-sub-only"} (str n)]))
 
 (defview prod-independent
   "No (frame), no sub, no lease → inert direct React.memo path."
@@ -73,6 +90,7 @@
 (deftest prod-frame-ops-views-consume-context-and-independent-stays-inert
   (reset! frame-only-log [])
   (reset! frame-sub-log [])
+  (reset! sub-only-log [])
   (reset! independent-log [])
   (frames/reset-frame-ops-cache!)
   (reg!)
@@ -86,37 +104,59 @@
       (try
         (ReactDOM/flushSync
          #(ui/render! root [ui/frame-provider {:frame fa}
-                            [prod-frame-only] [prod-frame-and-sub] [prod-independent]]))
+                            [prod-frame-only] [prod-frame-and-sub]
+                            [prod-sub-only] [prod-independent]]))
         (testing "initial resolution under provider A"
           (is (= fa-id (:frame (last @frame-only-log))))
           (is (= fa-id (:frame (last @frame-sub-log))))
           (is (= (str fa-id) (text container "[data-role='prod-frame-only']")))
-          (is (= (str fa-id "=1") (text container "[data-role='prod-frame-sub']"))))
+          (is (= (str fa-id "=1") (text container "[data-role='prod-frame-sub']")))
+          (is (= 1 (last @sub-only-log)) "sub-only resolved A's :retarget/n")
+          (is (= "1" (text container "[data-role='prod-sub-only']"))))
 
         (let [fo-before (count @frame-only-log)
               fs-before (count @frame-sub-log)
+              so-before (count @sub-only-log)
               ind-before (count @independent-log)]
-          ;; Retarget A→B; all three children keep rf=-equal (empty) props.
+          ;; Retarget A→B; all four children keep rf=-equal (empty) props.
           (ReactDOM/flushSync
            #(ui/render! root [ui/frame-provider {:frame fb}
-                              [prod-frame-only] [prod-frame-and-sub] [prod-independent]]))
+                              [prod-frame-only] [prod-frame-and-sub]
+                              [prod-sub-only] [prod-independent]]))
           (testing "render-frame: the frame-only view re-rendered and resolved B"
             (is (> (count @frame-only-log) fo-before))
             (is (= fb-id (:frame (last @frame-only-log))))
             (is (= (str fb-id) (text container "[data-role='prod-frame-only']"))))
-          (testing "render-subs-frame: the (frame)+sub view re-rendered and resolved B"
+          (testing "render-subs (frame+sub): the (frame)+sub view re-rendered and resolved B"
             (is (> (count @frame-sub-log) fs-before))
             (is (= fb-id (:frame (last @frame-sub-log))))
             (is (= (str fb-id "=2") (text container "[data-role='prod-frame-sub']"))))
+          (testing "render-subs (sub-only): the sub-only view repainted B and detached A"
+            (is (> (count @sub-only-log) so-before)
+                "the sub-only view re-rendered on the retarget despite rf=-equal props")
+            (is (= 2 (last @sub-only-log)) "it resolved B's :retarget/n, not the stale A")
+            (is (= "2" (text container "[data-role='prod-sub-only']"))))
           (testing "the frame-INDEPENDENT view stayed inert (direct memo, no re-render)"
             (is (= ind-before (count @independent-log))
                 "a genuinely frame-independent view is not charged a context re-render")))
 
-        (testing "a dispatch through the post-retarget frame-only bundle targets B"
-          (ReactDOM/flushSync
-           #((:dispatch-sync (last @frame-only-log)) [:retarget/set 77]))
+        (testing "the post-retarget frame-only bundle drives B, leaving A untouched"
+          ;; The sub-only view already proved it is subscribed to B (it resolved
+          ;; B's :retarget/n=2 above). A sub delta repaints on a later microtask,
+          ;; which act-free advanced React cannot flush synchronously here, so this
+          ;; asserts the write side only.
+          (ReactDOM/flushSync #((:dispatch-sync (last @frame-only-log)) [:retarget/set 77]))
           (is (= 77 (:n (rf/app-db-value fb))) "bundle drove B")
           (is (= 1 (:n (rf/app-db-value fa))) "A untouched"))
+
+        (testing "a same-provider re-render adds no sub-only render (no needless work)"
+          (let [before (count @sub-only-log)]
+            (ReactDOM/flushSync
+             #(ui/render! root [ui/frame-provider {:frame fb}
+                                [prod-frame-only] [prod-frame-and-sub]
+                                [prod-sub-only] [prod-independent]]))
+            (is (= before (count @sub-only-log))
+                "identical provider value → no context change → memo bail")))
         (finally
           (ReactDOM/flushSync #(ui/unmount! root))
           (.remove container))))))

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -397,33 +397,103 @@
            via the slice-scoped memo threaded through sub-read")
       (is (nil? (entry [:s/parent])) "probes stayed ownership-free — no cache node"))))
 
-(deftest slice-memo-dies-with-slice
-  ;; make-slice-memo scopes derivation sharing to ONE handle = ONE render slice.
-  ;; The reactive layer mints a FRESH handle per slice (and releases it on the
-  ;; next tick / microtask), so a DEAD slice's memo is never retained into the
-  ;; next slice. Proven at the port primitive the reactive layer consumes:
-  ;; sharing holds WITHIN a slice, and a fresh slice recomputes.
-  (let [parent-runs (atom 0)]
-    (rf/reg-sub :s/parent (fn [db _] (swap! parent-runs inc) (:n db)))
-    (rf/reg-sub :s/a :<- [:s/parent] (fn [n _] [:a n]))
-    (rf/reg-sub :s/b :<- [:s/parent] (fn [n _] [:b n]))
-    (seed! fid {:n 5})
-    (rf/with-frame fid
-      (let [h1 (obs/make-slice-memo)]
-        (is (= {:tag nil :memo nil} @h1) "a fresh slice handle retains no table")
-        (obs/probe (obs/resolve-target {:query-v [:s/a]}) h1)
-        (obs/probe (obs/resolve-target {:query-v [:s/b]}) h1)
-        (is (= 1 @parent-runs)
-            "WITHIN one slice the shared parent computes ONCE (memo hit)")
-        (is (some? (:memo @h1)) "the live slice retains its table")
-        ;; a NEW slice = a FRESH handle; the dead slice's memo is not reused
-        (let [h2 (obs/make-slice-memo)]
-          (obs/probe (obs/resolve-target {:query-v [:s/a]}) h2)
-          (obs/probe (obs/resolve-target {:query-v [:s/b]}) h2)
-          (is (= 2 @parent-runs)
-              "a FRESH slice recomputes the parent — the prior slice's memo did
-               NOT survive (dies with the slice; no retained memo)")
-          (is (not (identical? h1 h2)) "each slice owns a DISTINCT memo handle"))))))
+#?(:clj
+   (deftest slice-memo-dies-with-slice
+     ;; rf2-vxgfnd.174 — the slice memo dies with its slice, exercised through
+     ;; the REAL runtime path (`with-capture` → `sub-read` → `current-slice-memo`),
+     ;; NOT a proxy that hand-constructs two `obs/make-slice-memo` handles. On the
+     ;; JVM each top-level render (`with-capture`) opens a thread-local slice: the
+     ;; sibling sites share their derivation parent ONCE, and a LATER render
+     ;; recomputes because the prior slice's table did NOT survive — proven with
+     ;; the frame/incarnation/registry tag UNCHANGED and WITHOUT `reset-scheduler!`,
+     ;; so only the per-slice scope (not a tag flip or a reset) explains the
+     ;; recompute. On current main the JVM module holder persisted across slices
+     ;; and the second render MEMO-HIT the prior table (parent-runs stays 1). The
+     ;; CLJS boundary is the MICROTASK, not the synchronous with-capture — that
+     ;; host's counterpart is `cljs-slice-memo-holder-dies-at-the-microtask-checkpoint`.
+     (let [parent-runs (atom 0)]
+       (rf/reg-sub :s/parent (fn [db _] (swap! parent-runs inc) (:n db)))
+       (rf/reg-sub :s/a :<- [:s/parent] (fn [n _] [:a n]))
+       (rf/reg-sub :s/b :<- [:s/parent] (fn [n _] [:b n]))
+       (seed! fid {:n 5})
+       (let [render! (fn []
+                       (rf/with-frame fid
+                         (reactive/with-capture (reactive/make-cell ::v)
+                           (fn [] [(reactive/sub-read ::site-a [:s/a])
+                                   (reactive/sub-read ::site-b [:s/b])]))))]
+         (testing "WITHIN one slice sibling cold probes share the parent ONCE"
+           (let [[out _] (render!)]
+             (is (= [[:a 5] [:b 5]] out))
+             (is (= 1 @parent-runs)
+                 "the slice-scoped memo threaded through sub-read computes the
+                  shared parent once for the two sibling sites")
+             (is (nil? (entry [:s/parent])) "cold probes stayed ownership-free")))
+         (testing "a LATER slice recomputes — the prior slice's memo did NOT survive"
+           ;; Tag is IDENTICAL (same frame, commit epoch, registry epoch,
+           ;; incarnation) and NO reset-scheduler! ran between renders, so a
+           ;; recompute can only come from the slice dying — not a tag/reset.
+           (render!)
+           (is (= 2 @parent-runs)
+               "the fresh render slice recomputes the shared parent — the prior
+                slice's table is unreachable (dies with the slice)"))))))
+
+(deftest slice-memo-across-sequential-executor-tasks-never-reuses-a-table
+  ;; rf2-vxgfnd.174 AC — two SEQUENTIAL top-level renders on a background
+  ;; executor task cannot reuse the same memo table (the JVM concurrent-render
+  ;; case). Same tag, no reset-scheduler!; each render is its own slice, so the
+  ;; parent recomputes per render. JVM-only: it drives a real executor future.
+  #?(:clj
+     (let [parent-runs (atom 0)]
+       (rf/reg-sub :sx/parent (fn [db _] (swap! parent-runs inc) (:n db)))
+       (rf/reg-sub :sx/a :<- [:sx/parent] (fn [n _] [:a n]))
+       (rf/reg-sub :sx/b :<- [:sx/parent] (fn [n _] [:b n]))
+       (seed! fid {:n 9})
+       (let [render! (fn []
+                       (rf/with-frame fid
+                         (reactive/with-capture (reactive/make-cell ::v)
+                           (fn [] [(reactive/sub-read ::a [:sx/a])
+                                   (reactive/sub-read ::b [:sx/b])]))))
+             task    (fn [] (let [[out _] (render!)] out))]
+         (is (= [[:a 9] [:b 9]] @(future (task))) "task 1 renders on its own thread")
+         (is (= [[:a 9] [:b 9]] @(future (task))) "task 2 renders on its own thread")
+         (is (= 2 @parent-runs)
+             "two sequential executor tasks each got a FRESH slice — the table
+              is never reused across renders (no cross-task retention)")))
+     :cljs (is true "executor-task isolation is a JVM concern")))
+
+#?(:cljs
+   (deftest cljs-slice-memo-holder-dies-at-the-microtask-checkpoint
+     ;; rf2-vxgfnd.174 CLJS AC — the module holder shares one handle across a
+     ;; SYNCHRONOUS render pass and is released at the MICROTASK checkpoint (NOT
+     ;; the `next-tick` macrotask). Two headless probes in ONE synchronous task
+     ;; share the parent once; a probe scheduled on a later MICROTASK sees the
+     ;; holder already released and recomputes — proof the holder dies with the
+     ;; synchronous slice at the microtask boundary, aligned with the port's
+     ;; table clear. Reverting the holder clear to `interop/next-tick` (a
+     ;; macrotask) leaves the holder live through this microtask and the probe
+     ;; MEMO-HITS instead — this fixture goes red.
+     (async done
+       (let [parent-runs (atom 0)]
+         (rf/reg-sub :sm/parent (fn [db _] (swap! parent-runs inc) (:n db)))
+         (rf/reg-sub :sm/a :<- [:sm/parent] (fn [n _] [:a n]))
+         (rf/reg-sub :sm/b :<- [:sm/parent] (fn [n _] [:b n]))
+         (seed! fid {:n 3})
+         ;; ONE synchronous slice: two headless sibling probes share the module
+         ;; holder, so the parent computes once.
+         (rf/with-frame fid
+           (reactive/sub-read ::a [:sm/a])
+           (reactive/sub-read ::b [:sm/b]))
+         (is (= 1 @parent-runs) "the synchronous slice shared the parent ONCE")
+         ;; A later MICROTASK: the holder-clear microtask (armed by the first
+         ;; probe) runs first (FIFO), so this probe finds a released holder and
+         ;; recomputes.
+         (js/queueMicrotask
+           (fn []
+             (rf/with-frame fid (reactive/sub-read ::a [:sm/a]))
+             (is (= 2 @parent-runs)
+                 "the microtask probe recomputed — the holder died at the
+                  microtask checkpoint (macrotask next-tick would still memo-hit)")
+             (done)))))))
 
 ;; ===========================================================================
 ;; Bounded invalidation evidence across a coalesced batch (rf2-vxgfnd.46)

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -339,6 +339,47 @@
       (is (= 2 (reactive/root-cell-count inc-b))
           "both B cells still owned by B — A's teardown claimed neither"))))
 
+(deftest explicit-teardown-requires-positive-incarnation-evidence-not-absence
+  ;; rf2-vxgfnd.251 — an explicit teardown must reap ONLY cells whose root is
+  ;; IDENTICAL to the named incarnation (positive ownership evidence), never a
+  ;; captured cell that merely LACKS ownership evidence. A re-entrant cleanup
+  ;; disconnects BOTH root A's attached cell AND an unrelated UNATTACHED
+  ;; (nil-root, reconnectable) cell inside A's window. Pre-fix, `teardown-root!`
+  ;; kept every nil-root captured cell (absence-of-a-known-different-root was
+  ;; read as ownership), so the bystander was force-dead. A must be reaped; the
+  ;; unattached sibling must stay alive and reconnectable with unchanged lease.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid    (make-frame! :rt/frame {:a 1})
+        inc-a  (reactive/make-root-incarnation)
+        cell-a (mount! ::a inc-a fid [[:rt/a]])
+        ;; an unattached cell: connected + observing, but NEVER attach-root! —
+        ;; a bare/reconnectable cell not owned by any provider incarnation
+        bare   (render+commit! (reactive/make-cell ::bare) fid [[:rt/a]])]
+    (is (= :connected (reactive/lifecycle cell-a)))
+    (is (= :connected (reactive/lifecycle bare)))
+    (is (nil? (reactive/cell-root bare)) "the bystander carries NO root ownership")
+    (is (= 1 (reactive/teardown-root!
+              inc-a
+              (fn []
+                (reactive/disconnect! cell-a)
+                ;; re-entrant: the unrelated unattached cell disconnects too
+                (reactive/disconnect! bare))))
+        "exactly ONE cell reaped — A's attached cell — not the nil-root bystander")
+    (is (= :dead (reactive/lifecycle cell-a)) "the correctly-attached A cell is reaped")
+    (testing "the unattached bystander is NOT force-dead — a reconnectable hide"
+      (is (not= :dead (reactive/lifecycle bare))
+          "explicit teardown must not kill a captured cell it cannot prove it owns")
+      (is (= :disconnected (reactive/lifecycle bare)) "left a plain reconnectable hide"))
+    (testing "the bystander reconnects cleanly and reacquires its lease"
+      (reactive/settle-disconnect! bare)
+      (render+commit! bare fid [[:rt/a]])
+      (is (= :connected (reactive/lifecycle bare)) "reconnected, never :dead")
+      (is (= 1 (ref-count fid [:rt/a])) "reacquired a live lease — never disposed")
+      (is (= 1 (first (rf/with-frame fid
+                        (reactive/with-capture bare
+                          (fn [] (reactive/sub-read ::site [:rt/a]))))))
+          "reads live through the real observation port"))))
+
 (deftest legacy-one-arity-still-reaps-siblings-via-captured-incarnation
   ;; The one-arity path is UNCHANGED (rf2-vxgfnd.85): with no explicit
   ;; incarnation, a window-captured cell's own incarnation still reaps its

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -55,7 +55,14 @@
   (frame/replace-app-db! :rtw/frame {:a 1})
   (let [cell (connected-cell! :rtw/frame [[:rtw/a]])
         ;; the host `.unmount` fires the cell's cleanup, as React does
-        root (register! :rtw/root #(reactive/disconnect! cell))]
+        root (register! :rtw/root #(reactive/disconnect! cell))
+        inc  (:root-incarnation (client/live-root-entry :rtw/root))]
+    ;; Attach the cell to the REAL root incarnation, exactly as the production
+    ;; lifecycle effect does (rf2-vxgfnd.251): the explicit-incarnation teardown
+    ;; reaps ONLY cells that carry positive ownership of the named root, so this
+    ;; wiring fixture must own its cell rather than lean on the retired nil-root
+    ;; exception.
+    (reactive/attach-root! cell inc)
     (is (= :connected (reactive/lifecycle cell)) "precondition: mounted + connected")
     (is (= #{:rtw/root} (client/live-root-ids)) "precondition: root is live")
     (is (nil? (client/unmount!* root)) "unmount!* returns nil")


### PR DESCRIPTION
Three P1 ViewCell/reactive follow-ups on the ambient-frame + slice-memo-economy surface — follow-ups to the merged reactive-incarnation (#5854), frame-ops (#5857/.228), and G-13 (#5860) work. One PR, three commits (order `.174` → `.251` → `.253`). Each fix carries a red-before-fix fixture; the incarnation fences (#5854), evidence (#5844), and G-13 economics (#5860) stay green.

All four merged premises re-verified on fresh `origin/main` (#5854 reactive incarnation, #5857 frame-ops, #5860 G-13, #5844 evidence) — every repro still reproduced on this head before the fix.

## rf2-vxgfnd.174 — real-slice memo lifetime
The `slice-memo-dies-with-slice` gate hand-constructed two `obs/make-slice-memo` handles and never crossed the runtime path, so removing the runtime clear left it green. On the JVM the module holder was never released — two sequential/concurrent top-level renders reused a prior slice's table even with the frame/incarnation/registry tag unchanged; on CLJS the holder was released one macrotask late (`interop/next-tick`), not at the microtask checkpoint Spec 006 specifies.

- **JVM**: `with-capture` opens a thread-local per-render slice (`*slice*` via a re-entrant `with-slice-memo`) discarded on return — sibling probes share a derivation parent within a render, a later render recomputes, sequential executor tasks never share a table, concurrent renders stay isolated; no `reset-scheduler!`/tag-change dependency. A bare probe outside a slice gets a fresh per-call handle.
- **CLJS**: the module holder still shares the synchronous render pass (cross-cell fan-out economy intact — G-13 unaffected) but is released at the microtask checkpoint (`queue-microtask!`, aligned with the port's own table clear) under a CAS guard.

Red-before-fix fixtures (in `reactive_epoch_cljs_test.cljc`): JVM `slice-memo-dies-with-slice` (render-slice recompute) + `slice-memo-across-sequential-executor-tasks-never-reuses-a-table`; CLJS `cljs-slice-memo-holder-dies-at-the-microtask-checkpoint` (reddens if the holder clear reverts to the next-tick macrotask). Confirmed red on current main (parent-runs stuck at 1).

## rf2-vxgfnd.251 — positive teardown incarnation evidence
`teardown-root!` explicit-arity kept every captured cell whose `cell-root` was `nil`, reading absence-of-a-known-different-root as ownership. A re-entrant cleanup that disconnects both an attached root-A cell **and** an unrelated unattached (nil-root, reconnectable) cell inside A's window then force-dead the bystander.

- Explicit teardown now reaps ONLY cells whose `cell-root` is **identical** to the named incarnation (positive evidence). A different non-nil root OR a nil root is dropped, left reconnectable with its lease intact.
- Red-before-fix fixture `explicit-teardown-requires-positive-incarnation-evidence-not-absence` (in `reactive_root_teardown_cljs_test.cljc`): A reaped, the nil-root bystander stays `:disconnected` and reconnects + reacquires its lease. Reverting the predicate reddens exactly this fixture and no other teardown test.
- The bare wiring fixture (`unmount-drives-the-cell-to-dead`) now attaches its cell to the real root incarnation — exactly as the production lifecycle effect does — rather than leaning on the retired nil-root exception.

## rf2-vxgfnd.253 — ambient sub/lease views as frame-context consumers
Extends #5857/.228 (frame-only views) to every ambient-frame reader. Production sub-only, lease-only, and sub+lease wrappers did not call `use-frame-context!`, yet a sub target resolves against the ambient frame and a lease site captures the ambient frame/incarnation as its resource owner — so a provider retarget (A→B) with `rf=`-equal props memo-bailed the non-consumer, leaving it subscribed to A / owning A's resource. DEV masked it (`render-dev` always consumes context).

- `render-subs`, `render-leases`, and `render-subs-and-leases` now consume the frame context via a leading `use-frame-context!`. The redundant `render-subs-frame` / `render-leases-frame` / `render-subs-and-leases-frame` variants collapse away — frame-ops presence no longer forks the wrapper selection (`emit_cljs` `host-render` cond simplified). `render-frame` still covers frame-only views; an inert view stays on the direct `React.memo` path.
- Red-before-fix fixtures (advanced/`goog.DEBUG=false`): `frame_ops_provider_retarget_elision_prod_test` adds a **sub-only** retarget (`render-subs`); new `ambient_lease_provider_retarget_elision_prod_test` proves **lease-only** (`render-leases`) and **sub+lease** (`render-subs-and-leases`) re-render, ensure B, and release A exactly once in order on retarget. Removing `use-frame-context!` from the three sub/lease wrappers reddened exactly their fixtures (18 assertions) while `render-frame`'s fixture stayed green. The resource hook-cardinality matrix stays green — `useContext` adds no `useSyncExternalStore`/passive hook.

## Quality gates
All run from `implementation/`, foreground.

| Gate | Result |
|---|---|
| `clojure -M:test` (UI JVM) | 494 tests / 6348 assertions — 0 failures |
| `npm run test:ui` (node CLJS) | 495 tests / 2487 assertions — 0 failures |
| `npm run test:browser` (dev DOM) | 351 tests / 1905 assertions — 0 failures |
| `npm run test:browser-prod-elision` | 84 tests / 305 assertions — 0 failures (incl. `ui mounted production elision: PASS`) |
| Mutation-teeth (.174/.251/.253) | each confirmed red-before-fix |

## Spec ripples (follow-up)
- Spec 006 §The slice-scoped probe memo: the JVM per-render-slice scope + CLJS microtask-checkpoint holder lifetime should be reflected in prose (currently describes a single module holder + next-tick clear).
- Spec 004-Views §context-change repaint: the ambient-frame-consumer rule now covers every sub/lease site, not only `(frame)`/frame-ops sites.
- JVM SSR structural render (`ui.test/render` / `emit_jvm`) is not a `with-capture` slice, so it currently gets fresh per-call slice handles (no cross-cell fan-out sharing) rather than one slice per render tree; wiring the JVM render entry through `with-slice-memo` (an economy-only, non-gated improvement, out of this PR's scope fence) is a clean follow-up.
