### PR TITLE
docs(async): progressive guide rewrite

### DIFF
--- a/docs/async/coming-from-promises.md
+++ b/docs/async/coming-from-promises.md
@@ -1,8 +1,14 @@
 # Coming from Promises
 
-You arrive with the Promise triad — `.then`, `.catch`, `.finally`. re-frame2 has all three jobs covered, but the shapes moved, because a settlement here is a **value delivered to a handler**, not a pair of callbacks. A managed effect — [HTTP](http.md), a [resource](../resources/concepts.md), a [machine](../machines/concepts.md) — never hands you a promise object to chain. It dispatches the outcome back into your app as an ordinary [event](../core/glossary.md#event), carrying a canonical reply map you branch on. So the question stops being "what do I chain onto the promise?" and becomes "which handler receives the settlement, and how does it read it?"
+You know `.then` / `.catch` / `.finally`. re-frame2 covers all three jobs, but a
+settlement is a **value delivered to a handler**, not a promise you chain.
 
-This page is the translation. For the *why* underneath — why a continuation is data and not a closure — read [Why no await](continuations-are-data.md) once the mapping has landed.
+A managed effect — [HTTP](http.md), a [resource](../resources/concepts.md), a
+[machine](../machines/concepts.md) — never hands you a promise. It dispatches an
+ordinary [event](../core/glossary.md#event) with a canonical reply map. Question:
+*which handler receives the settlement, and how does it read it?*
+
+This page is the translation. The *why*: [Why no await](continuations-are-data.md).
 
 ## The mapping
 
@@ -57,4 +63,4 @@ And `finally` promises to **always run** — a guarantee re-frame2 deliberately 
 ## Where to go next
 
 - [Why no await: continuations are data](continuations-are-data.md) — the deeper *why*: named continuations, and the stale-world trap the data model closes by construction.
-- [Managed HTTP reference](http.md) — the surface reference: every reply key, the closed `:status` set, and both addressing spellings side by side.
+- [Managed HTTP](http.md) — the surface reference: every reply key, the closed `:status` set, and both addressing spellings side by side.

--- a/docs/async/continuations-are-data.md
+++ b/docs/async/continuations-are-data.md
@@ -1,12 +1,18 @@
 # Why no await: continuations are data
 
-You've met `:on-success` on [HTTP requests](http.md), `:reply-to` on mutations, `:on-done` on [machines](../machines/concepts.md). At some point you asked the obvious question: *why am I naming a second event instead of just `await`ing the result?* This page is the answer. It's one idea — and once it clicks, every async surface in re-frame2 reads the same way.
+You know `:on-success` on [HTTP](http.md), `:reply-to` on mutations, `:on-done` on
+[machines](../machines/concepts.md). Why name a second event instead of `await`?
 
-**The takeaway, up front: in re-frame2 a continuation is data, not a closure.** The rest of the page earns that sentence. We'll first see the one move that makes it true, then see — concretely — what `await` was quietly costing you, and finally what you get to do once the continuation is a value you can hold in your hand.
+**Takeaway: in re-frame2 a continuation is data, not a closure.** This page earns
+that sentence — the one move, what `await` costs, what you gain when the continuation
+is a value.
 
-!!! tip "Just want the `.then`/`.catch`/`.finally` translation?"
+**Prerequisites.** Issue at least one managed request ([tutorial](tutorial.md)).
 
-    [Coming from Promises](coming-from-promises.md) is the quick mapping table — this page is the *why* it points back to.
+!!! tip "Just want the `.then` / `.catch` / `.finally` map?"
+
+    [Coming from Promises](coming-from-promises.md) is the quick table; this page is
+    the *why*.
 
 ## Start with the one move
 

--- a/docs/async/custom-effects.md
+++ b/docs/async/custom-effects.md
@@ -1,10 +1,19 @@
 # Your own async effect
 
-Managed HTTP is one async effect the framework ships. But you'll meet others it doesn't: a **promise-returning SDK** (Stripe, Firebase, WebAuthn), a callback API, an IndexedDB request, a message from a worker. For those, write a small `fx`: start the host work, then dispatch a named reply [event](../core/introduction.md) when it finishes. That gives you the same continuation style as HTTP. It does not give you HTTP's managed extras — retry, abort, stale-result suppression, and the HTTP failure categories — unless you build those too.
+You know [managed HTTP](http.md). This page is one job: **wrap a non-HTTP async host
+API** (promise SDK, callback, IndexedDB, worker) so its result is a named reply
+[event](../core/introduction.md).
+
+Same continuation *style* as HTTP — not the managed extras (retry, abort, stale
+suppression, HTTP failure kinds) unless you build them.
+
+**Prerequisites.** [Effects](../core/effects.md); ideally the [HTTP tutorial](tutorial.md).
 
 !!! note "The one rule"
 
-    An [event handler](../core/effects.md) is pure — it can't `.then`, can't `await`. The **`fx` is the one seam where impurity lives**: it does the async work and *dispatches* the result as a named event. Same discipline as everything else — [name the continuation, don't await it](continuations-are-data.md).
+    An [event handler](../core/effects.md) is pure — no `.then`, no `await`. The **`fx`
+    is the impurity seam**: do host work, then `dispatch` a named event. Same discipline
+    everywhere — [name the continuation, don't await it](continuations-are-data.md).
 
 ## Wrapping a promise
 

--- a/docs/async/examples.md
+++ b/docs/async/examples.md
@@ -1,7 +1,10 @@
-# Async (HTTP) examples
+# Examples
 
-Worked apps that run on managed HTTP, readable end to end in the repo's example tree.
+Runnable apps on managed HTTP. Build something yourself first
+([tutorial](tutorial.md) or [Managed HTTP](http.md)), then open these in order.
 
-- **managed-http-counter** — the smallest end-to-end demo: a counter whose value is fetched and updated over `:rf.http/managed`, with the loading/error states wired from the reply, plus the manual-abort path. Start here. [→ source](../../examples/core/managed_http_counter)
-- **realworld** — a full Conduit clone (auth, articles, comments, profiles, favorites, settings) where **every endpoint goes out via `:rf.http/managed`** — no resources cache, just the transport. See the request-builder + retry policy in `http.cljs`, the auth/session flow, and the lifecycles held in state machines. This is managed HTTP under real load. [→ source](../../examples/real-apps/realworld_http)
-- **login** — hand-rolls a non-HTTP async `fx` (the [Your own async effect](custom-effects.md) pattern) and drives its reply into a state machine. [→ source](../../examples/core/login)
+| Example | What it shows | Read first |
+|---|---|---|
+| [managed_http_counter](../../examples/core/managed_http_counter) | Smallest end-to-end: fetch + update over `:rf.http/managed`, loading/error, manual abort | [Tutorial](tutorial.md) |
+| [realworld_http](../../examples/real-apps/realworld_http) | Full Conduit on managed HTTP only (no resources cache): request builders, retry, auth, machines | [Managed HTTP](http.md) |
+| [login](../../examples/core/login) | Custom non-HTTP async `fx` + reply into a state machine | [Your own async effect](custom-effects.md) |

--- a/docs/async/http-going-further.md
+++ b/docs/async/http-going-further.md
@@ -1,10 +1,20 @@
 # Interceptors and secrets
 
-Two cross-cutting production concerns, in one place: stamping something onto *every* request (auth headers, telemetry), and keeping secrets (tokens, passwords, PII) off the trace. Neither is required to be productive — reach for this page when your app grows into them.
+You know [managed HTTP](http.md). This page is two production jobs:
+
+1. **Stamp every request once** (auth headers, telemetry) via the HTTP interceptor chain.
+2. **Keep secrets off the trace** (tokens, passwords, PII).
+
+Neither is required to be productive — open this when the app grows into them.
+
+**Prerequisites.** [Managed HTTP](http.md) and the [tutorial](tutorial.md).
 
 ## Interceptors: stamp every request once
 
-Threading `"Authorization"` into every call site is the kind of cross-cutting concern that belongs in one place. re-frame2 ships a **per-frame HTTP interceptor chain** for exactly this — the same `{:before :after}` onion you know from [event interceptors](../core/interceptors.md), but wrapping the transport instead of the event handler. A `:before` transforms the request on its way out; an `:after` transforms the reply on its way back.
+Threading `"Authorization"` into every call site is a cross-cutting concern. re-frame2
+ships a **per-frame HTTP interceptor chain** — the same `{:before :after}` onion as
+[event interceptors](../core/interceptors.md), wrapping the *transport*. `:before`
+transforms the request on the way out; `:after` transforms the reply on the way back.
 
 `rf/reg-http-interceptor` takes a positional id and an interceptor map. Here's Bearer auth as a single registration — note it reads the token *fresh on every request*, so rotation is picked up with zero re-registration:
 

--- a/docs/async/http.md
+++ b/docs/async/http.md
@@ -1,12 +1,19 @@
-# Managed HTTP reference
+# Managed HTTP
 
-`:rf.http/managed` is the one [effect](../core/glossary.md#effect) for talking to a server. You describe the request as data, the runtime performs it — decoding, failure classification, retry, cancellation — and the reply arrives as an ordinary [event](../core/glossary.md#event).
+`:rf.http/managed` is the one [effect](../core/glossary.md#effect) for talking to a
+server. Describe the request as data; the runtime decodes, classifies failures,
+retries, and cancels; the reply arrives as an ordinary [event](../core/glossary.md#event).
 
-This page is the reference: every key, every contract. If you're new, do the [tutorial](tutorial.md) first. For the idea underneath, read [Why no await](continuations-are-data.md). For API-level detail — interceptor fn signatures, test-stub surfaces, trace events — see [re-frame.http](../api/re-frame.http.md).
+This page is the **model and reference** — every key, every contract. Build first with
+the [tutorial](tutorial.md). Idea underneath: [Why no await](continuations-are-data.md).
+API surfaces (interceptors, stubs, traces): [re-frame.http](../api/re-frame.http.md).
 
-## Setup
+!!! note "Optional artefact"
 
-Managed HTTP ships in its own artefact, `day8/re-frame2-http`, so apps that never issue a request build a bundle clean of it. Add the dep and require `re-frame.http.managed` once at app boot — that registers `:rf.http/managed` and family. Call a managed fx without the artefact loaded and the `re-frame.core` re-exports fail loud with a named "HTTP artefact missing" error rather than a silent miss.
+    Require `re-frame.http.managed` once at boot — Maven `day8/re-frame2-http`. Without
+    it, `[:rf.http/managed …]` raises `:rf.error/no-such-fx`. Late-bound helpers on
+    `re-frame.core` (e.g. test stubs, interceptor registration) raise
+    `:rf.error/http-artefact-missing`.
 
 ## The args map
 
@@ -340,10 +347,45 @@ Two notes. `rf.http/get` shadows `clojure.core/get`, so the namespace is meant t
 
 Tests need no network: the canned-stub fxs (`:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`) and the `with-managed-request-stubs` route-stubbing macro — all registered by requiring the sibling `re-frame.http.test-support` namespace — synthesize replies with the exact envelope a live request produces. The [tutorial's test step](tutorial.md) shows the pattern; [Test a pipeline run](../core/testing/pipeline-runs.md) is the full recipe; [re-frame.http](../api/re-frame.http.md) documents every stub surface.
 
+## A complete request loop
+
+Send + receive + view status (stubs for schema/retry):
+
+```clojure
+(ns app.article
+  (:require [re-frame.core :as rf]
+            [re-frame.http.managed]))
+
+(rf/reg-event :article/load
+  (fn [{:keys [db]} [_ slug]]
+    {:db (assoc-in db [:article :status] :loading)
+     :fx [[:rf.http/managed
+           {:request    {:method :get :url (str "/api/articles/" slug)}
+            :decode     :json
+            :on-success [:article/loaded]
+            :on-failure [:article/load-error]}]]}))
+
+(rf/reg-event :article/loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:article :status] :loaded)
+             (assoc-in [:article :data] value))}))
+
+(rf/reg-event :article/load-error
+  (fn [{:keys [db]} [_ {:keys [error]}]]
+    {:db (-> db
+             (assoc-in [:article :status] :error)
+             (assoc-in [:article :error] error))}))
+```
+
+Tutorial expands failures, schema decode, retry, and `:request-id`.
+
 ## When not to reach for it
 
-Managed HTTP is the right tool for a single request that gets a single reply. Where it isn't, reach for:
+Managed HTTP is right for a **single request → single reply**. Elsewhere:
 
-- **[Resources](../resources/concepts.md)** — the same server data read on several screens, with caching and invalidation. Declare it once; it rides this transport underneath. Hand-rolling `:loaded-at` freshness checks across features means you've outgrown raw requests.
-- **A [state machine](../machines/concepts.md)** — a long-lived connection (WebSocket, SSE) or any multi-step flow where retry decisions depend on state. There is no managed streaming surface yet; that's an honest gap, not a hidden feature.
-- **[Your own fx](custom-effects.md)** — wire-level weirdness: custom transports, exotic binary protocols, non-HTTP async APIs. The escape hatch is always there.
+| Need | Prefer |
+|---|---|
+| Same read, many screens, cache / invalidate | [Resources](../resources/concepts.md) (rides this transport) |
+| Long-lived connection or multi-step lifecycle | [Machines](../machines/concepts.md) — no managed streaming surface yet |
+| Non-HTTP async (SDK, IDB, worker) | [Your own fx](custom-effects.md) |

--- a/docs/async/index.md
+++ b/docs/async/index.md
@@ -1,33 +1,56 @@
 # Async (HTTP)
 
-Sooner or later your app must talk to a server, and the moment it does you inherit a family of problems: errors, timeouts, retries, loading states, stale replies racing each other.
+Sooner or later the app talks to a server — and inherits errors, timeouts, retries,
+loading states, and stale replies racing each other.
 
-re-frame2's answer is the **managed request**. You describe the request as data, return it from a pure [event handler](../core/effects.md), and finish. The runtime performs it. The reply arrives later as an **ordinary [event](../core/events.md)** — success and failure each named:
+re-frame2's answer is the **managed request**. Describe it as data, return it from a
+pure [event handler](../core/effects.md), and finish. The runtime performs it. The
+reply arrives later as an **ordinary [event](../core/events.md)**:
 
 ```clojure
-{:fx [[:rf.http/managed {:request    {:url "/api/articles/intro"}
-                         :on-success [:article/loaded]
-                         :on-failure [:article/load-error]}]]}
+(:require [re-frame.core :as rf]
+          [re-frame.http.managed])   ;; day8/re-frame2-http — forget this → :rf.error/no-such-fx
+
+{:fx [[:rf.http/managed
+       {:request    {:url "/api/articles/intro"}
+        :on-success [:article/loaded]
+        :on-failure [:article/load-error]}]]}
 ```
 
-No `await`, no callback nesting, no resumed stack frame. The answer comes back on the same wire as everything else in your app.
+No `await`, no callback nesting, no resumed stack frame. Success and failure each
+have a name on the same wire as everything else.
 
-## In this section
+## Start here
 
-- **[Tutorial: talk to a server](tutorial.md)** — build up from the smallest request that works to schema validation, retries, a cured search-box race, and a network-free test. Start here.
-- **[Managed HTTP reference](http.md)** — every key of `:rf.http/managed`: the request envelope, the reply contract, the closed set of failure categories, retry, cancellation, testing.
-- **[Interceptors and secrets](http-going-further.md)** — production cross-cutting concerns: stamp auth on every request once; keep tokens and passwords out of traces.
-- **[Your own async effect](custom-effects.md)** — wrap a promise-returning SDK, a callback API, or a worker message in the same pattern.
-- **[Why no await](continuations-are-data.md)** — the idea underneath it all: a continuation is data, not a closure. Read it once and every async surface in re-frame2 looks the same.
-- **[Examples](examples.md)** — complete apps built on managed HTTP.
+1. **[Tutorial](tutorial.md)** — smallest request → failures → view → schema → retry →
+   race cure → network-free test. Best first hour.
+2. **[Managed HTTP](http.md)** — the full model/reference: args map, reply envelope,
+   closed failure kinds, retry, cancel, testing.
+3. Production when you need it: [interceptors and secrets](http-going-further.md).
+
+**Prerequisites.** [Effects](../core/effects.md) — returning an effect map from a
+handler. Managed HTTP plugs into that pipeline; it does not replace events or app-db.
+
+Optional later: [your own async fx](custom-effects.md),
+[why no await](continuations-are-data.md), [Promises mapping](coming-from-promises.md),
+[examples](examples.md).
 
 ## Scope
 
-Two boundaries worth knowing before you dive in:
+| This section | Elsewhere |
+|---|---|
+| One request → one reply event (transport) | [Resources](../resources/index.md) — cache, stale, invalidate over this transport |
+| Continuations as **named events** | [Effects](../core/effects.md) — `dispatch-later`, drain / run-to-completion |
+| Custom promise/callback SDKs | [Your own async effect](custom-effects.md) |
 
-- This section covers *managed* async — effects whose completion returns as a reply event. That's narrower than "async" in general: the event loop, `dispatch-later`, and the event pipeline are async too, and they live in [Effects](../core/effects.md) (including [run to completion](../core/effects.md#run-to-completion)).
-- For the *cache* over server reads — staleness, invalidation, scope — see [Resources](../resources/index.md), which rides on managed HTTP underneath. This section is the transport.
+## When *not* to use managed HTTP alone
 
-!!! note "Setup"
+| Situation | Prefer |
+|---|---|
+| Same read on many screens, cache, invalidate | [Resources](../resources/concepts.md) |
+| Multi-step lifecycle (login, websocket) | [Machines](../machines/index.md) |
+| Non-HTTP async (Stripe, IndexedDB, worker) | [Your own fx](custom-effects.md) |
+| No server yet | app-db + events |
 
-    Managed HTTP ships as its own artefact, `day8/re-frame2-http`, so apps that never issue a request build clean of it. Add the dep and require `re-frame.http.managed` once at boot — that registers `:rf.http/managed` and family. The [tutorial](tutorial.md) walks it.
+Reach for managed HTTP when **one wire call needs a typed, testable reply** — not when
+the load-bearing concept is a cache or a named stage machine.

--- a/docs/async/tutorial.md
+++ b/docs/async/tutorial.md
@@ -1,24 +1,27 @@
 # Tutorial: talk to a server
 
-Let's make an app load an article from a server — adding one idea at a time: the request, the failure path, a view, schema validation, a retry policy, a cured race, and a test.
+Load an article from a server one idea at a time: request → failure path → view →
+schema → retry → race cure → network-free test. By the end you have every piece of
+`:rf.http/managed` everyday work needs.
 
-By the end you'll have used every part of `:rf.http/managed` that everyday work needs. The [reference](http.md) has the rest.
-
-!!! note "Before you start"
-
-    You've read [Effects](../core/effects.md) and can return an effect map from a handler. That's the only prerequisite.
+**Prerequisites.** [Effects](../core/effects.md) — return an effect map from a handler.
+Full key catalogue after this walk-through: [Managed HTTP](http.md).
 
 ## Step 0 — turn managed HTTP on
 
-Managed HTTP ships in its own artefact, `day8/re-frame2-http`, so apps that never issue a request don't carry it. Add the dependency, then require `re-frame.http.managed` once in your boot namespace:
+Managed HTTP ships in its own artefact, `day8/re-frame2-http`. Add the dep, then
+require `re-frame.http.managed` once at boot:
 
 ```clojure
 (ns app.boot
   (:require [re-frame.core :as rf]
-            [re-frame.http.managed]))   ;; ← registers :rf.http/managed and family
+            [re-frame.http.managed]))   ;; registers :rf.http/managed and family
 ```
 
-Forget the require and your first `:rf.http/managed` fails loud with a named "HTTP artefact missing" error — not a silent miss.
+Forget the require and the first `[:rf.http/managed …]` fails loud with
+`:rf.error/no-such-fx` (the fx was never registered). Test helpers re-exported on
+`re-frame.core` throw `:rf.error/http-artefact-missing` until the artefact (and
+`re-frame.http.test-support` for stubs) is loaded.
 
 ## Step 1 — the smallest request that works
 
@@ -213,4 +216,17 @@ The stubbed reply has the exact envelope a live request produces, so both tests 
 
     Run the app with [Xray](../xray/index.md) open. Dispatch `[:article/load "intro"]`: you'll see the issuing event row, the request going out on the [trace stream](../core/glossary.md#trace-stream), and the reply arriving as an ordinary event row of its own — two ledger entries, one round trip. Then re-fire a `:request-id` request before its reply lands and watch the superseded completion get recorded as stale, never dispatched.
 
-That's the everyday surface. The [Managed HTTP reference](http.md) has the rest — the full request envelope, `:accept`, timeouts, verb helpers, manual abort — and [Interceptors and secrets](http-going-further.md) covers stamping auth on every request once and keeping credentials out of traces.
+## The complete shape
+
+| Piece | Surface | You supply |
+|---|---|---|
+| Artefact | `(:require [re-frame.http.managed])` | Once at boot |
+| Send | `:fx [[:rf.http/managed {…}]]` | `:request` + reply target(s) |
+| Receive | `:on-success` / `:on-failure` (or `:reply-to`) | Ordinary events; reply map **appended** |
+| Failures | `(:kind error)` closed set | Branch with `case`, never message strings |
+| Race | `:request-id` | Same id supersedes / suppresses stale |
+| Test | `with-managed-request-stubs` | `re-frame.http.test-support` + canned envelope |
+
+Full catalogue (`:decode`, `:accept`, `:retry`, abort, verb helpers):
+[Managed HTTP](http.md). Production auth + secrets:
+[Interceptors and secrets](http-going-further.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,15 +268,15 @@ nav:
     - "Coming from TanStack Query": resources/coming-from-tanstack-query.md
 
   - "Async (HTTP)":
-    # Tutorial first (get productive), then the reference, then the
-    # cross-cutting production page, then the explanation shelf. The "why"
-    # essay reads best after you've issued a request, so it sits late.
+    # Tutorial first, then the model/reference, production, advanced essays.
     - async/index.md
     - "Tutorial: talk to a server": async/tutorial.md
-    - "Managed HTTP reference": async/http.md
-    - "Interceptors and secrets": async/http-going-further.md
-    - "Your own async effect": async/custom-effects.md
-    - "Why no await": async/continuations-are-data.md
+    - "Managed HTTP": async/http.md
+    - "Production":
+      - "Interceptors and secrets": async/http-going-further.md
+    - "Advanced":
+      - "Your own async effect": async/custom-effects.md
+      - "Why no await": async/continuations-are-data.md
     - "Coming from Promises": async/coming-from-promises.md
     - "Examples": async/examples.md
 


### PR DESCRIPTION
## Summary

Progressive rewrite of the Async (HTTP) guide: tutorial first, Managed HTTP as model/reference, Production and Advanced nests.

- Landing with start-here, scope vs resources/machines, when *not* managed HTTP alone
- Exact error wording: missing require → `:rf.error/no-such-fx`; core late-bind helpers → `:rf.error/http-artefact-missing`
- Complete request loop on Managed HTTP; complete-shape table on tutorial; examples table
- One-job openings on interceptors, custom fx, continuations essay, Promises map

## Test plan

- [ ] Async nav: tutorial → Managed HTTP → interceptors → custom/why await
- [ ] Tutorial Step 0 error ids match implementation
- [ ] Relative links under `docs/async/`
