### PR TITLE
fix(core): close the observation port grammar at every real boundary (rf2-vxgfnd.241)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -687,31 +687,119 @@
        (seq q)
        (keyword? (first q))))
 
+(defn- query-shape-class
+  "Bounded, leak-safe classification of a MALFORMED query-vector for
+  [[resolve-target]]'s rejection evidence (rf2-vxgfnd.241): which
+  [[valid-query-v?]] clause it violated — `:non-vector`, `:empty-vector`, or
+  `:non-keyword-head`. NEVER the query CONTENTS: a valid query's args can carry
+  app values, so even a malformed query is summarized STRUCTURALLY, never
+  serialized."
+  [q]
+  (cond
+    (not (vector? q)) :non-vector
+    (not (seq q))     :empty-vector
+    :else             :non-keyword-head))
+
+(defn- throw-malformed-query!
+  "Reject a malformed query-vector at [[resolve-target]] — the port's ONLY
+  resolution point (rf2-vxgfnd.241). resolve-target must validate the query
+  SHAPE before any sequence access (`(first query-v)`) and before minting a
+  target: an unvalidated scalar / empty / non-keyword-headed query-v otherwise
+  leaks a raw host `(first …)` error (the ambient-frame path threads
+  `(first query-v)` as the no-frame-context event-id) or DEFERS failure to the
+  downstream target validator at an unrelated probe/acquire call site. A
+  malformed query cannot yield a valid closed-grammar target, so resolve-target
+  throws the SAME typed `:rf.error/observation-malformed-target` its downstream
+  gate raises — closing the boundary at the earliest point rather than deferring.
+  Pure `throw-error!` (diagnostic channel) — a malformed query is a
+  substrate/consumer bug, unreachable in correct generated code, so it does NOT
+  fan the always-on axis. Carries BOUNDED structural evidence only
+  ([[query-shape-class]] plus a vector's element count), never the query
+  CONTENTS. Never returns."
+  [where query]
+  (let [shape (query-shape-class query)]
+    (error/throw-error!
+      :rf.error/observation-malformed-target
+      where
+      (str where " received a malformed query-vector (" shape
+           (when (vector? query) (str ", " (count query) " elements"))
+           "): a query must be a non-empty keyword-headed vector "
+           "[<sub-id> & args]. resolve-target is the port's ONLY resolution "
+           "point; a malformed query cannot yield a valid closed-grammar target "
+           "(rf2-vxgfnd.241).")
+      {:recovery :no-recovery
+       :extra    {:query-class shape
+                  :query-count (when (vector? query) (count query))}})))
+
 (defn- valid-target?
   "True iff `target` is EXACTLY one of the two complete shapes `resolve-target`
   emits (rf2-vxgfnd.183) — the port's CLOSED target grammar. Structural, pure,
-  allocation-light: a STRICT key-set match per `:kind` (so BOTH a missing AND an
-  extra key fail, and a legitimately-nil override value/token stays a VALUE
-  because its KEY is present — presence, never `some?`), plus the field-domain
-  checks. A `:subscription` needs a present keyword `:frame-id` (frame ids are
-  registry-keyed keywords per `re-frame.frame`) and a non-empty keyword-headed
-  `:query`; a `:story-override` needs `:query`/`:value`/`:override-id`/`:version`
-  all present and the same query domain. A non-map, an unknown `:kind`, a
-  supported-kind-but-INCOMPLETE target (a bare `{:kind :story-override}`), a
-  wrong-domain field, or a malformed query all read false."
+  and ALLOCATION-FREE on the hot success path (rf2-vxgfnd.241): a
+  FIXED-VOCABULARY key check — `count` (O(1); never enumerates the map's keys)
+  plus `contains?` of the port's OWN known keys — so BOTH a missing AND an extra
+  key fail WITHOUT allocating a key-set or hashing the target's
+  attacker-controllable extra keys. This replaces the prior
+  `(= #{…} (set (keys target)))`, which allocated a set and HASHED every key on
+  every hot probe/acquire, letting a hostile extra key's `hashCode`/`equals`
+  escape as an untyped host error and scaling with attacker-controlled extras. A
+  legitimately-nil override value/token stays a VALUE because its KEY is present
+  (`contains?`, never `some?`). The `:kind` discriminator compares with the known
+  keyword FIRST (`=` dispatches through the keyword's own equality), so a hostile
+  `:kind` value's own `hashCode`/`equals` is never invoked. A `:subscription`
+  needs EXACTLY `{:kind :frame-id :query}` with a present keyword `:frame-id`
+  (frame ids are registry-keyed keywords per `re-frame.frame`) and a non-empty
+  keyword-headed `:query`; a `:story-override` needs EXACTLY
+  `{:kind :query :value :override-id :version}` with the same query domain. A
+  non-map, an unknown `:kind`, a supported-kind-but-INCOMPLETE target (a bare
+  `{:kind :story-override}`), an EXTRA key, a wrong-domain field, or a malformed
+  query all read false — and a hostile-hash extra key can never escape as a raw
+  error."
   [target]
   (and (map? target)
-       (case (:kind target)
-         :subscription
-         (and (= #{:kind :frame-id :query} (set (keys target)))
+       (cond
+         ;; count is the fixed-vocabulary cardinality gate: the discriminator
+         ;; already proves `:kind` present, and `contains?` proves the remaining
+         ;; named keys, so an exact count pins the key-set to EXACTLY the closed
+         ;; grammar without ever touching (hashing/enumerating) an extra key.
+         (= :subscription (:kind target))
+         (and (= 3 (count target))
+              (contains? target :frame-id)
+              (contains? target :query)
               (keyword? (:frame-id target))
               (valid-query-v? (:query target)))
 
-         :story-override
-         (and (= #{:kind :query :value :override-id :version} (set (keys target)))
+         (= :story-override (:kind target))
+         (and (= 5 (count target))
+              (contains? target :query)
+              (contains? target :value)
+              (contains? target :override-id)
+              (contains? target :version)
               (valid-query-v? (:query target)))
 
-         false)))
+         :else false)))
+
+(def ^:private target-known-keys
+  "The port's CLOSED target grammar vocabulary — the union of the two shapes'
+  keys. Malformed-target rejection evidence names ONLY which of THESE (the
+  port's OWN keys) are present, never the target's raw/attacker keys
+  (rf2-vxgfnd.241)."
+  [:kind :frame-id :query :value :override-id :version])
+
+(defn- target-kind-class
+  "Bounded, leak-safe classification of a target's `:kind` for rejection
+  evidence (rf2-vxgfnd.241): the recognized closed-grammar kind (`:subscription`
+  / `:story-override`) echoed as-is — a known interned constant, bounded and
+  non-sensitive — or `:unrecognized` for anything else (a non-keyword, an unknown
+  keyword, an absent `:kind`, or a non-map target). So a structured or secret
+  `:kind` VALUE is never serialized into the diagnostic. Compares with the known
+  keyword FIRST so dispatch rides the keyword's own equality — a hostile `:kind`
+  value's `hashCode`/`equals` is never invoked."
+  [target]
+  (let [k (when (map? target) (:kind target))]
+    (cond
+      (= :subscription k)   :subscription
+      (= :story-override k) :story-override
+      :else                 :unrecognized)))
 
 (defn- throw-malformed-target!
   "Reject a target that violates the port's CLOSED target grammar
@@ -726,25 +814,45 @@
   ViewCell error boundary cannot classify. Throws the typed
   `:rf.error/observation-malformed-target`. Pure `throw-error!` (diagnostic
   channel) — a corrupted target is a programming defect, unreachable in correct
-  generated code, so it does NOT fan the always-on axis. Carries BOUNDED
-  STRUCTURAL evidence only — the `:kind` and the target's KEY-SET, never the
-  field VALUES (a `:story-override` embeds an app value under `:value`). Never
-  returns."
+  generated code, so it does NOT fan the always-on axis.
+
+  Evidence is BOUNDED + NORMALIZED (rf2-vxgfnd.241) — the prior evidence
+  serialized the raw `:kind` and the FULL key vector (`(vec (keys target))`),
+  which enumerated a 10k-key map into an unbounded message and leaked
+  structured/secret KEYS. It now carries only: the [[target-kind-class]] (a
+  recognized kind or `:unrecognized`, never a raw/secret kind value), the total
+  `:key-count` (an O(1) `count`, never the keys themselves), and
+  `:known-keys-present` — which of the port's OWN [[target-known-keys]] the map
+  carries (a `contains?` probe of fixed vocabulary, so an attacker's extra key is
+  never named, hashed, or enumerated). Never the field VALUES (a
+  `:story-override` embeds an app value under `:value`). Never returns."
   [where target]
-  (error/throw-error!
-    :rf.error/observation-malformed-target
-    where
-    (str where " received a malformed observation target (kind "
-         (pr-str (when (map? target) (:kind target))) ", keys "
-         (pr-str (when (map? target) (vec (keys target)))) "): it is not one of "
-         "the two closed shapes resolve-target emits — a :subscription with a "
-         "keyword :frame-id and a non-empty keyword-headed :query, or a "
-         ":story-override carrying :query/:value/:override-id/:version. A target "
-         "must come from resolve-target (the port's ONLY resolution point); a "
-         "hand-constructed, incomplete, or corrupted target is a substrate bug.")
-    {:recovery :no-recovery
-     :extra    {:kind        (when (map? target) (:kind target))
-                :target-keys (when (map? target) (vec (keys target)))}}))
+  (let [is-map     (map? target)
+        kind-class (target-kind-class target)
+        key-count  (when is-map (count target))
+        known      (when is-map
+                     (into #{}
+                           (filter #(contains? target %))
+                           target-known-keys))]
+    (error/throw-error!
+      :rf.error/observation-malformed-target
+      where
+      (str where " received a malformed observation target (kind-class "
+           kind-class
+           (when key-count (str ", " key-count " keys"))
+           "): it is not one of the two closed shapes resolve-target emits — a "
+           ":subscription with a keyword :frame-id and a non-empty keyword-headed "
+           ":query, or a :story-override carrying "
+           ":query/:value/:override-id/:version. A target must come from "
+           "resolve-target (the port's ONLY resolution point); a hand-constructed, "
+           "incomplete, or corrupted target is a substrate bug. Diagnostic "
+           "evidence is bounded + normalized — kind-class, total key count, and "
+           "known-key presence only, never raw key/value material "
+           "(rf2-vxgfnd.241).")
+      {:recovery :no-recovery
+       :extra    {:kind-class         kind-class
+                  :key-count          key-count
+                  :known-keys-present known}})))
 
 (defn- validate-target!
   "Grammar gate for the target-taking ops (`probe` / `acquire!`): throw the typed
@@ -858,10 +966,16 @@
 
 (defn owned?
   "True when `lease` owns a real sub-cache node (`acquire!` on a
-  `:subscription` target). The static override lease reports `false`
-  honestly — a pinned value owns nothing."
+  `:subscription` target). TOTAL and no-throw (rf2-vxgfnd.241): a non-lease reads
+  `false` rather than field-accessing [[lease-state]] and leaking a raw host
+  error (a JVM NPE / a CLJS TypeError) — the same ruled malformed-value contract
+  `current?` follows, since a value that is not a live node lease simply owns no
+  node. `lease?` short-circuits the `and` before `@(lease-state lease)`, so no
+  raw host error escapes. The static override lease reports `false` honestly — a
+  pinned value owns nothing."
   [lease]
-  (= :node (:lease-kind @(lease-state lease))))
+  (and (lease? lease)
+       (= :node (:lease-kind @(lease-state lease)))))
 
 (defn- throw-malformed-lease!
   "Reject a value that is not a real [[ObservationLease]] at the shared lease
@@ -1279,6 +1393,16 @@
   :query q}` — the node named by identity, re-resolved at acquire."
   [site-ctx]
   (let [{:keys [query-v override]} site-ctx]
+    ;; Grammar gate FIRST (rf2-vxgfnd.241): validate the query SHAPE before any
+    ;; sequence access (`(first query-v)`) and before minting a target. An
+    ;; unvalidated scalar / empty / non-keyword-headed query-v otherwise leaks a
+    ;; raw host `(first …)` error (the ambient-frame path threads
+    ;; `(first query-v)` as the no-frame-context event-id) or DEFERS failure to
+    ;; the downstream target validator at an unrelated probe/acquire call site.
+    ;; resolve-target is the port's ONLY resolution point, so it rejects here.
+    (when-not (valid-query-v? query-v)
+      (throw-malformed-query! 're-frame.substrate.observation/resolve-target
+                              query-v))
     (if (some? override)
       {:kind        :story-override
        :query       query-v

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -477,7 +477,9 @@
     (let [e (try (obs/probe {:kind :bogus :query [:obs/items]})
                  (catch #?(:clj Throwable :cljs :default) e e))]
       (is (= :rf.error/observation-malformed-target (error-id e)))
-      (is (= :bogus (:kind (ex-data e))) "the throw carries the malformed :kind")))
+      (is (= :unrecognized (:kind-class (ex-data e)))
+          "the throw carries the bounded kind-class (:unrecognized), never the
+           raw :kind value (rf2-vxgfnd.241)")))
   (testing "acquire! on a malformed :kind throws the same typed error"
     (let [e (try (obs/acquire! {:kind :bogus :query [:obs/items]} (fn [_]))
                  (catch #?(:clj Throwable :cljs :default) e e))]
@@ -627,6 +629,192 @@
     (doseq [bad [nil {} {:lease-kind :node} "lease" 42]]
       (is (false? (obs/current? bad target))
           (str "current? on a non-lease " (pr-str bad) " is false, never throws")))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.241 — finish the CLOSED grammar at every REAL boundary
+;;
+;; #5847 typed the target/lease REJECTS but left four boundaries half-hardened:
+;;   1. resolve-target inspected `(first query-v)` before validating the query
+;;      and could MINT an empty/non-keyword target the downstream validator only
+;;      later rejected (a scalar query-v even leaked a raw host `(first …)`).
+;;   2. owned? was not covered by the lease validator and raw-errored on a
+;;      non-lease.
+;;   3. valid-target? built `(set (keys target))` on every hot probe/acquire —
+;;      allocating + hashing every attacker-controllable key, letting a hostile
+;;      key's hashing escape as an untyped error and scaling with extras.
+;;   4. throw-malformed-target! serialized the raw `:kind` + the FULL key vector
+;;      — a 10k-key map produced an unbounded message and structured/secret keys
+;;      leaked.
+;; These fixtures are RED-before-fix witnesses that each boundary now emits the
+;; canonical closed grammar and rejects an open shape.
+;; ===========================================================================
+
+(defn- includes-substr?
+  "Portable substring test (the test ns's clojure.string is CLJ-only)."
+  [haystack needle]
+  #?(:clj  (.contains (str haystack) (str needle))
+     :cljs (not= -1 (.indexOf (str haystack) (str needle)))))
+
+;; A key that is INSERTABLE into a small map (a PersistentArrayMap linear-scans
+;; by equality, never hashing on insert) but whose HASHING throws — the exact
+;; pre-fix escape `(set (keys target))` triggered. Identity-only equality keeps
+;; array-map insertion from ever touching its hash.
+#?(:cljs
+   (deftype HostileHashKey []
+     Object
+     (toString [_] "<hostile-hash-key>")
+     IHash
+     (-hash [_] (throw (js/Error. "hostile -hash invoked")))
+     IEquiv
+     (-equiv [this o] (identical? this o))))
+
+(defn- make-hostile-hash-key []
+  #?(:clj  (reify Object
+             (hashCode [_] (throw (ex-info "hostile hashCode invoked" {})))
+             (equals [this o] (identical? this o))
+             (toString [_] "<hostile-hash-key>"))
+     :cljs (HostileHashKey.)))
+
+;; ---- gap 1: resolve-target validates the query BEFORE sequence access -------
+
+(deftest resolve-target-rejects-a-malformed-query-before-sequence-access
+  ;; resolve-target is the port's ONLY resolution point. A malformed query-v
+  ;; must throw the typed :rf.error/observation-malformed-target at resolve-target
+  ;; — never mint an open target for the downstream gate, never `(first query-v)`
+  ;; a scalar. Both hosts (this .cljc rides node CLJS + JVM).
+  (reg-items!)
+  (doseq [[label q] [[:non-vector  42]
+                     [:nil         nil]
+                     [:empty       []]
+                     [:non-kw-head [42]]
+                     [:string      "not-a-query"]
+                     [:list        '(:obs/items)]]]
+    (testing (str "explicit-pin resolve-target on a malformed :query-v ("
+                  (name label) ") rejects here, never mints an open target")
+      (is (= :rf.error/observation-malformed-target
+             (error-id (caught #(obs/resolve-target {:frame fid :query-v q}))))))
+    (testing (str "ambient resolve-target on a malformed :query-v (" (name label)
+                  ") rejects BEFORE require-current-frame! reads (first query-v)")
+      (is (= :rf.error/observation-malformed-target
+             (error-id (caught #(obs/resolve-target {:query-v q}))))))
+    (testing (str "override resolve-target on a malformed :query-v ("
+                  (name label) ") rejects before minting a :story-override")
+      (is (= :rf.error/observation-malformed-target
+             (error-id (caught #(obs/resolve-target
+                                  {:query-v q
+                                   :override {:value 1 :override-id :o :version 0}}))))))))
+
+(deftest resolve-target-malformed-query-does-not-fan-the-always-on-axis
+  ;; The malformed-query rejection is DIAGNOSTIC (a substrate/consumer bug,
+  ;; unreachable in correct generated code) — like malformed-target it must NOT
+  ;; fan the always-on axis, and its evidence is bounded (query-class, never the
+  ;; query contents, which for a valid query can carry app values).
+  (reg-items!)
+  (let [[[outcome e] records]
+        (with-error-records #(obs/resolve-target {:frame fid :query-v [42]}))]
+    (is (= :threw outcome))
+    (is (= :rf.error/observation-malformed-target (error-id e)))
+    (is (= :non-keyword-head (:query-class (ex-data e)))
+        "bounded query-class evidence — not the raw query")
+    (is (empty? records)
+        "diagnostic malformed-query does NOT fan the always-on axis")))
+
+;; ---- gap 2: owned? is total (false/no-throw for a non-lease) -----------------
+
+(deftest owned?-on-a-non-lease-is-false-no-throw
+  ;; owned? was not covered by the lease validator and raw-errored on a
+  ;; non-lease. Its ruled total contract mirrors current?: a non-lease is simply
+  ;; "owns nothing" → false, never a raw host throw. Both hosts.
+  (doseq [bad [nil {} {:lease-kind :node} "lease" 42 [:not :a :lease]]]
+    (is (false? (obs/owned? bad))
+        (str "owned? on a non-lease " (pr-str bad) " is false, never throws"))))
+
+;; ---- gap 3 + 4: fixed-vocabulary validation + bounded, leak-free evidence ----
+
+(deftest exact-key-validation-rejects-extra-keys-typed-with-bounded-evidence
+  ;; valid-target? now checks the key-set by fixed vocabulary (count + contains?
+  ;; of the port's OWN keys) — an EXTRA key fails the count without a set being
+  ;; built. The rejection evidence is bounded + normalized.
+  (reg-items!)
+  (let [t {:kind :subscription :frame-id fid :query [:obs/items] :surplus true}]
+    (testing "an extra key is rejected typed on both target-taking ops"
+      (is (= :rf.error/observation-malformed-target (error-id (caught #(obs/probe t)))))
+      (is (= :rf.error/observation-malformed-target
+             (error-id (caught #(obs/acquire! t (fn [_])))))))
+    (testing "evidence is BOUNDED + normalized — kind-class, key-count, known-key
+              presence; never the raw key vector"
+      (let [d (ex-data (caught #(obs/probe t)))]
+        (is (= :subscription (:kind-class d)) "kind-class is the recognized kind")
+        (is (= 4 (:key-count d)) "total key count is reported")
+        (is (= #{:kind :frame-id :query} (:known-keys-present d))
+            "only the port's OWN known keys are named — the :surplus extra is absent")
+        (is (nil? (:target-keys d)) "the raw key vector is GONE from evidence")))))
+
+(deftest malformed-target-evidence-never-leaks-secret-keys-or-values
+  ;; A target carrying a secret KEY and secret VALUE must reject with the secret
+  ;; nowhere in the message or the ex-data (rf2-vxgfnd.241 gap 4).
+  (reg-items!)
+  (let [secret-key   :app.secret/api-token
+        secret-value "sk-live-DEADBEEF-do-not-log"
+        t            {:kind :subscription :frame-id fid :query [:obs/items]
+                      secret-key secret-value}
+        e            (caught #(obs/probe t))
+        d            (ex-data e)
+        msg          (ex-message e)]
+    (is (= :rf.error/observation-malformed-target (error-id e)))
+    (is (= :subscription (:kind-class d)))
+    (is (= 4 (:key-count d)))
+    (is (= #{:kind :frame-id :query} (:known-keys-present d))
+        "the secret extra key is NOT named in evidence")
+    (is (not (includes-substr? msg (name secret-key)))
+        "the secret KEY does not appear in the human message")
+    (is (not (includes-substr? msg secret-value))
+        "the secret VALUE does not appear in the human message")
+    (is (not (includes-substr? (pr-str d) secret-value))
+        "the secret VALUE does not appear anywhere in the ex-data")
+    (is (not (includes-substr? (pr-str d) (name secret-key)))
+        "the secret KEY does not appear anywhere in the ex-data")))
+
+(deftest ten-thousand-extra-keys-reject-typed-with-bounded-evidence
+  ;; A 10k-key target rejects by count alone — no set allocated, no key
+  ;; enumerated into evidence, message bounded (rf2-vxgfnd.241 gap 3 + 4).
+  (reg-items!)
+  (let [t   (into {:kind :subscription :frame-id fid :query [:obs/items]}
+                  (map (fn [i] [(keyword (str "extra" i)) i]))
+                  (range 10000))
+        e   (caught #(obs/probe t))
+        d   (ex-data e)
+        msg (ex-message e)]
+    (is (= :rf.error/observation-malformed-target (error-id e)))
+    (is (= :subscription (:kind-class d)))
+    (is (= 10003 (:key-count d)) "the total count is reported, not the keys")
+    (is (= #{:kind :frame-id :query} (:known-keys-present d)))
+    (is (nil? (:target-keys d)) "the 10k-key vector is GONE from evidence")
+    (is (< (count msg) 1200) "the message is bounded — no 10k keys serialized")
+    (is (not (includes-substr? (pr-str d) "extra5000"))
+        "no attacker key leaks into the ex-data")))
+
+(deftest hostile-hash-extra-key-cannot-escape-as-a-raw-error
+  ;; The (set (keys target)) path HASHED every key; a small map can carry an
+  ;; extra key whose hashing THROWS (array-map insert never hashes). Pre-fix the
+  ;; untyped host error ESCAPED on the JVM; the fixed-vocabulary count+contains?
+  ;; check never hashes the attacker's extra key, so the port rejects TYPED
+  ;; (rf2-vxgfnd.241 gap 3). The typed-reject property holds on BOTH hosts; the
+  ;; JVM additionally witnesses the exact pre-fix escape (a JVM WeakHashMap-style
+  ;; set-build invokes the throwing hashCode where CLJS's set tolerated it).
+  (reg-items!)
+  (let [hostile (make-hostile-hash-key)
+        t       (assoc {:kind :subscription :frame-id fid :query [:obs/items]}
+                       hostile true)]
+    #?(:clj
+       (testing "the pre-fix JVM escape vector is real — hashing the target's
+                 keys into a set invokes the hostile hashCode and throws untyped"
+         (is (thrown? clojure.lang.ExceptionInfo (set (keys t)))
+             "building a key-set over the target DOES invoke the hostile hashCode")))
+    (testing "the port rejects TYPED — count+contains? never hashes the extra key"
+      (is (= :rf.error/observation-malformed-target (error-id (caught #(obs/probe t)))))
+      (is (= :rf.error/observation-malformed-target
+             (error-id (caught #(obs/acquire! t (fn [_])))))))))
 
 ;; ===========================================================================
 ;; rf2-vxgfnd.32 — first-owner disposal-hook install races node disposal


### PR DESCRIPTION
Finishes the observation port's closed grammar at the four boundaries #5847 left half-hardened (audit gaps 1-4 of rf2-vxgfnd.241). Extends the existing closed-grammar discipline (rf2-vxgfnd.183 typed rejects) — no parallel validation path, no new error id, no spec re-edit. Re-verified against the current `observation.cljc` after #5884 (fs99nq weak-identity + qyvyes schema) merged: all four boundaries were still open; #5884 reworked provenance/schema, not these.

## Boundaries closed

1. **`resolve-target` (gap 1)** — now validates the query SHAPE (`valid-query-v?`) BEFORE any `(first query-v)` sequence access and before minting a target. A scalar/empty/non-keyword-headed/`nil` query-v is rejected with the typed `:rf.error/observation-malformed-target` at the port's ONLY resolution point, instead of leaking a raw host `(first …)` error (ambient path) or deferring an open target to the downstream probe/acquire gate. Evidence is bounded (`:query-class`/`:query-count`), never the query contents (a valid query's args carry app values).
2. **`owned?` (gap 2)** — now TOTAL and no-throw: a non-lease reads `false` (mirroring `current?`'s ruled contract) instead of raw-erroring on `@(lease-state non-lease)`.
3. **`valid-target?` (gap 3)** — the exact-key check is now a FIXED-VOCABULARY `count` + `contains?` of the port's OWN keys, replacing `(= #{…} (set (keys target)))`. No set allocated on the hot success path, and the target's attacker-controllable extra keys are never enumerated or hashed — so a hostile-hash extra key can no longer escape as an untyped error. The `:kind` discriminator compares keyword-first so a hostile `:kind` value's `hashCode`/`equals` is never invoked.
4. **`throw-malformed-target!` evidence (gap 4)** — bounded + normalized: `:kind-class` (recognized kind or `:unrecognized`, never a raw/secret kind value), total `:key-count`, and `:known-keys-present` (which of the port's own keys are present). Replaces the prior raw `:kind` + full `(vec (keys target))`, which serialized a 10k-key map into an unbounded message and leaked structured/secret keys.

**Gap 5 (Spec 009 / Spec-Schemas doc):** out of scope for this core worker (spec/ is not editable here). Filed as a follow-up bead — no new catalogue row is needed (the reused id is already catalogued; the malformed-target category is diagnostic, not always-on), but the evidence-field rename and resolve-target's new throwing surface should be documented.

## Quality gates

Red-before-fix fixtures added to `observation_port_cljs_test.cljc` (both hosts unless noted), each proving the boundary now emits the canonical grammar and rejects an open shape:

- `resolve-target-rejects-a-malformed-query-before-sequence-access` — explicit-pin / ambient / override paths, scalar/nil/empty/non-kw-head/string/list.
- `resolve-target-malformed-query-does-not-fan-the-always-on-axis` — diagnostic, bounded `:query-class` evidence.
- `owned?-on-a-non-lease-is-false-no-throw`.
- `exact-key-validation-rejects-extra-keys-typed-with-bounded-evidence` — typed reject + `:kind-class`/`:key-count`/`:known-keys-present`, no `:target-keys`.
- `malformed-target-evidence-never-leaks-secret-keys-or-values` — secret key + value absent from message and ex-data.
- `ten-thousand-extra-keys-reject-typed-with-bounded-evidence` — rejects by count, bounded message, no key leak.
- `hostile-hash-extra-key-cannot-escape-as-a-raw-error` — cross-host typed reject; JVM additionally witnesses the exact pre-fix set-build escape.
- Updated `malformed-target-kind-throws-typed-not-a-bare-host-error` for the normalized `:kind-class` evidence.

Ran foreground (SLIM — core change, no browser surface):
- `(cd implementation/core && clojure -M:test)` → 1978 tests, 9095 assertions, 0 failures, 0 errors.
- `(cd implementation && npm run test:cljs)` → 9388 tests, 44500 assertions, 0 failures, 0 errors (both hosts; includes observation-port, error-catalogue, always-on-axis, and the #5884 record↔schema validation gate).
