### PR TITLE
fix(machines): fence every remaining lifecycle tail to its exact incarnation (rf2-i4aj9c)

### DIFF
--- a/implementation/machines/src/re_frame/machines/classification.cljc
+++ b/implementation/machines/src/re_frame/machines/classification.cljc
@@ -164,13 +164,24 @@
   write surface the four commit-plane effects and the marks API share — so
   the lowered declaration unions with every other source at egress-lookup
   time and the existing readers (`frame-snapshot-classification`, the SSR / trace
-  boundaries) redact with no change. Returns nil."
-  [frame-id actor-id spec]
-  (when actor-id
-    (when-let [decls (machine-declarations spec)]
-      (elision/swap-elision-slot! frame-id
-                                  (fn [reg] (apply-decls reg actor-id decls true)))))
-  nil)
+  boundaries) redact with no change. Returns nil.
+
+  rf2-i4aj9c — the 4-arity threads A's exact-incarnation `owner-token` through
+  `swap-elision-slot!`'s EXACT arity (the same exact-write the flow lifecycle
+  ops issue, rf2-vxgfnd.155): a synchronous container watch that destroys A and
+  publishes same-id B DURING this durable-registry write neither redirects the
+  write into B nor bumps B's commit epoch — on mid-write loss it writes nothing.
+  The 3-arity is the historical bare-id write (no event owner — conformance /
+  pure-fn callers)."
+  ([frame-id actor-id spec] (lower-at-spawn! frame-id actor-id spec nil))
+  ([frame-id actor-id spec owner-token]
+   (when actor-id
+     (when-let [decls (machine-declarations spec)]
+       (let [xf (fn [reg] (apply-decls reg actor-id decls true))]
+         (if owner-token
+           (elision/swap-elision-slot! frame-id owner-token xf)
+           (elision/swap-elision-slot! frame-id xf)))))
+   nil))
 
 (defn drop-at-destroy!
   "DROP the machine `spec`'s per-instance classification declarations for
@@ -180,10 +191,19 @@
   for the same path survive); an emptied axis slot is pruned so a frame that
   destroys its last classified actor is left without a stray registry
   sub-tree (no leak). A no-op when the spec declared no classification or
-  `actor-id` is nil. Returns nil."
-  [frame-id actor-id spec]
-  (when actor-id
-    (when-let [decls (machine-declarations spec)]
-      (elision/swap-elision-slot! frame-id
-                                  (fn [reg] (apply-decls reg actor-id decls false)))))
-  nil)
+  `actor-id` is nil. Returns nil.
+
+  rf2-i4aj9c — the 4-arity threads A's exact-incarnation `owner-token` through
+  `swap-elision-slot!`'s EXACT arity so a container watch that destroys A and
+  publishes same-id B mid-write cannot re-root the drop onto B's registry or
+  bump B's commit epoch (the drop tail of the incarnation-fence family). The
+  3-arity is the historical bare-id write (no event owner)."
+  ([frame-id actor-id spec] (drop-at-destroy! frame-id actor-id spec nil))
+  ([frame-id actor-id spec owner-token]
+   (when actor-id
+     (when-let [decls (machine-declarations spec)]
+       (let [xf (fn [reg] (apply-decls reg actor-id decls false))]
+         (if owner-token
+           (elision/swap-elision-slot! frame-id owner-token xf)
+           (elision/swap-elision-slot! frame-id xf)))))
+   nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -59,6 +59,7 @@
   call-sites."
   (:require [re-frame.frame :as frame]
             [re-frame.machines.classification :as classification]
+            [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
@@ -71,6 +72,45 @@
             [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; ---- exact-incarnation destroy fence (rf2-i4aj9c) --------------------------
+;;
+;; The ordinary `:rf.machine/destroy` effect runs inside the destroying event's
+;; fx drain, so `*event-owner*` names the exact frame incarnation A that owns
+;; the in-flight event. `teardown-live-actor!`'s pipeline crosses SEVERAL
+;; callback-bearing boundaries — the actor's `:exit` cascade, the late-bound
+;; HTTP-abort hook, the `:rf.machine.timer/cancelled` traces, the
+;; `:rf.machine/destroyed` trace, the `:rf.machine/system-id-released` trace,
+;; and the `:rf.registry/handler-cleared` unregister trace — any of which can
+;; synchronously destroy A and publish a same-id successor B. Every subsequent
+;; framework-owned action (classification / timer / spawn-order / registrar /
+;; resource-lease / the durable teardown projection) resolves a bare frame /
+;; actor id to the CURRENT incarnation B, so running it after A is lost erases
+;; or mutates B. The fence captures A's continuation + raw token ONCE at the
+;; effect entry and rechecks after every callback-bearing boundary before the
+;; next framework action; the durable writes ride the exact owner token.
+
+(def ^:private eventless-fence
+  "The inert fence for a genuinely eventless destroy caller — the frame-destroy
+  cascade running outside (or opting out of) an event drain (Spec 005
+  §Cross-Spec Interactions §1). `owner-gone?` never fires and there is no
+  exact-write token, so the tail keeps its full historical authority: frame
+  teardown must reap EVERY actor regardless of which event, if any, triggered
+  it."
+  {:owner-gone? (constantly false) :owner-token nil})
+
+(defn- effect-fence
+  "Capture the exact event-owner continuation + raw token at the
+  `:rf.machine/destroy` EFFECT entry. `owner-gone?` is true once a synchronous
+  callback has destroyed A / published same-id B (`data-validation/owner-
+  continuation` yields `(constantly true)` when no event owner is bound, so
+  `owner-gone?` is then always false — an eventless caller gets full authority);
+  `owner-token` is A's raw token (nil with no owner), threaded into the durable
+  writes so they bind to A's own container."
+  [frame-id]
+  (let [continue? (data-validation/owner-continuation frame-id)]
+    {:owner-gone? (fn [] (not (continue?)))
+     :owner-token (frame/current-event-owner-token)}))
 
 (defn- actor-live?
   "The silent-idempotent liveness probe, shared by the
@@ -154,11 +194,25 @@
        destroy (`destroy-resolved!`) and the frame-destroy cascade
        (`destroy-single-actor!`) since both route through here.
 
-  Returns the `db-swapped?` flag from the teardown projection."
-  [frame-id actor-id teardown-args emit-destroyed!-fn]
+  Returns the `db-swapped?` flag from the teardown projection.
+
+  rf2-i4aj9c — the pipeline is fenced to the exact incarnation `fence`
+  (`{:owner-gone? :owner-token}`, captured once at the destroy EFFECT entry).
+  Each step below crosses (or follows) a callback-bearing boundary; ownership
+  is rechecked before every next framework-owned action, the durable writes
+  ride the exact owner token, and the timer cancel threads the same gate. For a
+  genuinely eventless caller (`eventless-fence`) `owner-gone?` never fires and
+  the token is nil — the tail runs exactly as it historically did."
+  [frame-id actor-id teardown-args emit-destroyed!-fn {:keys [owner-gone? owner-token]}]
+  ;; (1) run the active configuration's `:exit` cascade — its `:exit` actions
+  ;; are authored callbacks that may destroy A. An already-entered callback
+  ;; stands; recheck before every subsequent framework action.
   (exit-cascade/run-child-exit! frame-id actor-id)
-  (finalize/abort-actor-in-flight-http! actor-id)
-  ;; Drop this actor's
+  ;; (2) abort in-flight HTTP — the late-bound `:http/abort-on-actor-destroy`
+  ;; hook is callback-bearing.
+  (when-not (owner-gone?)
+    (finalize/abort-actor-in-flight-http! actor-id))
+  ;; (3) Drop this actor's
   ;; per-instance classification declarations from the per-frame elision
   ;; registry — the teardown half of `classification/lower-at-spawn!`. A
   ;; subsystem instance's classification lives and dies with the instance,
@@ -167,39 +221,65 @@
   ;; Resolve the spec BEFORE the teardown projection clears the snapshot, via
   ;; the registered TYPE or the snapshot's `:rf/machine-type` (a `:spawn`
   ;; instance carries no registrar entry). A spec that declared no
-  ;; classification is a clean no-op.
-  (let [snapshot (get-in (frame/frame-runtime-db-value frame-id)
-                         (paths/snapshot-path actor-id))]
-    (when-let [spec (resolver/spec-from-id-or-snapshot actor-id snapshot)]
-      (classification/drop-at-destroy! frame-id actor-id spec)))
-  (timer/cancel-actor-timers! frame-id actor-id)
-  ;; `teardown-actor` returns [new-runtime-db released-sid]; `swap-runtime-db!`
-  ;; expects a fn returning the new runtime-db only, so capture the sid via a
-  ;; volatile side channel.
-  (let [sid         (volatile! nil)
-        db-swapped? (frame/swap-runtime-db! frame-id
-                                            (fn [runtime-db]
-                                              (let [[new-rt released-sid]
-                                                    (teardown/teardown-actor runtime-db teardown-args)]
-                                                (vreset! sid released-sid)
-                                                new-rt)))]
-    (when emit-destroyed!-fn
-      (emit-destroyed!-fn @sid))
-    (spawn-order/forget! frame-id actor-id)
-    (when db-swapped?
-      (traces/emit-system-id-released! frame-id @sid actor-id)
-      (registrar/unregister! :event actor-id))
-    ;; (9) release the actor's resource leases once it is gone, so
-    ;; a `[:machine actor-id]`-owned resource does not outlive the actor and
-    ;; keep refetching/polling. Fired regardless of `db-swapped?`: a re-destroy
-    ;; whose teardown projection no-op'd may still have a live owner-pinned
-    ;; resource entry to release, and the release effect is itself idempotent.
-    ;; Guarded on resources being loaded (machines never depends on resources).
-    ;; The `:final?`-state auto-destroy path (`finalize-machine`) does NOT route
-    ;; through here; it appends the symmetric `resource-release/release-fx-entry`
-    ;; to its returned `:fx` instead — together they cover every destroy cause.
-    (resource-release/release-actor-resource-leases! frame-id actor-id)
-    db-swapped?))
+  ;; classification is a clean no-op. rf2-i4aj9c — recheck ownership after the
+  ;; HTTP-abort callback and route the drop through the EXACT elision write so a
+  ;; mid-write watch cannot re-root the removal onto same-id B.
+  (when-not (owner-gone?)
+    (let [snapshot (get-in (frame/frame-runtime-db-value frame-id)
+                           (paths/snapshot-path actor-id))]
+      (when-let [spec (resolver/spec-from-id-or-snapshot actor-id snapshot)]
+        (classification/drop-at-destroy! frame-id actor-id spec owner-token))))
+  ;; (4) cancel armed `:after` timers — the 3-arity threads `owner-gone?` so the
+  ;; cancellation loop short-circuits on A→B loss AND each entry's within-cancel
+  ;; subscription release is skipped once A is gone (rf2-4ipqe4 + rf2-i4aj9c).
+  (when-not (owner-gone?)
+    (timer/cancel-actor-timers! frame-id actor-id owner-gone?))
+  ;; (5) apply the unified teardown projection through the EXACT durable write:
+  ;; `teardown-actor` returns [new-runtime-db released-sid], captured via a
+  ;; volatile side channel. `swap-runtime-db-exact!` binds the write to A's own
+  ;; container and returns nil on mid-write owner loss (no dissoc of B's
+  ;; snapshot, no epoch bump for B); the eventless caller (nil token) falls back
+  ;; to the historical bare write. If A is already gone before the write, do
+  ;; nothing and report no swap.
+  (if (owner-gone?)
+    false
+    (let [sid         (volatile! nil)
+          swap-fn     (fn [runtime-db]
+                        (let [[new-rt released-sid]
+                              (teardown/teardown-actor runtime-db teardown-args)]
+                          (vreset! sid released-sid)
+                          new-rt))
+          new-rt      (if owner-token
+                        (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+                        (frame/swap-runtime-db! frame-id swap-fn))
+          db-swapped? (some? new-rt)]
+      ;; (6) emit `:rf.machine/destroyed` (callback-bearing) — only while the
+      ;; exact owner survives (a mid-write watch that lost A flips `owner-gone?`).
+      (when (and emit-destroyed!-fn (not (owner-gone?)))
+        (emit-destroyed!-fn @sid))
+      ;; (7) forget the actor from the per-frame spawn-order channel — rechecked
+      ;; after the destroyed trace so a listener that published same-id B cannot
+      ;; have A's forget erase B's own freshly-recorded spawn-order entry.
+      (when-not (owner-gone?)
+        (spawn-order/forget! frame-id actor-id))
+      ;; (8) when the projection landed, emit `:rf.machine/system-id-released`
+      ;; (callback-bearing) and clear any registrar entry (`:rf.registry/handler-
+      ;; cleared`, callback-bearing). Fenced on both the swap outcome and live
+      ;; ownership.
+      (when (and db-swapped? (not (owner-gone?)))
+        (traces/emit-system-id-released! frame-id @sid actor-id)
+        (registrar/unregister! :event actor-id))
+      ;; (9) release the actor's resource leases once it is gone, so
+      ;; a `[:machine actor-id]`-owned resource does not outlive the actor and
+      ;; keep refetching/polling. Rechecked after the unregister callback: a lost
+      ;; owner must not fire `:rf.resource/release-owner` against B's live leases.
+      ;; Guarded on resources being loaded (machines never depends on resources).
+      ;; The `:final?`-state auto-destroy path (`finalize-machine`) does NOT route
+      ;; through here; it appends the symmetric `resource-release/release-fx-entry`
+      ;; to its returned `:fx` instead — together they cover every destroy cause.
+      (when-not (owner-gone?)
+        (resource-release/release-actor-resource-leases! frame-id actor-id))
+      db-swapped?)))
 
 (defn destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: run
@@ -228,19 +308,25 @@
   can gate their `:rf.machine/destroyed` emit on the truthy live-and-torn-down
   return, preventing a double-destroyed trace for join-cancelled survivors
   the resolution cascade already tore down. Mirrors the `live?` gate
-  `destroy-resolved!` carries."
-  [frame-id actor-id]
-  (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
-    ;; This site does NOT emit `:rf.machine/destroyed` — its callers
-    ;; (`destroy-spawn-all-children!`, the frame-destroy walker) own that
-    ;; emit, gating it on this fn's truthy return so each actor's destroyed
-    ;; trace fires exactly once. So no emit-destroyed callback.
-    (teardown-live-actor! frame-id actor-id {:actor-id actor-id} nil)
-    ;; Signal to callers (`destroy-spawn-all-children!`) that
-    ;; this actor was live and torn down this call, so they emit
-    ;; `:rf.machine/destroyed` exactly once. The `when` returns nil for
-    ;; an already-destroyed actor (silent no-op).
-    true))
+  `destroy-resolved!` carries.
+
+  rf2-i4aj9c — the 2-arity is the EVENTLESS entry (frame-destroy walker) — it
+  passes `eventless-fence`, so the full teardown runs regardless of any ambient
+  event owner. The 3-arity carries the destroy-effect `fence` for the
+  `:spawn-all` children iteration (which runs inside `destroy-machine-fx`)."
+  ([frame-id actor-id] (destroy-single-actor! frame-id actor-id eventless-fence))
+  ([frame-id actor-id fence]
+   (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
+     ;; This site does NOT emit `:rf.machine/destroyed` — its callers
+     ;; (`destroy-spawn-all-children!`, the frame-destroy walker) own that
+     ;; emit, gating it on this fn's truthy return so each actor's destroyed
+     ;; trace fires exactly once. So no emit-destroyed callback.
+     (teardown-live-actor! frame-id actor-id {:actor-id actor-id} nil fence)
+     ;; Signal to callers (`destroy-spawn-all-children!`) that
+     ;; this actor was live and torn down this call, so they emit
+     ;; `:rf.machine/destroyed` exactly once. The `when` returns nil for
+     ;; an already-destroyed actor (silent no-op).
+     true)))
 
 (declare destroy-spawn-all-children!*)
 
@@ -258,19 +344,26 @@
   mis-addressed; clearing it would orphan the live tracked child without
   teardown, so the form fails loud (`:cause :slot-shape-mismatch`) and
   mutates nothing."
-  [frame-id parent-id invoke-id args]
+  [frame-id parent-id invoke-id args fence]
   (let [join-state (get-in (frame/frame-runtime-db-value frame-id)
                            (paths/spawned-path parent-id invoke-id))]
     (if-not (or (nil? join-state) (map? join-state))
       (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
-      (destroy-spawn-all-children!* frame-id parent-id invoke-id join-state))))
+      (destroy-spawn-all-children!* frame-id parent-id invoke-id join-state fence))))
 
 (defn- destroy-spawn-all-children!*
   "The verified body of `destroy-spawn-all-children!` — `join-state` is
-  known to be a join-state map (or nil, the repeat-exit no-op)."
-  [frame-id parent-id invoke-id join-state]
+  known to be a join-state map (or nil, the repeat-exit no-op).
+
+  rf2-i4aj9c — each per-child teardown fires a callback-bearing
+  `:rf.machine/destroyed` trace; a listener that destroys A / publishes same-id
+  B mid-iteration must not let the NEXT child's teardown (or the final
+  join-slot clear) resolve to B. `owner-gone?` is rechecked before each child
+  and before the final clear (which rides the EXACT durable write)."
+  [frame-id parent-id invoke-id join-state {:keys [owner-gone? owner-token] :as fence}]
   (let [children (when (map? join-state) (:children join-state))]
-    (doseq [[child-id spawned-id] children]
+    (doseq [[child-id spawned-id] children
+            :while (not (owner-gone?))]
       ;; `destroy-single-actor!` runs the child's `:exit`
       ;; cascade before teardown; we fire `:rf.machine/destroyed` AFTER it
       ;; so the trace lands after `:exit` — the same exit-then-destroyed
@@ -290,18 +383,24 @@
       ;; tore the child down" from `:rf.machine/finished` (the auto-destroy
       ;; on `:final?`). Per-child fires omit `:system-id` (the join-state's
       ;; children aren't system-id-bound through the parent's slot).
-      (when (destroy-single-actor! frame-id spawned-id)
+      (when (destroy-single-actor! frame-id spawned-id fence)
         (traces/emit-destroyed! {:frame     frame-id
                                  :actor-id  spawned-id
                                  :parent-id parent-id
                                  :invoke-id invoke-id
                                  :child-id  child-id})))
-    ;; Clear the join-state slot via the unified projection (slot-only).
-    (frame/swap-runtime-db! frame-id
-                            (fn [runtime-db]
-                              (first (teardown/teardown-actor
-                                       runtime-db {:parent-id parent-id
-                                                   :invoke-id invoke-id}))))
+    ;; Clear the join-state slot via the unified projection (slot-only). rf2-i4aj9c —
+    ;; fenced on live ownership and routed through the EXACT durable write, so a
+    ;; child-`:rf.machine/destroyed` listener that published same-id B cannot have
+    ;; this A-derived clear vacate B's freshly-seeded join slot.
+    (when-not (owner-gone?)
+      (let [clear-fn (fn [runtime-db]
+                       (first (teardown/teardown-actor
+                                runtime-db {:parent-id parent-id
+                                            :invoke-id invoke-id})))]
+        (if owner-token
+          (frame/swap-runtime-db-exact! frame-id owner-token clear-fn)
+          (frame/swap-runtime-db! frame-id clear-fn))))
     nil))
 
 (defn- destroy-resolved!
@@ -329,8 +428,13 @@
   A truly-already-destroyed actor has ALL the probe's signals gone — the
   unified teardown projection, registrar cleanup, and `spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
-  See Spec 005 §Destroy is silent-idempotent for the normative paragraph."
-  [frame-id actor-id reason parent-id invoke-id old-db]
+  See Spec 005 §Destroy is silent-idempotent for the normative paragraph.
+
+  rf2-i4aj9c — `fence` carries the destroy-effect's exact-incarnation gate +
+  owner token; it is threaded into `teardown-live-actor!` so every
+  callback-bearing teardown boundary is rechecked and the durable writes ride
+  A's token."
+  [frame-id actor-id reason parent-id invoke-id old-db fence]
   (when (actor-live? frame-id actor-id old-db)
     ;; Shared ordered teardown pipeline (see `teardown-live-actor!`). The
     ;; `:exit` cascade runs BEFORE the `:rf.machine/destroyed` trace:
@@ -359,7 +463,8 @@
                                  :system-id released-sid
                                  :parent-id parent-id
                                  :invoke-id invoke-id
-                                 :reason    reason}))))
+                                 :reason    reason}))
+      fence))
   nil)
 
 (defn- destroy-join-reap!
@@ -406,7 +511,7 @@
   parent's join) verifies OK — the join still records it as a completed
   child — yet is a silent liveness no-op, so no second destroyed trace fires
   for the already-dead actor."
-  [frame-id args old-db]
+  [frame-id args old-db fence]
   (let [parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         child-id   (:rf/child-id args)
@@ -443,7 +548,7 @@
       ;; teardown slot keys). `parent-id` / `invoke-id` / `child-id` were used
       ;; ABOVE only to READ + verify the join state.
       (destroy-resolved! frame-id actor-id :rf.machine/join-reaped
-                         nil nil old-db))))
+                         nil nil old-db fence))))
 
 ;; ---- the closed map-form grammar (rf2-3phait) ------------------------------
 ;;
@@ -506,13 +611,20 @@
   handlers, child cascades, timer/resource cleanup, terminal replies, or a
   `:rf.machine/destroyed` trace — the actor the slot names is either
   already dead for this incarnation (its own destroy ran the full pipeline
-  once) or a live replacement this slot does not own."
-  [frame-id parent-id invoke-id]
-  (frame/swap-runtime-db! frame-id
-                          (fn [runtime-db]
-                            (first (teardown/teardown-actor
-                                     runtime-db {:parent-id parent-id
-                                                 :invoke-id invoke-id}))))
+  once) or a live replacement this slot does not own.
+
+  rf2-i4aj9c — routed through the EXACT durable write when an event owns the
+  frame (`owner-token` non-nil), so a container watch that destroys A / publishes
+  same-id B mid-write cannot vacate B's slot or bump B's commit epoch. A nil
+  token (eventless caller) falls back to the historical bare write."
+  [frame-id parent-id invoke-id owner-token]
+  (let [prune-fn (fn [runtime-db]
+                   (first (teardown/teardown-actor
+                            runtime-db {:parent-id parent-id
+                                        :invoke-id invoke-id})))]
+    (if owner-token
+      (frame/swap-runtime-db-exact! frame-id owner-token prune-fn)
+      (frame/swap-runtime-db! frame-id prune-fn)))
   nil)
 
 (defn- destroy-tracked!
@@ -541,7 +653,7 @@
     - live but a same-id REPLACEMENT this slot does not own → prune the
       stale slot only, leaving the replacement untouched;
     - live and owned → the normal exact-incarnation `:explicit` destroy."
-  [frame-id args old-db]
+  [frame-id args old-db {:keys [owner-token] :as fence}]
   (let [parent-id (:rf/parent-id args)
         invoke-id (:rf/invoke-id args)
         slot-id   (when old-db (get-in old-db (paths/spawned-path parent-id invoke-id)))]
@@ -554,10 +666,10 @@
 
       (and (actor-live? frame-id slot-id old-db)
            (slot-owned-incarnation? old-db slot-id parent-id invoke-id))
-      (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db)
+      (destroy-resolved! frame-id slot-id :explicit parent-id invoke-id old-db fence)
 
       :else
-      (prune-tracked-slot! frame-id parent-id invoke-id))))
+      (prune-tracked-slot! frame-id parent-id invoke-id owner-token))))
 
 (defn destroy-machine-fx
   "fx handler for `:rf.machine/destroy`. Parses the CLOSED destroy grammar
@@ -584,12 +696,20 @@
                    frame-id :rf.machine/destroy
                    {:where 'rf.machine/destroy
                     :event-id (when (map? args) (:rf/parent-id args))})
-        old-db   (frame/frame-runtime-db-value frame-id)]
+        old-db   (frame/frame-runtime-db-value frame-id)
+        ;; rf2-i4aj9c — capture the exact event-owner continuation + raw token
+        ;; ONCE at the destroy EFFECT entry. The `:rf.machine/destroy` fx runs
+        ;; inside the destroying event's drain, so this names the incarnation A
+        ;; that owns the in-flight event; every teardown path below threads it so
+        ;; each callback-bearing boundary rechecks ownership and the durable
+        ;; writes bind to A's own container. An eventless call (no owner bound)
+        ;; yields the inert fence — the tail keeps full authority.
+        fence    (effect-fence frame-id)]
     (cond
       ;; Imperative form — the actor-id IS the arg; a live in-progress
       ;; teardown is ALWAYS an `:explicit` cancellation.
       (keyword? args)
-      (destroy-resolved! frame-id args :explicit nil nil old-db)
+      (destroy-resolved! frame-id args :explicit nil nil old-db fence)
 
       (map? args)
       (let [shape (set (keys args))]
@@ -599,7 +719,7 @@
                    (true? (:rf/reap args))
                    (join-coordinates-ok? args)
                    (keyword? (:rf/child-id args)))
-            (destroy-join-reap! frame-id args old-db)
+            (destroy-join-reap! frame-id args old-db fence)
             (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           (contains? args :rf/spawn-all)
@@ -609,12 +729,13 @@
             (destroy-spawn-all-children! frame-id
                                          (:rf/parent-id args)
                                          (:rf/invoke-id args)
-                                         args)
+                                         args
+                                         fence)
             (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           (= shape tracked-form-keys)
           (if (join-coordinates-ok? args)
-            (destroy-tracked! frame-id args old-db)
+            (destroy-tracked! frame-id args old-db fence)
             (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           :else

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -34,7 +34,8 @@
   The actor-teardown runtime-db projection lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
   call-sites."
-  (:require [re-frame.interop :as interop]
+  (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.error-emit :as machine-error-emit]
             [re-frame.machines.classification :as classification]
@@ -240,6 +241,13 @@
         ;; `(constantly true)` for a non-router pure-fn / conformance caller
         ;; (no event owner), so that path stays unaffected.
         continue?  (data-validation/owner-continuation frame-id)
+        ;; rf2-i4aj9c — the RAW exact owner token (`continue?` closes over it),
+        ;; threaded into the teardown classification drop so it rides the EXACT
+        ;; elision write: a container watch that destroys A / publishes same-id B
+        ;; DURING the drop cannot re-root the removal onto B's registry or bump
+        ;; B's commit epoch. nil for a non-router pure-fn / conformance caller
+        ;; (no event owner) — the drop falls back to the historical bare write.
+        owner-token (frame/current-event-owner-token)
         child-data (:data next-snapshot)
         parallel?  (parallel/parallel? machine)
         ;; Resolve the ERROR-classifying leaf. For a PARALLEL
@@ -624,8 +632,10 @@
           ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
           ;; (which does NOT route through `destroy/teardown-live-actor!`). A spec
           ;; that declared no classification is a clean no-op, so the registry
-          ;; entry added at spawn dies with the instance (no leak).
-          (classification/drop-at-destroy! frame-id machine-id machine)
+          ;; entry added at spawn dies with the instance (no leak). rf2-i4aj9c —
+          ;; thread `owner-token` so the drop rides the EXACT elision write (a
+          ;; mid-write watch cannot re-root the removal onto same-id B).
+          (classification/drop-at-destroy! frame-id machine-id machine owner-token)
           ;; Forget the finished actor from the per-frame spawn-order channel — the
           ;; ONE synchronous teardown side-effect the `:final?`-auto-destroy path
           ;; shares with `destroy/teardown-live-actor!` (destroy.cljc step 7).

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -965,10 +965,18 @@
                     runtime-db (cond-> runtime-db boot? (dissoc :rf.runtime/elision))
                     ctx        (cond-> ctx        boot? (assoc :runtime-db runtime-db))]
                 ;; Value-independent + idempotent, dropped at destroy / finalize.
-                ;; A spec declaring no classification is a no-op.
+                ;; A spec declaring no classification is a no-op. rf2-i4aj9c — the
+                ;; singleton first-boot classification lowering rides the EXACT
+                ;; elision write: `maybe-boot` above fired the initial-entry
+                ;; `:entry` actions (authored callbacks that can destroy A /
+                ;; publish same-id B), so a mid-write container watch must not
+                ;; re-root this singleton's `:sensitive` / `:large` declarations
+                ;; onto B or bump B's commit epoch. nil token (no event owner)
+                ;; falls back to the historical bare write.
                 (when boot?
                   (classification/lower-at-spawn! (:frame-id ctx) (:machine-id ctx)
-                                                  (:machine ctx)))
+                                                  (:machine ctx)
+                                                  (frame/current-event-owner-token)))
               (result/with-ok [post-boot-snap boot-fx] boot-result
                 ;; PURE init-kick: when the routed inner event IS the
                 ;; reserved `:rf.machine/start` marker, `maybe-boot` has

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -646,8 +646,14 @@
         ;; (`re-frame.classification/frame-snapshot-classification`, SSR, trace) is unchanged —
         ;; this writes the registry-entry source `:source :machine`, a peer of
         ;; the general commit-plane `:source :effect` route. A spec declaring
-        ;; no classification is a no-op.
-        (classification/lower-at-spawn! frame-id spawned-id spec'')
+        ;; no classification is a no-op. rf2-i4aj9c — thread A's `owner-token`
+        ;; so the per-instance classification lowering rides the EXACT elision
+        ;; write: a container watch that destroys A / publishes same-id B DURING
+        ;; the registry write cannot re-root the lowered `:sensitive` / `:large`
+        ;; declarations onto B's snapshot path or bump B's commit epoch (the
+        ;; install itself is already exact; this closes the sibling classification
+        ;; write the earlier fences ran ahead of).
+        (classification/lower-at-spawn! frame-id spawned-id spec'' owner-token)
         ;; Record the spawned actor in the frame's spawn-order channel so
         ;; frame-destroy can walk in reverse-creation order per Spec 005
         ;; §Cross-Spec Interactions §1.

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -161,18 +161,31 @@
   subscription registration belonging to a single timer-table entry. Pure
   side-effect; the caller owns the swap that removes the entry from the
   outer atom. Tolerates partial-state entries (the watcher / reaction
-  slots are nil for literal- and fn-form delays)."
-  [frame-id entry delay-key]
-  ;; Shared best-effort host-clock cancel — swallows throws and no-ops a nil
-  ;; handle, tolerating the partial-state entries (literal- / fn-form delays
-  ;; whose watcher / reaction slots are nil).
-  (managed-timer/cancel! (:handle entry))
-  (when (and (:reaction entry) (:sub-watcher-key entry))
-    (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
-         (catch #?(:clj Throwable :cljs :default) _ nil))
-    (when (and (vector? delay-key) frame-id)
-      (try (subs/unsubscribe frame-id delay-key)
-           (catch #?(:clj Throwable :cljs :default) _ nil)))))
+  slots are nil for literal- and fn-form delays).
+
+  rf2-i4aj9c — the host-clock cancel and `remove-watch` release THIS entry's
+  own captured handle / reaction (A's own host work), so they always run. The
+  `subs/unsubscribe frame-id delay-key` is the ONE shared release: the
+  subscription cache is ref-counted by `(frame-id, query-v)`, so once the
+  cancellation trace has destroyed A and re-armed the SAME query in same-id
+  B (bumping the shared count), A's decrement would dispose B's fresh
+  reaction. The optional `owner-gone?` predicate (threaded from the destroy
+  tail's exact-incarnation gate) skips ONLY that shared decrement once A is
+  lost — B's reaction / dependency refs stay intact. `owner-gone?` is MONOTONIC.
+  The 3-arity is the historical unconditional release (fixture-reset,
+  frame-destroy — no event owner)."
+  ([frame-id entry delay-key] (release-entry-resources! frame-id entry delay-key (constantly false)))
+  ([frame-id entry delay-key owner-gone?]
+   ;; Shared best-effort host-clock cancel — swallows throws and no-ops a nil
+   ;; handle, tolerating the partial-state entries (literal- / fn-form delays
+   ;; whose watcher / reaction slots are nil).
+   (managed-timer/cancel! (:handle entry))
+   (when (and (:reaction entry) (:sub-watcher-key entry))
+     (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
+          (catch #?(:clj Throwable :cljs :default) _ nil))
+     (when (and (vector? delay-key) frame-id (not (owner-gone?)))
+       (try (subs/unsubscribe frame-id delay-key)
+            (catch #?(:clj Throwable :cljs :default) _ nil))))))
 
 (defonce ^:private after-attempt-counter
   ;; Monotonic per-arm attempt-token source (mirrors core's
@@ -311,12 +324,23 @@
   that claims an ARMING sentinel (`:handle nil`, host clock not yet armed)
   still emits the owed trace and releases the held subscription; the arming
   thread's publish phase then finds its token gone and cancels the returned
-  host handle."
-  [frame-id k reason]
-  (when-let [entry (get-in @after-timers [frame-id k])]
-    (when-let [claimed (claim-entry! frame-id k (:token entry))]
-      (emit-cancelled! frame-id k claimed reason)
-      (release-entry-resources! frame-id claimed (:delay k)))))
+  host handle.
+
+  rf2-i4aj9c — `emit-cancelled!` is CALLBACK-BEARING (the synchronous
+  `:rf.machine.timer/cancelled` trace). A listener can destroy the owning frame
+  incarnation A and re-arm the SAME subscription-vector query in same-id B on
+  that trace's own stack. The optional `owner-gone?` predicate is threaded into
+  `release-entry-resources!` so the shared `subs/unsubscribe` decrement is
+  skipped once A is lost — A's release cannot dispose B's fresh reaction. The
+  2-arity keeps the historical unfenced release for the non-destroy cancellation
+  reasons (`:on-exit` / `:on-resolution` / `:on-supersede` / `:on-frame-destroy`
+  / `:on-restore`)."
+  ([frame-id k reason] (cancel-after-timer-entry! frame-id k reason (constantly false)))
+  ([frame-id k reason owner-gone?]
+   (when-let [entry (get-in @after-timers [frame-id k])]
+     (when-let [claimed (claim-entry! frame-id k (:token entry))]
+       (emit-cancelled! frame-id k claimed reason)
+       (release-entry-resources! frame-id claimed (:delay k) owner-gone?)))))
 
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
@@ -684,7 +708,12 @@
                     (into [] (comp (filter (fn [[k _]] (= parent-id (:parent k))))
                                    (map first))))]
        (when (and (seq ks) (not (owner-gone?)))
-         (cancel-after-timer-entry! frame-id (first ks) :on-destroy)
+         ;; rf2-i4aj9c — thread `owner-gone?` into the single-entry cancel so
+         ;; the WITHIN-entry `emit-cancelled!` → subscription-release step is
+         ;; fenced too: a `:rf.machine.timer/cancelled` listener that re-arms the
+         ;; same query in same-id B cannot have A's release decrement B's ref.
+         ;; The loop-level guard short-circuits the REMAINING keys after the loss.
+         (cancel-after-timer-entry! frame-id (first ks) :on-destroy owner-gone?)
          (recur (subvec ks 1)))))))
 
 (defn cancel-all-timers!

--- a/implementation/machines/test/re_frame/machine_remaining_lifecycle_tail_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_remaining_lifecycle_tail_fence_test.clj
@@ -1,0 +1,522 @@
+(ns re-frame.machine-remaining-lifecycle-tail-fence-test
+  "rf2-i4aj9c — fence EVERY REMAINING machine lifecycle tail to its exact
+  incarnation. The completion of the family started by #5873/rf2-hloj0g
+  (spawn / finalize tails) and #5889/rf2-4ipqe4 (timer / registrar / spawn-write
+  tails). Those two fenced the FINAL-STATE auto-destroy path (`finalize-machine`)
+  and the spawn cascade; this closes the tails they ran ahead of:
+
+    1. ORDINARY `:rf.machine/destroy` — the effect runs inside the destroying
+       event's drain (an exact event-owner binding), but `teardown-live-actor!`
+       ran an UNFENCED pipeline: the `:exit` cascade, the late-bound HTTP-abort
+       hook, the `:rf.machine.timer/cancelled` traces, the bare classification
+       drop, the bare durable teardown projection, the `:rf.machine/destroyed`
+       trace, the spawn-order forget, the `:rf.machine/system-id-released` +
+       `:rf.registry/handler-cleared` traces, and the resource-lease release. A
+       callback at ANY of those boundaries could destroy A / publish same-id B,
+       and the whole tail continued against B. FIX: capture A's continuation +
+       raw token ONCE at the effect entry, recheck after every callback-bearing
+       boundary, and route the durable writes through the exact owner token.
+
+    2. CLASSIFICATION — `lower-at-spawn!` / `drop-at-destroy!` wrote the
+       per-instance `:sensitive` / `:large` declarations through the BARE
+       two-arity elision swap. A container watch that destroyed A mid-write
+       re-rooted the claim onto same-id B's registry. FIX: thread A's
+       `owner-token` through the EXACT elision write (the same exact-write the
+       flow lifecycle ops issue).
+
+    3. SUBSCRIPTION-VECTOR TIMER — `cancel-after-timer-entry!` emits the
+       callback-bearing `:rf.machine.timer/cancelled` trace and THEN releases
+       the timer entry, whose `subs/unsubscribe frame-id delay-key` decrements
+       the subscription cache ref-count keyed by `(frame-id, query-v)`. A
+       listener that re-armed the SAME query in same-id B would have A's release
+       dispose B's fresh reaction. FIX: skip ONLY that shared decrement once A
+       is lost (the entry's own host handle / watcher still release).
+
+  These fixtures drive the `:rf.machine/destroy` EFFECT (`destroy-machine-fx`)
+  DIRECTLY under a bound event owner (A's dequeue-time token) with a destroyer
+  that publishes same-id B on the callback's / hook's own stack, and assert B
+  stays byte-identical — the deterministic, single-threaded shape the #5873 /
+  #5889 fence fixtures use. Each loss fixture pairs with a LIVE-OWNER control
+  that must still tear down / release exactly once (the mutation tooth against an
+  over-eager fence), plus an EVENTLESS frame-destroy control that retains full
+  authority."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines :as machines]
+            [re-frame.machines.classification :as classification]
+            [re-frame.machines.lifecycle-fx.destroy :as destroy]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- shared seed ----------------------------------------------------------
+
+(def ^:private actor-type :rf2-i4aj9c/child)
+(def ^:private actor-id   (keyword "rf2-i4aj9c" "child#1"))
+(def ^:private the-sid    :rf2-i4aj9c/child-sid)
+
+(defn- snapshot-path [id] [:rf.runtime/machines :snapshots id])
+(defn- system-id-path [sid] [:rf.runtime/machines :system-ids sid])
+(defn- elision-slot [frame-id] (get-in (rf/frame-state-value frame-id) [:rf.db/runtime :rf.runtime/elision]))
+(defn- runtime-db [frame-id] (:rf.db/runtime (rf/frame-state-value frame-id)))
+(defn- snapshot [frame-id id] (get-in (runtime-db frame-id) (snapshot-path id)))
+
+(defn- classified-spec
+  "A classified spawned-actor spec: declares a `:sensitive` `:data` path so the
+  per-instance classification lowering writes into the frame's elision registry,
+  and an `:exit`-side-effect hook (fired by the destroy exit cascade) closing
+  over `on-exit`."
+  [on-exit]
+  {:initial   :running
+   :sensitive [[:data :token]]
+   :states    {:running {:exit (fn [ctx] (when on-exit (on-exit)) (:data ctx))
+                         :on   {:go :done}}
+               :done    {:final? true}}})
+
+(defn- seed-live-actor!
+  "Seed a LIVE spawned actor `actor-id` into `frame-id`: snapshot (with the
+  spawned-actor `:rf/machine-type` discriminator), a `:system-id` reverse-index
+  binding, a spawn-order entry, and its per-instance classification lowered into
+  the elision registry. Registers the TYPE so the spec (and its `:exit` hook)
+  resolves off the snapshot."
+  [frame-id on-exit]
+  (rf/reg-machine actor-type (classified-spec on-exit))
+  (frame/swap-runtime-db!
+    frame-id
+    (fn [rt] (-> rt
+                 (assoc-in (snapshot-path actor-id)
+                           {:state           :running
+                            :data            {:rf/self-id actor-id :token "secret"}
+                            :rf/machine-type actor-type})
+                 (assoc-in (system-id-path the-sid) actor-id))))
+  (spawn-order/record! frame-id actor-id)
+  (classification/lower-at-spawn! frame-id actor-id (classified-spec on-exit)))
+
+;; ---- ordinary-destroy tail loss fixtures ----------------------------------
+
+(defn- run-destroy-tail
+  "Seed a live actor in frame A, install a destroyer keyed on `trigger`, then
+  drive `destroy/destroy-machine-fx` (the imperative keyword form) DIRECTLY under
+  A's bound event owner. The destroyer — fired EXACTLY once on the trigger's
+  callback / hook stack — destroys frame A and republishes same-id B (re-seeding
+  B identically: snapshot, system-id, spawn-order, classification). Returns the
+  observable post-destroy state of B.
+
+  `trigger` ∈ {:exit :http-abort :timer-cancelled :destroyed :system-id-released}."
+  [frame-a trigger]
+  (spawn-order/reset-all!)
+  (rf/make-frame {:id frame-a})
+  (let [fired?     (atom false)
+        b-birth    (atom nil)
+        orig-abort (late-bind/get-fn :http/abort-on-actor-destroy)
+        destroy+B! (fn []
+                     (when (compare-and-set! fired? false true)
+                       (frame/destroy-frame! frame-a)     ;; destroy A
+                       (rf/make-frame {:id frame-a})        ;; same-id B
+                       ;; Re-seed B identically (no :exit hook on B).
+                       (frame/swap-runtime-db!
+                         frame-a
+                         (fn [rt] (-> rt
+                                      (assoc-in (snapshot-path actor-id)
+                                                {:state           :running
+                                                 :data            {:rf/self-id actor-id :token "secret"}
+                                                 :rf/machine-type actor-type})
+                                      (assoc-in (system-id-path the-sid) actor-id))))
+                       (spawn-order/record! frame-a actor-id)
+                       (classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
+                       (reset! b-birth (runtime-db frame-a))))]
+    (seed-live-actor! frame-a (when (= trigger :exit) destroy+B!))
+    (when (= trigger :timer-cancelled)
+      ;; Seed one armed `:after` timer entry so `cancel-actor-timers!` emits a
+      ;; `:rf.machine.timer/cancelled` trace we can hook.
+      (swap! timer/after-timers assoc-in
+             [frame-a {:parent actor-id :spawn [] :delay 3600000}]
+             {:handle nil :reaction nil :sub-watcher-key nil
+              :resolved-ms 3600000 :epoch 0 :state :running
+              :region nil :delay-source :literal :token ::a-timer}))
+    (trace-tooling/register-listener!
+      ::destroy-tail-fence
+      (fn [ev]
+        (case (:operation ev)
+          :rf.machine.timer/cancelled   (when (= trigger :timer-cancelled) (destroy+B!))
+          :rf.machine/destroyed         (when (= trigger :destroyed) (destroy+B!))
+          :rf.machine/system-id-released (when (= trigger :system-id-released) (destroy+B!))
+          nil)))
+    (try
+      (when (= trigger :http-abort)
+        (late-bind/set-fn! :http/abort-on-actor-destroy
+                           (fn [_actor-id] (destroy+B!) nil)))
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        (frame/call-with-event-owner-token frame-a token-a
+          (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+      {:fired?      @fired?
+       :b-birth     @b-birth
+       :b-runtime   (runtime-db frame-a)
+       :b-snapshot  (snapshot frame-a actor-id)
+       :b-system-id (get-in (runtime-db frame-a) (system-id-path the-sid))
+       :b-elision   (elision-slot frame-a)
+       :spawn-order (vec (spawn-order/frame-order frame-a))}
+      (finally
+        (trace-tooling/unregister-listener! ::destroy-tail-fence)
+        (late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)
+        (swap! timer/after-timers dissoc frame-a)))))
+
+(defn- assert-b-inert [{:keys [b-birth b-runtime b-snapshot b-system-id b-elision spawn-order]}]
+  (is (some? b-snapshot)
+      "successor B's snapshot survived — the A-derived teardown projection did not dissoc it")
+  (is (= actor-id b-system-id)
+      "successor B's :system-id binding survived — no A-derived release landed on B")
+  (is (= [actor-id] spawn-order)
+      "successor B's spawn-order entry survived — A's forget was fenced")
+  (is (and (some? b-elision) (seq b-elision))
+      "successor B's classification claim survived — A's drop-at-destroy! was fenced")
+  (is (= b-birth b-runtime)
+      "successor B's runtime-db is byte-identical to its birth value (no A-derived tail landed)"))
+
+(deftest exit-cascade-loss-fences-destroy-tail
+  (testing "the actor's `:exit` action (run by the teardown exit cascade)
+            destroys A + publishes same-id B: ownership is rechecked after the
+            exit cascade, so the HTTP-abort / classification drop / timer cancel
+            / teardown projection / destroyed trace / spawn-order forget /
+            system-id-release / registrar unregister / resource-release tail is
+            all fenced. Mutation tooth: the historically-unfenced tail runs
+            against B."
+    (let [result (run-destroy-tail :rf2-i4aj9c/exit-frame :exit)]
+      (is (true? (:fired? result)) "the :exit action ran (fence exercised)")
+      (assert-b-inert result))))
+
+(deftest http-abort-loss-fences-destroy-tail
+  (testing "the late-bound :http/abort-on-actor-destroy hook destroys A +
+            publishes same-id B: ownership is rechecked after the abort hook, so
+            the classification drop / timer cancel / teardown projection / rest of
+            the tail is fenced."
+    (let [result (run-destroy-tail :rf2-i4aj9c/abort-frame :http-abort)]
+      (is (true? (:fired? result)) "the HTTP-abort hook ran (fence exercised)")
+      (assert-b-inert result))))
+
+(deftest timer-cancelled-loss-fences-destroy-tail
+  (testing "a :rf.machine.timer/cancelled listener destroys A + publishes same-id
+            B: `cancel-actor-timers!` short-circuits and the destroy tail's
+            teardown projection / destroyed trace / spawn-order forget /
+            system-id-release / registrar / resource-release are fenced."
+    (let [result (run-destroy-tail :rf2-i4aj9c/timer-frame :timer-cancelled)]
+      (is (true? (:fired? result)) "the timer-cancelled listener ran (fence exercised)")
+      (assert-b-inert result))))
+
+(deftest destroyed-trace-loss-fences-destroy-tail
+  (testing "a :rf.machine/destroyed listener destroys A + publishes same-id B
+            (the trace fires after the teardown projection committed against A):
+            ownership is rechecked after it, so the spawn-order forget /
+            system-id-release / registrar unregister / resource-release tail is
+            fenced — B's re-seeded state survives."
+    (let [result (run-destroy-tail :rf2-i4aj9c/destroyed-frame :destroyed)]
+      (is (true? (:fired? result)) "the :rf.machine/destroyed listener ran (fence exercised)")
+      (assert-b-inert result))))
+
+(deftest system-id-released-loss-fences-destroy-tail
+  (testing "a :rf.machine/system-id-released listener destroys A + publishes
+            same-id B (late in the tail): ownership is rechecked after it, so the
+            registrar unregister + resource-release tail is fenced."
+    (let [result (run-destroy-tail :rf2-i4aj9c/released-frame :system-id-released)]
+      (is (true? (:fired? result)) "the system-id-released listener ran (fence exercised)")
+      (assert-b-inert result))))
+
+;; ---- live-owner control (full teardown once) ------------------------------
+
+(deftest live-owner-destroy-tears-down-once
+  (testing "control: an ordinary `:rf.machine/destroy` whose tail fires no
+            destroyer tears the actor down FULLY — snapshot dissoc'd, system-id
+            released, spawn-order forgotten, classification dropped, destroyed
+            trace fired exactly once. The fence is scoped to owner-loss only."
+    (spawn-order/reset-all!)
+    (let [frame-a   :rf2-i4aj9c/live-destroy-frame
+          destroyed (atom [])]
+      (rf/make-frame {:id frame-a})
+      (seed-live-actor! frame-a nil)
+      (trace-tooling/register-listener!
+        ::live-destroy
+        (fn [ev] (when (= :rf.machine/destroyed (:operation ev))
+                   (swap! destroyed conj ev))))
+      (try
+        (let [token-a (frame/frame-incarnation-token frame-a)]
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+        (is (nil? (snapshot frame-a actor-id))
+            "the live destroy dissoc'd the actor's snapshot")
+        (is (nil? (get-in (runtime-db frame-a) (system-id-path the-sid)))
+            "the live destroy released the :system-id binding")
+        (is (empty? (spawn-order/frame-order frame-a))
+            "the live destroy forgot the actor from spawn-order")
+        (is (empty? (or (elision-slot frame-a) {}))
+            "the live destroy dropped the actor's classification claim")
+        (is (= 1 (count @destroyed))
+            "exactly one :rf.machine/destroyed trace fired")
+        (finally
+          (trace-tooling/unregister-listener! ::live-destroy))))))
+
+;; ---- eventless frame-destroy control (retains authority) ------------------
+
+(deftest eventless-frame-destroy-tears-down-fully
+  (testing "control: `destroy-single-actor!` reached with NO event owner (the
+            frame-destroy cascade) uses the inert eventless fence — it tears the
+            actor down fully regardless of any ambient ownership. A wrongly-eager
+            fence would strand the actor on frame teardown."
+    (spawn-order/reset-all!)
+    (let [frame-a :rf2-i4aj9c/eventless-frame]
+      (rf/make-frame {:id frame-a})
+      (seed-live-actor! frame-a nil)
+      ;; No `call-with-event-owner-token` — genuinely eventless.
+      (destroy/destroy-single-actor! frame-a actor-id)
+      (is (nil? (snapshot frame-a actor-id))
+          "the eventless teardown dissoc'd the snapshot")
+      (is (nil? (get-in (runtime-db frame-a) (system-id-path the-sid)))
+          "the eventless teardown released the :system-id binding")
+      (is (empty? (spawn-order/frame-order frame-a))
+          "the eventless teardown forgot the actor from spawn-order"))))
+
+;; ===========================================================================
+;; SUBSCRIPTION-VECTOR TIMER seam — release fence (subs/unsubscribe)
+;; ===========================================================================
+
+(defn- seed-sub-vec-timer!
+  "Seed one armed subscription-vector `:after` timer entry for `parent-id` under
+  `frame-id`, carrying a `:reaction` + `:sub-watcher-key` and a vector
+  `delay-key` (so `release-entry-resources!` reaches the `subs/unsubscribe`
+  branch)."
+  [frame-id parent-id delay-key reaction]
+  (swap! timer/after-timers assoc-in
+         [frame-id {:parent parent-id :spawn [] :delay delay-key}]
+         {:handle          nil
+          :reaction        reaction
+          :sub-watcher-key ::a-watch
+          :resolved-ms     5000
+          :epoch           0
+          :state           :running
+          :region          nil
+          :delay-source    :sub
+          :token           ::a-token}))
+
+(deftest sub-vec-timer-release-loss-does-not-decrement-b
+  (testing "a subscription-vector `:after` timer is cancelled on actor destroy; a
+            :rf.machine.timer/cancelled listener re-arms the SAME query in same-id
+            B (bumping the shared (frame,query-v) ref-count), then A's release runs.
+            The shared `subs/unsubscribe` decrement is SKIPPED once A is lost, so
+            B's fresh reaction ref is not disposed. Mutation tooth: the unfenced
+            release decrements B's ref."
+    (let [frame-a     :rf2-i4aj9c/subvec-frame
+          delay-key   [:i4aj9c/dyn]
+          reaction    (atom 5000)
+          unsub-count (atom 0)
+          fired?      (atom false)]
+      (rf/make-frame {:id frame-a})
+      (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
+      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+                                        ([_ _] (swap! unsub-count inc) nil))]
+        (trace-tooling/register-listener!
+          ::subvec-fence
+          (fn [ev]
+            (when (and (= :rf.machine.timer/cancelled (:operation ev))
+                       (compare-and-set! fired? false true))
+              (frame/destroy-frame! frame-a)   ;; destroy A
+              (rf/make-frame {:id frame-a}))))   ;; same-id B re-arms the same query
+        (try
+          (let [token-a   (frame/frame-incarnation-token frame-a)
+                owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))]
+            (frame/call-with-event-owner-token frame-a token-a
+              (fn [] (timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
+          (is (true? @fired?) "the timer-cancelled listener ran (fence exercised)")
+          (is (zero? @unsub-count)
+              "A's release did NOT decrement the shared (frame,query-v) ref-count after the loss")
+          (finally
+            (trace-tooling/unregister-listener! ::subvec-fence)
+            (swap! timer/after-timers dissoc frame-a)))))))
+
+(deftest sub-vec-timer-release-live-owner-unsubscribes-once
+  (testing "control: when the cancelled listener does NOT destroy A, the
+            subscription-vector timer's release decrements the ref-count EXACTLY
+            once — the fence must not suppress the live release."
+    (let [frame-a     :rf2-i4aj9c/subvec-live-frame
+          delay-key   [:i4aj9c/dyn-live]
+          reaction    (atom 5000)
+          unsub-count (atom 0)]
+      (rf/make-frame {:id frame-a})
+      (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
+      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+                                        ([_ _] (swap! unsub-count inc) nil))]
+        (try
+          (let [token-a     (frame/frame-incarnation-token frame-a)
+                owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))]
+            (frame/call-with-event-owner-token frame-a token-a
+              (fn [] (timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
+          (is (= 1 @unsub-count)
+              "the live-owner release decremented the subscription ref-count exactly once")
+          (finally
+            (swap! timer/after-timers dissoc frame-a)))))))
+
+;; ===========================================================================
+;; SPAWN-ALL seam — children iteration + final join-slot cleanup fence
+;; ===========================================================================
+
+(def ^:private sa-parent :rf2-i4aj9c/sa-parent)
+(def ^:private sa-invoke [:sa])
+(def ^:private sa-child-a (keyword "rf2-i4aj9c" "sa-a#1"))
+(def ^:private sa-child-b (keyword "rf2-i4aj9c" "sa-b#1"))
+
+(defn- child-snap [id]
+  {:state :running :data {:rf/self-id id} :rf/machine-type actor-type})
+
+(defn- seed-spawn-all! [frame-id]
+  (rf/reg-machine actor-type (classified-spec nil))
+  (frame/swap-runtime-db!
+    frame-id
+    (fn [rt] (-> rt
+                 (assoc-in (snapshot-path sa-child-a) (child-snap sa-child-a))
+                 (assoc-in (snapshot-path sa-child-b) (child-snap sa-child-b))
+                 (assoc-in [:rf.runtime/machines :spawned sa-parent sa-invoke]
+                           {:children   {:a sa-child-a :b sa-child-b}
+                            :done       #{}
+                            :failed     #{}
+                            :resolved?  false
+                            :spec       {}
+                            :rf/attempt 1}))))
+  (spawn-order/record! frame-id sa-child-a)
+  (spawn-order/record! frame-id sa-child-b))
+
+(deftest spawn-all-iteration-loss-fences-remaining-children-and-clear
+  (testing "a `:spawn-all` teardown iterates its children, firing a
+            callback-bearing `:rf.machine/destroyed` per child. A listener on the
+            FIRST child's destroyed trace destroys A + republishes same-id B
+            (re-seeding the whole join): the iteration `:while` short-circuits and
+            the final join-slot clear is fenced, so B's re-seeded join slot +
+            children survive byte-identical. Mutation tooth: the unfenced
+            iteration tears down B's children and the unfenced clear vacates B's
+            join slot."
+    (spawn-order/reset-all!)
+    (let [frame-a :rf2-i4aj9c/spawn-all-frame
+          fired?  (atom false)
+          b-birth (atom nil)]
+      (rf/make-frame {:id frame-a})
+      (seed-spawn-all! frame-a)
+      (trace-tooling/register-listener!
+        ::spawn-all-fence
+        (fn [ev]
+          (when (and (= :rf.machine/destroyed (:operation ev))
+                     (compare-and-set! fired? false true))
+            (frame/destroy-frame! frame-a)       ;; destroy A
+            (rf/make-frame {:id frame-a})          ;; same-id B
+            (seed-spawn-all! frame-a)              ;; re-seed the whole join
+            (reset! b-birth (runtime-db frame-a)))))
+      (try
+        (let [token-a (frame/frame-incarnation-token frame-a)]
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (destroy/destroy-machine-fx
+                     {:frame frame-a}
+                     {:rf/spawn-all true :rf/parent-id sa-parent :rf/invoke-id sa-invoke}))))
+        (is (true? @fired?) "the per-child :rf.machine/destroyed listener ran (fence exercised)")
+        (is (some? @b-birth) "the listener published a same-id B")
+        (is (some? (get-in (runtime-db frame-a) [:rf.runtime/machines :spawned sa-parent sa-invoke]))
+            "B's re-seeded join slot survived — the A-derived final clear was fenced")
+        (is (= @b-birth (runtime-db frame-a))
+            "B's runtime-db is byte-identical to its birth (no A-derived iteration / clear landed)")
+        (finally
+          (trace-tooling/unregister-listener! ::spawn-all-fence))))))
+
+(deftest spawn-all-live-owner-tears-down-all-children
+  (testing "control: a `:spawn-all` teardown whose per-child destroyed traces fire
+            no destroyer tears down EVERY child and clears the join slot. The
+            fence must not suppress the live path."
+    (spawn-order/reset-all!)
+    (let [frame-a :rf2-i4aj9c/spawn-all-live-frame]
+      (rf/make-frame {:id frame-a})
+      (seed-spawn-all! frame-a)
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        (frame/call-with-event-owner-token frame-a token-a
+          (fn [] (destroy/destroy-machine-fx
+                   {:frame frame-a}
+                   {:rf/spawn-all true :rf/parent-id sa-parent :rf/invoke-id sa-invoke}))))
+      (is (nil? (snapshot frame-a sa-child-a)) "child A torn down")
+      (is (nil? (snapshot frame-a sa-child-b)) "child B torn down")
+      (is (nil? (get-in (runtime-db frame-a) [:rf.runtime/machines :spawned sa-parent sa-invoke]))
+          "the join slot was cleared once every child settled"))))
+
+;; ===========================================================================
+;; CLASSIFICATION exact-write seam — mid-write container-watch loss (removal)
+;; ===========================================================================
+
+(defn- install-watching-adapter!
+  "Install a plain-atom-backed adapter whose `replace-container!` runs `on-write`
+  exactly once, the first time a container write happens while `armed?` holds.
+  The physical write always lands FIRST so A's write that linearized before the
+  loss stands in A's captured container. Mirrors the #5889 spawn-write seam."
+  [armed? on-write]
+  (let [base-replace (:replace-container! plain-atom/adapter)]
+    (adapter/dispose-adapter!)
+    (reset! frame/frames {})
+    (adapter/install-adapter!
+      (assoc plain-atom/adapter
+             :kind :custom
+             :replace-container!
+             (fn [container value]
+               (base-replace container value)
+               (when (compare-and-set! armed? true false)
+                 (on-write)))))))
+
+(defn- restore-plain-adapter! []
+  (reset! frame/frames {})
+  (adapter/dispose-adapter!)
+  (adapter/install-adapter! plain-atom/adapter))
+
+(deftest classification-drop-write-watch-loss-fences-removal
+  (testing "a container watch that destroys A + publishes same-id B DURING the
+            classification-DROP elision write: the EXACT elision write binds to
+            A's own container and reports mid-write loss, so A's drop cannot
+            re-root the removal onto same-id B's registry (which re-lowered the
+            SAME `{:source :machine :actor-id …}` owner) nor bump B's commit
+            epoch. Mutation tooth: the bare `swap-elision-slot!` removes B's
+            claim."
+    (let [frame-a  :rf2-i4aj9c/class-drop-frame
+          armed?   (atom false)
+          fired?   (atom false)
+          b-claim  (atom nil)
+          b-commit (atom nil)]
+      (install-watching-adapter!
+        armed?
+        (fn []
+          (when (compare-and-set! fired? false true)
+            (frame/destroy-frame! frame-a)         ;; destroy A during the drop write
+            (rf/make-frame {:id frame-a})            ;; same-id B
+            ;; B re-lowers the SAME owner's classification claim.
+            (classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
+            (reset! b-claim (elision-slot frame-a))
+            (reset! b-commit (frame/frame-commit-epoch frame-a)))))
+      (try
+        (rf/reg-machine actor-type (classified-spec nil))
+        (rf/make-frame {:id frame-a})
+        (let [token-a (frame/frame-incarnation-token frame-a)]
+          (reset! armed? true)
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (classification/drop-at-destroy!
+                     frame-a actor-id (classified-spec nil) token-a))))
+        (is (true? @fired?) "the drop-write container watch ran (fence exercised)")
+        (is (and (some? @b-claim) (seq @b-claim))
+            "B re-lowered its classification claim")
+        (is (= @b-claim (elision-slot frame-a))
+            "B's classification claim SURVIVES — A's mid-write drop did not re-root onto B")
+        (is (= @b-commit (frame/frame-commit-epoch frame-a))
+            "A's mid-write loss never bumped B's commit epoch")
+        (finally
+          (restore-plain-adapter!))))))


### PR DESCRIPTION
Completes the incarnation-fence family started by #5873/rf2-hloj0g (spawn / finalize tails) and #5889/rf2-4ipqe4 (timer / registrar / spawn-write tails), which fenced the FINAL-STATE auto-destroy path and the spawn cascade. Re-verified against current `origin/main` (all three prior PRs + the #5901/kz0bmb de-flake merged); this closes the tails they ran ahead of.

## Remaining tails fenced

**1. Ordinary `:rf.machine/destroy` (the big one — `lifecycle_fx/destroy.cljc`).** The effect runs inside the destroying event's drain (an exact event-owner binding), but `teardown-live-actor!` ran an UNFENCED pipeline: the `:exit` cascade, the late-bound HTTP-abort hook, the `:rf.machine.timer/cancelled` traces, a bare classification drop, a bare durable teardown projection, the `:rf.machine/destroyed` trace, spawn-order forget, the `:rf.machine/system-id-released` + `:rf.registry/handler-cleared` traces, and the resource-lease release. A callback at ANY boundary could destroy A / publish same-id B, and the whole tail continued against B. Fix: `destroy-machine-fx` captures A's continuation + raw token ONCE at the effect entry (`effect-fence`) and threads it through every path (keyword / reap / spawn-all / tracked); each callback-bearing boundary rechecks `owner-gone?`; timers cancel via the 3-arity fenced helper; the durable teardown projection + `prune-tracked-slot!` + the `:spawn-all` final-slot clear route through `swap-runtime-db-exact!`; the per-child `:spawn-all` iteration short-circuits (`:while (not (owner-gone?))`). An explicit `eventless-fence` keeps the frame-destroy cascade at full authority.

**2. Classification (`classification.cljc` + call sites).** `lower-at-spawn!` / `drop-at-destroy!` wrote the per-instance `:sensitive` / `:large` declarations through the BARE two-arity elision swap; a container watch that destroyed A mid-write re-rooted the claim onto same-id B. Added the 4-arity threading `owner-token` through the EXACT elision write (the same exact-write the flow lifecycle ops issue, rf2-vxgfnd.155). Wired at spawn install (`spawn.cljc`), finalize auto-destroy drop (`finalize.cljc`), ordinary-destroy drop (`destroy.cljc`), and singleton first-boot lowering (`registration.cljc`).

**3. Subscription-vector timer (`timer.cljc`).** `cancel-after-timer-entry!` emits the callback-bearing `:rf.machine.timer/cancelled` trace and THEN releases the entry, whose `subs/unsubscribe frame-id delay-key` decrements the subscription cache ref-count keyed by `(frame-id, query-v)`. A listener that re-armed the SAME query in same-id B would have A's release dispose B's fresh reaction. `release-entry-resources!` now skips ONLY that shared decrement once A is lost (the entry's own host handle / watcher still release), threaded from `cancel-actor-timers!`'s `owner-gone?` gate.

No public API, no rollback framework, no lifecycle transaction, no parallel ownership registry. Reuses the merged `owner-gone?` / committed-AND-current / `swap-*-exact!` discipline.

## Scope note

The bead's three counterexamples span `classification.cljc` and `timer.cljc` in addition to `lifecycle_fx/**`; the exact-classification and subscription-release fences can only be applied inside those files (the mid-write / within-cancel seams are not reachable from the call site). Neither is a hot-zone file, neither is touched by any live worker, and #5889 already touched `timer.cljc` as part of this family. `lifecycle_fx/join.cljc` and `core/fx.cljc` were left untouched (settling on #5908).

## Quality gates

- `(cd implementation/machines && clojure -M:test)` — 1075 tests, 0 failures. Run **3×** (plus focused ns 5×), all green — no flake after the kz0bmb de-flake.
- `(cd implementation/core && clojure -M:test)` — 1984 tests, 0 failures.
- New loss fixtures (`machine_remaining_lifecycle_tail_fence_test.clj`, 12 deftests): `exit-cascade-loss`, `http-abort-loss`, `timer-cancelled-loss`, `destroyed-trace-loss`, `system-id-released-loss` (each drives `destroy-machine-fx` under a bound owner + asserts successor B byte-identical), `spawn-all-iteration-loss` (children iteration + final-slot clear), `sub-vec-timer-release-loss` (shared refcount not decremented), `classification-drop-write-watch-loss` (exact elision write, mid-write container-watch), plus live-owner + eventless-frame-destroy controls.
- Red-before-fix confirmed: disabling the ordinary-destroy fence reds 4 fixtures; forcing the bare classification write reds the drop fixture; restoring the post-trace bare unsubscribe reds the sub-vec fixture.

## Spec ripples (follow-ups, not in this PR)

Spec 005 (§Cancellation cascade / §Final states) and Spec 009 (actor-lifecycle observation) prose describes the destroy tail ordering but does not yet state the exact-incarnation terminal-fence law for the ORDINARY destroy path (the finalize path is covered). A small prose ripple to record "loss of the exact incarnation terminally fences every subsequent framework-owned destroy action; already-entered callbacks may unwind" belongs in a follow-up bead.
