### PR TITLE
fix(core): retain exact incarnation tokens through construction rollback (rf2-wduv35)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1853,9 +1853,15 @@
   `:rf.error/initial-events-step-failed` naming the failing step. `cause-ex` is
   the host throwable when the failure escaped (carried as `:cause`); nil for an
   in-band capture. `cause-msg` is the human cause text for the diagnostic
-  message. `where-sym` is the constructor symbol."
-  [id idx event cause-ex cause-msg where-sym]
-  (destroy-frame! id)
+  message. `where-sym` is the constructor symbol. `owner-token` is the EXACT
+  incarnation token this construction installed (the record's `:drain-lock`,
+  returned by `try-install-new-frame!`): teardown is exact-token-owned, so a
+  setup step that (re-entrantly / concurrently) destroyed A and seated a same-id
+  successor B before this rollback ran cannot make the stale A rollback destroy
+  B — the two-argument `destroy-frame!` no-ops unless A's token is still live
+  (rf2-wduv35)."
+  [id idx event cause-ex cause-msg where-sym owner-token]
+  (destroy-frame! id owner-token)
   (error/throw-error!
     :rf.error/initial-events-step-failed
     where-sym
@@ -1932,8 +1938,16 @@
   etc.), and the framework keys (`:frame` / `:source` / `:step-index`) win last.
 
   Reached through `dispatch-sync!` via late-bind to avoid a compile-time cyclic
-  dep (router requires frame)."
-  [id steps base-opts where-sym]
+  dep (router requires frame).
+
+  `owner-token` is the EXACT incarnation token the winning `make-frame` install
+  produced (the record's `:drain-lock`). Every teardown path here — the
+  escaping-throw + in-band `raise-setup-step-failed!` branches and the
+  runner-unavailable branch — destroys via the two-argument `destroy-frame! id
+  owner-token`, so a rollback owns exactly the incarnation it constructed and
+  can never destroy a same-id successor that replaced it in the interim
+  (rf2-wduv35)."
+  [id steps base-opts where-sym owner-token]
   (when (seq steps)
     ;; rf2-jsokxu: the setup runner reaches `dispatch-sync!` via late-bind (the
     ;; router requires frame, so a compile-time call would be a cyclic dep). If
@@ -2004,7 +2018,7 @@
                     ;; resolution throw escaping context assembly). Tear down +
                     ;; raise, carrying the original throwable as `:cause`.
                     (raise-setup-step-failed!
-                      id idx event t (error/ex-message-safe t) where-sym)))
+                      id idx event t (error/ex-message-safe t) where-sym owner-token)))
                 (finally
                   (when (and register remove-cb)
                     (remove-cb listener-k))))
@@ -2020,15 +2034,17 @@
                   id idx event nil
                   (str "the interceptor chain captured " (:error record)
                        (when-let [r (:reason record)] (str " (" r ")")))
-                  where-sym)))
+                  where-sym owner-token)))
             (recur (inc idx) (rest remaining)))))
       ;; The runner hook is unavailable but there ARE steps to run: fail loud
       ;; rather than silently dropping the setup (rf2-jsokxu). Tear down the
       ;; partial frame (the caller already swapped the container into `frames`)
       ;; so no half-created, never-setup frame is left live, then throw naming
-      ;; that re-frame.router is not loaded.
+      ;; that re-frame.router is not loaded. Teardown is exact-token-owned
+      ;; (`owner-token`) so it removes only the incarnation we installed
+      ;; (rf2-wduv35).
       (do
-        (destroy-frame! id)
+        (destroy-frame! id owner-token)
         (error/throw-error!
           :rf.error/initial-events-runner-unavailable
           where-sym
@@ -2158,18 +2174,31 @@
   container allocation, and registry install. A losing creator therefore
   allocates nothing: every state container returned by the adapter is installed
   as an owned frame record. This avoids inventing a disposal-free adapter
-  contract for abandoned speculative containers. Returns true on install."
+  contract for abandoned speculative containers.
+
+  Returns the INSTALLED incarnation's identity token (its `:drain-lock`) on a
+  successful install, `nil` when the id was already present (nothing installed).
+  Handing back the exact token of the record WE installed — rather than a bare
+  `true` the caller would have to re-read via `frame-incarnation-token` — lets
+  construction rollback OWN that exact incarnation: a failed-setup / handler-
+  guard teardown passes this token to the two-argument `destroy-frame!`, which
+  can then only destroy the frame this call created, never a same-id successor
+  that replaced it in the interim (rf2-wduv35). A later re-read would repeat the
+  same check-then-act race the token closes."
   [id config policy-token]
   (letfn [(install! []
             (if (contains? @frames id)
-              false
+              nil
               (let [f (assoc (new-frame-record id config)
                              :trace-policy-token policy-token)]
                 ;; `upsert-frame!` is the sole creator. Under `frame-create-lock`
                 ;; no other JVM creator can seat this id between the absence
                 ;; recheck and assoc; CLJS runs the block synchronously.
                 (swap! frames assoc id f)
-                true)))]
+                ;; The record's `:drain-lock` IS the incarnation identity token
+                ;; (`frame-incarnation-token`); return it so the winning caller
+                ;; owns this exact incarnation through construction rollback.
+                (:drain-lock f))))]
     #?(:clj  (call-with-frame-create-lock install!)
        :cljs (install!))))
 
@@ -2376,15 +2405,16 @@
         (cond
           ;; ---- CREATE: install the record iff the id is STILL absent ---------
           (nil? existing)
-          (if-not (try-install-new-frame! id config policy-token)
-              (if must-create?
-                ;; Exclusive mode (ui.test): a taken id is a hard COLLISION, not
-                ;; an adoption — throw the typed error (nothing was installed).
-                (throw-frame-id-taken! id)
-                ;; Ordinary construction: fall through to a RE-registration on the
-                ;; now-present id (idempotent replacement, EP-0024) — recur.
-                (recur))
-              ;; WON the create: our record is the sole installed one.
+          (if-let [installed-token (try-install-new-frame! id config policy-token)]
+              ;; WON the create: our record is the sole installed one, and
+              ;; `installed-token` is ITS exact incarnation identity token (the
+              ;; record's `:drain-lock`). Every construction-rollback teardown
+              ;; below owns this token and destroys via the two-argument
+              ;; `destroy-frame!`, so a failed-setup / handler-guard teardown can
+              ;; only ever destroy the incarnation THIS call installed — never a
+              ;; same-id successor that replaced it before the rollback ran
+              ;; (rf2-wduv35). Re-reading the live token here would repeat the
+              ;; check-then-act race the exact token closes.
               (do
                 ;; EP-0025: no durable app-db classification install here anymore
                 ;; — the frame `:sensitive` / `:large {:app-db …}` annotation was
@@ -2399,9 +2429,11 @@
                 ;; binds it for the duration of a handler's execution and ONLY
                 ;; then. The container was already installed above; tear it back
                 ;; down before throwing so a handler-time construction leaves NO
-                ;; half-registered frame.
+                ;; half-registered frame. Teardown owns `installed-token`, so it
+                ;; removes exactly the incarnation we just installed — never a
+                ;; concurrently-seated same-id successor (rf2-wduv35).
                 (when trace/*handler-scope*
-                  (destroy-frame! id)
+                  (destroy-frame! id installed-token)
                   (error/throw-error!
                     :rf.error/frame-construction-in-handler
                     'rf/make-frame
@@ -2425,14 +2457,25 @@
                 ;; BEFORE emitting :frame/created (Spec 002 §Frame creation;
                 ;; EP-0027 §Construction). `setup-steps` was PREFLIGHT-validated
                 ;; at the top of the engine. A step that throws at runtime tears
-                ;; down the partial frame inside the runner and rethrows. Runs
-                ;; ONCE — only on the WON install, never on a lost-create recur.
-                (run-setup-events! id setup-steps {} 'rf/make-frame)
+                ;; down the partial frame inside the runner and rethrows —
+                ;; teardown owns `installed-token`, so it destroys exactly this
+                ;; incarnation. Runs ONCE — only on the WON install, never on a
+                ;; lost-create recur.
+                (run-setup-events! id setup-steps {} 'rf/make-frame installed-token)
                 (trace/emit! :rf.frame :rf.frame/created
                              {:frame id :config (dissoc config :rf.frame/generation
                                                         :rf.frame/initial-db)})
                 (fire-frame-registered-hook! id)
-                id))
+                id)
+              ;; LOST the create: `try-install-new-frame!` returned nil — nothing
+              ;; was installed.
+              (if must-create?
+                ;; Exclusive mode (ui.test): a taken id is a hard COLLISION, not
+                ;; an adoption — throw the typed error (nothing was installed).
+                (throw-frame-id-taken! id)
+                ;; Ordinary construction: fall through to a RE-registration on the
+                ;; now-present id (idempotent replacement, EP-0024) — recur.
+                (recur)))
 
           ;; ---- must-create met a LIVE frame at the decide read → COLLISION ---
           ;; Exclusive mode never adopts or surgically refreshes; a present id is

--- a/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
@@ -559,6 +559,54 @@
           (late-bind/set-fn! :router/dispatch-sync! orig)
           (late-bind/invalidate-cache! :router/dispatch-sync!))))))
 
+(deftest construction-rollback-owns-exact-incarnation-not-live-id
+  (testing "rf2-wduv35: a setup-step-failure rollback (raise-setup-step-failed!)
+            destroys the EXACT incarnation this construction installed — via its
+            token — NOT whatever same-id incarnation happens to be live when the
+            rollback runs. If a same-id successor B replaces the failed A between
+            failure-known and the rollback's destroy, the stale A rollback must
+            NOT destroy B. Before the fix the rollback called the one-argument
+            `destroy-frame!` (which pins the live token = B's) and destroyed B;
+            with the fix it threads the installed token and the two-argument
+            destroy no-ops on the token mismatch, leaving B untouched.
+            CONFIRM-BY-REVERT: reverting run-setup-events!/raise-setup-step-failed!
+            to the bare-id `(destroy-frame! id)` makes (frame/frame id) nil here —
+            B was destroyed by A's stale rollback."
+    (reg-test-events!)
+    (let [id           :rollback/token-fence
+          real-destroy frame/destroy-frame!
+          b-token      (atom nil)
+          injected?    (atom false)]
+      ;; Model the bead's construction-rollback race deterministically: intercept
+      ;; the FIRST `destroy-frame!` for our id — the failed-A rollback — and, just
+      ;; before it resumes, seat a same-id successor B with a DISTINCT token
+      ;; (the "Install same-ID B … Resume A's rollback" step). We remove the
+      ;; failed A under its exact token, then top-level `make-frame` a fresh B
+      ;; (we are past the setup step's dispatch, so not in handler scope — the
+      ;; construction guard does not fire). Then we delegate the ORIGINAL rollback
+      ;; call verbatim, so WHICH arity/token the rollback used is what decides
+      ;; whether B survives.
+      (with-redefs
+        [frame/destroy-frame!
+         (fn [& args]
+           (if (and (= id (first args)) (not @injected?))
+             (do
+               (reset! injected? true)
+               (real-destroy id (frame/frame-incarnation-token id)) ; remove failed A
+               (rf/make-frame {:id id})                             ; seat successor B
+               (reset! b-token (frame/frame-incarnation-token id))
+               (apply real-destroy args))                           ; resume A's rollback
+             (apply real-destroy args)))]
+        (err-data
+          #(rf/make-frame {:id id :initial-events [[:test/set-db {:n 0}]
+                                                   [:test/boom]]})))
+      (is (some? @b-token)
+          "the successor B was seated with a distinct token before A's rollback ran")
+      (is (some? (frame/frame id))
+          "successor B survives — the stale A rollback did NOT destroy it")
+      (is (identical? @b-token (frame/frame-incarnation-token id))
+          "the live incarnation is still B (its exact token), untouched by A's rollback"))))
+
 ;; ===========================================================================
 ;; 8. The handler-time construction guard
 ;; ===========================================================================


### PR DESCRIPTION
## Problem

PR #5802 added the two-argument `destroy-frame! id expected-token` primitive, but framework-owned `make-frame` construction rollback still retained only the frame **id** and later called the one-argument overload. That overload pins whichever incarnation is live when cleanup begins, so an owner of a failed incarnation **A** could destroy a same-id successor **B** that replaced it between failure-known and the rollback's destroy.

The `destroy-frame!` recipe itself is already exact-token-guarded (verified CLEAN by the rf2-vxgfnd.22 Lens-1 review); the gap was in the **construction-rollback callers** in `frame.cljc`, which invoked the bare-id arity.

## Fix (scope: `implementation/core` only)

`try-install-new-frame!` now returns the **installed incarnation's identity token** (its `:drain-lock`) instead of a bare boolean — nil on a lost create. `upsert-frame!`'s won-create branch captures it (`if-let [installed-token ...]`) and threads it through all three construction-rollback teardowns:

- the handler-time construction guard (`:rf.error/frame-construction-in-handler`)
- `run-setup-events!` → `raise-setup-step-failed!` (escaping-throw **and** in-band setup-step failures)
- the runner-unavailable branch (`:rf.error/initial-events-runner-unavailable`)

Each now calls `(destroy-frame! id installed-token)`, which no-ops unless the exact incarnation is still live. A stale A rollback can therefore never destroy a fresh same-id B. Returning the exact token (rather than re-reading `frame-incarnation-token` at rollback time) avoids repeating the check-then-act race the token closes.

The public one-argument address-directed overload and the two-argument mismatch diagnostics are untouched.

## Red-before-fix

`construction-rollback-owns-exact-incarnation-not-live-id` (in `frame_initial_events_cljs_test.cljc`) deterministically models the bead's repro: it intercepts the failed-A rollback's `destroy-frame!`, seats a same-id successor B with a **distinct token** just before the rollback resumes, then delegates the original rollback call verbatim, and asserts B survives.

- **Pre-fix** (bare-id rollback reverted onto this test): **2 failures** — `(frame/frame id)` is nil; B was destroyed by A's stale rollback.
- **Post-fix**: pass — B survives, live incarnation is still B's exact token.

Confirmed by reverting `frame.cljc` to `origin/main` while keeping the new test: the other 23 tests in the namespace stayed green; only the new discriminator failed.

## Scope note (bead left OPEN)

rf2-wduv35 also names non-core paths — `with-new-frame` (`core_reg_view_macro.cljc`), `ui.test/render`, Story replay, and the SSR pipeline/lifecycle/ring/streaming cleanups. Those are separate surfaces (each with its own active worktree) and are **out of scope** for this PR. This PR closes the `frame.cljc` construction-rollback class; the bead stays open for the remaining owner-lifecycle paths.

## Quality gates

- `cd implementation/core && clojure -M:test` (full core JVM suite): **1988 tests, 9163 assertions, 0 failures, 0 errors** (green).
- Focused namespace `re-frame.frame-initial-events-cljs-test`: 24 tests / 73 assertions green post-fix; the new test fails pre-fix (red-before-fix confirmed).
- No browser / fast-pr run locally; CLJS (`npm run test:cljs`) left to CI — the change is platform-neutral `.cljc` (`if-let` + token return, no host-specific constructs).

Do not merge yet — leaving open per dispatch.