### PR TITLE
docs(synthesis): reconcile static-override split equality + landed fixture in S2 synthesis authorities (rf2-vxgfnd.226)

### DIFF
--- a/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
+++ b/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
@@ -46,7 +46,9 @@ are marked **[S2-CONFIRM]** — conservative rules to confirm in Stage 2, not op
 During render, each executed site resolves a first-class **observation target** via
 `resolve-target` — the **only** resolution point: ambient frame, explicit pins, and the
 Story override context all land there, and no later phase re-resolves context. A target
-is a stable identity carrying **no node handle and no `:value`/`:version`**:
+is a stable identity carrying **no node handle**; the `:subscription` kind carries **no
+`:value`/`:version`**, while the `:story-override` kind carries its pinned value and
+movement token (below):
 
 ```clojure
 {:kind :subscription  :frame-id :app  :query [:cart/total]}
@@ -122,10 +124,16 @@ is a boot error, never undefined behaviour.
   whose node was disposed out from under it is a no-op.
 - **Static override lease.** `acquire!` on a `:story-override` target returns a
   **static lease**: `:owned? false` reported honestly, `read` yields the pinned
-  value/version, `release!` no-ops, no callback is registered; `current?` fails when
-  the site's override id/version moved, which retargets through the normal staged path
-  — one uniform commit path. *(Shape ruled; unprototyped in S-3 — its Tier-3 fixture is
-  a named Stage-2 obligation.)*
+  value/version, `release!` no-ops, no callback is registered; `current?` holds under
+  the **split equality law** — `:override-id` (slot identity) by plain `=`, `:version`
+  (the movement token) by the frozen `rf=` law (core-local `node-value=`), so NaN-to-NaN
+  **retains** — and fails when the override moved or was removed, retargeting through the
+  normal staged path — one uniform commit path. *(Shape ruled and final. S-3 did not
+  exercise this — no Story context in the spike harness — but its Tier-3 mounted
+  Story-context fixture has since **landed** with the ViewCell layer
+  (`implementation/ui/test/re_frame/ui/mounted_story_override_image_schema_dom_cljs_test.cljs`),
+  and the port's own NaN split-equality assertion lives in
+  `implementation/core/test/re_frame/observation_port_cljs_test.cljc`.)*
 - **Internally fail-loud; publicly recover-to-nil.** The port throws typed:
   `:rf.error/no-such-sub` on an unknown sub (the **same** catalogue id the public
   surface records — the spike's `:rf.error/no-sub` spelling is superseded and must not

--- a/ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md
+++ b/ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md
@@ -246,8 +246,12 @@ commit path with honest ownership reporting ⟨S-3 §5; 09 codex2 F1⟩:
   retains — and fails when the override changed or was removed — retargeting through
   the normal staged commit path, exactly like a real node.
 
-*(Shape ruled and final; unprototyped in S-3 — no Story context existed in the harness.
-Its Tier-3 fixture is a named Stage-2 obligation.)*
+*(Shape ruled and final. S-3 itself did not prototype this — no Story context existed in
+the spike harness — but its Tier-3 mounted Story-context fixture has since **landed** with
+the ViewCell layer: `implementation/ui/test/re_frame/ui/mounted_story_override_image_schema_dom_cljs_test.cljs`
+proves the NaN→NaN keep and the map→NaN retarget in a live mount, and the port's own NaN
+split-equality assertion lives in
+`implementation/core/test/re_frame/observation_port_cljs_test.cljc`.)*
 
 ### Transactional multi-acquire — staging and rollback
 


### PR DESCRIPTION
## What

Reconciles the two **tracked** S2 synthesis authorities with the already-landed static Story-override split-equality contract (landed by rf2-vxgfnd.126 / #5835). Documentation-only; **no code, test, or spec/006 change**.

- `ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md`
  - Scope the blanket "target carries no `:value`/`:version`" claim to the **`:subscription`** kind — the `:story-override` kind carries its pinned value and movement token (its own example two lines down already showed this). Matches spec/006 §Observation targets ("no `:value`/`:version` for the `:subscription` kind").
  - Static-override-lease bullet now states the **split equality law** (`:override-id` by plain `=`; `:version` by the frozen `rf=` law / core-local `node-value=`, so **NaN-to-NaN retains**) and marks the mounted fixture as **landed** (was: "unprototyped in S-3 — its Tier-3 fixture is a named Stage-2 obligation").
- `ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md`
  - Split law was already stated correctly; only the fixture status was stale. Now marks the Tier-3 mounted Story-context fixture **landed** (was: "unprototyped in S-3 … named Stage-2 obligation"), preserving the genuinely-historical "S-3 itself did not prototype this" fact.

Both passages now link the two proving tests precisely:
`implementation/ui/test/re_frame/ui/mounted_story_override_image_schema_dom_cljs_test.cljs` (live mount: NaN→NaN keep, map→NaN retarget) and `implementation/core/test/re_frame/observation_port_cljs_test.cljc` (port NaN split-equality assertion).

## Key finding

The three **committed** authorities the dispatch brief named — the code (`re-frame.substrate.observation/current?`: `:override-id` by `=`, `:version` by `node-value=`), spec/006 §"The static override lease", and both landed tests — were **already fully reconciled** to the correct rule, including NaN retention and the fixture stated as landed. The remaining drift was entirely in the two tracked synthesis working-docs above (03 was never touched by the .126 landing; the draft got the law but kept "pending" fixture wording). This PR closes that.

Concrete NaN case (the counterexample that makes the split load-bearing), now consistent across all authorities: replacing `##NaN` with a fresh `##NaN` — plain `=` reports movement (would retarget every commit, forever); `node-value=` retains the exact lease.

## Red-before-fix

N/A — documentation reconciliation of synthesis working-docs; **zero code/test/spec-006 delta**. The runtime rule was landed and CI-green before this PR; there is no failing test for a doc-consistency fix to redden.

## Quality gates

- **Code gates (core / machines / `npm run test:cljs`): N/A** — no code changed. `observation.cljc` public seams are untouched (keeps #5957's `observation_port_cljs_test.cljc` touch rebasing clean). The observation-port and mounted Story NaN mutation tests are unaffected and remain green on the CI-green base.
- **mkdocs `--strict`: N/A** — the `ai/findings/new-substrate-synthesis/` tree is not in the mkdocs nav (working-artifacts, not the published site).
- **Classified search (bead AC): clean** — post-fix, `git grep -i unprototyped` over `ai/findings/new-substrate-synthesis` + `spec` returns only `reviews/codex2.md:462` (review question #40), correctly preserved as historical. No active passage still calls the fixture pending/unprototyped or compares both tokens by ordinary `=`.
- Rebased onto current `origin/main` (7e42110); no conflicts.

Closes rf2-vxgfnd.226.