### PR TITLE
docs(core): name frame-root alongside frame-provider in frame-context docstrings (rf2-rfprlp)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1119,7 +1119,8 @@
   "Return the active frame id the in-effect scope carries — a keyword.
   Resolution is the carried-invariant scope/hold chain via
   `frame/require-current-frame!` (EP-0002): the dynamic `*current-frame*`
-  stamp or a React-context frame-provider scope (CLJS only, via the
+  stamp or the closest React-context frame boundary, a `frame-provider`
+  (SCOPE) or `frame-root` (ENSURE) (CLJS only, via the
   `:adapter/current-frame` late-bind hook). There is NO `:rf/default`
   floor — called under no established scope it raises
   `:rf.error/no-frame-context` rather than reporting an invented default.
@@ -1150,7 +1151,8 @@
   The captured `frame` is closed over by every op — no dynamic-var read
   at op-call time — so the frame api dispatches / subscribes into `frame`
   even when an op fires after the surrounding `with-frame` /
-  `frame-provider` scope has unwound (the async-boundary case).
+  `frame-provider` / `frame-root` scope has unwound (the async-boundary
+  case).
 
   Per the frame-affordance redesign (rf2-kkut0) the captured frame is
   AUTHORITATIVE: `:frame` is assoc'd LAST in the dispatch opts, so a
@@ -2549,7 +2551,8 @@
   is an ordinary id (EP-0002), the runtime never synthesises a default
   frame — frame identity is carried, not found. Declare your app's root
   frame explicitly (`(rf/make-frame {:id :app …})` / `with-frame` / a
-  frame-provider) and dispatch / subscribe within that scope. A small app
+  `frame-root` (ENSURE — creates it if absent) or `frame-provider` (SCOPE —
+  scopes an already-created one)) and dispatch / subscribe within that scope. A small app
   or test may still choose `:rf/default` as its explicit frame id; the
   runtime will not infer it."
   [adapter-map]

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -297,13 +297,17 @@
 
     1. `*current-frame*` (dynamic var) — set by `with-frame` / `bind-fn`
        (INTERNAL) / the router's per-handler binding.
-    2. The closest enclosing frame-provider via React context (CLJS).
+    2. The closest enclosing frame boundary — a `frame-provider` (SCOPE)
+       or `frame-root` (ENSURE) — via React context (CLJS). Both install
+       the shared boundary context; the no-provider sentinel appears only
+       beneath neither.
 
   On CLJS this consults the `:adapter/current-frame` late-bind hook so
   the React-context tier is LIVE — adapters publish their React-context-
   aware impl through the hook at ns-load time. That impl returns nil when
-  neither the dynamic var nor an enclosing Provider names a frame (the
-  Provider default is the no-provider sentinel, per Spec 002 §`:rf/default`
+  neither the dynamic var nor an enclosing frame boundary (`frame-provider`
+  or `frame-root`) names a frame (the React-context default is the
+  no-provider sentinel, per Spec 002 §`:rf/default`
   is an ordinary id). When the hook is unbound (no adapter loaded yet, or JVM build)
   the result is `current-frame` — the dynamic-var tier alone; the React-
   context tier silently no-ops to nil.
@@ -589,8 +593,8 @@
   explicit frame binding rather than through `capture-frame`'s op bundle.
   The returned fn dispatches / reads into `frame` even when invoked after
   the caller's own dynamic / React-context scope has unwound (the async-
-  boundary case `with-frame` / a frame-provider cannot cover). NOT an
-  app-facing surface."
+  boundary case `with-frame` / a `frame-provider` / `frame-root` cannot
+  cover). NOT an app-facing surface."
   [frame f]
   (fn [& args]
     (binding [*current-frame* frame]

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -248,7 +248,8 @@
   never repairs absence). The two tiers it observes:
 
     1. Dynamic var (set by with-frame).
-    2. Closest enclosing frame-provider via React context.
+    2. Closest enclosing frame boundary — a `frame-provider` (SCOPE) or
+       `frame-root` (ENSURE) — via React context.
 
   Reagent-specific: the React-context tier reads `(.-context cmp)` on
   the in-flight Reagent component. Reagent's class-component machinery


### PR DESCRIPTION
## Problem

Post the rf2-nyea0r `frame-root` / `frame-provider` split, several active core frame-context **docstrings** still describe React-context frame resolution as `frame-provider`-only. Both boundaries install the shared React-context boundary — `frame-root {:id}` ENSUREs (creates if absent), `frame-provider {:frame}` SCOPEs an already-created frame — so a reader following those docstrings could model a read/scope beneath a `frame-root` as no-scope. This is active contract drift (rf2-rfprlp), distinct from the closed adapter README/test work in rf2-kopcit.

## Change (DOCSTRING-ONLY — no logic)

Named `frame-root` alongside `frame-provider` in the resolution/scope docstrings across the three core src files the bead scopes to:

- `implementation/core/src/re_frame/frame.cljc`
  - `resolve-current-frame` — React-context tier (#2) now names both boundaries; corrected "enclosing Provider" → "enclosing frame boundary" and "Provider default" → "React-context default".
  - `bind-fn` — async-boundary scope list adds `frame-root`.
- `implementation/core/src/re_frame/core.cljc`
  - `current-frame-id` — React-context scope now names `frame-provider` (SCOPE) / `frame-root` (ENSURE).
  - `make-capture-frame` — async-boundary scope list adds `frame-root`.
  - `init!` — "declare your app's root frame" now names `frame-root` (ENSURE — creates if absent) or `frame-provider` (SCOPE).
- `implementation/core/src/re_frame/views/provider.cljs`
  - `current-frame` — React-context tier (#2) now names both boundaries.

No runtime, API, comment, error-string, or broader-doc changes. Out-of-scope surfaces (adapter/context.cljs, resource_lease.cljs, elision.cljc, substrate/spine.cljs, reactive.cljc/client.cljs) untouched.

## Quality gates

- `cd implementation/core && clojure -M:test` → **1988 tests, 9163 assertions, 0 failures, 0 errors** (compile + suite green).
- Docstring-only diff (17 insertions / 9 deletions across 3 files); no logic, tests, spec, or fixtures touched.