### PR TITLE
fix(ui): fence overlapping async HMR activations by transaction generation (rf2-vxgfnd.243)

### DIFF
--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -733,9 +733,84 @@ async function main() {
            `descriptor ${JSON.stringify(recoveredDescriptorDigest)}, active ${recoveredC2}`);
     }
 
+    // Counterexample 3 — overlapping async activations (rf2-vxgfnd.243). The
+    // probe's default `:loader-mode :eval` runs a reload's
+    // before-load/stage!/after-load synchronously per cycle, so real Shadow
+    // never overlaps activations. Under `:loader-mode :script` a reload's
+    // sources load asynchronously and a second reload's before-load/stage! can
+    // interleave between a first reload's before-load and its after-load. We
+    // MODEL that interleaving deterministically by driving the REAL carrier
+    // cell's raw activation hooks (exported by base.cljs): two reloads paused,
+    // then RELEASED NEWEST-FIRST, then a stale straggler firing after a newer
+    // reload has re-fenced. The generation fence must make the stale after-load
+    // INERT — never regressing the published digest, never clearing the newer
+    // fence. (Deleting the `generation > activated` guard in digest-carrier's
+    // after-load turns the stale straggler back into an unconditional
+    // promote+release, flipping the "newer fence intact" assertion below red.)
+    // Driven last: mutating the live cell corrupts nothing downstream.
+    const dA = 'bd1-aaaaaaaaaaaaaaaa';
+    const dB = 'bd1-bbbbbbbbbbbbbbbb';
+    const dC = 'bd1-cccccccccccccccc';
+    const carrierReady = await page.evaluate(() =>
+      typeof globalThis.__rf2CarrierBeforeLoad === 'function' &&
+      typeof globalThis.__rf2CarrierStage === 'function' &&
+      typeof globalThis.__rf2CarrierAfterLoad === 'function');
+    if (!carrierReady) {
+      fail('counterexample 3: activation-transaction hooks were not exported');
+    }
+    if ((await page.evaluate(() => globalThis.__rf2ReadDigest())) !== recoveredC2) {
+      fail('counterexample 3 did not start from the last accepted activated digest');
+    }
+    // Step the model and read `current` after each hook. `beforeLoad` fences
+    // (null); `stage` mints the next generation; `afterLoad` promotes+releases
+    // only for a not-yet-activated generation.
+    const step = (op, arg) => page.evaluate(({ op, arg }) => {
+      if (op === 'before') globalThis.__rf2CarrierBeforeLoad();
+      else if (op === 'stage') globalThis.__rf2CarrierStage(arg);
+      else if (op === 'after') globalThis.__rf2CarrierAfterLoad();
+      return globalThis.__rf2ReadDigest();
+    }, { op, arg });
+
+    // Reload A pauses (fenced + staged); reload B pauses (fenced + staged).
+    if ((await step('before')) !== null) fail('c3: reload A before-load did not fence reads');
+    if ((await step('stage', dA)) !== null) fail('c3: staging under the fence published early');
+    if ((await step('before')) !== null) fail('c3: reload B before-load did not keep reads fenced');
+    if ((await step('stage', dB)) !== null) fail('c3: second staging published under the fence');
+    // Release NEWEST-FIRST: reload B (the newer generation) activates.
+    const afterB = await step('after');
+    if (afterB !== dB) {
+      fail(`c3: newest reload B did not publish its generation (got ${JSON.stringify(afterB)}, want ${dB})`);
+    }
+    // The STALE straggler — reload A's after-load, released second — must be
+    // inert: its generation is no longer ahead of the activated high-water mark.
+    const afterStaleA = await step('after');
+    if (afterStaleA !== dB) {
+      fail(`c3: stale reload A completion REGRESSED the active digest to ` +
+           `${JSON.stringify(afterStaleA)} (must stay on the newer ${dB})`);
+    }
+    // A newer reload C now re-fences. A late stale straggler firing here must
+    // NOT clear C's newer fence — the load-bearing overlap invariant.
+    if ((await step('before')) !== null) fail('c3: reload C before-load did not re-fence reads');
+    const staleAfterCFence = await step('after');
+    if (staleAfterCFence !== null) {
+      fail(`c3: a stale completion CLEARED the newer reload C's fence ` +
+           `(read ${JSON.stringify(staleAfterCFence)}; the newer fence must hold reads closed)`);
+    }
+    // C completes normally and publishes its generation exactly once.
+    if ((await step('stage', dC)) !== null) fail('c3: reload C staging published under its own fence');
+    const afterC = await step('after');
+    if (afterC !== dC) {
+      fail(`c3: reload C did not publish its generation after release (got ${JSON.stringify(afterC)}, want ${dC})`);
+    }
+    console.log(
+      'ui digest carrier: overlapping activations fenced by generation ' +
+      '(newest-first release inert for the stale straggler; newer fence held)',
+    );
+
     console.log(
       `ui digest carrier: PASS (${digest1} -> ${digest2} -> failed/LKG -> ${digest3}` +
-      ` -> v2-loaded-throw/fail-closed -> forward-recovery ${recoveredC2})`,
+      ` -> v2-loaded-throw/fail-closed -> forward-recovery ${recoveredC2}` +
+      ` -> overlap-fence ${dB}/${dC})`,
     );
   } finally {
     fs.writeFileSync(LAZY_SOURCE, original);

--- a/implementation/ui/src/re_frame/ui/digest_carrier.cljs
+++ b/implementation/ui/src/re_frame/ui/digest_carrier.cljs
@@ -18,7 +18,8 @@
 
   - `before-load` fences the runtime (`updating` true) so reads become
     fail-closed for the duration of the swap;
-  - carrier evaluation STAGES the generation's compiled digest;
+  - carrier evaluation STAGES the generation's compiled digest (`stage!`),
+    minting the next monotone activation GENERATION;
   - `after-load` promotes the staged digest to the published slot — and Shadow
     runs after-load hooks only once EVERY reloaded source has evaluated without
     throwing.
@@ -29,6 +30,26 @@
   a partially mutated runtime. The initial page load runs no before-load fence,
   so that first, whole load publishes immediately.
 
+  Overlapping async activations (rf2-vxgfnd.243). Under Shadow
+  `:loader-mode :script` a reload's sources load asynchronously, so a second
+  reload's `before-load`/`stage!` can interleave BETWEEN a first reload's
+  `before-load` and its `after-load` — CLJS is single-threaded, so this is
+  interleaved reload continuations, not threads. Without an ordering rule a
+  STALE after-load (an older reload finishing after a newer one already
+  published) would regress the published digest and/or clear the newer reload's
+  fence. The rule is a monotone `:generation` minted at each `stage!` plus an
+  `:activated` high-water mark: `after-load` promotes and releases the fence
+  ONLY when `generation > activated` — i.e. only for a NOT-yet-activated
+  staging. A stale after-load observes `generation == activated` (a newer
+  staging already advanced the high-water mark) and is INERT: it never
+  regresses `:published` and never clears a newer generation's `:updating`
+  fence. The high-water rule also keeps forward recovery intact — a throwing
+  reload's skipped after-load merely leaves `activated` lagging, and the next
+  successful reload's after-load jumps the mark forward and publishes. (Under
+  the default `:loader-mode :eval` a reload's before-load/stage!/after-load run
+  synchronously to completion, so activations never overlap; the generation
+  rule is the correctness guarantee for the `:script` interleaving.)
+
   Every operation is goog.DEBUG-gated. Closure removes the slot, sentinel,
   staging cell, reload hooks, validation and accessors from advanced production
   output."
@@ -36,14 +57,25 @@
 
 ;; The runtime activation cell. It PERSISTS across `^:dev/always` reloads
 ;; (`defonce` re-init is skipped once the slot exists), so the `updating` fence
-;; a hot reload's `before-load` sets survives this namespace re-evaluating.
-;;   :published — the digest reads observe; nil while fail-closed;
-;;   :staged    — the candidate digest of the generation currently evaluating;
-;;   :updating  — the fence: true between a hot reload's before-load and a
-;;                SUCCESSFUL after-load (a reloaded-source throw leaves it true).
+;; a hot reload's `before-load` sets — and the `generation`/`activated`
+;; activation ordinals — survive this namespace re-evaluating.
+;;   :published  — the digest reads observe; nil while fail-closed;
+;;   :staged     — the candidate digest of the generation most recently staged;
+;;   :updating   — the fence: true between a hot reload's before-load and a
+;;                 SUCCESSFUL after-load (a reloaded-source throw leaves it true);
+;;   :generation — monotone activation ordinal, bumped by each `stage!`; the
+;;                 generation of the currently-staged digest;
+;;   :activated  — high-water mark: the greatest generation an after-load has
+;;                 promoted+released. `after-load` acts only when
+;;                 `generation > activated`, so a stale (overlapping) after-load
+;;                 is inert;
+;;   :reloaded   — true once ANY hot reload has begun (before-load ran). Keeps
+;;                 the initial-load auto-publish from misfiring on a later
+;;                 staging whose fence a stale after-load happened to clear.
 (defonce ^:private cell
   (when ^boolean js/goog.DEBUG
-    #js {:published nil :updating false :staged nil}))
+    #js {:published nil :updating false :staged nil
+         :generation 0 :activated 0 :reloaded false}))
 
 ;; Exactly 20 bytes, matching a bd1- + 16-hex-digit digest. Keep this literal
 ;; unique and in ONE source location: the hook requires exactly one occurrence
@@ -52,15 +84,26 @@
 (def ^:private compiled-digest
   (when ^boolean js/goog.DEBUG "__RF2_UI_DIGEST_XX__"))
 
-;; (Re)evaluation stages this generation's compiled digest. On the initial page
-;; load no before-load fence has run, so the runtime is not `updating` and this
-;; whole, first load publishes immediately. During a hot reload before-load has
-;; set `updating`, so this only STAGES: after-load promotes it iff every
-;; reloaded source evaluated successfully.
+(defn stage!
+  "Stage `digest` as the next monotone activation GENERATION. Called by carrier
+  (re)evaluation and by the activation-ordering fixture. On the genuine initial
+  page load — no before-load fence has run and no reload has ever begun — the
+  runtime is not `updating`, so this whole first load PUBLISHES immediately and
+  seeds the activation high-water mark. During (or overlapping) a hot reload the
+  runtime is fenced (or has already been reloaded), so this only STAGES and
+  bumps `:generation`; a subsequent `after-load` promotes it iff its generation
+  is still ahead of `:activated`."
+  [digest]
+  (when ^boolean js/goog.DEBUG
+    (set! (.-generation cell) (inc (.-generation cell)))
+    (set! (.-staged cell) digest)
+    (when (and (not (.-updating cell)) (not (.-reloaded cell)))
+      (set! (.-published cell) digest)
+      (set! (.-activated cell) (.-generation cell)))))
+
+;; (Re)evaluation stages this generation's compiled digest.
 (when ^boolean js/goog.DEBUG
-  (set! (.-staged cell) compiled-digest)
-  (when-not (.-updating cell)
-    (set! (.-published cell) compiled-digest)))
+  (stage! compiled-digest))
 
 (defn- finalized-digest?
   "True only for a FINALIZED `bd1-` whole-build digest — never the unpatched
@@ -92,20 +135,33 @@
 (defn ^:dev/before-load before-load
   "Fence the runtime before Shadow swaps reloaded code: digest/descriptor reads
   become fail-closed until a successful after-load promotes the staged
-  generation."
+  generation. Records that a reload has begun so a later staging cannot be
+  mistaken for the initial whole-page load."
   []
   (when ^boolean js/goog.DEBUG
-    (set! (.-updating cell) true)))
+    (set! (.-updating cell) true)
+    (set! (.-reloaded cell) true)))
 
 (defn ^:dev/after-load after-load
   "Promote the staged generation once EVERY reloaded source has evaluated. A
   top-level throw in any reloaded source skips this hook (Shadow stops the
   reload before after-load), leaving reads fail-closed until a later successful
-  reload."
+  reload.
+
+  Overlapping-activation ordering (rf2-vxgfnd.243): promote + release the fence
+  ONLY when `generation > activated` — i.e. only for a staging that has not yet
+  been activated by a newer transaction. A STALE after-load from an earlier,
+  overlapping reload observes `generation == activated` (a newer `stage!`
+  already advanced both the staged digest and the high-water mark) and is
+  therefore INERT: it neither regresses `:published` nor clears a newer
+  reload's fence. Advancing `:activated` to the current generation is also what
+  preserves forward recovery after a throwing reload skipped its after-load."
   []
   (when ^boolean js/goog.DEBUG
-    (set! (.-published cell) (.-staged cell))
-    (set! (.-updating cell) false)))
+    (when (> (.-generation cell) (.-activated cell))
+      (set! (.-published cell) (.-staged cell))
+      (set! (.-activated cell) (.-generation cell))
+      (set! (.-updating cell) false))))
 
 ;; A configured build that omitted the load-bearing hook must not limp along
 ;; with a plausible but false identity. The hook patches the sentinel before

--- a/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/base.cljs
@@ -1,6 +1,12 @@
 (ns re-frame.ui.digest-probe.base
   (:require [re-frame.ui :as ui]
             [re-frame.ui.client :as client]
+            ;; The runtime half of the activation transaction. The overlapping-
+            ;; activation fixture (rf2-vxgfnd.243) drives its before-load /
+            ;; stage! / after-load hooks directly to MODEL two reloads paused and
+            ;; released newest-first — a deterministic interleaving real Shadow
+            ;; under `:loader-mode :eval` runs synchronously and never overlaps.
+            [re-frame.ui.digest-carrier :as digest-carrier]
             ;; A loaded application source in the base module: the
             ;; runtime-activation probe (counterexample 2) edits it to throw at
             ;; top-level during a compile-valid hot reload.
@@ -63,4 +69,16 @@
         (fn []
           (when-let [el (.querySelector js/document "[data-probe=\"loaded\"]")]
             (.-textContent el))))
+  ;; rf2-vxgfnd.243 — the raw activation-transaction hooks, so the runner can
+  ;; DRIVE a modeled overlapping-reload interleaving (two reloads paused,
+  ;; released newest-first) against the REAL carrier cell. Real Shadow under the
+  ;; probe's default `:loader-mode :eval` runs before-load/stage!/after-load
+  ;; synchronously per cycle, so it never produces the interleaving; the fixture
+  ;; reproduces it deterministically to prove a STALE after-load neither
+  ;; regresses the published digest nor clears a newer reload's fence. Driven
+  ;; LAST in the proof, so mutating the live cell corrupts nothing downstream.
+  (set! (.-__rf2CarrierBeforeLoad js/globalThis) digest-carrier/before-load)
+  (set! (.-__rf2CarrierStage js/globalThis)
+        (fn [digest] (digest-carrier/stage! digest)))
+  (set! (.-__rf2CarrierAfterLoad js/globalThis) digest-carrier/after-load)
   (set! (.-__rf2BaseLoaded js/globalThis) true))


### PR DESCRIPTION
## What

PR #5848 stored the published/staged digest and the `updating` fence in one **unversioned** activation cell (`{:published :updating :staged}`). Under Shadow `:loader-mode :script` a reload's sources load asynchronously, so a second reload's `before-load`/`stage!` can interleave **between** a first reload's `before-load` and its `after-load`. CLJS is single-threaded, so this is interleaved reload continuations, not threads. With the old **unconditional** `after-load`, a **stale completion** (an older reload finishing after a newer one already published) could regress the published digest and/or **clear the newer reload's fence**, exposing a partially-mutated runtime as fully activated.

## Mechanism (smallest correct)

A monotone `:generation` minted at each `stage!`, plus an `:activated` high-water mark. `after-load` promotes + releases the fence **only when `generation > activated`** — a not-yet-activated staging.

- A **stale** after-load observes `generation == activated` (a newer `stage!` already advanced both the staged digest and the mark) and is **inert**: it never regresses `:published`, never clears a newer generation's fence.
- **Forward recovery** (rf2-vxgfnd.242) is preserved: a throwing reload's skipped after-load merely leaves `:activated` lagging; the next successful reload jumps the mark forward and publishes.
- `:reloaded` guards the initial-load auto-publish so a later staging can't be mistaken for the first whole-page load.

No scheduler, no concurrency abstraction — just two integers + a boolean on the existing cell. Under the default `:loader-mode :eval` a reload runs `before-load`/`stage!`/`after-load` synchronously, so activations never overlap; the generation rule is the correctness guarantee for the `:script` interleaving. Fix is local to `digest_carrier.cljs`; `reactive.cljc`/`client.cljs` are unchanged (they only *read* via `current`).

## Fixture (AC)

`check-ui-digest-carrier.cjs` gains **counterexample 3**: it drives the **real** carrier cell's raw hooks (exported by `base.cljs`) to model two reloads paused and **released newest-first**, then a stale straggler firing after a newer reload re-fences. It asserts the active digest never regresses **and** a stale completion cannot clear the newer fence. Real Shadow under the probe's default `:eval` runs each cycle synchronously and never overlaps, so the runner reproduces the interleaving deterministically.

### Red-before-fix

Reverting only the `generation > activated` guard (unconditional promote+release = pre-243 behavior) reds the gate at exactly the load-bearing assertion, with every prior section still green:

```
ui digest carrier: loaded-source throw left carrier + mounted descriptor fail-closed ...
Error: FAIL: c3: a stale completion CLEARED the newer reload C's fence
  (read "bd1-bbbbbbbbbbbbbbbb"; the newer fence must hold reads closed)
EXIT: 1
```

With the guard restored:

```
ui digest carrier: overlapping activations fenced by generation
  (newest-first release inert for the stale straggler; newer fence held)
ui digest carrier: PASS (... -> forward-recovery bd1-d98f7a43b62575c9 -> overlap-fence bd1-bbb.../bd1-ccc...)
EXIT: 0
```

## Quality gates

- `cd implementation/ui && clojure -M:test` — **538 tests, 6622 assertions, 0 failures / 0 errors**
- `cd implementation && npm run test:cljs` — **9449 tests, 46380 assertions, 0 failures / 0 errors**
- `cd implementation && npm run test:ui-digest-carrier` (real Shadow watch + live browser) — **PASS (EXIT 0)**; red-before-fix demonstrated above.

No full browser matrix / fast-pr run locally (CI owns those).
