### PR TITLE
refactor(ui): one ui.test frame-init grammar — remove ui.test/frame + render :app-db (rf2-va5e61)

### DIFF
--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -168,7 +168,7 @@
     (nth sorted (js/Math.floor (* p (dec (count sorted)))))))
 
 (defn- run-size! [v]
-  (let [frame (uit/frame {:app-db (fixture/seed v)})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed v)]]})
         cold* (atom nil)]
     (-> (uit/with-root [root [ui/frame-provider {:frame frame}
                               [fixture/app {:v v}]]]

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -10,7 +10,7 @@
   data, so 'what does this button do' is an equality check — no click
   simulation, no DOM, no flake:
 
-      (let [frame (ui.test/frame {:app-db {:cart #{}}})
+      (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})
             tree  (ui.test/render [product-card {:product p}]
                                   {:frame frame})]
         (is (= [:cart/add 42]
@@ -687,46 +687,10 @@
          (.querySelector (.-container root) css-selector)))))
 
 ;; ---------------------------------------------------------------------------
-;; Frames (07 §2 — `frame`, `dispatch!`)
+;; Frames (07 §2 — `dispatch!`). A test frame is minted with the canonical
+;; `rf/make-frame` + `:initial-events` (seed via `[:rf/set-db {…}]`) — one
+;; frame-init grammar, shared with production.
 ;; ---------------------------------------------------------------------------
-
-(defn frame
-  "Mint a TEST frame — registrations come from the loaded namespaces (the
-  default image over the active source store + framework standards), the
-  app-db seed from `:app-db` (dispatched as `[:rf/set-db seed]`, drained
-  to fixed point before this returns).
-
-  `opts` is CLOSED: `{:app-db <map>}` (or `{}`). Anything richer —
-  images, ids, fx-overrides — is `rf/make-frame`'s vocabulary; use it
-  directly.
-
-  Returns the live frame VALUE — pass it (or hold it) wherever a frame
-  target is accepted: `(render … {:frame f})`, `(dispatch! f event)`,
-  `rf/app-db-value`. Prerequisite: an installed substrate adapter (JVM
-  tests: the plain-atom adapter via `re-frame.test-support/`
-  `make-reset-runtime-fixture` or `rf/init!`)."
-  ([] (frame {}))
-  ([opts]
-   (when-not (map? opts)
-     (bad-opts! 'rf.ui.test/frame
-                (str "frame opts must be a map; got " (pr-str opts))
-                {:got opts}))
-   (when-let [unknown (seq (remove #{:app-db} (keys opts)))]
-     (bad-opts! 'rf.ui.test/frame
-                (str "unknown frame opt" (when (next unknown) "s") " "
-                     (pr-str (vec unknown)) " — ui.test/frame's opts are "
-                     "CLOSED: {:app-db <map>}. Richer construction (images, "
-                     "ids, fx-overrides) is rf/make-frame's vocabulary")
-                {:unknown (vec unknown)}))
-   (when (and (contains? opts :app-db) (not (map? (:app-db opts))))
-     (bad-opts! 'rf.ui.test/frame
-                (str ":app-db must be a map (the app-db seed); got "
-                     (pr-str (:app-db opts)))
-                {:app-db (:app-db opts)}))
-   (live-frame/make-frame
-    (cond-> {}
-      (contains? opts :app-db)
-      (assoc :initial-events [[:rf/set-db (:app-db opts)]])))))
 
 (defn dispatch!
   "Real dispatch + drain into `frame-target` (a frame value or id):
@@ -813,31 +777,27 @@
          (bad-opts! 'rf.ui.test/render
                     (str "render opts must be a map; got " (pr-str opts))
                     {:got opts}))
-       (when-let [unknown (seq (remove #{:frame :app-db :props :sub-overrides}
+       (when-let [unknown (seq (remove #{:frame :props :sub-overrides}
                                        (keys opts)))]
          (bad-opts! 'rf.ui.test/render
                     (str "unknown render opt" (when (next unknown) "s") " "
                          (pr-str (vec unknown)) " — the opts are CLOSED: "
-                         ":frame XOR :app-db, :props (bare-view form only), "
+                         ":frame, :props (bare-view form only), "
                          ":sub-overrides")
                     {:unknown (vec unknown)}))
        (when (and (contains? opts :props) (not allow-props?))
          (bad-opts! 'rf.ui.test/render
                     "a literal root form carries its props IN the form — {:props …} combines only with a bare view reference"
                     {:props (:props opts)}))
-       (when (and plan-bearing? (or (contains? opts :frame) (contains? opts :app-db)))
+       (when (and plan-bearing? (contains? opts :frame))
          (bad-opts! 'rf.ui.test/render
                     (str "a PLAN-BEARING root form OWNS its frames — its "
                          "top-region frame-root(s) preflight fresh test frames "
-                         "before the render. Drop {:frame …}/{:app-db …}; a "
+                         "before the render. Drop {:frame …}; a "
                          "frame plan and an explicit frame are two ways to say "
                          "one thing. Explicit frame opts stay valid for "
                          "plan-free root/view forms")
-                    (select-keys opts [:frame :app-db])))
-       (when (and (contains? opts :frame) (contains? opts :app-db))
-         (bad-opts! 'rf.ui.test/render
-                    "{:frame f} XOR {:app-db v} — :app-db mints a fresh test frame, :frame targets one you hold; pass one"
-                    {:frame (:frame opts) :app-db (:app-db opts)}))
+                    (select-keys opts [:frame])))
        (when (and (contains? opts :props) (not (map? (:props opts))))
          (bad-opts! 'rf.ui.test/render
                     (str ":props must be a map — a view is a pure function of "
@@ -855,9 +815,9 @@
    (defn- render-with-opts
      "Establish the frame scope + override door, run the compiled render
   thunk, stamp the root with the tree version (the root is always the
-  view's boundary node — a map). With NEITHER :frame nor :app-db,
-  structural rendering proceeds frameless — any frame-scoped read
-  raises honestly rather than defaulting."
+  view's boundary node — a map). Without :frame, structural rendering
+  proceeds frameless — any frame-scoped read raises honestly rather
+  than defaulting."
      [opts thunk]
      (let [run   (if (contains? opts :sub-overrides)
                    #(binding [reactive/*sub-overrides* (:sub-overrides opts)] (thunk))
@@ -874,13 +834,6 @@
                    (binding [rframe/*current-frame*
                              (rframe/frame-target->id (:frame opts))]
                      (slice))
-
-                   (contains? opts :app-db)
-                   (let [id (rframe/frame-target->id
-                             (frame {:app-db (:app-db opts)}))]
-                     (try
-                       (binding [rframe/*current-frame* id] (slice))
-                       (finally (rframe/destroy-frame! id))))
 
                    :else (slice))]
        (assoc root :rf.ui/tree-version tree/tree-version))))
@@ -1071,7 +1024,7 @@
    (defn ^:no-doc render-form*
      "Runtime half of `render` form 2 (literal root form — the compiled
   template thunk). `plans-thunk` is nil for a plan-free form (frames combine
-  with :frame/:app-db, today's behaviour) and the evaluate-at-preflight
+  with :frame, today's behaviour) and the evaluate-at-preflight
   thunk when the root owns frames (a top-region frame-root); `root-id` and
   `ambient-frame-id` are the compile-resolved identity + innermost ambient
   frame the plan-bearing path binds."
@@ -1151,7 +1104,7 @@
   compile error there). One mounted view per root form is the invariant
   (root identity is the view's id). A plan-bearing form preflights fresh
   test frames and binds the ambient frame; a plan-free form combines with
-  the explicit :frame/:app-db opts as before."
+  the explicit :frame opt as before."
      [menv form opts]
      (let [e   (-> (env/make-env {:host :clj :ns-sym (ns-name *ns*)})
                    (env/with-locals (keys menv)))
@@ -1189,10 +1142,10 @@
 
     1. A VIEW REFERENCE — the compile-resolved defview var/symbol:
        `(render product-card {:props {:product p} :frame f})`.
-       Props ride `{:props p}`; frames ride `{:frame f}` XOR
-       `{:app-db v}` (a test frame is minted around the render and
-       destroyed after). With neither, structural rendering proceeds
-       frameless and any frame-scoped read raises honestly.
+       Props ride `{:props p}`; a frame rides `{:frame f}` (mint it
+       with `rf/make-frame` + `:initial-events`). With no frame,
+       structural rendering proceeds frameless and any frame-scoped
+       read raises honestly.
 
     2. A LITERAL ROOT FORM — the SAME root grammar `mount` takes
        (`root/analyze-root`): the top-region wrappers (element / fragment /
@@ -1205,9 +1158,9 @@
        plans preflight FRESH test frames (the S2c ENSURE executor) before
        the structural render, the mounted view resolves the innermost
        enclosing `frame-root`'s frame as its ambient scope, and every
-       test-owned frame is torn down after. `{:frame …}`/`{:app-db …}`
+       test-owned frame is torn down after. `{:frame …}`
        alongside a plan-bearing form is rejected ('the root form owns its
-       frames' — §9 [S1-CONFIRM]); with plan-free forms they combine.
+       frames' — §9 [S1-CONFIRM]); with plan-free forms it combines.
 
   A runtime-assembled vector is the same compile error as at `mount` —
   hiccup is compiled, not interpreted. `{:sub-overrides {query value}}`

--- a/implementation/ui/test/re_frame/ui/conditional_sub_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/conditional_sub_dom_cljs_test.cljs
@@ -99,7 +99,7 @@
                     {:db (assoc db :value first-value)
                      :fx [[:dispatch [::set-enabled false]]
                           [:dispatch [::set-value final-value]]]}))
-    (let [f              (uit/frame {:app-db {:enabled? false :value 0}})
+    (let [f              (rf/make-frame {:initial-events [[:rf/set-db {:enabled? false :value 0}]]})
           frame-id       (frame/frame-target->id f)
           evidence       (atom (empty-evidence))
           baseline       {:roots (client/live-root-ids)

--- a/implementation/ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs
@@ -60,7 +60,7 @@
       (reset! captured [])
       (frames/reset-frame-ops-cache!)
       (reg!)
-      (let [f        (uit/frame {:app-db {:n 42}})
+      (let [f        (rf/make-frame {:initial-events [[:rf/set-db {:n 42}]]})
             frame-id (frame/frame-target->id f)
             text     #(.-textContent (uit/query % "[data-role='ops-n']"))]
         (async done

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_dom_cljs_test.cljs
@@ -66,8 +66,8 @@
       (reset! captured [])
       (frames/reset-frame-ops-cache!)
       (reg!)
-      (let [fa    (uit/frame {:app-db {:n 1}})
-            fb    (uit/frame {:app-db {:n 2}})
+      (let [fa    (rf/make-frame {:initial-events [[:rf/set-db {:n 1}]]})
+            fb    (rf/make-frame {:initial-events [[:rf/set-db {:n 2}]]})
             fa-id (frame/frame-target->id fa)
             fb-id (frame/frame-target->id fb)
             container (js/document.createElement "div")]

--- a/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_provider_retarget_elision_prod_test.cljs
@@ -94,8 +94,8 @@
   (reset! independent-log [])
   (frames/reset-frame-ops-cache!)
   (reg!)
-  (let [fa    (uit/frame {:app-db {:n 1}})
-        fb    (uit/frame {:app-db {:n 2}})
+  (let [fa    (rf/make-frame {:initial-events [[:rf/set-db {:n 1}]]})
+        fb    (rf/make-frame {:initial-events [[:rf/set-db {:n 2}]]})
         fa-id (frame/frame-target->id fa)
         fb-id (frame/frame-target->id fb)
         container (js/document.createElement "div")]

--- a/implementation/ui/test/re_frame/ui/frame_ops_view_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_ops_view_jvm_test.clj
@@ -80,7 +80,7 @@
 
 (deftest explicit-frame-render-returns-the-locked-bundle
   (reg!)
-  (let [f  (uit/frame {:app-db {:n 5}})
+  (let [f  (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})
         id (rframe/frame-target->id f)
         [tree [bundle :as all]] (render-capturing #(uit/render ops-probe {:frame f}))]
     (is (= 1 (count all)) "one site, one bundle")
@@ -102,7 +102,7 @@
 
 (deftest ambient-provider-scope-binds-the-bundle
   (reg!)
-  (let [f  (uit/frame {:app-db {:n 1}})
+  (let [f  (rf/make-frame {:initial-events [[:rf/set-db {:n 1}]]})
         id (rframe/frame-target->id f)
         [_ [bundle]] (render-capturing #(uit/render [provider-host {:target f}]))]
     (is (= id (:frame bundle))
@@ -126,7 +126,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest bundle-is-stable-across-renders-within-one-incarnation
-  (let [f (uit/frame {:app-db {}})
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {}]]})
         [_ [b1]] (render-capturing #(uit/render ops-probe {:frame f}))
         [_ [b2]] (render-capturing #(uit/render ops-probe {:frame f}))]
     (is (identical? b1 b2)

--- a/implementation/ui/test/re_frame/ui/mounted_g3_cardinality_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/mounted_g3_cardinality_dom_cljs_test.cljs
@@ -182,7 +182,7 @@
          (< i (dec (count site-ids)))
          (assoc :fx [[:dispatch [::write-next (inc i)]]]))))
     (let [seed       (into {:writes 0} (map (fn [sid] [sid 0])) site-ids)
-          f          (uit/frame {:app-db seed})
+          f          (rf/make-frame {:initial-events [[:rf/set-db seed]]})
           frame-id   (frame/frame-target->id f)
           baseline   (reactive/current-live-cells)
           evidence   (atom (body-evidence))]

--- a/implementation/ui/test/re_frame/ui/mounted_s2_gates_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/mounted_s2_gates_dom_cljs_test.cljs
@@ -138,7 +138,7 @@
     (rf/reg-event ::equal-control
                   (fn [{:keys [db]} _]
                     {:db (update db :value inc)}))
-    (let [f        (uit/frame {:app-db {:value 1 :noise 0}})
+    (let [f        (rf/make-frame {:initial-events [[:rf/set-db {:value 1 :noise 0}]]})
           frame-id (frame/frame-target->id f)
           target-k [:sub frame-id [::equal-projection]]
           evidence (atom {:bodies 0 :root-commits 0})]
@@ -283,7 +283,7 @@
                   (fn [{:keys [db]} _] {:db (assoc db :hidden? true)}))
     (rf/reg-event ::show-activity
                   (fn [{:keys [db]} _] {:db (assoc db :hidden? false)}))
-    (let [f              (uit/frame {:app-db {:value 7 :hidden? false}})
+    (let [f              (rf/make-frame {:initial-events [[:rf/set-db {:value 7 :hidden? false}]]})
           frame-id       (frame/frame-target->id f)
           retained-key   [:sub frame-id [::retained-value]]
           hidden-key     [:sub frame-id [::activity-hidden?]]
@@ -352,7 +352,7 @@
 (deftest mounted-override-provider-uses-static-leases-and-restores-lifo
   (when (browser?)
     (rf/reg-sub ::provider-value (fn [db _] (:provider-value db)))
-    (let [f          (uit/frame {:app-db {:provider-value "ordinary"}})
+    (let [f          (rf/make-frame {:initial-events [[:rf/set-db {:provider-value "ordinary"}]]})
           frame-id   (frame/frame-target->id f)
           sub-key    [:sub frame-id [::provider-value]]
           override-k [:override [::provider-value]]

--- a/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_slice_memo_render_boundary_jvm_test.clj
@@ -76,7 +76,7 @@
 
 (deftest ui-test-render-view-reference-shares-one-slice-memo
   (reg-slice-subs!)
-  (let [f (uit/frame {:app-db {:n 5}})]
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})]
     (reset! parent-runs 0)
     (uit/render siblings {:frame f})
     (is (= 1 @parent-runs)
@@ -98,7 +98,7 @@
 
 (deftest ui-test-render-literal-form-shares-one-slice-memo
   (reg-slice-subs!)
-  (let [f (uit/frame {:app-db {:n 5}})]
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})]
     (reset! parent-runs 0)
     (uit/render [siblings {}] {:frame f})
     (is (= 1 @parent-runs)
@@ -191,7 +191,7 @@
   ;; pre-fix defect) would give four; a global holder shared across threads
   ;; would corrupt the count below two.
   (reg-slice-subs!)
-  (let [f     (uit/frame {:app-db {:n 5}})
+  (let [f     (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})
         _     (reset! parent-runs 0)
         gate  (CyclicBarrier. 2)
         run   (fn [] (future
@@ -212,7 +212,7 @@
   ;; (total two). A global holder with no per-scope discard would let the
   ;; second task reuse the tag-matching table (total one).
   (reg-slice-subs!)
-  (let [f    (uit/frame {:app-db {:n 5}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})
         _    (reset! parent-runs 0)
         exec (Executors/newSingleThreadExecutor)]
     (try
@@ -275,7 +275,7 @@
   ;; clobber) or converges both threads on one identity — either fails an
   ;; assertion here, DETERMINISTICALLY under the forced overlap (AC5).
   (reg-slice-subs!)
-  (let [f    (uit/frame {:app-db {:n 5}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:n 5}]]})
         gate (CyclicBarrier. 2)]
     ;; Re-register the shared cold parent so its compute trips the acquisition
     ;; barrier; siblings sharing one slice handle compute it once per render, so

--- a/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
@@ -61,7 +61,7 @@
 
 (deftest mounted-viewcell-provider-carriage-elides-in-production
   (rf/reg-sub ::prod-value (fn [db _] (:prod-value db)))
-  (let [f        (uit/frame {:app-db {:prod-value "ordinary"}})
+  (let [f        (rf/make-frame {:initial-events [[:rf/set-db {:prod-value "ordinary"}]]})
         frame-id (frame/frame-target->id f)
         sub-key  [:sub frame-id [::prod-value]]
         container (js/document.createElement "div")

--- a/implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj
@@ -71,7 +71,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest add-button-carries-intent
-  (let [frame (uit/frame {:app-db {:cart #{} :catalog fixture-catalog}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{} :catalog fixture-catalog}]]})
         tree  (uit/render [product-card {:product (product 42)}]
                           {:frame frame})]
     (is (= [:cart/add 42] (-> tree (uit/find :button) uit/attrs :on-click)))
@@ -90,7 +90,7 @@
 ;; included, runs on main today."
 (deftest drive-state-through-the-real-sub
   (reg-cart!)
-  (let [frame (uit/frame {:app-db {:cart #{} :catalog fixture-catalog}})]
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{} :catalog fixture-catalog}]]})]
     ;; before: the sub reads an empty cart → the button offers Add
     (is (= "Add to cart"
            (-> (uit/render [toggle-card {:product (product 42)}] {:frame frame})
@@ -110,7 +110,7 @@
 ;; membership directly (no dispatch); the sub-reading view renders against it.
 (deftest seeded-membership-renders-without-a-dispatch
   (reg-cart!)
-  (let [frame (uit/frame {:app-db {:cart #{42} :catalog fixture-catalog}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{42} :catalog fixture-catalog}]]})
         tree  (uit/render [toggle-card {:product (product 42)}] {:frame frame})]
     (is (= "Remove" (-> tree (uit/find :button) uit/text))
         "install a state, render against it — the (sub …) reads the seeded
@@ -120,7 +120,7 @@
 ;;  (ui.test/render [view] {:frame frame :sub-overrides {[:cart/locked?] true}})."
 (deftest stubbing-a-sub-is-the-explicit-option
   (reg-cart!)
-  (let [frame (uit/frame {:app-db {:cart #{} :catalog fixture-catalog}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{} :catalog fixture-catalog}]]})
         tree  (uit/render [toggle-card {:product (product 42)}]
                           {:frame frame
                            :sub-overrides {[:cart/contains? 42] true}})]

--- a/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.ui.test-render-jvm-test
   "`ui.test/render` — the two accepted root-or-view forms + rejection
-  rules (root-identity-and-mount §9), the frame opts (:frame XOR :app-db,
+  rules (root-identity-and-mount §9), the frame opts (:frame,
   :props, :sub-overrides), the tree-version stamp, and the JVM-only
   selector spellings (defview var; the compiled-view-fn guard)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -176,9 +176,6 @@
          (err-id #(uit/render badge {:props {:label "x"} :unknown 1})))
       "the opts map is CLOSED")
   (is (= :rf.error/ui-test-bad-opts
-         (err-id #(uit/render badge {:frame :rf/default :app-db {}})))
-      "{:frame f} XOR {:app-db v}")
-  (is (= :rf.error/ui-test-bad-opts
          (err-id #(uit/render badge {:props [:label "x"]})))
       ":props must be a map — a view is a pure fn of ONE props map")
   (is (= :rf.error/ui-test-bad-opts
@@ -204,21 +201,21 @@
 
 (deftest sub-read-against-a-frame
   (rf/reg-sub :greeting/text (fn [db _] (:greeting db)))
-  (let [f    (uit/frame {:app-db {:greeting "hello"}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:greeting "hello"}]]})
         tree (uit/render greeting {:frame f})]
     (is (= "hello" (uit/text (uit/find tree :h1)))
         "the compiled view's (sub …) reads the real cache value on the JVM"))
   (testing "app-db movement is reflected on re-render (headless read points)"
     (rf/reg-event ::set-greeting
       (fn [{:keys [db]} [_ v]] {:db (assoc db :greeting v)}))
-    (let [f (uit/frame {:app-db {:greeting "hi"}})]
+    (let [f (rf/make-frame {:initial-events [[:rf/set-db {:greeting "hi"}]]})]
       (uit/dispatch! f [::set-greeting "bye"])
       (is (= "bye" (uit/text (uit/find (uit/render greeting {:frame f}) :h1)))
           "a re-render reads the moved value"))))
 
 (deftest sub-read-honours-the-override-door
   (rf/reg-sub :greeting/text (fn [db _] (:greeting db)))
-  (let [f    (uit/frame {:app-db {:greeting "real"}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:greeting "real"}]]})
         tree (uit/render greeting {:frame f
                                    :sub-overrides {[:greeting/text] "pinned"}})]
     (is (= "pinned" (uit/text (uit/find tree :h1)))
@@ -226,25 +223,17 @@
          JVM spelling — 03 §3)")))
 
 (deftest sub-read-unknown-sub-is-fail-loud
-  (let [f (uit/frame {:app-db {}})]
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {}]]})]
     (is (= :rf.error/no-such-sub
            (err-id #(uit/render greeting {:frame f})))
         "an unregistered entry sub is fail-loud through the observation port")))
 
 ;; ---------------------------------------------------------------------------
-;; Frame opts — :app-db mints (and destroys) a test frame; :frame targets
-;; a held one
+;; Frame opts — :frame targets a held frame
 ;; ---------------------------------------------------------------------------
 
-(deftest app-db-mints-a-transient-test-frame
-  (let [before (set (keys @frame/frames))
-        tree   (uit/render badge {:props {:label "x"} :app-db {:seed 1}})]
-    (is (= 1 (:rf.ui/tree-version tree)))
-    (is (= before (set (keys @frame/frames)))
-        "the minted frame is destroyed after the render — no leak")))
-
 (deftest frame-opt-targets-a-held-frame
-  (let [f    (uit/frame {:app-db {:cart #{7}}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:cart #{7}}]]})
         tree (uit/render [badge {:label "held"}] {:frame f})]
     (is (= "held" (uit/text (uit/find tree :span))))
     (is (= {:cart #{7}} (rf/app-db-value f))
@@ -252,29 +241,16 @@
 
 (deftest frameless-render-proceeds
   (is (= ::badge (:view-id (uit/render badge {:props {:label "x"}})))
-      "with neither :frame nor :app-db, structural rendering proceeds"))
+      "with no :frame, structural rendering proceeds"))
 
 ;; ---------------------------------------------------------------------------
-;; frame + dispatch! (07 §2)
+;; dispatch! (07 §2)
 ;; ---------------------------------------------------------------------------
-
-(deftest frame-mints-with-app-db-seed
-  (let [f (uit/frame {:app-db {:cart #{} :catalog {42 "Hat"}}})]
-    (is (= {:cart #{} :catalog {42 "Hat"}} (rf/app-db-value f))
-        "the :app-db seed drains to fixed point before frame returns"))
-  (is (map? (rf/app-db-value (uit/frame)))
-      "a seed-less test frame is a fresh frame"))
-
-(deftest frame-opts-are-closed
-  (is (= :rf.error/ui-test-bad-opts (err-id #(uit/frame {:images []})))
-      "richer construction is rf/make-frame's vocabulary")
-  (is (= :rf.error/ui-test-bad-opts (err-id #(uit/frame {:app-db [:not-a-map]}))))
-  (is (= :rf.error/ui-test-bad-opts (err-id #(uit/frame :not-a-map)))))
 
 (deftest dispatch!-is-real-dispatch-plus-drain
   (rf/reg-event ::add
     (fn [{:keys [db]} [_ id]] {:db (update db :cart conj id)}))
-  (let [f (uit/frame {:app-db {:cart #{}}})]
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})]
     (uit/dispatch! f [::add 42])
     (is (= #{42} (:cart (rf/app-db-value f)))
         "dispatch! drains synchronously into the target frame")))
@@ -308,7 +284,7 @@
 ;; SAME root grammar ui/mount takes: a top-region frame-root contributes a
 ;; static frame plan, ENSURE preflights FRESH test frames before the JVM
 ;; structural render, the mounted view resolves the innermost enclosing
-;; frame-root's frame as ambient scope, {:frame}/{:app-db} is rejected, and
+;; frame-root's frame as ambient scope, {:frame} is rejected, and
 ;; every test-owned frame is torn down.
 ;; ---------------------------------------------------------------------------
 
@@ -375,21 +351,17 @@
 
 (deftest plan-bearing-root-rejects-explicit-frame-opts
   (reg-greeting!)
-  (let [f (uit/frame {:app-db {:greeting "held"}})]
+  (let [f (rf/make-frame {:initial-events [[:rf/set-db {:greeting "held"}]]})]
     (is (= :rf.error/ui-test-bad-opts
            (err-id #(uit/render [ui/frame-root {:id :test/greet} [greeting {}]]
                                 {:frame f})))
         "a plan-bearing root form OWNS its frames — {:frame} is rejected")
-    (is (= :rf.error/ui-test-bad-opts
-           (err-id #(uit/render [ui/frame-root {:id :test/greet} [greeting {}]]
-                                {:app-db {:greeting "x"}})))
-        "...and {:app-db} likewise")
     (is (= {:greeting "held"} (rf/app-db-value f))
         "the rejection is pure — the held frame is untouched")))
 
 (deftest plan-free-form-still-combines-with-frame-opts
   (reg-greeting!)
-  (let [f    (uit/frame {:app-db {:greeting "explicit"}})
+  (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:greeting "explicit"}]]})
         tree (uit/render [greeting {}] {:frame f})]
     (is (= "explicit" (uit/text (uit/find tree :h1)))
         "a plan-free literal root form still targets an explicit :frame")))

--- a/implementation/ui/test/re_frame/ui/test_render_sub_override_schema_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_sub_override_schema_jvm_test.clj
@@ -55,7 +55,7 @@
   (testing "a :sub-overrides HIT that violates the sub's :schema emits
             :where :sub-override and the compiled view surfaces nil"
     (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
-    (let [f      (uit/frame {:app-db {:n 7}})
+    (let [f      (rf/make-frame {:initial-events [[:rf/set-db {:n 7}]]})
           tree   (atom nil)
           errors (collect-errors
                    (fn []
@@ -76,7 +76,7 @@
 (deftest override-conforming-schema-renders-and-no-failure
   (testing "a :sub-overrides HIT that conforms surfaces unchanged, no failure"
     (rf/reg-sub :count/value {:schema :int} (fn [db _] (get db :n 0)))
-    (let [f      (uit/frame {:app-db {:n 7}})
+    (let [f      (rf/make-frame {:initial-events [[:rf/set-db {:n 7}]]})
           tree   (atom nil)
           errors (collect-errors
                    (fn []
@@ -92,7 +92,7 @@
 (deftest override-on-schemaless-sub-renders-any-value
   (testing "a sub with no :schema → the override renders with no validation"
     (rf/reg-sub :count/value (fn [db _] (get db :n 0)))
-    (let [f      (uit/frame {:app-db {:n 7}})
+    (let [f      (rf/make-frame {:initial-events [[:rf/set-db {:n 7}]]})
           tree   (atom nil)
           errors (collect-errors
                    (fn []

--- a/implementation/ui/test/re_frame/ui/test_tier3_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/test_tier3_dom_cljs_test.cljs
@@ -317,7 +317,7 @@
 (deftest with-root-strictmode-teardown-releases-cells-and-observation-owners
   (when (browser?)
     (rf/reg-sub ::observed-value (fn [db _] (:value db)))
-    (let [f            (uit/frame {:app-db {:value "owned"}})
+    (let [f            (rf/make-frame {:initial-events [[:rf/set-db {:value "owned"}]]})
           frame-id     (frame/frame-target->id f)
           cell-baseline (reactive/root-cell-count)]
       (async done
@@ -430,7 +430,7 @@
                   (fn [{:keys [db]} _]
                     {:db (assoc db :flush-error
                                 (error-id uit/flush!))}))
-    (let [f (uit/frame {:app-db {}})]
+    (let [f (rf/make-frame {:initial-events [[:rf/set-db {}]]})]
       (try
         (uit/dispatch! f [::flush-during-handler])
         (is (= :rf.error/flush-in-open-epoch
@@ -447,7 +447,7 @@
                       (rf/destroy-frame! @target)
                       (vreset! seen (error-id uit/flush!))
                       nil))
-      (let [f (uit/frame {:app-db {}})]
+      (let [f (rf/make-frame {:initial-events [[:rf/set-db {}]]})]
         (vreset! target f)
         (uit/dispatch! f [::destroy-self-then-flush])
         (is (= :rf.error/flush-in-open-epoch @seen)
@@ -462,7 +462,7 @@
                       (pos? remaining)
                       (assoc :fx [[:dispatch [::fixed-point-step
                                               (dec remaining)]]]))))
-    (let [f        (uit/frame {:app-db {:n 0}})
+    (let [f        (rf/make-frame {:initial-events [[:rf/set-db {:n 0}]]})
           evidence (atom {:reads 0 :renders 0 :commits 0})]
       (async done
         (-> (uit/with-root [root [ui/frame-provider {:frame f}
@@ -501,7 +501,7 @@
     (rf/reg-event ::cascade-step
                   (fn [{:keys [db]} _]
                     {:db (update db :n inc)}))
-    (let [f        (uit/frame {:app-db {:n 0}})
+    (let [f        (rf/make-frame {:initial-events [[:rf/set-db {:n 0}]]})
           evidence (atom {:renders 0 :commits 0 :cascaded? false})]
       (async done
         (-> (uit/with-root [root [ui/frame-provider {:frame f}

--- a/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
@@ -41,7 +41,7 @@
     (rf/reg-sub ::value (fn [db _] (:value db)))
     (rf/reg-event ::set-value
                   (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)}))
-    (let [f (uit/frame {:app-db {:value 0}})]
+    (let [f (rf/make-frame {:initial-events [[:rf/set-db {:value 0}]]})]
       (is (true? (evidence/install! ::xray-panel)))
       (async done
         (-> (uit/with-root [root [ui/frame-provider {:frame f}


### PR DESCRIPTION
Closes rf2-va5e61.

## What

Consolidates to **ONE** frame-init grammar. `ui.test/frame {:app-db seed}` and `ui.test/render`'s `{:app-db v}` frame-minting option were a second initialisation grammar redundant with the canonical `rf/make-frame` + `:initial-events` (seeded via `[:rf/set-db {…}]`, Spec 002 / EP-0027). Per Mike's ruling (2026-07-14 pair session; PR #5886), there is one way to create and initialise a frame — this removes the redundant affordance and migrates every consumer.

### Source (`implementation/ui/src/re_frame/ui/test.cljc`)
- Deleted the `frame` fn (it only desugared `{:app-db X}` → `rf/make-frame` + `[:rf/set-db X]`).
- `render`: removed `:app-db` from the closed opt-set; removed the `:frame` XOR `:app-db` check; removed the mint-a-transient-frame render branch; simplified the plan-bearing rejection to name only `{:frame …}`.
- Respelled the ns-docstring example, render docstrings, error messages, and section comments to the single grammar. `live-frame` require retained (still used by the plan-bearing executor).

### Consumers migrated — 38 `ui.test/frame` call sites across 15 files
Every `(uit/frame {:app-db X})` → `(rf/make-frame {:initial-events [[:rf/set-db X]]})` (the exact desugar the deleted fn performed):
- 33 mechanical sites across 14 files (dom/prod/jvm test suites + `g13/dev.cljs`).
- 5 sites in `test_render_jvm_test.clj`.

Removed the tests that exercised **the removed grammar itself** (cannot be respelled — the behaviour is gone): `app-db-mints-a-transient-test-frame`, `frame-mints-with-app-db-seed`, `frame-opts-are-closed`, the `{:frame} XOR {:app-db}` opts-validation assertion, and the `{:app-db}`-rejection assertion in `plan-bearing-root-rejects-explicit-frame-opts`. Unknown-opt rejection remains covered by the existing `:unknown` case.

`test_guide09_fixture_jvm_test.clj` is now verbatim-aligned with the merged guide fence (`guide/08-testing.md:17`, PR #5886): `(rf/make-frame {:initial-events [[:rf/set-db {:cart #{} :catalog fixture-catalog}]]})`.

No `examples/` touched (test-free/locked). No consumers exist outside `implementation/ui`.

## Quality gates
- `implementation/ui` JVM suite (`clojure -M:test`): **529 tests, 6577 assertions, 0 failures, 0 errors**.
- CLJS node suite (`npm run test:cljs`): **9437 tests, 46308 assertions, 0 failures, 0 errors**.
- Production elision probe (`npm run test:elision`): **PASS** (prod 52/52 absent, control 52/52 present, 0 warnings) — covers the two `_elision_prod_test.cljs` migrations.