### PR TITLE
fix(xray): honor exact-incarnation ownership on every ViewCell evidence init/read path (rf2-vxgfnd.238)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -678,23 +678,33 @@ invalidation-evidence accumulators the reactive scheduler's evidence-sink
 seam was built for). The Views panel renders it as the **VIEWCELL
 INVALIDATION EVIDENCE** section below the teardown lists.
 
-**Ownership + lifecycle.** The preload boot block claims the projection
-under the stable owner identity `:rf.xray/viewcell-evidence`
-(`day8.re-frame2-xray.viewcell-evidence/install!`). A shadow-cljs
-`:after-load` re-runs the same call as the evidence tier's idempotent
+**Ownership + lifecycle.** Two supported paths claim the projection under
+the stable owner identity `:rf.xray/viewcell-evidence`
+(`day8.re-frame2-xray.viewcell-evidence/install!`): the preload boot block,
+and the manual `day8.re-frame2-xray.core/init!` path (the alternative to
+`:devtools/preloads`). Both wire the identical install (rf2-vxgfnd.238), so
+a host that requires `core` and calls `init!` is never left with Xray
+enabled but evidence-blind. A shadow-cljs `:after-load` (or a second
+`init!`) re-runs the same call as the evidence tier's idempotent
 same-owner re-arm — accumulated evidence survives (the HMR path). A
 foreign owner already holding the projection is NEVER clobbered: Xray's
-install is rejected and the section simply projects zero rows.
-`viewcell-evidence/uninstall!` releases exactly Xray's registration —
-generation-fenced downstream (rf2-vxgfnd.147), so an in-flight delivery
-cannot repopulate the released projection and a stale release cannot
-touch a successor owner. A successful install mirrors onto the
-`__day8_re_frame2_xray_viewcell_evidence` global sentinel (the browser
+install is rejected. `viewcell-evidence/uninstall!` releases exactly
+Xray's registration — generation-fenced downstream (rf2-vxgfnd.147), so an
+in-flight delivery cannot repopulate the released projection and a stale
+release cannot touch a successor owner. A successful install mirrors onto
+the `__day8_re_frame2_xray_viewcell_evidence` global sentinel (the browser
 feature-gate's wiring probe; withdrawn on uninstall).
 
-**Query path.** `:rf.xray/viewcell-evidence` (registered by
-`reactive-panel-subs/install!`) → `viewcell-evidence/rows`: one row per
-live ViewCell instance in stable `:cell-id` order —
+**Query path — ownership-fenced.** `:rf.xray/viewcell-evidence` (registered
+by `reactive-panel-subs/install!`) → `viewcell-evidence/rows`. Every read
+is gated on the exact ownership token (rf2-vxgfnd.238): rows — and
+therefore the sub, the panel section, and any derived Xray query — observe
+evidence ONLY while Xray is the installed owner. The evidence tier's
+`projection` read exposes the shared slot's entries REGARDLESS of owner, so
+an ownership rejection (a foreign tool installed first) must — and does —
+mean zero observation through Xray, never the foreign owner's rows. When
+Xray owns the projection, one row per live ViewCell instance in stable
+`:cell-id` order —
 
     {:cell-id ord :view-id vid :root-id rid|nil
      :first-epoch e0 :latest-epoch eN :count n :batches b

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -51,7 +51,13 @@
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
-            [day8.re-frame2-xray.theme.global-styles :as global-styles]))
+            [day8.re-frame2-xray.theme.global-styles :as global-styles]
+            ;; The native ViewCell invalidation-evidence consumer
+            ;; (rf2-vxgfnd.146). `init!` claims the projection under Xray's
+            ;; stable owner identity, exactly as the preload boot block does —
+            ;; load-inert (this require runs no side-effects; only `init!`
+            ;; invokes `install!`), keeping manual startup inert until `init!`.
+            [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]))
 
 ;; ---- mount entry points (re-exports from mount.cljs) --------------------
 ;;
@@ -154,6 +160,15 @@
    (registry/register-xray-handlers!)
    (install/register-trace-collector!)
    (install/register-epoch-collector!)
+   ;; Claim the re-frame.ui ViewCell invalidation-evidence projection under
+   ;; Xray's stable owner identity (rf2-vxgfnd.146/.238). The manual `init!`
+   ;; path MUST wire this exactly as the preload boot block does — otherwise
+   ;; a clean process that requires core and calls `init!` (the supported
+   ;; alternative to `:devtools/preloads`) enables Xray WITHOUT ViewCell
+   ;; evidence. Idempotent: a second `init!` / shadow `:after-load` is the
+   ;; evidence tier's same-owner re-arm (accumulated evidence survives); a
+   ;; foreign owner is never clobbered (install rejected, Xray reads nothing).
+   (viewcell-evidence/install!)
    ;; The palette and Settings effects resolve mount operations through
    ;; these globals to avoid a mount/shell require cycle. Manual and
    ;; preload startup therefore install the same exports.

--- a/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
@@ -108,20 +108,30 @@
      :dropped-count  d        ; distinct omitted targets (honest loss)
      :dropped-exact? bool}    ; false ⇒ d is a lower bound (saturated)
 
-  `[]` when uninstalled, empty, or in a production build (where the
-  debug evidence plane is elided)."
+  `[]` when Xray does NOT own the installed projection (never installed,
+  uninstalled, or a FOREIGN owner holds it — ownership rejection must mean
+  no observation through Xray), when empty, or in a production build (where
+  the debug evidence plane is elided)."
   []
-  (into []
-        (map (fn [{:keys [cell-id view-id root-id evidence]}]
-               {:cell-id        cell-id
-                :view-id        view-id
-                :root-id        root-id
-                :first-epoch    (:first-epoch evidence)
-                :latest-epoch   (:latest-epoch evidence)
-                :count          (:count evidence)
-                :batches        (:batches evidence)
-                :causes         (:causes evidence)
-                :targets        (:targets evidence)
-                :dropped-count  (count (:dropped evidence))
-                :dropped-exact? (:dropped-exact? evidence)}))
-        (or (evidence/projection) [])))
+  ;; Ownership fence (rf2-vxgfnd.238). The evidence tier's `projection`
+  ;; read returns the shared slot's entries REGARDLESS of owner, so a bare
+  ;; read here would expose a foreign owner's evidence whenever Xray's
+  ;; install was rejected (`installed?` false). Gate EVERY read — rows and
+  ;; the `:rf.xray/viewcell-evidence` sub/UI that derive from it — on the
+  ;; exact ownership token: Xray observes iff Xray is the installed owner.
+  (if-not (installed?)
+    []
+    (into []
+          (map (fn [{:keys [cell-id view-id root-id evidence]}]
+                 {:cell-id        cell-id
+                  :view-id        view-id
+                  :root-id        root-id
+                  :first-epoch    (:first-epoch evidence)
+                  :latest-epoch   (:latest-epoch evidence)
+                  :count          (:count evidence)
+                  :batches        (:batches evidence)
+                  :causes         (:causes evidence)
+                  :targets        (:targets evidence)
+                  :dropped-count  (count (:dropped evidence))
+                  :dropped-exact? (:dropped-exact? evidence)}))
+          (or (evidence/projection) []))))

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -26,6 +26,7 @@
             [re-frame.frame :as frame]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.tool.evidence :as evidence]
+            [day8.re-frame2-xray.core :as core]
             [day8.re-frame2-xray.mount :as mount]
             ;; The REAL preload — its debug-gated boot block runs at load,
             ;; installing the evidence projection under Xray's identity.
@@ -189,3 +190,84 @@
     (is (false? (viewcell-evidence/uninstall!))
         "…and Xray's uninstall cannot release what it does not own")
     (is (= ::another-tool (evidence/installed-owner)))))
+
+;; ===========================================================================
+;; Ownership fence on the READ path (rf2-vxgfnd.238) — a foreign owner's
+;; accumulated evidence is NEVER observable through Xray
+;; ===========================================================================
+
+(deftest foreign-owner-evidence-never-surfaces-through-any-xray-read
+  ;; A foreign tool owns the shared projection AND has accumulated evidence
+  ;; in it — the case the earlier never-clobber test omitted (it installed a
+  ;; foreign owner but delivered nothing, so `rows` was empty for the wrong
+  ;; reason). Drive a real flush so `evidence/projection` is non-empty.
+  (is (true? (evidence/install! ::another-tool)))
+  (let [cell (reactive/make-cell ::foreign-v)]
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (is (= 1 (count (evidence/projection)))
+        "the FOREIGN owner accumulated a row in the shared projection")
+    ;; Xray's own claim is rejected — Xray does not own the projection.
+    (is (false? (viewcell-evidence/install!)))
+    (is (false? (viewcell-evidence/installed?)))
+    ;; AC: rows + every derived Xray query return NO evidence unless Xray
+    ;; owns the installed projection. Fail-before: pre-fix `rows` read the
+    ;; shared projection regardless of ownership and surfaced this row.
+    (is (= [] (viewcell-evidence/rows))
+        "ownership rejection ⇒ zero observation through Xray's rows")
+    (boot-xray!)
+    (is (= [] (xray-query))
+        "…and zero through the :rf.xray/viewcell-evidence query path")
+    ;; Xray neither released nor read the foreign owner's projection.
+    (is (= ::another-tool (evidence/installed-owner))
+        "the foreign registration is untouched")
+    (is (= 1 (count (evidence/projection)))
+        "…and its evidence still lives in the shared projection")))
+
+;; ===========================================================================
+;; core/init! is a full evidence-projection install path (rf2-vxgfnd.238)
+;; ===========================================================================
+
+(deftest core-init-claims-the-projection-under-xrays-identity
+  ;; A clean process that requires `core` and calls `init!` (the supported
+  ;; manual alternative to the preload) must claim the evidence projection,
+  ;; or Xray is enabled WITHOUT ViewCell evidence. Fail-before: pre-fix
+  ;; `init!` never installed, so this owner stayed nil.
+  (is (nil? (evidence/installed-owner)) "clean slate — nobody owns it")
+  (core/init!)
+  (is (= viewcell-evidence/owner-id (evidence/installed-owner))
+      "core/init! claims the projection under Xray's stable owner id")
+  (is (true? (viewcell-evidence/installed?)))
+  (is (some? (aget js/globalThis sentinel-key))
+      "…and mirrors the install on the browser-probe sentinel")
+  (testing "idempotent — a second init! is the same-owner re-arm, not a reject"
+    (core/init!)
+    (is (= viewcell-evidence/owner-id (evidence/installed-owner)))
+    (is (true? (viewcell-evidence/installed?)))))
+
+(deftest core-init-does-not-clobber-a-foreign-owner
+  ;; The manual path honours the same never-clobber contract as the preload.
+  (is (true? (evidence/install! ::another-tool)))
+  (core/init!)
+  (is (= ::another-tool (evidence/installed-owner))
+      "core/init! did not clobber the foreign registration")
+  (is (false? (viewcell-evidence/installed?)))
+  (is (= [] (viewcell-evidence/rows))
+      "…and exposes no evidence while another owner holds the projection"))
+
+(deftest uninstall-then-core-init-reclaims-a-fresh-projection
+  ;; dispose (uninstall) then re-init: the ordinary tool-shutdown / test
+  ;; door, and a re-init that reclaims a fresh, empty ownership span.
+  (is (true? (viewcell-evidence/install!)))
+  (let [cell (reactive/make-cell ::v)]
+    (reactive/mark-dirty! cell 1)
+    (reactive/flush-pending!)
+    (is (= 1 (:count (first (viewcell-evidence/rows))))))
+  (is (true? (viewcell-evidence/uninstall!)))
+  (is (nil? (evidence/installed-owner)))
+  (is (= [] (viewcell-evidence/rows)) "closed retains zero")
+  ;; re-init through the manual path reclaims the projection, empty
+  (core/init!)
+  (is (true? (viewcell-evidence/installed?)))
+  (is (= [] (viewcell-evidence/rows))
+      "re-init starts from a fresh, empty projection"))


### PR DESCRIPTION
## What

PR #5844 hardened the Xray ViewCell evidence projection, but two public integration paths still violated the projection's ownership boundary. This fixes both, keeping the change local to Xray integration.

### Paths fixed

1. **READ path** — `tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs` `rows`. It read `evidence/projection` regardless of ownership. The evidence tier's projection read exposes the shared slot's entries for whoever installed it, so when Xray's install was **rejected** (a foreign owner held the slot), Xray still surfaced that owner's evidence through `rows`, the `:rf.xray/viewcell-evidence` sub, and the Views panel. `rows` now gates on the exact ownership token (`installed?` → `evidence/installed-owner`): Xray observes iff Xray is the installed owner. Ownership rejection now means **no observation through Xray**. `rows` is the single choke point for every derived query (the sub reads it; the panel reads the sub), so the fence covers all read paths.

2. **INIT path** — `tools/xray/src/day8/re_frame2_xray/core.cljs` `init!`. The preload boot block installed the projection but the supported manual `core/init!` path did not, so a clean process that required `core` and called `init!` enabled Xray **without** ViewCell evidence. `init!` now claims the projection under Xray's stable owner id exactly as the preload does. Idempotent (same-owner re-arm); never clobbers a foreign owner. The `viewcell-evidence` require is load-inert, preserving "manual startup stays inert until `init!`".

### Xray spec

Updated (**not** "spec unchanged") — `tools/xray/spec/021-Dynamic-Panel-Designs.md` §3.4.1: the **ownership-fenced** read path (rows/sub/panel observe only while Xray is the installed owner; a foreign owner's evidence is never observable through Xray) and `core/init!` documented as the second supported install path alongside the preload.

### No implementation/ change / Spec 009 gap

None surfaced. The fix consumes the already-published `re-frame.ui.tool.evidence` contract; the ownership token (`installed-owner`) it fences on already exists. Nothing under `implementation/` was touched.

## Tests

Added to `tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs`, all **red-before-fix verified** (reverted source → the two new suites fail exactly on the ownership/init gaps; restored → green):

- `foreign-owner-evidence-never-surfaces-through-any-xray-read` — a foreign owner accumulates a real row in the shared projection; Xray's `rows` and the `:rf.xray/viewcell-evidence` query both return `[]`, and Xray neither releases nor reads the foreign registration. (The earlier never-clobber test installed a foreign owner but delivered nothing, so `rows` was empty for the wrong reason — this drives a real flush.)
- `core-init-claims-the-projection-under-xrays-identity` — `core/init!` claims the projection + mirrors the sentinel; idempotent second `init!` is a same-owner re-arm.
- `core-init-does-not-clobber-a-foreign-owner`.
- `uninstall-then-core-init-reclaims-a-fresh-projection` — dispose → re-init via the manual path reclaims a fresh, empty span.

Existing preload-wiring, HMR re-arm, exact-owner release, and never-clobber contracts unchanged.

## Quality gates

Run from `implementation/` against the shadow `node-test` build (the runtime the xray `*-cljs-test` suites execute under):

- Focused viewcell-evidence suite: **8 tests / 64 assertions, 0 failures, 0 errors** (green with fix; the two new suites red before fix).
- Full xray cljs suite (`re-frame2-xray.*cljs-test`): **3248 tests / 13674 assertions, 0 failures, 0 errors** — no regression in the registry / reactive-panel-subs consumers of `rows`.

Browser matrix (xray feature-matrix gate + adapter smokes) left to CI.
