### PR TITLE
fix(ui): exact per-pass Shadow compile provenance for final-schedule membership (rf2-vxgfnd.255)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -11,14 +11,22 @@
   `:compile-finish`:
 
   0. reconcile against Shadow's FINAL authoritative compile schedule — every
-     CLJS source actually compiled THIS pass (a fresh `:compiled-at` in its
-     output, no earlier than the recorded pass start) is pre-touched too. A
-     later `:compile-prepare` hook (Shadow deep-merges build-local hooks after
+     CLJS source actually compiled THIS pass is pre-touched too. Membership is
+     read from EXACT per-pass provenance, never wall-clock ordering: at
+     `:compile-prepare` re-frame.ui snapshots the `:output` map Shadow handed
+     it, and a source counts as recompiled iff its finish-time output OBJECT is
+     present and not `identical?` to that snapshot's. Shadow installs a
+     freshly-built output object only for the sources it recompiles this pass (a
+     warm cache hit keeps the byte-identical retained object), so identity is
+     the ground truth — immune to the millisecond collision where a retained
+     warm output's `:compiled-at` stamp equals the next pass start. A later
+     `:compile-prepare` hook (Shadow deep-merges build-local hooks after
      `:build-defaults` and lets them mutate build state) can force a source to
-     recompile AFTER re-frame.ui observed the schedule; observing the compiled
-     set at finish, not the intermediate prepare snapshot, closes that
-     hook-order gap so a forced recompile that removed a source's final
-     `ui/defview` evicts its accepted row instead of leaving a ghost view;
+     recompile AFTER re-frame.ui observed the schedule; comparing the finish
+     output objects against the prepare snapshot, not the intermediate prepare
+     schedule, closes that hook-order gap so a forced recompile that removed a
+     source's final `ui/defview` evicts its accepted row instead of leaving a
+     ghost view;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -103,32 +111,34 @@
 (defn- actually-recompiled-member-nss
   "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
   THIS pass, read from the FINAL build-state at `:compile-finish` — after every
-  schedule-mutating `:compile-prepare` hook and after compilation ran. Shadow
-  stamps a fresh `:compiled-at` on a source it compiles this pass
-  (`shadow.build.compiler` sets it to the compile wall-clock); a cache-loaded or
-  cross-pass-retained output keeps an OLDER stamp. Comparing that stamp against
-  `pass-start` (captured when re-frame.ui opened the pass, before any
-  compilation) therefore identifies Shadow's authoritative final compile
-  schedule — immune to the build-local hook merge order re-frame.ui cannot
-  control, and immune to the stale `:cached` marker a retained output carries
-  across passes. Returns the empty set when no pass start was recorded (a
-  non-Shadow/plain-JVM finish), leaving the prepare-time pre-touch as the sole
-  reconciler."
-  [{:keys [build-sources sources output]} pass-start]
-  (if-not (number? pass-start)
-    #{}
-    (let [pass-start (long pass-start)]
-      (reduce
-       (fn [acc resource-id]
-         (let [{:keys [type ns provides]} (get sources resource-id)
-               compiled-at (:compiled-at (get output resource-id))]
-           (if (and (= :cljs type)
-                    (number? compiled-at)
-                    (>= (long compiled-at) pass-start))
-             (into acc (or provides (when ns #{ns})))
-             acc)))
-       #{}
-       build-sources))))
+  schedule-mutating `:compile-prepare` hook and after compilation ran —
+  distinguished by EXACT per-pass provenance: output-object identity, never
+  wall-clock ordering.
+
+  `pass-output` is the `:output` map re-frame.ui snapshotted at
+  `:compile-prepare` (the outputs Shadow was about to compile from). Shadow
+  installs a freshly-built output OBJECT for a source iff it recompiles it this
+  pass: parallel compile leaves already-present outputs untouched, and
+  sequential `generate-output-for-source` returns the retained output object
+  unchanged for a warm cache hit. So a source whose finish-time output is
+  present and not `identical?` to its snapshot object was compiled this pass,
+  regardless of its `:compiled-at` stamp. This is immune to the millisecond
+  collision where a retained warm output's stamp equals the next pass start (the
+  former `compiled-at >= pass-start` test wrongly counted it as recompiled and
+  evicted its accepted row), and immune to the build-local hook merge order
+  re-frame.ui cannot control."
+  [{:keys [build-sources sources output]} pass-output]
+  (reduce
+   (fn [acc resource-id]
+     (let [{:keys [type ns provides]} (get sources resource-id)
+           final-output (get output resource-id)]
+       (if (and (= :cljs type)
+                (some? final-output)
+                (not (identical? final-output (get pass-output resource-id))))
+         (into acc (or provides (when ns #{ns})))
+         acc)))
+   #{}
+   build-sources))
 
 (defn- reconcile-final-schedule
   "Before deriving the finish candidate, pre-touch every source Shadow actually
@@ -138,18 +148,35 @@
   source whose successful recompile contributed no re-frame.ui declaration (its
   final `ui/defview` was removed), closing the ghost-view gap of CLOSED
   rf2-n7ff9f; a recompiled source that DID re-declare is already touched+staged,
-  so the union is idempotent, and a warm cache hit (no fresh `:compiled-at`)
-  keeps its accepted row. Pure build-state transform."
+  so the union is idempotent, and a warm cache hit (output object unchanged from
+  the prepare snapshot) keeps its accepted row.
+
+  When no re-frame.ui pass is open (a non-Shadow / plain-JVM finish with no
+  scratch) this is a no-op — the prepare-time pre-touch is the sole reconciler.
+  When a pass IS open the prepare-time `:pass-output` provenance snapshot MUST
+  be present; its absence is unobservable provenance and fails loudly rather
+  than silently reconciling against an assumed-empty compile schedule. Pure
+  build-state transform (apart from that guard)."
   [build-state]
-  (let [pass-start (get-in build-state
-                           [:compiler-env build/scratch-key :pass-start])
-        extra      (actually-recompiled-member-nss build-state pass-start)]
-    (if (and (seq extra)
-             (get-in build-state [:compiler-env build/scratch-key]))
-      (update-in build-state
-                 [:compiler-env build/scratch-key :touched]
-                 (fnil into #{}) extra)
-      build-state)))
+  (let [scratch (get-in build-state [:compiler-env build/scratch-key])]
+    (if-not scratch
+      build-state
+      (do
+        (when-not (contains? scratch :pass-output)
+          (throw
+           (ex-info
+            (str "re-frame.ui compile-finish observed no per-pass compile "
+                 "provenance (missing prepare-time :pass-output snapshot); "
+                 "refusing to reconcile against an assumed-empty compile schedule")
+            {::error ::missing-pass-provenance
+             :recovery :configure-ui-build-hook-once})))
+        (let [extra (actually-recompiled-member-nss build-state
+                                                    (:pass-output scratch))]
+          (if (seq extra)
+            (update-in build-state
+                       [:compiler-env build/scratch-key :touched]
+                       (fnil into #{}) extra)
+            build-state))))))
 
 (defn- marker-count [^String s ^String marker]
   (loop [from 0 n 0]
@@ -351,16 +378,17 @@
     (do
       (validate-ui-cache-blocker! build-state)
       (let [build-state (reset-cold-ui-consumer-output build-state)]
-        ;; Record the pass start BEFORE any compilation so `:compile-finish` can
-        ;; identify the sources Shadow actually recompiled this pass (fresh
-        ;; `:compiled-at`) — the final authoritative schedule, robust to a later
-        ;; prepare hook mutating it (rf2-vxgfnd.194).
+        ;; Snapshot the `:output` map Shadow handed us BEFORE any compilation, so
+        ;; `:compile-finish` can identify the sources Shadow actually recompiled
+        ;; this pass by output-object identity — exact per-pass provenance,
+        ;; robust to a later prepare hook mutating the schedule and immune to the
+        ;; millisecond stamp collision (rf2-vxgfnd.194, rf2-vxgfnd.255).
         (-> (build/prepare-shadow-build build-state
                                         build-id
                                         (member-nss build-state)
                                         (recompiled-member-nss build-state))
-            (assoc-in [:compiler-env build/scratch-key :pass-start]
-                      (System/currentTimeMillis)))))
+            (assoc-in [:compiler-env build/scratch-key :pass-output]
+                      (:output build-state)))))
 
     :compile-finish
     ;; Reconcile against Shadow's final compile schedule, then project. All are

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -218,7 +218,7 @@
   ;; source removed its final ui/defview it contributes nothing, and — pre-fix —
   ;; its accepted row survived as a ghost view because it was never pre-touched.
   ;; The :compile-finish reconcile against Shadow's authoritative compiled set
-  ;; (fresh :compiled-at) evicts it. Fails against pre-fix build_hook.clj.
+  ;; (a fresh output OBJECT, not identical to the prepare snapshot) evicts it.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :ghost parallel?)
@@ -231,24 +231,22 @@
             "the accepted build declares both sources' views")
         ;; Warm pass: app.a + app.b both retain output, so re-frame.ui pre-touches
         ;; neither. A later prepare hook then removes app.a's output; app.a
-        ;; recompiles this pass (fresh :compiled-at) contributing NO declaration.
-        ;; app.b stays a cache hit (older stamp, no re-declaration).
-        (let [warm-input (-> good
+        ;; recompiles this pass — Shadow installs a FRESH output object —
+        ;; contributing NO declaration. app.b stays a cache hit: its EXACT output
+        ;; object is retained unchanged across the pass.
+        (let [warm-b-output {:resource-id app-b-rid :js "app.b = {};"
+                             :cached true}
+              warm-input (-> good
                              (assoc-in [:output carrier-rid :js]
                                        build-hook/digest-sentinel)
                              (assoc-in [:output app-a-rid]
                                        {:resource-id app-a-rid :js "app.a = {};"
                                         :cached true})
-                             (assoc-in [:output app-b-rid]
-                                       {:resource-id app-b-rid :js "app.b = {};"
-                                        :cached true}))
+                             (assoc-in [:output app-b-rid] warm-b-output))
               prepared (prepare warm-input)
-              pass-start (get-in prepared
-                                 [:compiler-env build/scratch-key :pass-start])
               finished (-> prepared
                            (assoc-in [:output app-a-rid]
                                      {:resource-id app-a-rid :js "app.a = {};"
-                                      :compiled-at (inc (long pass-start))
                                       :cached false})
                            finish)]
           (is (not (contains?
@@ -264,6 +262,82 @@
           (is (not= (build/accepted-build-digest good)
                     (build/accepted-build-digest finished))
               "evicting the ghost changes the accepted whole-build digest"))))))
+
+(deftest exact-provenance-distinguishes-colliding-warm-hit-from-real-recompile
+  ;; rf2-vxgfnd.255: final-schedule membership is decided by exact per-pass
+  ;; provenance — output-object identity — not a wall-clock `compiled-at >=
+  ;; pass-start` test. In ONE warm pass, under the SAME optimizer/compile
+  ;; controls (sequential + parallel):
+  ;;   * app.b is a genuine cache hit whose retained output object is unchanged,
+  ;;     yet carries a `:compiled-at` stamp that EXCEEDS any pass start (the
+  ;;     adversarial collision the bead reproduces) — it must stay accepted and
+  ;;     digest-stable;
+  ;;   * app.a is genuinely recompiled (a fresh output object) with the SAME
+  ;;     colliding stamp and removed its final view — it must be evicted.
+  ;; Restoring the timestamp-only membership test would flag app.b too (its
+  ;; stamp >= pass-start) and wrongly evict it, failing the survival assertion.
+  (doseq [parallel? [true false]]
+    (testing (str (if parallel? "parallel" "sequential") " compilation")
+      (let [good (-> (two-source-state :collide parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            b-before (get (build/accepted-aggregate build/views good) :app/b-view)]
+        (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
+               (build/accepted-aggregate build/views good))
+            "the accepted build declares both sources' views")
+        ;; The EXACT same retained object stands in for app.b across prepare and
+        ;; finish (a true cache hit) even though its stamp collides with a fresh
+        ;; compile. app.a is replaced with a fresh output object.
+        (let [warm-b-output {:resource-id app-b-rid :js "app.b = {};"
+                             :compiled-at Long/MAX_VALUE :cached false}
+              warm-input (-> good
+                             (assoc-in [:output carrier-rid :js]
+                                       build-hook/digest-sentinel)
+                             (assoc-in [:output app-a-rid]
+                                       {:resource-id app-a-rid :js "app.a = {};"
+                                        :compiled-at 1 :cached true})
+                             (assoc-in [:output app-b-rid] warm-b-output))
+              prepared (prepare warm-input)
+              finished (-> prepared
+                           (assoc-in [:output app-a-rid]
+                                     {:resource-id app-a-rid :js "app.a = {};"
+                                      :compiled-at Long/MAX_VALUE :cached false})
+                           (assoc-in [:output app-b-rid] warm-b-output)
+                           finish)
+              views-after (build/accepted-aggregate build/views finished)]
+          (is (not (contains?
+                    (get-in prepared [:compiler-env build/scratch-key :touched])
+                    'app.a)))
+          (is (not (contains?
+                    (get-in prepared [:compiler-env build/scratch-key :touched])
+                    'app.b))
+              "neither output-present warm source is pre-touched at prepare")
+          (is (= {:app/b-view ["tfb-1" "hsb-1"]} views-after)
+              "the colliding-stamp warm hit survives; only the real recompile is evicted")
+          (is (= b-before (get views-after :app/b-view))
+              "app.b's accepted row is digest-stable across the warm pass")
+          (is (not (contains? views-after :app/a-view))
+              "the genuinely recompiled zero-declaration source is evicted"))))))
+
+(deftest missing-per-pass-provenance-fails-loud-not-empty-schedule
+  ;; rf2-vxgfnd.255: an open pass whose prepare-time provenance snapshot is
+  ;; unobservable must fail loudly at finish rather than silently reconcile
+  ;; against an assumed-empty compile schedule (which would leak ghost rows).
+  (let [prepared (-> (two-source-state :no-prov false)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"]))
+        blinded (update-in prepared [:compiler-env build/scratch-key]
+                           dissoc :pass-output)
+        ex (try (finish blinded) nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? (get-in prepared [:compiler-env build/scratch-key :pass-output]))
+        "an ordinary open pass records the provenance snapshot")
+    (is (some? ex) "finish with open scratch but no :pass-output must throw")
+    (is (= :re-frame.ui.compiler.build-hook/missing-pass-provenance
+           (:re-frame.ui.compiler.build-hook/error (ex-data ex))))))
 
 (deftest interleaved-build-values-carry-isolated-digests
   (let [a (-> (shadow-state :a build-hook/digest-sentinel)


### PR DESCRIPTION
## rf2-vxgfnd.255 — exact per-pass provenance replaces timestamp inference

### Re-verification (current main)
Reproduces on `origin/main`. #5880/.237 reworked the flush/publish path
(`promote-served-generation`) but left the compile-schedule membership logic
untouched: `build_hook.clj` still inferred "compiled this pass" from
`:compiled-at >= pass-start`, both millisecond `System/currentTimeMillis`
stamps.

### The bug
A retained warm-cache output whose `:compiled-at` stamp equals (or, in the
adversarial case, exceeds) the next pass start was falsely classified as
recompiled, pre-touched, and — declaring nothing that pass — evicted, silently
changing view authority and the whole-build digest. `>` is not a fix: a genuine
same-millisecond compile reopens the ghost-row false negative.

### The fix
Replace wall-clock inference with **exact per-pass provenance: output-object
identity**. At `:compile-prepare` the hook snapshots the `:output` map Shadow
hands it (`:pass-output` in scratch). At `:compile-finish` a source counts as
recompiled iff its finish-time output object is present and not `identical?` to
the snapshot's. Shadow installs a freshly-built output object only for sources
it recompiles this pass — parallel compile skips already-present outputs;
sequential `generate-output-for-source` returns the retained object unchanged
for a warm hit (verified against shadow-cljs 3.4.10 `shadow.build.compiler`) —
so identity is ground truth, independent of the `:compiled-at` value and of the
build-local prepare-hook merge order. An open pass with no observable prepare
snapshot now **fails loudly** rather than reconciling against an assumed-empty
schedule.

### Fixtures (red before fix)
`implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj`:
- **exact-provenance-distinguishes-colliding-warm-hit-from-real-recompile**
  (sequential + parallel): a warm cache hit carrying a fresh-looking stamp
  (`:compiled-at Long/MAX_VALUE`, object unchanged across the pass) survives and
  is digest-stable, while a genuine same-stamp recompile that dropped its final
  view is evicted. Verified **red under restored timestamp membership** (app.b
  wrongly evicted → projection `{}`, both modes) and green under identity.
- **missing-per-pass-provenance-fails-loud-not-empty-schedule**: an open pass
  whose `:pass-output` snapshot is stripped throws
  `::missing-pass-provenance` instead of silently assuming an empty schedule.
- **later-prepare-hook-forced-recompile control** updated to model the recompile
  as a fresh output object (the identity mechanism), keeping both compile modes.

`check-ui-digest-carrier.cjs` is unaffected — it exercises digest-carrier scalar
projection, not compile-schedule membership.

## rf2-vxgfnd.259 — NOT in this PR (scope + verification blockers)

Re-verified: **.259 reproduces** on current main (the G-13 "mutation teeth" in
`run-ui-g13.cjs` mutate an already-successful JSON result rather than executing
real mutated code; the only advanced positive control covers a different
owner-mint sentinel). It is **deferred** because its faithful completion is
blocked in this worker's scope:

1. **Off-limits surfaces.** The #5870-audit obligations (mutate the actual
   membership/owner-selection seam; close the `reactive/current-live-cells`
   bypass of the candidate witness; add a same-optimizer reachability/elision
   proof for the candidate-iteration witness) require editing
   `implementation/ui/src/re_frame/ui/reactive.cljc` and
   `implementation/core/src/re_frame/substrate/observation.cljc` — both fenced
   off this worker and, at dispatch, owned by the live `.182` and observation
   workers.
2. **Verification vs. gate discipline.** The achievable in-scope portion (a real
   gate-local source-mutation runner over the g13 fixture + advanced
   same-optimizer positive controls for the counter/Profiler/debug-evidence
   sentinel owners) is only validatable by running the full heavy G-13
   browser+compile gate, which this session's discipline reserves for CI; a
   multi-build real-mutant runner exceeds the single-targeted-build allowance.

The `.182`/observation PRs have since merged (04e6f047), which frees the
reactive/observation surfaces — so the recommendation is to **re-dispatch .259
solo, browser-gate-authorized, now that those surfaces are free**. A `bd` note
records this on the bead.

## Quality gates
- `implementation/ui`: `clojure -M:test -n compiler-digest-carrier-jvm-test -n
  compiler-build-hook-jvm-test -n build-repl-hmr-convergence-jvm-test -n
  compiler-build-jvm-test` → 54 tests, 217 assertions, 0 failures (post-rebase
  onto 04e6f047).
- Collision fixture verified red under restored timestamp membership, both
  compile modes.
- Full elision/bundle/digest/browser matrix left to CI (per gate discipline).