### PR TITLE
fix(ui): model destructuring scope in host evaluation order (rf2-vxgfnd.268)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -335,51 +335,138 @@
       (contains? lease-fqns fqn) :lease
       (contains? frame-fqns fqn) :frame)))
 
-(defn reject-reactive-binding!
-  "Reject executable sub/lease calls embedded in a binding pattern/default.
-  Destructuring forms are consumed by the host compiler, not expression
-  rewriting; allowing a call there would bypass lexical site ownership."
-  [e binding-form]
-  (when-let [kind (reactive-call-kind e binding-form #{})]
+(defn- key-group-kw?
+  "True for a `:keys`/`:strs`/`:syms` map-destructuring group directive (any
+  namespace: `:person/keys` too). Its map-entry VALUE is a vector of symbols;
+  its keys are keyword/string/symbol LITERALS, never evaluated expressions."
+  [k]
+  (and (keyword? k) (contains? #{"keys" "strs" "syms"} (name k))))
+
+(defn- binding-map-units
+  "The associative-destructuring binding units of `pattern`, in the host's
+  `bes` evaluation order: explicit `{local-pattern key-expr}` entries in source
+  order FIRST, then `:keys`/`:strs`/`:syms` expansions (that host order — the
+  `:or`/`:as` markers dissoc out and the group forms assoc their entries at the
+  tail). Each unit is `{:local-pattern p :key-expr e|nil}`; `key-expr` is the
+  EVALUATED lookup-key expression of an explicit entry (nil for the group
+  forms, whose keys are literals). The units are consumed in order so each
+  binding's default/lookup-key is judged against the scope established BEFORE
+  it — never against a symbol the same pattern binds later."
+  [pattern]
+  (let [explicit (for [[k v] pattern
+                       :when (not (or (= k :or) (= k :as) (key-group-kw? k)))]
+                   {:local-pattern k :key-expr v})
+        rank     {"keys" 0 "strs" 1 "syms" 2}
+        grouped  (->> pattern
+                      (filter (fn [[k _]] (key-group-kw? k)))
+                      (sort-by (fn [[k _]] (rank (name k))))
+                      (mapcat (fn [[_ syms]]
+                                (map (fn [s] {:local-pattern (symbol (name s))
+                                              :key-expr nil})
+                                     syms))))]
+    (concat explicit grouped)))
+
+(defn- reject-binding-escape!
+  "Reject a reactive authoring escape reaching ONE evaluated destructuring
+  expression `expr`, judged against `scope` — the locals live at this
+  expression's host evaluation point (ambient lexical locals PLUS the
+  same-pattern bindings established before it). Both the executable-call scan
+  and the bare-authoring-var scan use this one point-in-time scope, so an
+  earlier-bound local shadows the authoring var while a later-bound or self
+  binding does not. `slot` names the slot for the diagnostic."
+  [e scope slot pattern expr]
+  (when-let [kind (reactive-call-kind e expr scope)]
     (env/fail! e :rf.ui.compile/unsupported-form
                (if (= :opaque-macro kind)
                  (str "an unaudited macro cannot appear in a binding pattern "
-                      "or destructuring :or default — macro expansion could "
-                      "inject a reactive call after lexical site analysis. "
-                      "Compute the default in the view body instead")
+                      "or " slot " — macro expansion could inject a reactive "
+                      "call after lexical site analysis. Compute it in the view "
+                      "body instead")
                  (str "(" (name kind) " ...) cannot appear in a binding pattern "
-                      "or destructuring :or default — that position cannot own "
-                      "a lexical render site. Hoist the read into the view body "
-                      "and bind/destructure its value there"))
-               {:form binding-form :reactive-kind kind}))
-  ;; Sibling gap (rf2-dzyqis) that PR #5874 (rf2-vxgfnd.252) left open. The call
-  ;; scan above catches an executable `(sub …)`/`(lease …)`/`(frame)` embedded in
-  ;; the pattern, but a BARE reactive authoring var used as a destructuring `:or`
-  ;; DEFAULT is a value, not a call — `{:keys [x] :or {x sub}}`. Binding patterns
-  ;; never pass through expression rewriting, so that bare var flows as a VALUE
-  ;; into the host's destructuring `get` default with no compiler-owned render
-  ;; site: the manifest under-declares and the optimized build elides the read.
-  ;; The `:else` value-flow leaf guard in `rewrite-expr` never sees it (patterns
-  ;; are not rewritten), and a naive value-flow scan of the pattern would
-  ;; false-positive on legitimate lexical shadowing (`{:keys [sub]}` BINDS a local
-  ;; named sub), so this reject is binding-position-AWARE: every symbol the pattern
-  ;; BINDS is added to the ambient locals, so only a bare reactive var reaching a
-  ;; default from OUTSIDE the pattern still resolves to the authoring var. `:or`
-  ;; defaults are the only value-expression slots a binding pattern carries, so
-  ;; scanning the whole shadowed form targets exactly the :or-default path.
-  (let [own-scope (into (:locals e) (env/binding-syms binding-form))]
-    (when-let [kind (bare-reactive-reference-kind e binding-form own-scope)]
-      (env/fail! e :rf.ui.compile/unsupported-form
-                 (str "bare " (name kind) " reference as a destructuring :or "
-                      "default — re-frame.ui/" (name kind) " is a reactive "
-                      "authoring var, sound ONLY as a compiler-owned direct call "
-                      "head " (reactive-direct-form kind)
-                      ". A binding :or default is never rewritten, so the bare "
-                      "var flows as a VALUE where the compiler cannot own a "
-                      "lexical render site — the manifest under-declares and the "
-                      "optimized build elides the read. Hoist the read into the "
-                      "view body and destructure its committed value there")
-                 {:form binding-form :reactive-kind kind})))
+                      "or " slot " — that position cannot own a lexical render "
+                      "site. Hoist the read into the view body and bind/"
+                      "destructure its value there"))
+               {:form pattern :reactive-kind kind}))
+  (when-let [kind (bare-reactive-reference-kind e expr scope)]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "bare " (name kind) " reference as a " slot
+                    " — re-frame.ui/" (name kind) " is a reactive authoring "
+                    "var, sound ONLY as a compiler-owned direct call head "
+                    (reactive-direct-form kind)
+                    ". A " slot " is never rewritten, so the bare var flows as "
+                    "a VALUE where the compiler cannot own a lexical render "
+                    "site — the manifest under-declares and the optimized build "
+                    "elides the read. Hoist the read into the view body and "
+                    "destructure its committed value there")
+               {:form pattern :reactive-kind kind})))
+
+(defn- check-binding-scope!
+  "Thread the incremental local scope through binding `pattern` in host
+  evaluation order, rejecting a reactive authoring escape in every EVALUATED
+  binding expression against the scope live at THAT point. Returns `scope`
+  extended with every symbol `pattern` binds, so a caller can carry the roster
+  across sibling patterns. `scope` already carries the ambient locals."
+  [e scope pattern]
+  (cond
+    (symbol? pattern) (conj scope pattern)
+
+    (vector? pattern)
+    ;; Sequential destructuring `[p0 p1 … & prest :as asym]` carries no
+    ;; evaluated expression of its own; its element/rest/`:as` sub-patterns
+    ;; establish bindings left-to-right, so a later nested default sees an
+    ;; earlier sibling's local.
+    (loop [scope scope, xs (seq pattern)]
+      (if (nil? xs)
+        scope
+        (let [x (first xs)]
+          (cond
+            (= '& x)  (recur scope (next xs))
+            (= :as x) (recur (check-binding-scope! e scope (second xs)) (nnext xs))
+            :else     (recur (check-binding-scope! e scope x) (next xs))))))
+
+    (map? pattern)
+    ;; Associative destructuring. `:as` binds the whole map FIRST (host order),
+    ;; so it is in scope for every key default. Then the key bindings are
+    ;; established sequentially (`binding-map-units` order): each key's default
+    ;; AND each explicit lookup-key expression is evaluated against the scope
+    ;; BEFORE that key's own local is bound — the local is added only after.
+    (let [defaults (:or pattern)
+          scope    (cond-> scope (:as pattern) (conj (:as pattern)))]
+      (reduce
+       (fn [scope {:keys [local-pattern key-expr]}]
+         (when key-expr
+           (reject-binding-escape! e scope "destructuring lookup-key expression"
+                                   pattern key-expr))
+         (when (and (symbol? local-pattern) (contains? defaults local-pattern))
+           (reject-binding-escape! e scope "destructuring :or default"
+                                   pattern (get defaults local-pattern)))
+         (check-binding-scope! e scope local-pattern))
+       scope
+       (binding-map-units pattern)))
+
+    :else scope))
+
+(defn reject-reactive-binding!
+  "Reject a reactive authoring escape reaching an EVALUATED destructuring
+  expression — an executable `(sub …)`/`(lease …)`/`(frame)` call OR a bare
+  reactive authoring var — anywhere in a binding pattern. Binding patterns are
+  consumed by the host compiler, not expression rewriting, so such a position
+  can never own a lexical render site: the manifest would under-declare and the
+  optimized build elide the read.
+
+  CLJ/CLJS destructuring binds SEQUENTIALLY, so scope is modelled in host
+  evaluation order (`check-binding-scope!`): each `:or` default and each
+  explicit map lookup-key expression is judged against the locals live at ITS
+  binding point — ambient lexical locals plus the same-pattern bindings
+  established BEFORE it. A bare var reaching a default from OUTSIDE those locals
+  (a later-bound or self shadow — `{:keys [f sub] :or {f sub}}`,
+  `{:keys [sub] :or {sub sub}}`) still resolves to the public authoring var and
+  escapes; a genuine EARLIER-bound local shadows it and is legal
+  (`{:keys [sub a] :or {a sub}}`, `{:keys [sub f] :or {f (sub :fallback)}}`).
+  The call scan and the bare-reference scan share this one point-in-time scope,
+  so neither over-shadows (whole-pattern) nor under-shadows (ambient-only)."
+  [e binding-form]
+  (check-binding-scope! e (:locals e) binding-form)
   binding-form)
 
 (defn rewrite-expr

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -300,6 +300,29 @@
     (let [{:keys [sites]} (ana-full '[:div {:title (let [{:keys [x] :or {x 0}} m] x)}])]
       (is (empty? (:subs sites))))))
 
+(deftest destructuring-earlier-bound-shadow-compiles
+  ;; rf2-vxgfnd.268 — the reverse of the reject rows: a same-pattern local bound
+  ;; EARLIER in host evaluation order genuinely shadows the reactive authoring
+  ;; var, so its later use in a default is an ordinary local reference, mints no
+  ;; reactive site, and compiles. The pre-fix `reactive-call-kind` scan used no
+  ;; same-pattern scope (`#{}`), so the earlier-local function-call row was
+  ;; UNDER-shadowed and wrongly rejected; the ordered scope restores it.
+  (testing "a bare default referencing an EARLIER-bound local shadow (no site)"
+    (let [{:keys [sites]}
+          (ana-full '[:div {:title (let [{:keys [sub f] :or {f sub}} m] f)}])]
+      (is (empty? (:subs sites))
+          "sub binds before f, so f's default is the local, not the reactive var")))
+  (testing "a function CALL on an earlier-bound local shadow (no site)"
+    (let [{:keys [sites]}
+          (ana-full '[:div {:title (let [{:keys [sub f] :or {f (sub :fallback)}} m] f)}])]
+      (is (empty? (:subs sites))
+          "(sub :fallback) calls the earlier local sub, never re-frame.ui/sub")))
+  (testing "an explicit lookup key referencing an earlier-bound local (no site)"
+    (let [{:keys [sites]}
+          (ana-full '[:div {:title (let [{sub :s x sub} m] x)}])]
+      (is (empty? (:subs sites))
+          "x's lookup key `sub` is the local bound by the earlier {sub :s} entry"))))
+
 (deftest lexical-site-id-is-portable-stable-and-query-independent
   (let [template-a [:div (located-sub 102 8 [:item/by-id 'id])]
         template-b [:div (located-sub 202 8 [:item/by-id 'id])]

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -2,7 +2,7 @@
   "Template-grammar REJECT table: every rejected form throws a compile
   error carrying {:rf.ui.compile/error <id>} — the S1e didactic-message
   roster keys off these ids. Runs on both hosts (injected resolution)."
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.analyze-accept-cljs-test :refer [mk-env]]))
 
@@ -182,6 +182,57 @@
       "an ordinary literal :or default is untouched")
   (is (nil? (reject-id '[:div {:title (let [{:keys [x] :or {x 'sub}} m] x)}]))
       "quoted data in an :or default is inert — never a reactive read"))
+
+(deftest destructuring-scope-follows-host-evaluation-order
+  ;; rf2-vxgfnd.268 — the ordered-scope correction to rf2-dzyqis. CLJ/CLJS
+  ;; destructuring binds SEQUENTIALLY, so a bare reactive var in a default is
+  ;; shadowed ONLY by a same-pattern local bound EARLIER in evaluation order.
+  ;; The dzyqis guard put every symbol the pattern binds into one flat scope
+  ;; BEFORE scanning, so a LATER-bound local named sub/lease/frame (and a SELF
+  ;; default) falsely shadowed the escape and the pre-fix head compiled these
+  ;; with an EMPTY manifest, leaving the public authoring var to survive to
+  ;; runtime unindexed. Each row below reads the outer public var; reverting the
+  ;; ordered scope re-accepts them all, so this deftest is the mutation fixture.
+  (testing "a LATER-bound local does not shadow an earlier default (over-accept)"
+    ;; `f` binds first; its :or default `sub` evaluates before local `sub` — it
+    ;; is the outer re-frame.ui/sub, not the later local.
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [f sub] :or {f sub}} m] f)}]))
+        "bare sub default shadowed only by a LATER binding escapes")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [f lease] :or {f lease}} m] f)}]))
+        "bare lease escapes identically under a later shadow")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [f frame] :or {f frame}} m] f)}]))
+        "bare frame escapes identically under a later shadow"))
+  (testing "a SELF default is not its own shadow (over-accept)"
+    ;; `sub`'s :or default `sub` evaluates while local `sub` is still being
+    ;; bound — the default is the outer public var.
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [sub] :or {sub sub}} m] sub)}]))
+        "a self-referential sub default is the outer var, not the local")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [lease] :or {lease lease}} m] lease)}]))
+        "a self-referential lease default escapes identically")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [frame] :or {frame frame}} m] frame)}]))
+        "a self-referential frame default escapes identically"))
+  (testing "an explicit map lookup-key expression is an evaluated slot too"
+    ;; `{x sub}` binds x to (get m sub) — the lookup key `sub` is evaluated, so
+    ;; the bare reactive var escapes there just like a default.
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{x sub} m] x)}]))
+        "a bare reactive var as an explicit lookup key escapes")
+    (let [msg (try (ana/analyze (mk-env)
+                                '[:div {:title (let [{x sub} m] x)}])
+                   nil
+                   (catch #?(:clj clojure.lang.ExceptionInfo
+                             :cljs cljs.core/ExceptionInfo) ex
+                     (ex-message ex)))]
+      (is (re-find #"lookup-key" msg)
+          "the lookup-key diagnostic identifies the slot, not an :or default")
+      (is (not (re-find #":or default" msg))
+          "and does not misreport it as an :or default"))))
 
 (deftest reactive-verb-head-reserved-before-foreign-classification
   ;; rf2-vxgfnd.266 — the next escape in the .252/dzyqis family. sub/lease/frame

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -88,3 +88,28 @@
           (is (= 1 (count (:subs @(:sites e*)))) (pr-str form))
           (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
               (pr-str form)))))))
+
+(deftest real-cljs-destructuring-scope-follows-host-evaluation-order
+  ;; rf2-vxgfnd.268 — the ordered-scope correction under REAL CLJS analyzer
+  ;; resolution (bare sub/lease resolve to the reactive vars; core macro
+  ;; authority is genuine, not an injected :macro flag). Destructuring binds
+  ;; SEQUENTIALLY, so a bare reactive var in a default is shadowed ONLY by a
+  ;; same-pattern local bound EARLIER. Reverting the ordered scope re-accepts
+  ;; the escape rows (the dzyqis over-accept) and re-rejects the earlier-shadow
+  ;; rows (the older whole-pattern-blind call scan's under-shadow).
+  (with-real-cljs-env
+    (fn [_ e]
+      (testing "a self / later-bound shadow does not cover an earlier default"
+        (doseq [argv ['[{:keys [sub] :or {sub sub}}]
+                      '[{:keys [f sub] :or {f sub}}]
+                      '[{:keys [lease] :or {lease lease}}]
+                      '[{:keys [f lease] :or {f lease}}]]]
+          (is (= :rf.ui.compile/unsupported-form
+                 (compile-error-id #(analyze/reject-reactive-binding! e argv)))
+              (pr-str argv))))
+      (testing "an EARLIER-bound local genuinely shadows the reactive var"
+        (doseq [argv ['[{:keys [sub f] :or {f sub}}]
+                      '[{:keys [sub f] :or {f (sub :fallback)}}]
+                      '[{sub :s x sub}]]]
+          (is (nil? (compile-error-id #(analyze/reject-reactive-binding! e argv)))
+              (pr-str argv)))))))

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -5,7 +5,11 @@
   these pins hold for the CLJS expansion path too."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui :as ui :refer [defview]]
+            ;; `sub` is referred so a BARE `sub` in a header default resolves to
+            ;; re-frame.ui/sub through REAL CLJ macroexpansion — the rf2-vxgfnd.268
+            ;; ordered-scope proofs need the bare (non-qualified) spelling that the
+            ;; dzyqis flat scope over-accepted.
+            [re-frame.ui :as ui :refer [defview sub]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
@@ -86,6 +90,37 @@
   (is (nil? (expand-error
              '(re-frame.ui/defview shadowing-header [{:keys [sub]}] [:div sub])))
       "the header local shadows re-frame.ui/sub only in the body"))
+
+(deftest header-destructuring-scope-follows-host-evaluation-order
+  ;; rf2-vxgfnd.268 — the ordered-scope correction, proved through ACTUAL CLJ
+  ;; defview macroexpansion (the macro JVM expands the CLJS path too). A defview
+  ;; header destructures SEQUENTIALLY, so a bare `sub` default is shadowed only
+  ;; by a same-pattern local bound EARLIER. The dzyqis flat scope treated every
+  ;; header-bound symbol as in-scope before scanning, so a LATER-bound / SELF
+  ;; `sub` falsely shadowed the escape and the header compiled with an empty
+  ;; manifest, leaving public re-frame.ui/sub to survive to runtime unindexed.
+  ;; *ns* is bound to THIS ns (which refers `sub`) so the bare, non-qualified
+  ;; spelling resolves to re-frame.ui/sub through real macroexpansion — the test
+  ;; runner otherwise leaves *ns* at `user`, where only qualified names resolve.
+  (binding [*ns* (find-ns 're-frame.ui.defview-grammar-jvm-test)]
+    (is (= :rf.ui.compile/unsupported-form
+           (expand-error
+            '(re-frame.ui/defview self-default-header
+               [{:keys [sub] :or {sub sub}}] [:div sub])))
+        "a self-referential bare sub default is the outer var, not the local")
+    (is (= :rf.ui.compile/unsupported-form
+           (expand-error
+            '(re-frame.ui/defview later-shadow-header
+               [{:keys [f sub] :or {f sub}}] [:div f])))
+        "a bare sub default shadowed only by a LATER header binding escapes")
+    (is (nil? (expand-error
+               '(re-frame.ui/defview earlier-shadow-header
+                  [{:keys [sub f] :or {f sub}}] [:div f])))
+        "a default referencing an EARLIER-bound header local is the shadow — legal")
+    (is (nil? (expand-error
+               '(re-frame.ui/defview earlier-call-header
+                  [{:keys [sub f] :or {f (sub :fallback)}}] [:div f])))
+        "a call on an earlier-bound local shadow is an ordinary local call — legal")))
 
 (deftest reactive-verb-in-component-head-is-reserved-through-real-host-resolution
   ;; rf2-vxgfnd.266 — the pure-analyzer fixtures inject resolution; this pins the


### PR DESCRIPTION
Corrects the rf2-dzyqis destructuring `:or`-default guard to model host
evaluation order. Follows #5874/.252, #5877/dzyqis, #5883/.266 on `analyze.cljc`.

## The defect

CLJ/CLJS destructuring binds **sequentially** — each `:or` default (and each
explicit map lookup-key expression) is evaluated as its own `let` binding, so it
can only reference symbols bound **earlier** in evaluation order, never a later
one and never itself. `rf2-dzyqis` instead added **every** symbol the pattern
binds to one flat `own-scope` **before** scanning the whole pattern. Two wrongs:

- **Over-accept (dzyqis).** In `{:keys [f sub] :or {f sub}}`, `f`'s default `sub`
  evaluates before local `sub` is bound, so the RHS is the outer public
  `re-frame.ui/sub`. The flat scope contained `sub` (bound *later*), falsely
  shadowed the reference, accepted an empty reactive manifest, and the optimized
  build elided the read — a genuine reactive escape. Same for the self-default
  `{:keys [sub] :or {sub sub}}`. The authored legal control used the safe reverse
  order, so exact-head CI stayed green.
- **Under-shadow (older call scan).** `reactive-call-kind` ran with `#{}` locals,
  so it rejected `{:keys [sub f] :or {f (sub :fallback)}}` even though `sub` is a
  genuinely *earlier*-bound local — a legal local call, not a reactive verb.

The old guard also mis-modelled explicit map **lookup-key** expressions (`{x sub}`
evaluates `sub` as the `get` key): it caught them by whole-form scan but reported
them as `:or default`s and over-accepted them when the referenced symbol was
bound later in the pattern.

## The fix

`reject-reactive-binding!` now walks the pattern in host evaluation order
(`check-binding-scope!`), building the local scope **incrementally**: `:as` binds
first, then each key's default and each explicit lookup-key expression is judged
against the locals live **before** that key's own local is bound. Both the
executable-call scan and the bare-authoring-var scan share that one point-in-time
scope, so neither over-shadows (whole-pattern) nor under-shadows (ambient-only).
A bare reactive verb reaching a default from **outside** the in-scope-so-far
locals rejects; a genuine **earlier-bound** shadow compiles. Reuses
`:rf.ui.compile/unsupported-form` (no new id); lookup-key rejects now carry a
`destructuring lookup-key expression` diagnostic instead of claiming `:or
default`. The single shared roster covers ordinary `let`, `for`, `fn`/`fn*`
args, and the `defview` header (via `compiler.cljc`), and recurses through nested
destructuring.

## Quality gates

Foreground, both hosts green. Each new fixture is a mutation fixture: reverting
`analyze.cljc` to HEAD reds the escape rows (over-accept) **and** the
earlier-local-call rows (under-shadow) — verified (16 failures + 1 error on the
pre-fix source, 0 after).

- **`analyze_reject_cljs_test` / `destructuring-scope-follows-host-evaluation-order`**
  (both hosts): self-default + later-bound escapes reject for all three reserved
  vars (`sub`/`lease`/`frame`); an explicit lookup-key `{x sub}` rejects with a
  `lookup-key` (not `:or default`) diagnostic.
- **`analyze_accept_cljs_test` / `destructuring-earlier-bound-shadow-compiles`**
  (both hosts): reverse-order bare default, an earlier-local **function-call**
  default `(sub :fallback)`, and an earlier-bound lookup-key shadow `{sub :s x sub}`
  all compile with an empty manifest.
- **`compiler_macro_resolution_jvm_test` / `real-cljs-destructuring-scope-follows-host-evaluation-order`**:
  the same reject/accept rows through **real CLJS analyzer resolution + genuine
  macro authority**.
- **`defview_grammar_jvm_test` / `header-destructuring-scope-follows-host-evaluation-order`**:
  the escape/legal split through **actual CLJ `defview` macroexpansion**
  (`*ns*`-bound so the bare `sub` spelling resolves).

Gates: `(cd implementation/ui && clojure -M:test)` → 505 tests / 6447 assertions,
0 failures. `(cd implementation && npm run test:cljs)` → 9375 tests / 44432
assertions, 0 failures. Compiler-only change, no browser surface; CI runs the
browser/spine gates authoritatively.

## Follow-up

Spec 004 grammar-prose still states `:or` defaults are the only value-expression
slots a binding pattern carries — the lookup-key expression and the sequential
evaluation-order model are a prose ripple to coordinate with rf2-vxgfnd.224 (not
in this compiler-only PR).
