### PR TITLE
fix(ui): reject bare reactive var as a destructuring :or default (rf2-dzyqis)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -339,6 +339,36 @@
                       "a lexical render site. Hoist the read into the view body "
                       "and bind/destructure its value there"))
                {:form binding-form :reactive-kind kind}))
+  ;; Sibling gap (rf2-dzyqis) that PR #5874 (rf2-vxgfnd.252) left open. The call
+  ;; scan above catches an executable `(sub …)`/`(lease …)`/`(frame)` embedded in
+  ;; the pattern, but a BARE reactive authoring var used as a destructuring `:or`
+  ;; DEFAULT is a value, not a call — `{:keys [x] :or {x sub}}`. Binding patterns
+  ;; never pass through expression rewriting, so that bare var flows as a VALUE
+  ;; into the host's destructuring `get` default with no compiler-owned render
+  ;; site: the manifest under-declares and the optimized build elides the read.
+  ;; The `:else` value-flow leaf guard in `rewrite-expr` never sees it (patterns
+  ;; are not rewritten), and a naive value-flow scan of the pattern would
+  ;; false-positive on legitimate lexical shadowing (`{:keys [sub]}` BINDS a local
+  ;; named sub), so this reject is binding-position-AWARE: every symbol the pattern
+  ;; BINDS is added to the ambient locals, so only a bare reactive var reaching a
+  ;; default from OUTSIDE the pattern still resolves to the authoring var. `:or`
+  ;; defaults are the only value-expression slots a binding pattern carries, so
+  ;; scanning the whole shadowed form targets exactly the :or-default path.
+  (let [own-scope (into (:locals e) (env/binding-syms binding-form))]
+    (when-let [kind (bare-reactive-reference-kind e binding-form own-scope)]
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str "bare " (name kind) " reference as a destructuring :or "
+                      "default — re-frame.ui/" (name kind) " is a reactive "
+                      "authoring var, sound ONLY as a compiler-owned direct call "
+                      "head ("
+                      (if (= :frame kind) "(frame)"
+                          (str "(" (name kind) " query)"))
+                      "). A binding :or default is never rewritten, so the bare "
+                      "var flows as a VALUE where the compiler cannot own a "
+                      "lexical render site — the manifest under-declares and the "
+                      "optimized build elides the read. Hoist the read into the "
+                      "view body and destructure its committed value there")
+                 {:form binding-form :reactive-kind kind})))
   binding-form)
 
 (defn rewrite-expr

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -255,6 +255,23 @@
           "the direct (sub …) is a compiler-owned call head, not an escaping var")
       (is (= [[:n]] (map :query (:subs sites)))))))
 
+(deftest legitimate-or-default-shadow-still-compiles
+  ;; rf2-dzyqis — reject-reactive-binding! now also rejects a BARE reactive
+  ;; authoring var used as a destructuring :or default, but the reject is
+  ;; binding-position-AWARE: a local the pattern itself BINDS (a lexical shadow
+  ;; named sub/lease/frame) is not the reactive var, so it still compiles and
+  ;; mints no reactive site.
+  (testing "a local named sub bound by the pattern is an ordinary shadow (no site)"
+    (let [{:keys [sites]} (ana-full '[:div {:title (let [{:keys [sub]} m] (str sub))}])]
+      (is (empty? (:subs sites))
+          "the destructured local sub is a value, never a reactive read")))
+  (testing "an :or default referencing a same-pattern shadow compiles (no site)"
+    (let [{:keys [sites]} (ana-full '[:div {:title (let [{:keys [sub a] :or {a sub}} m] a)}])]
+      (is (empty? (:subs sites)))))
+  (testing "a literal :or default is untouched (no site)"
+    (let [{:keys [sites]} (ana-full '[:div {:title (let [{:keys [x] :or {x 0}} m] x)}])]
+      (is (empty? (:subs sites))))))
+
 (deftest lexical-site-id-is-portable-stable-and-query-independent
   (let [template-a [:div (located-sub 102 8 [:item/by-id 'id])]
         template-b [:div (located-sub 202 8 [:item/by-id 'id])]

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -146,6 +146,43 @@
   (is (nil? (reject-id '[:div {:title '((if p sub inc) [:q])}]))
       "quoted data is inert — never an invocation target"))
 
+(deftest or-default-value-escape
+  ;; rf2-dzyqis — the sibling gap PR #5874 (.252) left open. reject-reactive-
+  ;; binding! catches an executable (sub …)/(lease …)/(frame) embedded in a
+  ;; binding pattern, but a BARE reactive authoring var used as a destructuring
+  ;; :or DEFAULT is a value, not a call. Binding patterns never pass through
+  ;; expression rewriting, so that bare var flows as a VALUE into the host's
+  ;; destructuring default with no compiler-owned render site — the manifest
+  ;; under-declares and the optimized build elides the read. The reject is
+  ;; binding-position-AWARE: every symbol the pattern BINDS is treated as a
+  ;; local, so only a bare var reaching a default from OUTSIDE the pattern is
+  ;; rejected. Removing the :or-default guard silently re-accepts every reject
+  ;; row below, so this deftest is the mutation fixture too.
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [{:keys [x] :or {x sub}} m] x)}]))
+      "bare sub as an :or default — the rf2-dzyqis counterexample")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [{:keys [x] :or {x lease}} m] x)}]))
+      "bare lease as an :or default escapes identically")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [{:keys [x] :or {x frame}} m] x)}]))
+      "bare frame as an :or default escapes identically")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (fn [{:keys [x] :or {x sub}}] x)}]))
+      "a bare sub :or default in an fn destructuring arg escapes identically")
+  (is (= :rf.ui.compile/unsupported-form
+         (reject-id '[:div {:title (let [{:keys [x] :or {x (str sub)}} m] x)}]))
+      "a bare sub flowing through an :or default expression escapes too")
+  ;; The binding-position-aware guard leaves the legal forms alone:
+  (is (nil? (reject-id '[:div {:title (let [{:keys [sub]} m] (str sub))}]))
+      "a local NAMED sub the pattern binds is a legitimate lexical shadow")
+  (is (nil? (reject-id '[:div {:title (let [{:keys [sub a] :or {a sub}} m] a)}]))
+      "an :or default referencing a sub the SAME pattern binds is the shadow")
+  (is (nil? (reject-id '[:div {:title (let [{:keys [x] :or {x 0}} m] x)}]))
+      "an ordinary literal :or default is untouched")
+  (is (nil? (reject-id '[:div {:title (let [{:keys [x] :or {x 'sub}} m] x)}]))
+      "quoted data in an :or default is inert — never a reactive read"))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -255,6 +255,11 @@
    [:rf.ui.compile/unsupported-form
     '[:div {:title ((if p sub inc) [:q])}]
     ["direct call head" "defview"]]
+   ;; rf2-dzyqis — a bare reactive authoring var used as a destructuring :or
+   ;; DEFAULT (distinct throw site: reject-reactive-binding!'s :or-default guard).
+   [:rf.ui.compile/unsupported-form
+    '[:div {:title (let [{:keys [x] :or {x sub}} m] x)}]
+    ["destructuring :or" "direct call head"]]
    ;; handlers
    [:rf.ui.compile/loop-capturing-handler
     '(for [t ts] [:li {:key (:id t) :on-click [::open (:id t)]} "x"])


### PR DESCRIPTION
Closes the narrow sibling gap PR #5874 (rf2-vxgfnd.252) explicitly left for a binding-position-aware fix.

## The gap

#5874's `rewrite-expr` value-flow leaf reject catches a bare `sub`/`lease`/`frame` authoring var escaping into a **computed callee / let-alias / argument / collection** value flow. But a bare reactive var used as a destructuring **`:or` DEFAULT** is a *different* (binding-position) path:

- Binding patterns are **never rewritten** — `reject-reactive-binding!` scans them separately. Its existing `reactive-call-kind` check catches an executable `(sub …)` in a default, but a **bare** `sub` there is a value, not a call, so it slipped through.
- The `:else` value-flow leaf guard in `rewrite-expr` never sees the default (patterns don't pass through `rw`).
- A naive value-flow scan of a binding pattern would **false-positive on legitimate lexical shadowing** — `{:keys [sub]}` legitimately *binds* a local named `sub` — which is exactly why #5874 deliberately excluded this path.

So a bare reactive var as an `:or` default (`{:keys [x] :or {x sub}}`) would flow as a value into the host's destructuring `get` default with no compiler-owned render site: the manifest under-declares and the optimized build elides the read.

## The fix (binding-position-AWARE)

`reject-reactive-binding!` gains a second, shadow-aware pass reusing #5874's machinery (`bare-reactive-reference-kind`). Every symbol the pattern **binds** (`env/binding-syms` — `:keys`/`:syms`/`:strs`/`:as`/nested, recursively) is added to the ambient locals, so:

- a bare reactive var reaching a default **from outside** the pattern still resolves to the authoring var → **rejected** (didactic `:rf.ui.compile/unsupported-form`, the soundness-family id — no new id);
- a legitimate lexical shadow — a local *named* `sub`/`lease`/`frame`, or an `:or` default referencing a same-pattern shadow — resolves to nil → **still compiles**.

`:or` defaults are the only value-expression slots a binding pattern carries, so scanning the whole shadowed form targets exactly the `:or`-default path and does not broaden the reject.

## Quality gates

- `analyze_reject_cljs_test / or-default-value-escape` (new, red-before-fix + mutation fixture): bare `sub`/`lease`/`frame` as an `:or` default (and via an `:or` default expression, and an fn destructuring arg) all reject; the legal forms (a bound local named `sub`, an `:or` default referencing a same-pattern shadow, a literal default, quoted data) stay `nil`.
- `analyze_accept_cljs_test / legitimate-or-default-shadow-still-compiles` (new): the shadowing bindings compile and mint **no** reactive site.
- `error_roster_cljs_test`: new roster row for the distinct throw site (`reject-reactive-binding!`'s `:or`-default guard).
- Green locally: `implementation/ui` `clojure -M:test` (496 tests / 6382 assertions / 0 failures) and `implementation` `npm run test:cljs` node/both-hosts (9363 tests / 44367 assertions / 0 failures).

Compile-reject ids are prose-only (no Spec 009 catalogue row — `:rf.ui.compile/*` is a compile diagnostic).

## Follow-up

Spec 004 grammar-prose ripple: the §Template grammar reject enumeration should name the `:or`-default binding-position case alongside the value-flow escape. Coordinate with the rf2-vxgfnd.224/.252 grammar-prose follow-up rather than touch the hot-zone `spec/` file in this PR.