### PR TITLE
fix(core): reload-safe + weak-lifecycle-proven observation provenance + close schema-gate false-greens (rf2-qqvgk1/5iud0a)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -195,7 +195,8 @@
 ;;     drain mistook trace coverage for full coverage and emitted nothing.
 ;;   - THROWABLE-BOUND / NON-FORGEABLE (rf2-9m4oy7) — the [[EmissionProvenance]]
 ;;     token is bound to the EXACT throwable it attests through a PRIVATE weak
-;;     identity association ([[provenance-by-throwable]]), keyed by the throwable
+;;     identity association (the reload-safe [[provenance-storage]] holder on the
+;;     JVM, a `provenance-by-throwable` `js/WeakMap` on CLJS), keyed by the throwable
 ;;     OBJECT and written ONLY by [[attest-provenance!]] here. It is NOT carried
 ;;     in the thrown ex-data. This closes two spoof vectors an ex-data token
 ;;     could not: (a) an application `on-change` can call the cross-namespace
@@ -269,20 +270,103 @@
 ;; `hashCode`/`equals` — with cleared entries reclaimed on each access. `js/WeakMap`
 ;; is genuinely identity-keyed (reference keys, ephemeron semantics) with no such
 ;; hazard, so CLJS keeps it unchanged.
-#?(:clj
-   (defonce ^:private ^java.lang.ref.ReferenceQueue provenance-queue
-     (java.lang.ref.ReferenceQueue.)))
+;; ---- RELOAD-SAFE private provenance storage (rf2-qqvgk1) --------------------
+;;
+;; On the JVM the storage is a VERSIONED HOLDER — a plain Clojure map
+;; `{:version N :by-throwable <HashMap> :queue <ReferenceQueue>}` — `defonce`'d so
+;; an ordinary same-version namespace reload KEEPS the live entries, but reconciled
+;; at load ([[ensure-current-provenance-storage!]]) so a reload over an INCOMPATIBLE
+;; predecessor root is RECOGNIZED and REPLACED rather than silently mis-operated.
+;; This closes an HMR/REPL upgrade hazard the bare-`defonce` shape carried: the
+;; predecessor representation (rf2-9m4oy7) was a synchronized `WeakHashMap<Throwable>`
+;; under this same Var; a plain `defonce` retains that old root across a reload onto
+;; the current weak-identity code, so existing raw-Throwable entries are unreachable
+;; through the new `WeakReference` lookup key AND a freshly-`defonce`'d queue desyncs
+;; from the retained map. Bundling the map + queue in ONE holder makes them
+;; impossible to desync, and the version tag makes an incompatible predecessor
+;; detectable.
+;;
+;; The version carrier is a plain Clojure MAP, NOT a `deftype`, ON PURPOSE: a
+;; namespace reload REDEFINES a `deftype`'s class, so an `instance?`-based
+;; recognition would read false on EVERY reload and drop the entries; a Clojure
+;; map's class (`PersistentArrayMap`) is stable across reloads, so version
+;; recognition is stable and repeated reloads stay idempotent.
+;;
+;; A `WeakReference`-subclass identity-key ([[weak-identity-key]]) → `EmissionProvenance`.
+;; The inner `by-throwable` is a plain `HashMap` guarded by `locking` on that map
+;; (the node-records lock discipline); NOT a `WeakHashMap` — weakness comes from the
+;; `WeakReference` KEYS + ReferenceQueue expunge, IDENTITY from the keys' own
+;; `hashCode`/`equals`. `js/WeakMap` on CLJS is genuinely identity-keyed with
+;; ephemeron semantics and NO reload hazard (a page reload is a fresh JS realm), so
+;; CLJS keeps the bare `defonce` unchanged.
+#?(:clj (def ^:private provenance-storage-version
+          ;; Representation version of the private JVM provenance storage. BUMP when
+          ;; the holder shape changes so a reload over an older root REPLACES it. v2
+          ;; = the weak-identity `HashMap<WeakReference-key>` + `ReferenceQueue`
+          ;; (predecessor v1 was a raw synchronized `WeakHashMap<Throwable>` with NO
+          ;; version tag, so it reads uncurrent and is replaced).
+          2))
 
 #?(:clj
-   (defonce ^:private ^java.util.Map provenance-by-throwable
-     ;; identity-key (a `WeakReference` subclass, [[weak-identity-key]]) →
-     ;; `EmissionProvenance`. A plain `HashMap` guarded by `locking
-     ;; provenance-by-throwable` (the node-records lock discipline). NOT a
-     ;; `WeakHashMap`: weakness comes from the `WeakReference` KEYS + ReferenceQueue
-     ;; expunge, IDENTITY from the keys' own `hashCode`/`equals`.
-     (java.util.HashMap.))
+   (defn- fresh-provenance-storage
+     "A fresh CURRENT-version provenance storage holder: an empty identity-keyed
+     `HashMap` paired with its OWN `ReferenceQueue`, tagged with the current
+     representation version (rf2-qqvgk1)."
+     []
+     {:version      provenance-storage-version
+      :by-throwable (java.util.HashMap.)
+      :queue        (java.lang.ref.ReferenceQueue.)}))
+
+#?(:clj
+   (defn- current-provenance-storage?
+     "True when `s` is a CURRENT-version provenance storage holder — a Clojure map
+     tagged with [[provenance-storage-version]]. A predecessor raw `WeakHashMap`
+     (`map?` false) or an older/newer-version holder reads false, so the load-time
+     reconciliation replaces it (rf2-qqvgk1)."
+     [s]
+     (and (map? s) (= provenance-storage-version (:version s)))))
+
+#?(:clj
+   (defonce ^:private provenance-storage (fresh-provenance-storage))
    :cljs
    (defonce ^:private provenance-by-throwable (js/WeakMap.)))
+
+#?(:clj
+   (defn- ensure-current-provenance-storage!
+     "Reconcile the `defonce`'d [[provenance-storage]] root to the current
+     representation version. Idempotent + atomic — an `alter-var-root` with a pure
+     compare-and-replace: a fresh JVM keeps the `defonce` initializer's current
+     storage; a RELOAD over an incompatible predecessor / older-version root REPLACES
+     it with a fresh current holder; a SAME-version reload is a NO-OP that preserves
+     every live entry (and the SAME holder object, so repeated reloads converge).
+
+     The explicit private reload rule (rf2-qqvgk1): a same-version reload PRESERVES
+     entries; a version-mismatch REPLACE drops predecessor-bound provenance, so any
+     in-flight predecessor throwable reads UNCOVERED — the disposal drain then fails
+     LOUD (an extra catalogued `:rf.error/observation-on-change-failed` record),
+     never silent or corrupt. Runs on EVERY ns load (not `defonce`-guarded), so
+     reverting to a bare `defonce` of the map is a detectable regression: the reload
+     fixture, which seeds a predecessor root and re-runs this, reddens."
+     []
+     (alter-var-root #'provenance-storage
+                     (fn [s] (if (current-provenance-storage? s) s (fresh-provenance-storage))))
+     nil))
+
+;; Recognize + replace an incompatible predecessor / older-version root on load.
+#?(:clj (ensure-current-provenance-storage!))
+
+#?(:clj
+   (defn- provenance-map
+     "The current identity-keyed provenance `HashMap` (rf2-qqvgk1)."
+     ^java.util.Map []
+     (:by-throwable provenance-storage)))
+
+#?(:clj
+   (defn- provenance-ref-queue
+     "The current provenance `ReferenceQueue` — bundled with [[provenance-map]] in
+     the one holder so the two can never desync across a reload (rf2-qqvgk1)."
+     ^java.lang.ref.ReferenceQueue []
+     (:queue provenance-storage)))
 
 #?(:clj
    (defn- weak-identity-key
@@ -308,15 +392,16 @@
 #?(:clj
    (defn- expunge-stale-provenance!
      "Reclaim entries whose throwable has been collected (rf2-fs99nq): poll the
-     ReferenceQueue for cleared keys and drop each from the map. Removal matches the
-     EXACT enqueued key by identity (`equals` short-circuits on `identical? this o`),
-     so a cleared referent is never dereferenced and the throwable's own
-     `hashCode`/`equals` are never invoked. Call under `locking
-     provenance-by-throwable`."
-     []
+     ReferenceQueue `q` for cleared keys and drop each from the map `m`. Removal
+     matches the EXACT enqueued key by identity (`equals` short-circuits on
+     `identical? this o`), so a cleared referent is never dereferenced and the
+     throwable's own `hashCode`/`equals` are never invoked. `m` + `q` are the paired
+     members of the one [[provenance-storage]] holder (rf2-qqvgk1), so they never
+     desync. Call under `locking` on `m`."
+     [^java.util.Map m ^java.lang.ref.ReferenceQueue q]
      (loop []
-       (when-some [k (.poll ^java.lang.ref.ReferenceQueue provenance-queue)]
-         (.remove ^java.util.Map provenance-by-throwable k)
+       (when-some [k (.poll q)]
+         (.remove m k)
          (recur)))))
 
 (defn- attest-provenance!
@@ -328,13 +413,14 @@
   minted-and-bound is covered. A no-op-safe identity write; the entry dies with
   the throwable."
   [t provenance]
-  #?(:clj  (locking provenance-by-throwable
-             (expunge-stale-provenance!)
-             ;; Store under a WEAK IDENTITY key (rf2-fs99nq): keyed by t's object
-             ;; identity, never its own hashCode/equals; the key is registered on the
-             ;; ReferenceQueue so the entry is reclaimed once t is collected.
-             (.put ^java.util.Map provenance-by-throwable
-                   (weak-identity-key t provenance-queue) provenance))
+  #?(:clj  (let [m (provenance-map)
+                 q (provenance-ref-queue)]
+             (locking m
+               (expunge-stale-provenance! m q)
+               ;; Store under a WEAK IDENTITY key (rf2-fs99nq): keyed by t's object
+               ;; identity, never its own hashCode/equals; the key is registered on
+               ;; the ReferenceQueue so the entry is reclaimed once t is collected.
+               (.put ^java.util.Map m (weak-identity-key t q) provenance)))
      :cljs (.set provenance-by-throwable t provenance))
   t)
 
@@ -343,8 +429,9 @@
   channel-aware [[EmissionProvenance]] attesting its canonical record was ALREADY
   fanned on the ALWAYS-ON axis at the source (with the source's own attribution),
   so a containment drain must add nothing there. NON-FORGEABLE by binding to the
-  EXACT throwable identity through the PRIVATE weak [[provenance-by-throwable]]
-  association (rf2-9m4oy7): an application cannot write that association, so a
+  EXACT throwable identity through the PRIVATE weak provenance association (the
+  reload-safe [[provenance-storage]] holder on the JVM, a `js/WeakMap` on CLJS)
+  (rf2-9m4oy7): an application cannot write that association, so a
   forged `->EmissionProvenance` token in its ex-data reads false; and provenance
   is keyed by the exact original throwable, so an authentic token TRANSPLANTED
   onto a different exception reads false (that different throwable has no binding).
@@ -352,17 +439,18 @@
   false, so trace coverage is never mistaken for always-on coverage
   (rf2-w55bh0)."
   [t]
-  (let [prov #?(:clj  (locking provenance-by-throwable
-                        (expunge-stale-provenance!)
-                        ;; A transient IDENTITY LOOKUP key (nil queue) — HashMap.get
-                        ;; discriminates by our key's `System/identityHashCode` +
-                        ;; referent `identical?`, NEVER t's own hashCode/equals
-                        ;; (rf2-fs99nq). So a distinct application throwable that is
-                        ;; `.equals`/hash-collides with a bound one reads uncovered,
-                        ;; and a throwable whose hashCode/equals THROWS cannot make
-                        ;; this lookup escape the drain's catch.
-                        (.get ^java.util.Map provenance-by-throwable
-                              (weak-identity-key t nil)))
+  (let [prov #?(:clj  (let [m (provenance-map)
+                            q (provenance-ref-queue)]
+                        (locking m
+                          (expunge-stale-provenance! m q)
+                          ;; A transient IDENTITY LOOKUP key (nil queue) — HashMap.get
+                          ;; discriminates by our key's `System/identityHashCode` +
+                          ;; referent `identical?`, NEVER t's own hashCode/equals
+                          ;; (rf2-fs99nq). So a distinct application throwable that is
+                          ;; `.equals`/hash-collides with a bound one reads uncovered,
+                          ;; and a throwable whose hashCode/equals THROWS cannot make
+                          ;; this lookup escape the drain's catch.
+                          (.get ^java.util.Map m (weak-identity-key t nil))))
                 ;; `WeakMap.prototype.get` returns undefined (never throws) for a
                 ;; non-object key, so a raw thrown value (CLJS permits
                 ;; `(throw :kw)` / `(throw "x")`) simply reads uncovered — NO guard

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -3125,6 +3125,15 @@
         (is (valid-observation-on-change-failed-tags? (:tags tev))
             "the :hmr dev-trace tags satisfy the canonical schema")
         (is (= :hmr (:cause (:tags tev))))
+        (testing "the dev-trace :tags carry the EXACT original throwable and frame
+                  keyword — not only the always-on record (rf2-5iud0a false-greens
+                  #1 + #3: :exception is schema-typed :any and :frame is an OPEN
+                  optional key, so the schema alone accepts nil / a wrong throwable /
+                  a dropped frame in the trace tags; the fixtures assert real values)"
+          (is (identical? boom (:exception (:tags tev)))
+              "trace :exception is the exact original throwable, not nil / a copy")
+          (is (= fid (:frame (:tags tev)))
+              "trace :frame carries the exact emitting frame keyword"))
         (testing "the always-on record carries the wire fields the 009 row lists"
           (is (some? rec))
           (is (= [:obs/items] (:event rec)))
@@ -3148,6 +3157,13 @@
           (is (valid-observation-on-change-failed-tags? (:tags tev))
               "the :disposed dev-trace tags satisfy the canonical schema")
           (is (= :disposed (:cause (:tags tev))))
+          (testing "the :disposed dev-trace :tags likewise carry the EXACT throwable
+                    and frame keyword, independently of the always-on record
+                    (rf2-5iud0a false-greens #1 + #3)"
+            (is (identical? boom (:exception (:tags tev)))
+                "trace :exception is the exact original throwable, not nil / a copy")
+            (is (= fid (:frame (:tags tev)))
+                "trace :frame carries the exact emitting frame keyword"))
           (is (some? rec))
           (is (identical? boom (:exception rec))))
         (obs/release! la)))))
@@ -3175,7 +3191,27 @@
                      (assoc tags :cause :bogus)))))
         (testing "a spoofed :category fails"
           (is (not (valid-observation-on-change-failed-tags?
-                     (assoc tags :category :rf.error/handler-exception))))))
+                     (assoc tags :category :rf.error/handler-exception)))))
+        (testing "false-green #1 — :exception is schema-typed :any, so the SCHEMA
+                  alone accepts a mutated trace :exception; the real fixtures instead
+                  assert exact throwable identity, which catches nil / a substituted
+                  throwable (rf2-5iud0a)"
+          (is (identical? boom (:exception tags))
+              "baseline: the real trace tags carry the exact throwable")
+          (is (valid-observation-on-change-failed-tags? (assoc tags :exception nil))
+              "the schema (:any) still validates a nil'd :exception — schema alone is a false green")
+          (is (valid-observation-on-change-failed-tags?
+                (assoc tags :exception (ex-info "different" {})))
+              "the schema (:any) still validates a DIFFERENT throwable")
+          (is (not (identical? boom (:exception (assoc tags :exception nil))))
+              "the exact-identity assertion the fixtures use catches the nil mutation")
+          (is (not (identical? boom (:exception (assoc tags :exception (ex-info "different" {})))))
+              "…and catches a substituted throwable"))
+        (testing "false-green #3 — a legitimately-absent OPTIONAL :frame stays valid
+                  (the optional row must not silently become required) (rf2-5iud0a)"
+          (is (= fid (:frame tags)) "baseline: the real record emits the frame tag")
+          (is (valid-observation-on-change-failed-tags? (dissoc tags :frame))
+              "an absent optional :frame remains valid (frame is optional in the schema)")))
       (obs/release! la))))
 
 (defn- schema-entry-of
@@ -3215,7 +3251,32 @@
     (testing "required→optional drift — the required-key SET is exactly these eight"
       (is (= #{:category :rf.sub/id :rf.sub/query-v :where :cause
                :exception :exception-message :reason}
-             (set (map :key (remove :optional? (map-schema-entries s)))))))))
+             (set (map :key (remove :optional? (map-schema-entries s)))))))
+    (testing "false-green #3 — the OPTIONAL :frame row is pinned to
+              [:frame {:optional true} :keyword]; because the map is open, deleting
+              the row or weakening it to :any leaves real records + every OTHER shape
+              assertion green even though runtime emits the frame tag, so pin it
+              explicitly (rf2-5iud0a)"
+      (let [e (schema-entry-of s :frame)]
+        (is (some? e)
+            "the :frame row is PRESENT (deleting it from the markdown reddens here)")
+        (is (:optional? e) "the :frame row is optional")
+        (is (= :keyword (:schema e))
+            "the :frame row is :keyword, not weakened to :any")))))
+
+#?(:clj
+   (defn- dev-trace-backtick-keywords
+     "Extract the EXACT backtick-delimited keyword tokens from a Spec 009 DEV-TRACE
+     `:tags` fragment (rf2-5iud0a false-green #2): each `` `:kw` `` span parsed to a
+     keyword, so `:exception` and `:exception-message` are DISTINCT tokens and a
+     substring / prefix match or an un-backticked prose mention never counts. A
+     focused extraction helper, NOT a general Markdown parser."
+     [fragment]
+     (->> (re-seq #"`([^`]+)`" fragment)
+          (map second)
+          (filter #(str/starts-with? % ":"))
+          (map #(keyword (subs % 1)))
+          set)))
 
 #?(:clj
    (deftest spec-009-catalogue-lists-the-canonical-observation-tag-keys
@@ -3241,7 +3302,23 @@
        (is (some? tags)
            "the 009 row must carry a DEV-TRACE :tags list")
        (when tags
-         (doseq [k required]
-           (is (str/includes? tags (str k))
-               (str "the Spec 009 DEV-TRACE :tags list must enumerate the canonical "
-                    "schema key " k)))))))
+         ;; rf2-5iud0a false-green #2 — the prior check was a SUBSTRING scan, so
+         ;; deleting `:exception` while keeping `:exception-message` still passed
+         ;; (the shorter token is a prefix of the longer). Compare EXACT
+         ;; backtick-delimited keyword tokens instead.
+         (let [row-tokens (dev-trace-backtick-keywords tags)]
+           (doseq [k required]
+             (is (contains? row-tokens k)
+                 (str "the Spec 009 DEV-TRACE :tags list must enumerate the canonical "
+                      "schema key " k " as an exact backtick-delimited token")))
+           (testing "exact-token extraction rejects a PREFIX — `:exception-message`
+                     alone does NOT satisfy the required `:exception` token (the
+                     false-green #2 this closes), and never matches un-backticked prose"
+             (is (contains? row-tokens :exception))
+             (is (contains? row-tokens :exception-message))
+             (let [only-message (dev-trace-backtick-keywords
+                                  "DEV-TRACE `:exception-message`, :exception in prose")]
+               (is (not (contains? only-message :exception))
+                   "a fragment with only `:exception-message` (plus prose `:exception`)
+                    does NOT yield the `:exception` token")
+               (is (contains? only-message :exception-message)))))))))

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -2868,6 +2868,133 @@
          (obs/release! s1) (obs/release! lb) (obs/release! lc) (obs/release! s2)))))
 
 ;; ===========================================================================
+;; rf2-qqvgk1 — the JVM provenance STORAGE is reload-safe and its weak lifecycle
+;; is PROVEN.
+;;
+;; #5884 keeps the same `defonce` storage Var while changing its representation
+;; (predecessor rf2-9m4oy7: a synchronized `WeakHashMap<Throwable>`; current: a
+;; weak-identity `HashMap<WeakReference-key>` + `ReferenceQueue`). A normal reload
+;; retains the old `defonce` root, so predecessor entries become unreachable through
+;; the new key and a freshly-`defonce`'d queue desyncs from the retained map. The fix
+;; bundles map + queue in ONE versioned holder and RECONCILES it at load — recognizing
+;; + replacing an incompatible predecessor root — while a same-version reload is an
+;; idempotent no-op that preserves entries. These fixtures PROVE the reload-safety and
+;; the weak lifecycle (GC + expunge), rather than assuming them. JVM-only: CLJS uses
+;; `js/WeakMap` (ephemeron, fresh realm per page reload).
+;; ===========================================================================
+
+#?(:clj
+   (deftest jvm-provenance-storage-reload-replaces-an-incompatible-predecessor-root
+     ;; acceptance 1 + revert-detection: seed the PREDECESSOR representation
+     ;; (rf2-9m4oy7's synchronized WeakHashMap<Throwable>, unversioned) under the
+     ;; defonce'd storage Var, simulate a namespace reload by re-running the load-time
+     ;; reconciliation WITHOUT remove-ns, and prove the CURRENT versioned representation
+     ;; is installed and the port round-trips over it. A bare `defonce` (no
+     ;; reconciliation) would RETAIN the predecessor WeakHashMap, so this fixture
+     ;; reddens if the fix is reverted ("mutation back to an unversioned defonce
+     ;; retaining the predecessor map fails the reload fixture").
+     (let [saved @#'obs/provenance-storage]
+       (try
+         ;; A reload keeps the defonce root; seed the predecessor shape under the Var.
+         (alter-var-root #'obs/provenance-storage
+                         (constantly (java.util.Collections/synchronizedMap
+                                       (java.util.WeakHashMap.))))
+         (is (not (#'obs/current-provenance-storage? @#'obs/provenance-storage))
+             "precondition: the seeded predecessor root is NOT current-version")
+         ;; The reload's load-time reconciliation re-runs (as the top-level form does).
+         (#'obs/ensure-current-provenance-storage!)
+         (let [installed @#'obs/provenance-storage]
+           (is (#'obs/current-provenance-storage? installed)
+               "the current versioned representation is installed after reload")
+           (is (= @#'obs/provenance-storage-version (:version installed)))
+           (is (instance? java.util.HashMap (:by-throwable installed))
+               "the inner map is the current plain HashMap, not the predecessor WeakHashMap")
+           (is (instance? java.lang.ref.ReferenceQueue (:queue installed))
+               "the current holder carries its own paired ReferenceQueue"))
+         ;; The port round-trips over the reload-installed storage.
+         (let [t (ex-info "post-reload boom" {})]
+           (#'obs/attest-provenance! t @#'obs/provenance-both-channels)
+           (is (true? (#'obs/source-covered-always-on? t))
+               "attest/lookup round-trips over the reload-installed storage")
+           (is (false? (#'obs/source-covered-always-on? (ex-info "unbound" {})))
+               "an unbound throwable still reads uncovered"))
+         ;; Repeated reconciliation is idempotent — the SAME current holder is kept.
+         (let [before @#'obs/provenance-storage]
+           (#'obs/ensure-current-provenance-storage!)
+           (is (identical? before @#'obs/provenance-storage)
+               "a same-version reconciliation is a NO-OP (idempotent, entries preserved)"))
+         (finally
+           (alter-var-root #'obs/provenance-storage (constantly saved)))))))
+
+#?(:clj
+   (deftest jvm-provenance-survives-gc-while-throwable-strongly-held-no-duplicate-wrapper
+     ;; acceptance 2: a strongly-retained throwable's provenance SURVIVES bounded GC
+     ;; (the weak key is pinned by its strong referent), so the disposal drain still
+     ;; reads it covered and adds NO duplicate callback-failure wrapper.
+     (reg-items!)
+     (seed-items! [:a])
+     (let [setup (obs/acquire! (items-target) (fn [_]))
+           _     (obs/release! setup)
+           ;; A REAL port-minted always-on throwable, bound #{:always-on :trace} by
+           ;; read-after-release's emit-then-throw.
+           A     (try (obs/read setup) (catch Throwable e e))]
+       (is (= :rf.error/read-after-release (error-id A)))
+       (is (true? (#'obs/source-covered-always-on? A))
+           "authentic provenance reads covered before GC")
+       ;; Force bounded GC while A is strongly reachable (this local + the closure
+       ;; below both retain it); provenance MUST survive.
+       (dotimes [_ 10]
+         (System/gc) (System/runFinalization) (make-array Object 200000))
+       (is (true? (#'obs/source-covered-always-on? A))
+           "provenance survives GC while its throwable is strongly reachable")
+       (with-redefs [interop/next-tick (fn [_f] nil)]
+         (let [notes (atom [])
+               la (obs/acquire! (items-target) (fn [_n] (throw A)))
+               lc (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+           (force-dispose-node! [:obs/items])
+           (let [[_ records] (with-error-records #(obs/drain-pending-disposals! :disposed))
+                 wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                  records)]
+             (is (= 1 (count @notes)) "the healthy sibling was still notified")
+             (is (zero? (count wrapped))
+                 "the covered source stands — NO duplicate wrapper (exact-once)"))
+           (obs/release! la) (obs/release! lc))))))
+
+#?(:clj
+   (deftest jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies
+     ;; acceptance 3 (the weak-lifecycle PROOF): release the throwable, retain only a
+     ;; WeakReference, force bounded GC + a later map access, and prove the referent
+     ;; CLEARS (the storage retains it via NEITHER key NOR value) and the private
+     ;; storage returns to baseline (the cleared entry is expunged). A strong-map
+     ;; mutation — retaining the referent by key OR value — reddens gc-until-cleared?.
+     (let [prov @#'obs/provenance-both-channels
+           m    (:by-throwable @#'obs/provenance-storage)]
+       ;; Reach a stable baseline: drain any prior stale entries first.
+       (System/gc) (System/runFinalization)
+       (#'obs/source-covered-always-on? (ex-info "baseline drain" {}))
+       (let [baseline (.size ^java.util.Map m)
+             t-box    (volatile! (ex-info "weak-lifecycle boom" {}))
+             t-ref    (java.lang.ref.WeakReference. ^Object @t-box)]
+         (#'obs/attest-provenance! @t-box prov)
+         (is (= (inc baseline) (.size ^java.util.Map m))
+             "the attestation bound exactly one entry")
+         (is (true? (#'obs/source-covered-always-on? @t-box))
+             "the bound throwable reads covered")
+         (vreset! t-box nil) ;; drop the last strong ref — only t-ref (weak) remains
+         (is (gc-until-cleared? t-ref)
+             (str "the throwable is GC-collectable — the storage retains it via "
+                  "NEITHER the weak key NOR the provenance value"))
+         ;; A later map access polls the ReferenceQueue and expunges the cleared key;
+         ;; poll until the async reference-enqueue lands (bounded, deterministic).
+         (is (loop [i 0]
+               (#'obs/source-covered-always-on? (ex-info "post-gc access" {}))
+               (cond
+                 (= baseline (.size ^java.util.Map m)) true
+                 (>= i 40)                             false
+                 :else (do (System/gc) (System/runFinalization) (recur (inc i)))))
+             "the cleared entry was expunged — private storage returned to baseline")))))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 


### PR DESCRIPTION
Two follow-ups to the merged observation cluster (#5884 weak-identity provenance, #5895/.241 closed grammar, #5870/qyvyes schema gate), on `core/observation.cljc` + its tests. Both re-verified against current `origin/main` — each reproduced, each fixed. Commit order qqvgk1 → 5iud0a.

## rf2-qqvgk1 — reload-safe + weak-lifecycle-proven JVM provenance storage

**Re-verification:** #5884 keeps the `defonce provenance-by-throwable` Var while changing its representation from the predecessor synchronized `WeakHashMap<Throwable>` to a weak-identity `HashMap<WeakReference-key>` + `ReferenceQueue`. A namespace reload retains the old `defonce` root — predecessor entries then unreachable through the new key, and a freshly-`defonce`'d queue desyncs from the retained map. Confirmed present on current head; the fresh-process tests never covered predecessor-state reload or the promised weak lifecycle.

**Fix:** Bundle the map + queue into ONE versioned holder (a plain Clojure map — its class is stable across reloads, unlike a `deftype` whose redefined class would defeat `instance?` recognition every reload and drop the entries). Reconcile at load (`ensure-current-provenance-storage!`, an idempotent `alter-var-root` compare-and-replace): a fresh JVM keeps the `defonce` initializer, a reload over an incompatible predecessor/older-version root is recognized and replaced, a same-version reload is a no-op that preserves entries. Explicit private reload rule: a version-mismatch replace drops predecessor-bound provenance so an in-flight throwable reads uncovered and the drain fails LOUD (an extra catalogued record), never silent.

**Weak-lifecycle proof (three JVM fixtures, deterministic — no sleeps):**
- Reload over a seeded predecessor `WeakHashMap` installs the current versioned representation and round-trips attest/lookup; reconciliation is idempotent (same holder kept). Reddens if reverted to a bare `defonce`.
- Provenance SURVIVES bounded GC while its throwable is strongly held → the drain reads it covered with NO duplicate wrapper (exact-once).
- Released throwable: only a `WeakReference` retained → forced bounded GC clears the referent (storage retains it via neither key nor value) and a later map access expunges the entry to baseline.

## rf2-5iud0a — close the schema-gate false-greens

**Re-verification:** All three false-greens reproduced on current head.
1. Trace `:exception` is schema-typed `:any`, so the schema alone accepts nil / a different throwable; fixtures asserted identity only on the always-on record.
2. The Spec 009 catalogue check was a SUBSTRING scan — removing `:exception` while keeping `:exception-message` still passed (prefix).
3. The schema-shape pin omitted `[:frame {:optional true} :keyword]`; because the map is open, deleting/weakening it stayed green.

**Fix:**
1. Real HMR + disposed fixtures now assert `(identical? boom (:exception (:tags trace-event)))` independently of the always-on record (+ a companion test: schema accepts the mutation, identity assertion catches it). Frame keyword asserted on the real tags too.
2. Exact backtick-delimited keyword-token extraction (`dev-trace-backtick-keywords`) + set-membership, with an embedded proof that `:exception-message` (plus prose `:exception`) does not yield the `:exception` token.
3. The optional `:frame` row is pinned in the extracted-schema shape test (present + optional + `:keyword`); real trace tags carry the exact frame keyword; a legitimately-absent optional frame stays valid.

One compile-time-extracted canonical schema still validates both CLJ and CLJS records — no duplicate schema, no general parser.

## Quality gates

Foreground, all green:
- `core` JVM (`clojure -M:test`): 1981 tests, 9130 assertions, 0 failures/0 errors — observation-port + error-catalogue + schema gate.
- `machines` JVM (`clojure -M:test`): 1063 tests, 3643 assertions, 0 failures/0 errors — cross-artefact observation consumer, no regression.
- node CLJS (`npm run test:cljs`): 9398 tests, 44599 assertions, 0 failures/0 errors — js/WeakMap + compile-time schema extraction.

Scope: `implementation/core/src/re_frame/substrate/observation.cljc` + `implementation/core/test/re_frame/observation_port_cljs_test.cljc` only. `spec/` schema unchanged (referenced, not re-edited).