### PR TITLE
docs: reconcile reagent-slim FORM-3.md with the EP-0002 frame model (rf2-vxgfnd.22)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -340,11 +340,21 @@ Three variations worth knowing:
   (deferred-loaded API), wrap the `:component-did-mount` body in an
   async-load callback. The atoms are still the right state container — the
   callback just runs later.
-- **Render in response to subs.** Combine Form-3 with subscription: the inner
-  `:reagent-render` can `@(subscribe [...])` to trigger re-renders, which
-  causes `:component-did-update` to fire, which lets the imperative library
-  see new data. Don't `subscribe` in the lifecycle callbacks themselves
-  (reactive context is undefined there) — `subscribe` only in the render.
+- **Render in response to subs — route it through `reg-view*` + a captured
+  frame.** The architecture is sound: let the inner `:reagent-render` deref a
+  subscription so the view re-renders when the data changes, which fires
+  `:component-did-update`, which lets the imperative library see the new data.
+  But a **bare `@(subscribe [...])` in a plain-`defn` Form-3 throws
+  `:rf.error/no-frame-context` at first render** under any `frame-provider`
+  (EP-0002 — frame identity is carried, not found). The 7-key cap (§1) forbids
+  `:context-type`, and a plain-`defn` `create-class` carries none, so the class
+  can't read its provider's frame from React context and the ambient
+  `subscribe` resolves no scope. Register the class through
+  `re-frame.core/reg-view*` and capture the frame **once in the outer callable**
+  (`(rf/capture-frame)` — the one live-resolver site in a Form-3); deref the
+  captured `:subscribe` inside `:reagent-render`, never in a lifecycle callback
+  (reactive reads have no owner there, and the scope has already unwound). See
+  `guided-handlers-state.md` §M-11 Form-3 route 2 for the full recipe.
 - **DOM measurement during commit.** If you need to capture a measurement
   *before* React commits a re-render (typical for scroll preservation),
   use `:get-snapshot-before-update`. See §5 below.
@@ -480,7 +490,9 @@ dispatches events, etc.), put it on the surrounding frame, not in a Form-3
 `:component-did-mount`:
 
 ```clojure
-;; Wrong — Form-3 for app-state init
+;; Wrong — and it doesn't merely read worse: a bare (rf/dispatch …) in a
+;; plain-defn Form-3's :component-did-mount THROWS :rf.error/no-frame-context
+;; under any frame-provider (EP-0002 — the class carries no frame context).
 (r/create-class
   {:component-did-mount (fn [_] (rf/dispatch [:counter/initialise]))
    :reagent-render      ...})
@@ -490,9 +502,17 @@ dispatches events, etc.), put it on the surrounding frame, not in a Form-3
 ```
 
 The frame event is named, registered, queryable, traceable in re-frame-10x,
-and runs deterministically once per frame mount. The Form-3 version hides the
-dispatch behind a lifecycle callback and couples the side effect to a
-particular view.
+and runs deterministically once per frame mount — and it is the pattern to
+reach for regardless. The Form-3 version isn't just a worse idiom: under
+EP-0002 that bare `(rf/dispatch …)` **throws `:rf.error/no-frame-context`**,
+because a plain-`defn` `create-class` carries no `:contextType` (the 7-key cap
+forbids `:context-type`) and so can't resolve its provider's frame. A Form-3
+that genuinely must dispatch from a lifecycle hook has to go through
+`re-frame.core/reg-view*`, capturing the frame's `:dispatch` **once in the
+outer callable** and closing that handle over the hook — never a fresh
+`(rf/capture-frame)` inside the hook, which fires after the scope unwinds and
+re-throws. See `guided-handlers-state.md` §M-11 Form-3 route 2. For plain
+mount-time app-state init, prefer `:initial-events`.
 
 ### Use `:ref` callbacks, not Form-3, for DOM access
 
@@ -565,3 +585,11 @@ idioms.
 - **[Views spec](../../../spec/004-Views.md)** §"Form-3 (class — out of scope for the
   macro)" — Form-3 is intentionally not supported by the `reg-view` macro; use
   `re-frame.core/reg-view*` (the plain-fn surface) for Form-3 components.
+- **[Migration recipe](../../../skills/re-frame-migration/references/guided-handlers-state.md)**
+  §M-11 Form-3 routes 1 & 2 — the full recipe for a **frame-scoped** Form-3 (one
+  that subscribes or dispatches app state): extract the subscribing part into a
+  `reg-view` child, or register the outer fn through `reg-view*` and capture the
+  frame once in the outer callable. A bare `@(subscribe)` / `(rf/dispatch)` in a
+  plain-`defn` Form-3 under a `frame-provider` throws `:rf.error/no-frame-context`
+  (EP-0002). The worked examples in §4–§5 above are frame-independent and need
+  none of this.


### PR DESCRIPTION
## What & why

The S2 boundary review (rf2-vxgfnd.22, Lens 5 F1) found the frozen reagent-slim `FORM-3.md` contradicting the EP-0002 frame model in two frame-scoped spots. `FORM-3.md` predates EP-0002 and told adopters a plain-`defn` Form-3 could freely `@(subscribe …)` / `(rf/dispatch …)` — but under EP-0002 both **throw `:rf.error/no-frame-context`** at first render/mount under any `frame-provider`. Two shipped docs (this one and the migration recipe) gave opposite answers for the commonest case.

Bug bead: **rf2-v3fwtz**.

## The two reconciled spots

1. **§4 "Render in response to subs" bullet.** Was: the inner `:reagent-render` "can `@(subscribe […])`". Now: states that a bare `@(subscribe)` in a plain-`defn` Form-3 throws `:rf.error/no-frame-context` under a provider, and directs adopters to register the class through `re-frame.core/reg-view*` and capture the frame once in the outer callable (deref the captured `:subscribe` in render, never a lifecycle hook). Kept the sound architecture (subscription-driven render → `:component-did-update` → imperative library sees new data).

2. **§6 "Wrong — Form-3 for app-state init" example.** Was framed as merely a worse idiom ("hides the dispatch behind a lifecycle callback"). Now: the bare `(rf/dispatch …)` in a plain-`defn` `:component-did-mount` **throws** `:rf.error/no-frame-context` (no `:contextType`, 7-key cap forbids `:context-type`), with the `reg-view*` + captured-`:dispatch` escape hatch for a genuine lifecycle dispatch. The primary recommendation — prefer frame `:initial-events` — is unchanged.

Both spots cross-reference `guided-handlers-state.md` §M-11 Form-3 route 2 (the authoritative recipe), and a §7 cross-reference entry was added pointing at it.

## Not over-corrected

The four worked examples (google-map, vega, error-boundary, scroll-log) are **frame-independent** and correct as-is — left untouched. So are the other frame-independent variations (async init, DOM-measurement/`:get-snapshot-before-update`, `:ref` callbacks, and the §6 prop-change-reaction example which reads `r/argv`, not app state). The hole was narrowly the two spots that touch frame-scoped subscribe/dispatch.

## Source verification (the .22 diff-check)

Every claim was checked against shipped substrate behaviour:

- **7-key cap forbids `:context-type`** — `FORM-3.md` §1; confirmed by `reagent_slim.cljs:80,134` ("Slim's restricted create-class map cannot carry `:context-type`").
- **`:contextType` attached ONLY post-hoc, never via the cap** — `reagent2/impl/component.cljs:738-739` (`fn-to-class` sets `.-contextType` from `(:contextType (meta f))`, the meta `reg-view*` stamps as `{:contextType frame-context}`) and `re_frame/adapter/reagent_slim.cljs:142-145` (`with-resource-lease` sets `.-contextType` post-hoc). Both set the React static field AFTER `create-class*`, bypassing the 7-key cap. A plain-`defn` `create-class` carries no such meta → no `.-contextType`.
- **Read → nil → throw** — `views/provider.cljs:283-287` (`current-frame`: reads `(.-context cmp)`; plain fn yields the no-provider sentinel; `coerce-context-value` → nil; dynamic-var tier nil absent `with-frame`); `frame.cljc:517-546` (`require-current-frame!` emits + throws `:rf.error/no-frame-context` on nil).
- **subscribe/dispatch both route through it** — `subs.cljc:1547` (`subscribe-in-frame (frame/require-current-frame! …)`); `router.cljc:160,309` (dispatch resolves via `require-current-frame!` absent an explicit `:frame`).

The corrected guidance matches what the substrate does: a frame-scoped Form-3 needs `reg-view*` + a captured `capture-frame` handle.

## Hot-zone residue check

`migration/from-re-frame-v1/README.md` (hot-zone, not touched) already carries the correct EP-0002 Form-3 guidance (M-11 plain-fn boundary, `capture-frame`, `:rf.error/no-frame-context`) — no contradictory residue there, so **no hot-zone follow-up is needed**.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_readme_links.py --ci` — exit 0
- No `skills/` files edited (only cross-referenced), so skill-drift checks don't apply. Docs-only change: no npm/browser/fast-pr per the .22 slim gate discipline.
