### PR TITLE
test(ui): prove override-binding machinery absent under mounted production elision (rf2-vxgfnd.216)

### DIFF
--- a/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/sub_overrides_elision_prod_test.cljs
@@ -10,10 +10,22 @@
   - the shared override Context was never constructed;
   - the internal Provider is transparent;
   - compiled `ui/sub` takes the ordinary owned-node path, never a static
-    override lease.
+    override lease;
+  - the compiled render path establishes NO dynamic `*sub-overrides*` binding
+    (rf2-vxgfnd.216). The bundle string-scan owns the DEBUG-only validation
+    sentinel, but a string can elide while the actual
+    `(binding [reactive/*sub-overrides* ...] ...)` push/set/restore leaks into
+    production with a runtime-nil value. Here a sub-bearing body run through the
+    real `render-subs` -> `capture-with-overrides` path READS the seeded ROOT
+    value of `re-frame.ui.reactive/*sub-overrides*`, so a leaked
+    binding-to-nil would shadow the root during the body and flip that read to
+    nil — a causal signal the scanner cannot see.
 
   The normal mounted browser gate supplies the DEBUG=true positive control: the
-  same provider helper produces nested static leases there."
+  same provider helper produces nested static leases there. The
+  `render-body-observes-live-sub-overrides-binding` control below supplies the
+  same-optimizer positive control for the binding probe: an ambient binding in
+  the render's dynamic extent IS read through by that exact body."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             ["react" :as React]
             ["react-dom" :as ReactDOM]
@@ -110,5 +122,98 @@
           (when @root
             (ReactDOM/flushSync #(ui/unmount! @root)))
           (.remove container)
+          (rf/destroy-frame! f)
+          (done))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.216 — the compiled render path carries no `*sub-overrides*`
+;; binding.
+;;
+;; `capture-with-overrides` binds `re-frame.ui.reactive/*sub-overrides*` ONLY
+;; under `interop/debug-enabled?`; production goes straight to `with-capture`.
+;; The bundle string-scan proves the DEBUG-only validation sentinel is absent,
+;; but that string is not OWNED by the binding: an adversary could keep the
+;; sentinel under goog.DEBUG (it still elides) yet leak the bare
+;; `(binding [reactive/*sub-overrides* overrides] ...)` into the production
+;; branch, where `overrides` is always nil — the dynamic-var push/set/restore
+;; then ships and runs on every sub-bearing render while the scanner still
+;; passes.
+;;
+;; This probe is causal, not lexical. A sub-bearing view (routed to
+;; `render-subs` -> `capture-with-overrides`) reads the LIVE value of
+;; `reactive/*sub-overrides*` from inside its body and renders it. The test
+;; seeds a distinguishable non-nil ROOT (via `set!`, the persistent form that
+;; survives to the async flushSync render — mirroring
+;; `test-support/make-reset-runtime-fixture`). A correct production build runs
+;; the body with the root intact, so the DOM reads the root token; a leaked
+;; `(binding [reactive/*sub-overrides* nil] ...)` would shadow the root during
+;; the body and the DOM would read nil. Deleting, retaining, or relocating the
+;; validation string cannot mask that.
+;; ---------------------------------------------------------------------------
+
+(def ^:private probe-root-token "rf2-216-sub-overrides-root")
+(def ^:private control-binding-token "rf2-216-sub-overrides-control")
+
+(defview prod-binding-probe []
+  ;; A `ui/sub` site routes this view to `render-subs` -> `capture-with-overrides`
+  ;; (the exact wrapper that binds `*sub-overrides*` in a DEBUG build). The body
+  ;; also reads that dynamic var, so the committed DOM records the value in
+  ;; effect DURING this production render.
+  [:output {:data-role "prod-binding-probe"}
+   (str (ui/sub [::prod-value]) "|" (pr-str reactive/*sub-overrides*))])
+
+(defn- probe-text [container]
+  (.-textContent (.querySelector container "[data-role='prod-binding-probe']")))
+
+(deftest advanced-production-render-body-carries-no-sub-overrides-binding
+  (rf/reg-sub ::prod-value (fn [db _] (:prod-value db)))
+  (let [f          (rf/make-frame {:initial-events [[:rf/set-db {:prod-value "ordinary"}]]})
+        root-c     (js/document.createElement "div")
+        control-c  (js/document.createElement "div")
+        root-root  (volatile! nil)
+        ctrl-root  (volatile! nil)
+        prior      reactive/*sub-overrides*]
+    (async done
+      ;; Persistent root seed (survives to the async render), NOT a `binding`.
+      (set! reactive/*sub-overrides* probe-root-token)
+      (.appendChild js/document.body root-c)
+      (.appendChild js/document.body control-c)
+      (try
+        ;; --- Causal probe: no binding in the production body -> root read ---
+        (ReactDOM/flushSync
+         #(vreset! root-root
+                   (ui/mount [ui/frame-provider {:frame f}
+                              [prod-binding-probe]]
+                             root-c
+                             {:root-id ::prod-binding-root})))
+        (is (= (str "ordinary|" (pr-str probe-root-token))
+               (probe-text root-c))
+            (str "render-subs reached the body with *sub-overrides* at its "
+                 "seeded ROOT — no dynamic binding shipped into production"))
+
+        ;; --- Same-optimizer positive control: an ambient binding in the
+        ;; render's dynamic extent IS observed by the very same body, so the
+        ;; probe above would go red on a production-leaked binding. ---
+        (binding [reactive/*sub-overrides* control-binding-token]
+          (ReactDOM/flushSync
+           #(vreset! ctrl-root
+                     (ui/mount [ui/frame-provider {:frame f}
+                                [prod-binding-probe]]
+                               control-c
+                               {:root-id ::prod-binding-control}))))
+        (is (= (str "ordinary|" (pr-str control-binding-token))
+               (probe-text control-c))
+            (str "control: a live *sub-overrides* binding during render is read "
+                 "through the compiled body — the probe can detect a leak"))
+        (catch :default e
+          (is false (str "advanced sub-overrides binding probe rejected: " e)))
+        (finally
+          (when @root-root
+            (ReactDOM/flushSync #(ui/unmount! @root-root)))
+          (when @ctrl-root
+            (ReactDOM/flushSync #(ui/unmount! @ctrl-root)))
+          (set! reactive/*sub-overrides* prior)
+          (.remove root-c)
+          (.remove control-c)
           (rf/destroy-frame! f)
           (done))))))


### PR DESCRIPTION
## Summary

Strengthens the mounted advanced-production elision fixture so it proves the
`re-frame.ui.reactive/*sub-overrides*` dynamic-binding machinery is genuinely
**absent** from production renders — not merely that an adjacent diagnostic
string elides.

**Production is already correct** (`viewcell.cljs` binds `*sub-overrides*` only
under `interop/debug-enabled?`); this bead was UNDER-PROVEN, so the change is
**test-only** — no source touched (`viewcell.cljs` has zero diff vs `main`).

## The gap (rf2-vxgfnd.216)

`implementation/scripts/check-ui-mounted-prod-elision.cjs` scans the release
bundle for the DEBUG-only sentinel string `rf-ui-mounted-override-binding
expects a map`. That string is **not owned** by the binding: an adversary could
keep the sentinel under `goog.DEBUG` (it still elides) yet leak the bare
`(binding [reactive/*sub-overrides* overrides] ...)` into the production branch
(`overrides` is always `nil` there). The dynamic-var push/set/restore then ships
and runs on every sub-bearing render while the bundle scanner still passes.

## The causal probe (not lexical)

A new sub-bearing view routes through the exact `render-subs` ->
`capture-with-overrides` path and **reads** `reactive/*sub-overrides*` from
inside its body, rendering the live value into the DOM. The test seeds a
distinguishable non-nil ROOT via `set!` (the persistent form that survives to
the async `flushSync` render, mirroring `test-support/make-reset-runtime-fixture`).

- **Unmutated production**: body runs with the root intact -> DOM reads the root
  token. Ordinary subscription ownership / DOM / Context-absence / Provider-
  transparency assertions all unchanged.
- **Same-optimizer positive control**: a second mount within an ambient
  `(binding [reactive/*sub-overrides* ...] ...)` shows the very same body reads
  the bound value through -> the probe *can* detect a live binding.

## Red-before (deterministic)

Applied a real same-options source mutant making the `capture-with-overrides`
binding unconditional (production branch establishes `(binding
[reactive/*sub-overrides* overrides] ...)`, `overrides`=nil) and ran the full
mounted advanced command:

```
FAIL advanced-production-render-body-carries-no-sub-overrides-binding
  expected: "ordinary|\"rf2-216-sub-overrides-root\""
    actual: "ordinary|nil"
```

Critically, `ui mounted production elision: PASS` still printed under the mutant
(the string-scan is blind to the leak) — the browser suite ran and only the new
runtime probe went red. Mutant reverted; final run green.

## Quality gates

- `npm run test:browser-prod-elision` (the core gate): scanner **PASS**; browser
  86 tests / 313 assertions / **0 failures, 0 errors**.
- Mutant run: scanner still PASS, runtime probe **RED** (2 failures) — proves the
  probe catches what the scanner cannot.
- UI JVM suite (`cd implementation/ui && clojure -M:test`): 540 tests / 6651
  assertions / **0 failures, 0 errors**.
- `npm run test:elision` (general prod-elision probe): **PASS** (52/52 absent;
  control 52/52 present).

No new workflow or public API added; no scanner symbols retained for scanning;
UI/core changed-surface routing already schedules `test:browser-prod-elision`.