### PR TITLE
test(ui): commit-phase adapter settlement + slice-memo identity proofs (rf2-vxgfnd.276, .284)

### DIFF
--- a/implementation/ui/test/re_frame/ui/adapter_public_root_disposal_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/adapter_public_root_disposal_dom_cljs_test.cljs
@@ -9,6 +9,7 @@
   (:require [cljs.test :refer [async deftest is use-fixtures]]
             [clojure.string :as str]
             ["react" :as React]
+            ["react-dom/client" :as rdc]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.test-support :as test-support]
@@ -36,6 +37,34 @@
   [done label e]
   (is false (str label ": " e))
   (done))
+
+(defn- thrown-id
+  "The `:rf.error/id` of the ExceptionInfo `f` throws, or nil if it does not."
+  [f]
+  (try (f) nil (catch cljs.core/ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(defn- next-macrotask
+  "A promise resolving on the next macrotask — drains the whole microtask queue
+  (React's deferred teardown + `settle-deferred-root!`'s FIFO settlement) so a
+  post-settlement assertion observes the converged state."
+  []
+  (js/Promise. (fn [resolve _] (js/setTimeout resolve 0))))
+
+(defn- destroy-adapter-in-commit-phase!
+  "Invoke `rf/destroy-adapter!` from INSIDE a React layout effect (rf2-vxgfnd.276):
+  render a throwaway plain-React root whose sole layout effect runs `thunk` — so
+  a `.unmount` of any OTHER root reached from it hits react-dom 19.2's in-render
+  deferral (returns normally, teardown scheduled for a later microtask) — then
+  unmount the throwaway. Both act boundaries flush the deferred teardown +
+  settlement microtasks. `thunk` captures the SYNCHRONOUS post-return state
+  before those microtasks run. The throwaway is cell-less plain React, so it
+  never perturbs the observed public-root population."
+  [thunk]
+  (let [c2  (js/document.createElement "div")
+        r   (rdc/createRoot c2)
+        drv (fn [] (React/useLayoutEffect (fn [] (thunk) js/undefined) #js []) nil)]
+    (-> (act-promise #(.render r (React/createElement drv)))
+        (.then (fn [] (act-promise #(.unmount r)))))))
 
 (defview observed-root [{:keys [label renders]}]
   (let [_ (swap! renders inc)]
@@ -259,3 +288,108 @@
             (.then (fn [] (done))
                    (fn [e]
                      (unexpected! done "root-admission lifecycle rejected" e))))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.276 — adapter destruction from a React layout effect COMPLETES
+;; only after every deferred root settles.
+;;
+;; `adapter-destroy-drains-all-public-compiled-roots` above drives
+;; `destroy-adapter!` through `act`, which flushes any deferral, so it never
+;; observes the commit-phase window. This fixture invokes `rf/destroy-adapter!`
+;; from INSIDE a React layout effect: `drain-live-roots!` then loops
+;; `unmount!*` over roots whose `.unmount` react-dom 19.2 DEFERS. It proves the
+;; retained synchronous `destroy-adapter! → nil` contract is HONEST in commit
+;; phase — completion returns while each exact-root claim is still quarantined
+;; `:tearing-down` (so a fresh mount is fail-closed rejected, never clobbering a
+;; container React is still scheduled to clear), and the exact id/container
+;; becomes reusable only AFTER the deferred settlement releases the claim.
+;; ===========================================================================
+
+(defn- mount-commit-root!
+  "Mount a reactive public root under a LITERAL root-id (the `ui/mount` macro
+  validates :root-id at expansion, so each id must be a literal keyword)."
+  [container which label]
+  (case which
+    :a (ui/mount [observed-root {:label label :renders (atom 0)}]
+                 container {:root-id :adapter-public/commit-a})
+    :b (ui/mount [observed-root {:label label :renders (atom 0)}]
+                 container {:root-id :adapter-public/commit-b})))
+
+(deftest destroy-adapter-from-commit-phase-defers-then-settles
+  (when (browser?)
+    (async done
+      (rf/reg-sub ::adapter-value (fn [db _] (:value db)))
+      (frame/replace-app-db! :rf/default {:value 42})
+      (let [a         (js/document.createElement "div")
+            b         (js/document.createElement "div")
+            cell-base (reactive/root-cell-count)
+            ;; captured SYNCHRONOUSLY inside the layout effect, right after
+            ;; destroy returns and BEFORE the deferred settlement microtasks run.
+            returned          (atom :unset)
+            ids-at-return     (atom :unset)
+            reuse-at-return   (atom :unset)]
+        (-> (act-promise
+             #(do (mount-commit-root! a :a "a")
+                  (mount-commit-root! b :b "b")))
+            (.then
+             (fn []
+               (is (= #{:adapter-public/commit-a :adapter-public/commit-b}
+                      (client/live-root-ids)))
+               (is (= ["a:42" "b:42"] [(.-textContent a) (.-textContent b)]))
+               (is (> (reactive/root-cell-count) cell-base)
+                   "the two reactive roots each seated a ViewCell")
+               ;; Invoke destroy from a layout effect → each public root's
+               ;; `.unmount` is DEFERRED by react-dom.
+               (destroy-adapter-in-commit-phase!
+                (fn []
+                  (reset! returned (rf/destroy-adapter!))
+                  ;; Immediate post-return snapshot: the drain looped every root
+                  ;; but each deferred teardown is still in flight, so the claims
+                  ;; remain registered `:tearing-down` — completion did NOT wait,
+                  ;; yet did NOT release a still-scheduled container either.
+                  (reset! ids-at-return (client/live-root-ids))
+                  ;; Admission is fail-closed while completion is pending: a fresh
+                  ;; mount on the exact container is rejected (the terminal
+                  ;; breadcrumb keeps public creation closed until a fresh
+                  ;; adapter), never clobbering root a's deferred teardown.
+                  (reset! reuse-at-return
+                          (thrown-id #(mount-commit-root! a :a "a")))))))
+            (.then (fn [] (next-macrotask)))
+            (.then
+             (fn []
+               (is (nil? @returned)
+                   "destroy-adapter! kept its synchronous nil completion in commit
+                    phase (AC5 — the frozen contract is retained, not made async)")
+               (is (= #{:adapter-public/commit-a :adapter-public/commit-b}
+                      @ids-at-return)
+                   "at the immediate return every root was still quarantined
+                    :tearing-down — completion is reported without awaiting the
+                    microtask, and a mutation that eagerly released here would
+                    make this set empty (AC6)")
+               (is (= :rf.error/adapter-disposed @reuse-at-return)
+                   "a fresh mount before completion settles is rejected
+                    deterministically — no new root clobbers a deferred teardown
+                    (AC2)")
+               ;; After the settlement boundary every claim/cell/DOM converges.
+               (is (= #{} (client/live-root-ids))
+                   "the deferred settlement released every exact-root claim (AC3)")
+               (is (= ["" ""] [(.-textContent a) (.-textContent b)])
+                   "React cleared both deferred containers")
+               (is (= cell-base (reactive/root-cell-count))
+                   "every ViewCell was reaped — no observation owner survived")
+               ;; A fresh adapter generation, then reuse of the EXACT ids and
+               ;; containers, now succeeds (AC3 — the ratified reuse after settle).
+               (rf/init! ui/adapter)
+               (act-promise
+                #(do (mount-commit-root! a :a "a2")
+                     (mount-commit-root! b :b "b2")))))
+            (.then
+             (fn []
+               (is (= ["a2:42" "b2:42"] [(.-textContent a) (.-textContent b)])
+                   "the exact ids/containers re-mount after the settlement boundary")
+               (is (= #{:adapter-public/commit-a :adapter-public/commit-b}
+                      (client/live-root-ids)))
+               (act-promise rf/destroy-adapter!)))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "commit-phase adapter disposal rejected" e))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
@@ -34,6 +34,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.observation :as obs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.ui :as ui :refer [defview]]
@@ -224,3 +225,84 @@
              render is its own slice, discarded on return"))
       (finally
         (.shutdownNow exec)))))
+
+;; ---------------------------------------------------------------------------
+;; Causal identity witness (rf2-vxgfnd.284, AC4/AC5) — observe distinct
+;; slice-memo HANDLE IDENTITY per independent top-level render, forcing overlap
+;; AT MEMO ACQUISITION rather than inferring isolation from an aggregate
+;; recompute count.
+;;
+;; `concurrent-tier1-renders-do-not-share-a-memo` above synchronises only
+;; BEFORE `uit/render` and asserts `parent-runs=2`. That is FALSE-GREEN against
+;; a faulty single shared/reset global handle: with only a start barrier the two
+;; renders can still run end-to-end sequentially, and a per-render-entry
+;; global reset then yields two isolated computes (2) — the exact count a
+;; thread-local scope gives. The witness below closes that gap by (1) tripping
+;; the barrier INSIDE the shared cold parent's compute, so both renders provably
+;; hold an ALREADY-ACQUIRED handle simultaneously, and (2) recording the IDENTITY
+;; of every slice-memo handle each thread's probes actually thread — a direct
+;; per-render-slice identity proof, internal-only (no public memo token).
+;; ---------------------------------------------------------------------------
+
+(defn- with-probe-handle-witness
+  "Run `thunk` with `obs/probe` wrapped to record, keyed by the calling thread,
+  the IDENTITY of every non-nil slice-memo handle threaded through a probe.
+  Returns `{thread-id #{handle …}}`. Internal-only: it observes the handle a
+  slice already threads, adding no public token and leaving the runtime design
+  untouched. Restores the original `probe` on exit (var-root redef)."
+  [thunk]
+  (let [seen (atom {})
+        orig obs/probe]
+    (with-redefs [obs/probe
+                  (fn
+                    ([target] (orig target))
+                    ([target slice-memo]
+                     (when (some? slice-memo)
+                       (swap! seen update (.getId (Thread/currentThread))
+                              (fnil conj #{}) slice-memo))
+                     (orig target slice-memo)))]
+      (thunk))
+    @seen))
+
+(deftest concurrent-tier1-renders-thread-distinct-memo-handle-identity
+  ;; Two `uit/render`s on the SAME frame, forced to OVERLAP at memo acquisition:
+  ;; the barrier trips inside the shared cold parent's compute, so when it
+  ;; releases BOTH renders are mid-slice with a handle already threaded. The
+  ;; witness proves each render threaded EXACTLY ONE handle (within-render
+  ;; sharing) and the two are DISTINCT identities (thread-local render scope,
+  ;; never a shared global holder). A single reset global handle either hands a
+  ;; thread two handles across the overlap (its own, then the other thread's
+  ;; clobber) or converges both threads on one identity — either fails an
+  ;; assertion here, DETERMINISTICALLY under the forced overlap (AC5).
+  (reg-slice-subs!)
+  (let [f    (uit/frame {:app-db {:n 5}})
+        gate (CyclicBarrier. 2)]
+    ;; Re-register the shared cold parent so its compute trips the acquisition
+    ;; barrier; siblings sharing one slice handle compute it once per render, so
+    ;; each render trips the barrier exactly once → the 2-party barrier releases
+    ;; only when both renders are simultaneously mid-slice.
+    (rf/reg-sub :slice/parent
+                (fn [db _]
+                  (swap! parent-runs inc)
+                  (.await gate 10 TimeUnit/SECONDS)
+                  (:n db)))
+    (reset! parent-runs 0)
+    (let [seen (with-probe-handle-witness
+                 (fn []
+                   (let [run (fn [] (future (uit/render siblings {:frame f})))
+                         r1  (run)
+                         r2  (run)]
+                     @r1 @r2)))
+          thread-handle-sets (vals seen)]
+      (is (= 2 (count seen))
+          "two distinct render threads each threaded slice-memo handles")
+      (is (every? #(= 1 (count %)) thread-handle-sets)
+          "each render threaded EXACTLY ONE handle across both sibling probes —
+           within-render sharing held even under the forced acquisition overlap")
+      (let [[ha hb] (map first thread-handle-sets)]
+        (is (not (identical? ha hb))
+            "the two OVERLAPPING renders threaded DISTINCT handle identities — a
+             thread-local render scope, not a shared/reset global holder"))
+      (is (= 2 @parent-runs)
+          "each render computed the shared cold parent exactly once (2 total) —
+           the aggregate count companion, now backed by the identity witness"))))


### PR DESCRIPTION
Two P1 audit beads on the re-frame.ui reactive/adapter surface. Both target **already-correct production code** whose contract was under-proven; each adds the specific in-scope fixture axis its acceptance criteria demanded. **No production `.cljc`/`.cljs` source changed** — test-only.

## rf2-vxgfnd.276 — adapter destruction completes only after root teardown settlement

`drain-live-roots!` loops `unmount!*` over each public compiled Root; for a teardown react-dom 19.2 **defers** (a `.unmount` from inside render/commit returns normally, scheduling teardown for a later microtask), `unmount!*` marks the exact claim `:tearing-down` and schedules `settle-deferred-root!`, so the drain returns and the admission fence reopens while claims are still in flight.

**Verified correct on origin/main:** the retained synchronous `destroy-adapter! → nil` contract is honest in commit phase because (a) a fresh `rf/init!` does not wipe `live-roots` (`reset-live-roots!` is test-only), so the `:tearing-down` claims survive a reinstall and `check-root-claim!` fail-closes reuse of the exact container until settlement — no clobber — and (b) the exact id/container becomes reusable only after the deferred settlement releases the claim.

**Gap closed (AC1/AC2/AC3/AC5):** the existing adapter disposal fixture drives `destroy-adapter!` through `act` (which flushes any deferral), so it never observed the commit-phase window; the root-level `deferred-render-phase-unmount-fences-reentrant-remount` proves a single `unmount!*`, not the adapter-wide drain. New `destroy-adapter-from-commit-phase-defers-then-settles` invokes `rf/destroy-adapter!` from inside a React layout effect with two reactive roots and asserts:
- `destroy-adapter!` kept its synchronous `nil` completion in commit phase (AC5 — contract retained, not made async);
- at the immediate return every root was still quarantined `:tearing-down` (`live-root-ids` = `{commit-a commit-b}`) — completion reported without awaiting the microtask;
- a fresh mount before completion settles is rejected deterministically (`:rf.error/adapter-disposed`), clobbering nothing (AC2);
- after the settlement boundary every claim/cell/DOM converged and the exact ids/containers re-mounted (AC3).

**Non-vacuous / mutation witness (AC6):** the immediate-return assertion `live-root-ids = {commit-a commit-b}` is only satisfiable by the deferred path — a synchronous teardown would release the claims (empty set), so the assertion passing *witnesses* the deferral, and a mutation that eagerly released would empty it. (The eager-release code mutation is already the shipped root-level witness `deferred-render-phase-unmount-fences-reentrant-remount`.)

Note: cell-less public roots are not constructible in the dev `:browser-test` build (every dev view gets a ViewCell skeleton — see the existing NOTE in `root-teardown-dom-cljs-test`); the rendered cell-less deferral law is exercised by the cell-bearing path plus the graft/wiring fixtures.

## rf2-vxgfnd.284 — JVM slice-memo lifetime + causal isolation proof

The prior concurrent fixture synchronised only *before* `uit/render` and asserted `parent-runs=2` — false-green against a single shared/reset global handle (with only a start barrier the two renders can run sequentially, and a per-render-entry global reset then yields the same count a thread-local scope gives).

**Gap closed (AC4/AC5):** new `concurrent-tier1-renders-thread-distinct-memo-handle-identity` adds an internal-only identity witness — it wraps `obs/probe` to record, per thread, the **identity** of every slice-memo handle threaded, and trips the barrier **inside** the shared cold parent's compute so both renders provably hold an already-acquired handle simultaneously. Asserts each render threaded exactly one handle (within-render sharing under forced overlap) and the two are **distinct identities** (thread-local render scope, not a global holder). Adds no public memo token; runtime design unchanged.

### fixture-fails-pre-fix (AC5 red demonstration)
Temporarily replacing the JVM thread-local `*slice*` scope with a single shared global box (`(binding [*slice* @shared-box] …)`) made the run deterministically red — the identity witness fired first:
```
FAIL concurrent-tier1-renders-thread-distinct-memo-handle-identity
the two OVERLAPPING renders threaded DISTINCT handle identities …
expected: (not (identical? ha hb))
  actual: (not (not true))
```
(plus the existing between-render-disposal and sequential-reuse controls). Reverted to the shipped tree → green. The `nested-slice-scope` / `bare-probe` / sequential-reuse controls remain green (AC5 control set).

### Out of scope for this worker (noted, not done)
The bead's doc-reconciliation ACs (AC1–AC3 for .284: `spec/006-ReactiveSubstrate.md` still applies `queueMicrotask` lifetime unconditionally rather than distinguishing the JVM re-entrant thread-local render scope from the CLJS module-holder/microtask; and .276's Spec 006 disposal-lifecycle honesty) touch `spec/**`, which is outside this worker's `implementation/ui` scope. They need a spec-doc worker. Both beads left **open** accordingly.

## Quality gates (foreground, this branch)
- `implementation/ui $ clojure -M:test` — **527 tests / 6549 assertions, 0 failures, 0 errors** (includes strengthened .284)
- `implementation $ npm run test:cljs` — **9430 tests / 46268 assertions, 0 failures, 0 errors**
- `implementation $ npm run test:browser` — **358 tests / 1947 assertions, 0 failures, 0 errors** (includes new .276 fixture)
