### PR TITLE
test(machines): make lifecycle-tail incarnation-fence fixture deterministic (rf2-kz0bmb)

### DIFF
--- a/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
@@ -369,12 +369,13 @@
       {:initial :running
        :states  {:running {:on {:go :done}}
                  :done    {:final? true}}})
-    (let [frame-a  :rf2-4ipqe4/spawn-write-frame
-          armed?   (atom false)
-          fired?   (atom false)
-          traces   (atom [])
-          b-birth  (atom nil)
-          b-commit (atom nil)]
+    (let [frame-a        :rf2-4ipqe4/spawn-write-frame
+          armed?         (atom false)
+          fired?         (atom false)
+          traces         (atom [])
+          b-birth        (atom nil)
+          b-commit       (atom nil)
+          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
       (install-watching-adapter!
         armed?
         (fn []
@@ -384,6 +385,13 @@
             (reset! b-birth (mtest/runtime-db frame-a))
             (reset! b-commit (frame/frame-commit-epoch frame-a)))))
       (try
+        ;; DETERMINISM FENCE (rf2-kz0bmb) — sibling of the live-owner test's
+        ;; guard: hold the actor-bootstrap `:start` dispatch on a SYNCHRONOUS
+        ;; in-thread no-op so no JVM background-executor drain (`interop/
+        ;; next-tick`) races the assertions. The loss path fences the `:start`
+        ;; before it fires, so this is a pure guard here — but it keeps the
+        ;; whole spawn-write seam single-threaded and symmetric.
+        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
         (rf/make-frame {:id frame-a})
         (trace/register-listener!
           ::spawn-write-fence
@@ -411,6 +419,7 @@
               "no :rf.machine.lifecycle/spawned tail attributed after the write loss"))
         (finally
           (trace/unregister-listener! ::spawn-write-fence)
+          (late-bind/set-fn! :router/dispatch! orig-dispatch!)
           (restore-plain-adapter!))))))
 
 (deftest spawn-install-write-live-owner-installs-once
@@ -423,15 +432,29 @@
       {:initial :running
        :states  {:running {:on {:go :done}}
                  :done    {:final? true}}})
-    (let [frame-a    :rf2-4ipqe4/spawn-write-live-frame
-          armed?     (atom false)
-          watch-runs (atom 0)
-          traces     (atom [])
-          child-id   (keyword "rf2-4ipqe4" "spawn-write-live-child#1")]
+    (let [frame-a        :rf2-4ipqe4/spawn-write-live-frame
+          armed?         (atom false)
+          watch-runs     (atom 0)
+          traces         (atom [])
+          child-id       (keyword "rf2-4ipqe4" "spawn-write-live-child#1")
+          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
       (install-watching-adapter!
         armed?
         (fn [] (swap! watch-runs inc)))          ; observe only — A stays live
       (try
+        ;; DETERMINISM FENCE (rf2-kz0bmb) — drop the child's actor-bootstrap
+        ;; `:start` dispatch onto a SYNCHRONOUS in-thread no-op. The default
+        ;; `:router/dispatch!` hook schedules the bootstrap drain on the JVM
+        ;; background executor (`interop/next-tick`); that async drain runs the
+        ;; freshly-installed child's `[:go]` transition to its `:done`
+        ;; `:final?` leaf and REAPS the child's snapshot + spawn-order on a
+        ;; SEPARATE thread — racing the post-install assertions below (and the
+        ;; `restore-plain-adapter!` teardown). The install this test asserts on
+        ;; completes BEFORE the `:start` dispatch, so suppressing the async
+        ;; bootstrap leaves every assertion's subject unchanged while making the
+        ;; fixture single-threaded and deterministic (was green in isolation /
+        ;; 8/8 reruns, red under CI load).
+        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
         (rf/make-frame {:id frame-a})
         (trace/register-listener!
           ::spawn-write-live
@@ -454,4 +477,5 @@
               "the live-owner install emitted :rf.machine.lifecycle/spawned exactly once"))
         (finally
           (trace/unregister-listener! ::spawn-write-live)
+          (late-bind/set-fn! :router/dispatch! orig-dispatch!)
           (restore-plain-adapter!))))))


### PR DESCRIPTION
## What

De-flakes `machine_lifecycle_tail_incarnation_fence_test.clj` (rf2-kz0bmb, P1). Test-only; production source untouched.

The spawn-write seam's live-owner control `spawn-install-write-live-owner-installs-once` intermittently false-reddened CI (cost PR #5895 a full cycle, CONFIRMED by two independent workers) while passing in isolation and 8/8 on rerun.

## Root cause — a test-harness race, NOT a production race

`spawn-fx`'s final actor-bootstrap `:start` dispatch rode the DEFAULT `:router/dispatch!`, which on the JVM schedules the drain on a background single-thread executor (`interop/next-tick`). That async drain ran the freshly-installed child's `[:go]` transition to its `:done` `:final?` leaf and **reaped the child's snapshot + spawn-order on a separate thread** — racing the main thread's post-install assertions (`snapshot present?`, `spawn-order == [child]`) and the `restore-plain-adapter!` teardown.

Under CI load the reaper won the race; in isolation the main thread consistently won the ~50ms window. Async reaping of a completed child is **correct production behaviour** — the fixture simply failed to quiesce the async `:start` before asserting synchronous post-install state. No production race; the rf2-4ipqe4 install-write fence is correct.

## The latch/determinism mechanism

Both spawn-write tests now hold the child's actor-bootstrap `:start` on a **synchronous in-thread no-op** `:router/dispatch!` for the duration of the drive (captured + restored in `finally`) — the same pattern the registrar seam in this same file already uses via `run-erroring-finalize`. The install every assertion targets completes BEFORE the `:start` dispatch, so the fixture becomes single-threaded and deterministic with **every assertion's subject unchanged**. No assertion weakened, added, or removed — only the coordination changed.

## Repeated-run proof

**19 consecutive green machines-suite runs**: 1 standalone + 18 across 3 concurrent lanes creating deliberate JVM scheduler contention (the condition that triggered the original flake). 0 failures.

A standalone repro confirms the mechanism both ways:
- **default async dispatch** — child snapshot present at 25ms, then reaped (`nil`) by ~50ms (the flaky window).
- **synchronous dispatch (this fix)** — snapshot + spawn-order + `:running` state stable across a full 300ms window.

## Production race?

No. Investigated and ruled out — the async reaping is intended re-frame runtime behaviour; the gap was purely the fixture not controlling the async dispatch. Did not touch `machines/src/**` or any production source.

## Quality gates

- `cd implementation/machines && clojure -M:test` — 1063 tests, 3643 assertions, 0 failures / 0 errors.
- 18/18 green under 3-way concurrent contention (+ 1 standalone) = 19/19.
- Slim gate scope per bead (machines JVM only; no browser surface).
