### PR TITLE
test(ui): complete ViewCell final-fence + mixed-incarnation proofs (rf2-vxgfnd.260, .256)

### DIFF
--- a/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
@@ -34,7 +34,11 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                  :as rf]
+            [re-frame.features              :as features]
             [re-frame.frame                 :as frame]
+            [re-frame.registrar             :as registrar]
+            [re-frame.resource-lease-owner  :as lease-owner]
+            [re-frame.router                :as router]
             [re-frame.substrate.observation :as obs]
             [re-frame.substrate.plain-atom  :as plain-atom]
             [re-frame.test-support          :as test-support]
@@ -184,3 +188,237 @@
           (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
               "acquire-before-release kept the live lease untouched")
           (is (= 1 (ref-count [:r/a])) "no churn on a no-op reconcile"))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.260 — COMPLETE the final-fence proof: both commit-authority axes
+;; + a byte-for-byte rollback that leaves the prior committed set untouched.
+;;
+;; The fixtures above pin ONE of the two authorities `stale-body-authority?`
+;; consults — the registered HMR slot revision. The suite below completes the
+;; obligation: the cell-LOCAL generation arm (a direct/headless cell), an
+;; instrumented reverse-order/exactly-once staged rollback, a non-empty
+;; to-release drop preserved byte-for-byte, a re-registration landing INSIDE
+;; the acquire/cache-construction window, and the resource-capture publication
+;; path (`commit-resources!`) fenced without mutating desired/reserved/held.
+;; ===========================================================================
+
+;; ---------------------------------------------------------------------------
+;; Axis 1 — the cell-LOCAL generation arm (a direct/unregistered cell)
+;; ---------------------------------------------------------------------------
+;; `stale-body-authority?` re-reads the cell's OWN `:generation` at the
+;; publication boundary. A direct/headless cell has no registered slot, so the
+;; registry arm no-ops and this cell-local re-read is the SOLE catch: a
+;; synchronous `advance-generation!` (a sync/remount) landing mid-commit —
+;; after step 1 sampled the generation — must still fence the revision-0 publish.
+;; Removing the `(not= cap-gen state-gen)` arm lets the stale capture connect.
+
+(deftest direct-cell-local-generation-advance-mid-commit-is-fenced
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::direct-view                         ;; deliberately NEVER registered
+        cell (reactive/make-cell vid 0)
+        cap  (capture-of cell [[::a [:r/a]]])]
+    (is (= 0 (:generation cap)) "capture formed at cell body generation 0")
+    (is (nil? (reactive/registered-view-revision vid))
+        "precondition: no registered HMR slot — the registry authority arm no-ops")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [result (binding [reactive/*commit-barrier*
+                           (fn [phase c]
+                             (when (= phase :post-acquire)
+                               ;; a sync/remount advances the cell's OWN body
+                               ;; generation AFTER step 1 sampled it
+                               (reactive/advance-generation! c 1)))]
+                   (reactive/commit! cell cap))]
+      (is (= :stale result)
+          "the fresh cell-local generation re-read fences the revision-0 publish")
+      (is (= :fresh (reactive/lifecycle cell)) "a fenced candidate never connects")
+      (is (empty? (reactive/committed-sites cell)) "no dependency set published")
+      (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")
+      (is (= 1 (reactive/generation cell)) "the cell carries the advanced body generation")
+      (is (= 0 (reactive/revision cell))
+          "no revision advance — the sync/remount drives the re-render"))))
+
+;; ---------------------------------------------------------------------------
+;; Rollback: a DROPPED prior site (non-empty to-release) survives byte-for-byte
+;; ---------------------------------------------------------------------------
+;; When the fence fires, step 7 (release the dropped/retargeted prior leases)
+;; must NOT have run — the prior committed record keeps its exact lease, query,
+;; and value, and its node keeps its single owner. Releasing to-release ahead of
+;; the final fence would strand the dropped site's node at zero owners.
+
+(deftest fence-preserves-a-dropped-prior-site-byte-for-byte
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [vid  ::drop-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))
+    (let [prior   (reactive/committed-site cell ::a)
+          lease-a (:lease prior)
+          value-a (:value prior)
+          query-a (:query prior)
+          rev0    (reactive/revision cell)]
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= 1 (ref-count [:r/a])) "prior committed lease installed")
+      (testing "a later render DROPS :a (→ to-release) and stages :b; a
+                re-registration then fences the publish"
+        (let [cap    (capture-of cell [[::b [:r/b]]])   ;; :a absent, :b new
+              result (binding [reactive/*commit-barrier*
+                               (reregister-barrier vid :post-acquire hs0)]
+                       (reactive/commit! cell cap))]
+          (is (= :stale result) "the stale-body publish is fenced")
+          (testing "the DROPPED :a is preserved byte-for-byte"
+            (let [now (reactive/committed-site cell ::a)]
+              (is (identical? lease-a (:lease now))
+                  "prior lease identity unchanged — step 7 never released it")
+              (is (identical? query-a (:query now)) "prior query object unchanged")
+              (is (= value-a (:value now)) "prior value unchanged"))
+            (is (= 1 (ref-count [:r/a]))
+                ":a keeps its single owner — a pre-fence release would zero it")
+            (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell))
+                "the published dependency set is unchanged — the staged site never leaked")
+            (is (= :connected (reactive/lifecycle cell)) "lifecycle unchanged")
+            (is (= rev0 (reactive/revision cell)) "revision unchanged"))
+          (testing "the staged :b was released"
+            (is (nil? (entry [:r/b])) ":b staged then released → zero-owner node")))))))
+
+;; ---------------------------------------------------------------------------
+;; Rollback ordering: staged leases release EXACTLY ONCE, in REVERSE order
+;; ---------------------------------------------------------------------------
+;; A zero-owner read (`entry` nil) cannot distinguish one release from two, nor
+;; forward order from reverse. Instrument the observation port: the fence must
+;; release the newly staged :b/:c in reverse acquisition order (log [:c :b]),
+;; each exactly once, and must never touch the RETAINED prior :a.
+
+(deftest fence-releases-staged-leases-in-reverse-order-exactly-once
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (rf/reg-sub :r/c (fn [db _] (:c db)))
+  (seed! {:a 1 :b 2 :c 3})
+  (let [vid  ::order-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))   ;; connect owning :a
+    (let [acq          (atom [])           ;; [lease query] in acquisition order
+          rel          (atom [])           ;; query in release order
+          real-acquire obs/acquire!
+          real-release obs/release!
+          lease->query (fn [lease]
+                         (some (fn [[l q]] (when (identical? l lease) q)) @acq))
+          cap          (capture-of cell [[::a [:r/a]] [::b [:r/b]] [::c [:r/c]]])]
+      (with-redefs [obs/acquire! (fn [target on-change]
+                                   (let [lease (real-acquire target on-change)]
+                                     (swap! acq conj [lease (:query target)])
+                                     lease))
+                    obs/release! (fn [lease]
+                                   (swap! rel conj (lease->query lease))
+                                   (real-release lease))]
+        (let [result (binding [reactive/*commit-barrier*
+                               (reregister-barrier vid :post-acquire hs0)]
+                       (reactive/commit! cell cap))]
+          (is (= :stale result) "the stale-body publish is fenced")
+          (is (= [[:r/b] [:r/c]] (mapv second @acq))
+              "only the NEW sites acquire (:a retained, never re-acquired)")
+          (is (= [[:r/c] [:r/b]] @rel)
+              "the fence released the staged leases in REVERSE acquisition order")
+          (is (= 2 (count @rel)) "each staged lease released EXACTLY once")
+          (is (not (some #{[:r/a]} @rel)) "the RETAINED prior :a was never released"))))))
+
+;; ---------------------------------------------------------------------------
+;; A re-registration landing INSIDE the acquire/cache-construction window
+;; ---------------------------------------------------------------------------
+;; The `:post-stage-acquire` barrier fires AFTER every acquisition returns, so
+;; it cannot prove the fence catches an authority change that lands WHILE a
+;; lease is being acquired (a sub-cache construction hook synchronously
+;; re-registering the same view). Inject it through a port wrapper instead.
+
+(deftest reregistration-inside-the-acquire-window-is-fenced
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid          ::acquire-window-view
+        _            (reactive/register-view-generation! vid hs0)
+        cell         (reactive/make-cell vid 0)
+        cap          (capture-of cell [[::a [:r/a]]])
+        real-acquire obs/acquire!
+        fired        (atom 0)]
+    (is (= 0 (:generation cap)))
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (with-redefs [obs/acquire!
+                  (fn [target on-change]
+                    ;; a cache-construction hook re-registers the same view
+                    ;; WHILE the lease is acquired — advancing body revision
+                    (swap! fired inc)
+                    (reactive/register-view-generation! vid hs0)
+                    (real-acquire target on-change))]
+      (let [result (reactive/commit! cell cap)]
+        (is (= 1 @fired) "the re-registration fired inside the single acquire")
+        (is (= :stale result)
+            "a re-registration landing mid-acquire advances body revision and is fenced")
+        (is (= :fresh (reactive/lifecycle cell)) "a fenced candidate never connects")
+        (is (empty? (reactive/committed-sites cell)) "no dependency set published")
+        (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")))))
+
+;; ---------------------------------------------------------------------------
+;; The resource-capture publication path (`commit-resources!`) is fenced too,
+;; without mutating the accepted desired/reserved/held state
+;; ---------------------------------------------------------------------------
+;; `accept-resource-capture` (the publish step's accept-fn) sets
+;; `:resource-desired` + `:resource-capture`. It runs ONLY on the non-fence
+;; branch, so a fenced `commit-resources!` must leave the previously accepted
+;; plan, its reservations, and its held owners exactly as they were.
+
+(defn- register-resource! [rid]
+  (registrar/register! :resource rid {:rf/resource {}}))
+
+(defn- resource-capture-of [cell sites]
+  (reactive/enable-resource-lifecycle! cell)
+  (rf/with-frame fid
+    (reactive/with-capture
+     cell
+     (fn []
+       (doseq [[sid descriptor] sites]
+         (reactive/lease-site sid descriptor))
+       :element))))
+
+(defn- dispatch-standin
+  "Redefine router/dispatch! without breaking CLJS single-arity invoke."
+  [f]
+  (fn capture
+    ([event]      (capture event nil))
+    ([event opts] (f event opts))))
+
+(deftest commit-resources-fence-rejection-preserves-desired-reserved-held
+  (register-resource! ::feed)
+  (let [vid   ::resource-view
+        cell  (reactive/make-cell vid 0)
+        calls (atom [])
+        mints (atom 0)]
+    (with-redefs [features/require-feature! (constantly true)
+                  router/dispatch!          (dispatch-standin (fn [e o] (swap! calls conj [e o])))
+                  lease-owner/mint!         (fn [] [:owner (swap! mints inc)])]
+      ;; capture-1 connects, then reconcile mints/holds its owner
+      (let [[_ cap1] (resource-capture-of cell [[::s1 {:resource ::feed}]])]
+        (reactive/commit-resources! cell cap1)
+        (reactive/reconcile-resource-leases! cell cap1)
+        (is (= :connected (reactive/lifecycle cell)))
+        (let [res0  (reactive/resource-reservations cell)
+              held0 (reactive/resource-held cell)
+              ev0   (reactive/resource-lease-evidence cell)]
+          (is (= 1 (count res0)) "capture-1 reserved exactly one owner")
+          (is (= 1 (count held0)) "capture-1 holds exactly one owner")
+          (is (= 1 (count ev0)) "one accepted desired-plan evidence row")
+          ;; register the slot so the FINAL fence has a registered authority
+          (reactive/register-view-generation! vid hs0)
+          ;; a DIFFERENT-site resource render, fenced by a mid-commit
+          ;; re-registration — accept-resource-capture must NOT run
+          (let [[_ cap2] (resource-capture-of cell [[::s2 {:resource ::feed}]])
+                result   (binding [reactive/*commit-barrier*
+                                   (reregister-barrier vid :post-acquire hs0)]
+                           (reactive/commit-resources! cell cap2))]
+            (is (= :stale result) "the stale-body resource capture is fenced")
+            (is (= :connected (reactive/lifecycle cell)) "the connected cell is not torn down")
+            (is (= res0 (reactive/resource-reservations cell)) "reservations preserved")
+            (is (= held0 (reactive/resource-held cell)) "held owners preserved")
+            (is (= ev0 (reactive/resource-lease-evidence cell))
+                "the accepted desired plan is unchanged — capture-2 never overwrote it")))))))

--- a/implementation/ui/test/re_frame/ui/reactive_stale_lease_capture_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_stale_lease_capture_cljs_test.cljc
@@ -104,6 +104,84 @@
       (is (nil? (:ref-count (get @(:sub-cache (frame/frame fid)) [:sl/a])))
           "B's replacement cache is untouched — the rejected staging released cleanly"))))
 
+;; ---- THE MIXED-INCARNATION STAGED ATTEMPT (rf2-vxgfnd.256) --------------------
+;; The two-site test above acquires BOTH leases from A, then swaps A→B at the
+;; :post-stage-acquire barrier — so at the gate BOTH candidates are non-current,
+;; and a regression that rejected only when NO candidate is current would still
+;; pass. The bead's required barrier is stronger: acquire lease 1 from A, DESTROY
+;; A + publish a same-id B in the acquire→acquire window, then acquire lease 2
+;; from the LIVE B — a genuinely MIXED candidate set {lease1@A (NON-current),
+;; lease2@B (current)}. `candidate-current?` is `every?`, so the single
+;; non-current A lease rejects the whole commit. `incarnation-superseded?`
+;; cannot help here: both sites share the reused id, whose CURRENT token is B's,
+;; so the post-acquire `committed-frame-incarnations` snapshot reads B's token
+;; and the check is false — exactly the pre-#5821 blind spot .161 documents.
+;; This pins `candidate-current?` as the SOLE fence: weakening it to `some`, or
+;; dropping lease 1's exact check, connects a stale A lease and flips this red.
+;;
+;; The interleave is injected through a TEST-ONLY wrapper around the observation
+;; port (no production seam): the same `with-redefs` idiom the resource-owner
+;; wiring proof uses. The commit sees the ordinary staged `obs/acquire!`; the
+;; wrapper merely destroys/recreates the frame strictly BETWEEN the two calls.
+(deftest a-mixed-incarnation-staged-attempt-cannot-connect
+  (rf/reg-sub :sl/a (fn [db _] (:a db)))
+  (rf/reg-sub :sl/b (fn [db _] (:b db)))
+  (let [fid     :sl/mixed
+        _       (make-frame! fid {:a 1 :b 2})
+        token-a (frame/frame-incarnation-token fid)
+        cell    (reactive/make-cell ::mixed)
+        [_ capture] (rf/with-frame fid
+                      (reactive/with-capture
+                       cell (fn []
+                              (reactive/sub-read ::s1 [:sl/a])
+                              (reactive/sub-read ::s2 [:sl/b]))))
+        acq          (atom [])           ;; [lease query token-at-acquire]
+        rel          (atom [])           ;; query in release order
+        real-acquire obs/acquire!
+        real-release obs/release!
+        lease->query (fn [lease]
+                       (some (fn [[l q _]] (when (identical? l lease) q)) @acq))]
+    ;; ONE staged attempt: the A→B swap lands strictly BETWEEN the two acquires.
+    (with-redefs [obs/acquire!
+                  (fn [target on-change]
+                    (when (= 1 (count @acq))
+                      ;; lease 1 (from A) is in hand — destroy A and publish a
+                      ;; same-id B BEFORE lease 2 is acquired, so lease 2 binds B
+                      (frame/destroy-frame! fid)
+                      (make-frame! fid {:a 99 :b 88}))
+                    (let [lease (real-acquire target on-change)]
+                      (swap! acq conj [lease (:query target)
+                                       (frame/frame-incarnation-token fid)])
+                      lease))
+                  obs/release!
+                  (fn [lease]
+                    (swap! rel conj (lease->query lease))
+                    (real-release lease))]
+      (reactive/commit! cell capture))
+    (let [token-b (frame/frame-incarnation-token fid)]
+      (is (not (identical? token-a token-b))
+          "B is a distinct incarnation under the reused id")
+      (testing "the interleave was genuinely MIXED — lease 1 from A, lease 2 from B"
+        (is (= [[:sl/a] [:sl/b]] (mapv second @acq))
+            "both sites acquired, in render order")
+        (is (identical? token-a (nth (first @acq) 2))
+            "lease 1 was acquired while incarnation A was live")
+        (is (identical? token-b (nth (second @acq) 2))
+            "lease 2 was acquired against the fresh incarnation B"))
+      (testing "the mixed candidate set is rejected — no connect, no retained lease"
+        (is (not= :connected (reactive/lifecycle cell))
+            "a commit holding a superseded-incarnation lease never connects")
+        (is (empty? (reactive/committed-sites cell)) "nothing retained"))
+      (testing "the newly staged leases release exactly once, in reverse order"
+        (is (= [[:sl/b] [:sl/a]] @rel)
+            "reverse-order rollback: lease 2 (B) then lease 1 (A)")
+        (is (= 2 (count @rel)) "each staged lease released exactly once"))
+      (testing "B's replacement cache is untouched — the rejected staging released cleanly"
+        (is (nil? (:ref-count (get @(:sub-cache (frame/frame fid)) [:sl/a])))
+            "B's :sl/a node has no owner (it was never acquired from B)")
+        (is (nil? (:ref-count (get @(:sub-cache (frame/frame fid)) [:sl/b])))
+            "B's :sl/b node's lease was released — zero owners")))))
+
 ;; ---- ordinary same-incarnation multi-site commit is unaffected ---------------
 (deftest ordinary-same-incarnation-multi-site-commit-connects
   (rf/reg-sub :sl/a (fn [db _] (:a db)))


### PR DESCRIPTION
Two P2 ViewCell proof-completion beads. Both were re-verified against current
`origin/main` first: the runtime algorithms are correct — the fixes are
executable-proof fixtures (test-only), each demonstrated red under a targeted
source mutation that is NOT shipped. Scope: `implementation/ui` tests only; no
source change.

## rf2-vxgfnd.260 — complete the final-fence proof (both commit-authority axes + rollback)

PR #5862's tests pinned only one of the two authorities `stale-body-authority?`
consults (the registered HMR slot) and left several obligations
mutation-surviving. Extends `reactive_hmr_authority_fence_cljs_test.cljc` with:

- **`direct-cell-local-generation-advance-mid-commit-is-fenced`** — Axis 1, the
  cell-LOCAL generation arm on a direct/unregistered cell (registry arm no-ops).
- **`fence-preserves-a-dropped-prior-site-byte-for-byte`** — a DROPPED prior
  site (non-empty `to-release`) keeps its exact lease/query/value and single
  owner under the fence (step 7 must not run ahead of the fence).
- **`fence-releases-staged-leases-in-reverse-order-exactly-once`** —
  port-instrumented proof staged `:b`/`:c` release exactly once in REVERSE
  order (log `[:c :b]`); retained `:a` never released.
- **`reregistration-inside-the-acquire-window-is-fenced`** — a re-registration
  landing INSIDE `obs/acquire!` (a window `:post-stage-acquire` fires after).
- **`commit-resources-fence-rejection-preserves-desired-reserved-held`** — a
  fenced `commit-resources!` leaves the accepted desired plan, reservations, and
  held owners untouched.

**Fixture-fails-pre-fix (teeth verified, reverted):**
- Remove the `(not= cap-gen state-gen)` arm → the cell-local test connects instead of fencing (4 assertions red).
- Forward-order release in the fence branch → the reverse-order test reds.
- Release `to-release` before the fence exit → the byte-for-byte drop test reds.
- Neuter the whole final fence → the in-acquire and `commit-resources!` tests red (the unchanged-authority control stays green).

## rf2-vxgfnd.256 — prove a mixed-incarnation staged attempt cannot connect

The existing two-site test acquires BOTH leases from A then swaps A→B at
`:post-stage-acquire`, so at the gate BOTH candidates are non-current — it cannot
discriminate `some` from `every?`. Adds **`a-mixed-incarnation-staged-attempt-cannot-connect`**
to `reactive_stale_lease_capture_cljs_test.cljc`: acquire lease 1 from A, destroy
A + publish same-id B in the acquire→acquire window, acquire lease 2 from the live
B — a genuinely MIXED candidate set `{lease1@A non-current, lease2@B current}`.
`candidate-current?` (`every?`) rejects on the one non-current A lease;
`incarnation-superseded?` cannot help (both sites share the reused id whose current
token is B's — the pre-#5821 blind spot). Injected via a test-only
`obs/acquire!`/`obs/release!` wrapper (no production seam). Also pins reverse-order
exactly-once rollback and that B's replacement cache is untouched.

**Fixture-fails-pre-fix (teeth verified, reverted):** weaken `candidate-current?`
from `every?` to `some` → ONLY this test reds (5 assertions); the older both-from-A
test stays green, proving it could not discriminate.

## Quality gates

- `implementation/ui` JVM suite (`clojure -M:test`): **538 tests, 6628 assertions, 0 failures, 0 errors**
- Node CLJS suite (`npm run test:cljs`): **9443 tests, 46359 assertions, 0 failures, 0 errors**
- All `.cljc` fixtures graft-check on both JVM and node.
