### PR TITLE
fix(xray): make ViewCell evidence ownership exact, reactive, and lifecycle-complete (rf2-vxgfnd.286)

### DIFF
--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -448,9 +448,17 @@ available. The lifecycle is normative.
    `rf/register-listener!` facade, so the preload never requires
    `re-frame.core`). `day8/re-frame2-epoch` is a hard Xray dependency, so
    the artefact is always present in an Xray build.
-4. Attach a global `Ctrl+Shift+C` keydown listener on
+4. Acquire the re-frame.ui ViewCell invalidation-evidence projection under
+   Xray's stable owner identity, opening an ownership span
+   (`viewcell-evidence/acquire!`, rf2-vxgfnd.146/.286). Idempotent: an
+   `:after-load` re-run is the same-span re-arm (accumulated evidence
+   survives, the receipt is preserved); a foreign owner already holding
+   the projection is never clobbered (the acquire is rejected — returns
+   nil — and Xray projects zero rows); a host not running the re-frame.ui
+   substrate simply projects nothing. See spec/021 §3.4.1.
+5. Attach a global `Ctrl+Shift+C` keydown listener on
    `document`.
-5. Schedule default true-inline auto-open once the substrate adapter
+6. Schedule default true-inline auto-open once the substrate adapter
    is ready, unless `:rf.xray/auto-open?` is false before the probe
    observes readiness.
 
@@ -468,9 +476,9 @@ alternative — `(require '[day8.re-frame2-xray.core])` then `configure!`
 → `init!`/`open!` — MUST be inert until the host explicitly calls
 `init!`/`open!`. Requiring the `core` facade (or any namespace
 transitively required to reach `configure!`/`init!`) MUST NOT run any
-of the five foundation side-effects: no handler / trace / epoch
-registration, no browser-global install, no keybinding attach, no
-auto-open scheduled. Concretely, `core` MUST NOT `:require` a namespace
+of the foundation side-effects: no handler / trace / epoch registration,
+no ViewCell-evidence acquire, no browser-global install, no keybinding
+attach, no auto-open scheduled. Concretely, `core` MUST NOT `:require` a namespace
 whose load performs the installation side-effects — the callable install
 primitives live in a side-effect-free-on-load namespace
 (`day8.re-frame2-xray.install`) that both `core/init!` and the
@@ -481,9 +489,14 @@ sets `:rf.xray/auto-open? false` or `:rf.xray/keybinding-enabled? false`
 via `core/configure!` BEFORE calling `init!` wins deterministically,
 because nothing fired merely from requiring the facade. `core/init!`
 then performs the manual install explicitly (register handlers →
-register trace collector → register epoch collector → attach keybinding,
-the same boot order as the foundation phase), and auto-open remains a
-preload-only concern — `init!` is open-explicit (the host calls `open!`).
+register trace collector → register epoch collector → acquire the ViewCell
+evidence projection → attach keybinding, the same boot order as the
+foundation phase), and auto-open remains a preload-only concern — `init!`
+is open-explicit (the host calls `open!`). The evidence acquire is
+load-inert on `core` (the callable primitive lives in the side-effect-free
+`viewcell-evidence` ns, invoked only by `init!` and the preload boot
+block), so a foreign owner is honoured and merely requiring `core` never
+touches the projection.
 
 **Boot order.** Within the preload's foundation phase the side-
 effects MUST run in the order **register-handlers → register-

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -678,32 +678,56 @@ invalidation-evidence accumulators the reactive scheduler's evidence-sink
 seam was built for). The Views panel renders it as the **VIEWCELL
 INVALIDATION EVIDENCE** section below the teardown lists.
 
-**Ownership + lifecycle.** Two supported paths claim the projection under
-the stable owner identity `:rf.xray/viewcell-evidence`
-(`day8.re-frame2-xray.viewcell-evidence/install!`): the preload boot block,
-and the manual `day8.re-frame2-xray.core/init!` path (the alternative to
-`:devtools/preloads`). Both wire the identical install (rf2-vxgfnd.238), so
-a host that requires `core` and calls `init!` is never left with Xray
-enabled but evidence-blind. A shadow-cljs `:after-load` (or a second
-`init!`) re-runs the same call as the evidence tier's idempotent
-same-owner re-arm — accumulated evidence survives (the HMR path). A
-foreign owner already holding the projection is NEVER clobbered: Xray's
-install is rejected. `viewcell-evidence/uninstall!` releases exactly
-Xray's registration — generation-fenced downstream (rf2-vxgfnd.147), so an
-in-flight delivery cannot repopulate the released projection and a stale
-release cannot touch a successor owner. A successful install mirrors onto
-the `__day8_re_frame2_xray_viewcell_evidence` global sentinel (the browser
-feature-gate's wiring probe; withdrawn on uninstall).
+**Ownership + span receipt (rf2-vxgfnd.286).** The stable id
+`:rf.xray/viewcell-evidence` is the tier registration KEY, but it is a
+REUSABLE key — after one ownership span closes and another reclaims the
+same id, id equality alone cannot tell the two incarnations apart. So
+`day8.re-frame2-xray.viewcell-evidence` layers an opaque, per-span RECEIPT
+over the tier's identity+generation lifecycle (rf2-vxgfnd.147):
 
-**Query path — ownership-fenced.** `:rf.xray/viewcell-evidence` (registered
-by `reactive-panel-subs/install!`) → `viewcell-evidence/rows`. Every read
-is gated on the exact ownership token (rf2-vxgfnd.238): rows — and
+- Two supported paths ACQUIRE the projection under the stable id — the
+  preload boot block and the manual `core/init!` path (the alternative to
+  `:devtools/preloads`). Both wire the identical `viewcell-evidence/acquire!`
+  (rf2-vxgfnd.238), so a host that requires `core` and calls `init!` is
+  never left with Xray enabled but evidence-blind. `acquire!` returns the
+  span's opaque receipt (nil when rejected / in production).
+- A shadow-cljs `:after-load` (or a second `init!`) re-runs the same call
+  as the evidence tier's idempotent same-span RE-ARM — accumulated evidence
+  survives and the receipt is PRESERVED (the HMR path is one continuous
+  span).
+- A foreign owner already holding the projection is NEVER clobbered:
+  `acquire!` is rejected (returns nil) and Xray projects zero rows.
+- `viewcell-evidence/release!` frees EXACTLY the span named by a receipt;
+  `release-current!` frees whatever span Xray currently owns (the
+  owner-checked teardown the reset tier drives, below). A stale receipt
+  from a superseded span can neither read a successor's data nor clear a
+  successor's registration (the same-key ABA fence), on top of the tier's
+  downstream generation fence (rf2-vxgfnd.147). A successful acquire mirrors
+  onto the `__day8_re_frame2_xray_viewcell_evidence` global sentinel (the
+  browser feature-gate's wiring probe; withdrawn on release).
+
+`installed-owner` (the tier read) is DIAGNOSTIC-only: ownership is
+authorized by the receipt, not by owner-id equality.
+
+**Query path — receipt-fenced + reactive (rf2-vxgfnd.238/.286).**
+`:rf.xray/viewcell-evidence` (registered by `reactive-panel-subs/install!`)
+→ `viewcell-evidence/rows`. Every read is gated on BOTH the exact span
+receipt AND that Xray is still the installed tier owner: rows — and
 therefore the sub, the panel section, and any derived Xray query — observe
-evidence ONLY while Xray is the installed owner. The evidence tier's
-`projection` read exposes the shared slot's entries REGARDLESS of owner, so
-an ownership rejection (a foreign tool installed first) must — and does —
-mean zero observation through Xray, never the foreign owner's rows. When
-Xray owns the projection, one row per live ViewCell instance in stable
+evidence ONLY for Xray's current span. The evidence tier's `projection`
+read exposes the shared slot's entries REGARDLESS of owner, so an ownership
+rejection (a foreign tool installed first) or a superseded span must — and
+does — mean zero observation through Xray, never another span's rows.
+Because ownership is not app-db state, the query carries an
+ownership-REVISION reactive input alongside `:rf.xray/epoch-history`:
+`viewcell-evidence` bumps a monotonic revision on every acquire/release and
+the sub-layer listener mirrors it into Xray's `:rf/xray` app-db (the
+`:rf.xray/viewcell-evidence-ownership` sub), so a live subscription +
+rendered panel recomputes to empty the instant Xray releases (or a foreign
+owner takes the slot) — WITHOUT waiting for an unrelated epoch pump. The
+revision only TRIGGERS the recompute; the recompute's `rows` call still
+checks the exact receipt, so reactivity can never authorize a stale reader.
+When Xray owns the span, one row per live ViewCell instance in stable
 `:cell-id` order —
 
     {:cell-id ord :view-id vid :root-id rid|nil
@@ -714,10 +738,21 @@ Xray owns the projection, one row per live ViewCell instance in stable
 `:targets` is the bounded shown sample; `:dropped-count` /
 `:dropped-exact?` is the HONEST loss account (`false` ⇒ the count is a
 floor, rendered `≥N dropped`). Dead cells are pruned by the projection
-itself. Freshness rides the `:rf.xray/epoch-history` input (the standing
-epoch-pump axis): the ViewCell flush runs a microtask after drain-settle,
-so a same-epoch read may trail by one pump — the cumulative accumulators
-catch up, never lose.
+itself. Delivery freshness rides the `:rf.xray/epoch-history` input (the
+standing epoch-pump axis): the ViewCell flush runs a microtask after
+drain-settle, so a same-epoch read may trail by one pump — the cumulative
+accumulators catch up, never lose. OWNERSHIP freshness rides the separate
+`:rf.xray/viewcell-evidence-ownership` revision input (above), so a release
+/ foreign-takeover empties the query immediately, independent of epoch
+pumps.
+
+**Reset lifecycle (rf2-vxgfnd.286).** The canonical clean-slate reset tier
+(`test-support/reset-all!` → `reset-runtime!`) runs the owner-checked
+`viewcell-evidence/release-current!`, so a `core/init!` (or preload) that
+acquired the projection leaves NO tier owner, sink, retained entries or
+globalThis sentinel behind — process-global state the sentinel/ring resets
+do not otherwise touch. The release is owner-checked (never
+`force-release!`): a FOREIGN owner survives the reset intact.
 
 **Render.** One `list-row` per cell under
 `rf-xray-reactive-viewcell-evidence-section` (rows

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -16,7 +16,7 @@ wins.
 {:builds {:app {:devtools {:preloads [day8.re-frame2-xray.preload]}}}}
 ```
 
-Loading the preload runs the foundation's six side-effects — all
+Loading the preload runs the foundation side-effects — all
 gated on `interop/debug-enabled?` so production bundles strip them
 via Closure DCE, and all idempotent so shadow-cljs's `:after-load`
 cycle re-runs without double-registration:
@@ -28,16 +28,24 @@ cycle re-runs without double-registration:
 3. Registers the epoch-settle pump under `:rf.xray/epoch-collector`
    via `re-frame.core/register-listener!` on the `:epoch` stream (sentinel-guarded; no-op
    when the `day8/re-frame2-epoch` artefact is absent).
-4. Installs the dev-only browser API on `window.day8.re_frame2_xray.*`
+4. Acquires the re-frame.ui ViewCell invalidation-evidence projection
+   under Xray's stable owner identity, opening an ownership span
+   (`viewcell-evidence/acquire!`; the `:after-load` re-run is the
+   same-span re-arm — accumulated evidence survives, the receipt is
+   preserved). A foreign owner is never clobbered (the acquire is
+   rejected and Xray projects zero rows); a host without the re-frame.ui
+   substrate projects nothing. See `spec/021-Dynamic-Panel-Designs.md`
+   §3.4.1.
+5. Installs the dev-only browser API on `window.day8.re_frame2_xray.*`
    (`open!`, `toggle!`, `popout!`, `status`, …).
-5. Attaches the global keydown listener. The shipped chords (the
+6. Attaches the global keydown listener. The shipped chords (the
    `keybinding.cljs` predicates are the source of truth; UX rationale
    in `spec/007-UX-IA.md` §Global shortcuts): `Ctrl+Shift+C` (toggle
    shell), `Ctrl/Cmd+K` (command palette), `Ctrl/Cmd+Shift+M`
    (Dynamic ↔ Static mode toggle), and `Esc` (dismiss the
    open-in-editor hint). Inside the shell the LIVE-feed spine binds
    bare `Space` / `L` / `j` / `k` / `G`.
-6. Auto-opens the shell **true-inline** into the host app's
+7. Auto-opens the shell **true-inline** into the host app's
    normal-flow layout host (`[data-rf-xray-host]` by default) once
    the substrate adapter is ready — per rf2-eehov, this is the
    default landing posture. There is no floating pill, no body
@@ -215,8 +223,8 @@ install paths are strictly separated:
 
 - The **zero-config preload path** — wiring
   `day8.re-frame2-xray.preload` into shadow-cljs's `:devtools/preloads`
-  — auto-installs on namespace load (the six side-effects above): it is
-  the canonical convenience path and SHOULD self-install.
+  — auto-installs on namespace load (the foundation side-effects above):
+  it is the canonical convenience path and SHOULD self-install.
 - The **manual facade path** — `(require '[day8.re-frame2-xray.core])`
   then `configure!` → `init!`/`open!` — is INERT until the host calls
   `init!` (or `open!`). Requiring `core`, and calling its boot-time
@@ -271,7 +279,7 @@ facade:
 
 - **`keybinding/attach!` and `keybinding/detach!`.** The lifecycle
   pair lives in its own namespace because the preload's keybinding
-  install is one of the six side-effects (per §Installation API
+  install is one of the foundation side-effects (per §Installation API
   above) and `detach!` is the embed-host escape hatch — both surfaces
   are tightly coupled to the preload's listener contract rather than
   to the mount facade. Re-exporting through `core` would imply

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -129,9 +129,12 @@
   does NOT default the target to `:rf/default` (Spec 002 §Frame target
   resolution).
 
-  Wires the five foundation side-effects (registry, trace-cb, epoch-cb,
-  browser-API exports, keybinding listener), then threads each supplied
-  opt through to its backing surface:
+  Wires the foundation side-effects — the registry handlers, the trace
+  and epoch collectors, the ViewCell evidence acquire (rf2-vxgfnd.286 —
+  opens Xray's ownership span over the re-frame.ui evidence projection, or
+  is inertly rejected when a foreign owner holds it / no ui substrate is
+  present), the browser-API exports, and the keybinding listener — then
+  threads each supplied opt through to its backing surface:
 
   - `:target-frame` — dispatches `:rf.xray/set-target-frame` so the
     scrubber + every dependent panel re-fire on the standard reactive
@@ -160,15 +163,16 @@
    (registry/register-xray-handlers!)
    (install/register-trace-collector!)
    (install/register-epoch-collector!)
-   ;; Claim the re-frame.ui ViewCell invalidation-evidence projection under
-   ;; Xray's stable owner identity (rf2-vxgfnd.146/.238). The manual `init!`
-   ;; path MUST wire this exactly as the preload boot block does — otherwise
-   ;; a clean process that requires core and calls `init!` (the supported
-   ;; alternative to `:devtools/preloads`) enables Xray WITHOUT ViewCell
-   ;; evidence. Idempotent: a second `init!` / shadow `:after-load` is the
-   ;; evidence tier's same-owner re-arm (accumulated evidence survives); a
-   ;; foreign owner is never clobbered (install rejected, Xray reads nothing).
-   (viewcell-evidence/install!)
+   ;; Acquire the re-frame.ui ViewCell invalidation-evidence projection under
+   ;; Xray's stable owner identity, opening a fresh ownership span
+   ;; (rf2-vxgfnd.146/.238/.286). The manual `init!` path MUST wire this
+   ;; exactly as the preload boot block does — otherwise a clean process that
+   ;; requires core and calls `init!` (the supported alternative to
+   ;; `:devtools/preloads`) enables Xray WITHOUT ViewCell evidence.
+   ;; Idempotent: a second `init!` / shadow `:after-load` is the evidence
+   ;; tier's same-span re-arm (accumulated evidence survives); a foreign owner
+   ;; is never clobbered (acquire rejected — returns nil — Xray reads nothing).
+   (viewcell-evidence/acquire!)
    ;; The palette and Settings effects resolve mount operations through
    ;; these globals to avoid a mount/shell require cycle. Manual and
    ;; preload startup therefore install the same exports.

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -103,7 +103,9 @@
   `install!` registers `:rf.xray/reactive-data` + the panel-local
   disclosure-toggle state slot. Idempotent."
   (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs.tooling :as subs-tooling]
+            [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]))
 
@@ -567,21 +569,64 @@
                 :seed-paths   (when record (seed-paths record))
                 :has-event-bundle? (some? record)}))))
 
-  ;; -- the ViewCell invalidation-evidence query (rf2-vxgfnd.146) ------
+  ;; -- ViewCell evidence ownership reactivity bridge (rf2-vxgfnd.286) --
+  ;;
+  ;; Ownership of the evidence projection is NOT app-db state, so an
+  ;; acquire/release would not, on its own, invalidate the cumulative
+  ;; evidence query below — a live subscription + rendered panel could
+  ;; keep a stale row after Xray released the projection (or a foreign
+  ;; owner took the slot), until some unrelated epoch pump recomputed it.
+  ;; So each ownership transition bumps a monotonic revision the evidence
+  ;; ledger publishes through a listener; the listener mirrors it into
+  ;; Xray's OWN (`:rf/xray`) app-db, a reactive input to the derived
+  ;; query. Cache invalidation only TRIGGERS the recompute; the
+  ;; recompute's `rows` call still checks the exact ownership receipt, so
+  ;; reactivity can never authorize a stale reader.
+  (rf/reg-event :rf.xray/viewcell-evidence-ownership-changed
+    {:rf.trace/no-emit? true}
+    (fn [{:keys [db]} [_ revision]]
+      {:db (assoc db :viewcell-evidence-ownership-rev revision)}))
+
+  (rf/reg-sub :rf.xray/viewcell-evidence-ownership
+    (fn [db _query]
+      (get db :viewcell-evidence-ownership-rev 0)))
+
+  ;; The single ownership listener: on each acquire/release, mirror the
+  ;; revision into Xray's own frame — guarded on the `:rf/xray` frame
+  ;; existing (a pre-mount acquire has no live sub to invalidate) and
+  ;; dispatched SYNCHRONOUSLY so a held subscription reflects the change
+  ;; immediately, without an epoch pump. `:rf.trace/no-emit?` keeps this
+  ;; internal chrome event off the trace bus Xray inspects.
+  (viewcell-evidence/set-ownership-listener!
+    (fn [revision]
+      (when (frame/frame defaults/default-frame-id)
+        (rf/with-frame defaults/default-frame-id
+          (rf/dispatch-sync [:rf.xray/viewcell-evidence-ownership-changed
+                             revision])))))
+
+  ;; -- the ViewCell invalidation-evidence query (rf2-vxgfnd.146/.286) --
   ;;
   ;; The developer-facing query surface over Xray's OWNED
   ;; `re-frame.ui.tool.evidence` projection (see
   ;; `day8.re-frame2-xray.viewcell-evidence`). The accumulators are
-  ;; CUMULATIVE per cell (accretion since install), read live at compute
-  ;; time; the `:rf.xray/epoch-history` input is the panel's standing
-  ;; freshness axis — each epoch pump recomputes the read, so newly
-  ;; delivered batches surface on the next recorded epoch (the ViewCell
-  ;; flush runs a microtask AFTER the drain settles, so a same-epoch
-  ;; read may trail by one pump — cumulative rows catch up, never lose).
+  ;; CUMULATIVE per cell (accretion since acquire), read live at compute
+  ;; time; the `rows` read is ownership-receipt-fenced so a foreign owner
+  ;; or a superseded span never surfaces. Two reactive inputs, both pure
+  ;; cache-invalidation triggers (the compute reads the authoritative
+  ;; receipt-checked `rows`, never these values):
+  ;;   - `:rf.xray/epoch-history` — the standing freshness axis; each
+  ;;     epoch pump recomputes the read, so newly delivered batches
+  ;;     surface on the next recorded epoch (the ViewCell flush runs a
+  ;;     microtask AFTER drain-settle, so a same-epoch read may trail by
+  ;;     one pump — cumulative rows catch up, never lose).
+  ;;   - `:rf.xray/viewcell-evidence-ownership` — the ownership-revision
+  ;;     axis (rf2-vxgfnd.286), so an acquire/release recomputes the query
+  ;;     IMMEDIATELY, not only on the next epoch pump.
   ;; Hosts not running the re-frame.ui substrate project zero rows.
   (rf/reg-sub :rf.xray/viewcell-evidence
     :<- [:rf.xray/epoch-history]
-    (fn [_history _query]
+    :<- [:rf.xray/viewcell-evidence-ownership]
+    (fn [[_history _ownership-rev] _query]
       (viewcell-evidence/rows)))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -54,9 +54,9 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
             ;; The native ViewCell invalidation-evidence consumer
-            ;; (rf2-vxgfnd.146) — Xray owns the re-frame.ui.tool.evidence
-            ;; projection with a stable identity; load-inert, installed
-            ;; from the boot block below.
+            ;; (rf2-vxgfnd.146/.286) — Xray owns the re-frame.ui.tool.evidence
+            ;; projection under a stable identity + per-span receipt;
+            ;; load-inert, acquired from the boot block below.
             [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]
             ;; Loading the runtime installs its debug-gated session
             ;; sentinel for agent discovery; no second preload is needed.
@@ -105,14 +105,17 @@
   (registry/register-xray-handlers!)
   (install/register-trace-collector!)
   (install/register-epoch-collector!)
-  ;; Claim the re-frame.ui ViewCell invalidation-evidence projection
-  ;; under Xray's stable owner identity (rf2-vxgfnd.146). On
-  ;; `:after-load` this same call is the evidence tier's idempotent
-  ;; same-owner re-arm (accumulated evidence survives); a foreign owner
-  ;; is never clobbered (the install is rejected and Xray projects zero
-  ;; rows). Hosts not running the re-frame.ui substrate simply deliver
-  ;; nothing into the claimed projection.
-  (viewcell-evidence/install!)
+  ;; Acquire the re-frame.ui ViewCell invalidation-evidence projection
+  ;; under Xray's stable owner identity, opening a fresh ownership span
+  ;; (rf2-vxgfnd.146/.286). On `:after-load` this same call is the
+  ;; evidence tier's idempotent same-span re-arm (accumulated evidence
+  ;; and in-flight deliveries survive); a foreign owner is never
+  ;; clobbered (the acquire is rejected — returns nil — and Xray projects
+  ;; zero rows). Hosts not running the re-frame.ui substrate simply
+  ;; deliver nothing into the claimed projection. The returned receipt is
+  ;; retained in the ledger (`current-receipt`); the standing boot path
+  ;; ignores it.
+  (viewcell-evidence/acquire!)
   (install/install-browser-api-exports!)
   (keybinding/attach!)
   ;; Apply the persisted CSS-var + theme-class effects. The shell

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -41,6 +41,7 @@
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.viewcell-evidence :as viewcell-evidence]
             ;; rf2-e8330v (xxo3zz F3) — per-panel test-override seams.
             ;; Production registration installs NO `-for-test` ids; tests
             ;; opt into the override surface via `install-test-overrides!`.
@@ -73,9 +74,20 @@
 
 (defn reset-all!
   "`reset-sentinels!` PLUS the trace-collector rings
-  (`trace-collector/reset-for-test!`). The rings are process-global
-  `defonce` atoms the sentinel reset does NOT touch — clearing them
-  here closes the cross-test trace-bleed gap (rf2-sdqsla).
+  (`trace-collector/reset-for-test!`) PLUS an owner-checked release of
+  Xray's ViewCell evidence registration
+  (`viewcell-evidence/release-current!`, rf2-vxgfnd.286). The rings are
+  process-global `defonce` atoms the sentinel reset does NOT touch —
+  clearing them here closes the cross-test trace-bleed gap (rf2-sdqsla).
+
+  The evidence release is part of the clean-slate tier because a
+  `core/init!` (or preload) that acquired the projection leaves the tier
+  owner, sink, retained entries AND the globalThis sentinel set —
+  process-global state the sentinel/ring resets do NOT touch, so it would
+  leak across tests. The release is OWNER-CHECKED
+  (`release-current!`, never `force-release!`): it clears exactly Xray's
+  own registration and its sentinel, and a FOREIGN owner survives the
+  reset intact (rf2-vxgfnd.286 AC).
 
   Call at the START of a fixture, BEFORE registering frames — clearing
   the rings wipes the per-frame recording config, so a mid-setup call
@@ -86,6 +98,7 @@
   []
   (reset-sentinels!)
   (trace-collector/reset-for-test!)
+  (viewcell-evidence/release-current!)
   nil)
 
 (defn reset-runtime!

--- a/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
@@ -3,30 +3,59 @@
   projection (rf2-vxgfnd.146) — the real native runtime the
   `re-frame.ui.tool.evidence` tier was built for (rf2-vxgfnd.75/.46).
 
-  ## Ownership + lifecycle
+  ## Ownership span + receipt (rf2-vxgfnd.286)
 
   Xray claims the projection under the STABLE identity `owner-id`
   (`:rf.xray/viewcell-evidence`) from the preload's debug-gated boot
-  block. The evidence tier's identity-owned, generation-fenced lifecycle
-  (rf2-vxgfnd.147) does the rest:
+  block. But a stable identity is a REUSABLE key — after one ownership
+  span closes and another reclaims the same id, `owner-id` equality
+  alone cannot tell the two incarnations apart. So this ns layers an
+  opaque, per-span RECEIPT over the evidence tier's identity+generation
+  lifecycle (rf2-vxgfnd.147):
 
-    - first load → `install!` claims the projection; a shadow-cljs
-      `:after-load` re-runs the SAME call as the idempotent same-owner
-      re-arm (accumulated evidence survives — the HMR path);
+    - `acquire!` claims (or same-span re-arms) the projection and returns
+      the span's opaque receipt — a FRESH token for a fresh claim, the
+      SAME token for a same-owner re-arm (the `:after-load`/HMR path, so
+      accumulated evidence and in-flight deliveries stay valid together);
     - a foreign owner already holding the projection is NEVER clobbered:
-      Xray's install is rejected (returns false; the evidence tier emits
-      the one console diagnostic) and Xray simply projects zero rows;
-    - `uninstall!` releases exactly Xray's registration — the
-      tool-shutdown/test door. Generation fencing downstream guarantees
-      an in-flight delivery cannot repopulate the released projection,
-      and a stale release cannot touch a successor owner.
+      the acquire is rejected (returns nil; the evidence tier emits the
+      one console diagnostic) and Xray projects zero rows;
+    - `release!` frees EXACTLY the span named by a receipt — a stale
+      receipt from a superseded span can neither read a successor's data
+      nor clear a successor's registration (the same-key ABA fence);
+    - `release-current!` frees whatever span Xray currently owns — the
+      owner-checked teardown the clean-slate reset tier drives (a foreign
+      registration survives it);
+    - every AUTHORIZED read (`rows`) checks the exact receipt AND that
+      Xray is still the installed tier owner, so neither a foreign
+      takeover nor a same-key reclaim ever surfaces another span's data.
+
+  `installed-owner` (the tier read) remains DIAGNOSTIC-only: ownership is
+  authorized by the receipt, not by owner-id equality.
+
+  ## Reactive freshness (rf2-vxgfnd.286)
+
+  Ownership is not app-db state, so a change to it (acquire/release) would
+  not, on its own, invalidate the `:rf.xray/viewcell-evidence` sub — a
+  live subscription + rendered panel could keep a stale row after Xray
+  released the projection, until some unrelated epoch pump recomputed it.
+  So each ownership transition bumps a monotonic REVISION and notifies the
+  optional `ownership-listener*` the reactive bridge installs
+  (`set-ownership-listener!`): the bridge writes the revision into Xray's
+  own `:rf/xray` app-db, which is a reactive input to the single derived
+  query. Cache invalidation only TRIGGERS the recompute; the recompute's
+  `rows` call still checks the exact receipt, so reactivity can never
+  authorize a stale reader.
 
   ## Dependency boundary
 
   tools/xray depends on the ui artefact's TOOL tier (dev-only, exactly
   like the feature artefacts Xray already reads); `re-frame.ui` does NOT
-  know Xray exists — it exposes the projection, Xray consumes it.
-  Production applications never pull Xray (the tools/README
+  know Xray exists — it exposes the projection, Xray consumes it. The
+  reactive bridge (the sub, the ownership event, the listener) lives in
+  the Xray sub layer (`panels.reactive-panel-subs`), so this ns stays a
+  thin ownership/receipt ledger over the tier — no frame or dispatch
+  coupling. Production applications never pull Xray (the tools/README
   bundle-isolation contract), and tool absence stays zero-cost: this ns
   loads only from the dev-only preload, and the debug evidence plane
   itself DCEs out of production builds.
@@ -46,17 +75,64 @@
 
 (def owner-id
   "Xray's stable evidence-projection owner identity. ONE value for the
-  whole tool lifetime — preload install, `:after-load` re-arm, and
-  shutdown uninstall all name it, so HMR/reinstall and teardown release
-  and re-claim exactly this registration and never another owner's."
+  whole tool lifetime — preload acquire, `:after-load` re-arm, and
+  shutdown release all name it, so HMR/reinstall and teardown release
+  and re-claim exactly this registration and never another owner's. The
+  id is the tier registration KEY; a single ownership SPAN under this id
+  is identified exactly by the receipt (see the ns docstring)."
   :rf.xray/viewcell-evidence)
 
 (def ^:private sentinel-key
-  "`js/globalThis` marker mirroring a successful install — the browser
+  "`js/globalThis` marker mirroring a successful acquire — the browser
   feature-gate's cheap 'is the native evidence consumer wired?' probe
   (parallels the runtime session sentinel in
   `day8.re-frame2-xray.runtime`)."
   "__day8_re_frame2_xray_viewcell_evidence")
+
+(defonce ^:private state*
+  ;; Xray's own ownership-span ledger, layered over the evidence tier's
+  ;; identity+generation lifecycle (rf2-vxgfnd.147/.286):
+  ;;
+  ;;   :revision — a monotonic counter bumped on every ownership
+  ;;               TRANSITION (a fresh acquire and a release; NOT a
+  ;;               same-span re-arm, which continues the span). The
+  ;;               reactive freshness axis: the bridge writes it into
+  ;;               `:rf/xray` app-db so the single derived query
+  ;;               recomputes the instant ownership changes.
+  ;;   :receipt  — the opaque token identifying the CURRENT ownership
+  ;;               span, or nil when Xray does not own the projection.
+  ;;               A fresh reference is minted on a fresh acquire and
+  ;;               PRESERVED across a same-owner re-arm (HMR keeps the
+  ;;               span); it goes nil on release. Reference identity is
+  ;;               the exactness check — a stale span's receipt never
+  ;;               equals the current one.
+  ;;
+  ;; `defonce` (module-lived): a hot reload keeps the ledger in lock-step
+  ;; with the tier's own `defonce` state.
+  (atom {:revision 0 :receipt nil}))
+
+(defonce ^:private ownership-listener*
+  ;; The single optional sink the reactive bridge installs
+  ;; (`set-ownership-listener!`) — invoked with the new revision on every
+  ;; ownership transition so a live `:rf.xray/viewcell-evidence`
+  ;; subscription recomputes immediately, not only on the next epoch
+  ;; pump. One listener (the Xray sub-graph bridge), NOT a registry: nil
+  ;; until the sub layer wires it.
+  (atom nil))
+
+(defn set-ownership-listener!
+  "Install the ownership-transition sink (the reactive bridge). Called
+  once by the Xray sub layer; `f` is invoked with the new revision on
+  each fresh acquire and each release. `nil` clears it."
+  [f]
+  (reset! ownership-listener* f)
+  nil)
+
+(defn- notify-listener!
+  [revision]
+  (when-let [f @ownership-listener*]
+    (f revision))
+  nil)
 
 (defn- sync-sentinel!
   [installed?]
@@ -67,30 +143,137 @@
                         "installed" (.now js/Date)))
       (gobj/remove js/globalThis sentinel-key))))
 
-(defn install!
-  "Claim (or same-owner re-arm) the ViewCell evidence projection for
-  Xray — the preload boot step and the `:after-load` path. Idempotent.
-  Returns the evidence tier's verdict: true installed/re-armed; false
-  rejected (a foreign owner holds the projection — untouched) or
-  production no-op."
-  []
-  (let [ok? (evidence/install! owner-id)]
-    (when ok? (sync-sentinel! true))
-    ok?))
-
-(defn uninstall!
-  "Release exactly Xray's registration (owner-checked here,
-  generation-fenced downstream). Returns true when released; false when
-  Xray was not the current owner (nothing changes)."
-  []
-  (let [ok? (evidence/uninstall! owner-id)]
-    (when ok? (sync-sentinel! false))
-    ok?))
-
 (defn installed?
-  "True when Xray currently owns the projection (query/test read)."
+  "True when Xray currently owns the installed projection (diagnostic
+  read). Ownership is AUTHORIZED by the receipt, not by this alone — but
+  this catches a foreign takeover (tier owner ≠ Xray), which a stale
+  receipt match cannot."
   []
   (= owner-id (evidence/installed-owner)))
+
+(defn current-receipt
+  "Xray's CURRENT ownership-span receipt, or nil when Xray does not own
+  the projection. The token to present to `rows`/`release!` for an exact
+  read/release of the live span."
+  []
+  (when (installed?)
+    (:receipt @state*)))
+
+(defn ownership-revision
+  "The current monotonic ownership revision — the reactive-freshness
+  value the bridge mirrors into app-db. Diagnostic / seed read."
+  []
+  (:revision @state*))
+
+(defn- mint-fresh-span!
+  "Open a NEW ownership span: mint a fresh receipt, bump + publish the
+  revision, mirror the sentinel. Returns the receipt."
+  []
+  (let [receipt (js/Object.)
+        rev     (:revision (swap! state* (fn [s]
+                                           (-> s
+                                               (update :revision inc)
+                                               (assoc :receipt receipt)))))]
+    (sync-sentinel! true)
+    (notify-listener! rev)
+    receipt))
+
+(defn acquire!
+  "Claim (or same-span re-arm) the ViewCell evidence projection for Xray
+  — the preload boot step and the `:after-load` path. Idempotent.
+
+    - unowned            → fresh claim: opens a NEW span, mints + returns
+                           a fresh opaque receipt.
+    - owned by Xray      → same-span RE-ARM (HMR / `:after-load`): the
+                           accumulated evidence and in-flight deliveries
+                           survive; returns the SAME receipt.
+    - owned by another   → REJECTED (a foreign owner holds it, untouched;
+                           the tier emits one console diagnostic) — returns
+                           nil.
+    - production          → no-op; returns nil.
+
+  The returned receipt is the caller's handle for an exact read/release;
+  standing callers (preload, `core/init!`) may ignore it — the ledger
+  retains the current span, readable via `current-receipt`."
+  []
+  (let [pre-owner (evidence/installed-owner)
+        ok?       (evidence/install! owner-id)]
+    (cond
+      (not ok?)               nil                 ; rejected / production
+      (= pre-owner owner-id)                       ; same-owner re-arm
+      (if-some [receipt (:receipt @state*)]
+        (do (sync-sentinel! true) receipt)         ; continue the span
+        (mint-fresh-span!))                         ; ledger lost it → remint
+      :else                   (mint-fresh-span!)))) ; fresh claim
+
+(defn- release-span!
+  "Free Xray's current span: owner-checked tier release, ledger cleared,
+  revision bumped + published, sentinel withdrawn. Assumes the caller has
+  already authorized the release (receipt or owner check). Returns the
+  tier's verdict."
+  []
+  (let [ok? (evidence/uninstall! owner-id)]
+    (when ok?
+      (let [rev (:revision (swap! state* (fn [s]
+                                          (-> s
+                                              (update :revision inc)
+                                              (assoc :receipt nil)))))]
+        (sync-sentinel! false)
+        (notify-listener! rev)))
+    ok?))
+
+(defn release!
+  "Release EXACTLY the ownership span named by `receipt` (the value
+  `acquire!` returned). Receipt-checked AND owner-checked: releases iff
+  `receipt` is Xray's CURRENT span receipt and Xray still owns the tier —
+  so a stale receipt from a superseded span can NEVER clear a successor's
+  registration (the same-key ABA fence). Returns true when released;
+  false (nothing changes) otherwise."
+  [receipt]
+  (if (and (some? receipt)
+           (= receipt (current-receipt)))
+    (release-span!)
+    false))
+
+(defn release-current!
+  "Release whatever span Xray currently owns — the owner-checked teardown
+  the clean-slate reset tier drives. A foreign owner (Xray does not own)
+  survives (returns false). Returns true when Xray's own registration was
+  released."
+  []
+  (if (installed?)
+    (release-span!)
+    false))
+
+(defn reset-for-test!
+  "Test-only: force the WHOLE Xray evidence layer to baseline — the tier's
+  `force-release!` (drops ANY owner + entries + sink), Xray's own ledger
+  (receipt cleared), and the globalThis sentinel. The fixture-reset door
+  that leaves no cross-test owner/sentinel leakage; production teardown
+  uses the owner-checked `release-current!`. Returns nil."
+  []
+  (evidence/force-release!)
+  (swap! state* assoc :receipt nil)
+  (sync-sentinel! false)
+  nil)
+
+(defn- project-rows
+  "Shape the tier `projection` into the developer-facing row vector."
+  []
+  (into []
+        (map (fn [{:keys [cell-id view-id root-id evidence]}]
+               {:cell-id        cell-id
+                :view-id        view-id
+                :root-id        root-id
+                :first-epoch    (:first-epoch evidence)
+                :latest-epoch   (:latest-epoch evidence)
+                :count          (:count evidence)
+                :batches        (:batches evidence)
+                :causes         (:causes evidence)
+                :targets        (:targets evidence)
+                :dropped-count  (count (:dropped evidence))
+                :dropped-exact? (:dropped-exact? evidence)}))
+        (or (evidence/projection) [])))
 
 (defn rows
   "The developer-facing query projection over Xray's accumulated ViewCell
@@ -108,30 +291,29 @@
      :dropped-count  d        ; distinct omitted targets (honest loss)
      :dropped-exact? bool}    ; false ⇒ d is a lower bound (saturated)
 
-  `[]` when Xray does NOT own the installed projection (never installed,
-  uninstalled, or a FOREIGN owner holds it — ownership rejection must mean
-  no observation through Xray), when empty, or in a production build (where
-  the debug evidence plane is elided)."
-  []
-  ;; Ownership fence (rf2-vxgfnd.238). The evidence tier's `projection`
-  ;; read returns the shared slot's entries REGARDLESS of owner, so a bare
-  ;; read here would expose a foreign owner's evidence whenever Xray's
-  ;; install was rejected (`installed?` false). Gate EVERY read — rows and
-  ;; the `:rf.xray/viewcell-evidence` sub/UI that derive from it — on the
-  ;; exact ownership token: Xray observes iff Xray is the installed owner.
-  (if-not (installed?)
-    []
-    (into []
-          (map (fn [{:keys [cell-id view-id root-id evidence]}]
-                 {:cell-id        cell-id
-                  :view-id        view-id
-                  :root-id        root-id
-                  :first-epoch    (:first-epoch evidence)
-                  :latest-epoch   (:latest-epoch evidence)
-                  :count          (:count evidence)
-                  :batches        (:batches evidence)
-                  :causes         (:causes evidence)
-                  :targets        (:targets evidence)
-                  :dropped-count  (count (:dropped evidence))
-                  :dropped-exact? (:dropped-exact? evidence)}))
-          (or (evidence/projection) []))))
+  Two arities:
+
+    (rows)          reads whatever span Xray CURRENTLY owns — the standing
+                    panel/sub read.
+    (rows receipt)  reads ONLY the span named by `receipt` — a confined
+                    reader (one that captured a receipt) sees nothing once
+                    its span closed, even if the same owner-id was reclaimed.
+
+  `[]` when the presented span is not the installed owner (never
+  installed, uninstalled, a FOREIGN owner holds it, or the receipt names a
+  superseded span — ownership authorization must mean no observation
+  through Xray), when empty, or in a production build (debug evidence
+  plane elided). Every read compares the exact receipt AND that Xray still
+  owns the tier, so cache invalidation alone can never authorize a stale
+  reader (rf2-vxgfnd.238/.286)."
+  ([] (rows (current-receipt)))
+  ([receipt]
+   ;; Exact authorization (rf2-vxgfnd.286): the receipt must name Xray's
+   ;; CURRENT span AND Xray must still be the installed tier owner. The
+   ;; tier's `projection` read returns the shared slot's entries REGARDLESS
+   ;; of owner, so a bare read would expose a foreign owner's evidence or a
+   ;; superseded span's — gate EVERY read on both.
+   (if (and (some? receipt)
+            (= receipt (current-receipt)))
+     (project-rows)
+     [])))

--- a/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
@@ -142,8 +142,9 @@
 ;; ---- init! contract ----------------------------------------------------
 
 (deftest init!-no-opts-is-idempotent
-  (testing "init! wires the four foundation side-effects; second call is no-op"
-    ;; First call wires registry + trace-cb + epoch-cb + keybinding.
+  (testing "init! wires the foundation side-effects; second call is no-op"
+    ;; First call wires registry + trace-cb + epoch-cb + ViewCell-evidence
+    ;; acquire (rf2-vxgfnd.286) + browser-API exports + keybinding.
     ;; The keybinding listener requires js/window which the node-test
     ;; host does not expose; the attach call no-ops on that host (the
     ;; (when (exists? js/window) ...) guard inside keybinding/attach!).

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -476,7 +476,11 @@
    ;; rf2-vxgfnd.146 — the ViewCell Invalidation Evidence section's query
    ;; over Xray's OWNED `re-frame.ui.tool.evidence` projection
    ;; (spec/021 §3.4.1); registered by `reactive-panel-subs/install!`.
-   :rf.xray/viewcell-evidence))
+   :rf.xray/viewcell-evidence
+   ;; rf2-vxgfnd.286 — the ownership-REVISION reactive input to the query
+   ;; above: `viewcell-evidence` bumps it on every acquire/release so a live
+   ;; query recomputes to empty immediately (not on the next epoch pump).
+   :rf.xray/viewcell-evidence-ownership))
 
 (def ^:private all-event-names
   "Every Xray-namespaced event registered by `register-xray-handlers!`.
@@ -784,7 +788,12 @@
    ;; Reactive panel events (rf2-wyvf2 · spec/021 §3 · renamed from
    ;; Views per §11.5; tab key stays `:views`).
    :rf.xray/reactive-set-unchanged
-   :rf.xray/reactive-toggle-unchanged))
+   :rf.xray/reactive-toggle-unchanged
+   ;; rf2-vxgfnd.286 — the ownership reactivity bridge: `viewcell-evidence`'s
+   ;; listener dispatches this into `:rf/xray` on every evidence acquire/
+   ;; release, bumping `:rf.xray/viewcell-evidence-ownership` so a live
+   ;; query recomputes immediately (no epoch pump).
+   :rf.xray/viewcell-evidence-ownership-changed))
 
 (def ^:private all-fx-names
   "Every Xray-namespaced fx registered by `register-xray-handlers!`.

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -1,35 +1,46 @@
 (ns day8.re-frame2-xray.viewcell-evidence-cljs-test
-  "rf2-vxgfnd.146 — the REAL Xray runtime owns the re-frame.ui ViewCell
-  invalidation-evidence projection.
+  "rf2-vxgfnd.146/.238/.286 — the REAL Xray runtime owns the re-frame.ui
+  ViewCell invalidation-evidence projection, EXACTLY (per span, not per
+  reusable id), REACTIVELY (an ownership change invalidates the query), and
+  LIFECYCLE-COMPLETELY (every transition — acquire, read, HMR re-arm,
+  release, reclaim, canonical reset — keeps ownership correct).
 
   Requiring `day8.re-frame2-xray.preload` here runs the ACTUAL preload
   boot block (the same namespace shadow-cljs `:devtools/preloads` loads
   into every dev host), and `owner-at-load` snapshots the evidence
   tier's owner IMMEDIATELY after — before any fixture can reset it. If
-  the preload's `viewcell-evidence/install!` wiring is removed, that
+  the preload's `viewcell-evidence/acquire!` wiring is removed, that
   snapshot is nil and the wiring test goes RED (the mutation probe the
   bead demands; the browser counterpart lives in the feature-matrix
   shell sweep, which checks the install sentinel + the rendered Views
   panel section against the real chrome runtime).
 
-  The end-to-end row test drives a REAL observation-port movement — a
-  committed ViewCell whose subscription lease fans out an `:hmr`
-  invalidation, flushed by the scheduler — and asserts the row surfaces
-  through Xray's query path (`:rf.xray/viewcell-evidence`, subscribed in
-  the `:rf/xray` frame exactly as the Views panel section reads it) with
-  stable identity + the bounded epoch/count/batch/cause/target/loss
-  fields, then that teardown prunes it. Lifecycle tests pin the HMR
-  re-arm (evidence kept), the exact-owner release, and the
-  never-clobber-a-foreign-owner contract."
+  ## The three .286 properties, each with a red-before-fix control
+
+    - EXACT (rf2-vxgfnd.286 AC1) — `same-key-aba-*`: acquire span A, close
+      it, reclaim the SAME owner-id as span B, publish a real B row. A's
+      receipt reads NO B data and A's release cannot clear B. Reverting the
+      receipt fence to owner equality makes it fail (owner-id matches, so a
+      bare read would surface B and a bare release would clear B).
+    - REACTIVE (rf2-vxgfnd.286 AC3/AC4) — `ownership-change-is-reactive-*`:
+      the query DECLARES the ownership-revision axis as a `:<-` input, and
+      every transition bumps that revision in `:rf/xray` app-db. Removing
+      the listener/event or the `:<-` input makes it fail.
+    - LIFECYCLE-COMPLETE (rf2-vxgfnd.286 AC5) — `canonical-reset-*`:
+      `core/init!` then the clean-slate `reset-all!`/`reset-runtime!` tier
+      leaves owner, rows, entries and sentinel at baseline (owner-checked),
+      while a FOREIGN registration survives. Omitting the reset-tier
+      cleanup makes it fail."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.subs.tooling :as subs-tooling]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.tool.evidence :as evidence]
             [day8.re-frame2-xray.core :as core]
             [day8.re-frame2-xray.mount :as mount]
             ;; The REAL preload — its debug-gated boot block runs at load,
-            ;; installing the evidence projection under Xray's identity.
+            ;; acquiring the evidence projection under Xray's identity.
             [day8.re-frame2-xray.preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -47,18 +58,22 @@
   (xray-test-support/make-xray-runtime-fixture {})
   (fn [f]
     (reactive/reset-scheduler!)
-    (evidence/force-release!)
+    ;; The Xray-level fixture-reset door: force-releases the tier AND
+    ;; withdraws Xray's sentinel + clears the ledger receipt — so no
+    ;; cross-test owner/sentinel leakage (rf2-vxgfnd.286: the prior bespoke
+    ;; `evidence/force-release!` cleared the tier but LEAKED Xray's sentinel).
+    (viewcell-evidence/reset-for-test!)
     (try (f) (finally
                (reactive/reset-scheduler!)
-               (evidence/force-release!)))))
+               (viewcell-evidence/reset-for-test!)))))
 
 (def ^:private fid :rf/default)
 
 (defn- boot-xray!
   "The production init path (mirrors `init_filter_reset_cljs_test`):
   register the Xray handlers, then `ensure-xray-frame!` — so the
-  `:rf/xray` frame and the `:rf.xray/*` sub graph exist exactly as a
-  real page load builds them."
+  `:rf/xray` frame and the `:rf.xray/*` sub graph (incl. the ownership
+  reactivity bridge) exist exactly as a real page load builds them."
   []
   (registry/register-xray-handlers!)
   (mount/ensure-xray-frame!))
@@ -81,17 +96,21 @@
   (rf/with-frame :rf/xray
     @(rf/subscribe [:rf.xray/viewcell-evidence])))
 
+(defn- ownership-rev-sub []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/viewcell-evidence-ownership])))
+
 ;; ===========================================================================
-;; The preload wiring — no test-only direct install stands in for it
+;; The preload wiring — no test-only direct acquire stands in for it
 ;; ===========================================================================
 
-(deftest preload-boot-installs-the-projection-under-xrays-stable-identity
+(deftest preload-boot-acquires-the-projection-under-xrays-stable-identity
   (is (= viewcell-evidence/owner-id owner-at-load)
-      "the REAL preload boot block claimed the evidence projection —
-       removing the preload install wiring turns this nil (AC: a mutation
-       removing the Xray install must fail)")
+      "the REAL preload boot block acquired the evidence projection —
+       removing the preload acquire wiring turns this nil (AC: a mutation
+       removing the Xray acquire must fail)")
   (is (some? sentinel-at-load)
-      "…and mirrored the install on the browser-probe sentinel")
+      "…and mirrored the acquire on the browser-probe sentinel")
   (is (= (str viewcell-evidence/owner-id)
          (aget sentinel-at-load "owner"))))
 
@@ -101,7 +120,7 @@
 
 (deftest real-movement-surfaces-in-the-xray-query-row
   (boot-xray!)
-  (is (true? (viewcell-evidence/install!)))
+  (is (some? (viewcell-evidence/acquire!)))
   (rf/reg-sub :vce/a (fn [db _] (:a db)))
   (frame/replace-app-db! fid {:a 1})
   (let [cell (rc! (reactive/make-cell ::v) [[:vce/a]])]
@@ -152,43 +171,148 @@
       (is (= [] (xray-query))))))
 
 ;; ===========================================================================
-;; Lifecycle — HMR re-arm, exact-owner release, never clobber
+;; EXACT — same-key ABA: a superseded span reads no successor and cannot
+;; clear it (rf2-vxgfnd.286 AC1)
 ;; ===========================================================================
 
-(deftest hmr-rearm-keeps-the-accumulated-evidence
-  (is (true? (viewcell-evidence/install!)))
-  (let [cell (reactive/make-cell ::v)]
-    (reactive/mark-dirty! cell 1)
+(deftest same-key-aba-a-superseded-span-reads-no-successor-and-cannot-clear-it
+  ;; span A publishes a real row
+  (let [receipt-a (viewcell-evidence/acquire!)
+        cell-a    (reactive/make-cell ::a)]
+    (is (some? receipt-a))
+    (reactive/mark-dirty! cell-a 1)
     (reactive/flush-pending!)
-    (is (= 1 (:count (first (viewcell-evidence/rows)))))
-    ;; the `:after-load` path: the preload boot re-runs → same-owner re-arm
-    (is (true? (viewcell-evidence/install!)))
-    (is (true? (viewcell-evidence/installed?)))
-    (is (= 1 (:count (first (viewcell-evidence/rows))))
-        "accumulated evidence survives the re-arm")
-    (reactive/mark-dirty! cell 2)
-    (reactive/flush-pending!)
-    (is (= 2 (:count (first (viewcell-evidence/rows))))
-        "…and delivery continues into the SAME accumulator")))
+    (is (= 1 (:count (first (viewcell-evidence/rows receipt-a))))
+        "A sees A's own row through A's receipt")
+
+    ;; close A, reclaim the SAME logical id as span B
+    (is (true? (viewcell-evidence/release-current!)) "span A closed")
+    (let [receipt-b (viewcell-evidence/acquire!)
+          cell-b    (reactive/make-cell ::b)]
+      (is (some? receipt-b))
+      (is (not= receipt-a receipt-b)
+          "B is a DISTINCT span even under the SAME reusable owner-id")
+      (is (= viewcell-evidence/owner-id (evidence/installed-owner))
+          "…reclaimed under the same tier id")
+      (reactive/mark-dirty! cell-b 1)
+      (reactive/flush-pending!)
+      (is (= 1 (:count (first (viewcell-evidence/rows receipt-b))))
+          "B publishes a real, distinct row")
+
+      (testing "A reads NO B data — a superseded span's receipt authorizes nothing"
+        ;; Fail-before: with owner-equality the read passes the id fence
+        ;; (owner-id matches) and would surface B's row.
+        (is (= [] (viewcell-evidence/rows receipt-a))))
+
+      (testing "A's release cannot clear B's owner, sentinel, entries or delivery"
+        ;; Fail-before: an owner-checked-only release would call the tier's
+        ;; `uninstall!` for owner-id and release B.
+        (is (false? (viewcell-evidence/release! receipt-a))
+            "the stale receipt's release is refused")
+        (is (= viewcell-evidence/owner-id (evidence/installed-owner))
+            "B still owns the projection")
+        (is (some? (aget js/globalThis sentinel-key))
+            "B's install sentinel is intact")
+        (is (= 1 (:count (first (viewcell-evidence/rows receipt-b))))
+            "B's retained entries are intact")
+        ;; a LATER delivery still lands into B's live sink
+        (reactive/mark-dirty! cell-b 2)
+        (reactive/flush-pending!)
+        (is (= 2 (:count (first (viewcell-evidence/rows receipt-b))))
+            "B's sink still delivers after the stale release")))))
+
+;; ===========================================================================
+;; REACTIVE — ownership change is a reactive input to the evidence query
+;; (rf2-vxgfnd.286 AC3/AC4)
+;; ===========================================================================
+
+(deftest ownership-change-is-a-reactive-input-to-the-evidence-query
+  (boot-xray!)
+
+  (testing "the query DECLARES the ownership-revision axis as a `:<-` input"
+    ;; Fail-before: the composite `:<-`'d only `:rf.xray/epoch-history`, so an
+    ;; acquire/release invalidated nothing until an unrelated epoch pump.
+    (let [inputs    (:inputs (get (subs-tooling/sub-topology)
+                                  :rf.xray/viewcell-evidence))
+          input-ids (map #(if (vector? %) (first %) %) (or inputs []))]
+      (is (some #{:rf.xray/viewcell-evidence-ownership} input-ids)
+          "so an acquire/release recomputes the query without an epoch pump")))
+
+  (testing "each ownership transition bumps the reactive ownership revision"
+    ;; Fail-before: no listener / event / ownership slot ⇒ the value never
+    ;; changes on a release, so a live query keeps its stale rows.
+    (let [receipt       (viewcell-evidence/acquire!)
+          after-acquire (ownership-rev-sub)]
+      (is (some? receipt))
+      (is (true? (viewcell-evidence/release-current!)))
+      (let [after-release (ownership-rev-sub)]
+        (is (not= after-acquire after-release)
+            "release bumped the reactive ownership input — a held query
+             recomputes immediately, no epoch pump")
+        (is (> after-release after-acquire) "revisions are monotonic"))))
+
+  (testing "a held subscription reflects the release — receipt-fenced recompute"
+    ;; On the plain-atom node adapter every deref recomputes, so this is a
+    ;; live-surface smoke over the held-subscription path (the caching-adapter
+    ;; gate is the feature-matrix shell sweep); the receipt fence keeps the
+    ;; recompute honest.
+    (let [receipt (viewcell-evidence/acquire!)
+          cell    (reactive/make-cell ::live)
+          sub     (rf/with-frame :rf/xray
+                    (rf/subscribe [:rf.xray/viewcell-evidence]))]
+      (is (some? receipt))
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (seq @sub) "non-empty while Xray owns the span")
+      (viewcell-evidence/release-current!)
+      (is (= [] @sub)
+          "empty after release — the ownership axis recomputed it, not an
+           epoch pump"))))
+
+;; ===========================================================================
+;; Lifecycle — HMR re-arm keeps the span + evidence; exact-owner release;
+;; never clobber a foreign owner
+;; ===========================================================================
+
+(deftest hmr-rearm-keeps-the-same-span-and-accumulated-evidence
+  (let [receipt-1 (viewcell-evidence/acquire!)]
+    (is (some? receipt-1))
+    (let [cell (reactive/make-cell ::v)]
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (= 1 (:count (first (viewcell-evidence/rows)))))
+      ;; the `:after-load` path: the preload boot re-runs → same-span re-arm
+      (let [receipt-2 (viewcell-evidence/acquire!)]
+        (is (= receipt-1 receipt-2)
+            "the HMR re-arm PRESERVES the span receipt (same continuous span)")
+        (is (true? (viewcell-evidence/installed?)))
+        (is (= 1 (:count (first (viewcell-evidence/rows))))
+            "accumulated evidence survives the re-arm"))
+      (reactive/mark-dirty! cell 2)
+      (reactive/flush-pending!)
+      (is (= 2 (:count (first (viewcell-evidence/rows))))
+          "…and delivery continues into the SAME accumulator"))))
 
 (deftest shutdown-releases-the-exact-owner-and-never-clobbers-a-foreign-one
-  (testing "uninstall releases exactly Xray's registration"
-    (is (true? (viewcell-evidence/install!)))
+  (testing "release-current! frees exactly Xray's registration"
+    (is (some? (viewcell-evidence/acquire!)))
     (is (some? (aget js/globalThis sentinel-key)))
-    (is (true? (viewcell-evidence/uninstall!)))
+    (is (true? (viewcell-evidence/release-current!)))
     (is (nil? (evidence/installed-owner)))
+    (is (nil? (viewcell-evidence/current-receipt)) "the span receipt is cleared")
     (is (= [] (viewcell-evidence/rows)) "closed retains zero")
     (is (nil? (aget js/globalThis sentinel-key))
         "the install sentinel is withdrawn with the registration"))
 
-  (testing "a foreign owner is NEVER clobbered — Xray's install is refused"
+  (testing "a foreign owner is NEVER clobbered — Xray's acquire is refused"
     (is (true? (evidence/install! ::another-tool)))
-    (is (false? (viewcell-evidence/install!)))
+    (is (nil? (viewcell-evidence/acquire!)) "acquire rejected → nil receipt")
     (is (= ::another-tool (evidence/installed-owner))
         "the foreign registration stands")
     (is (false? (viewcell-evidence/installed?)))
-    (is (false? (viewcell-evidence/uninstall!))
-        "…and Xray's uninstall cannot release what it does not own")
+    (is (nil? (viewcell-evidence/current-receipt)))
+    (is (false? (viewcell-evidence/release-current!))
+        "…and Xray's release cannot free what it does not own")
     (is (= ::another-tool (evidence/installed-owner)))))
 
 ;; ===========================================================================
@@ -198,9 +322,9 @@
 
 (deftest foreign-owner-evidence-never-surfaces-through-any-xray-read
   ;; A foreign tool owns the shared projection AND has accumulated evidence
-  ;; in it — the case the earlier never-clobber test omitted (it installed a
-  ;; foreign owner but delivered nothing, so `rows` was empty for the wrong
-  ;; reason). Drive a real flush so `evidence/projection` is non-empty.
+  ;; in it — the case the never-clobber test omits (it installs a foreign
+  ;; owner but delivers nothing). Drive a real flush so `evidence/projection`
+  ;; is non-empty.
   (is (true? (evidence/install! ::another-tool)))
   (let [cell (reactive/make-cell ::foreign-v)]
     (reactive/mark-dirty! cell 1)
@@ -208,11 +332,10 @@
     (is (= 1 (count (evidence/projection)))
         "the FOREIGN owner accumulated a row in the shared projection")
     ;; Xray's own claim is rejected — Xray does not own the projection.
-    (is (false? (viewcell-evidence/install!)))
+    (is (nil? (viewcell-evidence/acquire!)))
     (is (false? (viewcell-evidence/installed?)))
     ;; AC: rows + every derived Xray query return NO evidence unless Xray
-    ;; owns the installed projection. Fail-before: pre-fix `rows` read the
-    ;; shared projection regardless of ownership and surfaced this row.
+    ;; owns the installed projection.
     (is (= [] (viewcell-evidence/rows))
         "ownership rejection ⇒ zero observation through Xray's rows")
     (boot-xray!)
@@ -225,25 +348,28 @@
         "…and its evidence still lives in the shared projection")))
 
 ;; ===========================================================================
-;; core/init! is a full evidence-projection install path (rf2-vxgfnd.238)
+;; core/init! is a full evidence-projection acquire path (rf2-vxgfnd.238)
 ;; ===========================================================================
 
-(deftest core-init-claims-the-projection-under-xrays-identity
+(deftest core-init-acquires-the-projection-under-xrays-identity
   ;; A clean process that requires `core` and calls `init!` (the supported
-  ;; manual alternative to the preload) must claim the evidence projection,
-  ;; or Xray is enabled WITHOUT ViewCell evidence. Fail-before: pre-fix
-  ;; `init!` never installed, so this owner stayed nil.
+  ;; manual alternative to the preload) must acquire the evidence projection,
+  ;; or Xray is enabled WITHOUT ViewCell evidence.
   (is (nil? (evidence/installed-owner)) "clean slate — nobody owns it")
   (core/init!)
   (is (= viewcell-evidence/owner-id (evidence/installed-owner))
-      "core/init! claims the projection under Xray's stable owner id")
+      "core/init! acquires the projection under Xray's stable owner id")
   (is (true? (viewcell-evidence/installed?)))
+  (is (some? (viewcell-evidence/current-receipt)) "…opening an ownership span")
   (is (some? (aget js/globalThis sentinel-key))
-      "…and mirrors the install on the browser-probe sentinel")
-  (testing "idempotent — a second init! is the same-owner re-arm, not a reject"
-    (core/init!)
-    (is (= viewcell-evidence/owner-id (evidence/installed-owner)))
-    (is (true? (viewcell-evidence/installed?)))))
+      "…and mirrors the acquire on the browser-probe sentinel")
+  (testing "idempotent — a second init! is the same-span re-arm, not a reject"
+    (let [receipt-before (viewcell-evidence/current-receipt)]
+      (core/init!)
+      (is (= viewcell-evidence/owner-id (evidence/installed-owner)))
+      (is (= receipt-before (viewcell-evidence/current-receipt))
+          "the re-arm keeps the span receipt")
+      (is (true? (viewcell-evidence/installed?))))))
 
 (deftest core-init-does-not-clobber-a-foreign-owner
   ;; The manual path honours the same never-clobber contract as the preload.
@@ -255,19 +381,60 @@
   (is (= [] (viewcell-evidence/rows))
       "…and exposes no evidence while another owner holds the projection"))
 
-(deftest uninstall-then-core-init-reclaims-a-fresh-projection
-  ;; dispose (uninstall) then re-init: the ordinary tool-shutdown / test
-  ;; door, and a re-init that reclaims a fresh, empty ownership span.
-  (is (true? (viewcell-evidence/install!)))
-  (let [cell (reactive/make-cell ::v)]
-    (reactive/mark-dirty! cell 1)
-    (reactive/flush-pending!)
-    (is (= 1 (:count (first (viewcell-evidence/rows))))))
-  (is (true? (viewcell-evidence/uninstall!)))
-  (is (nil? (evidence/installed-owner)))
-  (is (= [] (viewcell-evidence/rows)) "closed retains zero")
-  ;; re-init through the manual path reclaims the projection, empty
-  (core/init!)
-  (is (true? (viewcell-evidence/installed?)))
-  (is (= [] (viewcell-evidence/rows))
-      "re-init starts from a fresh, empty projection"))
+(deftest release-then-core-init-reclaims-a-fresh-span
+  ;; release then re-init: the ordinary tool-shutdown / test door, and a
+  ;; re-init that reclaims a fresh, empty ownership span with a NEW receipt.
+  (let [receipt-1 (viewcell-evidence/acquire!)]
+    (is (some? receipt-1))
+    (let [cell (reactive/make-cell ::v)]
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (= 1 (:count (first (viewcell-evidence/rows))))))
+    (is (true? (viewcell-evidence/release! receipt-1)))
+    (is (nil? (evidence/installed-owner)))
+    (is (= [] (viewcell-evidence/rows)) "closed retains zero")
+    ;; re-init through the manual path reclaims the projection, empty
+    (core/init!)
+    (is (true? (viewcell-evidence/installed?)))
+    (is (not= receipt-1 (viewcell-evidence/current-receipt))
+        "the reclaim mints a NEW span receipt")
+    (is (= [] (viewcell-evidence/rows))
+        "re-init starts from a fresh, empty projection")))
+
+;; ===========================================================================
+;; LIFECYCLE-COMPLETE — the canonical clean-slate reset tier releases Xray's
+;; evidence owner (owner-checked); a foreign owner survives (rf2-vxgfnd.286 AC5)
+;; ===========================================================================
+
+(deftest canonical-reset-tier-releases-xrays-evidence-owner-checked
+  (testing "core/init! then reset-all! leaves owner, rows, entries + sentinel baseline"
+    (core/init!)
+    (is (= viewcell-evidence/owner-id (evidence/installed-owner)))
+    (is (some? (aget js/globalThis sentinel-key)))
+    (let [cell (reactive/make-cell ::v)]
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (= 1 (count (viewcell-evidence/rows))) "a real row accumulated"))
+    ;; Fail-before: reset-all! omitted the evidence release, leaking owner +
+    ;; sentinel + entries across tests.
+    (xray-test-support/reset-all!)
+    (is (nil? (evidence/installed-owner))
+        "the clean-slate reset released Xray's registration")
+    (is (nil? (viewcell-evidence/current-receipt)) "…and its span receipt")
+    (is (= [] (viewcell-evidence/rows)) "no retained rows/entries")
+    (is (nil? (aget js/globalThis sentinel-key)) "the sentinel is withdrawn"))
+
+  (testing "reset-runtime! is likewise a full owner-checked evidence teardown"
+    (core/init!)
+    (is (= viewcell-evidence/owner-id (evidence/installed-owner)))
+    (xray-test-support/reset-runtime!)
+    (is (nil? (evidence/installed-owner)))
+    (is (nil? (aget js/globalThis sentinel-key))))
+
+  (testing "a FOREIGN registration SURVIVES the owner-checked reset"
+    ;; Fail-before/guard: an unconditional force-release in the reset tier
+    ;; would clobber the foreign owner — the reset must be owner-checked.
+    (is (true? (evidence/install! ::another-tool)))
+    (xray-test-support/reset-all!)
+    (is (= ::another-tool (evidence/installed-owner))
+        "owner-checked reset never clobbers a foreign owner")))


### PR DESCRIPTION
Follow-up audit of #5893/.238. That work fenced Xray's ViewCell evidence reads on a logical owner-id, but owner equality is not exact-incarnation ownership, and the surrounding reactive/reset integration could retain stale evidence. This makes ownership **exact**, **reactive**, and **lifecycle-complete**, consuming only the published `re-frame.ui.tool.evidence` API — `implementation/` is untouched.

## The three properties

- **EXACT (per-span receipt).** `day8.re-frame2-xray.viewcell-evidence` layers an opaque, per-span receipt over the tier's identity+generation lifecycle. `acquire!` mints a fresh receipt on a fresh claim and **preserves** it across a same-owner re-arm (HMR is one continuous span); `release!` frees exactly the span a receipt names; `release-current!` frees whatever span Xray owns (owner-checked). Every read (`rows`) checks the exact receipt **and** that Xray is still the installed tier owner, so a superseded same-key span or a foreign takeover surfaces nothing. `installed-owner` is diagnostic-only.
- **REACTIVE.** Each acquire/release bumps a monotonic revision the ledger publishes through a single listener; the sub layer mirrors it into `:rf/xray` app-db as the `:rf.xray/viewcell-evidence-ownership` input to the query, so a live subscription recomputes to empty the instant Xray releases (or a foreign owner takes the slot) — without an epoch pump. The revision only *triggers* the recompute; the recompute still checks the exact receipt, so cache invalidation cannot authorize a stale reader.
- **LIFECYCLE-COMPLETE.** The clean-slate reset tier (`test-support/reset-all!` → `reset-runtime!`) now runs the owner-checked `release-current!`, so `core/init!` or the preload leave no owner, sink, entries or globalThis sentinel behind; a **foreign** owner survives the owner-checked reset.

No polling, no second registry, no compatibility shim, no production ViewCell retention — a single listener hook, gated on the `:rf/xray` frame existing.

## Red-before-fix controls (real Xray/CLJS surface)

- `same-key-aba-a-superseded-span-reads-no-successor-and-cannot-clear-it` — acquire A, close it, reclaim the same owner-id as B, publish a real B row; A's receipt reads no B data and A's release cannot clear B. **Verified**: reverting the receipt fence to owner-equality fails 6 assertions in this test.
- `ownership-change-is-a-reactive-input-to-the-evidence-query` — the query declares the ownership axis as a `:<-` input, and every transition bumps the revision in `:rf/xray` app-db.
- `hmr-rearm-keeps-the-same-span-and-accumulated-evidence` — the receipt is preserved across a re-arm.
- `canonical-reset-tier-releases-xrays-evidence-owner-checked` — `core/init!` + `reset-all!`/`reset-runtime!` leave baseline; a foreign owner survives.

## Xray spec update

- `spec/021-Dynamic-Panel-Designs.md` §3.4.1 — rewritten for the per-span receipt (exact ownership), the ownership-revision reactive input, and the owner-checked reset lifecycle.
- `spec/011-Launch-Modes.md` + `spec/API.md` — the ViewCell-evidence acquire is placed accurately in the foundation enumeration (preload + manual `init!`), foreign-owner rejection and load-inertness stated; fragile "five/six foundation" counts removed.

## Quality gates

- Full xray CLJS suite (shadow-cljs `node-test`, `re-frame2-xray.*cljs-test$`): **3253 tests, 13760 assertions, 0 failures, 0 errors**.
- Focused `viewcell-evidence-cljs-test` (11 tests, 102 assertions): green; the exactness red-before-fix was reproduced and reverted.
- Registry-catalogue completeness test updated for the new sub (`:rf.xray/viewcell-evidence-ownership`) + event (`:rf.xray/viewcell-evidence-ownership-changed`).
- `implementation/` untouched; production elision unaffected (Xray is bundle-isolated; the acquire no-ops in production via the tier). Not run locally (SLIM tool-change gate): browser matrix, xray feature-gate, bundle-isolation — CI owns these.
