### PR TITLE
fix(ui): stable URLs resolve to accepted generation until pipeline succeeds (rf2-vxgfnd.237)

### DIFF
--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -27,15 +27,27 @@ const LOADED_SOURCE = path.join(
   IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'loaded.cljs',
 );
 const OUT = path.join(IMPL, 'out', 'ui-digest-probe-lazy');
-const LAZY_JS = path.join(OUT, 'lazy.js');
+// rf2-vxgfnd.237 — artifact generation/activation separation. Shadow flushes
+// the CANDIDATE generation to OUT/candidate (its :output-dir); the browser is
+// served the STABLE generation from OUT/stable (the dev-http :http-root). The
+// re-frame.ui promote hook publishes candidate -> stable only on a fully
+// successful flush, so a downstream failure leaves the served bytes on the
+// prior accepted generation.
+const CANDIDATE = path.join(OUT, 'candidate');
+const STABLE = path.join(OUT, 'stable');
+// The SERVED (stable) module bytes — what a fresh page load / first lazy-module
+// request actually receives.
+const LAZY_JS = path.join(STABLE, 'lazy.js');
 const CARRIER_JS = path.join(
-  OUT, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
+  STABLE, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
 );
-// Opt-in adversarial assertion of the still-open downstream-output invariant
-// (counterexample 1). Off by default so the gate stays green while the fix —
-// artifact generation/activation separation — is a hot-zone follow-up; set to
-// "1" to assert the fixed behaviour (red-before-fix).
-const ASSERT_DOWNSTREAM_OUTPUT = process.env.RF2_PROBE_ACTIVATION_TXN === '1';
+// The CANDIDATE module bytes Shadow speculatively flushed — after a downstream
+// failure these hold the REJECTED generation, which the separation must keep
+// off the served URLs.
+const CANDIDATE_LAZY_JS = path.join(CANDIDATE, 'lazy.js');
+const CANDIDATE_CARRIER_JS = path.join(
+  CANDIDATE, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
+);
 const TARGET = path.join(IMPL, 'target', 'ui-digest-probe');
 const FAIL_MARKER = path.join(TARGET, 'fail-after-compile');
 const ACCEPTED_FILE = path.join(TARGET, 'accepted-digest.txt');
@@ -339,6 +351,9 @@ async function main() {
   fs.rmSync(FAIL_MARKER, { force: true });
   fs.rmSync(ACCEPTED_FILE, { force: true });
   fs.rmSync(PREPARE_FILE, { force: true });
+  // Fresh candidate/stable slate so a prior run's promoted bytes or served
+  // shell cannot mask a regression in the generation/activation separation.
+  fs.rmSync(OUT, { recursive: true, force: true });
 
   let shadow;
   let browser;
@@ -349,9 +364,12 @@ async function main() {
     shadow = watchShadow(shadowRunner);
     await shadow.waitSuccess(0);
 
-    fs.mkdirSync(OUT, { recursive: true });
+    // The served shell lives in the STABLE directory (the dev-http :http-root),
+    // which the first successful build's promote hook has just created. It is
+    // not a build artifact, so the promote hook never overwrites or deletes it.
+    fs.mkdirSync(STABLE, { recursive: true });
     fs.writeFileSync(
-      path.join(OUT, 'index.html'),
+      path.join(STABLE, 'index.html'),
       '<!doctype html><meta charset="utf-8"><script src="/base.js"></script>',
     );
 
@@ -424,41 +442,91 @@ async function main() {
       fail('late failed pass changed active runtime or accepted JVM witness');
     }
 
-    // Counterexample 1 — the downstream-OUTPUT invariant the active-runtime
-    // witness above does NOT cover. Shadow's browser target flushed candidate
-    // d3 to the stable module URLs BEFORE the intentional :flush failure, then
-    // rolled its functional build-state back to accepted d2. So `/base.js`'s
-    // carrier and `/lazy.js` on disk hold rejected candidate d3 while compiler
-    // authority is d2: a hard reload or a first lazy import would execute /
-    // advertise d3. The fix is artifact generation/activation separation —
-    // stable URLs/manifests must keep resolving to the accepted generation
-    // until the whole pipeline succeeds. That is a Shadow output/flush surface
-    // beyond this carrier's fence (hot-zone shadow-cljs.edn), so this probe
-    // DOCUMENTS the gap by default and only ASSERTS the fixed behaviour under
-    // RF2_PROBE_ACTIVATION_TXN=1 (red-before-fix).
+    // Counterexample 1 — the downstream-OUTPUT invariant, CLOSED by the
+    // generation/activation separation (rf2-vxgfnd.237). Shadow's browser
+    // target flushed candidate d3 to its :output-dir (CANDIDATE) before the
+    // intentional :flush failure, then rolled its functional build-state back
+    // to accepted d2. The re-frame.ui promote hook — the LAST :flush hook —
+    // never ran (the earlier failure aborted the build), so the SERVED stable
+    // directory still holds accepted d2. First prove Shadow really did flush the
+    // rejected candidate (else the invariant would be vacuous), then assert the
+    // served generation stayed accepted. Asserted BY DEFAULT now the fix landed.
+    const candidateLazy = fs.existsSync(CANDIDATE_LAZY_JS)
+      ? fs.readFileSync(CANDIDATE_LAZY_JS, 'utf8') : '';
+    if (!candidateLazy.includes('digest-probe-v3')) {
+      fail('candidate output did not receive the rejected d3 generation; the ' +
+           'downstream-output separation would be vacuously satisfied');
+    }
     const servedLazy = fs.existsSync(LAZY_JS)
       ? fs.readFileSync(LAZY_JS, 'utf8') : '';
     const servedCarrier = fs.existsSync(CARRIER_JS)
       ? fs.readFileSync(CARRIER_JS, 'utf8') : '';
     const lazyServesRejected = servedLazy.includes('digest-probe-v3');
-    // The accepted digest is d2; a stable carrier that no longer contains d2
+    // The accepted digest is d2; a served carrier that no longer contains d2
     // (its bytes moved to the rejected candidate d3) is servable-rejected.
     const carrierServesRejected =
-      servedCarrier.length > 0 && !servedCarrier.includes(digest2);
+      servedCarrier.length === 0 || !servedCarrier.includes(digest2);
     if (lazyServesRejected || carrierServesRejected) {
-      const note =
-        `downstream-output gap: stable URLs serve rejected candidate d3 ` +
-        `after the failed :flush (lazy=${lazyServesRejected}, ` +
-        `carrier-not-d2=${carrierServesRejected}); accepted authority is d2 ` +
-        `(${digest2}). A hard reload / first lazy import would activate d3.`;
-      if (ASSERT_DOWNSTREAM_OUTPUT) {
-        fail(note);
+      fail(
+        `downstream-output gap: served stable URLs no longer resolve to the ` +
+        `accepted generation after the failed :flush (lazy-serves-v3=` +
+        `${lazyServesRejected}, carrier-not-d2=${carrierServesRejected}); ` +
+        `accepted authority is d2 (${digest2}). A hard reload / first lazy ` +
+        `import would activate the rejected candidate d3.`);
+    }
+    console.log(
+      'ui digest carrier: served (stable) generation stayed on accepted d2 ' +
+      'while the candidate output-dir held the rejected d3',
+    );
+
+    // rf2-vxgfnd.237 — the post-:flush-failure LAZY-MODULE-REQUEST fixture the
+    // existing fixtures deliberately do NOT exercise (they assert the ACTIVE
+    // runtime never lazy-loads). A brand-new page (a hard reload) and a genuine
+    // first `/lazy.js` request, both against the served origin while the failed
+    // d3 candidate is the latest build, must receive the prior accepted d2 — or
+    // a fail-closed response — never the rejected candidate.
+    const freshPage = await browser.newPage();
+    try {
+      await freshPage.goto(URL, { waitUntil: 'load', timeout: TIMEOUT });
+      // Hard reload: the served base carrier must read the accepted d2 (or, if
+      // ever fail-closed, null) — never the rejected candidate d3.
+      const freshDigest = await freshPage.evaluate(async () => {
+        for (let i = 0; i < 200; i += 1) {
+          if (typeof globalThis.__rf2ReadDigest === 'function') {
+            const d = globalThis.__rf2ReadDigest();
+            if (d === null || (typeof d === 'string' && d.startsWith('bd1-'))) return d;
+          }
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        return typeof globalThis.__rf2ReadDigest === 'function'
+          ? globalThis.__rf2ReadDigest() : 'accessor-absent';
+      });
+      if (freshDigest !== digest2 && freshDigest !== null) {
+        fail(`hard reload after the failed :flush advertised ${JSON.stringify(freshDigest)}; ` +
+             `expected the accepted d2 (${digest2}) or a fail-closed null`);
       }
-      console.log(`ui digest carrier: KNOWN GAP (rf2-vxgfnd.193 followup) — ${note}`);
-    } else {
+      // First lazy import: a genuine request for the served /lazy.js from the
+      // fresh origin must return the accepted d2 generation, never rejected d3.
+      const lazyBody = await freshPage.evaluate(async () => {
+        const res = await fetch('/lazy.js', { cache: 'no-store' });
+        return { ok: res.ok, status: res.status, text: await res.text() };
+      });
+      if (!lazyBody.ok) {
+        fail(`served first /lazy.js request failed (status ${lazyBody.status})`);
+      }
+      if (lazyBody.text.includes('digest-probe-v3')) {
+        fail('first lazy-module request served the rejected candidate d3 (digest-probe-v3)');
+      }
+      if (!lazyBody.text.includes('digest-probe-v2')) {
+        fail('first lazy-module request did not serve the accepted d2 generation (digest-probe-v2)');
+      }
       console.log(
-        'ui digest carrier: downstream output stayed on the accepted generation',
+        `ui digest carrier: post-failure hard reload + first lazy import both ` +
+        `resolved to the accepted generation ` +
+        `(reload=${freshDigest === null ? 'fail-closed' : freshDigest}, lazy=d2)`,
       );
+    } finally {
+      await freshPage.close();
     }
 
     // Recovery success starts from Shadow's retained d2 state, not the failed

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -739,20 +739,33 @@
   ;; carrier while a view declaration lives in an unexecuted lazy module. The
   ;; runner keeps one watch daemon and browser alive across good / downstream-
   ;; failed / good passes, proving warm recompilation and active-runtime LKG.
+  ;;
+  ;; rf2-vxgfnd.237 — artifact generation/activation separation. Shadow writes
+  ;; the CANDIDATE module bytes to :output-dir (out/.../candidate); the browser
+  ;; is served the STABLE generation from the dev-http :http-root
+  ;; (out/.../stable). The re-frame.ui promote hook, ordered LAST in
+  ;; :build-hooks, publishes candidate -> stable only when the whole flush
+  ;; pipeline succeeds. The digest-probe test hook (deep-merged FIRST, after the
+  ;; build-default compile hook) injects a downstream :flush failure; being
+  ;; earlier than the promote hook, its throw aborts the build before the
+  ;; publish, so the served stable generation stays on the accepted bytes and a
+  ;; fresh page load / first lazy import never activates the rejected candidate.
   :ui-digest-probe-lazy
   {:target :browser
-   :output-dir "out/ui-digest-probe-lazy"
+   :output-dir "out/ui-digest-probe-lazy/candidate"
    :asset-path "."
    :modules
    {:base {:entries [re-frame.ui.digest-probe.base]
            :init-fn re-frame.ui.digest-probe.base/init}
     :lazy {:entries [re-frame.ui.digest-probe.lazy]
            :depends-on #{:base}}}
-   :devtools {:http-root "out/ui-digest-probe-lazy"
+   :devtools {:http-root "out/ui-digest-probe-lazy/stable"
               :http-port 8059}
-   ;; Deep-merged after the load-bearing build-default hook, so this test hook
-   ;; runs at :flush after target output and can inject a true downstream fail.
-   :build-hooks [(re-frame.ui.digest-probe.build-hook/hook)]}
+   ;; Deep-merged after the load-bearing build-default compile hook: the
+   ;; test hook runs at :flush after target output and injects a true downstream
+   ;; failure; the promote hook runs LAST so that failure aborts before it.
+   :build-hooks [(re-frame.ui.digest-probe.build-hook/hook)
+                 (re-frame.ui.compiler.build-hook/promote-served-generation)]}
 
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -45,8 +45,12 @@
 
   Transaction boundary: the accepted build-state and active HMR runtime are
   last-known-good. Shadow may have partially rewritten its raw output directory
-  before a late failure; re-frame.ui does not claim filesystem rollback."
-  (:require [clojure.string :as str]
+  before a late failure; re-frame.ui does not claim filesystem rollback for that
+  raw directory. `promote-served-generation` below closes exactly that gap for
+  the SERVED bytes by publishing the candidate output-dir onto a separate stable
+  served directory only when the whole pipeline succeeds (rf2-vxgfnd.237)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [re-frame.ui.compiler.build :as build]))
 
 (def digest-sentinel
@@ -258,6 +262,82 @@
            {:carrier-resource-id rid :sentinel-count n :js-string? (string? js)}))
         (assoc-in build-state [:output rid :js]
                   (str/replace js digest-sentinel digest))))))
+
+;; ---------------------------------------------------------------------------
+;; Artifact generation/activation separation (rf2-vxgfnd.237)
+;;
+;; Shadow's browser target flushes the candidate module bytes to its raw
+;; `:output-dir` at `:flush`, BEFORE any later `:flush` step can fail; on a
+;; downstream failure Shadow discards the returned build-state (reverting the
+;; accepted compiler snapshot) but does NOT roll back that raw directory. So a
+;; fresh page load or a first lazy-module request served straight from
+;; `:output-dir` would execute/advertise the rejected candidate generation.
+;;
+;; The fix separates GENERATION from ACTIVATION at the served-bytes boundary:
+;; Shadow writes the candidate to `:output-dir`; the browser is served from a
+;; SEPARATE stable directory (the dev-http `:http-root`); and this hook — the
+;; LAST configured `:flush` hook — publishes the candidate onto the stable
+;; directory only once every earlier flush step succeeded. Because Shadow runs
+;; a stage's target flush first and then its `:build-hooks` in configured order
+;; (defaults before build-local), placing this hook last makes the publish the
+;; terminal action of a fully-successful build: any earlier downstream failure
+;; aborts before it, leaving the served generation on the prior accepted bytes.
+;; ---------------------------------------------------------------------------
+
+(defn- stale-copy?
+  "Cheap freshness check: copy `src` onto `dest` only when the destination is
+  missing or differs in length / is older. Keeps warm publishes O(changed)."
+  [^java.io.File src ^java.io.File dest]
+  (or (not (.exists dest))
+      (not= (.length src) (.length dest))
+      (> (.lastModified src) (.lastModified dest))))
+
+(defn- publish-tree!
+  "Recursively copy every regular file under `from` onto `to`, creating parent
+  directories and overwriting stale destinations. Deliberately does NOT delete
+  destination files absent from `from`: the served shell (a hand-written
+  index.html) lives in the stable directory and is not a build artifact."
+  [^java.io.File from ^java.io.File to]
+  (when (.isDirectory from)
+    (let [from-path (.toPath from)]
+      (doseq [^java.io.File src (file-seq from)
+              :when (.isFile src)]
+        (let [dest (io/file to (.toString (.relativize from-path (.toPath src))))]
+          (when (stale-copy? src dest)
+            (io/make-parents dest)
+            (io/copy src dest)))))))
+
+(defn promote-served-generation
+  "A `:flush`-stage build hook that PUBLISHES the just-flushed candidate output
+  onto the stable served directory, atomically w.r.t. the configured pipeline.
+
+  Configure it as the LAST entry in a dev `:browser` build's `:build-hooks`,
+  with the build's `:output-dir` pointing at a CANDIDATE directory and the
+  dev-http `:http-root` pointing at a separate STABLE served directory:
+
+    :output-dir \"out/<build>/candidate\"
+    :devtools   {:http-root \"out/<build>/stable\" ...}
+    :build-hooks [... (re-frame.ui.compiler.build-hook/promote-served-generation)]
+
+  Being the terminal `:flush` hook, it runs only after Shadow's target flush and
+  every other downstream flush step have succeeded, so the served generation
+  advances iff the whole pipeline succeeds; a downstream failure aborts before
+  the publish and leaves the served directory on the prior accepted generation.
+
+  When no separation is configured (`:http-root` absent, or the same path as
+  `:output-dir`) it is a no-op — the served directory IS the output directory,
+  the un-separated legacy behaviour. Dev-only JVM build tooling; never part of
+  any CLJS bundle."
+  {:shadow.build/stages #{:flush}}
+  [build-state]
+  (let [candidate (get-in build-state [:build-options :output-dir])
+        stable    (get-in build-state [:shadow.build/config :devtools :http-root])]
+    (when (and candidate (seq (str stable)))
+      (let [candidate (io/file candidate)
+            stable    (io/file stable)]
+        (when-not (= (.getCanonicalPath candidate) (.getCanonicalPath stable))
+          (publish-tree! candidate stable)))))
+  build-state)
 
 (defn hook
   "Shadow build hook. Configure once in `:build-defaults` as


### PR DESCRIPTION
Recovered stranded branch (worker completed the fix + committed locally, then died at a compaction/limit boundary before pushing). Rebased cleanly onto current main — the three files were untouched by intervening merges.

## What
Artifact generation/activation separation (rf2-vxgfnd.193 follow-up): a stable artifact URL must resolve to the last **accepted** generation until the new pipeline fully succeeds — a mid-pipeline generation must not be served under the stable URL until activation completes.

Files: `implementation/scripts/check-ui-digest-carrier.cjs`, `implementation/shadow-cljs.edn` (testbed digest/build-id — hot-zone, sole-owner), `implementation/ui/src/re_frame/ui/compiler/build_hook.clj`.

## Quality gates
Worker's local gate run was interrupted by the strand; **CI is the authoritative validation** here (full build/digest matrix). If any check reds, a fix-worker follows.