### PR TITLE
fix(ui): establish the slice memo at real JVM Tier-1 render boundaries (rf2-vxgfnd.267)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -336,8 +336,11 @@
 ;; slice's table never survives into the next (rf2-vxgfnd.174):
 ;;
 ;;   - JVM: a THREAD-LOCAL render-slice scope (`*slice*`, opened by
-;;     `with-slice-memo` — the reactive render entry `with-capture` opens one
-;;     around each render, and a Tier-1 render entry may too). The box holds
+;;     `with-slice-memo`). EVERY public Tier-1 JVM render entry opens one around
+;;     the render thunk — `re-frame.ui.tree/render` and `ui.test/render`'s
+;;     view-reference / literal / plan-bearing routes (all three converge on
+;;     `render-with-opts` / `render-plan-bearing`) — and the reactive host entry
+;;     `with-capture` opens one around each ViewCell render. The box holds
 ;;     this slice's handle; the `binding` discards it on scope exit, so the
 ;;     prior table is unreachable with NO `reset-scheduler!`/tag-change
 ;;     dependency, two sequential executor tasks never share a table, and
@@ -373,14 +376,21 @@
   Released at the microtask checkpoint by `current-slice-memo`."
   (atom nil))
 
-(defn- with-slice-memo
-  "Open a render/execution slice for `thunk`: every `sub-read`/probe run under
-  it shares ONE slice-memo handle, discarded when `thunk` returns. Re-entrant —
+(defn ^:no-doc with-slice-memo
+  "THE Tier-1 JVM render-slice runner. Open a render/execution slice for
+  `thunk`: every `sub-read`/probe run under it shares ONE slice-memo handle,
+  discarded when `thunk` returns, so N sibling probes of one cold derived parent
+  compute it once per render (the first-mount fan-out mitigation) yet a LATER
+  render recomputes it. Established at every real public Tier-1 render boundary —
+  `re-frame.ui.tree/render` and `ui.test/render`'s view/literal/plan-bearing
+  routes — plus the reactive host entry `with-capture`, so the public headless
+  path shares one memo exactly as the browser/Tier-3 path does. Re-entrant —
   a nested call reuses the enclosing slice rather than opening a second one, so a
-  Tier-1 render entry and the `with-capture` inside it share ONE slice. On CLJS
-  this is a passthrough: the single-threaded host shares a synchronous render
-  pass through the module holder (`slice-memo*`), microtask-released, and needs
-  no per-scope binding."
+  Tier-1 render entry and the `with-capture` inside it share ONE slice, and a
+  bare `sub-read` OUTSIDE any scope gets a fresh per-call handle. On CLJS this is
+  a passthrough: the single-threaded host shares a synchronous render pass
+  through the module holder (`slice-memo*`), microtask-released, and needs no
+  per-scope binding."
   [thunk]
   #?(:clj  (if (thread-bound? #'*slice*)
              (thunk)

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -868,23 +868,30 @@
   structural rendering proceeds frameless — any frame-scoped read
   raises honestly rather than defaulting."
      [opts thunk]
-     (let [run  (if (contains? opts :sub-overrides)
-                  #(binding [reactive/*sub-overrides* (:sub-overrides opts)] (thunk))
-                  thunk)
-           root (cond
-                  (contains? opts :frame)
-                  (binding [rframe/*current-frame*
-                            (rframe/frame-target->id (:frame opts))]
-                    (run))
+     (let [run   (if (contains? opts :sub-overrides)
+                   #(binding [reactive/*sub-overrides* (:sub-overrides opts)] (thunk))
+                   thunk)
+           ;; Establish the JVM render-slice memo scope around the render thunk
+           ;; (rf2-vxgfnd.267): the two `ui.test/render` compiled routes — a
+           ;; view reference and a plan-free literal root form — converge HERE,
+           ;; so a single render shares ONE slice memo (sibling cold probes of a
+           ;; shared derived parent compute it once) and a later render
+           ;; recomputes. Re-entrant, so a nested `with-capture` reuses it.
+           slice #(reactive/with-slice-memo run)
+           root  (cond
+                   (contains? opts :frame)
+                   (binding [rframe/*current-frame*
+                             (rframe/frame-target->id (:frame opts))]
+                     (slice))
 
-                  (contains? opts :app-db)
-                  (let [id (rframe/frame-target->id
-                            (frame {:app-db (:app-db opts)}))]
-                    (try
-                      (binding [rframe/*current-frame* id] (run))
-                      (finally (rframe/destroy-frame! id))))
+                   (contains? opts :app-db)
+                   (let [id (rframe/frame-target->id
+                             (frame {:app-db (:app-db opts)}))]
+                     (try
+                       (binding [rframe/*current-frame* id] (slice))
+                       (finally (rframe/destroy-frame! id))))
 
-                  :else (run))]
+                   :else (slice))]
        (assoc root :rf.ui/tree-version tree/tree-version))))
 
 #?(:clj
@@ -1044,9 +1051,14 @@
              (live-frame/make-frame (assoc (or config {}) :id frame-id
                                            :rf.frame/must-create? true))
              (vswap! owned conj [frame-id (rframe/frame-incarnation-token frame-id)]))
-           (let [root (if (some? ambient-frame-id)
-                        (binding [rframe/*current-frame* ambient-frame-id] (run))
-                        (run))]
+           ;; Establish the JVM render-slice memo scope around the plan-bearing
+           ;; render thunk (rf2-vxgfnd.267) — the plan-bearing literal route's
+           ;; Tier-1 boundary — so a single render shares ONE slice memo and a
+           ;; later render recomputes. Re-entrant (a nested capture reuses it).
+           (let [slice #(reactive/with-slice-memo run)
+                 root  (if (some? ambient-frame-id)
+                         (binding [rframe/*current-frame* ambient-frame-id] (slice))
+                         (slice))]
              (assoc root :rf.ui/tree-version tree/tree-version))
            (finally
              ;; Incarnation-owned teardown: destroy each frame we installed ONLY

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -26,6 +26,7 @@
   (:require [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.registrar :as registrar]
+            [re-frame.ui.reactive :as reactive]
             [re-frame.ui.rules :as rules]))
 
 (declare classify-event sanitize-prop)
@@ -348,9 +349,16 @@
 (defn render
   "Invoke a compiled view fn (its JVM realisation) with `props` and stamp
   the root with :rf.ui/tree-version. The root is always the view's
-  boundary node — a map. This is the entry `ui.test/render` (S1d)
-  consumes."
+  boundary node — a map. This is a public Tier-1 JVM render entry (S1d).
+
+  Establish the JVM render-slice memo scope (rf2-vxgfnd.267) around the view
+  thunk so a single render shares ONE slice memo — sibling cold probes of a
+  shared derived parent compute it once, and a later render recomputes — exactly
+  as the browser/Tier-3 path does. Re-entrant: a nested `with-capture` reuses the
+  enclosing slice."
   ([view] (render view {}))
   ([view props]
-   (let [root (view props)]
-     (assoc root :rf.ui/tree-version tree-version))))
+   (reactive/with-slice-memo
+     (fn []
+       (let [root (view props)]
+         (assoc root :rf.ui/tree-version tree-version))))))

--- a/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
@@ -1,0 +1,226 @@
+(ns re-frame.ui.reactive-slice-memo-render-boundary-jvm-test
+  "rf2-vxgfnd.267 — the slice-scoped probe memo must be established at the REAL
+  public Tier-1 JVM render boundaries, not only inside `reactive/with-capture`
+  (which the JVM path never enters).
+
+  The public headless render surface — `re-frame.ui.tree/render` and
+  `ui.test/render`'s view-reference / literal / plan-bearing routes — executes
+  the compiled view thunk and probes `sub-read` DIRECTLY. Before this fix the
+  JVM slice scope lived only in the reactive host entry `with-capture`, so a
+  Tier-1 render ran OUTSIDE any scope and `current-slice-memo` minted a FRESH
+  handle for every probe: two cold sibling sites sharing one derived parent
+  recomputed it once per site (deterministic multiplicative work), and the
+  first-mount fan-out mitigation `rf2-vxgfnd.174` required was absent precisely
+  on the public Tier-1 entry.
+
+  These fixtures exercise the ACTUAL public host boundary (unlike the
+  synthetic-ViewCell `.174`/`.160` fixtures), counting cold-parent recomputes:
+
+    - within ONE render the sibling probes share ONE memo — the parent computes
+      exactly once (fresh-per-call would make it two);
+    - a LATER render with UNCHANGED frame/incarnation/registry tags recomputes
+      the parent (between-render disposal — the prior slice is unreachable with
+      no `reset-scheduler!`/tag change; a surviving global holder would reuse it
+      and the parent would NOT recompute);
+    - the scope is re-entrant (a nested slice reuses the enclosing one) and a
+      bare probe outside any scope is fresh per call;
+    - concurrent renders are thread-local-isolated and a sequential executor
+      task cannot reuse a prior task's table.
+
+  JVM-only: the memo is a THREAD-LOCAL render scope on the JVM (the CLJS host
+  shares its synchronous pass through a module holder). Uses `future` /
+  `CyclicBarrier` / a single-thread executor for the isolation proofs."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]
+            [re-frame.ui.tree :as tree])
+  (:import [java.util.concurrent CyclicBarrier Executors TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t] (frames/reset-installed-plans!) (t) (frames/reset-installed-plans!)))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — two sibling subs sharing ONE cold derived parent, whose compute
+;; increments a shared counter so a recompute is observable.
+;; ---------------------------------------------------------------------------
+
+(def ^:private parent-runs (atom 0))
+
+(defn- reg-slice-subs! []
+  (reset! parent-runs 0)
+  (rf/reg-sub :slice/parent (fn [db _] (swap! parent-runs inc) (:n db)))
+  (rf/reg-sub :slice/a :<- [:slice/parent] (fn [n _] (str "a" n)))
+  (rf/reg-sub :slice/b :<- [:slice/parent] (fn [n _] (str "b" n))))
+
+(defview siblings
+  "Two sibling `(sub …)` sites reading DISTINCT children of ONE shared cold
+  derived parent. Rendered once, the parent computes once iff the sites share a
+  slice memo."
+  []
+  [:div
+   [:span (ui/sub [:slice/a])]
+   [:span (ui/sub [:slice/b])]])
+
+;; ---------------------------------------------------------------------------
+;; Route 1 — `ui.test/render` view reference (render-view* → render-with-opts)
+;; ---------------------------------------------------------------------------
+
+(deftest ui-test-render-view-reference-shares-one-slice-memo
+  (reg-slice-subs!)
+  (let [f (uit/frame {:app-db {:n 5}})]
+    (reset! parent-runs 0)
+    (uit/render siblings {:frame f})
+    (is (= 1 @parent-runs)
+        "within ONE Tier-1 view-reference render the sibling probes share one
+         memo — the cold derived parent computes ONCE, not once per sibling
+         (fresh-per-call, the pre-fix defect, would make it two)")
+    (uit/render siblings {:frame f})
+    (is (= 2 @parent-runs)
+        "a LATER render (unchanged frame/incarnation/registry tags, no
+         reset-scheduler!) recomputes the parent exactly once — the prior
+         slice's memo was unreachable when the render returned; a surviving
+         global holder would reuse the tag-matching table and NOT recompute")))
+
+;; ---------------------------------------------------------------------------
+;; Route 2 — `ui.test/render` plan-free literal root form
+;; (render-form* → render-with-opts): converges with route 1 through
+;; render-with-opts, and route 3 (plan-bearing) through render-plan-bearing.
+;; ---------------------------------------------------------------------------
+
+(deftest ui-test-render-literal-form-shares-one-slice-memo
+  (reg-slice-subs!)
+  (let [f (uit/frame {:app-db {:n 5}})]
+    (reset! parent-runs 0)
+    (uit/render [siblings {}] {:frame f})
+    (is (= 1 @parent-runs)
+        "the plan-free literal route shares one slice memo within a render —
+         it converges with the view-reference route through render-with-opts")))
+
+(deftest ui-test-render-plan-bearing-shares-one-slice-memo
+  (reg-slice-subs!)
+  (uit/render [ui/frame-root {:id :slice/plan-a
+                              :initial-events [[:rf/set-db {:n 5}]]}
+               [siblings {}]])
+  (is (= 1 @parent-runs)
+      "the plan-bearing Tier-1 route (render-plan-bearing) shares one slice memo
+       within a render — the parent computes once across both sibling probes")
+  (uit/render [ui/frame-root {:id :slice/plan-b
+                              :initial-events [[:rf/set-db {:n 7}]]}
+               [siblings {}]])
+  (is (= 2 @parent-runs)
+      "each plan-bearing render is its OWN slice — a later render recomputes
+       (its preflighted frame is a distinct render scope)"))
+
+;; ---------------------------------------------------------------------------
+;; Route 3 — `re-frame.ui.tree/render` (the frameless public JVM entry)
+;; ---------------------------------------------------------------------------
+
+(deftest tree-render-shares-one-slice-memo
+  (reg-slice-subs!)
+  (let [fid :slice/tree-frame]
+    (live-frame/make-frame {:id fid})
+    (frame/replace-app-db! fid {:n 5})
+    (reset! parent-runs 0)
+    (rf/with-frame fid (tree/render siblings {}))
+    (is (= 1 @parent-runs)
+        "tree/render establishes one slice memo — the sibling probes share the
+         cold derived parent, computing it once")
+    (rf/with-frame fid (tree/render siblings {}))
+    (is (= 2 @parent-runs)
+        "a later tree/render recomputes the parent once (unchanged tags, no
+         reset) — between-render disposal on the tree/render boundary too")
+    (frame/destroy-frame! fid)))
+
+;; ---------------------------------------------------------------------------
+;; Re-entrancy + the bare-probe boundary (AC4)
+;; ---------------------------------------------------------------------------
+
+(deftest nested-slice-scope-reuses-the-enclosing-slice
+  (reg-slice-subs!)
+  (let [fid :slice/nested]
+    (live-frame/make-frame {:id fid})
+    (frame/replace-app-db! fid {:n 5})
+    (reset! parent-runs 0)
+    (rf/with-frame fid
+      (reactive/with-slice-memo
+        (fn []
+          (reactive/sub-read [:slice/a])
+          ;; a NESTED slice scope must REUSE the enclosing one, never open a
+          ;; second table — so the shared parent is NOT recomputed inside it.
+          (reactive/with-slice-memo
+            (fn [] (reactive/sub-read [:slice/b]))))))
+    (is (= 1 @parent-runs)
+        "a nested with-slice-memo reuses the enclosing slice (re-entrant) — the
+         shared parent computes once across both scopes, so a Tier-1 render and
+         a with-capture nested in it share ONE slice")
+    (frame/destroy-frame! fid)))
+
+(deftest bare-probe-outside-a-scope-is-fresh-per-call
+  (reg-slice-subs!)
+  (let [fid :slice/bare]
+    (live-frame/make-frame {:id fid})
+    (frame/replace-app-db! fid {:n 5})
+    (reset! parent-runs 0)
+    ;; two bare sub-reads OUTSIDE any render slice: each mints a fresh per-call
+    ;; memo, so the shared parent is recomputed each time (no cross-call table).
+    (rf/with-frame fid (reactive/sub-read [:slice/a]))
+    (rf/with-frame fid (reactive/sub-read [:slice/b]))
+    (is (= 2 @parent-runs)
+        "outside a Tier-1 render slice each bare probe is fresh per call — the
+         parent recomputes (no cross-call/global memo retention on the JVM)")
+    (frame/destroy-frame! fid)))
+
+;; ---------------------------------------------------------------------------
+;; Thread isolation (AC3) — the memo is a THREAD-LOCAL render scope, never a
+;; global holder shared across renders/threads.
+;; ---------------------------------------------------------------------------
+
+(deftest concurrent-tier1-renders-do-not-share-a-memo
+  ;; Two barrier-interleaved renders on the SAME frame. Each render's two
+  ;; siblings share ONE memo internally (parent once per render), and the two
+  ;; renders never share a table — total two computes. Fresh-per-call (the
+  ;; pre-fix defect) would give four; a global holder shared across threads
+  ;; would corrupt the count below two.
+  (reg-slice-subs!)
+  (let [f     (uit/frame {:app-db {:n 5}})
+        _     (reset! parent-runs 0)
+        gate  (CyclicBarrier. 2)
+        run   (fn [] (future
+                       (.await gate 10 TimeUnit/SECONDS)
+                       (uit/render siblings {:frame f})))
+        r1    (run)
+        r2    (run)]
+    @r1 @r2
+    (is (= 2 @parent-runs)
+        "two interleaved Tier-1 renders each compute the shared parent ONCE
+         internally (2 total) — the slice memo is thread-local per render, not
+         a global holder")))
+
+(deftest sequential-executor-tasks-do-not-reuse-a-prior-table
+  ;; A single worker thread runs two render tasks in sequence. The first task's
+  ;; slice binding is discarded when its render returns, so the reused thread
+  ;; carries NO residual scope into the second task — the parent recomputes
+  ;; (total two). A global holder with no per-scope discard would let the
+  ;; second task reuse the tag-matching table (total one).
+  (reg-slice-subs!)
+  (let [f    (uit/frame {:app-db {:n 5}})
+        _    (reset! parent-runs 0)
+        exec (Executors/newSingleThreadExecutor)]
+    (try
+      (let [t1 (.submit exec ^Callable (fn [] (uit/render siblings {:frame f})))
+            _  (.get t1 10 TimeUnit/SECONDS)
+            t2 (.submit exec ^Callable (fn [] (uit/render siblings {:frame f})))]
+        (.get t2 10 TimeUnit/SECONDS)
+        (is (= 2 @parent-runs)
+            "the second sequential task cannot reuse the first's table — each
+             render is its own slice, discarded on return"))
+      (finally
+        (.shutdownNow exec)))))


### PR DESCRIPTION
## What & why

Merged PR #5876 (head 7180b5fa93) gave the JVM a render-slice memo scope **only** inside `re-frame.ui.reactive/with-capture`, which the public Tier-1 JVM path never enters. `ui.test/render` executes the compiled `defview`/literal/plan-bearing thunk through `render-view*` → `render-with-opts` / `render-plan-bearing` and probes `sub-read` directly; `re-frame.ui.tree/render` invokes the view directly. Outside a `with-capture` scope, `current-slice-memo` intentionally mints a **fresh** `obs/make-slice-memo` per call — so the memo never spanned a real Tier-1 render.

**Symptom (the fresh-per-call defect):** two cold sibling probes of one shared derived parent in a single JVM Tier-1 render each got a distinct memo handle and recomputed that parent — deterministic multiplicative derivation work, and the first-mount fan-out mitigation `rf2-vxgfnd.174` required was absent precisely on the public headless entry. Returned values were always correct (the memo is an economy, tag-validated), so the `#5876` synthetic-ViewCell fixtures (which call `with-capture` directly) never caught it.

## The render-boundary set the memo now spans

`with-slice-memo` (reactive.cljc) is promoted from private to `^:no-doc` public — the single re-entrant JVM render-slice runner — and established at every real public Tier-1 render boundary:

- **`render-with-opts`** (test.cljc) — covers `ui.test/render` form 1 (view reference, via `render-view*`) and form 2 plan-free literal (via `render-form*`); both converge here.
- **`render-plan-bearing`** (test.cljc) — `ui.test/render` form 2 plan-bearing literal (frame-root plan route).
- **`re-frame.ui.tree/render`** (tree.cljc) — the frameless public JVM entry.

Re-entrant, so a nested `with-capture` reuses the enclosing slice; a bare `sub-read` outside any scope stays fresh per call; CLJS is unchanged (module holder, microtask-released — passthrough). No public render token, cache node, owner, watch, scheduler, or context framework added. `tree.cljc` gains a `[re-frame.ui.reactive]` require (acyclic — reactive requires neither `ui.tree` nor `ui.rules`).

## Quality gates

New JVM Tier-1 fixture `reactive_slice_memo_render_boundary_jvm_test.clj` drives the **real** public boundary (unlike the synthetic `.174`/`.160` fixtures), counting cold-parent recomputes:

- view-reference / literal / plan-bearing `ui.test/render` routes + `tree/render`: within one render the shared parent computes **once**; a later render with unchanged frame/incarnation/registry tags (no `reset-scheduler!`) recomputes it (between-render disposal).
- re-entrancy: a nested `with-slice-memo` reuses the enclosing slice; a bare probe outside any scope is fresh per call.
- thread isolation: barrier-interleaved concurrent renders never share a table; a single-thread executor's sequential tasks cannot reuse a prior table.

**Red-before-fix verified:** neutralizing the JVM slice scope makes every new-boundary assertion fail with exactly the doubled counts (1→2 within-render, 2→4 between-render), reproducing the fresh-per-call defect.

- `(cd implementation/ui && clojure -M:test)` — **511 tests, 6432 assertions, 0 failures** (JVM Tier-1 render + slice-memo + ViewCell suites).
- `(cd implementation && npm run test:cljs)` — **9380 tests, 44438 assertions, 0 failures** (both hosts).

Browser/full matrix left to CI (SLIM gate discipline — no Chromium surface in this change).

## Follow-up (not in this PR)

Spec 006 §The slice-scoped probe memo and the active synthesis carry unqualified module-holder lifetime wording that is now stale for the JVM (a dynamic/thread-local top-level render scope discarded on return, vs CLJS's module holder cleared at the microtask checkpoint). `spec/**` is a hot-zone owned by the docs+spec worker — recommend a sequenced prose follow-up bead there rather than editing spec in this PR.
