### PR TITLE
docs(new-substrate): staged pair review of the UI guide + How-it-works page + one-frame-grammar respell

### DIFF
--- a/ai/findings/new-substrate-synthesis/07-testing.md
+++ b/ai/findings/new-substrate-synthesis/07-testing.md
@@ -21,15 +21,20 @@ suite + one smoke** (08 §5 Adapters) — two named suites, not one.
 
 | Fn | Contract |
 |---|---|
-| `(render root-or-view opts)` | run the real view against a real frame on the JVM → structural tree. `opts`: `{:frame f}` or `{:app-db v}` (test frame minted), `{:props p}`, **`{:sub-overrides {query value}}`** (the explicit JVM override door — 03 §3; not "the same mechanism" as the CLJS context, and not pretended to be) |
+| `(render root-or-view opts)` | run the real view against a real frame on the JVM → structural tree. `opts`: `{:frame f}` (a frame minted with `rf/make-frame`), `{:props p}`, **`{:sub-overrides {query value}}`** (the explicit JVM override door — 03 §3; not "the same mechanism" as the CLJS context, and not pretended to be) |
 | `(find tree selector)` / `(find-all …)` | structural queries over Tier-1 trees (tag, view id, attr predicates) |
 | `(query root css-selector)` | **Tier-3 DOM query** on a mounted root (the live-DOM counterpart of `find`) |
 | `(text node)` / `(attrs node)` | projections |
-| `(frame opts)` | mint a test frame (app-db seed, registrations from the loaded namespaces) |
 | `(dispatch! frame event)` | real dispatch + drain |
 | `(with-root [r root-form] …)` | CLJS Tier-3: return a Promise; await the initial real-React mount, the body value/Promise, and total teardown of the connected test-owned root/container on every exit. The Promise resolves to the awaited body value |
 | `(flush!)` / `(flush! thunk)` | CLJS: return a Promise; run the optional thunk inside React 19 `act`, let its queued write side reach drain quiescence, then alternate framework drains and React commits to a fixed point — the sole public test flush. JVM: synchronously drain the headless ViewCell registry and return nil. It is global across test roots; there is no public production `ui/flush!`. The open-drain guard throws `:rf.error/flush-in-open-epoch` synchronously before Promise construction; the boundary is the open drain, not an epoch/render bijection |
 | `(flush-presence!)` | advance presence transitions without wall-clock (02 §7) |
+
+There is deliberately **no frame constructor in `ui.test`** (ruled 2026-07-14): one
+way to create and initialise frames — `rf/make-frame` + `:initial-events`, with
+`[:rf/set-db {…}]` as the standard seeding step. An earlier `(frame {:app-db …})`
+helper and `render`'s `{:app-db v}` frame-minting option were removed as a second
+initialisation grammar.
 
 At S2, Tier-3 tests drive framework state with `dispatch!`. DOM mechanics already owned
 by the host or a foreign component use platform properties and native events directly;
@@ -100,7 +105,7 @@ before any conformance claim.
 
 Props schemas generate **props**; they cannot generate an app-db satisfying arbitrary
 subs — apps supply state generators/fixtures for sub-reading views (the harness makes
-this a one-liner around `ui.test/frame`). With inputs supplied: JVM tree vs CLJS
+this a one-liner around `rf/make-frame`). With inputs supplied: JVM tree vs CLJS
 `react-dom/server`-equivalent compare as normalized semantic nodes over the structural
 subset; memo invariants (`rf=` props ⇒ no **prop-driven** re-render and identical
 output); value-stabilization invariants (equal results ⇒ identical references).

--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -10,10 +10,9 @@
 ```
 
 `package.json` carries `react` and `react-dom` — nothing else. No Reagent, no UIx, no
-Helix. The published artifact's peer floor is planned as React 19.2.4+; the reference
-implementation today builds and tests against a 19.2.0 pin
-(`implementation/package.json`), and the floor takes effect when the artifact's peer
-contract ships with it.
+Helix. (The published artifact's peer floor is planned as React 19.2.4+; the reference
+implementation currently builds against a 19.2.0 pin, and the floor takes effect when
+the artifact's peer contract ships with it.)
 
 The compiler owns one whole-build view digest. For Shadow 3.4.10, configure its two
 load-bearing settings once (not once per build):
@@ -27,16 +26,19 @@ load-bearing settings once (not once per build):
  }
 ```
 
-On a daemon's version-zero pass, the hook clears retained output for UI macro consumers;
-the cache blocker then prevents a stale disk-cache reload, so those macros reconstruct the
-accepted registry. Later output-present cache hits stay warm. The hook carries a candidate
-digest in Shadow's returned functional build-state and patches the dev client carrier;
-Shadow accepts both only when the complete configured build/watch pass succeeds. Omitting
-either can produce an incomplete compiler view of the build, so a misconfigured dev bundle
-fails loudly instead of hydrating or debugging against a false identity. Direct
-unsaved REPL evaluation may replace a view body but does not change the build digest until
-the source is saved and the next pass completes. All of this machinery disappears from
-advanced production output.
+Both settings serve one contract: the compiler keeps a single, truthful, whole-build
+picture of your views (the *build digest*), across daemon restarts, cached builds, and
+hot reloads. Forget one and the failure is loud, not subtle — a misconfigured dev
+bundle refuses to hydrate or debug against a false identity rather than doing so
+silently. One habit worth knowing early: evaluating a view directly in the REPL
+repaints it, but the digest only advances when you save and the next watch pass
+completes. What the digest is and why the cache needs blocking is
+[11 — How it works](11-how-it-works.md); none of this machinery reaches advanced
+production output.
+
+A minimal project is four files: `deps.edn` and `shadow-cljs.edn` at the root
+(configured above), your app namespace under `src/`, and an `index.html` with a
+`<div id="root">`. Nothing else is load-bearing.
 
 ## The whole app
 
@@ -82,12 +84,13 @@ Three things carry the whole model:
    edits. No provider → `sub` raises `:rf.error/no-frame-context`; the runtime never
    guesses.
 
-> **Stage note.** The compiled template, the props model, and the mount grammar are
-> Stage 1; the reactive read loop — `sub` re-rendering the view, `frame-root`'s runtime
-> ENSURE, the `ui/adapter` you hand `rf/init!` — shipped with the S2 reactive core. All
-> of it is on main today. What's left is the button: committed dispatch from compiled
-> handler sites *(lands S3 — committed handlers)* — until then the vector is data you
-> can read and assert, and tests drive state with `ui.test/dispatch!`.
+> **Stage note.** Everything above is on main today except the button itself —
+> committed dispatch from compiled handler sites *(lands S3 — committed handlers)*.
+> Until then, **you are the click**: the live loop shipped with S2, so drive it
+> yourself — dispatch from your REPL or your AI pair against the running frame, or in
+> a test with `(ui.test/dispatch! frame [:count/inc])` — and watch the view repaint.
+> That's the deepest fact about this library, met early: the UI is an event stream,
+> and a button is just one of the emitters.
 
 One more default worth knowing: this single-root page needed no root identity — the
 root id derives from the mounted view. When a page mounts the same view twice, or you
@@ -101,11 +104,12 @@ needs no DOM, no browser, no flake — it runs on the JVM in your watch loop:
 ```clojure
 (ns my.app-test
   (:require [clojure.test :refer [deftest is]]
+            [re-frame.core :as rf]
             [re-frame.ui.test :as ui.test]
             [my.app :as app]))
 
 (deftest counter-carries-intent
-  (let [frame (ui.test/frame {:app-db {:count 3}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:count 3}]]})
         tree  (ui.test/render [app/counter] {:frame frame})]
     (is (= [:count/inc] (-> tree (ui.test/find :button) ui.test/attrs :on-click)))
     (is (= "+"          (-> tree (ui.test/find :button) ui.test/text)))))
@@ -113,7 +117,10 @@ needs no DOM, no browser, no flake — it runs on the JVM in your watch loop:
 
 Two ground rules, both cheap: the events/subs a view touches must be `.cljc` (they run
 on the JVM here — standard re-frame discipline anyway), and attribute reads go through
-`ui.test/attrs`, never keyword lookup on the node. The full testing story is
+`ui.test/attrs`, never keyword lookup on the node. And notice there is no test-only
+frame constructor: `rf/make-frame` with `:initial-events` is how every frame begins,
+and `[:rf/set-db {…}]` is the framework's standard seeding event for when a test wants
+a specific starting state. The full testing story is
 [09](09-testing.md). This test runs on main today, `sub` site included — the Tier-1
 harness shipped at Stage 1, and the snapshot path that lets a headless render resolve
 subscriptions arrived with the S2 reactive core.

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -85,37 +85,13 @@ Reagent users: home, minus the traps.
   child position are rejected too (silent-text mistakes) — literal ones at build time,
   runtime-produced ones at dev render; lazy seqs don't reach React.
 
-## Exit animations: `ui/presence` *(lands S4 — presence)*
+## Styling
 
-When state says an element is gone, React removes it instantly — but toasts slide out,
-modals fade, rows collapse. `ui/presence` owns the gap between *no longer true* and
-*no longer visible*. Each card reads where it is in that lifetime with `presence-phase`;
-the tray wraps the list in the presence boundary:
-
-```clojure
-(ui/defview toast-card [{:keys [toast]}]
-  (let [phase (presence-phase)]          ; :mounting | :present | :unmounting
-    [:div.toast {:class (name phase)}    ; your CSS does the animating
-     (:message toast)]))
-
-(ui/defview toast-tray []
-  (ui/presence {:timeout-ms 300}
-    (for [t (sub [:toasts/visible])]
-      [toast-card {:key (:id t) :toast t}])))
-```
-
-A child removed from the list keeps rendering as `:unmounting` until its transition ends
-(or `:timeout-ms` — nothing can strand a zombie), then is truly removed with all its
-subscriptions and leases released. Outside any presence boundary, `(presence-phase)`
-returns `:present` — presence-aware components work anywhere. What you get for free: exiting children are
-`inert`/`aria-hidden` (a departing toast can't steal a click), remove-then-re-add is
-deterministic (delete + undo doesn't ghost), reduced-motion users get the instant path,
-server-rendered content doesn't all slide in on load, and tests advance transitions with
-`(ui.test/flush-presence!)` instead of sleeping.
-
-It's a *presence* primitive, not an animation system: three phases and a lifetime
-contract. The animations themselves are CSS (or a foreign library at an interop
-boundary).
+`:class` and `:style` are the whole surface the compiler owns — it emits them (keyword
+CSS values included) identically on client and server. The CSS itself is yours: plain
+stylesheets, Tailwind, utility classes, anything that resolves to class names works
+unchanged, and there is no css-in-cljs layer to learn. Later, `ui/presence` hands you
+phase names precisely so your CSS — not a JS animation runtime — does the animating.
 
 ## Props discipline
 
@@ -175,6 +151,38 @@ interop tier)*. Inside ordinary views you never reach for them: `local`, `effect
 `sub` are the component story.
 
 That is the entire React surface you touch.
+
+## Exit animations: `ui/presence` *(lands S4 — presence)*
+
+When state says an element is gone, React removes it instantly — but toasts slide out,
+modals fade, rows collapse. `ui/presence` owns the gap between *no longer true* and
+*no longer visible*. Each card reads where it is in that lifetime with `presence-phase`;
+the tray wraps the list in the presence boundary:
+
+```clojure
+(ui/defview toast-card [{:keys [toast]}]
+  (let [phase (presence-phase)]          ; :mounting | :present | :unmounting
+    [:div.toast {:class (name phase)}    ; your CSS does the animating
+     (:message toast)]))
+
+(ui/defview toast-tray []
+  (ui/presence {:timeout-ms 300}
+    (for [t (sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
+```
+
+A child removed from the list keeps rendering as `:unmounting` until its transition ends
+(or `:timeout-ms` — nothing can strand a zombie), then is truly removed with all its
+subscriptions and leases released. Outside any presence boundary, `(presence-phase)`
+returns `:present` — presence-aware components work anywhere. What you get for free: exiting children are
+`inert`/`aria-hidden` (a departing toast can't steal a click), remove-then-re-add is
+deterministic (delete + undo doesn't ghost), reduced-motion users get the instant path,
+server-rendered content doesn't all slide in on load, and tests advance transitions with
+`(ui.test/flush-presence!)` instead of sleeping.
+
+It's a *presence* primitive, not an animation system: three phases and a lifetime
+contract. The animations themselves are CSS (or a foreign library at an interop
+boundary).
 
 ## Web boundaries: custom elements *(lands S4 — web boundaries)*
 

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -9,8 +9,9 @@ A view has four inputs, each with one spelling:
 | Ephemeral, mine, gone on unmount? | `(local initial)` |
 | Keep a resource alive while I'm visible? | `(lease descriptor)` |
 
-There is no fifth. No ratoms, cursors, reactions, or external stores — state that matters
-lives in app-db where events, time-travel, Story, and Xray can see it.
+There is no fifth — and that's the feature. No ratoms, cursors, reactions, or external
+stores: state that matters lives in app-db, where events, time-travel, Story, and Xray
+can all see it.
 
 ## Subscriptions: `sub`
 
@@ -48,6 +49,10 @@ lives in app-db where events, time-travel, Story, and Xray can see it.
 - Keep real computation in `reg-sub` (shared, cached, Xray-visible, JVM-testable); views
   do presentation math only.
 
+> **See it live.** Mount any view from this page and open Xray's inspector on it: the
+> Dependencies panel's static column is exactly the `sub` sites you just wrote,
+> readable before a single event fires. *(The inspector's causal surfaces land S3.)*
+
 ## Local state: `local` *(lands S3)*
 
 ```clojure
@@ -58,8 +63,9 @@ lives in app-db where events, time-travel, Story, and Xray can see it.
      [:button {:on-click [:search/run text]} "Search"]]))
 ```
 
-`(local initial)` → `[value set!]`. Re-renders this view only; host state underneath; not
-time-travelled — deliberately.
+`(local initial)` returns the current value and a setter. Setting it re-renders this
+view only. The value lives in host state underneath — deliberately outside app-db, so
+it is never time-travelled.
 
 **The doctrine (read twice):** `local` is for keystroke-latency ephemera — uncommitted
 input text, an open/closed disclosure, hover. Handlers in the same view may read it —
@@ -124,3 +130,10 @@ a hidden tile holds nothing alive — while a `lease` inside a loop is a compile
 with the same fix (extract a keyed child view). Rule of thumb:
 loading that belongs to navigation or workflow rides route/event resource plans; `lease`
 is for liveness that genuinely follows visible UI — dashboard tiles, hover cards, modals.
+
+Two pointers to keep this section honest. The status vocabulary shown is the common
+subset — the full enum (`:idle` included) and the query map's `:scope` key are
+Spec 016's. And nothing on this page *fetches*: the resource system does. Leases only
+declare that somebody is watching; how data actually arrives — effects, transports,
+the events they dispatch — is core re-frame2 dataflow (the core guide, `docs/core/`),
+and [10](10-worked-app.md) shows the seam from the view side.

--- a/ai/findings/new-substrate-synthesis/guide/04-events.md
+++ b/ai/findings/new-substrate-synthesis/guide/04-events.md
@@ -26,6 +26,11 @@ splicing, the sync door, `ui/event`/`ui/handler` semantics — lands S3.)*
 - **Fast** — vectors are values: no per-render closure churn, and props stay honestly
   comparable, which keeps memoization working ([07](07-performance.md)).
 
+> **See it live.** The vectors are on the rendered tree today — assert one headlessly
+> ([09](09-testing.md)), or hover the element in Xray's inspector and read it before
+> any click; your AI pair reads the same surface over MCP. *(Xray's UI-substrate
+> panels land S3.)*
+
 ## Payloads: placeholders (three, all scalars)
 
 ```clojure
@@ -124,11 +129,15 @@ testable:
 
 ```clojure
 (deftest plan-select-carries-intent
-  (let [frame (ui.test/frame {:app-db {:signup {:plan "free"}}})
+  (let [frame (rf/make-frame {:initial-events [[:signup/init]]})
         tree  (ui.test/render [signup-form] {:frame frame})]
     (is (= [:signup/set :plan :rf.ui/value]
            (-> tree (ui.test/find :select) ui.test/attrs :on-change)))))
 ```
+
+The frame is minted the one way every frame is — `rf/make-frame` — and initialised by
+the form's own `[:signup/init]`, so the fixture can never drift from what the app
+actually boots.
 
 *(This test runs on main today — a Tier-1 render resolves its `sub` sites against the
 frame you minted.)*
@@ -209,7 +218,9 @@ There is deliberately no `:on-mount`. React mounts, replays, hides, and restores
 components for mechanical reasons (StrictMode, Activity, HMR, error recovery) — "the
 user viewed this" cannot be inferred from them. Dispatch domain visibility from domain
 transitions (the route's `:on-match`, a machine state, the event that opened the modal);
-synchronize with the host world in `(effect …)` ([03](03-state.md)).
+synchronize with the host world in `(effect …)` ([03](03-state.md)). (Window-level
+listeners — global keyboard shortcuts, `error` events — are the same story one page
+over: an `effect` plus a held dispatch, [05](05-frames.md)'s `error-reporter`.)
 
 ## Safety nets
 

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -58,6 +58,10 @@ exactly one mounted view, which is why the mount above spells out `:page/home`.
 each root fails or hydrates independently ([08](08-ssr.md)). And you can mount one app N
 times side-by-side (each instance its own frame universe) for comparison demos and tests.
 
+> **See it live.** Mount the two-frame page, open Xray, and dispatch into `:shop` —
+> its epoch counter advances while `:assist` sits still. Frame isolation isn't a
+> promise to trust; it's something you can watch.
+
 ## Holding a frame: `(frame)`
 
 Data handlers and `sub` mean typical views never touch the frame directly. For the rare

--- a/ai/findings/new-substrate-synthesis/guide/06-debugging.md
+++ b/ai/findings/new-substrate-synthesis/guide/06-debugging.md
@@ -70,10 +70,13 @@ Errors fire at the earliest moment the mistake exists, and every message names t
 - **When they run:** `set!` during render; dispatch during render; `dispatch-fn` after
   disconnect (your leaked listener, found).
 
-The runtime ids are catalogued (Spec 009) and greppable — no bespoke console prose:
+The runtime ids are catalogued in the spec — Spec 004 owns the view-layer ids,
+Spec 009 the runtime-wide ones — and greppable, no bespoke console prose:
 `:rf.error/no-frame-context`, `:rf.error/dispatch-disconnected`,
 `:rf.warning/unregistered-event-id`, `:rf.warning/placeholder-in-dynamic-vector`,
-`:rf.warning/render-phase-dispatch` / `-set!`. One catalogue for the whole library.
+`:rf.warning/render-phase-dispatch` / `-set!`. One catalogue for the whole library;
+each id ships with its feature's stage (the `dispatch-fn` and registrar-check ids
+arrive with S3).
 
 ## The programmatic surface: `re-frame.ui.tool` *(lands S3 — dev-only)*
 
@@ -83,6 +86,27 @@ sites, leases, straight from the compiler, before any mount), `mounted-views` (w
 live right now), `explain-render` (the causes behind a commit), and
 `view-dependencies` / `view-event-sites` (the two halves of the inspector's panels).
 Tool tier: provably absent from production bundles, like the rest of this page.
+
+It's REPL-shaped on purpose — ask a view what it can do before anything is mounted:
+
+```clojure
+;; guide:no-fixture — schematic; the ruled fields, lands S3 with the tool namespace
+(require '[re-frame.ui.tool :as tool])
+(tool/view-manifest my.app/counter)
+;; => its subs, event sites, and leases — straight from the compiler
+```
+
+## Pairing with an AI on the live app
+
+Everything above is machine-readable on purpose. The repo's Pair tooling
+(`re-frame2-pair` and its MCP server) attaches to your running app and consumes the
+same surfaces this page describes: ask *"why did that tile just re-render?"* and the
+pair reads the causes; hand it a bug and it dispatches the events, reads the epoch
+history, hot-swaps the fix, scrubs back, and replays. A session against
+[10](10-worked-app.md)'s dashboard is the fastest way to *feel* why intent-as-data
+matters — the AI is only that useful because your buttons say what they do. (The Pair
+rides the core Tool-Pair contract, live today; the UI-substrate surfaces it reads —
+causes, manifests — deepen with S3.)
 
 ## React DevTools & profiler
 

--- a/ai/findings/new-substrate-synthesis/guide/07-performance.md
+++ b/ai/findings/new-substrate-synthesis/guide/07-performance.md
@@ -5,10 +5,11 @@ meticulous React engineer writes by hand — every view, every time.
 
 *(Stage note: the compiled output and memo comparators are Stage 1, and the reactive
 economics below ride the S2 core — both on main today, with the push-economics gate
-(G-13) already wired. Three surfaces named below land S3 — `effect` dependency
-semantics, the Xray heatmap, and the causes timeline — each marked where it appears.
-The CI gates that prove the production claims — bundle absence, size budget, output
-shape — wire in across S3–S6.)*
+(G-13) already wired. Two surfaces named below land S3 — `effect` dependency
+semantics and the causes timeline — and the Xray heatmap is staged behind its
+integration review; each is marked where it appears. The CI gates that prove the
+production claims — bundle absence, size budget, output shape — wire in across
+S3–S6.)*
 
 ## What you never write
 
@@ -46,7 +47,7 @@ exists to confirm this, not to negotiate with it.
    identity, and a parent that rebuilds child elements each render defeats the child's
    memo the same way (inherent to React; hand-written code pays it too). In hot lists,
    prefer data handlers, hoist fns, narrow what the parent rebuilds. The heatmap
-   *(lands S3)* makes offenders visible.
+   *(staged behind its Xray integration review)* makes offenders visible.
 4. **Broad values walk.** `rf=` short-circuits identity, so structurally-shared values are
    cheap — but a subscription that *rebuilds* a large equal collection forces walks
    downstream. Fix the producing sub (stabilize it); don't sprinkle comparators. Dev flags
@@ -65,8 +66,16 @@ diff — not intentions.
 
 ## Measuring
 
-Dev: the Xray heatmap and causes timeline *(lands S3)* beat flame graphs for "why is
-this slow" — counts, causes, and epochs, per view. Production: the React Profiler works
-normally (real component names, real memo boundaries), and renders should look like the
-model above — sparse, shallow, value-justified. If they don't, the timeline's cause
-column *(lands S3)* names the culprit before you reach for the profiler.
+Dev: the causes timeline *(lands S3)* — and, once staged, the Xray heatmap — beats
+flame graphs for "why is this slow": counts, causes, and epochs, per view. Production:
+the React Profiler works normally (real component names, real memo boundaries), and
+renders should look like the model above — sparse, shallow, value-justified. If they
+don't, the timeline's cause column *(lands S3)* names the culprit before you reach for
+the profiler.
+
+And measure your own build the way the library measures itself:
+`npx shadow-cljs run shadow.cljs.build-report <build-id> report.html` attributes every
+byte of an advanced build — the library's contribution should read as the kernel plus
+your compiled views and nothing else. The claims above are CI gates in the library's
+own pipeline; the report is how you check nothing in *your* app dragged the dev tier
+in.

--- a/ai/findings/new-substrate-synthesis/guide/08-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-ssr.md
@@ -29,7 +29,9 @@ keep the shared markup outside.
 ## Rendering a page
 
 Server lifecycle is standard re-frame2 SSR: per-request frames, drain `:initial-events`,
-render (a tree walk — fast, no JS engines), respond, teardown.
+render (a tree walk — fast, no JS engines), respond, teardown. (The request-to-response
+glue — routing the request into a frame and the render into a response — ships as the
+`ssr-ring` ecosystem adapter; this page covers everything the view layer itself owns.)
 
 ## Roots and frames — two different things
 

--- a/ai/findings/new-substrate-synthesis/guide/09-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/09-testing.md
@@ -11,7 +11,7 @@ real registrations, no React:
 
 ```clojure
 (deftest add-button-carries-intent
-  (let [frame (ui.test/frame {:app-db {:cart #{} :catalog fixture-catalog}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{} :catalog fixture-catalog}]]})
         tree  (ui.test/render [product-card {:product (product 42)}] {:frame frame})]
     (is (= [:cart/add 42] (-> tree (ui.test/find :button) ui.test/attrs :on-click)))
     (is (= "Add to cart"  (-> tree (ui.test/find :button) ui.test/text)))))
@@ -46,6 +46,13 @@ real registrations, no React:
   states are just app-db values you install or events you dispatch. Stubbing a sub is
   the explicit option:
   `(ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})`.
+- **One constructor, one grammar.** There is no test-only way to make a frame:
+  `rf/make-frame` is it, initialised through `:initial-events` exactly like every
+  frame (frames always start `{}`; initial state rides the same dispatch pipeline as
+  every later change, per Spec 002). Seed a specific starting state with the
+  framework's `[:rf/set-db {…}]` event — or better, run your app's own init events,
+  so fixtures can't drift from what the app actually boots. Images and fx overrides
+  are the same constructor's vocabulary (Spec 008).
 - `render` also takes a **literal root form** — the same literal top-region grammar
   `mount` accepts, deliberately tightened in one way: a test root mounts exactly *one*
   view, because root identity is that view's id. `mount` will take a multi-view form
@@ -54,8 +61,8 @@ real registrations, no React:
   test? Wrap it in one `defview` and render that.
   `(ui.test/render [ui/frame-root {:id :shop :initial-events [[:shop/boot]]} [app]] {})`
   runs the form's frame plans as preflight ENSURE against the test registrar, minting
-  the frames it declares. With a plan-bearing root form, `{:frame …}`/`{:app-db …}` are
-  rejected (the root form owns its frames — pass a bare view to control the frame), and
+  the frames it declares. With a plan-bearing root form, `{:frame …}` is rejected (the
+  root form owns its frames — pass a bare view to control the frame), and
   `{:props …}` belongs to the bare-view form only.
 - **Two Tier-1 ground rules.** The events/subs your view touches must be `.cljc` (they run
   on the JVM here — the standard re-frame discipline anyway). And Tier 1 renders the
@@ -65,10 +72,12 @@ real registrations, no React:
   themselves land S3; the subset rule here is their ruled Tier-1 contract.)*
 - These run in your JVM watch loop in milliseconds and never flake on timing. They're
   also exactly how the library tests itself, so the shapes are first-class.
-- *(Stage note: the Tier-1 core — `render`, `find`, `find-all`, `text`, `attrs`,
-  `frame` — shipped at Stage 1. `dispatch!`, Tier-1 `sub` snapshots, and the mounted
+- *(Stage note: the Tier-1 core — `render`, `find`, `find-all`, `text`, `attrs` —
+  shipped at Stage 1. `dispatch!`, Tier-1 `sub` snapshots, and the mounted
   Tier-3 `with-root` / native-CSS `query` / Promise-backed `flush!` surface shipped at
-  Stage 2. `flush-presence!` lands at Stage 4.)*
+  Stage 2. `flush-presence!` lands at Stage 4. An early `ui.test/frame {:app-db …}`
+  constructor was removed by ruling 2026-07-14 — one frame grammar everywhere; its
+  deletion from the shipped test namespace rides the respell bead.)*
 
 ## Tier 2 — dataflow tests (unchanged re-frame2)
 
@@ -78,12 +87,27 @@ The view tier above assumes this tier exists — don't test business logic throu
 ## Tier 3 — mounted tests, when the DOM is the point
 
 For focus, IME, foreign widgets — the things only a real mount exercises — use the
-Stage-2 mounted surface, `with-root`, `query`, and `flush!`:
+Stage-2 mounted surface: `with-root`, `query`, and `flush!`. A read-only mounted test
+is small — mount, query, done:
+
+```clojure
+(deftest search-box-really-mounts
+  (async done
+    (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:query ""}]]})]
+      (-> (ui.test/with-root [root [ui/frame-provider {:frame frame} [search-box]]]
+            (is (some? (ui.test/query root "input"))))
+          (.then (fn [_] (done))
+                 (fn [e] (is false (str e)) (done)))))))
+```
+
+When the test *writes*, the ceremony grows deliberately: the write needs an act
+boundary, and every Promise needs awaiting. Here is the complete shape you'll copy
+for real suites:
 
 ```clojure
 (deftest search-commits-the-latest-query
   (async done
-    (let [frame (ui.test/frame {:app-db {:query ""}})]
+    (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:query ""}]]})]
       (-> (ui.test/with-root
             [root [ui/frame-provider {:frame frame} [search-box]]]
             ;; with-root already awaited the initial mount. Put the write

--- a/ai/findings/new-substrate-synthesis/guide/10-worked-app.md
+++ b/ai/findings/new-substrate-synthesis/guide/10-worked-app.md
@@ -163,29 +163,35 @@ tree, no browser; both tests run on main today (`sub` reads and `dispatch!` alik
 ```clojure
 (ns dash.app-test
   (:require [clojure.test :refer [deftest is]]
+            [re-frame.core :as rf]
             [re-frame.ui.test :as ui.test]
             [dash.app :as app]))
 
-(def fixture-db
-  {:metrics {:cpu {:label "CPU" :value 41 :unit "%"}
-             :mem {:label "Memory" :value 62 :unit "%"}}
-   :watchlist #{}
-   :filter ""})
+(def fixture-metrics
+  {:cpu {:label "CPU" :value 41 :unit "%"}
+   :mem {:label "Memory" :value 62 :unit "%"}})
+
+(defn fixture-frame []
+  (rf/make-frame {:initial-events [[:dash/init]
+                                   [:metrics/arrived fixture-metrics]]}))
 
 (deftest tile-shows-metric-and-intent
-  (let [frame (ui.test/frame {:app-db fixture-db})
+  (let [frame (fixture-frame)
         tree  (ui.test/render [app/metric-tile {:id :cpu}] {:frame frame})]
     (is (= "CPU" (-> tree (ui.test/find :h3) ui.test/text)))
     (is (= [:watch/toggled :cpu :rf.ui/checked]
            (-> tree (ui.test/find :input) ui.test/attrs :on-change)))))
 
 (deftest filter-narrows-the-grid
-  (let [frame (ui.test/frame {:app-db fixture-db})]
+  (let [frame (fixture-frame)]
     (ui.test/dispatch! frame [:filter/typed "cp"])
     (let [tree (ui.test/render [app/dashboard] {:frame frame})]
       (is (= 1 (count (ui.test/find-all tree :dash.app/metric-tile)))))))
 ```
 
+Notice how the fixture is built: `rf/make-frame` — the one frame constructor — and
+the app's *own* events (`[:dash/init]`, `[:metrics/arrived …]`), so the test state can
+never drift from a state the real app can reach.
 The second test drives state with a real event and counts tiles by **view id** — the
 qualified-keyword selector matches `metric-tile`'s boundary marker in the tree
 ([09](09-testing.md)). Business logic (the filtering itself) belongs in a plain
@@ -196,3 +202,18 @@ Tier-2 sub test; these two assert the *view* contract only.
 No `useCallback` on the checkbox, no `React.memo` on the tile, no store wiring for the
 feed, no loading-state component library, no test IDs threaded through the DOM for a
 click simulator. The dashboard is the counter, more times.
+
+## Two codas
+
+**Serve it.** The dashboard is one mount away from [08](08-ssr.md)'s world: the same
+root form renders on the JVM, the same event vectors sit in the server tree, and
+hydration picks up where the server left off *(hydration lands S5)*. Nothing about
+the app changes shape.
+
+**Drive it.** Mount it, open Xray, and type into the filter: one epoch per keystroke,
+one tile repaint per changed metric — exactly the model [07](07-performance.md)
+promised *(the causes timeline lands S3)*. Then hand it to your AI pair
+([06](06-debugging.md)): ask why a tile repainted, have it dispatch
+`[:metrics/arrived …]` bursts, or break the filter handler and watch it scrub back
+and fix it. The dashboard makes a good first pairing target precisely because every
+intent on this page is data.

--- a/ai/findings/new-substrate-synthesis/guide/11-how-it-works.md
+++ b/ai/findings/new-substrate-synthesis/guide/11-how-it-works.md
@@ -1,0 +1,159 @@
+# 11 — How it works
+
+The rest of the guide states contracts: `sub` is the value, props memoize by value,
+the two emitters cannot drift, production carries nothing it doesn't use. This page
+explains the machinery that keeps those promises — read it when you want to *trust*
+the claims, not just use them. Nothing here is required to build apps; everything
+here is why the other pages can be short. (It describes the ruled architecture; the
+chapters' stage markers say what's on main today. The deeper, contributor-voiced
+story lives in the design docs one directory up.)
+
+## The compiler
+
+`defview` does not produce a function that *interprets* hiccup — it lowers the
+template at build time. Element vectors become direct element construction; `:class`
+and `:style` and attribute casing convert at compile time under one rule table;
+branches (`if`, `when`, `cond`, `case`, `let`, `for`) normalize into the compiler's
+AST, so every analyzer and both emitters see through them. Subtrees the compiler can
+prove inert — no props, no subs, no handlers, no keys — hoist to module constants and
+are built exactly once, at load.
+
+This is also why the template grammar is closed. A dynamic tag head, an unkeyed list,
+a `sub` inside a loop, an unaudited macro in expression position — each would put
+something into your view the compiler cannot see through, and everything downstream
+(the manifest, the memo comparators, the server emitter, Xray's static inspector)
+depends on the compiler seeing the whole template. The loud compile errors in
+[02](02-views.md) aren't taste; they're the price of the machinery on this page.
+
+Because the interesting work happens at compile time, your bundle contains no hiccup
+walker, no tag parser, no runtime prop converter on compiled paths — there is no
+interpreter to pay for, which is most of [07](07-performance.md)'s table.
+
+## The build digest and the registry
+
+Every `defview` registers the view — its source coordinates, template fingerprint,
+and capability profile — and the compiler maintains one whole-build summary of all of
+them: the *build digest*. Hydration checks it (does the client build match the markup
+the server emitted?), and the debugging surfaces trust it (click-to-source is only as
+good as the registry behind it).
+
+The two `shadow-cljs.edn` settings from [01](01-getting-started.md) exist to keep the
+digest truthful across a build daemon's lifetime: the build hook clears retained
+output for macro consumers on a daemon's first pass and carries the candidate digest
+through the build, and the cache blocker stops a stale disk cache from resurrecting a
+pre-restart view of the world. Shadow accepts the digest only when a complete
+build/watch pass succeeds — which is also why an unsaved REPL evaluation can replace
+a view's live body without changing build identity: the body is live immediately, the
+digest advances when you save and the next pass completes.
+
+## The reactive core
+
+A view with five `sub` sites does not have five subscriptions in React's eyes. All of
+a view's read sites share one **ViewCell** — a single `useSyncExternalStore` bridge
+with a single integer revision as its snapshot. That's the "one React bridge per
+view" line in [07](07-performance.md), and it's why `sub` may sit in a branch: sites
+are compile-indexed slots on the cell, not hooks in a positional list.
+
+The lifecycle of a read is split in two, and the split carries most of the
+correctness story:
+
+- **During render** the site *resolves* what it's reading (frame + query — a stable
+  identity) and *probes* it — a pure read of value and version. Rendering acquires
+  nothing and owns nothing, so an abandoned render, a StrictMode replay, or a
+  time-sliced pass can never leak a subscription.
+- **At commit** — when React has decided this render is real — the cell acquires
+  ownership of exactly the identities the committed render read, compares what it
+  acquired against what the render probed, and if anything moved in the gap, corrects
+  *before paint*. New sites are acquired before old ones release, so a shared
+  subscription never falls through a zero-owner gap during retargeting; on any
+  failure the staged acquisitions roll back and the previous committed set stays
+  installed.
+
+That render/commit split is the answer to a family of questions the other pages wave
+at: why parametric queries switch atomically (the old target releases only after the
+new one is acquired), why you never see one frame of order A's data against order B's
+id, why hiding a subtree in an Activity releases everything and reveal reacquires and
+corrects, and why frame destruction can mark cells dead loudly instead of leaving
+views silently attached to a corpse.
+
+On the write side, every dispatched event runs the ordinary re-frame2
+run-to-completion drain, each event committing its own epoch. Only when the drain
+reaches quiescence does each dirty cell advance its revision — once, no matter how
+many of its sites changed, no matter how many events the drain processed — and React
+gets one render batch for the views whose values actually moved. Unchanged
+derivations return identical references, so child memo comparators short-circuit and
+the cascade stops. One drain, one notification per affected view, one commit per
+root: that is [07](07-performance.md)'s "model in one paragraph", mechanically.
+
+## Memoization that is correct, not heuristic
+
+Every view compiles with a straight-line comparator over its declared prop slots —
+compare `:product`, compare `:on-select`, done. The comparator is `rf=`: identity
+first (structurally shared values are cheap), value equality for CLJS data, honest
+fallback to identity for host values. It can be *correct* — not a heuristic — because
+the inputs are values by construction: props are CLJS data, handlers are vectors,
+children are realized elements. This is why the guide keeps insisting on data
+handlers: a closure prop doesn't break memoization mechanically, it breaks the *idiom*
+that makes memoization mean something. (It's also why `:as` costs — a view that takes
+the whole map opts out of slot-wise comparison into generic comparison.)
+
+## Events without closures
+
+A literal vector in `:on-click` compiles to a *site*: the vector is retained as data
+(in the manifest, on the JVM tree, in dev tooling), and the client emits one stable
+per-site callback that reads its **committed** slot values when the event fires — not
+whatever a closure happened to capture some renders ago. Placeholders (`:rf.ui/value`
+and friends) splice at dispatch time, which is why they only work in literal vectors:
+they are compiled, not interpreted.
+
+Controlled inputs add the one deliberate exception to batching. Where the compiler
+can prove an element controlled — a literal `:value`/`:checked` beside a vector
+handler — dispatches from that site drain *synchronously inside the DOM event*:
+event → drain → commit → the new value is back in `:value` before React's re-render.
+That ordering is the entire caret/IME story; nothing about it is configurable
+because it is a proof obligation, not a preference.
+
+## One template, two emitters
+
+The compiler's AST feeds two emitters: direct element construction for the browser,
+and a string emitter for the JVM. They share the single conversion and escaping rule
+table — the same code decides what `:style {:cursor :pointer}` means on both sides —
+so client and server output are structurally equivalent by construction, and a
+fingerprint of the emitted structure rides along so hydration can *check* rather than
+hope. This is why [08](08-ssr.md) can say "no dual-emitter drift" flatly: there is no
+second implementation to drift.
+
+## Hot reload, mechanically
+
+`defview` exports a stable component shell keyed by the view's id; the registry holds
+the current body. Re-evaluating a namespace — shadow reload or REPL, one path —
+replaces the body and bumps a generation; the shell's identity never changes, so
+React state and cell identity survive. The compiler hashes each view's ordered hook
+signature: same hash, the mounted view renders the new body in place and commit
+reconciles the changed sites; different hash, that subtree remounts deliberately —
+never a corrupted hook order. Frames sit outside all of this: ENSURE runs at host
+preflight, finds the frame live on reload, and does not re-seed — which is exactly
+the "your state survives edits" behaviour [01](01-getting-started.md) promises.
+The Pair's hot-swap is this same mechanism, invoked over nREPL.
+
+## The dev/prod split
+
+Dev and prod run the same semantics with different amounts of evidence. In dev, every
+view carries its manifest, every commit its causes, every element its source
+coordinates — that's [06](06-debugging.md). In production, each component carries
+only the machinery its own source implies: the compiler records a capability profile
+per view (subs? local? presence? an error boundary?) and specializes the output, so a
+props-only view is a memoized function making direct element calls and nothing else.
+The debug tier isn't flagged off; it is *absent*, and CI proves the absence by
+scanning the bundle for a roster of things that must not appear — walkers, manifests,
+cause vectors, the JVM emitter, warning prose. The kernel that remains — cell, event
+dispatcher, dynamic-prop converter, frame context — is budgeted at ≤ 4 KB gzipped
+over React, and the budget is a gate, not a hope.
+
+## Where to go deeper
+
+The design documents one directory up carry the full contracts this page summarizes —
+the programming model, the ownership protocol and its fixtures, the production
+economics with their kill-gates — written for people changing the library rather than
+using it. If a claim on this page seems too good, that's where its proof obligations
+live.

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -1,33 +1,24 @@
 # The re-frame2 UI Guide
 
 re-frame2 UI is the view layer for re-frame2: views are hiccup, handlers are event
-vectors, and the compiler ships code with no interpreter, no hooks ceremony, and no manual
-memoization. This guide teaches the library as a user; design rationale lives one
-directory up. The examples are written to run as CI fixtures, and coverage grows with
-the stages. Today one chapter is partly covered: guide 09's Tier-1 code block and the
-dispatch → sub → re-render loop it teaches run as fixtures in the library's JVM suite
-(`implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj`) — the verbatim
-render, the intent-through-attrs respelling, the genuine dispatch → sub → re-render
-toggle (membership read through the compiled `sub` path), a seeded-state render, and the
-sub-override door. The chapter's selector-grammar and literal-root fences are not enrolled
-yet, and the remaining chapters are lifted as their stages land, per the fixture-pipeline
-draft one directory up (`drafts/guide-fixture-pipeline.md`). A fence that is deliberately
-schematic — an elided fragment, or a wave-2 surface — says so in a `;; guide:no-fixture`
-comment on the fence itself. The bar does not move with the coverage: if a guide example
-needs internals explained, that's an API bug, not a documentation problem.
+vectors, and the compiler ships code with no interpreter, no hooks ceremony, and no
+manual memoization. This guide teaches the library as a user. Design rationale lives
+one directory up, and the dataflow half of the story — events, effects, app-db — is
+the core guide's (`docs/core/`).
 
 | Chapter | You'll learn |
 |---|---|
 | [01 — Getting started](01-getting-started.md) | Install, mount, first interactive view, first headless test |
-| [02 — Views](02-views.md) | `defview`, templates, props, children, lists, presence (exit animations), custom elements |
+| [02 — Views](02-views.md) | `defview`, templates, styling, props, children, lists, presence (exit animations), custom elements |
 | [03 — State](03-state.md) | `sub` (including conditional reads), `local`, `effect`, `lease` |
 | [04 — Events](04-events.md) | Event vectors, placeholders, `ui/event`, forms & controlled inputs, the callback decision table |
 | [05 — Frames](05-frames.md) | `frame-root`, `frame-provider`, multi-frame pages, holds |
-| [06 — Debugging](06-debugging.md) | Render causes, the interaction surface, Xray navigation |
+| [06 — Debugging](06-debugging.md) | Render causes, the interaction surface, Xray navigation, pairing with an AI |
 | [07 — Performance](07-performance.md) | What you never do, the little you do |
 | [08 — Server rendering](08-ssr.md) | JVM rendering, roots and frames, root identity, the host tier, static output |
 | [09 — Testing](09-testing.md) | Headless view tests, selectors, `flush!`, Story |
 | [10 — A worked app](10-worked-app.md) | The counter grown into a dashboard: state shape, tiles, narrow subs, a live tile, tests |
+| [11 — How it works](11-how-it-works.md) | The mechanism: the compiler, the build digest, the reactive core, two emitters, the dev/prod split |
 
 **Stage honesty.** The library ships in stages (S1–S7). Everything unmarked on these
 pages is shipped on main today. That covers the Stage-1 compiler slice (compiled
@@ -39,7 +30,8 @@ Tier-1 `sub` reads, `frame-root`'s runtime ENSURE preflight, the `ui/adapter` yo
 compact marker like *(lands S3 — committed handlers)* flags a surface whose contract is
 final but whose implementation lands in a later stage; the spelling and semantics shown
 are the ruled contract either way. The *(lands S2)* marker survives on just one
-straggler — `lease`. Wave-2 names (`ui/element`, `ui/view`,
+straggler — `lease`, whose view-level semantics confirm at S3. Wave-2 names
+(`ui/element`, `ui/view`,
 `ui/portal`, `re-frame.ui.data/render`) are not v1 and only ever appear with that
 qualifier.
 
@@ -55,3 +47,29 @@ ratoms: app state lives in app-db, keystroke ephemera in `local`.
 **Coming from React / UIx / Helix?** Components, memo, context, and external stores are
 all here — the compiler writes them. You will not write a hook, a deps array, a
 `useCallback`, or a `memo` wrapper again. (And unlike hooks, `sub` may sit in a branch.)
+Where your reflexes reach for a hook, this is the map:
+
+| Looking for | Here |
+|---|---|
+| `useState` | `local` ([03](03-state.md)) — or app-db, the moment anything else cares |
+| `useEffect`, DOM work | `effect` ([03](03-state.md)) |
+| `useEffect`, data fetching | events + resources; views declare `lease` ([03](03-state.md)) |
+| `useCallback` / `memo` / deps arrays | gone — every view memoizes on value-equal props ([07](07-performance.md)) |
+| Context | props, subs, and frame scoping ([05](05-frames.md)); React context itself only at foreign boundaries ([02](02-views.md)) |
+| Suspense / loading states | resource status values you branch on ([03](03-state.md)) |
+| Error boundaries | `ui/error-boundary` ([02](02-views.md)) *(lands S3)* |
+| Refs | `(ui/raw-fn set-node)` + `effect` ([03](03-state.md)) |
+| Portals | wave-2 (`ui/portal`) — not v1 |
+
+---
+
+**About these docs.** The examples are written to run as CI fixtures, and coverage
+grows with the stages: guide 09's Tier-1 core — the verbatim render, the
+intent-through-attrs respelling, the dispatch → sub → re-render loop, a seeded-state
+render, and the sub-override door — already runs as fixtures in the library's JVM
+suite, and the remaining chapters are lifted as their stages land, per the
+fixture-pipeline draft one directory up (`drafts/guide-fixture-pipeline.md`). A fence
+that is deliberately schematic — an elided fragment, or a wave-2 surface — says so in
+a `;; guide:no-fixture` comment on the fence itself. The bar does not move with the
+coverage: if a guide example needs internals explained, that's an API bug, not a
+documentation problem.

--- a/ai/findings/new-substrate-synthesis/reviews/guide-staged-review-2026-07-14.md
+++ b/ai/findings/new-substrate-synthesis/reviews/guide-staged-review-2026-07-14.md
@@ -1,0 +1,441 @@
+# Staged review — the UI guide (`guide/`)
+
+**When:** 2026-07-14 17:27 AUSEST
+**Scope:** all 11 pages of `ai/findings/new-substrate-synthesis/guide/` (README + 01–10)
+**Brief:** (1) live coding as a teaching tool · (2) completeness · (3) correctness · (4) voice
+
+---
+
+## Stage 1 — Live coding as a teaching tool
+
+The guide teaches a live system with static prose. Meanwhile the repo's differentiating
+capability — an attachable, dispatchable, time-travellable runtime (Pair, Xray, Story,
+the REPL) — appears only as a *subject* (chapter 06 describes the tools) and never as a
+*method* (no page asks the reader to touch a running app). Five concrete moves, ordered
+by value-for-effort:
+
+### 1.1 Reframe the S3 gap as REPL-first teaching (cheap, do now)
+
+The guide repeatedly apologises that buttons don't dispatch until S3 ("until then the
+vector is data you can read and assert"). But the live loop — dispatch → drain → sub →
+repaint — **shipped with S2**. Only the DOM listener wiring is missing. So the honest,
+and pedagogically superior, framing is: *until S3, you are the click.* Chapter 01's
+counter should end with a REPL beat:
+
+> Mount the app, then evaluate `(rf/dispatch <frame> [:count/inc])` in your REPL —
+> watch the view repaint. That's the whole loop; S3 merely wires the button to do what
+> you just did.
+
+This turns a staging limitation into the deepest lesson the library has: the UI is an
+event stream you can drive from anywhere — a button, a REPL, a test, an AI pair.
+
+### 1.2 "See it in Xray" beats at the end of concept sections (cheap)
+
+Each core concept the guide states is directly observable in a tool, and the guide
+already asserts so without showing it ("you can read what the button does without
+running anything — and so can Xray"). Add a two-to-four-line *see it live* strip:
+
+- 03 Subscriptions → open the inspector's Dependencies panel on `order-summary`; the
+  static column is what you just wrote.
+- 04 Events → hover the button; the vector is right there, before any click.
+- 05 Frames → mount the two-frame page; watch `:shop` epochs advance while `:assist`
+  stays still.
+- 07 Performance → the model-in-one-paragraph is *verifiable*: type in the filter box
+  and read the render timeline — one epoch, one tile.
+
+These need no new infrastructure; they need sentences. (Marker discipline applies: the
+causes/manifest surfaces are S3, so the strips carry the same *(lands S3)* markers.)
+
+### 1.3 A pair-programming interlude (medium; the flagship)
+
+Nothing in the guide shows the workflow the repo is proudest of: an AI attached to the
+running app. Proposal: a short page (or a closing section in 06) that is a lightly
+annotated transcript of a real session against the chapter-10 dashboard —
+"why did `metric-tile` re-render?" → the pair reads the causes; "break the filter
+handler, hot-swap the fix, scrub back, replay". The retro loop (cascade → patch →
+restore-epoch → retry) demonstrates trace, epochs, and hot-swap in one story that no
+static paragraph can. This is also the page that makes *AI-first* concrete for a guide
+reader. (It rides shipped machinery — Pair + core frames — not the UI substrate's S3
+surfaces, though handler hot-swap of compiled `defview` bodies should be sanity-checked
+against the build-digest caveat in 01.)
+
+### 1.4 The guide playground: one mount for every chapter (medium)
+
+The fixture pipeline already proves guide fences compile and render headlessly. The
+live-coding extension: one dev build (`guide-playground`) that mounts each chapter's
+example under its own frame — the counter, the signup form, the dashboard. Every "see
+it in Xray" strip then has a canonical target, and a reader's first `npm run
+guide-playground` gives them the whole guide as a running app. The bar from the README
+extends naturally: if a live exercise needs ceremony beyond one command, that's an API
+bug, not a documentation problem.
+
+### 1.5 Converge fixtures and Story scenes at S6 (later; flag now)
+
+When Story integration lands, guide fixtures and Story variants want to be the same
+EDN — one source rendering as (a) a guide fence, (b) a CI fixture, (c) an openable
+scene with a time-travel scrubber. Worth a line in the fixture-pipeline draft now so
+S6 doesn't build a parallel corpus.
+
+**Anti-goal:** don't turn every page into a lab. The strips are optional sidebars; the
+prose must keep teaching on its own for the AI-reader and the offline reader.
+
+---
+
+## Stage 2 — Completeness
+
+### 2.1 The missing "How it works" page (requested; recommend `11-how-it-works.md`)
+
+The guide states *what* the model guarantees and 07 states the economics, but nowhere
+explains the **mechanism** — and this library's central claims (no interpreter, no
+hooks ceremony, correct memoization, two emitters that cannot drift) are exactly the
+kind readers won't trust without a mechanism sketch. Curious seniors and evaluators
+will go looking; today they'd land in the design docs, which are contributor-voiced.
+Proposed outline (each section: the mechanism in two-three paragraphs, then "where you
+feel it" cross-links back to guides):
+
+1. **The compiler.** What `defview` lowers to — a before/after fence: hiccup in,
+   direct element construction out; static subtrees hoisted to module constants; which
+   parts stay dynamic (branches, `for` bodies). Why there is no interpreter in the
+   bundle, and what the closed template grammar buys (the 02 fences: literal heads,
+   compile-time keys).
+2. **The build digest and the registry.** The honest home for 01's densest paragraph
+   (cache-blockers, build hooks, version-zero passes, why a misconfigured dev bundle
+   fails loudly). 01 keeps the recipe; this page keeps the why.
+3. **The reactive core.** How `sub` re-renders a view with one React bridge: read-site
+   registration, drain to quiescence, one notification per drain, identical references
+   short-circuiting child comparators. Ownership: acquire/release across mount,
+   unmount, Activity hide, abandoned renders — why there is no tearing window and no
+   order-A-data-against-order-B-id frame.
+4. **Memoization that is correct, not heuristic.** `rf=` per prop slot; identity fast
+   path; why value equality is sound for CLJS data and where host values honestly fall
+   back to identity.
+5. **Events without closures.** How a vector site compiles; the manifest; placeholder
+   splicing at dispatch time; the sync-input door mechanics — event → dispatch →
+   commit → value back in `:value` pre-repaint, and why that kills caret jumps.
+6. **One template, two emitters.** The shared conversion/escaping rule table; the JVM
+   string emitter; fingerprints; why parity is structural, not best-effort.
+7. **The dev/prod split.** How causes, manifests, and coords attach in dev and how
+   Closure elision removes them; the CI gates (bundle absence, size budget, output
+   shape, G-13) that turn 07's claims into proofs.
+
+Source material largely exists in design docs 02/03/05 — this page is a synthesis with
+a user-facing register, not new research. Placement after 07 keeps the learning path
+clean; 01 and 07 both link to it ("if you want to know why this is true → 11").
+
+### 2.2 Other missing pages
+
+- **Talking to servers** (highest-value gap). `lease`/`:rf/resource` are introduced
+  twice, but the fetch side never appears: 10 says "wire your transport as ordinary
+  re-frame2 fx" and stops. A consumer's first real question — *how does data get in?*
+  — has no page. One chapter showing `:rf.http/managed` → `:metrics/arrived` →
+  resource status → `lease`, end to end, would complete the Nine-States story the
+  README gestures at. (Even pre-S3 it can be REPL-driven per stage 1.1.)
+- **Routing, the view-layer face.** Core routing has its own guide, but the UI guide
+  never shows a link. How do you write navigation — an `<a>` with `:href` plus an
+  event? What does an active-route class read? Per-pane routes were a headline in the
+  repo README and 04 already leans on "the route's `:on-match`". A short page or a
+  05/04 section.
+- **Migration from Reagent** *(lands S6, flag now)*. Design doc 10 exists; the guide
+  README's four-line "Coming from Reagent?" will not carry a real port. The page is
+  the translation table: Form-2/`with-let` → `local`+`effect`, ratoms/cursors/track →
+  the four inputs, `r/adapt-react-class` → template heads, `reagent.dom/render` →
+  `mount`, plus `ui/->react` for incremental cohabitation.
+- **A "where did X go?" appendix for React people.** Context, portals, refs, Suspense,
+  `useEffect`-for-data — each with the one-line answer and a pointer (subs and frames;
+  wave-2; `ui/raw-fn`; status values; events/fx). The README's "Coming from React"
+  paragraph promises this implicitly; a table delivers it. Cheap and high-empathy.
+
+### 2.3 Missing sections in existing pages
+
+- **01:** a five-line project skeleton (where `deps.edn`, `shadow-cljs.edn`, `src/`,
+  the build entry live) before "The whole app"; move the digest deep-dive out (→ 2.1
+  §2), keep the recipe + one symptom sentence.
+- **02:** a short **styling** stance — what `:class`/`:style` compile to, that CSS
+  itself is yours (plain CSS, Tailwind, whatever), and that presence phases are
+  class-driven by design. Readers coming from styled-components will look for this
+  and find silence. Also: move **Presence** (S4) below Props discipline/Interop so
+  the shipped core reads contiguously.
+- **03:** one sentence + pointer on *who fulfils* `:rf/resource` (the fx/resource
+  system, → Talking-to-servers page) — the lease section currently reads as if data
+  appears by magic.
+- **04:** a **global listeners / keyboard shortcuts** cross-reference — the
+  `error-reporter` pattern in 05 answers it, but a 04 reader searching "keydown on
+  window" won't find it.
+- **06:** a REPL example of the `re-frame.ui.tool` surface (`view-manifest` on the
+  counter view) — ties into stage 1; today the namespace is named but never shown.
+- **07:** a "measure it yourself" paragraph: the npm scripts that run the perf-bundle
+  and size gates against *your* app, and what number to compare with the ≤ 4 KB
+  kernel budget.
+- **08:** one line on **streaming SSR** (in scope? out of scope? ruled later?) — the
+  contract is silent and evaluators will ask; plus a pointer to the `ssr-ring`
+  ecosystem adapter mentioned in the repo layout.
+- **09:** precede the Tier-3 example with the *simplest possible* mounted test (mount,
+  one query, done) before the full Promise-ceremony version; the current single
+  example is the guide's hardest code and it arrives unannounced.
+- **10:** close the worked app with two codas — the SSR variant of the same dashboard
+  (three lines: it's 08's mount with a manifest), and the live-coding coda ("open
+  Xray; type in the filter; read the timeline" / "ask your pair why the tile
+  repainted").
+
+### 2.4 Lean on `docs/core/`, don't duplicate it
+
+The shipped human guide (`docs/core/` — frames, subscriptions, effects, coeffects,
+errors, observability, testing, plus `how-to/`) already covers the dataflow half of
+several gaps above. The UI guide's new pages should link into it hard: the
+Talking-to-servers page teaches the *view-facing* seam (lease → status → tile) and
+defers fx mechanics to core; the routing section defers route registration the same
+way. Today the guide cites core concepts without ever linking to their chapters —
+worth a pass adding those links so the two guides read as one shelf.
+
+### 2.5 Ordering note
+
+With 11 (How it works) and a Talking-to-servers page, the arc becomes: learn (01–05),
+observe (06), trust (07, 11), deploy (08), verify (09), build (10, servers). That's a
+coherent shelf; routing/migration slot in behind their stages.
+
+---
+
+## Stage 3 — Correctness
+
+*(Verification ran three ways: guide vs `implementation/ui` on main, guide vs the
+synthesis design docs, guide examples vs the core spec. Findings below.)*
+
+### 3.1 Guide vs shipped implementation (main @ 2026-07-14)
+
+**Holds up well.** Verified against `implementation/ui/`: the guide-09 fixture file
+exists and enrolls exactly the five behaviours the README claims; `defview`, `sub`,
+`adapter`, `mount`, `frame-root`, `frame-provider`, `raw`, `html`, `spread` all
+exported; the Tier-1/Tier-3 test surface (`render`, `find`, `find-all`, `attrs`,
+`text`, `frame`, `dispatch!`, `with-root`, `query`, `flush!`, `:sub-overrides`) all
+present; JVM `flush!` synchronous returning nil as documented; placeholder set is
+exactly `#{:rf.ui/value :rf.ui/checked :rf.ui/key}` with no `:rf.ui/event` /
+`:rf.ui/form-data`; React pinned 19.2.0; shadow-cljs 3.4.10; `:cache-blockers` +
+`:build-defaults` build-hook exactly as the 01 recipe shows; G-13 wired
+(`ui/g13` source path, three builds, `test:ui-g13` script). Unshipped names (`local`,
+`effect`, `ui/event`, `ui/handler`, `render-fn`, `dispatch-fn`, `error-boundary`,
+`presence`, `client-only`, `->react`, `element`, `render-static`,
+`flush-presence!`) are all correctly stage-marked in the guide — the stage honesty is
+real.
+
+**Marker-freshness flags (guide vs main):**
+
+1. **`lease` exists on main** (`re-frame.ui/lease`), but the README still calls it
+   "the one straggler" carrying *(lands S2)*, and 03/10 hedge "view-level lease
+   semantics confirm at S3". If lease's S2 slice has landed, the README straggler
+   note is stale; if only the var landed, 03's hedge is right and the README should
+   say that instead.
+2. ~~The host tier vs 08's S5 marker~~ — **resolved, no guide change**: `hydrate-root`
+   exists on main as the ruled spelling and its docstring says every hydrate fails
+   loud pre-S5 (`:rf.error/root-manifest-invalid`), which is exactly what the guide's
+   *(lands S5)* marker claims.
+3. **Two catalogued ids are ahead of their code:** `:rf.error/dispatch-disconnected`
+   and `:rf.warning/unregistered-event-id` appear in 06's catalogue list but exist
+   nowhere in the implementation yet (their features are S3). 06's stage note
+   technically covers this, but the catalogue paragraph reads as shipped; a marker on
+   those two ids (or an "ids land with their features" clause) keeps 06 honest.
+
+### 3.2 Guide vs design docs
+
+**Agrees on essentially everything checked (15/15 claims).** The stage ledger matches
+12-implementation-plan §2b and 08-delivery §2 row for row (including `lease` S2 with
+S3 confirmation, `->react` S6, `client-only` S3 with its S5 phase flip); wave-2 names
+and the 2026-07-12 blessed-table qualifier are corroborated; the placeholder
+vocabulary, sync-door predicate, callback decision table, `local` doctrine (ruled
+2026-07-12), memoization posture (`:memo false` deliberately absent), loop/branch
+rules, error-boundary contract, root identity (including the `_S` slug escape and the
+manifest-wins hydration rule), Tier-1 subset, causes vocabulary, tool namespace,
+≤ 4 KB kernel, G-8/G-13, and the SSR guarantees all agree with their owning docs.
+
+**Divergences worth recording:**
+
+1. **`:rf.ui.compile/bad-test-root` + the single-view test-root tightening** appear
+   in the guide and in the *shipped implementation* (`re-frame.ui.test`, with a JVM
+   test asserting it) but not in `drafts/root-identity-and-mount.md` §9, which still
+   says `ui.test/render` takes "the same grammar `mount` takes". The **design draft is
+   the stale artefact** — it should adopt the tightening the code and guide already
+   implement. (No guide change.)
+2. **Heatmap staging**: guide 07 said *(lands S3)* twice while 04-debugging gates the
+   heatmap behind an information-architecture review (and guide 06 already said so).
+   **Fixed in the guide** — 07 now matches 06 and the design doc.
+3. **`:epoch-restore`** is the design-doc-ruled render-cause name (04-debugging §2
+   causes table; Xray IA draft) — the guide agrees with its owning doc, so it stands.
+   The residual issue is design-corpus vs core-spec naming drift
+   (`:rf.epoch/restored` / `:epoch-restored` elsewhere) — one to resolve at spec
+   promotion, not in the guide.
+4. **"Patched React 19.2.4+ peers"** (05-production §5) vs guide 01's plain-install
+   framing — most plausibly "React's own patch releases ≥ 19.2.4", in which case the
+   guide is fine; if it means locally patched peers, 01's install story must say so.
+   Flagged for a ruling rather than guessed at.
+
+### 3.3 Guide examples vs core re-frame2 spec
+
+**Clean:** `(rf/reg-event id (fn [cofx ev] {:db …}))` is exactly the one v2 event form
+(Spec 001/EP-0018; the retired names are hard errors); `(rf/reg-sub id (fn [db q] …))`
+is Mode-1 `reg-sub` per API.md; `(rf/init! ui/adapter)` appears verbatim in Spec 006
+(§ adapter selection at boot); `:initial-events` is the correct frame-plan key with
+exactly-once ENSURE semantics (Spec 002/EP-0027 — re-recorded but not replayed on
+reuse, matching 01/05's prose); `compute-sub` is the Spec-008 testing surface guide 09
+cites; and `:rf.ui/*`, `:rf.error/*`, `:rf.warning/*` are all reserved rows in
+Conventions.md, with the three placeholder keywords named there as the closed
+vocabulary. `:rf/resource` matches Spec 016 with two spec-superset details worth a
+guide clause: the query map also takes `:scope`, and the status enum also includes
+`:idle` — 03/10 show a subset and could say so ("the full enum is Spec 016's").
+
+**Two real errors to fix:**
+
+1. **06's catalogue sentence is wrong about where three ids live.** "The runtime ids
+   are catalogued (Spec 009)" — but `:rf.error/dispatch-disconnected`,
+   `:rf.warning/unregistered-event-id`, and `:rf.warning/placeholder-in-dynamic-vector`
+   are catalogued in **Spec 004-Views**, not 009 (only `no-frame-context` and
+   `ui-test-overlapping-act` have 009 rows). Fix the citation ("catalogued in the
+   spec's error registers — Spec 004 for the view-layer ids, Spec 009 for the
+   runtime-wide ones") or move the rows.
+2. **The `:epoch-restore` cause keyword doesn't exist in the spec.** A restore emits
+   `:rf.epoch/restored` (Tool-Pair §Time-travel); the suppression-reason spelling is
+   `:epoch-restored`. If the render-cause vocabulary means to introduce a *new*
+   `:epoch-restore` cause kind, it drifts from both existing spellings; align it
+   (likely `:epoch-restored`) or cite the design-doc ruling that names it.
+
+---
+
+## Stage 4 — Voice
+
+**Overall:** dense, confident, information-rich — and closer to a spec brief than to
+the "friendly, gentle, informative" target. The bones are excellent: concepts arrive
+in the right order, every claim has an example, forward references are disciplined,
+and the aphorisms ("you are the click", "There is no fifth") give it personality worth
+keeping. The problems are concentrated and fixable:
+
+### 4.1 The README opens with contributor talk
+
+The first paragraph a guide reader meets is fixture-pipeline meta — CI coverage
+percentages, a JVM test path, the `;; guide:no-fixture` convention, a pointer into
+`drafts/`. That is maintainer information on the user guide's front door. Move it to a
+short "About these docs" note at the bottom (or into the fixture draft) and open the
+README with what the second paragraph already does well: what the library is, the
+chapter table, and the two "coming from" on-ramps.
+
+### 4.2 Getting-started buries its lede under the digest machinery
+
+01's shadow-cljs paragraph ("On a daemon's version-zero pass, the hook clears retained
+output for UI macro consumers…") is the densest prose in the corpus, positioned before
+the reader has seen a single view. A newcomer needs: paste these two settings, here's
+the one symptom if you forget them, the why lives in [How it works]. Same page: the
+peer-floor sentence ("planned as React 19.2.4+… takes effect when the artifact's peer
+contract ships") is release-engineering voice; a footnote carries it fine.
+
+### 4.3 Stage notes have grown into a second navigation system
+
+Every chapter now opens with an italic stage paragraph, and some (08, 09) thread stage
+qualifiers through nearly every section. The honesty is non-negotiable pre-alpha; the
+*layout* is negotiable. Recommendation: one standard single-line badge under each H1
+("Everything unmarked ships on main today; *(lands S3)* marks a final contract landing
+later"), keep the inline markers, and delete the per-page stage paragraphs — their
+content is recoverable from the markers themselves. 08 additionally wants its
+parenthetical stage clauses pulled to section-head badges; three markers inside one
+sentence (the `client-only` line) is where gentle readers give up.
+
+### 4.4 Fragment chains where sentences should be
+
+The register memory applies ("tight, not terse; full sentences over dash-chained
+fragments"). The reference-shaped pages (04's table, 07's table) earn their density;
+the teaching pages don't. Worst offenders: 03's `local` block
+("`(local initial)` → `[value set!]`. Re-renders this view only; host state
+underneath; not time-travelled — deliberately.") and several 05 bullets. These want
+one pass converting arrows and semicolon chains into sentences — the content is
+right; the rhythm is a spec's.
+
+### 4.5 Progressive-disclosure inversions (two)
+
+- 02 teaches **Presence** (S4, animation lifetimes) *before* Props discipline and
+  Interop — the advanced optional feature interrupts the core path. Move it after
+  Interop, or to the end of the page.
+- 09's first mounted-test example is the hardest code in the guide (nested Promise
+  chains, `async done`, rejection callbacks). Show the trivial mounted test first;
+  then the full-ceremony one, introduced as "the complete shape you'll copy for real
+  suites".
+
+### 4.6 Gentleness, specifically
+
+Mostly the sternness lands as charm ("read twice" is fine; the didactic-error framing
+is genuinely friendly). Three spots overshoot: "What a Turing-complete mess they have
+become" belongs to the repo README's polemic register, not a guide teaching newcomers
+(02 note: it isn't in the guide — checked; the guide's equivalents are fine); "that's
+an API bug, not a documentation problem" is contributor-facing (moves out with 4.1);
+and the bare "There is no fifth." could take a softening clause ("There is no fifth —
+and that's the feature") without losing its point. Everything else: the examples do
+the gentle work, and they're good.
+
+### 4.7 What's already right (keep)
+
+The four-inputs table opening 03; the decision table in 04 with its two worked rows;
+the "What you just didn't write" closer in 10; the "Coming from…" paragraphs; the
+did-you-mean error framing in 05; chapter 10 as a whole — it's the best page and the
+model for the register the rest should relax into.
+
+---
+
+## Applied 2026-07-14 (same session)
+
+Done directly in `guide/`:
+
+- **README** — contributor/fixture meta moved to a bottom "About these docs" note;
+  front door now opens with the pitch + chapter table; `lease` straggler clause
+  harmonised with 03; "where did X go?" table added for React arrivals; chapter 11
+  row added. *(4.1, 3.1-1, 2.2)*
+- **01** — digest paragraph replaced with recipe + symptom + pointer to 11;
+  peer-floor sentence parenthesised; minimal project-skeleton note added; stage note
+  reframed as the "you are the click" REPL beat. *(4.2, 1.1)*
+- **02** — Presence moved below Interop (shipped core reads contiguously); short
+  Styling section added. *(4.5, 2.3)*
+- **03** — "no fifth" softened; `local` fragment chain rewritten as sentences;
+  lease section gains the `:idle`/`:scope` subset clause and the who-fulfils pointer
+  (resource system + core guide + 10); "See it live" beat on subs. *(4.4, 4.6, 3.3,
+  1.2)*
+- **04** — "See it live" beat after the vector pitch; window-listener cross-reference
+  to 05's `error-reporter`. *(1.2, 2.3)*
+- **05** — "See it live" beat on frame isolation. *(1.2)*
+- **06** — catalogue citation corrected (Spec 004 view-layer ids + Spec 009) with the
+  ships-with-its-stage clause; schematic `view-manifest` REPL fence; new "Pairing
+  with an AI on the live app" section. *(3.3-1, 1.2, 1.3)*
+- **07** — heatmap markers corrected to "staged behind its Xray integration review"
+  (stage note + both mentions); measure-your-own-build paragraph
+  (shadow build-report). *(3.2-2, 2.3)*
+- **08** — `ssr-ring` scope note under "Rendering a page". *(2.3)*
+- **09** — simple read-only mounted test now precedes the full-ceremony example.
+  *(4.5)*
+- **10** — "Two codas" closer: serve it (SSR) + drive it (Xray/pair). *(2.3, 1.2)*
+- **11-how-it-works.md** — new page: compiler, build digest, reactive core
+  (render-probe/commit-acquire, drain economics), `rf=` memoization, compiled event
+  sites + sync door, two emitters, HMR mechanics, dev/prod split. Sourced from design
+  docs 02/03/05. *(2.1)*
+
+## Addendum — frame-initialisation ruling (2026-07-14, later the same session)
+
+Mike ruled while pair-reviewing guide 01's test example: **one way to create and
+initialise frames** — `rf/make-frame` + `:initial-events` (with `[:rf/set-db {…}]` as
+the standard seeding step). `ui.test/frame {:app-db seed}` and `ui.test/render`'s
+`{:app-db v}` frame-minting option are a second initialisation grammar (the fact that
+they desugar to `[:rf/set-db]` defends the semantics, not the API surface) and are
+**removed from the contract**. Applied here: guide 01/04/09/10 respelled to
+`rf/make-frame` (04 and 10 now initialise through the app's own events — the stronger
+idiom), 09's Tier-1 bullet and stage note restated, `07-testing.md`'s contract table
+updated. The implementation respell (delete `ui.test/frame`, drop `render`'s
+`{:app-db}` branch, ~56 call sites across 15 files incl. the guide-09 fixture) is
+bead-filed for dispatch.
+
+## Remaining follow-ups (not done this session)
+
+1. **Talking-to-servers page** — the highest-value content gap (fetch side of
+   `:rf/resource`, `:rf.http/managed` → event → lease, end to end). *(2.2)*
+2. Routing's view-layer face (links, active state, per-pane routes). *(2.2)*
+3. Migration-from-Reagent page — S6, flag only. *(2.2)*
+4. docs/core cross-link pass through all chapters. *(2.4)*
+5. Guide playground build + Story/fixture convergence note in the pipeline draft
+   (S6). *(1.4, 1.5)*
+6. Per-page stage-note compression to a standard one-line badge — deliberately *not*
+   done wholesale: the notes carry real per-surface information; revisit if they're
+   still growing at S3. *(4.3)*
+7. Upstream, non-guide: `drafts/root-identity-and-mount.md` §9 adopt the test-root
+   tightening; `:epoch-restore(d)` naming drift at spec promotion; "patched React
+   peers" wording ruling. *(3.2)*


### PR DESCRIPTION
## What

A four-stage pair review of `ai/findings/new-substrate-synthesis/guide/` (live-coding pedagogy / completeness / correctness / voice), applied directly, plus the frame-initialisation ruling that came out of it.

### The ruling (2026-07-14)

**One way to create and initialise frames**: `rf/make-frame` + `:initial-events`, seeded via the framework''s `[:rf/set-db {…}]` event. `ui.test/frame {:app-db seed}` and `ui.test/render`''s `{:app-db v}` option were a second initialisation grammar and are removed from the contract:

- Guide 01/04/09/10 respelled to `rf/make-frame`; 04 and 10 now initialise through the app''s **own** events (`[:signup/init]`, `[:dash/init]` + `[:metrics/arrived …]`) — fixtures can''t drift from states the app can reach.
- `07-testing.md` contract table drops the `(frame opts)` row and `render`''s `{:app-db}`, with a dated ruling note.
- The implementation respell (delete `ui.test/frame`, drop the `render` branch, ~56 call sites / 15 files incl. the guide-09 fixture) is bead-filed for dispatch — the guide-09 fixture file will briefly trail the guide until that bead lands.

### New page

- `guide/11-how-it-works.md` — the mechanism: what `defview` lowers to, the build digest, the ViewCell reactive core (render-probes / commit-acquires, drain economics), `rf=` memoization, compiled event sites + the sync-input door, one template → two emitters, HMR mechanics, the dev/prod split. Sourced from design docs 02/03/05.

### Correctness fixes (verified against main, the design corpus, and spec/)

- 06: error-catalogue citation corrected (Spec 004 owns the view-layer ids; Spec 009 the runtime-wide ones) + ships-with-its-stage clause.
- 07: heatmap markers corrected to "staged behind its Xray integration review" (was wrongly *(lands S3)*).
- 03: `:idle`/`:scope` noted as Spec-016 supersets of the shown subset.

### Teaching-through-the-live-runtime

"You are the click" REPL framing in 01 (the S2 live loop, driven from REPL/pair/tests until S3 wires the button), "See it live" strips in 03/04/05, a `re-frame.ui.tool` REPL fence and a "Pairing with an AI on the live app" section in 06, and serve-it/drive-it codas closing 10.

### Voice and structure

README front door rewritten (fixture meta moved to a footer; "where did X go?" table for React arrivals; chapter 11 row), 01''s digest machinery slimmed to recipe + symptom + pointer, 02''s Presence moved below Interop with a new Styling stance, 03''s fragment chains converted to sentences, 09 gains a gentle mounted-test on-ramp before the full Promise ceremony, 08 gains the `ssr-ring` scope note.

`reviews/guide-staged-review-2026-07-14.md` records the full review, the three-way verification evidence, the ruling addendum, and the remaining follow-ups (Talking-to-servers page, routing''s view-layer face, docs/core link pass, upstream doc drifts).

Docs-only; no code paths touched. The implementation-side respell rides its own bead.