### PR TITLE
docs(routing): progressive guide rewrite

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -76,7 +76,7 @@ Two cross-feature bare keys are also accepted:
 - `:head` — SSR's head-metadata contract. It is always in the accepted set.
 - `:resources` — the Resources artefact's route integration, late-bound via the `:routing/extra-route-keys` hook. In an app without the Resources artefact, `:resources` is rejected like any other unknown bare key.
 
-Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full).
+Guide overview of the key groups: [Metadata map](../routing/concepts.md#the-metadata-map-in-full) (per-key catalogue is this table and the API rows below).
 
 ### `clear-route`
 

--- a/docs/routing/coming-from-react-router.md
+++ b/docs/routing/coming-from-react-router.md
@@ -4,7 +4,7 @@ If you've used React Router's data APIs — `createBrowserRouter`, loaders, `use
 
 So this page is mostly good news. The translation is honest and direct, with one structural difference that explains all the smaller ones: **React Router is a system that lives beside your app — its own context, its own component tree, its own lifecycle. re-frame2 routing isn't a system at all.** It's three things you already have ([events](../core/glossary.md#event), [subscriptions](../core/glossary.md#subscription), [registrations](../core/glossary.md#registration)) pointed at the URL. There's no router object, no `<RouterProvider>`, no context to thread. Once that lands, every row in the table below stops looking like a port and starts looking like a deletion.
 
-For the full model from scratch, read [Routing concepts](concepts.md); this page assumes you'd rather start from what you know.
+For the full model from scratch, read [The model](concepts.md); this page assumes you'd rather start from what you know.
 
 ## The mapping
 
@@ -22,7 +22,7 @@ For the full model from scratch, read [Routing concepts](concepts.md); this page
 | `errorElement` / `useRouteError()` | `:on-error` + `@(subscribe [:rf.route/error])` | A structured [error record](../core/glossary.md#error-record) in state, plus an optional event to respond. |
 | `useBlocker()` / `usePrompt()` | `:can-leave` guard + `@(rf/subscribe [:rf/pending-navigation])` | A [route guard](glossary.md#route-guard) sub (boolean) and a *pending navigation you render from* — your confirm dialog is an ordinary view. |
 | Splat route `path="*"`, no-match route | The reserved [`:rf.route/not-found`](glossary.md#not-found) route | An ordinary route you register and design; it carries its own loaders, scroll, and a `:reason` discriminator. |
-| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [Concepts → Nested layouts](concepts.md#nested-layouts) for the worked code). |
+| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [The model → Nested layouts](concepts.md#nested-layouts) for the worked code). |
 | `<RouterProvider router>` / router context | nothing | The route lives in [runtime-db](../core/glossary.md#runtime-db); any [view](../core/glossary.md#view) reads it via subscription. No provider, no context. |
 | Framework-mode (v7 / Remix) server loaders | The *same* `:on-match` / `:resources` | One loader runs on client **and** server. There's no second "server loader" to keep in sync. |
 
@@ -60,7 +60,7 @@ React Router's framework mode (v7, formerly Remix) gives you server loaders — 
 
 ### There's no `<Outlet/>` — layouts are data you compose
 
-Here's the one place re-frame2 asks *more* of you, and it's honest to say so. React Router's `<Outlet/>` is a genuinely nice ergonomic: declare nested routes and the parent layout renders its active child into a slot automatically. re-frame2 has no render-slot machinery. Nesting is still expressed as data — a route declares a `:parent`, and `@(subscribe [:rf.route/chain])` gives you the parent chain of the active route — but you walk that chain and compose the layout shells yourself in your root view. The trade is deliberate: it keeps composition in plain Clojure (the same `case`/`cond` you'd write for any conditional view) rather than introducing a routing-specific rendering primitive. Whether that's a feature or a chore depends on how much you liked `<Outlet/>`. Pre-alpha; this edge is on the list. ([Concepts → Nested layouts](concepts.md#nested-layouts) has the worked `reduce`-over-the-chain code; the [tutorial](tutorial.md#step-7--a-shared-layout) builds it up step by step.)
+Here's the one place re-frame2 asks *more* of you, and it's honest to say so. React Router's `<Outlet/>` is a genuinely nice ergonomic: declare nested routes and the parent layout renders its active child into a slot automatically. re-frame2 has no render-slot machinery. Nesting is still expressed as data — a route declares a `:parent`, and `@(subscribe [:rf.route/chain])` gives you the parent chain of the active route — but you walk that chain and compose the layout shells yourself in your root view. The trade is deliberate: it keeps composition in plain Clojure (the same `case`/`cond` you'd write for any conditional view) rather than introducing a routing-specific rendering primitive. Whether that's a feature or a chore depends on how much you liked `<Outlet/>`. Pre-alpha; this edge is on the list. ([The model → Nested layouts](concepts.md#nested-layouts) has the worked `reduce`-over-the-chain code; the [tutorial](tutorial.md#step-7--a-shared-layout) builds it up step by step.)
 
 ### A grab-bag of smaller, on-purpose differences
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -1,33 +1,35 @@
-# Routing: the URL is a sub
+# The model
 
-Here's the whole idea in one line: **the URL is application state, and your back button is a dispatch.**
+This page is the **routing model** — three moves, then the refinements you hit next
+(loaders, guards, not-found, URL binding). Full recipes for leave/enter guards live
+in the how-tos; API signatures live in [re-frame.routing](../api/re-frame.routing.md).
 
-Most frameworks bolt a router onto the side of your app — its own context, its own lifecycle, its own opinion about where truth lives. re-frame2 doesn't. A route is a [registration](../core/glossary.md#registration): one row in re-frame2's table of routes. Navigating is dispatching an [event](../core/glossary.md#event): a data vector sent through the app. The active route is a [subscription](../core/glossary.md#subscription): a read of state your [views](../core/glossary.md#view) watch. That's it — three things you already know, pointed at the URL.
+To *build* a three-page app step by step, use the [tutorial](tutorial.md).
 
-Which means everything you already know about [events](../core/introduction.md) and [subscriptions](../core/subscriptions.md) is genuinely everything you need here. There is no fourth concept hiding behind the curtain. By the end of this page you'll register a route table, navigate and link between pages, branch your views on the active route, load each page's data declaratively, handle the 404, block a navigation, wire up back/forward, and — for free — run the exact same routing on the server.
+!!! note "Optional artefact"
 
-> **From re-frame v1.** There was no routing in v1 — you reached for secretary, bidi, or reitit, wired a third-party router to `dispatch` by hand, and kept the active route somewhere in [app-db](../core/glossary.md#app-db) yourself. re-frame2 folds all of that into the framework: routes are registrations, navigation is a built-in event, and the active route is a built-in subscription. The bring-your-own-router era is over. (It's still a *separate* artefact — `day8/re-frame2-routing` — so an app with no shareable URLs ships zero routing bytes.)
+    Require `re-frame.routing` once at boot — Maven `day8/re-frame2-routing`. Forget
+    it and the first `reg-route` throws `:rf.error/routing-artefact-missing`.
 
-> **Coming from React Router or Remix?** Routes-as-data and per-route loaders will feel familiar. The deliberate divergences: there are no hooks (`useNavigate` is an event dispatch, `useLoaderData` is a subscription, `useBlocker` is a guard sub), there's no router context to thread through your tree, and the same route handler runs on the server with zero SSR-specific code.
+??? info "Coming from React Router?"
+
+    Routes-as-data and loaders will feel familiar. Divergences: no hooks
+    (`useNavigate` → dispatch, `useLoaderData` → sub, `useBlocker` → guard sub), no
+    router context, same handler on the server. Full map:
+    [Coming from React Router](coming-from-react-router.md).
 
 ## The whole model in three moves
 
-Read these three moves and you've read the whole framework's idea of routing. Everything after them is a refinement of one of the three.
+<a id="the-whole-model-in-three-moves"></a>
 
 ```clojure
 ;; Adapted from examples/capabilities/routing/routing/core.cljs
 (ns app.core
   (:require [re-frame.core :as rf]
-            ;; Ships in day8/re-frame2-routing. Requiring it at boot is what makes
-            ;; reg-route available; the alias serves the routing-namespace helpers
-            ;; you'll meet below (route-url, match-url).
             [re-frame.routing :as routing]))
 
 ;; 1. A route is data in the registry.
-(rf/reg-route :app/home
-  {}
-  "/")
-
+(rf/reg-route :app/home {} "/")
 (rf/reg-route :app/article
   {:params [:map [:id :string]]}
   "/articles/:id")
@@ -36,11 +38,6 @@ Read these three moves and you've read the whole framework's idea of routing. Ev
 (rf/dispatch [:rf.route/navigate :app/article {:id "intro"}])
 
 ;; 3. The root view reads the active route through an ordinary subscription.
-;;    Inside reg-view, you call `subscribe` and `dispatch` unprefixed: the macro
-;;    binds them for you to this view's frame. (Outside a view — like moves 1 and
-;;    2 above — you reach through the `rf/` facade: `rf/subscribe`, `rf/dispatch`.)
-;;    The leading `@` deref-es the subscription to its current value and registers
-;;    this view to re-render when that value changes — see the Subscriptions page.
 (rf/reg-view article-page []
   (let [{:keys [id]} @(subscribe [:rf.route/params])]
     [:h1 "Article " id]))
@@ -52,302 +49,214 @@ Read these three moves and you've read the whole framework's idea of routing. Ev
     :rf.route/not-found [:h1 "Not found"]))
 ```
 
-Move 1 is a couple of registry rows. Move 2 is a dispatch — the same verb you use everywhere. Move 3 is a `case` over a subscription. No router object, no provider, no context. The rest of this page builds gently on these three: query strings, data loading, the 404, blocking a navigation, back/forward, SSR. Once the three click, the rest is detail.
+Inside `reg-view`, `subscribe` / `dispatch` are injected (no `rf/` prefix). Outside
+a view, use `rf/subscribe` / `rf/dispatch`.
 
 ## Move 1: a route is a registry entry
 
-`reg-route` registers a route the same way `reg-event` registers an event: an id, a metadata map, and — in the third slot — the path. The path grammar is small enough to parse in your head. A path is made of exactly five kinds of thing, and no more: literal segments (`/articles`), named params (`:id`), an optional group (`{/:slug}?`), a catch-all splat (`*rest`), and the root (`/`).
+<a id="move-1-a-route-is-a-registry-entry"></a>
 
-> **Gotcha — `reg-route` needs the artefact loaded.** `reg-route` (and `route-link`, `match-url`, `route-url`, the route subs) all live in the separately-packaged `day8/re-frame2-routing` artefact, not in core. Requiring `re-frame.routing` *at boot* is what wires them up — that's the `(:require … [re-frame.routing])` in the three-moves snippet above. Forget it and the first `reg-route` call **throws** `:rf.error/routing-artefact-missing`, naming the namespace to require and the Maven coordinate to add — a loud, actionable error, not a silent no-op.
+`reg-route` is three slots: **id**, **metadata map**, **path** (third — never
+`:path` inside the map; that throws `:rf.error/route-bad-metadata`).
 
-The `:params` and `:query` keys take [schemas](../core/how-to/validate-with-schemas.md), which validate *and coerce* for you, so `?page=2` arrives as the integer `2`, not the string `"2"`. That coercion is the part everyone forgets to do by hand — so let the schema own it:
+Path grammar: literal segments, named params (`:id`), optional groups (`{/:slug}?`),
+splat (`*rest`), root (`/`).
 
-```clojure
-(rf/reg-route :app/search
-  {:query          [:map [:q :string] [:page {:optional true} :int]]
-   :query-defaults {:page 1}}
-  "/search")
-```
-
-`:query-defaults` fills absent query keys at match time, so a search page with no `?page=` still gets `{:page 1}`. Path params and query params stay separate maps the whole way through: captured separately, validated against separate schemas, never silently merged into one bag.
-
-### Carrying global state through the URL
-
-One more `:query` key earns its keep early. `:query-retain` is a set of keys carried through *subsequent* navigations even when the caller didn't supply them — exactly what you want for URL-encoded global state like `?theme=dark` or `?locale=fr`. Navigate from a search page to the cart and the theme rides along:
+`:params` and `:query` take [schemas](../core/how-to/validate-with-schemas.md) that
+**validate and coerce** — `?page=2` arrives as integer `2`.
 
 ```clojure
 (rf/reg-route :app/search
   {:query          [:map [:q :string] [:page {:optional true} :int]]
    :query-defaults {:page 1}
-   :query-retain   #{:theme :locale}}
+   :query-retain   #{:theme :locale}}   ;; ride along on later navigations
   "/search")
-
-;; From a /search?q=clojure&theme=dark page:
-(rf/dispatch [:rf.route/navigate :app/cart])
-;; → /cart?theme=dark   — :theme rode along, you never named it
 ```
 
-> **Gotcha — retained keys aren't re-coerced.** A retained key is merged **verbatim** into the next URL, *not* re-validated against the target route's `:query` schema. So keep a retain key's *type* consistent across every route that retains it: type `:theme` as `[:enum :light :dark]` on one route and `:string` on another and you'll carry a keyword `:dark` into a `:string` slot. That's caught (the target's `:query` validator runs and rejects the navigation), not silent — but it's friction you avoid by being consistent.
+Path params and query params stay **separate maps** end to end.
+
+!!! warning "Retained query keys aren't re-coerced"
+
+    `:query-retain` merges keys **verbatim** into the next URL. Keep types consistent
+    across routes that retain them.
 
 ### Routes are queryable data
 
-Because routes are registry entries, the route table is *queryable data* — and that pays off. Tag a route `:tags #{:requires-auth}` and an ordinary [interceptor](../core/interceptors.md) (a `:before`/`:after` wrapper around your navigation events) can read the tag and redirect. That's the entire auth-guard mechanism — no special router machinery, just data and a step that reads it:
+<a id="routes-are-queryable-data"></a>
+
+Tag a route; anything can query the table:
 
 ```clojure
 (rf/reg-route :app/admin
   {:tags     #{:requires-auth}
    :on-match [[:admin/load-dashboard]]}
   "/admin")
-
-;; An interceptor reads the tag off any navigation target and redirects when logged out.
-;; (rf/handler-meta :route route-id) returns the metadata, :tags and all.
+;; (rf/handler-meta :route :app/admin) → metadata including :tags
 ```
 
-[Require sign-in on a route](how-to/require-sign-in-on-a-route.md) is the routing-focused recipe; [Add authentication](../core/how-to/add-auth.md) walks through the whole auth flow end to end.
+Recipes: [Require sign-in](how-to/require-sign-in-on-a-route.md) (routing half),
+[Add authentication](../core/how-to/add-auth.md) (full flow). Prefer **`:can-enter`**
+for a single-route auth gate ([below](#guarding-entry--can-enter)); use an
+interceptor when one policy spans many routes (and attach it so all three entry
+doors are covered).
 
-> **For JavaScript developers.** This is the inverse of React Router's `<Route>` JSX tree, where each route is a *component* and you read it by being rendered inside it. Here a route is a *data row* you can `get`, `filter`, and `map` over from anywhere — auth guards, breadcrumb generators, sitemap builders, and analytics all just query the same table.
+### Metadata map (map of the territory)
 
-### The metadata map, in full
-
-You've now met the keys you'll reach for daily. The metadata map has fourteen reserved keys in total — the largest registration shape in re-frame2 — but you never learn them as a flat list. They cluster into four groups by *what they control*; pick the group first, then the key. The rest of this page introduces the remaining keys in context, so treat this table as a map of where you're going — and the [API reference](../api/re-frame.routing.md#reg-route) for the canonical, per-key spec.
-
-| Group | Keys | What it controls |
+| Group | Keys | Controls |
 |---|---|---|
-| **Shape** — URL ↔ params | `:params`, `:query`, `:query-defaults`, `:query-retain` | Which URLs match, and how their parts coerce into maps. The contract `match-url` and `route-url` agree on. |
-| **Lifecycle** — events at navigation boundaries | `:on-match`, `:on-error`, `:can-leave`, `:can-enter` | What the runtime dispatches when the route activates (`:on-match`), when a loader errors (`:on-error`), a guard sub consulted before you leave (`:can-leave`), and a guard sub consulted before you enter (`:can-enter`). |
-| **Layout** — how the route fits with neighbours | `:doc`, `:parent`, `:tags`, `:scroll` | How the route is described, nested (`:parent`), grouped for interceptors (`:tags`), and scrolled on entry (`:scroll`). |
-| **Classification** — data hygiene | `:sensitive`, `:large` | Which slice values are redacted or kept off the wire at egress while the route is active (see [Data classification](#keeping-tokens-off-the-wire) below). |
+| **Shape** | `:params`, `:query`, `:query-defaults`, `:query-retain` | URL ↔ maps |
+| **Lifecycle** | `:on-match`, `:on-error`, `:can-leave`, `:can-enter` | Activate / error / guards |
+| **Layout** | `:doc`, `:parent`, `:tags`, `:scroll` | Nesting, grouping, scroll |
+| **Classification** | `:sensitive`, `:large` | Egress redaction of the route slice |
+| **Borrowed** | `:resources` (resources artefact), `:head` ([SSR head](../ssr/head.md)) | Server state / head model |
 
-Two more bare keys are on loan from other parts of the framework, accepted when their owning artefact is loaded: `:resources` (declared server state — [below](#declaring-resources-instead), owned by the resources artefact) and `:head` (the server-rendered page's [head metadata](../ssr/head.md), owned by SSR). In an app that doesn't load the owning artefact, they're rejected like any other unknown bare key — so a `:resources` declaration can't silently do nothing.
-
-> **Gotcha — typos fail loud, at registration.** Because the shape is large, a typo like `:on-matched` or `:querey` would otherwise be silently accepted and then quietly do nothing forever. So `reg-route` validates its metadata *at the authoring boundary*: a **bare** (unqualified) key outside the reserved set throws `:rf.error/route-bad-metadata` the instant you register, naming the offending key and the valid vocabulary. Your own extension keys are fine — just namespace them (`:myapp/layout`, `:analytics/id`); namespaced keys are the open-extension surface, bare keys are the framework's reserved vocabulary. And note `:path` belongs in the *third slot*, not the map — leaving it inside the metadata is the same loud error.
-
-When two patterns could both match one URL, a structural ranking breaks the tie: more static segments win, and named params beat splats. The ranking is computed at *registration* time from the patterns alone — so the winner is decided before a single URL ever arrives, and there's no runtime ambiguity to debug.
-
-??? note "The full ranking cascade"
-
-    The five path elements above are the whole grammar; the ranking cascade, when two patterns compete, runs six rules deep: (1) more static segments win; (2) the *bare* catch-all `/*` is demoted below everything; (3) longer paths win; (4) named params beat splats; (5) exact routes beat optional-group routes; (6) registration order is the final, discouraged tiebreak — and the runtime warns (`:rf.warning/route-shadowed-by-equal-score`) at registration if two routes tie all the way down *and* could actually match the same URL (`/a/:x` and `/a/:y` warn; `/x/:id` and `/y/:slug` don't — they tie structurally but never compete). The warning names the new, shadowed route (`:route-id`), the earlier-registered winner (`:shadowed-by`), and the tied score (`:rank`). You won't need past rule (1) for everyday routes.
+Bare unknown keys fail loud at registration (`:rf.error/route-bad-metadata`).
+Namespaced keys (`:myapp/…`) are open extension. Canonical per-key list and
+ranking cascade: [API `reg-route`](../api/re-frame.routing.md#reg-route).
+`:path` is the **third** slot of `reg-route`, never a metadata key.
 
 ## Move 2: navigation is an event
 
-You navigate with the same verb you use for everything else, which is the whole reason the surface stays small:
+<a id="move-2-navigation-is-an-event"></a>
 
 ```clojure
 (rf/dispatch [:rf.route/navigate :app/article {:id "intro"}])
 
-;; Query params and options ride in the THIRD slot — params 2nd, opts 3rd:
+;; Params 2nd, opts 3rd — empty params when you only have opts:
 (rf/dispatch [:rf.route/navigate :app/search {} {:query {:q "clojure" :page 2}}])
-
-;; Replace instead of push (login redirects, search-as-you-type):
 (rf/dispatch [:rf.route/navigate :app/login {} {:replace? true}])
-
-;; Jump to a fragment:
 (rf/dispatch [:rf.route/navigate :app/article {:id "intro"} {:fragment "section-2"}])
 ```
 
-The opts map (third slot) is open; the runtime recognises these keys (the canonical enumeration lives in [Spec 012 §The `navigate` opts](../../spec/012-Routing.md), which this table mirrors):
-
 | Opt | Effect |
 |---|---|
-| `:replace?` | Use `replaceState` instead of `pushState` — for redirects, login-flow returns, and search-as-you-type, where the back button should *not* land on the intermediate URL. |
-| `:query` | The query-string params for the new URL — coerced and emitted as `?key=value`. Replaces the query wholesale. |
-| `:query-merge` | Fold these deltas into the **current** query instead of replacing it — the "stay here, change these params" move for search, pagination, and tabs. A `nil` value **removes** a key. Pairs with the `:rf.route/self` target (see [Navigate-in-place](#navigate-in-place) below). |
-| `:scroll` | Per-call override of the route's `:scroll` strategy (`:top` / `:restore` / `:preserve`; see [Fragments and scrolling](#fragments-and-scrolling)). |
-| `:fragment` | The target `#fragment` for the new URL. |
-| `:bypass-guards?` | A **set** of `#{:leave :enter}` naming which navigation guards to skip for this one navigation — `#{:leave}` skips the current route's `:can-leave`, `#{:enter}` skips the target route's `:can-enter`, `#{:leave :enter}` skips both (see [Blocking a navigation](#blocking-a-navigation) below). |
-
-Hosts and apps may add their own opts under a namespace.
+| `:replace?` | `replaceState` instead of `pushState` |
+| `:query` | Replace query wholesale |
+| `:query-merge` | Edit current query (`nil` removes a key) |
+| `:scroll` | `:top` / `:restore` / `:preserve` override |
+| `:fragment` | `#fragment` |
+| `:bypass-guards?` | Set `#{:leave :enter}` to skip named guards |
 
 <a id="navigate-in-place"></a>
-#### Navigate-in-place: change the query, stay on the route
 
-Changing `?page=`, a search term, or a tab means *stay on this route, change these query params* — the most common URL operation there is. Reach for the reserved `:rf.route/self` target and `:query-merge`:
+**Stay on this route, change query** — reserved target `:rf.route/self`:
 
 ```clojure
-;; On /search?q=clojure&page=1  →  /search?q=clojure&page=2
 (rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}])
-
-;; Clear a filter: a nil value removes the key  →  /search?q=clojure
-(rf/dispatch [:rf.route/navigate :rf.route/self {} {:query-merge {:page nil}}])
 ```
-
-`:rf.route/self` resolves to the route you're already on (id + path params, read from the current slice), so you never hand-roll a "read the route, branch on the id, rebuild the query" helper. `:query-merge` folds your deltas onto the current query — caller values win, a `nil` drops a key. It works with any target, but `:rf.route/self` is its natural partner. (`:query` *replaces* the whole query; `:query-merge` *edits* it — pick by whether you're building a fresh query or nudging the current one.)
-
-> **From re-frame v1.** `useNavigate`-style imperative calls and `secretary`'s `(set! js/window.location ...)` both become an ordinary `dispatch`. That means navigation is now *interceptable* and *replayable* like any other event — a navigate shows up in [Xray](../core/glossary.md#xray) on the same wire as your business events, and time-travel rewinds it for free, because it was never a side-channel. And this holds for **hash-URL apps too** — the shape most secretary-era apps have. Declare `:url-strategy routing/hash-url-strategy` on your URL-owning frame and the router speaks `#/…` at the edges (link hrefs, history, the URL-change listener) while `route-url` / `match-url` stay path-form; you use `:rf.route/navigate` and `route-link` exactly as a path-URL app does. There is no `(set! js/window.location.hash …)` side-channel left to write. See [URL strategies](#url-strategies) below.
 
 !!! warning "Params is 2nd, opts is 3rd"
 
-    `[:rf.route/navigate :app/cart {:replace? true}]` *reads* like "navigate with options" but actually drops `:replace?` into the **params** slot. The runtime catches the mistake and rejects the navigation with a named error (`:rf.error/navigate-arity-misuse`) rather than navigating wrongly — so you get a loud signal, not a silent bug. Just pass an empty params map: `[:rf.route/navigate :app/cart {} {:replace? true}]`. (A route that *legitimately* captures a path segment named `:fragment` isn't false-flagged — the runtime only complains when an opts-only key lands in the params slot of a route that doesn't declare it as a path-param.)
+    `[:rf.route/navigate :app/cart {:replace? true}]` dumps opts into **params** and
+    fails loud (`:rf.error/navigate-arity-misuse`). Use
+    `[:rf.route/navigate :app/cart {} {:replace? true}]`.
 
 ### Linking from views
 
-For links *in views*, use `route-link`. It renders a real `<a href>` (good for accessibility, hover-preview, and copy-link) and intercepts plain primary clicks into a dispatch. Crucially it also *defers* cmd-click, shift-click, and middle-click to the browser, so open-in-new-tab still works — the detail hand-rolled SPA links almost always forget:
+<a id="linking-from-views"></a>
 
 ```clojure
 [rf/route-link {:to :app/article :params {:id "intro"}} "Read more"]
-
-;; The full prop surface — query, fragment, and any HTML attrs pass through:
-[rf/route-link {:to       :app/search
-                :query    {:q "clojure" :page 2}
-                :fragment "results"
-                :class    "nav-link"
-                :title    "Search articles"}
- "Search"]
+[rf/route-link {:to :app/search :query {:q "clojure"} :class "nav-link"} "Search"]
 ```
 
-`route-link` takes `:to` (route id), `:params`, `:query`, and `:fragment` to build the URL, plus any HTML attributes (`:class`, `:title`, `:id`, `:aria-label`, …) which pass straight through to the `<a>`. A caller-supplied `:on-click` runs *before* the framework's interception and can pre-empt it with `.preventDefault`. Because `route-url` is the single point where the URL is synthesised, renaming or reshaping a route flows into every `route-link` site with no per-link edits.
+Real `<a href>` — hover, copy-link, cmd/middle-click work. Plain left-click becomes
+dispatch. `:target "_blank"` / `:download` are **not** SPA-intercepted (browser owns
+them). Plain `[:a {:href …}]` does a full navigation unless you install your own
+handler on `:rf.route/url-requested` (the policy seam every `route-link` uses).
 
-> **Gotcha — native-anchor attributes win.** A `route-link` carrying `:target "_blank"` (or `_parent`/`_top`/a named frame) or `:download` is **not** intercepted, even on a plain left-click — the browser handles it, exactly as the DOM attributes advertise. SPA-intercepting a `{:target "_blank"}` link would silently break open-in-new-tab; intercepting a `{:download ...}` link would turn it into a no-op. The link still renders as a real `<a>`; the click is just left to the browser. Want SPA interception? Omit those attributes (or set `:target "_self"`).
+### Order of effects
 
-Plain `[:a {:href "..."}]` anchors are **not** intercepted; they do a native full-page navigation. Site-wide anchor interception is a host-adapter concern, not framework magic, so you opt in per link (or install your own document-level click handler that dispatches `:rf.route/url-requested` — the same decision-point event `route-link` uses).
+Navigate runs in a **locked order**: update route slice in runtime-db → push URL →
+dispatch loaders. State before URL on purpose.
 
-> **`:rf.route/url-requested` is the policy seam.** Every `route-link` click dispatches `:rf.route/url-requested`, and *that* event is the single decision point for "in-app or external?", "is the leave-guard satisfied?", and any policy of your own (auth, modifier keys). Because it's an ordinary event, you can drive it from a test with zero DOM: dispatch `[:rf.route/url-requested {:url "/cart"}]` and assert what happened. An in-app request pushes the URL and runs the route transition. Anything not provably same-origin is treated as external — it emits a `:rf.route/external-url-requested` trace and pushes nothing. Re-registering `:rf.route/url-requested` is how you install app-wide navigation policy.
-
-### Navigating to a raw URL string
-
-The canonical target is a route id, because ids are enumerable, refactorable, and queryable. But sometimes you have a *string* you didn't build yourself — a deep-link handler, a server redirect target, a URL from an API. For those, navigate to a `{:url ...}` map:
-
-```clojure
-;; Escape hatch: navigate to a URL string the app didn't construct.
-(rf/dispatch [:rf.route/navigate {:url "/articles/intro"}])
-```
-
-The runtime runs `match-url` on the string. If it resolves to a registered route, navigation proceeds normally; if it matches nothing, it routes to `:rf.route/not-found` with the URL in `:params` — and pushes the *requested* URL to the address bar (not the not-found route's own path), so the user keeps the link they aimed at while your 404 view renders. The string is also passed through the same fail-closed open-redirect check as `route-link`: a URL that isn't provably same-origin is treated as external and *not* pushed into history.
-
-> **Tooling can nudge you back.** Because the route-id form is the well-formed one, tools can flag `{:url ...}` call sites as candidates to migrate to a registered route-id when the pattern is known. Reach for the string form only when you genuinely have a string.
-
-### What happens, in order
-
-When the navigate event runs, three things happen in a **locked order**: first the route slice in [runtime-db](../core/glossary.md#runtime-db) updates, then the browser URL pushes, then the route's loaders dispatch. State-before-URL is on purpose. If the URL push fails — offline, or the browser denies it — your application state is still consistent, so you never end up showing one page while the address bar swears you're on another.
+Raw URL escape hatch: `(rf/dispatch [:rf.route/navigate {:url "/articles/intro"}])`.
 
 ## Move 3: the active route is a subscription
 
-The current route lives in **runtime-db** — the framework-owned partition beside your app-db (see [the two partitions](../core/app-db.md#yours-and-the-frameworks-next-door)), addressed at `[:rf.db/runtime :rf.runtime/routing :current]`. Your code *reads* it and never *writes* it, and you read it like any other state:
+<a id="move-3-the-active-route-is-a-subscription"></a>
+
+The current route lives in **runtime-db** (not app-db). You read; you never write:
 
 ```clojure
-@(rf/subscribe [:rf/route])             ;; the full slice: {:route-id :params :query :fragment :transition :error :nav-token}
-@(rf/subscribe [:rf.route/id])          ;; just the route id
-@(rf/subscribe [:rf.route/params])      ;; path params
-@(rf/subscribe [:rf.route/query])       ;; query params
-@(rf/subscribe [:rf.route/fragment])    ;; the URL #fragment string, or nil
-@(rf/subscribe [:rf.route/transition])  ;; :idle | :loading | :error
-@(rf/subscribe [:rf.route/error])       ;; structured error map when :transition = :error
-@(rf/subscribe [:rf.route/chain])       ;; the :parent chain of the active route (for nested layouts)
-@(rf/subscribe [:rf/pending-navigation]);; the blocked navigation parked by a :can-leave guard, or nil
+@(rf/subscribe [:rf/route])              ;; full slice
+@(rf/subscribe [:rf.route/id])
+@(rf/subscribe [:rf.route/params])
+@(rf/subscribe [:rf.route/query])
+@(rf/subscribe [:rf.route/fragment])
+@(rf/subscribe [:rf.route/transition])   ;; :idle | :loading | :error
+@(rf/subscribe [:rf.route/error])
+@(rf/subscribe [:rf.route/chain])        ;; :parent ancestry (nested layouts)
+@(rf/subscribe [:rf/pending-navigation]) ;; blocked leave, or nil
 ```
 
-Nine subscriptions, every one a plain read — no special routing API in views. `:rf/route` is the whole slice; the rest are projections of it you'll reach for far more often. The [API reference](../api/re-frame.routing.md#subscriptions) lists each with its return shape.
-
-Two of those you'll read constantly — the whole slice and the pending navigation — through the ordinary `subscribe`: `@(rf/subscribe [:rf/route])` and `@(rf/subscribe [:rf/pending-navigation])`. Every framework read is a subscription vector, one grammar.
-
-`:transition` is a tiny state machine the runtime drives for you: `:loading` while a route's loaders drain, `:error` if one fails, `:idle` otherwise. So a global progress bar is just a view over `:rf.route/transition`, and an error banner is a view over `:rf.route/error`. You never wire per-page loading state again — it's a property of the slice, the same on every page:
+`:transition` drives a global progress bar without per-page loading flags:
 
 ```clojure
-(rf/reg-view global-progress-bar []
+(rf/reg-view progress-bar []
   (case @(subscribe [:rf.route/transition])
-    :loading [:div.progress-bar.active]
-    :error   [:div.error-banner (:rf.error/message @(subscribe [:rf.route/error]))]
-    nil))   ;; :idle ⇒ nothing
+    :loading [:div.progress.active]
+    :error   [:div.error (:rf.error/message @(subscribe [:rf.route/error]))]
+    nil))
 ```
-
-> **Coming from TanStack Query?** That global `:transition` plays the role `isFetching` plays at the page level — except you didn't have to thread it through any component, because it's a subscription anyone can read from anywhere in the tree.
-
-Try it with the [Xray inspector](../xray/index.md) open. Dispatch a navigation and watch the trace: the navigate event, the fresh nav-token allocation, then each loader dispatch, in order. Routing has no hidden machinery — everything it does shows up on the same wire as your own events, which is exactly what makes it easy to trust.
 
 ### Fragments and scrolling
 
-The `#fragment` part of a URL is first-class: it rides in the slice, it has its own sub (`:rf.route/fragment`), and `route-url`'s 4-arity emits one. A fragment-only change — same route, same params, just a new `#anchor` — updates the slice and emits a `:rf.route/fragment-changed` trace but does **not** re-fire the route's loaders (`:on-match`). You jumped to an anchor; you didn't reload the page.
+<a id="fragments-and-scrolling"></a>
 
-Scrolling on navigation is declarative too — a route's `:scroll` key (or a per-call `:scroll` in the navigate opts) names one of three strategies:
-
-| `:scroll` | Behaviour |
-|---|---|
-| `:top` | Scroll to the top of the page — *unless* a `#fragment` is present, in which case it scrolls that element into view (falling back to top if the element is absent). |
-| `:restore` | Restore the saved scroll position for this URL (the runtime captures positions on every navigation). |
-| `:preserve` | Leave the scroll position alone. `nil`/absent means the same. |
-
-The default is `:top` for forward navigation and `:restore` for back/forward (popstate) — the behaviour browsers give you natively, made explicit and overridable. A per-call `:scroll` opt wins over the route's metadata, which wins over the default.
-
-```clojure
-(rf/reg-route :app/article
-  {:params [:map [:id :string]]
-   :scroll :top}                       ;; forward nav scrolls to top
-  "/articles/:id")
-
-;; Override per call — keep position on this one navigation:
-(rf/dispatch [:rf.route/navigate :app/article {:id "next"} {:scroll :preserve}])
-```
+Fragment-only changes update the slice and do **not** re-fire `:on-match`. Route
+`:scroll` (or navigate opts): `:top` (default forward), `:restore` (default
+back/forward), `:preserve`.
 
 ## Nested layouts
 
-A real app wraps its pages in shared shells — a site header, a section sidebar — without each page repeating them. re-frame2 has no `<Outlet/>` render slot; instead, **nesting is data**. A child route names a `:parent`, and the `:rf.route/chain` sub hands you the active route's ancestry, so you compose the shells yourself.
+<a id="nested-layouts"></a>
+
+No `<Outlet/>` — nesting is data. Child names `:parent`; compose shells from
+`[:rf.route/chain]` (root-most first):
 
 ```clojure
 (rf/reg-route :app/articles {} "/articles")
-(rf/reg-route :app/article  {:parent :app/articles
-                             :params [:map [:id :string]]} "/articles/:id")
-```
+(rf/reg-route :app/article
+  {:parent :app/articles
+   :params [:map [:id :string]]}
+  "/articles/:id")
 
-`@(subscribe [:rf.route/chain])` returns the chain **root-most first** — on `/articles/intro`, `[:app/articles :app/article]`; on a route with no `:parent`, a single-element vector. The leaf is the page you're on; each ancestor contributes a wrapping shell. Fold from the leaf outward:
-
-```clojure
-;; page-for: a route id → its page view.  ancestor-shell: an ancestor id → the
-;; shell it wraps around `inner` (returning `inner` unchanged when it adds no chrome).
 (rf/reg-view root-view []
   (let [chain @(subscribe [:rf.route/chain])]
     (reduce (fn [inner ancestor] (ancestor-shell ancestor inner))
-            (page-for (last chain))          ;; the leaf page
-            (reverse (butlast chain)))))     ;; its ancestors, innermost first
+            (page-for (last chain))
+            (reverse (butlast chain)))))
 ```
 
-Truly global chrome — a header on every page — needs no chain at all; render it once in the root view and fold the chain inside it. You only reach for the chain when a shell wraps a *subtree*.
-
-> **Coming from React Router.** This is `<Outlet/>`'s job, done as plain view composition. The cost is one `reduce`; the gain is no routing-specific rendering primitive — the chain is an ordinary subscription, and the layout is the same `case`/`reduce` you'd write for any conditional view. The [tutorial](tutorial.md#step-7--a-shared-layout) builds this up step by step.
+Tutorial builds this: [Step 7](tutorial.md#step-7--a-shared-layout).
 
 ## Loaders: declaring a page's data
 
-A route can declare what data to load when it becomes active, so a page's data-needs live next to its URL instead of scattered through a dozen `componentDidMount`s. The simplest form is `:on-match`: a vector of ordinary event vectors the runtime dispatches, in order, whenever the route activates — *including* when the same route re-activates with **changed** params. Identical params don't re-fire, so you never get accidental double-loads from a no-op navigation.
+<a id="loaders-declaring-a-pages-data"></a>
+
+**`:on-match`** — vector of event vectors on activate (including same route with
+changed params; identical params don't re-fire):
 
 ```clojure
 (rf/reg-route :app/cart
-  {:on-match [[:cart/load-items]
-              [:user/load-prefs]]}   ;; dispatched in order, on every activation
+  {:on-match [[:cart/load-items] [:user/load-prefs]]
+   :on-error [:app/cart-load-failed]}
   "/cart")
 ```
 
-`:on-match` events run server- *and* client-side (SSR populates the same data through the same vector), and they're enumerable — `(rf/handler-meta :route :app/cart)` returns the list, so tooling can draw a route's data-dependency graph. Each event reads the freshly-written route slice through a [coeffect](../core/coeffects.md) (a fact the framework injects into a handler) or the route subs (`:rf.route/params`, `:rf.route/query`), so you don't hand-wire params into the event vector.
-
-> **Coming from React Router or Remix?** `:on-match` *is* the route loader — but as a list of event vectors, not a function. Because it's data, you can read it, test it, and draw a dependency graph from it without running it. And it runs on the server through the exact same vector, so there's no separate "server loader" to keep in sync.
-
-### When a loader fails
-
-If any `:on-match` event errors, the runtime flips `:rf.route/transition` to `:error`, populates `:rf.route/error` with the structured error, and — if the route declares `:on-error` — dispatches that event so you can respond (toast, redirect, contextual error UI):
-
-```clojure
-(rf/reg-route :app/cart
-  {:on-match [[:cart/load-items]]
-   :on-error [:app/cart-load-failed]}   ;; dispatched if a loader throws
-  "/cart")
-
-(rf/reg-event :app/cart-load-failed
-  (fn [{:keys [db] rt :rf.db/runtime} _]
-    (let [error (get-in rt [:rf.runtime/routing :current :error])]   ;; route slice is runtime-db
-      {:db (assoc-in db [:cart :load-error] (:rf.error/message error))})))
-```
-
-Routes with no `:on-error` simply leave `:transition :error` set; a view over `:rf.route/error` can render a banner. Either way, the structured-error trace still fires on the wire — `:on-error` is the route's *response*, layered over the framework's [error contract](../core/errors.md), not a replacement for it.
-
-> **Two subtleties worth knowing.** (1) *Later loaders still run.* re-frame2's [run-to-completion](../core/glossary.md#drain--run-to-completion) drain doesn't cancel events already queued, so `:on-match [[:a] [:b]]` runs `:b` even if `:a` threw. A loader that must short-circuit on a sibling's failure reads `:rf.route/transition` and self-guards. (2) *First error wins.* If both throw, `:rf.route/error` records the first, and `:on-error` fires exactly once. The slice always lands on `:error` regardless of how the events interleave.
+Runs client- and server-side. On loader failure, `:transition` → `:error`; optional
+`:on-error` event fires once (first error wins; later loaders still run).
 
 ### Declaring resources instead
 
-If the page's data is [server state managed as resources](../resources/concepts.md) — a [resource](../resources/glossary.md#resource) being a declared, cached unit of server data — declare it as data with the `:resources` key instead (available when both `re-frame.routing` and `re-frame.resources` are loaded):
+<a id="declaring-resources-instead"></a>
+
+With the resources artefact, declare cached server reads on the route:
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_resources/routing.cljs
 (rf/reg-route :realworld.article/show
   {:params [:map [:slug :string]]
-   :scroll :top
    :resources
    [{:resource  :realworld/article
      :params    (fn [route] {:slug (get-in route [:params :slug])})
@@ -359,210 +268,177 @@ If the page's data is [server state managed as resources](../resources/concepts.
   "/article/:slug")
 ```
 
-> **Coming from Remix?** This is the loader — as data. `:blocking? true` is the `await`: it holds the route transition (and, on the server, the render) until the resource settles. Non-blocking entries fetch in the background. `:keep-previous? true` keeps the old page on screen while the next one first-loads, so a slug change doesn't flash an empty article. A fourth flag, `:when` — a `(fn [route ctx] …)` predicate — makes an entry *conditional*: the resource is planned only when the predicate is truthy, which beats threading a sentinel `nil` param to mean "don't load yet".
-
-Here's the bug this design quietly kills. On route entry, the runtime marks each listed resource active, owned by the route, keyed by *this navigation's* **nav-token**. On route leave — or the moment a newer navigation supersedes this one — ownership is released by token, and any stale reply that lands late is *suppressed* rather than written. That's the classic race where you click away, an old fetch resolves a beat too late, and clobbers the page you're now looking at. Fixed once, in the substrate, instead of in every page you'll ever write.
-
-> **Going deeper.** The nav-token is just a counter. Every navigation gets the next number, and that number answers "which navigation am I?". Suppression uses it as a receipt check: a result is written only if its token still matches the live navigation's; otherwise it's quietly dropped. And it isn't a `:resources`-only trick. A hand-rolled async loader can capture the live token (declare the `:rf.route/nav-token` cofx) and either compare it when the reply lands, or route the reply through the `:rf.route/with-nav-token` effect wrapper, which does the check for you. Resources do all of this automatically; hand-rolled loaders opt in. If the host can also abort the in-flight fetch, great — that saves bandwidth — but abort is an optimisation *on top of* suppression, never a substitute, because an abort isn't guaranteed to win the race.
-
-When a resource is per-user, scope it with a **named scope resolver**. Register the resolver once, then reference it everywhere as `{:from-db ...}` — so the "who is this for?" logic lives in exactly one place:
-
-```clojure
-;; Adapted from examples/real-apps/realworld_resources/scope.cljs + routing.cljs
-(rf/reg-resource-scope :realworld/session
-  {:inputs {:username [:db [:auth :user :username]]}}
-  (fn [{:keys [username]} _ctx]
-    (when username
-      [:rf.scope/session {:username username}])))
-
-;; The personalised feed, as a route resource:
-{:resource :realworld/feed
- :scope    {:from-db :realworld/session}
- :params   (fn [route] {:page (get-in route [:query :page])})
- :blocking? false}
-```
-
-The runtime resolves `{:from-db :realworld/session}` against [app-db](../core/app-db.md) at route entry, and the resolution **fails closed**. Logged out, the resolver returns `nil` and the feed simply isn't loaded — that surfaces as a visible route error, never a quiet fall-back to a shared cache. So one user's feed can never leak into another's session. Security by construction, not by remembering to check.
+Ownership is nav-token keyed: leave or supersede → release; late replies
+**suppressed**. Per-user data uses a scope resolver (`{:from-db …}`) — fails closed
+when logged out. Full story: [Resources model](../resources/concepts.md).
 
 ## Blocking a navigation
 
-Navigation can be *blocked*, which is how you build an "are you sure? you have unsaved changes" guard. A route declares `:can-leave [:editor/can-leave?]`, a subscription naming the **positive** case (`true` means "yes, leaving is fine"). When it returns `false`, the navigation simply doesn't happen — no URL change, no state write. The attempted navigation parks in a pending slot that your confirm dialog renders from, and the user's choice is itself a dispatch: either `:rf.route/continue` or `:rf.route/cancel`.
+<a id="blocking-a-navigation"></a>
+
+`:can-leave` is a **boolean** sub (`true` = leave is fine). On `false`, navigation
+parks in `[:rf/pending-navigation]`. Resolve with the pending **id**:
 
 ```clojure
 (rf/reg-route :app/article-editor
   {:params    [:map [:id :string]]
-   :can-leave [:editor/can-leave?]}   ;; a sub: true ⇒ leaving is fine
+   :can-leave [:editor/can-leave?]}
   "/articles/:id/edit")
 
-;; The pending navigation surfaces through its own sub — your dialog renders from it:
-(rf/reg-view leave-guard-dialog []
-  (when-let [pending @(rf/subscribe [:rf/pending-navigation])]
+(rf/reg-view leave-dialog []
+  (when-let [p @(rf/subscribe [:rf/pending-navigation])]
     [:div.modal
-     [:p "You have unsaved changes. Leave anyway?"]
-     [:button {:on-click #(dispatch [:rf.route/cancel])}   "Stay"]
-     [:button {:on-click #(dispatch [:rf.route/continue])} "Discard & leave"]]))
+     [:button {:on-click #(dispatch [:rf.route/cancel (:id p)])} "Stay"]
+     [:button {:on-click #(dispatch [:rf.route/continue (:id p)])} "Leave"]]))
 ```
 
-When the guard blocks, the runtime also dispatches `:rf.route/navigation-blocked` and emits a matching trace, so you can react (toast, analytics) beyond just rendering the dialog. To leave *without* asking — a "save then navigate" button, say — pass `{:bypass-guards? #{:leave}}` in the navigate opts.
+Bypass one navigation: `{:bypass-guards? #{:leave}}` (or `#{:enter}` / both).
+Full recipe: [Guard against unsaved changes](how-to/guard-unsaved-changes.md).
 
-### Guarding *entry* — `:can-enter`
+### Guarding entry — `:can-enter`
 
-`:can-enter` is the first-class mirror of `:can-leave`: it guards navigation **into** a route, which is exactly the shape of an auth gate ("you must be signed in to reach this route"). It runs on the same one navigation gate, so it refuses a forbidden entry through *every* door — a programmatic nav, a link click, a URL-bar deep-link, or a Back/Forward — with no per-door wiring.
+<a id="guarding-entry--can-enter"></a>
+<a id="guarding-entry---can-enter"></a>
+
+Mirror for **enter** (the usual auth gate). Runs on every door (navigate, link, URL
+bar, Back/Forward). On block → `:rf.route/entry-blocked` (redirect to login there).
+`[:rf.route/continue <id>]` re-runs `:can-enter` on resume.
 
 ```clojure
 (rf/reg-route :app/account
-  {:can-enter [:auth/signed-in?]}          ;; a sub: true ⇒ entering is fine
+  {:can-enter [:auth/signed-in?]}
   "/account")
-
-(rf/reg-sub :auth/signed-in?
-  :<- [:auth/user]
-  (fn [user _] (some? user)))
-
-;; On a block the runtime dispatches :rf.route/entry-blocked (the mirror of
-;; :rf.route/navigation-blocked) — the natural place to redirect to login and
-;; remember where the user was headed for a post-login bounce-back:
-(rf/reg-event :rf.route/entry-blocked
-  (fn [{:keys [db]} [_ {:keys [requested-url]}]]
-    {:db (assoc-in db [:auth :return-to] requested-url)
-     :fx [[:dispatch [:rf.route/navigate :app/login]]]}))
 ```
 
-`:rf.route/continue` re-runs `:can-enter` on resume — so after the login flow completes and dispatches `[:rf.route/continue pn-id]`, the gate re-evaluates (now signed in, it passes) rather than sailing a still-signed-out user through. The [realworld_http example](../../examples/real-apps/realworld_http) shows the full shape: `:requires-auth` routes declare `:can-enter`, and one `:rf.route/entry-blocked` handler does the redirect.
+Non-boolean guard return → block + `:rf.error/can-leave-non-boolean` /
+`:rf.error/can-enter-non-boolean` (fail closed, fail loud).
 
-**Auth-on-a-route is `:can-enter`, not an interceptor.** Reach for an interceptor only for a policy that spans *many* routes uniformly (a whole gated section, a maintenance lockout) — and when you do, attach it to the frame's `:interceptors` so it covers all three doors (guarding only `:rf.route/navigate` is the classic fail-open bug).
-
-> **For JavaScript developers.** `:can-leave` replaces React Router's `useBlocker` / `usePrompt` and the old `beforeunload` hack; `:can-enter` replaces the `loader`-throws-`redirect` / `<ProtectedRoute>` wrapper pattern. Both are *subscriptions* (declarative, derive from state), and the pending navigation is *state you render from*, so your confirm dialog (or redirect) is ordinary re-frame2, not an imperative hook. No modal-automation flakiness, no native-dialog ugliness.
-
-> **Gotcha — the guard subs are strict.** `:can-leave` / `:can-enter` are a **boolean** contract: `true` allows, `false` blocks. Return anything else (a nil, a map, a truthy non-boolean) and the runtime **blocks the navigation** *and* emits `:rf.error/can-leave-non-boolean` / `:rf.error/can-enter-non-boolean` — it fails closed (deny) and fails loud (raise), never open. Keep the guard sub returning a real `true`/`false`.
-
-The payoff is that the entire flow is testable with zero DOM. Dispatch the navigate, assert the pending slot filled (`@(rf/subscribe [:rf/pending-navigation])`), dispatch `:rf.route/continue`, assert it went through — no browser, no `beforeunload`, no flaky modal automation. The editor routes in [examples/real-apps/realworld_resources](../../examples/real-apps/realworld_resources) show the shape, and [Guard against unsaved changes](how-to/guard-unsaved-changes.md) is the step-by-step recipe.
+**Prefer `:can-enter` for per-route auth** (see
+[realworld_http](../../examples/real-apps/realworld_http)). Use an interceptor only
+when one policy spans many routes:
+[Require sign-in](how-to/require-sign-in-on-a-route.md).
 
 ## Not found is a route you register
 
-When no pattern matches a URL — or a URL matches but its params fail their schema — the runtime activates the reserved id `:rf.route/not-found`, dropping the offending URL into `:params`. You **must** register it. It's an ordinary route, so it can carry its own loaders and scroll behaviour:
+<a id="not-found-is-a-route-you-register"></a>
 
-```clojure
-(rf/reg-route :rf.route/not-found
-  {:on-match [[:analytics/log-404]]
-   :scroll   :top}
-  "/404")
-```
+Register reserved id `:rf.route/not-found`. Offending URL lands in `:params`
+(with optional `:reason`):
 
-The not-found `:params` slot carries a `:reason` discriminator you can branch on in the view, so you can tell a plain miss from a malformed URL from a schema failure:
-
-| `:params` shape | What happened |
+| `:params` | What happened |
 |---|---|
-| `{:url "/no/such/page"}` | No registered route matched the URL. |
-| `{:url "/articles/abc" :reason :validation}` | A route matched, but the URL's params failed the route's `:params` / `:query` schema. |
-| `{:url "/bad%ZZ" :reason :malformed-url}` | The URL carried malformed percent-encoding — it fails *closed* to a 404, never crashes the handler (important for hostile or partner-supplied links, especially on SSR). |
+| `{:url "…"}` | No pattern matched |
+| `{:url "…" :reason :validation}` | Matched, schema failed |
+| `{:url "…" :reason :malformed-url}` | Bad percent-encoding (404, not crash) |
 
-!!! warning "Register your own not-found route"
-
-    Forget it and the runtime warns (`:rf.warning/no-not-found-route`) and falls back to a built-in placeholder — so the request still renders *something*, just not your design. Every real app registers its own.
-
-> **Gotcha — schema failures behave differently by entry point.** A *URL-driven* schema miss (a deep link, a back-button) is user input, so it's a 404 — never an exception. A *programmatic* miss is caller code, so it's loud: `route-url` **throws** `:rf.error/route-url-validation`, and `[:rf.route/navigate ...]` **rejects** the navigation with `:rf.error/schema-validation-failure` (the slice doesn't change). Same schemas, opposite failure modes — bugs in *your* code throw; bad input from *the world* 404s.
+Missing registration → warning + built-in placeholder. Programmatic schema miss is
+loud (`route-url` throws; navigate rejects); URL-driven miss is 404.
 
 ## Keeping tokens off the wire
 
-A route slice can hold secrets — an OAuth `?token=`, a `?code=` callback param. While the route is active, those values are live and your handlers and views see them normally. But you almost certainly *don't* want them copied onto the trace bus, into Xray, through the MCP pair tools, or into the SSR payload. The `:sensitive` and `:large` keys classify slice paths so the runtime redacts (or size-markers) them at *egress* — declared once, relative to the route's own `{:query ... :params ...}` projection, never naming the absolute storage position:
+<a id="keeping-tokens-off-the-wire"></a>
 
 ```clojure
 (rf/reg-route :app/oauth-callback
   {:query     [:map [:token :string] [:code :string]]
-   :sensitive [[:query :token] [:query :code]]   ;; redacted at egress while active
-   :large     [[:params :payload]]}              ;; kept off the wire (size marker only)
+   :sensitive [[:query :token] [:query :code]]}
   "/oauth/callback")
 ```
 
-`:sensitive` redacts a value's content; `:large` keeps a bulky value off the wire (emitting only a size marker). A path declared both lowers as `:sensitive` only. Classification is applied atomically when the route activates and dropped when it changes — so a route declaring none (including `:rf.route/not-found`) clears the previous route's classification cleanly. Crucially, it's *egress-only*: `@(rf/subscribe [:rf/route])` in your running app always returns the real values; only the copies that leave the box are redacted.
-
-> **Gotcha — classify only query keys the route declares.** A classification path like `[:query :token]` names the keyword `:token`, and the slice only holds a query value under a keyword when the route declares that key — in `:query`, `:query-defaults`, or `:query-retain`. Classify a key the route never declares and there'd be nothing at that path to redact, so `reg-route` warns (`:rf.warning/route-classification-query-key-unpromoted`) and points at the fix: add the key to the `:query` schema. Path params can't have this problem — captures are always keyword-keyed. And a structurally malformed declaration (a non-vector axis, a bad path segment) fails loud at registration with `:rf.error/invalid-route-classification`.
-
-Routing's classification is the framework-wide [data-classification](../core/glossary.md#data-classification) model applied to the singleton current-route — [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) is the full story; routes just declare the paths.
+Egress-only redaction while the route is active. Full story:
+[Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 
 ## The browser is just another event source
 
-Back/forward, deep links, and the initial page load are all, underneath, URL changes arriving *into* the app. Wiring them up is one flag on the frame:
+<a id="the-browser-is-just-another-event-source"></a>
 
 ```clojure
-;; Adapted from examples/capabilities/routing/routing/core.cljs (client-only)
-(rf/make-frame {:id :rf/default :doc "The app frame." :url-bound? true})
+(rf/make-frame {:id :rf/default :url-bound? true})
 ```
 
-`:url-bound? true` declares which [frame](../core/frames.md) owns the browser URL. Ownership is always explicit, never inferred. Only one frame may hold it — a second claimant is a loud `:rf.error/duplicate-url-binding` (and never installs a listener of its own) — and having *no* owner is legal too: URL pushes and the URL-change listener simply no-op.
-
-Frames without the flag still route internally, in memory. That's a feature, not a gap: a [Story](../core/observability.md) variant can sit on `/article/intro` without touching your address bar, and a test frame never calls `pushState`.
-
-Declaring `:url-bound? true` is the whole story — the frame's creation installs the URL-change listener (aimed at whichever frame owns the URL) and syncs the URL into state once at startup, so deep links and refreshes land on the right page, automatically. There is no separate install call to make (and none to remove — the frame's destroy tears the listener down). It's idempotent — a hot-reloaded re-registration that still resolves as the owner just reinstalls cleanly.
-
-> **From re-frame v1.** This is where the inversion lands hardest. In v1 the browser URL was the source of truth and your router *reacted* to it. Here the frame's state is the source of truth and the URL is a *print-out* of it. So a back-button press is, literally, a dispatch: popstate fires, the URL-change handler runs, the slice updates, the views re-derive. And [time-travel](../xray/index.md) falls out for free — rewind the frame and the URL rewinds with it, because the URL was never truth, only a projection.
+`:url-bound? true` — this frame owns the address bar (one owner;
+`:rf.error/duplicate-url-binding` if two claim). Installs listener + initial sync;
+no separate install API. Frames without the flag still route **in memory** (Story,
+tests).
 
 ### URL strategies
 
-By default the router speaks **path-form** URLs (`/active`) — it uses the HTML5 History API and a `popstate` listener. But plenty of apps live at a **hash** URL (`#/active`): no-server-rewrite static hosting needs it, and it's the shape most secretary-era re-frame v1 apps have. A **`:url-strategy`** on the URL-owning frame switches the address-bar shape without changing anything else:
+<a id="url-strategies"></a>
 
 ```clojure
 (rf/make-frame {:id           :app
                 :url-bound?   true
-                :url-strategy routing/hash-url-strategy})   ;; default: routing/history-url-strategy
+                :url-strategy routing/hash-url-strategy})  ;; default: history-url-strategy
 ```
 
-That one line is all it takes. `route-url` and `match-url` stay path-form — they still build and read `/active` — and the strategy encodes the `#` at exactly four edges: the `route-link` href, `pushState`, `replaceState`, and the URL-change listener (a hash app listens for `hashchange`, a history app for `popstate`). So your links are ordinary `route-link`s, navigation is ordinary `:rf.route/navigate`, and Back/Forward flows through the same event path — the `#` is a rendering detail the strategy owns. Two strategies ship, and the line holds at two:
+`route-url` / `match-url` stay path-form; strategy encodes `#` at the edges.
+`routing/with-base-path` for deploy under a subpath. SSR ignores strategies (path
+form on the wire; client re-encodes on hydrate).
 
-- `routing/history-url-strategy` — the default, path-form.
-- `routing/hash-url-strategy` — `#`-prefixed, for static hosting and v1 migrations.
-
-Memory URLs need no third strategy: a frame that isn't `:url-bound?` is already URL-free, so a Story variant or a test frame is the "memory" case for free.
-
-Because `:url-bound? true` frame creation installs the listener automatically (the previous section), the strategy you declare is picked up at whatever moment the frame actually gets created — even *asynchronously*, e.g. by a `frame-root` whose React commit effect registers it just after mount. There's no separate install call whose timing you have to worry about; declaring `:url-strategy` on the frame config is the whole story. The [TodoMVC example](https://github.com/day8/re-frame2/tree/main/examples/core/todomvc) is a hash app wired exactly this way.
-
-A third, orthogonal knob: **`with-base-path`** wraps either strategy for an app deployed under a sub-path — a host mounting several demos side by side, so an app that would otherwise own `/` instead lives at `/realworld/`:
+### Codec by hand
 
 ```clojure
-(rf/make-frame {:id           :app
-                :url-bound?   true
-                :url-strategy (routing/with-base-path
-                                routing/history-url-strategy
-                                "/realworld")})
-```
-
-It strips the base path off every inbound URL and re-adds it to every outbound one, at the same four edges, underneath whichever address-bar form the wrapped strategy provides — `route-url` / `match-url` stay base-agnostic. The [RealWorld example](https://github.com/day8/re-frame2/tree/main/examples/real-apps/realworld_http) is deployed this way.
-
-> **SSR ignores strategies.** On the server there's no address bar and a hash never arrives — the request URL is fed in path-form and `route-link` renders a path-form `<a href>` shell. On hydration the client re-encodes the href through the frame's strategy, so the server ships `/active` and the hydrated anchor becomes `#/active`, both pointing at the same route. The shape is a client-only concern.
-
-> **Frames seed with events, not config.** Note the frame carries `:doc` and `:url-bound?` and nothing else — there's no `:db` or `:initial-db` config key. A frame's startup state is built by dispatching ordinary events via `:initial-events`: `(rf/make-frame {:id :app :initial-events [[:rf/set-db {…}] [:app/initialise]]})`. "Events are the unit of state change" holds even for the very first state. See [Frames](../core/frames.md) for the full lifecycle.
-
-### Converting routes ↔ URLs by hand
-
-When you need to convert between a route and a URL by hand, two pure helpers do it on both JVM and browser, so you never hand-concatenate a query string again:
-
-```clojure
-;; Both live in re-frame.routing — the URL codec is in the routing artefact,
-;; not on the rf/ facade. Pure, JVM- and CLJS-runnable, and exact inverses.
-
 (routing/route-url :app/article {:id "intro"})
 ;; => "/articles/intro"
-
-(routing/route-url :app/search {} {:q "clojure" :page 2} "results")
-;; => "/search?q=clojure&page=2#results"   (4-arity: params, query, fragment)
-
 (routing/match-url "/articles/intro")
-;; => {:route-id :app/article :params {:id "intro"} :query {} :fragment nil :validation-failed? false}
-
-(routing/match-url "/no/such/page")
-;; => nil
+;; => {:route-id :app/article :params {:id "intro"} …}
 ```
 
-`route-url` has 2-, 3-, and 4-arities (params; + query; + fragment), and it's *pure*: no `pushState`, no dispatch, no app-db read — same inputs, same string out. It throws `:rf.error/route-url-validation` if your params don't conform to the route's schema (a caller bug). `match-url` returns the match map, or `nil` for no match, or `:validation-failed? true` when a route matched but its params failed schema.
-
-> **Gotcha — `route-url`'s nil-policy differs for path vs query.** A `nil` (or empty-string) **path** param is a hard error (`:rf.error/missing-route-param`) — there's no URL to build without the segment. A `nil` **query** param is *silently elided* — `{:page nil}` just omits the key, which is exactly what you want for "only add `?sort=` when a sort is chosen". Falsy-but-present values (`false`, `0`) round-trip on both sides. The asymmetry surprises people, so it's worth pinning in your memory: missing path segment = throw; missing query key = drop.
+Pure, JVM + CLJS. `nil` path param → throw; `nil` query param → elided.
 
 ## The same handler runs on the server
 
-This is the payoff of routing having no runtime of its own. During [server-side rendering](../ssr/concepts.md), the request URL is fed to the *same* URL-change handler, against a per-request frame. The slice is written, `:on-match` fires, blocking `:resources` give the server its wait-point before render, and the resulting state ships to the client, where hydration installs it **without re-fetching** because the data is already there. There's no server router, no client router, and no seam between them — one place where URLs become state, one place where state becomes URLs.
+<a id="the-same-handler-runs-on-the-server"></a>
 
-> **Going deeper.** This is what "the URL is a sub" buys you structurally. Because the route is a *derivable view* of state — a projection, not an independent variable — the same pure function (`match-url`) turns a request URL into a slice on the JVM and in the browser, and the same inverse (`route-url`) turns a slice back into a string on both. SSR isn't a parallel implementation that has to be kept in sync; it's the *same* implementation pointed at a different event source. The seam between server and client routing doesn't exist because there was never a second router to seam against.
+[SSR](../ssr/concepts.md) feeds the request URL to the **same** URL-change path on a
+per-request frame. `:on-match` / blocking `:resources` run; state ships in the
+payload; client hydrates without re-fetch. URL push and scroll are no-ops on the
+server. Detail: [SSR model](../ssr/concepts.md).
 
-!!! note "What is client-only"
+## A complete table + root
 
-    The URL-push and scroll effects are no-ops on the server, where there's no address bar, and the `:url-bound?` frame lifecycle installs no popstate listener server-side because there's no popstate to listen to. Everything else — your route table, handlers, loaders, and guards — runs unchanged on both sides. `route-url` and `match-url` are pure and run identically on the JVM, which is exactly why SSR can build links and parse the request URL with the same code.
+Copy-paste shape (pages and loaders are stubs — fill in as the tutorial does):
+
+```clojure
+(ns app.routes
+  (:require [re-frame.core :as rf]
+            [re-frame.routing]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.reagent :as reagent-adapter]))
+
+(rf/reg-route :app/home {} "/")
+(rf/reg-route :app/articles {} "/articles")
+(rf/reg-route :app/article
+  {:params   [:map [:id :string]]
+   :on-match [[:article/load]]}
+  "/articles/:id")
+(rf/reg-route :rf.route/not-found
+  {:doc "Unmatched URLs"} "/_404")   ;; path is a registration slot; id is reserved
+
+(rf/reg-view root-view []
+  (case @(subscribe [:rf.route/id])
+    :app/home           [home-page]
+    :app/articles       [articles-page]
+    :app/article        [article-page]
+    :rf.route/not-found [not-found-page]
+    [not-found-page]))
+
+(defn run []
+  (rf/init! reagent-adapter/adapter)
+  (rdc/render (rdc/create-root (js/document.getElementById "app"))
+              [rf/frame-root {:id :rf/default :url-bound? true}
+               [root-view]]))
+```
+
+## When the table grows
+
+| Need | Where |
+|---|---|
+| Unsaved-changes prompt | [Guard against unsaved changes](how-to/guard-unsaved-changes.md) |
+| Multi-route auth interceptor | [Require sign-in](how-to/require-sign-in-on-a-route.md) |
+| Cached server reads on a page | [Resources](../resources/concepts.md) + `:resources` above |
+| Head metadata / SSR | [SSR model](../ssr/concepts.md) |
+| Prove codec + navigation | [Testing](testing.md) |
+| Runnable apps | [Examples](examples.md) |
+
+API catalogue: [re-frame.routing](../api/re-frame.routing.md).

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -102,6 +102,9 @@ doors are covered).
 
 ### Metadata map (map of the territory)
 
+<a id="the-metadata-map-in-full"></a>
+<a id="metadata-map-map-of-the-territory"></a>
+
 | Group | Keys | Controls |
 |---|---|---|
 | **Shape** | `:params`, `:query`, `:query-defaults`, `:query-retain` | URL ↔ maps |

--- a/docs/routing/examples.md
+++ b/docs/routing/examples.md
@@ -1,9 +1,10 @@
-# Routing examples
+# Examples
 
-Worked routing apps you can read end to end in the repo's example tree.
+Runnable routing apps in the repo. Build something yourself first
+([tutorial](tutorial.md) or [the model](concepts.md)), then open these in order.
 
-- **routing** — the smallest app that exercises the whole routing surface: a route table via `reg-route`, navigation-as-event (`:rf.route/navigate`), route reads as plain subs (`:rf.route/id` / `:rf.route/params`), and a root view that switches on the route id. Start here. [→ source](../../examples/capabilities/routing/routing)
-- **realworld** — routing folded into a full Conduit clone: path params and `?page=N` query params, auth-gated routes via an `auth-guard` interceptor, route-driven data loads, and navigation blocking for the unsaved-editor form. See routing working under real load. [→ source](../../examples/real-apps/realworld_http)
-- **realworld_resources** — the same Conduit clone with its server state declared as *resources*: routes plan blocking and background fetches with the `:resources` key, scope the personalised feed per user with a named scope resolver, and guard the editor with `:can-leave`. The route-integration side of [resources](../resources/concepts.md), under the same real load. [→ source](../../examples/real-apps/realworld_resources)
-
-For the underlying ideas, see [Concepts](concepts.md).
+| Example | What it shows | Read first |
+|---|---|---|
+| [routing](../../examples/capabilities/routing/routing) | Minimal surface: `reg-route`, navigate event, route subs, root `case` | [Tutorial](tutorial.md) |
+| [realworld_http](../../examples/real-apps/realworld_http) | Conduit: path + query params, auth gate, loaders, leave guard | [The model](concepts.md), [Require sign-in](how-to/require-sign-in-on-a-route.md) |
+| [realworld_resources](../../examples/real-apps/realworld_resources) | Same Conduit with route `:resources`, session scope, editor `:can-leave` | [Resources](../resources/concepts.md) |

--- a/docs/routing/glossary.md
+++ b/docs/routing/glossary.md
@@ -1,16 +1,16 @@
 # Routing glossary
 
-re-frame2's optional routing capability — the URL is an *input* to your app, the active route is ordinary state you read through subscriptions, and navigation is just an [event](../core/glossary.md#event). See [Routing](concepts.md).
+re-frame2's optional routing capability — the URL is an *input* to your app, the active route is ordinary state you read through subscriptions, and navigation is just an [event](../core/glossary.md#event). See [The model](concepts.md).
 
 ### **navigate**
 
 Change the route by dispatching navigation — the URL is an input, the active [route](#route) a [subscription](../core/glossary.md#subscription) you read like any other. Because it's an event, navigation is traceable, interceptable, and rewound by time-travel.
 
 ```clojure
-(rf/dispatch [:rf.route/navigate :article {:id "abc"}])
+(rf/dispatch [:rf.route/navigate :app/article {:id "abc"}])
 ```
 
-Related: [Routing](concepts.md).
+Related: [The model](concepts.md).
 
 ### **route**
 
@@ -38,7 +38,7 @@ The counter that identifies one navigation. Route-declared resources are owned b
 
 ### **route guard**
 
-A `:can-leave` guard subscription (strict boolean: `true` means leaving is fine) consulted before leaving a [route](#route); a `false` parks the navigation as *pending* so your [view](../core/glossary.md#view) can render a "discard changes?" prompt, resolved by dispatching `:rf.route/continue` or `:rf.route/cancel`. The idiomatic home for unsaved-changes prompts — gating *entry* (an auth redirect) is an ordinary interceptor over the navigation events instead ([Require sign-in on a route](how-to/require-sign-in-on-a-route.md)).
+A boolean subscription on a [route](#route): **`:can-leave`** (`true` = leave is fine) or **`:can-enter`** (`true` = enter is fine). A `false` parks the attempt in `[:rf/pending-navigation]`; your [view](../core/glossary.md#view) resolves it with `[:rf.route/continue <id>]` or `[:rf.route/cancel <id>]` (the pending-nav id). Unsaved-changes → leave guard ([recipe](how-to/guard-unsaved-changes.md)); per-route auth → enter guard; multi-route policy → optional interceptor ([recipe](how-to/require-sign-in-on-a-route.md)).
 
 ### **not-found**
 

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -1,10 +1,13 @@
 # Guard against unsaved changes
 
-A reader is half-way through editing an article, clicks a link, and loses the lot. The fix is an "are you sure? you have unsaved changes" prompt — the one navigation interaction every editor needs.
+You know [the route model](../concepts.md). This page is one job: **"are you sure?
+unsaved changes"** before leaving an editor.
 
-In re-frame2 this is a [route guard](../glossary.md#route-guard): a route declares `:can-leave`, the runtime *blocks* the navigation when the guard says no, and the blocked navigation parks in state your prompt renders from. The whole flow is data — a subscription and two events — so it tests with zero DOM. We'll build it in four steps, then make it pass.
+Shape: `:can-leave` boolean sub (`true` = leave is fine) → `false` parks the attempt
+in `[:rf/pending-navigation]` → dialog dispatches `:rf.route/continue` or
+`:rf.route/cancel`. Data all the way; tests with zero DOM.
 
-> **The shape in one line.** `:can-leave` is a boolean sub (`true` = leaving is fine); a `false` parks the attempt in `:rf/pending-navigation`; your dialog renders from that slot and resolves it with `:rf.route/continue` or `:rf.route/cancel`.
+**Prerequisites.** [The model → Blocking](../concepts.md#blocking-a-navigation).
 
 ## 1. Write the "is it safe to leave?" sub
 
@@ -41,16 +44,20 @@ The blocked navigation lands in `:rf/pending-navigation`. Subscribe to it: when 
   (when-let [pending @(rf/subscribe [:rf/pending-navigation])]
     [:div.modal
      [:p "You have unsaved changes. Leave anyway?"]
-     [:button {:on-click #(dispatch [:rf.route/cancel])}   "Stay"]
-     [:button {:on-click #(dispatch [:rf.route/continue])} "Discard & leave"]]))
+     ;; Both events take the pending-nav *id* — not a bare keyword.
+     [:button {:on-click #(dispatch [:rf.route/cancel (:id pending)])}   "Stay"]
+     [:button {:on-click #(dispatch [:rf.route/continue (:id pending)])} "Discard & leave"]]))
 ```
 
-(`@(subscribe [:rf/pending-navigation])` reads the pending-nav slot — an ordinary framework subscription, no extra require needed.)
+(`@(subscribe [:rf/pending-navigation])` is an ordinary framework sub.) The reader's
+choice is a dispatch carrying **`(:id pending)`**:
 
-The reader's choice is itself a dispatch:
+- `[:rf.route/continue <id>]` — proceed with the parked navigation (re-runs
+  `:can-enter` on the target if any).
+- `[:rf.route/cancel <id>]` — drop it; stay put.
 
-- `:rf.route/continue` — proceed with the parked navigation (it commits now).
-- `:rf.route/cancel` — drop it; stay put.
+A bare `[:rf.route/continue]` / `[:rf.route/cancel]` without the id is wrong — the
+runtime keys the pending slot by that id (stale ids are safe no-ops).
 
 Mount `leave-guard-dialog` once near your root view and it covers every guarded route — it renders nothing until something is pending.
 
@@ -83,12 +90,14 @@ Because the whole flow is events and a subscription, the test needs no browser, 
 (is (= :app/article-editor @(rf/subscribe [:rf.route/id])))     ;; still here
 (is (some?                  @(rf/subscribe [:rf/pending-navigation])))  ;; parked
 
-;; The reader confirms — now it goes through.
-(rf/dispatch-sync [:rf.route/continue])
+;; The reader confirms — continue takes the pending id.
+(rf/dispatch-sync [:rf.route/continue
+                   (:id @(rf/subscribe [:rf/pending-navigation]))])
 (is (= :app/home @(rf/subscribe [:rf.route/id])))
 (is (nil?        @(rf/subscribe [:rf/pending-navigation])))
 ```
 
-That's the payoff of a guard that's *state*, not a side effect: every branch — blocked, confirmed, cancelled, bypassed — is a dispatch and an assertion.
+That's the payoff of a guard that's *state*, not a side effect: every branch —
+blocked, confirmed, cancelled, bypassed — is a dispatch and an assertion.
 
-> **For JavaScript developers.** This replaces React Router's `useBlocker` / `usePrompt` and the old `beforeunload` hack, with two upgrades: the guard is a *subscription* (declarative, derived from state), and the pending navigation is *state you render from*, so your confirm dialog is a normal view rather than an imperative blocker object you drive by hand.
+Also covered under [Testing routes](../testing.md).

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -1,14 +1,27 @@
 # Require sign-in on a route
 
-Some pages — a settings screen, an admin dashboard — should open only for signed-in users. In re-frame2 there's no special "protected route" primitive: a route is [queryable data](../concepts.md#routes-are-queryable-data), so you *tag* the routes that need a session and let an ordinary [interceptor](../../core/interceptors.md) read the tag and redirect. Data plus a step that reads it — no router machinery.
+You know routes are [queryable data](../concepts.md#routes-are-queryable-data). This
+page is one job: **one interceptor that bounces logged-out readers** off every
+route tagged `:requires-auth`.
 
-This page is the **routing half** of auth: tag a route, gate it, bounce the reader to login. The surrounding system — the login form, the token that requests carry, logout — is [Add authentication](../../core/how-to/add-auth.md), which embeds this same guard in the full picture. Start here for the route mechanics; go there for the whole flow.
+**Prefer `:can-enter` first.** A single protected page should declare
+`{:can-enter [:auth/signed-in?]}` and handle `:rf.route/entry-blocked` — that is
+what [realworld_http](../../../examples/real-apps/realworld_http) does, and it covers
+all three entry doors without an interceptor. Use **this recipe** when one policy
+must span *many* routes uniformly (a whole admin section, a maintenance lockout).
 
-> **The one mistake to avoid.** There are *three* ways into a route, and a guard that gates only one fails **open** on the most common path — a logged-out reader who types the URL or reloads the page walks straight in. Steps 2–3 are about gating all three.
+Full auth system (form, token, logout): [Add authentication](../../core/how-to/add-auth.md).
+
+!!! warning "Three doors — gate all of them"
+
+    Navigate, `route-link`, and URL-bar/reload/Back are three events. Guard only
+    `:rf.route/navigate` and a logged-out paste of `/settings` walks in. Steps 2–3
+    normalise all three. (`:can-enter` already does that for free.)
 
 ## 1. Tag the protected routes
 
-Mark the routes that need a session with a `:tag`. Tags are free-form data — the framework attaches no meaning to `:requires-auth`; *you* do, in the guard:
+Mark routes that need a session with **`:tags`**. Free-form — the framework attaches
+no meaning to `:requires-auth`; *you* do, in the guard:
 
 ```clojure
 (rf/reg-route :app/login    {} "/login")
@@ -16,7 +29,8 @@ Mark the routes that need a session with a `:tag`. Tags are free-form data — t
 (rf/reg-route :app/admin    {:tags #{:requires-auth}} "/admin")
 ```
 
-The tag is now readable off the route table from anywhere: `(rf/handler-meta :route :app/settings)` returns the metadata, `:tags` and all. That's the whole "which routes are protected?" query — no registry to hand-maintain.
+Readable anywhere: `(rf/handler-meta :route :app/settings)` → metadata including
+`:tags`.
 
 ## 2. Know the three navigation entry points
 
@@ -31,24 +45,31 @@ A reader reaches a route three different ways, each a different event:
 Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out reader pasting `/settings` into the address bar, or reloading a protected page, never goes through `navigate`. So the guard normalises **all three** to one "where are we headed?" target, then decides once:
 
 ```clojure
-;; Adapted from examples/real-apps/realworld_http/routing.cljs
+(:require [re-frame.routing :as routing])   ;; match-url lives here, not on rf/
+
 (defn- nav-target
-  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil for
-   a non-navigation event (the guard then short-circuits)."
+  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil."
   [[ev-id a b]]
   (case ev-id
-    :rf.route/navigate          {:id a :params (or b {})}
-    :rf.route/url-requested           (let [{:keys [to params url]} a]
-                                  (cond
-                                    to  {:id to :params (or params {})}
-                                    url (when-let [{:keys [route-id params]} (routing/match-url url)]
-                                          {:id route-id :params (or params {})})))
-    :rf.route/handle-url-change (when-let [{:keys [route-id params]} (routing/match-url a)]
-                                  {:id route-id :params (or params {})})
+    :rf.route/navigate
+    {:id a :params (or b {})}
+
+    :rf.route/url-requested
+    (let [{:keys [to params url]} a]
+      (cond
+        to  {:id to :params (or params {})}
+        url (when-let [{:keys [route-id params]} (routing/match-url url)]
+              {:id route-id :params (or params {})})))
+
+    :rf.route/handle-url-change
+    (when-let [{:keys [route-id params]} (routing/match-url a)]
+      {:id route-id :params (or params {})})
+
     nil))
 ```
 
-`routing/match-url` is pure (it lives in `re-frame.routing`, not on the `rf/` facade — add `[re-frame.routing :as routing]` to your ns) — it turns a URL string into a match map, or `nil` when nothing resolves, so a garbage URL short-circuits the guard rather than crashing it.
+`match-url` is pure: URL string → match map, or `nil` when nothing resolves (garbage
+URLs short-circuit the guard rather than crash it).
 
 ## 3. Redirect with skip-and-dispatch
 

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -1,30 +1,50 @@
 # Routing
 
-A URL is just another input. In most frameworks the router is a parallel system — its own components, its own lifecycle, its own place to hold state — bolted onto the side of your app. re-frame2 folds it into the event pipeline you already have: the **URL is an input**, the active route is ordinary state you read through a subscription, and **navigation is just an event**. So routing is traceable, time-travels, and tests like everything else.
-
-You register routes (`reg-route`) as a table mapping URL patterns to what they need — param/query schemas, a [loader](glossary.md#loader) for the page's data, a [`:can-leave`](glossary.md#route-guard) guard — and read the active route as state.
+A URL is just another input. Most stacks bolt on a parallel router — its own
+components, lifecycle, and store. re-frame2 folds routing into the pipeline you
+already have: the **URL is an input**, the active route is ordinary state via a
+subscription, and **navigation is an event**. Traceable, time-travelling, and
+testable like everything else.
 
 ```clojure
-;; A route is data: an id, a metadata map, and a path (the third slot).
+(:require [re-frame.core :as rf]
+          [re-frame.routing])   ;; day8/re-frame2-routing — forget this → :rf.error/routing-artefact-missing
+
 (rf/reg-route :app/article
   {:params [:map [:id :string]]}
-  "/articles/:id")
+  "/articles/:id")                    ;; path is the third slot, not a metadata key
 
-;; Read the active route as state; change it by dispatching an event.
-@(rf/subscribe [:rf.route/params])                  ;; => {:id "hello"}
+@(rf/subscribe [:rf.route/params])    ;; => {:id "hello"}
 (rf/dispatch [:rf.route/navigate :app/article {:id "hello"}])
 ```
 
-Because a route's [loader](glossary.md#loader) runs on the server too, routing and [SSR](../ssr/index.md) share one data-fetch story — there's no separate server fetch to keep in sync.
+Route [loaders](glossary.md#loader) run on the server too — one data-fetch story
+with [SSR](../ssr/index.md), no separate server router.
 
-## In this section
+## Start here
 
-- **[Tutorial: build a routed app](tutorial.md)** — a three-page app grown one step at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout. Start here.
-- **[Concepts](concepts.md)** — the whole model in three moves, then the refinements: query strings, loaders and resources, blocking a navigation, not-found, classification, and running the same handler on the server.
-- **How-to** — [Guard against unsaved changes](how-to/guard-unsaved-changes.md) and [Require sign-in on a route](how-to/require-sign-in-on-a-route.md): one task each, complete code.
-- **[Testing](testing.md)** — the URL codec as pure function calls, navigation through a test frame, deep links and the 404, and the leave guard — all with zero DOM.
-- **[Examples](examples.md)** — runnable routing apps, small and under real load.
-- **[Glossary](glossary.md)** — the section's vocabulary, one definition each.
-- **[Coming from React Router](coming-from-react-router.md)** — the mapping table and the deliberate divergences.
+1. **[Tutorial](tutorial.md)** — three-page app grown step by step (routes, links,
+   params, loaders, 404, Back button, layout). Best first hour.
+2. **[The model](concepts.md)** — three moves (registry row, navigate event, route
+   sub), then loaders, guards, not-found, URL binding.
+3. **Task recipes** when you have one job:
+   [unsaved changes](how-to/guard-unsaved-changes.md) (leave guard),
+   [require sign-in](how-to/require-sign-in-on-a-route.md) (multi-route interceptor —
+   prefer [`:can-enter`](concepts.md#guarding-entry--can-enter) for one page).
 
-The routing docs are a **guide** — read top to bottom to learn routing, or dip in to understand one part. Every signature, event, subscription, and keyword has its canonical home in the separate **[API reference](../api/re-frame.routing.md)**: the guide teaches, the reference is where you look things up.
+**Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db,
+subscriptions, views. Routing plugs into those; it does not replace them.
+
+Optional later: [testing](testing.md), [examples](examples.md),
+[React Router mapping](coming-from-react-router.md), [glossary](glossary.md).
+
+## When *not* to use routing
+
+| Situation | Prefer |
+|---|---|
+| Single-screen app, no shareable URLs | No routing artefact (zero cost) |
+| In-memory UI steps with no URL | app-db flags / a [machine](../machines/index.md) |
+| Server-only redirects | Host middleware or [SSR](../ssr/concepts.md) response effects |
+
+Reach for routing when **the address bar is part of the product** — deep links,
+shareable state, Back/Forward, SEO/SSR entry.

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -1,6 +1,12 @@
 # Testing routes
 
-Routing is a registration, an event, and a subscription — so it tests the way each of those tests: pure functions where the logic is pure, a dispatch into a test [frame](../core/glossary.md#frame) where the wiring matters. No browser anywhere. A test frame never declares `:url-bound? true`, so nothing here touches an address bar or calls `pushState` — the route slice is just state you assert on.
+You can [author](tutorial.md) and [understand](concepts.md) routing. This page is how
+you **prove** it.
+
+Routing is a registration, an event, and a subscription — pure codec where the logic
+is pure, dispatch into a test [frame](../core/glossary.md#frame) where the wiring
+matters. No browser. A test frame never sets `:url-bound? true`, so nothing here
+touches the address bar — the route slice is state you assert on.
 
 > **The URL codec is a pure function you call; a navigation is a dispatch you drive; the slice is state you read.**
 
@@ -91,13 +97,18 @@ The `:can-leave` flow is deliberately testable without a browser: the guard is a
     (is (some? @(rf/subscribe [:rf/pending-navigation])))
     (is (= :app/article-editor @(rf/subscribe [:rf.route/id])))
 
-    ;; the user chooses: continue releases the parked navigation
-    (rf/dispatch-sync [:rf.route/continue])
+    ;; the user chooses: continue takes the pending-nav id
+    (rf/dispatch-sync [:rf.route/continue
+                       (:id @(rf/subscribe [:rf/pending-navigation]))])
     (is (nil? @(rf/subscribe [:rf/pending-navigation])))
     (is (= :app/home @(rf/subscribe [:rf.route/id])))))
 ```
 
-Dispatch `:rf.route/cancel` instead and the pending slot clears with the slice unmoved — one more test, same shape. A `{:bypass-guards? #{:leave}}` navigate opt skips the park entirely; if a "save then leave" button relies on it, pin that too. The `:can-enter` mirror tests the same way — a guarded target, a signed-out sub, assert the pending slot fills with `:direction :enter`, then flip the sub and `:rf.route/continue` (which re-runs `:can-enter`).
+Dispatch `[:rf.route/cancel <id>]` instead and the pending slot clears with the slice
+unmoved — one more test, same shape. A `{:bypass-guards? #{:leave}}` navigate opt
+skips the park entirely. The `:can-enter` mirror tests the same way — guarded target,
+signed-out sub, assert pending fills with `:direction :enter`, then flip the sub and
+`[:rf.route/continue <id>]` (re-runs `:can-enter`).
 
 ## What lives elsewhere
 

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -1,10 +1,12 @@
 # Tutorial: build a routed app
 
-The fastest way to understand re-frame2 routing is to build something small and watch each piece arrive on its own. We'll make a three-page app — a **home** page, a **list of articles**, and a **detail** page for one article — then add the touches that make it real: page data, a 404, the Back button, and a shared layout.
+Build a three-page app — **home**, **articles list**, **article detail** — then add
+loaders, a 404, the Back button, and a shared layout. One idea the whole way: the
+URL is application state (read via a sub, change via dispatch).
 
-You'll meet every part of routing you reach for daily, one at a time. This page assumes you've done the [introduction](../core/introduction.md), [events](../core/events.md), and [app-db](../core/app-db.md) — you know what an [event](../core/events.md), a [subscription](../core/subscriptions.md), and a [view](../core/views.md) are. If you'd rather see the whole model at once, read [Concepts](concepts.md); if you're arriving from React Router, [the mapping](coming-from-react-router.md) may be the faster door.
-
-> **One idea to carry through.** The URL is just application state. You *read* the active route through a subscription and *change* it by dispatching an event. There's no router object to hold and no route context to thread down your tree. Keep that in mind and every step below is a small variation on something you already know.
+**Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db, views).
+Vocabulary after this walk-through: [The model](concepts.md). From React Router:
+[the mapping](coming-from-react-router.md).
 
 ## Step 0 — turn routing on
 
@@ -106,7 +108,7 @@ Link to it by passing `:params`:
 
 **What you see:** clicking the link lands on `/articles/intro`, and the page reads **Article intro**. (Add `:app/article [article-page]` to the root view's `case` — each new page gets its row.)
 
-> **Path params vs query params.** `:params` are the `/segments/` of the path. Query-string values (`?page=2`) are a *separate* map you declare with `:query` and read with `@(subscribe [:rf.route/query])` — the two never merge into one bag. [Concepts → Move 1](concepts.md#move-1-a-route-is-a-registry-entry) covers `:query`, defaults, and carrying global state like `?theme=dark` across pages.
+> **Path params vs query params.** `:params` are the `/segments/` of the path. Query-string values (`?page=2`) are a *separate* map you declare with `:query` and read with `@(subscribe [:rf.route/query])` — the two never merge into one bag. [The model → Move 1](concepts.md#move-1-a-route-is-a-registry-entry) covers `:query`, defaults, and carrying global state like `?theme=dark` across pages.
 
 ## Step 4 — give a page its data
 
@@ -148,14 +150,14 @@ There's no special "loader data" hook, because the loader just wrote to [app-db]
 
 **What you see:** click through to `/articles/intro` and the title appears. Navigate to another article and the loader fires again with the new id; re-navigate to the *same* one and it doesn't. Open [Xray](../xray/index.md) and you'll see exactly those dispatches on the wire.
 
-> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [Concepts → Loaders](concepts.md#loaders-declaring-a-pages-data).
+> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [The model → Loaders](concepts.md#loaders-declaring-a-pages-data).
 
 ## Step 5 — when nothing matches: the 404
 
 When no route matches a URL, the runtime activates a reserved id, `:rf.route/not-found`, with the missed URL dropped into its params. You register it like any other route — you own the design:
 
 ```clojure
-(rf/reg-route :rf.route/not-found {} "/404")
+(rf/reg-route :rf.route/not-found {} "/_404")
 
 (rf/reg-view not-found-page []
   (let [url (:url @(subscribe [:rf.route/params]))]
@@ -176,7 +178,7 @@ The "Nothing here yet" placeholder arm is gone — and that's the point. Now tha
 
 **What you see:** visit `/nonsense` and your own 404 renders, with `/nonsense` shown back to the reader.
 
-> Register it. Skip it and unmatched URLs fall to a bare built-in placeholder (plus a warning) — something renders, but not your design. The not-found params also carry a `:reason` so you can tell a plain miss from a malformed URL from a failed schema; see [Concepts → Not found](concepts.md#not-found-is-a-route-you-register).
+> Register it. Skip it and unmatched URLs fall to a bare built-in placeholder (plus a warning) — something renders, but not your design. The not-found params also carry a `:reason` so you can tell a plain miss from a malformed URL from a failed schema; see [The model → Not found](concepts.md#not-found-is-a-route-you-register).
 
 ## Step 6 — the Back button and deep links
 
@@ -199,7 +201,7 @@ Declaring it also does two jobs automatically, the moment the frame is created �
 
 > **One mount shape, two spellings.** `frame-root {:id …}` *creates* the frame if it doesn't exist — handy for a small app that boots everything in one spot. Elsewhere you'll see the two-step spelling: `make-frame` first, then `frame-provider {:frame …}` to scope it. Same frame, same result; the second form just makes the construction explicit.
 
-> **The inversion.** In most routers the URL is the source of truth and your app reacts to it. Here your frame's state is the truth and the URL is a *print-out* of it — which is why [time-travel](../xray/index.md) rewinds the URL for free. [Concepts → The browser is just another event source](concepts.md#the-browser-is-just-another-event-source) goes deeper.
+> **The inversion.** In most routers the URL is the source of truth and your app reacts to it. Here your frame's state is the truth and the URL is a *print-out* of it — which is why [time-travel](../xray/index.md) rewinds the URL for free. [The model → The browser is just another event source](concepts.md#the-browser-is-just-another-event-source) goes deeper.
 
 ## Step 7 — a shared layout
 
@@ -252,4 +254,19 @@ One wrap, from the inside out. A deeper chain just wraps more times.
 
 **What you see:** on `/articles/intro`, the article renders inside the `← All articles` section nav, under the site header — and every article detail page shares that frame with no copy-paste. Plain `/articles` (no parent above it) shows the bare list; `/` shows the home page. Note the split: truly *global* chrome (the `My Site` header) is just rendered in the root view — you only reach for the chain when a shell wraps a *subtree*.
 
-> **Coming from React Router?** This is the job `<Outlet/>` does there. The trade is deliberate: instead of a routing-specific render slot, you compose plain Clojure with the `case`/`reduce` you'd write for any conditional view. It's the one place routing asks a little more of you — and the only routing-specific piece is the one `:rf.route/chain` read. [Concepts → Nested layouts](concepts.md#nested-layouts) has the reference version.
+> **Coming from React Router?** This is the job `<Outlet/>` does there. The trade is deliberate: instead of a routing-specific render slot, you compose plain Clojure with the `case`/`reduce` you'd write for any conditional view. It's the one place routing asks a little more of you — and the only routing-specific piece is the one `:rf.route/chain` read. [The model → Nested layouts](concepts.md#nested-layouts) has the reference version.
+
+## The complete shape
+
+| Piece | Surface | You supply |
+|---|---|---|
+| Artefact | `(:require [re-frame.routing])` | Once at boot |
+| Table | `reg-route` id / metadata / **path** | Including `:rf.route/not-found` |
+| Change | `[:rf.route/navigate …]` or `route-link` | Params 2nd, opts 3rd |
+| Read | `[:rf.route/id]` / `params` / `query` / … | Ordinary subs |
+| Browser | `:url-bound? true` on the frame | One owner of the address bar |
+| Data | `:on-match` or `:resources` | Loaders as data |
+
+Full copy-paste table + mount: [The model → A complete table + root](concepts.md#a-complete-table--root).
+Growth: [unsaved changes](how-to/guard-unsaved-changes.md),
+[sign-in](how-to/require-sign-in-on-a-route.md), [testing](testing.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -287,18 +287,18 @@ nav:
     - "Examples": async/examples.md
 
   - Routing:
-    # Tutorial first, then the model, then task recipes; the React Router
-    # translation sits last, like XState in Machines and TanStack in Resources.
+    # Tutorial first, then the model, then task recipes; React Router last.
     - routing/index.md
     - "Tutorial: build a routed app": routing/tutorial.md
-    - "Concepts": routing/concepts.md
+    - "The model": routing/concepts.md
     - "How-to":
       - "Guard against unsaved changes": routing/how-to/guard-unsaved-changes.md
       - "Require sign-in on a route": routing/how-to/require-sign-in-on-a-route.md
-    - "Testing": routing/testing.md
-    - "Examples": routing/examples.md
-    - "Glossary": routing/glossary.md
+    - "Operating":
+      - "Testing": routing/testing.md
+      - "Examples": routing/examples.md
     - "Coming from React Router": routing/coming-from-react-router.md
+    - "Glossary": routing/glossary.md
 
   - SSR:
     # Tutorial first, then the model, then production growth pages;


### PR DESCRIPTION
## Summary

Progressive rewrite of the Routing guide, rebased onto current main after the other five docs PRs landed.

**Editorial resolution** (the branch previously had two commits that looked like they disagreed):

| Keep | Leave out of the model page |
|---|---|
| Tutorial-first arc, slim three-move **model**, Operating nest | The pre-rewrite ~54KB concepts essay |
| Full recipes in **how-tos** | Long ranking-cascade / typo gotcha prose in-guide |
| Canonical key catalogue + ranking → **API** `reg-route` | Re-expanding metadata into a second full reference |
| Second-pass **correctness** inline: continue/cancel take pending-nav **id**; prefer `:can-enter` for per-route auth | — |
| Teaching snippets that prove the contract: leave dialog, progress bar, complete mount | — |

Also: examples table, one-job how-to openings, `ssr/head` link for borrowed `:head` key (from SSR merge).

## Test plan

- [ ] MkDocs Routing nav: Tutorial → The model → How-to → Operating → React Router → Glossary
- [ ] Leave-guard how-to and testing page use `[:rf.route/continue (:id pending)]`
- [ ] Model metadata section stays short and links API for ranking
- [ ] Relative links under `docs/routing/`