### PR TITLE
fix(core): route join-dispatch through shared reserved-dispatch path, preserving full semantics (rf2-lud4af)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -598,6 +598,60 @@
       (update :fx-overrides #(apply dissoc % rejected-reserved-fx-ids)))
     {:frame frame-id}))
 
+(defn child-dispatch!
+  "The single reserved-dispatch seam (rf2-lud4af). The `:dispatch` and
+  `:dispatch-later` reserved-fx bodies — AND the machines artefact's reserved
+  `:rf.machine/join-dispatch` transport (rf2-t154jx) — queue a child dispatch
+  through HERE, so all three share ONE implementation of the reserved-dispatch
+  contract rather than duplicating override / lineage / ordering / timer /
+  replay semantics in a second effect:
+
+    - parent-envelope inheritance (`child-dispatch-opts`): `:fx-overrides`,
+      `:interceptor-overrides`, `:trace-id`, `:origin`, the per-call
+      `:rf.cofx/mint-policy` strict/replay discipline, and the
+      `:rf.machine/internal?` front-of-queue ordering flag — per Spec 002
+      §Cascade propagation + EP-0017 §6;
+    - the frame-owned `:dispatch-later` timer table (`arm-dispatch-later!`),
+      cancelled on frame destroy (`release-frame!`) — so a delayed child never
+      fires dead-on-arrival into a torn-down frame (rf2-uxz52g);
+    - immediate vs delayed routing keyed off a numeric `:ms`.
+
+  `event` is the child event vector. `parent-envelope` is the dispatch envelope
+  of the event that produced the fx (nil falls back to `{:frame frame-id}` —
+  legacy routing callers / test fixtures). `extras`:
+
+    :source        the child's immediate-trigger `:source` stamp
+                   (`:fx-dispatch` / `:fx-dispatch-later` / `:machine-action`);
+                   `:source` is NEVER inherited (rf2-ejtpd) — the call site
+                   stamps the immediate trigger.
+    :ms            a NUMBER arms the frame-owned timer (delayed dispatch);
+                   absent / non-number dispatches immediately to the router
+                   queue. A `:dispatch-later` always supplies a number; a plain
+                   `:dispatch` never does.
+    :source-detail optional; rides onto the `:rf.event/dispatched` trace (e.g.
+                   `{:ms n}` for the delayed path — rf2-5qp4g).
+    :rf.cofx       optional recordable causal-envelope coeffect map merged
+                   verbatim onto the child dispatch. `build-envelope` preserves
+                   a supplied `:rf.cofx` (extra owner-qualified keys kept) and
+                   fills `:rf/time-ms`, so an owner-qualified fact — the
+                   machines join-authority tuple `:rf.machine/join-auth` — is
+                   recorded and re-presented on strict replay (rf2-t154jx).
+
+  Public so the machines `:rf.machine/join-dispatch` fx routes a `:spawn-all`
+  child's completion carrier through the SAME seam that preserves every
+  reserved-dispatch guarantee, adding ONLY its private `:rf.cofx` authority
+  fact — never a second effect duplicating the semantics."
+  [frame-id parent-envelope event {:keys [source ms source-detail] rf-cofx :rf.cofx}]
+  (let [opts (cond-> (assoc (child-dispatch-opts frame-id parent-envelope) :source source)
+               (some? source-detail) (assoc :source-detail source-detail)
+               (some? rf-cofx)       (assoc :rf.cofx rf-cofx))]
+    (if (number? ms)
+      (arm-dispatch-later! frame-id ms event opts)
+      ;; Sticky hook (rf2-f72pd) — `:router/dispatch!` is published once at
+      ;; re-frame.router load and never withdrawn.
+      (when-let [f (late-bind/get-fn-cached :router/dispatch!)]
+        (f event opts)))))
+
 (def ^:private reserved-fx-handlers
   "Reserved fx-id → body-fn `(fn [frame-id parent-envelope args])`.
   Driven by `handle-one-fx`; emit of `:rf.fx/handled` lives in the
@@ -629,15 +683,15 @@
    ;; plain `:dispatch` fx cascades. The `:rf.machine/internal? true`
    ;; flag still rides on the envelope (via `child-dispatch-opts`) so
    ;; the router can front-of-queue insert per Spec 005 §Level 4.
+   ;; Routes through the shared `child-dispatch!` seam (rf2-lud4af) — the
+   ;; same implementation the machines `:rf.machine/join-dispatch` transport
+   ;; uses — so envelope inheritance / ordering / timer semantics live in one
+   ;; place. The immediate (no-`:ms`) path enqueues to the router queue.
    (fn [frame-id parent-envelope args]
-     ;; Sticky hook (rf2-f72pd) — `:router/dispatch!` is published once
-     ;; at re-frame.router load and never withdrawn; this fires per
-     ;; `:dispatch` fx invocation.
-     (when-let [f (late-bind/get-fn-cached :router/dispatch!)]
-       (f args (assoc (child-dispatch-opts frame-id parent-envelope)
-                      :source (if (:rf.machine/internal? parent-envelope)
-                                :machine-action
-                                :fx-dispatch)))))
+     (child-dispatch! frame-id parent-envelope args
+                      {:source (if (:rf.machine/internal? parent-envelope)
+                                 :machine-action
+                                 :fx-dispatch)}))
 
    :dispatch-later
    ;; Delayed dispatch — wraps the same router hook in `set-timeout!`.
@@ -668,12 +722,17 @@
    ;; retain, the armed timer + its captured closure leak until the delay
    ;; elapses, and the deferred dispatch is dead-on-arrival in the
    ;; destroyed frame.
+   ;; Same shared seam (rf2-lud4af): a numeric `:ms` routes through the
+   ;; frame-owned `dispatch-later-timers` table inside `child-dispatch!`
+   ;; (retain + cancel-on-destroy, rf2-uxz52g), carrying the `:source` /
+   ;; `:source-detail {:ms n}` stamps.
    (fn [frame-id parent-envelope {:keys [ms event]}]
-     (let [machine? (:rf.machine/internal? parent-envelope)
-           opts (assoc (child-dispatch-opts frame-id parent-envelope)
-                       :source        (if machine? :machine-action :fx-dispatch-later)
-                       :source-detail {:ms ms})]
-       (arm-dispatch-later! frame-id ms event opts)))
+     (child-dispatch! frame-id parent-envelope event
+                      {:source        (if (:rf.machine/internal? parent-envelope)
+                                        :machine-action
+                                        :fx-dispatch-later)
+                       :ms            ms
+                       :source-detail {:ms ms}}))
 
    ;; Per Spec 013 — flows are frame-scoped. The flow registers against
    ;; the dispatching frame.

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -50,8 +50,7 @@
   routes every inbound event through it before the machine's normal `:on`
   lookup."
   (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.fx :as fx]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.paths :as paths]
@@ -143,36 +142,45 @@
   survives BOTH the event/coeffect recording + strict-replay path AND the
   delayed-dispatch path (event-vector metadata survives neither).
 
+  A THIN handler over the shared core reserved-dispatch seam
+  `re-frame.fx/child-dispatch!` (rf2-lud4af). Routing the completion carrier
+  through the SAME seam the parent `:dispatch` / `:dispatch-later` reserved-fx
+  bodies use preserves the FULL reserved-dispatch contract — inheriting from the
+  emitting child's envelope its `:fx-overrides`, `:interceptor-overrides`,
+  `:trace-id`, `:origin`, the per-call `:rf.cofx/mint-policy` strict/replay
+  discipline, and the `:rf.machine/internal?` front-of-queue ordering (the
+  emitter is always a machine child) — and a POSITIVE-delay completion (a
+  `:dispatch-later` form) rides the frame-owned `:dispatch-later` timer table,
+  cancelled on frame destroy, rather than a raw host timeout. The transport adds
+  ONLY its private recordable `:rf.machine/join-auth` `:rf.cofx` fact and stamps
+  `:source :machine-action`; the public completion event VALUE is unchanged.
+
   Not an application control surface — reserved-`:rf.machine/*` internal, it
   re-dispatches ONLY the pre-built completion carrier it was handed (never
-  traverses arbitrary / custom effect payloads). The completion event VALUE is
-  unchanged; only the private `:rf.machine/join-auth` cofx fact is added.
+  traverses arbitrary / custom effect payloads).
 
-  args: `{:event <[parent-id inner-event]> :rf/join-auth <auth-tuple>
-          :ms <ms?>}`. A `:ms` (from a `:dispatch-later` completion) that is
-  positive arms a host timer; nil / non-positive dispatches immediately (the
-  same enqueue a direct `:dispatch` completion takes). The completion inherits
-  the machine-internal front-of-queue ordering + `:source :machine-action` the
-  child's original `:dispatch` carried (the emitter is always a machine child)."
-  [{frame-id :frame} {:keys [event ms] auth :rf/join-auth}]
+  ctx carries `:frame` and `:envelope` (the emitting child's dispatch envelope,
+  threaded by `re-frame.fx/do-fx`). args: `{:event <[parent-id inner-event]>
+  :rf/join-auth <auth-tuple> :ms <ms?>}`. A POSITIVE `:ms` (from a
+  `:dispatch-later` completion) arms a frame-owned delayed dispatch; nil /
+  non-positive dispatches immediately — the same enqueue a direct `:dispatch`
+  completion takes."
+  [{:keys [frame envelope]} {:keys [event ms] auth :rf/join-auth}]
   (let [frame-id (frame/require-frame-stamp!
-                   frame-id :rf.machine/join-dispatch
-                   {:where 'rf.machine/join-dispatch :event-id (first event)})
-        opts     {:frame                 frame-id
-                  :source                :machine-action
-                  :rf.machine/internal?  true
-                  ;; The recordable causal-envelope fact. `build-envelope`
-                  ;; preserves a supplied `:rf.cofx` map verbatim (extra
-                  ;; owner-qualified keys kept) and fills `:rf/time-ms`, so the
-                  ;; auth rides `:rf.event/cofx` at record time and is
-                  ;; re-presented on strict replay.
-                  :rf.cofx               {:rf.machine/join-auth auth}}
-        fire!    (fn []
-                   (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-                     (dispatch! event opts)))]
-    (if (and (number? ms) (pos? ms))
-      (interop/set-timeout! fire! ms)
-      (fire!)))
+                   frame :rf.machine/join-dispatch
+                   {:where 'rf.machine/join-dispatch :event-id (first event)})]
+    (fx/child-dispatch!
+      frame-id envelope event
+      ;; The recordable causal-envelope fact rides `:rf.cofx`; `:source
+      ;; :machine-action` matches the child's original `:dispatch` stamp; the
+      ;; `:rf.machine/internal?` front-of-queue ordering + override / lineage /
+      ;; mint-policy inheritance are lifted from `envelope` by `child-dispatch!`.
+      ;; A positive delay carries `:ms` + `:source-detail`; ms 0 / nil enqueues
+      ;; immediately (a `:dispatch-later {:ms 0}` completion folds synchronously
+      ;; on the in-progress drain, matching the direct `:dispatch` completion).
+      (cond-> {:source  :machine-action
+               :rf.cofx {:rf.machine/join-auth auth}}
+        (and (number? ms) (pos? ms)) (assoc :ms ms :source-detail {:ms ms}))))
   nil)
 
 (defn- stamp-fx-entry

--- a/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
@@ -1,0 +1,214 @@
+(ns re-frame.join-parallel-recordable-controls-cljs-test
+  "rf2-lud4af — the exact-authority fold gate, driven through the RECORDABLE
+  `:rf.cofx` transport (`:rf.machine/join-auth`) in the AMBIGUOUS PARALLEL
+  shape.
+
+  `join_exact_auth_cljs_test` covers the wrong-invoke / wrong-actor /
+  unstamped / unknown-child control classes in the FLAT shape via event-vector
+  METADATA. This file re-drives the same control classes in the two-region
+  parallel shape where both regions reuse the SAME logical child id `:worker`
+  and the SAME `:child/done` / `:child/failed` completion keywords — the exact
+  ambiguity `select-parallel-joins-by-exact-authority` (rf2-wsrtlw) routes —
+  and it carries every forged / legitimate carrier on the recordable
+  `:rf.cofx` fact rather than metadata, so the coverage matches the delivery
+  channel the rf2-lud4af transport actually uses (metadata does not survive an
+  EDN round-trip / delayed dispatch).
+
+  Named `*-cljs-test.cljc` so both the JVM run and shadow-cljs discover it."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.machines :as machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(def ^:private parent-kw :lud4af-par/parent)
+
+(defn- mk-worker
+  "A worker child that dispatches `:child/done` / `:child/failed` back to the
+  parent carrying its own `:worker` logical id — through its OWN handler
+  boundary, so the runtime stamps the exact `:rf/join-auth` on the recordable
+  `:rf.cofx` for its region's attempt."
+  []
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{d :data e :event}] {:data (assoc d :id (second e))})
+             :dispatch-done (fn [{d :data}] {:fx [[:dispatch [parent-kw [:child/done   (:id d)]]]]})
+             :dispatch-err  (fn [{d :data}] {:fx [[:dispatch [parent-kw [:child/failed (:id d)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-err}}}
+             :done {} :failed {}}})
+
+;; A never-completing helper so the two-child `:all` join stays OPEN after
+;; `:worker` folds (a single-child join would resolve + tear the region down,
+;; clearing the join-state we assert on).
+(def ^:private idle-helper {:initial :idle :states {:idle {}}})
+
+(defn- region-spawn-all [worker-type on-complete ready-state]
+  {:initial :idle
+   :states  {:idle   {:on {:start :racing}}
+             :racing {:spawn-all {:children       [{:id :worker :machine-id worker-type
+                                                    :start [:set-id :worker]}
+                                                   {:id :helper :machine-id :lud4af-par/helper}]
+                                  :join           :all
+                                  :on-child-done  :child/done
+                                  :on-child-error :child/failed
+                                  :on-all-complete on-complete}
+                      :on {(first on-complete) ready-state}}
+             ready-state {}}})
+
+(defn- reg-and-start! []
+  (rf/reg-machine :lud4af-par/wc-r1 (mk-worker))
+  (rf/reg-machine :lud4af-par/wc-r2 (mk-worker))
+  (rf/reg-machine :lud4af-par/helper idle-helper)
+  (rf/reg-machine parent-kw
+    {:type    :parallel
+     :regions {:r1 (region-spawn-all :lud4af-par/wc-r1 [:r1/done] :r1-ready)
+               :r2 (region-spawn-all :lud4af-par/wc-r2 [:r2/done] :r2-ready)}})
+  (rf/dispatch-sync [parent-kw [:start]]))
+
+(defn- spawned-joins []
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
+
+(defn- region-invoke+join
+  "`[invoke-id join-state]` for the region whose `:on-all-complete` is
+  `on-complete` (region-distinct)."
+  [on-complete]
+  (some (fn [[invoke js]]
+          (when (= on-complete (get-in js [:spec :on-all-complete])) [invoke js]))
+        (spawned-joins)))
+
+(defn- auth-for
+  "The exact-authority tuple for `:worker` in the region named by
+  `[invoke-id join-state]`, with optional per-key `overrides` (to forge a
+  wrong-spawned-id / wrong-invoke carrier)."
+  ([invoke-id js] (auth-for invoke-id js {}))
+  ([invoke-id js overrides]
+   (merge {:parent-id  parent-kw
+           :invoke-id  invoke-id
+           :child-id   :worker
+           :spawned-id (get-in js [:children :worker])
+           :attempt    (:rf/attempt js)}
+          overrides)))
+
+(defn- dispatch-carrier!
+  "Dispatch a completion carrier `[parent [kw child-id]]` carrying `auth` on the
+  recordable `:rf.cofx` fact (nil auth dispatches the bare, unstamped carrier)."
+  [inner auth]
+  (if auth
+    (rf/dispatch-sync [parent-kw inner] {:rf.cofx {:rf.machine/join-auth auth}})
+    (rf/dispatch-sync [parent-kw inner])))
+
+(defn- stale-reasons []
+  (mapv (comp :rf.reply/stale-reason :tags)
+        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+
+(defn- bad-child-ids []
+  (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+
+;; ---------------------------------------------------------------------------
+;; legitimate success / failure through the recordable transport
+;; ---------------------------------------------------------------------------
+
+(deftest legit-parallel-completion-folds-only-its-region
+  (testing "rf2-lud4af — a real :r2 worker completion carried on the recordable
+            :rf.cofx transport folds ONLY into :r2 (:done #{:worker}); :r1 is
+            untouched and no stale / bad-child evidence fires."
+    (reg-and-start!)
+    (let [[_ r2-js] (region-invoke+join [:r2/done])]
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [(get-in r2-js [:children :worker]) [:go]])
+      (let [[_ r1'] (region-invoke+join [:r1/done])
+            [_ r2'] (region-invoke+join [:r2/done])]
+        (is (= #{:worker} (:done r2')) ":r2 folded its worker")
+        (is (= #{} (:done r1')) ":r1 untouched")
+        (is (empty? (stale-reasons)) "no stale evidence for the legit carrier")
+        (is (empty? (bad-child-ids)) "no bad-child evidence for the legit carrier")))))
+
+(deftest legit-parallel-failure-folds-only-its-region
+  (testing "rf2-lud4af — the failure side: a real :r2 worker :fail carried on the
+            recordable transport folds ONLY into :r2 (:failed #{:worker})."
+    (reg-and-start!)
+    (let [[_ r2-js] (region-invoke+join [:r2/done])]
+      (mtest/reset-captured!)
+      (rf/dispatch-sync [(get-in r2-js [:children :worker]) [:fail]])
+      (let [[_ r1'] (region-invoke+join [:r1/done])
+            [_ r2'] (region-invoke+join [:r2/done])]
+        (is (= #{:worker} (:failed r2')) ":r2 folded its worker into :failed")
+        (is (= #{} (:failed r1')) ":r1 untouched")
+        (is (empty? (stale-reasons)) "no stale evidence for the legit failure")))))
+
+;; ---------------------------------------------------------------------------
+;; the four control classes — driven through the recordable :rf.cofx transport
+;; ---------------------------------------------------------------------------
+
+(deftest parallel-unstamped-carrier-suppressed-unverified
+  (testing "rf2-lud4af — a bare completion carrier with NO recordable authority
+            (never flowed through a member child's boundary) folds nothing in
+            either region and is classified :attempt-unverified."
+    (reg-and-start!)
+    (mtest/reset-captured!)
+    (dispatch-carrier! [:child/done :worker] nil)
+    (let [[_ r1'] (region-invoke+join [:r1/done])
+          [_ r2'] (region-invoke+join [:r2/done])]
+      (is (= #{} (:done r1')) ":r1 folded nothing")
+      (is (= #{} (:done r2')) ":r2 folded nothing")
+      (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+          "typed evidence: :attempt-unverified"))))
+
+(deftest parallel-wrong-spawned-id-carrier-superseded
+  (testing "rf2-lud4af — a carrier stamped for :r2's invoke + attempt + child but
+            a WRONG spawned instance address fails the exact actor-identity
+            clause and folds nothing (:attempt-superseded)."
+    (reg-and-start!)
+    (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
+      (mtest/reset-captured!)
+      (dispatch-carrier! [:child/done :worker]
+                         (auth-for r2-invoke r2-js {:spawned-id :lud4af-par/bogus-instance}))
+      (let [[_ r2'] (region-invoke+join [:r2/done])]
+        (is (= #{} (:done r2')) ":r2 folded nothing on the wrong-spawned-id carrier")
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
+            "typed evidence: :attempt-superseded")))))
+
+(deftest parallel-wrong-invoke-carrier-superseded
+  (testing "rf2-lud4af — a carrier naming a NON-EXISTENT invoke path fails the
+            parent/invoke identity clause and folds nothing (:attempt-superseded)."
+    (reg-and-start!)
+    (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
+      (mtest/reset-captured!)
+      (dispatch-carrier! [:child/done :worker]
+                         (auth-for r2-invoke r2-js {:invoke-id [:r9 :nope]}))
+      (let [[_ r1'] (region-invoke+join [:r1/done])
+            [_ r2'] (region-invoke+join [:r2/done])]
+        (is (= #{} (:done r1')) ":r1 folded nothing")
+        (is (= #{} (:done r2')) ":r2 folded nothing")
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
+            "typed evidence: :attempt-superseded")))))
+
+(deftest parallel-unknown-child-carrier-bad-child-id
+  (testing "rf2-lud4af — a carrier claiming a child id owned by NEITHER region
+            fails the seeded-children gate: no fold, and a
+            :rf.error/machine-spawn-all-bad-child-id error trace fires."
+    (reg-and-start!)
+    (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
+      (mtest/reset-captured!)
+      (dispatch-carrier! [:child/done :ghost]
+                         (auth-for r2-invoke r2-js {:child-id :ghost}))
+      (let [[_ r1'] (region-invoke+join [:r1/done])
+            [_ r2'] (region-invoke+join [:r2/done])]
+        (is (= #{} (:done r1')) ":r1 folded nothing")
+        (is (= #{} (:done r2')) ":r2 folded nothing")
+        (is (= 1 (count (bad-child-ids)))
+            "exactly one :rf.error/machine-spawn-all-bad-child-id error fired")
+        (is (empty? (stale-reasons)) "the unknown-child gate fires ahead of the stale gate")))))

--- a/implementation/machines/test/re_frame/join_reserved_dispatch_semantics_test.clj
+++ b/implementation/machines/test/re_frame/join_reserved_dispatch_semantics_test.clj
@@ -1,0 +1,306 @@
+(ns re-frame.join-reserved-dispatch-semantics-test
+  "rf2-lud4af — the `:spawn-all` join-completion transport
+  (`:rf.machine/join-dispatch`) preserves the FULL reserved-dispatch
+  contract while still recording the exact join authority.
+
+  #5856 rewrote a member child's completion `:dispatch` / `:dispatch-later`
+  into `:rf.machine/join-dispatch`, whose handler built a PARTIAL child-opts
+  map and used a RAW `interop/set-timeout!`. That bypassed the established
+  reserved-dispatch semantics the parent `:dispatch` / `:dispatch-later`
+  reserved-fx bodies guarantee:
+
+    - `:fx-overrides` / `:interceptor-overrides` / `:trace-id` / `:origin`
+      cascade inheritance (Spec 002 §Cascade propagation) — LOST;
+    - the per-call `:rf.cofx/mint-policy` strict/replay discipline
+      (EP-0017 §6) — fell back to `:live` minting;
+    - the frame-owned `:dispatch-later` timer table
+      (`re-frame.fx/dispatch-later-timers`, rf2-uxz52g) — a delayed
+      completion armed a RAW host timeout that `destroy-frame!` could not
+      cancel, firing dead-on-arrival into a torn-down frame;
+    - `:source-detail {:ms n}` on the delayed dispatch (rf2-5qp4g) — LOST.
+
+  The fix (rf2-lud4af) routes `join-dispatch-fx` through the single shared
+  core seam `re-frame.fx/child-dispatch!` — the SAME implementation the
+  `:dispatch` / `:dispatch-later` reserved-fx bodies use — adding ONLY the
+  private recordable `:rf.machine/join-auth` `:rf.cofx` fact and the
+  `:source :machine-action` stamp. These tests assert every lost guarantee
+  is restored; each is red against the pre-fix partial-opts / raw-timeout
+  handler (the mutation teeth)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.edn :as edn]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; helpers
+;; ---------------------------------------------------------------------------
+
+(defn- join-state
+  ([parent-id] (join-state :rf/default parent-id))
+  ([frame-id parent-id]
+   (get-in (mtest/runtime-db frame-id)
+           [:rf.runtime/machines :spawned parent-id [:racing]])))
+
+(defn- stale-reasons []
+  (mapv (comp :rf.reply/stale-reason :tags)
+        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+
+(defn- mk-child
+  "A dispatching child: on `:go` transitions to a plain terminal and dispatches
+  its completion back to `parent-id` via `:dispatch` (through its OWN handler
+  boundary, so the runtime attaches the recordable `:rf.machine/join-auth`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- mk-child-delayed
+  "Like `mk-child` but completes through a `:dispatch-later` with delay `ms`."
+  [parent-id ms]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch-later {:ms    ms
+                                                      :event [parent-id [:child/done (:id data)]]}]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- reg-parent!
+  "A two-child `:all` join parent (children `child-a-kw` / `child-b-kw`)."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}}))
+
+(defn- with-dispatch-observer
+  "Run `body-fn` with `:router/dispatch!` wrapped by a PASS-THROUGH observer
+  that records every `[event opts]` into `sink` (an atom vector) then delegates
+  to the real hook — so continuation dispatches (the join-dispatch transport's
+  completion re-dispatch) still enqueue + drain normally. Restores the real
+  hook in a `finally`.
+
+  Unlike a full stub, this observes the EXACT opts `child-dispatch!` produced
+  for the completion re-dispatch without perturbing the fold."
+  [sink body-fn]
+  (let [real (late-bind/get-fn :router/dispatch!)]
+    (try
+      (late-bind/set-fn! :router/dispatch!
+                         (fn [event opts]
+                           (swap! sink conj [event opts])
+                           (real event opts)))
+      (body-fn)
+      (finally
+        (late-bind/set-fn! :router/dispatch! real)))))
+
+(defn- completion-opts
+  "The opts of the FIRST observed re-dispatch whose event is the completion
+  carrier `[parent-id [:child/done child-id]]`, or nil."
+  [sink parent-id child-id]
+  (some (fn [[event opts]]
+          (when (= [parent-id [:child/done child-id]] event) opts))
+        @sink))
+
+;; ---------------------------------------------------------------------------
+;; (1) + (2) — the completion transport inherits the full reserved-dispatch
+;;             opts (fx-overrides / interceptor-overrides / trace-id / origin /
+;;             strict mint policy) and stamps :source :machine-action, while
+;;             recording the private join-auth fact.
+;; ---------------------------------------------------------------------------
+
+(deftest join-completion-transport-inherits-reserved-dispatch-opts
+  (testing "rf2-lud4af — a REAL child completion re-dispatched by the transport
+            carries the emitting child's cascade envelope verbatim:
+            :fx-overrides, :interceptor-overrides, :trace-id, :origin, and the
+            per-call :rf.cofx/mint-policy :strict — plus :source :machine-action,
+            the front-of-queue :rf.machine/internal? flag, and the recordable
+            :rf.machine/join-auth cofx fact. The pre-fix partial-opts handler
+            dropped every inherited key (mutation tooth)."
+    (rf/reg-machine :lud4af/ca (mk-child :lud4af/rp))
+    (rf/reg-machine :lud4af/cb (mk-child :lud4af/rp))
+    (reg-parent! :lud4af/rp :lud4af/ca :lud4af/cb)
+    (rf/dispatch-sync [:lud4af/rp [:start]])
+    (let [sink (atom [])
+          a    (get-in (join-state :lud4af/rp) [:children :a])]
+      (with-dispatch-observer sink
+        (fn []
+          ;; Drive child :a's completion through its OWN boundary, carrying a
+          ;; distinctive cascade envelope. :strict is inert for this child (it
+          ;; declares no :rf.cofx/requires) but MUST propagate to the child's
+          ;; completion re-dispatch.
+          (rf/dispatch-sync [a [:go]]
+                            {:fx-overrides          {:some/inert-fx :some/redirect-target}
+                             :interceptor-overrides {:some/ev [:some/icpt]}
+                             :trace-id              "lud4af-trace"
+                             :origin                :lud4af/origin
+                             :rf.cofx/mint-policy   :strict})))
+      (let [opts (completion-opts sink :lud4af/rp :a)]
+        (is (some? opts)
+            "the transport re-dispatched child :a's completion carrier")
+        (is (= :some/redirect-target (get (:fx-overrides opts) :some/inert-fx))
+            ":fx-overrides inherited from the emitting child's envelope (LOST pre-fix)")
+        (is (= {:some/ev [:some/icpt]} (:interceptor-overrides opts))
+            ":interceptor-overrides inherited (LOST pre-fix)")
+        (is (= "lud4af-trace" (:trace-id opts))
+            ":trace-id inherited (LOST pre-fix)")
+        (is (= :lud4af/origin (:origin opts))
+            ":origin inherited (LOST pre-fix)")
+        (is (= :strict (:rf.cofx/mint-policy opts))
+            ":rf.cofx/mint-policy :strict propagated — no live-mint fallback (LOST pre-fix)")
+        (is (= :machine-action (:source opts))
+            ":source stamped :machine-action (the emitter is a machine child)")
+        (is (true? (:rf.machine/internal? opts))
+            ":rf.machine/internal? front-of-queue ordering flag carried")
+        (is (= {:parent-id  :lud4af/rp
+                :invoke-id  [:racing]
+                :child-id   :a
+                :spawned-id a
+                :attempt    (:rf/attempt (join-state :lud4af/rp))}
+               (get-in opts [:rf.cofx :rf.machine/join-auth]))
+            "the recordable join-auth exact-authority tuple rides :rf.cofx"))
+      (is (= #{:a} (:done (join-state :lud4af/rp)))
+          "and the completion still folded end-to-end (the observer is pass-through)")
+      (is (empty? (stale-reasons)) "no stale suppression for the genuine completion"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) — a POSITIVE-delay completion rides the frame-owned :dispatch-later
+;;       timer table and is cancelled on frame destroy.
+;; ---------------------------------------------------------------------------
+
+(defn- timers-for-frame [frame-id]
+  (->> @@(resolve 're-frame.fx/dispatch-later-timers)
+       (filter (fn [[[fid _tid] _handle]] (= fid frame-id)))))
+
+(def ^:private df-frame :lud4af/df)
+
+(deftest positive-delay-completion-uses-frame-owned-timer-and-cancels-on-destroy
+  (testing "rf2-lud4af — a child completing through a POSITIVE-delay
+            :dispatch-later arms its completion re-dispatch in the FRAME-OWNED
+            dispatch-later timer table (re-frame.fx/dispatch-later-timers), so
+            destroy-frame! cancels it. Pre-fix the raw interop/set-timeout!
+            retained NOTHING, so the table stays empty and destroy cannot cancel
+            it (mutation tooth for the raw timeout)."
+    (fx/reset-dispatch-later-timers!)
+    (rf/make-frame {:id df-frame :doc "rf2-lud4af frame-owned-timer frame"})
+    (rf/reg-machine :lud4af/dfa (mk-child-delayed :lud4af/dfp 600000))
+    (rf/reg-machine :lud4af/dfb (mk-child-delayed :lud4af/dfp 600000))
+    (reg-parent! :lud4af/dfp :lud4af/dfa :lud4af/dfb)
+    (rf/dispatch-sync [:lud4af/dfp [:start]] {:frame df-frame})
+    (let [a (get-in (join-state df-frame :lud4af/dfp) [:children :a])]
+      ;; The completion is deferred 600000ms — it does NOT fold synchronously;
+      ;; the pending re-dispatch is held in the frame-owned timer table.
+      (rf/dispatch-sync [a [:go]] {:frame df-frame})
+      (is (= #{} (:done (join-state df-frame :lud4af/dfp)))
+          "the delayed completion has not folded yet (still pending in the timer)")
+      (is (= 1 (count (timers-for-frame df-frame)))
+          "the completion re-dispatch is RETAINED in the frame-owned
+           dispatch-later timer table (pre-fix the raw timeout retained nothing)")
+      (rf/destroy-frame! df-frame)
+      (is (zero? (count (timers-for-frame df-frame)))
+          "destroy-frame! cancelled + dropped the frame's pending completion
+           timer (pre-fix the raw timeout could not be cancelled)"))
+    (fx/reset-dispatch-later-timers!)))
+
+(def ^:private short-frame :lud4af/short)
+
+(deftest short-delay-completion-cancelled-on-destroy-never-fires-into-dead-frame
+  (testing "rf2-lud4af — a short-delay completion whose frame is destroyed
+            before it fires NEVER re-dispatches into the dead frame: no
+            :rf.error/frame-destroyed, no fold, and the sibling child receives
+            no stale completion. Pre-fix the raw timer fired dead-on-arrival."
+    (fx/reset-dispatch-later-timers!)
+    (let [errors (atom [])]
+      (rf/register-listener! :errors ::rec (fn [r] (swap! errors conj r)))
+      (rf/make-frame {:id short-frame :doc "rf2-lud4af short-delay frame"})
+      (rf/reg-machine :lud4af/sa (mk-child-delayed :lud4af/sp 40))
+      (rf/reg-machine :lud4af/sb (mk-child-delayed :lud4af/sp 40))
+      (reg-parent! :lud4af/sp :lud4af/sa :lud4af/sb)
+      (rf/dispatch-sync [:lud4af/sp [:start]] {:frame short-frame})
+      (let [a (get-in (join-state short-frame :lud4af/sp) [:children :a])]
+        (rf/dispatch-sync [a [:go]] {:frame short-frame})
+        ;; Destroy BEFORE the 40ms timer can fire.
+        (rf/destroy-frame! short-frame)
+        (Thread/sleep 300)
+        (rf/unregister-listener! :errors ::rec)
+        (is (empty? (filter #(= :rf.error/frame-destroyed (:error %)) @errors))
+            "no :rf.error/frame-destroyed — the cancelled completion timer never
+             enqueued a dead-on-arrival dispatch into the destroyed frame")
+        (is (empty? (stale-reasons))
+            "no stale completion surfaced against the sibling from a leaked timer")))
+    (fx/reset-dispatch-later-timers!)))
+
+;; ---------------------------------------------------------------------------
+;; (4) — real-completion strict replay: record an ACTUAL child completion, restore
+;;       the pre-event runtime-db, replay the recorded event + recorded cofx
+;;       through the transport, and reproduce the SAME fold / evidence.
+;; ---------------------------------------------------------------------------
+
+(defn- edn-roundtrip [x] (edn/read-string (pr-str x)))
+
+(deftest actual-completion-record-roundtrips-restores-and-strict-replays
+  (testing "rf2-lud4af — an ACTUAL child completion (captured as it flowed
+            through the transport, not hand-reconstructed) survives an EDN
+            round-trip of BOTH the recorded event and its recorded :rf.cofx;
+            after restoring the pre-event runtime-db, strict-replaying the
+            recorded pair reproduces the SAME :done fold. Stripping the recorded
+            authority fact is a fail-closed :attempt-unverified drop, never a
+            silent replay-success no-op."
+    (rf/reg-event ::restore-runtime (fn [_ [_ rt]] {:rf.db/runtime rt}))
+    (rf/reg-machine :lud4af/rca (mk-child :lud4af/rcp))
+    (rf/reg-machine :lud4af/rcb (mk-child :lud4af/rcp))
+    (reg-parent! :lud4af/rcp :lud4af/rca :lud4af/rcb)
+    (rf/dispatch-sync [:lud4af/rcp [:start]])
+    (let [pre-fold-runtime (mtest/runtime-db)          ;; attempt-1 join, :done #{}
+          a                (get-in (join-state :lud4af/rcp) [:children :a])
+          sink             (atom [])]
+      ;; RECORD an actual completion by driving child :a through its boundary.
+      (with-dispatch-observer sink
+        (fn [] (rf/dispatch-sync [a [:go]])))
+      (is (= #{:a} (:done (join-state :lud4af/rcp))) "the actual completion folded :a")
+      (let [[rec-event rec-opts] (some (fn [[ev op]]
+                                         (when (= [:lud4af/rcp [:child/done :a]] ev) [ev op]))
+                                       @sink)
+            rec-cofx  (:rf.cofx rec-opts)]
+        (is (some? rec-event) "captured the actual recorded completion event")
+        (is (some? (:rf.machine/join-auth rec-cofx))
+            "the actual record carries the recordable :rf.machine/join-auth fact")
+        ;; RESTORE pre-event runtime-db (the restore-epoch analogue): same
+        ;; attempt-1 tokens + spawned instances, :done #{}.
+        (rf/dispatch-sync [::restore-runtime pre-fold-runtime])
+        (is (= #{} (:done (join-state :lud4af/rcp))) "restored to the pre-fold epoch")
+        (mtest/reset-captured!)
+        ;; STRICT REPLAY the recorded pair, both halves EDN-roundtripped.
+        (rf/dispatch-sync (edn-roundtrip rec-event) {:rf.cofx (edn-roundtrip rec-cofx)})
+        (is (= #{:a} (:done (join-state :lud4af/rcp)))
+            "the round-tripped recorded event + cofx strict-replayed the SAME fold")
+        (is (empty? (stale-reasons)) "faithful replay — no stale suppression")
+        ;; Restore + replay WITHOUT the recorded authority → fail-closed stale drop.
+        (rf/dispatch-sync [::restore-runtime pre-fold-runtime])
+        (mtest/reset-captured!)
+        (rf/dispatch-sync (edn-roundtrip rec-event) {:rf.cofx (edn-roundtrip {})})
+        (is (= #{} (:done (join-state :lud4af/rcp)))
+            "replay with the authority fact stripped folded nothing")
+        (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+            "stripping the recorded authority is a typed stale drop, not a silent no-op")))))


### PR DESCRIPTION
## Problem (rf2-lud4af)

PR #5856 transports `:spawn-all` join authority by rewriting a member child's
own outbound `:dispatch` / `:dispatch-later` completion into the framework
effect `:rf.machine/join-dispatch`. Its handler built a **partial child-opts
map** and used a **raw `interop/set-timeout!`**, so it bypassed the
reserved-dispatch semantics the parent `:dispatch` / `:dispatch-later`
reserved-fx bodies guarantee.

**Reserved-dispatch semantics that were lost:**

- **`:fx-overrides` inheritance** — the completion re-dispatch did not inherit the cascade override map (Spec 002 §Cascade propagation).
- **`:interceptor-overrides` inheritance** — lost.
- **`:trace-id` inheritance** — lost.
- **`:origin` inheritance** — lost.
- **per-call `:rf.cofx/mint-policy` (strict/replay discipline, EP-0017 §6)** — fell back to `:live` minting.
- **frame-owned `:dispatch-later` timer table** (`re-frame.fx/dispatch-later-timers`, rf2-uxz52g) — a delayed completion armed a **raw** host timeout that `destroy-frame!` could not cancel, so it fired dead-on-arrival into a torn-down frame.
- **`:source-detail {:ms n}`** on the delayed dispatch (rf2-5qp4g) — lost.

## Fix — one shared child-dispatch seam

Expose a single `re-frame.fx/child-dispatch!` — the exact reserved-dispatch
implementation the parent `:dispatch` / `:dispatch-later` reserved-fx bodies
already use (parent-envelope inheritance via `child-dispatch-opts`, the
frame-owned `arm-dispatch-later!` timer table, immediate-vs-delayed routing).
The two reserved-fx bodies are refactored to route through it (behaviour
unchanged), and `:rf.machine/join-dispatch` becomes a **thin handler** that
routes the completion carrier through the same seam while stamping only its
private recordable `:rf.machine/join-auth` `:rf.cofx` fact and `:source
:machine-action`.

`join-dispatch-fx` now reads the emitting child's `:envelope` from its fx ctx
(threaded by `do-fx`) so the completion inherits the full reserved-dispatch
contract; a positive-delay completion rides the frame-owned timer table
(cancelled on frame destroy) instead of a raw timeout. **`router.cljc` needed
no change** — `build-envelope` already merges a supplied `:rf.cofx` verbatim,
and the router already threads the parent envelope through `do-fx` to registered
fx handlers as `:envelope`.

No new application-facing surface, no back-compat shim: `child-dispatch!` is a
reserved-internal seam; the public completion event VALUE and the closed join
grammar are unchanged.

## Fixtures (red-before-fix / real-completion / parallel)

- **`join_reserved_dispatch_semantics_test.clj`** (CLJ):
  - The completion transport inherits `:fx-overrides` / `:interceptor-overrides` / `:trace-id` / `:origin` / `:rf.cofx/mint-policy :strict`, stamps `:source :machine-action` + `:rf.machine/internal?`, and records `:rf.machine/join-auth` — captured off a **real** child completion via a pass-through `:router/dispatch!` observer (the 6 inheritance assertions are **red against the pre-fix partial-opts handler**).
  - A **positive-delay** completion is retained in the frame-owned `dispatch-later-timers` table and cancelled by `destroy-frame!` (**red against the pre-fix raw timeout** — table stays empty); a short-delay completion never fires dead-on-arrival into a destroyed frame.
  - **Real-completion strict-replay**: an ACTUAL child completion (captured as it flowed through the transport, not hand-reconstructed) EDN-roundtrips both the recorded event and its recorded `:rf.cofx`; after restoring the pre-event runtime-db, strict-replaying reproduces the SAME fold; stripping the recorded authority is a fail-closed `:attempt-unverified` drop.
- **`join_parallel_recordable_controls_cljs_test.cljc`** (CLJ + CLJS): the exact-authority fold gate in the ambiguous two-region parallel shape driven through the recordable `:rf.cofx` transport — legitimate success/failure fold only their own region, plus **unstamped / wrong-spawned-id / wrong-invoke / unknown-child** controls.

## Quality gates

- `implementation/core` JVM: **1967 tests, 9011 assertions, 0 failures**.
- `implementation/machines` JVM: **1053 tests, 3594 assertions, 0 failures** (includes join + reason-matrix conformance + the new fixtures).
- CLJS node integration (`npm run test:cljs`): **9364 tests, 44342 assertions, 0 failures** (includes the `.cljc` parallel-controls fixture under CLJS).
- `scripts/test-fast-pr.sh`: **PASS** (all drift gates, core JVM, JS harness helpers, CLJS node, per-ns isolation).
- Repro re-verified: restoring the pre-fix `fx.cljc` + `join.cljc` makes exactly the 6 semantic-loss assertions go red; the fix greens them.

## Spec ripples (follow-up, not in this PR)

- Spec 005 §Spawn-and-join / §Child completion protocol prose still describes the join-dispatch transport as a standalone effect; it should note it routes through the shared reserved-dispatch seam (rf2-lud4af).
- Spec 009 §Instrumentation: no new error-id introduced; `:rf.machine/join-dispatch` behaviour is now uniform with `:dispatch` / `:dispatch-later` source/source-detail stamping.

Closes rf2-lud4af.
