### PR TITLE
fix(ui): key compile-pass membership on authoritative Shadow evidence not output-object identity (rf2-vxgfnd.282)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -4,29 +4,32 @@
   Shadow's retained functional build-state is the successful-build authority.
   `:compile-prepare` seeds disposable compiler-env scratch from the incoming
   accepted snapshot, captures authoritative namespace membership, pre-touches
-  exactly the CLJS sources Shadow scheduled to compile, and records the pass
-  start time. That pre-touch makes removing a source's final declaration
-  observable even though no registry macro then runs, while output-present cache
-  hits remain accepted. Macro contributions write only that scratch.
-  `:compile-finish`:
+  exactly the CLJS sources Shadow scheduled to compile, and snapshots the
+  `:output` map Shadow handed it. That pre-touch makes removing a source's final
+  declaration observable even though no registry macro then runs, while
+  output-present cache hits remain accepted. Macro contributions write only that
+  scratch. `:compile-finish`:
 
   0. reconcile against Shadow's FINAL authoritative compile schedule — every
      CLJS source actually compiled THIS pass is pre-touched too. Membership is
-     read from EXACT per-pass provenance, never wall-clock ordering: at
-     `:compile-prepare` re-frame.ui snapshots the `:output` map Shadow handed
-     it, and a source counts as recompiled iff its finish-time output OBJECT is
-     present and not `identical?` to that snapshot's. Shadow installs a
-     freshly-built output object only for the sources it recompiles this pass (a
-     warm cache hit keeps the byte-identical retained object), so identity is
-     the ground truth — immune to the millisecond collision where a retained
-     warm output's `:compiled-at` stamp equals the next pass start. A later
-     `:compile-prepare` hook (Shadow deep-merges build-local hooks after
-     `:build-defaults` and lets them mutate build state) can force a source to
-     recompile AFTER re-frame.ui observed the schedule; comparing the finish
-     output objects against the prepare snapshot, not the intermediate prepare
-     schedule, closes that hook-order gap so a forced recompile that removed a
-     source's final `ui/defview` evicts its accepted row instead of leaving a
-     ghost view;
+     read from Shadow's AUTHORITATIVE per-source compile evidence, never
+     output-object identity and never wall-clock ordering: a source counts as
+     recompiled iff its finish-time output `:compiled-at` stamp advanced past
+     the stamp in the prepare snapshot. Shadow writes `:compiled-at` EXACTLY
+     inside `do-compile-cljs-resource`, so the stamp advances iff Shadow really
+     (re)compiled the source this pass; a warm cache hit keeps its retained
+     object and stamp. Keying on the stamp — not the object reference — is
+     immune to a later non-scheduling hook that replaces a retained output's
+     object (via assoc/update-in) while PRESERVING its stamp, and — because it
+     compares each source's own before/after stamp, never a pass boundary —
+     immune to the millisecond collision where a retained warm output's stamp
+     equals the next pass start. A later `:compile-prepare` hook (Shadow
+     deep-merges build-local hooks after `:build-defaults` and lets them mutate
+     build state) can force a source to recompile AFTER re-frame.ui observed the
+     schedule; reading the finish-time compile stamps, not the intermediate
+     prepare schedule, closes that hook-order gap so a forced recompile that
+     removed a source's final `ui/defview` evicts its accepted row instead of
+     leaving a ghost view;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -108,25 +111,47 @@
      #{}
      build-sources)))
 
+(defn- compiled-this-pass?
+  "Shadow's AUTHORITATIVE fresh-compile evidence for one source, robust to
+  output-object replacement.
+
+  Shadow writes `:compiled-at` (`System/currentTimeMillis`) EXACTLY inside
+  `do-compile-cljs-resource` — the actual compile path — so the stamp advances
+  iff Shadow really (re)compiled the source THIS pass. A warm cache hit keeps
+  its prior output object and stamp; a later non-scheduling `:compile-prepare`
+  hook that only annotates or normalizes a retained output (assoc/update-in)
+  yields a NEW object but PRESERVES `:compiled-at`. So the source was compiled
+  this pass iff its finish-time stamp advanced past the prepare-snapshot stamp
+  (a missing snapshot stamp — a freshly scheduled or output-reset source —
+  counts as advanced; Shadow's clock only ever moves forward for a real
+  compile). Keying on the stamp — never the object reference — is immune to the
+  metadata-mutation false positive that raw `identical?` produced, and — because
+  it compares the source's own before/after stamp, never a wall-clock pass
+  boundary — immune to the collision where a retained warm output's stamp equals
+  the next pass start."
+  [final-output snapshot-output]
+  (let [now  (:compiled-at final-output)
+        then (:compiled-at snapshot-output)]
+    (and (integer? now)
+         (or (not (integer? then))
+             (> now then)))))
+
 (defn- actually-recompiled-member-nss
   "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
   THIS pass, read from the FINAL build-state at `:compile-finish` — after every
   schedule-mutating `:compile-prepare` hook and after compilation ran —
-  distinguished by EXACT per-pass provenance: output-object identity, never
-  wall-clock ordering.
+  distinguished by Shadow's AUTHORITATIVE per-source compile stamp, never
+  output-object identity or wall-clock ordering.
 
   `pass-output` is the `:output` map re-frame.ui snapshotted at
-  `:compile-prepare` (the outputs Shadow was about to compile from). Shadow
-  installs a freshly-built output OBJECT for a source iff it recompiles it this
-  pass: parallel compile leaves already-present outputs untouched, and
-  sequential `generate-output-for-source` returns the retained output object
-  unchanged for a warm cache hit. So a source whose finish-time output is
-  present and not `identical?` to its snapshot object was compiled this pass,
-  regardless of its `:compiled-at` stamp. This is immune to the millisecond
-  collision where a retained warm output's stamp equals the next pass start (the
-  former `compiled-at >= pass-start` test wrongly counted it as recompiled and
-  evicted its accepted row), and immune to the build-local hook merge order
-  re-frame.ui cannot control."
+  `:compile-prepare` (the outputs Shadow was about to compile from). See
+  `compiled-this-pass?`: a source counts as recompiled iff its finish-time
+  `:compiled-at` advanced past its snapshot stamp — the evidence Shadow's own
+  compile path carries. This is immune both to a later hook replacing a retained
+  output's OBJECT while preserving its stamp (raw `identical?` misread the fresh
+  object as a recompile and evicted an untouched accepted view) and to the
+  millisecond stamp collision with a pass boundary, and it does not depend on
+  the build-local hook merge order re-frame.ui cannot control."
   [{:keys [build-sources sources output]} pass-output]
   (reduce
    (fn [acc resource-id]
@@ -134,7 +159,7 @@
            final-output (get output resource-id)]
        (if (and (= :cljs type)
                 (some? final-output)
-                (not (identical? final-output (get pass-output resource-id))))
+                (compiled-this-pass? final-output (get pass-output resource-id)))
          (into acc (or provides (when ns #{ns})))
          acc)))
    #{}
@@ -148,7 +173,7 @@
   source whose successful recompile contributed no re-frame.ui declaration (its
   final `ui/defview` was removed), closing the ghost-view gap of CLOSED
   rf2-n7ff9f; a recompiled source that DID re-declare is already touched+staged,
-  so the union is idempotent, and a warm cache hit (output object unchanged from
+  so the union is idempotent, and a warm cache hit (compile stamp unchanged from
   the prepare snapshot) keeps its accepted row.
 
   When no re-frame.ui pass is open (a non-Shadow / plain-JVM finish with no
@@ -380,9 +405,10 @@
       (let [build-state (reset-cold-ui-consumer-output build-state)]
         ;; Snapshot the `:output` map Shadow handed us BEFORE any compilation, so
         ;; `:compile-finish` can identify the sources Shadow actually recompiled
-        ;; this pass by output-object identity — exact per-pass provenance,
-        ;; robust to a later prepare hook mutating the schedule and immune to the
-        ;; millisecond stamp collision (rf2-vxgfnd.194, rf2-vxgfnd.255).
+        ;; this pass by their `:compiled-at` compile stamp — Shadow's own
+        ;; per-source compile evidence, robust to a later prepare hook mutating a
+        ;; retained output's OBJECT and immune to the millisecond stamp collision
+        ;; (rf2-vxgfnd.194, rf2-vxgfnd.255, rf2-vxgfnd.282).
         (-> (build/prepare-shadow-build build-state
                                         build-id
                                         (member-nss build-state)

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -217,8 +217,8 @@
   ;; Shadow to recompile it after re-frame.ui observed the schedule. If that
   ;; source removed its final ui/defview it contributes nothing, and — pre-fix —
   ;; its accepted row survived as a ghost view because it was never pre-touched.
-  ;; The :compile-finish reconcile against Shadow's authoritative compiled set
-  ;; (a fresh output OBJECT, not identical to the prepare snapshot) evicts it.
+  ;; The :compile-finish reconcile against Shadow's authoritative per-source
+  ;; compile stamp (`:compiled-at` advanced past the prepare snapshot) evicts it.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :ghost parallel?)
@@ -229,25 +229,25 @@
         (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
                (build/accepted-aggregate build/views good))
             "the accepted build declares both sources' views")
-        ;; Warm pass: app.a + app.b both retain output, so re-frame.ui pre-touches
-        ;; neither. A later prepare hook then removes app.a's output; app.a
-        ;; recompiles this pass — Shadow installs a FRESH output object —
-        ;; contributing NO declaration. app.b stays a cache hit: its EXACT output
-        ;; object is retained unchanged across the pass.
+        ;; Warm pass: app.a + app.b both retain a stamped output, so re-frame.ui
+        ;; pre-touches neither. A later prepare hook then removes app.a's output;
+        ;; app.a recompiles this pass — Shadow ADVANCES its `:compiled-at` stamp
+        ;; — contributing NO declaration. app.b stays a cache hit: its EXACT
+        ;; output object (and stamp) is retained unchanged across the pass.
         (let [warm-b-output {:resource-id app-b-rid :js "app.b = {};"
-                             :cached true}
+                             :compiled-at 1000 :cached false}
               warm-input (-> good
                              (assoc-in [:output carrier-rid :js]
                                        build-hook/digest-sentinel)
                              (assoc-in [:output app-a-rid]
                                        {:resource-id app-a-rid :js "app.a = {};"
-                                        :cached true})
+                                        :compiled-at 1000 :cached false})
                              (assoc-in [:output app-b-rid] warm-b-output))
               prepared (prepare warm-input)
               finished (-> prepared
                            (assoc-in [:output app-a-rid]
                                      {:resource-id app-a-rid :js "app.a = {};"
-                                      :cached false})
+                                      :compiled-at 2000 :cached false})
                            finish)]
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
@@ -320,6 +320,89 @@
               "app.b's accepted row is digest-stable across the warm pass")
           (is (not (contains? views-after :app/a-view))
               "the genuinely recompiled zero-declaration source is evicted"))))))
+
+(deftest metadata-only-output-mutation-is-not-a-recompile
+  ;; rf2-vxgfnd.282: output-object identity is NOT compile provenance. Shadow
+  ;; deep-merges build-local hooks after the inherited re-frame.ui hook, so a
+  ;; later :compile-prepare hook can annotate or normalize a source's
+  ;; STILL-VALID retained output with assoc/update-in — producing a NEW output
+  ;; object WITHOUT scheduling any compilation. Under raw `identical?`-of-output
+  ;; provenance re-frame.ui misreads that fresh object as a recompile,
+  ;; pre-touches the source, sees no registry macro, and silently EVICTS its
+  ;; accepted view — changing the whole-build digest. Shadow's authoritative
+  ;; fresh-compile evidence is the `:compiled-at` stamp it writes inside
+  ;; do-compile-cljs-resource: a metadata-only mutation preserves it, a real
+  ;; recompile advances it. Membership keys on the stamp, not the reference —
+  ;; so restoring the `identical?` test makes the survival arm below fail (the
+  ;; mutated object is not identical to the snapshot, so app.b is wrongly
+  ;; evicted). Both arms run in sequential and parallel compile modes.
+  (doseq [parallel? [true false]]
+    (let [mode (if parallel? "parallel" "sequential")
+          good (-> (two-source-state :meta parallel?)
+                   prepare
+                   (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                   (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                   finish)
+          digest-before (build/accepted-build-digest good)
+          views-before  (build/accepted-aggregate build/views good)
+          ;; A warm accepted generation: both app.a and app.b retain a stamped
+          ;; output object; the carrier sentinel is reset so finish re-projects.
+          warm-a {:resource-id app-a-rid :js "app.a = {};"
+                  :compiled-at 1000 :cached false}
+          warm-b {:resource-id app-b-rid :js "app.b = {};"
+                  :compiled-at 1000 :cached false}
+          warm-input (-> good
+                         (assoc-in [:output carrier-rid :js]
+                                   build-hook/digest-sentinel)
+                         (assoc-in [:output app-a-rid] warm-a)
+                         (assoc-in [:output app-b-rid] warm-b))]
+      (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
+             views-before)
+          (str mode ": the accepted build declares both sources' views"))
+
+      (testing (str mode " — later hook only annotates app.b's retained output")
+        ;; No source is scheduled this warm pass. A later build-local prepare hook
+        ;; replaces app.b's still-valid output with a NEW object that ONLY adds
+        ;; metadata; its `:compiled-at` stamp is untouched, so Shadow skips app.b.
+        ;; app.b must survive byte-identical and the digest must not move.
+        (let [prepared  (prepare warm-input)
+              mutated-b (assoc warm-b :shadow.build/annotation :normalized)
+              finished  (-> prepared
+                            (assoc-in [:output app-b-rid] mutated-b)
+                            finish)]
+          (is (not (identical? mutated-b warm-b))
+              "the later hook produced a fresh output object for app.b")
+          (is (= (:compiled-at warm-b) (:compiled-at mutated-b))
+              "but the metadata-only mutation preserved Shadow's compile stamp")
+          (is (not (contains?
+                    (get-in prepared [:compiler-env build/scratch-key :touched])
+                    'app.b))
+              "re-frame.ui does not pre-touch an output-present source at prepare")
+          (is (= views-before (build/accepted-aggregate build/views finished))
+              "a metadata-only mutation is not a recompile; both accepted rows survive")
+          (is (= (get views-before :app/b-view)
+                 (get (build/accepted-aggregate build/views finished) :app/b-view))
+              "app.b's accepted row is byte-identical across the pass")
+          (is (= digest-before (build/accepted-build-digest finished))
+              "the whole-build digest is unchanged")))
+
+      (testing (str mode " — companion: app.b output removed and recompiled")
+        ;; Same evidence, opposite verdict: the later hook instead REMOVES app.b's
+        ;; output and app.b genuinely recompiles (an ADVANCED `:compiled-at`)
+        ;; after its final defview was removed, contributing nothing. app.b is
+        ;; evicted; app.a stays a cache hit. Object identity would have flagged
+        ;; BOTH arms' app.b as recompiled; the stamp evidence distinguishes them.
+        (let [prepared (prepare warm-input)
+              finished (-> prepared
+                           (assoc-in [:output app-b-rid]
+                                     {:resource-id app-b-rid :js "app.b = {};"
+                                      :compiled-at 2000 :cached false})
+                           finish)]
+          (is (= {:app/a-view ["tfa-1" "hsa-1"]}
+                 (build/accepted-aggregate build/views finished))
+              "the genuinely recompiled zero-declaration source is evicted")
+          (is (not= digest-before (build/accepted-build-digest finished))
+              "evicting the recompiled ghost changes the whole-build digest"))))))
 
 (deftest missing-per-pass-provenance-fails-loud-not-empty-schedule
   ;; rf2-vxgfnd.255: an open pass whose prepare-time provenance snapshot is


### PR DESCRIPTION
Closes the P1 build-correctness defect in rf2-vxgfnd.282, extending #5888/.255 (per-pass provenance) and #5880/.237 (generation/activation).

## Problem (re-verified against current main)

`re-frame.ui.compiler.build-hook/actually-recompiled-member-nss` decided per-pass compile membership by comparing each finish-time `:output` object against the `:compile-prepare` `:pass-output` snapshot with `identical?`. Output-object identity is **not** compile provenance: Shadow deep-merges build-local hooks after the inherited re-frame.ui hook, so a later `:compile-prepare` hook can annotate/normalize a source's **still-valid retained output** with `assoc`/`update-in` — a **new object without any scheduled compilation**. The old code misread that fresh object as a recompile, pre-touched the namespace, saw no registry macro, and silently **evicted its accepted views and changed the whole-build digest**. Re-verified on current `origin/main`: the seam and defect were still present at branch point.

## Fix — authoritative Shadow compile evidence

Reuse the existing `:pass-output` snapshot channel (no parallel evidence channel); change only the discriminator. Shadow writes `:compiled-at` (`System/currentTimeMillis`) **exactly inside `do-compile-cljs-resource`** — the actual compile path — so a source's stamp advances iff Shadow truly (re)compiled it this pass. A warm cache hit keeps its stamp; a metadata-only mutation preserves it. New `compiled-this-pass?` keys membership on the stamp advancing past the snapshot stamp, never the object reference:

- **Immune** to the metadata-mutation false positive that `identical?` produced (the .282 defect).
- **Still immune** to the millisecond `compiled-at == pass-start` collision that #5888/.255 fixed — because it compares each source's own before/after stamp, never a wall-clock pass boundary.
- Does not depend on the build-local hook merge order re-frame.ui cannot control.

Stale `pass-start-time` / `output-object identity` docstrings and comments removed/rewritten to describe the stamp evidence.

## Red-before-fix

New `metadata-only-output-mutation-is-not-a-recompile` fixture (sequential + parallel):
- **Survival arm:** a later hook only annotates B's retained output (new object, same `:compiled-at`) → B skipped, its accepted row byte-identical, whole-build digest unchanged.
- **Companion arm:** the later hook removes B's output; B genuinely recompiles (advanced stamp) after its final `defview` is removed → B evicted, digest changes.

Temporarily restoring `identical?` fails **exactly** the survival arm (6 = 3 assertions × 2 modes) while the existing `.194` forced-recompile and `.255` stamp-collision fixtures stay green — proving the stamp evidence distinguishes compiles that object identity conflates. The `.194` fixture was updated to model its recompile as a `:compiled-at` advance (the faithful real-Shadow signal).

## Coordination

The real-host (real Shadow sequential/parallel, live build-local prepare hook) proof surface is owned by **open rf2-vxgfnd.195** (not amended here); this PR lands the authoritative JVM-unit falsifier + the fix.

## Quality gates

- `cd implementation/ui && clojure -M:test` → **518 tests, 6491 assertions, 0 failures, 0 errors** (build_hook / digest-carrier / build JVM suites + G-13/G-14).
- Red-before-fix verified by temporarily reverting to `identical?`: 6 failures isolated to the new survival arm; reverted.
- Change is JVM build-hook only (no runtime carrier or real-host harness change). `npm run test:ui-digest-carrier` (real Shadow + Chromium) and the full elision/digest matrix run authoritatively in CI.