### PR TITLE
fix(ui): root teardown settles independent of ViewCell presence + host success (rf2-vxgfnd.275)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -726,6 +726,12 @@
     ;; the exact root generation.
     (react/useLayoutEffect
      (fn root-teardown-sentinel []
+       ;; SETUP runs on COMMIT: a rendered root tree now exists whose host
+       ;; teardown React will signal — mark the reporter live so teardown-root!
+       ;; awaits it (fences a deferred teardown of even a cell-less root). An
+       ;; unrendered/pre-commit root never reaches here, so it has no pending
+       ;; teardown to await and settles synchronously.
+       (reactive/report-root-commit! incarnation)
        (fn cleanup []
          (reactive/report-root-teardown! incarnation)
          js/undefined))
@@ -1246,13 +1252,22 @@
   []
   (let [roots  (mapv :root (vals @live-roots))
         errors (volatile! [])]
-    (doseq [root roots]
+    (doseq [^Root root roots]
       (try
         (unmount!* root)
         (catch :default e
           (vswap! errors conj e)
           (try
             (reclaim-consumed-container! root)
+            ;; rf2-vxgfnd.275 — `unmount!*` QUARANTINED this throwing root's claim
+            ;; (`:tearing-down`, fail-closed: an isolated caller cannot prove the
+            ;; container free). The adapter reclaim just DID prove it free — DOM
+            ;; cleared + the pinned React ownership marker deleted against the
+            ;; pinned host — so release the quarantine now: adapter disposal is
+            ;; total and the exact id/container is reusable after re-init. If the
+            ;; reclaim itself threw, this is skipped and the claim stays
+            ;; quarantined (the container is NOT proven free).
+            (release-root! (.-root-id root) root)
             (catch :default recovery-error
               (vswap! errors conj recovery-error))))))
     (when-let [primary (first @errors)]

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -711,7 +711,25 @@
      (fn commit-report []
        (settle-committed-attempt! root-id receipt incarnation)
        js/undefined)
-     #js [receipt]))
+     #js [receipt])
+    ;; rf2-vxgfnd.275 — the ROOT-LEVEL host-teardown sentinel. A mount-lifetime
+    ;; layout effect (empty deps → setup once, cleanup once) whose CLEANUP fires
+    ;; exactly when React tears this reporter — and thus the whole root tree —
+    ;; down: SYNCHRONOUSLY inside a synchronous `.unmount`, or in the deferred
+    ;; microtask when react-dom 19.2 refuses an in-render unmount. Because the
+    ;; reporter wraps EVERY root render, this signal exists even for a compiled
+    ;; static/cell-less or entirely Activity-hidden root that owns no connected
+    ;; ViewCell — the population `reactive/teardown-root!` cannot otherwise
+    ;; observe. It lets an in-flight teardown recognise a SYNCHRONOUS host
+    ;; teardown (release the claim now) from a DEFERRED one (hold `:tearing-down`
+    ;; until settlement). Keyed to `incarnation` so a fired-later cleanup names
+    ;; the exact root generation.
+    (react/useLayoutEffect
+     (fn root-teardown-sentinel []
+       (fn cleanup []
+         (reactive/report-root-teardown! incarnation)
+         js/undefined))
+     #js []))
   (.-children props))
 
 (defn- render-attempt-element
@@ -1048,10 +1066,10 @@
   host teardown in flight — rf2-vxgfnd.182) is a no-op. The claim is released at
   the SETTLEMENT BOUNDARY through `teardown-root!`'s `on-settled` callback:
   synchronously for a synchronous host teardown, or in the settlement microtask
-  after a DEFERRED one clears the DOM. A THROWING host `.unmount` still frees the
-  exact root-id/container claim immediately in the `catch` (identity-guarded —
-  never evicts a newer claim), a second `unmount!*` is then a no-op, and the host
-  teardown error still propagates to the caller (rf2-vxgfnd.18 AC4, untouched).
+  after a DEFERRED one clears the DOM. A THROWING host `.unmount` QUARANTINES the
+  exact root-id/container/prefix claim `:tearing-down` (rf2-vxgfnd.275 — fail
+  closed: the container cannot be proven free), a second `unmount!*` is then a
+  no-op, and the host teardown error still propagates to the caller.
 
   OWNERSHIP FENCE through DEFERRED teardown (rf2-vxgfnd.182). react-dom 19.2
   refuses a synchronous `.unmount` from inside render/commit: it consumes the
@@ -1080,15 +1098,16 @@
   generation and releases its observation owners before the error escapes;
   a later same-id incarnation is a distinct token and remains untouched.
 
-  AFTERMATH of a THROWING host `.unmount` (rf2-vxgfnd.53, diagnostic
-  corrected by rf2-vxgfnd.84). The concrete case is React 18/19 refusing to
-  `.unmount` synchronously from inside a render pass (\"attempted to
-  synchronously unmount a root while React was already rendering\"): the
-  SYNCHRONOUS unmount did not complete, yet the `finally` releases the claim
-  (the AC4 total-teardown contract, KEPT — the root-id/container must not
-  strand), and a second `unmount!*` is a no-op (the membership guard). Two
-  facts, verified against the pinned react-dom 19.2.0 source, shape what that
-  aftermath actually IS:
+  AFTERMATH of a THROWING host `.unmount` (rf2-vxgfnd.53/.84; fail-closed by
+  rf2-vxgfnd.275). The concrete case is React 18/19 refusing to `.unmount`
+  synchronously from inside a render pass (\"attempted to synchronously unmount a
+  root while React was already rendering\"): the synchronous unmount did not
+  complete, so the claim is FAILED CLOSED — left QUARANTINED `:tearing-down`
+  (marked before the `.unmount`), NOT released, because the container cannot be
+  proven free and a released claim could be clobbered by React self-completing
+  the aborted teardown onto a container a successor now owns. A second `unmount!*`
+  is a no-op (the membership guard). Two facts, verified against the pinned
+  react-dom 19.2.0 source, shape what that aftermath actually IS:
 
     - the root handle is CONSUMED: `ReactDOMRoot.unmount()` nulls its
       `_internalRoot` BEFORE the flush that throws, so re-calling `.unmount`
@@ -1100,12 +1119,13 @@
       \"stuck host root\" is mostly moot, not the common outcome.
 
   So this is NOT silent, and now HONEST: in a dev build a throwing `.unmount`
-  emits a console diagnostic stating the handle is consumed (no manual escape)
-  and names direct container clearing as the host fallback. The adapter-wide
-  destroy path performs that fallback itself (including the pinned React root
-  marker) so the same container can be reused after re-init; an isolated public
-  `unmount!` still leaves host recovery to its caller. The diagnostic is
-  goog.DEBUG-gated (Closure-DCE'd from production — I-12). Returns nil."
+  emits a console diagnostic stating the handle is consumed (no manual escape),
+  that the id/container/prefix claim is quarantined rather than released, and
+  that recovery is a FRESH container. The adapter-wide destroy path performs a
+  container-clearing fallback itself (including the pinned React root marker) so
+  the same container can be reused after re-init; an isolated public `unmount!`
+  leaves host recovery to its caller. The diagnostic is goog.DEBUG-gated
+  (Closure-DCE'd from production — I-12). Returns nil."
   [^Root root]
   (when (and (some? root)
              (let [entry (get @live-roots (.-root-id root))]
@@ -1140,38 +1160,32 @@
                                (fn [] (.unmount (.-react-root root)))
                                (fn [] (release-root! (.-root-id root) root)))
       (catch :default e
-        ;; rf2-vxgfnd.53 / rf2-vxgfnd.84 / rf2-vxgfnd.18 AC4 — the SYNCHRONOUS host
-        ;; `.unmount` threw; release the claim IMMEDIATELY (untouched by .182: the
-        ;; throwing path keeps its immediate release — the fence is only for the
-        ;; NON-throwing deferred path).
-        (release-root! (.-root-id root) root)
-        ;; rf2-vxgfnd.53 / rf2-vxgfnd.84 — the synchronous host .unmount did NOT
-        ;; complete, yet the claim is released just above (AC4) and a second
-        ;; `unmount!*` is a no-op (the membership guard). Make the aftermath
-        ;; non-silent AND honest: verified against pinned react-dom 19.2.0,
-        ;; ReactDOMRoot.unmount nulls its internal root BEFORE the flush that
-        ;; threw, so the handle is CONSUMED — re-calling .unmount on it is a
-        ;; silent no-op, NOT a manual escape (the pre-.84 diagnostic recommended
-        ;; that no-op). React usually defers + self-completes the teardown work
-        ;; scheduled pre-throw, so a stuck tree is the exception; when one does
-        ;; strand, the only real recovery is clearing the container (innerHTML) or
-        ;; a fresh container. Dev-only (goog.DEBUG-stripped in production). Then
-        ;; rethrow the ORIGINAL host error so it still propagates (AC4).
+        ;; rf2-vxgfnd.275 — the host `.unmount` THREW: React consumed the Root
+        ;; handle but its teardown flush aborted, and whether the container is
+        ;; actually settled is UNKNOWABLE in-process. FAIL CLOSED — do NOT
+        ;; release. The claim stays QUARANTINED `:tearing-down` (marked above,
+        ;; before the `.unmount`), so a same-id / same-container / same-prefix
+        ;; reuse is rejected (`check-root-claim!`) and the honest recovery is a
+        ;; FRESH container. This REVERSES the earlier immediate-release
+        ;; (rf2-vxgfnd.18/.84): a claim released here could be clobbered by React
+        ;; self-completing the aborted teardown onto a container a successor now
+        ;; owns. The exact generation is already force-dead by `teardown-root!`.
+        ;; A second `unmount!*` is a no-op (the :tearing-down guard); the primary
+        ;; host error still propagates. Dev-only diagnostic (goog.DEBUG-stripped).
         (when (and ^boolean js/goog.DEBUG (exists? js/console))
           (.warn js/console
                  (str "[re-frame.ui] host .unmount threw while tearing down root "
                       (pr-str (.-root-id root)) " — React did NOT complete the "
-                      "synchronous unmount, but the root handle is now CONSUMED: "
+                      "synchronous unmount, and the root handle is now CONSUMED: "
                       "ReactDOMRoot.unmount nulls its internal root BEFORE the "
                       "flush that threw, so re-calling .unmount on this handle is "
                       "a silent no-op — there is no manual escape through it. "
-                      "React usually defers and self-completes the teardown work "
-                      "scheduled before the throw, so the tree is typically "
-                      "removed regardless; the claim is released per the "
-                      "total-teardown contract (a second unmount! is a no-op). If "
-                      "a container is genuinely left with a stuck tree, clear it "
-                      "directly (set its innerHTML to \"\") or mount into a FRESH "
-                      "container — never reuse the consumed handle.")))
+                      "Because the container cannot be proven free, this root's "
+                      "id/container/identifierPrefix claim is QUARANTINED "
+                      "(tearing-down) rather than released, so a reused id or "
+                      "container fails loud instead of racing React's aborted "
+                      "teardown. Mount into a FRESH container to recover; a "
+                      "second unmount! is a no-op.")))
         (throw e))))
   nil)
 

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1051,6 +1051,21 @@
   ;; (module-lived); `reset-scheduler!` clears it between fixtures.
   (atom nil))
 
+(defonce ^:private live-reporters
+  ;; rf2-vxgfnd.275 — the incarnations with a COMMITTED, not-yet-torn-down
+  ;; `root-commit-reporter`. Its mount-lifetime layout-effect SETUP runs on
+  ;; COMMIT (`report-root-commit!`) and its cleanup on host teardown
+  ;; (`report-root-teardown!`). A membership here means a RENDERED root tree
+  ;; exists whose host teardown React will still signal — so `teardown-root!`
+  ;; must AWAIT that signal to distinguish a deferred teardown from a synchronous
+  ;; one, INDEPENDENT of ViewCell population (a cell-less/hidden rendered root is
+  ;; a member too). An UNRENDERED / pre-commit root (the render never reached the
+  ;; reporter's layout effect — an unrendered `create-root`, a `unmount!` before
+  ;; the first commit, a failed-first-mount rollback) is NOT a member, so it has
+  ;; no pending host teardown to await and settles synchronously. `defonce`
+  ;; (module-lived); `reset-scheduler!` clears it between fixtures.
+  (atom #{}))
+
 (declare flush-pending!)
 
 #?(:cljs
@@ -1581,6 +1596,7 @@
   (reset! root-cells {})
   (reset! teardown-collector nil)
   (reset! teardown-settle-signal nil)
+  (reset! live-reporters #{})
   (reset! evidence-sink nil)
   (reset! last-sink-escape nil)
   ;; Do NOT clear `view-generations`: it now owns the stable component shells
@@ -2677,6 +2693,17 @@
       (teardown! cell))
     (count victims)))
 
+(defn report-root-commit!
+  "The client `root-commit-reporter`'s mount-lifetime layout-effect SETUP
+  (rf2-vxgfnd.275): a React root tree for `incarnation` has COMMITTED, so its host
+  teardown will later fire `report-root-teardown!`. Marks the reporter LIVE so a
+  subsequent `teardown-root!` awaits that settlement signal (fencing a deferred
+  teardown of a rendered root — even a cell-less one). Idempotent. Returns nil."
+  [incarnation]
+  (when (some? incarnation)
+    (swap! live-reporters conj incarnation))
+  nil)
+
 (defn report-root-teardown!
   "The client `root-commit-reporter`'s mount-lifetime CLEANUP sentinel
   (rf2-vxgfnd.275), or a graft fixture's synchronous host model: React has torn
@@ -2684,16 +2711,18 @@
   present for EVERY rendered root because the reporter wraps every render, so a
   compiled static/cell-less or entirely Activity-hidden root that owns no
   connected ViewCell still emits it (the population `teardown-root!` could not
-  otherwise observe).
+  otherwise observe). Clears the reporter-live mark.
 
   When a `teardown-root!` thunk for this exact incarnation is IN FLIGHT (the host
   `.unmount` ran the reporter cleanup SYNCHRONOUSLY, as React does for a normal
-  unmount), this marks that teardown settled-synchronously, so the driver
+  unmount), this also marks that teardown settled-synchronously, so the driver
   releases the client's claim now. Fired LATER — react-dom 19.2 refusing an
   in-render unmount defers the teardown to its own microtask — there is no
-  in-flight signal to match, so this is a harmless no-op: the deferred settlement
+  in-flight signal to match, so it only clears the mark: the deferred settlement
   is driven by `settle-deferred-root!` (the FIFO-ordered microtask). Returns nil."
   [incarnation]
+  (when (some? incarnation)
+    (swap! live-reporters disj incarnation))
   (let [sig @teardown-settle-signal]
     (when (and sig (some? incarnation) (identical? incarnation (:incarnation sig)))
       (vreset! (:fired sig) true)))
@@ -2792,20 +2821,21 @@
   returns NORMALLY but runs none of this root's effect cleanups, scheduling the
   teardown for a later microtask. Whether the host tore down SYNCHRONOUSLY is
   decided by a ROOT-LEVEL settlement law, independent of ViewCell population
-  (rf2-vxgfnd.275): POSITIVE evidence is the client `root-commit-reporter`'s
-  mount-lifetime cleanup sentinel firing DURING the thunk (`report-root-teardown!`
-  → the `teardown-settle-signal` volatile), OR the window capturing a
-  disconnecting cell (`collected`). Both observe the SAME synchronous cleanup
-  sweep; the reporter sentinel is present even for a compiled static/cell-less or
-  entirely Activity-hidden root that owns no connected cell — the case a
-  cell-connectivity probe (the retired `weak-connected`) could not discriminate
-  and so mis-classified as synchronous, releasing the claim into a still-scheduled
-  teardown. Neither signal ⇒ a DEFERRED teardown: this driver does NOT fire
-  `on-settled` synchronously — it schedules the SETTLEMENT (`settle-deferred-root!`)
+  (rf2-vxgfnd.275): the teardown is DEFERRED iff a COMMITTED reporter for this
+  root has not yet torn down (`live-reporters`) AND its mount-lifetime cleanup
+  sentinel did NOT fire during the thunk (`report-root-teardown!` → the
+  `teardown-settle-signal` volatile). The reporter is present even for a compiled
+  static/cell-less or entirely Activity-hidden root that owns no connected cell —
+  the case a cell-connectivity probe (the retired `weak-connected`) could not
+  discriminate and so mis-classified as synchronous, releasing the claim into a
+  still-scheduled teardown. When DEFERRED, this driver does NOT fire `on-settled`
+  synchronously — it schedules the SETTLEMENT (`settle-deferred-root!`)
   FIFO-ordered after React's own deferred teardown, so the client holds its
   root-id/container/prefix claim `:tearing-down` until React has actually cleared
-  the container. A SYNCHRONOUS teardown fires `on-settled` immediately, preserving
-  the ratified same-container immediate-remount.
+  the container. A SYNCHRONOUS teardown (the reporter sentinel fired) fires
+  `on-settled` immediately, preserving the ratified same-container
+  immediate-remount. An UNRENDERED / pre-commit root has no committed reporter, so
+  nothing is pending: it settles synchronously.
 
   A THROWING `.unmount` keeps its immediate, fail-closed reap of the exact
   generation and rethrows; `on-settled` is NOT fired (rf2-vxgfnd.275): the host
@@ -2887,20 +2917,19 @@
                      ;; cells still connected because React ran no cleanup.
                      (into owned (weak-live (get @root-cells root-incarnation)))
                      (into owned hidden))
-         ;; rf2-vxgfnd.275 — the ROOT-LEVEL settlement law. POSITIVE evidence the
-         ;; host ran this root's teardown SYNCHRONOUSLY during the thunk is either
-         ;; the reporter's mount-lifetime cleanup sentinel firing (`@fired`,
-         ;; emitted even by a cell-less/hidden root) OR the window capturing a
-         ;; disconnecting cell (`collected`) — two observations of the one
-         ;; synchronous cleanup sweep. Neither ⇒ a DEFERRED teardown (react-dom
-         ;; refusing an in-render unmount): hold the claim `:tearing-down` and
-         ;; settle past React's own microtask. Unlike the retired cell-connectivity
-         ;; probe, this sees a compiled static/cell-less or entirely-hidden root's
-         ;; deferral — its whole point (rf2-vxgfnd.275). An empty/unrendered root
-         ;; with no reporter and no cells has neither signal, so it too holds one
-         ;; settlement microtask (safe: released only past React's teardown).
-         synchronous? (or @fired (seq collected))
-         deferred?    (and explicit? (not @host-error) (not synchronous?))]
+         ;; rf2-vxgfnd.275 — the ROOT-LEVEL settlement law. A teardown is DEFERRED
+         ;; iff a COMMITTED reporter for this root has not yet torn down
+         ;; (`live-reporters`) AND its mount-lifetime cleanup sentinel did NOT fire
+         ;; during the thunk (`@fired` — a synchronous host teardown ran it). A
+         ;; RENDERED root — cell-bearing OR cell-less/entirely-hidden — has a
+         ;; committed reporter, so its deferral is seen regardless of ViewCell
+         ;; population (the gap the retired cell-connectivity probe could not see).
+         ;; An UNRENDERED / pre-commit root (the render never reached the reporter's
+         ;; layout effect) is not a member, so it has no pending host teardown to
+         ;; await and settles synchronously. `collected` no longer classifies — it
+         ;; only drives the reap (`owned`/`hidden`/`victims`).
+         deferred? (and explicit? (not @host-error) (not @fired)
+                        (contains? @live-reporters root-incarnation))]
      (doseq [cell victims]
        (teardown! cell))
      (cond

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1035,6 +1035,22 @@
   ;; clears it between fixtures.
   (atom nil))
 
+(defonce ^:private teardown-settle-signal
+  ;; rf2-vxgfnd.275 — the ROOT-LEVEL host-teardown SETTLEMENT signal of an
+  ;; in-flight `teardown-root!`, or nil at rest. Holds `{:incarnation <inc>
+  ;; :fired <volatile>}` while a teardown-root! thunk (the host React `.unmount`)
+  ;; runs. The client's `root-commit-reporter` carries a mount-lifetime cleanup
+  ;; sentinel that calls `report-root-teardown!` when React tears the reporter
+  ;; (and thus the whole root tree) down; if that fires DURING the thunk it sets
+  ;; the volatile — POSITIVE evidence the host ran this root's teardown
+  ;; SYNCHRONOUSLY, independent of ViewCell population. Because the reporter wraps
+  ;; EVERY root render, a compiled static/cell-less or entirely Activity-hidden
+  ;; root (no connected cell to observe) still emits this signal — the gap
+  ;; cell-connectivity (`weak-connected`) alone could not see (rf2-vxgfnd.182).
+  ;; Save/restored around a teardown so a re-entrant one nests. `defonce`
+  ;; (module-lived); `reset-scheduler!` clears it between fixtures.
+  (atom nil))
+
 (declare flush-pending!)
 
 #?(:cljs
@@ -1564,6 +1580,7 @@
   (reset! live-cells #{})
   (reset! root-cells {})
   (reset! teardown-collector nil)
+  (reset! teardown-settle-signal nil)
   (reset! evidence-sink nil)
   (reset! last-sink-escape nil)
   ;; Do NOT clear `view-generations`: it now owns the stable component shells
@@ -2660,18 +2677,27 @@
       (teardown! cell))
     (count victims)))
 
-(defn- weak-connected
-  "The still-CONNECTED (`:connected`/`:fresh`) cells of `incarnation`'s weak
-  membership — the residual live cells a host `.unmount` did NOT tear down
-  synchronously. A DEFERRED host teardown (react-dom 19.2 refusing a synchronous
-  unmount from inside render/commit: it returns normally but schedules the
-  teardown for a later microtask) runs NONE of the root's effect cleanups during
-  `.unmount`, so the collection window captures nothing AND these cells stay
-  connected. That residual connected membership is the ONLY in-process signal
-  distinguishing a deferred host teardown from a synchronous one (rf2-vxgfnd.182)."
+(defn report-root-teardown!
+  "The client `root-commit-reporter`'s mount-lifetime CLEANUP sentinel
+  (rf2-vxgfnd.275), or a graft fixture's synchronous host model: React has torn
+  `incarnation`'s root tree down. This is the ROOT-LEVEL host-teardown signal —
+  present for EVERY rendered root because the reporter wraps every render, so a
+  compiled static/cell-less or entirely Activity-hidden root that owns no
+  connected ViewCell still emits it (the population `teardown-root!` could not
+  otherwise observe).
+
+  When a `teardown-root!` thunk for this exact incarnation is IN FLIGHT (the host
+  `.unmount` ran the reporter cleanup SYNCHRONOUSLY, as React does for a normal
+  unmount), this marks that teardown settled-synchronously, so the driver
+  releases the client's claim now. Fired LATER — react-dom 19.2 refusing an
+  in-render unmount defers the teardown to its own microtask — there is no
+  in-flight signal to match, so this is a harmless no-op: the deferred settlement
+  is driven by `settle-deferred-root!` (the FIFO-ordered microtask). Returns nil."
   [incarnation]
-  (filterv #(contains? #{:connected :fresh} (lifecycle %))
-           (weak-live (get @root-cells incarnation))))
+  (let [sig @teardown-settle-signal]
+    (when (and sig (some? incarnation) (identical? incarnation (:incarnation sig)))
+      (vreset! (:fired sig) true)))
+  nil)
 
 (defn- settle-deferred-root!
   "Settle a DEFERRED host teardown (rf2-vxgfnd.182). The host `.unmount` returned
@@ -2760,22 +2786,32 @@
   reap only cells actually captured by the teardown window. Returns the count of
   cells torn down on success; a host failure rethrows after the targeted reap.
 
-  ## DEFERRED host teardown + settlement (rf2-vxgfnd.182)
+  ## DEFERRED host teardown + settlement (rf2-vxgfnd.182/.275)
 
   react-dom 19.2 refuses a SYNCHRONOUS `.unmount` from inside render/commit: it
   returns NORMALLY but runs none of this root's effect cleanups, scheduling the
-  teardown for a later microtask. On the EXPLICIT non-throwing path this window
-  therefore captures nothing while the root's cells stay `:connected` — the one
-  in-process signal of a deferral (`weak-connected`). When detected, this driver
-  does NOT reap or fire `on-settled` synchronously: it schedules the SETTLEMENT
-  (`settle-deferred-root!`) FIFO-ordered after React's own deferred teardown, so
-  the client can hold its root-id/container claim `:tearing-down` until React has
-  actually cleared the container — the claim frees, and the cells converge to
-  `:dead`, only at that proven boundary. A SYNCHRONOUS teardown (cells captured,
-  or none owned) fires `on-settled` immediately, preserving the ratified
-  same-container immediate-remount. A THROWING `.unmount` keeps its immediate,
-  fail-closed reap and rethrow — `on-settled` is NOT fired here; the client
-  releases in its own catch (rf2-vxgfnd.18 AC4, untouched).
+  teardown for a later microtask. Whether the host tore down SYNCHRONOUSLY is
+  decided by a ROOT-LEVEL settlement law, independent of ViewCell population
+  (rf2-vxgfnd.275): POSITIVE evidence is the client `root-commit-reporter`'s
+  mount-lifetime cleanup sentinel firing DURING the thunk (`report-root-teardown!`
+  → the `teardown-settle-signal` volatile), OR the window capturing a
+  disconnecting cell (`collected`). Both observe the SAME synchronous cleanup
+  sweep; the reporter sentinel is present even for a compiled static/cell-less or
+  entirely Activity-hidden root that owns no connected cell — the case a
+  cell-connectivity probe (the retired `weak-connected`) could not discriminate
+  and so mis-classified as synchronous, releasing the claim into a still-scheduled
+  teardown. Neither signal ⇒ a DEFERRED teardown: this driver does NOT fire
+  `on-settled` synchronously — it schedules the SETTLEMENT (`settle-deferred-root!`)
+  FIFO-ordered after React's own deferred teardown, so the client holds its
+  root-id/container/prefix claim `:tearing-down` until React has actually cleared
+  the container. A SYNCHRONOUS teardown fires `on-settled` immediately, preserving
+  the ratified same-container immediate-remount.
+
+  A THROWING `.unmount` keeps its immediate, fail-closed reap of the exact
+  generation and rethrows; `on-settled` is NOT fired (rf2-vxgfnd.275): the host
+  cannot prove the container free, so the client FAILS CLOSED, leaving the exact
+  id/container/prefix claim QUARANTINED `:tearing-down` (reuse requires a fresh
+  container), never released into a possibly-still-scheduled teardown.
 
   Three arities: `[unmount-thunk]` (no explicit incarnation — window +
   captured-cell incarnations only), `[root-incarnation unmount-thunk]` (the
@@ -2786,17 +2822,27 @@
   ([root-incarnation unmount-thunk] (teardown-root! root-incarnation unmount-thunk nil))
   ([root-incarnation unmount-thunk on-settled]
    (let [prev       @teardown-collector
+         prev-sig   @teardown-settle-signal
+         fired      (volatile! false)
          host-error (volatile! nil)
          captured   (volatile! #{})
          _          (do
                       (reset! teardown-collector #{})
+                      ;; rf2-vxgfnd.275 — publish the root-level settlement signal
+                      ;; so the reporter's teardown sentinel (fired synchronously
+                      ;; by React during a normal `.unmount`) marks this teardown
+                      ;; settled. Only armed for the explicit-incarnation path.
+                      (reset! teardown-settle-signal
+                              (when root-incarnation
+                                {:incarnation root-incarnation :fired fired}))
                       (try
                         (unmount-thunk)
                         (catch #?(:clj Throwable :cljs :default) e
                           (vreset! host-error e))
                         (finally
                           (vreset! captured @teardown-collector)
-                          (reset! teardown-collector prev))))
+                          (reset! teardown-collector prev)
+                          (reset! teardown-settle-signal prev-sig))))
          collected  @captured
          explicit?  (some? root-incarnation)
          ;; When an explicit root incarnation is named it is AUTHORITATIVE: this
@@ -2841,19 +2887,28 @@
                      ;; cells still connected because React ran no cleanup.
                      (into owned (weak-live (get @root-cells root-incarnation)))
                      (into owned hidden))
-         ;; rf2-vxgfnd.182 — DEFERRED host teardown: the explicit non-throwing
-         ;; unmount ran none of this root's cleanups, so the window captured
-         ;; nothing yet the incarnation still owns CONNECTED cells. That residual
-         ;; connected membership is the discriminator; a synchronous teardown (or
-         ;; an empty root) has none. Computed BEFORE the reap — the captured
-         ;; victims are `:disconnected`, never in this connected set.
-         deferred? (and explicit? (not @host-error)
-                        (seq (weak-connected root-incarnation)))]
+         ;; rf2-vxgfnd.275 — the ROOT-LEVEL settlement law. POSITIVE evidence the
+         ;; host ran this root's teardown SYNCHRONOUSLY during the thunk is either
+         ;; the reporter's mount-lifetime cleanup sentinel firing (`@fired`,
+         ;; emitted even by a cell-less/hidden root) OR the window capturing a
+         ;; disconnecting cell (`collected`) — two observations of the one
+         ;; synchronous cleanup sweep. Neither ⇒ a DEFERRED teardown (react-dom
+         ;; refusing an in-render unmount): hold the claim `:tearing-down` and
+         ;; settle past React's own microtask. Unlike the retired cell-connectivity
+         ;; probe, this sees a compiled static/cell-less or entirely-hidden root's
+         ;; deferral — its whole point (rf2-vxgfnd.275). An empty/unrendered root
+         ;; with no reporter and no cells has neither signal, so it too holds one
+         ;; settlement microtask (safe: released only past React's teardown).
+         synchronous? (or @fired (seq collected))
+         deferred?    (and explicit? (not @host-error) (not synchronous?))]
      (doseq [cell victims]
        (teardown! cell))
      (cond
        @host-error
-       ;; on-settled is NOT fired — the client releases in its own catch (AC4).
+       ;; rf2-vxgfnd.275 — the exact generation is force-dead (victims) above;
+       ;; on-settled is NOT fired. The host teardown threw, so the container is
+       ;; NOT proven free: the client FAILS CLOSED in its own catch, leaving the
+       ;; id/container/prefix claim quarantined `:tearing-down` (never released).
        (throw @host-error)
 
        deferred?

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -499,6 +499,8 @@
         cell    (mount! ::v inc fid [[:rt/a]])
         settled (atom false)]
     (is (= :connected (reactive/lifecycle cell)) "precondition: connected")
+    ;; a rendered root has a COMMITTED reporter teardown-root! must await
+    (reactive/report-root-commit! inc)
     (reactive/teardown-root! inc
                              (fn [] nil)                    ;; deferred: no cleanup fired
                              (fn [] (reset! settled true)))
@@ -553,6 +555,9 @@
   (let [inc     (reactive/make-root-incarnation)
         settled (atom false)]
     (is (zero? (reactive/root-cell-count inc)) "precondition: a cell-less root")
+    ;; a RENDERED cell-less root still has a committed reporter to await — the
+    ;; ROOT-LEVEL signal ViewCell-connectivity could not supply (rf2-vxgfnd.275)
+    (reactive/report-root-commit! inc)
     (reactive/teardown-root! inc
                              (fn [] nil)          ;; deferred: no cleanup, no sentinel
                              (fn [] (reset! settled true)))

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -516,6 +516,55 @@
              "the connected cell is NOT reaped synchronously — the claim stays fenced")))))
 
 ;; ===========================================================================
+;; rf2-vxgfnd.275 — settlement is INDEPENDENT of ViewCell presence
+;;
+;; A compiled static/cell-less root — and an entirely Activity-hidden one — owns
+;; NO connected ViewCell, so residual cell-connectivity (the retired
+;; `weak-connected`) cannot tell a DEFERRED host teardown from a synchronous one.
+;; The ROOT-LEVEL settlement law uses the reporter's teardown sentinel
+;; (`report-root-teardown!`) instead: it fires even for a cell-less root, so a
+;; deferred cell-less teardown HOLDS the claim (never released into a
+;; still-scheduled teardown) and a synchronous one settles at once.
+;; ===========================================================================
+
+(deftest cell-less-root-synchronous-teardown-via-reporter-settles-immediately
+  ;; The reporter sentinel IS the root-level law: a host `.unmount` that runs the
+  ;; reporter cleanup SYNCHRONOUSLY (as React does for a normal unmount) settles
+  ;; immediately even though the incarnation owns NO ViewCell — no cell need be
+  ;; observed. Reverting to a cell-connectivity probe would hold this needlessly.
+  (let [inc     (reactive/make-root-incarnation)
+        settled (atom false)]
+    (is (zero? (reactive/root-cell-count inc)) "precondition: a cell-less root")
+    (reactive/teardown-root! inc
+                             ;; the host `.unmount` runs the reporter's cleanup
+                             ;; sentinel synchronously — the root-level signal
+                             (fn [] (reactive/report-root-teardown! inc))
+                             (fn [] (reset! settled true)))
+    (is (true? @settled)
+        "a synchronous cell-less teardown settles immediately, on every host")))
+
+(deftest cell-less-root-deferred-teardown-holds-settlement-past-the-window
+  ;; The red-before-fix core: a DEFERRED host teardown of a cell-less root (the
+  ;; thunk fires NEITHER a cell cleanup NOR the reporter sentinel, modelling
+  ;; react-dom 19.2's in-render deferral of an empty/static root). Pre-fix,
+  ;; `weak-connected` saw no connected cell and mis-classified this SYNCHRONOUS,
+  ;; firing `on-settled` immediately (releasing the claim into React's still-
+  ;; scheduled teardown). Now it is recognised DEFERRED and the settlement is held.
+  (let [inc     (reactive/make-root-incarnation)
+        settled (atom false)]
+    (is (zero? (reactive/root-cell-count inc)) "precondition: a cell-less root")
+    (reactive/teardown-root! inc
+                             (fn [] nil)          ;; deferred: no cleanup, no sentinel
+                             (fn [] (reset! settled true)))
+    #?(:clj
+       (testing "JVM: no async host teardown — the deferred settlement runs synchronously"
+         (is (true? @settled) "on-settled fired at the synchronous settlement"))
+       :cljs
+       (testing "CLJS: a cell-less DEFERRAL holds — on-settled did NOT fire synchronously"
+         (is (false? @settled)
+             "the claim is held past the window — never released while teardown is deferred")))))
+
+;; ===========================================================================
 ;; Re-entrancy — a nested teardown does not corrupt the outer window
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_wiring_cljs_test.cljs
@@ -40,13 +40,22 @@
   (:root-incarnation (client/live-root-entry root-id)))
 
 (defn- register!
-  "Register a fake Root whose host `.unmount` runs `on-unmount`."
+  "Register a fake Root whose host `.unmount` runs `on-unmount`, then fires the
+  root-commit-reporter's teardown sentinel — modelling a SYNCHRONOUS React
+  teardown that runs the reporter cleanup during `.unmount` (rf2-vxgfnd.275: the
+  ROOT-LEVEL host-teardown signal, emitted even when the root's cells are all
+  already Activity-hidden and the window captures nothing)."
   [root-id on-unmount]
-  (let [react-root #js {:unmount (fn [] (when on-unmount (on-unmount)))}
+  (let [react-root #js {}
         container  (js-obj)
         root       (client/->Root react-root container root-id)]
     (client/register-live-root! {:root-id root-id :provenance :authored}
                                 container root)
+    (let [inc (root-incarnation root-id)]
+      (unchecked-set react-root "unmount"
+                     (fn []
+                       (when on-unmount (on-unmount))
+                       (reactive/report-root-teardown! inc))))
     root))
 
 (defn- owned-cell!

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -391,10 +391,12 @@
                    (fn [] (throw (js/Error. "host teardown boom"))))
     (client/->Root rr container root-id)))
 
-(deftest unmount-releases-claim-even-when-host-teardown-throws
-  ;; rf2-vxgfnd.18 — TOTAL teardown: a throwing host `.unmount` must not
-  ;; strand the framework claim. The registry release rides a `finally`,
-  ;; the host error still propagates, and a second unmount!* is a no-op.
+(deftest unmount-quarantines-claim-when-host-teardown-throws
+  ;; rf2-vxgfnd.275 — a throwing host `.unmount` cannot PROVE the container free,
+  ;; so the framework FAILS CLOSED: the exact claim is left QUARANTINED
+  ;; `:tearing-down` (NOT released — reversing the earlier .18 AC4 immediate
+  ;; release, which could be clobbered by React self-completing the aborted
+  ;; teardown). The host error still propagates and a second unmount!* is a no-op.
   (let [c    (js-obj)
         root (root-with-throwing-unmount :reg/boom c)]
     (client/register-live-root! {:root-id :reg/boom :provenance :authored} c root)
@@ -402,10 +404,12 @@
     (is (thrown-with-msg? js/Error #"host teardown boom"
                           (client/unmount!* root))
         "the host teardown error propagates to the caller")
-    (is (= #{} (client/live-root-ids))
-        "the exact claim is released despite the throw (finally-shaped)")
+    (is (= #{:reg/boom} (client/live-root-ids))
+        "the exact claim is QUARANTINED :tearing-down, not released")
+    (is (:tearing-down? (client/live-root-entry :reg/boom))
+        "…the entry is marked tearing-down (reuse fails loud; recover via a fresh container)")
     (is (nil? (client/unmount!* root))
-        "a second unmount!* is a no-op — the claim is already gone")))
+        "a second unmount!* is a no-op — the tearing-down guard short-circuits")))
 
 (deftest unmount-throw-release-is-identity-guarded
   ;; a STALE handle whose root-id now maps to a NEWER root must not evict
@@ -513,17 +517,15 @@
     (client/->Root rr container root-id)))
 
 (deftest unmount-throw-aftermath-warns-honestly-there-is-no-manual-escape
-  ;; rf2-vxgfnd.53 + rf2-vxgfnd.84 — the aftermath of .18 AC4's release-on-throw.
-  ;; RULING (b), UNCHANGED: KEEP AC4 (release the claim on a throwing host
-  ;; .unmount; a second unmount!* is a no-op; the host error propagates).
-  ;; rf2-vxgfnd.84 corrects the DIAGNOSTIC to the truth verified against pinned
-  ;; react-dom 19.2.0: ReactDOMRoot.unmount() nulls its internal root BEFORE the
-  ;; flush that throws, so after a throwing unmount the handle is CONSUMED and
-  ;; (.unmount (.-react-root root)) again is a SILENT NO-OP — there is NO manual
-  ;; escape through it. React defers + usually self-completes the teardown work
-  ;; scheduled pre-throw; a genuinely stuck container needs innerHTML clearing or
-  ;; a fresh container. The .53 release-on-throw CONTRACT is untouched — only the
-  ;; diagnostic's guidance and this test's fake fidelity change.
+  ;; rf2-vxgfnd.53/.84 diagnostic honesty, now FAIL-CLOSED per rf2-vxgfnd.275.
+  ;; The handle is CONSUMED — ReactDOMRoot.unmount() nulls its internal root
+  ;; BEFORE the flush that throws (pinned react-dom 19.2.0), so (.unmount
+  ;; (.-react-root root)) again is a SILENT NO-OP: no manual escape. rf2-vxgfnd.275
+  ;; REVERSES the .18 AC4 release-on-throw: because the container cannot be proven
+  ;; free, the claim is QUARANTINED `:tearing-down` (not released), so a reused id
+  ;; or container fails loud instead of racing React's aborted teardown; recovery
+  ;; is a FRESH container. The host error still propagates and a second unmount!*
+  ;; is a no-op (the tearing-down guard).
   (let [c        (js-obj)
         calls    (atom 0)
         root     (root-with-consuming-unmount-throws-once :reg/orphan c calls)
@@ -542,16 +544,19 @@
       (finally
         (set! (.-warn js/console) orig)))
     (is (= 1 @calls) "React's .unmount was reached exactly once (and it threw)")
-    (is (= #{} (client/live-root-ids))
-        "the exact claim is released despite the throw (.18 AC4, finally-shaped)")
+    (is (= #{:reg/orphan} (client/live-root-ids))
+        "the exact claim is QUARANTINED :tearing-down, not released (rf2-vxgfnd.275)")
+    (is (:tearing-down? (client/live-root-entry :reg/orphan))
+        "…the entry is marked tearing-down — reuse fails loud, recover via a fresh container")
     (is (nil? (client/unmount!* root))
-        "a second unmount!* is a no-op — the framework cannot retry the host unmount")
+        "a second unmount!* is a no-op — the tearing-down guard short-circuits")
     (is (= 1 @calls)
         "the no-op second unmount!* never reaches React's .unmount again")
-    ;; (2) rf2-vxgfnd.84: the aftermath is NON-SILENT AND HONEST — the diagnostic
-    ;; states the handle is consumed (no manual escape) and names the real
-    ;; recovery, and does NOT recommend the (no-op) (.unmount (.-react-root root)).
-    (let [msg (str/join "\n" @captured)]
+    ;; (2) the aftermath is NON-SILENT AND HONEST — the diagnostic states the
+    ;; handle is consumed (no manual escape), that the claim is quarantined rather
+    ;; than released, and names the real recovery (a fresh container); it does NOT
+    ;; recommend the (no-op) (.unmount (.-react-root root)).
+    (let [msg (str/lower-case (str/join "\n" @captured))]
       (is (seq @captured) "a dev diagnostic fired on the throwing unmount")
       (is (not (str/includes? msg "(.unmount (.-react-root root))"))
           "the diagnostic NO LONGER recommends the consumed-handle no-op escape")
@@ -559,8 +564,10 @@
           "the diagnostic states re-calling the consumed handle is a no-op")
       (is (str/includes? msg "consumed")
           "the diagnostic names the CONSUMED handle as the reason there is no escape")
-      (is (str/includes? msg "innerHTML")
-          "the diagnostic names the real recovery — clear the container directly"))
+      (is (str/includes? msg "quarantin")
+          "the diagnostic states the claim is quarantined, not released (fail closed)")
+      (is (str/includes? msg "fresh container")
+          "the diagnostic names the real recovery — mount into a fresh container"))
     ;; (3) FIDELITY: the handle is CONSUMED — calling .unmount on the SAME handle
     ;; again is a SILENT NO-OP (this._internalRoot was nulled BEFORE the throw),
     ;; NOT a successful teardown. The pre-.84 fake modelled a second-call SUCCESS,

--- a/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
@@ -121,6 +121,11 @@
 ;; One sub-bearing view → one ViewCell under the mounted root.
 (defview leaf [_] [:span.leaf (str (sub [:rt.dom/n]))])
 
+;; A compiled STATIC (subless) view → NO ViewCell under the mounted root
+;; (rf2-vxgfnd.275): the CLJS emitter wraps only a sub-bearing body in
+;; `viewcell/render`, so this root owns nothing residual cell-connectivity can see.
+(defview static-leaf [_] [:span.static "static"])
+
 (defn- register-app! []
   (rf/make-frame {:id frame-kw :doc "root-teardown DOM probe frame"})
   (rf/reg-sub :rt.dom/n (fn [db _] (:n db)))
@@ -274,3 +279,62 @@
             (is (some? M2))
             (is (= "7" (.-textContent (.querySelector c ".leaf"))))
             (act! #(ui/unmount! M2))))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.275 — a DEFERRED render-phase teardown FENCES a CELL-LESS root
+;;
+;; The real-React proof that settlement is INDEPENDENT of ViewCell presence. A
+;; compiled static (subless) view mounts NO ViewCell, so residual cell-
+;; connectivity (the retired `weak-connected`) cannot see a deferred teardown and
+;; the claim was released immediately — into a container React was still scheduled
+;; to clear. The root-commit-reporter's mount-lifetime sentinel is a ROOT-LEVEL
+;; signal present even here, so the deferred teardown is recognised and the
+;; id/container claim held until React settles.
+;; ===========================================================================
+
+(deftest deferred-render-phase-unmount-fences-a-cell-less-root
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (async
+     done
+     (register-app!)
+     (let [c    (container)
+           M    (act! #(ui/mount [frame-provider {:frame frame-kw} [static-leaf {}]]
+                                 c {:root-id :rt.dom/cell-less}))
+           same-id-error (atom :unset)
+           diff-id-error (atom :unset)]
+       (is (= "static" (.-textContent (.querySelector c ".static"))) "precondition: rendered")
+       (is (zero? (count (reactive/current-live-cells)))
+           "precondition: the static view owns NO ViewCell — a cell-less root")
+       (in-commit-phase!
+        (fn []
+          ;; `.unmount` during a React commit → react-dom 19.2 DEFERS it. With no
+          ;; cell to observe, ONLY the reporter's root-level sentinel can fence it.
+          (client/unmount!* M)
+          (reset! same-id-error
+                  (thrown-id #(client/mount*
+                               {:root-id :rt.dom/cell-less :provenance :authored}
+                               c (fn [] (React/createElement "div" nil "reentrant"))
+                               nil nil)))
+          (reset! diff-id-error
+                  (thrown-id #(client/check-root-claim!
+                               'test {:root-id :rt.dom/other :provenance :authored} c)))))
+       (testing "while the cell-less teardown is deferred, BOTH id arms are fenced (AC1)"
+         (is (contains? #{:rf.error/duplicate-root-id :rf.error/root-container-in-use}
+                        @same-id-error)
+             "a same-id/same-container reentrant mount is rejected before React allocation")
+         (is (= :rf.error/root-container-in-use @diff-id-error)
+             "a different-id/same-container claim is rejected too"))
+       (js/queueMicrotask
+        (fn []
+          (testing "after settlement the claim frees and a fresh mount succeeds (AC1)"
+            (is (not (contains? (client/live-root-ids) :rt.dom/cell-less))
+                "the claim is freed only at the settlement boundary — no predecessor clobber")
+            (is (= "" (.-innerHTML c)) "React cleared the container")
+            (let [M2 (act! #(ui/mount [frame-provider {:frame frame-kw} [static-leaf {}]]
+                                      c {:root-id :rt.dom/cell-less}))]
+              (is (some? M2))
+              (is (= "static" (.-textContent (.querySelector c ".static")))
+                  "the replacement renders on the settled container")
+              (act! #(ui/unmount! M2))))
+          (done)))))))

--- a/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_dom_cljs_test.cljs
@@ -121,11 +121,6 @@
 ;; One sub-bearing view → one ViewCell under the mounted root.
 (defview leaf [_] [:span.leaf (str (sub [:rt.dom/n]))])
 
-;; A compiled STATIC (subless) view → NO ViewCell under the mounted root
-;; (rf2-vxgfnd.275): the CLJS emitter wraps only a sub-bearing body in
-;; `viewcell/render`, so this root owns nothing residual cell-connectivity can see.
-(defview static-leaf [_] [:span.static "static"])
-
 (defn- register-app! []
   (rf/make-frame {:id frame-kw :doc "root-teardown DOM probe frame"})
   (rf/reg-sub :rt.dom/n (fn [db _] (:n db)))
@@ -280,61 +275,14 @@
             (is (= "7" (.-textContent (.querySelector c ".leaf"))))
             (act! #(ui/unmount! M2))))))))
 
-;; ===========================================================================
-;; rf2-vxgfnd.275 — a DEFERRED render-phase teardown FENCES a CELL-LESS root
-;;
-;; The real-React proof that settlement is INDEPENDENT of ViewCell presence. A
-;; compiled static (subless) view mounts NO ViewCell, so residual cell-
-;; connectivity (the retired `weak-connected`) cannot see a deferred teardown and
-;; the claim was released immediately — into a container React was still scheduled
-;; to clear. The root-commit-reporter's mount-lifetime sentinel is a ROOT-LEVEL
-;; signal present even here, so the deferred teardown is recognised and the
-;; id/container claim held until React settles.
-;; ===========================================================================
-
-(deftest deferred-render-phase-unmount-fences-a-cell-less-root
-  (if-not (browser?)
-    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
-    (async
-     done
-     (register-app!)
-     (let [c    (container)
-           M    (act! #(ui/mount [frame-provider {:frame frame-kw} [static-leaf {}]]
-                                 c {:root-id :rt.dom/cell-less}))
-           same-id-error (atom :unset)
-           diff-id-error (atom :unset)]
-       (is (= "static" (.-textContent (.querySelector c ".static"))) "precondition: rendered")
-       (is (zero? (count (reactive/current-live-cells)))
-           "precondition: the static view owns NO ViewCell — a cell-less root")
-       (in-commit-phase!
-        (fn []
-          ;; `.unmount` during a React commit → react-dom 19.2 DEFERS it. With no
-          ;; cell to observe, ONLY the reporter's root-level sentinel can fence it.
-          (client/unmount!* M)
-          (reset! same-id-error
-                  (thrown-id #(client/mount*
-                               {:root-id :rt.dom/cell-less :provenance :authored}
-                               c (fn [] (React/createElement "div" nil "reentrant"))
-                               nil nil)))
-          (reset! diff-id-error
-                  (thrown-id #(client/check-root-claim!
-                               'test {:root-id :rt.dom/other :provenance :authored} c)))))
-       (testing "while the cell-less teardown is deferred, BOTH id arms are fenced (AC1)"
-         (is (contains? #{:rf.error/duplicate-root-id :rf.error/root-container-in-use}
-                        @same-id-error)
-             "a same-id/same-container reentrant mount is rejected before React allocation")
-         (is (= :rf.error/root-container-in-use @diff-id-error)
-             "a different-id/same-container claim is rejected too"))
-       (js/queueMicrotask
-        (fn []
-          (testing "after settlement the claim frees and a fresh mount succeeds (AC1)"
-            (is (not (contains? (client/live-root-ids) :rt.dom/cell-less))
-                "the claim is freed only at the settlement boundary — no predecessor clobber")
-            (is (= "" (.-innerHTML c)) "React cleared the container")
-            (let [M2 (act! #(ui/mount [frame-provider {:frame frame-kw} [static-leaf {}]]
-                                      c {:root-id :rt.dom/cell-less}))]
-              (is (some? M2))
-              (is (= "static" (.-textContent (.querySelector c ".static")))
-                  "the replacement renders on the settled container")
-              (act! #(ui/unmount! M2))))
-          (done)))))))
+;; NOTE (rf2-vxgfnd.275): a real-React *cell-less* deferred-fence fixture is NOT
+;; constructible in this DEV `:browser-test` build — the emitter gives EVERY dev
+;; view a stable ViewCell hook skeleton (HMR same-signature), so no rendered view
+;; is cell-less here; a subless view goes cell-less only under `:advanced` +
+;; `goog.DEBUG=false` (direct React.memo). The ROOT-LEVEL settlement law
+;; (`live-reporters` / `report-root-teardown!`) that makes a rendered cell-less
+;; root's deferral observable is exercised in real React by the cell-bearing
+;; `deferred-render-phase-unmount-fences-reentrant-remount` above (which now
+;; routes through the reporter sentinel), and the cell-less-specific path
+;; (reporter live, `root-cell-count` 0) is pinned by the graft + wiring fixtures
+;; (`reactive-root-teardown-cljs-test`, `root-teardown-wiring-cljs-test`).

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -152,6 +152,9 @@
         root (register! :rtw/root (fn [] nil))
         inc  (:root-incarnation (client/live-root-entry :rtw/root))]
     (reactive/attach-root! cell inc)
+    ;; a rendered root has a COMMITTED reporter whose host teardown teardown-root!
+    ;; must await — the ROOT-LEVEL deferral signal (rf2-vxgfnd.275)
+    (reactive/report-root-commit! inc)
     (is (= :connected (reactive/lifecycle cell)) "precondition: mounted + connected")
     (is (nil? (client/unmount!* root)) "unmount!* returns nil (host .unmount did not throw)")
     (testing "the deferred teardown is FENCED — the claim is held :tearing-down"
@@ -176,6 +179,7 @@
         inc  (:root-incarnation (client/live-root-entry :rtw/root))
         c    (:container (client/live-root-entry :rtw/root))]
     (reactive/attach-root! cell inc)
+    (reactive/report-root-commit! inc)     ;; rendered root: committed reporter to await
     (is (nil? (client/unmount!* root)))
     (is (= :rf.error/root-container-in-use
            (thrown-id #(client/check-root-claim!
@@ -194,6 +198,7 @@
         root   (register! :rtw/root (fn [] (swap! calls inc)))
         inc    (:root-incarnation (client/live-root-entry :rtw/root))]
     (reactive/attach-root! cell inc)
+    (reactive/report-root-commit! inc)     ;; rendered root: committed reporter to await
     (is (nil? (client/unmount!* root)))
     (is (= 1 @calls) "first unmount drove the host handle once")
     (is (nil? (client/unmount!* root)) "a second unmount during deferral is a no-op")
@@ -214,12 +219,15 @@
 (deftest deferred-cell-less-teardown-fences-the-claim-not-released-immediately
   (live-frame/make-frame {:id :rtw/frame})
   (frame/replace-app-db! :rtw/frame {:a 1})
-  ;; NO cell is attached to this root — it is cell-less. The fake host `.unmount`
-  ;; DEFERS: it returns normally, firing no cleanup and no reporter sentinel.
+  ;; NO cell is attached to this root — it is cell-less. But a RENDERED cell-less
+  ;; root DID commit a reporter (report-root-commit!), so its host teardown is
+  ;; awaited. The fake host `.unmount` DEFERS: it returns normally, firing no
+  ;; cleanup and no reporter sentinel.
   (let [root (register! :rtw/root (fn [] nil))
+        inc  (:root-incarnation (client/live-root-entry :rtw/root))
         c    (:container (client/live-root-entry :rtw/root))]
-    (is (zero? (reactive/root-cell-count
-                (:root-incarnation (client/live-root-entry :rtw/root))))
+    (reactive/report-root-commit! inc)     ;; the rendered cell-less root's reporter
+    (is (zero? (reactive/root-cell-count inc))
         "precondition: a cell-less root — no ViewCell to observe")
     (is (nil? (client/unmount!* root)) "unmount!* returns nil (host .unmount did not throw)")
     (testing "the cell-less deferral is FENCED — the claim is held :tearing-down"

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -49,6 +49,9 @@
                                 container root)
     root))
 
+(defn- thrown-id [f]
+  (try (f) nil (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
+
 (deftest unmount-drives-the-cell-to-dead-and-releases-the-claim
   (rf/reg-sub :rtw/a (fn [db _] (:a db)))
   (live-frame/make-frame {:id :rtw/frame})
@@ -73,10 +76,14 @@
     (testing "the live-root claim is released (contract §7)"
       (is (= #{} (client/live-root-ids))))))
 
-(deftest a-throwing-host-unmount-still-releases-the-claim-and-rethrows
-  ;; React can consume its Root handle before a synchronous unmount flush
-  ;; throws. The public claim is released and the exact incarnation's framework
-  ;; ownership is force-dead before the original host error propagates.
+(deftest a-throwing-host-unmount-quarantines-the-claim-and-rethrows
+  ;; rf2-vxgfnd.275 — the host-throws settlement fixture. React can consume its
+  ;; Root handle before a synchronous unmount flush throws; whether the container
+  ;; is actually free is then UNKNOWABLE in-process. FAIL CLOSED: the exact
+  ;; id/container/prefix claim is QUARANTINED `:tearing-down` (NOT released — the
+  ;; pre-.275 behaviour), so a reused id or container fails loud instead of racing
+  ;; React self-completing the aborted teardown. The primary host error still
+  ;; propagates and the exact generation is force-dead.
   (rf/reg-sub :rtw/a (fn [db _] (:a db)))
   (live-frame/make-frame {:id :rtw/frame})
   (frame/replace-app-db! :rtw/frame {:a 1})
@@ -89,8 +96,15 @@
                     (try (client/unmount!* root) nil
                          (catch :default e e)))
         "the original host error propagates, never masked")
-    (testing "the claim is released despite the throw (AC4)"
-      (is (= #{} (client/live-root-ids))))
+    (testing "the claim is QUARANTINED despite the throw — fail closed (rf2-vxgfnd.275)"
+      (is (contains? (client/live-root-ids) :rtw/root)
+          "the id/container claim is NOT released — the container is not proven free")
+      (is (= :rf.error/duplicate-root-id
+             (thrown-id #(client/check-root-claim!
+                          'test {:root-id :rtw/root :provenance :authored}
+                          (:container (client/live-root-entry :rtw/root)))))
+          "a reused root-id fails loud — the honest recovery is a fresh container")
+      (is (nil? (client/unmount!* root)) "a second unmount! is a no-op (tearing-down guard)"))
     (testing "the consumed root generation retains no framework owner"
       (is (= :dead (reactive/lifecycle cell)))
       (is (zero? (reactive/root-cell-count inc))))))
@@ -127,9 +141,6 @@
 ;; synchronously on the JVM (`reactive-root-teardown-cljs-test`) and end-to-end
 ;; under real react-dom in `root-mount-dom-cljs-test`.
 ;; ===========================================================================
-
-(defn- thrown-id [f]
-  (try (f) nil (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
 
 (deftest deferred-host-teardown-fences-the-claim-not-released-immediately
   (rf/reg-sub :rtw/a (fn [db _] (:a db)))
@@ -187,3 +198,38 @@
     (is (= 1 @calls) "first unmount drove the host handle once")
     (is (nil? (client/unmount!* root)) "a second unmount during deferral is a no-op")
     (is (= 1 @calls) "the consumed host handle was not re-driven")))
+
+;; ===========================================================================
+;; rf2-vxgfnd.275 — a DEFERRED teardown of a CELL-LESS root still fences
+;;
+;; A compiled static/cell-less root owns NO ViewCell. Pre-fix, `unmount!*` drove
+;; teardown-root! whose only deferral signal was residual cell-connectivity, so a
+;; cell-less root — nothing to observe — was always classified SYNCHRONOUS and the
+;; claim released immediately, even when react-dom deferred the actual teardown.
+;; The root-level settlement law fences it: the fake host `.unmount` here DEFERS
+;; (returns without firing the reporter sentinel), and no cell exists, so the
+;; claim must be held `:tearing-down` past the window.
+;; ===========================================================================
+
+(deftest deferred-cell-less-teardown-fences-the-claim-not-released-immediately
+  (live-frame/make-frame {:id :rtw/frame})
+  (frame/replace-app-db! :rtw/frame {:a 1})
+  ;; NO cell is attached to this root — it is cell-less. The fake host `.unmount`
+  ;; DEFERS: it returns normally, firing no cleanup and no reporter sentinel.
+  (let [root (register! :rtw/root (fn [] nil))
+        c    (:container (client/live-root-entry :rtw/root))]
+    (is (zero? (reactive/root-cell-count
+                (:root-incarnation (client/live-root-entry :rtw/root))))
+        "precondition: a cell-less root — no ViewCell to observe")
+    (is (nil? (client/unmount!* root)) "unmount!* returns nil (host .unmount did not throw)")
+    (testing "the cell-less deferral is FENCED — the claim is held :tearing-down"
+      (is (contains? (client/live-root-ids) :rtw/root)
+          "the claim is NOT released immediately though the root owns no cell")
+      (is (= :rf.error/duplicate-root-id
+             (thrown-id #(client/check-root-claim!
+                          'test {:root-id :rtw/root :provenance :authored} c)))
+          "a reentrant mount on the exact root-id is rejected while teardown is deferred")
+      (is (= :rf.error/root-container-in-use
+             (thrown-id #(client/check-root-claim!
+                          'test {:root-id :rtw/other :provenance :authored} c)))
+          "a different root-id targeting the fenced container is rejected too"))))


### PR DESCRIPTION
Reworks the freshly-landed root-lifecycle surface (#5885 `:tearing-down` fence + settlement microtask; #5903 flush-render settle + preflight receipts) so root teardown **settlement** is independent of ViewCell presence and host success. Builds on the merged mechanisms — no parallel one.

## rf2-vxgfnd.275 — root teardown settlement independent of ViewCell presence + host success (P1)

**Re-verified against current `reactive.cljc` / `client.cljs`.** Both holes still reproduced on `origin/main`:
- The `.182` deferred-teardown detector was `weak-connected` — residual *connected* ViewCells. A compiled static/cell-less root and an entirely Activity-hidden root own **no connected cell**, so a deferred host teardown was mis-classified **synchronous** and the exact id/container/prefix claim released immediately — into a container React was still scheduled to clear (a same-stack successor could then be clobbered by the predecessor's queued teardown).
- A **throwing** host `.unmount` released the claim even though React can still complete scheduled cleanup later.

### Fix — one ROOT-LEVEL settlement law, gated on the committed reporter
- **`live-reporters` registry + reporter sentinel** (`reactive.cljc` + `client.cljs`): the `root-commit-reporter`'s mount-lifetime `useLayoutEffect` marks the root's reporter **live on COMMIT** (`report-root-commit!`, its SETUP) and clears it on host teardown (`report-root-teardown!`, its cleanup — synchronously inside a synchronous `.unmount`, or in react-dom's deferred microtask). Because the reporter wraps **every** root render, this signal exists even for a cell-less/hidden root.
- **`teardown-root!`** now classifies a teardown as **DEFERRED iff** a committed reporter for the root has not yet torn down (`live-reporters`) **and** its sentinel did not fire during the thunk (`report-root-teardown!` → a `teardown-settle-signal` volatile). A RENDERED root — cell-bearing OR cell-less/hidden — has a committed reporter, so its deferral is observed regardless of ViewCell population (**retiring `weak-connected`**). An **unrendered / pre-commit** root (unrendered `create-root`, `unmount!` before first commit) has no committed reporter → nothing pending → settles synchronously. `collected` no longer classifies; it only drives the cell reap.
- **Throwing host `.unmount` fails closed**: `unmount!*` leaves the exact id/container/prefix claim **quarantined `:tearing-down`** (never released), the primary error still propagates, a second `unmount!` is a no-op, and the dev diagnostic names a fresh container as recovery. Under **adapter disposal**, `drain-live-roots!` releases that quarantine once `reclaim-consumed-container!` **proves the container free** (the "quarantined until proven safe" release of AC3) — so a throwing root's container is reusable after `destroy-adapter!`, while an isolated `unmount!` throw stays fail-closed.

`check-root-claim!` already fences a `:tearing-down` entry across id + container + prefix, so quarantine needs no new admission code.

### Fixtures (red-before-fix)
- **cell-less-root settlement**: graft `cell-less-root-deferred-teardown-holds-settlement-past-the-window` + `cell-less-root-synchronous-teardown-via-reporter-settles-immediately` (`reactive_root_teardown_cljs_test.cljc`, JVM+node) and wiring `deferred-cell-less-teardown-fences-the-claim-not-released-immediately` (`root_teardown_wiring_cljs_test.cljs`, node) — a root with `root-cell-count` 0, reporter live, deferred `.unmount` → held; both same-id and different-id/same-container fenced.
- **host-.unmount-throws settlement**: wiring `a-throwing-host-unmount-quarantines-the-claim-and-rethrows` + registry `unmount-quarantines-claim-when-host-teardown-throws` / `unmount-throw-aftermath-warns-honestly-...` updated to the fail-closed quarantine (reversing the `.18` AC4 release-on-throw). The adapter disposal DOM fixtures (`throwing-public-root-cleanup-is-total-and-container-is-reusable`) prove the reclaim-then-release reuse under real React.
- The reporter-live mechanism is exercised in **real React** by the existing cell-bearing `deferred-render-phase-unmount-fences-reentrant-remount` (now routed through the reporter sentinel). A rendered *cell-less* root is not constructible in the DEV `:browser-test` build — the emitter gives every dev view a ViewCell hook skeleton (HMR same-signature); a subless view goes cell-less only under `:advanced` + `goog.DEBUG=false` — so no DEV browser cell-less fixture (documented inline).

### Scope
- Touches only `implementation/ui/src/re_frame/ui/{reactive.cljc, client.cljs}` + their tests.
- Not in this PR: **AC2 (failed-first-mount rollback fencing)** — the mount* rollback still releases before its raw host `.unmount`. Deferred as scoped follow-up (a failed first render commits no reporter, so it needs its own treatment); outside the two red-before-fix fixtures this PR was scoped to.

## rf2-vxgfnd.262 — NOT in this PR (docs-only, out of scope)

Re-verified: the runtime is already correct — `commit!` step 1 runs the cell-local `(not= (:generation cap) (:generation st0))` comparison **unconditionally**, with only the `registered-view-revision` arm `interop/debug-enabled?`-gated. The defect is **docs**: `spec/006-ReactiveSubstrate.md` (§"Body authority under hot reload", ~lines 1176-1178) falsely claims the *whole* two-point fence constant-folds away in production, and `ai/findings/new-substrate-synthesis/03` needs the matching reconciliation. The bead says "No runtime/API change — one docs-contract sweep." Those targets are outside this code PR's scope fence (spec/** is hot-zone and overlaps `.277`'s owned Specs 004C/006/009 pass; the ai/ tree is never git-added). Recommend re-dispatch as a docs bead, folded into or sequenced with `.277`.

## Quality gates
- JVM: `(cd implementation/ui && clojure -M:test)` — **519 tests, 0 failures**.
- node: `(cd implementation && npm run test:ui)` — **519 tests, 0 failures**.
- browser: `(cd implementation && npm run test:browser)` — **357 tests, 1936 assertions, 0 failures** (headless Chromium, local).
- Production-elision, bundle-isolation, public-API-manifest-drift, G-1/G-13 CI gates green on the prior run.
