### PR TITLE
fix(flows): fence first-registration flow trace to the exact incarnation (rf2-pwum1g)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -691,12 +691,35 @@
                ;; A's :rf.flow/registered is never delivered against B and B's
                ;; trace policy is never consulted for A. (`clear-flow` fences its
                ;; :rf.flow/cleared the same way, via its returned cleared-path.)
+               ;;
+               ;; rf2-pwum1g: the postcheck above only proves A is live at the
+               ;; instant emission STARTS. `trace/emit!` is itself a synchronous,
+               ;; callback-bearing pipeline — classification projection, then
+               ;; epoch capture, then the ordered tooling listeners — and each of
+               ;; those stages rechecks ownership ONLY while a continuation
+               ;; predicate is installed (`trace/continuation-live?` reads the
+               ;; always-true default otherwise). The event router installs its
+               ;; own exact-owner predicate for the reserved-effect `:rf.fx/reg-flow`
+               ;; route, but a DIRECT cold `reg-flow` does not — so absent this
+               ;; wrap, an epoch-capture callback or the first listener could
+               ;; destroy A and publish same-id B, and later listeners would still
+               ;; receive A's incarnation-less :rf.flow/registered after B owns the
+               ;; id (and later policy/capture could observe B). Wrap the emit in
+               ;; the pinned incarnation's exact-owner continuation so every
+               ;; trace-internal stage is fenced: already-entered delivery may
+               ;; stand once, but no later framework-owned trace stage starts after
+               ;; A's exact ownership is lost. This composes with any parent
+               ;; predicate (AND-combined in `call-with-continuation-predicate`),
+               ;; so the reserved-effect route's router predicate is preserved.
                (when (and interop/debug-enabled? (nil? @prior-on-frame))
-                 (trace/emit! :flow :rf.flow/registered
-                              {:flow-id flow-id
-                               :inputs  (:inputs flow)
-                               :path    (:output-path flow)
-                               :frame   frame-id}))))))))
+                 (trace/call-with-continuation-predicate
+                   #(frame/event-continuation-live? frame-id pinned-incarnation)
+                   (fn []
+                     (trace/emit! :flow :rf.flow/registered
+                                  {:flow-id flow-id
+                                   :inputs  (:inputs flow)
+                                   :path    (:output-path flow)
+                                   :frame   frame-id}))))))))))
      flow-id))))
 
 (defn- dissoc-in-safe

--- a/implementation/flows/test/re_frame/flows_first_registration_trace_incarnation_test.clj
+++ b/implementation/flows/test/re_frame/flows_first_registration_trace_incarnation_test.clj
@@ -1,0 +1,218 @@
+(ns re-frame.flows-first-registration-trace-incarnation-test
+  "rf2-pwum1g — exact-incarnation fence for the FIRST-registration flow trace
+  THROUGH the synchronous trace-emit callback pipeline (classification
+  projection → epoch capture → ordered tooling listeners).
+
+  rf2-ytpeqf moved the first-time `:rf.flow/registered` evidence behind ONE
+  exact-owner postcheck, so a loss during the PRECEDING mark write withholds
+  the trace. But that postcheck only proves A is live at the instant emission
+  STARTS. `trace/emit!` is itself a callback-bearing pipeline whose stages
+  recheck ownership ONLY while a continuation predicate is installed
+  (`trace/continuation-live?` reads the always-true default otherwise). The
+  event router installs an exact-owner predicate for the reserved-effect
+  `:rf.fx/reg-flow` route, but a DIRECT cold `reg-flow` does not. So with the
+  default always-true continuation, A's first-registration emit could START
+  while A is live, then an ordered trace LISTENER (or the epoch-capture
+  callback) could destroy A and publish same-id B, and every SUBSEQUENT
+  listener would still receive A's incarnation-less `:rf.flow/registered`
+  after B owns the bare id (and later policy/capture could observe B).
+
+  rf2-pwum1g wraps that emit in `trace/call-with-continuation-predicate` bound
+  to A's pinned incarnation, so the trace pipeline is fenced to A: the
+  already-entered delivery (the listener that destroys A) stands once, and
+  every LATER listener / capture / policy stage is suppressed the instant A's
+  exact ownership is lost.
+
+  The seam here is DELIBERATELY the trace-internal listener boundary, not the
+  ytpeqf mark write: A's flow declares NO output marks, so `reg-flow` reaches
+  `trace/emit!` with A fully live and the ONLY callback seam is the ordered
+  listener fan-out inside emission — the boundary the merged ytpeqf fixture
+  (which loses A during the preceding mark write, before emission starts, with
+  a passive recorder) cannot reach. Removing the `call-with-continuation-
+  predicate` wrapper (leaving the always-true default) makes the subsequent
+  listener receive A's stale event and the focused assertion fail.
+
+  The whole scenario runs SYNCHRONOUSLY on the single JVM test thread: the
+  destroyer listener destroys A and publishes B reentrantly inside emission, so
+  the cross-incarnation ordering is deterministic without threads. Listener
+  fan-out order is insertion order (the array-map the listener registry holds),
+  which is exactly the delivery order the fence's between-listener recheck is
+  defined against — the destroyer is registered FIRST so it is the
+  already-entered delivery and the observer is the SUBSEQUENT one."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.flows :as flows]
+            [re-frame.flows.registry :as registry]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The trace-internal boundary: A's first-registration emit reaches ordered
+;; tooling listeners with A live; the FIRST listener destroys A and publishes
+;; same-id B; the SUBSEQUENT listener must NOT receive A's stale
+;; :rf.flow/registered after B owns the bare id.
+;; ---------------------------------------------------------------------------
+
+(deftest first-registration-trace-listener-loss-fences-subsequent-listeners
+  ;; rf2-pwum1g (red before fix). Registering A's first flow (NO output marks)
+  ;; reaches `trace/emit!` with A live. The destroyer listener — the
+  ;; already-entered delivery — destroys A and publishes same-id B mid-fan-out.
+  ;; Before the fix the emit ran under the always-true continuation, so the
+  ;; observer (the subsequent listener) still received A's incarnation-less
+  ;; :rf.flow/registered after B owned the id. After the fix the pinned-A
+  ;; continuation predicate suppresses every listener past the loss.
+  (let [id               :flow.trace.fence/subject
+        a-flow-id        :flow.trace.fence/a
+        b-flow-id        :flow.trace.fence/b
+        destroyer-hits   (atom 0)
+        observer-a-regs  (atom [])       ;; A's :rf.flow/registered the SUBSEQUENT listener saw
+        observer-regs    (atom [])       ;; every :rf.flow/registered the observer saw
+        armed?           (atom true)
+        b-token          (atom nil)
+        b-flow-registry  (atom ::unset)
+        b-commit         (atom ::unset)
+        b-sensitive      (atom ::unset)
+        b-trace-disabled (atom ::unset)]
+    (rf/make-frame {:id id})
+    ;; Listener 1 (registered FIRST → fans out FIRST): the DESTROYER. On A's
+    ;; own :rf.flow/registered — the already-entered delivery — it destroys A
+    ;; and publishes same-id B, exactly once (one-shot CAS), then snapshots B's
+    ;; stores for the byte-identical assertions. This is the trace-internal loss
+    ;; the ytpeqf mark-write seam cannot reach.
+    (trace/register-listener!
+      ::destroyer
+      (fn [ev]
+        (when (and (= :rf.flow/registered (:operation ev))
+                   (= id (get-in ev [:tags :frame]))
+                   (compare-and-set! armed? true false))
+          (swap! destroyer-hits inc)
+          (frame/destroy-frame! id)
+          (rf/make-frame {:id id})
+          (reset! b-token (frame/frame-incarnation-token id))
+          (reset! b-flow-registry (get (registry/flows-snapshot) id ::none))
+          (reset! b-commit (frame/frame-commit-epoch id))
+          (reset! b-sensitive (elision/sensitive-declarations id))
+          (reset! b-trace-disabled (trace/frame-trace-disabled? id)))))
+    ;; Listener 2 (registered SECOND → fans out AFTER the destroyer): the
+    ;; SUBSEQUENT observer. Absent the fence it receives A's stale
+    ;; :rf.flow/registered after B owns the bare id; the fence suppresses it.
+    (trace/register-listener!
+      ::observer
+      (fn [ev]
+        (when (= :rf.flow/registered (:operation ev))
+          (swap! observer-regs conj ev)
+          (when (= a-flow-id (get-in ev [:tags :flow-id]))
+            (swap! observer-a-regs conj ev)))))
+    (try
+      ;; A's FIRST-TIME registration — NO output marks, so `reg-flow` reaches
+      ;; `trace/emit!` with A fully live; the only callback seam is the ordered
+      ;; listener fan-out inside emission.
+      (is (= a-flow-id
+             (rf/reg-flow a-flow-id
+               {:frame id :inputs [[:an]] :output-path [:aout]}
+               (fn [n] (or n 0))))
+          "reg-flow returns its flow-id even though A's owner was lost mid-emit")
+      ;; The destroyer received A's registered event exactly once — the
+      ;; already-entered delivery that may stand.
+      (is (= 1 @destroyer-hits)
+          "the destroyer listener received A's :rf.flow/registered once — the
+           already-entered delivery stands")
+      (is (some? @b-token) "the destroyer published a same-id B")
+      (is (identical? @b-token (frame/frame-incarnation-token id))
+          "B remains the live incarnation")
+      ;; THE TOOTH: the subsequent listener never receives A's stale event.
+      (is (empty? @observer-a-regs)
+          "the SUBSEQUENT listener received ZERO A :rf.flow/registered events —
+           the fence suppresses every trace stage after A's exact ownership is
+           lost (removing the call-with-continuation-predicate wrapper makes
+           this fail)")
+      ;; B is never observed by A's tail: B's stores are byte-identical to the
+      ;; clean slate the destroy handed it; no A work consulted or mutated B.
+      (is (= ::none @b-flow-registry) "B started with an empty flow registry")
+      (is (= ::none (get (registry/flows-snapshot) id ::none))
+          "A's stale first-registration tail never wrote a flow row onto B")
+      (is (= @b-commit (frame/frame-commit-epoch id))
+          "A's stale tail never bumped B's commit epoch")
+      (is (= @b-sensitive (elision/sensitive-declarations id))
+          "A's stale tail never wrote B's output-mark declaration")
+      (is (= @b-trace-disabled (trace/frame-trace-disabled? id))
+          "A's stale tail never changed B's trace policy")
+      ;; The fence does not POISON the successor: a later independent
+      ;; registration owned by B (outside A's continuation scope) emits
+      ;; :rf.flow/registered normally, exactly once, observed by the observer.
+      (reset! observer-regs [])
+      (is (= b-flow-id
+             (rf/reg-flow b-flow-id
+               {:frame id :inputs [[:bn]] :output-path [:bout]}
+               (fn [n] (or n 0)))))
+      (is (= 1 (count @observer-regs))
+          "B's own later registration emits :rf.flow/registered exactly once —
+           the fence did not poison the successor")
+      (is (= b-flow-id (get-in (first @observer-regs) [:tags :flow-id]))
+          "the sole post-loss registration observed is B's own")
+      (finally
+        (trace/unregister-listener! ::destroyer)
+        (trace/unregister-listener! ::observer)))))
+
+;; ---------------------------------------------------------------------------
+;; Green control / over-fence tooth — when A retains ownership through a
+;; NON-destroying listener, the ordinary first-registration trace still reaches
+;; the subsequent listener exactly once. A wrongly-over-fencing predicate would
+;; silently swallow the trace.
+;; ---------------------------------------------------------------------------
+
+(deftest first-registration-trace-with-live-owner-emits-once
+  ;; rf2-pwum1g mutation tooth. The exact-incarnation fence must NOT suppress
+  ;; the normal first-registration trace when A stays live through the fan-out:
+  ;; :rf.flow/registered reaches BOTH the first and the subsequent listener,
+  ;; carrying A's own payload.
+  (let [id       :flow.trace.fence/live
+        flow-id  :flow.trace.fence/h
+        touched  (atom 0)
+        observed (atom [])]
+    (rf/make-frame {:id id})
+    (trace/register-listener!
+      ::live-touch
+      (fn [ev]
+        (when (= :rf.flow/registered (:operation ev))
+          (swap! touched inc))))          ;; observe only — A stays live
+    (trace/register-listener!
+      ::live-observer
+      (fn [ev]
+        (when (= :rf.flow/registered (:operation ev))
+          (swap! observed conj ev))))
+    (try
+      (rf/reg-flow flow-id
+        {:frame id :inputs [[:n]] :output-path [:out]}
+        (fn [n] (or n 0)))
+      (is (= 1 @touched) "the first listener saw A's registered event")
+      (is (= 1 (count @observed))
+          "the SUBSEQUENT listener also received it — the live-owner first
+           registration is not over-fenced")
+      (let [tags (:tags (first @observed))]
+        (is (= flow-id (:flow-id tags)) "A's own :flow-id")
+        (is (= [:out]  (:path tags))    "A's own :output-path")
+        (is (= id      (:frame tags))   "A's own frame"))
+      (finally
+        (trace/unregister-listener! ::live-touch)
+        (trace/unregister-listener! ::live-observer)))))
+
+;; ---------------------------------------------------------------------------
+;; The reserved-effect `:rf.fx/reg-flow` route already runs the first-
+;; registration emit UNDER the router's own exact-owner continuation predicate
+;; (`re-frame.router` binds `#(frame/event-continuation-live? frame owner-token)`
+;; around the event pipeline). rf2-pwum1g's wrapper AND-composes with any parent
+;; predicate (see `trace/call-with-continuation-predicate`), so a first
+;; registration reached through the reserved-effect route inherits the router
+;; fence and gains this one — the DIRECT cold `reg-flow` covered above is the
+;; only path that lacked a predicate. The reserved-effect route's exactly-once
+;; live-owner registration behaviour is exercised by
+;; `re-frame.flows-trace-test` (e.g. `fx-reg-flow-cycle-routes-through-error-
+;; emit-substrate`) and the router's incarnation-fence suite.
+;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`rf2-ytpeqf` (merged #5879) moved the first-time `:rf.flow/registered` evidence behind **one** exact-owner postcheck, so a loss during the *preceding* mark write withholds the trace. But that postcheck only proves incarnation A is live at the instant emission **starts**. `trace/emit!` is itself a synchronous, callback-bearing pipeline — classification projection → epoch capture → the ordered tooling listeners — and each stage rechecks ownership **only while a continuation predicate is installed** (`trace/continuation-live?` reads the always-true default otherwise).

The event router installs its own exact-owner predicate for the reserved-effect `:rf.fx/reg-flow` route, but a **direct cold `reg-flow`** does not. So with the default always-true continuation, A's first-registration emit could start while A is live, an epoch-capture callback or the first listener could destroy A and publish same-id B, and every **subsequent** listener would still receive A's incarnation-less `:rf.flow/registered` after B owns the bare id (and later policy/capture could observe B).

## The fix — continuation-predicate wrap

Wrap the first-registration emit in the **existing** published API `trace/call-with-continuation-predicate`, bound to the already-pinned frame incarnation:

```clojure
(trace/call-with-continuation-predicate
  #(frame/event-continuation-live? frame-id pinned-incarnation)
  (fn []
    (trace/emit! :flow :rf.flow/registered { … })))
```

This is the exact idiom the router already uses (`router.cljc` binds `#(frame/event-continuation-live? frame owner-token)` around the event pipeline). The emit stays inside the serialized registration window, so its initial bare-id policy lookup still belongs to A. **`core/trace.cljc` is not edited** — only its published `call-with-continuation-predicate` is consumed. No rollback, no incarnation field on the public event, no second trace-delivery mechanism.

## Terminal-fence semantics

Every trace-internal stage now consults A's exact liveness: **already-entered delivery may stand once** (the listener that observes A's event and destroys A), but **no later framework-owned trace stage starts after A's exact ownership is lost** — later listeners, and any later capture/policy work, are suppressed. `call-with-continuation-predicate` AND-composes with any parent predicate, so a first registration reached through the reserved-effect route inherits the router fence *and* gains this one; the direct cold `reg-flow` was the only path that lacked a predicate.

## Quality gates

- **Red-before-fix fixture** — new `re-frame.flows-first-registration-trace-incarnation-test` installs **two ordered trace/tooling callbacks** on a **direct cold `reg-flow`** (A's flow declares no output marks, so the *only* callback seam is the ordered listener fan-out **inside** emission — the boundary the ytpeqf mark-write fixture cannot reach). The **first** (already-entered) listener destroys A and publishes same-id B; the assertions require the already-entered delivery to stand once, every **subsequent** listener delivery to be suppressed, B never observed (B's frame / flow registry / commit epoch / sensitive declarations / trace policy byte-identical), and a later B-owned registration to emit exactly once (the fence does not poison the successor). A green-control test proves a live-owner first registration is **not** over-fenced. **Removing the `call-with-continuation-predicate` wrapper makes exactly this fixture's subsequent-listener assertion fail** (verified locally: `1 failures` — the observer received A's stale `:rf.flow/registered`).
- `implementation/flows` JVM — **230 tests, 5982 assertions, 0 failures/0 errors**.
- `implementation/core` JVM — **1978 tests, 9095 assertions, 0 failures/0 errors**.
- node CLJS (`npm run test:cljs`) — **9396 tests, 44540 assertions, 0 failures/0 errors** (the `.cljc` path compiles + runs clean in CLJS).

## Follow-up

Spec 006 / Spec 009 trace-continuation prose could name the direct-cold-`reg-flow` first-registration emit as a framework-owned terminal-fence site (alongside the router event pipeline) — not required for this correctness fix; flagged for a docs pass.

Closes rf2-pwum1g.
