### PR TITLE
fix(core): join completions honor dispatch overrides + preserve the zero-delay boundary (rf2-ulsbgr/21hsb1)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -491,11 +491,27 @@
     :rf.fx/clear-flow
     :rf.route/with-nav-token})
 
+(defn real-override?
+  "True iff `overrides` carries a GENUINE override for `fx-id` — a fn body, a
+  keyword redirect, or any other non-noop value (which `resolve-fx-with-
+  overrides` then reports) — as opposed to the documented nil/false no-op
+  placeholder (spec/002 §`:fx-overrides`: \"nil/false → no override, fall
+  through\"). The single definition of \"is this fx actually overridden\",
+  shared by the reject-tier gate (`real-reject-override?`) and the machines
+  `:rf.machine/join-dispatch` transport's override-first resolution (rf2-ulsbgr
+  — a `:spawn-all` child completion whose canonical `:dispatch` / `:dispatch-
+  later` is overridden must route through that override, NOT be lowered to the
+  private recordable transport). Public so the machines transport reuses this
+  one definition rather than forking a second override engine."
+  [overrides fx-id]
+  (let [v (get overrides fx-id)]
+    (and (some? v) (not (false? v)))))
+
 (defn- real-reject-override?
   "True iff `overrides` carries a GENUINE reject-tier override attempt for
   reserved `fx-id` — i.e. `fx-id` is in `rejected-reserved-fx-ids` AND its
-  override VALUE is a real override (a fn body or keyword redirect, or any
-  other non-noop value), NOT the documented nil/false no-op placeholder.
+  override VALUE is a real override (`real-override?`), NOT the documented
+  nil/false no-op placeholder.
 
   rf2-x76af2.27: the reject-tier gates previously tested bare key PRESENCE
   (`contains?`), so an override entry `{:rf.fx/reg-flow nil}` — the collapsed
@@ -508,8 +524,7 @@
   through silently, only a real fn/keyword override emits + is neutralised."
   [overrides fx-id]
   (and (contains? rejected-reserved-fx-ids fx-id)
-       (let [v (get overrides fx-id)]
-         (and (some? v) (not (false? v))))))
+       (real-override? overrides fx-id)))
 
 ;; Inheritable envelope fields — copied from parent to child when
 ;; `:dispatch` / `:dispatch-later` queue a new envelope. Per Spec 002

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -155,32 +155,76 @@
   ONLY its private recordable `:rf.machine/join-auth` `:rf.cofx` fact and stamps
   `:source :machine-action`; the public completion event VALUE is unchanged.
 
+  CANONICAL DISPATCH OVERRIDES INTERCEPT FIRST (rf2-ulsbgr). #5881 lowered the
+  authored `:dispatch` / `:dispatch-later` completion to this PRIVATE id BEFORE
+  core override resolution, so `do-fx` looked up `:fx-overrides` under the
+  private id and a `{:fx-overrides {:dispatch capture-fn}}` never intercepted
+  the completion. Here we resolve the CANONICAL override FIRST: when the
+  completion's authored id (`:dispatch-later` for a numeric `:ms`, else
+  `:dispatch`) is overridden in the SAME effective override map `do-fx` used
+  (per-frame ⋈ per-call, per-call winning — `re-frame.router/apply-overrides`),
+  we route the canonical `[fx-id args]` back through the shared core seam
+  `re-frame.fx/handle-one-fx` (fn-value pre-empts / keyword-redirect / traces,
+  the identical resolution a normal dispatch flows through). The override
+  captures / redirects the completion, queues nothing, folds nothing, and NO
+  private join authority is minted — an application override can never forge or
+  replay the recordable authority into the normal transport. Only the
+  UNOVERRIDDEN completion is lowered to the recordable transport below.
+
   Not an application control surface — reserved-`:rf.machine/*` internal, it
   re-dispatches ONLY the pre-built completion carrier it was handed (never
   traverses arbitrary / custom effect payloads).
 
-  ctx carries `:frame` and `:envelope` (the emitting child's dispatch envelope,
-  threaded by `re-frame.fx/do-fx`). args: `{:event <[parent-id inner-event]>
-  :rf/join-auth <auth-tuple> :ms <ms?>}`. A POSITIVE `:ms` (from a
-  `:dispatch-later` completion) arms a frame-owned delayed dispatch; nil /
-  non-positive dispatches immediately — the same enqueue a direct `:dispatch`
-  completion takes."
-  [{:keys [frame envelope]} {:keys [event ms] auth :rf/join-auth}]
-  (let [frame-id (frame/require-frame-stamp!
-                   frame :rf.machine/join-dispatch
-                   {:where 'rf.machine/join-dispatch :event-id (first event)})]
-    (fx/child-dispatch!
-      frame-id envelope event
-      ;; The recordable causal-envelope fact rides `:rf.cofx`; `:source
-      ;; :machine-action` matches the child's original `:dispatch` stamp; the
-      ;; `:rf.machine/internal?` front-of-queue ordering + override / lineage /
-      ;; mint-policy inheritance are lifted from `envelope` by `child-dispatch!`.
-      ;; A positive delay carries `:ms` + `:source-detail`; ms 0 / nil enqueues
-      ;; immediately (a `:dispatch-later {:ms 0}` completion folds synchronously
-      ;; on the in-progress drain, matching the direct `:dispatch` completion).
-      (cond-> {:source  :machine-action
-               :rf.cofx {:rf.machine/join-auth auth}}
-        (and (number? ms) (pos? ms)) (assoc :ms ms :source-detail {:ms ms}))))
+  ctx carries `:frame`, `:envelope` (the emitting child's dispatch envelope),
+  and `:event` (the originating event, threaded by `re-frame.fx/do-fx`). args:
+  `{:event <[parent-id inner-event]> :rf/join-auth <auth-tuple> :ms <ms?>}`. A
+  POSITIVE `:ms` (from a `:dispatch-later` completion) arms a frame-owned
+  delayed dispatch; nil / non-positive `:ms` dispatches immediately — the same
+  enqueue a direct `:dispatch` completion takes."
+  [{:keys [frame envelope] origin-event :event} {:keys [event ms] auth :rf/join-auth}]
+  (let [frame-id     (frame/require-frame-stamp!
+                       frame :rf.machine/join-dispatch
+                       {:where 'rf.machine/join-dispatch :event-id (first event)})
+        ;; The CANONICAL authored effect this completion was lowered from: a
+        ;; `:dispatch-later` completion carries a numeric `:ms` (zero or
+        ;; positive); a direct `:dispatch` completion carries none.
+        canonical-id (if (number? ms) :dispatch-later :dispatch)
+        frame-record (frame/frame frame-id)
+        ;; The SAME effective override map `do-fx` resolved against — per-frame
+        ;; ⋈ per-call, per-call winning (mirrors `router/apply-overrides`). The
+        ;; per-call tier rides the emitting child's dispatch envelope.
+        overrides    (merge (:fx-overrides (:config frame-record))
+                            (:fx-overrides envelope))]
+    (if (fx/real-override? overrides canonical-id)
+      ;; OVERRIDDEN (rf2-ulsbgr): route the canonical `:dispatch` /
+      ;; `:dispatch-later` back through the shared core override-resolution seam
+      ;; so the override intercepts the completion exactly as it would a normal
+      ;; dispatch. `handle-one-fx` (not `do-fx`) keeps the single `:event/do-fx`
+      ;; boundary marker on the outer walk (the nav-token wrapper precedent). No
+      ;; `child-dispatch!` → no fold, no queue, and no private authority minted.
+      (fx/handle-one-fx
+        frame-id
+        (if (number? ms)
+          [:dispatch-later {:ms ms :event event}]
+          [:dispatch event])
+        (fx/platform-for-frame-record frame-record)
+        overrides
+        origin-event
+        envelope)
+      ;; UNOVERRIDDEN: the normal recordable transport. The recordable causal-
+      ;; envelope fact rides `:rf.cofx`; `:source :machine-action` matches the
+      ;; child's original `:dispatch` stamp; the `:rf.machine/internal?`
+      ;; front-of-queue ordering + override / lineage / mint-policy inheritance
+      ;; are lifted from `envelope` by `child-dispatch!`. A POSITIVE-delay
+      ;; `:dispatch-later` completion carries `:ms` + `:source-detail`, so
+      ;; `child-dispatch!` arms the frame-owned delayed dispatch; ms 0 / nil
+      ;; enqueues immediately (a `:dispatch-later {:ms 0}` completion folds
+      ;; synchronously on the in-progress drain, matching a direct `:dispatch`).
+      (fx/child-dispatch!
+        frame-id envelope event
+        (cond-> {:source  :machine-action
+                 :rf.cofx {:rf.machine/join-auth auth}}
+          (and (number? ms) (pos? ms)) (assoc :ms ms :source-detail {:ms ms})))))
   nil)
 
 (defn- stamp-fx-entry

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -149,11 +149,12 @@
   emitting child's envelope its `:fx-overrides`, `:interceptor-overrides`,
   `:trace-id`, `:origin`, the per-call `:rf.cofx/mint-policy` strict/replay
   discipline, and the `:rf.machine/internal?` front-of-queue ordering (the
-  emitter is always a machine child) — and a POSITIVE-delay completion (a
-  `:dispatch-later` form) rides the frame-owned `:dispatch-later` timer table,
-  cancelled on frame destroy, rather than a raw host timeout. The transport adds
-  ONLY its private recordable `:rf.machine/join-auth` `:rf.cofx` fact and stamps
-  `:source :machine-action`; the public completion event VALUE is unchanged.
+  emitter is always a machine child) — and a DELAYED completion (a
+  `:dispatch-later` form, ANY numeric `:ms` including zero — rf2-21hsb1) rides
+  the frame-owned `:dispatch-later` timer table, cancelled on frame destroy,
+  rather than a raw host timeout. The transport adds ONLY its private recordable
+  `:rf.machine/join-auth` `:rf.cofx` fact and stamps `:source :machine-action`;
+  the public completion event VALUE is unchanged.
 
   CANONICAL DISPATCH OVERRIDES INTERCEPT FIRST (rf2-ulsbgr). #5881 lowered the
   authored `:dispatch` / `:dispatch-later` completion to this PRIVATE id BEFORE
@@ -178,9 +179,9 @@
   ctx carries `:frame`, `:envelope` (the emitting child's dispatch envelope),
   and `:event` (the originating event, threaded by `re-frame.fx/do-fx`). args:
   `{:event <[parent-id inner-event]> :rf/join-auth <auth-tuple> :ms <ms?>}`. A
-  POSITIVE `:ms` (from a `:dispatch-later` completion) arms a frame-owned
-  delayed dispatch; nil / non-positive `:ms` dispatches immediately — the same
-  enqueue a direct `:dispatch` completion takes."
+  NUMERIC `:ms` (from a `:dispatch-later` completion, INCLUDING `:ms 0` —
+  rf2-21hsb1) arms a frame-owned delayed dispatch; a nil `:ms` (a direct
+  `:dispatch` completion) dispatches immediately in the current drain."
   [{:keys [frame envelope] origin-event :event} {:keys [event ms] auth :rf/join-auth}]
   (let [frame-id     (frame/require-frame-stamp!
                        frame :rf.machine/join-dispatch
@@ -215,16 +216,19 @@
       ;; envelope fact rides `:rf.cofx`; `:source :machine-action` matches the
       ;; child's original `:dispatch` stamp; the `:rf.machine/internal?`
       ;; front-of-queue ordering + override / lineage / mint-policy inheritance
-      ;; are lifted from `envelope` by `child-dispatch!`. A POSITIVE-delay
-      ;; `:dispatch-later` completion carries `:ms` + `:source-detail`, so
-      ;; `child-dispatch!` arms the frame-owned delayed dispatch; ms 0 / nil
-      ;; enqueues immediately (a `:dispatch-later {:ms 0}` completion folds
-      ;; synchronously on the in-progress drain, matching a direct `:dispatch`).
+      ;; are lifted from `envelope` by `child-dispatch!`. A `:dispatch-later`
+      ;; completion carries its numeric `:ms` + `:source-detail` for EVERY delay
+      ;; INCLUDING ZERO (rf2-21hsb1) — the canonical `child-dispatch!` path treats
+      ;; every numeric `:ms` as host-clock-delayed, so a `:dispatch-later {:ms 0}`
+      ;; yields through the frame-owned timer (a render/scheduling boundary,
+      ;; Spec 002 §long-running work) rather than folding synchronously. A direct
+      ;; `:dispatch` completion (nil `:ms`) enqueues immediately in the current
+      ;; drain — it alone carries no numeric `:ms` and no synthetic delayed detail.
       (fx/child-dispatch!
         frame-id envelope event
         (cond-> {:source  :machine-action
                  :rf.cofx {:rf.machine/join-auth auth}}
-          (and (number? ms) (pos? ms)) (assoc :ms ms :source-detail {:ms ms})))))
+          (number? ms) (assoc :ms ms :source-detail {:ms ms})))))
   nil)
 
 (defn- stamp-fx-entry

--- a/implementation/machines/test/re_frame/join_dispatch_override_intercept_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_dispatch_override_intercept_cljs_test.cljc
@@ -1,0 +1,196 @@
+(ns re-frame.join-dispatch-override-intercept-cljs-test
+  "rf2-ulsbgr — canonical dispatch OVERRIDES intercept `:spawn-all` join
+  completions.
+
+  Merged PR #5881 rewrites an authored join-completion `[:dispatch completion]`
+  / `:dispatch-later` effect into the private `:rf.machine/join-dispatch` effect
+  BEFORE core effect override resolution, so `do-fx` looked up per-call
+  `:fx-overrides` under the PRIVATE rewritten id rather than the canonical
+  authored `:dispatch` / `:dispatch-later` id. A caller using
+  `{:fx-overrides {:dispatch capture-fn}}` inherited that override in the
+  envelope but never got to intercept the completion — the reserved transport
+  called `child-dispatch!` and folded the parent anyway.
+
+  The fix (`join-dispatch-fx`) resolves the CANONICAL override FIRST against the
+  SAME effective override map `do-fx` used (per-frame ⋈ per-call), routing an
+  overridden completion back through the shared core seam
+  `re-frame.fx/handle-one-fx`. The override captures / redirects it, queues
+  nothing, folds nothing, and NO private join authority is minted. Only an
+  UNOVERRIDDEN completion is lowered to the recordable transport (authority
+  attached).
+
+  MUTATION TOOTH: reverting the fix so `join-dispatch-fx` always
+  `child-dispatch!`es (resolving only under the private `:rf.machine/join-
+  dispatch` id) makes every capture assertion fail — the override never fires
+  and the parent folds instead."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- join-state [parent-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+
+(defn- mk-child
+  "A dispatching child: on `:go` transitions to a terminal and dispatches its
+  completion back to `parent-id` via `:dispatch` (through its OWN boundary, so
+  the runtime attaches the recordable `:rf.machine/join-auth`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- mk-child-delayed
+  "Like `mk-child` but completes through a `:dispatch-later` with delay `ms`."
+  [parent-id ms]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch-later {:ms    ms
+                                                      :event [parent-id [:child/done (:id data)]]}]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- reg-parent!
+  "A two-child `:all` join parent (children `child-a-kw` / `child-b-kw`)."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}}))
+
+;; ---------------------------------------------------------------------------
+;; (1) fn-value :dispatch override intercepts the completion — capture, no fold.
+;; ---------------------------------------------------------------------------
+
+(deftest fn-value-dispatch-override-intercepts-join-completion
+  (testing "rf2-ulsbgr — a per-call `{:fx-overrides {:dispatch capture-fn}}`
+            intercepts a `:spawn-all` child's completion: the fn captures the
+            UNCHANGED public completion event exactly once, queues nothing, and
+            the parent join does NOT fold / resolve. Before the fix the override
+            was looked up under the private `:rf.machine/join-dispatch` id and
+            never fired — the transport folded the parent regardless."
+    (rf/reg-machine :ulsbgr.fn/ca (mk-child :ulsbgr.fn/rp))
+    (rf/reg-machine :ulsbgr.fn/cb (mk-child :ulsbgr.fn/rp))
+    (reg-parent! :ulsbgr.fn/rp :ulsbgr.fn/ca :ulsbgr.fn/cb)
+    (rf/dispatch-sync [:ulsbgr.fn/rp [:start]])
+    (let [captured (atom [])
+          a        (get-in (join-state :ulsbgr.fn/rp) [:children :a])]
+      (rf/dispatch-sync [a [:go]]
+                        {:fx-overrides {:dispatch (fn [_ctx args] (swap! captured conj args))}})
+      (is (= [[:ulsbgr.fn/rp [:child/done :a]]] @captured)
+          "the :dispatch override captured the UNCHANGED public completion event exactly once")
+      (is (= #{} (:done (join-state :ulsbgr.fn/rp)))
+          "the parent join folded NOTHING — the override pre-empted the transport (queues nothing)")
+      (is (not (true? (:resolved? (join-state :ulsbgr.fn/rp))))
+          "the join did not resolve on the captured (un-folded) completion"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) keyword-redirect :dispatch override intercepts the completion.
+;; ---------------------------------------------------------------------------
+
+(deftest keyword-redirect-dispatch-override-intercepts-join-completion
+  (testing "rf2-ulsbgr — an id-redirect `{:fx-overrides {:dispatch :test/capture}}`
+            resolves through the ordinary core seam: the registered redirect
+            target runs in place of the completion `:dispatch`, capturing it,
+            and the parent does not fold."
+    (let [captured (atom [])]
+      (rf/reg-fx :ulsbgr.kw/capture (fn [_ctx args] (swap! captured conj args)))
+      (rf/reg-machine :ulsbgr.kw/ca (mk-child :ulsbgr.kw/rp))
+      (rf/reg-machine :ulsbgr.kw/cb (mk-child :ulsbgr.kw/rp))
+      (reg-parent! :ulsbgr.kw/rp :ulsbgr.kw/ca :ulsbgr.kw/cb)
+      (rf/dispatch-sync [:ulsbgr.kw/rp [:start]])
+      (let [a (get-in (join-state :ulsbgr.kw/rp) [:children :a])]
+        (rf/dispatch-sync [a [:go]]
+                          {:fx-overrides {:dispatch :ulsbgr.kw/capture}})
+        (is (= [[:ulsbgr.kw/rp [:child/done :a]]] @captured)
+            "the keyword-redirect target captured the completion event")
+        (is (= #{} (:done (join-state :ulsbgr.kw/rp)))
+            "the parent join folded nothing under the redirect")))))
+
+;; ---------------------------------------------------------------------------
+;; (3) :dispatch-later completion is intercepted under the :dispatch-later key.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-later-override-intercepts-delayed-join-completion
+  (testing "rf2-ulsbgr — a completion authored as `:dispatch-later` is
+            intercepted by a `{:fx-overrides {:dispatch-later capture-fn}}`
+            override under its CANONICAL `:dispatch-later` id: the capture
+            observes the canonical delayed payload (`{:ms _ :event _}`),
+            schedules no timer, and the parent does not fold. Covers both
+            `:ms 0` and a positive delay."
+    (doseq [ms [0 500]]
+      (let [captured (atom [])
+            rp       (keyword "ulsbgr.dl" (str "rp" ms))
+            ca       (keyword "ulsbgr.dl" (str "ca" ms))
+            cb       (keyword "ulsbgr.dl" (str "cb" ms))]
+        (rf/reg-machine ca (mk-child-delayed rp ms))
+        (rf/reg-machine cb (mk-child-delayed rp ms))
+        (reg-parent! rp ca cb)
+        (rf/dispatch-sync [rp [:start]])
+        (let [a (get-in (get-in (mtest/runtime-db)
+                                [:rf.runtime/machines :spawned rp [:racing]])
+                        [:children :a])]
+          (rf/dispatch-sync [a [:go]]
+                            {:fx-overrides {:dispatch-later (fn [_ctx args] (swap! captured conj args))}})
+          (is (= [{:ms ms :event [rp [:child/done :a]]}] @captured)
+              (str ":dispatch-later completion captured with the canonical delayed payload (ms=" ms ")"))
+          (is (= #{} (:done (get-in (mtest/runtime-db)
+                                    [:rf.runtime/machines :spawned rp [:racing]])))
+              (str "the parent join folded nothing under the :dispatch-later override (ms=" ms ")")))))))
+
+;; ---------------------------------------------------------------------------
+;; (4) control — WITHOUT an override the completion folds normally (authority
+;;     path intact). Also: an override of an UNRELATED effect does NOT divert
+;;     the completion (only the canonical dispatch id is consulted).
+;; ---------------------------------------------------------------------------
+
+(deftest unoverridden-completion-folds-and-unrelated-override-does-not-divert
+  (testing "rf2-ulsbgr — the fix is surgical: WITHOUT a `:dispatch` override the
+            completion follows the normal recordable transport and folds; and a
+            `:fx-overrides` for an UNRELATED effect does NOT divert the
+            completion (only the canonical `:dispatch` / `:dispatch-later` id is
+            consulted), so the authority path is untouched."
+    (rf/reg-machine :ulsbgr.ctl/ca (mk-child :ulsbgr.ctl/rp))
+    (rf/reg-machine :ulsbgr.ctl/cb (mk-child :ulsbgr.ctl/rp))
+    (reg-parent! :ulsbgr.ctl/rp :ulsbgr.ctl/ca :ulsbgr.ctl/cb)
+    (rf/dispatch-sync [:ulsbgr.ctl/rp [:start]])
+    (let [a (get-in (join-state :ulsbgr.ctl/rp) [:children :a])]
+      ;; No override at all — folds via the recordable transport.
+      (rf/dispatch-sync [a [:go]])
+      (is (= #{:a} (:done (join-state :ulsbgr.ctl/rp)))
+          "the unoverridden completion folded :a through the normal transport")
+      ;; Child :b completes carrying an override of an UNRELATED inert effect —
+      ;; the completion must still fold (only :dispatch/:dispatch-later divert).
+      (let [b (get-in (join-state :ulsbgr.ctl/rp) [:children :b])]
+        (rf/reg-fx :ulsbgr.ctl/inert (fn [_ _] nil))
+        (rf/dispatch-sync [b [:go]]
+                          {:fx-overrides {:ulsbgr.ctl/inert :ulsbgr.ctl/inert}})
+        (is (= #{:a :b} (:done (join-state :ulsbgr.ctl/rp)))
+            "an override of an unrelated effect did NOT divert the completion — :b folded")
+        (is (true? (:resolved? (join-state :ulsbgr.ctl/rp)))
+            "both completions folded → the :all join resolved")))))

--- a/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
@@ -27,6 +27,8 @@
    #?(:clj  [clojure.edn :as edn]
       :cljs [cljs.reader :as edn])
    [re-frame.core :as rf]
+   [re-frame.interop :as interop]
+   [re-frame.late-bind :as late-bind]
    [re-frame.machines]
    [re-frame.machines.test-support :as mtest]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
@@ -108,6 +110,27 @@
      :spawned-id (get-in j [:children :a])
      :attempt    (:rf/attempt j)}))
 
+(defn- with-dispatch-stub
+  "Run `body-fn` with `:router/dispatch!` replaced by a RECORDING stub that
+  captures each `[event opts]` into `sink` WITHOUT draining — so a deferred
+  completion's re-dispatch is observed deterministically on both platforms (no
+  async router drain to await). Restores the real hook in a `finally`."
+  [sink body-fn]
+  (let [real (late-bind/get-fn :router/dispatch!)]
+    (try
+      (late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
+      (body-fn)
+      (finally
+        (late-bind/set-fn! :router/dispatch! real)))))
+
+(defn- completion-opts
+  "The opts of the FIRST recorded re-dispatch whose event is the completion
+  carrier `[parent-id [:child/done child-id]]`, or nil."
+  [sink parent-id child-id]
+  (some (fn [[event opts]]
+          (when (= [parent-id [:child/done child-id]] event) opts))
+        @sink))
+
 ;; ---------------------------------------------------------------------------
 ;; replay-faithful recordable transport
 ;; ---------------------------------------------------------------------------
@@ -165,25 +188,50 @@
 ;; live delayed dispatch
 ;; ---------------------------------------------------------------------------
 
-(deftest zero-delay-dispatch-later-completion-authenticates-and-folds
-  (testing "rf2-t154jx — a real child completing through a zero-delay
-            :dispatch-later authenticates (the delayed path #5839's metadata
-            stamp never covered) and folds + resolves the join exactly once."
+(deftest zero-delay-dispatch-later-completion-defers-then-authenticates-and-folds
+  (testing "rf2-21hsb1 / rf2-t154jx — a real child completing through a
+            zero-delay :dispatch-later is DEFERRED on the host clock (it does NOT
+            fold synchronously — rf2-21hsb1; the canonical child-dispatch! path
+            treats every numeric :ms including zero as host-clock-delayed). Once
+            the controlled host-clock callback fires, the re-dispatched
+            completion retains :source-detail {:ms 0} + the recordable
+            :rf.machine/join-auth, authenticates (the delayed path #5839's
+            metadata stamp never covered), and folds the join exactly once.
+            (This test previously asserted a SYNCHRONOUS fold — the (pos? ms)
+            regression rf2-21hsb1 corrects.)"
     (rf/reg-machine :jt/da (mk-child-delayed :jt/dp))
     (rf/reg-machine :jt/db (mk-child-delayed :jt/dp))
     (reg-parent! :jt/dp :jt/da :jt/db)
     (rf/dispatch-sync [:jt/dp [:start]])
-    (let [j (join-state :jt/dp)
-          a (get-in j [:children :a])
-          b (get-in j [:children :b])]
+    (let [a           (get-in (join-state :jt/dp) [:children :a])
+          captured-cb (atom nil)
+          sink        (atom [])]
       (mtest/reset-captured!)
-      (rf/dispatch-sync [a [:go]])
-      (is (= #{:a} (:done (join-state :jt/dp)))
-          ":a folded via the zero-delay :dispatch-later completion")
-      (is (empty? (stale-reasons)) "no stale suppression for the delayed completion")
-      (rf/dispatch-sync [b [:go]])
-      (is (true? (:resolved? (join-state :jt/dp)))
-          "the second delayed completion resolves the :all join"))))
+      (with-dispatch-stub sink
+        (fn []
+          (with-redefs [interop/set-timeout!   (fn [f _ms] (reset! captured-cb f) ::handle)
+                        interop/clear-timeout! (fn [_] nil)]
+            ;; The zero-delay :dispatch-later completion is DEFERRED — armed on
+            ;; the host clock, NOT folded synchronously (rf2-21hsb1). Restoring
+            ;; the (pos? ms) guard would fold it in THIS drain and fail here.
+            (rf/dispatch-sync [a [:go]])
+            (is (= #{} (:done (join-state :jt/dp)))
+                "the zero-delay :dispatch-later completion did NOT fold synchronously (async boundary)")
+            (is (some? @captured-cb) "the completion was armed on the host clock (deferred)")
+            (is (empty? @sink) "nothing re-dispatched yet — the completion is pending on the host clock")
+            ;; Fire the controlled host-clock callback → the deferred re-dispatch.
+            (@captured-cb))))
+      (let [opts (completion-opts sink :jt/dp :a)]
+        (is (some? opts) "the host-clock callback re-dispatched the completion carrier")
+        (is (= {:ms 0} (:source-detail opts)) "retains :source-detail {:ms 0} (rf2-21hsb1)")
+        (is (some? (get-in opts [:rf.cofx :rf.machine/join-auth]))
+            "the recordable join authority rode the deferred zero-delay completion")
+        ;; Deliver the deferred completion (its recorded event + causal cofx): it
+        ;; authenticates and folds the join exactly once.
+        (rf/dispatch-sync [:jt/dp [:child/done :a]] {:rf.cofx (:rf.cofx opts)})
+        (is (= #{:a} (:done (join-state :jt/dp)))
+            "after the callback fires, the delayed completion authenticates and folds :a exactly once")
+        (is (empty? (stale-reasons)) "no stale suppression for the authenticated delayed completion")))))
 
 (deftest old-attempt-delayed-completion-across-reentry-is-superseded
   (testing "rf2-t154jx — an old-attempt completion arriving across re-entry with

--- a/implementation/machines/test/re_frame/join_zero_delay_boundary_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_zero_delay_boundary_cljs_test.cljc
@@ -1,0 +1,156 @@
+(ns re-frame.join-zero-delay-boundary-cljs-test
+  "rf2-21hsb1 — preserve the zero-delay scheduling boundary for join completions.
+
+  #5881 routes join completions through the shared reserved-dispatch path, but
+  `join-dispatch-fx` forwarded `:ms` only when `(pos? ms)`. An application-
+  authored `:dispatch-later {:ms 0 ...}` completion therefore lost its delayed
+  classification and folded IMMEDIATELY in the current drain. The canonical
+  `re-frame.fx/child-dispatch!` path treats every numeric `:ms`, INCLUDING zero,
+  as host-clock-delayed (Spec 002 §long-running work uses zero delay to yield
+  through the host clock for a render/scheduling opportunity). Collapsing zero
+  into immediate dispatch changed event order, drain batching, render
+  opportunities, frame-owned timer cancellation, and observability, and dropped
+  `:source-detail {:ms 0}`.
+
+  The fix forwards `:ms` + delayed source-detail for EVERY numeric delay; a
+  direct `:dispatch` (no numeric `:ms`) remains immediate.
+
+  These fixtures control the host clock deterministically through the
+  `interop/set-timeout!` seam (capturing the deferred callback without firing or
+  scheduling), so they pin the boundary identically on CLJ and CLJS.
+
+  MUTATION TOOTH: restoring the `(pos? ms)` guard folds a zero-delay completion
+  synchronously, failing `zero-delay-completion-defers-not-immediate`."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.interop :as interop]
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+(defn- join-state [parent-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+
+(defn- mk-child
+  "A child completing through a DIRECT `:dispatch` (no numeric `:ms`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- mk-child-delayed
+  "A child completing through a `:dispatch-later` with delay `ms`."
+  [parent-id ms]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch-later {:ms    ms
+                                                      :event [parent-id [:child/done (:id data)]]}]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- reg-parent!
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}}))
+
+;; ---------------------------------------------------------------------------
+;; (1) zero-delay :dispatch-later DEFERS — the mutation tooth.
+;; ---------------------------------------------------------------------------
+
+(deftest zero-delay-completion-defers-not-immediate
+  (testing "rf2-21hsb1 — a `:dispatch-later {:ms 0 ...}` join completion is armed
+            on the host clock (numeric `:ms` 0 forwarded to `child-dispatch!`)
+            and does NOT fold synchronously in the current drain. Restoring the
+            `(pos? ms)` guard would fold it immediately, failing this test on CLJ
+            and CLJS."
+    (rf/reg-machine :hsb.z/ca (mk-child-delayed :hsb.z/rp 0))
+    (rf/reg-machine :hsb.z/cb (mk-child-delayed :hsb.z/rp 0))
+    (reg-parent! :hsb.z/rp :hsb.z/ca :hsb.z/cb)
+    (rf/dispatch-sync [:hsb.z/rp [:start]])
+    (let [a           (get-in (join-state :hsb.z/rp) [:children :a])
+          captured-cb (atom nil)
+          captured-ms (atom ::none)]
+      (with-redefs [interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
+                    interop/clear-timeout! (fn [_] nil)]
+        (rf/dispatch-sync [a [:go]]))
+      (is (= 0 @captured-ms)
+          "the numeric :ms 0 was forwarded to the host-clock timer (host-clock-delayed)")
+      (is (some? @captured-cb)
+          "the zero-delay completion armed a frame-owned delayed dispatch")
+      (is (= #{} (:done (join-state :hsb.z/rp)))
+          "it did NOT fold synchronously in the current drain (async boundary)")
+      (is (not (true? (:resolved? (join-state :hsb.z/rp))))
+          "the join did not resolve on the un-folded (deferred) completion"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) a DIRECT :dispatch completion is IMMEDIATE — no timer, no delayed detail.
+;; ---------------------------------------------------------------------------
+
+(deftest direct-dispatch-completion-is-immediate
+  (testing "rf2-21hsb1 — a direct `:dispatch` join completion carries no numeric
+            `:ms`, so it enqueues immediately and folds in the current drain — no
+            host-clock timer is armed and no synthetic delayed metadata is
+            attached."
+    (rf/reg-machine :hsb.d/ca (mk-child :hsb.d/rp))
+    (rf/reg-machine :hsb.d/cb (mk-child :hsb.d/rp))
+    (reg-parent! :hsb.d/rp :hsb.d/ca :hsb.d/cb)
+    (rf/dispatch-sync [:hsb.d/rp [:start]])
+    (let [a           (get-in (join-state :hsb.d/rp) [:children :a])
+          armed?      (atom false)]
+      (with-redefs [interop/set-timeout!   (fn [_f _ms] (reset! armed? true) ::handle)
+                    interop/clear-timeout! (fn [_] nil)]
+        (rf/dispatch-sync [a [:go]]))
+      (is (false? @armed?)
+          "a direct :dispatch completion armed NO host-clock timer")
+      (is (= #{:a} (:done (join-state :hsb.d/rp)))
+          "the direct :dispatch completion folded synchronously in the current drain"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) a POSITIVE-delay :dispatch-later completion also DEFERS (parity w/ ms=0).
+;; ---------------------------------------------------------------------------
+
+(deftest positive-delay-completion-defers
+  (testing "rf2-21hsb1 — a positive-delay `:dispatch-later {:ms 500 ...}`
+            completion also defers on the host clock and does not fold
+            synchronously (the fix keeps every numeric delay — 0 and positive —
+            host-clock-delayed, uniformly)."
+    (rf/reg-machine :hsb.p/ca (mk-child-delayed :hsb.p/rp 500))
+    (rf/reg-machine :hsb.p/cb (mk-child-delayed :hsb.p/rp 500))
+    (reg-parent! :hsb.p/rp :hsb.p/ca :hsb.p/cb)
+    (rf/dispatch-sync [:hsb.p/rp [:start]])
+    (let [a           (get-in (join-state :hsb.p/rp) [:children :a])
+          captured-cb (atom nil)
+          captured-ms (atom ::none)]
+      (with-redefs [interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
+                    interop/clear-timeout! (fn [_] nil)]
+        (rf/dispatch-sync [a [:go]]))
+      (is (= 500 @captured-ms) "the positive :ms was forwarded to the host-clock timer")
+      (is (some? @captured-cb) "the positive-delay completion armed a delayed dispatch")
+      (is (= #{} (:done (join-state :hsb.p/rp)))
+          "the positive-delay completion did NOT fold synchronously"))))


### PR DESCRIPTION
Follow-up to the merged #5881 / rf2-lud4af (join-dispatch through the shared reserved-dispatch path). Two P1 correctness fixes on `core/fx` + `machines/join`, built on `fx/child-dispatch!` + the `:rf.machine/join-dispatch` thin handler — no parallel dispatch path added. Commit order: ulsbgr → 21hsb1.

## rf2-ulsbgr — canonical dispatch overrides intercept join completions

**Problem.** #5881 rewrites an authored join-completion `[:dispatch completion]` / `:dispatch-later` effect into the private `:rf.machine/join-dispatch` effect **before** core effect override resolution. `do-fx` therefore looked up per-call `:fx-overrides` under the private rewritten id, so a caller's `{:fx-overrides {:dispatch capture-fn}}` inherited the override in the envelope but never got to intercept the completion — the reserved transport called `child-dispatch!` and folded the parent anyway (violating Spec 008's rule that an effect override pre-empts queueing, and missing rf2-lud4af's capture-override acceptance criterion).

**Fix.** `join-dispatch-fx` now resolves the **canonical** override first, against the same effective override map `do-fx` used (per-frame join per-call, per-call winning — mirrors `router/apply-overrides`). When the completion's authored id (`:dispatch-later` for a numeric `:ms`, else `:dispatch`) is overridden, it routes the canonical `[fx-id args]` back through the shared core seam `re-frame.fx/handle-one-fx` — the identical resolution a normal dispatch flows through (fn-value pre-empts / keyword-redirect / traces), the same wrapper-fx re-entry pattern `:rf.route/with-nav-token` uses. The override captures/redirects the completion, queues nothing, folds nothing, and **no** private join authority is minted, so an application override can never forge or replay the recordable authority into the normal path. Only an **unoverridden** completion is lowered to the recordable transport. Extracts `fx/real-override?` as the shared "is this fx overridden" predicate (DRY with the reject-tier gate) — no second override engine, no exposed private effect.

**Red-before-fix fixture:** `implementation/machines/test/re_frame/join_dispatch_override_intercept_cljs_test.cljc` (CLJ + CLJS). A fn-value `:dispatch` override, a keyword-redirect `:dispatch` override, and a `:dispatch-later` override (both `:ms 0` and positive) each capture the unchanged public completion exactly once with the parent folding nothing; a control asserts an unoverridden completion still folds and an override of an *unrelated* effect does not divert it. Disabling the override branch (verified locally) fails all seven capture assertions — the parent folds instead.

## rf2-21hsb1 — preserve the zero-delay scheduling boundary for join completions

**Problem.** `join-dispatch-fx` forwarded `:ms` only when `(pos? ms)`, so an application-authored `:dispatch-later {:ms 0 ...}` completion lost its delayed classification and folded **immediately** in the current drain. The canonical `re-frame.fx/child-dispatch!` path treats every numeric `:ms` — including zero — as host-clock-delayed (Spec 002 §long-running work uses zero delay to yield through the host clock for a render/scheduling opportunity). Collapsing zero into immediate dispatch changed event order, drain batching, render opportunities, frame-owned timer cancellation, and observability, and dropped `:source-detail {:ms 0}`. The merged t154jx transport test asserted the synchronous fold, so green CI had encoded the regression.

**Fix.** Forward `:ms` + delayed source-detail for **every** numeric delay (`(number? ms)`, not `(pos? ms)`); a direct `:dispatch` (nil `:ms`) stays immediate. Reuses `child-dispatch!`'s existing frame-owned scheduling/cancellation path — no join-specific timer.

**Red-before-fix fixtures.** `implementation/machines/test/re_frame/join_zero_delay_boundary_cljs_test.cljc` (CLJ + CLJS) pins: a `:ms 0` completion is armed on the host clock and does **not** fold synchronously (the mutation tooth — restoring `(pos? ms)` folds it in-drain and fails), a positive delay defers likewise, and a direct `:dispatch` stays immediate (no timer, no synthetic delayed metadata) — all deterministic via the `interop/set-timeout!` seam. The t154jx test in `join_recordable_transport_cljs_test.cljc` is corrected from asserting a synchronous `:ms 0` fold to pinning the async boundary: the zero-delay completion defers, then authenticates + folds after the controlled host-clock callback, retaining `:source-detail {:ms 0}`. Restoring `(pos? ms)` (verified locally) fails these zero-delay assertions on CLJ and CLJS.

## Dedup note — rf2-i7uodx

`rf2-i7uodx` is a **byte-identical duplicate** of `rf2-ulsbgr`: same title, Problem, Acceptance Criteria, external ref (`gh-5881-audit-dispatch-overrides`), and discovered-from (`rf2-lud4af`). It is fixed by this PR's ulsbgr work and should be closed as a duplicate of rf2-ulsbgr — no separate PR.

## Quality gates

- `implementation/machines` `clojure -M:test` — 1070 tests, 0 failures.
- `implementation/core` `clojure -M:test` (fx + reserved-dispatch + dispatch-later suites) — 1978 tests, 0 failures.
- `implementation` `npm run test:cljs` (node) — 9405 tests, 0 failures. Both new fixtures verified to *execute* on CLJS (a deliberate assertion break failed the CLJS run, then reverted).
- Rebased onto current `origin/main`; scope limited to `core/fx.cljc` + `machines/lifecycle_fx/join.cljc` + their tests. Browser suite / full PR spine deferred to CI (no browser surface).
