### PR TITLE
fix(ui): normalize inline-sub metadata once + prove classification through real image assembly (rf2-vxgfnd.257/.258)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -377,19 +377,44 @@
   An inline descriptor (`:rf.provenance/inline`) with an `:impl` fn is merged
   with the runnable slots its kind's late-bound lowering produces (the same
   slots `register!` stores for a `reg-*` of that kind) — preserving `:impl`,
-  provenance, `:kind` / `:id`, and `:metadata`. A non-inline descriptor (a
-  registered or standard one), a metadata-only inline entry (no `:impl`), or a
-  kind with no published lowering hook returns UNCHANGED. Pure modulo the
-  late-bind lookup."
+  provenance, `:kind` / `:id`. A non-inline descriptor (a registered or standard
+  one), a metadata-only inline entry (no `:impl`), or a kind with no published
+  lowering hook returns UNCHANGED. Pure modulo the late-bind lookup.
+
+  The `:sub` kind is the one kind whose lowering runs registrar-contract
+  metadata NORMALIZATION (validate retired/unknown keys + `:sensitive`/`:large`
+  classification, strip dev-only `:doc` in production — rf2-vxgfnd.219). It
+  ALONE therefore (a) needs the AUTHORED descriptor id so a retired/unknown-key
+  diagnostic names the author's subscription (e.g. `:counter/value`), never a
+  synthetic `:rf.image/inline-sub`, and (b) yields a NORMALIZED `:metadata` that
+  must REPLACE the descriptor's RAW nested `:metadata` — otherwise a production
+  image still carries dev-only `:doc` under `[:metadata …]` alongside the
+  doc-stripped top level, a second, divergent representation (rf2-vxgfnd.257).
+  Its return carries the metadata normalized ONCE (spread at top level AND under
+  `:metadata`); we let that normalized `:metadata` win over the descriptor's raw
+  copy. Selection/dedupe already ran (`lower-inline-descriptors` is a post-
+  selection map), so replacing `:metadata` here never decides a collision
+  winner. Other kinds keep the descriptor's own `:metadata` untouched."
   [descriptor]
   (if (and (:rf.provenance/inline descriptor)
            (contains? descriptor :impl))
     (if-let [lower (late-bind/get-fn
                      (keyword "image" (str "lower-inline-" (name (:kind descriptor)))))]
-      ;; Merge runnable slots UNDER the descriptor's own keys (the descriptor
-      ;; wins on any shared key — :impl / provenance / :kind / :id stay put;
-      ;; the lowering only contributes :handler-fn + the per-kind runtime slots).
-      (merge (lower (:metadata descriptor) (:impl descriptor)) descriptor)
+      (if (= :sub (:kind descriptor))
+        ;; Thread the authored id; let the lowering's normalized :metadata win
+        ;; over the descriptor's raw copy (the descriptor otherwise wins every
+        ;; shared key — :impl / provenance / :kind / :id stay put). When the
+        ;; normalized metadata is empty (e.g. a doc-only map in production) the
+        ;; lowering omits :metadata, and the descriptor's raw copy is dropped
+        ;; rather than resurrected.
+        (let [lowered (lower (:id descriptor) (:metadata descriptor) (:impl descriptor))]
+          (-> (merge lowered descriptor)
+              (dissoc :metadata)
+              (merge (select-keys lowered [:metadata]))))
+        ;; Other kinds — merge runnable slots UNDER the descriptor's own keys
+        ;; (the descriptor wins on any shared key; the lowering only contributes
+        ;; :handler-fn + the per-kind runtime slots).
+        (merge (lower (:metadata descriptor) (:impl descriptor)) descriptor))
       descriptor)
     descriptor))
 

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -2199,30 +2199,35 @@
 (defn lower-inline-sub
   "Lower an inline `:reg-sub` descriptor's raw computation fn into the runnable
   layer-1 (`:input-kind :db`) sub slots `reg-sub` installs (`:handler-fn` +
-  `:input-kind :db` + empty `:input-signals`). `metadata` is NORMALIZED through
-  the SAME `normalize-sub-metadata` seam public `reg-sub` runs (rf2-vxgfnd.219),
-  so an inline registration accepts, rejects, and elides identical metadata: a
-  retired bare `:spec` hard-errors with `:rf.error/retired-registration-key`, a
-  malformed `:sensitive` / `:large` declaration raises
-  `:rf.error/bad-classification`, and production strips `:doc` — neither looser
-  nor stricter than the public path. The normalized meta is projected onto the
-  runnable descriptor's top level, matching the shape `reg-sub` installs so
-  runtime consumers (return-schema validation, classification projection) read
-  the same slots regardless of registration path. Normalization is side-effect-
-  free with respect to the global registrar; the runtime-owned runnable slots
-  are installed AFTER it, so metadata can never override them. Image assembly
-  still keeps the original nested `:metadata` plus `:impl` and provenance for
-  inspection.
+  `:input-kind :db` + empty `:input-signals`). `metadata` is NORMALIZED ONCE
+  through the SAME `normalize-sub-metadata` seam public `reg-sub` runs
+  (rf2-vxgfnd.219), so an inline registration accepts, rejects, and elides
+  identical metadata: a retired bare `:spec` hard-errors with
+  `:rf.error/retired-registration-key`, a malformed `:sensitive` / `:large`
+  declaration raises `:rf.error/bad-classification`, and production strips
+  `:doc` — neither looser nor stricter than the public path. Normalization is
+  side-effect-free with respect to the global registrar; the runtime-owned
+  runnable slots are installed AFTER it, so metadata can never override them.
 
-  The concrete sub id is not threaded through the image-assembly lowering
-  boundary (`lower` receives only `[metadata impl]`), so a generic
-  `:rf.image/inline-sub` id names the registration in any normalization
-  diagnostic; the error TYPE + named replacement key match the public path."
-  [metadata impl]
-  (assoc (normalize-sub-metadata 'rf/reg-sub :rf.image/inline-sub metadata)
-         :handler-fn    impl
-         :input-kind    :db
-         :input-signals []))
+  `id` is the AUTHORED descriptor id (e.g. `:counter/value`) threaded from the
+  image-assembly lowering boundary (rf2-vxgfnd.257), so a retired/unknown-key or
+  bad-classification diagnostic names the author's subscription — never a
+  synthetic fallback.
+
+  The normalized meta is projected onto the runnable descriptor's top level,
+  matching the shape `reg-sub` installs so runtime consumers (return-schema
+  validation, classification projection) read the same slots regardless of
+  registration path. It is ALSO carried under `:metadata` (when non-empty) — the
+  ONE normalized representation — so image assembly threads the same doc-stripped
+  map into the descriptor's nested `:metadata` for inspection/dedupe rather than
+  retaining a second, raw copy that would leak dev-only `:doc` into production."
+  [id metadata impl]
+  (let [normalized (normalize-sub-metadata 'rf/reg-sub id metadata)]
+    (cond-> (assoc normalized
+                   :handler-fn    impl
+                   :input-kind    :db
+                   :input-signals [])
+      (seq normalized) (assoc :metadata normalized))))
 
 (late-bind/set-fn! :image/lower-inline-sub lower-inline-sub)
 

--- a/implementation/core/test/re_frame/subs_image_local_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_image_local_classification_cljs_test.cljc
@@ -18,12 +18,28 @@
   sensitive sub and proves the subscriber reads RAW while the projected trace
   redacts, across an ongoing recompute.
 
+  rf2-vxgfnd.258 — the chokepoint fixtures HAND a `:rf.sub/classification` map
+  to the projector, so they stay green even if REAL image-local resolution fell
+  back to the global/nil. The `image-local-*` deftests below close that gap:
+  they ASSEMBLE a real inline `:reg-sub` (`image/image` → `lf/make-frame` →
+  `image-assembly/lower-inline-descriptors`, the rf2-vxgfnd.219/.257 path),
+  install it on a LIVE frame carrying a resolved image GENERATION, and observe
+  the Xray-facing `:trace` listener stream. They prove the image-local
+  `:sensitive` declaration is the one that redacts even against a conflicting
+  same-id GLOBAL, a SECOND frame with the same id resolves its OWN declaration,
+  and REPLACING frame A's generation reflects the NEW declaration without leaking
+  the old generation or the global. Mutating image-local sub-meta resolution to
+  nil/global (the projector re-resolving through the ambient registrar) makes
+  these fail on CLJ and CLJS.
+
   `.cljc` — runs under both `clojure -M:test` (JVM) and `npm run test:cljs`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.classification :as classification]
             [re-frame.elision :as elision]
+            [re-frame.image :as image]
+            [re-frame.live-frame :as lf]
             [re-frame.privacy :as privacy]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
@@ -144,3 +160,141 @@
               "the internal carrier never reaches a listener")))
       (finally
         (rf/unregister-listener! :trace :sec-e2e)))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.258 — REAL image-local assembly + generation replacement
+;;
+;; Not `project-trace-event` fed a fabricated classification: an inline
+;; `:reg-sub` ASSEMBLED by `image/image` → `lf/make-frame` → image-assembly's
+;; `lower-inline-descriptors`, installed on a live frame's resolved GENERATION,
+;; observed through the Xray-facing `:trace` listener. If image-local sub-meta
+;; resolution fell back to the global/nil, the projected value would ride RAW and
+;; these fail.
+;; ===========================================================================
+
+(defn- inline-sub-image
+  "An image whose ONLY registration is an inline layer-1 `:reg-sub` under `id`
+  carrying `classification` metadata and returning the constant `value`. The
+  inline descriptor is NORMALIZED + lowered by image assembly when the frame's
+  generation is sealed (the REAL path — not a hand-built descriptor). The
+  `image/image` inline `:reg-sub` path stamps `:input-kind :db` for us."
+  [image-id id classification value]
+  (image/image {:id            image-id
+                :registrations {:reg-sub [[id classification (fn [_db _q] value)]]}}))
+
+(defn- install-image-frame!
+  "Create/update a runnable frame under `frame-id` and seal its generation from
+  `image` — the REAL image-assembly path (`asm/assemble` → lower-inline-
+  descriptors). The empty descriptor pool keeps the generation to the image's
+  OWN inline registrations (no live source-store contamination). Returns the
+  frame value."
+  [frame-id image]
+  (lf/make-frame {:id frame-id :images [image]} []))
+
+(defn- image-local-sub-runs
+  "The projected `:tags` of every `:rf.sub/run` the `:trace` listener saw for
+  `sub-id` in `frame-id` — the Xray-facing evidence, post-projection."
+  [recorded sub-id frame-id]
+  (into []
+        (comp (filter (fn [ev] (and (= :rf.sub/run (:operation ev))
+                                    (= sub-id  (get-in ev [:tags :rf.sub/id]))
+                                    (= frame-id (get-in ev [:tags :frame])))))
+              (map :tags))
+        @recorded))
+
+(defn- with-trace-listener
+  "Register a `:trace` listener that accumulates into a fresh atom, run `(f
+  recorded)`, and unregister in a finally."
+  [f]
+  (let [recorded (atom [])
+        lid      ::image-local-e2e]
+    (rf/register-listener! :trace lid (fn [ev] (swap! recorded conj ev)))
+    (try (f recorded)
+         (finally (rf/unregister-listener! :trace lid)))))
+
+(deftest image-local-sensitive-redacts-over-conflicting-global-through-real-assembly
+  (testing "an ASSEMBLED inline sub's :sensitive declaration redacts its
+            :rf.sub/run evidence in the frame that owns it — even though a same-id
+            GLOBAL registration declares NO classification (a fallback to the
+            global/nil would leak the value RAW)"
+    ;; Conflicting global: SAME id, NO classification.
+    (rf/reg-sub :img/read (fn [_db _q] {:token "GLOBAL" :public 0}))
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/a :img/read {:sensitive [[:token]]}
+                        {:token "SECRET" :public 1}))
+    (with-trace-listener
+      (fn [recorded]
+        (is (= {:token "SECRET" :public 1}
+               @(rf/subscribe [:img/read] {:frame :img/frame-a}))
+            "the subscriber derefs the RAW image-local value")
+        (let [runs (image-local-sub-runs recorded :img/read :img/frame-a)]
+          (is (seq runs) "the :trace listener saw the image-local sub run")
+          (doseq [tags runs]
+            (is (= privacy/redacted-sentinel (get-in tags [:rf.sub/value :token]))
+                "image-local :sensitive redacted the value, NOT the unclassified global")
+            (is (= 1 (get-in tags [:rf.sub/value :public]))
+                "the unclassified sibling rides raw")
+            (is (not (contains? tags :rf.sub/classification))
+                "the internal carrier never reaches the listener")))))))
+
+(deftest second-frame-same-id-resolves-its-own-image-local-classification
+  (testing "two frames install the SAME inline id with DIFFERENT classifications;
+            each frame's evidence redacts per its OWN image-local declaration —
+            no cross-frame classification bleed, no shared global"
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/a :img/read {:sensitive [[:token]]}
+                        {:token "A-SECRET" :public "A-pub"}))
+    (install-image-frame! :img/frame-b
+      (inline-sub-image :img/b :img/read {:sensitive [[:public]]}
+                        {:token "B-tok" :public "B-SECRET"}))
+    (with-trace-listener
+      (fn [recorded]
+        @(rf/subscribe [:img/read] {:frame :img/frame-a})
+        @(rf/subscribe [:img/read] {:frame :img/frame-b})
+        (let [a (last (image-local-sub-runs recorded :img/read :img/frame-a))
+              b (last (image-local-sub-runs recorded :img/read :img/frame-b))]
+          (is (some? a) "frame A's sub ran")
+          (is (some? b) "frame B's sub ran")
+          (is (= privacy/redacted-sentinel (get-in a [:rf.sub/value :token]))
+              "frame A redacts :token (its own declaration)")
+          (is (= "A-pub" (get-in a [:rf.sub/value :public]))
+              "frame A leaves :public raw")
+          (is (= privacy/redacted-sentinel (get-in b [:rf.sub/value :public]))
+              "frame B redacts :public (ITS declaration), independently")
+          (is (= "B-tok" (get-in b [:rf.sub/value :token]))
+              "frame B leaves :token raw — no bleed from A's :token declaration"))))))
+
+(deftest replacing-frame-a-generation-updates-evidence-without-old-or-global-leak
+  (testing "replacing frame A's image generation with a NEW :sensitive
+            declaration makes subsequent evidence redact per the NEW generation —
+            not the OLD generation's path, not the conflicting global"
+    ;; Conflicting global: SAME id, NO classification.
+    (rf/reg-sub :img/read (fn [_db _q] {:token "GLOBAL" :public "GLOBAL"}))
+    ;; Generation 1 — classifies :token.
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/g1 :img/read {:sensitive [[:token]]}
+                        {:token "SECRET" :public "pub"}))
+    (with-trace-listener
+      (fn [recorded]
+        (let [g1 (last (do @(rf/subscribe [:img/read] {:frame :img/frame-a})
+                          (image-local-sub-runs recorded :img/read :img/frame-a)))]
+          (is (= privacy/redacted-sentinel (get-in g1 [:rf.sub/value :token]))
+              "generation 1 redacts :token"))
+        ;; Swap to generation 2 — classifies :public instead. Frame memory
+        ;; (sub-cache) is preserved across the swap, so clear it to force a fresh
+        ;; reaction resolved against the NEW generation (an HMR sub reload).
+        (install-image-frame! :img/frame-a
+          (inline-sub-image :img/g2 :img/read {:sensitive [[:public]]}
+                            {:token "tok2" :public "SECRET2"}))
+        (rf/clear-sub-cache! :img/frame-a)
+        (reset! recorded [])
+        @(rf/subscribe [:img/read] {:frame :img/frame-a})
+        (let [g2 (last (image-local-sub-runs recorded :img/read :img/frame-a))]
+          (is (some? g2) "the new generation's sub ran")
+          (is (= privacy/redacted-sentinel (get-in g2 [:rf.sub/value :public]))
+              "the NEW generation redacts :public")
+          (is (= "tok2" (get-in g2 [:rf.sub/value :token]))
+              "the OLD generation's :token classification did NOT persist, and the
+               unclassified global did not supply one")
+          (is (not (contains? g2 :rf.sub/classification))
+              "the internal carrier never reaches the listener"))))))

--- a/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
@@ -12,10 +12,25 @@
   `:doc`, and the runtime-owned runnable slots win over any metadata that names
   them. A mutation restoring the direct `(assoc metadata …)` fails these rows.
 
+  rf2-vxgfnd.257 — normalize ONCE, and thread the authored descriptor id +
+  normalized metadata through the REAL image assembly. The `.219` parity above
+  called the lowerer directly; a residual defect only surfaced through the
+  assembled artifact: image assembly kept the descriptor's ORIGINAL RAW
+  `:metadata`, so a production image still carried `[:metadata :doc]` alongside
+  the doc-stripped top level; and the lowering hardcoded a synthetic
+  `:rf.image/inline-sub` id, so a retired/unknown-key diagnostic could not name
+  the author's subscription. The `production-assembly-*` and
+  `retired-key-diagnostic-*` deftests below drive `re-frame.image` +
+  `re-frame.image-assembly/lower-inline-descriptor` (the runnable descriptor a
+  frame resolves — NOT a direct `lower-inline-sub` call) and fail if the raw
+  metadata merge returns or the authored id is dropped.
+
   `.cljc` — the normalizer is host-agnostic, so this runs under both
   `clojure -M:test` (JVM) and `npm run test:cljs` (node CLJS)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.subs :as subs]
+            [re-frame.image :as image]
+            [re-frame.image-assembly :as asm]
             [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
             [re-frame.test-support :as test-support]))
@@ -44,7 +59,7 @@
   (testing "public reg-sub and inline lower-inline-sub BOTH reject the retired
             `:spec` bare key with the same discriminator + named replacement"
     (let [pub    (caught-ex-data #(subs/reg-sub :norm/pub-retired {:spec [:map]} body))
-          inline (caught-ex-data #(subs/lower-inline-sub {:spec [:map]} body))]
+          inline (caught-ex-data #(subs/lower-inline-sub :norm/inline-retired {:spec [:map]} body))]
       (doseq [[label ed] [["public" pub] ["inline" inline]]]
         (testing label
           (is (some? ed) "must throw")
@@ -57,7 +72,7 @@
 (deftest bad-classification-hard-errors-on-inline-and-public
   (testing "public and inline BOTH reject a malformed `:sensitive` declaration"
     (let [pub    (caught-ex-data #(subs/reg-sub :norm/pub-badcls {:sensitive :wrong} body))
-          inline (caught-ex-data #(subs/lower-inline-sub {:sensitive :wrong} body))]
+          inline (caught-ex-data #(subs/lower-inline-sub :norm/inline-badcls {:sensitive :wrong} body))]
       (doseq [[label ed] [["public" pub] ["inline" inline]]]
         (testing label
           (is (some? ed) "must throw")
@@ -68,7 +83,7 @@
             top-level slot — the descriptor and registrar entry agree"
     (subs/reg-sub :norm/pub-cls {:sensitive [[:token]]} body)
     (let [pub-meta   (registrar/handler-meta :sub :norm/pub-cls)
-          inline-desc (subs/lower-inline-sub {:sensitive [[:token]]} body)]
+          inline-desc (subs/lower-inline-sub :norm/inline-cls {:sensitive [[:token]]} body)]
       (is (= [[:token]] (:sensitive pub-meta)))
       (is (= [[:token]] (:sensitive inline-desc))
           "inline descriptor carries the SAME classification declaration"))))
@@ -77,12 +92,12 @@
 
 (deftest doc-stripped-in-production-retained-in-dev-on-inline-path
   (testing "dev (default gate on) retains `:doc` for tooling / agent inspection"
-    (let [desc (subs/lower-inline-sub {:doc "kept in dev"} body)]
+    (let [desc (subs/lower-inline-sub :norm/inline-doc {:doc "kept in dev"} body)]
       (is (= "kept in dev" (:doc desc)))))
   (testing "production (gate off) strips `:doc` from the inline runnable
             descriptor, exactly as the public registrar does"
     (with-redefs [interop/debug-enabled? false]
-      (let [desc (subs/lower-inline-sub {:doc "elided in prod" :schema :int} body)]
+      (let [desc (subs/lower-inline-sub :norm/inline-doc {:doc "elided in prod" :schema :int} body)]
         (is (not (contains? desc :doc)) ":doc absent from the inline descriptor in prod")
         (is (= :int (:schema desc)) "a load-bearing key like :schema is retained")))))
 
@@ -91,7 +106,7 @@
 (deftest runtime-owned-slots-win-over-metadata
   (testing "the runnable slots are installed AFTER normalization, so metadata
             naming them cannot override the runtime-owned values"
-    (let [desc (subs/lower-inline-sub {:input-kind :parametric :input-signals [:x]} body)]
+    (let [desc (subs/lower-inline-sub :norm/inline-slots {:input-kind :parametric :input-signals [:x]} body)]
       (is (= body (:handler-fn desc)) ":handler-fn is the lowered impl")
       (is (= :db (:input-kind desc)) ":input-kind is the layer-1 :db, not the metadata's")
       (is (= [] (:input-signals desc)) ":input-signals is empty, not the metadata's"))))
@@ -99,5 +114,65 @@
 (deftest namespaced-extension-keys-survive-on-inline-path
   (testing "namespaced extension keys pass normalization untouched (the open-map
             carve-out), matching public reg-sub"
-    (let [desc (subs/lower-inline-sub {:myapp/analytics-id 7} body)]
+    (let [desc (subs/lower-inline-sub :norm/inline-ext {:myapp/analytics-id 7} body)]
       (is (= 7 (:myapp/analytics-id desc))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.257 — through the REAL image assembly (not a direct lowerer call)
+;;
+;; `assemble-sub` drives `re-frame.image` → the image's `:rf.image/inline`
+;; descriptors → `image-assembly/lower-inline-descriptor`, i.e. the runnable
+;; descriptor a frame actually resolves. These are the fixtures a mutation that
+;; restores the raw-metadata merge, or drops the authored id, must fail.
+;; ---------------------------------------------------------------------------
+
+(defn- assemble-sub
+  "Assemble ONE inline `:reg-sub` through the LIVE image + assembly-side lowering
+  and return its runnable descriptor. `metadata` nil uses the 2-tuple form."
+  [id metadata body]
+  (-> (image/image
+        {:id            :norm/inline-image
+         :registrations {:reg-sub [(if (nil? metadata) [id body] [id metadata body])]}})
+      :rf.image/inline
+      first
+      asm/lower-inline-descriptor))
+
+(deftest production-assembly-strips-doc-from-top-level-and-nested-metadata
+  (testing "dev — the authored `:doc` survives at BOTH the top level and under the
+            nested `:metadata` of the assembled image descriptor"
+    (let [d (assemble-sub :counter/value {:doc "author note" :schema :int} body)]
+      (is (= "author note" (:doc d)) "top-level :doc retained in dev")
+      (is (= "author note" (get-in d [:metadata :doc]))
+          "nested [:metadata :doc] retained in dev")
+      (is (= :counter/value (:id d)) "authored id survives assembly")))
+  (testing "production (gate off) — the assembled image carries NO `:doc` at the
+            top level OR under nested `:metadata`; load-bearing keys are retained"
+    (with-redefs [interop/debug-enabled? false]
+      (let [d (assemble-sub :counter/value {:doc "author note" :schema :int} body)]
+        (is (not (contains? d :doc)) "no top-level :doc in a production image")
+        (is (not (contains? (:metadata d) :doc))
+            "no dev-only :doc under nested [:metadata …] in a production image")
+        (is (= :int (:schema d)) "load-bearing :schema retained at top level")
+        (is (= :int (get-in d [:metadata :schema]))
+            "and consistently under the normalized nested :metadata")))))
+
+(deftest production-assembly-doc-only-metadata-drops-the-nested-map
+  (testing "a doc-ONLY inline sub normalizes to empty metadata in production, so
+            the assembled descriptor carries neither :doc nor a stale raw
+            :metadata map"
+    (with-redefs [interop/debug-enabled? false]
+      (let [d (assemble-sub :counter/note {:doc "only a note"} body)]
+        (is (not (contains? d :doc)))
+        (is (not (contains? (:metadata d) :doc)))
+        (is (= body (:handler-fn d)) "the runnable slot is still installed")))))
+
+(deftest retired-key-diagnostic-names-the-authored-inline-id
+  (testing "a retired `:spec` key on an inline sub fails at REAL assembly naming
+            the AUTHORED id (`:counter/value`), not a synthetic
+            `:rf.image/inline-sub`"
+    (let [ed (caught-ex-data #(assemble-sub :counter/value {:spec [:map]} body))]
+      (is (some? ed) "assembly must throw on the retired key")
+      (is (= :rf.error/retired-registration-key (:rf.error/id ed)))
+      (is (= :counter/value (:id ed))
+          "the diagnostic names the author's subscription, not a synthetic id")
+      (is (= :schema (:replacement ed)) "still names the v2 replacement key"))))


### PR DESCRIPTION
Two P2 inline-sub beads on the core inline-sub surface (`re-frame.subs` /
`re-frame.image-assembly` / `re-frame.classification`). Re-verified reproducing
against current `origin/main` before fixing. One PR, two independent commits
(`.257` → `.258`). No public API change.

> Note: the original dispatch brief mis-located this as a `ui/compiler`
> (analyze/emit) cluster; the inline-sub metadata + classification surface lives
> entirely in `implementation/core/`. Scope was corrected to core `subs.cljc` +
> `image_assembly.cljc` + `classification.cljc` (read-only) + the two named tests
> before any edit; `substrate/observation.cljc`, `fx.cljc`, `frame.cljc` and all
> other live-worker surfaces were left untouched.

## rf2-vxgfnd.257 — normalize inline-sub metadata once + preserve authored id

`lower-inline-sub` normalized the runnable descriptor's TOP-LEVEL metadata
(doc-stripped in production) but `image-assembly/lower-inline-descriptor` then
merged the descriptor's ORIGINAL RAW `:metadata` on top — so a production image
carried `[:metadata :doc]` alongside the stripped top level (a second, divergent
representation paying unwanted bytes). The lowering also hardcoded a synthetic
`:rf.image/inline-sub` id, so a retired/unknown-key or bad-classification
diagnostic named a fallback rather than the author's subscription.

Fix: `lower-inline-sub` now takes the authored `[id metadata impl]`, runs the
single `normalize-sub-metadata` seam with the real id, and carries the normalized
map both spread at top level AND under `:metadata` (when non-empty).
`lower-inline-descriptor` threads the authored id to the sub lowering (the one
kind that runs registrar-contract normalization) and lets that normalized
`:metadata` replace the descriptor's raw copy — dropping it entirely when
normalization empties it (a doc-only map in production). Selection/dedupe already
ran, so this never decides a collision winner; other kinds are untouched.

Red-before-fix fixtures (`subs_inline_normalization_cljs_test`, both hosts,
driving the REAL `image/image` + `image-assembly/lower-inline-descriptor` path):
- `production-assembly-strips-doc-from-top-level-and-nested-metadata` — the prod
  leg fails when the raw `:metadata` merge returns.
- `production-assembly-doc-only-metadata-drops-the-nested-map`.
- `retired-key-diagnostic-names-the-authored-inline-id` — fails when the authored
  id is dropped for `:rf.image/inline-sub`.

## rf2-vxgfnd.258 — prove classification through real image-local assembly

The image-local classification suite's chokepoint fixtures HAND a
`:rf.sub/classification` map straight to the projector, so they stayed green even
if real image-local sub-meta resolution fell back to the ambient global/nil.
Added three fixtures that ASSEMBLE a real inline `:reg-sub` (`image/image` →
`lf/make-frame` → `image-assembly/lower-inline-descriptors`, the .219/.257 path),
install it on a live frame's resolved GENERATION, and observe the Xray-facing
`:trace` listener:
- `image-local-sensitive-redacts-over-conflicting-global-through-real-assembly` —
  the image-local `:sensitive` redacts even against a same-id unclassified global.
- `second-frame-same-id-resolves-its-own-image-local-classification` — frame A
  redacts `:token`, frame B redacts `:public`, independently.
- `replacing-frame-a-generation-updates-evidence-without-old-or-global-leak` —
  swapping A's generation (sub-cache cleared for a fresh reaction) reflects the
  NEW declaration, not the old generation's path nor the global.

No production change (the rf2-vxgfnd.220 carry mechanism already resolves
image-local classification correctly). Red-check: mutating `project-sub-tags` to
re-resolve through the ambient registrar (ignoring the captured carrier) fails
all three on CLJ and CLJS (verified — 11 failures, then reverted clean).

## Quality gates

- `(cd implementation/core && clojure -M:test)` — 1977 tests / 9073 assertions, 0 failures / 0 errors (JVM).
- `(cd implementation && npm run test:cljs)` — 9389 tests / 44491 assertions, 0 failures / 0 errors (node CLJS). (One unrelated flake in a `re-frame.mcp-base.sensitive` tools namespace on the first run cleared on an identical re-run.)
- Browser matrix + fast-pr spine left to CI (authoritative).