### PR TITLE
docs(resources): progressive guide rewrite

### DIFF
--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -180,7 +180,7 @@ A mutation is the causal-WRITE counterpart of a resource: a named write to remot
 
 > **Mutation `:scope` is not fail-closed.** A resource read's `:scope` is required and fails closed. A mutation's `:scope` is optional: it resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it MUST match the scope of the resources the write changes. A write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead. It silently misses the scoped entries — stale reads, no error. Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site. The `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
 
-**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Guide ch.27 §Optimistic writes](../resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile)):
+**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Invalidate after a mutation](../resources/how-to/invalidate-after-a-mutation.md) / [model § mutations](../resources/concepts.md#writes-invalidate-by-tag--causally)):
 
 - `:optimistic` — a registration-level forward plan applied **before** the server confirms. It is the twin of `:patches`, with signature `(fn [params] → {target patch-fn})`. There is no `result` arg; the reply does not exist yet.
 - `:optimistic-tags` — its tag-addressed twin for cross-view consistency.
@@ -344,7 +344,7 @@ A resource may declare an optional `:poll-interval-ms` policy. While an entry ha
   (fn [_ _ctx] {:request {:method :get :url "/notifications/unread"} :decode :json}))
 ```
 
-Semantics (per [Guide ch.27 §Polling](../resources/concepts.md#polling-keep-this-fresh-every-n-ms)):
+Semantics (per [The model — owners and refetch](../resources/concepts.md#owners-and-causes-and-the-refetch-rules)):
 
 - **Positive integer ms; non-positive / absent = no polling.** The poll timer is the third member of the freshness-timer family (beside `:stale-after-ms` / `:gc-after-ms`).
 - **Unconditional active-owner tick.** A tick refetches by the interval, not gated on `:stale?`. `:stale-after-ms` stays the orthogonal focus/route-entry knob. (Structural sharing keeps views quiet when an unchanged response comes back.)
@@ -357,7 +357,7 @@ A "just polling" view with no natural route/machine owner needs an app-minted `[
 
 ## Infinite resources
 
-An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021](../EP/EP-0021-infinite-resources.md); the tutorial is [Guide ch.27 §Infinite feeds](../resources/concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`. The user accumulates pages — 1, then 1+2, then 1+2+3 — rendered as one growing list. The *next* page param is derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal; an app picks per feed.
+An infinite resource is the load-more / infinite-scroll feed kind (see [EP-0021](../EP/EP-0021-infinite-resources.md); the recipe is [Paginate a feed](../resources/how-to/paginate-a-feed.md)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`. The user accumulates pages — 1, then 1+2, then 1+2+3 — rendered as one growing list. The *next* page param is derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal; an app picks per feed.
 
 ```clojure
 (rf/reg-resource :feed/timeline
@@ -409,7 +409,7 @@ These direct functions are the tool/test projection lane, not an app-read API:
 - `resource-meta` / `mutation-meta` project the **registration** (the registered spec).
 - `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame.
 
-They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions — they do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
+They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions — they do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [The model — three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
 
 `:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md)). There is no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed.
 

--- a/docs/resources/coming-from-tanstack-query.md
+++ b/docs/resources/coming-from-tanstack-query.md
@@ -1,5 +1,9 @@
 # Coming from TanStack Query
 
+This page is a **translation**, not a tutorial. For a first resource in re-frame2,
+use the [RealWorld tutorial](tutorial/index.md) (from Part 2) and [the model](concepts.md).
+Here: vocabulary mapping and deliberate divergences.
+
 If you've shipped a React app in the last few years, you've almost certainly reached for TanStack Query (née React Query). You know the move: stop hand-rolling `useEffect` + loading flags, declare a keyed async read, and let a library own the cache, the dedupe, the staleness, and the refetch. SWR and RTK Query are the same instinct wearing different hats.
 
 re-frame2's [resources](concepts.md) capability is that instinct, ported to a data-oriented Clojure world. The core idea transfers almost completely: **a keyed cache of server reads, with staleness, request deduplication, tag-based invalidation, and garbage collection.** If you hold that model, you already understand 80% of resources. This page maps the vocabulary so the remaining 20% lands fast — and then spends most of its words on the handful of places re-frame2 deliberately walked away from the TanStack design, because *that's* the interesting part.

--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -96,9 +96,22 @@ On entry the runtime **ensures** the resource with the route as **owner**; on le
 releases. `:blocking? true` holds the transition until the read settles (also an SSR
 wait point).
 
-Other causes: `(dispatch [:rf.resource/ensure {…}])`, a machine-owned ensure, a manual
-refresh (`:rf.resource/refetch`). Same entry, different **cause** recorded for the
-trace.
+Other causes use the same entry with a different **cause** recorded for the trace:
+
+```clojure
+;; Explicit ensure from a handler (app-minted owner lease — release on leave)
+(rf/dispatch [:rf.resource/ensure
+              {:resource :realworld/article
+               :params   {:slug "hello"}
+               :owner    [:lease :article-page]
+               :cause    [:event :article/opened]}])
+
+;; Pull-to-refresh — new generation, no owner
+(rf/dispatch [:rf.resource/refetch
+              {:resource :realworld/article
+               :params   {:slug "hello"}
+               :cause    [:manual :article/refresh]}])
+```
 
 ??? info "Coming from TanStack Query?"
 
@@ -219,9 +232,29 @@ Resolve the old scope **before** stripping auth from `db`.
 | Explicit refetch | New generation; supersedes in-flight |
 | Cancel vs stale reply | Abort if possible; generation check always suppresses stale replies |
 
-Focus revalidation is opt-in: `(rf/install-revalidation-listeners! frame-id)`.
-Polling is `:poll-interval-ms` on the resource — owner-driven, pauses when the tab
-is hidden.
+Focus revalidation is opt-in: `(rf/install-revalidation-listeners! frame-id)` —
+refetches only entries that are **stale and still owned**.
+
+Polling is a registration key — owner-driven, pauses when the tab is hidden:
+
+```clojure
+(rf/reg-resource :dashboard/build-status
+  {:scope            :rf.scope/global
+   :params-schema    [:map [:repo :string]]
+   :poll-interval-ms 5000
+   :tags             (fn [_ _] #{[:build]})}
+  (fn [{:keys [repo]} _ctx]
+    {:request {:method :get :url (str "/repos/" repo "/build")}
+     :decode  :json}))
+```
+
+Three freshness tools, three questions:
+
+| Tool | Question |
+|---|---|
+| `:poll-interval-ms` | Changes on its own — keep fresh on a clock |
+| Focus revalidation | User came back — refresh stale owned data |
+| Mutation `:invalidates` | *This* write made *that* read wrong |
 
 ## Routes with several resources
 
@@ -258,12 +291,24 @@ remembered in `onSuccess`:
 ```
 
 Success plan arms (fixed order): `:populates` → `:patches` → `:removes` →
-`:invalidates`. Execute with `[:rf.mutation/execute …]`; watch with
-`[:rf/mutation …]` / `mutation-state`.
+`:invalidates`.
+
+Execute and watch (instance id is app-chosen — reuse it for the sub):
+
+```clojure
+(rf/dispatch [:rf.mutation/execute
+              {:mutation :realworld/favorite
+               :params   {:slug "hello"}
+               :instance [:ui :favorite "hello"]
+               :cause    [:click :article/favorite]}])
+
+@(rf/subscribe [:rf/mutation {:instance [:ui :favorite "hello"]}])
+;; => {:status :pending …} then :success / :error
+```
 
 **Scope footgun.** Invalidation matches only entries **in the scopes you name**.
-Wrong scope ⇒ silent miss (dev warning). Recipe and optimistic writes:
-[Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
+Wrong scope ⇒ silent miss (dev warning). Recipe, populate/patch arms, and optimistic
+writes: [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
 
 ??? info "Coming from TanStack Query?"
 
@@ -280,6 +325,43 @@ the viewer" to "served another user's cache." Named ids live in the
 [API](../api/re-frame.resources.md) and error catalogue; [testing](testing.md)
 turns the same failures into assertions.
 
+## A complete read loop
+
+Register → route causes → view projects. Copy-paste skeleton:
+
+```clojure
+(ns app.articles
+  (:require [re-frame.core :as rf]
+            [re-frame.resources]
+            [re-frame.http.managed]
+            [re-frame.routing]))
+
+(rf/reg-resource :app/article
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :stale-after-ms 60000
+   :tags          (fn [{:keys [slug]} _] #{[:article slug] [:article-list]})}
+  (fn [{:keys [slug]} _ctx]
+    {:request {:method :get :url (str "/api/articles/" slug)}
+     :decode  :json}))
+
+(rf/reg-route :app/article
+  {:params    [:map [:slug :string]]
+   :resources [{:resource  :app/article
+                :params    (fn [route] {:slug (get-in route [:params :slug])})
+                :blocking? true}]}
+  "/articles/:slug")
+
+(rf/reg-view article-page []
+  (let [slug  (get @(rf/subscribe [:rf.route/params]) :slug)  ;; or your route projection
+        state @(rf/subscribe [:rf/resource {:resource :app/article
+                                            :params   {:slug slug}}])]
+    (cond
+      (:loading? state) [skeleton]
+      (:error state)    [error-panel (:error state)]
+      :else             [article-body (:data state)])))
+```
+
 ## Advanced (elsewhere)
 
 | Topic | Where |
@@ -288,6 +370,7 @@ turns the same failures into assertions.
 | Optimistic UI, patches, populate | [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md) |
 | SSR / hydration of the cache | [SSR concepts](../ssr/concepts.md) + tutorial Part 2 |
 | Full RealWorld build | [Tutorial](tutorial/index.md) |
+| Prove the cache in tests | [Testing](testing.md) |
 
 <a id="infinite-feeds-accumulate-pages-with-infinite"></a>
 <a id="ssr-and-hydration"></a>
@@ -295,6 +378,7 @@ turns the same failures into assertions.
 <a id="the-full-read-and-command-surface"></a>
 <a id="polling-keep-this-fresh-every-n-ms"></a>
 <a id="logout-is-one-causal-event"></a>
+<a id="running-a-mutation-and-reading-its-state"></a>
 
 ## When resources are the wrong tool
 

--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -1,67 +1,89 @@
-# Server state: resources
+# The model
 
-Your app shows articles, feeds, profiles. That data's real home is a server, so what you hold on the client is only ever a copy — and that copy starts going stale the moment it arrives. **Server state is the state your app doesn't own — hold it as a declared, inspectable cache, not a private fetch.**
+Server state is data your app **does not own** — a declared, inspectable cache, not a
+private fetch inside each view. This page is the **core model**: register a read,
+cause a fetch, project five statuses, scope the cache, and declare writes that
+invalidate by tag.
 
-This page builds that idea up one step at a time. We'll register a single server read, trigger a fetch from a route, read the result passively from a view, and render the five statuses the read can be in. Once that loop is solid we'll layer on the harder questions — whose cache is this, what happens at logout, how a write keeps reads honest — each with a small example first. It's the full model behind what [Part 2 of the tutorial](tutorial/02-server-data.md) builds, and the page the rest of this section leans on for definitions.
+To *build* Conduit end to end, use the [tutorial](tutorial/index.md). Task recipes:
+[paginate](how-to/paginate-a-feed.md), [invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
 
 ??? info "Coming from TanStack Query?"
 
-    You already know the shape: a keyed cache of server reads with staleness, request deduplication, invalidation, and garbage collection. (RTK Query and SWR are the same family.) Keep that mental model — it carries you most of the way. Three deliberate differences are flagged as `> **Coming from TanStack Query?**` callouts as we go: views never fetch, scope is a required key segment, and invalidation is causal rather than an imperative call you remember to make.
+    Keep the mental model of a keyed cache with staleness and invalidation. Three
+    deliberate differences show up below: views never fetch; scope is a required key
+    axis; invalidation is declared on the mutation, not an `onSuccess` call you
+    remember. Full mapping: [Coming from TanStack Query](coming-from-tanstack-query.md).
 
-!!! note "Resources are optional — don't reach for them on day one"
+!!! note "Optional artefact"
 
-    Resources ship as a separate, opt-in library (the Maven coordinate `day8/re-frame2-resources`; you switch it on by requiring `re-frame.resources` once at boot). An app with one or two reads is perfectly happy with [a managed HTTP request](../async/http.md) and a small [app-db](../core/glossary.md#app-db) slice, and that's the simpler choice. Reach for resources when cached server reads start *multiplying*; [Where should this value live?](../core/where-state-lives.md) has the decision table.
+    Require `re-frame.resources` (and usually `re-frame.http.managed`) once at boot —
+    Maven coordinate `day8/re-frame2-resources`. An app with one or two reads is often
+    happier with [managed HTTP](../async/http.md) alone.
 
 ## The cache you don't own
 
-Every SPA answers the same five questions, usually privately and re-decided per feature. Where does the cached copy live? When is it stale? Who may refetch it? What happens when two screens want the same data at once? And how does logout stop the next user from reading this user's cache?
+<a id="the-cache-you-dont-own"></a>
 
-A **[resource](glossary.md#resource)** — a named server read you register once — turns those five private answers into declared data: a cache scope, a params schema, a request, and a staleness policy, all in one place. The runtime then owns everything between the declaration and the pixels.
+A **[resource](glossary.md#resource)** answers five questions that SPAs usually re-decide
+per feature: where the copy lives, when it is stale, who may refetch, how concurrent
+readers share one request, and how logout stops a cross-user leak.
 
-That cache lives in **[runtime-db](../core/glossary.md#runtime-db)** — the framework-owned half of a [frame](../core/glossary.md#frame) (one running instance of your app), addressed by the projection path `:rf.db/runtime`. The resource cache is one runtime-db subsystem, addressed `:rf.runtime/resources`; [app-db](../core/app-db.md) introduces [the two partitions](../core/glossary.md#the-two-partitions) in full. It is **not** your app-db — so an ordinary [event handler](../core/glossary.md#event-handler) can't reach in and wipe it by accident. You read it through [subscriptions](../core/glossary.md#subscription) and change it only through [events](../core/glossary.md#event). Same in / out discipline as the rest of re-frame2; only the storage moved next door.
+That cache lives in **[runtime-db](../core/glossary.md#runtime-db)** (path
+`:rf.runtime/resources`), not [app-db](../core/app-db.md). Ordinary handlers cannot
+wipe it by accident. You change it only through [events](../core/glossary.md#event)
+and read it through [subscriptions](../core/glossary.md#subscription).
 
-??? info "From re-frame v1"
+## Register a resource
 
-    You hand-built this: an event fires the HTTP effect, writes a `{:status :data :error}` slice into app-db, and a sub reads it back. Resources keep that causal shape — reads are subs, fetches are events — and move the per-read bookkeeping into the framework.
+<a id="your-first-resource-register-it"></a>
 
-## Your first resource: register it
-
-A resource is *a subscription you read and a cause you fire.* That one sentence is the whole model. (A **cause** is just an event that triggers a fetch — a route entry, a click, a write. We say "cause" rather than "trigger" because re-frame2 records *why* every fetch happened; more on that below.) And the simplest possible resource fits on a screen — you register the read once, at boot:
+A resource is *a subscription you read and a cause you fire* — two different jobs.
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/resources.cljs
+;; cf. examples/real-apps/realworld_resources/resources.cljs
 (ns app.resources
   (:require [re-frame.core :as rf]
-            [re-frame.http.managed]    ;; the managed-HTTP transport
-            [re-frame.resources]))     ;; boots the optional artefact
+            [re-frame.http.managed]
+            [re-frame.resources]))
 
 (rf/reg-resource :realworld/article
   {:params-schema [:map [:slug :string]]
-   :scope         :rf.scope/global}       ;; REQUIRED — an explicit, auditable claim
+   :scope         :rf.scope/global}       ;; REQUIRED — whose cache?
   (fn [{:keys [slug]} _ctx]
     {:request {:method :get
                :url    (str "/api/articles/" slug)}
      :decode  :json}))
 ```
 
-Two keys carry the minimum model. `:params-schema` defines the read's *identity*: every variable that changes the server's answer — the slug, the page number, a filter — must live in params. `:scope` declares *whose* cache this is; `:rf.scope/global` is the claim "every viewer gets the same answer" (we'll meet viewer-relative scope shortly). The function in the third slot describes the request itself — method, url, `:decode`.
+Strict **three-slot** grammar: `(reg-resource id metadata request-fn)`. Putting the
+request fn in the metadata map is `:rf.error/resource-bad-spec`.
 
-`reg-resource` records a handler in the [registrar](../core/glossary.md#registrar), exactly like `reg-event` or `reg-sub` does. It does **not** fetch anything, and it does **not** read any cache; it only teaches the runtime *how* to. The cache fills only when a *cause* fires, and a [view](../core/glossary.md#view) only ever sees it through a subscription.
+| Metadata key | Role |
+|---|---|
+| `:params-schema` | **Required.** Malli schema of params — the read's identity |
+| `:scope` | **Required.** `:rf.scope/global`, `{:from-db resolver-id}`, or `:rf.scope/from-caller` |
+| `:tags` | `(fn [params data] #{…})` — facts this data is about (for invalidation) |
+| `:stale-after-ms` | Freshness window; next ensure refetches after this |
+| `:gc-after-ms` | Lifetime after last owner leaves (default 5 min; `:never` to pin) |
+| `:poll-interval-ms` | Clocked re-read while owned and tab visible |
+| `:infinite` | `true` → load-more feed kind ([paginate how-to](how-to/paginate-a-feed.md)) |
 
-!!! warning "Gotcha — the metadata is the middle slot; the request is the third"
+The request fn describes the **domain** request only. It must **not** set
+`:request-id`, `:on-success`, or `:on-failure` — the runtime owns reply addressing
+(stale-reply suppression). Cross-cutting headers live in `reg-http-interceptor`.
 
-    The shape is a strict 3-slot grammar: `(rf/reg-resource resource-id metadata request-fn)`. The `:request` fetch function is the **third** slot, *never* a `:request` key inside the metadata map. Putting it in the metadata is a loud `:rf.error/resource-bad-spec`, not a silent no-op. `reg-mutation` (later) follows the same three-slot shape.
+`reg-resource` does not fetch. It only teaches the runtime *how* to.
 
-!!! warning "Gotcha — the `_ctx` second argument is reserved, currently `nil`"
+## Cause a fetch
 
-    Every author-supplied function this artefact calls (`:request`, a scope resolver's resolver fn) receives a trailing `ctx` that is **literal nil** in this slice — declared for forward-compatibility, not to be relied on. Derive your request from `params` and your scope from declared `:inputs`, never from `ctx`. (The one exception is a route-resource `:params` / `:scope` / `:when` function, which carries a populated route context, because route-entry planning has a real match to thread.)
+<a id="cause-it-to-fetch-from-a-route"></a>
 
-## Cause it to fetch from a route
-
-The cleanest cause is the page itself, because a page already knows what data it needs. `:resources` is [route](../routing/glossary.md#route) metadata that says, in effect, "this page needs this server state":
+The cleanest cause is the **page**. Route metadata `:resources` means "this page needs
+this server state":
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/routing.cljs
+;; cf. examples/real-apps/realworld_resources/routing.cljs
 (rf/reg-route :realworld/article
   {:params    [:map [:slug :string]]
    :resources [{:resource  :realworld/article
@@ -70,27 +92,29 @@ The cleanest cause is the page itself, because a page already knows what data it
   "/articles/:slug")
 ```
 
-On entry, the runtime ensures the resource with the route as its **owner** — the thing keeping the cache entry alive. On leave, or on a superseding navigation, it releases it. `:blocking? true` holds the route transition until that read settles (which also hands server-side rendering a natural wait point); a non-blocking resource fetches in the background instead.
+On entry the runtime **ensures** the resource with the route as **owner**; on leave it
+releases. `:blocking? true` holds the transition until the read settles (also an SSR
+wait point).
 
-Navigate to an article page with [Xray](../core/glossary.md#xray) (the dev inspector) open and you can watch the whole [pipeline run](../core/glossary.md#run): the route-entry event row shows the ensure it caused, and the Resources panel shows the entry move from `:idle` through `:loading` to `:loaded`. Visit the same article a second time and you get a cache hit — no network row at all.
+Other causes: `(dispatch [:rf.resource/ensure {…}])`, a machine-owned ensure, a manual
+refresh (`:rf.resource/refetch`). Same entry, different **cause** recorded for the
+trace.
 
 ??? info "Coming from TanStack Query?"
 
-    Difference one of three: **views never fetch.** With `useQuery`, the component fetches on mount. Here a *route entry or event* causes the fetch; the view only reads. That separation is what lets the same view render on the server, in a test, or after a cache hit with no network at all — the render never has a side effect hiding inside it.
+    **Views never fetch.** A route or event causes the load; the view only reads. That
+    is what lets the same view render on the server, in a test, or on a cache hit.
 
-??? info "From re-frame v1"
+## Project: five statuses
 
-    A route containing `:resources` only validates because the resources artefact teaches the router about that key. The router rejects unknown bare route-metadata keys by default — so if you forget to `(:require [re-frame.resources])` at boot, a route with `:resources` is correctly rejected at registration. That's the [fail-loud](../core/glossary.md#fail-loud-not-silent) ethos: a typo'd or un-loaded feature fails at registration, not as a mysterious empty page. `:resources` sits *beside* `:on-match` (still the canonical hook for arbitrary route-entry work), not in place of it.
-
-## Read it from a view
-
-A view reads the entry passively, through an ordinary subscription, and never fetches. The `:rf/resource` subscription hands you a single ready-to-render map — a *view-model* carrying everything the view needs to decide what to show:
+<a id="read-it-from-a-view"></a>
+<a id="what-a-view-sees-five-statuses"></a>
+<a id="three-lanes--registering-causing-projecting"></a>
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/views.cljs
 (rf/reg-view article-page [slug]
   (let [state @(rf/subscribe [:rf/resource {:resource :realworld/article
-                                                  :params   {:slug slug}}])]
+                                            :params   {:slug slug}}])]
     (cond
       (:loading? state)                              [article-skeleton]
       (and (:error state) (not (:has-data? state)))  [article-error (:error state)]
@@ -101,152 +125,58 @@ A view reads the entry passively, through an ordinary subscription, and never fe
        [article-view (:data state)]])))
 ```
 
-That three-branch `cond` is the canonical render shape, and the next section explains the statuses it's switching on. The thing to notice now is that the view does nothing but *read and render* — no fetch, no effect.
-
-??? info "Coming from TanStack Query?"
-
-    There is no `:select` key, and that's deliberate. `useQuery` lets you pass `select` to derive a slice. Here a projection is just an ordinary subscription layered over `[:rf.resource/data …]`, the same way you'd derive anything else in [the derivation graph](../core/glossary.md#the-derivation-graph) — which already gives you memoised, shared, re-render-minimal derivations for free. A query-local `:select` would be a worse version of a thing you already have.
-
-!!! warning "Gotcha — no subscription ever fetches"
-
-    This is the rule that surprises query-library refugees most. A subscription that finds no entry reads `:idle` and *stays* `:idle` until a route entry, an event, or a [machine](../machines/glossary.md#machine) causes the fetch. So "I registered the resource but my view is a permanent skeleton" almost always means a cause hasn't fired yet — you're missing a cause, not a sub.
-
-### Three lanes — registering, causing, projecting
-
-Those three steps you just wrote are three different jobs, and the whole surface gets easier to hold once you stop reading them as competing APIs. **Registering a resource is not the same as reading its state, and neither is the same as causing it to fetch:**
-
-| Lane | What it does | The spelling | Who uses it |
-|---|---|---|---|
-| **Register** | Declare the handler, once, at boot | `(rf/reg-resource …)` / `(rf/reg-mutation …)` — plain functions | Author |
-| **Cause** | Make a fetch or a write happen | `(rf/dispatch [:rf.resource/ensure …])`, `[:rf.mutation/execute …]` — event vectors | Routes, events, machines |
-| **Project (app read)** | Read the runtime state into a view | `@(subscribe [:rf/resource …])` — subscription vectors | Views |
-
-A route's `:resources` is one *cause* spelling; dispatching `[:rf.resource/ensure {:resource :realworld/article :params {:slug "welcome"} :cause [:event :article/opened]}]` from an event handler is another. Both make the same entry fetch.
-
-## What a view sees: five statuses
-
-The `:rf/resource` subscription projects one view-model with five statuses. Learn these five and the render `cond` above stops being mysterious:
-
 | `:status` | Meaning | Show |
 |---|---|---|
-| `:idle` | No load attempted | Nothing, or a placeholder |
-| `:loading` | First load, no usable data yet | A skeleton |
-| `:fetching` | Refreshing while prior data stays visible | The data, plus a quiet refresh indicator |
-| `:loaded` | Usable data present (possibly stale) | The data |
-| `:error` | First load failed — no usable data | An error |
+| `:idle` | No load attempted | Placeholder |
+| `:loading` | First load, no usable data | Skeleton |
+| `:fetching` | Refresh while prior data stays | Data + quiet indicator |
+| `:loaded` | Usable data (maybe stale) | Data |
+| `:error` | First load failed | Error |
 
-Two invariants keep views simple. First, **`:error` is reserved for first-load failure.** A failed *background* refresh keeps the entry `:loaded` with its prior data and records the failure separately in `:refresh-error`, so users keep reading last-known-good data straight through a flaky network. Second, **freshness is orthogonal to status.** A `:loaded` entry may well be stale; staleness only decides whether the next ensure refetches, not what the view renders now.
+**Invariants.** `:error` is first-load only — a failed background refresh keeps
+`:loaded` and records `:refresh-error`. Freshness is orthogonal to status. Prefer
+the booleans (`:loading?`, `:has-data?`, …) over re-deriving rules from `:status`.
 
-The derived booleans — `:loading?`, `:fetching?`, `:has-data?`, `:stale?` — exist so a view never has to reverse-engineer those two rules. That's why the canonical `cond` reads them directly rather than matching on `:status`.
+!!! warning "No subscription ever fetches"
 
-??? note "Going deeper"
+    Missing cause ⇒ permanent `:idle` / skeleton. You are missing a route
+    `:resources` or an ensure, not a sub.
 
-    That status enum is the *data lifecycle* only — a real page renders from this cache entry *plus* its own app-db (cardinality, form, and domain state), so the page's render decision is one derivation over both. [Part 2](tutorial/02-server-data.md) builds that full set of nine page states.
+### Three lanes
 
-## The full read and command surface
-
-You now have the working loop. Here is the rest of the vocabulary, in one place, for when the simple case isn't enough.
-
-**Reads** are subscription vectors — all passive, all taking the same `{:resource :scope :params}` key. `:rf/resource` is the one you'll reach for most, but the narrower projections exist so a view can subscribe to *just* the fact it cares about and re-render only when *that* fact changes:
-
-```clojure
-[:rf/resource         {:resource … :scope … :params …}]  ;; the whole view-model
-[:rf.resource/data          {:resource … :scope … :params …}]  ;; just :data
-[:rf.resource/status        {:resource … :scope … :params …}]  ;; the status keyword
-[:rf.resource/loading?      {:resource … :scope … :params …}]
-[:rf.resource/fetching?     {:resource … :scope … :params …}]
-[:rf.resource/stale?        {:resource … :scope … :params …}]
-[:rf.resource/error         {:resource … :scope … :params …}]
-[:rf.resource/refresh-error {:resource … :scope … :params …}]
-[:rf.resource/has-data?     {:resource … :scope … :params …}]
-[:rf.resource/previous-data {:resource … :scope … :params …}]  ;; prior page (:keep-previous?)
-```
-
-**Commands** are dispatched event vectors that *cause* work — each takes a map payload, never positional args:
-
-```clojure
-;; Cause a fetch (cache hit if fresh; joins an in-flight request for the same key)
-[:rf.resource/ensure   {:resource … :scope … :params … :owner … :cause …}]
-;; Force a refresh — starts a new generation, supersedes any in-flight attempt
-[:rf.resource/refetch  {:resource … :scope … :params … :cause …}]
-;; Mark matching cached reads stale (refetches the owned ones)
-[:rf.resource/invalidate-tags {:scope … :tags #{…} :cause …}]
-;; Drop a liveness lease (the matching release for an app-minted :owner)
-[:rf.resource/release-owner   {:owner …}]
-;; Tear down a whole scope at logout / account switch (later)
-[:rf.resource/clear-scope     {:scope … :cause …}]
-;; Evict one exact entry now, regardless of GC policy
-[:rf.resource/remove   {:resource … :scope … :params …}]
-```
-
-The most common one after `ensure` is **`:rf.resource/refetch`** — your "pull to refresh" / manual refresh button. It forces a new generation and supersedes any in-flight attempt, so a user mashing the refresh button never stacks requests. Pass a `:cause [:manual :article/refresh]` so the trace can explain the fetch; don't pass an `:owner` (a refresh keeps nothing alive — it just refreshes what's already owned).
-
-??? note "Going deeper"
-
-    You'll also find direct functions — `(rf/resource-state {:resource … :scope … :params … :frame …})`, `(rf/resources {:frame …})`, `(rf/resource-meta :realworld/article)`, `(rf/mutation-state {:instance … :frame …})`, `(rf/mutations {:frame …})`. The `*-meta` functions project the *registration*; `*-state` / `resources` / `mutations` project the *same runtime state* the `[:rf.resource/*]` subscriptions read, but as a one-shot, non-reactive snapshot at an explicit frame. They exist for tools (Xray), unit tests, and SSR serialization — places with no reactive subscription context. **In a view, always project through a subscription:** a `resource-state` call won't re-render when the data changes, so reaching for it in UI is reading the right value through the wrong lane. (And `:frame` is an explicit, app-registered frame id — there's no ambient default, so a frameless introspection call with no resolvable context [fails closed](../core/glossary.md#fail-loud-not-silent) rather than peeking at the wrong frame.)
-
-## Freshness and lifetime: the policy keys
-
-So far our resource has stayed fresh forever, refetching only when something forces it. Two more registration keys give it a freshness and a lifetime policy:
-
-```clojure
-(rf/reg-resource :realworld/article
-  {:params-schema  [:map [:slug :string]]
-   :scope          :rf.scope/global
-   :stale-after-ms 60000                ;; fresh for a minute; then refetch on next ensure
-   :gc-after-ms    (* 5 60 1000)        ;; reclaim after 5 min with no owner
-   :tags           (fn [{:keys [slug]} _data]
-                     #{[:article slug] [:article-list]})}
-  (fn [{:keys [slug]} _ctx]
-    {:request {:method :get :url (str "/api/articles/" slug)} :decode :json}))
-```
-
-`:stale-after-ms` is the freshness window — after it elapses, the next *ensure* refetches; absent, the entry stays fresh until explicitly invalidated. `:gc-after-ms` is the lifetime once the entry goes *owner-free* — absent, it defaults to `300000` (5 minutes); `:gc-after-ms :never` is the explicit opt-out for a resource that genuinely wants an owner-free entry pinned indefinitely. And `:tags` *label what this data is about*: a tag is a vector like `[:article slug]`, read as "this entry holds article `slug`." Those labels are how a later write says "I changed article `slug`" and refreshes exactly the reads that showed it — the machinery the "Writes invalidate by tag" section builds on.
-
-The full **registration metadata** is small and worth knowing in one glance. These are the keys `reg-resource`'s middle slot accepts:
-
-| Key | Required? | What it does |
+| Lane | Spelling | Who |
 |---|---|---|
-| `:params-schema` | **yes** | A Malli [schema](../core/glossary.md#schema) validating and canonicalising params. Defines the read's identity; missing it is `:rf.error/resource-bad-spec`. |
-| `:scope` | **yes** | The scope *policy* — `:rf.scope/global`, a `{:from-db <id>}` resolver reference, or `:rf.scope/from-caller`. Missing it is `:rf.error/resource-missing-scope-policy`. |
-| `:tags` | no | `(fn [params data] -> #{tag …})` naming the facts the data carries, so a write can invalidate exactly the reads it broke. A tag is a *vector* (`[:article slug]`). |
-| `:stale-after-ms` | no | Freshness window. After this, the next *ensure* refetches. Absent ⇒ fresh until explicitly invalidated. |
-| `:gc-after-ms` | no | Lifetime after the entry goes owner-free. Absent ⇒ `300000` (5 min). `:never` ⇒ an explicit, auditable opt-out that lingers the entry unowned indefinitely. |
-| `:poll-interval-ms` | no | Re-read on a clock while actively owned and the tab is visible (see [Polling](#polling-keep-this-fresh-every-n-ms)). |
-| `:data-schema` | no | A **static declaration** of the shape the resource's data has — surfaced to tooling (the resource's `:schema` fact) and `resource-meta`. It does **not** validate at runtime (runtime shape-validation rides the request's `:decode`) and does **not** drive egress classification. |
-| `:sensitive` / `:large` | no | Projection-relative path-vectors (`[[:data :ssn] [:params :account-id]]`) marking which slots redact / summarise at every egress boundary (SSR, tools, trace) — the framework's [data classification](../core/glossary.md#data-classification) applied to a cache entry. The coarse whole-entry `:sensitive?` / `:large?` booleans are the degenerate root-prop case. |
-| `:transport` | no | `:rf.http/managed` is the only built-in (and the default); the model is transport-neutral so a later transport can plug in. |
-| `:infinite` | no | `true` registers a load-more / infinite-scroll feed instead of a keyed cache — a different kind, with its own `:next-page-param` / `:page->items` keys and `load-more` surface. See [Infinite feeds](#infinite-feeds-accumulate-pages-with-infinite). |
+| Register | `reg-resource` / `reg-mutation` | Author at boot |
+| Cause | route `:resources`, `ensure` / `execute` events | Routes, handlers, machines |
+| Project | `[:rf/resource …]` and friends | Views |
 
-!!! warning "Gotcha — the `:request` function describes the domain request only"
+Narrower projections (`[:rf.resource/data …]`, `[:rf.resource/status …]`, …) re-render
+only when that slice changes. Commands include
+`ensure`, `refetch`, `invalidate-tags`, `release-owner`, `clear-scope`, `remove` —
+full list in the [API](../api/re-frame.resources.md).
 
-    It MUST NOT supply `:request-id`, `:on-success`, or `:on-failure`: the runtime owns reply addressing (it threads those from the scoped key and current generation, which is what makes stale-reply suppression airtight), and an args map that supplies them is rejected. Cross-cutting decoration — auth headers, tracing, a base URL, a default retry — belongs in a frame-registered `reg-http-interceptor` that decorates *every* managed request, not copied into each resource's `:request`.
+## Scope: whose cache?
 
-## The scoped key: a leak boundary that fails closed
+<a id="the-scoped-key-a-leak-boundary-that-fails-closed"></a>
 
-So far every resource has been `:rf.scope/global` — the same answer for everyone. Most real reads aren't. A user's feed, a tenant's dashboard, a profile under impersonation: these must *never* leak between viewers. **[Scope](glossary.md#scope)** is how re-frame2 makes that leak unrepresentable.
+Cache identity is a triple: `[scope resource-id canonical-params]`.
 
-A cache entry's identity is a triple:
-
-```clojure
-[scope  resource-id  canonical-params]
-```
-
-Params say *which* article. Scope says *whose* cache. A genuinely public read declares `:scope :rf.scope/global` — an explicit, auditable claim. A viewer-relative read names a **scope resolver** once and references it everywhere:
+- **`:rf.scope/global`** — same answer for every viewer (explicit claim).
+- **`{:from-db resolver-id}`** — viewer-relative; resolver pure over declared
+  `:inputs`.
+- **`:rf.scope/from-caller`** — every ensure/sub must supply `:scope` or fail loud.
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/scope.cljs
 (rf/reg-resource-scope :realworld/session
   {:inputs {:username [:db [:auth :user :username]]}}
   (fn [{:keys [username]} _ctx]
     (when username
       [:rf.scope/session {:username username}])))
 
-;; Adapted from examples/real-apps/realworld_resources/resources.cljs
 (rf/reg-resource :realworld/feed
   {:params-schema [:map [:page {:optional true} [:maybe :int]]]
-   :scope         {:from-db :realworld/session}   ;; whose feed? resolved from app-db
-   :tags          (fn [_params _data] #{[:feed]})}
+   :scope         {:from-db :realworld/session}
+   :tags          (fn [_ _] #{[:feed]})}
   (fn [{:keys [page]} _ctx]
     {:request {:method :get
                :url    "/api/articles/feed"
@@ -254,29 +184,9 @@ Params say *which* article. Scope says *whose* cache. A genuinely public read de
      :decode  :json}))
 ```
 
-The resolver is pure, and its declared `:inputs` are the app-db facts that decide the scope. That buys two structural properties:
-
-- **Subscriptions re-key when the viewer changes.** At login, logout, or account switch, the same feed subscription re-points to the *new* viewer's cache entry. During the switch it reads the new key's state — typically `:idle` or `:loading` — never the previous viewer's data.
-- **Nil resolution fails closed.** Logged out, the resolver yields `nil`. A route entry simply doesn't plan the feed, and a subscription raises a loud "scope unresolved" diagnostic. There is no path from "I forgot the viewer" to "I served someone else's cache."
-
-There's one honest consequence of "subscriptions are passive": a re-keyed subscription does not fetch. The new viewer's data loads only when something *causes* it — usually the route re-entering after login. If your app switches viewer with *no* route change (a cold-boot session restore, say), dispatch an explicit `:rf.resource/ensure` under the new scope, carrying an app-minted owner lease with a matching release at logout so the entry stays alive. Without that lease, the entry just sits at `:idle`.
-
-There is a third `:scope` policy for the resource that legitimately has *no* fixed answer of its own — **`:rf.scope/from-caller`**. Instead of declaring `:rf.scope/global` or naming a resolver, the resource *defers the scope to its use site*: every `ensure` / refetch / `:rf/resource` call MUST supply `:scope` on the payload (or a route resolver must supply it). This suits a reusable read that different callers legitimately scope differently — the resource owns no scope policy, so it demands one at every call. It keeps the same fail-closed floor: a `from-caller` resource reached with no payload `:scope` and no route resolver is a loud use-time error, `:rf.error/resource-scope-required-from-caller` — never a silent global read.
-
-??? info "Coming from TanStack Query?"
-
-    Difference two of three: **scope is a required, structural key segment.** In a query-key library the viewer id is one segment you assemble by hand at every call site — forget it once and one user silently reads another's cache. Here scope is a required declaration at registration, with no default. A read that can't resolve its scope raises a structured error; it **never** falls through to a silent shared read. The failure mode is loud, not leaky.
-
-??? note "Going deeper — the shape of the whole boundary"
-
-    A scope you *forgot* is a registration or read error; a scope you got *wrong* is a dev warning at the moment it bites; a scope you supplied with a *typo* (a `:rf.scope/*` keyword outside the closed enum) is rejected loudly wherever it appears. There is, by construction, no path from any of these to "served another user's cache." The full table of these signals is in [When it fails loud](#when-it-fails-loud--the-errors-and-warnings) below — but the property worth carrying now is that every footgun on this boundary has been moved from "silent leak" to "loud failure."
-
-## Logout is one causal event
-
-The classic cross-session leak — user B sees user A's dashboard — has a structural fix here. Every session-scoped entry lives under A's scope, and logout clears that scope. One subtlety is worth pausing on: resolve the *old* scope from the `db` the handler received (which still carries the logging-out user) *before* you remove the auth slice — otherwise you've thrown away the very identity you need to name the scope:
+Nil resolution **fails closed** — no silent shared read. Logout clears a scope:
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/auth.cljs
 (rf/reg-event :auth/logout
   (fn [{:keys [db]} _]
     (let [old-scope (rf/resolve-resource-scope db :realworld/session)]
@@ -287,91 +197,52 @@ The classic cross-session leak — user B sees user A's dashboard — has a stru
                                {:scope old-scope :cause :logout}]]))})))
 ```
 
-`clear-scope` removes every entry in that scope, releases its owners, and aborts or suppresses its in-flight requests. It leaves every other scope untouched, including still-valid global reads like article lists.
+Resolve the old scope **before** stripping auth from `db`.
 
 ??? info "Coming from TanStack Query?"
 
-    In the query-key world, logout is either `queryClient.clear()` (which drops the *global* cache too) or a hand-maintained list of keys to forget — both more brittle than clearing one scope. Here the leak boundary you declared at registration *is* the teardown boundary at logout.
+    Scope is a **required structural axis**, not a key segment you assemble by hand
+    and sometimes forget.
 
-## Owners and causes, and the refetch rules
+## Owners, causes, refetch rules
 
-Query libraries talk about *observers* — a mounted hook keeps a query alive. Resources split that one idea into two that never blur, because keeping a thing alive and explaining why it fetched are different concerns ([owner & cause](glossary.md#owner--cause) in the glossary):
+<a id="owners-and-causes-and-the-refetch-rules"></a>
 
-- An **owner** is a liveness lease: "this route (or machine, or explicit app lease) needs this entry." Owners decide whether invalidation refetches now or just marks stale, and whether GC may reclaim the entry. Every owner has a defined releaser — the route on leave, a machine on destroy, an app-minted lease via a matching release event.
-- A **cause** is an explanation: "why did this fetch happen?" — a route entry, a click, an invalidation, a focus return. Causes change nothing about liveness; they exist so the trace can answer *why*.
+- **Owner** — liveness lease (route, machine, app lease). Controls GC and whether
+  invalidation refetches now or only marks stale.
+- **Cause** — why this fetch happened (trace / Xray). Does not keep the entry alive.
 
-The race rules are few, and worth knowing cold:
-
-- **Ensure of a fresh entry is a cache hit** — no fetch; the cached value serves immediately.
-- **Ensure while the same key is in flight joins the existing request** — two screens asking for the same article fire one fetch.
-- **An explicit refetch starts a new generation**, superseding any in-flight attempt.
-- **Cancellation is opportunistic; stale-reply suppression is mandatory.** When an owner leaves or a newer generation starts, the runtime aborts the request if it can. Even when it can't, a generation check guarantees a late reply can never overwrite a newer entry. Abort saves bandwidth; suppression is what makes it *correct*.
-
-The familiar refetch-on-window-focus behaviour is opt-in per frame — `(rf/install-revalidation-listeners! frame-id)` at boot (client-only). It refetches only entries that are both stale *and* still owned, so a tab return never triggers a fetch storm for data nothing is showing.
-
-### Polling: keep this fresh every N ms
-
-For a dashboard, a build-status badge, a notification count, or a "is this long job done yet" read, declare a **`:poll-interval-ms`** on the resource and the runtime re-reads it on that interval — no `setInterval`, no manual unmount / tab-hide bookkeeping:
-
-```clojure
-(rf/reg-resource :dashboard/build-status
-  {:scope            :rf.scope/global
-   :params-schema    [:map [:repo :string]]
-   :poll-interval-ms 5000          ;; re-read every 5s while actively owned + the tab is visible
-   :tags    (fn [_ _] #{[:build]})}
-  (fn [{:keys [repo]} _ctx]
-    {:request {:method :get :url (str "/repos/" repo "/build")} :decode :json}))
-```
-
-Polling is **owner-driven**: it runs only while the entry has an active owner (a route, a machine, or an app-minted `[:lease …]`) and pauses automatically while the tab is hidden — so it stops the instant nothing is looking at it. A poll tick refetches *unconditionally by the interval* (cause `:poll`, never an owner), coalesces with any in-flight work (a slow endpoint never stacks overlapping requests), and a failed poll keeps the prior data and keeps polling.
-
-Three freshness tools, three questions:
-
-- **Polling (`:poll-interval-ms`)** — "this changes on its own; keep it fresh on a clock" (build status, queue depth, presence).
-- **Focus/reconnect revalidation** — "refresh stale data when the user comes back" (the default freshness most reads want; cheap, event-driven, no clock).
-- **Invalidation (a mutation's `:invalidates`)** — "*this* write made *that* read wrong; refresh it now" (the causal, surgical refresh after a known change).
-
-They compose: a polled entry still revalidates on focus and still gets invalidated by a write — the in-flight coalescing gate keeps the overlap to one fetch.
-
-## Routes can declare more than one resource
-
-The route example earlier ensured a single resource. A real page often needs several, with ordering and pagination concerns. Each `:resources` entry is a small map, and these are the keys it accepts:
-
-```clojure
-;; Adapted from examples/real-apps/realworld_resources/routing.cljs
-(rf/reg-route :realworld/article
-  {:params    [:map [:slug :string]]
-   :resources [{:resource  :realworld/article
-                :params    (fn [route] {:slug (get-in route [:params :slug])})
-                :blocking? true}
-               {:resource  :realworld/comments
-                :params    (fn [route] {:slug (get-in route [:params :slug])})
-                :blocking? false}]}
-  "/articles/:slug")
-```
-
-| Entry key | What it does |
+| Rule | Behaviour |
 |---|---|
-| `:resource` | The registered resource id to ensure. |
-| `:params` | A `(fn [route] params)` deriving params from the route match (or a literal map). |
-| `:scope` | A `{:from-db <id>}` named-resolver reference, or a `(fn [route ctx] scope)` for a *route* fact (a tenant in a path segment). For viewer identity, always the named resolver. |
-| `:blocking?` | `true` holds the route transition until the read settles (and gives SSR a wait point); `false` fetches in the background. |
-| `:when` | A `(fn [route ctx] boolean)` predicate — plan this resource only when it returns true. Use this for conditional resources, never sentinel `nil` params. |
-| `:keep-previous?` | Keep the prior key's data visible while the new one first-loads — see below. |
-| `:id` / `:after` | A route-local id, and a `#{id …}` set ordering the *ensure-dispatch* of dependent entries. |
+| Ensure of a fresh entry | Cache hit |
+| Ensure while in flight | Join the existing request |
+| Explicit refetch | New generation; supersedes in-flight |
+| Cancel vs stale reply | Abort if possible; generation check always suppresses stale replies |
 
-`:keep-previous? true` on a paginated list keeps the prior page visible while the next one loads, so paging never flashes a skeleton ([Paginate a feed](how-to/paginate-a-feed.md) is the recipe). The prior data arrives in the new entry's `:rf/resource` projection as `:previous?`, `:previous-key`, and `:previous-data` — a *read* from the old key, never merged into the new entry, so it can't pollute the new key's tags.
+Focus revalidation is opt-in: `(rf/install-revalidation-listeners! frame-id)`.
+Polling is `:poll-interval-ms` on the resource — owner-driven, pauses when the tab
+is hidden.
 
-??? info "Coming from TanStack Query?"
+## Routes with several resources
 
-    `:after` orders *dispatch*, not data. If you've used `enabled` to chain dependent queries, hold the shape but adjust the promise: `:after` guarantees the *ensure* of a dependent entry is dispatched after the one it names — so the dependency's fetch kicks off first — but the route plan is a pure synchronous planner that resolves *every* entry's params at route entry, before anything settles. A later entry's params therefore **cannot** depend on an earlier entry's loaded *data* (that's a data-waterfall, a deferred slice). `:after` must target a route-local `:id`; a dangling target or a cycle is a loud route-planning error, never a silent fall-back to declaration order.
+<a id="routes-can-declare-more-than-one-resource"></a>
 
-## Writes invalidate by tag — causally
+Each `:resources` entry may carry `:params`, `:scope`, `:blocking?`, `:when`,
+`:keep-previous?` (show prior page while the next loads), and `:id` / `:after`
+(order ensure **dispatch**, not data waterfalls). Full recipe for pages:
+[Paginate a feed](how-to/paginate-a-feed.md).
 
-A read is half the story; eventually you favorite an article, post a comment, edit a profile. A **[mutation](glossary.md#mutation)** is a named causal write. On success it [invalidates](glossary.md#invalidate) the tags it broke, through the same scoped machinery, recorded on the event record — so keeping reads honest after a write is a *declaration*, not a call you remember to make:
+## Mutations invalidate by tag
+
+<a id="writes-invalidate-by-tag--causally"></a>
+<a id="optimistic-writes-commit-roll-back-or-reconcile"></a>
+
+A **[mutation](glossary.md#mutation)** is a named write. On success it
+[invalidates](glossary.md#invalidate) the tags it broke — declared once, not
+remembered in `onSuccess`:
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/mutations.cljs
+;; cf. examples/real-apps/realworld_resources/mutations.cljs
 (rf/reg-mutation :realworld/favorite
   {:params-schema [:map [:slug :string]]
    :scope         :rf.scope/global
@@ -386,222 +257,55 @@ A read is half the story; eventually you favorite an article, post a comment, ed
      :decode  :json}))
 ```
 
-??? info "Coming from TanStack Query?"
+Success plan arms (fixed order): `:populates` → `:patches` → `:removes` →
+`:invalidates`. Execute with `[:rf.mutation/execute …]`; watch with
+`[:rf/mutation …]` / `mutation-state`.
 
-    Difference three of three: **invalidation is causal.** In TanStack Query, keeping reads honest after a write is an imperative `queryClient.invalidateQueries(...)` you remember to make in `onSuccess`. Here it's a declared consequence of a named write, visible on the event record — there's nothing to remember and nothing to forget.
-
-A mutation's success-phase plan has four declarative arms, and they run in a fixed order before the success-time invalidation:
-
-- **`:populates`** — `(fn [params result] {target result})` *seeds* a cache entry from the reply, as if that key had loaded normally. A populated key becomes `:loaded`, arms its freshness timers, and is **exempt from this same mutation's invalidation pass** (so a write that populates an article *and* invalidates a broad article tag doesn't immediately refetch the key it just learned). The populated value must be the resource's stored shape — the same value a successful load produces — or you get a cache-coherence bug.
-- **`:patches`** — `(fn [params result] {target (fn [old result] …)})` *transforms* an existing exact key. Patch only touches keys that already exist; it does not target tags.
-- **`:removes`** — `(fn [params result] [target …])` *evicts* exact keys (a delete write).
-- **`:invalidates`** — runs last, marking matching reads stale.
-
-The `target` in `:populates` / `:patches` / `:removes` is a **map** — `{:resource :realworld/article :params {:slug slug} :scope :rf.scope/global}` — the one canonical exact-target shape (no hand-built key tuples in app code).
-
-Invalidation timing is explicit via **`:invalidate-timing`** — `:after-success` (the default), `:before-request`, `:after-failure`, or `:after-settle`. Entries with live owners refetch; unowned entries are marked stale and refetch when next ensured. Invalidation is **scoped by default**, so a write can't accidentally stale another tenant's cache.
-
-!!! warning "Gotcha — match the scope or the invalidation silently misses"
-
-    A mutation's `:invalidates` matches only entries *in the mutation's resolved scope*. If a `:rf.scope/global`-defaulted mutation invalidates a tag owned by a session-scoped read (or the reverse), no entry matches, nothing refreshes, and **no error is raised** — it's a legitimate "no match in this scope." When a write affects session- or tenant-scoped reads, name the matching scope on the execute payload (`:scope` accepts a concrete scope *or* a `{:from-db …}` resolver reference, resolved against app-db at execute time — and a reference that resolves to `nil`, e.g. logged out, fails loud rather than falling through to global), or — cleaner when one write touches facts in *different* scopes — use the **per-target descriptor form**, where each descriptor carries its own scope:
-
-    ```clojure
-    :invalidates
-    (fn [{:keys [slug]} _result]
-      [{:scope :rf.scope/global              ;; global facts
-        :tags  #{[:article slug] [:article-list]}}
-       {:scope {:from-db :realworld/session} ;; viewer-relative facts
-        :tags  #{[:feed]}}])
-    ```
-
-    In dev, a mismatch trips a `:rf.warning/mutation-scope-mismatch` warning at the moment it misses, so the silent case becomes loud. The genuinely-broad "invalidate this tag wherever it lives" operation is the separate, *audited* `:cross-scope? true` escape — it must carry a `:cause` and shows up in Xray.
-
-### Running a mutation and reading its state
-
-`reg-mutation` only *registers* the write — the same register / cause / read split you saw for resources. You **run** it (the cause) with `:rf.mutation/execute` and **read** its progress through the passive `:rf.mutation/*` subs. Both the run and the read are keyed by an **instance** id rather than the mutation id — an instance is one particular submission of the write — so two concurrent submissions of the same mutation never clobber each other's pending/result state:
-
-```clojure
-;; In a form-submit event handler:
-[:rf.mutation/execute
- {:mutation :realworld/favorite
-  :params   {:slug slug}
-  :instance [:favorite slug]            ;; caller-supplied (or generated) instance id
-  :scope    {:from-db :realworld/session} ;; optional — a concrete scope or a {:from-db <id>}
-                                          ;; resolver reference, resolved against app-db at
-                                          ;; execute time; omitted ⇒ the registration :scope,
-                                          ;; else :rf.scope/global
-  :cause    [:click :article/favorite]
-  :reply-to [:favorite/replied slug]}]  ;; optional continuation (below)
-```
-
-A view reads the instance's progress through `:rf/mutation` (or the narrower `:rf.mutation/pending?` / `:result` / `:error`) — the whole-instance view-model:
-
-```clojure
-;; Adapted from examples/real-apps/realworld_resources/views.cljs
-(rf/reg-view favorite-button [slug]
-  (let [m @(rf/subscribe [:rf/mutation {:instance [:favorite slug]}])]
-    [:button {:disabled (:pending? m)
-              :on-click #(dispatch [:rf.mutation/execute
-                                    {:mutation :realworld/favorite
-                                     :params   {:slug slug}
-                                     :instance [:favorite slug]
-                                     :cause    [:click :article/favorite]}])}
-     (cond
-       (:pending? m) "Saving…"
-       (:error? m)   "Retry"
-       :else         "Favorite")]))
-```
-
-`:rf/mutation` projects `{:status :result :error :pending? :success? :error? :settled? :optimistic?}`. A failed write settles `:error` (there's no `:refresh-error` analogue — a write has no last-known-good to keep). `[:rf.mutation/clear {:instance …}]` is the causal reset: it clears the instance row and best-effort aborts in-flight work — the idiom for "dismiss this error and let the form retry cleanly."
-
-??? note "Going deeper — `:reply-to` is a call-site event target, not a callback"
-
-    A verified mutation reply is ordinary causal input, so a continuation can only drive durable state by dispatching an event — never by returning effects from a callback (that would escape the event tape, interceptors, and replay). When the reply is accepted, the runtime dispatches your `:reply-to` target with the canonical reply map *appended* as the final argument: `:reply-to [:favorite/replied slug]` dispatches `[:favorite/replied slug reply]`. The reply map carries `:status`, `:value` (on `:ok`), `:error` (on `:error`), `:mutation`, `:instance`, `:affected-keys`, and the carried frame stamp. The continuation fires **exactly once for an accepted terminal reply** and **never** for a stale/superseded one (a re-execute under the same instance, or a `:rf.mutation/clear`) — you inherit stale-suppression for free. By the time it runs, cache consequences and the instance row are already settled, so a `:reply-to` handler sees the world fully reconciled. Use it for workflow that *isn't* cache state — a toast, a redirect, focusing the next field.
-
-The operational details — instance-keyed pending state, the full `:reply-to` reply-map fields, seeding the cache from the reply — live in [Part 4](tutorial/04-mutations-and-invalidation.md) and [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
-
-## Optimistic writes commit, roll back, or reconcile
-
-The mutation above settles the cache only when the server replies. For a write that should *feel* instant — the favorite heart flips on click, the count ticks up — a mutation may declare an **[optimistic plan](glossary.md#optimistic-update--rollback)** that patches the cache *before* the request is sent, then commits, rolls back, or reconciles when the reply settles.
-
-You declare the forward change; the runtime records the inverse for you, so a rollback restores exactly the entry that existed — never an author-written inverse that can drift from the forward patch:
-
-```clojure
-(rf/reg-mutation :realworld/favorite
-  {:params-schema [:map [:slug :string]]
-   :scope         :rf.scope/global
-   ;; Patch every cached entry carrying these tags, in its scope, before the
-   ;; request leaves — the detail, every list, and the session feed flip at once.
-   :optimistic-tags (fn [{:keys [slug]}]
-                      [{:scope :rf.scope/global
-                        :tags  #{[:article slug]}
-                        :patch (fn [article] (update-favorite article true))}])
-   ;; The accepted reply still seeds the authoritative value and invalidates.
-   :populates     (fn [{:keys [slug]} result]
-                    {{:resource :realworld/article :params {:slug slug}} result})
-   :invalidates   (fn [{:keys [slug]} _result]
-                    [{:scope :rf.scope/global :tags #{[:article slug] [:article-list]}}
-                     {:scope {:from-db :realworld/session} :tags #{[:feed]}}])}
-  (fn [{:keys [slug]} _ctx]
-    {:request {:method :post
-               :url    (str "/api/articles/" slug "/favorite")}
-     :decode  :json}))
-```
-
-Two forward forms exist: `:optimistic` patches **exact** cache targets (the twin of `:populates`/`:patches`), and `:optimistic-tags` patches **every** entry carrying a tag in its scope (the twin of tag-addressed `:invalidates`) — the cross-view-consistency case the author can't enumerate by key. Both are exact-key or tag-within-named-scope only, and **fail closed**: a `{:from-db …}` scope that resolves to `nil` drops that target rather than writing globally, so an optimistic write can never leak across viewers.
-
-Settle is deterministic, decided on recorded facts (the generation acceptance verdict and a per-entry `:revision`), so there's no wall-clock race:
-
-- an accepted **`:ok`** reply **commits** — the authoritative `:populates`/`:patches` overwrite the optimistic value with the server's, then `:invalidates` runs.
-- an accepted **`:error`**/`:cancelled` reply **rolls back** — the recorded inverse is restored.
-- a **stale/superseded** reply rolls back nothing; the current generation already owns the entry.
-
-A view renders the in-flight optimistic state from the instance sub's derived **`:optimistic?`** flag.
+**Scope footgun.** Invalidation matches only entries **in the scopes you name**.
+Wrong scope ⇒ silent miss (dev warning). Recipe and optimistic writes:
+[Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
 
 ??? info "Coming from TanStack Query?"
 
-    This is the re-frame2 counterpart of `onMutate`/`onError` rollback (and SWR's `optimisticData` + `rollbackOnError`). The one deliberate divergence is a *contested* rollback — a concurrent write landed on the entry between your apply and the failure. `:on-conflict` governs it: the default **`:invalidate`** declines to restore a now-stale inverse and instead marks the entry stale so the read path refetches the authoritative value (re-frame2's deliberate departure from the query libraries' unconditional context-restore); `:force` restores the inverse anyway (the single-writer escape, with a tooling warning).
+    Invalidation is **causal** — a declared consequence of the mutation, visible on
+    the event record.
 
-??? note "Going deeper"
+## When things fail loud
 
-    The settle decision runs entirely on recorded facts — the generation acceptance verdict and the per-entry `:revision` the conflict check compares against — so it never depends on the wall clock. A malformed optimistic descriptor (a bad target, a scope that doesn't resolve) is warned and skipped per descriptor rather than half-applying the plan.
+<a id="when-it-fails-loud--the-errors-and-warnings"></a>
 
-## SSR and hydration
+Registration and use-time errors fail closed (missing scope policy, bad request
+shape, unresolved scope on sub, …). The property: there is no path from "forgot
+the viewer" to "served another user's cache." Named ids live in the
+[API](../api/re-frame.resources.md) and error catalogue; [testing](testing.md)
+turns the same failures into assertions.
 
-On the server, each request renders in its own [frame](../core/glossary.md#frame) — which matters, because a process-global cache would itself be a cross-user leak. Blocking route resources are the render's wait point. Every durable entry present at serialize time rides the projection, not just the blocking ones — a non-blocking resource that happened to settle before render serializes exactly like a blocking one, and one still in flight simply has no `:data` to ship yet (the client refetches it on hydration if the route still needs it). The settled entries are serialized (sensitive data redacted) and shipped with the page, and on the client, [hydration](../ssr/glossary.md#hydration) installs them under the same freshness rules. A hydrated entry that's still fresh is **not** refetched, so there's no duplicate-fetch flash on first paint; a stale one background-refreshes by policy. Hydration never crosses scopes — the serialized scope and the client's resolved scope must agree before hydrated data is usable. The mental model is in [Server-side rendering](../ssr/concepts.md), and `examples/capabilities/ssr/resources_ssr/` is the worked demo.
+## Advanced (elsewhere)
 
-!!! warning "Gotcha — a blocking SSR resource needs a deadline, not an open wait"
+| Topic | Where |
+|---|---|
+| Numbered pages & infinite feeds | [Paginate a feed](how-to/paginate-a-feed.md) |
+| Optimistic UI, patches, populate | [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md) |
+| SSR / hydration of the cache | [SSR concepts](../ssr/concepts.md) + tutorial Part 2 |
+| Full RealWorld build | [Tutorial](tutorial/index.md) |
 
-    `:blocking? true` holds the render until the read settles, so a slow upstream can't be allowed to hang the request forever. A blocking resource that exceeds the render deadline settles as a structured first-load failure for that SSR frame — an `:error` envelope `{:kind :rf.http/timeout :reason :ssr-blocking-timeout}` (the `:kind` stays inside the closed `:rf.http/*` taxonomy; the `:reason` lets your [error projector](../core/glossary.md#registration) tell an SSR-deadline failure apart from a genuine upstream timeout). The renderer then chooses error markup, a skeleton, or an app fallback; the client picks the read up again on hydration.
-
-## When it fails loud — the errors and warnings
-
-Resources lean hard on the [fail-loud](../core/glossary.md#fail-loud-not-silent) ethos: the dangerous mistakes are *unrepresentable* or *raised*, not silent. Knowing the names means you can recognise them on sight — and, as an [error record](../core/glossary.md#error-record), branch on the `:rf.error/*` category, never on the prose `:reason`. These are the ones you'll actually meet:
-
-| Signal | When | What it's telling you |
-|---|---|---|
-| `:rf.error/resource-missing-scope-policy` | at `reg-resource` | You didn't declare `:scope`. "I forgot this read is user-scoped" is unrepresentable — say `:rf.scope/global` (a claim) or name a resolver. |
-| `:rf.error/resource-bad-spec` | at `reg-resource` | A malformed spec — usually `:request` left *inside* the metadata map (it's the third slot), or a missing/bad `:params-schema`, or a malformed `:sensitive` / `:large` path-vector. |
-| `:rf.error/resource-sub-unresolved-scope` | at a subscription | A `[:rf/resource …]` whose scope can't be resolved — pass `:scope` on the payload, the same scope the owning route/event ensured under. Never a silent `:idle`, never a silent global read. |
-| `:rf.error/resource-scope-unresolved-reference` | at an ensure / route / `:rf.mutation/execute` site | The ensure/route counterpart to the sub-side error above: a `{:from-db <id>}` scope reference that resolved to `nil` against the current db (e.g. logged out) at a scope-*requiring* site — an event, a route, or a supplied mutation-execute `:scope`. A derived scope that can't resolve is fail-closed — never a fall-through to global. |
-| `:rf.error/resource-invalidate-scope-required` | at `:rf.resource/invalidate-tags` | A bare invalidate with no scope. Name the scope, or opt into the audited `:cross-scope? true`. The fail-closed floor — never silently global. |
-| `:rf.error/resource-route-plan` | at a route with `:resources` | A route resource couldn't be planned — its params or scope didn't resolve, its params failed the schema, or a `:when` guard threw. Recorded on the route slice's `:error` (visible to the `:rf/route` sub and Xray) so navigation surfaces the failure instead of silently dropping the read. |
-| `:rf.error/resource-ssr-blocking-timeout` | at SSR render | A `:blocking? true` resource exceeded the render deadline. Each unsettled blocking entry settles as a first-load `:error` (`{:kind :rf.http/timeout :reason :ssr-blocking-timeout}`) so the render never hangs; the client picks the read up on hydration. |
-| `:rf.error/mutation-bad-spec` | at `reg-mutation` | The mutation twin of the resource spec error (e.g. `:request` in the metadata map). |
-
-And the **dev-only warnings** (elided from production) that catch the *resolvable-but-wrong* footguns — the ones fail-closed can't catch, because a scope *did* resolve, just to the wrong place:
-
-- **`:rf.warning/resource-sub-scope-mismatch`** — a subscription resolved a perfectly valid scope key that has *no owner*, while a *different* scope key for the same resource *is* active. Almost always: your view's `:scope` doesn't match the route/event that ensured the data. You'll see a permanent skeleton; the warning names the active scope you probably meant.
-- **`:rf.warning/mutation-scope-mismatch`** — the write-side twin: a mutation's `:invalidates` matched zero entries in its scope while the same tags match an entry in *another* scope. Your write succeeded but the cached read it should have refreshed didn't, because the scopes don't line up.
-- **`:rf.warning/resource-clear-scope-unresolved`** — a `:rf.resource/clear-scope` whose `{:from-db <id>}` scope reference resolved to `nil` against the current db (e.g. logging out with no logged-in user left). Fail-closed: it clears **nothing** rather than silently no-op'ing or wiping global, and names the resolver so you can fix the scope you meant to tear down.
-
-## Advanced
-
-### Infinite feeds: accumulate pages with `:infinite`
-
-Everything so far has treated a paginated list as *independent* entries — page 2 is its own cache key, addressable as "go to page N", and `:keep-previous?` stops it flashing a skeleton on the way there. A **load-more / infinite-scroll feed** is the complementary shape: the user *accumulates* pages (page 1, then 1+2, then 1+2+3) into one growing list, and the *next* page's cursor is derived from the last page's data. You opt one resource into that shape with `:infinite true`:
-
-```clojure
-(rf/reg-resource :feed/timeline
-  {:infinite         true
-   :params-schema    [:map [:filter :keyword]]   ;; the FEED identity — not the page
-   :scope            {:from-db :realworld/session}
-   :next-page-param  (fn [last-page _all-pages]   ;; REQUIRED for :infinite
-                       (get-in last-page [:page-info :next-cursor]))  ;; nil ⇒ end of feed
-   :page->items      :items                       ;; REQUIRED when a page isn't already a vector
-   :tags             (fn [{:keys [filter]} _data] #{[:feed filter]})}
-  ;; the per-page cursor rides the (otherwise-reserved) ctx — no new arity
-  (fn [{:keys [filter]} {:rf.resource/keys [page-param]}]
-    {:request {:method :get :url "/api/timeline"
-               :params (cond-> {:filter filter :limit 20}
-                         page-param (assoc :cursor page-param))}
-     :decode  :app/timeline-page}))
-```
-
-The whole feed is **one** scoped entry — its `:data` is an ordered vector of pages, not N per-page cache keys — so it gets one owner, one GC clock, one SSR-restore unit, one Xray row. Only the *identity* params (filter / sort / search) name the feed; the per-page cursor is internal sequencing state and is **never** part of the cache key. Change a filter and you get a different feed instance; the old accumulation becomes a separate, GC-eligible entry.
-
-Extending the feed is a **cause**, not a view fetch — dispatch `[:rf.resource/load-more {:resource :feed/timeline :scope … :params … :cause [:user :feed/load-more]}]`. A `load-more` is **ownerless** by rule: the route (or whatever first-loaded the feed) already owns the one entry, and a load-more only *extends* it, so it carries a `:cause` and never an `:owner` (a supplied owner is warn-and-ignored, `:rf.warning/resource-load-more-owner-ignored`). It reuses the work ledger and stale-suppression exactly as `ensure` does, and there's **no sixth FSM state** — a load-more on a `:loaded` feed transitions to `:fetching` (the accumulated pages stay visible, no skeleton) and back to `:loaded` with the new page appended.
-
-A view reads the feed through a small infinite-specific projection family — all passive, all derived, all framework-owned and memoised:
-
-```clojure
-@(subscribe [:rf.resource/infinite-state {:resource :feed/timeline :scope … :params …}])
-;; => {:status :loaded
-;;     :items          [<item> <item> …]   ;; the merged list — the everyday read
-;;     :pages          [<page-0> <page-1> …]
-;;     :page-count     3
-;;     :has-next-page? true                ;; (some? next-page-param)
-;;     :fetching-next? false               ;; a load-more in flight (distinct from :fetching?)
-;;     :has-data?      true
-;;     :error          nil                 ;; page-0 first-load failure
-;;     :refresh-error  nil
-;;     :page-error     nil}                ;; last load-more failure
-```
-
-`:rf.resource/items` is the headline read — the flat list every feed view wants (the thing a TanStack user reaches for `.flatMap(p => p.items)` to get). The narrower `:rf.resource/pages`, `:has-next-page?`, `:fetching-next?`, `:page-count`, and `:page-error` exist so a view subscribes to just the fact it cares about. A worked feed view renders `:items`, shows a spinner while `:fetching-next?`, a "Load more" button (dispatching `:rf.resource/load-more`) while `:has-next-page?`, and an end-of-feed marker otherwise.
-
-??? info "Coming from TanStack Query?"
-
-    This is `useInfiniteQuery`. `:next-page-param` is `getNextPageParam(lastPage, allPages)` — with two deliberate alignments: re-frame2 standardises the terminal on **`nil`** (not `undefined` / an empty page) and additionally hands you `:has-next-page?` so a view never re-derives "are we at the end". The merge that TanStack leaves to your render (`pages.flatMap(...)`) is the framework-owned, memoised `:rf.resource/items` here.
-
-!!! warning "Gotcha — the third error channel: `:page-error`"
-
-    A *load-more* page-fetch failure is **not** a feed first-load failure and **not** a whole-feed refresh failure. The feed stays `:loaded`, **keeps every accumulated page**, and records the failure in `:page-error` — so the view shows "couldn't load more — retry" without losing the list the user already scrolled. It's cleared by the next successful load-more or whole-feed load. (First-load failure is still `:error`; a failed background refresh of the whole feed is still `:refresh-error`.)
-
-!!! warning "Gotcha — `:page->items` is required, not guessed"
-
-    If a page is already a vector it flattens by identity. If a page is *enveloped* (`{:items [...] :page-info {…}}`), you **must** declare a `:page->items` accessor — a keyword key or `(fn [page] …)`; the framework will not guess `:items` / `:data`. A non-vector page with no accessor is a loud registration error (`:rf.error/infinite-missing-page-accessor`), the same fail-loud floor as a missing `:next-page-param` (`:rf.error/infinite-missing-next-page-param`).
-
-A few load-bearing edges: an `:rf.resource/ensure` (or a blocking route entry) on an infinite resource fetches **page 0 only** — it doesn't re-fetch the accumulation. A `:refetch` of a feed defaults to **window-preserving** (the visible pages stay rendered until their replacement succeeds, so a focus/reconnect refetch never collapses the feed back to page 0); `:refetch-all-pages?` and `:refetch-window` are the opt-ins. And a mutation that touches one item *inside* a feed invalidates the **whole feed** in this slice (coarse but correct) rather than patching one element in place. A page's per-page **validation** rides the request's `:decode`, and a page's durable per-page **egress classification** rides the resource's projection-relative `:sensitive` / `:large` declarations (the index-free walk classifies every page) — the same two surfaces every resource uses; there is no `:page-data-schema`. One edge is named but deferred: a backward `:rf.resource/load-prev` is reserved for a later slice. [Paginate a feed](how-to/paginate-a-feed.md) is the worked recipe for both pagination shapes.
+<a id="infinite-feeds-accumulate-pages-with-infinite"></a>
+<a id="ssr-and-hydration"></a>
+<a id="freshness-and-lifetime-the-policy-keys"></a>
+<a id="the-full-read-and-command-surface"></a>
+<a id="polling-keep-this-fresh-every-n-ms"></a>
+<a id="logout-is-one-causal-event"></a>
 
 ## When resources are the wrong tool
 
-Resources earn their keep when cached server reads multiply. When they don't, reach for something simpler — pick the cheapest of [the four homes](../core/glossary.md#the-four-homes-where-state-lives) that fits:
+<a id="when-resources-are-the-wrong-tool"></a>
 
-- **A handful of reads, no caching story.** A [managed HTTP request](../async/http.md) plus a small app-db slice is less machinery and entirely idiomatic.
-- **Login and other commands.** Auth is a [state machine](../machines/glossary.md#machine) driving a write — don't contort it into a cached read.
-- **GraphQL.** The transport is HTTP-only for now; GraphQL is a planned later phase.
+| Situation | Prefer |
+|---|---|
+| One-off uncached call | [Managed HTTP](../async/http.md) |
+| Client-only state | app-db |
+| Named stage machine | [Machines](../machines/index.md) |
+| No server yet | app-db + events |
 
-!!! note "Don't avoid resources just because a write needs to feel instant"
-
-    A mutation *can* flip the UI immediately and reconcile when the server replies — see [Optimistic writes commit, roll back, or reconcile](#optimistic-writes-commit-roll-back-or-reconcile) above. That's a property of the mutation, not a reason to keep server state out of the cache.
+**Cached server reads that multiply** are the load-bearing concept — not every
+network call.

--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -18,8 +18,10 @@ To *build* Conduit end to end, use the [tutorial](tutorial/index.md). Task recip
 !!! note "Optional artefact"
 
     Require `re-frame.resources` (and usually `re-frame.http.managed`) once at boot —
-    Maven coordinate `day8/re-frame2-resources`. An app with one or two reads is often
-    happier with [managed HTTP](../async/http.md) alone.
+    Maven coordinate `day8/re-frame2-resources`. Forget the require and the first
+    `reg-resource` / `reg-mutation` throws `:rf.error/resources-artefact-missing`.
+    An app with one or two uncached reads is often happier with
+    [managed HTTP](../async/http.md) alone.
 
 ## The cache you don't own
 

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -1,9 +1,12 @@
-# Resources examples
+# Examples
 
-Worked, runnable apps in the repo that exercise the resources surface — read them next to the [Concepts](concepts.md) page to see the ideas in real code.
+Runnable apps next to the docs. Build something yourself first
+([tutorial](tutorial/index.md) or the [model](concepts.md)), then open these in order.
 
-- **resources** — the focused read-resource lifecycle: one articles list + one detail, showing all four ways a read gets *caused* (route entry, an event lease, a manual refresh, a machine-owned ensure) plus the passive `:loading` / `:fetching` / `:refresh-error` status flow. Read-side only — start here. [→](../../examples/capabilities/resources/resources)
-- **realworld_resources** — the full Conduit app rebuilt on resources (reads) + mutations (writes), so you can watch the whole **read → write → invalidate → refetch** loop end to end: scoped invalidation, optimistic favourites with rollback, declarative pagination, and a named session scope. [→](../../examples/real-apps/realworld_resources)
-- **realworld** — the *same* Conduit app, but with reads/writes hand-rolled on raw `:rf.http/managed` and Pattern-RemoteData slices instead of resources. The before-picture: read it beside `realworld_resources` to see exactly what the resource surface buys you. [→](../../examples/real-apps/realworld_http)
-- **infinite_feed** — a load-more / infinite-scroll timeline on the `:infinite true` resource primitive: one growing cache entry, a causal `load-more`, a runtime-owned cursor (the view never threads it), and a `nil` next-page terminal. The accumulate-together counterpart to numbered pagination. [→](../../examples/capabilities/resources/infinite_feed)
-- **managed_http_counter** — the bare `:rf.http/managed` transport that resources lower onto, with no resource layer at all: default reply addressing, real-vs-stubbed traffic, and a genuine in-flight abort. Useful for seeing the substrate resources are built on. [→](../../examples/core/managed_http_counter)
+| Example | What it shows | Read first |
+|---|---|---|
+| [resources](../../examples/capabilities/resources/resources) | Focused read lifecycle: four *causes* (route, event lease, manual refresh, machine ensure); passive statuses | [The model](concepts.md) |
+| [infinite_feed](../../examples/capabilities/resources/infinite_feed) | `:infinite true` load-more; runtime-owned cursor | [Paginate a feed](how-to/paginate-a-feed.md) |
+| [realworld_resources](../../examples/real-apps/realworld_resources) | Full Conduit: scope, mutations, optimistic favorite, session | [Tutorial](tutorial/index.md) |
+| [realworld_http](../../examples/real-apps/realworld_http) | Same Conduit on raw managed HTTP — the *before* picture | [Async HTTP](../async/http.md) |
+| [managed_http_counter](../../examples/core/managed_http_counter) | Bare `:rf.http/managed` substrate resources lower onto | [Async tutorial](../async/tutorial.md) |

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -7,7 +7,10 @@ re-frame2's optional server-state capability — declarative, cached reads and w
 A declared, cached server-state **read** (the read-side partner to a [mutation](#mutation)'s write), registered with `reg-resource`. Its [`:scope`](#scope) is a required, fail-closed leak boundary — part of the read's identity (with its `:params`) — so one user's data can't surface in another's cache.
 
 ```clojure
-(rf/reg-resource :article {:scope :rf.scope/global} request-fn)
+(rf/reg-resource :article
+  {:params-schema [:map [:slug :string]]   ;; required — the read's identity
+   :scope         :rf.scope/global}        ;; required — whose cache?
+  request-fn)
 ```
 
 Related: [Server state](concepts.md). "Server state" is the category, not the noun.
@@ -17,7 +20,11 @@ Related: [Server state](concepts.md). "Server state" is the category, not the no
 A declared server-state **write** — the write-side partner to a [resource](#resource)'s read. Its cache consequences (which cached reads it [invalidates](#invalidate), by [cache tag](#cache-tag)) are declared *once, on the registration*, never imperatively at the call site.
 
 ```clojure
-(rf/reg-mutation :article/favorite {:scope :rf.scope/global} request-fn)
+(rf/reg-mutation :article/favorite
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :invalidates   (fn [{:keys [slug]} _result] #{[:article slug]})}
+  request-fn)
 ```
 
 Related: [Server state](concepts.md). The reply field is `:value`; the instance sub field is `:result`.
@@ -28,7 +35,7 @@ A [mutation](#mutation) declares — as data on its registration, never imperati
 
 ```clojure
 {:invalidates (fn [{:keys [slug]} _result]
-                {:tags #{[:article slug]}})}     ;; declared once, on the mutation
+                #{[:article slug]})}     ;; bare tag-set; or [{:scope … :tags #{…}}]
 ```
 
 Related: [Server state](concepts.md).

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -1,5 +1,9 @@
 # Invalidate after a mutation
 
+You can [read the cache](../concepts.md). This recipe is one job: after a **write**,
+declare which reads go stale (and optionally patch, populate, or flip the UI
+optimistically) so the UI stays honest without a remembered `invalidateQueries` call.
+
 Your app just wrote to the server. It saved an article, posted a comment, toggled a favorite. The cached reads covering that data are now wrong, and every view still showing them is now showing the past. This guide wires that write to invalidate exactly those reads, so the views refetch automatically and nothing else moves.
 
 Here's the idea underneath, in one sentence: **the write that made the cache stale is the thing that says so.** A timer only guesses, and polling pays for that guess on every interval. The [mutation](../glossary.md#mutation) actually knows — it just changed the data — so it names the reads it broke, once, at registration. That's what we mean by invalidation being *causal*: the cause of the staleness declares it directly.

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -97,7 +97,7 @@ One thing about the code below: the read uses the `[:rf/mutation {:instance …}
 
 ```cljs-rf2
 (rf/reg-view article-editor [article]
-  (let [save @(rf/subscribe [:rf/mutation {:instance [:article-save (:slug article}])])]
+  (let [save @(rf/subscribe [:rf/mutation {:instance [:article-save (:slug article)]}])]
     [:<>
      [editor-fields article]
      [:button {:disabled (:pending? save)
@@ -110,7 +110,7 @@ One thing about the code below: the read uses the `[:rf/mutation {:instance …}
      (when (:error? save) [save-error (:error save)])]))
 ```
 
-A quick tour of what that view is doing. The `[:rf/mutation {:instance …}]` read is a passive read of one write's lifecycle: it never fires the write, it just watches it, and it yields a map: `{:status :pending? :success? :error? :settled? :result :error :optimistic?}`. That's what the button reads to flip its label to "Saving…" and disable itself. The `:instance` id — `[:article-save (:slug article)]` — is per-slug on purpose: it keeps two articles being saved at once from clobbering each other's pending/success/error state. (`editor-fields` and `save-error` are your own child views.)
+A quick tour of what that view is doing. The `[:rf/mutation {:instance …}]` read is a passive read of one write's lifecycle: it never fires the write, it just watches it, and it yields a map with keys like `:status`, `:pending?`, `:success?`, `:error?`, `:settled?`, `:result`, `:error`, and `:optimistic?`. That's what the button reads to flip its label to "Saving…" and disable itself. The `:instance` id — `[:article-save (:slug article)]` — is per-slug on purpose: it keeps two articles being saved at once from clobbering each other's pending/success/error state. (`editor-fields` and `save-error` are your own child views.)
 
 Now notice what's *absent*: the view never dispatches an invalidate, never refetches a list, and never touches [app-db](../../core/glossary.md#app-db) — your app's single state map. It doesn't have to, because the registration in §2 already declared which reads this write breaks. That absence is the payoff of doing the work once, at registration.
 

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -1,20 +1,28 @@
 # Invalidate after a mutation
 
 You can [read the cache](../concepts.md). This recipe is one job: after a **write**,
-declare which reads go stale (and optionally patch, populate, or flip the UI
-optimistically) so the UI stays honest without a remembered `invalidateQueries` call.
+declare which reads go stale — and optionally patch, populate, or flip the UI
+optimistically — so the UI stays honest without a remembered
+`invalidateQueries` call.
 
-Your app just wrote to the server. It saved an article, posted a comment, toggled a favorite. The cached reads covering that data are now wrong, and every view still showing them is now showing the past. This guide wires that write to invalidate exactly those reads, so the views refetch automatically and nothing else moves.
+> **The write that made the cache stale is the thing that says so.**
 
-Here's the idea underneath, in one sentence: **the write that made the cache stale is the thing that says so.** A timer only guesses, and polling pays for that guess on every interval. The [mutation](../glossary.md#mutation) actually knows — it just changed the data — so it names the reads it broke, once, at registration. That's what we mean by invalidation being *causal*: the cause of the staleness declares it directly.
+A timer only guesses. Polling pays for that guess on every interval. A
+[mutation](../glossary.md#mutation) just changed the data, so it names the tags it
+broke **once, at registration**. That is *causal* invalidation.
 
-We'll build that up one step at a time: tag the reads, declare what a write breaks, fire the write and watch it, then — only once the simple path is solid — reach for the optional arms (seed the cache, run side-effects, cross scopes).
+**Path on this page:** tag the reads → declare what the write breaks → fire and
+watch → optional arms (populate, patches, optimistic, cross-scope).
 
 ??? info "Coming from TanStack Query?"
 
-    Your anchor is `queryClient.invalidateQueries({ queryKey: ['articles'] })` inside a mutation's `onSuccess`. Same instinct here, with two deliberate differences. First, in re-frame2 you **declare the invalidation as data on the mutation registration** rather than calling it imperatively in a callback at every call site — so you write it once, not at every place the mutation fires. Second, it matches by tags within a scope, so it refetches only the entries something on screen still owns.
+    Your anchor is `queryClient.invalidateQueries(...)` in `onSuccess`. Here you
+    **declare** invalidation on the mutation registration (once), and it matches by
+    **tags within a scope** — only owned entries refetch immediately.
 
-You need two things in place before any of this works. Boot the resources artefact (`day8/re-frame2-resources`) by putting `re-frame.resources` plus the `re-frame.http.managed` transport on your require list. Then register your reads with `reg-resource` — a [resource](../glossary.md#resource) is a managed server-state read, and registering it is how the framework knows how to fetch and cache it. If you haven't done that yet, start at [Server state: resources](../concepts.md).
+**Prerequisites.** `re-frame.resources` + `re-frame.http.managed` on the require
+list; reads registered with `reg-resource`. If that is unfamiliar, start at
+[the model](../concepts.md).
 
 ## 1. Tag the reads
 

--- a/docs/resources/how-to/paginate-a-feed.md
+++ b/docs/resources/how-to/paginate-a-feed.md
@@ -1,19 +1,26 @@
 # Paginate a feed
 
 You know how to [register a resource and read five statuses](../concepts.md). This
-recipe is one job: **page a list** — numbered pages in the URL, or a load-more
-infinite feed — without skeletons on every page turn and without hand-rolled cursors.
+recipe is one job: **page a list** without skeletons on every turn and without
+hand-rolled cursors in app-db.
 
-You have a list with more rows than you want to fetch at once. There are two pagination shapes you actually ship, and they behave differently *on purpose*:
+Two shapes, on purpose different:
 
-- **Numbered pages** — page 2 *replaces* page 1 on screen. Think search results, an admin table, a "1 2 3 … 29" pager.
-- **Load more** — page 2 *appends* to what's already there, the way a social feed grows.
+| Shape | On screen | Identity |
+|---|---|---|
+| **Numbered pages** | Page 2 *replaces* page 1 (search, admin tables) | Page is part of the resource key |
+| **Load more** | Page 2 *appends* (social feed) | One growing entry (`:infinite true`) |
 
-Both ride on [**resources**](../glossary.md#resource). A resource is a declared, cached server-state read: you register it once with `reg-resource`, and from then on the framework owns the fetching, caching, and freshness — [views](../../core/glossary.md#view) just subscribe to its current state. [Server state: resources](../concepts.md) is the full introduction; this page assumes you've met them. We'll build the numbered shape first, then load-more. By the end you'll have both wired with *no pagination state in [app-db](../../core/glossary.md#app-db) at all* — no page-number slice, no `:loading-more?` flag, no cursor, no append handler. That's the headline: the page cursor and the page cache are all framework-owned [runtime-db](../../core/glossary.md#runtime-db), so pagination adds *nothing* to the state you own. (Remember [the two partitions](../../core/glossary.md#the-two-partitions): app-db is yours, runtime-db is the framework's.)
+The headline: the page cursor and page cache live in framework
+[runtime-db](../../core/glossary.md#runtime-db) — pagination adds nothing to the
+[app-db](../../core/glossary.md#app-db) you own. Numbered first, then load-more.
 
 !!! note "The one idea to hold onto"
 
-    A numbered page is part of the resource's *identity* — page 7 is its own separately-cached value. An infinite feed is *one* identity that *grows* — page 1, then 1+2, then 1+2+3, kept together as a single reactive value. Almost everything below falls out of that one distinction.
+    A numbered page is part of the resource's *identity* — page 7 is its own
+    separately-cached value. An infinite feed is *one* identity that *grows* —
+    page 1, then 1+2, then 1+2+3. Almost everything below falls out of that
+    distinction.
 
 ??? info "Coming from TanStack Query?"
 

--- a/docs/resources/how-to/paginate-a-feed.md
+++ b/docs/resources/how-to/paginate-a-feed.md
@@ -1,5 +1,9 @@
 # Paginate a feed
 
+You know how to [register a resource and read five statuses](../concepts.md). This
+recipe is one job: **page a list** — numbered pages in the URL, or a load-more
+infinite feed — without skeletons on every page turn and without hand-rolled cursors.
+
 You have a list with more rows than you want to fetch at once. There are two pagination shapes you actually ship, and they behave differently *on purpose*:
 
 - **Numbered pages** — page 2 *replaces* page 1 on screen. Think search results, an admin table, a "1 2 3 … 29" pager.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -60,6 +60,7 @@ Hold this split and the whole surface stays clear:
 | **Project** | Read state into a view | `@(subscribe [:rf/resource …])` — never fetches |
 
 A subscription that finds no entry stays `:idle` until something **causes** a load.
+The model page ends with a [complete register + route + view skeleton](concepts.md#a-complete-read-loop).
 
 ## When *not* to use resources
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,26 +1,75 @@
-# Resources & Server State
+# Resources & server state
 
-Most of what a real app shows isn't *its* state — it's the **server's**, borrowed and cached: the article you're reading, the feed you're scrolling, the profile you just edited. Manage that by hand and you rebuild the same machinery in every component — fetch on mount, store the result, track loading and error, dedupe in-flight calls, decide when it's stale, refetch after a write, and try not to leak one user's data into another's session. It's the bulk of the bugs in a typical SPA.
+Most of what a real app shows is not *its* state — it is the **server's**, borrowed
+and cached: the article you are reading, the feed you are scrolling, the profile you
+just edited. Manage that by hand and you rebuild the same machinery everywhere —
+fetch on mount, store the result, track loading and error, dedupe in-flight calls,
+decide staleness, refetch after a write, and not leak one user's data into another's
+session.
 
-re-frame2's **resources** capability makes server state declarative. You register a cached **read** ([`reg-resource`](glossary.md#resource)) and a **write** ([`reg-mutation`](glossary.md#mutation)); the framework owns the cache, the dedupe, the [staleness and invalidation](glossary.md#invalidate), and a fail-closed [`:scope`](glossary.md#scope) leak boundary. Views *read* — they never fetch. A mutation declares — once, on its registration — which reads it [invalidates](glossary.md#invalidate), and exactly those refresh.
+**Resources** make server state declarative. You register a cached **read**
+([`reg-resource`](glossary.md#resource)) and a **write**
+([`reg-mutation`](glossary.md#mutation)). The framework owns the cache, dedupe,
+[invalidation](glossary.md#invalidate), and a fail-closed [`:scope`](glossary.md#scope)
+leak boundary. Views *read* — they never fetch.
 
 ```clojure
-(rf/reg-resource :article
-  {:scope :rf.scope/global}
-  (fn [{:keys [slug]}] {:method :get :url (str "/api/articles/" slug)}))
+(:require [re-frame.core :as rf]
+          [re-frame.resources]
+          [re-frame.http.managed])
 
-;; a view just reads — no fetching, no loading flags to wire
-@(rf/subscribe [:rf/resource :article {:slug "hello"}])
-;; => {:status :loading}  …then {:status :loaded :value {...}}
+(rf/reg-resource :article
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global}
+  (fn [{:keys [slug]} _ctx]
+    {:request {:method :get :url (str "/api/articles/" slug)}
+     :decode  :json}))
+
+;; a view only reads — no fetch on mount
+@(rf/subscribe [:rf/resource {:resource :article :params {:slug "hello"}}])
+;; => {:status :loading …}  then  {:status :loaded :data …}
 ```
 
-## In this section
+## Start here
 
-- **[Tutorial: Build RealWorld](tutorial/index.md)** — five parts that grow a real Medium-style app: pages and state, real server data, auth and forms, writes and invalidation, tests and a production build. Start here.
-- **[Concepts](concepts.md)** — the whole model, built up from a single read: registration, causes, the view-model, scope, owners, mutations, optimistic writes, infinite feeds, and every named failure.
-- **How-to** — [Paginate a feed](how-to/paginate-a-feed.md) and [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md): one task each, complete code.
-- **[Examples](examples.md)** — runnable apps, from a focused read lifecycle to the full read → write → invalidate → refetch loop.
-- **[Glossary](glossary.md)** — the section's vocabulary, one definition each.
-- **[Coming from TanStack Query](coming-from-tanstack-query.md)** — the vocabulary mapping and the five deliberate divergences, for query-library refugees.
+1. **[Tutorial: Build RealWorld](tutorial/index.md)** — five parts growing a Medium-style
+   app (pages → resources → auth → mutations → tests). Best first path if you want a
+   full app.
+2. **[The model](concepts.md)** — the grammar behind Part 2 onward: register, cause,
+   project, five statuses, scope, mutations.
+3. **Task recipes** when you have one job: [Paginate a feed](how-to/paginate-a-feed.md),
+   [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
+4. **[Testing](testing.md)** — cause with a dispatch, answer with canned HTTP, read the
+   cache projection.
 
-Underneath sits [**managed HTTP**](../async/index.md) (`:rf.http/managed`) — you describe a request as data and the runtime drives its whole lifecycle, dispatching the result back as an ordinary event. Resources are the high-level cache; [Async (HTTP)](../async/index.md) is the transport they ride on, and it's there for the requests that aren't cached reads.
+**Prerequisites.** The [Core introduction](../core/introduction.md). Resources plug into
+events, app-db, and effects; they do not replace them. The transport underneath is
+[managed HTTP](../async/index.md) (`:rf.http/managed`).
+
+Optional later: [examples](examples.md), [TanStack mapping](coming-from-tanstack-query.md),
+[glossary](glossary.md).
+
+## Three lanes
+
+Hold this split and the whole surface stays clear:
+
+| Lane | Job | Spelling |
+|---|---|---|
+| **Register** | Declare the handler once | `(rf/reg-resource …)` / `(rf/reg-mutation …)` |
+| **Cause** | Make a fetch or write happen | route `:resources`, `[:rf.resource/ensure …]`, `[:rf.mutation/execute …]` |
+| **Project** | Read state into a view | `@(subscribe [:rf/resource …])` — never fetches |
+
+A subscription that finds no entry stays `:idle` until something **causes** a load.
+
+## When *not* to use resources
+
+| Situation | Prefer |
+|---|---|
+| One or two uncached requests | [Managed HTTP](../async/http.md) + a small app-db slice |
+| Pure client state (UI flags, form drafts) | app-db + events |
+| Named lifecycle stages (login, websocket) | [machines](../machines/index.md) |
+| No server yet | Tutorial [Part 1](tutorial/01-pages-and-state.md) only |
+
+Reach for resources when **cached server reads start multiplying** — not on day one of
+a counter. [Where should this value live?](../core/where-state-lives.md) has the full
+decision table.

--- a/docs/resources/testing.md
+++ b/docs/resources/testing.md
@@ -45,7 +45,8 @@ Ensure is the cause; the stub answers; the projection settles — all inside one
         (is (= "Welcome" (get-in state [:data :article :title])))))))
 ```
 
-Three properties worth pinning while you're here, because each is a contract, not an accident:
+The registration under test is the same shape as [the model](concepts.md#register-a-resource)
+and [tutorial Part 2](tutorial/02-server-data.md). Three contracts worth pinning:
 
 - **A subscription never fetches.** Read the state *before* any cause fires and it's `:idle` — a test that asserts that is the honest check for "my view was a permanent skeleton because I forgot the cause."
 - **A first-load failure is `:error` with no data.** Stub `{:reply {:failure {:kind :rf.http/http-5xx :status 503}}}` and assert `:status :error`, `:has-data? false`, and the failure's `:kind` — [branch on the category, never the prose](../core/errors.md#test-the-structure-not-the-string).

--- a/docs/resources/testing.md
+++ b/docs/resources/testing.md
@@ -1,6 +1,13 @@
 # Testing resources
 
-Resources split into three lanes — register, cause, project — and that split is exactly what makes them testable: a test *causes* with an ordinary dispatch, answers the network with the same canned replies a [pipeline-run test](../core/testing/pipeline-runs.md) uses, and *reads* the outcome through the projections. No live server, no waiting, no browser.
+You can [author](concepts.md) and [build](tutorial/index.md) resources. This page is
+how you **prove** the cache.
+
+Resources split into three lanes — register, cause, project — and that split is
+what makes them testable: a test *causes* with an ordinary dispatch, answers the
+network with the same canned replies a [pipeline-run test](../core/testing/pipeline-runs.md)
+uses, and *reads* the outcome through projections. No live server, no waiting, no
+browser.
 
 > **Cause with a dispatch, answer with a canned reply, read the cache projection.**
 

--- a/docs/resources/tutorial/01-pages-and-state.md
+++ b/docs/resources/tutorial/01-pages-and-state.md
@@ -1,5 +1,8 @@
 # Part 1: pages, state, and the first feed
 
+No server yet — app-db, events, subs, views, and a routing skeleton. Server reads
+arrive in [Part 2](02-server-data.md).
+
 You left [the setup page](index.md) with an empty Conduit shell. By the end of this part it has two real pages — the home feed and the article page — and the URL decides which one you see. Type `/article/welcome-to-conduit` into the address bar and that article renders; press Back and the feed returns. Along the way you'll write your first [event](../../core/glossary.md#event), your first [subscriptions](../../core/glossary.md#subscription), and your first [views](../../core/glossary.md#view).
 
 That trio — events write, subs read, views render — is the loop everything else in re-frame2 builds on. Get comfortable with it here and the rest of the guide is variations on a theme.

--- a/docs/resources/tutorial/02-server-data.md
+++ b/docs/resources/tutorial/02-server-data.md
@@ -1,6 +1,6 @@
 # Part 2: real data — resources and the nine states
 
-In [Part 1](01-pages-and-state.md) the feed rendered from `seed-articles`. The data was born `:loaded` and never moved, so the `{:status :data :error}` shape looked like overkill — a lot of ceremony for something that never changed. Now the articles come from a real Conduit API, and that `:status` starts earning its keep. The feed genuinely *loads*, then is *loaded*, sometimes comes back *empty*, sometimes *fails*.
+In [Part 1](01-pages-and-state.md) the feed rendered from `seed-articles`. The data was born `:loaded` and never moved, so the `{:status :data :error}` shape looked like overkill — a lot of ceremony for something that never changed. Now the articles come from a real Conduit API, and that `:status` starts earning its keep. The feed genuinely *loads*, then is *loaded*, sometimes comes back *empty*, sometimes *fails*. The contracts behind this part are summarised in [the model](../concepts.md).
 
 By the end of this part the home page fetches the global article list on entry, the article page fetches one article by slug, a second visit is a cache hit with no network, and every render state the feed can be in is a branch *you* chose rather than one that surprised you at 2am in production.
 

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -1,6 +1,13 @@
 # Part 3: auth — login, register, and the guard
 
-In [Part 2](02-server-data.md) Conduit learned to read server data. Now it learns *who you are*. You'll add a sign-in page, a sign-up page, a session that survives reload, routes that refuse to open while signed out, and a clean sign-out. Most of it lands in one new namespace, `conduit/auth.cljs`.
+In [Part 2](02-server-data.md) Conduit learned to read server data. Now it learns
+*who you are* — forms, JWT, route guards — still mostly app-db and managed HTTP.
+Session-scoped resources and mutations return in
+[Part 4](04-mutations-and-invalidation.md).
+
+You'll add a sign-in page, a sign-up page, a session that survives reload, routes
+that refuse to open while signed out, and a clean sign-out. Most of it lands in one
+new namespace, `conduit/auth.cljs`.
 
 Here's the idea the whole part rests on. **A form is a tiny state machine wearing a trenchcoat.** Strip away the inputs and login is `idle → submitting → submitted | error`, plus a draft and an error map. Build that *once*, and every later form is a fill-in-the-blanks job.
 

--- a/docs/resources/tutorial/04-mutations-and-invalidation.md
+++ b/docs/resources/tutorial/04-mutations-and-invalidation.md
@@ -1,6 +1,8 @@
 # Part 4: writes — favoriting, posting, invalidation
 
-In [Part 2](02-server-data.md) the app *read* server state through [resources](../glossary.md#resource) — a resource is a cached, declarative read of remote data. In [Part 3](03-auth-and-forms.md) you added login. Reads are only half a real app, though. The moment a user clicks the favorite heart on an article card, or hits **Publish Article** in the editor, the app has to *write* — and a write is harder than a read, because a write makes other reads wrong. Favorite an article and three cached reads go stale at once: the article detail, every list it appears in, and your personal feed.
+In [Part 2](02-server-data.md) the app *read* server state through [resources](../glossary.md#resource). In [Part 3](03-auth-and-forms.md) you added login. Reads are only half a real app: a write makes other reads wrong. The contracts for mutations and tags are in [the model](../concepts.md#writes-invalidate-by-tag--causally); the focused recipe is [Invalidate after a mutation](../how-to/invalidate-after-a-mutation.md).
+
+Favorite an article and three cached reads go stale at once: the article detail, every list it appears in, and your personal feed.
 
 The naive fix is to wire each write to "and now refetch these reads" at the call site. That works right up until you have forty call sites and one of them forgets. re-frame2's answer is a [**mutation**](../glossary.md#mutation): a write registered *once*, with its consequences — which cached reads it breaks — declared on the registration, not at the call site. Click the heart anywhere and the right reads refresh, because the write knows what it breaks.
 

--- a/docs/resources/tutorial/05-test-and-ship.md
+++ b/docs/resources/tutorial/05-test-and-ship.md
@@ -1,5 +1,9 @@
 # Part 5: test it, ship it
 
+You have a working Conduit. This part is **prove and ship** — JVM tests for handlers,
+subs, and views, plus a production build. Resource-specific cache tests also live in
+[Testing resources](../testing.md).
+
 Your Conduit slice works. You watched it run in the browser across [Parts 1–4](index.md): the feed loads, login guards the editor, favoriting [invalidates and refetches](04-mutations-and-invalidation.md). Now prove it. You'll write tests that run on the JVM in milliseconds, with no browser anywhere. Then you'll cut the production bundle and see exactly what ships — and, just as importantly, what *doesn't*.
 
 There's one sentence to carry out of this whole page:

--- a/docs/resources/tutorial/index.md
+++ b/docs/resources/tutorial/index.md
@@ -1,6 +1,12 @@
 # Build RealWorld — what you'll make, and setup
 
-The [introduction](../../core/introduction.md) and [app-db](../../core/app-db.md) taught you the loop in a browser cell, with nothing installed and no server on the other end. That was the idea in a petri dish. Now you'll grow it into a real app on the real toolchain: **Conduit**, a working Medium-style blogging app — feeds, tags, auth, favoriting, posting, tests, and a production build. This page orients you (where the five parts go) and scaffolds the project (the part those cells hid). Budget five minutes from `npm install` to pixels.
+The [Core introduction](../../core/introduction.md) taught the loop in a browser
+cell. This tutorial grows it into **Conduit** — a Medium-style app with feeds,
+auth, favoriting, and a production build — on the real toolchain. Server-cache
+vocabulary lives in [the model](../concepts.md); this path is **do → observe → explain**.
+
+This page orients you (five parts) and scaffolds the project. Budget five minutes
+from `npm install` to pixels.
 
 Conduit follows the [RealWorld spec](https://github.com/gothinkster/realworld), the ecosystem's shared benchmark — which means the same app already exists in React, Vue, Svelte, Solid, and Elm. So every pattern you write here has a direct counterpart in a stack you already know. By the end of Part 5 you'll have built a real app, not a toy: **one app, grown a part at a time.** And you'll grow it the same way you worked the quickstart — *do* a thing, *observe* what the app actually did, *explain* why. (That **do → observe → explain** loop is the spine of this whole tutorial; the *observe* step is where [Xray](../../core/glossary.md#xray), the inspector you'll set up below, earns its keep.)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -248,8 +248,7 @@ nav:
     - "Coming from XState": machines/coming-from-xstate.md
 
   - Resources:
-    # Tutorial first (build something real), then the model, then task
-    # recipes. The TanStack translation sits last, like XState in Machines.
+    # Landing → tutorial (build) → model → recipes / test → examples → migrate.
     - resources/index.md
     - "Tutorial: Build RealWorld":
       - resources/tutorial/index.md
@@ -258,14 +257,14 @@ nav:
       - "3. Auth and forms": resources/tutorial/03-auth-and-forms.md
       - "4. Mutations and invalidation": resources/tutorial/04-mutations-and-invalidation.md
       - "5. Test and ship": resources/tutorial/05-test-and-ship.md
-    - "Concepts": resources/concepts.md
-    - "How-to":
+    - "The model": resources/concepts.md
+    - "Recipes":
       - "Paginate a feed": resources/how-to/paginate-a-feed.md
       - "Invalidate after a mutation": resources/how-to/invalidate-after-a-mutation.md
-    - "Testing": resources/testing.md
+      - "Testing": resources/testing.md
     - "Examples": resources/examples.md
-    - "Glossary": resources/glossary.md
     - "Coming from TanStack Query": resources/coming-from-tanstack-query.md
+    - "Glossary": resources/glossary.md
 
   - "Async (HTTP)":
     # Tutorial first (get productive), then the reference, then the


### PR DESCRIPTION
## Summary

Progressive rewrite of the Resources guide: RealWorld tutorial track first, then a slim three-lane model (register / cause / project), then how-to recipes and testing.

- Nav: tutorial parts, **The model**, How-to, testing, examples, TanStack last
- Concepts trimmed; complete register+route+view skeleton retained
- Correctness: `resources-artefact-missing`, required `params-schema` on glossary examples, fix mutation instance vector syntax and view-model key list in invalidate how-to

## Test plan

- [ ] Walk Resources nav and tutorial Part 2 opening
- [ ] Confirm complete read loop and how-to openings
- [ ] Relative links under `docs/resources/`
