### PR TITLE
fix(spec/core): name the pre-dissoc epoch snapshot in Spec 002 destroy order + destroy-frame! docstring; integrated throwing-snapshot fixture (rf2-vxgfnd.289)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -3287,6 +3287,27 @@
                                               pending :dispatch-later timers.
     8. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER every
                                       feature cleanup hook has completed.
+    8a. snapshot-epoch-terminal-    — bind A's terminal :halted-destroy
+        evidence!                     evidence (its epoch record + the
+                                      listener/silencing snapshot) via the
+                                      :epoch/snapshot-frame-destroyed hook
+                                      while A still SOLELY owns its id-keyed
+                                      epoch stores — i.e. BEFORE the step-10
+                                      dissoc, after which a same-id successor
+                                      B can be constructed and claim (drop)
+                                      those stores. The bundle is bound
+                                      lexically here and published by step 11
+                                      regardless of whether A still owns the
+                                      stores when it fires (rf2-vxgfnd.151).
+                                      Taken BEFORE the step-9 ring release so a
+                                      snapshot-hook failure's ordinary-delivery
+                                      warning rides A's ring and is cleared by
+                                      that release instead of recreating an
+                                      already-freed one (rf2-vxgfnd.244).
+                                      Best-effort: a throw is recorded on both
+                                      Spec 009 channels and swallowed; a nil
+                                      bundle (no epoch layer / debug disabled)
+                                      publishes nothing.
     9. trace-policy release         — clear the per-frame trace ring and the
                                       frame-no-emit flag after the destroyed
                                       trace has flowed.
@@ -3295,8 +3316,13 @@
                                       is the ONE store a seated frame lives in
                                       (rf2-h1vqa4 — no registrar row exists).
     11. notify-epoch-listeners!     — fire the epoch hook so tools see
-                                      :rf.epoch.cb/silenced-on-frame-destroy,
-                                      threading the pre-run
+                                      :rf.epoch.cb/silenced-on-frame-destroy.
+                                      This is the PUBLISH half of the epoch
+                                      destroy contract: it ships the terminal
+                                      evidence step 8a bound pre-dissoc,
+                                      whether or not a same-id successor now
+                                      owns the id-keyed stores. It threads the
+                                      pre-run
                                       (`*run-frame-state-before*`) and
                                       destroy-time (live frame-state value
                                       captured at the TOP of this fn, before

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -769,6 +769,106 @@
         (when (frame/frame id) (frame/destroy-frame! id))
         (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)))))
 
+(deftest snapshot-hook-failure-still-publishes-reports-and-spares-successor
+  ;; rf2-vxgfnd.289 — the integrated full-destroy peer to the epoch-seam unit
+  ;; `epoch-test/terminal-publish-noops-on-nil-bundle-no-fabrication` and the
+  ;; ring-residue pin `snapshot-hook-failure-leaves-no-residual-ring` above. A
+  ;; throwing PRE-dissoc `:epoch/snapshot-frame-destroyed` (step 8a) MUST NOT
+  ;; abort teardown. The recipe walks straight on:
+  ;;
+  ;;   (1) the POST-dissoc publish hook (`:epoch/on-frame-destroyed`, step 11)
+  ;;       STILL RUNS — the snapshot/publish split (rf2-vxgfnd.151/.246) threads
+  ;;       the (now nil) bundle through to the publish regardless of outcome;
+  ;;   (2) exactly ONE bounded always-on `:rf.error/frame-teardown-failed`
+  ;;       report ships (EP-0008 R1 finally-flush) and its :hook-failures NAMES
+  ;;       the failing `:epoch/snapshot-frame-destroyed` hook;
+  ;;   (3) a same-id successor B installed in the post-dissoc window is left
+  ;;       PRISTINE — the nil bundle makes the publish fabricate nothing, so it
+  ;;       cannot silence the observing cb, and B is a FRESH incarnation, live
+  ;;       after the destroy returns, not A's.
+  ;;
+  ;; An epoch cb OBSERVES A before the destroy, so a SUCCESSFUL snapshot WOULD
+  ;; have owed it a terminal silence (per `terminal-publish-noops-on-nil-bundle-
+  ;; no-fabrication`); the throwing snapshot must owe — and fire — none. A is
+  ;; destroyed via a DIRECT `destroy-frame!` (not mid-drain) so the proven
+  ;; make-frame-B-in-publish-window pattern (see
+  ;; `run-terminal-teardown-hook-exception-scenario`) is safe.
+  (let [id             :destroy/snap-fail-integrated
+        cb             ::snap-fail-observer
+        reports        (atom [])                       ; :rf.error/frame-teardown-failed
+        silencings     (atom [])                       ; :rf.epoch.cb/silenced-on-frame-destroy
+        publish-calls  (atom 0)
+        a-token        (atom nil)
+        b-token        (atom nil)
+        original-snap  (late-bind/get-fn :epoch/snapshot-frame-destroyed)
+        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+    (rf/reg-event :snap-fail/seed (fn [_ _] {:db {:n 0}}))
+    (rf/make-frame {:id id})
+    ;; An epoch cb OBSERVES A: delivery of the settled :seed record stamps its
+    ;; observation of the frame, so a live snapshot would owe it a silence.
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (rf/dispatch-sync [:snap-fail/seed] {:frame id})
+    (reset! a-token (frame/frame-incarnation-token id))
+    (rf/register-listener! :errors cb
+      (fn [r] (when (= :rf.error/frame-teardown-failed (:error r))
+                (swap! reports conj r))))
+    (rf/register-listener! :trace cb
+      (fn [ev] (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                 (swap! silencings conj ev))))
+    (try
+      ;; Fail the PRE-dissoc snapshot for this id (delegate every other id).
+      (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+        (fn [& args]
+          (if (= id (first args))
+            (throw (ex-info "snapshot blew" {}))
+            (when original-snap (apply original-snap args)))))
+      ;; Spy the POST-dissoc publish: prove it ran, install same-id B inside its
+      ;; window, then delegate to the real (nil-bundle → no-op) publish.
+      (late-bind/set-fn! :epoch/on-frame-destroyed
+        (fn [& args]
+          (when (= id (first args))
+            (swap! publish-calls inc)
+            (rf/make-frame {:id id})
+            (reset! b-token (frame/frame-incarnation-token id)))
+          (when original-epoch (apply original-epoch args))))
+      (frame/destroy-frame! id)
+      (executor-barrier!)
+
+      ;; (1) The post-dissoc publish still ran despite the failed snapshot.
+      (is (= 1 @publish-calls)
+          "the post-dissoc :epoch/on-frame-destroyed publish (step 11) still
+           fires after the pre-dissoc snapshot (step 8a) threw")
+
+      ;; (2) Exactly one bounded always-on report, naming the snapshot hook.
+      (is (= 1 (count @reports))
+          "exactly one bounded :rf.error/frame-teardown-failed ships (finally-flush)")
+      (let [r (first @reports)]
+        (is (= id (:frame r)) "the report names the destroyed frame")
+        (is (= 1 (count (:hook-failures r)))
+            "one :hook-failures entry — only the snapshot hook failed")
+        (is (= :epoch/snapshot-frame-destroyed (:hook (first (:hook-failures r))))
+            "the report names the failing pre-dissoc snapshot hook")
+        (is (= :ignored (:recovery r))
+            ":recovery :ignored — teardown is best-effort"))
+
+      ;; (3) The same-id successor B is pristine.
+      (is (some? @b-token)
+          "same-id B was installed in the post-dissoc window")
+      (is (= @b-token (frame/frame-incarnation-token id))
+          "B is the live incarnation after the destroy returns")
+      (is (not= @a-token @b-token)
+          "B is a FRESH incarnation, not A's token")
+      (is (empty? @silencings)
+          "the nil-bundle publish owes no silence — the observing cb is untouched")
+      (finally
+        ;; Restore the real hooks BEFORE destroying B so B's teardown runs clean.
+        (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
+        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :errors cb)
+        (rf/unregister-listener! :trace cb)
+        (when (frame/frame id) (frame/destroy-frame! id))))))
+
 ;; ---- rf2-vxgfnd.245 — honest delayed epoch fan-out after same-id rearm -------
 ;;
 ;; #5850 snapshots predecessor A's `silenced-cbs` before dissoc and later

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -661,13 +661,32 @@ exact-token teardown cascade described below is the sole executable exception.
     have no second registrar row to unregister.
 11. **Notify epoch listeners** — fire `:rf.epoch.cb/silenced-on-frame-destroy` after the
     live frame has vanished so tools silence their per-frame event buffers in one pass.
-    The internal hook carries the destroyed incarnation token and compare-cleans only
-    that owner: if a fresh same-id incarnation has already published epoch state, stale
-    cleanup is a no-op for the replacement.
+    This is the PUBLISH half of the epoch destroy contract: it ships the terminal
+    evidence the pre-dissoc snapshot (below) bound. The internal hook carries the
+    destroyed incarnation token and compare-cleans only that owner: if a fresh same-id
+    incarnation has already published epoch state, stale cleanup is a no-op for the
+    replacement.
 
 Steps 3, 4, 7, 9, and 11's optional/per-artefact calls are **best-effort**: an unbound
 hook silently no-ops and the rest of the recipe continues. The relative order between
 registered hooks does not change.
+
+**The epoch layer's terminal evidence is snapshotted before the dissoc — a step in its
+own right.** Between step 8 and step 9 — before the trace-ring release, and before the
+step-10 registry dissoc — `destroy-frame!` invokes `snapshot-terminal-destroy-evidence!`
+(the `:epoch/snapshot-frame-destroyed` hook). It binds the dying incarnation's terminal
+`:halted-destroy` evidence (the partial epoch record plus the listener/silencing snapshot)
+while that incarnation still **solely** owns its id-keyed epoch stores. A same-id successor
+is constructable only *after* the dissoc, so it can never claim — and thereby drop — those
+stores out from under the snapshot; step 11 then publishes the bound evidence whether or
+not the incarnation still owns the stores when it fires, and that split is exactly what
+keeps a paused predecessor's terminal facts intact once a replacement claims the id. The
+snapshot is best-effort like the numbered hooks above: a throw is caught, recorded on both
+Spec 009 channels, and teardown continues; a nil bundle (no epoch layer, or debug disabled)
+publishes nothing — step 11 fabricates no evidence the snapshot did not bind. It runs before
+the trace-ring release so a snapshot-hook failure's ordinary-delivery warning rides the
+incarnation's ring and is cleared by that release rather than recreating an already-freed
+one.
 
 **The claim-to-dead dispatch window is distinct from dispatch after death.** A racing
 ordinary dispatch that linearizes after the claim but before lifecycle-dead may still


### PR DESCRIPTION
The rf2-vxgfnd.246 follow-up. PR #5939 proved the split epoch snapshot/publish destroy contract and reconciled Spec 009, but flagged two gaps this PR closes.

## What changed

**(a) Name the pre-dissoc snapshot step.** Spec 002 §Destroy order and `frame.cljc`'s `destroy-frame!` docstring listed step 10=dissoc / step 11=notify without naming the separate pre-dissoc snapshot step. `snapshot-terminal-destroy-evidence!` (the `:epoch/snapshot-frame-destroyed` hook) binds A's terminal `:halted-destroy` evidence **before** the dissoc — while A still solely owns its id-keyed epoch stores — and step 11 publishes it whether or not a same-id successor B (constructable only *after* the dissoc) now owns those stores. That split is what keeps a paused predecessor's terminal facts intact once a replacement claims the id (rf2-vxgfnd.151/.246). Ordering the snapshot before the trace-ring release is the rf2-vxgfnd.244 subtlety: a snapshot-hook failure's ordinary-delivery warning rides A's ring and is cleared by that release.

- `spec/002-Frames.md` — a dedicated prose paragraph after the numbered recipe names the snapshot step, plus a one-clause pairing note in step 11.
- `implementation/core/src/re_frame/frame.cljc` — the `destroy-frame!` **docstring only** gains a `8a` step (between emit-destroyed and the ring release) + a pairing note in step 11. No logic change.

**Why no renumber.** python-markdown renders ordered lists by position, and `step 10 = dissoc` / `step 11 = notify` are load-bearing cross-references in `router.cljc`, the epoch/flows/core test suites, and other `frame.cljc` docstrings (all out of scope, and the flag wants them preserved). So the snapshot is named as a distinct step (`8a` in the plain-text docstring; a prose paragraph in the markdown spec) without displacing any ordinal. Verified the rendered list still has exactly 11 items with step 10=Dissoc, step 11=Notify.

**(b) Integrated throwing-snapshot fixture** — `frame_destroy_incarnation_jvm_test/snapshot-hook-failure-still-publishes-reports-and-spares-successor` (core, JVM). Sits next to the existing `snapshot-hook-failure-leaves-no-residual-ring` (.244) peer, which only covered the dev-only `:rf.warning/teardown-hook-exception` + ring + destruction. The fuller fixture adds the three unguarded legs: a throwing pre-dissoc snapshot hook leaves teardown intact — **(1)** the post-dissoc publish (`:epoch/on-frame-destroyed`, step 11) still runs; **(2)** exactly one bounded always-on `:rf.error/frame-teardown-failed` ships and its `:hook-failures` names `:epoch/snapshot-frame-destroyed`; **(3)** a same-id successor installed in the post-dissoc window is left pristine (fresh incarnation, live after destroy, and — since an observing cb would have been owed a terminal silence on a successful snapshot — the nil-bundle publish fires none).

## Red-before-fix

The guarded behavior is already shipped (this is a doc-reconciliation + regression-guard bead, no product-logic change), so the fixture is green on `main`. To prove it has teeth, I temporarily reverted the shipped contract locally — guarding the publish on a non-nil bundle in `notify-epoch-listeners!` (the pre-.246 hazard where a lost snapshot skips the publish). The fixture went red exactly where expected:

```
FAIL … expected: (= 1 @publish-calls)   actual: (not (= 1 0))   ; publish skipped
FAIL … expected: (some? @b-token)        actual: (not (some? nil)) ; B never installed
Ran 1 tests containing 11 assertions. 2 failures, 0 errors.
```

Leg 2 (the report) stayed green because the snapshot still threw + accumulated + flushed — precisely isolating the "publish still runs on the nil bundle" guarantee. The break was reverted; the committed `frame.cljc` diff is docstring-only.

## Quality gates

- `implementation/core` — `clojure -M:test`: **1989 tests / 9174 assertions, 0 failures, 0 errors** (includes the new fixture).
- `implementation/epoch` — `clojure -M:test`: **403 tests / 6043 assertions, 0 failures, 0 errors**.
- New fixture in isolation: **11 assertions, 0 failures**.
- Spec render check: destroy-order list still renders 11 items, step 10=Dissoc / step 11=Notify preserved; new paragraph renders as `<p>`, not a list item.
- mkdocs `--strict` not run locally (not on PATH; CI owns it). The spec edit adds no new headings/slugs/links.

Do not merge; leaving open per brief.