### PR TITLE
fix(epoch): make delayed-silence lineage exact, linearizable, and bounded (rf2-vxgfnd.285)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -290,16 +290,25 @@
   `{cb-id → generation}` map, not a bare set (rf2-vxgfnd.265). The delayed
   silence is later decided PER identity: a cb re-registered to a fresh generation
   in the deferred window never observed this incarnation and must receive no
-  stale signal, which a bare set could not express. Identities come from the
-  observers this exact incarnation accrued (`cbs-observing-frame`, already scoped
-  to each cb's live generation) plus, for a mid-drain `:halted-destroy`, every
-  listener the record will be fanned to (they observe it at delivery).
+  stale signal, which a bare set could not express. The identities and their
+  generations come from ONE consistent `state/snapshot-terminal-observers` read
+  (rf2-vxgfnd.285) — each observing cb's generation is the OBSERVATION STAMP, so
+  a replacement landing mid-snapshot can never attribute A's observation to a
+  fresh generation H it never observed under (the exactness guarantee). For a
+  mid-drain `:halted-destroy`, the SAME registry read additionally owes every
+  listener the record will be fanned to (they observe it at delivery), so the
+  owed generations and the record's listener fan can never disagree across two
+  registry reads.
 
   `:baseline-silence-seq` is the terminal-silence counter snapshotted BEFORE
   dissoc. A same-id successor is constructable only AFTER dissoc, so any silence
   it emits is stamped strictly above this baseline — the monotonic evidence a
   paused predecessor uses to recognise a successor already silenced a cb (the
   A→B→nil ABA) rather than re-emitting the identical unqualified signal.
+
+  Producing a non-nil bundle also OPENS this frame's deferred-silence window
+  (`state/open-silence-lineage!`), keeping its terminal-silence marks alive until
+  `on-frame-destroyed!` publishes and closes the window (the boundedness bracket).
 
   Schema digesting is intentionally omitted: A's schemas are already torn down
   and a bare-id digest could only resolve absent state or a same-id B."
@@ -314,27 +323,27 @@
                                 committed-at :halted-destroy
                                 {:operation :rf.frame/destroyed-mid-drain}
                                 nil))
-          listener-snapshot (if record (state/listeners-snapshot) {})
-          live              (state/listeners-snapshot)
-          ;; EXACT identities: cb-id → the generation that observed this
-          ;; incarnation. Observers carry their live generation; a mid-drain
-          ;; record additionally owes every current listener (each observes the
-          ;; halted record when it is fanned out in `on-frame-destroyed!`).
-          silenced-cbs      (as-> {} m
-                              (into m
-                                    (map (fn [cb]
-                                           [cb (:generation (get live cb))]))
-                                    (state/cbs-observing-frame frame-id))
-                              (if record
-                                (into m
-                                      (map (fn [[cb {:keys [generation]}]]
-                                             [cb generation]))
-                                      listener-snapshot)
-                                m))]
+          ;; ONE consistent (listeners, observed) read (rf2-vxgfnd.285): the
+          ;; owed-observer generations come from the SAME registry read used to
+          ;; qualify them, so a replacement mid-snapshot can never attribute A's
+          ;; observation to a fresh generation it never observed under.
+          {:keys [listeners observing]} (state/snapshot-terminal-observers frame-id)
+          ;; A mid-drain record is fanned to every current listener, so each owes
+          ;; a silence under ITS live generation (from the same `listeners` read).
+          listener-snapshot (if record listeners {})
+          silenced-cbs      (cond-> observing
+                              record (into (map (fn [[cb {:keys [generation]}]]
+                                                  [cb generation]))
+                                           listeners))
+          baseline          (state/current-terminal-silence-seq)]
+      ;; Open the frame's deferred-silence window BEFORE dissoc so its
+      ;; terminal-silence marks survive until this predecessor publishes; the
+      ;; paired `close-silence-lineage!` runs in `on-frame-destroyed!`.
+      (state/open-silence-lineage! frame-id)
       {:record               record
        :listener-snapshot    listener-snapshot
        :silenced-cbs         silenced-cbs
-       :baseline-silence-seq (state/current-terminal-silence-seq)})))
+       :baseline-silence-seq baseline})))
 
 (defn on-frame-destroyed!
   "Publish a destroyed frame's terminal epoch evidence and drop its id-keyed
@@ -359,86 +368,113 @@
   so listener delivery is the only channel for this terminal partial record.
 
   The delayed silence is decided PER snapshotted callback-generation identity
-  (rf2-vxgfnd.265). Store claim, callback re-arm, and terminal silence are
-  DISTINCT events, so the coarse `cleanup-frame-owner!` result cannot gate the
-  fan: a successor that claims the stores but delivers no epoch (A still owes the
-  silence, losing the comparison notwithstanding); a successor that re-armed a cb
-  then destroyed before A resumes (A must NOT re-emit the silence B already
-  fired, even though A now wins the comparison); a cb re-registered to a fresh
-  generation (must receive no stale signal). Each owed identity is delivered iff
-  `state/delayed-silence-owed?` holds — its generation is still live, no live
-  successor re-armed it, and no successor silenced it after A's baseline.
+  (rf2-vxgfnd.265), and .285 makes that decision EXACT, LINEARIZABLE and BOUNDED.
+  Store claim, callback re-arm, and terminal silence are DISTINCT events, so the
+  coarse `cleanup-frame-owner!` result cannot gate the fan: a successor that
+  claims the stores but delivers no epoch (A still owes the silence, losing the
+  comparison notwithstanding); a successor that re-armed a cb then destroyed
+  before A resumes (A must NOT re-emit the silence B already fired, even though A
+  now wins the comparison); a cb re-registered to a fresh generation (must
+  receive no stale signal). Each owed identity is published iff
+  `state/claim-delayed-silence!` grants it — a single atomic operation that
+  rechecks the CURRENT generation, the CURRENT live observers (read fresh, not a
+  stale pre-loop set), and any existing mark, then RESERVES a fresh monotonic seq
+  BEFORE external delivery. The seq is the total order the observer relies on;
+  two overlapping same-id publishers can never both claim. A reservation is
+  rolled back only if the external envelope delivery itself throws. The owed
+  identities are fanned in a deterministic (cb-id-ordered) sequence so a trace
+  listener re-arming a LATER identity during an EARLIER silence sees a stable,
+  linearizable order.
 
   The id-keyed store DROP is compare-owned (`state/cleanup-frame-owner!`): it
   runs only while `owner-token` still owns the stores, so stale A can never
   erase a fresh same-id B. PUBLICATION of A's already-snapshotted terminal
   record and its structural trailers is INDEPENDENT of winning that comparison —
   the evidence was bound to A's exact incarnation before dissoc and is A's to
-  deliver whether or not A still owns the stores (rf2-vxgfnd.151). The live
-  observation state is read AFTER the compare-owned cleanup, so a winning cleanup
-  has already dropped this incarnation's own stamps while a losing one leaves the
-  successor's — exactly the re-arm evidence the per-identity decision consults.
-  All terminal emits use structural delivery so a same-id B's frame-no-emit
-  policy can neither suppress nor capture them. Repeated destroys are idempotent
-  (a re-destroyed frame has no observers and no mid-drain record, so nothing is
-  owed)."
+  deliver whether or not A still owns the stores (rf2-vxgfnd.151). Live
+  observation is re-read INSIDE each per-identity claim AFTER the compare-owned
+  cleanup, so a winning cleanup has already dropped this incarnation's own stamps
+  while a losing one leaves the successor's — exactly the re-arm evidence the
+  claim consults. All terminal emits use structural delivery so a same-id B's
+  frame-no-emit policy can neither suppress nor capture them. Repeated destroys
+  are idempotent (a re-destroyed frame has no observers and no mid-drain record,
+  so nothing is owed). The frame's deferred-silence window opened by
+  `snapshot-terminal-destroy-evidence!` is closed here in a `finally`, reclaiming
+  the frame's marks once its last outstanding predecessor resolves (BOUNDED)."
   ([frame-id owner-token fs-before fs-after committed-at]
    (on-frame-destroyed! frame-id owner-token
                        (snapshot-terminal-destroy-evidence!
                          frame-id fs-before fs-after committed-at)))
   ([frame-id owner-token terminal-evidence]
+   ;; Sole-condition `interop/debug-enabled?` gate so :advanced + goog.DEBUG=false
+   ;; dead-code-eliminates this whole publish path (Spec 009 §Production builds);
+   ;; the nil-bundle check nests INSIDE it, never folded into the gate condition.
+   ;; A non-nil bundle means `snapshot-terminal-destroy-evidence!` participated
+   ;; (debug on) and opened the deferred-silence window; that is the exact
+   ;; condition under which we must publish AND close it. A nil bundle (no epoch
+   ;; layer) opened nothing and has nothing to publish.
    (when interop/debug-enabled?
-     (let [{:keys [record listener-snapshot silenced-cbs baseline-silence-seq]}
-           terminal-evidence]
-       ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
-       ;; same-id B has already claimed them, this no-ops and leaves B untouched.
-       ;; The return value is intentionally ignored for the silencing decision —
-       ;; winning this comparison is NOT the same fact as "no successor re-armed
-       ;; the observers" (a claim without delivery loses it; a re-arm-then-destroy
-       ;; wins it), which the per-identity decision below resolves precisely
-       ;; (rf2-vxgfnd.265). The DROP itself still runs here so a winning A frees
-       ;; its stores (and leaves the live observation ledger showing the
-       ;; successor's re-arm evidence when A loses).
-       (state/cleanup-frame-owner!
-         frame-id owner-token
-         (fn []
-           ;; Data-only exact-owner transaction: no external callback runs
-           ;; between owner comparison and the complete drop.
-           (state/drop-frame-observation! frame-id)
-           (state/drop-frame-history! frame-id)
-           (state/drop-frame-buffer! frame-id)
-           (state/drop-last-settled-epoch! frame-id)
-           (state/drop-frame-mount-attribution! frame-id)
-           true))
-       ;; Publish A's terminal RECORD + trailers regardless of the cleanup
-       ;; comparison — the evidence was snapshotted before dissoc and belongs to
-       ;; A's incarnation (rf2-vxgfnd.151). A late predecessor terminal record may
-       ;; arrive after a newer same-id epoch; it is HISTORICAL and consumers must
-       ;; not treat it as the successor's current ring/focus (Spec 009 / Tool-Pair
-       ;; late-record consumer rule).
-       (when record
-         ;; Same detailed/coarse trailer pair as normal commits, delivered
-         ;; structurally: excluded from capture ownership and immune to a same-id
-         ;; B's frame-no-emit policy.
-         (trace/call-with-structural-delivery
-           #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
-                                                (:event-id record) :halted-destroy))
-         (deliver-listener-snapshot! record listener-snapshot))
-       ;; PER-IDENTITY silencing (rf2-vxgfnd.265). The live observer set is read
-       ;; AFTER the compare-owned cleanup: a winning A has just dropped its own
-       ;; stamps (so none of its identities are "live"), while a losing A leaves
-       ;; the SUCCESSOR's stamps — the delivery/re-arm evidence. Each owed
-       ;; identity is emitted iff its generation is still live, it is not a live
-       ;; observer, and no successor already silenced it after A's baseline; a
-       ;; successful emit records the monotonic mark so a still-paused peer (or a
-       ;; later re-destroy) will not repeat it.
-       (let [live-observers (set (state/cbs-observing-frame frame-id))]
-         (doseq [[cb-id observed-gen] silenced-cbs]
-           (when (state/delayed-silence-owed?
-                   frame-id cb-id observed-gen baseline-silence-seq live-observers)
-             ;; The silencing fact belongs to destroyed A too; never let a same-id
-             ;; successor's trace policy suppress or capture it.
-             (trace/call-with-structural-delivery
-               #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                             {:frame frame-id :cb-id cb-id}))
-             (state/record-terminal-silence! frame-id cb-id))))))))
+     (when terminal-evidence
+       (try
+        (let [{:keys [record listener-snapshot silenced-cbs baseline-silence-seq]}
+              terminal-evidence]
+         ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
+         ;; same-id B has already claimed them, this no-ops and leaves B untouched.
+         ;; The return value is intentionally ignored for the silencing decision —
+         ;; winning this comparison is NOT the same fact as "no successor re-armed
+         ;; the observers" (a claim without delivery loses it; a re-arm-then-destroy
+         ;; wins it), which the per-identity claim below resolves precisely. The
+         ;; DROP itself still runs here so a winning A frees its stores (and leaves
+         ;; the live observation ledger showing the successor's re-arm evidence
+         ;; when A loses).
+         (state/cleanup-frame-owner!
+           frame-id owner-token
+           (fn []
+             ;; Data-only exact-owner transaction: no external callback runs
+             ;; between owner comparison and the complete drop.
+             (state/drop-frame-observation! frame-id)
+             (state/drop-frame-history! frame-id)
+             (state/drop-frame-buffer! frame-id)
+             (state/drop-last-settled-epoch! frame-id)
+             (state/drop-frame-mount-attribution! frame-id)
+             true))
+         ;; Publish A's terminal RECORD + trailers regardless of the cleanup
+         ;; comparison — the evidence was snapshotted before dissoc and belongs to
+         ;; A's incarnation (rf2-vxgfnd.151). A late predecessor terminal record may
+         ;; arrive after a newer same-id epoch; it is HISTORICAL and consumers must
+         ;; not treat it as the successor's current ring/focus (Spec 009 / Tool-Pair
+         ;; late-record consumer rule).
+         (when record
+           ;; Same detailed/coarse trailer pair as normal commits, delivered
+           ;; structurally: excluded from capture ownership and immune to a same-id
+           ;; B's frame-no-emit policy.
+           (trace/call-with-structural-delivery
+             #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
+                                                  (:event-id record) :halted-destroy))
+           (deliver-listener-snapshot! record listener-snapshot))
+         ;; PER-IDENTITY atomic-claim silencing (rf2-vxgfnd.285). Iterate the owed
+         ;; identities in a deterministic cb-id order so the linearizable claim
+         ;; sees a stable sequence. `claim-delayed-silence!` reserves the one
+         ;; signal atomically — rechecking current generation, FRESH live
+         ;; observers, and any existing mark, then writing the monotonic mark —
+         ;; BEFORE external delivery. Only a granted reservation emits; if the
+         ;; external delivery throws, the reservation is rolled back.
+         (doseq [[cb-id observed-gen] (sort-by (comp str key) silenced-cbs)]
+           (when-let [reserved (state/claim-delayed-silence!
+                                 frame-id cb-id observed-gen baseline-silence-seq)]
+             (try
+               ;; The silencing fact belongs to destroyed A too; never let a
+               ;; same-id successor's trace policy suppress or capture it.
+               (trace/call-with-structural-delivery
+                 #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                               {:frame frame-id :cb-id cb-id}))
+               (catch #?(:clj Throwable :cljs :default) ex
+                 ;; Envelope delivery failed — release the reservation so the one
+                 ;; signal can be legitimately re-attempted, and let the fault
+                 ;; propagate contained.
+                 (state/rollback-delayed-silence! frame-id cb-id reserved)
+                 (throw ex))))))
+        (finally
+          ;; Close the deferred-silence window opened at snapshot time. When the
+          ;; frame's last outstanding predecessor resolves, its marks are reclaimed.
+          (state/close-silence-lineage! frame-id)))))))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -879,34 +879,56 @@
   ;; cb-id → {frame-id → generation-token}
   (atom {}))
 
-;; ---- delayed predecessor-silencing lineage (rf2-vxgfnd.265) ---------------
+;; ---- delayed predecessor-silencing lineage (rf2-vxgfnd.265 / .285) ---------
 ;;
 ;; A destroyed incarnation A's `:rf.epoch.cb/silenced-on-frame-destroy` fan can
 ;; be DEFERRED past a same-id successor B's whole lifecycle: A's post-dissoc
 ;; publish hook is held while B — constructable only after dissoc — claims,
 ;; settles/re-arms, and even destroys. #5872 gated the WHOLE fan on one coarse
 ;; `cleanup-frame-owner!` result, conflating three DISTINCT events — store claim,
-;; callback delivery/re-arm, and terminal silence. Deciding PER callback-
-;; generation identity needs two kinds of evidence:
+;; callback delivery/re-arm, and terminal silence. .265 decided each silence PER
+;; callback-generation identity; .285 makes that lineage additionally EXACT,
+;; LINEARIZABLE, and BOUNDED. Deciding PER identity needs two kinds of evidence:
 ;;
 ;;   * delivery/re-arm (live): a successor that re-armed a cb and is STILL LIVE
 ;;     leaves that cb in the live observation ledger (`cbs-observing-frame`), so
 ;;     the callback is live on the successor rather than silent.
 ;;   * terminal-silence (survives cleanup): a successor that re-armed then
 ;;     DESTROYED already emitted the one truthful silence AND dropped its live
-;;     observation on cleanup — so the live ledger no longer shows it. This
+;;     observation on cleanup — so the live ledger no longer shows it. A
 ;;     monotonic mark records that a `(frame, cb)` silence fired and is NOT
 ;;     dropped by `cleanup-frame-owner!`; it survives long enough for a paused
 ;;     predecessor to see it and NOT re-emit the identical unqualified signal
 ;;     (the A→B→nil ABA). A fresh delivery to the cb supersedes the mark
 ;;     (`record-observation!` prunes it — a new continuum will owe its own
-;;     silence), which keeps the ledger bounded across incarnation churn.
+;;     silence).
 ;;
 ;; A snapshots a `baseline` seq BEFORE dissoc (a same-id B is constructable only
 ;; AFTER dissoc, so any successor silence is stamped strictly after A's baseline).
 ;; A mark ABOVE that baseline is a successor's → A skips; a mark at/below is a
 ;; superseded earlier continuum, which the live-observation and generation checks
 ;; already resolve.
+;;
+;; The three .285 properties and where each is enforced:
+;;
+;;   EXACT — the owed `{cb-id → generation}` map is derived from ONE consistent
+;;     (listeners, observed) read (`snapshot-terminal-observers`) with the
+;;     generation taken from the OBSERVATION STAMP, never a second registry
+;;     re-read. A replacement landing mid-snapshot can therefore never attribute
+;;     A's observation to a fresh generation H it never observed under.
+;;   LINEARIZABLE — eligibility AND the mark write are ONE atomic operation
+;;     (`claim-delayed-silence!`, under `silence-lock`): it rechecks the current
+;;     generation, the CURRENT live observers (fresh, not a stale pre-loop set),
+;;     and the existing mark, then reserves a fresh monotonic seq BEFORE external
+;;     delivery. The seq is the single total order the observer relies on; two
+;;     overlapping same-id publishers can never both claim. A reservation is
+;;     rolled back only if envelope delivery itself throws.
+;;   BOUNDED — a per-frame outstanding-predecessor counter
+;;     (`open-`/`close-silence-lineage!`) brackets the deferred window. Marks for
+;;     a frame are retained ONLY while a deferred predecessor of THAT frame is
+;;     outstanding; when the last one resolves the frame's marks are reclaimed,
+;;     so a persistent callback destroying unboundedly many unique frame ids does
+;;     not accrete a permanent tombstone per id.
 
 (defonce ^:private terminal-silence-seq (atom 0))
 
@@ -928,14 +950,6 @@
   ;; re-emit a silence a successor already delivered; pruned when a fresh
   ;; delivery re-arms the cb (`record-observation!`) or the cb unregisters.
   (atom {}))
-
-(defn record-terminal-silence!
-  "Stamp that `(frame-id, cb-id)` was terminally silenced now, under a fresh
-  monotonic marker. Overwrites any earlier mark — only the latest matters."
-  [frame-id cb-id]
-  (swap! terminal-silence-marks assoc-in [frame-id cb-id]
-         (next-terminal-silence-seq))
-  nil)
 
 (defn- prune-terminal-silence-mark!
   "Drop the terminal-silence mark for `(frame-id, cb-id)` — a fresh delivery to
@@ -967,39 +981,140 @@
                       m)))
   nil)
 
+;; The silence ledger is read + written across three atoms (`listeners`,
+;; `observed-frames-by-cb`, `terminal-silence-marks`). `silence-lock` makes the
+;; eligibility-recheck + mark-reservation of `claim-delayed-silence!` — and the
+;; bracket bookkeeping — ONE linearizable critical section, mirroring
+;; `frame-owner-lock`. It serialises silence operations against each other; the
+;; registry/observation atoms keep their own lock-free swaps, so an ordinary
+;; fan-out never contends on it.
+#?(:clj
+   (defonce ^:private silence-lock (Object.)))
+
+(defn- with-silence-lock [f]
+  #?(:clj  (locking silence-lock (f))
+     :cljs (f)))
+
+;; frame-id → count of deferred predecessors of THAT frame whose terminal
+;; evidence is currently outstanding (snapshotted but not yet published). A
+;; `(frame, cb)` mark can only ever be consulted by a deferred predecessor OF
+;; THAT SAME frame (`claim-delayed-silence!` reads marks keyed by its own
+;; frame-id), so the frame's marks are needed only while its count is positive.
+;; When the last outstanding predecessor of a frame resolves, the frame's marks
+;; are reclaimed — this is what bounds `terminal-silence-marks` under a persistent
+;; callback that observes and destroys unboundedly many unique frame ids
+;; (rf2-vxgfnd.285). Marks for OTHER frames are untouched, so a held predecessor
+;; keeps only the marks it can still consume.
+(defonce ^:private outstanding-silence-lineages (atom {}))
+
+(defn open-silence-lineage!
+  "Open the deferred-silence window for one destroyed incarnation of `frame-id`.
+  Called by `snapshot-terminal-destroy-evidence!` when it binds A's owed evidence
+  before dissoc, so the frame's terminal-silence marks survive until A publishes.
+  Balanced by exactly one `close-silence-lineage!`."
+  [frame-id]
+  (with-silence-lock
+    (fn []
+      (swap! outstanding-silence-lineages update frame-id (fnil inc 0))
+      nil)))
+
+(defn close-silence-lineage!
+  "Close one deferred-silence window for `frame-id`. When the frame's last
+  outstanding predecessor resolves, no paused predecessor of the frame can
+  consult its marks, so they are reclaimed — the boundedness guarantee. Balances
+  exactly one `open-silence-lineage!`."
+  [frame-id]
+  (with-silence-lock
+    (fn []
+      (let [remaining (swap! outstanding-silence-lineages
+                             (fn [m]
+                               (let [n (dec (get m frame-id 0))]
+                                 (if (pos? n)
+                                   (assoc m frame-id n)
+                                   (dissoc m frame-id)))))]
+        (when-not (contains? remaining frame-id)
+          (swap! terminal-silence-marks dissoc frame-id)))
+      nil)))
+
 (defn reset-frame-silences!
-  "Wipe every terminal-silence mark and reset the monotonic counter for
-  fixture/global reset."
+  "Wipe every terminal-silence mark and every outstanding-predecessor bracket for
+  fixture/global reset.
+
+  The monotonic `terminal-silence-seq` is deliberately NOT reset. Recycling it to
+  0 could make a post-reset successor's mark compare at/below an outstanding
+  predecessor's earlier baseline, letting that predecessor re-emit a silence the
+  successor already fired (rf2-vxgfnd.285). The seq is a plain process-monotonic
+  comparison domain — its absolute value is never observed, only ordering — so
+  letting it climb across resets is free and keeps the domain non-recycling."
   []
   (reset! terminal-silence-marks {})
-  (reset! terminal-silence-seq 0)
+  (reset! outstanding-silence-lineages {})
   nil)
 
-(defn delayed-silence-owed?
-  "Decide, PER callback-generation identity, whether a DEFERRED predecessor A
-  should still emit its `:rf.epoch.cb/silenced-on-frame-destroy` for `cb-id`.
+(defn live-observer?
+  "True when `cb-id`'s CURRENT generation observes `frame-id` right now — the
+  observation stamp for the frame equals the cb's live generation token. Read
+  fresh (both derefs here), so a successor re-arming a cb mid-fan is honoured the
+  instant it lands rather than against a stale pre-loop set (rf2-vxgfnd.285)."
+  [frame-id cb-id]
+  (let [token (get-in @observed-frames-by-cb [cb-id frame-id] ::absent)]
+    (and (not= token ::absent)
+         (= token (:generation (get @listeners cb-id))))))
 
-  A snapshotted `cb-id` observing its frame under `observed-gen`, plus a
-  `baseline` terminal-silence seq, before dissoc. `live-observers` is the set of
-  cbs whose CURRENT generation observes the frame at decision time (read AFTER
-  the compare-owned cleanup). A owes the silence iff ALL hold:
+(defn claim-delayed-silence!
+  "Atomically CLAIM the one `:rf.epoch.cb/silenced-on-frame-destroy` for
+  `(frame-id, cb-id)` on behalf of a deferred predecessor A whose snapshot
+  observed the frame under `observed-gen` with terminal-silence `baseline`.
 
-    1. `cb-id`'s current generation is still the one that observed A — a
-       re-registered / dropped cb is a fresh generation that never observed A, so
-       it receives no stale signal.
-    2. `cb-id` is NOT currently a live observer — a successor that re-armed it
-       and is STILL LIVE owns the silence (the callback is live on the successor,
-       not silent).
-    3. no terminal silence for (frame, cb) was recorded AFTER A's baseline — a
-       successor that re-armed then DESTROYED already emitted the one truthful
-       silence, so re-emitting would be the ABA double-signal. (A mark at/below
-       the baseline is A's own idempotent re-run or a superseded earlier
-       continuum, already resolved by checks 1 and 2.)"
-  [frame-id cb-id observed-gen baseline live-observers]
-  (and (= observed-gen (:generation (get @listeners cb-id)))
-       (not (contains? live-observers cb-id))
-       (let [s (get-in @terminal-silence-marks [frame-id cb-id])]
-         (or (nil? s) (<= s (or baseline 0))))))
+  Under `silence-lock` — the single linearization point for this signal — it
+  rechecks, against the FRESHEST listener and observation state, that:
+
+    1. `cb-id`'s current generation still equals `observed-gen` — a replacement /
+       drop in the deferred window is a fresh generation that never observed A,
+       and a callback swapped between eligibility and delivery cannot inherit A's
+       unqualified silence.
+    2. `cb-id` is NOT a current live observer — a still-live successor that
+       re-armed it owns the live callback, not a silence. Read fresh, so a trace
+       listener that re-arms this identity earlier in the same fan is honoured.
+    3. no terminal-silence mark for `(frame, cb)` stands ABOVE `baseline` — a
+       successor (or an overlapping same-id publisher) already claimed the one
+       signal; re-emitting would be the A→B→nil ABA / concurrent double-signal.
+
+  When all hold it RESERVES a fresh monotonic seq (writing the mark inside the
+  same critical section) and returns it — the caller then delivers the envelope
+  externally and, only if that delivery THROWS, calls `rollback-delayed-silence!`
+  with this seq. When any check fails it writes nothing and returns nil (no
+  silence). Two overlapping publishers cannot both reserve: the first writes the
+  mark, the second sees it above baseline and returns nil."
+  [frame-id cb-id observed-gen baseline]
+  (with-silence-lock
+    (fn []
+      (when (and (= observed-gen (:generation (get @listeners cb-id)))
+                 (not (live-observer? frame-id cb-id))
+                 (let [s (get-in @terminal-silence-marks [frame-id cb-id])]
+                   (or (nil? s) (<= s (or baseline 0)))))
+        (let [seq (next-terminal-silence-seq)]
+          (swap! terminal-silence-marks assoc-in [frame-id cb-id] seq)
+          seq)))))
+
+(defn rollback-delayed-silence!
+  "Undo a `claim-delayed-silence!` reservation `reserved-seq` for `(frame, cb)`
+  when the external envelope delivery threw — but only if OUR reservation still
+  stands (no fresher delivery or claim superseded it). Restores the ledger to
+  as-if-unclaimed so the one signal can be legitimately re-attempted, keeping a
+  failed delivery from leaving a phantom mark that permanently suppresses it."
+  [frame-id cb-id reserved-seq]
+  (with-silence-lock
+    (fn []
+      (when (= reserved-seq (get-in @terminal-silence-marks [frame-id cb-id]))
+        (prune-terminal-silence-mark! frame-id cb-id))
+      nil)))
+
+(defn terminal-silence-marks-snapshot
+  "Read-only view of the `frame-id → {cb-id → seq}` terminal-silence ledger —
+  a boundedness probe for tests."
+  []
+  @terminal-silence-marks)
 
 (defn put-listener!
   "Install or replace `f` under `id` as a fresh listener GENERATION.
@@ -1030,10 +1145,15 @@
   nil)
 
 (defn reset-listeners!
-  "Drop every registered listener and clear all observation bookkeeping."
+  "Drop every registered listener and clear all observation bookkeeping —
+  registry, observation stamps, AND the terminal-silence lineage. Leaving the
+  silence marks behind stranded a tombstone per destroyed frame past a full
+  listener wipe (rf2-vxgfnd.285); with every listener gone no predecessor can owe
+  a silence, so the whole ledger is cleared here too."
   []
   (reset! listeners {})
   (reset! observed-frames-by-cb {})
+  (reset-frame-silences!)
   nil)
 
 (defn listeners-snapshot
@@ -1116,6 +1236,38 @@
                               (= token (:generation (get live cb-id))))
                      cb-id))))
          vec)))
+
+(defn snapshot-terminal-observers
+  "Snapshot the destroyed `frame-id`'s owed observers from ONE consistent read of
+  the listener registry and the observation ledger, returning
+  `{:listeners <live-registry> :observing {cb-id → generation}}`.
+
+  `:observing` carries EACH observing cb's EXACT generation, taken from the
+  OBSERVATION STAMP — never a second registry re-read. This is the exactness
+  guarantee (rf2-vxgfnd.285): the predecessor's old two-step shape validated a
+  generation G through `cbs-observing-frame` and then re-read the registry for
+  the generation, so a replacement landing between the two reads could record a
+  fresh generation H as having observed A. Deriving the generation from the same
+  stamp used to qualify the observer makes that attribution impossible — a cb
+  already replaced by snapshot time simply fails the stamp/live-generation match
+  and is omitted (its stale silence, if any, is the successor's to decide).
+
+  `:listeners` is the SAME registry read used to qualify the observers, so a
+  mid-drain `:halted-destroy` record's listener fan and the owed-observer
+  generations can never disagree across two registry reads."
+  [frame-id]
+  (let [live     @listeners
+        observed @observed-frames-by-cb]
+    {:listeners live
+     :observing (reduce-kv
+                  (fn [acc cb-id frames]
+                    (let [token (get frames frame-id ::absent)]
+                      (if (and (not= token ::absent)
+                               (= token (:generation (get live cb-id))))
+                        (assoc acc cb-id token)
+                        acc)))
+                  {}
+                  observed)}))
 
 (defn drop-frame-observation!
   "Drop `frame-id` from every cb's observation ledger. cbs whose ledger goes

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -571,3 +571,90 @@
         (finally
           (rf/unregister-listener! :epoch cb)
           (rf/unregister-listener! :trace ::rf2-265-aba-silencing))))))
+
+;; ---- 10. rf2-vxgfnd.285 — exact / linearizable / bounded lineage -----------
+
+(defn- vxgfnd285-total-marks
+  "Count of `[frame cb]` terminal-silence marks currently retained."
+  []
+  (reduce + 0 (map count (vals (state/terminal-silence-marks-snapshot)))))
+
+(deftest vxgfnd285-trace-listener-rearming-later-identity-mid-fan-rechecked-cljs
+  (testing "rf2-vxgfnd.285 (reentrant CLJS, red before fix) — LINEARIZABLE. The
+            owed identities fan in a deterministic cb-id order; a trace listener
+            fired by the FIRST silence re-arms a LATER identity on a live
+            successor B synchronously mid-fan. Because eligibility is re-read
+            FRESH inside each per-identity claim, the re-armed identity is skipped.
+            A stale pre-loop observer set would miss the re-arm and wrongly
+            silence it."
+    (let [id         :rf2-285-rearm/frame
+          trigger    ::a-trigger            ; sorts first
+          target     ::z-target             ; sorts last
+          token-a    #js {}
+          token-b    #js {}
+          silencings (atom [])
+          silences-for (fn [cb] (count (filter #(= cb (:cb-id (:tags %))) @silencings)))]
+      (rf/register-listener! :epoch trigger (fn [_] nil))
+      (rf/register-listener! :epoch target (fn [_] nil))
+      (try
+        (state/claim-frame-owner! id token-a)
+        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (let [target-gen (:generation (get (state/listeners-snapshot) target))
+              a-ev       (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+          ;; Live successor B claims (dropping every observation); neither identity
+          ;; is a live observer at fan start.
+          (state/claim-frame-owner! id token-b)
+          (rf/register-listener! :trace ::rf2-285-rearm-silencing
+            (fn [ev]
+              (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                (swap! silencings conj ev)
+                (when (= trigger (:cb-id (:tags ev)))
+                  ;; Re-arm z-target on B mid-fan, before it is reached.
+                  (state/record-observation! target target-gen id)))))
+          (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+          (is (= 1 (silences-for trigger)) "a-trigger — A-only — is silenced first")
+          (is (zero? (silences-for target))
+              "z-target — re-armed live mid-fan — is rechecked and skipped"))
+        (finally
+          (rf/unregister-listener! :epoch trigger)
+          (rf/unregister-listener! :epoch target)
+          (rf/unregister-listener! :trace ::rf2-285-rearm-silencing))))))
+
+(deftest vxgfnd285-lineage-marks-bounded-across-unique-frames-cljs
+  (testing "rf2-vxgfnd.285 (synchronous CLJS, red before fix) — BOUNDED. One
+            persistent callback observes and destroys many UNIQUE frame ids at the
+            epoch-state seam; each destroy's deferred window closes and reclaims
+            that frame's marks, so lineage storage returns to a constant (empty)
+            baseline rather than accreting a permanent tombstone per id."
+    (let [cb ::rf2-285-bounded-cb
+          n  1500]
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      (try
+        (dotimes [i n]
+          (let [id    (keyword "rf2-285-bounded" (str i))
+                token #js {}]
+            (state/claim-frame-owner! id token)
+            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (epoch.listeners/on-frame-destroyed! id token
+              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+            (is (<= (vxgfnd285-total-marks) 1)
+                "at most one frame's marks are ever retained at once")))
+        (is (zero? (vxgfnd285-total-marks))
+            "after all destroys settle, lineage storage returns to a constant baseline")
+        (finally
+          (rf/unregister-listener! :epoch cb))))))
+
+(deftest vxgfnd285-reset-listeners-clears-silence-lineage-cljs
+  (testing "rf2-vxgfnd.285 (CLJS) — BOUNDED. A full listener wipe clears the
+            terminal-silence lineage too — the old reset-listeners! left a
+            tombstone per destroyed frame behind."
+    (let [id :rf2-285-reset/frame
+          cb ::rf2-285-reset-cb]
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      ;; cb is owed (never a live observer of id), so the claim reserves a mark.
+      (state/open-silence-lineage! id)
+      (state/claim-delayed-silence! id cb (:generation (get (state/listeners-snapshot) cb)) 0)
+      (is (pos? (vxgfnd285-total-marks)) "a terminal-silence mark is present")
+      (state/reset-listeners!)
+      (is (zero? (vxgfnd285-total-marks))
+          "reset-listeners! clears the terminal-silence lineage, not just the registry"))))

--- a/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
@@ -1,0 +1,402 @@
+(ns re-frame.epoch-silencing-lineage-285-test
+  "rf2-vxgfnd.285 — make the delayed predecessor-silencing lineage EXACT,
+  LINEARIZABLE, and BOUNDED, the exact audit follow-up to the merged .265
+  per-callback-generation work.
+
+  .265 decided each delayed `:rf.epoch.cb/silenced-on-frame-destroy` PER
+  callback-generation identity, but snapshot, eligibility, publication and
+  retention were still split across non-linearizable reads/writes. .285 closes
+  three residual gaps, each pinned here (red before the fix; the noted mutation
+  re-reddens it):
+
+    EXACT — `snapshot-terminal-destroy-evidence!` validated a generation through
+      the observation ledger, then RE-READ the registry to build cb→generation.
+      A replacement between the two reads recorded a fresh generation as having
+      observed A. The fix derives the generation from ONE consistent read, taking
+      it from the observation STAMP. Mutation: restore the second registry read.
+
+    LINEARIZABLE — the publish loop snapshotted live observers ONCE, then for
+      each identity separately checked eligibility, emitted, and only afterward
+      recorded the mark. Two publishers could both pass before either mark; a
+      trace listener could re-arm a later identity against the stale pre-loop
+      set; a callback replaced between predicate and emit inherited an unqualified
+      silence. The fix makes eligibility-recheck + mark-reservation ONE atomic
+      claim before delivery, over a deterministic identity order, rolling back
+      only on delivery failure. Mutations: split predicate→emit→mark; reuse a
+      stale pre-loop observer set.
+
+    BOUNDED — `terminal-silence-marks` grew one tombstone per unique destroyed
+      frame until that id/cb was reused; `reset-listeners!` left marks; and
+      `reset-frame-silences!` recycled the monotonic seq below an outstanding
+      baseline. The fix brackets each frame's deferred window with a per-frame
+      outstanding-predecessor count, reclaiming the frame's marks when its last
+      predecessor resolves, clears marks on `reset-listeners!`, and never recycles
+      the seq. Mutations: retain marks past resolution; recycle the seq on reset.
+
+  JVM fixtures compose the successor lineage at the epoch-state seam (a single
+  real fan-out re-arms every listener uniformly and cannot diverge them) and use
+  aligned threads for the concurrent claim seam; the synchronous/reentrant CLJS
+  peers live in `re-frame.epoch-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
+            [re-frame.epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- silences-for
+  "Count silencing traces in `silencings` whose `:cb-id` is `cb`."
+  [silencings cb]
+  (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+
+(defn- silences-for-frame
+  "Count silencing traces in `silencings` for `cb` on `frame`."
+  [silencings cb frame]
+  (count (filter #(and (= cb (:cb-id (:tags %)))
+                       (= frame (:frame (:tags %))))
+                 @silencings)))
+
+(defn- cb-generation
+  "The live generation token currently registered under `cb`."
+  [cb]
+  (:generation (get (epoch-state/listeners-snapshot) cb)))
+
+(defn- total-marks
+  "Count of `[frame cb]` terminal-silence marks currently retained."
+  []
+  (reduce + 0 (map count (vals (epoch-state/terminal-silence-marks-snapshot)))))
+
+;; ---- EXACTNESS ------------------------------------------------------------
+
+(deftest snapshot-attributes-the-observation-stamp-generation
+  ;; The owed `{cb → generation}` map is derived from ONE consistent read with
+  ;; the generation taken from the OBSERVATION STAMP. A cb replaced AFTER it
+  ;; observed (stamp G, live H) is omitted — its current generation never
+  ;; observed A — and the fresh generation H is never attributed the old
+  ;; observation. Re-observing under H re-includes it at H.
+  (let [id :vxgfnd285/exact
+        cb ::vxgfnd285-exact-cb]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (try
+      (epoch-state/claim-frame-owner! id (Object.))
+      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (let [g (cb-generation cb)
+            observing-1 (:observing (epoch-state/snapshot-terminal-observers id))]
+        (is (= g (get observing-1 cb))
+            "the owed generation is the exact generation that observed the frame")
+        ;; Replace cb → fresh generation H, WITHOUT re-observing (stamp stays G).
+        (rf/register-listener! :epoch cb (fn [_] nil))
+        (let [h (cb-generation cb)
+              observing-2 (:observing (epoch-state/snapshot-terminal-observers id))]
+          (is (not= g h) "replacement minted a fresh generation")
+          (is (not (contains? observing-2 cb))
+              "a cb replaced after it observed is omitted — H never observed A")
+          ;; Re-observe under H → included again, now attributed H (the new stamp).
+          (epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
+          (let [observing-3 (:observing (epoch-state/snapshot-terminal-observers id))]
+            (is (= h (get observing-3 cb))
+                "re-observing re-includes the cb under its current generation stamp"))))
+      (finally
+        (rf/unregister-listener! :epoch cb)))))
+
+(deftest generation-replaced-between-snapshot-and-publish-gets-no-stale-silence
+  ;; The emit-time consequence of exactness (never emits A silence for H): A's
+  ;; snapshot owes cb under generation G; cb is then re-registered to a fresh
+  ;; generation before A publishes. The atomic claim rechecks the current
+  ;; generation, so H — which never observed A — receives no stale signal.
+  (let [id         :vxgfnd285/replace-gap
+        cb         ::vxgfnd285-replace-gap-cb
+        token-a    (Object.)
+        silencings (atom [])]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd285-replace-gap-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      (epoch-state/claim-frame-owner! id token-a)
+      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        ;; cb re-registered to a fresh generation in the deferred window.
+        (rf/register-listener! :epoch cb (fn [_] nil))
+        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (is (zero? (silences-for silencings cb))
+            "the re-registered generation receives no stale prior-generation silence"))
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd285-replace-gap-silencing)))))
+
+;; ---- LINEARIZABLE: atomic single-claim ------------------------------------
+
+(deftest two-overlapping-publishers-exactly-one-claims-the-signal
+  ;; Two deferred predecessors of the same (frame, cb) publish concurrently, with
+  ;; aligned threads maximising the overlap. The eligibility-recheck + mark write
+  ;; is ONE atomic claim, so exactly one publisher reserves and emits the single
+  ;; signal; the other sees the mark and skips. A split predicate→emit→mark lets
+  ;; both pass before either mark → a double signal.
+  (dotimes [round 60]
+    (let [id         (keyword "vxgfnd285" (str "dual-" round))
+          cb         ::vxgfnd285-dual-cb
+          silencings (atom [])]
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      (rf/register-listener! :trace ::vxgfnd285-dual-silencing
+        (fn [ev]
+          (when (and (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                     (= id (:frame (:tags ev))))
+            (swap! silencings conj ev))))
+      (try
+        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (let [ev-1    (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
+              ev-2    (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
+              ;; Both bundles owe cb; drop its live observation so the silence is
+              ;; genuinely owed (as A's own compare-owned cleanup would).
+              _       (epoch-state/drop-frame-observation! id)
+              barrier (CyclicBarrier. 2)
+              publish (fn [ev token]
+                        (future
+                          (.await barrier 5 TimeUnit/SECONDS)
+                          (epoch.listeners/on-frame-destroyed! id token ev)))
+              f1      (publish ev-1 (Object.))
+              f2      (publish ev-2 (Object.))]
+          (is (not= ::timeout (deref f1 5000 ::timeout)) "publisher 1 completes")
+          (is (not= ::timeout (deref f2 5000 ::timeout)) "publisher 2 completes")
+          (is (= 1 (silences-for silencings cb))
+              "exactly one publisher atomically claimed the one signal"))
+        (finally
+          (rf/unregister-listener! :epoch cb)
+          (rf/unregister-listener! :trace ::vxgfnd285-dual-silencing))))))
+
+(deftest trace-listener-rearming-a-later-identity-mid-fan-is-rechecked
+  ;; The owed identities fan in a deterministic cb-id order. A trace listener,
+  ;; fired by the FIRST (a-trigger) silence, re-arms a LATER identity (z-target)
+  ;; on a live successor B. Because eligibility is re-read FRESH inside each
+  ;; per-identity claim, z-target — now a live observer — is skipped. A stale
+  ;; pre-loop observer set (computed before the fan) would miss the re-arm and
+  ;; wrongly silence z-target.
+  (let [id         :vxgfnd285/rearm
+        trigger    ::a-trigger            ; sorts first
+        target     ::z-target             ; sorts last
+        token-a    (Object.)
+        token-b    (Object.)
+        silencings (atom [])]
+    (rf/register-listener! :epoch trigger (fn [_] nil))
+    (rf/register-listener! :epoch target (fn [_] nil))
+    (try
+      (epoch-state/claim-frame-owner! id token-a)
+      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (is (= #{trigger target} (set (epoch-state/cbs-observing-frame id)))
+          "both identities observed A")
+      (let [target-gen (cb-generation target)
+            a-ev       (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        ;; A live successor B claims (dropping every observation). Neither
+        ;; identity is a live observer at fan start.
+        (epoch-state/claim-frame-owner! id token-b)
+        (is (empty? (epoch-state/cbs-observing-frame id))
+            "successor B dropped both observations")
+        ;; The trace listener re-arms z-target on B the moment a-trigger's silence
+        ;; fires — mid-fan, before z-target is reached.
+        (rf/register-listener! :trace ::vxgfnd285-rearm-silencing
+          (fn [ev]
+            (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+              (swap! silencings conj ev)
+              (when (= trigger (:cb-id (:tags ev)))
+                (epoch-state/record-observation! target target-gen id)))))
+        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (is (= 1 (silences-for silencings trigger))
+            "a-trigger — A-only — is silenced first")
+        (is (zero? (silences-for silencings target))
+            "z-target — re-armed live mid-fan — is rechecked and skipped")
+        (is (= [target] (epoch-state/cbs-observing-frame id))
+            "z-target is a live observer of B after the re-arm"))
+      (finally
+        (rf/unregister-listener! :epoch trigger)
+        (rf/unregister-listener! :epoch target)
+        (rf/unregister-listener! :trace ::vxgfnd285-rearm-silencing)))))
+
+(deftest failed-delivery-rolls-back-the-reservation-only-then
+  ;; A granted claim RESERVES the signal (mark written) before external delivery,
+  ;; so a concurrent re-claim of the same identity is refused. Rolling back the
+  ;; reservation (the delivery-failed path) releases it so the one signal can be
+  ;; legitimately re-attempted; a successful reservation that is NOT rolled back
+  ;; stays claimed.
+  (let [id       :vxgfnd285/rollback
+        cb       ::vxgfnd285-rollback-cb]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (try
+      ;; cb is owed (not a live observer of id), so the claim reserves the signal.
+      (let [g        (cb-generation cb)
+            baseline 0
+            reserved (epoch-state/claim-delayed-silence! id cb g baseline)]
+        (is (some? reserved) "the first claim reserves the signal")
+        (is (nil? (epoch-state/claim-delayed-silence! id cb g baseline))
+            "a second claim is refused while the reservation stands")
+        (epoch-state/rollback-delayed-silence! id cb reserved)
+        (is (some? (epoch-state/claim-delayed-silence! id cb g baseline))
+            "after rollback the one signal can be re-claimed")
+        ;; A stale rollback (wrong seq) must NOT release a standing reservation.
+        (let [current (epoch-state/claim-delayed-silence! id cb g baseline)]
+          (is (nil? current) "reservation still stands")
+          (epoch-state/rollback-delayed-silence! id cb (- reserved 1))
+          (is (nil? (epoch-state/claim-delayed-silence! id cb g baseline))
+              "a rollback for a superseded seq is a no-op")))
+      (finally
+        (rf/unregister-listener! :epoch cb)))))
+
+;; ---- BOUNDED --------------------------------------------------------------
+
+(deftest lineage-marks-are-bounded-across-many-unique-frame-destroys
+  ;; One persistent callback observes and destroys thousands of UNIQUE frame ids
+  ;; at the epoch-state seam. Each destroy is a self-contained deferred window
+  ;; whose count returns to zero, reclaiming that frame's marks — so lineage
+  ;; storage returns to a constant (empty) baseline rather than accreting one
+  ;; permanent tombstone per id.
+  (let [cb         ::vxgfnd285-bounded-cb
+        n          3000
+        silencings (atom 0)]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd285-bounded-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings inc))))
+    (try
+      (dotimes [i n]
+        (let [id    (keyword "vxgfnd285-bounded" (str i))
+              token (Object.)]
+          (epoch-state/claim-frame-owner! id token)
+          (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+          (epoch.listeners/on-frame-destroyed! id token
+            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+          (is (<= (total-marks) 1)
+              "at most one frame's marks are ever retained at once")))
+      (is (= n @silencings) "each unique destroy silenced the persistent cb once")
+      (is (zero? (total-marks))
+          "after all destroys settle, lineage storage returns to a constant baseline")
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd285-bounded-silencing)))))
+
+(deftest held-predecessor-keeps-only-its-own-frame-marks-reclaimed-after
+  ;; A deferred predecessor A of frame F-a is held. A successor B of F-a fires the
+  ;; one silence, leaving a mark A must still see. Meanwhile MANY unrelated frames
+  ;; are destroyed synchronously. While A is held, ONLY F-a's mark is retained —
+  ;; the unrelated frames self-clean — and when A resolves (skipping the ABA
+  ;; re-emit) its mark is reclaimed too.
+  (let [f-a        :vxgfnd285/held-a
+        cb         ::vxgfnd285-held-cb
+        token-a    (Object.)
+        token-b    (Object.)
+        silencings (atom [])]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd285-held-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (try
+      ;; A observes F-a and snapshots (opening F-a's window) but does NOT publish.
+      (epoch-state/claim-frame-owner! f-a token-a)
+      (epoch.listeners/notify-listeners! {:frame f-a :epoch-id 1})
+      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil)]
+        ;; Successor B of F-a re-arms cb, then retires — firing the one silence and
+        ;; leaving a (F-a, cb) mark above A's baseline.
+        (epoch-state/claim-frame-owner! f-a token-b)
+        (epoch.listeners/notify-listeners! {:frame f-a :epoch-id 2})
+        (epoch.listeners/on-frame-destroyed! f-a token-b
+          (epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil))
+        (is (= 1 (silences-for-frame silencings cb f-a)) "B fired the one truthful F-a silence")
+        (is (= 1 (total-marks)) "exactly F-a's mark is retained while A is held")
+        ;; Destroy many UNRELATED frames synchronously — they must not accrete.
+        (dotimes [i 500]
+          (let [id    (keyword "vxgfnd285-held-other" (str i))
+                token (Object.)]
+            (epoch-state/claim-frame-owner! id token)
+            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (epoch.listeners/on-frame-destroyed! id token
+              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))))
+        (is (= 1 (total-marks))
+            "held A keeps ONLY F-a's mark — unrelated frames self-clean")
+        (is (= #{cb} (set (keys (get (epoch-state/terminal-silence-marks-snapshot) f-a))))
+            "the retained mark is exactly the one A could still consume")
+        ;; A resumes: it must NOT re-emit (B's mark is above A's baseline)…
+        (epoch.listeners/on-frame-destroyed! f-a token-a a-ev)
+        (is (= 1 (silences-for-frame silencings cb f-a))
+            "late A adds no F-a silence — the retired successor already fired it")
+        (is (zero? (total-marks))
+            "F-a's mark is reclaimed once A — its last predecessor — resolves"))
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace ::vxgfnd285-held-silencing)))))
+
+(deftest reset-listeners-clears-the-silence-lineage
+  ;; A full listener wipe must clear the terminal-silence marks too — the old
+  ;; `reset-listeners!` left a tombstone per destroyed frame behind.
+  (let [id :vxgfnd285/reset-listeners
+        cb ::vxgfnd285-reset-listeners-cb]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    ;; A destroyed predecessor left a terminal-silence mark that `reset-listeners!`
+    ;; must clear (cb is owed — not a live observer — so the claim reserves it).
+    (epoch-state/open-silence-lineage! id)
+    (epoch-state/claim-delayed-silence! id cb (cb-generation cb) 0)
+    (is (pos? (total-marks)) "a terminal-silence mark is present")
+    (epoch-state/reset-listeners!)
+    (is (zero? (total-marks))
+        "reset-listeners! clears the terminal-silence lineage, not just the registry")))
+
+(deftest reset-does-not-recycle-the-monotonic-domain-under-an-outstanding-baseline
+  ;; `reset-frame-silences!` clears marks but must NOT recycle the monotonic seq:
+  ;; recycling to 0 could make a post-reset successor's mark compare at/below an
+  ;; outstanding predecessor's earlier baseline, letting it re-emit a silence the
+  ;; successor already fired. The seq only ever climbs.
+  (let [;; An outstanding predecessor's baseline, taken after the domain has moved
+        ;; well above zero.
+        _        (dotimes [_ 5] (epoch-state/next-terminal-silence-seq))
+        baseline (epoch-state/current-terminal-silence-seq)]
+    (is (pos? baseline) "the comparison domain has advanced above zero")
+    (epoch-state/reset-frame-silences!)
+    (is (zero? (total-marks)) "reset cleared the marks")
+    (let [after (epoch-state/next-terminal-silence-seq)]
+      (is (> after baseline)
+          "a post-reset mark is stamped ABOVE an outstanding baseline — the domain never recycles"))))
+
+;; ---- concurrent seam stress (EXACT + LINEARIZABLE under load) --------------
+
+(deftest concurrent-claim-seam-never-double-signals-under-generation-churn
+  ;; A background thread churns cb's generation (replace + re-observe) while the
+  ;; main thread repeatedly destroys the shared frame at the seam. The claim seam
+  ;; must stay coherent: no destroy ever yields more than one silence for the
+  ;; cb, and a callback re-registered mid-flight inherits no unqualified stale
+  ;; silence.
+  (let [id         :vxgfnd285/churn
+        cb         ::vxgfnd285-churn-cb
+        rounds     400
+        stop?      (atom false)
+        silencings (atom [])]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/register-listener! :trace ::vxgfnd285-churn-silencing
+      (fn [ev]
+        (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+          (swap! silencings conj ev))))
+    (let [churner (future
+                    (while (not @stop?)
+                      (rf/register-listener! :epoch cb (fn [_] nil))
+                      (epoch-state/record-observation! cb (cb-generation cb) id)))]
+      (try
+        (dotimes [_ rounds]
+          (reset! silencings [])
+          (let [token (Object.)]
+            (epoch-state/claim-frame-owner! id token)
+            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (epoch.listeners/on-frame-destroyed! id token
+              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
+          (is (<= (silences-for silencings cb) 1)
+              "no destroy double-signals the cb under concurrent generation churn"))
+        (finally
+          (reset! stop? true)
+          (deref churner 5000 ::timeout)
+          (rf/unregister-listener! :epoch cb)
+          (rf/unregister-listener! :trace ::vxgfnd285-churn-silencing))))))


### PR DESCRIPTION
Exact audit follow-up to the merged #5892/.265 per-callback-generation silencing. #5892 made delayed `:rf.epoch.cb/silenced-on-frame-destroy` per-generation, but snapshot, eligibility, publication and retention were still split across non-linearizable reads/writes. This makes the delayed-silence lineage additionally **exact**, **linearizable**, and **bounded**, preserving A's unconditional halted-record/trailers and the compare-owned store cleanup. No public token, scheduler, multi-incarnation API, or second event bus.

## The three properties

**EXACT** — `snapshot-terminal-destroy-evidence!` validated a generation through the observation ledger, then RE-READ the registry to build `cb→generation`; a replacement between the two reads recorded a fresh generation H as having observed A. Now the owed `{cb → generation}` map is derived from ONE consistent `state/snapshot-terminal-observers` read, with the generation taken from the OBSERVATION STAMP — never a second registry read. A cb already replaced by snapshot time fails the stamp/live-generation match and is omitted; a mid-drain record's listener fan and the owed generations share that single read so they can never disagree.

**LINEARIZABLE** — the publish loop snapshotted live observers ONCE, then for each identity separately checked eligibility, emitted, and only afterward recorded the mark (two publishers could both pass before either mark; a trace listener could re-arm a later identity against the stale pre-loop set; a callback replaced between predicate and emit inherited an unqualified silence). Now `state/claim-delayed-silence!` makes eligibility-recheck + mark-reservation ONE atomic operation under `silence-lock` — rechecking current generation, FRESH live observers, and any existing mark, then reserving a fresh monotonic seq BEFORE external delivery. The seq is the total order the observer relies on; two overlapping same-id publishers can never both claim. Owed identities fan in a deterministic cb-id order, and a reservation is rolled back (`state/rollback-delayed-silence!`) only if envelope delivery itself throws.

**BOUNDED** — `terminal-silence-marks` grew one `[frame cb]` tombstone per unique destroyed frame until that id/cb was reused; `reset-listeners!` left marks; `reset-frame-silences!` recycled the monotonic seq below an outstanding baseline. Now a per-frame outstanding-predecessor count (`open-`/`close-silence-lineage!`) brackets each frame's deferred window: a frame's marks are retained only while a deferred predecessor OF THAT FRAME is outstanding, and reclaimed when the last one resolves — so a persistent callback destroying unboundedly many unique frame ids returns lineage storage to a constant baseline and a held predecessor keeps only the marks it can still consume. `reset-listeners!` now clears the lineage; the seq is never recycled.

## Scope

`implementation/epoch/src/re_frame/epoch/{state.cljc, listeners.cljc}` + tests only. No touch to `core/trace.cljc`, `core/frame.cljc` (the trace/epoch seam is reused), `observation.cljc`, `flows/**`, `ui/**`, `machines/**`, or `spec/**`.

## Quality gates

All foreground (slim, no browser surface). Every fixture is red-before-fix (verified by reverting each property in turn — the noted mutation re-reddens exactly its fixture).

- **epoch JVM** `(cd implementation/epoch && clojure -M:test)` — 402 tests, 6040 assertions, 0 failures. New `re-frame.epoch-silencing-lineage-285-test`:
  - EXACT: `snapshot-attributes-the-observation-stamp-generation`, `generation-replaced-between-snapshot-and-publish-gets-no-stale-silence`
  - LINEARIZABLE: `two-overlapping-publishers-exactly-one-claims-the-signal` (aligned CyclicBarrier), `trace-listener-rearming-a-later-identity-mid-fan-is-rechecked`, `failed-delivery-rolls-back-the-reservation-only-then`
  - BOUNDED: `lineage-marks-are-bounded-across-many-unique-frame-destroys` (3000 unique ids), `held-predecessor-keeps-only-its-own-frame-marks-reclaimed-after`, `reset-listeners-clears-the-silence-lineage`, `reset-does-not-recycle-the-monotonic-domain-under-an-outstanding-baseline`
  - concurrent seam stress: `concurrent-claim-seam-never-double-signals-under-generation-churn`
- **core JVM** `(cd implementation/core && clojure -M:test)` — 1984 tests, 0 failures (epoch depends on core).
- **CLJS node** `(cd implementation && npm run test:cljs)` — 9410 tests, 46121 assertions, 0 failures. New synchronous/reentrant peers in `re-frame.epoch-cljs-test`: `vxgfnd285-trace-listener-rearming-later-identity-mid-fan-rechecked-cljs`, `vxgfnd285-lineage-marks-bounded-across-unique-frames-cljs`, `vxgfnd285-reset-listeners-clears-silence-lineage-cljs`.

## Follow-up

Spec 009 / Tool-Pair silencing-lineage prose (deterministic fan order + the exact/linearizable/bounded properties) is a doc follow-up, not touched here (spec/** is fenced).
