### PR TITLE
fix(machines): fence timer, registrar, and spawn-write callbacks in lifecycle tails (rf2-4ipqe4)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -604,8 +604,21 @@
           ;; (6) Abort in-flight HTTP (late-bound hook — callback-bearing).
           (abort-actor-in-flight-http! machine-id))
         (when-not (owner-gone?)
-          ;; Cancel armed `:after` timers (`:reason :on-destroy`).
-          (timer/cancel-actor-timers! frame-id machine-id)
+          ;; Cancel armed `:after` timers (`:reason :on-destroy`). rf2-4ipqe4 —
+          ;; each cancellation emits a callback-bearing `:rf.machine.timer/
+          ;; cancelled` trace; a listener can destroy A / publish same-id B on
+          ;; the FIRST cancellation's stack, after which the loop would cancel B's
+          ;; timer under a later snapshotted key. Thread `owner-gone?` so the
+          ;; cancellation loop short-circuits the instant A is lost (it is
+          ;; MONOTONIC), leaving B's re-armed timers untouched.
+          (timer/cancel-actor-timers! frame-id machine-id owner-gone?))
+        ;; rf2-4ipqe4 — RECHECK after the timer-cancellation callbacks before the
+        ;; classification / spawn-order / system-id-release work. #5856/#5873
+        ;; grouped these under the timer cancel with NO recheck, so a
+        ;; `:rf.machine.timer/cancelled` listener that published same-id B let the
+        ;; A-derived classification drop, spawn-order forget, and system-id-released
+        ;; trace resolve their bare frame/actor ids to the CURRENT incarnation B.
+        (when-not (owner-gone?)
           ;; Drop this actor's per-instance classification declarations from the
           ;; per-frame elision registry — the teardown half of
           ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
@@ -627,7 +640,16 @@
           ;; registrar unregister + `:on-error` dispatch against a B it published.
           (traces/emit-system-id-released! frame-id released-sid machine-id))
         (when-not (owner-gone?)
-          (registrar/unregister! :event machine-id)
+          ;; `registrar/unregister!` emits a synchronous callback-bearing
+          ;; `:rf.registry/handler-cleared` trace.
+          (registrar/unregister! :event machine-id))
+        ;; rf2-4ipqe4 — RECHECK after the registrar unregister before the
+        ;; `:on-error` dispatch. #5856/#5873 grouped the unregister with the
+        ;; dispatch under ONE check, so a `:rf.registry/handler-cleared` listener
+        ;; that published same-id B let the stale A-derived spawn-error dispatch
+        ;; route into B. The unregister is an already-delivered callback (it
+        ;; stands); the dispatch it enables must be fenced.
+        (when-not (owner-gone?)
           ;; (7) Per Spec 005 §Final states §`:on-error`: when the child finished
           ;; via an ERROR leaf AND the spawning parent declares `:spawn :on-error`,
           ;; dispatch the synthetic reserved failure event into the parent. It

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -321,7 +321,7 @@
   re-read is value-equal to the snapshot the caller already had. Machine
   snapshots are durable runtime-db state (EP-0001)."
   [frame-id rt-after-alloc spec spawned-id initial-snap
-   {:keys [system-id parent-id invoke-id track? type-ref continue?]}]
+   {:keys [system-id parent-id invoke-id track? type-ref continue? owner-token]}]
   (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))
         ;; Stamp the revertible TYPE reference onto the snapshot root so the
         ;; lazy resolver can re-materialise the handler from runtime-db alone. The
@@ -354,23 +354,40 @@
     ;; `:skipped`) so the caller can fence its own post-install tail on it (the
     ;; earlier `:ok`/nil return was IGNORED, so a `:skipped` install still let
     ;; classification / spawn-order / lifecycle-spawned run against B).
+    ;; rf2-4ipqe4 — the pre-swap `(continue?)` check fences a system-id-collision
+    ;; LISTENER, but the WRITE ITSELF is callback-bearing: a synchronous
+    ;; container watch can destroy A / publish same-id B DURING the physical
+    ;; install. The bare `swap-runtime-db!` would still bump the id-keyed commit
+    ;; epoch (now B's) and let `:rf.machine/system-id-bound` fire for B. With an
+    ;; event owner, route the install through `swap-runtime-db-exact!`: it binds
+    ;; the write to A's own container, and on mid-write loss returns nil WITHOUT
+    ;; bumping B's epoch — so we report `:skipped` and suppress the system-id-bound
+    ;; trace. Without an owner (conformance / pure-fn), fall back to the bare
+    ;; write (its non-nil return marks `:committed`).
     (if (or (nil? continue?) (continue?))
-      (do
-        (frame/swap-runtime-db! frame-id
-                                (fn [_rt]
-                                  (cond-> rt-after-alloc
-                                    spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
-                                    system-id (assoc-in (paths/system-id-path system-id) spawned-id)
-                                    track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
-        (when system-id
-          (trace/emit! :rf.machine :rf.machine/system-id-bound
-                       {:frame      frame-id
-                        :system-id  system-id
-                        ;; The live actor INSTANCE address (the spawned id), not
-                        ;; the registered TYPE; `:machine-id` is reserved for the
-                        ;; type.
-                        :actor-id   spawned-id}))
-        :committed)
+      (let [install-fn (fn [_rt]
+                         (cond-> rt-after-alloc
+                           spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                           system-id (assoc-in (paths/system-id-path system-id) spawned-id)
+                           track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id)))
+            written    (if owner-token
+                         (frame/swap-runtime-db-exact! frame-id owner-token install-fn)
+                         (frame/swap-runtime-db! frame-id install-fn))]
+        (if (some? written)
+          (do
+            (when system-id
+              (trace/emit! :rf.machine :rf.machine/system-id-bound
+                           {:frame      frame-id
+                            :system-id  system-id
+                            ;; The live actor INSTANCE address (the spawned id),
+                            ;; not the registered TYPE; `:machine-id` is reserved
+                            ;; for the type.
+                            :actor-id   spawned-id}))
+            :committed)
+          ;; The exact write reported mid-write owner loss (a container watch
+          ;; published same-id B): no snapshot / system-id / spawn-slot landed on
+          ;; B, no commit epoch bumped for B, and no system-id-bound trace fires.
+          :skipped))
       :skipped)))
 
 ;; ---- :rf.machine/spawn -----------------------------------------------------
@@ -472,6 +489,17 @@
         ;; threaded into `spawn-rejected?` so the callback and the cascade fence
         ;; against the SAME token.
         continue?  (data-validation/owner-continuation frame-id)
+        ;; rf2-4ipqe4 — the RAW exact owner token (`continue?` closes over it),
+        ;; threaded into `install-spawn!` so the snapshot / system-id / spawn-slot
+        ;; install rides `swap-runtime-db-exact!`: a synchronous container watch
+        ;; that destroys A / publishes same-id B DURING the physical write neither
+        ;; redirects the write into B nor bumps B's commit epoch (a bare
+        ;; `swap-runtime-db!` bumps the id-keyed epoch — now B's — and emits
+        ;; `:rf.machine/system-id-bound` before the later owner check). nil for a
+        ;; non-router pure-fn / conformance caller (no event owner) — the install
+        ;; falls back to the historical bare-id write and that path stays
+        ;; unaffected, symmetric with `continue?`'s `(constantly true)`.
+        owner-token (frame/current-event-owner-token)
         ;; Prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
@@ -588,12 +616,13 @@
       ;; trace it may emit gets a recheck before the runtime-db swap too.
       (when (continue?)
         (let [installed (install-spawn! frame-id rt-after-alloc spec'' spawned-id initial-snap
-                                        {:system-id system-id
-                                         :parent-id parent-id
-                                         :invoke-id invoke-id
-                                         :track?    track?
-                                         :type-ref  type-ref
-                                         :continue? continue?})]
+                                        {:system-id   system-id
+                                         :parent-id   parent-id
+                                         :invoke-id   invoke-id
+                                         :track?      track?
+                                         :type-ref    type-ref
+                                         :continue?   continue?
+                                         :owner-token owner-token})]
         ;; rf2-hloj0g — `install-spawn!`'s `:rf.error/system-id-collision`
         ;; (pre-swap → `:skipped`) and `:rf.machine/system-id-bound` (post-swap)
         ;; traces are callback-bearing: a listener can destroy A / publish

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -661,12 +661,31 @@
   any timer that fires between destroy and host-clock teardown; this
   helper releases the host-clock handle eagerly and emits the trace
   so the Xray Handler section can attribute the cancel to the actor's
-  destroy event."
-  [frame-id parent-id]
-  (when (and frame-id parent-id)
-    (doseq [[k _entry] (vec (get @after-timers frame-id))
-            :when (= parent-id (:parent k))]
-      (cancel-after-timer-entry! frame-id k :on-destroy))))
+  destroy event.
+
+  rf2-4ipqe4 — each `:rf.machine.timer/cancelled` emit is CALLBACK-BEARING:
+  a listener can synchronously destroy the finishing actor's owning frame
+  incarnation A and publish a same-id successor B ON THE FIRST CANCELLATION's
+  own stack. The cancellation loop reads each key's LIVE entry (so a stale
+  snapshot key whose slot B re-armed under a new token would be cancelled
+  against B) and the destroy tail that follows this call (classification /
+  spawn-order / system-id release) resolves bare frame/actor ids to the
+  CURRENT incarnation B. The optional `owner-gone?` predicate (the finalize
+  cascade's exact-incarnation gate) is rechecked BEFORE each snapshotted
+  cancellation, so once the first cancellation loses A the loop short-circuits
+  and never cancels B's timer. `owner-gone?` is MONOTONIC (once A→B it stays
+  gone). The 2-arity (the imperative `destroy` tail, which carries no event
+  owner) passes `(constantly false)` — unfenced, its historical behaviour."
+  ([frame-id parent-id]
+   (cancel-actor-timers! frame-id parent-id (constantly false)))
+  ([frame-id parent-id owner-gone?]
+   (when (and frame-id parent-id)
+     (loop [ks (->> (vec (get @after-timers frame-id))
+                    (into [] (comp (filter (fn [[k _]] (= parent-id (:parent k))))
+                                   (map first))))]
+       (when (and (seq ks) (not (owner-gone?)))
+         (cancel-after-timer-entry! frame-id (first ks) :on-destroy)
+         (recur (subvec ks 1)))))))
 
 (defn cancel-all-timers!
   "Cancel every in-flight :after timer the runtime is currently tracking

--- a/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
@@ -1,0 +1,457 @@
+(ns re-frame.machine-lifecycle-tail-incarnation-fence-test
+  "rf2-4ipqe4 — fence the TIMER, REGISTRAR, and SPAWN-WRITE callbacks in the
+  machine lifecycle tails after incarnation loss. The sibling of #5873/rf2-hloj0g
+  (which fenced the destroyed / spawned-trace / HTTP-abort tails): #5873 grouped
+  three still-callback-bearing operations under EARLIER ownership checks, so a
+  lost-owner machine could still write / cancel / register against a same-id
+  successor B.
+
+  Three seams, one per callback class:
+
+    - TIMER: `timer/cancel-actor-timers!` emits a SYNCHRONOUS
+      `:rf.machine.timer/cancelled` per cancellation. A listener replaces A with
+      same-id B after the FIRST cancellation; the stale snapshot loop then reads
+      B's LIVE entry under a later key and cancels B's timer, and the finalize
+      tail continues into classification / spawn-order / system-id-release
+      against B. FIX: thread the monotonic `owner-gone?` gate into the
+      cancellation loop (short-circuit after the losing cancellation) AND recheck
+      it at the finalize call-site before the classification / spawn-order /
+      system-id-release work.
+
+    - REGISTRAR: `registrar/unregister!` emits a SYNCHRONOUS
+      `:rf.registry/handler-cleared`. A listener replaces A with B; the stale
+      A-derived `:on-error` (spawn-error) dispatch then routes into B. FIX:
+      recheck `owner-gone?` immediately after the unregister, before the
+      `:on-error` dispatch.
+
+    - SPAWN-WRITE: `install-spawn!` used a non-exact `frame/swap-runtime-db!`. A
+      container watch replaces A DURING the physical write; the bare write bumps
+      B's id-keyed commit epoch and emits `:rf.machine/system-id-bound` before
+      the later owner check. FIX: route the install through the exact owner token
+      + `frame/swap-runtime-db-exact!`, which binds the write to A's own
+      container and returns nil on mid-write loss (no epoch bump, no
+      system-id-bound, no lifecycle tail).
+
+  These fixtures drive the tails DIRECTLY under a bound event owner (A's
+  dequeue-time token) with a destroyer that publishes same-id B on the callback's
+  own stack, and assert B stays byte-identical — the same deterministic,
+  single-threaded shape the #5873 fence fixtures use (the destroyer runs INSIDE
+  the callback / watch, so no latch coordination is needed). Each seam pairs its
+  loss fixture with a LIVE-OWNER control that must still tear down / dispatch /
+  install exactly once — the mutation tooth against an over-eager fence."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines :as machines]
+            [re-frame.machines.lifecycle-fx.finalize :as finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ===========================================================================
+;; TIMER seam — cancel-actor-timers! per-cancellation fence + finalize recheck
+;; ===========================================================================
+
+(defn- finishing-machine
+  "A runtime-stamped finished singleton spec resting on a `:final?` leaf."
+  [frame-id]
+  {:initial  :done
+   :rf/frame frame-id
+   :rf/cofx  {:rf/time-ms 0}
+   :data     {:result 42}
+   :states   {:done {:final? true :output-key :result}}})
+
+(defn- finishing-snapshot []
+  {:state :done :data {:result 42}})
+
+(defn- seed-finishing-runtime-db! [frame-id machine-id]
+  (frame/swap-runtime-db!
+    frame-id
+    (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots machine-id]
+                       (finishing-snapshot)))))
+
+(defn- timer-key [parent-id delay-key]
+  {:parent parent-id :spawn [] :delay delay-key})
+
+(defn- seed-timer!
+  "Install a minimal armed-timer table entry under `[frame-id (timer-key
+  parent-id delay-key)]` carrying a unique `token` and a nil host handle
+  (release is then a no-op). Enough for `cancel-actor-timers!` to claim + emit
+  a `:rf.machine.timer/cancelled` trace."
+  [frame-id parent-id delay-key token]
+  (swap! timer/after-timers assoc-in
+         [frame-id (timer-key parent-id delay-key)]
+         {:handle          nil
+          :reaction        nil
+          :sub-watcher-key nil
+          :resolved-ms     delay-key
+          :epoch           0
+          :state           :done
+          :region          nil
+          :delay-source    :literal
+          :token           token}))
+
+(deftest timer-cancel-loss-fences-loop-and-tail
+  (testing "A has two snapshotted `:after` timers. The FIRST cancellation's
+            `:rf.machine.timer/cancelled` listener destroys A + publishes same-id
+            B + arms B's timer under the SECOND key and records B's own
+            spawn-order. The cancellation loop short-circuits (B's timer
+            survives), and the finalize call-site rechecks ownership so the
+            A-derived spawn-order forget never lands on B. Mutation tooth:
+            without the fences the loop cancels B's timer under the second key
+            and `spawn-order/forget!` drops B's entry."
+    (spawn-order/reset-all!)
+    (reset! timer/after-timers {})
+    (let [frame-a    :rf2-4ipqe4/timer-loss-frame
+          machine-id :rf2-4ipqe4/timer-loss
+          k1         (timer-key machine-id 100)
+          k2         (timer-key machine-id 200)]
+      (rf/reg-machine machine-id (finishing-machine frame-a))
+      (rf/make-frame {:id frame-a})
+      (seed-finishing-runtime-db! frame-a machine-id)
+      ;; A's two snapshotted timers (insertion order k1 then k2 → the loop's
+      ;; PersistentArrayMap seq processes k1 first).
+      (seed-timer! frame-a machine-id 100 ::a-tok-1)
+      (seed-timer! frame-a machine-id 200 ::a-tok-2)
+      (let [token-a       (frame/frame-incarnation-token frame-a)
+            fired?        (atom false)
+            first-delay   (atom nil)
+            cancelled     (atom [])
+            b-runtime     (atom nil)]
+        (trace-tooling/register-listener!
+          ::timer-fence
+          (fn [ev]
+            (when (= :rf.machine.timer/cancelled (:operation ev))
+              (swap! cancelled conj ev)
+              (when (compare-and-set! fired? false true)
+                (reset! first-delay (get-in ev [:tags :delay]))
+                (frame/destroy-frame! frame-a)          ;; destroy A
+                (rf/make-frame {:id frame-a})            ;; publish same-id B
+                (reset! b-runtime (mtest/runtime-db frame-a))
+                ;; B re-arms a timer under the SECOND snapshot key + records its
+                ;; own spawn-order entry — the A-derived tail must touch neither.
+                (seed-timer! frame-a machine-id 200 ::b-tok-2)
+                (spawn-order/record! frame-a machine-id)))))
+        (try
+          (let [ret (frame/call-with-event-owner-token frame-a token-a
+                      (fn []
+                        (finalize/finalize-machine
+                          (finishing-machine frame-a)
+                          machine-id frame-a (mtest/runtime-db frame-a)
+                          (finishing-snapshot) [:some-completing-event] [])))]
+            (is (true? @fired?) "the timer-cancelled listener ran (fence exercised)")
+            (is (= 100 @first-delay)
+                "the FIRST cancellation was A's k1 (delay 100) — insertion order held")
+            ;; --- loop fence: B's k2 timer survives ---
+            (is (= ::b-tok-2 (get-in @timer/after-timers [frame-a k2 :token]))
+                "B's timer under the second key survives — the cancellation loop
+                 short-circuited after losing A and never cancelled B's timer")
+            (is (= 1 (count (filter #(= :on-destroy (get-in % [:tags :reason])) @cancelled)))
+                "exactly ONE :reason :on-destroy cancellation fired (A's k1); the
+                 loop short-circuited before cancelling B's k2 timer. (A's OTHER
+                 timer is cancelled by destroy-frame!'s own timer-table clear with
+                 :reason :on-frame-destroy — the loop itself never reached it.)")
+            (is (nil? (get-in @timer/after-timers [frame-a k1]))
+                "A's own k1 timer was cancelled (already-delivered — it stands)")
+            ;; --- call-site recheck: A-derived spawn-order forget never lands ---
+            (is (= [machine-id] (spawn-order/frame-order frame-a))
+                "B's spawn-order entry survives — the finalize call-site rechecked
+                 ownership before the classification / spawn-order / system-id
+                 tail, so `spawn-order/forget!` never ran against B")
+            ;; --- inert publication ---
+            (is (= [] (:fx ret)) "finalize published no fx after the loss")
+            (is (contains? ret :rf.db/runtime) "finalize returns a runtime-db effect"))
+          (finally
+            (trace-tooling/unregister-listener! ::timer-fence)))))))
+
+(deftest timer-cancel-live-owner-cancels-all
+  (testing "control: a completion whose timer-cancelled callbacks do NOT destroy
+            A cancels BOTH armed timers and continues the teardown normally — the
+            fence is scoped to owner-loss only."
+    (spawn-order/reset-all!)
+    (reset! timer/after-timers {})
+    (let [frame-a    :rf2-4ipqe4/timer-live-frame
+          machine-id :rf2-4ipqe4/timer-live]
+      (rf/reg-machine machine-id (finishing-machine frame-a))
+      (rf/make-frame {:id frame-a})
+      (seed-finishing-runtime-db! frame-a machine-id)
+      (seed-timer! frame-a machine-id 100 ::live-tok-1)
+      (seed-timer! frame-a machine-id 200 ::live-tok-2)
+      (let [token-a   (frame/frame-incarnation-token frame-a)
+            cancelled (atom [])]
+        (trace-tooling/register-listener!
+          ::timer-live
+          (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
+                     (swap! cancelled conj ev))))
+        (try
+          (let [ret (frame/call-with-event-owner-token frame-a token-a
+                      (fn []
+                        (finalize/finalize-machine
+                          (finishing-machine frame-a)
+                          machine-id frame-a (mtest/runtime-db frame-a)
+                          (finishing-snapshot) [:some-completing-event] [])))]
+            (is (= 2 (count @cancelled))
+                "both armed timers were cancelled (:reason :on-destroy) under the live owner")
+            (is (empty? (get @timer/after-timers frame-a))
+                "the live-owner teardown released both host-clock entries")
+            (is (nil? (get-in (:rf.db/runtime ret)
+                              [:rf.runtime/machines :snapshots machine-id]))
+                "the live-owner completion tore down the actor's snapshot in the returned runtime-db"))
+          (finally
+            (trace-tooling/unregister-listener! ::timer-live)))))))
+
+;; ===========================================================================
+;; REGISTRAR seam — recheck after handler-cleared before the :on-error dispatch
+;; ===========================================================================
+
+(defn- erroring-child-machine
+  "A finished child resting on an `:error? :final?` leaf, its `:data` carrying
+  the spawn ownership stamps so finalize routes the failure to the parent's
+  `:spawn :on-error`."
+  [parent-id invoke-id]
+  {:initial  :failed
+   :rf/frame :ignored
+   :rf/cofx  {:rf/time-ms 0}
+   :data     {:err "boom" :rf/parent-id parent-id :rf/invoke-id invoke-id}
+   :states   {:failed {:final? true :error? true :output-key :err}}})
+
+(defn- erroring-child-snapshot [parent-id invoke-id]
+  {:state :failed :data {:err "boom" :rf/parent-id parent-id :rf/invoke-id invoke-id}})
+
+(defn- on-error-parent-machine []
+  {:initial :waiting
+   :states  {:waiting {:spawn {:machine-id :rf2-4ipqe4/some-child
+                               :on-error   {:target :recover}}}
+             :recover {}}})
+
+(defn- run-erroring-finalize
+  "Register the parent (declaring `:spawn :on-error` at `[:waiting]`) + child,
+  seed the child's finishing snapshot, install `on-cleared` as a
+  `:rf.registry/handler-cleared` listener, and drive `finalize-machine` for the
+  child under A's bound event owner. Captures every `:router/dispatch!`."
+  [frame-a parent-id child-id on-cleared]
+  (spawn-order/reset-all!)
+  (let [invoke-id [:waiting]]
+    (rf/reg-machine parent-id (on-error-parent-machine))
+    (rf/reg-machine child-id  (erroring-child-machine parent-id invoke-id))
+    (rf/make-frame {:id frame-a})
+    (frame/swap-runtime-db!
+      frame-a (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots child-id]
+                                 (erroring-child-snapshot parent-id invoke-id))))
+    (let [token-a        (frame/frame-incarnation-token frame-a)
+          dispatches     (atom [])
+          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+      (trace-tooling/register-listener!
+        ::registrar-fence
+        (fn [ev] (when (= :rf.registry/handler-cleared (:operation ev))
+                   (on-cleared ev))))
+      (try
+        (late-bind/set-fn! :router/dispatch!
+                           (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
+        (let [ret (frame/call-with-event-owner-token frame-a token-a
+                    (fn []
+                      (finalize/finalize-machine
+                        (erroring-child-machine parent-id invoke-id)
+                        child-id frame-a (mtest/runtime-db frame-a)
+                        (erroring-child-snapshot parent-id invoke-id)
+                        [:some-completing-event] [])))]
+          {:ret        ret
+           :dispatches @dispatches})
+        (finally
+          (trace-tooling/unregister-listener! ::registrar-fence)
+          ;; Restore the prior hook (nil re-registers as absent, matching a
+          ;; conformance / no-router baseline).
+          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+
+(deftest registrar-clear-loss-fences-on-error-dispatch
+  (testing "a `:rf.registry/handler-cleared` listener (fired by the child's
+            `registrar/unregister!`) destroys A + publishes same-id B: ownership
+            is rechecked AFTER the unregister, so the stale A-derived spawn-error
+            (:on-error) dispatch is fenced and finalize publishes no fx. Mutation
+            tooth: without the post-unregister recheck the spawn-error dispatch
+            routes `[:rf.machine.spawn/error …]` into B."
+    (let [frame-a    :rf2-4ipqe4/registrar-loss-frame
+          parent-id  :rf2-4ipqe4/registrar-loss-parent
+          child-id   :rf2-4ipqe4/registrar-loss-child
+          fired?     (atom false)]
+      (let [{:keys [ret dispatches]}
+            (run-erroring-finalize
+              frame-a parent-id child-id
+              (fn [_ev]
+                (when (compare-and-set! fired? false true)
+                  (frame/destroy-frame! frame-a)     ;; destroy A
+                  (rf/make-frame {:id frame-a}))))]   ;; publish same-id B
+        (is (true? @fired?) "the handler-cleared listener ran (fence exercised)")
+        (is (empty? (filter (fn [[ev _]]
+                              (and (vector? ev)
+                                   (= :rf.machine.spawn/error
+                                      (first (second ev)))))
+                            dispatches))
+            "no spawn-error / :on-error dispatch routed into B after the loss")
+        (is (= [] (:fx ret)) "finalize published no A-derived fx after the loss")
+        (is (contains? ret :rf.db/runtime) "finalize returns a runtime-db effect")))))
+
+(deftest registrar-clear-live-owner-dispatches-on-error-once
+  (testing "control: when the handler-cleared callback does NOT destroy A, the
+            child's error leaf routes the `:on-error` (spawn-error) dispatch into
+            the parent EXACTLY once — the fence must not suppress the live path."
+    (let [frame-a    :rf2-4ipqe4/registrar-live-frame
+          parent-id  :rf2-4ipqe4/registrar-live-parent
+          child-id   :rf2-4ipqe4/registrar-live-child]
+      (let [{:keys [dispatches]}
+            (run-erroring-finalize frame-a parent-id child-id (fn [_ev] nil))]
+        (let [spawn-errors (filter (fn [[ev _]]
+                                     (and (vector? ev)
+                                          (= :rf.machine.spawn/error
+                                             (first (second ev)))))
+                                   dispatches)]
+          (is (= 1 (count spawn-errors))
+              "the live-owner error leaf dispatched the spawn-error into the parent exactly once")
+          (let [[[ev opts] _] [(first spawn-errors)]]
+            (is (= parent-id (first ev)) "the dispatch targeted the parent")
+            (is (= [:rf.machine.spawn/error [:waiting] "boom"] (second ev))
+                "the spawn-error carried the child's invoke-id + error payload")
+            (is (= frame-a (:frame opts)) "the dispatch was stamped with the frame")))))))
+
+;; ===========================================================================
+;; SPAWN-WRITE seam — install through swap-runtime-db-exact! (container watch)
+;; ===========================================================================
+
+(defn- install-watching-adapter!
+  "Install a plain-atom-backed adapter whose `replace-container!` runs `on-write`
+  exactly once, the first time a container write happens while `armed?` holds.
+  The physical write always lands FIRST so A's write that linearized before the
+  loss stands in A's captured container."
+  [armed? on-write]
+  (let [base-replace (:replace-container! plain-atom/adapter)]
+    (adapter/dispose-adapter!)
+    (reset! frame/frames {})
+    (adapter/install-adapter!
+      (assoc plain-atom/adapter
+             :kind :custom
+             :replace-container!
+             (fn [container value]
+               (base-replace container value)
+               (when (compare-and-set! armed? true false)
+                 (on-write)))))))
+
+(defn- restore-plain-adapter! []
+  (reset! frame/frames {})
+  (adapter/dispose-adapter!)
+  (adapter/install-adapter! plain-atom/adapter))
+
+(def ^:private spawn-child-instance-id (keyword "rf2-4ipqe4" "spawn-write-child#1"))
+
+(deftest spawn-install-write-watch-loss-fences-tail
+  (testing "a container watch that destroys A + publishes same-id B DURING the
+            spawn install write: the exact write binds to A's own container and
+            reports mid-write loss, so no A-derived child snapshot lands on B, no
+            id-keyed commit epoch is bumped for B, and no `:rf.machine/
+            system-id-bound` / `:rf.machine.lifecycle/spawned` / spawn-order tail
+            is attributed after loss. Mutation tooth: the bare `swap-runtime-db!`
+            bumps B's commit epoch and fires system-id-bound for B."
+    (spawn-order/reset-all!)
+    (rf/reg-machine :rf2-4ipqe4/spawn-write-child
+      {:initial :running
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a  :rf2-4ipqe4/spawn-write-frame
+          armed?   (atom false)
+          fired?   (atom false)
+          traces   (atom [])
+          b-birth  (atom nil)
+          b-commit (atom nil)]
+      (install-watching-adapter!
+        armed?
+        (fn []
+          (when (compare-and-set! fired? false true)
+            (frame/destroy-frame! frame-a)       ;; destroy A during the install write
+            (rf/make-frame {:id frame-a})          ;; publish same-id B
+            (reset! b-birth (mtest/runtime-db frame-a))
+            (reset! b-commit (frame/frame-commit-epoch frame-a)))))
+      (try
+        (rf/make-frame {:id frame-a})
+        (trace/register-listener!
+          ::spawn-write-fence
+          (fn [ev] (swap! traces conj ev)))
+        (let [token-a (frame/frame-incarnation-token frame-a)]
+          (reset! armed? true)
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-fx {:frame frame-a}
+                                   {:machine-id :rf2-4ipqe4/spawn-write-child
+                                    :system-id  :rf2-4ipqe4/sys-1
+                                    :start      [:go]})))
+          (is (true? @fired?) "the install-write container watch ran (fence exercised)")
+          (is (some? @b-birth) "the watch published a same-id B")
+          (is (nil? (mtest/snapshot frame-a spawn-child-instance-id))
+              "no A-derived child snapshot installed onto same-id B")
+          (is (= @b-birth (mtest/runtime-db frame-a))
+              "B's runtime-db is byte-identical to its birth value (no A-derived install)")
+          (is (= @b-commit (frame/frame-commit-epoch frame-a))
+              "A's mid-write loss never bumped B's id-keyed commit epoch")
+          (is (empty? (spawn-order/frame-order frame-a))
+              "no A-derived spawn-order entry recorded against B")
+          (is (empty? (filter #(= :rf.machine/system-id-bound (:operation %)) @traces))
+              "no :rf.machine/system-id-bound trace attributed after the write loss")
+          (is (empty? (filter #(= :rf.machine.lifecycle/spawned (:operation %)) @traces))
+              "no :rf.machine.lifecycle/spawned tail attributed after the write loss"))
+        (finally
+          (trace/unregister-listener! ::spawn-write-fence)
+          (restore-plain-adapter!))))))
+
+(deftest spawn-install-write-live-owner-installs-once
+  (testing "control: a non-destroying install-write watch keeps A live — the
+            exact write commits, the child snapshot installs, and the
+            system-id-bound / lifecycle-spawned / spawn-order tail all fire
+            exactly once. A wrongly-fencing exact write would skip the install."
+    (spawn-order/reset-all!)
+    (rf/reg-machine :rf2-4ipqe4/spawn-write-live-child
+      {:initial :running
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a    :rf2-4ipqe4/spawn-write-live-frame
+          armed?     (atom false)
+          watch-runs (atom 0)
+          traces     (atom [])
+          child-id   (keyword "rf2-4ipqe4" "spawn-write-live-child#1")]
+      (install-watching-adapter!
+        armed?
+        (fn [] (swap! watch-runs inc)))          ; observe only — A stays live
+      (try
+        (rf/make-frame {:id frame-a})
+        (trace/register-listener!
+          ::spawn-write-live
+          (fn [ev] (swap! traces conj ev)))
+        (let [token-a (frame/frame-incarnation-token frame-a)]
+          (reset! armed? true)
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-fx {:frame frame-a}
+                                   {:machine-id :rf2-4ipqe4/spawn-write-live-child
+                                    :system-id  :rf2-4ipqe4/sys-live
+                                    :start      [:go]})))
+          (is (pos? @watch-runs) "the install-write watch fired (the exact write hit the container)")
+          (is (some? (mtest/snapshot frame-a child-id))
+              "the live-owner install committed the child snapshot through the exact write")
+          (is (= [child-id] (spawn-order/frame-order frame-a))
+              "the live-owner install recorded the child in spawn-order")
+          (is (= 1 (count (filter #(= :rf.machine/system-id-bound (:operation %)) @traces)))
+              "the live-owner install emitted :rf.machine/system-id-bound exactly once")
+          (is (= 1 (count (filter #(= :rf.machine.lifecycle/spawned (:operation %)) @traces)))
+              "the live-owner install emitted :rf.machine.lifecycle/spawned exactly once"))
+        (finally
+          (trace/unregister-listener! ::spawn-write-live)
+          (restore-plain-adapter!))))))


### PR DESCRIPTION
Sibling of #5873/rf2-hloj0g (which fenced the destroyed / spawned-trace / HTTP-abort tails to the exact incarnation). #5873 grouped three still-callback-bearing operations under EARLIER ownership checks, so a lost-owner machine could still write / cancel / register against a same-id successor B. Re-verified against current `origin/main` (508c4a6 — after #5873 and #5881/lud4af merged): all three seams still reproduce; nothing was closed by those merges.

## The three fenced callback classes

- **TIMER** — `timer/cancel-actor-timers!` emits a synchronous `:rf.machine.timer/cancelled` per cancellation. A listener replaces A with same-id B on the FIRST cancellation's stack; the stale snapshot loop then reads B's LIVE entry under a later key and cancels B's timer, and `finalize-machine` continues into classification / spawn-order / system-id-release against B (bare frame/actor ids resolve to the CURRENT incarnation B). Fix: thread the monotonic `owner-gone?` gate into the cancellation loop (short-circuit after the losing cancellation) AND recheck it at the finalize call-site before that tail.

- **REGISTRAR** — `registrar/unregister!` emits a synchronous `:rf.registry/handler-cleared`. A listener replaces A with B; the stale A-derived `:on-error` (spawn-error) dispatch then routes `[:rf.machine.spawn/error …]` into B. Fix: recheck `owner-gone?` immediately after the unregister, before the dispatch. The unregister is an already-delivered callback (it stands); the dispatch it enables is fenced.

- **SPAWN-WRITE** — `install-spawn!` used a non-exact `frame/swap-runtime-db!`. A container watch replaces A DURING the physical write; the bare write bumps B's id-keyed commit epoch and emits `:rf.machine/system-id-bound` before the later owner check. Fix: route the install through the exact owner token + `frame/swap-runtime-db-exact!`, which binds the write to A's own container and returns nil on mid-write loss (no epoch bump, no system-id-bound, no lifecycle tail → `:skipped`). No event owner (conformance / pure-fn) falls back to the bare write, unaffected.

Reuses #5873's owner-gone? / committed-AND-current discipline. No back-compat shims, no rollback framework, no public API. Ownership loss (A→B frame-incarnation) is a TERMINAL fence for every subsequent framework-owned action; already-delivered callbacks unwind.

## Quality gates

Red-before-fix verified: reverting all three source files to `origin/main` turns the three loss fixtures RED (B's k2 timer cancelled + spawn-order forgotten; spawn-error dispatched into B; B's commit epoch bumped + system-id-bound fired) while the three live-owner controls stay GREEN.

New fixtures — `implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj` (one loss fixture per callback class + a live-owner control each), driving the tails directly under A's bound event owner with a destroyer / container watch that publishes same-id B on the callback's own stack:

- `timer-cancel-loss-fences-loop-and-tail` + `timer-cancel-live-owner-cancels-all`
- `registrar-clear-loss-fences-on-error-dispatch` + `registrar-clear-live-owner-dispatches-on-error-once`
- `spawn-install-write-watch-loss-fences-tail` + `spawn-install-write-live-owner-installs-once`

Foreground (no browser surface; CI owns the full matrix):
- `implementation/machines` `clojure -M:test` — **1059 tests, 3626 assertions, 0 failures** (lifecycle + reason-matrix conformance + the new fence fixtures)
- `implementation/core` `clojure -M:test` — **1968 tests, 9020 assertions, 0 failures** (machines depends on core)

## Spec ripples (follow-up, not in this PR)
Spec 005 (lifecycle) / Spec 009 (instrumentation) describe the destroy / completion tails but do not yet spell out the per-callback-class incarnation fence within `cancel-actor-timers!` / the registrar-unregister→on-error seam / the exact-write spawn install. Worth a follow-up prose pass aligning the normative text with the #5873 + rf2-4ipqe4 fence family.