### PR TITLE
docs: reconcile Spec 006 + synthesis slice-memo lifetime per-host (JVM thread-local vs CLJS microtask) (rf2-2mop6r)

### DIFF
--- a/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
+++ b/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
@@ -156,9 +156,17 @@ Probes are ownership-free: no ref-count, no watch, no zero-owner cache node.
 **First-mount fan-out mitigation:** probes share a **slice-scoped pure memo table** —
 the `?slice-memo` argument — so N sibling rows probing `[:orders/by-id id]` compute
 shared derivation parents once per slice, not once per row. There is no public React
-render-pass token; the table is scoped to the **current synchronous execution slice**:
-created lazily on first probe, cleared by `queueMicrotask`, belt-and-braces tagged with
-`(frame, frame-epoch, registry-epoch)` and invalidated on any mismatch. A time-sliced
+render-pass token; the table is scoped to the **current synchronous execution slice**,
+created lazily on first probe and bounded **per-host**. On the **JVM** the slice is a
+thread-local render scope (`*slice*` / `with-slice-memo`, opened around every public
+Tier-1 render entry — `re-frame.ui.tree/render`, the `ui.test/render` routes, and each
+ViewCell capture) whose table is **discarded synchronously when the render thunk
+returns** — there is no microtask on the JVM. On **CLJS** a single-threaded module holder
+shares the pass and is **released at the host microtask checkpoint** (`queueMicrotask`,
+under a CAS guard, aligned with the port's own table clear). Both hosts belt-and-braces
+tag the table with `(frame, frame-epoch, registry-epoch)`, invalidate on any mismatch,
+and enforce the one law: sharing is allowed within a slice, but no table or handle
+survives into a later render slice. A time-sliced
 pass spanning k slices builds k tables (fixture 1b: 3 tables across an interrupted
 3,000-row transition) — the economy is **once-per-slice, not once-per-pass**; bounded,
 allocation-trivial, zero React internals. An interrupted or abandoned slice's table

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1400,10 +1400,31 @@ share computed derivation parents; the table dies with the slice. No entry survi
 into cache state, ownership state, or a later slice.
 
 **Lifetime (S-3-settled).** There is no public React render-pass token; the table is
-scoped to the **current synchronous execution slice**: created lazily on first probe,
-cleared by `queueMicrotask`, and belt-and-braces tagged with
-`(frame, frame-epoch, registry-epoch)` — invalidated on any mismatch. A time-sliced
-pass spanning k slices builds k tables, so the economy is **once-per-slice, not
+scoped to the **current synchronous execution slice** and created lazily on first probe.
+How the slice is bounded — and how the table dies with it — is **per-host**, because the
+two runtimes reach the same law by different means:
+
+- **JVM — a thread-local render scope.** A private dynamic binding (`*slice*`, opened by
+  `with-slice-memo`) wraps every public Tier-1 render entry: `re-frame.ui.tree/render`,
+  the `ui.test/render` routes (view-reference / literal / plan-bearing, all converging on
+  `render-with-opts` / `render-plan-bearing`), and the reactive host entry (one scope per
+  ViewCell render). The binding **discards the table synchronously when the render thunk
+  returns** — there is no microtask on the JVM, and no scheduler- or tag-change
+  dependency. The scope is re-entrant, so a Tier-1 render and the ViewCell capture nested
+  inside it share one table, while a bare probe outside any render scope gets a fresh
+  per-call handle; two sequential executor tasks and two concurrent renders on distinct
+  threads never share a table.
+- **CLJS — a module holder cleared at the microtask checkpoint.** The single-threaded
+  host needs no thread-local scope: one module holder shares the handle across every probe
+  of a synchronous render pass, then is **released at the host microtask checkpoint**
+  (`queueMicrotask`, under a CAS guard so a stale clear cannot erase a newer holder,
+  aligned with the port's own table clear — deliberately not the macrotask `next-tick`
+  path, which would leave a dead slice's holder live for one more host turn).
+
+Both hosts belt-and-braces tag the table with `(frame, frame-epoch, registry-epoch)` and
+invalidate on any mismatch, and both enforce the same law: probes may share within one
+slice, but **no table or handle survives into a later render slice**. A time-sliced pass
+spanning k slices builds k tables, so the economy is **once-per-slice, not
 once-per-pass** — bounded, allocation-trivial, and requiring zero React internals; an
 interrupted or abandoned slice's table becomes unreachable garbage. ⟨S-3 §5, fixtures
 1b/6⟩


### PR DESCRIPTION
## What & why (rf2-2mop6r)

Spec 006 described the slice-scoped probe-memo **Lifetime** with the CLJS mechanism applied unconditionally — "the table is … cleared by `queueMicrotask`" — which is wrong for the JVM. The shipped JVM behaviour (per #5891 / rf2-vxgfnd.267, and the causal-identity fixtures added in rf2-vxgfnd.284 / PR #5931) establishes the memo in a **thread-local render scope**, discarded **synchronously** when the render thunk returns. There is no microtask on the JVM — that is the CLJS host's mechanism.

This reconciles both authoritative docs to the real **per-host** model:

- **JVM** — a thread-local render scope (`*slice*` / `with-slice-memo`) opened around every public Tier-1 render entry (`re-frame.ui.tree/render`, the `ui.test/render` routes converging on `render-with-opts` / `render-plan-bearing`, and one scope per ViewCell render via the reactive host entry). The `binding` discards the table synchronously on thunk return — no microtask, no scheduler/tag-change dependency. Re-entrant; a bare probe outside any scope gets a fresh per-call handle.
- **CLJS** — a single-threaded module holder shared across a synchronous render pass, released at the host microtask checkpoint (`queueMicrotask`, under a CAS guard, aligned with the port's own table clear — not the macrotask `next-tick` path).

Both docs restate the **shared semantic law**: sharing is allowed within a slice, but no table or handle survives into a later render slice (the memo is an economy, never an authority).

## Files

- `spec/006-ReactiveSubstrate.md` — §The slice-scoped probe memo → **Lifetime (S-3-settled)** rewritten to a per-host split.
- `ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md` — §3 first-mount fan-out mitigation lifetime sentence reconciled to the same per-host model.

## Source verification (`implementation/ui/src/re_frame/ui/reactive.cljc`)

The docstrings already carried the correct JVM-vs-CLJS distinction; the spec prose had generalised the CLJS clause. Verified against:

- `*slice*` (L364) — private dynamic var, thread-bound inside a render slice; "Effective on the JVM only: the CLJS host … never binds this var."
- `with-slice-memo` (L379) — "THE Tier-1 JVM render-slice runner … discarded when `thunk` returns … On CLJS this is a passthrough." Re-entrant: `(if (thread-bound? #'*slice*) (thunk) (binding [*slice* (volatile! nil)] (thunk)))` (L395–398).
- `current-slice-memo` (L400) — JVM handle lives in the `*slice*` box, discarded on scope return; CLJS uses the module holder released by `queue-microtask!` under a CAS guard (L413–425).
- `slice-memo*` (L373) — "CLJS module holder … Released at the microtask checkpoint."
- `with-capture` (L876–884) — "on the JVM `with-slice-memo` opens a thread-local per-render slice (discarded on return) … on CLJS this is a passthrough."

`obs/make-slice-memo`'s docstring in `implementation/core/src/re_frame/substrate/observation.cljc` ("On CLJS the table is cleared by queueMicrotask") is correct as a port-level CLJS detail and is left untouched — the bug was only the spec prose generalising it.

## Scope

Docs only — `spec/006-ReactiveSubstrate.md` + the synthesis 03 passage. No `implementation/**` or other spec files touched.

## Quality gates

- `python scripts/check_doc_slugs.py` → exit 0
- `python scripts/check_readme_links.py` → exit 0
- `mkdocs build --strict` → skipped (mkdocs not on PATH in this env; SLIM docs-only change, no slug/nav additions)
- No code changed → no npm/browser/fast-pr gates (SLIM discipline).
