### PR TITLE
docs(machines): progressive guide rewrite

### DIFF
--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -227,7 +227,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
   ```clojure
   [:rf/machine machine-id]
   ```
-- **Description**: The canonical machine read. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. The [machines concept guide](../machines/concepts.md#registering-and-running-it) walks through subscribing to a snapshot and chaining named projections off it.
+- **Description**: The canonical machine read. Returns a reaction whose value is the snapshot `{:state :data}` (plus framework-managed `:tags`), or `nil` if the machine is not yet initialised. The [machines model](../machines/concepts.md#register-and-drive) walks through subscribing to a snapshot and chaining named projections off it.
 - **Example**:
   ```clojure
   (let [{:keys [state data]} @(rf/subscribe [:rf/machine :auth.login/flow])]
@@ -306,7 +306,7 @@ The framework-registered subscription vectors and reserved effect tuples that ad
 | `:output-key` | Requires `:final?`. Designates the child's `:data` slot reported back via the parent's `:on-done`. |
 | `:on-done` (spawn-spec key) | `(fn [{:keys [data result]}] new-data)` on the parent's `:spawn` map. Fires synchronously when the spawned child enters a `:final?` state. `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). |
 
-See [Final states: when a machine is done](../machines/concepts.md#final-states-when-a-machine-is-done) in the machines concept guide.
+See [Final states](../machines/concepts.md#final-states) in the machines model guide.
 
 ### `[:rf.machine/dispatch-to-system [system-id event]]`
 

--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -53,13 +53,13 @@ The map under `:spawn` accepts:
 |---|---|
 | `:machine-id` **or** `:definition` | which machine to spawn — a registered machine id, or an inline transition table. Supply **exactly one** (both, or neither, is a registration error). |
 | `:data` | initial `:data` for the child — a literal map, or `(fn [{:keys [snapshot event]}] data)` evaluated at entry against the **post-action** snapshot (the transition's own `:action` has already run, so its writes are visible). |
-| `:id-prefix` | base for the gensym'd actor id (`:websocket/socket#0`); defaults to `:machine-id`. |
+| `:id-prefix` | base for the allocated actor id (`:websocket/socket#0`); defaults to `:machine-id`. Ids are deterministic counters, never `gensym`. |
 | `:start` | an event vector dispatched to the newborn as its first event (see [the synthetic kick-off](#the-synthetic-spawned-event-and-start) below). |
-| `:system-id` | bind the actor to a per-frame **name** so other code can address it without knowing the gensym'd id (see [Messaging](#cross-machine-messaging)). |
+| `:system-id` | bind the actor to a per-frame **name** so other code can address it without knowing the allocated id (see [Messaging](#cross-machine-messaging)). |
 | `:on-spawn` | `(fn [{:keys [data id]}] _)` — an **advisory** observation hook; **its return is dropped** (see [Recording the id](#recording-the-spawned-id)). |
 | `:on-done` | `(fn [{:keys [data result]}] new-data)` — success notification when the child reaches a non-error `:final?` leaf. |
 | `:on-error` | an `:on`-shaped **transition** — fires when the child fails (an `:error?` final leaf, or a thrown action). The parent changes state. |
-| `:fixed-actor-id` | an explicit actor id instead of a gensym, for a per-state singleton actor. |
+| `:fixed-actor-id` | an explicit actor id instead of counter allocation, for a per-state singleton actor. |
 
 `:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf, and they get [their own section below](#when-a-child-finishes). The [API reference](../api/re-frame.machines.md) lists the exact shapes.
 
@@ -153,7 +153,7 @@ This is re-frame2's spelling of XState v5's `spawn(...)`-into-`context` capture,
 
 ### 2. `:system-id` (address the actor by a stable name)
 
-Give the spawn a `:system-id` and message it by that *role name* instead of the gensym'd id — best when you want a stable correspondent rather than to hold the id yourself. See [Addressing by name with `:system-id`](#addressing-by-name-with-system-id) below.
+Give the spawn a `:system-id` and message it by that *role name* instead of the allocated id — best when you want a stable correspondent rather than to hold the id yourself. See [Addressing by name with `:system-id`](#addressing-by-name-with-system-id) below.
 
 !!! note "The runtime registry, for outside-the-machine reads"
 
@@ -174,7 +174,7 @@ You get the id where the actor was created and carry it as an ordinary value: re
 
 ### Addressing by name with `:system-id`
 
-When you don't want to thread the gensym'd id around, name the actor at spawn with `:system-id`, then message it by that name. The canonical action-side surface is the reserved `:rf.machine/dispatch-to-system` fx (a machine action can't read app-db, so it can't look the id up itself):
+When you don't want to thread the allocated id around, name the actor at spawn with `:system-id`, then message it by that name. The canonical action-side surface is the reserved `:rf.machine/dispatch-to-system` fx (a machine action can't read app-db, so it can't look the id up itself):
 
 ```clojure
 ;; spawn under a role-name:

--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -1,5 +1,11 @@
 # Actors: spawning child machines
 
+Long-lived singletons are only half the story. **Actors** are machines started for
+a job — a per-request protocol, a worker, a wizard step — via declarative
+`:spawn` / `:spawn-all` (or imperative fx). Assumes the [flat model](concepts.md);
+child completion often uses [final states](concepts.md#final-states) and parent
+`:on-done`.
+
 A machine doesn't have to be a singleton. When a state needs to run some self-contained, asynchronous activity — an HTTP request, a websocket session, a worker grinding through a shard — you can **spawn a child machine** to do it, scoped to that state's lifetime. The child is a full machine instance with its own `:state` and `:data`; we call it an **actor**.
 
 The pattern earns its keep when an activity has a *lifetime that should match a state's lifetime*: start it when you enter the state, and — this is the part that's easy to get wrong by hand — tear it down on **every** way out of the state, including the ones you forgot about. Declare the binding once and the runtime enforces it.
@@ -112,7 +118,7 @@ A freshly-spawned actor needs a first nudge. Two ways:
   :idle {:on {:rf.machine.spawn/spawned :processing}}
   ```
 
-  Both work; new code prefers `:entry` (it fires for every kick-off mode). An unhandled `:rf.machine.spawn/spawned` is a benign no-op — it's reserved framework lifecycle traffic, exempt from the [unhandled-event trace](concepts.md#one-thing-that-wont-throw-the-unhandled-event).
+  Both work; new code prefers `:entry` (it fires for every kick-off mode). An unhandled `:rf.machine.spawn/spawned` is a benign no-op — it's reserved framework lifecycle traffic, exempt from the [unhandled-event trace](concepts.md#one-thing-that-wont-throw-the-unhandled-event) (see [See one run](concepts.md#see-one-run)).
 
 - **With `:start [:begin url]`.** Hand the child a specific first event payload. The two paths are mutually exclusive — an actor gets the synthetic kick-off *or* your `:start`, never both.
 

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -2,7 +2,11 @@
 
 Not every move is a user click. This page is the grammar for transitions the
 **table** takes on its own: eventless `:always`, choice nodes, delayed `:after`,
-and named timeouts. Works on flat machines ([the model](concepts.md)) and inside
+and named timeouts.
+
+You already met `:after` on the [login tutorial](tutorial.md#step-4--talk-to-a-real-server)
+(8s server deadline). Everything below works on **flat** machines
+([the model](concepts.md)) and the same keys nest inside
 [hierarchical](hierarchical-states.md) / [parallel](parallel-states.md) states.
 
 Most [transitions](glossary.md#transition) wait for the world: a user clicks, an HTTP reply lands, a timer you wired by hand goes off. An **automatic transition** is one the [machine](glossary.md#machine) takes *on its own*, with no external event — the instant a condition becomes true, or a deadline passes, the [snapshot](glossary.md#snapshot) moves.

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -1,5 +1,10 @@
 # Automatic transitions
 
+Not every move is a user click. This page is the grammar for transitions the
+**table** takes on its own: eventless `:always`, choice nodes, delayed `:after`,
+and named timeouts. Works on flat machines ([the model](concepts.md)) and inside
+[hierarchical](hierarchical-states.md) / [parallel](parallel-states.md) states.
+
 Most [transitions](glossary.md#transition) wait for the world: a user clicks, an HTTP reply lands, a timer you wired by hand goes off. An **automatic transition** is one the [machine](glossary.md#machine) takes *on its own*, with no external event — the instant a condition becomes true, or a deadline passes, the [snapshot](glossary.md#snapshot) moves.
 
 These are the statechart features that let a machine *drive itself*: a form that routes the moment it's validated, a splash screen that dismisses after three seconds, a reconnect that backs off and retries, a request that gives up after ten. Without them you reach for the same fragile pattern every time — a `setTimeout` paired with a cancel flag, or a synthetic event you `dispatch` by hand from every place that could enable the next step. re-frame2 turns each of those into one declarative key on a state node.
@@ -17,7 +22,7 @@ There are four authoring grammars, and underneath them just **two engines**:
 
     `:type :choice` is sugar that **desugars to `:always`**; `:timeout` / `:on-timeout` is sugar that **desugars to `:after`**. So everything on this page runs on one of two mechanisms: the **guard-driven microstep loop** (`:always`, `:choice`) and the **wall-clock timer** (`:after`, `:timeout`). One fact, one mechanism — the extra grammars exist only to *name the author's intent* so tools and diagrams can read it.
 
-Everything below assumes the core loop from the [concepts guide](concepts.md#registering-and-running-it): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [Concepts → Guards and actions](concepts.md#guards-and-actions) first.
+Everything below assumes the core loop from [the model](concepts.md#register-and-drive): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [The model → Guards and actions](concepts.md#guards-and-actions) first.
 
 ## Eventless `:always` — fire the instant a condition holds
 
@@ -55,7 +60,7 @@ This is classic statechart **macrostep** semantics: the externally-observable tr
 
 !!! note "It runs at birth, too"
 
-    The same settle loop runs when the machine first starts. If the [`:initial`](concepts.md#registering-and-running-it) state cascades into a leaf whose `:always` guard already holds, that transition is taken *before* the birth commit — so a transient initial state is settled past, unobserved, on start. (This is also why `:always` lives on a state node, never on the root: the root's cascade entry-point is `:initial`.)
+    The same settle loop runs when the machine first starts. If the [`:initial`](concepts.md#register-and-drive) state cascades into a leaf whose `:always` guard already holds, that transition is taken *before* the birth commit — so a transient initial state is settled past, unobserved, on start. (This is also why `:always` lives on a state node, never on the root: the root's cascade entry-point is `:initial`.)
 
 ### Ordering, depth, and self-loops
 

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -317,7 +317,7 @@ Starting a child actor on state entry and tearing it down on exit is XState's `i
 :authenticating
 {:spawn {:machine-id :http/post
          :data       (fn [{snap :snapshot}] {:url "/api/login" :body (-> snap :data :credentials)})
-         :system-id  :auth-actor                ;; address the child by role, not gensym'd id
+         :system-id  :auth-actor                ;; address the child by role, not allocated id
          :on-done    (fn [{:keys [data result]}] (assoc data :result result))
          :on-error   :idle}
  :on    {:auth/cancelled :idle}}
@@ -364,7 +364,7 @@ Once a machine has several "loading-ish" states, views should ask a predicate (*
   [spinner])
 ```
 
-At every transition the runtime stamps the union of active states' tags onto the snapshot's `:tags`. The framework ships `[:rf.machine/has-tag? <id> <tag>]` — a derived predicate sub that re-renders only when *this* tag's bit flips — and the `rf/machine-has-tag?` sugar over it. Add a fifth busy state later and it's one `:tags` entry, zero view changes (*ask, don't tell*).
+At every transition the runtime stamps the union of active states' tags onto the snapshot's `:tags`. The framework ships `[:rf.machine/has-tag? <id> <tag>]` — a derived predicate sub that re-renders only when *this* tag's bit flips. Add a fifth busy state later and it's one `:tags` entry, zero view changes (*ask, don't tell*).
 
 ### Schemas: types that actually run
 

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -1,5 +1,9 @@
 # Coming from XState
 
+This page is a **translation**, not a tutorial. For a first machine in re-frame2,
+use the [login tutorial](tutorial.md) and [the model](concepts.md). Here: how
+XState v5/v6 concepts map, and where re-frame2 deliberately diverges.
+
 If you've built statecharts with [XState](https://stately.ai/docs) — v5, or the v6 alpha — most of your mental model ports straight across. re-frame2's [machines](concepts.md) borrow XState's grammar on purpose: transition tables as data, guards, actions, tags, delayed transitions, final states, run-to-completion, internal-by-default self-transitions. You can read a re-frame2 machine spec on day one and a re-frame2 author can read yours. The *behaviour* is the contract re-frame2 tracks; what changes is the *expression* and one piece of *plumbing*.
 
 Two things transfer almost untouched:
@@ -23,7 +27,7 @@ Skim this, then read the worked build-up in [The grammar, concept by concept](#t
 
 | XState (v6 direction) | re-frame2 | Notes |
 |---|---|---|
-| `createMachine({ ... })` / `setup().createMachine()` | a transition-table map passed to [`reg-machine`](concepts.md#registering-and-running-it) | Plain Clojure data. No builder, no fluent API. |
+| `createMachine({ ... })` / `setup().createMachine()` | a transition-table map passed to [`reg-machine`](concepts.md#register-and-drive) | Plain Clojure data. No builder, no fluent API. |
 | `context` (extended state) | [`:data`](#context-becomes-data) | Same idea. "Context" was already taken (interceptor context, React context); `:data` tracks FSM / `gen_statem` "state data". |
 | `state.value` | the snapshot's `:state` | Flat → keyword; compound → vector path; parallel → region-name→state map (each region's value is itself a keyword or path). |
 | `states: { idle: { on: { ... } } }` | `:states {:idle {:on {...}}}` | Near-identical shape. `on` → `:on`, target strings → state keywords. |
@@ -74,7 +78,7 @@ const loginMachine = setup({
 });
 ```
 
-In re-frame2 the definition is *just data* — one map, with its `:guards` and `:actions` tables carried inline, registered with [`reg-machine`](concepts.md#registering-and-running-it):
+In re-frame2 the definition is *just data* — one map, with its `:guards` and `:actions` tables carried inline, registered with [`reg-machine`](concepts.md#register-and-drive):
 
 ```clojure
 (rf/reg-machine :auth.login/flow

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -199,16 +199,27 @@ Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine` time
 
 ## Strict encapsulation
 
-A guard or action gets only `{:data :event :state :meta}` — never app-db.
+A guard or action gets only `{:data :event :state :meta}` — never app-db. That is
+what keeps a machine's whole state inside one snapshot for time-travel and SSR.
 
 | Need | How |
 |---|---|
 | Fact from outside | Put it on the **event** when you dispatch |
 | Write outside the machine | Return `:fx [[:dispatch […]]]` — a real, named event |
+| Clock / random / host fact | Declare a [coeffect](../core/coeffects.md) on the guard or action — do **not** call `(js/Date.now)` |
 
-Facts from the world (clock, random) must be declared coeffects on the guard/action
-entry (`:rf.cofx/requires`), not grabbed with `(js/Date.now)`. See
-[Coeffects](../core/coeffects.md).
+```clojure
+:guards
+{:within-retry-window?
+ {:rf.cofx/requires [:rf/time-ms]
+  :fn (fn [{:keys [data rf/time-ms]}]
+        (< (- time-ms (:first-attempt-at data)) 60000))}}
+```
+
+Returning `:db` from an action is a hard error
+(`:rf.error/machine-action-wrote-db`) — the key is dropped and the failure is
+loud. Actions also never choose the next state; only the transition's `:target`
+moves the machine.
 
 ## The snapshot
 
@@ -240,17 +251,43 @@ Full rules: see schemas section of
 <a id="self-transitions-internal-by-default-external-on-demand"></a>
 <a id="wildcard-transitions-handle-a-whole-class-of-events"></a>
 
-**Internal by default** for self-moves:
+Self-moves are **internal by default** — the turnstile's push-while-locked counts a
+push without leaving `:locked`. Three shapes:
 
 | Shape | Effect |
 |---|---|
-| No `:target` | Action only — no exit/entry, timers and spawns undisturbed |
-| `:target` same state, no `:reenter?` | Action; compounds re-resolve descendants to `:initial` |
+| No `:target` | Action only — no exit/entry; timers and spawns undisturbed |
+| `:target` same state, no `:reenter?` | Action; **compounds** re-resolve descendants to `:initial` |
 | `:reenter? true` | Full exit → action → entry (timers reset, spawns restart) |
 
-**Wildcards** on `:on` keys, most-specific first: exact id → `:ns/*` → `:*`. A
-deliberate empty handler `{:on {:E {}}}` **consumes** the event (blocks fallthrough);
-a missing key is a no-op.
+A self-rescheduling poll uses the external form so `:entry` re-fires:
+
+```clojure
+:polling
+{:entry :start-fetch
+ :after {30000 {:target :polling :reenter? true}}   ;; every 30s: re-enter → fetch again
+ :on    {:got-data {:action :merge}                  ;; internal: merge without resetting the clock
+         :stop     :idle}}
+```
+
+!!! note "Targeted self ≠ re-enter"
+
+    A self-target without `:reenter? true` does **not** re-run `:entry`. If you meant
+    to re-arm a timer or re-spawn a child, say so explicitly.
+
+**Wildcards** on `:on` keys, most-specific first: exact id → `:ns/*` → `:*`.
+
+```clojure
+:tracking
+{:on {:mouse/down {:action :begin-drag}   ;; exact wins for :mouse/down
+      :mouse/*    {:action :note-move}     ;; any other :mouse/…
+      :*          {:action :log-unknown}}} ;; anything else
+```
+
+A **forbidden** handler — `{:on {:E {}}}` or `{:on {:E nil}}` — **consumes** the
+event and stops the search (how a child opts out of a parent transition). A
+**missing** key is a silent no-op. A bare id like `:go` has no `:ns/*` tier — only
+exact or `:*`.
 
 ## Final states
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -1,138 +1,99 @@
-# State machines
+# The model
 
-Some state isn't a value you read — it's a *question*: what state are we even **in**? A login is idle, then submitting, then authed, error-shown, or locked-out. A websocket is connecting, connected, dropped, reconnecting. For flows like those the interesting fact isn't what sits in [app-db](../core/glossary.md#app-db) — it's which of a fixed set of **named states** you occupy, and which [events](../core/glossary.md#event) move you between them.
+This page is the **flat machine model** — everything you need for a single-level
+state machine. Nested states, parallel regions, history, and actors grow the same
+grammar; each has its own page.
 
-A **[machine](glossary.md#machine)** makes that shape first-class, so you stop reconstructing it from code scattered across handlers. This page lays out the whole model at once. To *build* a machine step by step instead — turning it on, then adding a guard, an action, an async call, a view, and a test — start with the [tutorial](tutorial.md).
+To *build* a login machine step by step (guard → action → HTTP → view → test), use
+the [tutorial](tutorial.md). Here the goal is understanding the pieces and their
+contracts.
 
-!!! note "Deciding where a value should live?"
+!!! note "Where should this value live?"
 
-    A machine is the right home when a value has a *lifecycle* — named states, timers, retries, cancellation — not just a value you read. [Where should this value live?](../core/where-state-lives.md) has the full decision procedure, and machine is the last of [the four homes](../core/glossary.md#the-four-homes-where-state-lives) you reach for.
+    A machine fits when a value has a *lifecycle* of named states — not when it is
+    only data to store. See [Where should this value live?](../core/where-state-lives.md).
 
-## A machine at a glance
-
-You already write state machines — you just call them other things. A `:state` keyword in app-db (`:idle`, `:submitting`, `:authed`) plus the rules in your head about which states may legally follow which: that's a machine, written informally and scattered across handlers. A machine writes that shape down as *one value*, so the rules live in one place you can read, draw, test, and hand to an AI whole.
-
-Here's a login flow as that one value — five states in a single map. Read it top to bottom; it tells the whole story.
+## The idea
 
 <a id="the-same-flow-as-a-transition-table"></a>
 
+You already write state machines: a `:status` keyword in app-db plus informal rules
+in handlers about what may follow what. A machine writes those rules down as **one
+value** — a transition table — so you can read, draw, test, and change the flow in
+one place.
+
 ```clojure
-;; Adapted from examples/capabilities/machines/state_machine_walkthrough/core.cljc
-(rf/defmachine login-flow
-  {:initial :idle
-   :data    {:attempts 0 :error nil}
-
-   :guards
-   {:under-retry-limit
-    (fn [{data :data}] (< (:attempts data) 3))}
-
-   :actions
-   {:clear-error
-    (fn [_] {:data {:error nil}})
-
-    :issue-request
-    (fn [{[_ creds] :event}]
-      {:fx [[:rf.http/managed
-             {:request    {:method :post :url "/api/login" :body creds
-                           :request-content-type :json}
-              :decode     :json
-              :on-success [:auth.login/flow [:auth.login/success]]
-              :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
-
-    :record-error
-    ;; the classified failure map rides under :error on the canonical reply
-    (fn [{data :data [_ {:keys [error]}] :event}]
-      {:data (-> data
-                 (update :attempts inc)
-                 (assoc :error (or (:message error) "Login failed.")))})
-
-    :store-session
-    (fn [{[_ {:keys [value]}] :event}]
-      {:fx [[:auth.session/store {:token (:token value)}]]})}
-
+(rf/defmachine turnstile
+  {:initial :locked
+   :data    {:coins 0}
+   :actions {:take-coin (fn [{data :data}] {:data (update data :coins inc)})}
    :states
-   {:idle
-    {:on {:auth.login/submit {:target :submitting :action :clear-error}}}
-
-    :submitting
-    {:tags  #{:auth/busy}
-     :entry :issue-request
-     :on    {:auth.login/success {:target :authed :action :store-session}
-             :auth.login/failure [{:target :error-shown
-                                   :guard  :under-retry-limit
-                                   :action :record-error}
-                                  {:target :locked-out}]}}
-
-    :error-shown
-    {:on {:auth.login/dismiss {:target :idle}
-          :auth.login/submit  {:target :submitting}}}
-
-    ;; Persistent sinks — no outgoing transitions; :meta is tooling-only.
-    ;; (:final? true would auto-destroy the machine; omit it to persist.)
-    :authed     {:meta {:terminal? true}}
-    :locked-out {:meta {:terminal? true}}}})
+   {:locked   {:on {:coin {:target :unlocked :action :take-coin}
+                    :push {:target :locked}}}     ;; blocked: stays locked
+    :unlocked {:on {:push {:target :locked}
+                    :coin {:target :unlocked :action :take-coin}}}}})
 ```
 
-Five states. `:idle` starts. Submit takes it to `:submitting`; from there success goes to `:authed`, and a failure goes to `:error-shown` *if* the `:under-retry-limit` guard passes, otherwise to `:locked-out`. Two words carry the behaviour, both in the [glossary](glossary.md):
+Two words do most of the work ([glossary](glossary.md)):
 
-- A **[guard](glossary.md#guard)** is a yes/no test that gates a [transition](glossary.md#transition) — `:under-retry-limit` answers "attempts left?".
-- An **[action](glossary.md#action)** is the side work a transition performs — `:issue-request` asks for the HTTP call.
+- A **[guard](glossary.md#guard)** — yes/no gate on a transition.
+- An **[action](glossary.md#action)** — side work that returns effects, never performs them.
 
-Both are referenced from the table *by id*; their implementations sit once, up top, in the `:guards` / `:actions` maps. Because the whole flow is one value, you can pretty-print it, render it as a diagram, or add a `:two-factor` state with one new node and its arrows — the existing nodes don't move.
+## Register and drive
 
-!!! note "Build it by hand"
+<a id="registering-and-running-it"></a>
 
-    The [tutorial](tutorial.md) constructs exactly this machine step by step — turn machines on, add a guard, an action, a real server call, a view per state, and a pure-function test — one idea at a time.
-
-## Registering and running it
-
-Registering the table is one line — and there's no new runtime concept under it. **A machine *is* an event handler.** [`reg-machine`](../core/glossary.md#registration) is sugar over a `reg-event` whose body interprets the table: look up the current **[snapshot](glossary.md#snapshot)** (its live `{:state :data}` value), compute the transition, write the new snapshot back, return the action's [effects](../core/glossary.md#effect).
+**A machine is an event handler.** `reg-machine` is sugar over `reg-event` whose body
+interprets the table: read the live [snapshot](glossary.md#snapshot), take a
+transition, write the new snapshot, return action effects.
 
 ```clojure
-(rf/reg-machine :auth.login/flow login-flow)
+(:require [re-frame.core :as rf]
+          [re-frame.machines])   ;; opt-in: forget this → :rf.error/machines-artefact-missing
+
+(rf/reg-machine :turnstile turnstile)
 ```
 
-There are **two blessed ways to register a machine**, and you pick by where the spec lives:
+Two blessed registration shapes:
 
-- **`defmachine` + `reg-machine`** — for a named, reusable spec (the `def`-then-register shape shown here). [`defmachine`](../api/re-frame.machines.md#defmachine) is a drop-in for `def` that walks the literal spec *at the definition site* and stamps per-element source onto the value, so it travels into `reg-machine` and Xray's click-to-source lights up for every guard, action, and state node.
-- **Inline `reg-machine`** — pass the spec map *literal* straight to `reg-machine` for a small, local machine; the macro walks the literal in place, capturing the same source.
+| Shape | Use when |
+|---|---|
+| `defmachine` + `reg-machine` | Named, reusable specs (Xray click-to-source on guards/actions) |
+| Inline `reg-machine` with a **literal** map | Small local machines |
 
-The one shape to avoid is a plain `(def m {…})` followed by `(reg-machine :id m)`: the macro sees only the `m` *symbol*, so its literal-walk captures nothing and Xray silently loses click-to-source for that machine. Reach for `defmachine` whenever you want a named spec. (The runtime emits a dev-only `:rf.warning/machine-source-unstamped` advisory when a registered spec carries no per-element source — a runtime-built spec via `reg-machine*` may ignore it.)
+Avoid `(def m {…})` then `(reg-machine :id m)` — the macro never sees the literal, so
+source stamps are empty (dev warns `:rf.warning/machine-source-unstamped`).
 
-So every event reaches the machine through the same `dispatch` and the same [event pipeline](../core/glossary.md#event-pipeline) as everything else — no actor object, no second messaging system. Dispatching routes through the machine's id, wrapping an inner event vector; you read the snapshot through a [subscription](../core/glossary.md#subscription) addressed by that id:
+**Dispatch** addresses the machine id; the *inner* vector is the machine event:
 
 ```clojure
-(rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
-
-@(rf/subscribe [:rf/machine :auth.login/flow])
-;; => {:state :submitting :data {:attempts 0 :error nil}}   (nil before the first event)
+(rf/dispatch [:turnstile [:coin]])
 ```
 
-`[:rf/machine <id>]` is an ordinary [query vector](../core/glossary.md#query-vector), so it's traceable like the rest of your [derivation graph](../core/glossary.md#the-derivation-graph), and named projections chain off it — `(rf/reg-sub :auth.login/error :<- [:rf/machine :auth.login/flow] ...)` — like any other [subscription](../core/subscriptions.md).
+**Subscribe** with the framework sub:
 
-!!! note "One-time setup"
+```clojure
+@(rf/subscribe [:rf/machine :turnstile])
+;; => {:state :unlocked :data {:coins 1}}   ; nil before the first event
+```
 
-    Machines ship in their own artefact, `day8/re-frame2-machines`, so an app without machines builds a bundle clean of them. Add the dep and require `re-frame.machines` once at app boot; forget it and `reg-machine` throws `:rf.error/machines-artefact-missing`, naming the artefact to add. (`reg-machine` is the source-stamping macro; the plain-fn `reg-machine*` and the `def`-shaped `defmachine` are in [`re-frame.machines`](../api/re-frame.machines.md).)
+The snapshot lives in [runtime-db](../core/glossary.md#runtime-db) (framework half of
+the frame), so undo, time-travel, and SSR hydration apply for free.
 
-!!! note "Where the snapshot lives"
+!!! note "Async composes"
 
-    The snapshot lives in the [frame](../core/glossary.md#frame)'s **[runtime-db](../core/glossary.md#runtime-db)** — the framework's half of [the two partitions](../core/glossary.md#the-two-partitions), kept apart from the app data you own. Because it's just a value riding the frame, [undo, time-travel](../core/glossary.md#time-travel), persistence, and SSR [hydration](../ssr/glossary.md#hydration) all work on machines for free.
-
-!!! note "Async composes for free"
-
-    `:issue-request` names its reply events machine-wrapped — `:on-success [:auth.login/flow [:auth.login/success]]`, written one element short on purpose. When the request returns, [managed HTTP](../async/http.md) *appends* its reply to that inner event, so it lands back *inside* the machine as `[:auth.login/success {:status :ok :value v …}]` — exactly the event `:store-session` destructures. A machine and an async [effect](../core/glossary.md#effect) compose with no adapter layer.
+    Point managed HTTP replies at the machine:
+    `:on-success [:auth.login/flow [:auth.login/success]]` (outer id, inner event).
+    The reply is *appended* into the inner event — no adapter. Full walk-through in
+    the [tutorial](tutorial.md#step-4--talk-to-a-real-server).
 
 ## See one run
 
-Here's a turnstile with two states and a counter riding in `:data`, live in your browser. Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to re-evaluate after edits. This is the real `rf/reg-machine` — the same call you'd write in your own app.
+Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
 
 ```cljs-rf2
-(require '[reagent2.core :as r]
-         '[re-frame.core :as rf])
+(require '[re-frame.core :as rf])
 
-;; A small, local machine — inline reg-machine (the second blessed form): the
-;; macro walks the spec literal in place, so source is captured. (For a named,
-;; reusable spec you'd reach for defmachine + reg-machine instead.)
 (rf/reg-machine :turnstile/flow
   {:initial :locked
    :data    {:coins 0 :pushes 0}
@@ -140,11 +101,10 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
              :count-push (fn [{data :data}] {:data (update data :pushes inc)})}
    :states
    {:locked   {:on {:coin {:target :unlocked :action :take-coin}
-                    :push {:target :locked   :action :count-push}}}  ;; blocked: stays locked
+                    :push {:target :locked   :action :count-push}}}
     :unlocked {:on {:push {:target :locked}
                     :coin {:target :unlocked :action :take-coin}}}}})
 
-;; [:rf/machine ...] returns nil until the first event; render the initial until then.
 (defn turnstile-view []
   (let [{:keys [state data]} (or @(rf/subscribe [:rf/machine :turnstile/flow])
                                  {:state :locked :data {:coins 0 :pushes 0}})
@@ -160,343 +120,185 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
 
 !!! tip "Try it"
 
-    Push while `:locked` — nothing opens, but the push counter climbs (a self-transition running an action). Then add a third state: give `:unlocked` an `:on {:break {:target :broken}}`, add `:broken {:on {}}` to `:states`, add a button dispatching `[:turnstile/flow [:break]]`, re-evaluate. You added a reachable state by editing *one value* — no new handler, no `cond` surgery.
+    Push while locked — the door stays locked, but the push counter climbs (a
+    **self-transition** with an action). Dispatch an unknown event
+    `[:turnstile/flow [:wat]]` — silent no-op (benign
+    `:rf.machine.event/unhandled-no-op` trace). Almost every *other* mistake
+    (bad target, missing guard name) fails loud at **registration**.
 
-### One thing that *won't* throw: the unhandled event
-
-If the current state has no transition for an event, it's a **silent no-op** — nothing throws, the snapshot doesn't move. Try it in the turnstile: dispatch `[:turnstile/flow [:wat]]`, an event no state handles, and the machine simply ignores it. (This is different from the `:push`-while-`:locked` case earlier: that state *does* declare a `:push` transition, so its action ran — here there's no transition at all.) The runtime still emits a benign `:rf.machine.event/unhandled-no-op` trace, so a debugger can show the event arrived and was dropped.
-
-!!! note "Fail-loud is the rule elsewhere"
-
-    The unhandled event is the one silent no-op. Almost everything *else* that's wrong (a guard referencing an undefined name, a target naming a missing state) [fails loud](../core/glossary.md#fail-loud-not-silent) — but at *registration* time, not on the unlucky dispatch. More on that fail-loud / silent-no-op split below.
+<a id="one-thing-that-wont-throw-the-unhandled-event"></a>
 
 ## Guards and actions
 
-The arrows in the table named two kinds of helper — `:under-retry-limit` (a guard) and `:issue-request` (an action) — and pointed at implementations sitting up top in the `:guards` and `:actions` maps. Those two maps *are* the machine's behaviour. Here's the contract they follow.
+<a id="guards-and-actions"></a>
 
-**Every callback receives one context map and destructures what it needs.** A guard, an action, an `:entry`, an `:exit` — all of them get the *same* single-map argument:
-
-```clojure
-{:data  {:attempts 1 :error nil}      ;; the snapshot's :data slot — a plain map
- :event [:auth.login/failure {...}]   ;; the inbound event vector
- :state :submitting                   ;; the discrete state keyword
- :meta  {...}}                        ;; any user :meta on the snapshot
-```
-
-Pull out the keys you want and ignore the rest. `data` is already the `:data` slot — you read `(:attempts data)`, never `(get-in snapshot [:data :attempts])`. Note what is *not* in that map: there is no `:db`. A machine callback cannot see [app-db](../core/glossary.md#app-db) at all — only its own data plus the event that woke it. That boundary is load-bearing; **Strict encapsulation** below is the why.
-
-### A guard is a yes/no gate
-
-A guard returns truthy or falsey: take this transition, or fall through to the next candidate. `:under-retry-limit` answers "attempts left?":
+Every callback receives one context map:
 
 ```clojure
-:guards
-{:under-retry-limit
- (fn [{data :data}] (< (:attempts data) 3))}
+{:data  {:attempts 1 :error nil}   ;; machine-private memory
+ :event [:auth.login/failure …]    ;; inbound event vector
+ :state :submitting
+ :meta  {…}}
 ```
 
-You reference it from an arrow by id — `:guard :under-retry-limit` — and the runtime resolves it against this machine's `:guards` map. There is deliberately **no combinator DSL**: no `{:and [...]}`, `{:or [...]}`, `{:not ...}`. Compound logic goes in one ordinary Clojure fn, and if it's worth a name, a named entry in `:guards`:
+There is **no `:db`**. A machine cannot see [app-db](../core/app-db.md). That is
+[strict encapsulation](#strict-encapsulation) — the rule that keeps the whole
+machine inside one snapshot for time-travel.
+
+### Guards
+
+Return truthy/falsey. No combinator DSL — compound logic is ordinary Clojure:
 
 ```clojure
 :guards
-{:ready-to-submit?
- (fn [{:keys [data]}]
-   (and (email-valid? data) (under-quota? data)))}
+{:under-retry-limit (fn [{data :data}] (< (:attempts data) 3))
+ :form-valid?       (fn [{[_ creds] :event}]
+                      (and (seq (:email creds)) (seq (:password creds))))}
 ```
 
-### An action returns effects
+Reference by id (`:guard :form-valid?`) or inline a one-liner. Prefer named ids —
+trace rows and Xray can address them.
 
-An action does the side work a transition performs — but it doesn't *perform* it. It **returns a description of effects**, exactly the way a `reg-event` handler does, and the runtime actions them. `:issue-request` never calls the HTTP client; it returns an `:fx` asking for one. Two small actions from the login flow:
+A list of transition candidates is tried in order; first guard that passes wins.
+
+### Actions
+
+Return **descriptions**, same idea as `reg-event`:
 
 ```clojure
 :actions
 {:clear-error  (fn [_] {:data {:error nil}})
-
- :record-error (fn [{data :data [_ {:keys [error]}] :event}]
-                 {:data (-> data
-                            (update :attempts inc)
-                            (assoc  :error (or (:message error) "Login failed.")))})}
+ :issue-request
+ (fn [{[_ creds] :event}]
+   {:fx [[:rf.http/managed {… :on-success [:auth.login/flow [:auth.login/success]]}]]})}
 ```
 
-The return shape — that `{:data ...}` map — gets a section of its own just below. Like guards, actions are referenced by id (`:action :clear-error`) against the machine's `:actions` map, or written inline.
+Also: `:entry` / `:exit` on a state (run when the state is entered / left).
 
-### Name them, or inline them
+### The effect map `{:data :fx}`
 
-Both `:guard` and `:action` accept **either** a keyword (resolved through the `:guards` / `:actions` map) **or** a bare inline fn:
+<a id="the-action-effect-map--data-fx"></a>
+<a id="the-effect-map-data-fx"></a>
+
+| Key | Meaning |
+|---|---|
+| `:data` | **Merged** into the snapshot's current `:data` (not replaced). Explicit `nil` sets a key to nil; it does not remove keys. |
+| `:fx` | Ordinary effects vector (`:dispatch`, `:rf.http/managed`, …). Machine-only ids: `:raise`, `:rf.machine/spawn`, `:rf.machine/destroy`. |
+
+Both keys optional; `nil` / `{}` means no effects. Returning `:db` is an error
+(`:rf.error/machine-action-wrote-db`) — machines must not scribble on app-db.
+
+!!! warning "`:fx` cannot read this action's own `:data` write"
+
+    Both keys are returned together. Bind fresh values in a `let` and use the local
+    in both places, or write in the transition action and read in the target's
+    `:entry`.
+
+Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine` time
+(`:rf.error/machine-unresolved-guard`, etc.), not on first dispatch.
+
+## Strict encapsulation
+
+A guard or action gets only `{:data :event :state :meta}` — never app-db.
+
+| Need | How |
+|---|---|
+| Fact from outside | Put it on the **event** when you dispatch |
+| Write outside the machine | Return `:fx [[:dispatch […]]]` — a real, named event |
+
+Facts from the world (clock, random) must be declared coeffects on the guard/action
+entry (`:rf.cofx/requires`), not grabbed with `(js/Date.now)`. See
+[Coeffects](../core/coeffects.md).
+
+## The snapshot
 
 ```clojure
-{:on {:auth.login/submit {:guard  (fn [{:keys [data]}] (some? (:email data)))  ;; inline
-                          :target :submitting}}}
-
-{:on {:auth.login/submit {:guard  :ready-to-submit?                            ;; by id — the default
-                          :target :submitting}}}
+{:state :submitting
+ :data  {:attempts 1 :error nil}
+ :tags  #{:auth/busy}}   ;; optional — union of active states' tags
 ```
 
-**Reach for the keyword by default; inline only for a one-line triviality.** The id is a *name* — a stable, reusable handle that trace rows print, that a diagram arrow is labelled with, that a test can stub, that an AI can address and jump to source for. An anonymous closure has none of that. (Inline fns aren't second-class for *tooling* — in dev the `reg-machine` macro co-locates their source text, so a visualiser still renders the body — they're just unnamed.) Compound or reused logic always earns a name.
+| Slot | Role |
+|---|---|
+| `:state` | Discrete state — keyword (flat), path vector (hierarchy), or region map (parallel) |
+| `:data` | Machine-private memory |
+| `:tags` | Runtime-projected set of active tags (omit when empty) |
 
-!!! note "Fail-loud, not silent"
+`[:rf/machine id]` is `nil` until the first event; views should fall back to
+`:initial` / default `:data` if they render earlier.
 
-    Reference a `:guard` / `:action` keyword the machine's maps don't define and registration throws (`:rf.error/machine-unresolved-guard` / `…-unresolved-action`); a `:target` naming a state not in `:states` is `:rf.error/machine-unresolved-target`. These are caught at `reg-machine` time, not on the unlucky dispatch that first hits the bad arrow — a [fail-loud](../core/glossary.md#fail-loud-not-silent), not silent, posture. The one thing that is genuinely *not* an error is an event the current state has no transition for — that's the silent no-op you met just above.
+Optional **`:schemas {:data …}`** (Malli) validates `:data` at commit in dev and
+rolls back a bad transition.
 
-## The action effect map — `{:data :fx}`
+<a id="validating-a-machines-data"></a>
 
-An action returns a two-key map — and **it's the same shape a `reg-event` handler returns**, just scoped to the machine instead of to app-db:
+Full rules: see schemas section of
+[`re-frame.machines` API](../api/re-frame.machines.md) and Spec 005 (authors).
 
-```clojure
-{:data {<updates to the machine's own data>}   ;; cf. reg-event's :db
- :fx   [[<fx-id> <args>] ...]}                  ;; the standard re-frame fx vector
-```
+## Self-transitions and wildcards
 
-Both keys are optional; returning `nil` (or `{}`) means "no effects." That symmetry is the point — you already know this shape from [event handlers](../core/glossary.md#event-handler).
+<a id="self-transitions-internal-by-default-external-on-demand"></a>
+<a id="wildcard-transitions-handle-a-whole-class-of-events"></a>
 
-**`:data` is a merge, not a replace.** What you return is merged into the snapshot's current `:data`, key by key, last-write-wins. You mention only the keys you're changing:
+**Internal by default** for self-moves:
 
-```clojure
-;; current :data is {:attempts 1 :error nil}
-(fn [{data :data}] {:data {:error "Login failed."}})
-;; → :data becomes {:attempts 1 :error "Login failed."}  — :attempts untouched
-```
+| Shape | Effect |
+|---|---|
+| No `:target` | Action only — no exit/entry, timers and spawns undisturbed |
+| `:target` same state, no `:reenter?` | Action; compounds re-resolve descendants to `:initial` |
+| `:reenter? true` | Full exit → action → entry (timers reset, spawns restart) |
 
-One sharp edge: an explicit `nil` **sets** a key to `nil` (the key stays present) — the merge never *removes* keys. `{:data {:error nil}}` leaves `:error` present-and-`nil`; it doesn't drop it. There is no key-removal idiom in a `:data` write.
+**Wildcards** on `:on` keys, most-specific first: exact id → `:ns/*` → `:*`. A
+deliberate empty handler `{:on {:E {}}}` **consumes** the event (blocks fallthrough);
+a missing key is a no-op.
 
-**`:fx` is the ordinary effects vector** — `:dispatch`, `:rf.http/managed`, your own registered effects, all flow to the normal machinery untouched. Three fx-ids are *machine-only* and intercepted before they get there: `[:raise [...]]` loops an event back into this same machine (atomically, before the transition commits), and `[:rf.machine/spawn ...]` / `[:rf.machine/destroy ...]` are the actor-lifecycle pair. You'll meet all three under [When the machine grows](#when-the-machine-grows); the reference is [`re-frame.machines`](../api/re-frame.machines.md).
+## Final states
 
-!!! warning "Gotcha — `:fx` can't read this action's own `:data` write"
+<a id="final-states"></a>
+<a id="final-states-when-a-machine-is-done"></a>
 
-    The two keys are returned *together*, so at the moment the runtime reads your `:fx` vector the `:data` merge hasn't happened. To act on a freshly-computed value, bind it in a `let` and use the local in both keys:
+- **Ordinary leaf** with no outgoing transitions — machine **persists** (login's
+  `:authed`). Do **not** set `:final?`.
+- **`:final? true`** — machine **terminates** and is destroyed. Use for spawned
+  protocols that finish, not for "last screen of a long-lived machine."
 
-    ```clojure
-    (fn [{data :data}]
-      (let [next-id (inc (:last-id data))]
-        {:data {:last-id next-id}
-         :fx   [[:dispatch [:thing/created next-id]]]}))   ;; the local, not (:last-id data)
-    ```
+Nested finals and parent `:on-done` live in
+[Hierarchical states](hierarchical-states.md) and [Actors](actors.md).
 
-    Or split the work across two slots — write in the transition `:action`, read in the target state's `:entry`.
+## Tags and automatic moves (pointers)
 
-When several slots fire in one transition (`:exit` → the transition's `:action` → `:entry`), their `:data` updates merge in that order — a later slot sees the earlier writes — and the `:fx` vectors concatenate left to right.
+- **Tags** — label intent on states (`:tags #{:auth/busy}`); views ask
+  `[:rf.machine/has-tag? id :auth/busy]` instead of enumerating state names.
+  → [Tags](tags.md)
+- **`:after` / `:always` / choice / timeout** — moves the table takes without a
+  user event. → [Automatic transitions](automatic-transitions.md)
 
-## Strict encapsulation — a machine sees only its own `:data`
+## When the table grows
 
-This is the rule hovering over that context map: a guard or action gets `{:data :event :state :meta}` and **never app-db**. It cannot read app-db, and it cannot write it.
+<a id="when-the-machine-grows"></a>
 
-!!! note "Why it's locked"
+Same model, more keys — each page assumes this one:
 
-    A machine's whole state — its `:state` and its `:data` — lives in one place, the [runtime-db](../core/glossary.md#runtime-db), so it reverts, time-travels, persists, and SSR-hydrates as a single value along with the rest of the [frame](../core/glossary.md#frame). If an action could quietly write some *other* slice of app-db, that change wouldn't live in the snapshot and wouldn't roll back with it. Encapsulation is what keeps a machine's state *all* inside the snapshot.
+| Need | Page |
+|---|---|
+| Nested sub-flows | [Hierarchical states](hierarchical-states.md) |
+| Independent axes at once | [Parallel regions](parallel-states.md) |
+| Resume mid-compound | [History](history.md) |
+| Per-request / worker children | [Actors](actors.md) |
+| Prove the table / watch live | [Inspecting and testing](inspecting-machines.md) |
 
-So how does a machine read or write things outside itself? Two disciplined moves:
+**`:raise`** in an action's `:fx` re-enters *this* machine atomically before commit.
+**`:internal-events`** marks event ids that external dispatch must not send.
 
-**A fact from outside arrives in the event.** Whoever dispatches has the data; they pass it in. The view that knows a circle's current radius puts it in the dispatch, and the action reads it from `:event`:
+Eventless loops and raise storms are depth-bounded (default 16); tripping aborts the
+macrostep with a loud error — not a silent no-op.
 
-```clojure
-(rf/dispatch [:drawer/editor [:right-click-circle id radius]])
-```
+## When to reach for a machine
 
-**A write to a sibling slice goes out as a named event.** An action that needs to touch app-db emits a `:dispatch` fx — so the write becomes a real, traced, reusable event *with a name*, not a quiet reach into someone else's data:
+**Yes:** named mutually exclusive stages; conditional transitions scattered as
+`when`s; the flow is worth drawing on a whiteboard.
 
-```clojure
-:action (fn [{:keys [data]}]
-          {:fx   [[:dispatch [:drawer/apply-radius (:circle-id data) (:preview-radius data)]]]
-           :data {:circle-id nil :preview-radius nil}})
-```
+**No:** plain data; two-state flags; server cache lifecycles ([resources](../resources/concepts.md));
+mere operation sequences (chained events).
 
-Two guard-rails enforce the boundary:
-
-- **Returning `:db` is a hard error.** A `:db` key in an action's effect map surfaces `:rf.error/machine-action-wrote-db` and the `:db` key is dropped (the rest of the effects still flow). Fail loud, don't silently let a machine scribble on app-db.
-- **The next state isn't in the return shape either.** An action returns `:data` and `:fx` — never a state keyword. Only the transition's `:target` moves the machine. Callbacks update working memory; they can't nudge the machine into a state the table didn't declare.
-
-!!! warning "Gotcha — facts from the world are *declared*, not grabbed"
-
-    A guard or action that needs the time (or a random draw) must not call `(js/Date.now)` or `(rand)`: that buries nondeterminism where replay can't reach it, and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry with `:rf.cofx/requires`, and the framework threads it into the context map:
-
-    ```clojure
-    :guards
-    {:within-retry-window?
-     {:rf.cofx/requires [:rf/time-ms]
-      :fn (fn [{:keys [data rf/time-ms]}]
-            (< (- time-ms (:first-attempt-at data)) 60000))}}
-    ```
-
-    The fact rides the event's causal token (it's a *recordable* coeffect — see [recordable vs ambient coeffects](../core/glossary.md#recordable-vs-ambient-coeffects)), so the decision — and any `:data` it folds in — replays identically. [Effects & coeffects](../core/coeffects.md) has the general mechanism: a coeffect is a fact pulled *into* a handler, the mirror of an effect pushed out.
-
-## The snapshot — `{:state :data :tags}`
-
-A machine's entire live value at any instant is one small map, its [snapshot](glossary.md#snapshot):
-
-```clojure
-{:state :submitting               ;; where we are
- :data  {:attempts 1 :error nil}  ;; the machine's private memory
- :tags  #{:auth/busy}}            ;; the active state's tags, projected on (optional)
-```
-
-Three slots do the work:
-
-- **`:state`** — the discrete state. For the flat machines on this page it's a single keyword (`:idle`, `:submitting`). It grows two more shapes as machines do: a **vector path** from root to active leaf once states nest (`[:authenticated :cart :browsing]`), and a **region→state map** for parallel machines (`{:data :loading :form :neutral}`). One slot, read three ways.
-- **`:data`** — the machine's working memory: a plain map, yours to shape, private to this machine (the encapsulation rule above). Optionally schema-checked — see [Validating a machine's `:data`](#validating-a-machines-data).
-- **`:tags`** — a set the runtime *projects* onto the snapshot: the union of every active state's declared `:tags`. `:submitting` declares `:tags #{:auth/busy}`, so while you're there the snapshot carries it. It's how a view asks "is it busy?" rather than "which exact state?".
-
-(A `:meta` slot carries any user metadata; the runtime additionally stamps a closed set of framework-owned `:rf/*` bookkeeping slots inside the snapshot, which you never write to.)
-
-You read the snapshot through the framework's `[:rf/machine <id>]` [subscription](../api/re-frame.machines.md) — it returns the `{:state :data}` value (plus `:tags`), or `nil` before the first event:
-
-```clojure
-@(rf/subscribe [:rf/machine :auth.login/flow])
-;; => {:state :submitting :data {:attempts 1 :error nil} :tags #{:auth/busy}}
-```
-
-Because the snapshot is *just a value* — no functions, no atoms, nothing unprintable in `:data` — it `pr-str` / `read-string` round-trips; and because it lives in [runtime-db](../core/glossary.md#runtime-db) it inherits [time-travel](../core/glossary.md#time-travel), undo, persistence, and SSR hydration for free, exactly as app-db does. That is the quiet dividend of "a machine is just an event handler whose state rides the frame."
-
-## Tags and timers
-
-Two keys round out the everyday kit, and each has earned a page of its own rather than a paragraph here:
-
-- **Tags** — `:tags #{:auth/busy}` on a state node, read with `@(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])`. This is the *ask-don't-tell* pattern: a view tracks "is it busy?" across any number of states without hard-coding state names, and adding a sixth busy state later is one `:tags` entry with zero view changes. (See [state tag](glossary.md#state-tag).) The deep treatment is in [Tags](tags.md).
-- **Automatic transitions** — `:after` (a declarative timer: arm on entry, cancel on exit, no `setTimeout` or cancel-flag to wire) and `:always` (an eventless transition that fires the moment a guard turns true). The machine's *automatic* moves — the ones no event drives. See [Automatic transitions](automatic-transitions.md).
-
-## Self-transitions: internal by default, external on demand
-
-Look again at the turnstile. Pushing while `:locked` is a *self-transition* — `{:push {:target :locked :action :count-push}}` — and the push counter climbs even though the state never changes. That works because re-frame2 follows the **internal-by-default** rule. Three shapes are worth keeping straight, because they behave differently:
-
-- **Targetless — a true internal no-op.** *Omit `:target` entirely.* The transition's `:action` runs; `:exit` and `:entry` do **not**; `:after` timers aren't restarted; `:spawn` children aren't torn down; active descendant states are left exactly as they are. This is how you mutate `:data` without disturbing anything else — `{:on {:typed {:action :record-keystroke}}}`.
-- **Explicit target on the active path, no `:reenter?`.** Name yourself (`:target :same-state`, or your own state keyword) or an ancestor. Your *own* `:exit` / `:entry` still don't fire — but if you're a compound state, targeting yourself **re-resolves your descendants**: the active children below you exit and your `:initial` chain re-descends. So this is *not* a no-op for a compound; it resets the subtree to its initial child. (Reach for the targetless form when you want descendants preserved.)
-- **External — `:reenter? true`.** Add `:reenter? true` to the target and the state is genuinely **exited and re-entered**: `:exit` runs, then the transition's `:action`, then `:entry`. On a compound, the whole subtree restarts — `:after` timers reset to zero, `:spawn` children tear down and respawn.
-
-```clojure
-:polling
-{:entry :start-fetch                                    ;; kicks off a request
- :after {30000 {:target :polling :reenter? true}}        ;; every 30s: re-enter → :start-fetch fires again
- :on    {:got-data {:action :merge}                       ;; arrives mid-window: internal, no re-fetch
-         :stop     :idle}}
-```
-
-Here the `:after` self-transition is **external** (`:reenter? true`), so re-entering `:polling` re-runs `:start-fetch` and rearms the 30-second timer — a self-rescheduling poll in two keys. The `:got-data` transition is **internal** (no target), so a reply landing mid-window merges into `:data` without resetting the clock. Picking internal vs external per transition is exactly the control this rule buys you.
-
-!!! note "The self-target subtlety"
-
-    A *targeted* self-transition does **not** re-enter by default. A self-target you *meant* to re-fire `:entry` on needs `:reenter? true`; without it, only the transition `:action` runs. (One related restriction: an eventless `:always` may never self-target at all — it's rejected at registration. See [Automatic transitions](automatic-transitions.md).)
-
-## Wildcard transitions: handle a whole class of events
-
-Sometimes a state should react to *any* event in a family rather than enumerate each one. `:on` resolves **three tiers**, most-specific first, and you can register a handler at any tier:
-
-1. the **exact** event id — `:mouse/down`;
-2. the **namespace wildcard** `:ns/*` — `:mouse/*` matches every event in the `mouse` namespace (`:mouse/down`, `:mouse/up`, `:mouse/move`) and *only* those (it won't catch `:keyboard/down`);
-3. the **total wildcard** `:*` — matches anything.
-
-```clojure
-:tracking
-{:on {:mouse/down {:action :begin-drag}    ;; exact wins for :mouse/down
-      :mouse/*    {:action :note-move}      ;; any other :mouse/… event
-      :*          {:action :log-unknown}}}  ;; anything else
-```
-
-One subtlety worth knowing: a guard-**blocked** exact match falls through to the coarser tiers (it wasn't *handled*), but a deliberate **forbidden block** — `{:on {:E {}}}` or `{:on {:E nil}}` — is itself a handler that *consumes* the event and stops the search. That distinction is how a child state opts out of an event its parent would otherwise handle. In a hierarchical machine the same three tiers run at each level of the deepest-wins walk — see [Hierarchical states](hierarchical-states.md#transition-resolution-deepest-wins-with-parent-fallthrough).
-
-!!! note "A non-namespaced id has no wildcard tier"
-
-    A bare id like `:go` has no `:ns/*` tier — only its exact key or `:*` can catch it. The `:ns/*` tier lives on the keyword's `/` boundary: one prefix level between the exact id and the catch-all `:*`.
-
-## Final states: when a machine is *done*
-
-The login flow above parks in `:authed` and `:locked-out` forever — ordinary leaf states with no outgoing transitions, which is right when the machine *persists* (a view keeps reading the snapshot). But some machines genuinely *finish*: a spawned per-request protocol machine completes and should report back. For those, a leaf declares **`:final? true`**, and entering it **terminates the machine** — the runtime auto-destroys it.
-
-!!! warning "Gotcha — final means final"
-
-    A `:final? true` leaf auto-destroys *even a top-level singleton machine*. If you want a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit `:final?`** — exactly what the login flow does. `:final?` is for "this run is over," not "this is the last screen."
-
-The payoff is composition, and it comes in two scopes:
-
-- **A spawned child reports back.** The child names a result key with `:output-key`; its parent's `:spawn` declares `:on-done`, which receives that value the moment the child finishes — then the runtime tears the child down. The full protocol, including the `:on-error` failure path, is in [Actors → When a child finishes](actors.md#when-a-child-finishes).
-- **A nested sub-flow advances the outer flow.** A `:final?` leaf *inside a compound state* doesn't end the machine — it signals "this sub-flow is done" to the enclosing compound's `:on-done`, and the machine keeps running. [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states) owns that pattern.
-
-## Validating a machine's `:data`
-
-A machine's `:data` is just a map, and a typo there (`:cirles` for `:circles`) is the same silent rot any app-db shape is prone to. So a machine spec may declare a machine-level **`:schemas`** map whose **`:data`** entry — a [Malli schema](../core/glossary.md#schema), the same machinery events and subscriptions use — validates the `:data` slot. The `:schemas` map is the single home for all of a machine's schema declarations; `:data` is the first of them that's actually wired up to run:
-
-```clojure
-(rf/reg-machine :drawer/editor
-  {:initial :idle
-   :data    {:circles [] :undo [] :redo []}
-   :schemas {:data DrawerData}                      ;; validates :data at every transition
-   :guards  {...}
-   :actions {...}
-   :states  {...}})
-```
-
-The check runs at the [commit](../core/glossary.md#commit) — the machine's *macrostep*, the one deferred runtime-db write a transition lands — once per transition no matter how many actions fired, plus at bootstrap and at spawn time. A violation emits a structured `:rf.error/schema-validation-failure` with `:where :machine-data` and **rolls the whole transition back**, so an invalid `:data` never reaches runtime-db. Like every schema in re-frame2, it's dev-only by default: the validation site is `debug-enabled?`-gated and is [elided](../core/glossary.md#elide) under `:advanced` production builds.
-
-To *also* validate the inbound event vector, use the three-argument `reg-machine` arity, where the middle `opts` map carries an event `:schema` (the ordinary `:where :event` boundary that runs before the handler):
-
-```clojure
-(rf/reg-machine :auth.login/flow
-  {:schema AuthLoginEvent}                  ;; validates the OUTER [:auth.login/flow [...]] event
-  {:initial :idle
-   :schemas {:data AuthLoginData}           ;; validates the machine's :data
-   :data    {:attempts 0 :error nil}
-   :states  {...}})
-```
-
-The `:schemas` map's sub-keys are a closed set. Two of them — `:data` and `:output` — are wired up to actually run a check (you've now seen both). The other three — `:events`, `:tags`, and `:meta` — are accepted so you can declare them today, but they don't validate anything yet; they're accepted declaration-only, each with a recorded post-v1 wiring trigger (see [Spec 005 §The `:schemas` map](../../spec/005-StateMachines.md#the-schemas-map)). Either way, a sub-key *outside* the set (a typo, or one you hoped was live but isn't) fails loud at registration rather than silently validating nothing.
-
-??? info "Coming from TypeScript?"
-
-    There's a runtime guarantee TypeScript's typed context *can't* give you: TS types are erased before the machine ever runs, whereas `[:schemas :data]` is an *actually-running* validation in dev that rolls a bad transition back. Same declaration, plus the runtime check the type-erased layer leaves out.
-
-!!! note "Fail-loud guard"
-
-    Because the schema only does its job through `reg-machine`'s registration stamp, hand-rolling `(reg-event id meta (machines/make-machine-handler spec))` around a `[:schemas :data]`-bearing spec is rejected with `:rf.error/machine-schema-requires-reg-machine` — the framework refuses to let your schema sit there validating nothing. A schema-less spec is fine through either path.
-
-### Validating a machine's completion output
-
-The other wired `:schemas` category is **`:output`** — it validates the machine's **completion-output payload**: the value a finishing machine selects from its final state's `:data` via `:output-key` (the `result` its parent's `:on-done` receives). re-frame2 keeps completion *event-shaped* — there's no long-lived `snapshot.output` slot — so `[:schemas :output]` schemas the value *as it flows*, validated at the moment the machine finishes:
-
-```clojure
-(rf/reg-machine :auth-flow
-  {:initial :running
-   :data    {}
-   :schemas {:output :string}                 ;; the :output-key payload must be a string
-   :states  {:running {:on {:server-ok {:target :done
-                                         :action (fn [{data :data ev :event}]
-                                                   {:data (assoc data :token (second ev))})}}}
-             :done    {:final?     true
-                       :output-key :token}}})  ;; ← this :token value is what gets validated
-```
-
-Unlike the `:data` boundary, output validation is **best-effort fail-loud**: the machine has *already* reached its final state when its output is checked, so a violation emits `:rf.error/schema-validation-failure` with `:where :machine-output` **loudly** but the completion still flows — there's nothing to roll back, and a schema typo surfaces the mismatch without deadlocking a finishing machine. Same dev-only posture as `:data` (`debug-enabled?`-gated, elided in production) and the same optional validator adapter — a project with no schema library still uses the grammar and pays zero cost.
-
-## Testing: transitions are pure function calls
-
-This is where machines pay you back hardest. A transition is a pure function of *(definition, snapshot, event)*, and `machine-transition` runs exactly one — no frame, no browser, no mocks. Table in, snapshot in, event in; result out:
-
-```clojure
-(machines/machine-transition login-flow
-                             {:state :submitting :data {:attempts 3 :error nil}}
-                             [:auth.login/failure {:failure {:message "bad creds"}}])
-;; => a Result — ::result/snap holds {:state :locked-out …}, ::result/fx the emitted effects
-```
-
-Feed in a snapshot and an event; assert on the value that comes back. These tests run on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Inspecting and testing machines](inspecting-machines.md) has the full treatment: the Result accessors, asserting effects as data, and the three test levels.
-
-## When the machine grows
-
-The flat grammar above carries most machines. When a flow gets richer, the grammar grows *without changing the model* — each of these is the same transition-table data, one more key. Each has its own page in this guide:
-
-- **[Hierarchical states](hierarchical-states.md)** — a compound state contains sub-states; entering the parent cascades to its `:initial` child (an `:authenticated` super-state over `:browsing` / `:checkout`). A parent factors out transitions every descendant inherits, and a nested `:final?` leaf advances the outer flow when a sub-flow completes.
-- **[Parallel regions](parallel-states.md)** — one machine, several orthogonal axes active at once (`:type :parallel` + `:regions`) sharing one `:data`; the snapshot's `:state` becomes a map of region → state, tags union across regions. Three axes of 3 states each is 3 regions, not 27 cross-product states. When the axes *don't* share data, prefer N separate machines — that page works the trade-off.
-- **[History states](history.md)** — re-enter a compound at the substate it was in when you left (a paused player resumes mid-track), via a `:type :history` pseudo-state. The recording rides the snapshot, so it survives undo and hydration for free.
-- **[Automatic transitions](automatic-transitions.md)** — the moves no event drives, in depth: eventless `:always` (fires when a guard becomes true), `:type :choice` (a transient decision node that routes on entry), `:after` (the declarative timer), and `:timeout` / `:on-timeout` (a named deadline that lowers onto `:after`).
-- **[Spawned actors](actors.md)** — machines that aren't long-lived singletons: a per-request protocol machine, a wizard's per-step subprocess. The declarative [`:spawn`](glossary.md#spawn) key starts a child on state entry and destroys it on exit; `:spawn-all` fans out N children and joins on their completion.
-- **`:raise` loops an event back into this machine.** An action can return `:fx [[:raise [:some-event …]]]` to fire an event *at its own machine*, atomically, before the transition commits — useful when one transition's outcome should immediately drive another (a wizard step that completes and re-asks "is the whole form done?"). `:raise` is a reserved fx-id, alongside `[:rf.machine/spawn …]` and `[:rf.machine/destroy …]`, the actor-lifecycle pair behind the `:spawn` sugar. Everything else in `:fx` — `:dispatch`, `:rf.http/managed`, your own effects — flows to the ordinary effects machinery untouched.
-- **`:internal-events` makes an event private.** Some events are machine *plumbing* — a `:check-complete` the machine raises at itself, not for a view or test to dispatch. Declare those in a top-level `:internal-events` **set** (`#{:check-complete}`); an internal `:raise` is handled normally, but an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires). It's a set because membership is what you're declaring, not order.
-
-!!! warning "Gotcha"
-
-    Eventless transitions and `:raise` both re-enter the transition machinery within the same macrostep, so a non-converging loop (`:a` `:always`-targets `:b`, `:b` `:always`-targets `:a`, both guards true) could spin forever. It can't: each is bounded by a depth limit (default **16**, set per-frame via `:always-depth-limit` / `:raise-depth-limit`). Trip it and the macrostep **aborts atomically** — the snapshot stays at its pre-event value, no observer sees the partial path — and a single `:rf.error/machine-always-depth-exceeded` (or `:rf.error/machine-raise-depth-exceeded`) [error record](../core/glossary.md#error-record) fires. It is **distinct** from the silent no-op of an unhandled event: a runaway loop is a bug you want surfaced, not swallowed. There's no automatic recovery.
-
-## When to reach for a machine — and when not
-
-**Reach for one when:** the flow has named, mutually-exclusive stages (handlers that `cond` on a state field are the tell); transitions are conditional (`(when (ready? db) ...)` scattered across handlers are guards in disguise); the flow is worth drawing on a whiteboard — the diagram *is* the machine.
-
-**Don't reach for one when:** the "state" is just data (a counter, a list); there are only two stages (a `:loading?` boolean is fine); the lifecycle belongs to server data — fetching, caching, invalidation is what [resources](../resources/concepts.md) already manage, and hand-building that machine re-implements the framework; or you're enforcing a *sequence of operations* rather than a set of states — chained events handle the simple cases.
-
-**Reach for machines when named states are the load-bearing concept — not when named operations are.** [Part 3 of the tutorial](../resources/tutorial/03-auth-and-forms.md) puts a login machine to work in a real app, and [Server state: resources](../resources/concepts.md) covers the one lifecycle you should *not* hand-build as a machine — the framework already runs it for you.
+**Named states are the load-bearing concept — not named operations.**

--- a/docs/machines/examples.md
+++ b/docs/machines/examples.md
@@ -1,15 +1,15 @@
 # Examples
 
 Runnable apps that exercise the machine grammar. Build a machine yourself first
-([tutorial](tutorial.md)), then skim [the model](concepts.md). Work these apps in
-order — each adds machinery.
+([tutorial](tutorial.md) — ends with a complete login table), then skim
+[the model](concepts.md). Work these apps in order — each adds machinery.
 
 | Example | What it shows | Read first |
 |---|---|---|
-| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | Flat login-style table; guards and actions co-located with the spec; pure `machine-transition` tests | [The model](concepts.md) |
-| [nine_states](../../examples/patterns/nine_states) | One parallel machine, three regions; tags collapse 3×3×3 UI into one view decision | [Parallel regions](parallel-states.md), [Tags](tags.md) |
+| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | Flat login-style table; guards and actions co-located; pure `machine-transition` tests — the tutorial's cousin in-repo | [The model](concepts.md) |
+| [nine_states](../../examples/patterns/nine_states) | One parallel machine, three regions; tags collapse 3×3×3 UI into one view decision | [Tags](tags.md), [Parallel regions](parallel-states.md) |
 | [long_running_work](../../examples/patterns/long_running_work) | Parent spawns N workers with `:spawn-all`; cooperative cancel on every exit path | [Actors](actors.md) |
-| [websocket](../../examples/patterns/websocket) | Hierarchical connection machine; spawned socket actor; `:after` backoff; `:always` flush | [Hierarchical states](hierarchical-states.md), [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
+| [websocket](../../examples/patterns/websocket) | Hierarchical connection machine; spawned socket actor; `:after` backoff; `:always` flush | [Hierarchical states](hierarchical-states.md), [Automatic transitions](automatic-transitions.md), [Actors](actors.md) |
 
 **Not a machine** (substrate only): [process_monitor_helix](../../examples/substrates/helix/process_monitor) —
 Helix + `use-subscribe` and a tick loop, no state machine. Use it to see another

--- a/docs/machines/examples.md
+++ b/docs/machines/examples.md
@@ -1,14 +1,16 @@
-# Machines examples
+# Examples
 
-Worked, runnable apps — the machine features you read about, running.
+Runnable apps that exercise the machine grammar. Build a machine yourself first
+([tutorial](tutorial.md)), then skim [the model](concepts.md). Work these apps in
+order — each adds machinery.
 
-New to machines? Build one yourself first — the [Tutorial](tutorial.md) walks you through a login machine step by step — then skim [Concepts](concepts.md) for the whole model. After that, work through the apps below in order: each adds a little more machinery than the last.
+| Example | What it shows | Read first |
+|---|---|---|
+| [state_machine_walkthrough](../../examples/capabilities/machines/state_machine_walkthrough) | Flat login-style table; guards and actions co-located with the spec; pure `machine-transition` tests | [The model](concepts.md) |
+| [nine_states](../../examples/patterns/nine_states) | One parallel machine, three regions; tags collapse 3×3×3 UI into one view decision | [Parallel regions](parallel-states.md), [Tags](tags.md) |
+| [long_running_work](../../examples/patterns/long_running_work) | Parent spawns N workers with `:spawn-all`; cooperative cancel on every exit path | [Actors](actors.md) |
+| [websocket](../../examples/patterns/websocket) | Hierarchical connection machine; spawned socket actor; `:after` backoff; `:always` flush | [Hierarchical states](hierarchical-states.md), [Actors](actors.md), [Automatic transitions](automatic-transitions.md) |
 
-- **state_machine_walkthrough** — your first machine, end to end. The Concepts login flow as runnable code: a self-contained transition table, with guards and actions living *with* the spec rather than in a global registry, driven headlessly to show the pure-transition + drain testing story. Read first: [Concepts](concepts.md). [→ source](../../examples/capabilities/machines/state_machine_walkthrough)
-- **nine_states** — parallel regions and tags. One `:type :parallel` machine with three orthogonal regions (`:data` / `:form` / `:mode`) and `:tags`; a render-priority table over the tag union collapses all nine canonical UI states into a single `case` in the root view. Read first: [Parallel states](parallel-states.md) and [Tags](tags.md). [→ source](../../examples/patterns/nine_states)
-- **long_running_work** — spawning workers, and cancelling them cleanly. Cancellable long-running work via `:spawn-all`: one parent coordinator spawns N parallel worker children, with per-step progress as an internal self-transition and a cooperative cancellation cascade that fires on every exit path — including unmount. Read first: [Actors](actors.md). [→ source](../../examples/patterns/long_running_work)
-- **websocket** — the lot, in one machine. The canonical connection machine: a hierarchical compound `:active` state parenting connect/auth/connected, a `:spawn`'d socket actor bound to that state, `:after` exponential backoff, `:always` queue-flush on reconnect, and connection-epoch staleness against the live socket id. Read first: [Hierarchical states](hierarchical-states.md), [Actors](actors.md), and [Automatic transitions](automatic-transitions.md). [→ source](../../examples/patterns/websocket)
-
-One more — not a machine, included only for substrate variety:
-
-- **process_monitor_helix** — a Helix two-pane process monitor. It shows Helix consuming subs via `use-subscribe` and a live `:dispatch-later` tick loop, but has *no* state machine. Reach for it to see the ideas under another substrate, not as a machine example. [→ source](../../examples/substrates/helix/process_monitor)
+**Not a machine** (substrate only): [process_monitor_helix](../../examples/substrates/helix/process_monitor) —
+Helix + `use-subscribe` and a tick loop, no state machine. Use it to see another
+substrate, not as a machines example.

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -190,7 +190,7 @@ See [Actors](actors.md).
 
 ### **actor**
 
-A *live machine instance* — a [snapshot](#snapshot) sitting at `[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db). Two kinds: a long-lived **singleton** (one per `reg-machine` id) and a dynamically **[spawned](#spawn)** child (a per-request protocol machine, a wizard's per-step subprocess). An actor's *liveness IS its snapshot's presence* — there's no parallel registry; destroying it removes the snapshot. Address a spawned actor by its gensym'd id, or by role via a [system-id](#system-id).
+A *live machine instance* — a [snapshot](#snapshot) sitting at `[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db). Two kinds: a long-lived **singleton** (one per `reg-machine` id) and a dynamically **[spawned](#spawn)** child (a per-request protocol machine, a wizard's per-step subprocess). An actor's *liveness IS its snapshot's presence* — there's no parallel registry; destroying it removes the snapshot. Address a spawned actor by its allocated id (`<prefix>#<n>`, never `gensym`), or by role via a [system-id](#system-id).
 
 The live instance is just a value in the frame, so time-travel and SSR extend to it for free.
 
@@ -216,7 +216,7 @@ See [Actors → When a child finishes](actors.md#when-a-child-finishes).
 
 ### **system-id**
 
-A stable **role name** (`:logger`, `:websocket`, `:retry-coordinator`) bound to a spawned [actor](#actor), so a parent can address its child by *role* instead of by gensym'd id. The action-side surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` [effect](../core/glossary.md#effect) — a machine [action](#action) can't read app-db, so the fx tuple is how it messages a named child.
+A stable **role name** (`:logger`, `:websocket`, `:retry-coordinator`) bound to a spawned [actor](#actor), so a parent can address its child by *role* instead of by allocated id. The action-side surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` [effect](../core/glossary.md#effect) — a machine [action](#action) can't read app-db, so the fx tuple is how it messages a named child.
 
 ```clojure
 {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -31,7 +31,7 @@ The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), t
            :submitting {...}}}
 ```
 
-See [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
+See [The idea](concepts.md#the-idea) / [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ### **snapshot**
 
@@ -49,7 +49,7 @@ Related: [Machines](concepts.md); the [`[:rf/machine machine-id]` sub](../api/re
 
 A machine's private working memory — the *extended state* that rides alongside the named [state](#state) in every [snapshot](#snapshot). Counters, the in-flight error string, captured credentials: anything that isn't itself a named mode. [Guards](#guard) and [actions](#action) read it from their context map (`{:data …}`); an action *updates* it by returning `{:data …}` (see [action effect map](#action-effect-map)). It must be a printable value so the snapshot round-trips through persistence and time-travel, and a machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
 
-Taught in [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
+Taught in [The idea](concepts.md#the-idea).
 
 ### **state**
 
@@ -78,7 +78,7 @@ What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-ev
                   (assoc :error (:message error)))})
 ```
 
-See [The action effect map](concepts.md#the-action-effect-map--data-fx).
+See [The effect map](concepts.md#the-effect-map-data-fx).
 
 ## State structure
 
@@ -120,7 +120,7 @@ A [transition](#transition) back into the state you're already in. re-frame2 fol
 - **Explicit self-target, no `:reenter?`** — your own `:exit` / `:entry` still don't fire, but a compound **re-resolves its descendants** to `:initial`.
 - **External (`:reenter? true`)** — genuinely exits and re-enters: `:exit` → `:action` → `:entry`, and on a compound the whole subtree restarts (`:after` timers reset, `:spawn` children respawn).
 
-See [Self-transitions](concepts.md#self-transitions-internal-by-default-external-on-demand).
+See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **wildcard transition**
 
@@ -132,13 +132,13 @@ An `:on` entry that matches a *class* of events instead of one id. `:on` resolve
                 :*          {:action :log-unknown}}}  ;; anything else
 ```
 
-See [Wildcard transitions](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **forbidden transition**
 
 A present `:on` key whose value is the **empty map** (`{:on {:E {}}}`) or **`nil`** — a handler that *consumes* an event and stops the deepest-wins search without changing state. It's how a child [compound state](#compound-state) **opts out** of a transition its parent would otherwise inherit to it. Distinct from an *unhandled* event (which falls through to coarser tiers and up to ancestors): a forbidden block is itself a match, so the search stops there.
 
-Covered with [wildcards](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+Covered with [wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **eventless transition (`:always`)**
 

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -36,7 +36,8 @@ The canonical worked example is the connection machine in
 [`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — its
 `:active` state parents the three happy-path leaves. The snippets on this page
 are simplified from it. For the flat grammar this builds on, read
-[Concepts](concepts.md) first.
+[The model](concepts.md) first. Spawned sockets on a parent state are covered in
+[Actors](actors.md).
 
 ---
 
@@ -67,7 +68,7 @@ thing they can't do without: the live socket, spawned on the parent.
     {:initial :connecting                     ;; required — every compound declares it
 
      ;; One socket actor, spawned on the PARENT, so it spans all three leaves
-     ;; below without re-spawning on each leaf transition. (See Concepts > :spawn.)
+     ;; below without re-spawning on each leaf transition. (See Actors.)
      :spawn {:machine-id :websocket/socket}
 
      ;; Transitions every leaf inherits. A leaf may override any of them; what

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -1,5 +1,10 @@
 # Hierarchical (compound) states
 
+Flat machines ([the model](concepts.md)) put every state at one level. A
+**compound** state holds sub-states — factor shared transitions into a parent,
+cascade entry into an `:initial` child, and finish a sub-flow without ending the
+whole machine.
+
 A flat machine is a single list of states, one active at a time. That carries
 most flows. But some states are really a *cluster*: three leaves that share a
 resource, a sub-flow with its own beginning and end, a family of states that

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -1,5 +1,8 @@
 # History states
 
+Re-enter a [compound](hierarchical-states.md) at the substate you left — a media
+player resumes mid-track. History is a transition *target*, not a state you occupy.
+
 Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](hierarchical-states.md).
 
 Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table — a first-class `:type :history` node — and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free.

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -9,34 +9,21 @@ A **machine** makes that shape first-class: one data table of states and
 transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`, living in
 the same [frame](../core/frames.md) as the rest of re-frame2. No second runtime.
 
-## What you get
+## Start here
 
-- **Hierarchical** states (nested flows), **parallel** regions, **history**,
-  **spawned** child machines, guards, delayed transitions — near the power of
-  [XState](coming-from-xstate.md), expressed as Clojure data.
-- **Deep integration** — `reg-machine` is sugar over `reg-event`. Snapshots ride
-  runtime-db; undo, Xray, SSR, and tests share the same pipeline.
+1. **[Tutorial](tutorial.md)** — build a login machine in six steps (guard, action,
+   HTTP, view, pure test). Best first hour.
+2. **[The model](concepts.md)** — the flat grammar those steps rely on: register,
+   snapshot, encapsulation, self-transitions, finals.
+3. Then open a growth page only when a need appears (tags for views, hierarchy for
+   nested flows, actors for workers, …). The left nav lists them in a sensible
+   order; MkDocs prev/next walks them.
 
-## How to read this section
+**Prerequisites.** The [Core introduction](../core/introduction.md) — events, app-db,
+subscriptions, effects. Machines plug into those; they do not replace them.
 
-| Job | Page |
-|---|---|
-| Build a real machine once | [Tutorial: login flow](tutorial.md) |
-| The flat model in full | [The model](concepts.md) |
-| Labels for views ("busy?") | [Tags](tags.md) |
-| Nested states | [Hierarchical states](hierarchical-states.md) |
-| Orthogonal axes in one machine | [Parallel regions](parallel-states.md) |
-| `:always`, `:after`, choice, timeout | [Automatic transitions](automatic-transitions.md) |
-| Resume where you left off | [History](history.md) |
-| Child machines / workers | [Actors](actors.md) |
-| Xray + pure tests | [Inspecting and testing](inspecting-machines.md) |
-| Runnable apps | [Examples](examples.md) |
-| XState mapping | [Coming from XState](coming-from-xstate.md) |
-| Term definitions | [Glossary](glossary.md) |
-
-**Prerequisites.** The [Core introduction](../core/introduction.md) — events,
-app-db, subscriptions, and effects. Machines plug into those; they do not replace
-them.
+Optional later: [examples](examples.md), [XState mapping](coming-from-xstate.md),
+[glossary](glossary.md).
 
 ## A machine in four lines
 
@@ -56,8 +43,8 @@ them.
 ;; => {:state :open :data {}}
 ```
 
-The tutorial turns that idea into a login with guards, actions, HTTP, a view, and a
-test. The model page explains every slot.
+`reg-machine` is sugar over `reg-event`. The snapshot rides runtime-db — undo, Xray,
+SSR, and tests share the same pipeline as the rest of the app.
 
 ## When *not* to use a machine
 

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -1,63 +1,72 @@
-# Hierarchical State Machines
+# Hierarchical state machines
 
-## They're everywhere
+Some state is not a number in app-db — it is **which named stage you are in**, and
+which events may legally leave it. Login is idle, then submitting, then authed or
+error or locked-out. A websocket is connecting, open, reconnecting, closed. Those
+flows usually hide as enums and booleans scattered across handlers.
 
-Finite state machines (FSMs) are hiding in plain sight all over your app:
+A **machine** makes that shape first-class: one data table of states and
+transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`, living in
+the same [frame](../core/frames.md) as the rest of re-frame2. No second runtime.
 
-- Your app's boot process — load config, check the session, get some codes, then go ready.
-- Auth — user logged out, or logged in; and if logged in, an admin or not. And do we have a JWT yet?
-- A single HTTP request — `idle → loading → timeout → retry → loaded | failed`.
-- A websocket — `connecting → open → reconnecting → closed`.
-- A humble dropdown — `disabled | enabled → closed → open → selecting`.
+## What you get
 
-Keep looking and you'll find them at every scale — usually tangled up in a cluster of enums and boolean flags. 
+- **Hierarchical** states (nested flows), **parallel** regions, **history**,
+  **spawned** child machines, guards, delayed transitions — near the power of
+  [XState](coming-from-xstate.md), expressed as Clojure data.
+- **Deep integration** — `reg-machine` is sugar over `reg-event`. Snapshots ride
+  runtime-db; undo, Xray, SSR, and tests share the same pipeline.
 
-But if you have a way of modelling them formally, your code becomes more explicit, robust, and easier to understand.
+## How to read this section
 
-## First-class support
+| Job | Page |
+|---|---|
+| Build a real machine once | [Tutorial: login flow](tutorial.md) |
+| The flat model in full | [The model](concepts.md) |
+| Labels for views ("busy?") | [Tags](tags.md) |
+| Nested states | [Hierarchical states](hierarchical-states.md) |
+| Orthogonal axes in one machine | [Parallel regions](parallel-states.md) |
+| `:always`, `:after`, choice, timeout | [Automatic transitions](automatic-transitions.md) |
+| Resume where you left off | [History](history.md) |
+| Child machines / workers | [Actors](actors.md) |
+| Xray + pure tests | [Inspecting and testing](inspecting-machines.md) |
+| Runnable apps | [Examples](examples.md) |
+| XState mapping | [Coming from XState](coming-from-xstate.md) |
+| Term definitions | [Glossary](glossary.md) |
 
-re-frame2 has first-class, **hierarchical** state machines — including nested states, parallel regions, spawned children, guards, and delayed transitions. 
+**Prerequisites.** The [Core introduction](../core/introduction.md) — events,
+app-db, subscriptions, and effects. Machines plug into those; they do not replace
+them.
 
-The re-frame2 implementation seeks near-parity with the 500-pound gorilla in this space, [XState v6](coming-from-xstate.md) — a wonderful library which has taught me a lot.
-
-## Deeply integrated
-
-The machines implementation is wired into the **core** of re-frame2 — not bolted on as a side-car. And it is infused with the re-frame2 ethos. 
-
-A machine is **expressed** via a data-oriented DSL — state, transitions, guards, etc. The whole machine is just a value. You bind that value with `defmachine` — a drop-in for `def` that also captures per-element source so tooling like Xray can jump from a live snapshot back to the guard/action/state definition — like this.
-
-```clojure
-(rf/defmachine auth-login-machine
-  {:initial :idle
-   :states  {:idle       {:on {:submit :submitting}}   ;; :submit → :submitting
-             :submitting {:on {:ok   :authed            ;; :ok     → :authed
-                               :fail :error}}           ;; :fail   → :error
-             :authed     {}
-             :error      {:on {:submit :submitting}}}})
-```
-
-And a singleton machine (based on this specification value) can be defined as an event handler using `reg-machine` (which is just a machine-specific `reg-event`), like this:
-
-```clojure
-(rf/reg-machine :auth-login auth-login-machine)
-```
-
-The state for all machines lives in a [frame](../core/frames.md) alongside your `app-db`. It moves on the same pipeline, can be "undone" the same way, debugged with the same tools (like Xray), and tested the same way — **there's no second runtime to learn**.
-
-Triggers are sent to machines by normal events, dispatched the normal way, so you drive a machine straight from an ordinary handler. Dispatching `[:auth-login [:submit …]]` fires the machine's `:submit` arrow:
+## A machine in four lines
 
 ```clojure
-(rf/reg-event :login/submit
-  (fn [_ [_ credentials]]
-    {:fx [[:dispatch [:auth-login [:submit credentials]]]]}))
+(:require [re-frame.core :as rf]
+          [re-frame.machines])   ;; opt-in artefact
 
-(rf/dispatch [:login/submit credentials])   ;; fire it the normal way
+(rf/defmachine door
+  {:initial :closed
+   :states  {:closed {:on {:open :open}}
+             :open   {:on {:close :closed}}}})
+
+(rf/reg-machine :door door)
+
+(rf/dispatch [:door [:open]])
+@(rf/subscribe [:rf/machine :door])
+;; => {:state :open :data {}}
 ```
 
-And the state of a machine is **read** like an ordinary subscription — you get back a [snapshot](glossary.md#snapshot), `{:state … :data …}`:
+The tutorial turns that idea into a login with guards, actions, HTTP, a view, and a
+test. The model page explains every slot.
 
-```clojure
-@(rf/subscribe [:rf/machine :auth-login])   ;; => {:state :submitting :data {}}
-```
+## When *not* to use a machine
 
-The snapshot moves, and the views that read it follow.
+| Situation | Prefer |
+|---|---|
+| A counter, list, or form field | app-db + events |
+| Two stages (`:loading?` boolean) | a keyword or flag |
+| Server fetch / cache / invalidate | [resources](../resources/concepts.md) |
+| A fixed sequence of operations | chained events / effects |
+
+Reach for a machine when **named stages and legal transitions** are the load-bearing
+concept — not when the load-bearing concept is a value or a network cache.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -136,7 +136,7 @@ Because a machine is an event handler, every guard evaluation, action run, and t
 
 A few things to read off these:
 
-- **`:actor-id` is the live instance; `:machine-id` is reserved for the registered *type*.** For a singleton the two coincide; for a [spawned](glossary.md#spawn) actor `:actor-id` is the gensym'd instance id.
+- **`:actor-id` is the live instance; `:machine-id` is reserved for the registered *type*.** For a singleton the two coincide; for a [spawned](glossary.md#spawn) actor `:actor-id` is the allocated instance id (`<prefix>#<n>`).
 - **`:state` on the guard trace is the source discriminator.** Two states declaring the same event with the same guard are otherwise indistinguishable; the active `:state` tag attributes a block to the right edge.
 - **`:phase` on the action trace** tells cascade actions apart from transition actions — `:exit` / `:entry` for the LCA cascade, `:transition` for an `:on`-driven action, `:always` for an eventless step, and so on.
 

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -181,34 +181,42 @@ This is the surface Xray's focused-transition lens and the re-frame2 pair MCP us
 
 ## Unit-test transitions as pure function calls — `machine-transition`
 
-This is where machines pay you back hardest. A transition is a pure function of *(definition, snapshot, event)*, exposed as `re-frame.machines/machine-transition`. No frame, no browser, no mocks, no clock — table in, snapshot in, event in; result out. These tests run on the JVM in microseconds, which is exactly the testing experience you want for the flows where testing usually gets *hard*.
+This is where machines pay you back hardest. A transition is a pure function of
+*(definition, snapshot, event)*, exposed as `re-frame.machines/machine-transition`.
+No frame, no browser, no mocks, no clock — table in, snapshot in, event in; result
+out. These tests run on the JVM in microseconds.
 
-The return value is a **Result map**. Discriminate it with `result/ok?` / `result/fail?`, and read the post-transition snapshot and emitted effects with the `result/snap` / `result/fx` accessors (or destructure the `::result/snap` / `::result/fx` keys directly):
+Use the same `login-flow` value from the [tutorial](tutorial.md#the-complete-machine)
+(the `defmachine` binding, not the registered id):
 
 ```clojure
-(ns my-app.login-flow-test
+(ns app.login-test
   (:require [clojure.test :refer [deftest is]]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [my-app.login :refer [login-flow]]))   ;; the transition-table value
+            [app.login :refer [login-flow]]))
 
 (deftest login-flow-test
-  ;; happy path: :idle --submit--> :submitting, whose :entry fires the request fx
+  ;; :idle --submit--> :submitting; :entry fires the HTTP fx description
   (let [r (machines/machine-transition
             login-flow
             {:state :idle :data {:attempts 0 :error nil}}
             [:auth.login/submit {:email "a@b.com" :password "secret"}])]
     (is (result/ok? r))
     (is (= :submitting (:state (result/snap r))))
-    (is (= :rf.http/managed (ffirst (result/fx r)))))   ;; the :issue-request action's fx
+    (is (= :rf.http/managed (ffirst (result/fx r)))))
 
-  ;; at the retry limit the guard rejects :error-shown, so :locked-out wins
+  ;; at the retry limit the first failure candidate is skipped → :locked-out
   (let [r (machines/machine-transition
             login-flow
             {:state :submitting :data {:attempts 3 :error nil}}
-            [:auth.login/failure {:failure {:message "bad creds"}}])]
+            [:auth.login/failure {:error {:message "bad creds"}}])]
     (is (= :locked-out (:state (result/snap r))))))
 ```
+
+The return value is a **Result map**. Discriminate with `result/ok?` / `result/fail?`;
+read the post-transition snapshot and emitted effects with `result/snap` /
+`result/fx` (or destructure `::result/snap` / `::result/fx`).
 
 Two things make this pleasant:
 

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -1,6 +1,12 @@
 # Inspecting and testing machines
 
-A machine in re-frame2 is [just an event handler](concepts.md#registering-and-running-it) whose body interprets a transition table, and whose whole state is a plain value sitting in the frame's runtime-db. That one fact is the theme of this page: there is **no parallel machine runtime** to attach a special debugger to, and **no second store** to mock in a test. You inspect a machine the way you inspect any re-frame2 state — you `subscribe` to it. You watch it the way you watch any event — through Xray and the trace bus. And you test it the way you'd test a pure function — because a transition literally *is* one.
+You can [author](tutorial.md) and [understand](concepts.md) machines. This page is
+how you **watch** one and **prove** the table.
+
+A machine is [just an event handler](concepts.md#register-and-drive) whose body
+interprets a transition table; its whole state is a plain value in runtime-db.
+There is **no parallel machine runtime** and **no second store**. Subscribe like
+any re-frame2 state; watch events in Xray; unit-test with a pure function call.
 
 You reach for the tools here in two situations:
 

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -1,5 +1,9 @@
 # Parallel regions
 
+One machine, several **orthogonal** axes active at once — form validity × load
+state × mode — without exploding a cross-product of flat states. Assumes the
+[flat model](concepts.md); pairs naturally with [tags](tags.md).
+
 Some lifecycles aren't *one* question — they're several, all live at once. A todos screen is *somewhere in its fetch* (nothing / loading / empty / some / too-many), *somewhere in its form* (neutral / valid / invalid), and *somewhere in its page mode* (active / archived). Those three axes are **orthogonal**: each moves on its own, and any combination is legal.
 
 Model that as one flat machine and the states multiply — three axes of three states each is `3 × 3 × 3 = 27` cross-product states, most of them named things like `:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart. One machine declares `:type :parallel` and a `:regions` map; each region is a full little state-tree minding one axis; all regions are active simultaneously. Three axes of three states becomes **nine states across three regions**, not twenty-seven flat ones.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -1,16 +1,25 @@
 # State tags
 
-Some questions a view asks aren't "which state is the machine in?" but "is the machine *busy*?" — across `:loading`, `:retrying`, `:reconnecting`, and whatever in-flight state you add next month. A **[state tag](glossary.md#state-tag)** is a semantic label you pin to a state so a view can ask for the *intent* — busy, read-only, terminal — instead of enumerating the exact state names that happen to mean it. *Ask, don't tell.*
+You know the [flat model](concepts.md): states, transitions, snapshot. This page is
+the first growth feature — how views ask **what is true** without hard-coding state
+names.
+
+Some questions are not "which state?" but "is it *busy*?" across `:loading`,
+`:retrying`, `:reconnecting`, and whatever you add next month. A
+**[state tag](glossary.md#state-tag)** is a semantic label on a state so a view asks
+for intent — busy, read-only, terminal — instead of enumerating names. *Ask, don't
+tell.*
 
 Reach for tags when:
 
-- several states share a meaning a view cares about ("any of these is loading-ish"), and you don't want a boolean sub per state;
-- a page's render decision slices across more than one axis (data cardinality × form validity × mode) and you want one decision table instead of an N-way `cond`;
-- a guard in one [parallel region](parallel-states.md) needs to know what a *sibling* region is doing without reaching into its private state.
+- several states share a meaning a view cares about;
+- render decisions slice across more than one axis (see also
+  [parallel regions](parallel-states.md));
+- a guard in one parallel region needs a sibling region's *intent* without private
+  state.
 
-If a label would only ever match exactly one state, skip it — query the state directly with `(= :loading (:state snap))`. Tags earn their keep by matching *many* states with one shared intent.
-
-This page assumes the [machine grammar](concepts.md) — `reg-machine`, the transition table, the `{:state :data}` snapshot — from the concepts chapter.
+If a label would only ever match one state, skip it — compare `:state` directly.
+Tags earn their keep when one label covers many states.
 
 ## Declaring tags on a state
 

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -69,21 +69,18 @@ How the union is computed depends on the machine's shape:
 
 `:tags` is **read-only** for you. It's a pure projection of `:state` — set the state, the tags follow — so an action can't return `:tags` in its `{:data :fx}` effect map; the runtime owns the slot. And when the union is **empty** (no active state declares any tag), the runtime **elides** the key entirely: a tag-free machine carries no `:tags` slot at all, so `(contains? snap :tags)` can be `false` even after the machine has settled. Don't declare an empty `:tags #{}` to "have the slot" — just omit it.
 
-## Querying with `machine-has-tag?`
+## Querying with `[:rf.machine/has-tag? …]`
 
-The framework ships one **derived subscription** for the containment question — *does this machine's snapshot carry this tag?*
+The framework ships one **derived subscription** for the containment question — *does this machine's snapshot carry this tag?* There is no separate function sugar; every runtime-db read is a subscription vector:
 
 ```clojure
-;; The query vector …
 @(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])   ;; => true | false
-;; … and its sugar, re-exported on the re-frame.core facade:
-@(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])                   ;; => true | false
 ```
 
 In a view that's all you need to render on intent:
 
 ```clojure
-(reg-view spinner-or-list []
+(rf/reg-view spinner-or-list []
   (if @(rf/subscribe [:rf.machine/has-tag? :todos/loader :data/in-flight])
     [spinner]
     [todo-list]))
@@ -143,8 +140,8 @@ Three axes run at once, so several tags are live simultaneously — `:data/loadi
 The root view's entire branching logic is then one `case` — the only place the UI ever forks:
 
 ```clojure
-(reg-view root-view []
-  (case @(subscribe [:ui/render])
+(rf/reg-view root-view []
+  (case @(rf/subscribe [:ui/render])
     :done      [view-done]
     :correct   [view-correct]
     :incorrect [view-incorrect]
@@ -160,7 +157,7 @@ Nine states, three regions, one branch site. The priority order is a *product de
 And the controls disable themselves the same ask-don't-tell way — they ask for the *intent*, not the state:
 
 ```clojure
-(reg-view new-todo-form []
+(rf/reg-view new-todo-form []
   (let [read-only? @(rf/subscribe [:rf.machine/has-tag? :ui/nine-states :mode/read-only])]
     [:button {:disabled read-only?} "Add"]))
 ```

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -1,11 +1,11 @@
 # Tutorial: build a login machine
 
 Build one machine end to end — idle → submitting → authed / error / locked-out —
-adding one idea at a time: a guard, an action, a server call, a view, and a pure
-test.
+adding one idea at a time. By the end you have a **complete, copy-pasteable** table
+(guards, actions, HTTP, timeout, tags, lock-out) plus a view and a pure test.
 
-You need the [Core loop](../core/introduction.md) (events, app-db, effects). Machine
-theory beyond this walk-through is [The model](concepts.md).
+**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db,
+effects). Vocabulary after this walk-through: [The model](concepts.md).
 
 ## Step 0 — turn machines on
 
@@ -47,7 +47,7 @@ Register a **singleton** under an event id (`reg-machine` ≈ specialised `reg-e
 Drive it by dispatching to that id; the **inner** vector is the machine event:
 
 ```clojure
-(rf/dispatch [:auth.login/flow [:auth.login/submit]])
+(rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "x"}]])
 ```
 
 Read the live [snapshot](glossary.md#snapshot):
@@ -58,94 +58,77 @@ Read the live [snapshot](glossary.md#snapshot):
 ;;    nil before the first event — the machine boots on first dispatch
 ```
 
+Outer handlers stay ordinary. They only wrap the machine address:
+
+```clojure
+(rf/reg-event :login/submit
+  (fn [_ [_ credentials]]
+    {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
+```
+
 ## Step 2 — a guard
 
 Refuse empty credentials. Name the guard once; reference it from every arrow that
 needs it:
 
 ```clojure
-(rf/defmachine login-flow
-  {:initial :idle
-   :data    {:attempts 0 :error nil}
+:guards
+{:form-valid?
+ (fn [{[_ creds] :event}]
+   (and (seq (:email creds)) (seq (:password creds))))}
 
-   :guards
-   {:form-valid?
-    (fn [{[_ creds] :event}]
-      (and (seq (:email creds)) (seq (:password creds))))}
-
-   :states
-   {:idle        {:on {:auth.login/submit  {:target :submitting
-                                            :guard  :form-valid?}}}
-    :submitting  {:on {:auth.login/success {:target :authed}
-                       :auth.login/failure {:target :error-shown}}}
-    :error-shown {:on {:auth.login/dismiss {:target :idle}
-                       :auth.login/submit  {:target :submitting :guard :form-valid?}}}
-    :authed      {}}})
+;; on the arrows:
+:idle        {:on {:auth.login/submit {:target :submitting :guard :form-valid?}}}
+:error-shown {:on {:auth.login/submit {:target :submitting :guard :form-valid?}
+                   :auth.login/dismiss {:target :idle}}}
 ```
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "" :password ""}]])
 @(rf/subscribe [:rf/machine :auth.login/flow])
-;; => still :idle
-
-(rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "secret"}]])
-;; => :submitting
+;; => still :idle  (guard said no)
 ```
 
-The guard reads credentials from **`:event`**, not app-db — machines are
-[encapsulated](concepts.md#strict-encapsulation).
+The guard reads credentials from **`:event`**, not app-db —
+[encapsulation](concepts.md#strict-encapsulation).
 
 ## Step 3 — actions and candidate lists
 
 An **action** returns `{:data … :fx …}` like a pure event handler — it never calls
-HTTP itself. Below: clear error on submit, record failures, store session on success,
-and **lock out** after three failures via a candidate list:
+HTTP itself.
+
+- `:clear-error` — wipe the last error on a fresh submit
+- `:record-error` — bump `:attempts` and store a message
+- `:store-session` — dispatch an ordinary effect on success
+- **Candidate list** on failure — under three attempts → error UI; otherwise lock out
 
 ```clojure
-(rf/defmachine login-flow
-  {:initial :idle
-   :data    {:attempts 0 :error nil}
+:guards
+{:form-valid?       …
+ :under-retry-limit (fn [{data :data}] (< (:attempts data) 3))}
 
-   :guards
-   {:form-valid?
-    (fn [{[_ creds] :event}]
-      (and (seq (:email creds)) (seq (:password creds))))
-    :under-retry-limit
-    (fn [{data :data}] (< (:attempts data) 3))}
+:actions
+{:clear-error
+ (fn [_] {:data {:error nil}})
+ :record-error
+ (fn [{data :data [_ {:keys [error]}] :event}]
+   {:data (-> data
+              (update :attempts inc)
+              (assoc  :error (or (:message error) "Login failed.")))})
+ :store-session
+ (fn [{[_ {:keys [value]}] :event}]
+   {:fx [[:auth.session/store {:token (:token value)}]]})}
 
-   :actions
-   {:clear-error
-    (fn [_] {:data {:error nil}})
-    :record-error
-    (fn [{data :data [_ {:keys [error]}] :event}]
-      {:data (-> data
-                 (update :attempts inc)
-                 (assoc  :error (or (:message error) "Login failed.")))})
-    :store-session
-    (fn [{[_ {:keys [value]}] :event}]
-      {:fx [[:auth.session/store {:token (:token value)}]]})}
-
-   :states
-   {:idle
-    {:on {:auth.login/submit {:target :submitting
-                              :guard  :form-valid?
-                              :action :clear-error}}}
-    :submitting
-    {:on {:auth.login/success {:target :authed :action :store-session}
-          :auth.login/failure [{:target :error-shown
-                                :guard  :under-retry-limit
-                                :action :record-error}
-                               {:target :locked-out}]}}
-    :error-shown
-    {:on {:auth.login/dismiss {:target :idle}
-          :auth.login/submit  {:target :submitting :guard :form-valid?}}}
-    :authed     {:meta {:terminal? true}}
-    :locked-out {:meta {:terminal? true}}}})
+:submitting
+{:on {:auth.login/success {:target :authed :action :store-session}
+      :auth.login/failure [{:target :error-shown
+                            :guard  :under-retry-limit
+                            :action :record-error}
+                           {:target :locked-out}]}}
 ```
 
-`:auth.login/failure` is a **vector of candidates** — first guard that passes wins.
-After three failures, `:under-retry-limit` fails and the unguarded candidate locks
-out.
+A **vector of candidates** is tried in order; first guard that passes wins. After
+three failures, `:under-retry-limit` fails and the unguarded candidate locks out.
 
 !!! note "`:data` merges"
 
@@ -153,7 +136,6 @@ out.
     Details: [The model → effect map](concepts.md#the-effect-map-data-fx).
 
 ```clojure
-(rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "x"}]])
 (rf/dispatch [:auth.login/flow [:auth.login/failure {:error {:message "nope"}}]])
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :error-shown :data {:attempts 1 :error "nope"}}
@@ -162,49 +144,40 @@ out.
 ## Step 4 — talk to a real server
 
 Add an **`:entry`** action on `:submitting` that fires [managed HTTP](../async/http.md),
-and an **`:after`** deadline if the server stalls:
+and an **`:after`** deadline if the server stalls. Tag the state so views can ask
+"busy?" without naming it:
 
 ```clojure
-:actions
-{;; … clear-error, record-error, store-session …
+:issue-request
+(fn [{[_ creds] :event}]
+  {:fx [[:rf.http/managed
+         {:request    {:method :post :url "/api/login" :body creds
+                       :request-content-type :json}
+          :decode     :json
+          :on-success [:auth.login/flow [:auth.login/success]]
+          :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
- :issue-request
- (fn [{[_ creds] :event}]
-   {:fx [[:rf.http/managed
-          {:request    {:method :post :url "/api/login" :body creds
-                        :request-content-type :json}
-           :decode     :json
-           :on-success [:auth.login/flow [:auth.login/success]]
-           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
+:record-timeout
+(fn [{data :data}]
+  {:data (-> data (update :attempts inc) (assoc :error "Server took too long."))})
 
- :record-timeout
- (fn [{data :data}]
-   {:data (-> data (update :attempts inc) (assoc :error "Server took too long."))})}
-```
-
-```clojure
 :submitting
 {:tags  #{:auth/busy}
  :entry :issue-request
  :after {8000 {:target :error-shown :action :record-timeout}}
- :on    {:auth.login/success {:target :authed :action :store-session}
-         :auth.login/failure [{:target :error-shown
-                               :guard  :under-retry-limit
-                               :action :record-error}
-                              {:target :locked-out}]}}
+ :on    {…}}   ;; success / failure as in step 3
 ```
 
 `:on-success [:auth.login/flow [:auth.login/success]]` is written one element short
 on purpose — managed HTTP **appends** the reply map onto the inner event, so
 `:store-session` sees `[:auth.login/success {:value {:token "…"}}]`.
 
-`:after` arms on entry and cancels on exit. No `setTimeout`, no cancel flag.
-Deeper timer grammar: [Automatic transitions](automatic-transitions.md).
+`:after` arms on entry and cancels on exit. Deeper timer grammar:
+[Automatic transitions](automatic-transitions.md).
 
 ## Step 5 — render every state
 
-Project the snapshot; ask **tags** for shared intent ("busy?") instead of listing
-state names:
+Project the snapshot; ask **tags** for shared intent:
 
 ```clojure
 (rf/reg-sub :auth.login/state
@@ -220,16 +193,20 @@ state names:
         error @(subscribe [:auth.login/error])
         busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     (case state
-      :idle        [:button {:disabled busy?} "Sign in"]
+      :idle        [:button {:disabled busy?
+                             :on-click #(dispatch [:login/submit @draft-creds])}
+                    "Sign in"]
       :submitting  [:p "Signing in…"]
-      :error-shown [:div [:p error] [:button "Try again"]]
+      :error-shown [:div [:p error]
+                    [:button {:on-click #(dispatch [:auth.login/flow [:auth.login/dismiss]])}
+                     "Try again"]]
       :authed      [:h1 "Welcome back"]
       :locked-out  [:h1 "Account locked"]
       [:p "…"])))   ;; nil before first event
 ```
 
-The `:auth/busy` tag on `:submitting` is why `busy?` works — add another in-flight
-state later and the view keeps working. Pattern: [Tags](tags.md).
+Add another in-flight state later with the same `:auth/busy` tag and this view keeps
+working. Pattern: [Tags](tags.md).
 
 ## Step 6 — test a transition as a pure function
 
@@ -259,10 +236,88 @@ No frame, no browser, no network:
 
 More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
 
-## What you built
+## The complete machine
 
-A single data value that owns login lifecycle, pure enough to unit-test, wired to
-HTTP and views through ordinary re-frame2 events and subscriptions. The rest of this
-section deepens the grammar when a flat table is no longer enough — start with
-[The model](concepts.md) if you want vocabulary, or [Hierarchical states](hierarchical-states.md)
-when a state needs sub-states.
+Everything above in one registration — the form you copy into a real app:
+
+```clojure
+(ns app.login
+  (:require [re-frame.core :as rf]
+            [re-frame.machines]))
+
+(rf/defmachine login-flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:form-valid?
+    (fn [{[_ creds] :event}]
+      (and (seq (:email creds)) (seq (:password creds))))
+    :under-retry-limit
+    (fn [{data :data}] (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error
+    (fn [_] {:data {:error nil}})
+
+    :record-error
+    (fn [{data :data [_ {:keys [error]}] :event}]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc  :error (or (:message error) "Login failed.")))})
+
+    :store-session
+    (fn [{[_ {:keys [value]}] :event}]
+      {:fx [[:auth.session/store {:token (:token value)}]]})
+
+    :issue-request
+    (fn [{[_ creds] :event}]
+      {:fx [[:rf.http/managed
+             {:request    {:method :post :url "/api/login" :body creds
+                           :request-content-type :json}
+              :decode     :json
+              :on-success [:auth.login/flow [:auth.login/success]]
+              :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
+
+    :record-timeout
+    (fn [{data :data}]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc  :error "Server took too long."))})}
+
+   :states
+   {:idle
+    {:on {:auth.login/submit {:target :submitting
+                              :guard  :form-valid?
+                              :action :clear-error}}}
+
+    :submitting
+    {:tags  #{:auth/busy}
+     :entry :issue-request
+     :after {8000 {:target :error-shown :action :record-timeout}}
+     :on    {:auth.login/success {:target :authed :action :store-session}
+             :auth.login/failure [{:target :error-shown
+                                   :guard  :under-retry-limit
+                                   :action :record-error}
+                                  {:target :locked-out}]}}
+
+    :error-shown
+    {:on {:auth.login/dismiss {:target :idle}
+          :auth.login/submit  {:target :submitting
+                               :guard  :form-valid?
+                               :action :clear-error}}}
+
+    ;; Resting leaves — omit :final? so the machine persists for the session.
+    :authed     {:meta {:terminal? true}}
+    :locked-out {:meta {:terminal? true}}}})
+
+(rf/reg-machine :auth.login/flow login-flow)
+
+(rf/reg-event :login/submit
+  (fn [_ [_ credentials]]
+    {:fx [[:dispatch [:auth.login/flow [:auth.login/submit credentials]]]]}))
+```
+
+When a flat table is no longer enough — nested checkout under auth, parallel form
+axes, spawned workers — open [The model](concepts.md) for vocabulary, then the
+matching growth page (hierarchy, parallel, actors, …).

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -116,6 +116,7 @@ HTTP itself.
               (update :attempts inc)
               (assoc  :error (or (:message error) "Login failed.")))})
  :store-session
+ ;; HTTP appends {:status :ok :value …}; pull the decoded body from :value.
  (fn [{[_ {:keys [value]}] :event}]
    {:fx [[:auth.session/store {:token (:token value)}]]})}
 
@@ -169,8 +170,9 @@ and an **`:after`** deadline if the server stalls. Tag the state so views can as
 ```
 
 `:on-success [:auth.login/flow [:auth.login/success]]` is written one element short
-on purpose — managed HTTP **appends** the reply map onto the inner event, so
-`:store-session` sees `[:auth.login/success {:value {:token "…"}}]`.
+on purpose — managed HTTP **appends** the [canonical reply envelope](../async/http.md)
+onto the inner event, so `:store-session` sees
+`[:auth.login/success {:status :ok :value {:token "…"} …}]`.
 
 `:after` arms on entry and cancels on exit. Deeper timer grammar:
 [Automatic transitions](automatic-transitions.md).
@@ -220,18 +222,22 @@ No frame, no browser, no network:
             [app.login :refer [login-flow]]))
 
 (deftest login-flow-test
-  (let [{snap ::result/snap fx ::result/fx}
-        (machines/machine-transition login-flow
-          {:state :idle :data {:attempts 0 :error nil}}
-          [:auth.login/submit {:email "a@b.com" :password "secret"}])]
-    (is (= :submitting (:state snap)))
-    (is (= :rf.http/managed (ffirst fx))))   ;; :entry ran :issue-request
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :idle :data {:attempts 0 :error nil}}
+            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+    (is (result/ok? r))
+    (is (= :submitting (:state (result/snap r))))
+    (is (= :rf.http/managed (ffirst (result/fx r)))))   ;; :entry ran :issue-request
 
-  (let [{snap ::result/snap}
-        (machines/machine-transition login-flow
-          {:state :submitting :data {:attempts 3 :error nil}}
-          [:auth.login/failure {:error {:message "bad creds"}}])]
-    (is (= :locked-out (:state snap)))))
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :submitting :data {:attempts 3 :error nil}}
+            ;; Pure-table test: invent the failure shape the action expects.
+            ;; Live HTTP would append {:status :error :error …} instead.
+            [:auth.login/failure {:error {:message "bad creds"}}])]
+    (is (result/ok? r))
+    (is (= :locked-out (:state (result/snap r))))))
 ```
 
 More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
@@ -267,6 +273,7 @@ Everything above in one registration — the form you copy into a real app:
                  (assoc  :error (or (:message error) "Login failed.")))})
 
     :store-session
+    ;; Managed HTTP appends {:status :ok :value <decoded> …}; :value is the body.
     (fn [{[_ {:keys [value]}] :event}]
       {:fx [[:auth.session/store {:token (:token value)}]]})
 

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -1,29 +1,33 @@
 # Tutorial: build a login machine
 
-Let's build a machine to model a **login flow** — idle, then submitting, then either signed-in or showing an error, and locked out after too many tries — adding one idea at a time: a guard, an action, a real server call, a view, and a test.
+Build one machine end to end — idle → submitting → authed / error / locked-out —
+adding one idea at a time: a guard, an action, a server call, a view, and a pure
+test.
 
+You need the [Core loop](../core/introduction.md) (events, app-db, effects). Machine
+theory beyond this walk-through is [The model](concepts.md).
 
 ## Step 0 — turn machines on
 
-To reduce bundle size, re-frame2 doesn't include the machines capability by default, so if you want to use it, you have to explicitly require it into your boot/root namespace. Like this:
+Machines are an optional artefact. Require them once in a boot or feature namespace:
 
 ```clojure
 (ns app.login
   (:require [re-frame.core :as rf]
-            [re-frame.machines]))   ;; ← requiring it is what turns machines on
+            [re-frame.machines]))   ;; loads the capability
 ```
 
-If you forget to do this, your first `reg-machine` will loudly throw `:rf.error/machines-artefact-missing`.  
+Forget this and the first `reg-machine` throws
+`:rf.error/machines-artefact-missing`.
 
+## Step 1 — a table and a registration
 
-## Step 1 — your first machine
-
-A machine is a data structure which defines a set of named states, and for each one, which triggers move it where. Here's a login as that data structure — four states, and the triggers that connect them.
+A machine is data: named states and which triggers move where.
 
 ```clojure
 (rf/defmachine login-flow
   {:initial :idle
-   :data    {:attempts 0 :error nil}     ;; the machine's private state; Step 3 puts it to work
+   :data    {:attempts 0 :error nil}
 
    :states
    {:idle        {:on {:auth.login/submit  {:target :submitting}}}
@@ -31,46 +35,39 @@ A machine is a data structure which defines a set of named states, and for each 
                        :auth.login/failure {:target :error-shown}}}
     :error-shown {:on {:auth.login/dismiss {:target :idle}
                        :auth.login/submit  {:target :submitting}}}
-    :authed      {}}})                    ;; a resting state — no outgoing transitions
+    :authed      {}}})   ;; resting — no outgoing transitions
 ```
 
-Those triggers — the `:on` keys, `:auth.login/submit` and friends — are ordinary event ids. You'll see how one reaches the machine in a moment.
-
-Register it — one line to create a singleton machine:
+Register a **singleton** under an event id (`reg-machine` ≈ specialised `reg-event`):
 
 ```clojure
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-This singleton machine is identifiable via `:auth.login/flow` because the code above literally wrapped it in an event handler. `reg-machine` is pretty much syntactic sugar over `reg-event`.
-
-And that means, to drive this machine, we dispatch events. The event id is that of the machine, and the trigger rides *inside* an event wrapper, like this:
+Drive it by dispatching to that id; the **inner** vector is the machine event:
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit]])
 ```
 
-And when a view needs to know what state the machine is in, it reads the machine's [snapshot](glossary.md#snapshot) — its live `{:state … :data …}` value — through the framework subscription `[:rf/machine machine-id]`:
+Read the live [snapshot](glossary.md#snapshot):
 
 ```clojure
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :submitting :data {:attempts 0 :error nil}}
-;;    (nil before the very first event — the machine starts itself on its first dispatch)
+;;    nil before the first event — the machine boots on first dispatch
 ```
 
+## Step 2 — a guard
 
-**Why it works:** `reg-machine` is sugar over `reg-event`, so the snapshot rides the [frame](../core/frames.md) and you read it with an ordinary subscription — same `dispatch`, same `subscribe`. [Concepts → Registering and running it](concepts.md#registering-and-running-it) walks the machinery.
-
-## Step 2 — a guard: refuse an invalid submit
-
-Right now *any* `:auth.login/submit` trigger moves you from `:idle` to `:submitting`, even with an empty form. A **guard** is a yes/no test that gates a transition. Below we add one named guard `:form-valid?`, and reference it from the arrow:
+Refuse empty credentials. Name the guard once; reference it from every arrow that
+needs it:
 
 ```clojure
 (rf/defmachine login-flow
   {:initial :idle
    :data    {:attempts 0 :error nil}
 
-   ;; guards defined here
    :guards
    {:form-valid?
     (fn [{[_ creds] :event}]
@@ -78,7 +75,7 @@ Right now *any* `:auth.login/submit` trigger moves you from `:idle` to `:submitt
 
    :states
    {:idle        {:on {:auth.login/submit  {:target :submitting
-                                            :guard  :form-valid?}}}   ;; <- use here.
+                                            :guard  :form-valid?}}}
     :submitting  {:on {:auth.login/success {:target :authed}
                        :auth.login/failure {:target :error-shown}}}
     :error-shown {:on {:auth.login/dismiss {:target :idle}
@@ -86,25 +83,23 @@ Right now *any* `:auth.login/submit` trigger moves you from `:idle` to `:submitt
     :authed      {}}})
 ```
 
-You name the guard once in `:guards`, then point at it by id — `:guard :form-valid?` — from every arrow that needs it.
-
-**What you see:** submit empty credentials and the machine stays put; submit real ones and it moves.
-
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "" :password ""}]])
-@(rf/subscribe [:rf/machine :auth.login/flow])     ;; => {:state :idle …}        (guard said no)
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => still :idle
 
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "secret"}]])
-@(rf/subscribe [:rf/machine :auth.login/flow])     ;; => {:state :submitting …}
+;; => :submitting
 ```
 
-**Notice:** the guard read the credentials from `:event`, not [app-db](../core/app-db.md) — a machine callback sees only its own `:data` and the event that woke it. [Concepts → Strict encapsulation](concepts.md#strict-encapsulation--a-machine-sees-only-its-own-data) explains why that boundary matters.
+The guard reads credentials from **`:event`**, not app-db — machines are
+[encapsulated](concepts.md#strict-encapsulation).
 
-## Step 3 — an action, and the `{:data :fx}` it returns
+## Step 3 — actions and candidate lists
 
-A guard decides *whether*; an **action** computes change. But it never performs a side-effect itself — it **returns** the same `{:data :fx}` map a `reg-event` does: `:data` is merged into the machine's own data, `:fx` is the ordinary effects vector. [Concepts → The action effect map](concepts.md#the-action-effect-map--data-fx) has the full shape.
-
-Below, we add three actions and a second guard, and wire them in. `:clear-error` wipes the last error on submit; `:record-error` counts a failure into `:data`; `:store-session` fires an effect on success:
+An **action** returns `{:data … :fx …}` like a pure event handler — it never calls
+HTTP itself. Below: clear error on submit, record failures, store session on success,
+and **lock out** after three failures via a candidate list:
 
 ```clojure
 (rf/defmachine login-flow
@@ -115,71 +110,63 @@ Below, we add three actions and a second guard, and wire them in. `:clear-error`
    {:form-valid?
     (fn [{[_ creds] :event}]
       (and (seq (:email creds)) (seq (:password creds))))
-
     :under-retry-limit
-    (fn [{data :data}] (< (:attempts data) 3))}        ;; reads its own :data
+    (fn [{data :data}] (< (:attempts data) 3))}
 
    :actions
    {:clear-error
     (fn [_] {:data {:error nil}})
-
     :record-error
-    (fn [{data :data [_ {:keys [error]}] :event}]        ;; failure map rides under :error
+    (fn [{data :data [_ {:keys [error]}] :event}]
       {:data (-> data
                  (update :attempts inc)
                  (assoc  :error (or (:message error) "Login failed.")))})
-
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
-      {:fx [[:auth.session/store {:token (:token value)}]]})}   ;; an fx, not a side-effect
+      {:fx [[:auth.session/store {:token (:token value)}]]})}
 
    :states
    {:idle
     {:on {:auth.login/submit {:target :submitting
                               :guard  :form-valid?
                               :action :clear-error}}}
-
     :submitting
     {:on {:auth.login/success {:target :authed :action :store-session}
           :auth.login/failure [{:target :error-shown
                                 :guard  :under-retry-limit
                                 :action :record-error}
                                {:target :locked-out}]}}
-
     :error-shown
     {:on {:auth.login/dismiss {:target :idle}
           :auth.login/submit  {:target :submitting :guard :form-valid?}}}
-
-    :authed     {:meta {:terminal? true}}      ;; resting states — :meta is a tooling hint,
-    :locked-out {:meta {:terminal? true}}}})   ;; NOT :final? (which would auto-destroy the machine)
+    :authed     {:meta {:terminal? true}}
+    :locked-out {:meta {:terminal? true}}}})
 ```
 
-The `:auth.login/failure` arrow is now a **list of candidates** — the runtime takes the first whose guard passes. Under the retry limit, a failure records the error and shows it; past it, the unguarded candidate wins and the machine locks out.
+`:auth.login/failure` is a **vector of candidates** — first guard that passes wins.
+After three failures, `:under-retry-limit` fails and the unguarded candidate locks
+out.
 
-**What you see:** drive a failure and watch `:data` change.
+!!! note "`:data` merges"
+
+    `{:data {:error nil}}` changes only `:error`. It does not replace the whole map.
+    Details: [The model → effect map](concepts.md#the-effect-map-data-fx).
 
 ```clojure
 (rf/dispatch [:auth.login/flow [:auth.login/submit {:email "a@b.com" :password "x"}]])
-(rf/dispatch [:auth.login/flow [:auth.login/failure {:failure {:message "nope"}}]])
+(rf/dispatch [:auth.login/flow [:auth.login/failure {:error {:message "nope"}}]])
 @(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :error-shown :data {:attempts 1 :error "nope"}}
 ```
 
-Keep submitting and failing. The first three failures each land in `:error-shown` with `:attempts` climbing `1 → 2 → 3`. On the fourth, `:under-retry-limit` returns false, the guarded candidate is skipped, and the machine settles in `:locked-out`.
-
-!!! note "`:data` is a merge, not a replace"
-
-    — `:clear-error` changes only `:error`, leaving `:attempts` alone. [Concepts → The action effect map](concepts.md#the-action-effect-map--data-fx) has the sharp edges.
-
 ## Step 4 — talk to a real server
 
-So far you've moved the machine by hand-dispatching `:auth.login/success` / `:auth.login/failure`. Now make `:submitting` actually call the server and let the reply drive the machine.
-
-Give `:submitting` an `:entry` action — it runs the moment the state is entered — that fires [managed HTTP](../async/http.md). Name the reply events as *machine-wrapped* events, and the reply loops straight back in. Add a `:record-timeout` action for the deadline case:
+Add an **`:entry`** action on `:submitting` that fires [managed HTTP](../async/http.md),
+and an **`:after`** deadline if the server stalls:
 
 ```clojure
 :actions
-{;; …clear-error, record-error, store-session as in Step 3…
+{;; … clear-error, record-error, store-session …
 
  :issue-request
  (fn [{[_ creds] :event}]
@@ -198,27 +185,28 @@ Give `:submitting` an `:entry` action — it runs the moment the state is entere
 ```clojure
 :submitting
 {:tags  #{:auth/busy}
- :entry :issue-request                                          ;; fire the request on entry
- :after {8000 {:target :error-shown :action :record-timeout}}  ;; …or give up after 8s
+ :entry :issue-request
+ :after {8000 {:target :error-shown :action :record-timeout}}
  :on    {:auth.login/success {:target :authed :action :store-session}
-         :auth.login/failure [{:target :error-shown :guard :under-retry-limit :action :record-error}
+         :auth.login/failure [{:target :error-shown
+                               :guard  :under-retry-limit
+                               :action :record-error}
                               {:target :locked-out}]}}
 ```
 
-Look at `:on-success [:auth.login/flow [:auth.login/success]]` — the machine id outside, the inner event inside, written one element short on purpose. When the request returns, managed HTTP *appends* its reply to that inner event, so what actually arrives is `[:auth.login/success {:value {:token "…"}}]` — exactly what `:store-session` destructures. A machine and an async effect compose with no glue code in between.
+`:on-success [:auth.login/flow [:auth.login/success]]` is written one element short
+on purpose — managed HTTP **appends** the reply map onto the inner event, so
+`:store-session` sees `[:auth.login/success {:value {:token "…"}}]`.
 
-The `:after` is a declarative timer: it arms when you enter `:submitting` and cancels the moment you leave. If the reply lands first, the timer is cancelled; if 8 seconds pass first, the machine records a timeout and shows the error. No `setTimeout`, no cancel flag.
-
-!!! note "Do, then observe"
-
-    Dispatch a submit with [Xray](../xray/index.md) open. The request leaves; when the reply returns, the transition shows up as an ordinary event row — snapshot before and after — riding the same trace stream as everything else.
+`:after` arms on entry and cancels on exit. No `setTimeout`, no cancel flag.
+Deeper timer grammar: [Automatic transitions](automatic-transitions.md).
 
 ## Step 5 — render every state
 
-A view reads the snapshot and shows the right thing for each state. Inside `reg-view` you call `subscribe` unprefixed — the macro binds it to this view's frame for you. (Outside a view, reach through the facade: `rf/subscribe`, `rf/dispatch`.) Read small projections off the snapshot, and ask the machine a *question* rather than naming a state:
+Project the snapshot; ask **tags** for shared intent ("busy?") instead of listing
+state names:
 
 ```clojure
-;; Two small projections off the snapshot — ordinary subscriptions.
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]
   (fn [m _] (:state m)))
@@ -237,26 +225,15 @@ A view reads the snapshot and shows the right thing for each state. Inside `reg-
       :error-shown [:div [:p error] [:button "Try again"]]
       :authed      [:h1 "Welcome back"]
       :locked-out  [:h1 "Account locked"]
-      [:p "…"])))                          ;; nil state — before the first event
+      [:p "…"])))   ;; nil before first event
 ```
 
-For that `busy?` read to work, tag the busy state. A **tag** is a label on a state node; the view asks "is this tag set?" rather than hard-coding which states count as busy:
+The `:auth/busy` tag on `:submitting` is why `busy?` works — add another in-flight
+state later and the view keeps working. Pattern: [Tags](tags.md).
 
-```clojure
-:submitting {:tags  #{:auth/busy}
-             :entry :issue-request
-             ;; …the rest as in Step 4…}
-```
+## Step 6 — test a transition as a pure function
 
-**What you see:** the page shows **Sign in**; a valid submit moves it to **Signing in…**; the reply lands you on **Welcome back** or the error; and a fourth failure swaps in **Account locked**.
-
-!!! note "Why a tag, not a state name?"
-
-    Add a sixth state that's also "busy" later — `:retrying`, say — and a view that branches on the `:auth/busy` tag picks it up with zero changes. Asking *what's true* scales; enumerating state names doesn't. [Tags](tags.md) is the whole pattern.
-
-## Step 6 — test it: a transition is a pure function
-
-Here's the payoff. A transition is a pure function of *(table, snapshot, event)* — no frame, no browser, no network. `machine-transition` runs exactly one, and hands back a result you destructure:
+No frame, no browser, no network:
 
 ```clojure
 (ns app.login-test
@@ -266,20 +243,26 @@ Here's the payoff. A transition is a pure function of *(table, snapshot, event)*
             [app.login :refer [login-flow]]))
 
 (deftest login-flow-test
-  ;; a valid submit enters :submitting and fires the request fx
   (let [{snap ::result/snap fx ::result/fx}
         (machines/machine-transition login-flow
-                                     {:state :idle :data {:attempts 0 :error nil}}
-                                     [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+          {:state :idle :data {:attempts 0 :error nil}}
+          [:auth.login/submit {:email "a@b.com" :password "secret"}])]
     (is (= :submitting (:state snap)))
-    (is (= :rf.http/managed (ffirst fx))))         ;; :entry ran :issue-request
+    (is (= :rf.http/managed (ffirst fx))))   ;; :entry ran :issue-request
 
-  ;; at the retry limit, a failure routes to :locked-out instead of :error-shown
   (let [{snap ::result/snap}
         (machines/machine-transition login-flow
-                                     {:state :submitting :data {:attempts 3 :error nil}}
-                                     [:auth.login/failure {:failure {:message "bad creds"}}])]
+          {:state :submitting :data {:attempts 3 :error nil}}
+          [:auth.login/failure {:error {:message "bad creds"}}])]
     (is (= :locked-out (:state snap)))))
 ```
 
-Feed in a snapshot and an event; assert on what comes back. The result is a value — `::result/snap` / `::result/fx`, or `result/ok?` / `result/fail?` (a throwing action is a *failure value*, not an exception out of your test). It runs on the JVM in microseconds — exactly the testing experience you want for the flows where testing usually gets hard. [Inspecting and testing machines](inspecting-machines.md) goes deeper: the Result accessors, asserting effects as data, and the three test levels.
+More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
+
+## What you built
+
+A single data value that owns login lifecycle, pure enough to unit-test, wired to
+HTTP and views through ordinary re-frame2 events and subscriptions. The rest of this
+section deepens the grammar when a flat table is no longer enough — start with
+[The model](concepts.md) if you want vocabulary, or [Hierarchical states](hierarchical-states.md)
+when a state needs sub-states.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,10 +239,12 @@ nav:
     - "Tutorial: login machine": machines/tutorial.md
     - "The model": machines/concepts.md
     - "Growing the table":
+      # Tags and automatic transitions work on flat machines (tutorial uses both).
+      # Hierarchy / parallel / history / actors build on the flat model next.
       - "Tags": machines/tags.md
+      - "Automatic transitions": machines/automatic-transitions.md
       - "Hierarchical states": machines/hierarchical-states.md
       - "Parallel regions": machines/parallel-states.md
-      - "Automatic transitions": machines/automatic-transitions.md
       - "History": machines/history.md
       - "Actors": machines/actors.md
     - "Operating":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,19 +233,23 @@ nav:
     - "re-frame.test-helpers": api/re-frame.test-helpers.md
 
   - Machines:
+    # Landing routes; tutorial first (build), then the flat model, then
+    # growth features in order of dependency, then operate / migrate.
     - machines/index.md
-    - "Tutorial: build a login machine": machines/tutorial.md
-    - "Concepts": machines/concepts.md
-    - "Tags": machines/tags.md
-    - "Automatic transitions": machines/automatic-transitions.md
-    - "Hierarchical states": machines/hierarchical-states.md
-    - "Parallel states": machines/parallel-states.md
-    - "History": machines/history.md
-    - "Actors": machines/actors.md
-    - "Inspecting and testing": machines/inspecting-machines.md
-    - "Examples": machines/examples.md
-    - "Glossary": machines/glossary.md
+    - "Tutorial: login machine": machines/tutorial.md
+    - "The model": machines/concepts.md
+    - "Growing the table":
+      - "Tags": machines/tags.md
+      - "Hierarchical states": machines/hierarchical-states.md
+      - "Parallel regions": machines/parallel-states.md
+      - "Automatic transitions": machines/automatic-transitions.md
+      - "History": machines/history.md
+      - "Actors": machines/actors.md
+    - "Operating":
+      - "Inspecting and testing": machines/inspecting-machines.md
+      - "Examples": machines/examples.md
     - "Coming from XState": machines/coming-from-xstate.md
+    - "Glossary": machines/glossary.md
 
   - Resources:
     # Tutorial first (build something real), then the model, then task


### PR DESCRIPTION
## Summary

Progressive rewrite of the Machines guide so readers build a login machine first, then learn the flat model, then open growth pages (tags, automatic transitions, hierarchy, parallel, history, actors).

- Tutorial-first nav with **Growing** / **Operating** nesting in MkDocs
- Slim **The model** page; restore self-transition / wildcard / cofx examples where needed
- Completeness pass: correct has-tag subscription docs (no function sugar), deterministic actor ids (not gensym), HTTP success envelope shape, pure-test Result accessors

## Test plan

- [ ] Spot-check Machines nav in MkDocs (tutorial → model → growth → inspect/examples)
- [ ] Open tutorial complete machine + model effect map claims
- [ ] Confirm relative links under `docs/machines/`
