### PR TITLE
fix(ui): flush-render! settles pending ViewCells + terminal preflight-receipt settle on abort (rf2-vxgfnd.207/.264)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -348,22 +348,27 @@
   The effective `:identifier-prefix` rides the entry so a later claim can
   assert prefix uniqueness and release frees it by dissoc (rf2-ez3fqk).
 
-  MINTS the root's per-mount INCARNATION here (rf2-vxgfnd.85/.92) — a fresh
-  opaque token that scopes every ViewCell under this Root (provided via the
-  root-incarnation React context at render) and drives the incarnation-aware
-  root teardown reap at `unmount!*`. Stable for the Root's lifetime (registration
-  runs once per Root); a re-mount under the same root-id after `unmount!` mints a
-  DISTINCT incarnation, so a stale teardown can never reap the replacement's
-  cells."
-  [{:keys [root-id provenance site descriptor identifier-prefix]} container root]
-  (swap! live-roots assoc root-id {:root root
-                                   :container container
-                                   :provenance provenance
-                                   :identifier-prefix identifier-prefix
-                                   :site site
-                                   :descriptor descriptor
-                                   :root-incarnation (reactive/make-root-incarnation)})
-  nil)
+  Takes the root's per-mount INCARNATION (rf2-vxgfnd.85/.92) — a fresh opaque
+  token. The 4-arity form receives one minted by the caller BEFORE `createRoot`
+  (rf2-vxgfnd.264, so the root's `onUncaughtError` wrapper can close over the EXACT
+  incarnation it settles); the 3-arity form mints one internally (the low-level
+  test/tool seam that installs no host error wrapper). It scopes every ViewCell
+  under this Root (provided via the root-incarnation React context at render) and
+  drives the incarnation-aware root teardown reap at `unmount!*`. Stable for the
+  Root's lifetime (registration runs once per Root); a re-mount under the same
+  root-id after `unmount!` mints a DISTINCT incarnation, so a stale teardown can
+  never reap the replacement's cells."
+  ([info container root]
+   (register-live-root! info container root (reactive/make-root-incarnation)))
+  ([{:keys [root-id provenance site descriptor identifier-prefix]} container root incarnation]
+   (swap! live-roots assoc root-id {:root root
+                                    :container container
+                                    :provenance provenance
+                                    :identifier-prefix identifier-prefix
+                                    :site site
+                                    :descriptor descriptor
+                                    :root-incarnation incarnation})
+   nil))
 
 (defn- root-incarnation-of
   "The per-mount root incarnation minted for live root `root-id` at
@@ -382,6 +387,112 @@
            (if (identical? (:root (get m root-id)) root)
              (dissoc m root-id)
              m)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The pending render-attempt owner — terminal receipt settlement on React
+;; abort / abandonment (rf2-vxgfnd.264)
+;; ---------------------------------------------------------------------------
+;;
+;; The `root-commit-reporter` (rf2-vxgfnd.248) finalizes a preflight receipt from
+;; a layout effect only after React COMMITS the render. But it provides no owner
+;; for a receipt when React FAILS or ABANDONS the render before that reporter
+;; mounts: a descendant throw AFTER `.render` returns goes to root
+;; `onUncaughtError` (the commit is aborted; the reporter's layout effect never
+;; runs), a fresh async render followed by an immediate unmount never commits, and
+;; a superseding render leaves the old attempt provisional. Left alone, each such
+;; receipt lingers forever — neither committed nor terminally failed.
+;;
+;; The fix gives each live Root entry ONE exact pending render-attempt owner — the
+;; seated `receipt`, keyed to the root `:root-incarnation`. It is seated BEFORE
+;; `.render`; the exact reporter commit finalizes and clears it; a host error
+;; (`onUncaughtError`), an explicit supersession (a later `.render` seating a new
+;; attempt), and unmount TERMINALLY settle (abort) that exact pending receipt. The
+;; frames-layer `abort-preflight-attempt!`/`finalize-preflight-attempt!` stay
+;; REV-GUARDED, so a stale/late/cross-root/reincarnation signal can never settle a
+;; newer attempt. Suspense stays pending until a real terminal edge (commit,
+;; supersession, unmount, or host failure). No global flushSync, no second
+;; coordinator, no public API.
+
+(defn- seat-pending-attempt!
+  "Seat `receipt` (this render attempt's preflight evidence — possibly nil for a
+  no-plan render) as root `root-id`'s single pending render-attempt owner, keyed
+  to `incarnation`. A prior UNCOMMITTED attempt is a SUPERSESSION: its receipt is
+  aborted (only the OLD receipt — the new attempt proceeds to commit). Seated
+  BEFORE `.render`, and identity-guarded to the live incarnation, so a same-id
+  reincarnation's entry is never seated by a stale caller. Returns nil."
+  [root-id receipt incarnation]
+  (let [superseded (volatile! nil)]
+    (swap! live-roots
+           (fn [m]
+             (let [entry (get m root-id)]
+               (if (and entry (identical? (:root-incarnation entry) incarnation))
+                 (do (vreset! superseded (:pending-attempt entry))
+                     (assoc m root-id (assoc entry :pending-attempt receipt)))
+                 m))))
+    (when-some [old @superseded]
+      (frames/abort-preflight-attempt! old)))
+  nil)
+
+(defn- settle-committed-attempt!
+  "The reporter's HOST-COMMIT edge (rf2-vxgfnd.248/.264): finalize `receipt`
+  (mark its records `:committed`) and clear it from root `root-id`'s pending slot,
+  BOTH identity-guarded to the exact `receipt` + `incarnation` so a stale/late
+  reporter, a same-id reincarnation, or a cross-root control can never clear (or
+  finalize past) a newer attempt. Returns nil."
+  [root-id receipt incarnation]
+  (frames/finalize-preflight-attempt! receipt)
+  (swap! live-roots
+         (fn [m]
+           (let [entry (get m root-id)]
+             (if (and entry
+                      (identical? (:root-incarnation entry) incarnation)
+                      (identical? (:pending-attempt entry) receipt))
+               (assoc m root-id (dissoc entry :pending-attempt))
+               m))))
+  nil)
+
+(defn- abort-pending-attempt!
+  "The host-error / unmount edge (rf2-vxgfnd.264): TERMINALLY settle root
+  `root-id`'s currently-seated pending render attempt as FAILED (`:fresh` writes →
+  `:mount-incomplete`, `:live`/committed refreshes → `:preflight-attempt-failed`)
+  and clear it. Identity-guarded to `incarnation` (a same-id reincarnation's entry
+  is a distinct incarnation, left untouched); the frames abort is rev-guarded, so
+  a stale receipt never clobbers an overtaking write. No-op when nothing is
+  seated (a committed attempt already cleared its slot). Returns nil."
+  [root-id incarnation]
+  (let [pending (volatile! nil)]
+    (swap! live-roots
+           (fn [m]
+             (let [entry (get m root-id)]
+               (if (and entry
+                        (identical? (:root-incarnation entry) incarnation)
+                        (some? (:pending-attempt entry)))
+                 (do (vreset! pending (:pending-attempt entry))
+                     (assoc m root-id (dissoc entry :pending-attempt)))
+                 m))))
+    (when-some [r @pending]
+      (frames/abort-preflight-attempt! r)))
+  nil)
+
+(defn- abort-seated-attempt!
+  "The SYNCHRONOUS post-preflight-throw edge (the element thunk, host `.render`,
+  or the post-preflight ownership fence threw BEFORE React scheduled the commit):
+  terminally settle `receipt` as failed AND clear it from root `root-id`'s pending
+  slot when still seated. Unlike `abort-pending-attempt!`, the receipt is aborted
+  UNCONDITIONALLY (it is the caller's exact receipt) — a throw before the seat, or
+  after a first-mount rollback dissoc'd the entry, still settles it — preserving
+  the pre-.264 catch behaviour while also clearing any seated slot. Returns nil."
+  [root-id receipt incarnation]
+  (frames/abort-preflight-attempt! receipt)
+  (swap! live-roots
+         (fn [m]
+           (let [entry (get m root-id)]
+             (if (and entry
+                      (identical? (:root-incarnation entry) incarnation)
+                      (identical? (:pending-attempt entry) receipt))
+               (assoc m root-id (dissoc entry :pending-attempt))
+               m))))
   nil)
 
 (defn- mark-tearing-down!
@@ -518,6 +629,40 @@
       (unchecked-set o "onRecoverableError" on-recoverable))
     o))
 
+(defn- report-uncaught-default!
+  "React 19's default `onUncaughtError` reporting, preserved when the app authored
+  NO callback (rf2-vxgfnd.264): once we install a wrapper to catch the receipt-abort
+  edge, React no longer runs its own default, so we replicate it —
+  `globalThis.reportError` when present (React 19.2's `reportGlobalError`), else
+  `console.error`."
+  [error]
+  (if (fn? (.-reportError js/globalThis))
+    (js/reportError error)
+    (when (exists? js/console) (.error js/console error))))
+
+(defn- react-opts-with-attempt-abort
+  "Compose the (already-built) React root options with the .264 host-error edge:
+  an `onUncaughtError` that TERMINALLY settles root `root-id`'s currently-seated
+  pending render attempt (React aborts the commit before the reporter's layout
+  effect can finalize it), keyed to the EXACT `incarnation` this `createRoot`
+  registers, and THEN delegates to the authored callback — or to React's default
+  global-error report when none was authored. Every other option (identifierPrefix,
+  onCaughtError, onRecoverableError) is carried through unchanged. Returns a fresh
+  options object; the caller passes it straight to `createRoot`."
+  [react-opts root-id incarnation]
+  (let [authored (when react-opts (unchecked-get react-opts "onUncaughtError"))
+        composed (fn on-uncaught [error error-info]
+                   ;; React aborted this commit — the reporter never runs. Settle
+                   ;; the exact seated attempt (rev-guarded downstream), THEN honour
+                   ;; the authored React error callback / React's default.
+                   (abort-pending-attempt! root-id incarnation)
+                   (if (fn? authored)
+                     (authored error error-info)
+                     (report-uncaught-default! error)))
+        o        (if react-opts (js/Object.assign #js {} react-opts) #js {})]
+    (unchecked-set o "onUncaughtError" composed)
+    o))
+
 ;; ---------------------------------------------------------------------------
 ;; The host-commit reporter — preflight evidence finalizes on a REAL commit
 ;; (rf2-vxgfnd.248)
@@ -549,17 +694,22 @@
 ;; the only cost is one transparent wrapper + one layout effect per root render.
 
 (defn- root-commit-reporter
-  "React function component wrapping a root render (rf2-vxgfnd.248). Renders its
-  `children` unchanged and, in a `useLayoutEffect` keyed to the exact attempt
-  `rfReceipt`, finalizes that attempt at React's REAL commit boundary. Because
-  layout effects fire only for committed renders, an aborted/abandoned render
-  never finalizes; `finalize-preflight-attempt!`'s nil-receipt and rev guards
-  keep a no-plan render and a stale commit signal both harmless."
+  "React function component wrapping a root render (rf2-vxgfnd.248/.264). Renders
+  its `children` unchanged and, in a `useLayoutEffect` keyed to the exact attempt
+  `rfReceipt`, finalizes that attempt AND clears its pending-attempt slot at
+  React's REAL commit boundary (`settle-committed-attempt!`). Because layout
+  effects fire only for committed renders, an aborted/abandoned render never
+  reaches here — its receipt is instead terminally settled by the host-error /
+  supersession / unmount edges (rf2-vxgfnd.264). The finalize + clear are both
+  identity/rev-guarded, so a stale commit signal, a no-plan render, and a same-id
+  reincarnation are all harmless."
   [^js props]
-  (let [receipt (.-rfReceipt props)]
+  (let [receipt     (.-rfReceipt props)
+        root-id     (.-rfRootId props)
+        incarnation (.-rfIncarnation props)]
     (react/useLayoutEffect
      (fn commit-report []
-       (frames/finalize-preflight-attempt! receipt)
+       (settle-committed-attempt! root-id receipt incarnation)
        js/undefined)
      #js [receipt]))
   (.-children props))
@@ -567,14 +717,15 @@
 (defn- render-attempt-element
   "The exact element a root's `.render` receives for one attempt: the root
   incarnation-provided `element` wrapped in the `root-commit-reporter` carrying
-  this attempt's `receipt`, so the preflight attempt finalizes only after React
-  commits this render (rf2-vxgfnd.248), never merely because `.render` returned.
-  `element-thunk` is still evaluated eagerly by the caller, so a synchronous
-  throw from it (a top-region provider naming an absent frame) still propagates
-  into the caller's rollback try/catch unchanged."
-  [receipt incarnation element]
+  this attempt's `receipt` (plus its `root-id` + `incarnation`, so the commit can
+  clear the exact pending-attempt slot — rf2-vxgfnd.264), so the preflight attempt
+  finalizes only after React commits this render (rf2-vxgfnd.248), never merely
+  because `.render` returned. `element-thunk` is still evaluated eagerly by the
+  caller, so a synchronous throw from it (a top-region provider naming an absent
+  frame) still propagates into the caller's rollback try/catch unchanged."
+  [receipt root-id incarnation element]
   (react/createElement root-commit-reporter
-                       #js {:rfReceipt receipt}
+                       #js {:rfReceipt receipt :rfRootId root-id :rfIncarnation incarnation}
                        (viewcell/provide-root-incarnation incarnation element)))
 
 ;; ---------------------------------------------------------------------------
@@ -643,7 +794,8 @@
          (:identifier-prefix info) (:identifier-prefix existing))
         ;; re-preflight BEFORE the re-render: a failure leaves the live
         ;; root and its last committed render untouched (Q49).
-        (let [receipt (run-preflight! root-id plans-thunk)]
+        (let [receipt     (run-preflight! root-id plans-thunk)
+              incarnation (root-incarnation-of root-id)]
           (try
             ;; rf2-vxgfnd.69: run-preflight! drained :initial-events SYNCHRONOUSLY
             ;; (arbitrary app code) that may have unmount!ed this root and mounted
@@ -652,6 +804,10 @@
             ;; never commit, and `.render`ing the stale handle would write into a
             ;; root the replacement now owns. Mirrors the fresh-path re-check.
             (require-live-root! root 're-frame.ui/mount)
+            ;; rf2-vxgfnd.264: seat this attempt as the root's single pending
+            ;; render-attempt owner BEFORE `.render`, so a host error / supersession
+            ;; / unmount that aborts the commit still terminally settles the receipt.
+            (seat-pending-attempt! root-id receipt incarnation)
             ;; rf2-vxgfnd.139/.248: wrap the render in the host-commit reporter so
             ;; the attempt's evidence is finalized (clear stale tags + mark
             ;; committed) only when React actually COMMITS this render, never
@@ -660,15 +816,16 @@
             ;; render intact even if this re-render never commits.
             (.render (.-react-root root)
                      (render-attempt-element
-                      receipt (root-incarnation-of root-id) (element-thunk)))
+                      receipt root-id incarnation (element-thunk)))
             root
             (catch :default e
               ;; the re-render (or the post-preflight ownership fence) threw AFTER
               ;; preflight completed. The existing live root + its last committed
               ;; render are untouched (Q49); record only the FAILED ATTEMPT — an
               ;; already-committed refresh stays :committed + :preflight-attempt-
-              ;; failed, never falsely mount-incomplete (rf2-vxgfnd.139).
-              (frames/abort-preflight-attempt! receipt)
+              ;; failed, never falsely mount-incomplete (rf2-vxgfnd.139) — and clear
+              ;; the seated slot (rf2-vxgfnd.264).
+              (abort-seated-attempt! root-id receipt incarnation)
               (throw e)))))
       (do
         (check-root-claim! 're-frame.ui/mount info container)
@@ -681,7 +838,11 @@
         ;; cannot let this attempt allocate a Root under a generation that never
         ;; admitted it.
         (let [adapter-receipt (current-adapter-generation)
-              receipt (run-preflight! root-id plans-thunk)]
+              receipt (run-preflight! root-id plans-thunk)
+              ;; rf2-vxgfnd.264: mint the root incarnation BEFORE createRoot so the
+              ;; onUncaughtError wrapper closes over the EXACT incarnation it settles,
+              ;; and the register + the pending-attempt seat all share it.
+              incarnation (reactive/make-root-incarnation)]
           (try
             ;; REVALIDATE adapter admission FIRST — before the root-claim
             ;; re-check and any React work (rf2-vxgfnd.199). A terminal disposal
@@ -704,11 +865,18 @@
             ;; (createRoot is React-internal, register is a swap!), so the window
             ;; is closed.
             (check-root-claim! 're-frame.ui/mount info container)
-            (let [react-root (rdc/createRoot container react-opts)
+            (let [react-root (rdc/createRoot
+                              container
+                              (react-opts-with-attempt-abort react-opts root-id incarnation))
                   root       (Root. react-root container root-id)]
-              ;; register BEFORE any render (contract §7 Layer 3) — this MINTS the
-              ;; root incarnation the provider below scopes every ViewCell to.
-              (register-live-root! info container root)
+              ;; register BEFORE any render (contract §7 Layer 3) — installs the
+              ;; incarnation minted above that scopes every ViewCell to this root and
+              ;; drives the onUncaughtError receipt-abort wrapper (rf2-vxgfnd.264).
+              (register-live-root! info container root incarnation)
+              ;; rf2-vxgfnd.264: seat this attempt as the root's single pending
+              ;; render-attempt owner BEFORE `.render`, so a host error / unmount that
+              ;; aborts the commit still terminally settles the receipt.
+              (seat-pending-attempt! root-id receipt incarnation)
               (try
                 ;; rf2-vxgfnd.139/.248: wrap the FIRST render in the host-commit
                 ;; reporter so the attempt's evidence binds to React's real
@@ -717,10 +885,11 @@
                 ;; (onUncaughtError aborts the commit after `.render` returned),
                 ;; the reporter's layout effect never runs, so the fresh install is
                 ;; left uncommitted — never falsely recorded as a committed root
-                ;; scope for a render that never committed.
+                ;; scope, and the seated receipt is terminally settled
+                ;; :mount-incomplete by the onUncaughtError edge (rf2-vxgfnd.264).
                 (.render react-root
                          (render-attempt-element
-                          receipt (root-incarnation-of root-id) (element-thunk)))
+                          receipt root-id incarnation (element-thunk)))
                 root
                 (catch :default e
                   ;; TOTAL rollback of a failed FIRST mount — the element thunk
@@ -761,8 +930,9 @@
               ;; rollback above rethrowing). A fresh install whose host mount
               ;; never committed is :mount-incomplete — no root scopes it — never
               ;; a phantom completed installer. Rev-guarded: a re-entrant root
-              ;; that took ownership of the same frame is untouched.
-              (frames/abort-preflight-attempt! receipt)
+              ;; that took ownership of the same frame is untouched. Clears the
+              ;; seated slot too when still present (rf2-vxgfnd.264).
+              (abort-seated-attempt! root-id receipt incarnation)
               (throw e))))))))
 
 (defn create-root*
@@ -772,9 +942,16 @@
   [{:keys [root-id] :as info} container react-opts]
   (require-root-creation-open! 're-frame.ui/create-root)
   (check-root-claim! 're-frame.ui/create-root info container)
-  (let [react-root (rdc/createRoot container react-opts)
-        root       (Root. react-root container root-id)]
-    (register-live-root! info container root)
+  (let [incarnation (reactive/make-root-incarnation)
+        ;; rf2-vxgfnd.264: install the onUncaughtError receipt-abort wrapper at
+        ;; createRoot (closing over this incarnation) so a later `render!*`'s
+        ;; host-aborted attempt is terminally settled — the render seats onto THIS
+        ;; entry's incarnation.
+        react-root  (rdc/createRoot
+                     container
+                     (react-opts-with-attempt-abort react-opts root-id incarnation))
+        root        (Root. react-root container root-id)]
+    (register-live-root! info container root incarnation)
     root))
 
 (defn render!*
@@ -802,8 +979,9 @@
   attempt is never falsely marked committed off a `.render` return."
   [^Root root element-thunk plans-thunk descriptor-base]
   (require-live-root! root 're-frame.ui/render!)
-  (let [rid     (.-root-id root)
-        receipt (run-preflight! rid plans-thunk)]
+  (let [rid         (.-root-id root)
+        receipt     (run-preflight! rid plans-thunk)
+        incarnation (root-incarnation-of rid)]
     (try
       ;; rf2-vxgfnd.69: revalidate ownership AFTER the side-effecting preflight
       ;; (which may have unmount!ed this root and mounted a replacement under
@@ -824,21 +1002,26 @@
                                             :root-id rid
                                             :root-id-provenance (:provenance entry))))
                        m))))))
+      ;; rf2-vxgfnd.264: seat this attempt as the root's single pending
+      ;; render-attempt owner BEFORE `.render` (a host error / supersession /
+      ;; unmount aborting the commit then terminally settles the receipt).
+      (seat-pending-attempt! rid receipt incarnation)
       ;; rf2-vxgfnd.139/.248: wrap the render in the host-commit reporter so the
       ;; attempt finalizes at React's real COMMIT of this render, not the
       ;; `.render` return. A live root's re-render that never commits (an
       ;; uncaught render throw) leaves its prior committed record untouched.
       (.render (.-react-root root)
                (render-attempt-element
-                receipt (root-incarnation-of rid) (element-thunk)))
+                receipt rid incarnation (element-thunk)))
       root
       (catch :default e
         ;; the post-preflight ownership fence, element thunk, or host render
         ;; threw AFTER preflight completed. A live root's failed re-render leaves
         ;; its last committed render untouched (Q49); record only the failed
         ;; ATTEMPT (rf2-vxgfnd.139) — rev-guarded, never falsely mount-incomplete
-        ;; on an already-committed root, never clobbering a superseding root.
-        (frames/abort-preflight-attempt! receipt)
+        ;; on an already-committed root, never clobbering a superseding root — and
+        ;; clear the seated slot (rf2-vxgfnd.264).
+        (abort-seated-attempt! rid receipt incarnation)
         (throw e)))))
 
 (defn hydrate-root*
@@ -935,6 +1118,11 @@
     ;; deferred host teardown cannot advertise the id/container as free while
     ;; React is still scheduled to clear the DOM.
     (mark-tearing-down! (.-root-id root) root)
+    ;; rf2-vxgfnd.264 — a render attempt seated but not yet committed when the
+    ;; root is torn down never commits: TERMINALLY settle it now (a fresh install's
+    ;; :fresh writes → :mount-incomplete), rather than leaving it forever
+    ;; provisional. Identity-guarded to this root's incarnation.
+    (abort-pending-attempt! (.-root-id root) (root-incarnation-of (.-root-id root)))
     (try
       ;; rf2-vxgfnd.62 — drive the host unmount through the root-teardown window
       ;; so this root's ViewCells are retroactively proven :unmounted → :dead

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1406,6 +1406,34 @@
   []
   (flush-scope! (constantly true)))
 
+(defn guard-open-drain!
+  "The SHARED open-event-drain guard — the DEV-tier `:rf.error/flush-in-open-epoch`
+  signal (03 §11; Spec 006 §Epoch finalization). Reject a synchronous
+  registry-flush forced from `where` while a frame's run-to-completion event
+  drain is STILL OPEN: flushing there could publish a partially-settled queued
+  write side (a torn read/render). The single owner of the ruling — reused by
+  BOTH `ui.test/flush!` (the test all-roots spelling) and the first-party
+  adapter's `flush-render!` (the production synchronous render-commit), so there
+  is ONE guard, not two copies drifting apart.
+
+  `re-frame.frame/*run-frame-state-before*` is bound around the current
+  event-pipeline run and SURVIVES a handler destroying its own frame — a live
+  registry scan cannot, since destroy removes the active frame before the handler
+  returns, which used to let a destroy-self-then-flush call cross the guard and
+  deliver read-side work inside the still-open run. Throws BEFORE the registry is
+  touched (no partial flush); a no-op outside any drain."
+  [where]
+  (when (some? frame/*run-frame-state-before*)
+    (let [frame-id (frame/frame-target->id frame/*current-frame*)]
+      (error/throw-error!
+       :rf.error/flush-in-open-epoch where
+       (str where " was called while frame " (pr-str frame-id)
+            " is still inside its event drain — let the queued write side "
+            "settle to drain quiescence before forcing the one read/render batch")
+       {:recovery :no-recovery
+        :extra {:frame frame-id
+                :frame-epoch (frame/frame-commit-epoch frame-id)}}))))
+
 (defn- cell-frames
   "The set of frame-ids `cell`'s committed subscription sites observe.
 

--- a/implementation/ui/src/re_frame/ui/substrate.cljs
+++ b/implementation/ui/src/re_frame/ui/substrate.cljs
@@ -59,6 +59,7 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.substrate.spine :as spine]
+            [re-frame.ui.reactive :as reactive]
             [re-frame.views.frame-boundary :as boundary]))
 
 ;; The React-context-tier frame-id reader for the pure compiled-view runtime.
@@ -141,12 +142,70 @@
          @spine-error (throw @spine-error)
          :else nil)))))
 
+(defn- ui-flush-render!
+  "The first-party adapter's `:flush-render!` — the ViewCell-settling override of
+  the generic spine verb (rf2-vxgfnd.207).
+
+  The inherited spine `flush-render!` only runs `react-dom/flushSync`, which
+  commits React work SCHEDULED inside its callback. But a compiled ViewCell
+  invalidation does NOT notify React synchronously: `reactive/enrol-dirty!` marks
+  the cell and arms a LATER microtask. So a caller that flushes a thunk which
+  dispatches — changing a subscribed value — would see `flushSync` return while
+  the ViewCell is still pending and the DOM still stale (the .207 defect).
+
+  The fix runs the supplied thunk AND the pending ViewCell registry publication
+  (`reactive/flush-pending!`) INSIDE the spine's synchronous commit boundary, so
+  the dirty cells' revision bumps + `useSyncExternalStore` notifications fire and
+  React commits them before the call returns. It then continues to a bounded
+  fixed point: a legitimate commit-triggered re-dirty (a layout effect that
+  dispatches) is drained by re-flushing until the registry is quiescent.
+
+  Write-all-queued-events THEN one read/render is preserved: the thunk's
+  `dispatch-sync!` runs its whole run-to-completion drain (every queued event,
+  each committing its own epoch) BEFORE `flush-pending!` performs the single
+  coalesced read/render — this is NOT a per-epoch renderer. Any redundant
+  microtask armed during the drain later finds the registry already drained and
+  renders nothing.
+
+  Runaway convergence is NOT this loop's to bound: commit-triggered re-dirty is
+  always write-driven, so a genuinely non-quiescent cascade trips the EXISTING
+  diagnostics loudly — the router's `:rf.error/drain-depth-exceeded` for a
+  dispatch cascade, React's own maximum-update-depth guard for an update-in-effect
+  loop — each propagating out of `flushSync` and breaking this loop non-silently
+  (the same reliance `ui.test/flush!`'s loop-to-quiescence rests on).
+
+  An open router drain fails loud through the SHARED guard rather than publishing
+  a partial read side. Exceptions from the thunk propagate unchanged (the pending
+  publication does not run when the thunk throws). The 0-arity flushes
+  already-pending work with an empty thunk; a no-op flush stays a no-op. This
+  override is installed ONLY on the first-party adapter — the generic spine
+  contract for stacks that do not use ViewCells is untouched."
+  ([] (ui-flush-render! (fn [] nil)))
+  ([f]
+   (reactive/guard-open-drain! 're-frame.ui.substrate/flush-render!)
+   (let [spine-flush (:flush-render! spine-adapter)]
+     ;; One React sync-commit boundary: run the write side, then publish the
+     ;; pending ViewCell notifications so React commits them before returning.
+     (spine-flush (fn [] (f) (reactive/flush-pending!)))
+     ;; Drain any commit-triggered re-dirty to a fixed point — each pass is its
+     ;; own sync-commit boundary; loud ambient diagnostics break a runaway.
+     (loop []
+       (when (pos? (reactive/pending-cell-count))
+         (spine-flush reactive/flush-pending!)
+         (recur))))
+   nil))
+
 (defn adapter-with-client-roots
   "Build the retained first-party adapter around the client kernel's
   all-public-roots admission fence + exact-snapshot drain. The injections keep
   this namespace below the client/frames layer and avoid a substrate → client →
-  frames → substrate dependency cycle."
+  frames → substrate dependency cycle.
+
+  Also overrides the generic spine `:flush-render!` with the ViewCell-settling
+  `ui-flush-render!` (rf2-vxgfnd.207), so a synchronous `flush-render!` settles
+  every pending compiled ViewCell — and its React commit — before returning."
   [with-root-admission-closed! drain-live-roots!]
   (assoc spine-adapter
          :dispose-adapter!
-         #(dispose-adapter! with-root-admission-closed! drain-live-roots!)))
+         #(dispose-adapter! with-root-admission-closed! drain-live-roots!)
+         :flush-render! ui-flush-render!))

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -744,21 +744,12 @@
 
 (defn- guard-open-drain!
   []
-  ;; `*run-frame-state-before*` is bound around the current event-pipeline
-  ;; run and survives a handler destroying its own frame. A live-registry scan
-  ;; cannot: destroy removes the active frame before the handler returns, which
-  ;; used to let a destroy-self-then-flush call cross this guard and deliver
-  ;; read-side work inside the still-open run.
-  (when (some? rframe/*run-frame-state-before*)
-    (let [frame-id (rframe/frame-target->id rframe/*current-frame*)]
-      (error/throw-error!
-       :rf.error/flush-in-open-epoch 'rf.ui.test/flush!
-       (str "ui.test/flush! was called while frame " (pr-str frame-id)
-            " is still inside its event drain — let the queued write side "
-            "settle to drain quiescence before forcing the one read/render batch")
-       {:recovery :no-recovery
-        :extra {:frame frame-id
-                :frame-epoch (rframe/frame-commit-epoch frame-id)}}))))
+  ;; The open-event-drain ruling is owned by `re-frame.ui.reactive` and shared
+  ;; with the first-party adapter's `flush-render!` — ONE guard, not two copies.
+  ;; It survives a handler destroying its own frame (`*run-frame-state-before*`
+  ;; outlives a live-registry scan), so a destroy-self-then-flush call still
+  ;; fails before delivering read-side work inside the still-open run.
+  (reactive/guard-open-drain! 'rf.ui.test/flush!))
 
 #?(:clj
    (defn flush!

--- a/implementation/ui/test/re_frame/ui/adapter_conformance_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/adapter_conformance_dom_cljs_test.cljs
@@ -8,11 +8,27 @@
             ["react" :as react]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.core :as rf]
+            [re-frame.router :as router]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.ui :as ui]))
+            [re-frame.ui :as ui :refer [defview frame-root]]
+            [re-frame.ui.reactive :as reactive]))
 
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; React's act() — the canonical committing-mount helper (mirrors the shared
+;; suite / root_mount pattern). Used to COMMIT the initial compiled mount; the
+;; rf2-vxgfnd.207 proof itself drives the production `flush-render!` (a real
+;; flushSync commit, act env OFF) on the already-mounted view.
+(defn- get-act []
+  (or (when (exists? (.-act react)) (.-act react))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- act! [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
 
 (use-fixtures
   :each
@@ -84,3 +100,69 @@
       (render-label! container "second")
       (is (= "second" (.-textContent container))
           "re-init re-arms render ownership after disposal"))))
+
+;; ---------------------------------------------------------------------------
+;; flush-render! settles pending compiled ViewCells before returning
+;; (rf2-vxgfnd.207)
+;;
+;; The existing conformance fixtures exercise flush-render! with STATIC react
+;; elements, where a bare `react-dom/flushSync` suffices. This arm proves the
+;; first-party adapter's flush-render! against a REACTIVE compiled view: a
+;; `dispatch-sync!` inside the flush changes a subscribed value, which marks the
+;; ViewCell dirty and arms a LATER microtask — so the inherited spine verb would
+;; return with the DOM still stale. The override must settle the pending ViewCell
+;; (and its React commit) before returning.
+;; ---------------------------------------------------------------------------
+
+(defview greeter []
+  [:span.greet (str (ui/sub [::greeting]))])
+
+(deftest flush-render-settles-pending-viewcells-before-returning
+  (if-not (browser?)
+    (is true ":node — browser-test exercises the mounted flush-render! contract")
+    (let [container (js/document.createElement "div")
+          flush!    (:flush-render! ui/adapter)
+          root      (atom nil)
+          prior-act (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+      (js/document.body.appendChild container)
+      (is (nil? (rf/init! ui/adapter)))
+      ;; Register the sub/event PER-TEST (after the fixture reset), like the other
+      ;; mounted suites — the fixture clears the registrar between tests.
+      (rf/reg-sub ::greeting (fn [db _] (:greeting db)))
+      (rf/reg-event ::set-greeting (fn [{:keys [db]} [_ v]] {:db (assoc db :greeting v)}))
+      (try
+        ;; COMMIT the initial compiled mount under React act: frame-root creates +
+        ;; seeds the frame ("old") at preflight, so the mounted sub-bearing view
+        ;; reads the seeded value. (The rf2-vxgfnd.207 proof is the DISPATCH below,
+        ;; on this already-mounted view — the bead's "a mounted view CHANGED by
+        ;; dispatch-sync! inside flush-render!".)
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+        (act!
+         #(reset! root
+                  (ui/mount [frame-root {:id :rf.ui-adapter-test/flush-render-frame
+                                         :initial-events [[::set-greeting "old"]]}
+                             [greeter]]
+                            container
+                            {:root-id :rf.ui-adapter-test/flush-render})))
+        (is (= "old" (.-textContent container))
+            "the mounted compiled view reads the frame-root-seeded value")
+
+        ;; THE PROOF (RED pre-fix): a dispatch-sync! INSIDE flush-render! must
+        ;; expose the new DOM before the call returns. The dispatch changes the
+        ;; subscribed value → `reactive/enrol-dirty!` marks the ViewCell and arms
+        ;; a LATER microtask WITHOUT notifying React; the inherited spine
+        ;; flush-render! (bare flushSync) therefore returns with the DOM still
+        ;; "old" and the cell still pending. Drive the PRODUCTION flush-render!
+        ;; with the act env OFF — a real flushSync commit path.
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (flush! #(router/dispatch-sync! [::set-greeting "new"]
+                                        {:frame :rf.ui-adapter-test/flush-render-frame}))
+        (is (= "new" (.-textContent container))
+            "flush-render! settled the pending ViewCell + React commit before returning (rf2-vxgfnd.207)")
+        (is (zero? (reactive/pending-cell-count))
+            "the dirty registry is empty on return — no redundant later microtask render")
+        (finally
+          (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+          (when @root (act! #(ui/unmount! @root)))
+          (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior-act)
+          (.remove container))))))

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -337,6 +337,92 @@
       (act! #(client/unmount!* (:root (client/live-root-entry :dom139/live)))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.264 — TERMINALLY settle an exact preflight receipt when React
+;; ABORTS or ABANDONS the render before the commit reporter can finalize it.
+;;
+;; The rf2-vxgfnd.248 commit reporter binds finalization to a REAL commit, so an
+;; aborted render publishes no COMMITTED evidence — but left alone the receipt
+;; LINGERS FOREVER, neither committed nor failed (the .248 fixture above asserts
+;; only `not :committed`, accepting that permanent-provisional evidence). .264
+;; gives each live Root ONE exact pending render-attempt owner, seated before
+;; `.render`; the host-error and unmount edges terminally settle it as
+;; :mount-incomplete for a fresh install.
+;; ---------------------------------------------------------------------------
+
+(defn- no-act!
+  "Run `thunk` with React's act env toggled OFF and NO flush — the initial render
+  is SCHEDULED but not committed (drives the unmount-before-commit edge). Restores
+  the prior flag."
+  [thunk]
+  (let [prior (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    (try (thunk)
+         (finally (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior)))))
+
+(deftest host-abort-terminally-settles-a-fresh-receipt-mount-incomplete
+  ;; The CORE .264 defect: the element thunk succeeds (React receives an element),
+  ;; the component throws during React's render, and `onUncaughtError` ABORTS the
+  ;; commit AFTER `.render` returned — the reporter's layout effect never runs. The
+  ;; .248 fixture proves the receipt is NOT falsely :committed; .264 additionally
+  ;; requires it be TERMINALLY settled :mount-incomplete, never left provisional.
+  ;; RED before fix: the record is neither :committed NOR :mount-incomplete.
+  (when (browser?)
+    (reg-events!)
+    (let [c        (container)
+          captured (atom nil)
+          info     {:root-id :dom264/host :provenance :authored}
+          element-thunk (fn [] (React/createElement throwing-during-render #js {}))
+          plans    (fn [] [{:frame-id :frame/abort264
+                            :config {:initial-events [[:test/set-db {:n 1}]]}
+                            :config-fingerprint "cf1-abort264aaaa"}])
+          ;; an AUTHORED onUncaughtError — it MUST still be delegated after the
+          ;; receipt abort (rf2-vxgfnd.264), and capturing the deliberate throw keeps
+          ;; it off the window as an uncaught error (rf2-mwx08).
+          opts     (client/root-options
+                    nil (fn [error _info] (reset! captured error)) nil nil)
+          _        (flush-without-act!
+                    #(client/mount* info c element-thunk opts plans))]
+      (is (some? @captured)
+          "the authored onUncaughtError is still delegated after the receipt abort")
+      (is (some? (frame/frame :frame/abort264))
+          "preflight installed the frame — a receipt exists to settle")
+      (let [entry (frames/installed-plan-entry :frame/abort264)]
+        (is (true? (:mount-incomplete entry))
+            "the host-aborted FRESH render is TERMINALLY settled :mount-incomplete (rf2-vxgfnd.264)")
+        (is (not (:committed entry))
+            "and never a phantom committed root scope (rf2-vxgfnd.248 preserved)"))
+      ;; the root stays registered after an aborted commit (`.render` returned) —
+      ;; release its claim so no live-root leaks into the next test.
+      (act! #(some-> (:root (client/live-root-entry :dom264/host)) client/unmount!*)))))
+
+(deftest unmount-before-commit-terminally-settles-a-fresh-receipt-mount-incomplete
+  ;; A fresh async render, SCHEDULED but never committed, followed by an immediate
+  ;; unmount: the seated receipt is terminally settled :mount-incomplete rather than
+  ;; left forever provisional. RED before fix: unmount never settled the receipt.
+  (when (browser?)
+    (reg-events!)
+    (let [c     (container)
+          info  {:root-id :dom264/unmount :provenance :authored}
+          ok    (fn [] (React/createElement "div" #js {:className "u264"} "u264"))
+          plans (fn [] [{:frame-id :frame/unmount264
+                         :config {:initial-events [[:test/set-db {:n 1}]]}
+                         :config-fingerprint "cf1-unmount264aa"}])]
+      ;; mount schedules the initial render (act env off, no flush → uncommitted),
+      ;; then unmount BEFORE it can commit.
+      (no-act!
+       #(let [root (client/mount* info c ok (client/root-options nil nil nil nil) plans)]
+          (client/unmount!* root)))
+      (is (some? (frame/frame :frame/unmount264))
+          "preflight installed the frame — a receipt exists to settle")
+      (let [entry (frames/installed-plan-entry :frame/unmount264)]
+        (is (true? (:mount-incomplete entry))
+            "the unmounted-before-commit FRESH render is TERMINALLY settled :mount-incomplete (rf2-vxgfnd.264)")
+        (is (not (:committed entry))
+            "and never a phantom committed root scope"))
+      (is (not (contains? (client/live-root-ids) :dom264/unmount))
+          "the unmounted root is released"))))
+
+;; ---------------------------------------------------------------------------
 ;; frame-provider — scope a live frame through the compiled template
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two P1 fixes on the re-frame.ui adapter/reactive/client root-settle surface, on the merged root-teardown fence (#5885/.182) + slice-memo (#5891/.267). One PR, two independent commits.

## rf2-vxgfnd.207 — flush-render! settles pending ViewCells before returning

The first-party adapter inherited the generic spine `flush-render!` (bare `react-dom/flushSync`). A compiled ViewCell invalidation does not notify React synchronously — `reactive/enrol-dirty!` marks the cell and arms a *later* microtask — so a caller that flushes a `dispatch-sync!` that changes a subscribed value saw `flushSync` return with the DOM still stale and the cell still pending.

The override at the first-party adapter's composition boundary (`adapter-with-client-roots`) runs the thunk **and** the pending ViewCell registry publication (`reactive/flush-pending!`) inside the spine's synchronous commit boundary, then drains commit-triggered re-dirty to a bounded fixed point. Write-all-queued-events then one read/render is preserved. The open-event-drain guard is hoisted into `re-frame.ui.reactive` and reused by both `ui.test/flush!` and this adapter verb (one guard). Runaway convergence rests on the existing ambient diagnostics (router `:rf.error/drain-depth-exceeded`, React max-update-depth), exactly as `ui.test/flush!`'s loop-to-quiescence.

**Red-before-fix fixture:** `adapter_conformance_dom_cljs_test/flush-render-settles-pending-viewcells-before-returning` — a mounted compiled sub-bearing view dispatched inside `(:flush-render! ui/adapter)` reads the OLD DOM under the inherited flush, the NEW DOM (+ empty dirty registry) under the override.

## rf2-vxgfnd.264 — terminally settle exact preflight receipts on React abort/abandon

The .248 commit-reporter finalizes a receipt only after React commits. It provided no owner when React fails/abandons the render before that reporter mounts: a descendant throw after `.render` returns → root `onUncaughtError` (commit aborted, layout effect never runs); a fresh async render + immediate unmount never commits; a superseding render leaves the old attempt provisional. Each such receipt lingered forever — neither committed nor terminally failed (the .248 test asserted only `not :committed`, accepting permanent-provisional evidence).

Each live Root entry now carries one exact pending render-attempt owner — the seated receipt, keyed to the root incarnation. Seated before `.render`; the exact reporter commit finalizes + clears it; host error, explicit supersession, and unmount terminally settle (abort) it. The incarnation is minted before `createRoot` so the `onUncaughtError` wrapper closes over the exact incarnation and delegates to the authored React error callback (or React's default report). The frames-layer finalize/abort stay rev-guarded (stale/late/cross-root/reincarnation signals can't settle a newer attempt); Suspense stays pending until a real terminal edge. No global flushSync, second coordinator, or public API. (Final cross-root authority coordination stays with rf2-vxgfnd.191.)

**Red-before-fix fixtures** (`preflight_frame_wiring_dom_cljs_test`):
- `host-abort-terminally-settles-a-fresh-receipt-mount-incomplete` — a component throwing during React's render aborts the commit via `onUncaughtError`; the fresh receipt is settled `:mount-incomplete` (not provisional), and the authored `onUncaughtError` is still delegated.
- `unmount-before-commit-terminally-settles-a-fresh-receipt-mount-incomplete` — a scheduled-but-uncommitted render unmounted before commit settles `:mount-incomplete`.

## Quality gates
- JVM Tier-1 (`cd implementation/ui && clojure -M:test`): 517 tests, 0 failures.
- node (`node out/node-test-ui.js`): 514 tests, 0 failures.
- browser DOM suite (`shadow-cljs compile browser-test` + serve-and-run): 357 tests, 0 failures/errors — both new fixtures green, no regression across the DOM suite (incl. the existing .248/.139/root-mount/root-teardown seams).
- Compile: 0 warnings (node-test-ui + browser-test).

Full pre-checkin spine deferred to CI (runs the matrix authoritatively).
