### PR TITLE
fix(machines): fence update-snapshot-fx escape-hatch store-write to exact incarnation (rf2-vxgfnd.22)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -55,7 +55,18 @@
   next dispatch); the patch fx itself does not run `state-resolves?` on the
   candidate. This is the deliberate escape-hatch trade-off: the hatch is the
   low-frequency \"I need to touch `:state` + something else atomically\"
-  primitive, not a guarded `:on`-transition."
+  primitive, not a guarded `:on`-transition.
+
+  Incarnation fence (rf2-vxgfnd.22): the escape-hatch store-write is fenced to
+  the exact frame incarnation, mirroring the destroy / finalize / spawn
+  incarnation-fencing family. The `:db` hard-disallow trace below is a PRE-WRITE
+  callback that fires synchronous trace listeners (the observation-port epoch
+  capture + any app-registered `:trace` handler); one may destroy the frame
+  incarnation A that owns the in-flight event and publish a same-id successor B.
+  Ownership is rechecked AFTER that emit and before the read/merge/write, and
+  the store-write rides the EXACT owner token (`swap-runtime-db-exact!`) so a
+  merge never lands on — nor bumps the commit epoch of — successor B. An
+  eventless caller (nil token) keeps the historical bare write."
   [{frame-id :frame} args]
   (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
         ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
@@ -65,7 +76,21 @@
                      {:where 'rf.machine/update-snapshot
                       :event-id (:rf/machine-id args)})
         machine-id (:rf/machine-id args)
-        patch      (:rf/patch args)]
+        patch      (:rf/patch args)
+        ;; rf2-vxgfnd.22 — capture A's exact-frame-incarnation continuation +
+        ;; raw owner token ONCE at the fx entry, mirroring the destroy /
+        ;; finalize / spawn incarnation-fencing family. This fx runs inside the
+        ;; emitting event's fx drain, so `*event-owner*` names the exact
+        ;; incarnation A that owns the in-flight event. `owner-gone?` fires once
+        ;; a synchronous callback below — the `:db` hard-disallow trace, whose
+        ;; sync listeners include the observation-port epoch capture + any
+        ;; app-registered `:trace` handler — has destroyed A / published a
+        ;; same-id successor B; `owner-token` binds the store-write to A's OWN
+        ;; container. An eventless caller (no owner bound) yields
+        ;; `(constantly false)` / nil — the historical full-authority bare write.
+        continue?   (data-validation/owner-continuation frame-id)
+        owner-gone? (fn [] (not (continue?)))
+        owner-token (frame/current-event-owner-token)]
     (when (and machine-id (map? patch))
       ;; Hard-disallow `:db` — symmetric with the action-effect path
       ;; (Spec 005:463). Canonical id / tags per Spec 009 §Error event
@@ -87,38 +112,60 @@
                             :offending-value (:db patch)
                             :frame           frame-id
                             :recovery        :logged-and-skipped}))
-      (let [clean-patch (select-keys patch permitted-patch-keys)]
-        (when (seq clean-patch)
-          ;; Machine snapshots are durable runtime-db state: the
-          ;; escape-hatch patch is a runtime-db partition write.
-          ;;
-          ;; The escape-hatch `:data` patch is NOT exempt from the
-          ;; `:where :machine-data` boundary. Spec 005 §Snapshot-
-          ;; level escape hatch says user error/status state lives under
-          ;; `:data` *where `[:schemas :data]` validation covers it*. The fx
-          ;; runs on the single drainer (Spec 002), so read-then-write is
-          ;; atomic for this actor's snapshot: read the current snapshot,
-          ;; compute the would-be-merged candidate, validate its `:data`
-          ;; against the actor's resolved `[:schemas :data]` schema, and SKIP
-          ;; the write when it fails (a PRE-WRITE rejection — nothing is
-          ;; committed, so `:rollback? false`; the trace fires with
-          ;; `:phase :update-snapshot`). A valid patch — or a machine with
-          ;; no `[:schemas :data]` schema — writes exactly as before. Absent actor
-          ;; (destroyed / unknown) is a no-op: nothing to merge into, and
-          ;; nothing to validate.
-          (let [snapshots (get-in (frame/frame-runtime-db-value frame-id)
-                                  (paths/snapshot-path))]
-            (when (contains? snapshots machine-id)
-              (let [merged (merge (get snapshots machine-id) clean-patch)]
-                (when (data-validation/validate-update-snapshot-data!
-                        machine-id merged)
-                  (frame/swap-runtime-db!
-                    frame-id
-                    (fn [runtime-db]
-                      ;; Re-check presence inside the swap — never conjure
-                      ;; a snapshot for an actor torn down between the read
-                      ;; and the write.
-                      (if (contains? (get-in runtime-db (paths/snapshot-path)) machine-id)
-                        (update-in runtime-db (paths/snapshot-path machine-id) merge clean-patch)
-                        runtime-db))))))))))
+      ;; rf2-vxgfnd.22 — the `:db` hard-disallow trace above fires SYNC trace
+      ;; listeners (the observation-port epoch capture + any app-registered
+      ;; `:trace` listener); one may destroy A and re-seed a same-id successor
+      ;; B on this stack. Recheck ownership BEFORE the read/merge/write — a
+      ;; callback that lost A must not drive an A-derived merge onto B: B's
+      ;; presence-check would pass, and `resolve-data-schema`'s branches go nil
+      ;; once A is lost, so the pre-write `validate-update-snapshot-data!`
+      ;; returns vacuously true (no schema to reject on) and the bare write
+      ;; would merge A's patch onto B AND bump B's commit epoch. Short-circuit
+      ;; to the inert outcome. The eventless caller keeps full authority
+      ;; (`owner-gone?` never fires).
+      (when-not (owner-gone?)
+        (let [clean-patch (select-keys patch permitted-patch-keys)]
+          (when (seq clean-patch)
+            ;; Machine snapshots are durable runtime-db state: the
+            ;; escape-hatch patch is a runtime-db partition write.
+            ;;
+            ;; The escape-hatch `:data` patch is NOT exempt from the
+            ;; `:where :machine-data` boundary. Spec 005 §Snapshot-
+            ;; level escape hatch says user error/status state lives under
+            ;; `:data` *where `[:schemas :data]` validation covers it*. The fx
+            ;; runs on the single drainer (Spec 002), so read-then-write is
+            ;; atomic for this actor's snapshot: read the current snapshot,
+            ;; compute the would-be-merged candidate, validate its `:data`
+            ;; against the actor's resolved `[:schemas :data]` schema, and SKIP
+            ;; the write when it fails (a PRE-WRITE rejection — nothing is
+            ;; committed, so `:rollback? false`; the trace fires with
+            ;; `:phase :update-snapshot`). A valid patch — or a machine with
+            ;; no `[:schemas :data]` schema — writes exactly as before. Absent actor
+            ;; (destroyed / unknown) is a no-op: nothing to merge into, and
+            ;; nothing to validate.
+            (let [snapshots (get-in (frame/frame-runtime-db-value frame-id)
+                                    (paths/snapshot-path))]
+              (when (contains? snapshots machine-id)
+                (let [merged (merge (get snapshots machine-id) clean-patch)]
+                  (when (data-validation/validate-update-snapshot-data!
+                          machine-id merged)
+                    ;; rf2-vxgfnd.22 — route the store-write through the EXACT
+                    ;; durable write so it NO-OPS on owner loss: no merge onto
+                    ;; B, and no phantom commit-epoch bump (the observation-port
+                    ;; signal B never earned). The `validate-update-snapshot-
+                    ;; data!` callback above is itself schema/app code that can
+                    ;; lose A, so the exact write is the terminal fence for that
+                    ;; boundary too. The eventless caller (nil token) falls back
+                    ;; to the historical bare write.
+                    (let [swap-fn
+                          (fn [runtime-db]
+                            ;; Re-check presence inside the swap — never conjure
+                            ;; a snapshot for an actor torn down between the read
+                            ;; and the write.
+                            (if (contains? (get-in runtime-db (paths/snapshot-path)) machine-id)
+                              (update-in runtime-db (paths/snapshot-path machine-id) merge clean-patch)
+                              runtime-db))]
+                      (if owner-token
+                        (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+                        (frame/swap-runtime-db! frame-id swap-fn)))))))))))
     nil))

--- a/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
@@ -266,6 +266,86 @@
           (finally
             (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
 
+(deftest update-snapshot-db-trace-listener-fences-write-to-successor
+  (testing "the :rf.machine/update-snapshot escape hatch, :db-TRACE path (the
+            pre-validator callback the validator-callback fence does NOT cover,
+            rf2-vxgfnd.22): a `:db` key in the patch fires the
+            :rf.error/machine-action-wrote-db hard-disallow trace; a SYNC :trace
+            listener on it destroys A + publishes same-id B (with a distinct
+            sentinel snapshot). The A-derived patch must NOT merge onto B, and
+            B's commit epoch must NOT bump.
+
+            Counterexample (why the existing validator-callback fence misses
+            this): A is destroyed BEFORE `validate-update-snapshot-data!` runs,
+            so `resolve-data-schema`'s branches (`(when (continue?) …)`-guarded)
+            go nil — the would-REJECT validator is never even consulted and the
+            validator returns vacuously true. Only the :db-trace incarnation
+            fence blocks the write.
+
+            Mutation tooth: dropping the post-:db-trace `(when-not (owner-gone?)
+            …)` recheck + the `swap-runtime-db-exact!` store-write lets the bare
+            swap merge {:v :patched} onto same-id B AND bump B's commit epoch."
+    (rf/reg-machine :rf2-vxgfnd22/sing
+      {:initial :running
+       :data    {:v :a-init}
+       :schemas {:data ::db-trace-schema}
+       :states  {:running {:on {:go :done}}
+                 :done    {:final? true}}})
+    (let [frame-a :rf2-vxgfnd22/dbtrace-frame
+          fired?  (atom false)
+          b-snap  (atom ::unset)
+          b-epoch (atom ::unset)
+          orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        ;; Seed A's singleton snapshot so the escape hatch has a live target.
+        (frame/swap-runtime-db! frame-a
+          (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd22/sing]
+                             {:state :running :data {:v :a-init}})))
+        ;; The DESTROYER is a :trace listener on the :db hard-disallow trace (NOT
+        ;; the schema validator) — that is the whole point: this pre-validator
+        ;; callback path is the one the validator-callback fence cannot cover.
+        (rf/register-listener! :trace ::db-trace-destroyer
+          (fn [ev]
+            (when (and (= :rf.error/machine-action-wrote-db (:operation ev))
+                       (compare-and-set! fired? false true))
+              (frame/destroy-frame! frame-a)      ;; destroy incarnation A
+              (rf/make-frame {:id frame-a})        ;; publish same-id successor B
+              (frame/swap-runtime-db! frame-a      ;; B's DISTINCT sentinel snapshot
+                (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd22/sing]
+                                   {:state :running :data {:v :b-sentinel}})))
+              (reset! b-snap  (mtest/snapshot frame-a :rf2-vxgfnd22/sing))
+              (reset! b-epoch (frame/frame-commit-epoch frame-a)))))
+        (try
+          ;; A REJECTING validator (false for the machine's schema). It is NEVER
+          ;; consulted on the destroyed-A path (`resolve-data-schema` goes nil
+          ;; once A is lost) — registered only to prove the validator-callback
+          ;; fence leaves this :db-trace path open.
+          (late-bind/set-fn! :schemas/validate-with-registered-fn
+            (fn [schema _data] (not= schema ::db-trace-schema)))
+          ;; Drive the escape-hatch fx DIRECTLY under A's bound event owner. The
+          ;; patch carries a `:db` key (the hard-disallow) so the trace fires and
+          ;; the listener destroys A on its own stack; `:data` is the escape-hatch
+          ;; payload that must not reach same-id B.
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (update-snapshot/update-snapshot-fx
+                     {:frame frame-a}
+                     {:rf/machine-id :rf2-vxgfnd22/sing
+                      :rf/patch      {:db   {:naughty :write}
+                                      :data {:v :patched}}})))
+          (is (true? @fired?)
+              "the :db-trace hard-disallow listener ran (the fence boundary was exercised)")
+          (is (= {:v :b-sentinel} (:data @b-snap))
+              "sanity: B's snapshot at birth carried the distinct sentinel")
+          (is (= {:v :b-sentinel}
+                 (:data (mtest/snapshot frame-a :rf2-vxgfnd22/sing)))
+              "B's snapshot :data is untouched — the A-derived patch did not merge onto same-id B")
+          (is (= @b-epoch (frame/frame-commit-epoch frame-a))
+              "B's commit epoch is unbumped — no phantom observation-port signal from an A-derived write")
+          (finally
+            (rf/unregister-listener! :trace ::db-trace-destroyer)
+            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+
 ;; ---- completion-output finalize diagnostic fence --------------------------
 
 (defn- run-completion-validation


### PR DESCRIPTION
## What

Fences the `:rf.machine/update-snapshot` escape-hatch store-write to the exact
frame incarnation — the ONE reserved-fx write path the i4aj9c/4ipqe4/3evq0x
incarnation-fence sweep skipped (found by the rf2-vxgfnd.22 S2 boundary review
re-run, Lens 1 ownership). Bead: **rf2-og0ti4**.

Before this change `update-snapshot-fx` captured no effect-fence, threaded no
owner token, and its store-write was a bare `frame/swap-runtime-db!` that
resolves to the CURRENT incarnation.

## Counterexample (the defect)

A machine callback emits `[:rf.machine/update-snapshot {:rf/machine-id :m
:rf/patch {:db {…} :data {:v :patched}}}]` — the `:db` key is a caller error the
escape hatch traces-and-continues. During the fx drain (event owner = A):

1. the `:db` hard-disallow trace fires (`trace/emit-error!
   :rf.error/machine-action-wrote-db`), running its sync `:trace` listeners +
   observation-port epoch capture;
2. a registered `:trace` listener destroys frame A and `make-frame`s a same-id
   successor B (re-seeding actor `:m`);
3. the read (`~:109`) now reads B's container; the presence-check passes;
4. `validate-update-snapshot-data!` returns **vacuously true** — once A is lost
   `resolve-data-schema`'s `(when (continue?) …)`-guarded branches go nil, so
   there is no schema to reject on (the would-reject validator is never even
   consulted — this is precisely why the existing validator-callback fence does
   NOT cover this path);
5. the bare swap (`~:115`) merges A's `{:data {:v :patched}}` onto B's snapshot
   AND unconditionally bumps B's commit epoch (a phantom observation-port
   signal). The S2 terminal fence is violated.

## The fix (mechanical parity with the i4aj9c sweep)

Mirrors the sibling paths (`destroy.cljc` `effect-fence`, `finalize.cljc`)
exactly — no new mechanism, no public API:

- capture `owner-continuation` / `owner-gone?` + the raw `owner-token` ONCE at
  the fx entry (the event-owner token IS bound — this runs as an fx mid-drain);
- **recheck `owner-gone?` after the `:db` trace emit**, before the
  read/merge/write — short-circuit to the inert outcome on owner loss;
- route the store-write through **`frame/swap-runtime-db-exact!`** (no-ops on
  owner loss — no merge onto B, no epoch bump); the eventless caller (nil token)
  falls back to the historical bare `swap-runtime-db!`.

The existing validator-callback fence (`validate-update-snapshot-data!`) is
untouched — the exact write is additionally the terminal fence for that boundary
too.

## Red-before-fix fixture

New test `update-snapshot-db-trace-listener-fences-write-to-successor`
(`machine_lifecycle_schema_incarnation_fence_test.clj`) reproduces the
**pre-validator `:db`-trace** case the existing `:220` test does not cover
(that one only exercises the validator-callback case): a `:trace` listener on
`:rf.error/machine-action-wrote-db` destroys A + republishes same-id B with a
distinct sentinel snapshot, and asserts B's snapshot `:data` and B's commit
epoch are byte-identical (unpatched, unbumped).

**Confirmed RED pre-fix / GREEN post-fix.** With the source reverted to
`origin/main` (test kept), the two teeth fail exactly:

```
B's snapshot :data … actual: (not (= {:v :b-sentinel} {:v :patched}))
B's commit epoch  … actual: (not (= 1 2))
```

All other tests in the namespace stay green. Restoring the fix → 8 tests / 33
assertions / 0 failures.

## Quality gates

FOREGROUND (slim + cross-artefact; machines consumes core):

- `implementation/machines` `clojure -M:test` — **1083 tests / 3725 assertions /
  0 failures**, run **3×** (no flake).
- `implementation/core` `clojure -M:test` — **1987 tests / 9160 assertions / 0
  failures**.

No browser, no fast-pr (per gate discipline).

## Scope

- `implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc`
- `implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj`

No `core/**`, other `lifecycle_fx`, or `spec/**` touched. The one docstring
edited (the fn docstring) was diff-checked.
