### PR TITLE
fix(ui): parse letfn* flat bindings with their real lexical grammar (rf2-vxgfnd.221; .224 design-bearing → held)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -647,6 +647,41 @@
                      (apply list (first f) specs*
                             (map-indexed #(rw %2 scope (conj p :body %1))
                                          (drop 2 f))))))))
+           (rw-letfn* [f locals p]
+             ;; The HOST special form `letfn*` (what the `letfn` macro expands
+             ;; to) has FLAT name/initializer bindings `[n0 init0 n1 init1 …]`,
+             ;; NOT source `letfn`'s paired fnspec-LIST grammar. Its lexical
+             ;; grammar: every name is in scope for every initializer AND the
+             ;; body (mutual recursion), and each initializer is a `fn*` whose
+             ;; body is deferred — so routing an initializer through `rw`
+             ;; (→ `rw-fn`) makes a render-time `sub`/`lease` inside it illegal,
+             ;; while a visible `sub` in the OUTER body still lowers to a site.
+             (let [bindings (second f)]
+               (if-not (and (vector? bindings) (even? (count bindings)))
+                 (env/fail! e :rf.ui.compile/bad-let
+                            (str "letfn* needs a vector of an even number of flat "
+                                 "name/initializer bindings [name init …]")
+                            {:form f})
+                 (let [pairs (partition 2 bindings)
+                       names (map first pairs)]
+                   (when-not (every? symbol? names)
+                     (env/fail! e :rf.ui.compile/bad-let
+                                "letfn* binding names must be symbols"
+                                {:form f}))
+                   (let [scope     (into locals names)
+                         bindings* (with-same-meta
+                                     bindings
+                                     (into []
+                                           (comp (map-indexed
+                                                  (fn [i [nm init]]
+                                                    [nm (rw init scope (conj p :binding i))]))
+                                                 cat)
+                                           pairs))]
+                     (with-same-meta
+                       f
+                       (apply list (first f) bindings*
+                              (map-indexed #(rw %2 scope (conj p :body %1))
+                                           (drop 2 f)))))))))
            (rw-try [f locals p]
              ;; `catch` introduces a local, so it cannot go through generic
              ;; traversal. `finally` does not. Preserve the marker/type slots
@@ -776,7 +811,8 @@
 
                    (fn-form? f) (rw-fn f locals p)
                    (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)
-                   (contains? #{'letfn 'letfn*} head) (rw-letfn f locals p)
+                   (= 'letfn head)  (rw-letfn f locals p)
+                   (= 'letfn* head) (rw-letfn* f locals p)
                    (= 'try head) (rw-try f locals p)
 
                    (and (macro-info e* head locals)

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -308,6 +308,42 @@
       (is (not (some #{:callee} (:expr-path site)))
           "a symbol head is preserved verbatim — no :callee token is minted"))))
 
+(deftest letfn*-flat-bindings-parse-with-their-real-lexical-grammar
+  ;; rf2-vxgfnd.221 — the HOST special form letfn* has FLAT name/initializer
+  ;; bindings [name init …], NOT source letfn's paired fnspec-LIST grammar. The
+  ;; opaque-expression rewriter parses the flat shape directly; a mutation that
+  ;; routes letfn* back through the source-letfn parser crashes / mis-scopes
+  ;; these fixtures, so they double as the anti-regression guard. Runs on both
+  ;; hosts (the analyzer is pure), so this IS the CLJ/CLJS parity fixture.
+  (testing "a legal flat letfn* compiles and preserves its flat binding shape"
+    (let [{:keys [ast sites]}
+          (ana-full '[:div {:title (letfn* [f (fn* f ([x] x))] (f 7))}])]
+      (is (empty? (:subs sites)))
+      (is (= '(letfn* [f (fn* f ([x] x))] (f 7))
+             (get-in ast [:props :attrs 0 :value]))
+          "the flat [name init …] vector is preserved verbatim")))
+  (testing "a visible sub in the OUTER letfn* body lowers to exactly one site"
+    (let [{:keys [sites]}
+          (ana-full '[:div {:title (letfn* [f (fn* f ([x] x))] (sub [:q]))}])]
+      (is (= 1 (count (:subs sites))))
+      (is (= [[:q]] (map :query (:subs sites))))))
+  (testing "mutually recursive flat bindings each see every declared name"
+    (let [{:keys [ast]}
+          (ana-full '[:div {:title (letfn* [evn (fn* evn ([x] (odd* x)))
+                                            odd* (fn* odd* ([x] (evn x)))]
+                                     (evn 4))}])]
+      (is (= '(letfn* [evn (fn* evn ([x] (odd* x)))
+                       odd* (fn* odd* ([x] (evn x)))]
+                (evn 4))
+             (get-in ast [:props :attrs 0 :value]))
+          "each initializer resolves its sibling name; the flat shape is kept")))
+  (testing "a local flat binding named sub shadows the public authoring var"
+    (let [{:keys [ast sites]}
+          (ana-full '[:div {:title (letfn* [sub (fn* sub ([x] x))] (sub 3))}])]
+      (is (empty? (:subs sites)) "the shadowed sub mints no reactive site")
+      (is (= '(letfn* [sub (fn* sub ([x] x))] (sub 3))
+             (get-in ast [:props :attrs 0 :value]))))))
+
 (deftest legitimate-value-flow-still-compiles
   ;; rf2-vxgfnd.252 — the escape guard rejects ONLY bare reactive authoring
   ;; vars (sub/lease/frame). Ordinary NON-reactive value flow through a computed

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -356,6 +356,21 @@
     (is (= :view (:op (ana/analyze e '[sub {}])))
         "control: without a shadow the same self head IS the internal view")))
 
+(deftest letfn*-malformed-flat-bindings
+  ;; rf2-vxgfnd.221 — letfn* has FLAT name/initializer bindings; a malformed
+  ;; flat vector fails through the typed :rf.ui.compile/* surface, never a raw
+  ;; host exception (before the split, an odd/mis-shaped letfn* threw a bare
+  ;; IllegalArgumentException from the source-letfn parser).
+  (is (= :rf.ui.compile/bad-let
+         (reject-id '[:div {:title (letfn* [f (fn* f ([x] x)) g] (f 7))}]))
+      "odd-length flat bindings -> typed bad-let (never IllegalArgumentException)")
+  (is (= :rf.ui.compile/bad-let
+         (reject-id '[:div {:title (letfn* [42 (fn* _ ([x] x))] 1)}]))
+      "non-symbol binding name -> typed bad-let")
+  (is (= :rf.ui.compile/sub-in-loop
+         (reject-id '[:div {:title (letfn* [f (fn* f ([x] (sub [:q])))] (f 7))}]))
+      "a reactive read inside a deferred local fn body is not a finite render site"))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))


### PR DESCRIPTION
Compiler-grammar cluster (surface `implementation/ui/src/re_frame/ui/compiler/analyze.cljc`). One bead fixed; the sibling is a genuine design decision and is reported, not guessed.

## rf2-vxgfnd.221 — Parse `letfn*` flat bindings with their real lexical grammar — **FIXED**

**Defect (re-verified red on current main).** The opaque-expression rewriter dispatched both source `letfn` and the host special form `letfn*` through one `rw-letfn` parser that assumes source `letfn`'s paired fnspec-LIST grammar `[(f [x] x) …]`. Legal `letfn*` has FLAT name/initializer bindings `[f (fn* f ([x] x)) …]`.

Red-before-fix, reproduced on the exact-tree analyzer at `origin/main`:

```
(ana/rewrite-expr e '(letfn* [f (fn* f ([x] x))] (f 7)))
;; => IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Symbol
```

The raw host exception originates while destructuring the flat binding entry as if it were a fnspec list, before either emitter — exactly as the bead states. `letfn*` is an explicitly recognized special form (dispatched structurally at the analyzer boundary), so it must compile or fail with a structured `:rf.ui.compile/*` diagnostic, never a raw host throw.

**Fix (minimal, surgical).** Split the dispatch — source `letfn` keeps `rw-letfn` (paired grammar); `letfn*` gets a new `rw-letfn*` that parses its real flat grammar:

- require a vector with an **even** number of flat name/initializer entries;
- validate binding names are **symbols**;
- place **all** names into lexical scope **before** rewriting any initializer (mutual recursion);
- rewrite each initializer preserving the flat vector shape/metadata — each initializer is a `fn*`, so `rw → rw-fn` marks its body **deferred scope** (a render-time `sub`/`lease` inside a local fn body is illegal);
- rewrite the outer body under the full name scope, honouring a local shadow named `sub`/`lease`.

Malformed flat bindings now fail through the typed `:rf.ui.compile/bad-let` surface (an existing catalogued id — no new error row), never `IllegalArgumentException`/`ClassCastException`.

**Coverage (both hosts — the analyzer is pure `.cljc`, so these fixtures ARE the CLJ/CLJS parity proof):**
- `analyze_accept_cljs_test.cljc` → `letfn*-flat-bindings-parse-with-their-real-lexical-grammar`: legal flat `letfn*` compiles + preserves the flat shape verbatim; a visible `sub` in the OUTER body lowers to exactly one indexed site; mutually recursive flat bindings each resolve their sibling name; a local binding named `sub` shadows the authoring var and mints no site.
- `analyze_reject_cljs_test.cljc` → `letfn*-malformed-flat-bindings`: odd-length → `bad-let`; non-symbol name → `bad-let`; a reactive read in a deferred local fn body → `sub-in-loop` — none leaks a raw host exception.

The accept fixtures double as the **anti-regression guard**: routing `letfn*` back through the source-`letfn` parser crashes/mis-scopes them.

No spec/004 change required — the spec already lists `letfn`/`letfn*` as structurally-handled binder forms; the flat-vs-paired *parse* is an implementation detail below spec prose.

## rf2-vxgfnd.224 — Close the compiler's accepted special-form grammar — **HELD: design-bearing, not a mechanical reconciliation**

Re-verified against current `origin/main`. **The current fallback is production-SOUND** — there is no reachable manifest hole forcing a rushed fix — but the change the bead asks for is a genuine grammar-semantics decision for Mike, so it is reported here rather than guessed.

Empirical probe of every special form that flows through analyze.cljc's `:else` generic-invocation arm (each with a visible `(sub …)`):

| form | result |
|---|---|
| `(if (sub [:enabled?]) 1 0)` | sub indexed — **1 site** |
| `(new java.lang.String (sub [:q]))` | sub indexed — 1 site |
| `(. obj method (sub [:q]))` | sub indexed — 1 site |
| `(set! (.-x obj) (sub [:q]))` | sub indexed — 1 site |
| `(def foo (sub [:q]))` | sub indexed — 1 site |
| `(throw (sub [:q]))` / `(monitor-enter (sub [:q]))` / `(do (sub [:q]) 1)` | sub indexed — 1 site |
| `(var sub)` | safely **rejected** `:rf.ui.compile/unsupported-form` |

Findings:

1. **No reachable soundness hole.** Every special form flowing through the fallback traverses all its operand slots, so a visible reactive site in any evaluated slot is indexed — the manifest never under-declares. The only "divergence" (`(var sub)` false-rejecting a bare reactive symbol in a non-evaluated slot) fails **loud**, the safe direction.
2. **Spec 004 and the compiler are already consistent** under the current model. The bead's premise is that Spec 004:180-207 "omits `if`," but bullet 3 (lines 194-203) explicitly covers *"a plain fn/**special-form name** … is preserved verbatim and the arguments are analyzed"* — which is exactly the `:else` arm that handles `if`, `do`, `new`, `.`, etc. There is no red inconsistency to reconcile.
3. **The requested change is a new design posture, not a reconciliation.** "Close the fallback, bless the smallest ergonomic v1 roster, reject unblessed host-only forms, add a slot table + parity fixtures" requires *deciding the roster* and *per-form slot rules* — a judgment call:
   - `if` is clearly needed (accepted + tested today).
   - Interop `.`/`new`/`set!` appear in **real** view expressions (e.g. `(.toUpperCase name)` in a prop). Common interop sugar (`.method`) is portable across hosts; only java-class-specific forms (`java.lang.String`, `monitor-enter`, `case*`, `deftype*`) are host-divergent — and those are never authored in portable views.
   - So the true portability risk is narrow and pathological, and it affects **emission** (a host-only form compiles on one host), not analysis soundness.
4. Given the pre-alpha "no over-engineering / no gold-plating" posture, whether to build a closed roster + slot table to defend against forms nobody writes in a view is exactly the ELEGANCE-vs-completeness call Mike should make. The already-merged rf2-vxgfnd.217 (computed callees) closed the one arm with an actual soundness bug; what remains in .224 is roster policy.

**Recommendation for Mike's ruling:** either (a) accept the current sound fallback and amend Spec 004's binder bullet to name `if` explicitly (documentation-only, closes .224 as "sound-as-is + documented"), or (b) commit to a closed special-form roster — in which case the roster (`if` + interop? + `do`?) and each form's evaluated/binder/deferred slot rule need to be ruled before implementation. No guess is made here.

## Quality gates

- JVM ui suite (`cd implementation/ui && clojure -M:test`): **537 tests / 6632 assertions / 0 failures**.
- Node-runtime CLJS (`cd implementation && npm run test:cljs`): **9451 tests / 46390 assertions / 0 failures**.

Both hosts run the pure `.cljc` analyzer, so the new `letfn*` accept/reject fixtures are exercised at both JVM macroexpand and node runtime.
