### PR TITLE
docs(api): re-frame.ui and public-surface gaps

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,96 @@
 # The re-frame2 API
 
-This is the complete API reference for the ClojureScript implementation of re-frame2. On the left, there is one document per namespace.
+This is the **complete public API reference** for the ClojureScript implementation of
+re-frame2. One page per public namespace. Entries use a fixed shape: **Kind**,
+**Signature**, **Description** (contract, including error ids where they are part of
+the surface), **Example**.
+
+For the mental model, start with the [Core guide](../core/introduction.md). This
+corpus is deliberately terse: it states *what* you may call, not *why* the design
+chose it.
+
+## How to read these pages
+
+| Audience need | Where |
+|---|---|
+| Day-to-day app API | [`re-frame.core`](re-frame.core.md) (the facade) |
+| Compiled views (`defview`, `mount`, `sub`) | [`re-frame.ui`](re-frame.ui.md) |
+| Optional capabilities | machines, routing, resources, flows, schemas, HTTP, SSR |
+| Substrate adapters | `re-frame.adapter.{reagent,uix,helix}` — or `re-frame.ui/adapter` |
+| Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md) |
+| Production timing | [`re-frame.performance`](re-frame.performance.md) |
+
+**Facade vs owning namespace.** Many optional features re-export registration verbs
+through `re-frame.core` (for example `reg-machine`, `reg-flow`, `reg-resource`). The
+core page carries a short entry and points at the owning namespace for the full
+contract. Prefer requiring the feature namespace when you need depth; `rf/` remains
+valid for the re-export.
+
+**Keyword surfaces.** Events, fx, subs, and similar *keyword-addressed*
+registrations (`:rf.http/managed`, `:rf/machine`, …) appear as tables or sections on
+the owning page. They are not vars; the [api-manifest](../../spec/api-manifest.edn)
+tracks vars.
+
+**Completeness.** Public vars in the manifest with tiers `:front-porch`,
+`:advanced`, `:adapter`, or `:testing` under `re-frame.*` are expected to appear on
+these pages (or as an explicit facade pointer). Tooling and implementation tiers are
+out of scope here.
+
+## Namespaces
+
+### Facade and core dataflow
+
+| Page | Role |
+|---|---|
+| [re-frame.core](re-frame.core.md) | Registration, dispatch, subscribe, views (`reg-view`), frames, boot, interceptors, feature re-exports |
+| [re-frame.ui](re-frame.ui.md) | Compiled-view substrate: `defview`, `sub`, `mount`, `frame-root`, interop forms |
+
+### Optional capabilities
+
+| Page | Role |
+|---|---|
+| [re-frame.schemas](re-frame.schemas.md) | App / event / effect schemas |
+| [re-frame.flows](re-frame.flows.md) | Materialised derivations into app-db |
+| [re-frame.http](re-frame.http.md) | Managed HTTP fx and interceptors |
+| [re-frame.machines](re-frame.machines.md) | State machines |
+| [re-frame.routing](re-frame.routing.md) | Router, routes, route link |
+| [re-frame.resources](re-frame.resources.md) | Resource cache, leases, mutations |
+| [re-frame.ssr](re-frame.ssr.md) | Server render, head, payloads |
+| [re-frame.ssr.ring](re-frame.ssr.ring.md) | Ring adapter for SSR |
+| [re-frame.epoch](re-frame.epoch.md) | Epoch history / time-travel surface |
+
+### Adapters, tests, tooling
+
+| Page | Role |
+|---|---|
+| [re-frame.adapter.reagent](re-frame.adapter.reagent.md) | Stock / slim Reagent substrate |
+| [re-frame.adapter.uix](re-frame.adapter.uix.md) | UIx substrate |
+| [re-frame.adapter.helix](re-frame.adapter.helix.md) | Helix substrate |
+| [re-frame.test-support](re-frame.test-support.md) | Fixtures, registrar snapshot, poll, sequester |
+| [re-frame.test-helpers](re-frame.test-helpers.md) | Hiccup walkers, testids |
+| [re-frame.performance](re-frame.performance.md) | Compile-time User-Timing flags |
+
+## Require patterns
+
+```clojure
+;; Typical app (Reagent or ui substrate)
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.reagent :as reagent-adapter]
+          ;; or: [re-frame.ui :as ui :refer [defview sub]]
+          )
+
+(rf/init! reagent-adapter/adapter)
+;; (rf/init! ui/adapter)
+
+;; Tests
+(:require [re-frame.core :as rf]
+          [re-frame.test-support :as ts]
+          [re-frame.test-helpers :as th])
+```
+
+## Related corpora
+
+- [Core guide](../core/introduction.md) — progressive teaching
+- [spec/API.md](../../spec/API.md) — normative var catalogue with tiers (projection of
+  the api-manifest)
+- Feature guides under Machines, Resources, Routing, SSR, Async tabs

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -481,28 +481,41 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   ```
 - **Description**: **Not an app-facing surface** — the internal constructor behind `capture-frame` and the `reg-view` injection sugar. It is a public Var only so the `reg-view` macro's emitted body can reference it fully-qualified. Call `capture-frame` instead.
 
-### `with-frame` / `with-new-frame`
+### `with-frame`
 
-- **Kind**: macros (a sibling pair)
-- **Signatures**:
+- **Kind**: macro
+- **Signature**:
   ```clojure
-  (with-frame :keyword body)        ;; pin *current-frame* to an existing frame-id
-  (with-new-frame [sym expr] body)  ;; eval expr, bind id to sym, run, destroy on exit
+  (with-frame :keyword body)
   ```
-- **Description**: The two **lexical** (non-React) frame-scoping macros — for regions that aren't a view tree (tests, the REPL, SSR). Each rejects the other's argument shape at compile time.
-  - `with-frame` pins `*current-frame*` to an **existing** frame-id for the dynamic extent of `body`, creating and destroying nothing. The lexical counterpart to the `rf/frame-provider` `{:frame …}` SCOPE shape.
-  - `with-new-frame` evaluates `expr` and binds the resulting frame target to `sym` — typically the live frame value from `make-frame` (a frame value or a keyword id is accepted downstream). It runs `body` in that frame's dynamic context, then **destroys the frame on exit**. The throwaway-frame form for one-off harnesses.
+- **Description**: Lexical (non-React) frame scoping for regions that are not a view
+  tree (tests, the REPL, SSR). Pins `*current-frame*` to an **existing** frame-id
+  for the dynamic extent of `body`, creating and destroying nothing. The lexical
+  counterpart to `rf/frame-provider` `{:frame …}` SCOPE. Rejects the
+  `with-new-frame` argument shape at compile time.
 - **Example**:
   ```clojure
-  ;; Pin form — bind *current-frame* to an existing id for the body (most common)
   (rf/with-frame :todo
     (rf/dispatch-sync [:todo/add {:text "milk"}]))
+  ```
 
-  ;; Eval-bind-run-destroy — a throwaway frame for one test, torn down on exit.
+### `with-new-frame`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (with-new-frame [sym expr] body)
+  ```
+- **Description**: Evaluates `expr` and binds the resulting frame target to `sym`
+  (typically the live frame from `make-frame`). Runs `body` in that frame's dynamic
+  context, then **destroys the frame on exit**. Throwaway-frame form for one-off
+  harnesses. Rejects the `with-frame` argument shape at compile time.
+- **Example**:
+  ```clojure
   (rf/with-new-frame [f (rf/make-frame {:images [todo-image]})]
-    (rf/dispatch-sync [:rf/set-db {:todos []}])         ;; seed via a setup dispatch
+    (rf/dispatch-sync [:rf/set-db {:todos []}])
     (rf/dispatch-sync [:todo/add {:text "milk"}])
-    (is (= 1 (count (:todos (rf/app-db-value f))))))    ;; frame destroyed on exit
+    (is (= 1 (count (:todos (rf/app-db-value f))))))
   ```
 
 ## Effects and interceptors

--- a/docs/api/re-frame.performance.md
+++ b/docs/api/re-frame.performance.md
@@ -36,9 +36,9 @@ See [Find and fix a slow view](../core/how-to/fix-a-slow-view.md) for turning th
 
 ### `retain-entries?`
 
-- **Kind**: Var (`^boolean`)
-- **Signature**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/retain-entries? true}`.
-- **Description**: Skips the per-emit `performance.clearMeasures(name)` so measure entries persist in the host's retained User-Timing buffer.
+- **Kind**: Compile-time flag (`goog.define` / Closure define)
+- **Signature**: Set via `:closure-defines {re-frame.performance/retain-entries? true}` (CLJS). JVM is a no-op constant.
+- **Description**: Skips the per-emit `performance.clearMeasures(name)` so measure entries persist in the host's retained User-Timing buffer. Not listed as a separate runtime-exported Var in the public api-manifest (it is consumed only by compile-time elision); document it here because it is part of the build contract for this namespace.
     - Enables one-shot `performance.getEntriesByType("measure")` readers (DevTools / console workflows).
     - Default `false`: each entry is delivered to any live `PerformanceObserver` at `measure()` time, then cleared. The buffer therefore does not grow across a long-running (RUM) session, and `getEntriesByType` returns no `rf:*` entries.
     - No effect unless `enabled?` is also on.

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -82,6 +82,90 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
     (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter :async? true}))
   ```
 
+## Bundle co-load hygiene
+
+CLJS node runners often load **every** test namespace into one bundle before any
+test runs. Two example apps that both register the same per-app id (for example
+`:rf.route/not-found`, or shared event vocabulary) leave duplicate provenance rows
+in the shared source store; default-image assembly then fails loud with
+`:rf.error/image-duplicate-id`. The sequester / reinstate pair removes a suite's
+sibling registrations for the duration of its tests.
+
+Call sequester at **namespace load** (right after requiring the app ns), and
+reinstate from a per-test `:init-fn` (or equivalent) when the suite must see its
+own registrations again.
+
+### `sequester-app-registration!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sequester-app-registration! kind id provenance-ns) → descriptor | nil
+  ```
+- **Description**: Remove **one** app namespace's registration row for
+  `(kind, id)` from the live registrar **and** the provenance source store.
+  Returns the captured source-store descriptor, or `nil` when absent. Reinstate
+  with `reinstate-app-registration!`.
+- **Example**:
+  ```clojure
+  ;; At ns load, after requiring the app under test:
+  (defonce !not-found
+    (ts/sequester-app-registration! :event :rf.route/not-found
+                                    "my.app.routes"))
+  ```
+
+### `reinstate-app-registration!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reinstate-app-registration! descriptor) → nil
+  ```
+- **Description**: Reinstate a descriptor captured by
+  `sequester-app-registration!` through `registrar/register!` (registrar and
+  source store in lockstep). No-op on `nil`.
+- **Example**:
+  ```clojure
+  (ts/reinstate-app-registration! !not-found)
+  ```
+
+### `sequester-app-namespaces!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sequester-app-namespaces! ns-prefix) → captured-row-count
+  ```
+- **Description**: Namespace-tree form: remove **every** source-store row whose
+  provenance namespace starts with `ns-prefix` (and the matching registrar ids when
+  the current registrar row belongs to that prefix). Capture is **memoized** per
+  prefix; scrubbing runs on every call so merge-form restores cannot reintroduce
+  sibling rows. Returns the captured row count. Reinstate with
+  `reinstate-app-namespaces!`.
+- **Example**:
+  ```clojure
+  ;; At ns load — drop the co-loaded sibling app's registrations:
+  (ts/sequester-app-namespaces! "realworld.uix")
+  ```
+
+### `reinstate-app-namespaces!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reinstate-app-namespaces! ns-prefix) → nil
+  ```
+- **Description**: Reinstate every row `sequester-app-namespaces!` captured for
+  `ns-prefix` through `registrar/register!`. Call from a suite's per-test
+  `init-fn` when that suite owns the prefix.
+- **Example**:
+  ```clojure
+  (use-fixtures :each
+    (ts/make-reset-runtime-fixture
+     {:adapter plain-atom/adapter
+      :init-fn #(ts/reinstate-app-namespaces! "realworld.reagent")}))
+  ```
+
 ## Test-flavoured helpers
 
 To fire several events in order, call `rf/dispatch-sync` per event — each drains to fixed point before the next, so observable state between calls reflects committed effects:

--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -1,0 +1,230 @@
+# re-frame.ui
+
+`re-frame.ui` is the first-party **compiled-view substrate** (Maven coordinate
+`day8/re-frame2-ui`). Views are authored as `defview` + hiccup; the compiler lowers
+templates to direct React construction (browser) and a versioned structural tree
+(JVM). There is no hiccup interpreter in production bundles on the compiled path.
+
+This namespace is **not** re-exported from `re-frame.core`. Require it explicitly and
+install its adapter at boot:
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.ui :as ui :refer [defview sub]])
+
+(rf/init! ui/adapter)
+```
+
+Concept teaching lives in the UI guide (when published under `docs/ui/`) and the
+substrate design suite. This page is the contract surface for public symbols.
+
+**Stage honesty.** Front-porch symbols below are the ruled public API. Some
+runtime behaviours (committed DOM handlers, full lease semantics, hydration
+manifests) land with later substrate stages; the **names and signatures** are the
+v1 surface. Where a direct call is only a compile-time resolution symbol, the
+description says so.
+
+## Boot
+
+### `adapter`
+
+- **Kind**: Var (adapter map)
+- **Signature**: pass to `(rf/init! ui/adapter)`
+- **Description**: The `re-frame.ui` substrate adapter. CLJS installs the native
+  React observation substrate (no Reagent / UIx / Helix). JVM uses the headless atom
+  realisation of the same closed adapter contract. Discriminator
+  `:rf.adapter/ui`. Destroying the adapter tears down every public compiled Root,
+  then the generic React spine.
+- **Example**:
+  ```clojure
+  (rf/init! ui/adapter)
+  ```
+
+## Views
+
+### `defview`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (defview name docstring? opts? [props?] template)
+  ```
+- **Description**: The one component form. A pure function of **zero or one** props
+  map to a hiccup template, compiled to direct React (browser) and the JVM structural
+  tree. Header destructuring lowers to per-slot reads. Closed options map:
+  - `:props` — Malli schema (dev-checked; compile-time when the call site is literal)
+  - `:id` — registry override
+  - `:display-name` — React display name
+  Every view is memoised on a per-slot `rf=` comparator and registers under the
+  registrar's `:view` kind. No Form-2 / Form-3 / positional args.
+- **Example**:
+  ```clojure
+  (ui/defview counter []
+    [:div
+     [:span "Count: " (sub [:count])]
+     [:button {:on-click [:count/inc]} "+"]])
+  ```
+
+### `custom-element`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (custom-element tag {:properties #{…}})
+  ```
+- **Description**: Declares a custom-element tag and which kebab-case prop names are
+  JS **properties** (camelCased on the client). Undeclared names are attributes;
+  undeclared elements need no declaration (all-attributes default). JVM emits
+  attributes only; property props apply at hydration.
+- **Example**:
+  ```clojure
+  (ui/custom-element :user-picker {:properties #{:users :selected-id}})
+  ```
+
+## Template forms (compiler-owned)
+
+These symbols resolve in templates so the compiler can lower them. **A direct call
+from ordinary Clojure code fails loud** (they are not runtime helpers).
+
+### `sub`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(sub query-vector) → value` (inside a compiled view only)
+- **Description**: Lexical subscription read site. Returns the current value; the view
+  re-renders when it changes. Conditional sites are legal; sites inside `for` are a
+  compile error (extract a keyed child view). Not a one-shot helper — use core
+  `subscribe` / `subscribe-once` outside views.
+- **Errors**: direct call → `:rf.error/ui-tree-malformed`.
+
+### `lease`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(lease descriptor)`
+- **Description**: Declares resource interest while the view is mounted/visible. Does
+  not return data and does not fetch; read status via `(sub [:rf/resource …])`.
+  Leading declaration form in a `defview` body. Direct calls fail loud.
+
+### `frame`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(frame) → {:frame :dispatch :dispatch-sync :subscribe}`
+- **Description**: Inside a compiled view, returns the capture-frame-shaped ops bundle
+  bound to the **committed** frame. Ops fail loud after the frame incarnation dies
+  (`:rf.error/frame-destroyed`). Outside views use `rf/capture-frame`.
+
+### `raw`
+
+- **Kind**: function (template interop form)
+- **Signature**: `(raw react-element)`
+- **Description**: Embed an existing React element in child position. On the JVM a
+  rendered `raw` child is a host-op error.
+
+### `html`
+
+- **Kind**: function (template interop form)
+- **Signature**: `(html string)`
+- **Description**: Trusted markup bypass — the sole child of a DOM element
+  (`[:div (ui/html s)]`). Visible at the call site; both emitters treat it
+  identically.
+
+### `raw-fn`
+
+- **Kind**: function
+- **Signature**: `(raw-fn f) → f`
+- **Description**: Identity-as-protocol callback marker (also the explicit callback-ref
+  form). Passes the function through to the host untouched.
+
+### `spread`
+
+- **Kind**: function (template interop form)
+- **Signature**: `(spread base overrides)`
+- **Description**: Runtime prop-map merge through the **same conversion rule table**
+  as the compiler. Legal in a DOM element's props position only:
+  `[:div (ui/spread base attrs)]`. Direct call → `:rf.error/ui-spread-outside-template`.
+
+## Roots and mounting
+
+### `mount`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (mount root-form dom-node)
+  (mount root-form dom-node opts)
+  ```
+- **Description**: One-shot client mount: create-root + frame preflight + `render!`.
+  **Idempotent per root** (same root-id + container re-renders; live frames are not
+  re-seeded). `root-form` must be a **literal** vector. Identity opts
+  (`:root-id`, `:disambiguator`, `:identifier-prefix`) are compile-time literals.
+  Host error callbacks (`:on-uncaught-error`, …) are plain fns. Returns the Root.
+- **Example**:
+  ```clojure
+  (ui/mount [ui/frame-root {:id :app :initial-events [[:app/init]]}
+              [counter]]
+            (js/document.getElementById "root"))
+  ```
+
+### `create-root`
+
+- **Kind**: macro
+- **Signature**: `(create-root dom-node opts) → Root`
+- **Description**: Fix root identity for the Root's lifetime without rendering.
+  Authored `:root-id` is **required** (no root form to derive from). Prefer `mount`
+  for the one-liner path.
+
+### `render!`
+
+- **Kind**: macro
+- **Signature**: `(render! root root-form)`
+- **Description**: Render / re-render a **literal** root form into an existing Root.
+  Frame plans in the top region preflight before render. Identity is unchanged.
+
+### `hydrate-root`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (hydrate-root dom-node root-form)
+  (hydrate-root dom-node root-form opts)
+  ```
+- **Description**: Hydrating mount. Identity comes from the **server manifest**, not
+  client identity opts (passing `:root-id` / `:identifier-prefix` is an error). Full
+  hydration lands with SSR roots; earlier stages fail loud with
+  `:rf.error/root-manifest-invalid` when no valid manifest is present.
+
+### `unmount!`
+
+- **Kind**: function
+- **Signature**: `(unmount! root) → nil`
+- **Description**: Total teardown: unmount the React root and unregister the root-id.
+  Idempotent. Client-only; JVM host-op error.
+
+### `frame-root`
+
+- **Kind**: function (root-form template symbol)
+- **Signature**: `(frame-root {:id … :initial-events …} & children)`
+- **Description**: Static **ENSURE** plan wrapper, legal only in the **top region** of
+  a root form passed to `mount` / `render!` / `hydrate-root`. `:id` must be a
+  compile-time keyword. Creates the frame if absent, seeds `:initial-events` once,
+  never destroys on unmount. Compiles away — direct call fails with
+  `:rf.error/ui-frame-root-outside-root-form`. To **scope** an already-live frame
+  inside a view tree, use `frame-provider`.
+
+### `frame-provider`
+
+- **Kind**: function (template symbol)
+- **Signature**: `(frame-provider {:frame f} & children)`
+- **Description**: Scope a subtree to an **already-live** frame through React
+  context. Creates nothing, seeds nothing, destroys nothing. `:frame` is a runtime
+  frame id or live frame value. Absent frame →
+  `:rf.error/frame-provider-frame-absent`. Direct call fails with
+  `:rf.error/ui-frame-provider-outside-template`.
+
+## See also
+
+- [`re-frame.core`](re-frame.core.md) — events, subs, frames (`make-frame`,
+  `capture-frame`), boot (`init!`)
+- [Introduction](../core/introduction.md) — the pure dataflow loop this substrate
+  plugs into
+- Substrate design / UI guide under the synthesis suite (force-tracked findings) when
+  reader-facing `docs/ui/` is not yet landed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -216,6 +216,7 @@ nav:
   - API:
     - api/README.md
     - "re-frame.core": api/re-frame.core.md
+    - "re-frame.ui": api/re-frame.ui.md
     - "re-frame.schemas": api/re-frame.schemas.md
     - "re-frame.flows": api/re-frame.flows.md
     - "re-frame.http": api/re-frame.http.md


### PR DESCRIPTION
## Summary

Fill gaps in the public API docs surface for the guide site.

- New `docs/api/re-frame.ui.md` for the UI substrate public surface
- Expand `re-frame.test-support` coverage (sequester and related test APIs)
- Wire MkDocs API index; small performance page touch-ups

## Test plan

- [ ] API nav lists `re-frame.ui` and updated test-support
- [ ] Spot-check Kind/Signature/Description/Example shape on new pages
