### PR TITLE
feat(machines): make spawn-all catalogue proof authoritative (rf2-2ai15g)

### DIFF
--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -1,57 +1,73 @@
 (ns re-frame.spawn-all-authority-catalogue-test
-  "rf2-p53o47 — the focused catalogue/schema proof for `:spawn-all`
-  exact authority.
+  "The AUTHORITATIVE catalogue/schema proof for `:spawn-all` exact authority
+  (rf2-p53o47, completed rf2-2ai15g).
 
-  This pins the three normative facts the spec/catalogue reconciliation
-  landed, so a regression FAILS here rather than drifting the spec silently:
+  This pins the normative facts the spec/catalogue reconciliation landed so a
+  regression FAILS here rather than drifting the spec silently. Every schema
+  assertion validates runtime-produced records against the EXECUTABLE canonical
+  schema EXTRACTED from `spec/Spec-Schemas.md` (via
+  `re-frame.spawn-all-schema-extract`), and every catalogue assertion is pinned
+  to a NARROW read of the actual `spec/009-Instrumentation.md` row — so
+  weakening the authoritative document is what turns a test red:
 
-    1. SCHEMA — `InvokeAllJoinState` requires `:rf/attempt`
-       (Spec-Schemas §`InvokeAllJoinState`). `spawn-all-init-fx` ALWAYS
-       mints the opaque per-attempt token into a LIVE child-bearing join
-       BEFORE the per-child spawns run, and `join.cljc`'s fold gate
-       requires a non-nil exact match — so a token-less child-bearing
-       join is permanently unable to accept a completion and is NOT a
-       valid live shape. This test mirrors the normative schema slice
-       (token REQUIRED, per Spec-Schemas) and proves a runtime-produced
-       join validates while dissociating the token fails: the proof fails
-       if the token is ever weakened back to `{:optional true}`.
+    1. SCHEMA — the `:spawned` slot union has THREE legal runtime arms
+       (Spec-Schemas §`Machines`): the `:spawn` leaf keyword, the LIVE
+       child-bearing `InvokeAllJoinState` (with `:rf/attempt` REQUIRED — a
+       token-less join is not a valid live shape; `join.cljc`'s fold gate
+       requires a non-nil exact match), and the childless REJECT sentinel
+       `InvokeAllRejectedState` (`{:closed true}`, only `:rf/spawn-all-rejected?
+       true`). A real unregistered-child `:spawn-all` fixture validates the
+       COMPLETE `:rf.runtime/machines` runtime-db against the extracted
+       `Machines` form during the legal pre-parent-exit interval; a sentinel
+       carrying `:children`/authority, and a token-less live join, both fail.
 
-    2. CATALOGUE — the `:rf.machine.spawn-all/child-completed` trace emits
-       `:rf.reply/correlation` (Spec 009 detailed row + `join.cljc`
-       `child-completion-reply-facts`), carrying the fold's
-       parent/invoke/child/spawned identity.
+    2. CATALOGUE — `:rf.machine.spawn-all/child-completed` emits
+       `:rf.reply/correlation` (Spec 009 detailed row + `join.cljc`), carrying
+       the fold's parent/invoke/child/spawned identity.
 
-    3. CATALOGUE — the spawn-all completion ops + their classifier key do
-       not drift: the POST-resolution straggler fires
-       `:rf.machine.spawn-all/late-completion` (Spec 009 quick index +
-       detailed row) classified by `:rf.reply/stale-reason`
-       `:rf.machine.spawn-all/join-resolved`; the PRE-resolution
-       suppression fires `:rf.machine.spawn-all/stale-completion` also
-       classified by `:rf.reply/stale-reason` (NOT the bare `:reason`)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+    3. CATALOGUE — the spawn-all completion ops + their classifier key do not
+       drift: the POST-resolution straggler fires
+       `:rf.machine.spawn-all/late-completion` (Spec 009 quick index + detailed
+       row) classified by `:rf.reply/stale-reason`
+       `:rf.machine.spawn-all/join-resolved` (a stale-reason VALUE, never an
+       operation); the PRE-resolution suppression fires
+       `:rf.machine.spawn-all/stale-completion` also classified by
+       `:rf.reply/stale-reason` (NOT the bare `:reason`)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
             ;; load the machines artefact so its fx handlers + late-bind
             ;; hooks are installed when this ns runs in isolation.
             [re-frame.machines]
             [re-frame.machines.test-support :as mtest]
+            [re-frame.spawn-all-schema-extract :as extract]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (mtest/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     ;; the reject fixture fans an always-on `:rf.error/machine-spawn-
+     ;; unregistered-type` record; clear the always-on listener registry so a
+     ;; leaked listener from an earlier test cannot see it.
+     :init-fn (fn [] (error-emit/clear-error-listeners!))})
   mtest/trace-capture-fixture)
 
-;; The normative `InvokeAllJoinState` slice, mirrored from
-;; Spec-Schemas §`InvokeAllJoinState` with `:rf/attempt` REQUIRED. The
-;; runtime seed shape (`spawn-all-init-fx`) is exactly this map.
-(def ^:private InvokeAllJoinState
-  [:map
-   [:children  [:map-of :keyword :keyword]]
-   [:done      [:set :keyword]]
-   [:failed    [:set :keyword]]
-   [:resolved? :boolean]
-   [:spec      :map]
-   [:rf/attempt :int]])
+;; The canonical `:spawn-all` runtime-db schema forms, EXTRACTED from
+;; spec/Spec-Schemas.md (rf2-2ai15g) — NOT hand-copied. Removing / renaming a
+;; def, or weakening `:rf/attempt` to `{:optional true}`, or dropping the
+;; `InvokeAllRejectedState` arm from the markdown is a test-build / assertion
+;; failure here, so the schema surface and the document cannot drift silently.
+(def ^:private InvokeAllJoinState     (extract/canonical-invoke-all-join-schema))
+(def ^:private InvokeAllRejectedState (extract/canonical-invoke-all-rejected-schema))
+(def ^:private SpawnedSlot            (extract/canonical-spawned-slot-schema))
+(def ^:private Machines               (extract/canonical-machines-schema))
+
+(defn- machines-runtime-db
+  "The frame's live `:rf.runtime/machines` runtime-db partition value."
+  []
+  (get (mtest/runtime-db) :rf.runtime/machines))
 
 (defn- join-state [parent-id invoke-id]
   (get-in (mtest/runtime-db)
@@ -104,20 +120,84 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest live-join-requires-the-attempt-token
-  (testing "rf2-p53o47 — a runtime-produced `:spawn-all` join validates
-            against the normative `InvokeAllJoinState` (token REQUIRED),
-            and dissociating `:rf/attempt` FAILS the schema — the proof a
-            child-bearing join can never be token-less (no optional arm)."
+  (testing "rf2-2ai15g — a runtime-produced `:spawn-all` join validates
+            against the EXTRACTED `InvokeAllJoinState` (token REQUIRED per the
+            authoritative Spec-Schemas document), and dissociating `:rf/attempt`
+            FAILS the schema — the proof a child-bearing join can never be
+            token-less (no optional arm). Guards Spec-009 AC: `:rf/attempt`
+            going `{:optional true}` in the authoritative document turns this
+            red, because the extracted schema would then accept the dissoc."
     (let [j (reg-join-parent! :sac/p1 :sac/p1a :sac/p1b
                               {:join :all :on-all-complete [:all/done]})]
       (is (int? (:rf/attempt j))
           "the live seed always mints an int per-attempt token")
       (is (m/validate InvokeAllJoinState j)
-          (str "the runtime join validates against the required-token schema; "
-               "explain: " (m/explain InvokeAllJoinState j)))
+          (str "the runtime join validates against the extracted required-token "
+               "schema; explain: " (m/explain InvokeAllJoinState j)))
       (is (not (m/validate InvokeAllJoinState (dissoc j :rf/attempt)))
-          "dissociating the token FAILS the schema — the token is required,
-           not optional"))))
+          "dissociating the token FAILS the extracted schema — the token is
+           required in the authoritative document, not optional"))))
+
+;; ---------------------------------------------------------------------------
+;; 1b. SCHEMA — the childless REJECT sentinel is a THIRD legal `:spawned` arm,
+;;     and the COMPLETE Machines runtime-db validates with it present
+;; ---------------------------------------------------------------------------
+
+(deftest reject-sentinel-is-a-legal-spawned-arm
+  (testing "rf2-2ai15g — an UNREGISTERED child TYPE in a `:spawn-all` set seeds
+            the childless `InvokeAllRejectedState` sentinel; the COMPLETE
+            `:rf.runtime/machines` runtime-db validates against the extracted
+            `Machines` form during the legal pre-parent-exit interval, the
+            sentinel validates as the reject arm, and both a sentinel carrying
+            authority keys and a token-less live join FAIL the extracted
+            `:spawned` union."
+    (let [ok-child {:initial :running :data {} :states {:running {}}}
+          ;; :sac/missing is NEVER reg-machine'd — the unregistered child TYPE.
+          parent   {:initial :idle
+                    :states
+                    {:idle    {:on {:start :forking}}
+                     :forking {:spawn-all
+                               {:children        [{:id :ok      :machine-id :sac/rok}
+                                                  {:id :missing :machine-id :sac/missing}]
+                                :join            :all
+                                :on-child-done   :c/done
+                                :on-child-error  :c/failed
+                                :on-all-complete [:all/done]}}
+                     :ready   {}}}]
+      (rf/reg-machine :sac/rok ok-child)
+      (rf/reg-machine :sac/rparent parent)
+      ;; ALSO stand up a genuine LIVE join in the same frame, so the complete
+      ;; runtime-db carries BOTH a reject sentinel and a live child-bearing
+      ;; join at once — the mixed real value the `Machines` form must admit.
+      (reg-join-parent! :sac/live :sac/livea :sac/liveb
+                        {:join :all :on-all-complete [:all/done]})
+      (rf/dispatch-sync [:sac/rparent [:start]])
+      (let [sentinel (join-state :sac/rparent [:forking])]
+        ;; the runtime seeded the childless reject sentinel (pre-parent-exit).
+        (is (= {:rf/spawn-all-rejected? true} sentinel)
+            "the reject sentinel (no :children) is seeded")
+        ;; COMPLETE Machines runtime-db validates WITH the sentinel present.
+        (is (m/validate Machines (machines-runtime-db))
+            (str "the complete :rf.runtime/machines validates against the "
+                 "extracted Machines form; explain: "
+                 (m/explain Machines (machines-runtime-db))))
+        ;; the sentinel is a legal reject arm ...
+        (is (m/validate InvokeAllRejectedState sentinel)
+            "the real sentinel validates against the extracted InvokeAllRejectedState")
+        (is (m/validate SpawnedSlot {:sac/rparent {[:forking] sentinel}})
+            "the sentinel is accepted by the extracted :spawned union")
+        ;; ... but a sentinel that ALSO carries authority is NOT a clean reject:
+        ;; the closed map rejects the extra keys, and it is not a live join.
+        (is (not (m/validate InvokeAllRejectedState (assoc sentinel :children {:a :a#1})))
+            "a sentinel carrying :children FAILS the closed reject schema")
+        (is (not (m/validate SpawnedSlot {:sac/rparent {[:forking] (assoc sentinel :rf/attempt 9)}}))
+            "a sentinel carrying an authority token FAILS the :spawned union")
+        ;; a token-less live join fails BOTH arms → fails the union.
+        (let [live (join-state :sac/live [:racing])]
+          (is (m/validate SpawnedSlot {:sac/live {[:racing] live}})
+              "the real live join is accepted by the :spawned union")
+          (is (not (m/validate SpawnedSlot {:sac/live {[:racing] (dissoc live :rf/attempt)}}))
+              "a token-less live join FAILS the :spawned union — not a valid live shape"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. CATALOGUE — `child-completed` emits `:rf.reply/correlation`
@@ -191,3 +271,57 @@
       (is (= :rf.machine.spawn-all/attempt-unverified
              (:rf.reply/stale-reason (:tags stale)))
           "classified by :rf.reply/stale-reason (pre-resolution)"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. CATALOGUE — the Spec-009 rows themselves carry the facts (narrow reads of
+;;    the AUTHORITATIVE document; each assertion fails independently)
+;; ---------------------------------------------------------------------------
+
+(defn- quick-index-row
+  "The ONE quick-index table row that pipe-lists the spawn-all lifecycle ops —
+  the row containing both `started` and `child-completed`."
+  [text]
+  (->> (str/split-lines text)
+       (filter #(and (str/starts-with? (str/triml %) "|")
+                     (str/includes? % ":rf.machine.spawn-all/started")
+                     (str/includes? % ":rf.machine.spawn-all/child-completed")))
+       first))
+
+(defn- detailed-row
+  "The detailed-catalogue prose bullet that OPENS with `- `<op>`…`."
+  [text op-kw]
+  (->> (str/split-lines text)
+       (filter #(str/starts-with? (str/triml %) (str "- `" op-kw "`")))
+       first))
+
+(defn- line-with [text needle]
+  (->> (str/split-lines text) (filter #(str/includes? % needle)) first))
+
+(deftest spec-009-catalogue-pins-the-spawn-all-ops
+  (testing "rf2-2ai15g — the authoritative Spec-009 rows carry the exact
+            vocabulary the runtime emits; each fact fails independently."
+    (let [text (extract/spec-009-text)
+          qidx (quick-index-row text)
+          cc   (detailed-row text :rf.machine.spawn-all/child-completed)
+          sc   (detailed-row text :rf.machine.spawn-all/stale-completion)]
+      (is (some? qidx) "the spawn-all quick-index row exists")
+      ;; late-completion must stay in the QUICK INDEX (not only the detailed row).
+      (is (str/includes? qidx ":rf.machine.spawn-all/late-completion")
+          "the quick index lists :rf.machine.spawn-all/late-completion")
+      ;; the classifier note stays `:rf.reply/stale-reason`, not bare `:reason`.
+      (is (str/includes? qidx ":rf.reply/stale-reason")
+          "the quick index classifies the stale/late ops by :rf.reply/stale-reason")
+      ;; child-completed correlation must stay documented.
+      (is (some? cc) "the child-completed detailed row exists")
+      (is (str/includes? cc ":rf.reply/correlation")
+          "the child-completed row documents :rf.reply/correlation")
+      ;; stale-completion classifier key stays `:rf.reply/stale-reason`.
+      (is (some? sc) "the stale-completion detailed row exists")
+      (is (str/includes? sc ":rf.reply/stale-reason")
+          "the stale-completion row classifies by :rf.reply/stale-reason")
+      ;; join-resolved is a stale-reason VALUE, never an operation — it appears
+      ;; ONLY as `:rf.reply/stale-reason :rf.machine.spawn-all/join-resolved`.
+      (let [jr (line-with text ":rf.machine.spawn-all/join-resolved")]
+        (is (some? jr) "the join-resolved stale-reason value is documented")
+        (is (str/includes? jr ":rf.reply/stale-reason :rf.machine.spawn-all/join-resolved")
+            "join-resolved is presented as a :rf.reply/stale-reason VALUE, not an op")))))

--- a/implementation/machines/test/re_frame/spawn_all_schema_extract.clj
+++ b/implementation/machines/test/re_frame/spawn_all_schema_extract.clj
@@ -1,0 +1,112 @@
+(ns re-frame.spawn-all-schema-extract
+  "Compile-time extraction of the CANONICAL `:spawn-all` runtime-db schema
+  forms from `spec/Spec-Schemas.md`, and narrow reads of the authoritative
+  `spec/009-Instrumentation.md` catalogue rows (rf2-2ai15g).
+
+  The `:spawn-all` exact-authority proof must validate runtime-produced
+  records against the EXECUTABLE canonical schema — not a hand-copied mirror
+  that can silently drift from the markdown (the precursor rf2-p53o47 proof
+  carried a `^:private` handwritten `InvokeAllJoinState` copy; this replaces
+  it). Mirrors the `re-frame.observation-schema-extract` pattern (rf2-qyvyes):
+  read the markdown on the JVM, find exactly the NAMED `def` forms, and return
+  the parsed EDN `[…]` forms as data. It reads exactly these enumerated forms
+  and fails loudly if any is absent or is not a vector form (removing a schema
+  from the markdown is then a test-build error, so the two surfaces cannot
+  drift silently). This is NOT a general markdown/schema generator — it names
+  its inputs.
+
+  The extracted `Machines` form references two `:spawned`-union arms as bare
+  symbols (`InvokeAllJoinState` / `InvokeAllRejectedState`) and the machine
+  snapshot as `:rf/machine-snapshot`. `resolve-machines-refs` substitutes the
+  two union arms with their VERBATIM extracted forms (the shapes under test)
+  and the snapshot ref with a permissive `:map` — the `MachineSnapshot` form
+  carries a live `(fn …)` `:multi` dispatch that cannot be read as pure data,
+  AND the snapshot shape is not what this proof guards (it has its own
+  dedicated conformance gates). So the two arms under test come straight from
+  the authoritative markdown; the snapshot slot is validated structurally."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.walk :as walk]))
+
+;; ---------------------------------------------------------------------------
+;; File location — resolve the spec docs relative to whichever directory the
+;; JVM test runner starts from: `clojure -M:test` runs from
+;; implementation/machines.
+;; ---------------------------------------------------------------------------
+
+(defn- locate ^java.io.File [candidates what]
+  (or (some (fn [p] (let [f (io/file p)] (when (.exists f) f))) candidates)
+      (throw (ex-info (str "rf2-2ai15g: cannot locate " what) {:candidates candidates}))))
+
+(def ^:private spec-schemas-candidates
+  ["../../spec/Spec-Schemas.md" "../spec/Spec-Schemas.md" "spec/Spec-Schemas.md"])
+
+(def ^:private spec-009-candidates
+  ["../../spec/009-Instrumentation.md" "../spec/009-Instrumentation.md" "spec/009-Instrumentation.md"])
+
+(defn spec-schemas-text [] (slurp (locate spec-schemas-candidates "spec/Spec-Schemas.md")))
+(defn spec-009-text     [] (slurp (locate spec-009-candidates "spec/009-Instrumentation.md")))
+
+;; ---------------------------------------------------------------------------
+;; Schema extraction
+;; ---------------------------------------------------------------------------
+
+(defn extract-def-form
+  "Read `text`, find `(def <sym> …)`, and return its schema VECTOR (the form at
+  position 2 — the `;;` comments are dropped by the EDN reader, so the result is
+  the pure canonical form). Throws if the `def` is absent or is not a vector."
+  [text sym]
+  (let [start (str/index-of text (str "(def " sym))]
+    (when (nil? start)
+      (throw (ex-info (str "rf2-2ai15g: (def " sym " …) not found in Spec-Schemas.md") {:sym sym})))
+    (let [schema (nth (edn/read-string (subs text start)) 2 nil)]
+      (when-not (vector? schema)
+        (throw (ex-info (str "rf2-2ai15g: " sym " is not a schema vector form") {:sym sym :read schema})))
+      schema)))
+
+(defn canonical-invoke-all-join-schema
+  "The canonical `InvokeAllJoinState` `[:map …]` form, extracted from
+  Spec-Schemas.md. `:rf/attempt` is REQUIRED here (the authoritative document);
+  a token-less child-bearing join is not a valid live shape."
+  []
+  (extract-def-form (spec-schemas-text) 'InvokeAllJoinState))
+
+(defn canonical-invoke-all-rejected-schema
+  "The canonical `InvokeAllRejectedState` `[:map {:closed true} …]` form — the
+  childless `:spawn-all` reject sentinel — extracted from Spec-Schemas.md."
+  []
+  (extract-def-form (spec-schemas-text) 'InvokeAllRejectedState))
+
+(defn- resolve-machines-refs
+  "Substitute the `Machines` form's three named refs with self-contained forms:
+  the two `:spawned`-union arms come VERBATIM from the authoritative markdown
+  (the shapes under test); the snapshot ref becomes a permissive `:map` (see ns
+  docstring). Yields a fully inline malli schema — no registry needed."
+  [machines-form join-form reject-form]
+  (walk/postwalk-replace
+    {'InvokeAllJoinState     join-form
+     'InvokeAllRejectedState reject-form
+     :rf/machine-snapshot    :map}
+    machines-form))
+
+(defn canonical-machines-schema
+  "The canonical `Machines` runtime-db validator form (`:rf.runtime/machines`),
+  extracted from Spec-Schemas.md with its `:spawned` union arms resolved to the
+  authoritative `InvokeAllJoinState` / `InvokeAllRejectedState` forms."
+  []
+  (let [text (spec-schemas-text)]
+    (resolve-machines-refs (extract-def-form text 'Machines)
+                           (extract-def-form text 'InvokeAllJoinState)
+                           (extract-def-form text 'InvokeAllRejectedState))))
+
+(defn canonical-spawned-slot-schema
+  "The canonical `:spawned` slot schema — `[:map-of :keyword [:map-of [:vector
+  :keyword] [:or :keyword InvokeAllJoinState InvokeAllRejectedState]]]` — pulled
+  from the resolved `Machines` form, so the three-arm union under test is the
+  ACTUAL Spec-Schemas union, not a reconstruction."
+  []
+  (->> (rest (canonical-machines-schema))
+       (filter #(and (vector? %) (= :spawned (first %))))
+       first
+       last))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2579,7 +2579,8 @@ A frame owns two durable partitions held as one physical frame-state container (
    [:spawned       {:optional true} [:map-of :keyword                            ;; parent-machine-id
                                              [:map-of [:vector :keyword]         ;; invoke-id (absolute prefix-path)
                                                       [:or :keyword              ;; :spawn leaf — gensym'd spawned-id
-                                                           InvokeAllJoinState]]]] ;; :spawn-all bookkeeping
+                                                           InvokeAllJoinState     ;; :spawn-all LIVE child-bearing join bookkeeping
+                                                           InvokeAllRejectedState]]]] ;; :spawn-all pre-per-child REJECT sentinel (childless — atomic reject)
    [:spawn-counter {:optional true} [:map-of :keyword :int]]])                   ;; per-machine-id integer counter for hand-emitted :rf.machine/spawn fxs
 
 (def InvokeAllJoinState
@@ -2590,7 +2591,31 @@ A frame owns two durable partitions held as one physical frame-state container (
    [:failed    [:set :keyword]]                                               ;; user-ids that signalled :on-child-error
    [:resolved? :boolean]                                                      ;; latch flips once the join condition resolves
    [:spec      :map]                                                          ;; back-reference for the join intercept
-   [:rf/attempt :int]])                                                       ;; REQUIRED on every live child-bearing join. Opaque monotonic per-attempt token minted at seed by spawn-all-init-fx; stamped into each child's :rf/join-child so the fold gate binds every completion carrier to the exact join attempt (rf2-nvxehu; 005 §Exact-authority fold gate). `spawn-all-init-fx` ALWAYS mints it before the per-child spawns run, and `join.cljc`'s fold gate requires a non-nil exact match, so a token-less join is permanently unable to accept a completion — not a valid live shape. The pre-per-child REJECT sentinel (an unregistered sibling TYPE) is a SEPARATE shape carrying `:rf/spawn-all-rejected?` and NO `:children`, so it never validates as an InvokeAllJoinState; the token is required rather than optional. Treat as opaque — int today, per-session accident-gating.
+   [:rf/attempt :int]])                                                       ;; REQUIRED on every live child-bearing join. Opaque monotonic per-attempt token minted at seed by spawn-all-init-fx; stamped into each child's :rf/join-child so the fold gate binds every completion carrier to the exact join attempt (rf2-nvxehu; 005 §Exact-authority fold gate). `spawn-all-init-fx` ALWAYS mints it before the per-child spawns run, and `join.cljc`'s fold gate requires a non-nil exact match, so a token-less join is permanently unable to accept a completion — not a valid live shape. The pre-per-child REJECT sentinel (an unregistered sibling TYPE) is a SEPARATE shape (`InvokeAllRejectedState`, below) carrying `:rf/spawn-all-rejected?` and NO `:children`, so it never validates as an InvokeAllJoinState; the token is required rather than optional. Treat as opaque — int today, per-session accident-gating.
+
+(def InvokeAllRejectedState
+  ;; The pre-per-child REJECT SENTINEL `spawn-all-init-fx` seeds at the join
+  ;; slot `[:rf.runtime/machines :spawned <parent> <invoke>]` when a `:spawn-all`
+  ;; names an UNREGISTERED child TYPE. The whole invoke rejects ATOMICALLY
+  ;; before any live join-state is seeded (rf2-qb1j5z; 005 §Spawn-and-join via
+  ;; `:spawn-all` §atomic reject): rather than a live `InvokeAllJoinState`, the
+  ;; slot holds this CLOSED single-key marker carrying ONLY
+  ;; `:rf/spawn-all-rejected? true` and — critically — NO `:children` and NO
+  ;; `:rf/attempt`. Because it is childless, `join.cljc`'s interceptor treats
+  ;; the slot as UNSEEDED (a stray completion is a no-op, no deadlock) and
+  ;; `destroy-spawn-all-children!` finds nothing to tear down and clears the
+  ;; slot on parent exit; the registered siblings' per-child `:rf.machine/spawn`
+  ;; fxs read it (`spawn-all-invoke-rejected?`) and suppress themselves, so the
+  ;; malformed invoke spawns NOTHING. This is the THIRD legal runtime shape of
+  ;; the `:spawned` slot's `[:or …]` above — a SEPARATE type from
+  ;; `InvokeAllJoinState`, never a live join with the bookkeeping keys stripped:
+  ;; a live join can never validate as this (it carries `:children` the closed
+  ;; map forbids) and this can never validate as a live join (it lacks the
+  ;; required `:children` / `:rf/attempt`). `{:closed true}` is load-bearing —
+  ;; a sentinel that ALSO carried `:children` or authority keys would be
+  ;; neither a clean reject nor a live join, and must fail closed.
+  [:map {:closed true}
+   [:rf/spawn-all-rejected? [:= true]]])
 
 (def Routing
   ;; The routing runtime's per-frame runtime-db state. :current is the live


### PR DESCRIPTION
Completes the spawn-all exact-authority schema and makes its catalogue proof authoritative, finishing the bounded slice `rf2-p53o47` (#5896) opened. Closes rf2-2ai15g.

## What landed

**Schema completion (Spec-Schemas — hot-zone, sole-owner, minimal).** Added a closed `InvokeAllRejectedState` schema and included it as the THIRD arm of the `[:spawned parent invoke]` union. `spawn-all-init-fx` seeds the childless reject sentinel `{:rf/spawn-all-rejected? true}` at the join slot when a `:spawn-all` names an unregistered child TYPE — a legal runtime interval the previous two-arm union (`[:or :keyword InvokeAllJoinState]`) rejected. `{:closed true}` keeps it discriminable: a sentinel carrying `:children`/authority, and a token-less live join, both fail the union.

**Authoritative proof (deleted the hand-rolled mirror).** The precursor test carried a `^:private` handwritten `InvokeAllJoinState` copy. Replaced it with a compile-time extraction of the ACTUAL Spec-Schemas forms — new `re-frame.spawn-all-schema-extract` ns, mirroring the existing `re-frame.observation-schema-extract` pattern (rf2-qyvyes). The proof now validates the live join, the reject sentinel, and the COMPLETE `:rf.runtime/machines` runtime-db (during the legal pre-parent-exit interval) against the extracted `Machines` / `InvokeAllJoinState` / `InvokeAllRejectedState` forms.

**Spec-009 catalogue binding.** Added narrow reads of the authoritative Spec-009 rows so each fact fails independently: `late-completion` leaving the quick index, `:rf.reply/stale-reason` regressing to bare `:reason`, `child-completed` `:rf.reply/correlation` disappearing, or `join-resolved` being presented as an operation.

## Red-before-fix

Against the pre-fix two-arm union the authoritative proof REJECTS the real runtime sentinel `{:rf/spawn-all-rejected? true}` (the AC-1 bug: "the normative Machines union now rejects a separate legal runtime state"); against the completed three-arm union it validates. Verified via the extraction/validation code path.

## Fixture

`implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj` (`reject-sentinel-is-a-legal-spawned-arm`): a real unregistered-child `:spawn-all` fixture seeds the sentinel; the complete `:rf.runtime/machines` validates against the extracted `Machines`; the sentinel validates as the reject arm; a sentinel carrying an authority token and a token-less live join both fail the extracted `:spawned` union.

## Scope note

Delivers the schema + catalogue-authority core (AC 1-4, AC 7). The AC-5/AC-6 vocabulary reconciliation that reaches `Conventions.md` and `machines/join.cljc` docstrings is out of this worker's file scope (join.cljc is owned by a concurrent join worker; Conventions.md is a separate hot-zone spec file) — flagged for a follow-up.

## Quality gates

- `cd implementation/machines && clojure -M:test` — 1085 tests, 3742 assertions, 0 failures, 0 errors (+2 new deftests, +17 assertions).
- `cd implementation/core && clojure -M:test` — 1987 tests, 9160 assertions, 0 failures, 0 errors (core extracts from Spec-Schemas.md; unaffected by the additive edit).

Hot-zone `spec/Spec-Schemas.md` edit is additive (one new closed schema + one union arm); no new commits touched Spec-Schemas / 009 / 005 on origin/main since the branch base.