### PR TITLE
fix(ui): fence root/container ownership through deferred host teardown (rf2-vxgfnd.182)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -265,21 +265,34 @@
   (when-let [existing (get @live-roots root-id)]
     (error/throw-error!
      :rf.error/duplicate-root-id where
-     (str "root-id " (pr-str root-id) " is already live in this document — "
-          "root-ids are page-unique identity. "
-          (if (= :derived (:provenance existing) provenance)
-            "both ids derived from the same view — add :disambiguator or author :root-id"
-            "unmount! the existing root, or author a distinct :root-id"))
+     (if (:tearing-down? existing)
+       ;; rf2-vxgfnd.182 — a deferred host teardown still owns this id.
+       (str "root-id " (pr-str root-id) " is tearing down — a host teardown is "
+            "in flight (a deferred React unmount that returned but has not yet "
+            "settled). The root-id frees once teardown settles; re-mount after "
+            "settlement, or use a distinct :root-id and a fresh container")
+       (str "root-id " (pr-str root-id) " is already live in this document — "
+            "root-ids are page-unique identity. "
+            (if (= :derived (:provenance existing) provenance)
+              "both ids derived from the same view — add :disambiguator or author :root-id"
+              "unmount! the existing root, or author a distinct :root-id")))
      {:recovery :make-root-ids-unique
       :extra {:root-id  root-id
-              :existing (select-keys existing [:provenance :site])
+              :existing (select-keys existing [:provenance :site :tearing-down?])
               :arriving {:provenance provenance :site site}}}))
   (when-let [owner (container-owner container)]
     (error/throw-error!
      :rf.error/root-container-in-use where
-     (str "the container for root " (pr-str root-id) " is already owned by "
-          "live root " (pr-str owner) " — one container, one root. "
-          "unmount! the owning root first, or mount into a different node")
+     (if (:tearing-down? (get @live-roots owner))
+       ;; rf2-vxgfnd.182 — the owner is tearing down; the node is not yet free.
+       (str "the container for root " (pr-str root-id) " is still owned by root "
+            (pr-str owner) ", whose host teardown is in flight (a deferred React "
+            "unmount that has not yet settled) — one container, one root. The "
+            "node frees once teardown settles; mount into a fresh node, or "
+            "re-mount after settlement")
+       (str "the container for root " (pr-str root-id) " is already owned by "
+            "live root " (pr-str owner) " — one container, one root. "
+            "unmount! the owning root first, or mount into a different node"))
      {:recovery :unmount-the-owning-root-first
       :extra {:root-id root-id :owner-root-id owner}}))
   (when (some? identifier-prefix)
@@ -371,6 +384,26 @@
              m)))
   nil)
 
+(defn- mark-tearing-down!
+  "Move live root `root-id`'s claim into the `:tearing-down` state — the
+  `:live -> :tearing-down -> :released` transition of rf2-vxgfnd.182. Marked
+  BEFORE the host `.unmount` so that if react-dom DEFERS teardown (a non-throwing
+  in-render `.unmount` that returns while its work is still scheduled), a
+  reentrant `mount*`/`create-root*` on the exact root-id/container is REJECTED —
+  the entry stays in `live-roots`, occupying both id and container, until the
+  settlement boundary frees it (`release-root!`). A SYNCHRONOUS teardown clears
+  the mark by releasing before `unmount!*` returns, so the state is invisible to
+  callers; only a deferred teardown observes it. Identity-guarded to THIS exact
+  Root; a no-op if the entry was superseded."
+  [root-id root]
+  (swap! live-roots
+         (fn [m]
+           (let [entry (get m root-id)]
+             (if (identical? (:root entry) root)
+               (assoc m root-id (assoc entry :tearing-down? true))
+               m))))
+  nil)
+
 (defn require-live-root!
   "The shared live-root OWNERSHIP invariant — the render-side mirror of
   `unmount!*`'s membership check. A `Root` is LIVE iff the live-root
@@ -398,17 +431,27 @@
        untouched, mirroring the fresh-mount re-check.
 
   Thrown BEFORE the descriptor write / `.render`; retry = `create-root` +
-  `render!` (or `mount`) a fresh root."
+  `render!` (or `mount`) a fresh root.
+
+  A root whose claim is `:tearing-down` (rf2-vxgfnd.182 — a deferred host
+  teardown in flight) is NOT live either: its React tree is being unmounted, so
+  a `render!` into it would `.render` a consumed/unmounting handle. It fails the
+  same LOUD `:rf.error/root-not-live` — recreate after the teardown settles."
   [^Root root where]
-  (let [rid (.-root-id root)]
-    (when-not (identical? (:root (get @live-roots rid)) root)
+  (let [rid   (.-root-id root)
+        entry (get @live-roots rid)]
+    (when (or (not (identical? (:root entry) root))
+              (:tearing-down? entry))
       (error/throw-error!
        :rf.error/root-not-live where
        (str "the Root handle for root-id " (pr-str rid) " is no longer the "
-            "live root for that id — it was unmount!ed, or superseded by a "
-            "newer root claiming the same id (possibly during this "
-            "operation's frame preflight, which drains :initial-events — "
-            "arbitrary app code). A superseded root can never commit a "
+            "live root for that id — it was unmount!ed"
+            (if (:tearing-down? entry)
+              " (a host teardown is in flight — the root is tearing down)"
+              (str ", or superseded by a newer root claiming the same id "
+                   "(possibly during this operation's frame preflight, which "
+                   "drains :initial-events — arbitrary app code)"))
+            ". A superseded or tearing-down root can never commit a "
             "render; rendering into it would drain :initial-events "
             "(irreversible fx) and write install records against a dead "
             "root. create-root + render! (or mount) a fresh root")
@@ -583,7 +626,12 @@
   (require-root-creation-open! 're-frame.ui/mount)
   (require-container! 're-frame.ui/mount root-id container)
   (let [existing (get @live-roots root-id)]
-    (if (and existing (identical? (:container existing) container))
+    ;; rf2-vxgfnd.182 — a `:tearing-down` entry is NOT eligible for the
+    ;; idempotent re-mount fast path (its React tree is being unmounted). Fall
+    ;; through to `check-root-claim!`, which rejects the reentrant mount with the
+    ;; tearing-down diagnostic rather than `.render`ing into a dying root.
+    (if (and existing (not (:tearing-down? existing))
+             (identical? (:container existing) container))
       (let [^Root root (:root existing)]
         ;; rf2-vxgfnd.59: the effective identifierPrefix is IMMUTABLE for a
         ;; live root (React root options are fixed at createRoot). A same-root
@@ -683,7 +731,29 @@
                   ;; root residue. Rethrow the ORIGINAL mount error even if the
                   ;; host cleanup also throws (cleanup never masks it).
                   (release-root! root-id root)
-                  (try (.unmount react-root) (catch :default _ nil))
+                  ;; rf2-vxgfnd.182 — do NOT silently swallow a cleanup-`.unmount`
+                  ;; failure. The original mount error stays PRIMARY, but a failed
+                  ;; rollback unmount is surfaced with exact root/container context
+                  ;; (a dev diagnostic + a secondary-evidence property on the
+                  ;; primary error), matching the adapter drain's discipline — a
+                  ;; consumed handle means same-container reuse is NOT proven
+                  ;; clean, so the honest guidance is a fresh/replaced container.
+                  (try (.unmount react-root)
+                    (catch :default cleanup-error
+                      (when (and ^boolean js/goog.DEBUG (exists? js/console))
+                        (.warn js/console
+                               (str "[re-frame.ui] rollback of a failed first mount "
+                                    "of root " (pr-str root-id) " could not cleanly "
+                                    "unmount the host root — the original mount error "
+                                    "is rethrown as primary, but this container's "
+                                    "React teardown did not complete. Do NOT assume "
+                                    "same-container reuse is clean; retry into a "
+                                    "fresh/replaced container.")
+                               cleanup-error))
+                      (try (js/Object.defineProperty
+                            e "rfUiRollbackCleanupError"
+                            #js {:value cleanup-error :configurable true})
+                        (catch :default _ nil))))
                   (throw e))))
             (catch :default e
               ;; rf2-vxgfnd.139: preflight completed but the post-preflight
@@ -791,11 +861,26 @@
 (defn unmount!*
   "Runtime half of `ui/unmount!` — TOTAL teardown: unmount the React root
   and unregister the root-id (contract §7). Idempotent: a Root already
-  torn down (or superseded in the registry) is a no-op. Framework
-  ownership is released in a `finally`, so a throwing host `.unmount`
-  still frees the exact root-id/container claim (identity-guarded — never
-  evicts a newer claim) and a second `unmount!*` is then a no-op; the
-  host teardown error still propagates to the caller (rf2-vxgfnd.18 AC4).
+  torn down, superseded in the registry, OR already `:tearing-down` (a deferred
+  host teardown in flight — rf2-vxgfnd.182) is a no-op. The claim is released at
+  the SETTLEMENT BOUNDARY through `teardown-root!`'s `on-settled` callback:
+  synchronously for a synchronous host teardown, or in the settlement microtask
+  after a DEFERRED one clears the DOM. A THROWING host `.unmount` still frees the
+  exact root-id/container claim immediately in the `catch` (identity-guarded —
+  never evicts a newer claim), a second `unmount!*` is then a no-op, and the host
+  teardown error still propagates to the caller (rf2-vxgfnd.18 AC4, untouched).
+
+  OWNERSHIP FENCE through DEFERRED teardown (rf2-vxgfnd.182). react-dom 19.2
+  refuses a synchronous `.unmount` from inside render/commit: it consumes the
+  handle and returns NORMALLY while the teardown work stays scheduled for a later
+  microtask. The claim is marked `:tearing-down` BEFORE the host `.unmount`, so
+  during that deferred window a reentrant `mount*`/`create-root*` on the exact
+  root-id/container is REJECTED (`check-root-claim!`) rather than admitted onto a
+  container React is about to clear. `teardown-root!` observes the deferral (the
+  root's cells stay `:connected` — nothing hit its cleanup window) and holds
+  `on-settled` until React's teardown settles; a SYNCHRONOUS teardown fires
+  `on-settled` at once, freeing the claim before this fn returns and preserving
+  the ratified same-container immediate re-mount.
 
   LIFECYCLE (03 §4; rf2-vxgfnd.62). The host `.unmount` is driven through
   `reactive/teardown-root!`, which arms a collection window around it: React
@@ -840,26 +925,44 @@
   goog.DEBUG-gated (Closure-DCE'd from production — I-12). Returns nil."
   [^Root root]
   (when (and (some? root)
-             (identical? (:root (get @live-roots (.-root-id root))) root))
+             (let [entry (get @live-roots (.-root-id root))]
+               (and (identical? (:root entry) root)
+                    ;; rf2-vxgfnd.182 — a teardown already in flight (deferred) is
+                    ;; not re-driven: the host handle is consumed; a second
+                    ;; unmount! is a no-op until the settlement frees the claim.
+                    (not (:tearing-down? entry)))))
+    ;; rf2-vxgfnd.182 — fence the exact claim BEFORE the host `.unmount`, so a
+    ;; deferred host teardown cannot advertise the id/container as free while
+    ;; React is still scheduled to clear the DOM.
+    (mark-tearing-down! (.-root-id root) root)
     (try
       ;; rf2-vxgfnd.62 — drive the host unmount through the root-teardown window
       ;; so this root's ViewCells are retroactively proven :unmounted → :dead
       ;; after React sweeps their effect cleanups (see the docstring LIFECYCLE
       ;; note). teardown-root! rethrows a throwing host `.unmount` unchanged, so
-      ;; the catch/finally below keep the rf2-vxgfnd.53 ownership behaviour.
+      ;; the catch below keeps the rf2-vxgfnd.53 ownership behaviour.
       ;; rf2-vxgfnd.85/.92 — pass this root's INCARNATION so a cell Activity-hidden
       ;; BEFORE the unmount window (which the window can never capture) is still
       ;; reaped through the root-incarnation ownership registry, even when the
       ;; whole root was hidden and the window collects nothing.
+      ;; rf2-vxgfnd.182 — `on-settled` releases the exact claim at the settlement
+      ;; boundary: inline for a synchronous teardown, or via the settlement
+      ;; microtask after a deferred one clears the container.
       (reactive/teardown-root! (root-incarnation-of (.-root-id root))
-                               (fn [] (.unmount (.-react-root root))))
+                               (fn [] (.unmount (.-react-root root)))
+                               (fn [] (release-root! (.-root-id root) root)))
       (catch :default e
+        ;; rf2-vxgfnd.53 / rf2-vxgfnd.84 / rf2-vxgfnd.18 AC4 — the SYNCHRONOUS host
+        ;; `.unmount` threw; release the claim IMMEDIATELY (untouched by .182: the
+        ;; throwing path keeps its immediate release — the fence is only for the
+        ;; NON-throwing deferred path).
+        (release-root! (.-root-id root) root)
         ;; rf2-vxgfnd.53 / rf2-vxgfnd.84 — the synchronous host .unmount did NOT
-        ;; complete, yet the `finally` below still releases the claim (AC4) and a
-        ;; second `unmount!*` is a no-op (the membership guard). Make the
-        ;; aftermath non-silent AND honest: verified against pinned react-dom
-        ;; 19.2.0, ReactDOMRoot.unmount nulls its internal root BEFORE the flush
-        ;; that threw, so the handle is CONSUMED — re-calling .unmount on it is a
+        ;; complete, yet the claim is released just above (AC4) and a second
+        ;; `unmount!*` is a no-op (the membership guard). Make the aftermath
+        ;; non-silent AND honest: verified against pinned react-dom 19.2.0,
+        ;; ReactDOMRoot.unmount nulls its internal root BEFORE the flush that
+        ;; threw, so the handle is CONSUMED — re-calling .unmount on it is a
         ;; silent no-op, NOT a manual escape (the pre-.84 diagnostic recommended
         ;; that no-op). React usually defers + self-completes the teardown work
         ;; scheduled pre-throw, so a stuck tree is the exception; when one does
@@ -881,9 +984,7 @@
                       "a container is genuinely left with a stuck tree, clear it "
                       "directly (set its innerHTML to \"\") or mount into a FRESH "
                       "container — never reuse the consumed handle.")))
-        (throw e))
-      (finally
-        (release-root! (.-root-id root) root))))
+        (throw e))))
   nil)
 
 (defn- reclaim-consumed-container!

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2622,6 +2622,38 @@
       (teardown! cell))
     (count victims)))
 
+(defn- weak-connected
+  "The still-CONNECTED (`:connected`/`:fresh`) cells of `incarnation`'s weak
+  membership — the residual live cells a host `.unmount` did NOT tear down
+  synchronously. A DEFERRED host teardown (react-dom 19.2 refusing a synchronous
+  unmount from inside render/commit: it returns normally but schedules the
+  teardown for a later microtask) runs NONE of the root's effect cleanups during
+  `.unmount`, so the collection window captures nothing AND these cells stay
+  connected. That residual connected membership is the ONLY in-process signal
+  distinguishing a deferred host teardown from a synchronous one (rf2-vxgfnd.182)."
+  [incarnation]
+  (filterv #(contains? #{:connected :fresh} (lifecycle %))
+           (weak-live (get @root-cells incarnation))))
+
+(defn- settle-deferred-root!
+  "Settle a DEFERRED host teardown (rf2-vxgfnd.182). The host `.unmount` returned
+  but scheduled this root's teardown for a later microtask, so its cells are
+  still connected and the owning claim must stay fenced. Schedule the SETTLEMENT
+  — a microtask FIFO-ordered AFTER React's own deferred teardown (so it runs once
+  React has swept the cleanups and cleared the container) — that reaps every cell
+  still owned by `incarnation` to `:dead` (idempotent: a cell React already
+  disconnected upgrades from `:disconnected`, one it left connected is force-dead)
+  and then fires `on-settled` to release the client's ownership claim. On the JVM
+  headless host there is no async React teardown to await, so the settlement runs
+  synchronously."
+  [incarnation on-settled]
+  (let [settle (fn []
+                 (doseq [cell (weak-live (get @root-cells incarnation))]
+                   (teardown! cell))
+                 (when on-settled (on-settled)))]
+    #?(:cljs (queue-microtask! settle)
+       :clj  (settle))))
+
 (defn teardown-root!
   "Explicit host/ROOT teardown driver (03 §4) — the root-path counterpart to
   the frame-destroy sweep, driven from `re-frame.ui.client/unmount!*` at the
@@ -2690,11 +2722,31 @@
   reap only cells actually captured by the teardown window. Returns the count of
   cells torn down on success; a host failure rethrows after the targeted reap.
 
-  Two arities: `[unmount-thunk]` (no explicit incarnation — window + captured-cell
-  incarnations only, the current `client/unmount!*` call) and
-  `[root-incarnation unmount-thunk]` (the incarnation-aware path)."
-  ([unmount-thunk] (teardown-root! nil unmount-thunk))
-  ([root-incarnation unmount-thunk]
+  ## DEFERRED host teardown + settlement (rf2-vxgfnd.182)
+
+  react-dom 19.2 refuses a SYNCHRONOUS `.unmount` from inside render/commit: it
+  returns NORMALLY but runs none of this root's effect cleanups, scheduling the
+  teardown for a later microtask. On the EXPLICIT non-throwing path this window
+  therefore captures nothing while the root's cells stay `:connected` — the one
+  in-process signal of a deferral (`weak-connected`). When detected, this driver
+  does NOT reap or fire `on-settled` synchronously: it schedules the SETTLEMENT
+  (`settle-deferred-root!`) FIFO-ordered after React's own deferred teardown, so
+  the client can hold its root-id/container claim `:tearing-down` until React has
+  actually cleared the container — the claim frees, and the cells converge to
+  `:dead`, only at that proven boundary. A SYNCHRONOUS teardown (cells captured,
+  or none owned) fires `on-settled` immediately, preserving the ratified
+  same-container immediate-remount. A THROWING `.unmount` keeps its immediate,
+  fail-closed reap and rethrow — `on-settled` is NOT fired here; the client
+  releases in its own catch (rf2-vxgfnd.18 AC4, untouched).
+
+  Three arities: `[unmount-thunk]` (no explicit incarnation — window +
+  captured-cell incarnations only), `[root-incarnation unmount-thunk]` (the
+  incarnation-aware path), and `[root-incarnation unmount-thunk on-settled]` (the
+  `client/unmount!*` call — `on-settled` releases the claim at the settlement
+  boundary)."
+  ([unmount-thunk] (teardown-root! nil unmount-thunk nil))
+  ([root-incarnation unmount-thunk] (teardown-root! root-incarnation unmount-thunk nil))
+  ([root-incarnation unmount-thunk on-settled]
    (let [prev       @teardown-collector
          host-error (volatile! nil)
          captured   (volatile! #{})
@@ -2750,12 +2802,31 @@
                      ;; Fail closed over the EXACT root generation, including
                      ;; cells still connected because React ran no cleanup.
                      (into owned (weak-live (get @root-cells root-incarnation)))
-                     (into owned hidden))]
+                     (into owned hidden))
+         ;; rf2-vxgfnd.182 — DEFERRED host teardown: the explicit non-throwing
+         ;; unmount ran none of this root's cleanups, so the window captured
+         ;; nothing yet the incarnation still owns CONNECTED cells. That residual
+         ;; connected membership is the discriminator; a synchronous teardown (or
+         ;; an empty root) has none. Computed BEFORE the reap — the captured
+         ;; victims are `:disconnected`, never in this connected set.
+         deferred? (and explicit? (not @host-error)
+                        (seq (weak-connected root-incarnation)))]
      (doseq [cell victims]
        (teardown! cell))
-     (if @host-error
+     (cond
+       @host-error
+       ;; on-settled is NOT fired — the client releases in its own catch (AC4).
        (throw @host-error)
-       (count victims)))))
+
+       deferred?
+       ;; hold the claim: settle (reap + on-settled) past React's deferred boundary.
+       (do (settle-deferred-root! root-incarnation on-settled)
+           (count victims))
+
+       :else
+       ;; synchronous teardown (or nothing owned): settle immediately.
+       (do (when on-settled (on-settled))
+           (count victims))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The 8-step layout-commit reconciler (03 §3)

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -458,6 +458,64 @@
         "the consumed incarnation is removed from root ownership")))
 
 ;; ===========================================================================
+;; rf2-vxgfnd.182 — the DEFERRED-vs-SYNCHRONOUS host-teardown discriminator
+;;
+;; react-dom 19.2 refuses a SYNCHRONOUS unmount from inside render/commit: the
+;; host `.unmount` returns NORMALLY but runs NONE of the root's effect cleanups,
+;; scheduling the teardown for a later microtask. The ONLY in-process signal is
+;; at this cleanup window — a deferred `.unmount` leaves the root's cells still
+;; `:connected` (the window captured nothing). teardown-root! must then hold the
+;; settlement (which reaps the cells and fires `on-settled` to free the client's
+;; claim) until that boundary, distinguishing it from a synchronous teardown
+;; whose cells the window already captured.
+;; ===========================================================================
+
+(deftest synchronous-teardown-settles-and-fires-on-settled-immediately
+  ;; A host `.unmount` that DID tear down synchronously (the thunk fired the
+  ;; cell's cleanup, as React does inside a normal `.unmount`): the window
+  ;; captured the cell, so settlement is IMMEDIATE — on-settled fires before
+  ;; teardown-root! returns, on every host.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid     (make-frame! :rt/frame {:a 1})
+        inc     (reactive/make-root-incarnation)
+        cell    (mount! ::v inc fid [[:rt/a]])
+        settled (atom false)]
+    (reactive/teardown-root! inc
+                             (fn [] (reactive/disconnect! cell))
+                             (fn [] (reset! settled true)))
+    (is (true? @settled) "a synchronous teardown fires on-settled immediately")
+    (is (= :dead (reactive/lifecycle cell)) "the captured cell is reaped now")))
+
+(deftest deferred-teardown-holds-settlement-past-the-window
+  ;; A host `.unmount` that DEFERRED (the thunk left the connected cell alone,
+  ;; modelling react-dom 19.2's in-render deferral): the window captured nothing
+  ;; and the cell is still connected, so teardown-root! must NOT settle
+  ;; synchronously. On the JVM headless host there is no async React teardown to
+  ;; await, so the settlement runs synchronously; on CLJS it is a real microtask
+  ;; still pending immediately after the call.
+  (rf/reg-sub :rt/a (fn [db _] (:a db)))
+  (let [fid     (make-frame! :rt/frame {:a 1})
+        inc     (reactive/make-root-incarnation)
+        cell    (mount! ::v inc fid [[:rt/a]])
+        settled (atom false)]
+    (is (= :connected (reactive/lifecycle cell)) "precondition: connected")
+    (reactive/teardown-root! inc
+                             (fn [] nil)                    ;; deferred: no cleanup fired
+                             (fn [] (reset! settled true)))
+    #?(:clj
+       (testing "JVM: no async host teardown — settlement runs synchronously"
+         (is (true? @settled) "on-settled fired at the synchronous settlement")
+         (is (= :dead (reactive/lifecycle cell)) "the still-connected cell is reaped")
+         (is (= {:state :unmounted :reason :unmounted :proof :host-teardown}
+                (peek (reactive/intervals cell)))
+             "…proven a host teardown"))
+       :cljs
+       (testing "CLJS: settlement is deferred to a microtask, not run synchronously"
+         (is (false? @settled) "on-settled has NOT fired synchronously")
+         (is (not= :dead (reactive/lifecycle cell))
+             "the connected cell is NOT reaped synchronously — the claim stays fenced")))))
+
+;; ===========================================================================
 ;; Re-entrancy — a nested teardown does not corrupt the outer window
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
@@ -16,9 +16,10 @@
   `(browser?)` and no-ops. The first-party `re-frame.ui` adapter is the
   watchable substrate the other browser fixtures use; here it provides the
   production observation path beneath a real React mount."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             ["react" :as React]
             ["react-dom" :as react-dom]
+            ["react-dom/client" :as rdc]
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
             [re-frame.ui :as ui :refer [defview frame-provider sub]]
@@ -71,26 +72,51 @@
     (act-fn (fn [] (vreset! ret (thunk))))
     @ret))
 
+;; Map-form fixtures (`:before`/`:after`) so this ns can host ASYNC tests
+;; (rf2-vxgfnd.182 — the deferred-teardown settlement is a real microtask the
+;; test must await); the prior act-env flag is stashed across the pair.
+(def ^:private prior-act-env (atom nil))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-   {:adapter ui/adapter :ambient-frame nil})
-  (fn [f]
-    ;; Enable React's act environment for this ns's DOM tests, then RESTORE the
-    ;; prior value so the fixture neither depends on nor leaks the shared-page
-    ;; flag.
-    (let [prior (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))]
-      (enable-react-act-env!)
-      (reactive/reset-scheduler!)
-      (client/reset-live-roots!)
-      (try (f)
-           (finally (reactive/reset-scheduler!)
-                    (client/reset-live-roots!)
-                    (when (browser?)
-                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))))
+   {:adapter ui/adapter :ambient-frame nil :async? true})
+  {:before (fn []
+             ;; Enable React's act environment for this ns's DOM tests, stashing
+             ;; the prior value so :after can RESTORE it (no shared-page leak).
+             (reset! prior-act-env
+                     (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)))
+             (enable-react-act-env!)
+             (reactive/reset-scheduler!)
+             (client/reset-live-roots!))
+   :after (fn []
+            (reactive/reset-scheduler!)
+            (client/reset-live-roots!)
+            (when (browser?)
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) @prior-act-env)))})
 
 (def ^:private frame-kw :rt.dom/frame)
 
 (defn- container [] (js/document.createElement "div"))
+
+(defn- thrown-id [f]
+  (try (f) nil (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(defn- in-commit-phase!
+  "Run `thunk` synchronously inside a React COMMIT (a layout effect), so a
+  `.unmount` called within it hits react-dom 19.2's in-render deferral path (it
+  returns normally, scheduling teardown for a later microtask). Renders a
+  throwaway root whose sole layout effect calls `thunk`, all under `act` (which
+  also flushes the deferred teardown + settlement microtasks), then unmounts the
+  throwaway. The throwaway is a plain React component — no ViewCell — so it never
+  perturbs the observed live-cell population."
+  [thunk]
+  (let [c2  (container)
+        r   (rdc/createRoot c2)
+        drv (fn drv []
+              (React/useLayoutEffect (fn [] (thunk) js/undefined) #js [])
+              nil)]
+    (act! (fn [] (.render r (React/createElement drv))))
+    (act! (fn [] (.unmount r)))))
 
 ;; One sub-bearing view → one ViewCell under the mounted root.
 (defview leaf [_] [:span.leaf (str (sub [:rt.dom/n]))])
@@ -153,3 +179,98 @@
               (is (= "7" (.-textContent (.querySelector cb ".leaf")))
                   "root B still renders")))
           (act! #(ui/unmount! root-b)))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.182 — a DEFERRED render-phase host teardown FENCES the claim
+;;
+;; react-dom 19.2 refuses a SYNCHRONOUS `.unmount` from inside render/commit: it
+;; consumes the handle, clears its container marker, emits a console error, and
+;; RETURNS NORMALLY while the teardown work stays scheduled for a later
+;; microtask. Pre-fix, `unmount!*` released the root-id/container claim
+;; immediately, so a same-stack reentrant remount was ADMITTED onto a container
+;; React was about to clear — a second root over a clobbered container. The fence
+;; holds the claim `:tearing-down` until React's deferred teardown settles.
+;; ===========================================================================
+
+(deftest deferred-render-phase-unmount-fences-reentrant-remount
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (async
+     done
+     (register-app!)
+     (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
+     (let [c    (container)
+           M    (act! #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                 c {:root-id :rt.dom/deferred}))
+           cell (first (reactive/current-live-cells))
+           unmount-threw   (atom :unset)
+           reentrant-error (atom :unset)]
+       (is (= "7" (.-textContent (.querySelector c ".leaf"))) "precondition: rendered")
+       (is (= :connected (reactive/lifecycle cell)) "precondition: connected cell")
+       (in-commit-phase!
+        (fn []
+          ;; `.unmount` during a React commit → react-dom 19.2 DEFERS: it returns
+          ;; NORMALLY, scheduling the teardown (AC1 — proves the non-throwing path).
+          (reset! unmount-threw
+                  (try (client/unmount!* M) false (catch :default _ true)))
+          ;; a same-stack reentrant remount on the EXACT container/id is FENCED,
+          ;; rejected BEFORE any React root creation (caught here so it does not
+          ;; escape into the driver's commit).
+          (reset! reentrant-error
+                  (thrown-id #(client/mount*
+                               {:root-id :rt.dom/deferred :provenance :authored}
+                               c
+                               (fn [] (React/createElement "div" nil "reentrant"))
+                               nil nil)))))
+       (testing "the host .unmount returned normally — teardown deferred, not thrown (AC1)"
+         (is (false? @unmount-threw)))
+       (testing "the reentrant remount was REJECTED while teardown was deferred (AC2)"
+         (is (contains? #{:rf.error/duplicate-root-id :rf.error/root-container-in-use}
+                        @reentrant-error)
+             "and admitted only AFTER settlement — never onto the deferred container"))
+       ;; The settlement is a real microtask FIFO-ordered after React's deferred
+       ;; teardown; await it, then assert convergence + the ratified reuse.
+       (js/queueMicrotask
+        (fn []
+          (testing "after the settlement boundary the root/cell/DOM converge (AC3/AC4)"
+            (is (= :dead (reactive/lifecycle cell)) "the deferred teardown reaped the cell")
+            (is (= :host-teardown (:proof (peek (reactive/intervals cell))))
+                "…proven a host teardown, not left :unknown/reconnectable")
+            (is (= "" (.-innerHTML c)) "React cleared the container")
+            (is (not (contains? (client/live-root-ids) :rt.dom/deferred))
+                "the claim is freed only at the settlement boundary"))
+          (testing "a fresh mount on the settled container now succeeds"
+            (let [M2 (act! #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                      c {:root-id :rt.dom/deferred}))]
+              (is (some? M2))
+              (is (= "7" (.-textContent (.querySelector c ".leaf"))) "the replacement renders")
+              (act! #(ui/unmount! M2))))
+          (done)))))))
+
+(deftest synchronous-unmount-frees-identity-for-immediate-remount
+  ;; The CONTROL (the ratified case, rf2-vxgfnd.18): a SYNCHRONOUS host teardown
+  ;; (a normal `ui/unmount!`, not from inside render/commit) tears down during
+  ;; `.unmount`, so the claim frees immediately and a same-stack immediate
+  ;; remount on the exact container succeeds — the fence must NOT hold here.
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:rt.dom/seed] {:frame frame-kw})
+      (let [c    (container)
+            M    (act! #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                  c {:root-id :rt.dom/sync}))
+            cell (first (reactive/current-live-cells))]
+        (is (= :connected (reactive/lifecycle cell)))
+        (act! #(client/unmount!* M))
+        (testing "a synchronous teardown reaps + frees immediately"
+          (is (= :dead (reactive/lifecycle cell)))
+          (is (= "" (.-innerHTML c)))
+          (is (not (contains? (client/live-root-ids) :rt.dom/sync))
+              "the claim is released synchronously — no lingering :tearing-down fence"))
+        (testing "an IMMEDIATE same-container remount succeeds (ratified reuse)"
+          (let [M2 (act! #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                    c {:root-id :rt.dom/sync}))]
+            (is (some? M2))
+            (is (= "7" (.-textContent (.querySelector c ".leaf"))))
+            (act! #(ui/unmount! M2))))))))

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -12,7 +12,7 @@
   No DOM — the react-root is a plain JS object with an `unmount` method;
   container ownership is identity-based. The real-React counterpart is the
   browser `re-frame.ui.root-teardown-dom-cljs-test`."
-  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer [deftest is testing use-fixtures async]]
             [re-frame.core                 :as rf]
             [re-frame.frame                :as frame]
             [re-frame.live-frame           :as live-frame]
@@ -110,3 +110,80 @@
     (is (nil? (client/unmount!* stale)) "stale unmount is an idempotent no-op")
     (is (false? @fired?) "the host `.unmount` was never called")
     (is (= :connected (reactive/lifecycle cell)) "the cell is untouched")))
+
+;; ===========================================================================
+;; rf2-vxgfnd.182 — a DEFERRED host teardown fences the root-id/container claim
+;;
+;; react-dom 19.2 refuses a SYNCHRONOUS unmount from inside render/commit: it
+;; consumes the handle, clears its container marker, and RETURNS NORMALLY while
+;; the teardown work stays scheduled for a later microtask. The ONLY in-process
+;; signal is at `reactive/teardown-root!`'s cleanup window: a deferred `.unmount`
+;; ran NONE of the root's effect cleanups, so the cell is still `:connected`
+;; after the thunk. Here the fake host `.unmount` models exactly that — it
+;; returns without firing the cell's cleanup. `unmount!*` must therefore HOLD the
+;; claim `:tearing-down` (rejecting a reentrant mount/create-root) until the
+;; settlement boundary reaps the cell and frees the claim. These fixtures pin the
+;; SYNCHRONOUS fence; the microtask-settlement completion is graft-checked
+;; synchronously on the JVM (`reactive-root-teardown-cljs-test`) and end-to-end
+;; under real react-dom in `root-mount-dom-cljs-test`.
+;; ===========================================================================
+
+(defn- thrown-id [f]
+  (try (f) nil (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(deftest deferred-host-teardown-fences-the-claim-not-released-immediately
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell (connected-cell! :rtw/frame [[:rtw/a]])
+        ;; the host `.unmount` DEFERS: it returns normally without firing the
+        ;; cell's effect cleanup (react-dom 19.2's in-render unmount refusal)
+        root (register! :rtw/root (fn [] nil))
+        inc  (:root-incarnation (client/live-root-entry :rtw/root))]
+    (reactive/attach-root! cell inc)
+    (is (= :connected (reactive/lifecycle cell)) "precondition: mounted + connected")
+    (is (nil? (client/unmount!* root)) "unmount!* returns nil (host .unmount did not throw)")
+    (testing "the deferred teardown is FENCED — the claim is held :tearing-down"
+      (is (contains? (client/live-root-ids) :rtw/root)
+          "the root-id/container claim is NOT released while teardown is deferred")
+      (is (= :rf.error/duplicate-root-id
+             (thrown-id #(client/check-root-claim!
+                          'test {:root-id :rtw/root :provenance :authored}
+                          (:container (client/live-root-entry :rtw/root)))))
+          "a reentrant mount on the exact root-id is rejected before any React root")
+      (is (not= :dead (reactive/lifecycle cell))
+          "the cell is not yet reaped — React's deferred teardown has not settled"))))
+
+(deftest deferred-teardown-rejects-a-reentrant-different-id-same-container
+  ;; The container arm: while root A's teardown is deferred, a DIFFERENT root-id
+  ;; targeting A's exact container is rejected `:root-container-in-use`.
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell (connected-cell! :rtw/frame [[:rtw/a]])
+        root (register! :rtw/root (fn [] nil))
+        inc  (:root-incarnation (client/live-root-entry :rtw/root))
+        c    (:container (client/live-root-entry :rtw/root))]
+    (reactive/attach-root! cell inc)
+    (is (nil? (client/unmount!* root)))
+    (is (= :rf.error/root-container-in-use
+           (thrown-id #(client/check-root-claim!
+                        'test {:root-id :rtw/other :provenance :authored} c)))
+        "a different root-id targeting the fenced container is rejected")))
+
+(deftest double-unmount-during-deferred-teardown-is-a-noop
+  ;; A second `unmount!*` while the first teardown is still deferred must NOT
+  ;; re-drive the (consumed) host handle — the :tearing-down guard makes it a
+  ;; no-op, extending idempotency across the deferral window.
+  (rf/reg-sub :rtw/a (fn [db _] (:a db)))
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  (let [cell   (connected-cell! :rtw/frame [[:rtw/a]])
+        calls  (atom 0)
+        root   (register! :rtw/root (fn [] (swap! calls inc)))
+        inc    (:root-incarnation (client/live-root-entry :rtw/root))]
+    (reactive/attach-root! cell inc)
+    (is (nil? (client/unmount!* root)))
+    (is (= 1 @calls) "first unmount drove the host handle once")
+    (is (nil? (client/unmount!* root)) "a second unmount during deferral is a no-op")
+    (is (= 1 @calls) "the consumed host handle was not re-driven")))


### PR DESCRIPTION
## The defect

react-dom 19.2 refuses a **synchronous** `.unmount` from inside render/commit: it consumes the handle, clears its container marker, emits a console error, and **returns normally** while the teardown work stays scheduled for a later microtask. `unmount!*` released the root-id/container claim in a `finally` regardless — so a same-stack reentrant `mount`/`create-root` on that container was **admitted onto a container React was about to clear**: a second root over an empty/clobbered container. The prior client-root worker (#5871) surfaced this as a remainder because a correct fix needs the deferred-vs-synchronous discriminator in `reactive.cljc`, which was out of its `client.cljs`-only scope.

## Deferred-vs-synchronous distinction

The discriminator is observable **only at `reactive/teardown-root!`'s cleanup window**: a **deferred** `.unmount` runs *none* of the root's effect cleanups, so the window captures nothing **and** the incarnation's ViewCells stay `:connected`. A **synchronous** `.unmount` fires the cleanups during the call, so the window captures them. That residual connected membership (`weak-connected`) is the only in-process signal.

## The `:tearing-down` fence

- `reactive/teardown-root!` gains a 3-arity `[incarnation thunk on-settled]`. On the deferred signal it schedules the **settlement** (reap the incarnation's cells → `:dead` + fire `on-settled`) in a microtask **FIFO-ordered after React's own deferred teardown** — so the claim frees, and the cells converge, only once React has cleared the container. A synchronous teardown (or an empty root) fires `on-settled` immediately, preserving the ratified same-container immediate re-mount.
- `client/unmount!*` marks the claim `:live → :tearing-down` **before** the host `.unmount`, and releases (`:tearing-down → :released` = dissoc) via `on-settled` at the settlement boundary. During the deferred window `check-root-claim!` / the `mount*` idempotent fast path / `require-live-root!` reject the exact root-id/container with the **existing catalogued ids** — `:rf.error/duplicate-root-id` / `:rf.error/root-container-in-use` / `:rf.error/root-not-live` (no new id). A second `unmount!*` during deferral is a no-op.

## AC4 is untouched

A **throwing** host `.unmount` keeps its immediate release in the `catch` + rethrow and the honest consumed-handle diagnostic (rf2-vxgfnd.18 AC4 / .53 / .84). The fence concerns **only** the non-throwing deferred path. The failed-first-mount rollback additionally now surfaces a cleanup-`.unmount` failure with root/container context instead of silently swallowing it (bead title "or **failed** host teardown"; the happy retry-clean path is unchanged).

## Red-before-fix mounted fixture + control

Verified **red on pre-fix source** (`git checkout origin/main` of the two source files, tests retained): the fence assertions fail because the claim was released immediately (`live-root-ids` empty; reentrant claim-check does not reject) — 3 failures + 2 errors. Coverage added:

- **`root-teardown-dom-cljs-test`** (real react-dom 19.2, `:browser-test`): a render-phase `.unmount` proves it returns normally while teardown is deferred (AC1), a same-stack reentrant remount is rejected before any React root (AC2), and after the settlement microtask the cell/DOM/claim converge and a fresh same-container mount succeeds (AC3/AC4). Plus a **synchronous control** proving immediate same-container reuse still works.
- **`root-teardown-wiring-cljs-test`** (node): fence held (claim `:tearing-down`, reentrant id/container rejected, double-unmount no-op).
- **`reactive-root-teardown-cljs-test`** (`.cljc`, JVM + node): the deferred-vs-synchronous discriminator — JVM settles synchronously (full reap proof); node defers to a microtask.

## Quality gates

- `implementation/ui $ clojure -M:test` — **498 tests, 0 failures** (JVM graft, incl. synchronous-settlement path)
- `implementation $ npm run test:ui` — **505 tests, 0 failures** + adapter-isolation PASS
- `implementation $ shadow-cljs compile browser-test && serve-and-run-browser-tests` — **354 tests, 0 failures** (real react-dom deferral end-to-end)
- Full spine + browser matrix run authoritatively by CI.

## Follow-ups (not in this PR)

- **Spec 004C/011 root-contract ripple**: the `:live → :tearing-down → :released` claim transition and the deferred-teardown fence want a prose note in `spec/004C-Roots-and-Mount.md` (§7 ownership) and the Spec 009 `duplicate-root-id` / `root-container-in-use` catalogue rows (spec/ is out of this worker's scope).
- Cell-**less** roots (no ViewCell) have no reactive ownership at the cleanup window, so their deferred teardown is not detected by the cell-based signal; a raw-DOM deferral fence for them is a narrower follow-up.
- `hydrate-root*` hard-fails `:rf.error/root-manifest-invalid` at S1 (reentrant hydrate already rejected before any React); it will route through `check-root-claim!` and inherit the fence when hydration lands at S5.
