### PR TITLE
docs: adopt frame-init ruling residues + test-root tightening in synthesis/skill (rf2-3t5znd)

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
+++ b/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
@@ -360,15 +360,19 @@ server in sight (guide 01):
 `(ui.test/render root-or-view opts)` accepts exactly two forms:
 
 1. **A view reference** (compile-resolved Var/symbol of a `defview`). Props ride
-   `{:props p}`. Frames ride `{:frame f}` XOR `{:app-db v}` (test frame minted); with
-   neither, structural rendering proceeds and any `sub` raises
-   `:rf.error/no-frame-context` — honest, not defaulted.
-2. **A literal root form** — the same grammar `mount` takes, top-region wrappers
-   included. Then:
+   `{:props p}`. A frame rides `{:frame f}` — minted with `rf/make-frame` +
+   `:initial-events` (07 §2); with none, structural rendering proceeds and any `sub`
+   raises `:rf.error/no-frame-context` — honest, not defaulted.
+2. **A literal root form** — the same top-region root grammar `mount` takes,
+   tightened so the form mounts exactly **ONE** view (root identity is that view's
+   id). A form with zero or two-plus views fails at expansion with
+   `:rf.ui.compile/bad-test-root` — the shipped `ui.test/render` asserts this (a
+   fragment of two views has no single identity; wrap bare markup in a `defview`).
+   Then:
    - `{:props p}` is **rejected** (didactic: props live in the form);
    - the form's `frame-root` plans run preflight ENSURE against the test registrar,
      minting fresh test frames from the plans;
-   - `{:frame f}`/`{:app-db v}` alongside a plan-bearing root form is **rejected**
+   - `{:frame f}` alongside a plan-bearing root form is **rejected**
      (*"the root form owns its frames — pass a bare view to control the frame"*).
      `[S1-CONFIRM]` — 07 §2 is silent on this combination; rejection is the
      conservative contract (no ambiguity about which frame is ambient).
@@ -376,7 +380,7 @@ server in sight (guide 01):
 A runtime-assembled vector is the same compile error as at `mount` (§3). In both
 forms, `{:sub-overrides {query value}}` combines freely — it is the explicit JVM
 override door (03 §3), with `:owned? false` honesty unchanged. Registrations come from
-the loaded namespaces (07 §2 `frame`).
+the loaded namespaces (07 §2).
 
 **Test-scope identity:** each `ui.test/render` call is its own document scope — root
 identity derives normally (so descriptor-shaped assertions work) but the duplicate
@@ -413,5 +417,5 @@ unregisters (a leaked registration failing a later mount is a test-harness bug, 
    alongside the Spec 011 payload-encoding rows.
 3. **§7** — entry-point-closure scoping as the build-time projection of "one page" for
    duplicate root-id detection (vs. whole-build strictness).
-4. **§9** — rejection of `{:frame …}`/`{:app-db …}` combined with a plan-bearing root
+4. **§9** — rejection of `{:frame …}` combined with a plan-bearing root
    form in `ui.test/render`.

--- a/ai/findings/new-substrate-synthesis/prep/w2-migration-skill-extension.md
+++ b/ai/findings/new-substrate-synthesis/prep/w2-migration-skill-extension.md
@@ -232,7 +232,8 @@ runtime class is frame scoping at boundaries and interaction-time behaviour, so 
 done-bar per subtree is still live, not "compiles":
 
 1. **Tier-1 structural tests** (`re-frame.ui.test`; JVM, no DOM): `(uit/render view
-   {:app-db seed})`, structural `find`/`text`/`attrs`, and **event-intent assertions**
+   {:frame (rf/make-frame {:initial-events [[:rf/set-db seed]]})})`, structural
+   `find`/`text`/`attrs`, and **event-intent assertions**
    — assert the button *carries* `[:cart/add id]` as data; no DOM click needed.
    `uit/dispatch!` drives Tier-1 state — real dispatch + drain to fixed point,
    re-render and assert, no flush call needed (`flush!` belongs to the Tier-3 mounted

--- a/ai/findings/new-substrate-synthesis/skill/SKILL.md
+++ b/ai/findings/new-substrate-synthesis/skill/SKILL.md
@@ -396,7 +396,7 @@ Props compare by value (`rf=`, per slot) to decide re-renders:
 
 ```clojure
 (deftest add-button-carries-intent
-  (let [frame (uit/frame {:app-db {:cart #{}}})
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})
         tree  (uit/render [product-card {:product {:id 42 :name "Hat" :price 9.5}}]
                           {:frame frame})]
     (is (= "Hat"          (uit/text (uit/find tree :h3))))
@@ -404,13 +404,17 @@ Props compare by value (`rf=`, per slot) to decide re-renders:
 ```
 
 - **Tier-1 (default): real view + real frame on the JVM, no DOM.** `render`
-  opts are CLOSED: `{:frame f}` XOR `{:app-db seed}`, `:props` (bare-view
-  form only), `:sub-overrides {query value}` (the explicit JVM override
-  door). Unknown keys throw didactically.
-- `render` also takes a **literal root form** — plan-bearing `frame-root`
+  opts are CLOSED: `{:frame f}` (a frame minted with `rf/make-frame` +
+  `:initial-events`), `:props` (bare-view form only),
+  `:sub-overrides {query value}` (the explicit JVM override door). Unknown
+  keys throw didactically.
+- `render` also takes a **literal root form** — the same top-region root
+  grammar `mount` takes, tightened so the form mounts exactly ONE view (root
+  identity is that view's id); a form with zero or two-plus views fails at
+  expansion with `:rf.ui.compile/bad-test-root`. Plan-bearing `frame-root`
   forms preflight fresh isolated test frames and tear down after. With a root
-  form, `:props` is rejected (props live in the form); `:frame`/`:app-db`
-  alongside a plan-bearing form are rejected (the form owns its frames).
+  form, `:props` is rejected (props live in the form), and `:frame` alongside
+  a plan-bearing form is rejected (the form owns its frames).
 - **Assert structure and intent, not pixels.** Handler slots hold event
   vectors as data — "what does this button do" is an equality check, no
   click simulation. **Reads go through the projections**: `(uit/attrs node)`


### PR DESCRIPTION
Follow-on from the frame-init ruling (Mike, 2026-07-14 — rf2-va5e61, PR #5886, since merged). The guide tree and `07-testing.md` were respelled in that PR; this cleans up the residual mentions of the removed `ui.test/frame {:app-db …}` grammar left in three other synthesis docs, and adopts the single-view test-root tightening in the root-identity draft.

The one frame-init grammar: `rf/make-frame` + `:initial-events` (with `[:rf/set-db {…}]` as the standard seeding step). The `ui.test/frame` helper and `ui.test/render`'s `{:app-db v}` frame-minting branch are removed from the contract. The test-root tightening (already shipped in `re-frame.ui.test`, with a JVM assertion): a `render` root form mounts exactly ONE view — root identity is that view's id — and zero or two-plus views fail at expansion with `:rf.ui.compile/bad-test-root`.

## Residue disposition

**`skill/SKILL.md`** (§10 Testing)
- `(uit/frame {:app-db {:cart #{}}})` example → **respelled** to `(rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})`.
- `render` opts "`{:frame f}` XOR `{:app-db seed}`" → **respelled** to `{:frame f}` (a frame minted with `rf/make-frame` + `:initial-events`); `{:app-db seed}` dropped.
- Literal-root-form bullet: `:frame`/`:app-db` rejection → **respelled** to `:frame`-only, and **adopted** the single-view tightening (`bad-test-root`) so the skill's testing surface matches shipped.

**`prep/w2-migration-skill-extension.md`** (Tier-1 done-bar)
- `(uit/render view {:app-db seed})` → **respelled** to `(uit/render view {:frame (rf/make-frame {:initial-events [[:rf/set-db seed]]})})`.

**`drafts/root-identity-and-mount.md`** (§9 accepted forms + `[S1-CONFIRM]` register)
- Form 1 "`{:frame f}` XOR `{:app-db v}`" → **respelled** to `{:frame f}` minted with `rf/make-frame` + `:initial-events`.
- Form 2 "the same grammar `mount` takes" → **adopted** the tightening: same top-region root grammar, but the form mounts exactly ONE view; zero/two-plus views fail at expansion with `:rf.ui.compile/bad-test-root` (matches the shipped `ui.test/render` docstring + JVM test).
- Plan-bearing rejection "`{:frame f}`/`{:app-db v}`" → **respelled** to `{:frame f}`-only.
- "Registrations come from the loaded namespaces (07 §2 `frame`)" → **respelled** to drop the removed-helper citation.
- `[S1-CONFIRM]` item 4 "`{:frame …}`/`{:app-db …}`" → **respelled** to `{:frame …}`-only.

**Left as-is (classified, not stale):** `reviews/guide-staged-review-2026-07-14.md` records the ruling as historical minutes (the removed grammar is quoted there deliberately); the `guide/` tree and `07-testing.md` were already respelled by #5886; no `skills/` (top-level) tree files carry the grammar. No `rf2-` id was introduced into any skill leaf.

## Quality gates

- `python scripts/check_doc_slugs.py` → exit 0
- `python scripts/check_readme_links.py` → exit 0
- Skill-drift checks: **N/A** — the top-level `skills/` tree is untouched (the edited `SKILL.md` lives under `ai/findings/new-substrate-synthesis/skill/`).
- Docs-only; no `implementation/`, `spec/`, `guide/`, or hot-zone files touched.
