### PR TITLE
fix(core): native derived fan-out obeys rf= movement + contains subscriber failures (rf2-vxgfnd.203)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -285,14 +285,40 @@
 ;; before any render reads the reaction, an observable cross-adapter
 ;; divergence (extra body invocations, different trace timing) that
 ;; contradicts Spec 006 §No-op via value equality's "body runs on demand"
-;; intent. The sentinel `not=` any real value, so the first post-
+;; intent. The sentinel is never `rf=` any real value, so the first post-
 ;; construction change always notifies — the same first-change-notifies
 ;; semantics Reagent gives.
 
 (def ^:private unset
   "Sentinel for a derived value whose baseline has not yet been computed.
-  Distinct object identity so it can never `=` a real derived value (incl.
+  Distinct object identity so it can never `rf=` a real derived value (incl.
   `nil`/`false`), making the first flush after construction always notify."
+  (js-obj))
+
+(defn- rf=
+  "The compiled-view substrate's frozen per-slot MOVEMENT law, spelled
+  spine-local for the React-hook derived-value fan-out gate: `Object.is(a,b)
+  OR (= a b)` — the CLJS branch of `re-frame.ui.eq/rf=`. Kept core-local (a
+  transcription, NOT a `:require`) so core does not depend on the UI artefact,
+  exactly as the observation port keeps its own `node-value=` spelling (Spec
+  006). The load-bearing consequence for rf2-vxgfnd.203: `##NaN` is STABLE
+  (`Object.is(##NaN, ##NaN)` is true), so a derived value that stays NaN across
+  a source tick reports NO movement and does not fan out — unlike raw `=`/`not=`,
+  under which `(= ##NaN ##NaN)` is false so every NaN reads as fresh and fans
+  out on a no-move. (`-0.0`/`+0.0` still compare EQUAL via the `=` branch, as
+  the ruled law and the prior `not=` gate both give — no behaviour change
+  there; NaN→NaN is the sole pair this gate now treats differently.) One frozen
+  relation across the direct adapter, the observation port, and the ViewCell
+  layer, so the three fan-out boundaries agree on cardinality."
+  [a b]
+  (or ^boolean (js/Object.is a b)
+      (= a b)))
+
+(def ^:private capture-none
+  "Presence sentinel for the derived fan-out's first-thrown capture: a distinct
+  object identity so a subscriber that throws `nil`/`false` (both legal CLJS
+  throws) is still recorded and re-raised by PRESENCE — never masked by a
+  truthiness test (rf2-vxgfnd.203)."
   (js-obj))
 
 (defn build-recompute-fn
@@ -369,12 +395,48 @@
           ;; loop, never escapes this closure — `volatile!` is the right
           ;; primitive (matches `prev-state` / `dirty?` above).
           disposed?      (volatile! false)
-          ;; Iterate via `run!` over `vals` rather than `doseq` over
-          ;; map-entries — skips one map-entry seq allocation per
-          ;; source-change notification.
+          ;; Movement-gated, failure-contained fan-out (rf2-vxgfnd.203).
+          ;; Two disciplines at this one boundary:
+          ;;
+          ;;   1. Gate on the frozen `rf=` MOVEMENT law, not raw `not=`. Raw
+          ;;      `(not= ##NaN ##NaN)` is true, so a derived value that stays
+          ;;      NaN across a source tick would fan out on a NO-move — a false
+          ;;      direct invalidation the observation port and ViewCell layer
+          ;;      (both `rf=`-gated) do not raise. `rf=` treats NaN→NaN as
+          ;;      stable, so all three fan-out boundaries agree on cardinality.
+          ;;      The `unset` baseline is never `rf=` a real value, so the first
+          ;;      post-construction change still notifies (unchanged).
+          ;;
+          ;;   2. CONTAIN a throwing subscriber. Bare `run!` aborted at the
+          ;;      first throw, skipping every later sibling, and the scheduler's
+          ;;      per-thunk drain guard silently swallowed the escape — so ONE
+          ;;      subscriber could permanently suppress another's invalidation,
+          ;;      order-dependently. Instead: snapshot the callbacks (an
+          ;;      add/remove-watch during fan-out is an immutable-map swap, so
+          ;;      this seq is stable and the change lands on the NEXT wave),
+          ;;      attempt EVERY subscriber independently, capture the FIRST
+          ;;      thrown value by PRESENCE (`capture-none`, not truthiness —
+          ;;      `nil`/`false` are legal CLJS throws), then re-raise it AFTER
+          ;;      delivery so the primary failure still surfaces through the
+          ;;      established scheduler error channel (the drain's per-thunk
+          ;;      isolation, rf2-l3lelt) rather than disappearing inside the
+          ;;      fan-out. `vals` over the map (rather than `doseq` over
+          ;;      map-entries) skips a map-entry seq allocation; the zero-
+          ;;      subscriber and no-move paths allocate nothing extra.
           notify         (fn [prev nu]
-                           (when (not= prev nu)
-                             (run! (fn [w] (w prev nu)) (vals @watchers))))
+                           (when-not (rf= prev nu)
+                             (let [ws (vals @watchers)]
+                               (when (seq ws)
+                                 (let [captured (volatile! capture-none)]
+                                   (run! (fn [w]
+                                           (try
+                                             (w prev nu)
+                                             (catch :default e
+                                               (when (identical? capture-none @captured)
+                                                 (vreset! captured e)))))
+                                         ws)
+                                   (when-not (identical? capture-none @captured)
+                                     (throw @captured)))))))
           ;; Baseline derived value. LAZY (rf2-ee38b.1 P2): seeded with the
           ;; `unset` sentinel rather than `(recompute)`, so `compute-fn`
           ;; (the memo wrapper running the user sub body) is NOT invoked at
@@ -385,8 +447,8 @@
           ;; the baseline, and a `replace-container!` change after that
           ;; notifies `[prev-derived new-derived]` exactly as before. If a
           ;; change flushes before any deref ever happened (no reader),
-          ;; `prev-state` is still `unset`; `unset` `not=` any real value
-          ;; (incl. nil/false) so the first flush still notifies — the same
+          ;; `prev-state` is still `unset`; `unset` is never `rf=` any real
+          ;; value (incl. nil/false) so the first flush still notifies — the same
           ;; first-change-notifies semantics Reagent gives. (Seeding from
           ;; the *derived* value, never the raw source, still holds: the
           ;; flush thunk compares the recomputed derived value against the

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -360,3 +360,102 @@
       (is (= [[50 60]] @notes)
           "the bare reset! drained immediately (no epoch open) and notified
            once with the recomputed value"))))
+
+;; ---- native derived fan-out: rf= movement law ----------------------------
+;; (rf2-vxgfnd.203)
+
+(deftest nan-to-nan-derived-does-not-fan-out-on-no-move
+  (testing "a derived value that stays ##NaN across a source tick reports NO
+            movement under the frozen rf= law and fans out ZERO direct
+            callbacks. Raw `not=` treated `(not= ##NaN ##NaN)` as true and
+            fired a false invalidation — disagreeing with the observation
+            port and ViewCell layer, which are both rf=-gated. An ordinary
+            value movement still notifies exactly once, so the gate is a
+            movement test, not a blanket suppression. (rf2-vxgfnd.203)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          nan-d     (make-derived [root] (fn [_db] js/NaN))
+          ord-d     (make-derived [root] (fn [db] (:a db)))
+          nan-notes (atom 0)
+          ord-notes (atom 0)]
+      ;; Lazy baselines (the sub-cache reads on subscribe): establish
+      ;; prev-state = ##NaN / 1 before watching.
+      (is (js/isNaN @nan-d) "NaN baseline establishes prev-state = ##NaN")
+      (is (= 1 @ord-d) "ordinary baseline establishes prev-state = 1")
+      (add-watch nan-d :w (fn [_ _ _ _] (swap! nan-notes inc)))
+      (add-watch ord-d :w (fn [_ _ _ _] (swap! ord-notes inc)))
+      ;; ONE write ticks the shared source: :a moves 1→2 (ordinary derived
+      ;; MOVES) while the NaN derived recomputes ##NaN again (NO move).
+      (replace! root {:a 2 :b 10})
+      (is (= 0 @nan-notes)
+          "##NaN→##NaN is stable under rf= — zero direct callbacks (raw not=
+           would have fired one)")
+      (is (= 1 @ord-notes)
+          "an ordinary value movement produces exactly one direct callback"))))
+
+;; ---- native derived fan-out: throwing-subscriber containment --------------
+;; (rf2-vxgfnd.203)
+
+(deftest throwing-first-subscriber-does-not-suppress-later-sibling
+  (testing "with the throwing subscriber registered FIRST (drained first), a
+            later sibling still receives the same movement. Bare `run!`
+            aborted at the throw and skipped every later subscriber; the fan-
+            out now attempts each independently. The throw is contained — it
+            re-raises through the scheduler's per-thunk drain isolation, so
+            replace-container! returns normally. (rf2-vxgfnd.203)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1      (make-derived [root] (fn [db] (:a db)))
+          a-fired (atom 0)
+          b-fired (atom 0)]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      ;; :a registered FIRST → iterates first → throws; :b registered second.
+      (add-watch l1 :a (fn [_ _ _ _]
+                         (swap! a-fired inc)
+                         (throw (js/Error. "subscriber A boom"))))
+      (add-watch l1 :b (fn [_ _ _ _] (swap! b-fired inc)))
+      (is (nil? (replace! root {:a 2 :b 10}))
+          "the subscriber throw is contained — replace-container! returns nil")
+      (is (= 1 @a-fired) "the throwing subscriber ran")
+      (is (= 1 @b-fired)
+          "the later sibling STILL fired despite A throwing (bare run! would
+           have skipped it)"))))
+
+(deftest throwing-subscriber-delivery-is-order-independent
+  (testing "a throwing subscriber in the MIDDLE of the registration order does
+            not prevent EITHER an earlier or a later sibling from receiving the
+            movement — delivery depends on ownership + movement, not iteration
+            order. Covers the reversed registration order relative to the
+            throwing-first test (a sibling registered BEFORE the thrower).
+            (rf2-vxgfnd.203)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1    (make-derived [root] (fn [db] (:a db)))
+          fired (atom #{})]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      ;; Registration order: :b (before), :a (throws), :c (after).
+      (add-watch l1 :b (fn [_ _ _ _] (swap! fired conj :b)))
+      (add-watch l1 :a (fn [_ _ _ _]
+                         (swap! fired conj :a)
+                         (throw (js/Error. "middle subscriber boom"))))
+      (add-watch l1 :c (fn [_ _ _ _] (swap! fired conj :c)))
+      (is (nil? (replace! root {:a 2 :b 10}))
+          "the middle throw is contained")
+      (is (= #{:a :b :c} @fired)
+          "every subscriber fired — the earlier (:b), the thrower (:a), AND the
+           later (:c) sibling a bare run! would have skipped"))))
+
+(deftest falsey-subscriber-throws-are-contained-by-presence
+  (testing "a subscriber that throws a FALSEY value (`false` / `nil` — both
+            legal CLJS throws) is captured by PRESENCE, so a later sibling
+            still fires and the primary failure is not masked by a truthiness
+            test. (rf2-vxgfnd.203)"
+    (doseq [thrown-val [false nil]]
+      (let [{:keys [make-derived replace! root]} (build-graph)
+            l1      (make-derived [root] (fn [db] (:a db)))
+            b-fired (atom 0)]
+        (is (= 1 @l1) "baseline deref establishes prev-state")
+        (add-watch l1 :a (fn [_ _ _ _] (throw thrown-val)))
+        (add-watch l1 :b (fn [_ _ _ _] (swap! b-fired inc)))
+        (is (nil? (replace! root {:a 2 :b 10}))
+            (str "a `" (pr-str thrown-val) "` throw is contained"))
+        (is (= 1 @b-fired)
+            (str "sibling still fired after a `" (pr-str thrown-val)
+                 "` throw — captured by presence, not truthiness"))))))


### PR DESCRIPTION
## What

Fixes two correctness defects at the React-hook spine's `make-derived-value` notify boundary (`implementation/core/src/re_frame/substrate/spine.cljs`), the direct-adapter half of the fan-out that `rf2-vxgfnd.185` covers on the observation-port side. Both lines were on current main (provenance: paired audits of merged PR #5809).

**1. Movement gate: raw `not=` → frozen `rf=` law.** `(not= ##NaN ##NaN)` is true, so a derived value that stays `##NaN` across a source tick fanned out on a **no-move** — a false direct invalidation the observation port and ViewCell layer (both `rf=`-gated) do not raise. The gate now uses a spine-local `rf=` (`Object.is OR =`, the CLJS branch of `re-frame.ui.eq/rf=`), kept **core-local** (a transcription, not a `:require`) so core does not depend on the UI artefact — the same reason the observation port keeps its own `node-value=` spelling. `##NaN`→`##NaN` is now stable; all three fan-out boundaries agree on cardinality. `##NaN`→`##NaN` is the sole pair the gate treats differently (`-0.0`/`+0.0` stay equal via the `=` branch, as before).

**2. Throwing-subscriber containment: bare `run!` → snapshot + independent + re-raise.** A throwing subscriber aborted the `run!` loop, skipping every later sibling, and the scheduler's per-thunk drain guard silently swallowed the escape — so one subscriber could permanently suppress another's invalidation, order-dependently. The fan-out now snapshots the callbacks (an add/remove during fan-out lands on the **next** wave — `@watchers` is an immutable map), attempts **every** subscriber independently, captures the first thrown value by **presence** (a distinct `capture-none` sentinel, not truthiness — `nil`/`false` are legal CLJS throws), then re-raises it **after** delivery so the primary failure still surfaces through the established scheduler error channel (the drain's per-thunk isolation, rf2-l3lelt). The zero-subscriber and no-move fast paths allocate nothing extra.

Scope: `spine.cljs` + its test only. The ratom spine's `make-derived-value` (native Reagent reaction) is untouched — it has its own `=` gate. Does not amend or absorb `rf2-vxgfnd.185`.

## Red-before-fix

New tests in `spine_glitch_free_cljs_test.cljs`. Against the **pre-fix** `not=` + bare `run!` spine (fix reverted, tests kept), the node CLJS suite reported exactly **5 failures, 0 errors** — all 5 are the new tests, nothing else in the 9464-test suite:

- `nan-to-nan-derived-does-not-fan-out-on-no-move` — `(= 0 @nan-notes)` → `actual (not (= 0 1))` (pre-fix fired one false callback)
- `throwing-first-subscriber-does-not-suppress-later-sibling` — `(= 1 @b-fired)` → `actual (not (= 1 0))`
- `throwing-subscriber-delivery-is-order-independent` — `actual (not (= #{:c :b :a} #{:b :a}))` (`:c` skipped)
- `falsey-subscriber-throws-are-contained-by-presence` — both `false` and `nil` cases fail

With the fix restored: **9464 tests / 46459 assertions, 0 failures, 0 errors.**

## Quality gates

Run foreground from the worktree on `origin/main` (base `7e42110e2b`):

- `implementation/core` JVM — `clojure -M:test` → **1988 tests / 9163 assertions, 0 failures, 0 errors**
- `implementation/machines` JVM — `clojure -M:test` → **1093 tests / 3791 assertions, 0 failures, 0 errors**
- `implementation` node CLJS — `npm run test:cljs` → **9464 tests / 46459 assertions, 0 failures, 0 errors**

(Cross-artefact gate: spine is core substrate consumed by ui/machines; the machines JVM suite is the downstream regression check. No browser / fast-pr per brief.)

Closes rf2-vxgfnd.203.