### PR TITLE
fix(ui): preserve self-head precedence + prove real CLJS authoring-head routing (rf2-vxgfnd.274)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -1833,6 +1833,43 @@
         {:op :expr :form (walk-expr e [:expr] form)
          :static? false :path (:path e)}))))
 
+;; ---------------------------------------------------------------------------
+;; Vector-head precedence (rf2-vxgfnd.274)
+;; ---------------------------------------------------------------------------
+;;
+;; A symbol head classifies by RESOLUTION at expansion time (the Q5 rule,
+;; env/classify-head), but two reservations run in `analyze`'s dispatch
+;; AHEAD of `env/classify-head`: the frame-boundary heads (frame-root /
+;; frame-provider) and the reactive-authoring verbs (sub / lease / frame,
+;; rf2-vxgfnd.266). Both key on Var resolution — so a head equal to the view
+;; being `defview`d right now (`:self`) that ALSO resolves to a referred
+;; public authoring Var (`(defview sub [] [sub …])` in a namespace that
+;; refers `re-frame.ui/sub`) was reserved-then-rejected BEFORE the Q5
+;; self-recursion rule could select it as an internal view — even though the
+;; view Var may not exist yet, so classification here cannot depend on Var
+;; resolution at all (Q5 rule 1). The one true precedence ordering is:
+;;
+;;   1. a local/dynamic binding of the spelling (checked inside every head
+;;      predicate and env/classify-head) — a lexical shadow outranks self;
+;;   2. the exact, unshadowed `:self` — an internal-view head, resolution-free;
+;;   3. the reserved frame-boundary / reactive-authoring heads (Var-resolved);
+;;   4. ordinary internal/foreign classification (env/classify-head).
+;;
+;; `self-head?` is tier 2 — it fires before every reserved-head predicate so a
+;; genuine self-recursive head is never reclassified as a reserved verb.
+
+(defn- self-head?
+  "True when `head` is the exact, unshadowed symbol of the view currently
+  being compiled (`:self`). Self-recursion outranks every reserved-head
+  reservation because the view Var may not exist yet — classification cannot
+  depend on Var resolution here (Q5 rule 1). A local binding of the same
+  spelling (checked first) still outranks self and yields a dynamic head."
+  [e head]
+  (and (:self e)
+       (symbol? head)
+       (= head (:self e))
+       (not (contains? (:locals e) head))))
+
 (defn analyze
   "Template form -> AST node."
   [e form]
@@ -1851,6 +1888,12 @@
       (cond
         (= :<> head)     (analyze-fragment e form)
         (keyword? head)  (analyze-element e form)
+        ;; The exact unshadowed self outranks every reserved-head reservation
+        ;; below (rf2-vxgfnd.274): the view Var may not exist yet, so a
+        ;; self-recursive head classifies as an internal view up front —
+        ;; resolution-free — before any Var-resolved reservation (frame
+        ;; boundary / reactive authoring) can reclassify it.
+        (self-head? e head) (analyze-component e form)
         (frame-root-head? e head) (analyze-frame-root e form)
         (frame-provider-head? e head) (analyze-frame-provider e form)
         ;; Reserve sub/lease/frame BEFORE generic component classification

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -52,6 +52,19 @@
                      :resolver resolver})
       (assoc :self-children? false :self-closed-keys nil)))
 
+(defn mk-self-env
+  "Like `mk-env` but the view being compiled (`:self`) is `self-sym`. The
+  injected resolver ALSO resolves sub/lease/frame to their public reactive
+  authoring vars, so this env is the rf2-vxgfnd.274 crux: a head equal to
+  `self-sym` must classify as a self-recursive internal view BEFORE the
+  reactive-authoring reservation can reject it."
+  [self-sym]
+  (-> (env/make-env {:host :clj :ns-sym 'app.test
+                     :self self-sym
+                     :self-id (keyword "app.test" (name self-sym))
+                     :resolver resolver})
+      (assoc :self-children? false :self-closed-keys nil)))
+
 (defn ana* [form]
   (ana/analyze (mk-env) form))
 
@@ -182,6 +195,38 @@
     (let [{:keys [sites]} (ana-full '[:div (:frame (frame))])]
       (is (= 1 (count (:frame-ops sites)))
           "a direct (frame) read is one indexed frame-ops site"))))
+
+(deftest self-head-outranks-reactive-verb-reservation
+  ;; rf2-vxgfnd.274 — vector-head precedence. A head equal to the view being
+  ;; `defview`d right now (`:self`) classifies as an internal view BEFORE the
+  ;; reactive-authoring reservation (rf2-vxgfnd.266) can reject it, EVEN THOUGH
+  ;; the same injected resolver resolves that spelling to a public reactive
+  ;; authoring var. Self-recursion works because the view Var need not exist yet
+  ;; (Q5 rule 1) — so classification here is resolution-free. Reverting the
+  ;; precedence to reserved-before-self throws :rf.ui.compile/unsupported-form
+  ;; on every accept row below, so this deftest is the mutation fixture.
+  (doseq [verb '[sub lease frame]]
+    (let [e   (mk-self-env verb)
+          ast (ana/analyze e [verb {}])]
+      (is (= :view (:op ast))
+          (str "a recursive [" verb " …] self head classifies as an internal view"))
+      (is (= (keyword "app.test" (name verb)) (:view-id ast))
+          (str verb " registers under the defview's own view id, not the verb var"))
+      (is (= verb (:sym ast)) "the authored self spelling is preserved")))
+  (testing "a self head nested deep in the template still classifies as a view"
+    (let [ast (ana/analyze (mk-self-env 'sub) '[:div [:section [sub {}]]])]
+      (is (= :view (get-in ast [:children 0 :children 0 :op]))
+          "self precedence is carried through the whole template walk")))
+  (testing "a self head accepts children when the view declares them"
+    (let [ast (ana/analyze (assoc (mk-self-env 'sub) :self-children? true)
+                           '[sub {} [:p "kid"]])]
+      (is (= :view (:op ast)))
+      (is (= 1 (count (:children ast))) "self-recursion with declared children")))
+  (testing "a self head mints NO reactive site — it is a view, not a sub read"
+    (let [e   (mk-self-env 'sub)
+          _   (ana/analyze e '[sub {}])]
+      (is (empty? (:subs @(:sites e)))
+          "the self head does not leak the public authoring var into the manifest"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Handlers

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -4,13 +4,22 @@
   roster keys off these ids. Runs on both hosts (injected resolution)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.analyze-accept-cljs-test :refer [mk-env]]))
+            [re-frame.ui.analyze-accept-cljs-test :refer [mk-env mk-self-env]]))
 
 (defn reject-id
   "nil when accepted; the :rf.ui.compile/error id when rejected."
   [form]
   (try
     (ana/analyze (mk-env) form)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
+      (:rf.ui.compile/error (ex-data ex)))))
+
+(defn reject-id-in
+  "reject-id against a supplied env (for self-head precedence rows)."
+  [e form]
+  (try
+    (ana/analyze e form)
     nil
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
       (:rf.ui.compile/error (ex-data ex)))))
@@ -268,6 +277,22 @@
   ;; a genuine foreign component head still classifies (accepts)
   (is (nil? (reject-id '[ForeignComp {}]))
       "a genuine foreign component head still classifies as :foreign"))
+
+(deftest local-shadow-outranks-self-head
+  ;; rf2-vxgfnd.274 — self precedence is tier 2: a LEXICAL SHADOW of the self
+  ;; spelling (tier 1) still outranks it. In a view `defview`d as `sub`, a local
+  ;; also named `sub` makes the head a dynamic (local) head — never the self
+  ;; view — exactly as the Q5 rule pins (a local-bound head is a compile error,
+  ;; since dynamic component heads are rejected).
+  (let [e (mk-self-env 'sub)]
+    (is (= :rf.ui.compile/dynamic-head
+           (reject-id-in e '(let [sub identity] [sub {}])))
+        "a let-bound local named sub outranks the self view named sub")
+    (is (= :rf.ui.compile/dynamic-head
+           (reject-id-in e '(letfn [(sub [_] nil)] [sub {}])))
+        "a letfn binding named sub shadows self and is a dynamic head too")
+    (is (= :view (:op (ana/analyze e '[sub {}])))
+        "control: without a shadow the same self head IS the internal view")))
 
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -6,7 +6,8 @@
             [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing]]
             [re-frame.ui.compiler.analyze :as analyze]
-            [re-frame.ui.compiler.env :as env]))
+            [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.compiler.root :as root]))
 
 (defmacro user-binder
   [[binding init] then else]
@@ -113,3 +114,117 @@
                       '[{sub :s x sub}]]]
           (is (nil? (compile-error-id #(analyze/reject-reactive-binding! e argv)))
               (pr-str argv)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.274 — self-head precedence + real CLJS authoring-head routing
+;; ---------------------------------------------------------------------------
+;;
+;; The .266 pure-analyzer fixtures inject Q5 resolution, and its real-host proof
+;; (defview_grammar_jvm_test) covers CLJ macroexpansion + fully-qualified
+;; spellings only. Neither exercised production `cljs.analyzer.api/resolve` with
+;; REFERRED / ALIASED spellings, nor the separate CLJS root-entry compiler. This
+;; harness stands up a REAL CLJS analyzer namespace state where cljs.user refers
+;; re-frame.ui/{sub,lease,frame} (and aliases the ns `ui`), so every spelling
+;; resolves through the production resolver — NOT an injected stub — and drives
+;; both the defview route (analyze) and the root-entry route (root/analyze-root).
+
+(defn- with-referred-cljs-env
+  "Populate a real CLJS compiler state where cljs.user REFERS re-frame.ui/sub,
+  lease, frame (+ frame-root/frame-provider) and aliases the ns as `ui`, then
+  call `(f aenv)` with a live analyzer env over that ns. Resolution runs through
+  production `cljs.analyzer.api/resolve` — there is no injected `:resolver`."
+  [f]
+  (binding [cljs-env/*compiler* (cljs-env/default-compiler-env)]
+    (swap! cljs-env/*compiler* update :cljs.analyzer/namespaces merge
+           {'re-frame.ui  {:name 're-frame.ui
+                           :defs {'sub            {:name 're-frame.ui/sub}
+                                  'lease          {:name 're-frame.ui/lease}
+                                  'frame          {:name 're-frame.ui/frame}
+                                  'frame-root     {:name 're-frame.ui/frame-root}
+                                  'frame-provider {:name 're-frame.ui/frame-provider}}}
+            'cljs.user    {:name 'cljs.user
+                           ;; `(:require [re-frame.ui :as ui :refer [...]])`
+                           :requires {'ui 're-frame.ui 're-frame.ui 're-frame.ui}
+                           :uses     {'sub 're-frame.ui 'lease 're-frame.ui
+                                      'frame 're-frame.ui 'frame-root 're-frame.ui
+                                      'frame-provider 're-frame.ui}
+                           :defs {}}})
+    (f (assoc (cljs-api/empty-env)
+              :ns (get-in @cljs-env/*compiler*
+                          [:cljs.analyzer/namespaces 'cljs.user])))))
+
+(defn- referred-env
+  "An analyzer env over the referred cljs.user; `self-sym` (or nil) is the view
+  currently being compiled."
+  [aenv self-sym]
+  (cond-> (env/make-env {:host :cljs :cljs-env aenv :ns-sym 'cljs.user})
+    self-sym (assoc :self self-sym
+                    :self-id (keyword "cljs.user" (name self-sym))
+                    :self-children? false :self-closed-keys nil)))
+
+(deftest real-cljs-referred-verb-resolution-is-genuine
+  ;; Sanity: production cljs.analyzer.api/resolve — not an injected resolver —
+  ;; resolves every referred / aliased / fully-qualified spelling to the
+  ;; re-frame.ui authoring vars. The rows below route through THIS resolution.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [base (referred-env aenv nil)]
+        (doseq [[sym fqn] '{sub               re-frame.ui/sub
+                            ui/sub            re-frame.ui/sub
+                            re-frame.ui/sub   re-frame.ui/sub
+                            lease             re-frame.ui/lease
+                            ui/lease          re-frame.ui/lease
+                            frame             re-frame.ui/frame
+                            re-frame.ui/frame re-frame.ui/frame}]
+          (is (= fqn (:fqn (env/resolve-sym base sym))) (str sym)))
+        (is (nil? (env/resolve-sym base 'not-a-thing))
+            "an unresolvable spelling is genuinely unresolved (no stub)")))))
+
+(deftest real-cljs-self-head-outranks-reservation-defview-route
+  ;; rf2-vxgfnd.274 defview route under REAL CLJS resolution. The REFERRED
+  ;; spelling is the self-recursive case (a view named `sub` recursing on a bare
+  ;; [sub …] head) — it classifies as an internal view. The ALIASED and
+  ;; FULLY-QUALIFIED spellings in an UNRELATED view (no :self) stay reserved
+  ;; typed rejects, never foreign components. A local shadow outranks self.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (testing "a referred self head classifies as an internal view"
+        (doseq [verb '[sub lease frame]]
+          (let [e   (referred-env aenv verb)
+                ast (analyze/analyze e [verb {}])]
+            (is (= :view (:op ast)) (str verb))
+            (is (= (keyword "cljs.user" (name verb)) (:view-id ast)) (str verb)))))
+      (testing "aliased / fully-qualified / referred verbs in an unrelated view stay reserved"
+        (let [e (referred-env aenv nil)]
+          (doseq [form '[[ui/sub {}] [re-frame.ui/lease {}] [frame]
+                         [ui/frame {}] [re-frame.ui/sub {}] [lease {}]]]
+            (is (= :rf.ui.compile/unsupported-form
+                   (compile-error-id #(analyze/analyze e form)))
+                (pr-str form)))))
+      (testing "a local shadow of the self spelling is a dynamic head (tier 1 wins)"
+        (let [e (referred-env aenv 'sub)]
+          (is (= :rf.ui.compile/dynamic-head
+                 (compile-error-id #(analyze/analyze e '(let [sub identity] [sub {}])))))))
+      (testing "the reservation stays narrow — a direct (sub …) still indexes one site"
+        (let [e (referred-env aenv 'panel)]
+          (analyze/analyze e '[:div (sub [:q])])
+          (is (= 1 (count (:subs @(:sites e))))
+              "a direct compiler-owned (sub …) call still lowers to a manifest site"))))))
+
+(deftest real-cljs-root-entry-reserves-reactive-verbs
+  ;; rf2-vxgfnd.274 root-entry route. The mount/render!/hydrate-root compiler
+  ;; (root/analyze-root) REUSES analyze/analyze, so the reservation holds at the
+  ;; root too: a public authoring verb head at root can never become a :foreign
+  ;; component. Bypassing the canonical-FQN reservation makes each [verb …] root
+  ;; compile :foreign and fail these rows (the root-compilation mutation
+  ;; fixture); a legal element root is untouched. (Roots carry no :self, so the
+  ;; self-precedence tier never applies here — only the reservation does.)
+  (with-referred-cljs-env
+    (fn [aenv]
+      (doseq [form '[[sub {}] [ui/lease {}] [re-frame.ui/frame] [frame]]]
+        (is (= :rf.ui.compile/unsupported-form
+               (compile-error-id #(root/analyze-root (referred-env aenv nil) 'ui/mount form)))
+            (pr-str form)))
+      (testing "a legal element root still analyzes through the root compiler"
+        (is (= :element
+               (:op (:ast (root/analyze-root (referred-env aenv nil) 'ui/mount '[:div "x"])))))))))

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -5,11 +5,13 @@
   these pins hold for the CLJS expansion path too."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            ;; `sub` is referred so a BARE `sub` in a header default resolves to
-            ;; re-frame.ui/sub through REAL CLJ macroexpansion — the rf2-vxgfnd.268
-            ;; ordered-scope proofs need the bare (non-qualified) spelling that the
-            ;; dzyqis flat scope over-accepted.
-            [re-frame.ui :as ui :refer [defview sub]]
+            ;; `sub`/`lease`/`frame` are referred so a BARE spelling resolves to
+            ;; the public reactive authoring var through REAL CLJ macroexpansion.
+            ;; The rf2-vxgfnd.268 ordered-scope proofs need the bare `sub` the
+            ;; dzyqis flat scope over-accepted; the rf2-vxgfnd.274 self-precedence
+            ;; proofs need all three bare spellings so a recursive `defview`
+            ;; named for a verb reproduces the reserved-before-self escape.
+            [re-frame.ui :as ui :refer [defview sub lease frame]]
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
@@ -149,6 +151,42 @@
       "sub is still legal as its compiler-owned direct call — only the head is reserved")
   (is (nil? (expand-error '(re-frame.ui/defview v [] [:div (:frame (re-frame.ui/frame))])))
       "a direct (frame) read still expands — only the head form is reserved"))
+
+(deftest self-recursive-defview-named-reactive-verb-compiles-through-real-resolution
+  ;; rf2-vxgfnd.274 — the escape the .266 reservation opened. A `defview` whose
+  ;; OWN name is a referred reactive authoring verb recurses on itself with a
+  ;; bare `[self …]` head. That head resolves (through REAL CLJ macroexpansion,
+  ;; *ns* bound below so the bare spelling is the referred re-frame.ui var) to
+  ;; the public authoring var — so the .266 reservation rejected it BEFORE the
+  ;; Q5 self-recursion rule could select it, even though the view Var may not
+  ;; exist yet. Self precedence (tier 2) now fires ahead of the reservation.
+  ;; Reverting to reserved-before-self re-throws :rf.ui.compile/unsupported-form
+  ;; on the accept rows, so this deftest is the real-host mutation fixture.
+  (binding [*ns* (find-ns 're-frame.ui.defview-grammar-jvm-test)]
+    (testing "a recursive defview named for each reactive verb expands cleanly"
+      (is (nil? (expand-error '(re-frame.ui/defview sub [] [sub {}])))
+          "a view named sub recurses on a bare [sub …] self head")
+      (is (nil? (expand-error '(re-frame.ui/defview lease [] [lease {}])))
+          "a view named lease recurses on a bare [lease …] self head")
+      (is (nil? (expand-error '(re-frame.ui/defview frame [] [frame {}])))
+          "a view named frame recurses on a bare [frame …] self head"))
+    (testing "a local binding of the self spelling still outranks self (tier 1)"
+      (is (= :rf.ui.compile/dynamic-head
+             (expand-error
+              '(re-frame.ui/defview sub [{:keys [sub]}] [sub {}])))
+          "a header slot named sub shadows self — the head is a dynamic head"))
+    (testing "the emitted output carries NO surviving public authoring var"
+      ;; rf2-vxgfnd.274 output proof: the self head lowers to the view's own
+      ;; registered component, never a re-frame.ui/sub reference or a lowered
+      ;; sub-read site — the public authoring function does not reach executable
+      ;; output through the recursive head.
+      (let [text (pr-str (macroexpand-1 '(re-frame.ui/defview sub [] [sub {}])))]
+        (is (not (re-find #"re-frame\.ui/sub" text))
+            "no qualified re-frame.ui/sub survives the self head")
+        (is (not (re-find #"sub-read" text))
+            "the self head is a view element, not a lowered reactive read")
+        (is (re-find #"register-view!" text)
+            "the recursive view still registers as an ordinary internal view")))))
 
 (deftest an-opaque-macro-cannot-inject-an-unmanifested-template-site
   (is (= :rf.ui.compile/unsupported-form


### PR DESCRIPTION
Follow-up to the merged authoring-head/reserve-verbs family (#5883/.266 reserve reactive verbs, #5890/.268 destructuring scope) on `analyze.cljc`.

## Problem

`.266` reserved resolved `sub`/`lease`/`frame` component heads BEFORE generic component classification, but that reservation runs ahead of the compiler's Q5 self-recursion rule. In a namespace that refers the public verbs, each recursive definition — `(defview sub [] [sub {}])`, and the equivalents named `lease` / `frame` — failed with `:rf.ui.compile/unsupported-form`: the environment correctly marks `:self`, but the resolver still sees the referred `re-frame.ui/sub`, so the reserved-head rejection won before `env/classify-head` could select self. An unshadowed head equal to the current `defview`'s `:self` must classify as an internal view WITHOUT Var resolution, because the view Var may not exist yet.

Re-verified against current `analyze.cljc` (post #5883/.266 + #5890/.268): the bug reproduced on `main` through the pure analyzer, real CLJS `cljs.analyzer.api/resolve`, and real CLJ macroexpansion.

## Fix (smallest elegant correction)

Centralize vector-head precedence in `analyze`'s dispatch — one new `self-head?` predicate, one branch, extending the merged head-classification (no parallel classifier):

1. a local/dynamic binding of the spelling (checked inside every head predicate and `env/classify-head`) — a lexical shadow outranks self;
2. the exact, unshadowed `:self` — an internal-view head, **resolution-free**;
3. the reserved frame-boundary / reactive-authoring heads (Var-resolved);
4. ordinary internal/foreign classification.

`self-head?` (tier 2) fires before every reserved-head predicate, so a genuine self-recursive head is never reclassified as a reserved verb. The root-entry compiler (`root/analyze-root`) reuses `analyze/analyze`, so the ordering holds identically for `mount`/`render!`/`hydrate-root` (roots carry no `:self`, so only the reservation applies there).

## Proof of real CLJS authoring-head routing

The `.266` fixtures inject Q5 resolution; `.268`'s real-host proof covered CLJ macroexpansion + fully-qualified spellings only. This PR adds a real-CLJS analyzer fixture (`compiler_macro_resolution_jvm_test`) that stands up genuine `cljs.analyzer/namespaces` state where `cljs.user` **refers** `re-frame.ui/{sub,lease,frame}` and **aliases** the ns `ui`, so referred / aliased / fully-qualified spellings all resolve through production `cljs.analyzer.api/resolve` — no injected resolver — and drives BOTH the `defview` route and the `root/analyze-root` root-entry route.

- **Self precedence (accept):** referred `[sub …]`/`[lease …]`/`[frame …]` self heads classify `:view` under real resolution, pure-analyzer resolution, and real CLJ macroexpansion.
- **Reservation stays typed (reject):** aliased `[ui/sub …]`, fully-qualified `[re-frame.ui/lease …]`, and referred verbs in unrelated views (and at root) remain `:rf.ui.compile/unsupported-form`, never `:foreign`.
- **Local outranks self:** a lexical shadow of the self spelling is a dynamic head.
- **Narrow reservation preserved:** a direct `(sub [:q])` call still lowers to one manifest site.
- **Output proof:** the emitted output of a recursive `defview sub` carries no surviving `re-frame.ui/sub` reference and no lowered `sub-read` — the public authoring function does not reach executable output through the recursive head.

## Mutation controls (verified)

- **A — reserved-before-self:** disabling the `self-head?` branch throws `:rf.ui.compile/unsupported-form` on the recursive controls across all three routes (3 fails / 4 errors in the affected nses).
- **B — bypass canonical-FQN reservation:** removing the reactive-authoring reservation makes the real-CLJS `defview` and root-entry fixtures compile `:foreign` and fail.

## Scope / coordination

- Touches `analyze.cljc` + its tests only. Diagnostic wording stays with open `.233`; the Spec 004 special-form grammar ripple is coordinated with `.224` (no grammar reserves these verbs as view-definition names — this fix preserves that: local binding precedence still outranks self, self outranks the Var-resolved reservations).

## Quality gates

- `cd implementation/ui && clojure -M:test` — **523 tests, 6527 assertions, 0 failures, 0 errors** (analyze_accept / analyze_reject / defview_grammar / compiler_macro_resolution / error_roster / g14 …).
- `cd implementation && npm run test:cljs` — **9400 tests, 44601 assertions, 0 failures, 0 errors** (node runtime; real CLJS `.cljc` fixtures).
- Mutation controls A + B verified red; restored fix green.
