### PR TITLE
fix(ui): unify analysis/emission on one host-faithful binding plan (rf2-vxgfnd.283)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -342,29 +342,98 @@
   [k]
   (and (keyword? k) (contains? #{"keys" "strs" "syms"} (name k))))
 
-(defn- binding-map-units
-  "The associative-destructuring binding units of `pattern`, in the host's
-  `bes` evaluation order: explicit `{local-pattern key-expr}` entries in source
-  order FIRST, then `:keys`/`:strs`/`:syms` expansions (that host order — the
-  `:or`/`:as` markers dissoc out and the group forms assoc their entries at the
-  tail). Each unit is `{:local-pattern p :key-expr e|nil}`; `key-expr` is the
-  EVALUATED lookup-key expression of an explicit entry (nil for the group
-  forms, whose keys are literals). The units are consumed in order so each
-  binding's default/lookup-key is judged against the scope established BEFORE
-  it — never against a symbol the same pattern binds later."
+(defn- key-group-directive-fn
+  "The lookup-key transform host `destructure` applies to a `:keys`/`:strs`/
+  `:syms` group directive `mk` (any namespace). This is the SHARED CLJ/CLJS
+  transform — both hosts run `destructure` on the JVM at macro-expansion time —
+  reproduced verbatim so the produced key (and, through it, the map's iteration
+  order) matches the host exactly."
+  [mk]
+  (let [mkns (namespace mk)]
+    (case (name mk)
+      "keys" #(keyword (or mkns (namespace %)) (name %))
+      "syms" #(list 'quote (symbol (or mkns (namespace %)) (name %)))
+      "strs" str)))
+
+(defn- assoc-binding-units
+  "The associative-destructuring binding units of map `pattern`, in the EXACT
+  host `destructure` `bes` order — the ONE canonical, host-faithful binding
+  plan (`reject-reactive-binding!` scope checking and the CLJS header emitter
+  both consume it, so neither can drift from the other or from the host).
+
+  It reproduces `destructure`'s remaining-bindings transformation rather than
+  invoking a general macroexpander: start from `(dissoc pattern :as :or)`, then
+  for each group directive — in the order it appears in the pattern's keys —
+  `dissoc` the directive and `assoc` each expanded local exactly as the host
+  does, and read the units off `(seq bes)` in the resulting map-iteration order.
+  Small patterns stay a `PersistentArrayMap` (insertion order); at nine or more
+  remaining bindings the host promotes to a `PersistentHashMap` and the order
+  becomes hash-driven. Because every host computes this on the JVM the 8→9
+  threshold and the hash order are identical on CLJ and CLJS, so reproducing the
+  transform here is faithful to both.
+
+  `:as` is NOT included — it binds first, before `bes`, so the caller seeds it
+  into scope. Each unit is `{:local-pattern p :key-expr e}`: for an explicit
+  `{p key-expr}` entry `p` is the local pattern and `key-expr` its EVALUATED
+  lookup-key expression; for a group local `p` is the simple symbol and the key
+  is the produced literal (a keyword/string/quoted symbol — never a reactive
+  escape). The units are consumed in order so each binding's default/lookup-key
+  is judged against the scope established BEFORE it — never against a symbol the
+  same pattern binds later, and never in an order the host would not use."
   [pattern]
-  (let [explicit (for [[k v] pattern
-                       :when (not (or (= k :or) (= k :as) (key-group-kw? k)))]
-                   {:local-pattern k :key-expr v})
-        rank     {"keys" 0 "strs" 1 "syms" 2}
-        grouped  (->> pattern
-                      (filter (fn [[k _]] (key-group-kw? k)))
-                      (sort-by (fn [[k _]] (rank (name k))))
-                      (mapcat (fn [[_ syms]]
-                                (map (fn [s] {:local-pattern (symbol (name s))
-                                              :key-expr nil})
-                                     syms))))]
-    (concat explicit grouped)))
+  (let [start      (dissoc pattern :as :or)
+        transforms (reduce (fn [t k] (if (key-group-kw? k) (assoc t k true) t))
+                           {} (keys pattern))
+        explicit   (set (keys (reduce dissoc start (keys transforms))))
+        bes        (reduce
+                    (fn [bes [mk _]]
+                      (let [f (key-group-directive-fn mk)]
+                        (reduce (fn [b s] (assoc b s (f s)))
+                                (dissoc bes mk)
+                                (get bes mk))))
+                    start
+                    transforms)]
+    (for [[bb bk] bes]
+      (if (contains? explicit bb)
+        {:local-pattern bb :key-expr bk}
+        {:local-pattern (symbol (name bb)) :key-expr nil}))))
+
+(defn- check-portable-map-shape!
+  "Reject the nonportable associative-destructuring shapes the host tolerates
+  but that bind ambiguously across analysis and emission (or across CLJ/CLJS):
+  a keyword or namespace-qualified EXPLICIT local, and a composite (non-simple-
+  symbol) `:or` key. The host strips the namespace off a qualified local and
+  binds a keyword local name-only, while the analyzer's scope walk keeps the
+  written form — a divergence that can mis-lower a reactive read. A composite
+  `:or` key never matches a bound local, so its default is silently dead. We
+  close the portable grammar to simple-symbol (and nested) locals with the
+  shared typed unsupported-form error rather than reproducing those shapes."
+  [e pattern]
+  (doseq [[k _] pattern]
+    (cond
+      (or (= k :as) (= k :or) (key-group-kw? k)) nil
+
+      (keyword? k)
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str "keyword destructuring local " k " is not portable — an "
+                      "explicit binding local must be a simple symbol (or a "
+                      "nested destructuring pattern). Bind {a-symbol " k "}")
+                 {:form pattern :key k})
+
+      (and (symbol? k) (namespace k))
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str "namespace-qualified destructuring local " k " is not "
+                      "portable — the host binds it name-only while analysis "
+                      "keeps the namespace, so a reactive read can mis-lower. "
+                      "Use the simple symbol " (symbol (name k)))
+                 {:form pattern :key k})))
+  (doseq [k (keys (:or pattern))]
+    (when-not (and (symbol? k) (nil? (namespace k)))
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str ":or default key " (pr-str k) " is not a simple symbol — "
+                      "the host only defaults simple-symbol locals, so this "
+                      "default is dead. Default a bound symbol")
+                 {:form pattern :or-key k}))))
 
 (defn- reject-binding-escape!
   "Reject a reactive authoring escape reaching ONE evaluated destructuring
@@ -425,24 +494,28 @@
             :else     (recur (check-binding-scope! e scope x) (next xs))))))
 
     (map? pattern)
-    ;; Associative destructuring. `:as` binds the whole map FIRST (host order),
-    ;; so it is in scope for every key default. Then the key bindings are
-    ;; established sequentially (`binding-map-units` order): each key's default
-    ;; AND each explicit lookup-key expression is evaluated against the scope
-    ;; BEFORE that key's own local is bound — the local is added only after.
-    (let [defaults (:or pattern)
-          scope    (cond-> scope (:as pattern) (conj (:as pattern)))]
-      (reduce
-       (fn [scope {:keys [local-pattern key-expr]}]
-         (when key-expr
-           (reject-binding-escape! e scope "destructuring lookup-key expression"
-                                   pattern key-expr))
-         (when (and (symbol? local-pattern) (contains? defaults local-pattern))
-           (reject-binding-escape! e scope "destructuring :or default"
-                                   pattern (get defaults local-pattern)))
-         (check-binding-scope! e scope local-pattern))
-       scope
-       (binding-map-units pattern)))
+    ;; Associative destructuring. Close the portable grammar first, then thread
+    ;; scope in host `destructure` order. `:as` binds the whole map FIRST (host
+    ;; order), so it is in scope for every key default. Then the key bindings are
+    ;; established sequentially (`assoc-binding-units` = the host `bes` order):
+    ;; each key's default AND each explicit lookup-key expression is evaluated
+    ;; against the scope BEFORE that key's own local is bound — the local is
+    ;; added only after, and never in an order the host would not use.
+    (do
+      (check-portable-map-shape! e pattern)
+      (let [defaults (:or pattern)
+            scope    (cond-> scope (:as pattern) (conj (:as pattern)))]
+        (reduce
+         (fn [scope {:keys [local-pattern key-expr]}]
+           (when key-expr
+             (reject-binding-escape! e scope "destructuring lookup-key expression"
+                                     pattern key-expr))
+           (when (and (symbol? local-pattern) (contains? defaults local-pattern))
+             (reject-binding-escape! e scope "destructuring :or default"
+                                     pattern (get defaults local-pattern)))
+           (check-binding-scope! e scope local-pattern))
+         scope
+         (assoc-binding-units pattern))))
 
     :else scope))
 
@@ -468,6 +541,18 @@
   [e binding-form]
   (check-binding-scope! e (:locals e) binding-form)
   binding-form)
+
+(defn header-binding-order
+  "The explicit/group local-patterns of a defview header map `binding-form`, in
+  host `destructure` `bes` order (`:as` excluded — it binds first). The CLJS
+  header emitter consumes this so its property-read bindings land in the same
+  order the JVM native destructuring would use; a dependent `:or` default then
+  resolves to the same symbol on both hosts and no public authoring var can
+  survive through a reordered default. One plan (`assoc-binding-units`), both
+  emitters. Returns nil for a non-map header (`[sym]` ≡ `{:as sym}`)."
+  [binding-form]
+  (when (map? binding-form)
+    (mapv :local-pattern (assoc-binding-units binding-form))))
 
 (defn rewrite-expr
   "Rewrite an opaque expression, lowering resolved unshadowed `(sub q)` calls

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -410,13 +410,28 @@
        (if (cljs.core/undefined? v#) ~default v#))
     `(cljs.core/unchecked-get ~props-sym ~slot)))
 
-(defn header-bindings [header]
-  (concat
-   (mapcat (fn [{:keys [slot pattern default]}]
-             [pattern (slot-read slot default)])
-           (:entries header))
-   (when (:as-sym header)
-     [(:as-sym header) `(re-frame.ui.runtime/props->map ~props-sym)])))
+(defn header-bindings
+  "The CLJS header `let` bindings, in canonical host `destructure` order
+  (rf2-vxgfnd.283): `:as` binds the whole props map FIRST — matching the JVM
+  native destructuring the JVM emitter uses — then the property-read entries in
+  the host `bes` order supplied by the ONE shared binding plan
+  (`ana/header-binding-order`). Emitting `:as` last, or the entries in parse
+  order, could resolve a dependent `:or` default to a different symbol on CLJS
+  than on the JVM — including a public reactive authoring var. Ordering by the
+  shared plan keeps both emitters and the scope check on one order. `sort-by` is
+  stable, so any entry the plan does not enumerate keeps its relative place."
+  [header]
+  (let [order   (ana/header-binding-order (:binding-form header))
+        idx     (when order (zipmap order (range)))
+        entries (cond->> (:entries header)
+                  idx (sort-by (fn [{:keys [pattern]}]
+                                 (get idx pattern (count order)))))]
+    (concat
+     (when (:as-sym header)
+       [(:as-sym header) `(re-frame.ui.runtime/props->map ~props-sym)])
+     (mapcat (fn [{:keys [slot pattern default]}]
+               [pattern (slot-read slot default)])
+             entries))))
 
 (defn comparator-form
   "The generated straight-line rf= comparator (RULED: Object.is OR = per

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -243,6 +243,68 @@
       (is (not (re-find #":or default" msg))
           "and does not misreport it as an :or default"))))
 
+(deftest binding-plan-is-host-faithful-order
+  ;; rf2-vxgfnd.283 — the ordered-scope model must be the HOST `destructure`
+  ;; `bes` order, not an invented explicit-first + rank-sorted `:keys`/`:strs`/
+  ;; `:syms` order. Where the two disagree, a bare reactive var in a default
+  ;; that the host binds BEFORE its shadow escapes while the invented order
+  ;; falsely accepts it. These rows reject ONLY under the faithful order —
+  ;; restoring the source/rank order re-accepts them (the mutation fixture).
+  (testing "the ≥9-entry hash-map regime reorders the shadow behind the default"
+    ;; The host promotes the transformed bindings map to a PersistentHashMap at
+    ;; nine entries; here it binds `target` (with default `sub`) BEFORE `sub`, so
+    ;; the default is the outer public var. The invented explicit-first order put
+    ;; `sub` first and false-accepted.
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [sub a b c d e f g h target]
+                                            :or {target sub}} m] target)}]))
+        "a 10-entry hash-regime default the host expands before its shadow escapes")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:keys [lease a b c d e f g h target]
+                                            :or {target lease}} m] target)}]))
+        "lease escapes identically in the hash regime"))
+  (testing "mixed :keys/:strs/:syms follow SOURCE group order, not a fixed rank"
+    ;; Host group order = the order the group directives appear in the pattern.
+    ;; With `:strs`/`:keys`/`:syms` written in that order the host binds
+    ;; a, target, sub — so target's default `sub` is the outer var. A fixed
+    ;; keys<strs<syms rank would bind sub first and false-accept.
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:strs [a] :keys [target] :syms [sub]
+                                            :or {target sub}} m] target)}]))
+        "reordered mixed groups keep the host's source group order"))
+  (testing "the faithful order does not over-reject a genuine earlier shadow"
+    ;; Array-map regime (two entries): the host binds `sub` then `target`, so
+    ;; target's `:or` default resolves to the earlier local, not the outer var.
+    ;; (In the hash regime source order is NOT bind order — the 10-entry row
+    ;; above binds `target` before `sub` even though `sub` is written first.)
+    (is (nil? (reject-id '[:div {:title (let [{:keys [sub target] :or {target sub}}
+                                              m] target)}]))
+        "an earlier-bound local in the array regime still shadows the default")))
+
+(deftest portable-binding-grammar-close
+  ;; rf2-vxgfnd.283 — close the portable grammar to simple-symbol (and nested)
+  ;; explicit locals and simple-symbol :or keys. The host tolerates keyword and
+  ;; namespace-qualified explicit locals (binding them name-only) and composite
+  ;; :or keys (a dead default), but the analyzer's scope walk keeps the written
+  ;; form — a divergence that can mis-lower a reactive read. Reject up front with
+  ;; the shared typed unsupported-form error rather than reproduce those shapes.
+  (testing "keyword and qualified explicit locals are rejected"
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{:foo :bar} m] 1)}]))
+        "a keyword explicit local is nonportable")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{a/b :bar} m] 1)}]))
+        "a namespace-qualified explicit local is nonportable"))
+  (testing "composite :or keys are rejected"
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id '[:div {:title (let [{[a b] :pair :or {[a b] [1 2]}} m] a)}]))
+        "a composite :or key never defaults a bound local"))
+  (testing "portable simple-symbol and nested destructuring stays legal"
+    (is (nil? (reject-id '[:div {:title (let [{:keys [x] :or {x 0}} m] x)}]))
+        "simple-symbol keys + literal default")
+    (is (nil? (reject-id '[:div {:title (let [{[a b] :pair} m] [a b])}]))
+        "a nested destructuring explicit local")))
+
 (deftest reactive-verb-head-reserved-before-foreign-classification
   ;; rf2-vxgfnd.266 — the next escape in the .252/dzyqis family. sub/lease/frame
   ;; are reactive authoring verbs, sound ONLY as their compiler-owned DIRECT

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -1,0 +1,109 @@
+(ns re-frame.ui.binding-plan-host-faithful-jvm-test
+  "rf2-vxgfnd.283 — the ONE host-faithful binding plan. The analyzer's scope
+  walk and the CLJS header emitter must derive their binding order from a single
+  plan that reproduces the host `destructure` `bes` transformation, so neither
+  drifts from the other or from what the JVM native destructuring (the JVM
+  emitter) and the CLJS lowering actually bind.
+
+  These fixtures compare the plan against REAL `clojure.core/destructure`
+  expansion (macro-level, JVM). The CLJS `destructure` is byte-for-byte the same
+  transformation run on the same JVM maps at macro-expansion time, so a match
+  here is a match on both hosts — the `.cljc` reject table pins the CLJS path
+  end to end."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.header :as header]))
+
+(defn- real-local-order
+  "The user locals `clojure.core/destructure` binds for map `pat`, in order —
+  the ground truth the plan must reproduce (gensym scaffolding dropped)."
+  [pat]
+  (->> (destructure [pat 'the-map])
+       (partition 2)
+       (map first)
+       (remove #(re-find #"^(map__|vec__|seq__|first__|p__|the-map)" (name %)))
+       vec))
+
+(defn- plan-order
+  "The shared binding plan's local order for map `pat` (`:as` excluded — it
+  binds first, before the `bes` walk)."
+  [pat]
+  (ana/header-binding-order pat))
+
+(defn- emit-local-order
+  "The locals the CLJS header emitter binds, in emission order."
+  [argv]
+  (->> (header/parse-header argv)
+       emit-cljs/header-bindings
+       (partition 2)
+       (map first)
+       vec))
+
+;; ---------------------------------------------------------------------------
+;; The plan reproduces the host bes order
+;; ---------------------------------------------------------------------------
+
+(deftest plan-matches-real-clojure-destructure
+  (testing "explicit + group, array-map regime (source order)"
+    (doseq [pat '[{:keys [a b c d e f g h]}                 ; 8 = array-map
+                  {ex1 :e1 :keys [ka kb] ex2 :e2}           ; explicit around a group
+                  {p1 :k1 p2 :k2 :keys [a b] :strs [s1 s2] :syms [y1 y2]}]]
+      (is (= (real-local-order pat) (plan-order pat))
+          (str "plan reproduces host order for " (pr-str pat)))))
+  (testing "mixed :keys/:strs/:syms follow SOURCE group order (not a fixed rank)"
+    (let [pat '{:syms [y1 y2] :keys [k1 k2] :strs [s1 s2]}]
+      (is (= (real-local-order pat) (plan-order pat)))
+      (is (= '[y1 y2 k1 k2 s1 s2] (plan-order pat))
+          "syms-first source order, not keys<strs<syms rank")
+      (is (not= '[k1 k2 s1 s2 y1 y2] (plan-order pat))
+          "the invented rank order would silently regress this")))
+  (testing "the 8→9 entry map-representation threshold"
+    (is (= '[a b c d e f g h] (plan-order '{:keys [a b c d e f g h]}))
+        "8 entries stay a PersistentArrayMap in source order")
+    (let [nine '{:keys [a b c d e f g h i]}]
+      (is (= (real-local-order nine) (plan-order nine))
+          "9 entries promote to a PersistentHashMap — reproduce that order")
+      (is (not= '[a b c d e f g h i] (plan-order nine))
+          "the 9-entry order is hash-driven, NOT source order")))
+  (testing "the bead counterexample binds target before its sub default"
+    (let [pat '{:keys [sub a b c d e f g h target] :or {target sub}}]
+      (is (= (real-local-order pat) (plan-order pat)))
+      (is (< (.indexOf ^clojure.lang.PersistentVector (plan-order pat) 'target)
+             (.indexOf ^clojure.lang.PersistentVector (plan-order pat) 'sub))
+          "target is bound before sub, so its default reaches the outer var"))))
+
+;; ---------------------------------------------------------------------------
+;; The CLJS header emitter binds in the same host order — :as FIRST
+;; ---------------------------------------------------------------------------
+
+(deftest cljs-header-emission-is-host-faithful
+  (testing "entries land in host destructure order, not parse order"
+    (doseq [argv '[[{:keys [a] x :foo}]
+                   [{:keys [a] x :foo :or {x 0}}]
+                   [{:keys [a b c d e f g h i]}]]]
+      (is (= (real-local-order (first argv)) (emit-local-order argv))
+          (str "CLJS header binds in host order for " (pr-str argv)))))
+  (testing ":as binds the whole props map FIRST (never after the entries)"
+    (let [order (emit-local-order '[{:keys [a b] :as whole}])]
+      (is (= '[whole a b] order))
+      (is (= 'whole (first order))
+          "moving :as after the entries would let an :as-dependent default escape")
+      (is (= (real-local-order '{:keys [a b] :as whole}) order)))))
+
+;; ---------------------------------------------------------------------------
+;; The JVM emitter delegates to the host, so the two emitters agree
+;; ---------------------------------------------------------------------------
+
+(deftest jvm-and-cljs-emitters-share-the-order
+  ;; The JVM emitter emits `(let [<raw pattern> props] …)` and lets the host
+  ;; destructure natively; the CLJS emitter now orders its property reads by the
+  ;; same plan. So for every header pattern the two emitters bind in one order —
+  ;; a dependent :or default resolves to the same symbol on both hosts.
+  (doseq [argv '[[{:keys [a] x :foo :or {x 0}}]
+                 [{:keys [a b] :as whole}]
+                 [{:keys [a b c d e f g h i] :as whole}]]]
+    (let [host (real-local-order (first argv))
+          cljs (emit-local-order argv)]
+      (is (= host cljs)
+          (str "JVM host order == CLJS emission order for " (pr-str argv))))))


### PR DESCRIPTION
Closes rf2-vxgfnd.283.

## The divergence

The compiler modeled destructuring binding order **three** different ways, and where they disagreed a bare reactive authoring var in an `:or` default could escape the manifest:

| Surface | Order it used |
|---|---|
| `analyze.cljc` scope check (`binding-map-units`) | invented: explicit-first, then `:keys`/`:strs`/`:syms` **rank-sorted** |
| `emit_cljs.cljc` header (`header-bindings`) | parse order, **`:as` bound LAST** |
| host `destructure` (what JVM native emission + CLJS lowering actually bind) | `bes` map-iteration order, **`:as` FIRST** |

Empirically confirmed against `clojure.core/destructure` on the JVM:

- `{:keys [sub a b c d e f g h target] :or {target sub}}` (10 entries → `PersistentHashMap`) binds `[target a sub …]` — **`target` before `sub`**, so its default reaches public `re-frame.ui/sub`. The invented order put `sub` first and **false-accepted** (empty manifest → optimized build elides the read → the public var survives unindexed).
- Mixed groups follow **source** group order: `{:syms [y] :keys [k] :strs [s]}` → `[y k s]`, not the fixed `keys<strs<syms` rank.
- `{:keys [a b] :as whole}` → `[whole a b]` — the host binds `:as` **first**, but `emit_cljs` bound it last, so an `:as`-dependent default (or a reordered dependent default) resolved to a different symbol on CLJS than on the JVM.

## Portability (why reproduce, not reject)

`cljs.core/destructure` runs on the JVM at macro-expansion time using JVM maps, so its `bes` order is **byte-for-byte identical to `clojure.core/destructure`** — including the ≥9-entry hash regime. Verified by evaluating both `destructure` fns over the same battery (all matched). So the shared transformation is portable and is *reproduced*, not rejected.

## The unification

- New `assoc-binding-units` (analyze.cljc) reproduces the shared `destructure` `bes` transformation verbatim (start `(dissoc pattern :as :or)`, apply each group directive in source order, read units off the resulting map-iteration order). This is the **one** canonical, host-faithful plan.
- `check-binding-scope!` (scope checking, both body and header — the header pattern flows through `reject-reactive-binding!`) consumes it; `:as` seeds scope first.
- `emit_cljs/header-bindings` consumes it via the new public `ana/header-binding-order`, binding `:as` **first** then entries in host order. The JVM emitter already hands the raw pattern to the host, so both emitters now bind in one order.
- `check-portable-map-shape!` closes the portable grammar to simple-symbol (and nested) explicit locals + simple-symbol `:or` keys, rejecting keyword/qualified explicit locals and composite `:or` keys with the shared typed `:rf.ui.compile/unsupported-form` (no new error id, no macroexpander, no compat fallback).

## Fixtures fail pre-fix

Reverting only the two source files and running the new fixtures against pre-fix code → **5 discriminating failures**:

```
FAIL binding-plan-is-host-faithful-order — 10-entry hash-regime default (sub) — pre-fix ACCEPTS
FAIL binding-plan-is-host-faithful-order — 10-entry hash-regime default (lease) — pre-fix ACCEPTS
FAIL portable-binding-grammar-close — keyword explicit local {:foo :bar} — pre-fix ACCEPTS
FAIL portable-binding-grammar-close — qualified explicit local {a/b :bar} — pre-fix ACCEPTS
FAIL portable-binding-grammar-close — composite :or key {[a b] :pair :or {[a b] …}} — pre-fix ACCEPTS
```

New JVM fixtures compare the plan and CLJS emission against **real** `clojure.core/destructure` (mixed `:keys`/`:strs`/`:syms`, explicit/group collisions, `:as` with dependent defaults, the 8→9 threshold). The `.cljc` reject table pins the same rejections on the CLJS host. Restoring source/rank order, moving `:as` after the entries, or accepting the nonportable counterexamples fails focused fixtures.

## Quality gates

- `cd implementation/ui && clojure -M:test` → **531 tests, 6577 assertions, 0 failures, 0 errors** (foreground)
- `cd implementation && npm run test:cljs` → **9431 tests, 46277 assertions, 0 failures, 0 errors** (foreground; includes the CLJS reject table)

Scope: `implementation/ui/src/re_frame/ui/compiler/{analyze.cljc,emit_cljs.cljc}` + tests only.