### PR TITLE
fix(machines): validate join completion authority before post-resolution attribution (rf2-ixjd48)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -325,13 +325,21 @@
   actor / mis-routed join; `:rf.machine.spawn-all/duplicate-completion` —
   exact re-completion of an already-folded child), and return the no-op
   effect map. ZERO mutation: no fold, no terminal publication, no
-  resolution, no reap. The post-resolution `:resolved?` branch keeps its
+  resolution, no reap. The exact-current post-resolution carrier keeps its
   own `:rf.machine.spawn-all/late-completion` trace — this op covers the
-  PRE-resolution suppression classes."
-  [frame-id parent-id invoke-id join-state child-id kind completed-at
+  ownership/authority suppression classes on BOTH the pre- and
+  post-resolution paths (rf2-ixjd48).
+
+  `spawned-id` is the completion's OWN spawned-instance address: the
+  CARRIER's stamped id (`(:spawned-id auth)`) for an `:attempt-superseded`
+  straggler — NOT the current join's `[:children child-id]` — so the stale
+  evidence never borrows the current attempt's work identity (rf2-ixjd48).
+  For `:attempt-unverified` there is no carrier authority to read, so the
+  caller passes the live child mapping (the slot the carrier claimed); for
+  `:duplicate-completion` the carrier is exact-current, so the two coincide."
+  [frame-id parent-id invoke-id child-id spawned-id kind completed-at
    runtime-db stale-reason]
-  (let [spawned-id  (get-in join-state [:children child-id])
-        stale-reply (m-reply/stale-join-child-reply
+  (let [stale-reply (m-reply/stale-join-child-reply
                       {:parent-id    parent-id
                        :invoke-id    invoke-id
                        :child-id     child-id
@@ -849,9 +857,82 @@
               (not (contains? join-state :children)))
           {:rf.db/runtime runtime-db :fx []}
 
-          ;; Already resolved: post-resolution LATE completion. Trace once
-          ;; for observability + classify it stale (no further PARENT event
-          ;; ever fires — the `:resolved?` latch already flipped). The
+          ;; Validate OWNERSHIP + EXACT AUTHORITY *before* the
+          ;; resolved-vs-unresolved classification (rf2-ixjd48). Pre-fix the
+          ;; `:resolved?` branch ran FIRST and attributed ANY matching event
+          ;; shape to the CURRENT attempt: it built a `:late-completion` record
+          ;; from the current join's `[:children child-id]`, so an old-attempt
+          ;; straggler, an unstamped carrier, or an unknown child all forged
+          ;; evidence carrying the current attempt's spawned/work identity.
+          ;; Ordering the ownership + authority gates ahead of `:resolved?`
+          ;; means ONLY an exact-current carrier may enter the post-resolution
+          ;; late-completion path; every other carrier is classified the SAME
+          ;; way it is on the pre-resolution path — resolved or not — with ZERO
+          ;; db mutation.
+
+          ;; Forged / unknown child-id: the inbound `child-id` is NOT in
+          ;; the seeded `:children` map. The accident class is a
+          ;; hand-crafted dispatch (copy-paste from a sibling :spawn-all,
+          ;; typo, cascaded event from a sibling parent) that the runtime
+          ;; would otherwise silently fold into `:done` / `:failed`,
+          ;; collapsing the join early. Gate it: emit a structured error
+          ;; trace and short-circuit with a no-op fx (do NOT mutate the
+          ;; join state). Per Spec 005 §Spawn-and-join and the machines
+          ;; security-audit finding F1.
+          (not (contains? (:children join-state) child-id))
+          (do (trace/emit-error! :rf.error/machine-spawn-all-bad-child-id
+                                 {:actor-id parent-id
+                                  :invoke-id invoke-id
+                                  :child-id   child-id
+                                  :children   (set (keys (:children join-state)))
+                                  :kind       kind
+                                  :frame      frame-id
+                                  :recovery   :event-dropped})
+              {:rf.db/runtime runtime-db :fx []})
+
+          ;; Exact-authority gate (rf2-nvxehu). The carrier must prove it
+          ;; belongs to THIS join attempt: the `:rf/join-auth` tuple the member
+          ;; child's own handler boundary stamped (`stamp-join-completion-fx`)
+          ;; and carried on the recordable `:rf.cofx` transport (rf2-t154jx) —
+          ;; resolved via `carrier-auth` above as `auth` — must match the
+          ;; current join's parent/invoke identity, logical child id, exact
+          ;; current actor id, and exact attempt token. An UNSTAMPED carrier (a
+          ;; hand-crafted dispatch that never flowed through the member child's
+          ;; boundary, OR a strict replay whose recordable authority fact was
+          ;; stripped) is `:attempt-unverified`; a SUPERSEDED one (a prior
+          ;; attempt's straggler after parent re-entry / child respawn —
+          ;; including a `:fixed-actor-id` respawn where the actor id alone
+          ;; cannot discriminate attempts, and an old-attempt DELAYED completion
+          ;; arriving across re-entry) is `:attempt-superseded`. Both fold
+          ;; NOTHING; both are zero-mutation fail-closed drops with stable typed
+          ;; evidence (`:rf.reply/stale-reason` on the stale-completion trace) —
+          ;; never a silent replay-success no-op.
+          ;;
+          ;; The unstamped carrier has no authority to source a work identity
+          ;; from, so its evidence carries the live child mapping (the slot it
+          ;; CLAIMED); the superseded carrier carries the CARRIER's OWN stamped
+          ;; `:spawned-id`, so the evidence never borrows the current attempt's
+          ;; work identity (rf2-ixjd48).
+          (nil? auth)
+          (suppress-stale-completion!
+            frame-id parent-id invoke-id child-id
+            (get-in join-state [:children child-id])
+            kind completed-at runtime-db
+            :rf.machine.spawn-all/attempt-unverified)
+
+          (not (join-auth-current? auth parent-id invoke-id child-id join-state))
+          (suppress-stale-completion!
+            frame-id parent-id invoke-id child-id
+            (:spawned-id auth)
+            kind completed-at runtime-db
+            :rf.machine.spawn-all/attempt-superseded)
+
+          ;; The carrier is now proven EXACT-CURRENT for this attempt.
+
+          ;; Already resolved: post-resolution LATE completion of the carrier's
+          ;; OWN current attempt (a genuine survivor draining after the
+          ;; `:resolved?` latch already flipped). Trace once for observability +
+          ;; classify it stale (no further PARENT event ever fires). The
           ;; reply-envelope facts mark the completion `:status :stale` /
           ;; `:rf.reply/work-status :suppressed` (Managed-Effects §Stale suppression):
           ;; it is SUPPRESSED from RE-RESOLVING the join — exactly the
@@ -895,71 +976,21 @@
             {:rf.db/runtime runtime-db
              :fx []})
 
-          ;; Forged / unknown child-id: the inbound `child-id` is NOT in
-          ;; the seeded `:children` map. The accident class is a
-          ;; hand-crafted dispatch (copy-paste from a sibling :spawn-all,
-          ;; typo, cascaded event from a sibling parent) that the runtime
-          ;; would otherwise silently fold into `:done` / `:failed`,
-          ;; collapsing the join early. Gate it: emit a structured error
-          ;; trace and short-circuit with a no-op fx (do NOT mutate the
-          ;; join state). Per Spec 005 §Spawn-and-join and the machines
-          ;; security-audit finding F1.
-          (not (contains? (:children join-state) child-id))
-          (do (trace/emit-error! :rf.error/machine-spawn-all-bad-child-id
-                                 {:actor-id parent-id
-                                  :invoke-id invoke-id
-                                  :child-id   child-id
-                                  :children   (set (keys (:children join-state)))
-                                  :kind       kind
-                                  :frame      frame-id
-                                  :recovery   :event-dropped})
-              {:rf.db/runtime runtime-db :fx []})
+          ;; DUPLICATE exact completion of an already-folded child in a
+          ;; still-live join — suppressed so one child attempt can never
+          ;; publish two terminals (rf2-ir4t5v).
+          (or (contains? (:done   join-state) child-id)
+              (contains? (:failed join-state) child-id))
+          (suppress-stale-completion!
+            frame-id parent-id invoke-id child-id
+            (get-in join-state [:children child-id])
+            kind completed-at runtime-db
+            :rf.machine.spawn-all/duplicate-completion)
 
           :else
-          ;; Exact-authority fold gate (rf2-nvxehu). Before ANY fold, the
-          ;; carrier must prove it belongs to THIS join attempt: the
-          ;; `:rf/join-auth` tuple the member child's own handler boundary
-          ;; stamped (`stamp-join-completion-fx`) and carried on the recordable
-          ;; `:rf.cofx` transport (rf2-t154jx) — resolved via `carrier-auth`
-          ;; above as `auth` — must match the current join's parent/invoke
-          ;; identity, logical child id, exact current actor id, and exact
-          ;; attempt token. An UNSTAMPED carrier (a hand-crafted dispatch that
-          ;; never flowed through the member child's boundary, OR a strict
-          ;; replay whose recordable authority fact was stripped) and a
-          ;; SUPERSEDED one (a prior attempt's straggler after parent re-entry /
-          ;; child respawn — including a `:fixed-actor-id` respawn where the
-          ;; actor id alone cannot discriminate attempts, and an old-attempt
-          ;; DELAYED completion arriving across re-entry) are classified stale
-          ;; and fold NOTHING; a DUPLICATE exact completion of an already-folded
-          ;; child is likewise suppressed so one child attempt can never publish
-          ;; two terminals (rf2-ir4t5v). All three suppressions are
-          ;; zero-mutation fail-closed drops with stable typed evidence
-          ;; (`:rf.reply/stale-reason` on the stale-completion trace) — never a
-          ;; silent replay-success no-op.
-          (cond
-            (nil? auth)
-            (suppress-stale-completion!
-              frame-id parent-id invoke-id join-state child-id kind
-              completed-at runtime-db
-              :rf.machine.spawn-all/attempt-unverified)
-
-            (not (join-auth-current? auth parent-id invoke-id child-id join-state))
-            (suppress-stale-completion!
-              frame-id parent-id invoke-id join-state child-id kind
-              completed-at runtime-db
-              :rf.machine.spawn-all/attempt-superseded)
-
-            (or (contains? (:done   join-state) child-id)
-                (contains? (:failed join-state) child-id))
-            (suppress-stale-completion!
-              frame-id parent-id invoke-id join-state child-id kind
-              completed-at runtime-db
-              :rf.machine.spawn-all/duplicate-completion)
-
-            :else
-            (intercept-fold frame-id parent-id invoke-id spec join-state
-                            child-id kind child-extra completed-at
-                            runtime-db)))))))
+          (intercept-fold frame-id parent-id invoke-id spec join-state
+                          child-id kind child-extra completed-at
+                          runtime-db))))))
 
 (defn- intercept-fold
   "The verified fold body of `intercept-spawn-all-event` — the carrier has

--- a/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
@@ -224,10 +224,17 @@
                                    :attempt    (:rf/attempt (join-state :jct/p5))}})])
       (is (= [:completed] (terminals-for a))
           "the duplicate added NO second terminal (suppressed, not re-published)")
-      ;; Resolve, then a post-resolution straggler for :a.
+      ;; Resolve, then :a's EXACT-CURRENT completion re-arrives post-resolution
+      ;; (the late-completion path is gated on exact authority — rf2-ixjd48).
       (rf/dispatch-sync [b [:go]])
       (is (true? (:resolved? (join-state :jct/p5))))
-      (rf/dispatch-sync [:jct/p5 [:child/done :a]])
+      (rf/dispatch-sync
+        [:jct/p5 (with-meta [:child/done :a]
+                   {:rf/join-auth {:parent-id  :jct/p5
+                                   :invoke-id  [:racing]
+                                   :child-id   :a
+                                   :spawned-id a
+                                   :attempt    (:rf/attempt (join-state :jct/p5))}})])
       (is (= [:completed] (terminals-for a))
           "the post-resolution straggler stayed :stale — still one terminal")
       (is (some #(= :stale (:rf.reply/status (:tags %)))

--- a/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
@@ -331,3 +331,134 @@
         (rf/dispatch-sync [(get-in j2 [:children :a]) [:go]])
         (rf/dispatch-sync [(get-in j2 [:children :b]) [:go]])
         (is (true? (:resolved? (join-state :jea/p9))) "attempt 2 resolved")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ixjd48 — validate ownership + exact authority BEFORE the
+;; resolved-vs-unresolved classification. Pre-fix the `:resolved?` branch ran
+;; FIRST, so ANY matching event shape against a resolved join was attributed
+;; to the CURRENT attempt: an old-attempt straggler, an unstamped carrier, or
+;; even an unknown child forged a `:late-completion` record built from the
+;; CURRENT join's `[:children child-id]`, borrowing the current attempt's
+;; spawned/work identity. The fix gates the post-resolution late-completion
+;; path on an EXACT-CURRENT carrier; every stale/forged carrier is classified
+;; the same way it is on the pre-resolution path, with ZERO db mutation.
+;; ---------------------------------------------------------------------------
+
+(defn- late-completions []
+  (mtest/events-of :rf.machine.spawn-all/late-completion))
+
+(defn- bad-child-errors []
+  (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+
+(defn- resolve-all-join!
+  "Resolve a fresh `reg-join-parent!` `:all` join by completing BOTH children
+  through their own handler boundaries (so they fold with valid attempt
+  authority). The parent has no `:on` for `:all/done`, so it stays on
+  `:racing` and the resolved join slot survives for post-resolution probes.
+  Returns the resolved join state."
+  [parent-kw]
+  (let [j (join-state parent-kw)]
+    (rf/dispatch-sync [(get-in j [:children :a]) [:go]])
+    (rf/dispatch-sync [(get-in j [:children :b]) [:go]])
+    (join-state parent-kw)))
+
+(deftest old-attempt-straggler-against-resolved-successor-is-superseded
+  (testing "rf2-ixjd48 — THE COUNTEREXAMPLE. Attempt A's completion is queued;
+            the parent re-enters, installs attempt B, and B RESOLVES; then A
+            drains. Pre-fix the `:resolved?` branch ran first and forged a
+            join-resolved `:late-completion` carrying B's CURRENT spawned/work
+            identity for A's straggler. The fix validates authority first: A is
+            classified `:attempt-superseded` carrying ITS OWN (attempt-A)
+            identity, NO late-completion fires, and B's resolved join is
+            untouched (zero db mutation)."
+    (let [j1     (reg-join-parent! :jea/pr1 :jea/pr1a :jea/pr1b)
+          token1 (:rf/attempt j1)
+          a1     (get-in j1 [:children :a])]
+      ;; Tear attempt 1 down (its completion is still 'in flight'), re-enter
+      ;; (attempt 2 = B), and RESOLVE B.
+      (rf/dispatch-sync [:jea/pr1 [:abort]])
+      (rf/dispatch-sync [:jea/pr1 [:start]])
+      (let [j2 (resolve-all-join! :jea/pr1)
+            a2 (get-in j2 [:children :a])]
+        (is (true? (:resolved? j2)) "attempt B resolved")
+        (is (not= a1 a2) "attempt B respawned :a as a fresh instance")
+        (mtest/reset-captured!)
+        ;; Attempt A's exact carrier drains AFTER B resolved.
+        (dispatch-forged! :jea/pr1 [:child/done :a]
+                          {:parent-id  :jea/pr1
+                           :invoke-id  [:racing]
+                           :child-id   :a
+                           :spawned-id a1
+                           :attempt    token1})
+        ;; (1) exactly :attempt-superseded evidence; NO late-completion.
+        (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
+            "the old-attempt straggler is superseded, not late-completed")
+        (is (empty? (late-completions))
+            "no late-completion record for a superseded straggler")
+        ;; (2) the evidence carries ATTEMPT A's own identity, never B's.
+        (let [wid (:rf.reply/work-id (:tags (first (stale-completions))))]
+          (is (= a1 (nth wid 1))
+              "the superseded evidence carries the CARRIER's own (attempt-A) actor")
+          (is (not= a2 (nth wid 1))
+              "the superseded evidence does NOT borrow attempt B's current identity"))
+        ;; (3) zero db mutation — B's resolved join is untouched.
+        (let [j2' (join-state :jea/pr1)]
+          (is (= #{:a :b} (:done j2')) "B's :done set unchanged")
+          (is (true? (:resolved? j2')) "B stays resolved")
+          (is (= (:children j2) (:children j2')) "B's children mapping unchanged"))))))
+
+(deftest exact-current-carrier-after-resolution-is-late-completion
+  (testing "rf2-ixjd48 — THE PRESERVED PATH. An EXACT-CURRENT authenticated
+            carrier arriving after its OWN join resolved (a genuine current
+            survivor draining post-latch) still takes the join-resolved
+            `:late-completion` path — the fix gates late-completion on exact
+            authority, it does not remove it."
+    (reg-join-parent! :jea/pr2 :jea/pr2a :jea/pr2b)
+    (let [j (resolve-all-join! :jea/pr2)
+          a (get-in j [:children :a])]
+      (is (true? (:resolved? j)))
+      (mtest/reset-captured!)
+      (dispatch-forged! :jea/pr2 [:child/done :a]
+                        {:parent-id  :jea/pr2
+                         :invoke-id  [:racing]
+                         :child-id   :a
+                         :spawned-id a
+                         :attempt    (:rf/attempt j)})
+      (is (= 1 (count (late-completions)))
+          "the exact-current carrier still fires the late-completion op")
+      (is (empty? (stale-completions))
+          "no pre-resolution stale-completion class fired")
+      (let [tags (:tags (first (late-completions)))]
+        (is (= :stale (:rf.reply/status tags)))
+        (is (= :rf.machine.spawn-all/join-resolved
+               (:rf.reply/stale-reason tags))))
+      (is (= #{:a :b} (:done (join-state :jea/pr2))) "record frozen — no re-fold"))))
+
+(deftest unstamped-carrier-against-resolved-join-is-unverified
+  (testing "rf2-ixjd48 — acceptance: an UNSTAMPED carrier against a RESOLVED
+            join is `:attempt-unverified`, NOT late-completion. Pre-fix the
+            `:resolved?` branch attributed it before checking authority."
+    (reg-join-parent! :jea/pr3 :jea/pr3a :jea/pr3b)
+    (resolve-all-join! :jea/pr3)
+    (mtest/reset-captured!)
+    (dispatch-forged! :jea/pr3 [:child/done :a] nil)
+    (is (empty? (late-completions))
+        "no late-completion for an unauthenticated carrier")
+    (is (= [:rf.machine.spawn-all/attempt-unverified] (stale-reasons))
+        "an unstamped post-resolution carrier is attempt-unverified")
+    (is (= #{:a :b} (:done (join-state :jea/pr3))) "record frozen")))
+
+(deftest unknown-child-against-resolved-join-is-bad-child
+  (testing "rf2-ixjd48 — acceptance: an UNKNOWN child-id against a RESOLVED
+            join takes the canonical bad-child-id error path, NOT the resolved
+            late-completion path (pre-fix it forged a late-completion built
+            from a nil `[:children child-id]`)."
+    (reg-join-parent! :jea/pr4 :jea/pr4a :jea/pr4b)
+    (resolve-all-join! :jea/pr4)
+    (mtest/reset-captured!)
+    (dispatch-forged! :jea/pr4 [:child/done :zzz] nil)
+    (is (empty? (late-completions))
+        "no late-completion for an unknown child")
+    (is (= 1 (count (bad-child-errors)))
+        "the canonical bad-child-id error fires against the resolved join")
+    (is (= #{:a :b} (:done (join-state :jea/pr4))) "record frozen")))

--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -243,8 +243,16 @@
       (rf/dispatch-sync [a [:go]])
       (is (true? (:resolved? (join-state :sac/p3 [:racing]))) "the :any join resolved")
       (mtest/reset-captured!)
-      ;; A known child-id re-completes AFTER the :resolved? latch flipped.
-      (rf/dispatch-sync [:sac/p3 [:child/done :a]])
+      ;; :a's EXACT-CURRENT completion re-completes AFTER the :resolved? latch
+      ;; flipped — the late-completion path is gated on exact authority
+      ;; (rf2-ixjd48), so the carrier is stamped for the current attempt.
+      (rf/dispatch-sync
+        [:sac/p3 (with-meta [:child/done :a]
+                   {:rf/join-auth {:parent-id  :sac/p3
+                                   :invoke-id  [:racing]
+                                   :child-id   :a
+                                   :spawned-id a
+                                   :attempt    (:rf/attempt (join-state :sac/p3 [:racing]))}})])
       (let [late (first (mtest/events-of :rf.machine.spawn-all/late-completion))]
         (is (some? late) "the late-completion op fired")
         (is (= :stale (:rf.reply/status (:tags late))))

--- a/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
@@ -200,9 +200,19 @@
           ;; First child resolves the :any join.
           (rf/dispatch-sync [(:a ids) [:go]])
           ;; The decisive child :a re-completes LATE (the join already
-          ;; latched :resolved?). Its :on-child-done lands as a
-          ;; post-resolution late-completion.
-          (rf/dispatch-sync [:sup/relp3 [:asset/loaded :a]]))
+          ;; latched :resolved?). Its EXACT-CURRENT :on-child-done lands as a
+          ;; post-resolution late-completion — the fix gates that path on exact
+          ;; authority, so the carrier is stamped for the current attempt
+          ;; (rf2-ixjd48).
+          (let [j (get-in (mtest/runtime-db)
+                          [:rf.runtime/machines :spawned :sup/relp3 [:hydrating]])]
+            (rf/dispatch-sync
+              [:sup/relp3 (with-meta [:asset/loaded :a]
+                            {:rf/join-auth {:parent-id  :sup/relp3
+                                            :invoke-id  [:hydrating]
+                                            :child-id   :a
+                                            :spawned-id (:a ids)
+                                            :attempt    (:rf/attempt j)}})])))
         (let [late (->> @captured
                         (filter #(= :rf.machine.spawn-all/late-completion (:operation %)))
                         first)]

--- a/implementation/machines/test/re_frame/spawn_all_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_test.clj
@@ -617,9 +617,19 @@
           (let [j (get-in (frame-db) [:rf.runtime/machines :spawned :sup/latek [:hydrating]])]
             (is (true? (:resolved? j)) ":any resolved on first :go")
             (is (= #{:a} (:done j))))
-          ;; Re-dispatch a KNOWN child-id's completion AFTER resolution (the
-          ;; late straggler). It flows through the :resolved? branch.
-          (rf/dispatch-sync [:sup/latek [:asset/loaded :a]])
+          ;; Re-dispatch :a's EXACT-CURRENT completion AFTER resolution (a
+          ;; genuine current survivor draining post-latch). It flows through
+          ;; the :resolved? late-completion branch — which the fix now gates on
+          ;; exact authority, so the carrier is stamped for the current attempt
+          ;; (rf2-ixjd48).
+          (let [j (get-in (frame-db) [:rf.runtime/machines :spawned :sup/latek [:hydrating]])]
+            (rf/dispatch-sync
+              [:sup/latek (with-meta [:asset/loaded :a]
+                            {:rf/join-auth {:parent-id  :sup/latek
+                                            :invoke-id  [:hydrating]
+                                            :child-id   :a
+                                            :spawned-id (:a ids)
+                                            :attempt    (:rf/attempt j)}})]))
           (let [j (get-in (frame-db) [:rf.runtime/machines :spawned :sup/latek [:hydrating]])]
             (is (= #{:a} (:done j))
                 "rf2-w8gxxz: the record stays frozen — no fold on late completion")


### PR DESCRIPTION
## Problem (rf2-ixjd48)

`intercept-spawn-all-event` classified a `:spawn-all` child completion with the `:resolved?` branch running **first**, so any matching event shape against a resolved join was attributed to the **current** attempt. It built a `:rf.machine.spawn-all/late-completion` record from the current join's `[:children child-id]`, borrowing the current attempt's spawned/work identity. Ownership + exact-attempt authority were only checked on the *unresolved* path.

Counterexample (durable join state never mutated, but Xray/work-ledger evidence corrupted):

1. Attempt A's completion is queued.
2. The parent re-enters, installs attempt B, and B resolves.
3. A drains → the resolved-first branch emits ordinary join-resolved late-completion evidence carrying **B's** current spawned/work identity — a forged fact attributed to the wrong attempt.

An unstamped carrier or an unknown-child carrier against a resolved join was likewise attributed before validation (the latter forged a late-completion with a `nil` spawned-id).

## Fix

Reorder the classifier so **ownership + exact authority are validated before** the resolved-vs-unresolved split:

- **unknown child** → canonical `:rf.error/machine-spawn-all-bad-child-id` (was: forged late-completion, nil spawned-id);
- **missing authority** → `:attempt-unverified`;
- **prior/wrong authority** → `:attempt-superseded`, carrying the **carrier's own** stamped `:spawned-id` — never the current join's child mapping — so the evidence cannot borrow the current attempt's work identity;
- **exact-current carrier** → the existing post-resolution join-resolved late-completion path, preserved unchanged.

`suppress-stale-completion!` now takes the completion's own `spawned-id` explicitly. Every stale path stays **zero runtime-db mutation**. No new public event form, error family, or compatibility path is added (acceptance criterion 8).

## Red-before-fix

New counterexample fixtures live in `join_exact_auth_cljs_test.cljc`. Against the **unmodified** source they fail exactly as the defect predicts — e.g. the old-attempt straggler produced:

```
:rf.reply/work-id [:rf.work/machine :jea/pr1a#2 [:racing] 2]   ; B's identity, forged onto A
```

and `stale-reasons` was `[]` (a `:late-completion`, not `:attempt-superseded`); the unknown-child case forged `[:rf.work/machine nil [:racing] nil]`. Post-fix: `[:attempt-superseded]` carrying `:jea/pr1a#1` (A's own), no late-completion, join untouched.

Reordering `:resolved?` back ahead of the ownership/authority gates re-fails these focused tests (acceptance criterion 7).

New tests:
- `old-attempt-straggler-against-resolved-successor-is-superseded` — the primary counterexample (superseded, carrier's own identity, no late-completion bearing B's work-id, zero db mutation);
- `unstamped-carrier-against-resolved-join-is-unverified`;
- `unknown-child-against-resolved-join-is-bad-child`;
- `exact-current-carrier-after-resolution-is-late-completion` — guards that the legitimate path is preserved (green before and after).

Four existing tests that re-dispatched **bare unstamped** carriers post-resolution (they encoded the pre-fix behavior) now stamp exact-current carriers so they keep exercising the late-completion path: `late-completion-of-known-child-is-stale-record-frozen`, `late-completion-carries-stale-reply`, `late-completion-op-classifies-by-stale-reason`, `duplicate-and-post-resolution-signals-add-no-terminals`.

## Quality gates

- `cd implementation/machines && clojure -M:test` → **1093 tests, 3791 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **9453 tests, 46401 assertions, 0 failures, 0 errors** (covers the machines `.cljc` node surface)

Scope: `implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc` + its tests only. No core/ui/compiler/reactive/spec changes.
