### PR TITLE
fix(core): genuine weak-identity provenance keying + schema-bound callback-failure tests (rf2-fs99nq/qyvyes)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -242,23 +242,82 @@
   axis is NOT covered and a containment drain still owes production a record."
   (->EmissionProvenance #{:trace}))
 
-;; The PRIVATE weak throwable→provenance association (rf2-9m4oy7). Provenance is
-;; bound to the EXACT throwable it attests — keyed by the throwable OBJECT
-;; IDENTITY (the JVM `WeakHashMap` keys by `.equals`/`.hashCode`, which
-;; `Throwable` inherits from `Object` as identity; `js/WeakMap` keys by object
-;; identity with ephemeron semantics). It is WEAK and self-pruning: an entry
-;; lives exactly as long as its throwable, so a caught-and-processed throwable's
-;; binding is collectable the moment the throwable is — never a growing global
-;; registry (the bead's explicit non-goal). Written ONLY by [[attest-provenance!]]
-;; from this ns's own emit-then-throw sites; an application cannot reach it, so a
-;; forged `->EmissionProvenance` token in an app's ex-data, or an authentic token
-;; transplanted onto a DIFFERENT throwable, is never associated here and reads
-;; uncovered.
+;; The PRIVATE weak throwable→provenance association (rf2-9m4oy7 + rf2-fs99nq).
+;; Provenance is bound to the EXACT throwable it attests — keyed by the throwable
+;; OBJECT IDENTITY, WEAK and self-pruning so an entry lives exactly as long as its
+;; throwable (a caught-and-processed throwable's binding is reclaimed the moment the
+;; throwable is — never a growing global registry, the bead's explicit non-goal).
+;; Written ONLY by [[attest-provenance!]] from this ns's own emit-then-throw sites;
+;; an application cannot reach it, so a forged `->EmissionProvenance` token in an
+;; app's ex-data, or an authentic token transplanted onto a DIFFERENT throwable, is
+;; never associated here and reads uncovered.
+;;
+;; GENUINE IDENTITY, NOT `.equals`/`.hashCode` (rf2-fs99nq): `Throwable` leaves
+;; `hashCode` and `equals` VIRTUAL — a throwable is identity-keyed ONLY while it
+;; inherits Object's defaults, which an APPLICATION throwable is free to OVERRIDE. So
+;; a raw `java.util.WeakHashMap` keyed by the throwable is NOT genuine identity: it
+;; keys by `.equals`/`.hashCode`, so two distinct application throwables that are
+;; `.equals` (or one with a forged `hashCode`) COLLIDE, and its `.get` returns the
+;; bound throwable's provenance for a DIFFERENT one — the drain then reads a raw
+;; application exception as already-covered and SUPPRESSES its required
+;; `:rf.error/observation-on-change-failed` record; worse, an application
+;; `hashCode`/`equals` that THROWS makes provenance lookup itself escape the drain's
+;; catch and abort the reduce before healthy siblings drain (breaking the full-drain
+;; / first-original-identity law). On the JVM the association is therefore a small
+;; ReferenceQueue-backed weak map whose keys hash by `System/identityHashCode` and
+;; compare by referent `identical?` — NEVER invoking the throwable's own
+;; `hashCode`/`equals` — with cleared entries reclaimed on each access. `js/WeakMap`
+;; is genuinely identity-keyed (reference keys, ephemeron semantics) with no such
+;; hazard, so CLJS keeps it unchanged.
+#?(:clj
+   (defonce ^:private ^java.lang.ref.ReferenceQueue provenance-queue
+     (java.lang.ref.ReferenceQueue.)))
+
 #?(:clj
    (defonce ^:private ^java.util.Map provenance-by-throwable
-     (java.util.Collections/synchronizedMap (java.util.WeakHashMap.)))
+     ;; identity-key (a `WeakReference` subclass, [[weak-identity-key]]) →
+     ;; `EmissionProvenance`. A plain `HashMap` guarded by `locking
+     ;; provenance-by-throwable` (the node-records lock discipline). NOT a
+     ;; `WeakHashMap`: weakness comes from the `WeakReference` KEYS + ReferenceQueue
+     ;; expunge, IDENTITY from the keys' own `hashCode`/`equals`.
+     (java.util.HashMap.))
    :cljs
    (defonce ^:private provenance-by-throwable (js/WeakMap.)))
+
+#?(:clj
+   (defn- weak-identity-key
+     "Wrap throwable `t` as a map key with genuine IDENTITY hash/equality that NEVER
+     touches `t`'s own `hashCode`/`equals` (rf2-fs99nq): a `WeakReference` subclass
+     whose `hashCode` is the captured `System/identityHashCode` and whose `equals` is
+     referent `identical?`. A non-nil `queue` registers the key for reclamation (the
+     STORED key); a nil `queue` makes a transient LOOKUP key. `equals` short-circuits
+     on `identical? this o` (so expunging a cleared key never dereferences it) and
+     otherwise compares referents by identity, treating a cleared referent as no
+     match."
+     ^java.lang.ref.WeakReference [t ^java.lang.ref.ReferenceQueue queue]
+     (let [h (System/identityHashCode t)]
+       (proxy [java.lang.ref.WeakReference] [t queue]
+         (hashCode [] h)
+         (equals [o]
+           (or (identical? this o)
+               (and (instance? java.lang.ref.WeakReference o)
+                    (let [r (.get ^java.lang.ref.WeakReference this)]
+                      (and (some? r)
+                           (identical? r (.get ^java.lang.ref.WeakReference o)))))))))))
+
+#?(:clj
+   (defn- expunge-stale-provenance!
+     "Reclaim entries whose throwable has been collected (rf2-fs99nq): poll the
+     ReferenceQueue for cleared keys and drop each from the map. Removal matches the
+     EXACT enqueued key by identity (`equals` short-circuits on `identical? this o`),
+     so a cleared referent is never dereferenced and the throwable's own
+     `hashCode`/`equals` are never invoked. Call under `locking
+     provenance-by-throwable`."
+     []
+     (loop []
+       (when-some [k (.poll ^java.lang.ref.ReferenceQueue provenance-queue)]
+         (.remove ^java.util.Map provenance-by-throwable k)
+         (recur)))))
 
 (defn- attest-provenance!
   "Bind `provenance` to the EXACT throwable `t` in the private weak association,
@@ -269,7 +328,13 @@
   minted-and-bound is covered. A no-op-safe identity write; the entry dies with
   the throwable."
   [t provenance]
-  #?(:clj  (.put ^java.util.Map provenance-by-throwable t provenance)
+  #?(:clj  (locking provenance-by-throwable
+             (expunge-stale-provenance!)
+             ;; Store under a WEAK IDENTITY key (rf2-fs99nq): keyed by t's object
+             ;; identity, never its own hashCode/equals; the key is registered on the
+             ;; ReferenceQueue so the entry is reclaimed once t is collected.
+             (.put ^java.util.Map provenance-by-throwable
+                   (weak-identity-key t provenance-queue) provenance))
      :cljs (.set provenance-by-throwable t provenance))
   t)
 
@@ -287,15 +352,27 @@
   false, so trace coverage is never mistaken for always-on coverage
   (rf2-w55bh0)."
   [t]
-  (let [prov #?(:clj  (.get ^java.util.Map provenance-by-throwable t)
+  (let [prov #?(:clj  (locking provenance-by-throwable
+                        (expunge-stale-provenance!)
+                        ;; A transient IDENTITY LOOKUP key (nil queue) — HashMap.get
+                        ;; discriminates by our key's `System/identityHashCode` +
+                        ;; referent `identical?`, NEVER t's own hashCode/equals
+                        ;; (rf2-fs99nq). So a distinct application throwable that is
+                        ;; `.equals`/hash-collides with a bound one reads uncovered,
+                        ;; and a throwable whose hashCode/equals THROWS cannot make
+                        ;; this lookup escape the drain's catch.
+                        (.get ^java.util.Map provenance-by-throwable
+                              (weak-identity-key t nil)))
                 ;; `WeakMap.prototype.get` returns undefined (never throws) for a
                 ;; non-object key, so a raw thrown value (CLJS permits
                 ;; `(throw :kw)` / `(throw "x")`) simply reads uncovered — NO guard
-                ;; is needed here. In particular do NOT guard with cljs `object?`:
-                ;; it is `(identical? (.-constructor x) js/Object)`, which is FALSE
-                ;; for an `ExceptionInfo` (its constructor is not `js/Object`), so
-                ;; it would wrongly exclude every real framework throwable and make
-                ;; the covered path never fire on CLJS.
+                ;; is needed here. `js/WeakMap` is genuinely identity-keyed (reference
+                ;; keys), so CLJS carries none of the JVM `.equals`/`.hashCode`
+                ;; collision hazard (rf2-fs99nq). In particular do NOT guard with cljs
+                ;; `object?`: it is `(identical? (.-constructor x) js/Object)`, which
+                ;; is FALSE for an `ExceptionInfo` (its constructor is not
+                ;; `js/Object`), so it would wrongly exclude every real framework
+                ;; throwable and make the covered path never fire on CLJS.
                 :cljs (.get provenance-by-throwable t))]
     (and (instance? EmissionProvenance prov)
          (contains? (.-channels ^EmissionProvenance prov) :always-on))))

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -2542,6 +2542,136 @@
         (obs/release! la) (obs/release! lb) (obs/release! lc) (obs/release! ld)))))
 
 ;; ===========================================================================
+;; rf2-fs99nq — provenance is keyed by genuine WEAK OBJECT IDENTITY on the JVM,
+;; never by the throwable's own `.equals`/`.hashCode`.
+;;
+;; rf2-9m4oy7's JVM map was a `java.util.WeakHashMap` keyed by the throwable
+;; directly. `WeakHashMap` keys by `.equals`/`.hashCode`, and `Throwable` leaves
+;; both VIRTUAL — so an APPLICATION throwable that OVERRIDES them defeats the
+;; exact-identity contract two ways:
+;;
+;;   1. COLLISION — a distinct throwable whose `hashCode` equals a bound throwable's
+;;      and whose `equals` accepts it reads that bound throwable's `#{:always-on}`
+;;      provenance, so the drain treats a raw application exception as already
+;;      covered and SUPPRESSES its required :rf.error/observation-on-change-failed
+;;      record (production silence).
+;;   2. THROWING CLASSIFICATION — a throwable whose `hashCode`/`equals` THROWS makes
+;;      `provenance-by-throwable.get` itself escape `source-covered-always-on?`,
+;;      propagating out of the drain's per-lease catch, aborting the reduce before
+;;      healthy siblings drain and replacing the first-original rethrow — breaking
+;;      the full-drain / first-original-identity law.
+;;
+;; The fix keys the JVM association by a WEAK IDENTITY key (a ReferenceQueue-backed
+;; `WeakReference` subclass hashing by `System/identityHashCode`, comparing by
+;; referent `identical?`), so provenance classification NEVER invokes an application
+;; throwable's `hashCode`/`equals`. Red-before-fix (revert to `WeakHashMap<Throwable>`
+;; lookup): the collision fixture SUPPRESSES B (zero wrappers), and the throwing-
+;; method fixture aborts the drain before the trailing siblings.
+;;
+;; CLJS is inherently identity-keyed — `js/WeakMap` uses reference keys with no
+;; `.equals`/`.hashCode` seam — and its exact-throwable binding is already pinned
+;; cross-host by `disposed-drain-binds-emission-provenance-to-the-exact-throwable`
+;; (the transplanted-token leg reads uncovered on CLJS too). So this leg is JVM-only.
+;; ===========================================================================
+
+#?(:clj
+   (deftest jvm-forged-equality-throwable-does-not-read-covered
+     ;; A DISTINCT custom RuntimeException B whose hash collides with an authentic
+     ;; bound throwable A and whose equality accepts A must NOT read covered: it is a
+     ;; different object, so the drain owns its production record (rf2-fs99nq).
+     (reg-items!)
+     (seed-items! [:a])
+     ;; A = an AUTHENTIC port-minted throwable bound `#{:always-on :trace}` at its
+     ;; source (read-after-release! fans always-on and binds THAT exact throwable).
+     (let [setup (obs/acquire! (items-target) (fn [_]))
+           _     (obs/release! setup)
+           A     (try (obs/read setup)
+                      (catch Throwable e e))
+           ;; B forges A's identity hash and reports equality with A — exactly the
+           ;; keys a WeakHashMap<Throwable> would collide on. `System/identityHashCode`
+           ;; discrimination + `identical?` ignore both, so B stays uncovered.
+           B     (proxy [RuntimeException] ["forged-equality boom"]
+                   (hashCode [] (System/identityHashCode A))
+                   (equals [o] (identical? o A)))]
+       (is (= :rf.error/read-after-release (error-id A))
+           "the fixture carries a REAL port-minted always-on throwable")
+       (with-redefs [interop/next-tick (fn [_f] nil)]
+         (let [notes (atom [])
+               ;; la RE-THROWS the exact bound A (covered → no wrapper);
+               ;; lb throws the forged-equality B (uncovered → exactly one wrapper).
+               la (obs/acquire! (items-target) (fn [_n] (throw A)))
+               lb (obs/acquire! (items-target) (fn [_n] (throw B)))
+               lc (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+           (force-dispose-node! [:obs/items])
+           (let [[_ records]
+                 (with-error-records #(obs/drain-pending-disposals! :disposed))
+                 wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                  records)
+                 causes  (mapv :exception wrapped)]
+             (testing "the healthy sibling was still notified"
+               (is (= 1 (count @notes))))
+             (testing "the forged-equality throwable CANNOT read covered — it gets
+                       exactly one stable wrapper carrying B (pre-fix / WeakHashMap:
+                       B collides onto A and is suppressed, zero wrappers)"
+               (is (= 1 (count wrapped)))
+               (is (some #(identical? % B) causes))
+               (is (every? #(= :obs/items (:event-id %)) wrapped)))
+             (testing "the EXACT bound A is covered — its source emission stands, so
+                       the drain adds NO wrapper for it (exact-once)"
+               (is (not (some #(identical? % A) causes)))))
+           (obs/release! la) (obs/release! lb) (obs/release! lc))))))
+
+#?(:clj
+   (deftest jvm-throwing-hashcode-or-equals-throwable-is-classified-by-identity
+     ;; Provenance classification must call NEITHER `hashCode` NOR `equals` on an
+     ;; application throwable (rf2-fs99nq): a throwable whose method throws must not
+     ;; make the lookup escape the drain's catch. Every healthy sibling — including
+     ;; ones queued AFTER the throwing throwables — is notified; each throwing
+     ;; throwable is wrapped exactly once carrying itself; and the DIRECT drain
+     ;; rethrows the FIRST original only after the COMPLETE drain.
+     (reg-items!)
+     (seed-items! [:a])
+     (with-redefs [interop/next-tick (fn [_f] nil)]
+       (let [notes    (atom [])
+             hc-boom  (proxy [RuntimeException] ["hashCode-must-not-be-called"]
+                        (hashCode [] (throw (IllegalStateException.
+                                              "application hashCode was invoked during provenance classification"))))
+             eq-boom  (proxy [RuntimeException] ["equals-must-not-be-called"]
+                        (equals [_o] (throw (IllegalStateException.
+                                              "application equals was invoked during provenance classification"))))
+             ;; Queue order: sibling, hc-boom (FIRST escape), eq-boom, sibling. The
+             ;; trailing sibling proves the drain did not abort mid-reduce.
+             s1 (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))
+             lb (obs/acquire! (items-target) (fn [_n] (throw hc-boom)))
+             lc (obs/acquire! (items-target) (fn [_n] (throw eq-boom)))
+             s2 (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+         (force-dispose-node! [:obs/items])
+         (let [[[outcome thrown] records]
+               (with-error-records #(obs/drain-pending-disposals! :disposed))
+               wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                records)
+               causes  (mapv :exception wrapped)]
+           (testing "every healthy sibling is notified — including the one queued
+                     AFTER the throwing throwables (pre-fix: the throwing hashCode
+                     escapes classification and aborts the reduce before s2)"
+             (is (= 2 (count @notes))))
+           (testing "each throwing-method throwable is wrapped exactly once carrying
+                     its OWN original throwable"
+             (is (= 2 (count wrapped)))
+             (is (some #(identical? % hc-boom) causes))
+             (is (some #(identical? % eq-boom) causes)))
+           (testing "the direct drain rethrows the first ORIGINAL throwable only
+                     after the complete drain (identity/cause intact — never a
+                     classification-derived exception; drain order rides the
+                     :owners set so either original may be first)"
+             (is (= :threw outcome))
+             (is (or (identical? hc-boom thrown)
+                     (identical? eq-boom thrown))
+                 "the rethrow is one of the two ORIGINAL throwables, not a
+                  hashCode/equals-classification escape")))
+         (obs/release! s1) (obs/release! lb) (obs/release! lc) (obs/release! s2)))))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -18,6 +18,12 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             #?(:clj [clojure.java.io :as io])
             #?(:clj [clojure.string :as str])
+            ;; rf2-qyvyes — the canonical ObservationOnChangeFailedTags schema is
+            ;; EXTRACTED from spec/Spec-Schemas.md at COMPILE TIME (a JVM-only macro
+            ;; that runs for both the CLJ eval and the CLJS compilation), so both
+            ;; hosts validate emitted records against the executable canonical form.
+            #?(:clj [re-frame.observation-schema-extract
+                     :refer [canonical-observation-schema]])
             [re-frame.core                  :as rf]
             [re-frame.error-emit            :as error-emit]
             [re-frame.frame                 :as frame]
@@ -28,7 +34,9 @@
             [re-frame.subs.cache            :as subs-cache]
             [re-frame.substrate.observation :as obs]
             [re-frame.substrate.plain-atom  :as plain-atom]
-            [re-frame.test-support          :as test-support]))
+            [re-frame.test-support          :as test-support])
+  #?(:cljs (:require-macros [re-frame.observation-schema-extract
+                             :refer [canonical-observation-schema]])))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -2688,46 +2696,104 @@
         "the boot skew fans the always-on record before throwing")))
 
 ;; ===========================================================================
-;; rf2-xakb4p — the catalogue-to-schema / record validation gate.
+;; rf2-xakb4p + rf2-qyvyes — the catalogue-to-schema / record validation gate,
+;; bound to the EXECUTABLE canonical schema.
 ;;
-;; The disposal-notify wrapper's record shape is now FROZEN by a canonical
-;; per-category schema ([Spec-Schemas §ObservationOnChangeFailedTags]). This
-;; gate binds that schema to the ACTUAL runtime record fanned at BOTH drain
-;; boundaries, in two directions:
+;; The disposal-notify wrapper's record shape is FROZEN by a canonical per-category
+;; schema ([Spec-Schemas §ObservationOnChangeFailedTags]). rf2-qyvyes replaces the
+;; earlier HAND-COPIED predicate (which merely MIRRORED the markdown and could drift
+;; from it silently — required→optional, enum→keyword, vector→any, symbol→keyword
+;; would all stay green while real HMR/disposed records stopped conforming) with the
+;; actual schema form EXTRACTED from Spec-Schemas.md at compile time
+;; ([[canonical-observation-schema-form]]) and a minimal structural interpreter. The
+;; gate binds that executable schema in three directions:
 ;;
-;;   1. RECORD → SCHEMA (both hosts): a real :hmr drain and a real :disposed
-;;      drain produce dev-trace `:tags` that satisfy the schema's required-key
-;;      contract, and the always-on record carries the wire fields the 009
-;;      catalogue row lists. Dropping any required key, or drifting the
-;;      channel-discriminating :cause / spoofing :category, fails the gate.
-;;   2. SCHEMA → MARKDOWN (JVM only): Spec-Schemas.md must declare the schema
-;;      enumerating every required key — so removing the row or dropping a key
-;;      from the markdown fails too, and the two surfaces cannot drift silently.
+;;   1. RECORD → SCHEMA (both hosts): a real :hmr drain and a real :disposed drain
+;;      produce dev-trace `:tags` that VALIDATE against the extracted `[:map …]`
+;;      form, and the always-on record carries the wire fields the 009 catalogue row
+;;      lists. Dropping any required key, or drifting the channel-discriminating
+;;      :cause / spoofing :category, fails the gate.
+;;   2. SCHEMA SHAPE (both hosts): the extracted form itself is pinned to the strict
+;;      shape ([[canonical-schema-form-pins-the-strict-observation-shape]]) — so a
+;;      required→optional / enum→keyword / vector→any / field-type weakening in the
+;;      markdown reddens deterministically, and removing the def is a compile error.
+;;   3. SCHEMA ↔ SPEC 009 (JVM only): the extracted schema's required keys are the
+;;      SAME keys the Spec 009 catalogue row enumerates as DEV-TRACE :tags, so a
+;;      tag-key drift between the two surfaces reddens.
 ;;
 ;; (The CHANNEL classification — always-on — is already pinned by
 ;; error-catalogue-channel-conformance-test + always-on-axis-conformance's
 ;; `always-on-categories` literal, which includes this category.)
 ;; ===========================================================================
 
+(def ^:private canonical-observation-schema-form
+  "The `ObservationOnChangeFailedTags` `[:map …]` schema, EXTRACTED at compile time
+  from spec/Spec-Schemas.md (rf2-qyvyes) — the executable canonical form, identical on
+  both hosts. Runtime records are validated against THIS, so markdown schema drift
+  reddens the gate (and removing the def is a build error)."
+  (canonical-observation-schema))
+
+(declare valid-against-map-schema?)
+
+(defn- leaf-schema-valid?
+  "Minimal structural validator for the leaf Malli forms the extracted
+  ObservationOnChangeFailedTags schema uses — `:any` / `:keyword` / `:string` /
+  `:symbol` / `:boolean` / `:int`, `[:= v]`, `[:enum …]`, `[:vector inner]`, and a
+  nested `[:map …]`. Intentionally NOT a general Malli engine (rf2-qyvyes)."
+  [schema v]
+  (cond
+    (= schema :any)     true
+    (= schema :keyword) (keyword? v)
+    (= schema :string)  (string? v)
+    (= schema :symbol)  (symbol? v)
+    (= schema :boolean) (boolean? v)
+    (= schema :int)     (integer? v)
+    (vector? schema)
+    (case (first schema)
+      :=      (= v (second schema))
+      :enum   (contains? (set (rest schema)) v)
+      :vector (and (vector? v) (every? #(leaf-schema-valid? (second schema) %) v))
+      :map    (valid-against-map-schema? schema v)
+      false)
+    :else false))
+
+(defn- map-schema-entries
+  "Parse an extracted Malli `[:map [:k schema] [:k {:optional true} schema] …]` form
+  into a seq of `{:key k :optional? bool :schema s}` (rf2-qyvyes)."
+  [map-schema]
+  (for [entry (rest map-schema)
+        :let  [k (first entry)
+               r (rest entry)
+               [opts s] (if (map? (first r)) [(first r) (second r)] [nil (first r)])]]
+    {:key k :optional? (boolean (:optional opts)) :schema s}))
+
+(defn- valid-against-map-schema?
+  "True when record map `m` conforms to the extracted Malli `[:map …]` `map-schema`:
+  every REQUIRED key present and leaf-valid, every present OPTIONAL key leaf-valid.
+  Extra keys are allowed (Malli maps are open by default). rf2-qyvyes."
+  [map-schema m]
+  (and (map? m)
+       (every? (fn [{:keys [key optional? schema]}]
+                 (if (contains? m key)
+                   (leaf-schema-valid? schema (get m key))
+                   optional?))
+               (map-schema-entries map-schema))))
+
 (def ^:private observation-tags-required-keys
-  [:category :rf.sub/id :rf.sub/query-v :where :cause :exception
-   :exception-message :reason])
+  "The required keys of the EXTRACTED canonical schema (rf2-qyvyes) — DERIVED, not
+  hand-copied, so removing a required runtime field fails the same causal gate."
+  (->> (map-schema-entries canonical-observation-schema-form)
+       (remove :optional?)
+       (mapv :key)))
 
 (defn- valid-observation-on-change-failed-tags?
-  "Structural conformance of a dev-trace `:tags` payload against the canonical
-  [Spec-Schemas §ObservationOnChangeFailedTags] required-key contract. Mirrors
-  the markdown schema; the JVM leg below pins the markdown itself so the two
-  cannot drift silently."
+  "Validate a dev-trace `:tags` payload against the EXECUTABLE canonical
+  ObservationOnChangeFailedTags schema extracted from Spec-Schemas.md (rf2-qyvyes) —
+  no longer a hand-copied predicate. Markdown schema drift (required→optional,
+  enum→keyword, vector→any, a field type, the category) changes what conforms, so the
+  record-validation tests below redden on drift."
   [tags]
-  (and (map? tags)
-       (= :rf.error/observation-on-change-failed (:category tags))
-       (keyword? (:rf.sub/id tags))
-       (vector? (:rf.sub/query-v tags))
-       (symbol? (:where tags))
-       (contains? #{:hmr :disposed} (:cause tags))
-       (some? (:exception tags))
-       (string? (:exception-message tags))
-       (string? (:reason tags))))
+  (valid-against-map-schema? canonical-observation-schema-form tags))
 
 (deftest hmr-and-disposed-records-validate-against-the-canonical-schema
   (testing ":hmr boundary — the record validates against the frozen schema"
@@ -2797,23 +2863,70 @@
                      (assoc tags :category :rf.error/handler-exception))))))
       (obs/release! la))))
 
+(defn- schema-entry-of
+  [map-schema k]
+  (first (filter #(= k (:key %)) (map-schema-entries map-schema))))
+
+(defn- schema-of
+  [map-schema k]
+  (:schema (schema-entry-of map-schema k)))
+
+(defn- schema-required?
+  [map-schema k]
+  (let [e (schema-entry-of map-schema k)]
+    (and (some? e) (not (:optional? e)))))
+
+(deftest canonical-schema-form-pins-the-strict-observation-shape
+  ;; rf2-qyvyes — bind each drift class to the EXTRACTED schema form (structural, not
+  ;; a substring scan of the markdown): weakening the markdown schema reddens here
+  ;; deterministically, and removing the def is already a compile error (the extract
+  ;; macro throws), so the schema and its consumers cannot drift silently.
+  (let [s canonical-observation-schema-form]
+    (testing "category / channel — pinned to the exact = literal (not weakened to :keyword)"
+      (is (= [:= :rf.error/observation-on-change-failed] (schema-of s :category)))
+      (is (schema-required? s :category)))
+    (testing "enum→keyword drift — :cause stays the [:enum :hmr :disposed] discriminator"
+      (is (= [:enum :hmr :disposed] (schema-of s :cause)))
+      (is (schema-required? s :cause)))
+    (testing "vector→any drift — :rf.sub/query-v stays [:vector :any]"
+      (is (= [:vector :any] (schema-of s :rf.sub/query-v))))
+    (testing "field-type drift — :where is a :symbol, :rf.sub/id a :keyword"
+      (is (= :symbol (schema-of s :where)))
+      (is (= :keyword (schema-of s :rf.sub/id))))
+    (testing ":exception-message / :reason are :string, :exception :any"
+      (is (= :string (schema-of s :exception-message)))
+      (is (= :string (schema-of s :reason)))
+      (is (= :any (schema-of s :exception))))
+    (testing "required→optional drift — the required-key SET is exactly these eight"
+      (is (= #{:category :rf.sub/id :rf.sub/query-v :where :cause
+               :exception :exception-message :reason}
+             (set (map :key (remove :optional? (map-schema-entries s)))))))))
+
 #?(:clj
-   (deftest spec-schemas-declares-the-observation-on-change-failed-schema
-     (let [f     (let [nested (io/file "../../spec/Spec-Schemas.md")
-                       legacy (io/file "../spec/Spec-Schemas.md")]
-                   (if (.exists nested) nested legacy))
-           text  (slurp f)
-           start (str/index-of text "(def ObservationOnChangeFailedTags")
-           block (when start
-                   (let [rest*    (subs text start)
-                         next-def (str/index-of (subs rest* 5) "(def ")]
-                     (subs rest* 0 (if next-def (+ 5 next-def) (count rest*)))))]
-       (is (some? block)
-           "Spec-Schemas.md must declare ObservationOnChangeFailedTags")
-       (when block
-         (is (str/includes? block ":rf.error/observation-on-change-failed")
-             "the schema pins the canonical category")
-         (doseq [k [":category" ":rf.sub/id" ":rf.sub/query-v" ":where"
-                    ":cause" ":exception" ":exception-message" ":reason"]]
-           (is (str/includes? block k)
-               (str "the schema must enumerate the required key " k)))))))
+   (deftest spec-009-catalogue-lists-the-canonical-observation-tag-keys
+     ;; rf2-qyvyes — bind the EXTRACTED schema's required keys to the Spec 009
+     ;; catalogue row's DEV-TRACE :tags list, so a tag-key drift between the two
+     ;; surfaces reddens. Structural on the schema side (the extracted form, not a
+     ;; substring scan of Spec-Schemas.md — that surface is now pinned by the compile-
+     ;; time extraction + canonical-schema-form-pins-the-strict-observation-shape).
+     (let [required (->> (map-schema-entries canonical-observation-schema-form)
+                         (remove :optional?)
+                         (map :key))
+           f        (let [nested (io/file "../../spec/009-Instrumentation.md")
+                          legacy (io/file "../spec/009-Instrumentation.md")]
+                      (if (.exists nested) nested legacy))
+           row      (->> (str/split-lines (slurp f))
+                         (filter #(str/includes?
+                                    % "`:rf.error/observation-on-change-failed`"))
+                         first)
+           tags     (when (and row (str/index-of row "DEV-TRACE"))
+                      (subs row (str/index-of row "DEV-TRACE")))]
+       (is (some? row)
+           "the Spec 009 catalogue must carry the observation-on-change-failed row")
+       (is (some? tags)
+           "the 009 row must carry a DEV-TRACE :tags list")
+       (when tags
+         (doseq [k required]
+           (is (str/includes? tags (str k))
+               (str "the Spec 009 DEV-TRACE :tags list must enumerate the canonical "
+                    "schema key " k)))))))

--- a/implementation/core/test/re_frame/observation_schema_extract.clj
+++ b/implementation/core/test/re_frame/observation_schema_extract.clj
@@ -1,0 +1,56 @@
+(ns re-frame.observation-schema-extract
+  "Compile-time extraction of the ONE canonical `ObservationOnChangeFailedTags`
+  schema form from `spec/Spec-Schemas.md` (rf2-qyvyes).
+
+  The observation callback-failure tests must validate emitted records against the
+  EXECUTABLE canonical schema — not a hand-copied predicate that can silently drift
+  from the markdown. This macro runs on the JVM at COMPILE TIME (both for `clojure
+  -M:test` eval and for shadow-cljs CLJS compilation), reads the markdown, and embeds
+  the parsed `[:map …]` EDN form as a literal — so CLJS carries the exact same
+  extracted schema without any runtime file access. It is JVM-only / compile-time by
+  construction and NOT a general markdown-schema framework: it reads exactly this one
+  `def` form and fails loudly at compile time if it is absent or is not a `[:map …]`
+  form (removing the schema from the markdown is then a build error, so the two
+  surfaces cannot drift silently)."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private spec-schemas-candidates
+  ;; Resolve Spec-Schemas.md relative to whichever directory the compiler runs from:
+  ;; `clojure -M:test` runs from implementation/core; shadow-cljs from implementation.
+  ["../../spec/Spec-Schemas.md" "../spec/Spec-Schemas.md" "spec/Spec-Schemas.md"])
+
+(defn- spec-schemas-file
+  ^java.io.File []
+  (or (some (fn [p] (let [f (io/file p)] (when (.exists f) f)))
+            spec-schemas-candidates)
+      (throw (ex-info (str "rf2-qyvyes: cannot locate spec/Spec-Schemas.md to extract "
+                           "ObservationOnChangeFailedTags")
+                      {:candidates spec-schemas-candidates}))))
+
+(defn extract-observation-schema-form
+  "Read `spec/Spec-Schemas.md`, find `(def ObservationOnChangeFailedTags …)`, and
+  return its schema VECTOR (the `[:map …]` form) as data — the `;;` comments in the
+  `def` are dropped by the EDN reader, so the result is the pure canonical form.
+  Throws at compile time if the `def` is absent or is not a `[:map …]` form."
+  []
+  (let [text  (slurp (spec-schemas-file))
+        start (str/index-of text "(def ObservationOnChangeFailedTags")]
+    (when (nil? start)
+      (throw (ex-info (str "rf2-qyvyes: (def ObservationOnChangeFailedTags …) not found "
+                           "in Spec-Schemas.md")
+                      {})))
+    (let [form   (edn/read-string (subs text start))
+          schema (nth form 2 nil)]
+      (when-not (and (vector? schema) (= :map (first schema)))
+        (throw (ex-info "rf2-qyvyes: ObservationOnChangeFailedTags is not a [:map …] form"
+                        {:read schema})))
+      schema)))
+
+(defmacro canonical-observation-schema
+  "Emit the extracted `ObservationOnChangeFailedTags` `[:map …]` form as a quoted
+  literal (pure keyword/vector/map data), so the canonical schema is available
+  identically on CLJ and CLJS from the single compile-time extraction (rf2-qyvyes)."
+  []
+  (list 'quote (extract-observation-schema-form)))


### PR DESCRIPTION
Two follow-ups to the merged observation provenance work (#5875/9m4oy7 + #5870/xakb4p), on `implementation/core/src/re_frame/substrate/observation.cljc` + its tests. One PR, two independent commits.

## rf2-fs99nq (P1) — genuine weak-identity provenance keying on the JVM

**Re-verification against current `observation.cljc`:** confirmed the bug. #5875's JVM `provenance-by-throwable` was `java.util.Collections/synchronizedMap` over a `java.util.WeakHashMap` keyed by the throwable directly. **`WeakHashMap` keys by `.equals`/`.hashCode`, and `Throwable` leaves both virtual** — so an application `on-change` throwable that overrides them defeats the exact-identity contract two ways:

1. **Collision** — a distinct throwable whose `hashCode` equals a bound throwable's and whose `equals` accepts it reads that throwable's `#{:always-on}` provenance, so `source-covered-always-on?` returns true and the drain **suppresses** the required `:rf.error/observation-on-change-failed` record (production silence).
2. **Throwing classification** — a throwable whose `hashCode`/`equals` **throws** makes the `WeakHashMap.get` in `source-covered-always-on?` escape `report-disposal-notify-escape!`, propagating out of the drain's per-lease `catch`, aborting the reduce before healthy siblings drain and replacing the first-original rethrow.

#5875's fixture only used ordinary `ex-info` (generated-constructor forge + ex-data transplant), which key by identity, so exact-head CI stayed green.

**Fix:** key the JVM association by a genuine **weak identity** key — a `ReferenceQueue`-backed `WeakReference` subclass (`weak-identity-key`) hashing by `System/identityHashCode` and comparing by referent `identical?`, stored in a plain `HashMap` under the node-records `locking` discipline, with cleared entries expunged on each access (`expunge-stale-provenance!`). Classification now **never** invokes an application throwable's `hashCode`/`equals`, and the map stays weak (a processed throwable's entry is reclaimed once collected — no strong global registry). CLJS `js/WeakMap` is inherently identity-keyed (reference keys, ephemeron semantics) and is unchanged.

**Red-before-fix fixtures (JVM-only):**
- `jvm-forged-equality-throwable-does-not-read-covered` — a custom `RuntimeException` B whose hash collides with an authentic bound A and whose equality accepts A stays uncovered (exactly one wrapper carrying B; exact-A rethrow stays covered / unwrapped).
- `jvm-throwing-hashcode-or-equals-throwable-is-classified-by-identity` — throwables whose `hashCode`/`equals` throw are classified by identity: every sibling notified, each wrapped once, direct drain rethrows an original after the complete drain.

Both **fail** against a revert to `WeakHashMap<Throwable>` keying (verified: the collision fixture suppresses B, the throwing-method fixture aborts the drain — 7 assertion failures on revert). CLJS exact-throwable binding stays pinned cross-host by the existing `disposed-drain-binds-emission-provenance-to-the-exact-throwable`.

## rf2-qyvyes (P2) — bind callback-failure tests to the executable canonical schema

**Re-verification:** confirmed. The #5870 gate's runtime validator was a **hand-copied** `valid-observation-on-change-failed-tags?` predicate, and the Spec-Schemas leg only **substring-scanned** the markdown block — so the canonical schema could change `:where` symbol→keyword, weaken the `:cause` enum, make required keys optional, or replace vector types with `:any`, all staying green.

**Fix:** extract the one canonical `ObservationOnChangeFailedTags` `[:map …]` form from `spec/Spec-Schemas.md` at **compile time** (new JVM-only macro `re-frame.observation-schema-extract`, runs for both the CLJ eval and the shadow-cljs compilation, embeds the parsed form as a literal so both hosts carry it), and validate emitted records against it with a minimal structural interpreter — no general Malli engine, no markdown-schema framework. The hand-copied predicate is gone; `observation-tags-required-keys` is now derived from the extracted form.

**Red-before-fix fixture / drift binding:**
- `hmr-and-disposed-records-validate-against-the-canonical-schema` — real `:hmr`/`:disposed` records validate against the **extracted** form on CLJ and CLJS.
- `canonical-schema-form-pins-the-strict-observation-shape` — asserts the extracted DATA (category `=` literal, `:cause [:enum :hmr :disposed]`, `:rf.sub/query-v [:vector :any]`, `:where :symbol`, the required-key set), so required→optional / enum→keyword / vector→any / field-type drift reddens deterministically; removing the def is a compile error.
- `spec-009-catalogue-lists-the-canonical-observation-tag-keys` (JVM) — binds the extracted required keys to the Spec 009 DEV-TRACE `:tags` list.

Verified end-to-end: temporarily weakening `:cause` to `:keyword` in `Spec-Schemas.md` reddens **both** the shape pin AND the record-validation gate (a `:cause :bogus` then validates), proving records validate against the executable schema, not a hand-copy. No `spec/**` files changed — the #5870 schema is referenced, not re-edited.

## Quality gates

- **JVM** `(cd implementation/core && clojure -M:test -n observation-port -n error-catalogue-channel-conformance -n always-on-axis-conformance)` — **90 tests, 623 assertions, 0 failures**.
- **CLJS node** `(cd implementation && npm run test:cljs)` — **9364 tests, 44370 assertions, 0 failures** (both hosts; confirms `js/WeakMap` identity behavior and the compile-time schema extraction under shadow-cljs).
- Red-before-fix verified for all fixtures (JVM source revert → 7 failures; markdown `:cause` weakening → 2 failures), then restored.

Slim gate scope per the bead: no browser surface touched; `test:browser` / full fast-PR spine left to CI's authoritative matrix.