### PR TITLE
fix(epoch): decide delayed silencing per callback generation to prevent ABA (rf2-vxgfnd.265)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -280,14 +280,29 @@
   constructed after that dissoc, so it can never claim — and thereby drop — the
   buffer / observation ledger out from under this snapshot (rf2-vxgfnd.151).
 
-  Returns the evidence bundle `{:record :listener-snapshot :silenced-cbs}`
-  consumed by `on-frame-destroyed!`, or nil when no epoch layer participates
-  (production / debug disabled). `:record` is the `:halted-destroy` partial
-  record when the frame was mid-drain (a `:rf.event/run-start` is buffered),
-  else nil; the silencing fan is derived either way from the observers the
-  exact incarnation accrued. Schema digesting is intentionally omitted: A's
-  schemas are already torn down and a bare-id digest could only resolve absent
-  state or a same-id B."
+  Returns the evidence bundle
+  `{:record :listener-snapshot :silenced-cbs :baseline-silence-seq}` consumed by
+  `on-frame-destroyed!`, or nil when no epoch layer participates (production /
+  debug disabled). `:record` is the `:halted-destroy` partial record when the
+  frame was mid-drain (a `:rf.event/run-start` is buffered), else nil.
+
+  `:silenced-cbs` captures EXACT callback-generation identities — a
+  `{cb-id → generation}` map, not a bare set (rf2-vxgfnd.265). The delayed
+  silence is later decided PER identity: a cb re-registered to a fresh generation
+  in the deferred window never observed this incarnation and must receive no
+  stale signal, which a bare set could not express. Identities come from the
+  observers this exact incarnation accrued (`cbs-observing-frame`, already scoped
+  to each cb's live generation) plus, for a mid-drain `:halted-destroy`, every
+  listener the record will be fanned to (they observe it at delivery).
+
+  `:baseline-silence-seq` is the terminal-silence counter snapshotted BEFORE
+  dissoc. A same-id successor is constructable only AFTER dissoc, so any silence
+  it emits is stamped strictly above this baseline — the monotonic evidence a
+  paused predecessor uses to recognise a successor already silenced a cb (the
+  A→B→nil ABA) rather than re-emitting the identical unqualified signal.
+
+  Schema digesting is intentionally omitted: A's schemas are already torn down
+  and a bare-id digest could only resolve absent state or a same-id B."
   [frame-id fs-before fs-after committed-at]
   (when interop/debug-enabled?
     (let [buffered-events   (state/buffer-for frame-id)
@@ -300,11 +315,26 @@
                                 {:operation :rf.frame/destroyed-mid-drain}
                                 nil))
           listener-snapshot (if record (state/listeners-snapshot) {})
-          silenced-cbs      (into (set (state/cbs-observing-frame frame-id))
-                                  (keys listener-snapshot))]
-      {:record            record
-       :listener-snapshot listener-snapshot
-       :silenced-cbs      silenced-cbs})))
+          live              (state/listeners-snapshot)
+          ;; EXACT identities: cb-id → the generation that observed this
+          ;; incarnation. Observers carry their live generation; a mid-drain
+          ;; record additionally owes every current listener (each observes the
+          ;; halted record when it is fanned out in `on-frame-destroyed!`).
+          silenced-cbs      (as-> {} m
+                              (into m
+                                    (map (fn [cb]
+                                           [cb (:generation (get live cb))]))
+                                    (state/cbs-observing-frame frame-id))
+                              (if record
+                                (into m
+                                      (map (fn [[cb {:keys [generation]}]]
+                                             [cb generation]))
+                                      listener-snapshot)
+                                m))]
+      {:record               record
+       :listener-snapshot    listener-snapshot
+       :silenced-cbs         silenced-cbs
+       :baseline-silence-seq (state/current-terminal-silence-seq)})))
 
 (defn on-frame-destroyed!
   "Publish a destroyed frame's terminal epoch evidence and drop its id-keyed
@@ -328,49 +358,58 @@
   causal time). The record is not stored: destroyed frames have empty history,
   so listener delivery is the only channel for this terminal partial record.
 
-  Each listener whose CURRENT generation observed the frame receives one
-  silencing trace (a stale observation from a since-replaced same-id generation
-  is skipped — `state/cbs-observing-frame` scopes the fan to the live
-  generation).
+  The delayed silence is decided PER snapshotted callback-generation identity
+  (rf2-vxgfnd.265). Store claim, callback re-arm, and terminal silence are
+  DISTINCT events, so the coarse `cleanup-frame-owner!` result cannot gate the
+  fan: a successor that claims the stores but delivers no epoch (A still owes the
+  silence, losing the comparison notwithstanding); a successor that re-armed a cb
+  then destroyed before A resumes (A must NOT re-emit the silence B already
+  fired, even though A now wins the comparison); a cb re-registered to a fresh
+  generation (must receive no stale signal). Each owed identity is delivered iff
+  `state/delayed-silence-owed?` holds — its generation is still live, no live
+  successor re-armed it, and no successor silenced it after A's baseline.
 
   The id-keyed store DROP is compare-owned (`state/cleanup-frame-owner!`): it
   runs only while `owner-token` still owns the stores, so stale A can never
   erase a fresh same-id B. PUBLICATION of A's already-snapshotted terminal
-  record, its structural trailers, and its silencing fan is INDEPENDENT of
-  winning that comparison — the evidence was bound to A's exact incarnation
-  before dissoc and is A's to deliver whether or not A still owns the stores
-  (rf2-vxgfnd.151). All terminal emits use structural delivery so a same-id B's
-  frame-no-emit policy can neither suppress nor capture them. Repeated destroys
-  are idempotent."
+  record and its structural trailers is INDEPENDENT of winning that comparison —
+  the evidence was bound to A's exact incarnation before dissoc and is A's to
+  deliver whether or not A still owns the stores (rf2-vxgfnd.151). The live
+  observation state is read AFTER the compare-owned cleanup, so a winning cleanup
+  has already dropped this incarnation's own stamps while a losing one leaves the
+  successor's — exactly the re-arm evidence the per-identity decision consults.
+  All terminal emits use structural delivery so a same-id B's frame-no-emit
+  policy can neither suppress nor capture them. Repeated destroys are idempotent
+  (a re-destroyed frame has no observers and no mid-drain record, so nothing is
+  owed)."
   ([frame-id owner-token fs-before fs-after committed-at]
    (on-frame-destroyed! frame-id owner-token
                        (snapshot-terminal-destroy-evidence!
                          frame-id fs-before fs-after committed-at)))
   ([frame-id owner-token terminal-evidence]
    (when interop/debug-enabled?
-     (let [{:keys [record listener-snapshot silenced-cbs]} terminal-evidence
-           ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If
-           ;; a same-id B has already claimed them, this no-ops and leaves B
-           ;; untouched. The return value records whether A STILL WON its
-           ;; compare-owned cleanup: `cleanup-fn` returns true when A owned the
-           ;; stores (or no epoch state was ever claimed), nil when a successor B
-           ;; has already claimed them. That truth is exactly "no successor has
-           ;; re-armed the id-keyed observation state" (a successor claims by
-           ;; SETTLING, which fans its record to — and thereby re-arms — every
-           ;; live-generation observer of the reused id), so it gates A's
-           ;; silencing fan below (rf2-vxgfnd.245).
-           a-won-cleanup?
-           (state/cleanup-frame-owner!
-             frame-id owner-token
-             (fn []
-               ;; Data-only exact-owner transaction: no external callback runs
-               ;; between owner comparison and the complete drop.
-               (state/drop-frame-observation! frame-id)
-               (state/drop-frame-history! frame-id)
-               (state/drop-frame-buffer! frame-id)
-               (state/drop-last-settled-epoch! frame-id)
-               (state/drop-frame-mount-attribution! frame-id)
-               true))]
+     (let [{:keys [record listener-snapshot silenced-cbs baseline-silence-seq]}
+           terminal-evidence]
+       ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
+       ;; same-id B has already claimed them, this no-ops and leaves B untouched.
+       ;; The return value is intentionally ignored for the silencing decision —
+       ;; winning this comparison is NOT the same fact as "no successor re-armed
+       ;; the observers" (a claim without delivery loses it; a re-arm-then-destroy
+       ;; wins it), which the per-identity decision below resolves precisely
+       ;; (rf2-vxgfnd.265). The DROP itself still runs here so a winning A frees
+       ;; its stores (and leaves the live observation ledger showing the
+       ;; successor's re-arm evidence when A loses).
+       (state/cleanup-frame-owner!
+         frame-id owner-token
+         (fn []
+           ;; Data-only exact-owner transaction: no external callback runs
+           ;; between owner comparison and the complete drop.
+           (state/drop-frame-observation! frame-id)
+           (state/drop-frame-history! frame-id)
+           (state/drop-frame-buffer! frame-id)
+           (state/drop-last-settled-epoch! frame-id)
+           (state/drop-frame-mount-attribution! frame-id)
+           true))
        ;; Publish A's terminal RECORD + trailers regardless of the cleanup
        ;; comparison — the evidence was snapshotted before dissoc and belongs to
        ;; A's incarnation (rf2-vxgfnd.151). A late predecessor terminal record may
@@ -385,19 +424,21 @@
            #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                                 (:event-id record) :halted-destroy))
          (deliver-listener-snapshot! record listener-snapshot))
-       ;; The SILENCING fan is HONEST only when A still wins its compare-owned
-       ;; cleanup. If a same-id successor B has claimed the id-keyed stores, the
-       ;; same current listener generation already received B's newer record and
-       ;; is re-armed — so a bare A `:silenced-on-frame-destroy` would falsely
-       ;; claim a callback that is LIVE on B went silent (and B's own later
-       ;; destroy re-emits the identical unqualified signal). Gating on
-       ;; `a-won-cleanup?` republishes A's silencing ONLY when no successor
-       ;; re-armed the observation state; B silences those callbacks itself when B
-       ;; is destroyed (rf2-vxgfnd.245).
-       (when a-won-cleanup?
-         (doseq [cb-id silenced-cbs]
-           ;; The silencing fact belongs to destroyed A too; never let a same-id
-           ;; successor's trace policy suppress or capture it.
-           (trace/call-with-structural-delivery
-             #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                           {:frame frame-id :cb-id cb-id}))))))))
+       ;; PER-IDENTITY silencing (rf2-vxgfnd.265). The live observer set is read
+       ;; AFTER the compare-owned cleanup: a winning A has just dropped its own
+       ;; stamps (so none of its identities are "live"), while a losing A leaves
+       ;; the SUCCESSOR's stamps — the delivery/re-arm evidence. Each owed
+       ;; identity is emitted iff its generation is still live, it is not a live
+       ;; observer, and no successor already silenced it after A's baseline; a
+       ;; successful emit records the monotonic mark so a still-paused peer (or a
+       ;; later re-destroy) will not repeat it.
+       (let [live-observers (set (state/cbs-observing-frame frame-id))]
+         (doseq [[cb-id observed-gen] silenced-cbs]
+           (when (state/delayed-silence-owed?
+                   frame-id cb-id observed-gen baseline-silence-seq live-observers)
+             ;; The silencing fact belongs to destroyed A too; never let a same-id
+             ;; successor's trace policy suppress or capture it.
+             (trace/call-with-structural-delivery
+               #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                             {:frame frame-id :cb-id cb-id}))
+             (state/record-terminal-silence! frame-id cb-id))))))))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -879,6 +879,128 @@
   ;; cb-id → {frame-id → generation-token}
   (atom {}))
 
+;; ---- delayed predecessor-silencing lineage (rf2-vxgfnd.265) ---------------
+;;
+;; A destroyed incarnation A's `:rf.epoch.cb/silenced-on-frame-destroy` fan can
+;; be DEFERRED past a same-id successor B's whole lifecycle: A's post-dissoc
+;; publish hook is held while B — constructable only after dissoc — claims,
+;; settles/re-arms, and even destroys. #5872 gated the WHOLE fan on one coarse
+;; `cleanup-frame-owner!` result, conflating three DISTINCT events — store claim,
+;; callback delivery/re-arm, and terminal silence. Deciding PER callback-
+;; generation identity needs two kinds of evidence:
+;;
+;;   * delivery/re-arm (live): a successor that re-armed a cb and is STILL LIVE
+;;     leaves that cb in the live observation ledger (`cbs-observing-frame`), so
+;;     the callback is live on the successor rather than silent.
+;;   * terminal-silence (survives cleanup): a successor that re-armed then
+;;     DESTROYED already emitted the one truthful silence AND dropped its live
+;;     observation on cleanup — so the live ledger no longer shows it. This
+;;     monotonic mark records that a `(frame, cb)` silence fired and is NOT
+;;     dropped by `cleanup-frame-owner!`; it survives long enough for a paused
+;;     predecessor to see it and NOT re-emit the identical unqualified signal
+;;     (the A→B→nil ABA). A fresh delivery to the cb supersedes the mark
+;;     (`record-observation!` prunes it — a new continuum will owe its own
+;;     silence), which keeps the ledger bounded across incarnation churn.
+;;
+;; A snapshots a `baseline` seq BEFORE dissoc (a same-id B is constructable only
+;; AFTER dissoc, so any successor silence is stamped strictly after A's baseline).
+;; A mark ABOVE that baseline is a successor's → A skips; a mark at/below is a
+;; superseded earlier continuum, which the live-observation and generation checks
+;; already resolve.
+
+(defonce ^:private terminal-silence-seq (atom 0))
+
+(defn next-terminal-silence-seq
+  "Mint a fresh, process-monotonic terminal-silence marker."
+  []
+  (swap! terminal-silence-seq inc))
+
+(defn current-terminal-silence-seq
+  "Read the current terminal-silence marker — a destroying predecessor's
+  pre-dissoc baseline. A same-id successor's silence, stamped only after that
+  predecessor snapshots, always exceeds it."
+  []
+  @terminal-silence-seq)
+
+(defonce ^:private terminal-silence-marks
+  ;; frame-id → {cb-id → terminal-silence-seq of the latest silence emitted for
+  ;; (frame, cb)}. Survives compare-owned cleanup so a paused predecessor cannot
+  ;; re-emit a silence a successor already delivered; pruned when a fresh
+  ;; delivery re-arms the cb (`record-observation!`) or the cb unregisters.
+  (atom {}))
+
+(defn record-terminal-silence!
+  "Stamp that `(frame-id, cb-id)` was terminally silenced now, under a fresh
+  monotonic marker. Overwrites any earlier mark — only the latest matters."
+  [frame-id cb-id]
+  (swap! terminal-silence-marks assoc-in [frame-id cb-id]
+         (next-terminal-silence-seq))
+  nil)
+
+(defn- prune-terminal-silence-mark!
+  "Drop the terminal-silence mark for `(frame-id, cb-id)` — a fresh delivery to
+  the cb has re-armed it, so the prior continuum's mark is superseded."
+  [frame-id cb-id]
+  (swap! terminal-silence-marks
+         (fn [m]
+           (if-let [cbs (get m frame-id)]
+             (let [cbs' (dissoc cbs cb-id)]
+               (if (empty? cbs')
+                 (dissoc m frame-id)
+                 (assoc m frame-id cbs')))
+             m)))
+  nil)
+
+(defn drop-cb-silences!
+  "Forget one cb's terminal-silence marks across every frame — invoked when the
+  listener unregisters (its identity is gone; no predecessor can owe it a
+  silence any longer)."
+  [cb-id]
+  (swap! terminal-silence-marks
+         (fn [m]
+           (reduce-kv (fn [acc frame-id cbs]
+                        (let [cbs' (dissoc cbs cb-id)]
+                          (if (empty? cbs')
+                            (dissoc acc frame-id)
+                            (assoc acc frame-id cbs'))))
+                      {}
+                      m)))
+  nil)
+
+(defn reset-frame-silences!
+  "Wipe every terminal-silence mark and reset the monotonic counter for
+  fixture/global reset."
+  []
+  (reset! terminal-silence-marks {})
+  (reset! terminal-silence-seq 0)
+  nil)
+
+(defn delayed-silence-owed?
+  "Decide, PER callback-generation identity, whether a DEFERRED predecessor A
+  should still emit its `:rf.epoch.cb/silenced-on-frame-destroy` for `cb-id`.
+
+  A snapshotted `cb-id` observing its frame under `observed-gen`, plus a
+  `baseline` terminal-silence seq, before dissoc. `live-observers` is the set of
+  cbs whose CURRENT generation observes the frame at decision time (read AFTER
+  the compare-owned cleanup). A owes the silence iff ALL hold:
+
+    1. `cb-id`'s current generation is still the one that observed A — a
+       re-registered / dropped cb is a fresh generation that never observed A, so
+       it receives no stale signal.
+    2. `cb-id` is NOT currently a live observer — a successor that re-armed it
+       and is STILL LIVE owns the silence (the callback is live on the successor,
+       not silent).
+    3. no terminal silence for (frame, cb) was recorded AFTER A's baseline — a
+       successor that re-armed then DESTROYED already emitted the one truthful
+       silence, so re-emitting would be the ABA double-signal. (A mark at/below
+       the baseline is A's own idempotent re-run or a superseded earlier
+       continuum, already resolved by checks 1 and 2.)"
+  [frame-id cb-id observed-gen baseline live-observers]
+  (and (= observed-gen (:generation (get @listeners cb-id)))
+       (not (contains? live-observers cb-id))
+       (let [s (get-in @terminal-silence-marks [frame-id cb-id])]
+         (or (nil? s) (<= s (or baseline 0))))))
+
 (defn put-listener!
   "Install or replace `f` under `id` as a fresh listener GENERATION.
 
@@ -904,6 +1026,7 @@
   [id]
   (swap! listeners dissoc id)
   (swap! observed-frames-by-cb dissoc id)
+  (drop-cb-silences! id)
   nil)
 
 (defn reset-listeners!
@@ -965,7 +1088,15 @@
                          ;; undone by arming a retired/replaced generation.
                          (not= token (:generation (get @listeners cb-id))))
                    m
-                   (assoc-in m [cb-id frame-id] token))))))))
+                   (assoc-in m [cb-id frame-id] token))))
+        ;; A fresh observation re-arms this cb for the reused id: a new
+        ;; continuum begins and will owe its own silence, so a stale terminal-
+        ;; silence mark for (frame, cb) is superseded. Pruning it keeps the
+        ;; lineage ledger bounded across incarnation churn (rf2-vxgfnd.265). It
+        ;; is correctness-preserving either way — a paused predecessor's baseline
+        ;; predates this delivery, so a still-present mark would compare below
+        ;; the SUCCESSOR's baseline, never falsely gating it.
+        (prune-terminal-silence-mark! frame-id cb-id)))))
 
 (defn cbs-observing-frame
   "Return the cb-ids whose CURRENT generation observed `frame-id` — the frame
@@ -1107,4 +1238,5 @@
   "Clear the private incarnation ledger for fixture/global history reset."
   []
   (reset! frame-owner-tokens {})
+  (reset-frame-silences!)
   nil)

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -44,6 +44,9 @@
             [re-frame.epoch :as epoch]
             [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
+            ;; rf2-vxgfnd.265 — the reentrant claim-before-delivery fixture reads
+            ;; the successor incarnation's token to model its pre-first-epoch claim.
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             ;; rf2-vxgfnd.245 — the reentrant CLJS fail-before fixture wraps the
             ;; `:epoch/on-frame-destroyed` late-bind hook to install + settle a
@@ -485,3 +488,86 @@
           (late-bind/set-fn! :epoch/on-frame-destroyed original)
           (rf/unregister-listener! :epoch cb)
           (rf/unregister-listener! :trace ::rf2-245-cljs-silencing))))))
+
+;; ---- 9. rf2-vxgfnd.265 — per-identity delayed silencing (claim / ABA) -------
+
+(deftest predecessor-silences-after-reentrant-successor-claims-without-delivery-cljs
+  (testing "rf2-vxgfnd.265 (reentrant CLJS, red before fix) — A's post-dissoc
+            epoch hook re-entrantly installs a same-id successor B which CLAIMS
+            the id-keyed stores (the pre-first-epoch render/backfill claim routes
+            through `claim-frame-owner!`) but SETTLES nothing — cb never observes
+            B. When A resumes it must STILL emit its one owed silence for cb. Under
+            #5872's coarse gate A LOST the cleanup comparison to B's claim and
+            emitted nothing — a false negative."
+    (let [id         :rf2-265-claim/frame
+          cb         ::rf2-265-claim-cb
+          silencings (atom [])
+          armed?     (atom true)
+          original   (late-bind/get-fn :epoch/on-frame-destroyed)]
+      (rf/reg-event :rf2-265-claim/seed (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/make-frame {:id id})
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      ;; cb observes A by settling one ordinary event; A claims the id-keyed stores.
+      (rf/dispatch-sync [:rf2-265-claim/seed] {:frame id})
+      (rf/register-listener! :trace ::rf2-265-claim-silencing
+        (fn [ev]
+          (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+            (swap! silencings conj ev))))
+      (try
+        (late-bind/set-fn! :epoch/on-frame-destroyed
+          (fn [& args]
+            (when (and (= id (first args)) (compare-and-set! armed? true false))
+              ;; Same-id B claims the id-keyed stores WITHOUT settling — no B
+              ;; record reaches cb, so cb never observes B.
+              (rf/make-frame {:id id})
+              (state/claim-frame-owner! id (frame/frame-incarnation-token id)))
+            (when original (apply original args))))
+        (rf/destroy-frame! id)
+        ;; THE FIX: cb never observed B, so A owes and emits exactly one silence.
+        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+            "A emits its one owed silence for cb — B claimed but never delivered")
+        (finally
+          (late-bind/set-fn! :epoch/on-frame-destroyed original)
+          (rf/unregister-listener! :epoch cb)
+          (rf/unregister-listener! :trace ::rf2-265-claim-silencing)
+          (when (frame/frame id) (rf/destroy-frame! id)))))))
+
+(deftest late-predecessor-does-not-re-emit-silence-a-retired-successor-fired-cljs
+  (testing "rf2-vxgfnd.265 (synchronous CLJS, red before fix) — a same-id
+            successor B re-arms cb and then RETIRES before paused predecessor A
+            resumes (the A→B→nil ABA). B emits the one truthful silence and
+            releases the stores; late A now WINS the cleanup comparison but must
+            NOT re-emit the identical unqualified signal. #5872's coarse gate let
+            A re-fire it — a double signal. The monotonic terminal-silence mark
+            surviving B's cleanup is what lets late A recognise B already fired."
+    (let [id         :rf2-265-aba/frame
+          cb         ::rf2-265-aba-cb
+          silencings (atom [])
+          token-a    #js {}
+          token-b    #js {}]
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      (rf/register-listener! :trace ::rf2-265-aba-silencing
+        (fn [ev]
+          (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+            (swap! silencings conj ev))))
+      (try
+        ;; A claims + cb observes A.
+        (state/claim-frame-owner! id token-a)
+        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        ;; A snapshots its owed identities + terminal-silence baseline BEFORE the
+        ;; successor acts (a same-id B is constructable only after dissoc).
+        (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+          ;; B re-arms cb, then RETIRES — its terminal hook fires cb's one silence.
+          (state/claim-frame-owner! id token-b)
+          (epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
+          (epoch.listeners/on-frame-destroyed! id token-b
+            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+          (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+              "B's retire fired exactly one truthful silence for cb")
+          ;; A resumes with its stale snapshot — must add NO silence.
+          (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+          (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+              "late A adds no silence — the retired successor already fired the one signal"))
+        (finally
+          (rf/unregister-listener! :epoch cb)
+          (rf/unregister-listener! :trace ::rf2-265-aba-silencing))))))

--- a/implementation/epoch/test/re_frame/epoch_silencing_lineage_aba_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_lineage_aba_test.clj
@@ -1,0 +1,281 @@
+(ns re-frame.epoch-silencing-lineage-aba-test
+  "rf2-vxgfnd.265 — delayed predecessor-silencing decided PER callback-generation
+  identity across the three events #5872 conflated under one coarse
+  `cleanup-frame-owner!` result: store CLAIM, callback DELIVERY/re-arm, and
+  terminal SILENCE.
+
+  #5872 gated a destroyed predecessor A's whole `:rf.epoch.cb/silenced-on-frame-
+  destroy` fan on A still winning its compare-owned cleanup — equating losing the
+  frame-store owner comparison with a same-id successor having re-armed the
+  listeners. Those are distinct events, so the coarse gate produces three failure
+  modes this suite pins (each red before the fix; reverting to cleanup-result-wide
+  gating re-reddens them):
+
+    1. claim-before-delivery — B claims the id-keyed stores (a pre-first-epoch
+       render/backfill) but delivers no epoch. A LOSES the comparison yet still
+       owes the only silence: cb never observed B. Coarse gate → 0 (false
+       negative). Both `remains idle` and `retires` sub-cases.
+    2. rearm-then-retire (A→B→nil ABA) — B re-arms cb and DESTROYS before A
+       resumes. B emits the one truthful silence and releases the stores; A then
+       WINS the comparison and re-emits the identical unqualified signal. Coarse
+       gate → 2 (double signal). The monotonic terminal-silence mark, surviving
+       B's cleanup, is what lets late A recognise B already silenced cb.
+    3. mixed identities — a B-rearmed identity is suppressed, an A-only identity
+       is silenced, and a generation re-registered in the gap receives no stale
+       signal, ALL in one destroy. The coarse gate can only silence-all-or-none;
+       per-identity decision is required.
+
+  These JVM fixtures pause A with a `:epoch/on-frame-destroyed` late-bind wrapper
+  (matching the merged .151/.245 fixtures) or compose the successor lineage at the
+  epoch-state seam directly; the synchronous/reentrant CLJS peers live in
+  `re-frame.epoch-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
+            [re-frame.epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- executor-barrier!
+  "Wait until work already submitted through `interop/next-tick` has run."
+  []
+  (let [latch (CountDownLatch. 1)]
+    (interop/next-tick #(.countDown latch))
+    (is (.await latch 5 TimeUnit/SECONDS)
+        "the executor reached the deterministic barrier")))
+
+(defn- silences-for
+  "Count `:rf.epoch.cb/silenced-on-frame-destroy` traces captured in `silencings`
+  whose `:cb-id` is `cb`."
+  [silencings cb]
+  (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+
+;; ---- Mode 1: claim-before-delivery ----------------------------------------
+
+(deftest predecessor-silences-after-successor-claims-without-delivery
+  ;; A settles (cb observes A + A claims the id-keyed stores), self-destroys
+  ;; mid-drain and pauses at its POST-DISSOC epoch hook (owed identities incl cb
+  ;; snapshotted before dissoc). Same-id B is created and CLAIMS the id-keyed
+  ;; stores through the exact `claim-frame-owner!` a pre-first-epoch render/
+  ;; backfill routes through, but SETTLES nothing — cb never observes B. When A
+  ;; resumes it must emit its one owed silence for cb even though it LOST the
+  ;; cleanup comparison to B's claim.
+  (let [id             :vxgfnd265/claim-idle
+        cb             ::vxgfnd265-claim-idle-cb
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        silencings     (atom [])
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :vxgfnd265/claim-idle-settle
+      (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :vxgfnd265/claim-idle-destroy
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/make-frame {:id id})
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/dispatch-sync [:vxgfnd265/claim-idle-settle] {:frame id})
+    (rf/register-listener! :trace ::vxgfnd265-claim-idle-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:vxgfnd265/claim-idle-destroy]
+                                           {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A is paused at its post-dissoc epoch hook (owed incl cb snapshotted)")
+        ;; Same-id B claims the id-keyed stores (models the pre-first-epoch
+        ;; render/backfill claim) but never settles → cb never observes B.
+        (rf/make-frame {:id id})
+        (epoch-state/claim-frame-owner! id (frame/frame-incarnation-token id))
+        (is (nil? (get-in (epoch-state/observations-snapshot) [cb id]))
+            "B's claim dropped cb's observation; B delivered nothing to re-arm it")
+        (.countDown release-a)
+        (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+            "A's terminal recipe completes")
+        (executor-barrier!)
+        ;; THE FIX: A still owes and emits exactly one silence for cb.
+        (is (= 1 (silences-for silencings cb))
+            "A emits its one owed silence for cb — B claimed but never delivered"))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd265-claim-idle-silencing)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
+(deftest predecessor-silences-after-successor-claims-then-retires-without-delivery
+  ;; Mode 1 `retires` variant, composed at the epoch-state seam. cb observes A;
+  ;; A's owed identities + baseline are snapshotted. B claims (no delivery) and
+  ;; then RETIRES (its terminal hook silences nothing — it never observed cb).
+  ;; A then resumes and, being the last owner, WINS the comparison; it must emit
+  ;; exactly the one owed silence (never observed B, no successor silenced cb).
+  (let [id         :vxgfnd265/claim-retire
+        cb         ::vxgfnd265-claim-retire-cb
+        token-a    (Object.)
+        token-b    (Object.)
+        silencings (atom [])]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd265-claim-retire-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      ;; A: claim + cb observes A.
+      (epoch-state/claim-frame-owner! id token-a)
+      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        ;; B claims (dropping cb's observation) but never delivers, then retires.
+        (epoch-state/claim-frame-owner! id token-b)
+        (epoch.listeners/on-frame-destroyed! id token-b
+          (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+        (is (zero? (silences-for silencings cb))
+            "B's retire silences nothing — B never delivered to cb")
+        ;; A resumes: still owes the one silence.
+        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (is (= 1 (silences-for silencings cb))
+            "A emits its one owed silence after B claimed-then-retired without delivery"))
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd265-claim-retire-silencing)))))
+
+;; ---- Mode 2: rearm-then-retire (A→B→nil ABA) ------------------------------
+
+(deftest late-predecessor-does-not-re-emit-silence-a-retired-successor-already-fired
+  ;; A settles (cb observes A), self-destroys mid-drain and pauses at its
+  ;; POST-DISSOC epoch hook. Same-id B settles an ordinary event (cb receives B's
+  ;; record → re-armed), then B RETIRES: its terminal hook emits the one truthful
+  ;; silence for cb and releases the stores. When A resumes it now WINS the
+  ;; compare-owned cleanup (no owner left), but must NOT re-emit the identical
+  ;; unqualified signal — the monotonic terminal-silence mark B left (surviving
+  ;; B's cleanup) proves a successor already silenced cb after A's baseline.
+  (let [id             :vxgfnd265/aba
+        cb             ::vxgfnd265-aba-cb
+        a-after-dissoc (CountDownLatch. 1)
+        release-a      (CountDownLatch. 1)
+        first-epoch?   (atom true)
+        received       (atom [])
+        silencings     (atom [])
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :vxgfnd265/aba-settle
+      (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :vxgfnd265/aba-destroy
+      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+    (rf/reg-event :vxgfnd265/aba-b-settle
+      (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
+    (rf/make-frame {:id id})
+    (rf/register-listener! :epoch cb (fn [r] (swap! received conj r)))
+    (rf/dispatch-sync [:vxgfnd265/aba-settle] {:frame id})
+    (rf/register-listener! :trace ::vxgfnd265-aba-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (and (= id (first args))
+                     (compare-and-set! first-epoch? true false))
+            (.countDown a-after-dissoc)
+            (.await release-a 10 TimeUnit/SECONDS))
+          (when original-epoch (apply original-epoch args))))
+      (let [dispatch-a (future
+                         (rf/dispatch-sync [:vxgfnd265/aba-destroy] {:frame id}))]
+        (is (.await a-after-dissoc 10 TimeUnit/SECONDS)
+            "A is paused at its post-dissoc epoch hook")
+        ;; Same-id B settles (re-arms cb) then RETIRES at the epoch seam — its
+        ;; terminal hook fires cb's one truthful silence and drops the stores.
+        (rf/make-frame {:id id})
+        (rf/dispatch-sync [:vxgfnd265/aba-b-settle] {:frame id})
+        (is (= 2 (count @received))
+            "cb received A's settle and B's settle — re-armed for the reused id")
+        (let [token-b (frame/frame-incarnation-token id)]
+          (epoch.listeners/on-frame-destroyed! id token-b
+            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
+        (is (= 1 (silences-for silencings cb))
+            "B's retire fired exactly one truthful silence for cb")
+        ;; A resumes: must add NO further silence for cb (ABA prevented).
+        (.countDown release-a)
+        (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+            "A's terminal recipe completes")
+        (executor-barrier!)
+        (is (= 1 (silences-for silencings cb))
+            "late A adds no silence — the retired successor already fired the one signal"))
+      (finally
+        (.countDown release-a)
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd265-aba-silencing)
+        (when (frame/frame id) (frame/destroy-frame! id))
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+
+;; ---- Mode 3: mixed identities decided independently -----------------------
+
+(deftest delayed-silence-decided-per-identity-across-mixed-generations
+  ;; One destroy, three owed identities, three outcomes — the per-identity
+  ;; decision the coarse gate cannot express. Composed at the epoch-state seam so
+  ;; each identity is placed under a distinct successor outcome (a single real
+  ;; fan-out re-arms every listener uniformly and cannot diverge them):
+  ;;
+  ;;   U — re-armed by a still-LIVE successor  → suppressed (live-observer)
+  ;;   V — never re-armed by the successor      → silenced (A still owes it)
+  ;;   W — re-registered to a fresh generation  → no stale signal (gen mismatch)
+  (let [id         :vxgfnd265/mixed
+        u          ::vxgfnd265-mixed-u
+        v          ::vxgfnd265-mixed-v
+        w          ::vxgfnd265-mixed-w
+        token-a    (Object.)
+        token-b    (Object.)
+        silencings (atom [])]
+    (rf/register-listener! :epoch u (fn [_] nil))
+    (rf/register-listener! :epoch v (fn [_] nil))
+    (rf/register-listener! :epoch w (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd265-mixed-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      ;; A claims and fans one record → U, V, W all observe A.
+      (epoch-state/claim-frame-owner! id token-a)
+      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (is (= #{u v w} (set (epoch-state/cbs-observing-frame id)))
+          "U, V, W all observed A")
+      (let [u-gen (:generation (get (epoch-state/listeners-snapshot) u))
+            a-ev  (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        ;; Successor B claims (dropping every observation) and stays LIVE. It
+        ;; re-arms ONLY U; V is left un-rearmed; W is re-registered to a fresh
+        ;; generation that never observed the frame.
+        (epoch-state/claim-frame-owner! id token-b)
+        (epoch-state/record-observation! u u-gen id)     ; U live on B
+        (rf/register-listener! :epoch w (fn [_] nil))     ; W → fresh generation
+        (is (= [u] (epoch-state/cbs-observing-frame id))
+            "only U is a live observer of the reused id under the successor")
+        ;; A resumes with its stale snapshot (token-a is no longer the owner).
+        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (is (= 1 (silences-for silencings v))
+            "V — A-only identity — is silenced")
+        (is (zero? (silences-for silencings u))
+            "U — re-armed and live on the successor — is suppressed")
+        (is (zero? (silences-for silencings w))
+            "W — re-registered to a fresh generation — receives no stale signal")
+        (is (= 1 (count @silencings))
+            "exactly one silence total across the three mixed identities"))
+      (finally
+        (rf/unregister-listener! :epoch u)
+        (rf/unregister-listener! :epoch v)
+        (rf/unregister-listener! :epoch w)
+        (rf/unregister-listener! :trace ::vxgfnd265-mixed-silencing)))))


### PR DESCRIPTION
## Summary

`#5872` (rf2-vxgfnd.245) made a destroyed predecessor A's delayed
`:rf.epoch.cb/silenced-on-frame-destroy` fan gate on ONE coarse `cleanup-frame-owner!`
result — equating "losing the frame-store owner comparison" with "a same-id successor
re-armed the listeners." Store **claim**, callback **delivery/re-arm**, and terminal
**silence** are DISTINCT events, so that single gate mis-decides three ways. This PR
separates frame-store cleanup ownership from callback-notification truth and decides the
delayed silence **per callback-generation identity** using monotonic evidence that
survives a successor's cleanup.

Constraints honoured: no public token, no scheduler, no multi-incarnation API, no second
event bus. A's unconditional historical halted-record/trailers and the compare-owned store
cleanup are preserved unchanged.

## The three failure modes (red before the fix)

1. **Claim-before-delivery** — B claims the id-keyed stores (a pre-first-epoch
   render/backfill) but delivers no epoch. A loses the comparison yet still owes the only
   silence: the callback never observed B. Coarse gate emitted **0** (false negative).
2. **A→B→nil ABA (rearm-then-retire)** — B re-arms a callback and destroys before paused A
   resumes. B fires the one truthful silence and releases the stores; A then *wins* the
   comparison and re-emits the identical unqualified signal. Coarse gate emitted **2**
   (double signal).
3. **Replacement generation** — a callback id re-registered to a fresh generation in the
   deferred window received A's stale signal though the new generation never observed A.

The merged fixtures kept a settled B alive until A resumed, coupling claim + rearm and
excluding all three.

## The per-identity monotonic-evidence fix

- `snapshot-terminal-destroy-evidence!` now captures **exact callback-generation
  identities** (a `cb-id → generation` map, not a bare set) plus a **monotonic
  terminal-silence baseline** taken before dissoc (a same-id successor is constructable
  only after dissoc, so any silence it emits is stamped strictly above the baseline).
- `on-frame-destroyed!` decides each owed identity via `state/delayed-silence-owed?`,
  emitting iff ALL hold:
  1. the callback's current generation still equals the one that observed A (else a
     re-registered/dropped cb — a fresh generation — gets no stale signal);
  2. the cb is **not** a live observer of the frame — the live observation ledger is read
     **after** the compare-owned cleanup, so a losing A sees the successor's re-arm
     evidence (a callback live on the successor is not silent);
  3. no terminal silence for `(frame, cb)` was recorded **after** A's baseline — the
     monotonic mark, which is NOT dropped by `cleanup-frame-owner!` and is superseded only
     by a fresh delivery (`record-observation!`), lets a paused predecessor recognise a
     retired successor already fired the one signal (ABA).
- The compare-owned store DROP still runs (its return value is simply no longer the
  silencing gate). A's halted-record + structural trailers still publish unconditionally
  (rf2-vxgfnd.151).

## Quality gates

Foreground, all green with the fix; the three focused modes fail when the src is reverted
to origin/main's cleanup-result-wide gating (red-before-fix verified):

- `epoch/ clojure -M:test` — **392 tests / 2432 assertions, 0 failures** (new
  `epoch_silencing_lineage_aba_test.clj` fixtures + all existing silencing controls:
  B-live rearm, no-successor, halted-record/trailer, trace-ring boundary, repeated-destroy,
  generation-scoped). Reverting the fix → **4 failures** in `claim-idle` (got 0),
  `ABA` (got 2), and `mixed` (V got 0).
- `core/ clojure -M:test` — **1968 tests / 9020 assertions, 0 failures** (the merged
  .151/.245 paused-A JVM fixtures stay green).
- `implementation/ npm run test:cljs` — **9373 tests / 44397 assertions, 0 failures**
  (the synchronous/reentrant CLJS peers: reentrant claim-before-delivery + synchronous
  rearm-then-retire).

New fixtures:
- `epoch_silencing_lineage_aba_test.clj` — paused-A JVM (claim-idle, claim-retire), the
  A→B→nil ABA (rearm-then-retire), and the mixed-generation per-identity decision.
- `epoch_cljs_test.cljs` — the two reentrant/synchronous CLJS equivalents.

## Follow-up (not in this PR)

- Spec 009 / Tool-Pair silencing-lineage prose and the `:epoch/snapshot-frame-destroyed`
  late-bind directory description (`core/.../late_bind/directory.cljc`, currently
  `{:record :listener-snapshot :silenced-cbs}`) should note the exact-identity map + the
  `:baseline-silence-seq` bundle key. Left out to keep this PR scoped to
  `implementation/epoch/**` and out of the core/frame seam other workers hold.