### PR TITLE
fix(ui): reserve reactive authoring verbs before foreign component classification (rf2-vxgfnd.266)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -308,6 +308,19 @@
       (coll? x) (some #(bare-reactive-reference-kind e % locals) x)
       :else nil)))
 
+(defn- reactive-direct-form
+  "The kind-correct compiler-owned direct form a reactive authoring verb must
+  take in evaluated code — the ONLY shape in which the public var is legal, and
+  what every escape diagnostic must recommend. `sub` reads a query, `lease`
+  DECLARES a descriptor (the leading prefix, never a second-form read), `frame`
+  takes no argument. Kept as one function so no diagnostic can drift into
+  recommending an invalid form (e.g. a lease `query` second element)."
+  [kind]
+  (case kind
+    :sub   "(sub query)"
+    :lease "(lease descriptor)"
+    :frame "(frame)"))
+
 (defn- reactive-authoring-var-kind
   "Return :sub/:lease/:frame when `sym` is an unquoted, unshadowed reference to
   a public reactive authoring var. Such a var is sound ONLY as a compiler-owned
@@ -360,10 +373,8 @@
                  (str "bare " (name kind) " reference as a destructuring :or "
                       "default — re-frame.ui/" (name kind) " is a reactive "
                       "authoring var, sound ONLY as a compiler-owned direct call "
-                      "head ("
-                      (if (= :frame kind) "(frame)"
-                          (str "(" (name kind) " query)"))
-                      "). A binding :or default is never rewritten, so the bare "
+                      "head " (reactive-direct-form kind)
+                      ". A binding :or default is never rewritten, so the bare "
                       "var flows as a VALUE where the compiler cannot own a "
                       "lexical render site — the manifest under-declares and the "
                       "optimized build elides the read. Hoist the read into the "
@@ -677,10 +688,9 @@
                  (env/fail! e :rf.ui.compile/unsupported-form
                             (str "bare " (name kind) " reference — re-frame.ui/"
                                  (name kind) " is a reactive authoring var, sound "
-                                 "ONLY as a compiler-owned direct call head ("
-                                 (if (= :frame kind) "(frame)"
-                                     (str "(" (name kind) " query)"))
-                                 "). Here it flows as a VALUE (into a computed "
+                                 "ONLY as a compiler-owned direct call head "
+                                 (reactive-direct-form kind)
+                                 ". Here it flows as a VALUE (into a computed "
                                  "callee, let-binding, argument, or collection) "
                                  "where the compiler cannot own a lexical render "
                                  "site, so the manifest would under-declare and "
@@ -1287,6 +1297,48 @@
      :path (:path e)}))
 
 ;; ---------------------------------------------------------------------------
+;; Reactive authoring verbs in head position (rf2-vxgfnd.266)
+;; ---------------------------------------------------------------------------
+;;
+;; sub/lease/frame are reactive authoring verbs, sound in evaluated code ONLY as
+;; their compiler-owned DIRECT forms — (sub query), the leading (lease
+;; descriptor) declaration, (frame) — which the expression rewriter lowers to
+;; indexed runtime sites. A Hiccup component HEAD is not such a form:
+;; env/classify-head resolves any resolved non-:rf.ui/view var to a plain
+;; :foreign React component, so [sub {…}] / [lease {…}] / [frame] would
+;; otherwise compile as a foreign component with an EMPTY reactive manifest,
+;; leaving the public authoring var to survive to runtime unindexed and
+;; bypassing reactive-site indexing entirely. These verbs are therefore
+;; RESERVED BEFORE generic component classification — `analyze`'s dispatch
+;; checks this head predicate ahead of `analyze-component`/`env/classify-head`
+;; — so a reactive verb can never be reclassified as foreign. A lexical shadow
+;; resolves to nil (`resolve-sym` skips locals) and falls through to the
+;; ordinary local-head (`:dynamic-head`) rule; a genuine foreign component still
+;; classifies as :foreign.
+
+(defn- reactive-authoring-head-kind
+  "Return :sub/:lease/:frame when `head` is an unshadowed symbol resolving to a
+  public reactive authoring var — the reserved-head discriminator, mirroring
+  frame-root-head?/frame-provider-head?."
+  [e head]
+  (when (and (symbol? head) (not (contains? (:locals e) head)))
+    (reactive-authoring-var-kind e head)))
+
+(defn- analyze-reactive-authoring-head! [e form head]
+  (let [kind (reactive-authoring-head-kind e head)]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "reactive authoring verb " (name kind) " in component-head "
+                    "position [" (name kind) " …] — re-frame.ui/" (name kind)
+                    " is sound ONLY as its compiler-owned direct call head "
+                    (reactive-direct-form kind)
+                    ", which the compiler lowers to an indexed render site. As a "
+                    "Hiccup head it would classify as a plain foreign React "
+                    "component with an empty reactive manifest, leaving the "
+                    "public authoring var to survive to runtime unindexed. Keep "
+                    "the read at a visible " (reactive-direct-form kind) " site")
+               {:form form :reactive-kind kind})))
+
+;; ---------------------------------------------------------------------------
 ;; frame-root (S1c, rf2-vxgfnd.3) — the static ENSURE-plan position
 ;; ---------------------------------------------------------------------------
 ;;
@@ -1714,6 +1766,11 @@
         (keyword? head)  (analyze-element e form)
         (frame-root-head? e head) (analyze-frame-root e form)
         (frame-provider-head? e head) (analyze-frame-provider e form)
+        ;; Reserve sub/lease/frame BEFORE generic component classification
+        ;; (rf2-vxgfnd.266): a reactive authoring verb can never be
+        ;; reclassified as a :foreign component with an empty manifest.
+        (reactive-authoring-head-kind e head)
+        (analyze-reactive-authoring-head! e form head)
         (symbol? head)   (analyze-component e form)
         :else
         (env/fail! e :rf.ui.compile/dynamic-head

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -18,6 +18,14 @@
       sub         {:fqn 're-frame.ui/sub :meta {}}
       lease       {:fqn 're-frame.ui/lease :meta {}}
       frame       {:fqn 're-frame.ui/frame :meta {}}
+      ;; aliased + fully-qualified spellings resolve to the same vars
+      ;; (rf2-vxgfnd.266 head reservation must key on the fqn, not the spelling)
+      ui/sub            {:fqn 're-frame.ui/sub :meta {}}
+      ui/lease          {:fqn 're-frame.ui/lease :meta {}}
+      ui/frame          {:fqn 're-frame.ui/frame :meta {}}
+      re-frame.ui/sub   {:fqn 're-frame.ui/sub :meta {}}
+      re-frame.ui/lease {:fqn 're-frame.ui/lease :meta {}}
+      re-frame.ui/frame {:fqn 're-frame.ui/frame :meta {}}
       raw         {:fqn 're-frame.ui/raw :meta {}}
       html        {:fqn 're-frame.ui/html :meta {}}
       raw-fn      {:fqn 're-frame.ui/raw-fn :meta {}}
@@ -154,6 +162,26 @@
   (is (= :foreign (:op (ana* '[ForeignComp {:anything (quote x)}]))))
   (is (= :foreign (:op (ana* '[var-copy {}])))
       "var copies do not carry view-ness (def does not copy var meta) — foreign"))
+
+(deftest reactive-verb-head-reservation-is-narrow
+  ;; rf2-vxgfnd.266 — reserving sub/lease/frame heads BEFORE generic component
+  ;; classification must not disturb genuine foreign components or ordinary view
+  ;; heads: only a head resolving to one of the three public reactive authoring
+  ;; vars is reserved. A DIRECT (sub …)/(frame) CALL in child position is still
+  ;; the compiler-owned form and mints exactly one manifest site.
+  (is (= :foreign (:op (ana* '[ForeignComp {}])))
+      "a genuine foreign component head still classifies as :foreign")
+  (is (= :view (:op (ana* '[child-view {}])))
+      "an ordinary view head is untouched")
+  (is (= :foreign (:op (ana* '[var-copy {}])))
+      "a non-reactive var copy still classifies as :foreign (unchanged)")
+  (testing "the reservation touches ONLY the head form — direct calls still index"
+    (let [{:keys [sites]} (ana-full '[:div (sub [:q])])]
+      (is (= 1 (count (:subs sites)))
+          "a direct (sub …) child is one indexed site, not a reserved head"))
+    (let [{:keys [sites]} (ana-full '[:div (:frame (frame))])]
+      (is (= 1 (count (:frame-ops sites)))
+          "a direct (frame) read is one indexed frame-ops site"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Handlers

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -183,6 +183,41 @@
   (is (nil? (reject-id '[:div {:title (let [{:keys [x] :or {x 'sub}} m] x)}]))
       "quoted data in an :or default is inert — never a reactive read"))
 
+(deftest reactive-verb-head-reserved-before-foreign-classification
+  ;; rf2-vxgfnd.266 — the next escape in the .252/dzyqis family. sub/lease/frame
+  ;; are reactive authoring verbs, sound ONLY as their compiler-owned DIRECT
+  ;; forms. A distinct analyzer route reaches a Hiccup component HEAD directly:
+  ;; env/classify-head resolves any non-:rf.ui/view var to a plain :foreign
+  ;; React component, so [sub {…}]/[lease {…}]/[frame] would compile as a foreign
+  ;; component with an EMPTY reactive manifest — the public authoring var
+  ;; survives to runtime unindexed, bypassing reactive-site indexing entirely.
+  ;; The verbs are RESERVED before generic classification. Removing the
+  ;; reserved-head check re-accepts every reject row below as :foreign, so this
+  ;; deftest is the mutation fixture too.
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[sub {}]))
+      "bare sub in component-head position — the rf2-vxgfnd.266 counterexample")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[lease {}]))
+      "bare lease in component-head position escapes identically")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[frame]))
+      "bare frame in component-head position (no props) escapes identically")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[sub {} [:p "child"]]))
+      "children do not change the reserved-head classification")
+  ;; qualified + aliased spellings resolve to the exact vars — reserved too
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[ui/sub {}]))
+      "an aliased spelling resolving to re-frame.ui/sub is reserved")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[re-frame.ui/lease {}]))
+      "a fully-qualified spelling resolving to re-frame.ui/lease is reserved")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[re-frame.ui/frame]))
+      "a fully-qualified frame head is reserved")
+  ;; a lexical shadow is NOT the reactive var: it falls through to the ordinary
+  ;; local-head rule (a local binding can never be a literal head → dynamic-head)
+  (is (= :rf.ui.compile/dynamic-head
+         (reject-id '(let [sub child-view] [sub {}])))
+      "a local shadowing sub is an ordinary local head, never a reserved verb")
+  ;; a genuine foreign component head still classifies (accepts)
+  (is (nil? (reject-id '[ForeignComp {}]))
+      "a genuine foreign component head still classifies as :foreign"))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -87,6 +87,34 @@
              '(re-frame.ui/defview shadowing-header [{:keys [sub]}] [:div sub])))
       "the header local shadows re-frame.ui/sub only in the body"))
 
+(deftest reactive-verb-in-component-head-is-reserved-through-real-host-resolution
+  ;; rf2-vxgfnd.266 — the pure-analyzer fixtures inject resolution; this pins the
+  ;; same reservation through ACTUAL CLJ var resolution during defview
+  ;; macroexpansion (the macro JVM expands for the CLJS path too). A Hiccup head
+  ;; resolving to a public reactive authoring var (sub/lease/frame) must be
+  ;; reserved BEFORE env/classify-head can classify it as a plain :foreign
+  ;; component with an empty reactive manifest, letting the public authoring var
+  ;; survive to runtime unindexed.
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error '(re-frame.ui/defview v [] [:div [re-frame.ui/sub {}]])))
+      "a fully-qualified sub head is reserved through real resolution")
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error '(re-frame.ui/defview v [] [:div [re-frame.ui/lease {}]])))
+      "a fully-qualified lease head is reserved")
+  (is (= :rf.ui.compile/unsupported-form
+         (expand-error '(re-frame.ui/defview v [] [:div [re-frame.ui/frame]])))
+      "a fully-qualified frame head is reserved")
+  ;; (aliased/unqualified spellings are covered by the pure-analyzer reject
+  ;; fixture, whose injected resolver models the analyzer resolution contract;
+  ;; this file follows the established convention of fully-qualified spellings
+  ;; under raw macroexpand-1, where namespace-alias resolution is not available.)
+  ;; the reservation is NARROW: a direct (sub …) CALL is still the compiler-owned
+  ;; form and expands to exactly one manifest site — only the head form is reserved
+  (is (nil? (expand-error '(re-frame.ui/defview v [] [:div (re-frame.ui/sub [:q])])))
+      "sub is still legal as its compiler-owned direct call — only the head is reserved")
+  (is (nil? (expand-error '(re-frame.ui/defview v [] [:div (:frame (re-frame.ui/frame))])))
+      "a direct (frame) read still expands — only the head form is reserved"))
+
 (deftest an-opaque-macro-cannot-inject-an-unmanifested-template-site
   (is (= :rf.ui.compile/unsupported-form
          (expand-error

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -260,6 +260,13 @@
    [:rf.ui.compile/unsupported-form
     '[:div {:title (let [{:keys [x] :or {x sub}} m] x)}]
     ["destructuring :or" "direct call head"]]
+   ;; rf2-vxgfnd.266 — a reactive authoring verb in Hiccup component-head
+   ;; position (distinct throw site: the reserved-head guard, ahead of
+   ;; env/classify-head's :foreign classification). Recovery is kind-correct:
+   ;; (sub query), the leading (lease descriptor) — never (lease query) — and (frame).
+   [:rf.ui.compile/unsupported-form '[sub {}] ["component-head" "(sub query)"]]
+   [:rf.ui.compile/unsupported-form '[lease {}] ["component-head" "(lease descriptor)"]]
+   [:rf.ui.compile/unsupported-form '[frame] ["component-head" "(frame)"]]
    ;; handlers
    [:rf.ui.compile/loop-capturing-handler
     '(for [t ts] [:li {:key (:id t) :on-click [::open (:id t)]} "x"])


### PR DESCRIPTION
## Problem

A distinct analyzer route bypassed #5874/`rf2-vxgfnd.252`'s value-flow guard. A symbol in Hiccup component-head position is sent straight through `analyze-component` → `env/classify-head`, which classifies any resolved var that is not a registered `:rf.ui/view` as `:foreign`. So `[sub {}]`, `[lease {}]`, `[frame]` (and qualified/aliased/unqualified spellings that resolve to those exact vars) compiled as **foreign React components with an empty reactive manifest** — the public authoring var survived to runtime unindexed, bypassing reactive-site indexing entirely.

Re-verified against fresh `origin/main` (HEAD `62ba04ff5f`, after .252 + `rf2-dzyqis` merged): `[sub {}]`/`[lease {}]`/`[frame]` all classified `:foreign` with the public `re-frame.ui/sub`/`lease`/`frame` fqn. Still reproduced — not closed by the prior two.

## The ordering fix

`analyze`'s vector-head dispatch now checks a reserved-verb predicate (`reactive-authoring-head-kind`) **before** the generic `(symbol? head) → analyze-component` catch-all — mirroring the existing `frame-root-head?` / `frame-provider-head?` reservations. A head resolving (unshadowed) to `re-frame.ui/sub`/`lease`/`frame` is rejected with the existing typed `:rf.ui.compile/unsupported-form`, so a reactive verb can **never** be reclassified as `:foreign`. Lexical shadows resolve to nil (`resolve-sym` skips locals) and fall through to the ordinary local-head (`:dynamic-head`) rule; a genuine foreign component still classifies as `:foreign`.

Recovery text is now kind-correct across all three reactive-authoring diagnostics via one shared `reactive-direct-form` helper: `(sub query)`, the **leading `(lease descriptor)`** (never the invalid `(lease query)`), and `(frame)`. This also corrects the pre-existing lease wording in the .252 value-flow-leaf and `rf2-dzyqis` `:or`-default messages.

Narrow by design: a direct `(sub …)`/`(frame)` **call** is untouched and still lowers to exactly one manifest site — only the head form is reserved.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`) — **501 tests / 6424 assertions / 0 failures**. Covers:
  - `analyze_reject_cljs_test` — new `reactive-verb-head-reserved-before-foreign-classification` (the mutation fixture: removing the reserved-head check re-accepts every row as `:foreign`); bare + qualified + aliased spellings reject with `:rf.ui.compile/unsupported-form`; lexical shadow → `:dynamic-head`; genuine foreign → accepted.
  - `analyze_accept_cljs_test` — new `reactive-verb-head-reservation-is-narrow` (foreign/view/var-copy heads untouched; direct `(sub …)`/`(frame)` still index one site); shared resolver extended with aliased/qualified spellings.
  - `defview_grammar_jvm_test` — new `reactive-verb-in-component-head-is-reserved-through-real-host-resolution` (ACTUAL CLJ var resolution via `defview` macroexpansion, fully-qualified spellings; direct-call control still expands).
  - `error_roster_cljs_test` — 3 kind-correct message rows at the new throw site (`(sub query)` / `(lease descriptor)` / `(frame)`); frozen-roster completeness unchanged (`:rf.ui.compile/unsupported-form` already listed).
  - `g14_compile_budget_jvm_test` — green.
- `implementation` node CLJS (`npm run test:cljs`) — **9367 tests / 44401 assertions / 0 failures**.

Compile-reject id is `:rf.ui.compile/unsupported-form` (already frozen) — no new id, no Spec 009 catalogue row (all `:rf.ui.compile/*` are compile-time diagnostics).

## Scope / coordination

Touches only `compiler/analyze.cljc` + its tests. **Spec 004 grammar-prose ripple** (state compactly that public `sub`/`lease`/`frame` are legal in evaluated code only in their compiler-owned direct forms) is deferred to coordinate with the `rf2-vxgfnd.224` special-form roster edit rather than stretching this PR into the shared hot-zone. The mounted/advanced-build negative proof in the bead's acceptance is moot for this route: a rejected head never reaches emit, so no executable output exists to inspect.

Closes rf2-vxgfnd.266.
