### PR TITLE
fix(xray): reactive-panel projection test-integrity — delete doubly-dead subs-skipped + add real-substrate e2e (rf2-vxgfnd.22)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -670,6 +670,21 @@ Rationale: unchanged subs are coverage signal, not signal-of-the-moment.
 Hiding by default keeps the dense view scannable; the toggle preserves
 the "I want to see what DIDN'T fire" affordance.
 
+**Data-availability (rf2-vxgfnd.22).** The projection tier
+(`reactive-panel-subs/project-record`) carries NO `subs-skipped` slot. A
+memo-hit (input-unchanged short-circuit) emits NO `:sub-runs` row — the
+substrate's `sub-run-row` hardcodes `:recomputed? true`, and a
+`:rf.sub/skip` memo-hit rides only `:trace-events` — so `:subs-ran` is
+the whole run-set. Surfacing *skipped* subs (the "what DIDN'T fire"
+coverage above) awaits the `:rf.sub/skipped` attribution op (§12, not yet
+landed); it MUST NOT be reconstructed by filtering `:sub-runs` on
+`(complement :recomputed?)`, which is structurally always empty — a
+projected slot that shape produced was doubly-dead (unproducible AND
+consumed by no panel: the §3.2 flow graph reads `:level-1/2-subs` /
+`:view-rows` / `:sub-readers`). The graph's `unchanged` (dashed,
+short-circuited) nodes are subs that RAN with `:value-changed? false`,
+NOT memo-hit skips.
+
 ### §3.4.1 ViewCell invalidation evidence (re-frame.ui substrate · rf2-vxgfnd.146)
 
 Xray is the OWNING native consumer of the `re-frame.ui.tool.evidence`

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -9,11 +9,17 @@
   `:trace-events` by op-keyword: the canonical ops are `:rf.sub/run` /
   `:rf.sub/skip` / `:rf.view/rendered` (Spec 009 §:op-type vocabulary),
   and the earlier op-keyword path grepped for names the substrate never
-  emits (`:rf.sub/computed` / `:rf.sub/skipped`), pinning subs-ran /
-  subs-skipped to zero regardless of how many subs actually ran.
+  emits (`:rf.sub/computed` / `:rf.sub/skipped`), pinning subs-ran to
+  zero regardless of how many subs actually ran.
 
-  - `:sub-runs` → subs-ran (`:recomputed?` true) + subs-skipped
-    (memo-hit, `:recomputed?` false); each carries `:value-changed?`.
+  - `:sub-runs` → subs-ran; every `:sub-runs` row is a genuine recompute
+    (the substrate's `sub-run-row` hardcodes `:recomputed? true` and a
+    `:rf.sub/skip` memo-hit projects NO `:sub-runs` row — it rides only
+    `:trace-events`), so there is no memo-hit / `subs-skipped` split to
+    surface here. Each row carries `:value-changed?`. Surfacing skipped
+    (memo-hit) subs awaits the `:rf.sub/skipped` attribution op (spec/021
+    §12) — it MUST NOT be reconstructed by filtering `:sub-runs` on
+    `(complement :recomputed?)`, which is structurally always empty.
   - `:renders`  → views-rendered (`:render-key` → top-level `:view-id`)
   - flow counts → tallied from `:trace-events` (`:rf.flow/computed` /
     `:rf.flow/skip`), the one slice with no structured projection.
@@ -66,14 +72,13 @@
          :triggered-by    <event-vec>
          :seed-paths      [<path> ...]
          :subs-ran        [{:sub-id _ :value-changed? _ ...} ...]
-         :subs-skipped    [{:sub-id _ ...} ...]
          :views-rendered  [{:view-id _ ...} ...]      ; legacy count slot
          :level-1-subs    [{:sub-id _ :changed? _ :coord _ :readers [...]} ...]
          :level-2-subs    [{:sub-id _ :changed? _ :inputs [...] :coord _
                             :readers [...]} ...]
          :sub-readers     {<sub-id> [<view-id> ...] ...}
          :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
-         :counts          {:subs-ran N :subs-skipped N
+         :counts          {:subs-ran N
                            :views-rendered N
                            :flows-recomputed N}}
 
@@ -477,9 +482,11 @@
   sub to Level 1 with no inputs / no coord — the panel still renders.
 
   `:sub-runs` entries carry `:sub-id` / `:query-v` / `:recomputed?` /
-  `:value-changed?`; `:recomputed?` splits genuine recomputes (subs-ran)
-  from memo-hit skips (subs-skipped). The view rows ride the phase-A
-  rf2-9hoos fields on the view-render ops.
+  `:value-changed?`. Every `:sub-runs` row is a genuine recompute
+  (`:recomputed? true` — the substrate's `sub-run-row` hardcodes it; a
+  `:rf.sub/skip` memo-hit emits NO `:sub-runs` row), so there is no
+  memo-hit / `subs-skipped` split — `:subs-ran` IS the run-set. The view
+  rows ride the phase-A rf2-9hoos fields on the view-render ops.
 
   Returns the map shape documented in the ns docstring (sans the
   focus / frame / dispatch-id keys; those come from the spine sub)."
@@ -487,7 +494,6 @@
   ([record topology]
    (let [sub-runs (vec (:sub-runs record))
          ran      (filterv :recomputed? sub-runs)
-         skipped  (filterv (complement :recomputed?) sub-runs)
          renders  (mapv (fn [r] (assoc r :view-id (first (:render-key r))))
                         (:renders record))
          trace-events (or (:trace-events record) [])
@@ -501,7 +507,6 @@
          unmounted     (unmounted-views trace-events)
          destroyed     (destroyed-subscriptions trace-events)]
      {:subs-ran        ran
-      :subs-skipped    skipped
       :views-rendered  renders
       :level-1-subs    level-1
       :level-2-subs    level-2
@@ -510,7 +515,6 @@
       :unmounted-views unmounted
       :destroyed-subs  destroyed
       :counts          {:subs-ran         (count ran)
-                        :subs-skipped     (count skipped)
                         :views-rendered   (count renders)
                         :view-rows        (count v-rows)
                         :unmounted-views  (count unmounted)

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -10,8 +10,11 @@
   The canonical op / projection shapes (Spec 009 §:op-type vocabulary +
   spec/018):
 
-  - `:sub-runs` entry → `{:sub-id _ :query-v _ :recomputed? bool}`;
-    `:recomputed?` splits subs-ran (true) from memo-hit skips (false).
+  - `:sub-runs` entry → `{:sub-id _ :query-v _ :recomputed? true}`; the
+    substrate's `sub-run-row` hardcodes `:recomputed? true` and a
+    `:rf.sub/skip` memo-hit projects NO `:sub-runs` row, so `:subs-ran`
+    IS the run-set — there is no producible memo-hit / `subs-skipped`
+    split (see the `project-record` fabrication note below).
   - `:renders`  entry → `{:render-key [view-id idx] ...}`.
   - flow ops on `:trace-events` → `:rf.flow/computed` / `:rf.flow/skip`.
 
@@ -24,8 +27,13 @@
 
 ;; ---- helpers -----------------------------------------------------------
 
-(defn- sub-run [sub-id recomputed?]
-  {:sub-id sub-id :query-v [sub-id] :recomputed? recomputed?})
+(defn- sub-run
+  "A `:sub-runs` projection row as the substrate actually emits it —
+  `sub-run-row` (capture.cljc) hardcodes `:recomputed? true`, and a
+  `:rf.sub/skip` memo-hit projects no row at all, so there is no
+  `:recomputed? false` shape to fabricate here."
+  [sub-id]
+  {:sub-id sub-id :query-v [sub-id] :recomputed? true})
 
 (defn- render [view-id]
   {:render-key [view-id 0] :triggered-by nil :elapsed-ms nil})
@@ -70,10 +78,8 @@
     (doseq [r [nil {}]]
       (let [p (subs/project-record r)]
         (is (= [] (:subs-ran p)))
-        (is (= [] (:subs-skipped p)))
         (is (= [] (:views-rendered p)))
         (is (= 0 (-> p :counts :subs-ran)))
-        (is (= 0 (-> p :counts :subs-skipped)))
         (is (= 0 (-> p :counts :views-rendered)))
         (is (= 0 (-> p :counts :flows-recomputed)))
         (is (= 0 (-> p :counts :flows-skipped)))))))
@@ -81,38 +87,29 @@
 ;; ---- project-record: subs ran (:recomputed? true) ---------------------
 
 (deftest project-subs-ran
-  (testing ":sub-runs entries with :recomputed? true become :subs-ran rows"
-    (let [record {:sub-runs [(sub-run :cart/state true)
-                             (sub-run :cart/items true)
-                             (sub-run :cart/total true)]}
+  (testing "every :sub-runs entry (:recomputed? true — the only shape the
+            substrate emits) becomes a :subs-ran row; :subs-ran IS the
+            whole run-set"
+    (let [record {:sub-runs [(sub-run :cart/state)
+                             (sub-run :cart/items)
+                             (sub-run :cart/total)]}
           p (subs/project-record record)]
       (is (= 3 (count (:subs-ran p))))
-      (is (= :cart/state (-> p :subs-ran first :sub-id)))
-      (is (= 3 (-> p :counts :subs-ran)))
-      (is (= 0 (-> p :counts :subs-skipped))))))
+      (is (= [:cart/state :cart/items :cart/total]
+             (mapv :sub-id (:subs-ran p)))
+          "order preserved from :sub-runs")
+      (is (= 3 (-> p :counts :subs-ran))))))
 
-;; ---- project-record: subs skipped (memo hits) -------------------------
-
-(deftest project-subs-skipped
-  (testing ":sub-runs entries with :recomputed? false become :subs-skipped rows (§3.4)"
-    (let [record {:sub-runs [(sub-run :user/name false)
-                             (sub-run :cart/eligibility false)]}
-          p (subs/project-record record)]
-      (is (= 2 (count (:subs-skipped p))))
-      (is (= :user/name (-> p :subs-skipped first :sub-id)))
-      (is (= 2 (-> p :counts :subs-skipped)))
-      (is (= 0 (-> p :counts :subs-ran))))))
-
-;; ---- project-record: split a mixed :sub-runs vector -------------------
-
-(deftest project-subs-split-by-recomputed
-  (testing "A mixed :sub-runs vector splits ran vs skipped, order preserved"
-    (let [record {:sub-runs [(sub-run :first true)
-                             (sub-run :second false)
-                             (sub-run :third true)]}
-          p (subs/project-record record)]
-      (is (= [:first :third] (mapv :sub-id (:subs-ran p))))
-      (is (= [:second]       (mapv :sub-id (:subs-skipped p)))))))
+;; NOTE (rf2-vxgfnd.22): the deleted `project-subs-skipped` +
+;; `project-subs-split-by-recomputed` deftests fabricated `:recomputed?
+;; false` `:sub-runs` rows — a shape the SUBSTRATE NEVER EMITS
+;; (`sub-run-row` hardcodes `:recomputed? true`; a `:rf.sub/skip` memo-hit
+;; projects no `:sub-runs` row). The projected `:subs-skipped` slot they
+;; asserted on was doubly-dead — permanently `[]` (unproducible) AND
+;; consumed by no panel (the flow graph reads `:level-1/2-subs` /
+;; `:view-rows` / `:sub-readers`). Surfacing memo-hit subs awaits the real
+;; `:rf.sub/skipped` attribution op (spec/021 §12); it must NOT be
+;; reconstructed by filtering `:sub-runs` on `(complement :recomputed?)`.
 
 ;; ---- project-record: views rendered -----------------------------------
 
@@ -142,12 +139,12 @@
 
 (deftest project-full-record
   (testing "All projections compose from one record"
-    (let [record {:sub-runs     [(sub-run :a true) (sub-run :b false) (sub-run :c true)]
+    (let [record {:sub-runs     [(sub-run :a) (sub-run :b) (sub-run :c)]
                   :renders      [(render :v-x) (render :v-y)]
                   :trace-events [(flow-ev :rf.flow/computed)]}
           p (subs/project-record record)]
-      (is (= 2 (-> p :counts :subs-ran)))
-      (is (= 1 (-> p :counts :subs-skipped)))
+      (is (= 3 (-> p :counts :subs-ran)))
+      (is (= [:a :b :c] (mapv :sub-id (:subs-ran p))))
       (is (= 2 (-> p :counts :views-rendered)))
       (is (= 1 (-> p :counts :flows-recomputed)))
       (is (= [:v-x :v-y] (mapv :view-id (:views-rendered p)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/reactive_data_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/reactive_data_e2e_cljs_test.cljs
@@ -1,0 +1,128 @@
+(ns day8.re-frame2-xray.panels-e2e.reactive-data-e2e-cljs-test
+  "Real-substrate e2e coverage for the Views panel's reactive-data
+  projection (rf2-vxgfnd.22, Finding B · spec/021 §3).
+
+  ## The gap this closes
+
+  Every prior test of `reactive-panel-subs/project-record` fed HAND-BUILT
+  epoch records (`{:sub-runs [...] :renders [...]}`) — see
+  `panels/reactive-panel-subs-cljs-test` (pure projection) and
+  `panels-e2e/evicted-epoch-all-panels-cljs-test` (directly-seeded
+  `:epoch-history`). None drove a REAL cascade whose `:sub-runs` rows were
+  projected by the substrate's `capture.cljc/sub-run-row`. So a key-rename
+  in `sub-run-row` (e.g. `:sub-id` -> `:subid`, or dropping `:recomputed?`)
+  reddened NO e2e — the rf2-wyvf2 class (subs-ran pinned to zero while the
+  panel showed empty) re-emerging one level up.
+
+  ## What this test drives
+
+  The SAME real-pipeline harness the machine / trace e2e use
+  (`e2e/with-host-and-xray-frames` — NO `:rf.xray/set-epoch-history-for-test`
+  injection seam):
+
+    - install the canonical counter host (`:counter/value` sub +
+      `:counter/inc` event);
+    - dispatch the REAL `[:counter/inc]` host event;
+    - force `:counter/value` to recompute (plain-atom recomputes on every
+      deref) so the substrate emits a real `:rf.sub/run` that back-fills
+      (rf2-wi900) into the just-settled `:counter/inc` epoch;
+    - mirror the framework epoch ring into Xray's `:epoch-history`;
+    - read `:rf.xray/reactive-data` and assert on CONTENT — the real sub
+      that ran (`:counter/value`), captured through `sub-run-row` into the
+      focused epoch's `:sub-runs` and projected to `:subs-ran`.
+
+  ## Mutation-proof (rf2-vxgfnd.22 fix-PR protocol)
+
+  Renaming any `sub-run-row` output key in
+  `implementation/epoch/src/re_frame/epoch/capture.cljc` — e.g.
+  `:sub-id` -> `:subid`, or `:query-v` -> `:queryv` — reddens
+  `reactive-data-subs-ran-names-real-sub`: the projected `:subs-ran` row
+  then lacks that key, so the content match fails. (Verified by mutating
+  the key, running this ns, then reverting.)
+
+  ## Scope note — view-rows / renders
+
+  The Node CLJS test process runs the plain-atom substrate, so views
+  cannot mount (no React) — there are no real `:rf.view/rendered` ops, so
+  `:view-rows` / `:views-rendered` (the `render-row` path) can't be
+  exercised headlessly here. Real-render coverage of the `render-row`
+  keys belongs to a mounted-adapter (browser) harness, outside this slim
+  node gate; tracked as a follow-up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-xray.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- inc-and-recompute!
+  "Drive a REAL `[:counter/inc]` cascade, then force `:counter/value` to
+  recompute so the substrate emits a real `:rf.sub/run`.
+
+  The plain-atom substrate recomputes a derived value on every deref (no
+  eager reactive flush), so a post-settle `@(subscribe ...)` runs the sub
+  body and emits the `:rf.sub/run` the framework back-fills (rf2-wi900)
+  into the just-settled `:counter/inc` epoch's `:sub-runs`. We then mirror
+  the framework epoch ring into Xray's `:epoch-history` (the same sync the
+  production epoch-collector does) so the panel subs see the back-filled
+  record."
+  []
+  (rf/dispatch-sync [:counter/inc] {:frame e2e/default-host-frame})
+  @(rf/subscribe [:counter/value] {:frame e2e/default-host-frame})
+  (e2e/sync-xray-trace-mirror!)
+  (e2e/sync-xray-epoch-history!))
+
+(deftest reactive-data-subs-ran-names-real-sub
+  (testing "rf2-vxgfnd.22 — a REAL `[:counter/inc]` cascade recomputes the
+            `:counter/value` sub; the reactive-data projection's
+            `:subs-ran` names that real sub, captured through the
+            substrate's `sub-run-row` (NO injection seam). Reddens on a
+            `sub-run-row` key rename in capture.cljc."
+    (e2e/with-host-and-xray-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (inc-and-recompute!)
+        (let [d        (e2e/sub-xray [:rf.xray/reactive-data])
+              subs-ran (:subs-ran d)]
+          (is (seq subs-ran)
+              (str ":subs-ran is EMPTY — no real :rf.sub/run captured into "
+                   "the focused epoch (the rf2-wyvf2 class). reactive-data: "
+                   (pr-str (select-keys d [:subs-ran :counts :has-event-bundle?]))))
+          (let [row (some #(when (= :counter/value (:sub-id %)) %) subs-ran)]
+            (is (some? row)
+                (str ":subs-ran does not name the real :counter/value sub — "
+                     "sub-run-row projection broke (key rename?). subs-ran: "
+                     (pr-str subs-ran)))
+            (is (true? (:recomputed? row))
+                "the real sub-run row carries :recomputed? true (sub-run-row)")
+            (is (= [:counter/value] (:query-v row))
+                (str "the row carries the real :query-v (a :query-v key "
+                     "rename in sub-run-row reddens here). row: " (pr-str row))))
+          (is (pos? (-> d :counts :subs-ran))
+              ":counts :subs-ran tallies the real run-set"))))))
+
+(deftest reactive-data-composite-shape-holds-through-real-pipeline
+  (testing "rf2-vxgfnd.22 — the composite `:rf.xray/reactive-data` resolves
+            its documented shape over a REAL cascade: the flow-graph slots
+            (`:level-1-subs` / `:view-rows` / `:sub-readers`) are present
+            and `:subs-ran` is the whole run-set (no `:subs-skipped` slot —
+            Finding A)."
+    (e2e/with-host-and-xray-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (inc-and-recompute!)
+        (let [d (e2e/sub-xray [:rf.xray/reactive-data])]
+          (is (contains? d :subs-ran))
+          (is (contains? d :level-1-subs))
+          (is (contains? d :view-rows))
+          (is (contains? d :sub-readers))
+          (is (not (contains? d :subs-skipped))
+              "Finding A — no doubly-dead :subs-skipped slot survives")
+          ;; :counter/value reads app-db directly → a Level-1 sub.
+          (is (some #(= :counter/value (:sub-id %)) (:level-1-subs d))
+              (str ":counter/value should partition to Level 1 (reads "
+                   "app-db directly). level-1-subs: "
+                   (pr-str (:level-1-subs d)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -1445,7 +1445,9 @@
     (rf/with-frame :rf/xray
       (let [data @(rf/subscribe [:rf.xray/reactive-data])]
         (is (contains? data :subs-ran))
-        (is (contains? data :subs-skipped))
+        ;; rf2-vxgfnd.22 — no `:subs-skipped` slot: the substrate emits no
+        ;; memo-hit `:sub-runs` row, so `:subs-ran` is the whole run-set.
+        (is (not (contains? data :subs-skipped)))
         (is (contains? data :views-rendered))
         (is (false? (:has-event-bundle? data)))))))
 


### PR DESCRIPTION
Fixes two P1 test-integrity findings from the rf2-vxgfnd.22 S2 boundary review, both in the Xray reactive-panel projection tier ("green does not mean correct"). Bead: rf2-454jk1. Scope: `tools/xray/**` only (no `implementation/**` changes).

## Finding A — FABRICATION + DEAD CODE (resolution: DELETE)

`reactive-panel-subs/project-record` split `:sub-runs` into `subs-ran` (`:recomputed? true`) + `subs-skipped` (`:recomputed? false`). Verified the slot is **doubly-dead**:

- **Unproducible.** The only producer, `implementation/epoch/src/re_frame/epoch/capture.cljc` `sub-run-row` (~L469), hardcodes `:recomputed? true`, and a `:rf.sub/skip` memo-hit projects **no** `:sub-runs` row at all (it rides only `:trace-events`). So `(filterv (complement :recomputed?) sub-runs)` is permanently `[]`.
- **Unrendered.** Grep-confirmed nothing consumes `:subs-skipped`. The §3.2 flow graph (`reactive-flow-graph/layout`, the live panel) reads `:level-1/2-subs` / `:view-rows` / `:sub-readers` only.

The `:rf.sub/skipped` attribution op the memo-hit disclosure needs is a **not-yet-landed** candidate (spec/021 §12, and §3.4 line "New trace op needed"). The code shipped a broken stub ahead of that contract. **Deletion is correct** — when memo-hit surfacing lands it will read the real `:rf.sub/skipped` op, never a `(complement :recomputed?)` filter over `:sub-runs`.

Changes:
- Removed the `:subs-skipped` slot + count from `project-record`.
- Deleted the two fabricated deftests (`project-subs-skipped`, `project-subs-split-by-recomputed`) that hand-built `:recomputed? false` rows; removed the fabricated `false` row from `project-full-record`; the `sub-run` test helper now emits `:recomputed? true` like the substrate.
- `registry-cljs-test` now asserts `:subs-skipped` is **absent**.
- **Diff-checked docstrings** (protocol b): corrected the false "memo-hit → subs-skipped" claims in the ns + `project-record` docstrings.
- **spec/021 §3.4** data-availability note added: the projection carries no `subs-skipped` slot; memo-hit surfacing awaits `:rf.sub/skipped` (§12); consumers MUST NOT reconstruct it via `(complement :recomputed?)`; graph `unchanged` nodes are ran-but-`:value-changed? false` subs, not memo-hit skips.

Confirmed nothing else consumes the slot (grep): only the forward-looking §12 `:rf.cascade/captured` candidate row still names `:subs-skipped N` (correctly not-landed) — left as-is.

## Finding B — MISSING REAL-SUBSTRATE E2E (added)

The whole `project-record` reactive-data projection was validated **only** against hand-built epoch records (pure projection tests + directly-seeded `:epoch-history` in evicted-epoch). No test drove a REAL cascade whose `:sub-runs` rows were projected by `capture.cljc/sub-run-row` — so a key-rename there reddened no e2e (rf2-wyvf2 class, one level up).

New `tools/xray/test/day8/re_frame2_xray/panels_e2e/reactive_data_e2e_cljs_test.cljs` on the SAME real-pipeline harness the machine/trace e2e use (`with-host-and-xray-frames`, **no** `:rf.xray/set-epoch-history-for-test` injection seam):
- dispatch a REAL `[:counter/inc]` host event;
- force `:counter/value` to recompute (plain-atom recomputes on deref → real `:rf.sub/run` back-fills, rf2-wi900, into the settled `:counter/inc` epoch);
- mirror the framework epoch ring into Xray, then assert `:rf.xray/reactive-data` `:subs-ran` names the REAL `:counter/value` with its `:query-v` + `:recomputed?`, and that `:counter/value` partitions to Level 1.

### Fixture mutation-proof (protocol a)

Mutated `sub-run-row`'s `:sub-id` → `:subid` in `capture.cljc`, recompiled, ran the e2e ns → **4 failures** (the projected `:subs-ran` row lost `:sub-id`, so the content match failed). **Reverted** the mutation (`git diff implementation/` is empty). This confirms the e2e reddens on a `capture.cljc` row-key rename.

### Scope note

`:view-rows` / `:renders` (the `render-row` path) can't be exercised headlessly — the Node CLJS harness runs plain-atom (no React), so no `:rf.view/rendered` ops fire. Real-render coverage of `render-row` keys needs a mounted-adapter (browser adapter-smoke), out of this slim node gate → follow-up **rf2-yr6wtx**.

## Quality gates

- `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js --test=<the 3 affected ns>` → **84 tests, 683 assertions, 0 failures** (reactive-panel-subs projection + registry + new reactive-data e2e).
- `cd tools/xray && clojure -M:test` (JVM xray gate) → **1250 tests, 5800 assertions, 0 failures**.
- Mutation-proof run (above): red on mutation, green after revert.
- Slim/foreground only — no browser matrix, no fast-pr. CI xray feature-gate watched below.

## xray/spec

Updated `tools/xray/spec/021-Dynamic-Panel-Designs.md` §3.4 in the same PR (Finding A rationale + guard).
