### PR TITLE
fix(xray): surface both spawn-all stale-completion operations (rf2-hj4skn)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -388,12 +388,32 @@ machines / timers:
   literals (`:rf.resource/work-started`, `:rf.http/replied`,
   `:rf.http/retry-attempt`, `:rf.resource/stale-suppressed`,
   `:rf.reply/suppressed`, the routing `:rf.route.nav-token/stale-suppressed`,
-  the machine `:rf.machine.timer/stale-after`, and the HTTP-supersession
-  `:rf.http/stale-suppressed` — rf2-waawic / rf2-azcmd3; the suffix heuristic
-  catches `stale-suppress` / `suppressed` but NOT `stale-after`, so the
-  machine-timer op is enumerated explicitly); a name-suffix heuristic
+  the machine `:rf.machine.timer/stale-after`, the HTTP-supersession
+  `:rf.http/stale-suppressed`, and the `:spawn-all` join's two
+  exact-authority stale rows `:rf.machine.spawn-all/stale-completion`
+  (PRE-resolution exact-authority suppression) +
+  `:rf.machine.spawn-all/late-completion` (POST-resolution `:resolved?`-latched
+  straggler) — rf2-waawic / rf2-azcmd3 / rf2-hj4skn; the suffix heuristic
+  catches `stale-suppress` / `suppressed` but NOT `stale-after`, and NOT the
+  spawn-all `*-completion` names (which end in `-completion`, not
+  `-completed`), so those ops are enumerated explicitly. The NON-DECISIVE
+  `:rf.machine.spawn-all/child-completed` terminal is a REAL `:completed`
+  (its `-completed` suffix classifies correctly) and is deliberately left on
+  the heuristic — the heuristic is NOT broadened to admit arbitrary
+  `*completion` ops without reply-envelope proof). A name-suffix heuristic
   classifies a not-yet-enumerated family op (e.g. a future `:rf.stream/*`
   surface) before the table learns its literal.
+- **Single-map correlation + completion time on a stale row (rf2-hj4skn).**
+  A `:stale-suppressed` row surfaces the carried/current gate pair
+  (`:rf.reply/carried` / `:rf.reply/current`, HTTP / resource supersession)
+  AND a single `:rf.reply/correlation` identity map when the family stamps
+  one instead — the `:spawn-all` join stamps `{:parent-id … :invoke-id …
+  :child-id … :spawned-id …}`, the machine `:after` timer stamps
+  `{:carried … :current …}`. `work-event-row` surfaces it as `:correlation`
+  (summarized for PRIVACY, the same contract `reply-row` uses) plus the
+  causal `:completed-at` from `:rf.reply/completed-at`, so the
+  exact-authority evidence an operator diagnoses a superseded / unverified /
+  duplicate / post-resolution join completion FROM is not silently dropped.
 - **Production `:rf.reply/*` trace vocabulary (rf2-waawic).** Family
   completion / stale rows stamp the canonical reply facts ADDITIVELY as
   `:rf.reply/status` / `:rf.reply/work-id` / `:rf.reply/work-status` /

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -446,6 +446,29 @@
    :rf.route.nav-token/stale-suppressed    :stale-suppressed
    :rf.machine.timer/stale-after           :stale-suppressed
    :rf.http/stale-suppressed               :stale-suppressed
+   ;; rf2-hj4skn — the `:spawn-all` join's TWO exact-authority stale rows
+   ;; (005 §`:spawn-all` join-child completion / 009 §op-type vocabulary):
+   ;;   - `:rf.machine.spawn-all/stale-completion` — the PRE-resolution
+   ;;     exact-authority suppression: a completion carrier that failed the
+   ;;     fold gate (`:rf.reply/stale-reason` one of
+   ;;     `:rf.machine.spawn-all/attempt-unverified` /
+   ;;     `.../attempt-superseded` / `.../duplicate-completion`);
+   ;;   - `:rf.machine.spawn-all/late-completion` — the POST-resolution
+   ;;     `:resolved?`-latched straggler (`:rf.reply/stale-reason
+   ;;     :rf.machine.spawn-all/join-resolved`).
+   ;; Both carry the canonical `:status :stale` / `:rf.reply/work-status
+   ;; :suppressed` reply facts additively on the public `:child-id` / `:kind`
+   ;; shape. NEITHER name matches a `stale-suppress` / `suppressed` /
+   ;; `completed` suffix (`stale-completion` / `late-completion` end in
+   ;; `-completion`, not `-completed`), so the heuristic returned nil for
+   ;; both and their exact-authority evidence was silently dropped — enumerate
+   ;; them explicitly. The NON-DECISIVE
+   ;; `:rf.machine.spawn-all/child-completed` terminal is a REAL `:completed`
+   ;; (its `-completed` suffix classifies correctly) and is NOT lowered here;
+   ;; the suffix heuristic is NOT broadened to admit arbitrary `*completion`
+   ;; ops without reply-envelope proof.
+   :rf.machine.spawn-all/stale-completion  :stale-suppressed
+   :rf.machine.spawn-all/late-completion   :stale-suppressed
    ;; Mutations emit `:rf.mutation/stale-suppressed` for a superseded / cleared
    ;; / cross-frame reply (EP-0016 D1 — a stale reply NEVER fires the
    ;; `:reply-to` continuation; it suppresses here instead), carrying the
@@ -535,6 +558,9 @@
        :stale?      false                           ; on a :stale-suppressed row
        :carried     {:work/id … :generation …}      ; suppression carried gate
        :current     {:work/id … :generation …}      ; suppression current gate
+       :correlation {:parent-id … :child-id …}      ; single-map correlation (summarized)
+       :stale-reason :rf.machine.spawn-all/join-resolved ; on a :stale-suppressed row
+       :completed-at <ms>                           ; causal reply completion time
        :cancel-reason :actor-destroyed              ; on a :cancel-requested row
        :delivered?  true                            ; on a :delivered row
        :time        <ms>
@@ -619,6 +645,23 @@
                             (rh/summarize (:rf.reply/carried tags)))
                  :current (when (contains? tags :rf.reply/current)
                             (rh/summarize (:rf.reply/current tags)))
+                 ;; rf2-hj4skn — some families carry a SINGLE
+                 ;; `:rf.reply/correlation` identity map instead of (or
+                 ;; alongside) the carried/current gate pair: the `:spawn-all`
+                 ;; join stamps `{:parent-id … :invoke-id … :child-id …
+                 ;; :spawned-id …}`, the machine `:after` timer stamps
+                 ;; `{:carried … :current …}`. Surface it (summarized for
+                 ;; PRIVACY, the SAME contract `reply-row` uses) so the
+                 ;; exact-authority correlation the operator diagnoses a
+                 ;; superseded / unverified / duplicate / post-resolution join
+                 ;; completion FROM is not silently dropped.
+                 :correlation (when (contains? tags :rf.reply/correlation)
+                                (rh/summarize (:rf.reply/correlation tags)))
+                 ;; rf2-hj4skn — the causal reply completion time (Managed-
+                 ;; Effects §The reply map — `:rf.reply/completed-at`), distinct
+                 ;; from the trace event `:time`; present on the spawn-all
+                 ;; stale rows "when present" per the 009 catalogue.
+                 :completed-at (:rf.reply/completed-at tags)
                  :stale-reason (or (:stale/reason tags) (:rf.reply/stale-reason tags)
                                    (:reason tags) (:outcome tags)))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -268,7 +268,27 @@
     ;; routing emits the explicit literal too.
     (is (= :stale-suppressed (re/phase-of :rf.route.nav-token/stale-suppressed)))
     ;; rf2-azcmd3 — HTTP supersession's superseded-attempt stale row.
-    (is (= :stale-suppressed (re/phase-of :rf.http/stale-suppressed))))
+    (is (= :stale-suppressed (re/phase-of :rf.http/stale-suppressed)))
+    ;; rf2-hj4skn — the `:spawn-all` join's TWO exact-authority stale rows.
+    ;; Neither name ends in a `-completed` / `stale-suppress` / `suppressed`
+    ;; suffix (`stale-completion` / `late-completion` end in `-completion`), so
+    ;; the heuristic returned nil for both until they were enumerated
+    ;; explicitly. `stale-completion` is the PRE-resolution exact-authority
+    ;; suppression; `late-completion` the POST-resolution `:resolved?`-latched
+    ;; straggler.
+    (is (= :stale-suppressed (re/phase-of :rf.machine.spawn-all/stale-completion)))
+    (is (= :stale-suppressed (re/phase-of :rf.machine.spawn-all/late-completion))))
+  (testing "rf2-hj4skn — the NON-DECISIVE `:spawn-all` child terminal is a REAL
+            completion (its `-completed` suffix classifies correctly) and stays
+            `:completed`, NOT lowered to stale"
+    (is (= :completed (re/phase-of :rf.machine.spawn-all/child-completed))))
+  (testing "rf2-hj4skn — the suffix heuristic is NOT broadened: an arbitrary
+            `*completion`-suffixed op with NO reply-envelope proof is not
+            admitted as a completion (only the enumerated spawn-all stale
+            literals lower)"
+    (is (nil? (re/phase-of :rf.fake/some-completion)))
+    (is (nil? (re/phase-of :rf.other/late-completion)))
+    (is (not (re/reply-trace-op? :rf.fake/some-completion))))
   (testing "delivery — the call-site :reply-to continuation is the mutation
             delivery row (EP-0016 D1, phase 6)"
     (is (= :delivered (re/phase-of :rf.mutation/replied)))
@@ -576,6 +596,166 @@
         (is (= :completed (:phase row)))
         (is (= s (:status row)) (str "completed status " s " unchanged"))
         (is (= expected-class (:status-class row)))))))
+
+;; ---------------------------------------------------------------------------
+;; (6b-spawn-all) The `:spawn-all` join's TWO exact-authority stale-completion
+;; operations (rf2-hj4skn). Both lower to `:stale-suppressed` and project the
+;; canonical `:rf.reply/*` work identity / status / work-status / stale-reason
+;; / correlation / completion time on the SAME uniform row a resource / HTTP
+;; suppression renders. The fixtures are RUNTIME-shaped per the 009 catalogue:
+;; `:tags {:actor-id :invoke-id :child-id :kind}` (the preserved public shape)
+;; PLUS the additive `:rf.reply/*` reply-envelope facts. Four `:rf.reply/
+;; stale-reason` classes: attempt-unverified / attempt-superseded /
+;; duplicate-completion (the PRE-resolution `stale-completion` classes) and
+;; join-resolved (the POST-resolution `late-completion` straggler).
+;; ---------------------------------------------------------------------------
+
+(defn- spawn-all-stale-row
+  "Build a RUNTIME-shaped `:spawn-all` stale trace event (009 catalogue) for a
+  given op / stale-reason / spawned-id / generation, feeding `work-event-row`."
+  [{:keys [id op child-id spawned-id generation stale-reason completed-at]}]
+  {:id id :operation op :time (+ 400 id)
+   :tags {:actor-id :hydrate#1 :invoke-id [:hydrating :spawn-all]
+          :child-id child-id :kind :done
+          :rf.frame/id :rf/default
+          :rf.reply/work-id      [:rf.work/machine spawned-id [:hydrating :spawn-all] generation]
+          :rf.reply/work-kind    :machine
+          :rf.reply/status       :stale
+          :rf.reply/work-status  :suppressed
+          :rf.reply/stale-reason stale-reason
+          :rf.reply/correlation  {:parent-id :hydrate#1 :invoke-id [:hydrating :spawn-all]
+                                  :child-id child-id :spawned-id spawned-id}
+          :rf.reply/completed-at completed-at}})
+
+(deftest spawn-all-stale-completions
+  (testing "rf2-hj4skn — a PRE-resolution `stale-completion` carrier that failed
+            the exact-authority fold gate (:attempt-unverified) projects the
+            full canonical reply identity on the uniform stale-suppressed row"
+    (let [row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 70 :op :rf.machine.spawn-all/stale-completion
+                   :child-id :fetch-user :spawned-id :fetch-user#1 :generation 1
+                   :stale-reason :rf.machine.spawn-all/attempt-unverified
+                   :completed-at 471}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (true? (:stale? row)))
+      (is (= :machine (:work-kind row)) "machine work-kind retained")
+      (is (= [:rf.work/machine :fetch-user#1 [:hydrating :spawn-all] 1] (:work-id row))
+          "canonical :rf.reply/work-id join key")
+      (is (= :stale (:status row)) "canonical EP-0011 :stale status")
+      (is (= :suppression (:status-class row)) "cross-surface suppression badge")
+      (is (= :suppressed (:work-status row)) "canonical :rf.reply/work-status")
+      (is (= :rf.machine.spawn-all/attempt-unverified (:stale-reason row))
+          "precise :rf.reply/stale-reason surfaced")
+      (is (= :rf/default (:frame row)) "carried-frame stamp preserved")
+      (is (= 471 (:completed-at row)) "causal reply completion time surfaced")
+      (is (some? (:correlation row)) "single-map correlation surfaced")
+      (is (= "map" (:type (:correlation row))) "correlation summarized (PRIVACY)")))
+  (testing "rf2-hj4skn — the :attempt-superseded PRE-resolution class (a carrier
+            bound to a prior attempt / wrong actor after respawn)"
+    (let [row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 71 :op :rf.machine.spawn-all/stale-completion
+                   :child-id :fetch-prefs :spawned-id :fetch-prefs#2 :generation 2
+                   :stale-reason :rf.machine.spawn-all/attempt-superseded
+                   :completed-at 472}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :rf.machine.spawn-all/attempt-superseded (:stale-reason row)))
+      (is (= :stale (:status row)))
+      (is (= :suppressed (:work-status row)))))
+  (testing "rf2-hj4skn — the :duplicate-completion PRE-resolution class (an
+            exact re-completion of an already-folded child)"
+    (let [row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 72 :op :rf.machine.spawn-all/stale-completion
+                   :child-id :fetch-perms :spawned-id :fetch-perms#1 :generation 1
+                   :stale-reason :rf.machine.spawn-all/duplicate-completion
+                   :completed-at 473}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :rf.machine.spawn-all/duplicate-completion (:stale-reason row)))
+      (is (= :stale (:status row)))))
+  (testing "rf2-hj4skn — the POST-resolution `late-completion` straggler (a
+            completion arriving after the `:resolved?` latch flipped)
+            :join-resolved"
+    (let [row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 73 :op :rf.machine.spawn-all/late-completion
+                   :child-id :fetch-flags :spawned-id :fetch-flags#1 :generation 1
+                   :stale-reason :rf.machine.spawn-all/join-resolved
+                   :completed-at 474}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :rf.machine.spawn-all/join-resolved (:stale-reason row)))
+      (is (= :machine (:work-kind row)))
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))
+      (is (= :suppressed (:work-status row)))
+      (is (= 474 (:completed-at row)))
+      (is (some? (:correlation row))))))
+
+;; ---------------------------------------------------------------------------
+;; (6b-spawn-all-races) The spawn-all stale rows flow into the cross-family
+;; stale-suppression tally + attempt-arc grouping with NO panel-specific code —
+;; `stale-suppressions` / `stale-tally-by-kind` / `races-by-work-id` all read
+;; `project-work-events`, so classifying the ops is all that is needed. Two
+;; superseded FIXED-id attempts (distinct `:work/id` generations) must stay
+;; DISTINCT rows, never merged.
+;; ---------------------------------------------------------------------------
+
+(def ^:private spawn-all-stale-trace
+  "A trace buffer of `:spawn-all` join completions: one non-decisive child
+  completion (a REAL `:completed`, not stale) + the four stale-suppression
+  classes, two of them fixed-id superseded attempts with DISTINCT generations."
+  [{:id 80 :operation :rf.machine.spawn-all/child-completed
+    :time 480 :tags {:actor-id :hydrate#1 :invoke-id [:hydrating :spawn-all]
+                     :child-id :fetch-user :spawned-id :fetch-user#1 :kind :done
+                     :rf.reply/work-id [:rf.work/machine :fetch-user#1 [:hydrating :spawn-all] 1]
+                     :rf.reply/work-kind :machine :rf.reply/status :ok
+                     :rf.reply/work-status :completed}}
+   (spawn-all-stale-row {:id 81 :op :rf.machine.spawn-all/stale-completion
+                         :child-id :fetch-a :spawned-id :fixed-a :generation 1
+                         :stale-reason :rf.machine.spawn-all/attempt-superseded
+                         :completed-at 481})
+   (spawn-all-stale-row {:id 82 :op :rf.machine.spawn-all/stale-completion
+                         :child-id :fetch-a :spawned-id :fixed-a :generation 2
+                         :stale-reason :rf.machine.spawn-all/attempt-superseded
+                         :completed-at 482})
+   (spawn-all-stale-row {:id 83 :op :rf.machine.spawn-all/stale-completion
+                         :child-id :fetch-b :spawned-id :fetch-b#1 :generation 1
+                         :stale-reason :rf.machine.spawn-all/duplicate-completion
+                         :completed-at 483})
+   (spawn-all-stale-row {:id 84 :op :rf.machine.spawn-all/late-completion
+                         :child-id :fetch-c :spawned-id :fetch-c#1 :generation 1
+                         :stale-reason :rf.machine.spawn-all/join-resolved
+                         :completed-at 484})])
+
+(deftest spawn-all-stale-races
+  (testing "rf2-hj4skn — stale-suppressions surfaces every spawn-all stale row
+            (the four suppression classes), NOT the non-decisive child terminal"
+    (let [sup (re/stale-suppressions spawn-all-stale-trace)]
+      (is (= 4 (count sup)) "four stale rows, the :completed child terminal excluded")
+      (is (every? #(= :machine (:work-kind %)) sup))
+      (is (= #{:rf.machine.spawn-all/attempt-superseded
+               :rf.machine.spawn-all/duplicate-completion
+               :rf.machine.spawn-all/join-resolved}
+             (into #{} (map :stale-reason) sup)))))
+  (testing "rf2-hj4skn — the cross-surface stale tally counts the spawn-all
+            suppressions under :machine"
+    (is (= {:machine 4} (re/stale-tally-by-kind spawn-all-stale-trace))))
+  (testing "rf2-hj4skn — races-by-work-id keeps the two FIXED-id superseded
+            attempts DISTINCT (distinct :work/id generations never merge); the
+            non-decisive child arc is a completed :ok, the stragglers :stale"
+    (let [races (re/races-by-work-id spawn-all-stale-trace)
+          a1 (get races [:rf.work/machine :fixed-a [:hydrating :spawn-all] 1])
+          a2 (get races [:rf.work/machine :fixed-a [:hydrating :spawn-all] 2])
+          child (get races [:rf.work/machine :fetch-user#1 [:hydrating :spawn-all] 1])]
+      (is (some? a1) "first fixed-id attempt has its own arc")
+      (is (some? a2) "second fixed-id attempt has its own arc — NOT merged")
+      (is (= :stale (:terminal-status a1)))
+      (is (= :stale (:terminal-status a2)))
+      (is (true? (:suppressed? a1)))
+      (is (true? (:suppressed? a2)))
+      (is (= :ok (:terminal-status child)) "the non-decisive child folded :ok")
+      (is (false? (:suppressed? child)) "the non-decisive child is NOT a suppression"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (6c) Frame attribution across families (rf2-l9vb09). Two LEGITIMATE frame


### PR DESCRIPTION
## What

Teach Xray to lower BOTH `:spawn-all` join exact-authority stale-completion operations into its uniform reply-envelope lifecycle, consuming the merged Spec 009 catalogue (#5896/p53o47 + #5839/#5842). Neither op was recognized before — both silently discarded the exact evidence a developer needs to diagnose superseded / unverified / duplicate / post-resolution join completions.

The two ops surfaced (both lower to `:stale-suppressed`):

- **`:rf.machine.spawn-all/stale-completion`** — the PRE-resolution exact-authority suppression: a completion carrier that failed the fold gate. Classified by `:rf.reply/stale-reason` ∈ { `:rf.machine.spawn-all/attempt-unverified`, `.../attempt-superseded`, `.../duplicate-completion` }.
- **`:rf.machine.spawn-all/late-completion`** — the POST-resolution `:resolved?`-latched straggler (`:rf.reply/stale-reason :rf.machine.spawn-all/join-resolved`).

Neither name matches the `-completed` / `stale-suppress` / `suppressed` suffix heuristic (both end in `-completion`), so `phase-of` returned nil for both. They are now enumerated explicitly in `op->phase`. The NON-DECISIVE `:rf.machine.spawn-all/child-completed` terminal is a REAL `:completed` (its `-completed` suffix classifies correctly) and is deliberately left on the heuristic — the heuristic is NOT broadened to admit arbitrary `*completion` ops without reply-envelope proof.

`work-event-row`'s `:stale-suppressed` branch additionally surfaces the single-map `:rf.reply/correlation` (spawn-all stamps `{:parent-id :invoke-id :child-id :spawned-id}`; summarized for PRIVACY, same contract `reply-row` uses) and the causal `:completed-at` from `:rf.reply/completed-at` — so the exact-authority correlation + completion time are no longer dropped. `stale-suppressions` / `stale-tally-by-kind` / `races-by-work-id` pick the rows up with no panel-specific code (they all read `project-work-events`).

## Xray spec update

`tools/xray/spec/013-Trace-Consumer.md` §One work/reply vocabulary updated: the `phase-of` bullet now enumerates the two spawn-all stale ops + documents the child-completed non-broadening, and a new bullet documents the single-map correlation + completion time on a stale row.

## Spec 009 gap

None surfaced. The merged catalogue (`:rf.machine.spawn-all/stale-completion`, `.../late-completion`, `:rf.reply/stale-reason`, `:rf.reply/correlation`, `:rf.reply/completed-at`) carried every field Xray needed; this is a pure consumer-side change (no `implementation/` touch).

## Quality gates

- `cd tools/xray && clojure -M:test` — **1250 tests, 5800 assertions, 0 failures, 0 errors** (green).
- **Red-before-fix verified**: with the two `op->phase` mappings removed, `phase-classification` + `spawn-all-stale-completions` + `spawn-all-stale-races` go red (38 failures); the child-completed regression + negative-guard tests stay green (they ride the unchanged heuristic). Restoring the mappings → green.

Fixtures are RUNTIME-shaped per the 009 catalogue (`:tags {:actor-id :invoke-id :child-id :kind}` + additive `:rf.reply/*` facts), covering all four `:rf.reply/stale-reason` classes. Two fixed-id superseded attempts (distinct `:work/id` generations) are asserted to stay DISTINCT in `races-by-work-id`, never merged.

Closes rf2-hj4skn.
