### PR TITLE
fix(ui): track UI test/teardown failures by presence not JS truthiness (rf2-vxgfnd.201)

### DIFF
--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -516,9 +516,24 @@
          (reset! cleanup-tail tail)
          task))
 
+     ;; A failure slot holds this unique private sentinel until a failure is
+     ;; recorded. PRESENCE — not JS truthiness — decides "did a failure occur?",
+     ;; so a legitimately falsy caught/rejected reason (nil, false, 0) is a real,
+     ;; preserved failure rather than being silently reclassified as success.
+     (defonce ^:private absent #js {})
+
+     (defn- recorded?
+       "Has a failure been recorded into `slot`? Presence, not truthiness."
+       [slot]
+       (not (identical? @slot absent)))
+
      (defn- remember-first-error!
+       "Record the FIRST failure in `slot` BY PRESENCE: once the slot holds a
+       reason — even a falsy one (nil, false) — a later failure never overwrites
+       it, so first-failure ordering is stable regardless of payload truthiness.
+       The slot starts at the private `absent` sentinel."
        [slot e]
-       (when-not @slot (vreset! slot e))
+       (when (identical? @slot absent) (vreset! slot e))
        nil)
 
      (defn- cleanup-step!
@@ -529,16 +544,46 @@
                     (remember-first-error! slot e)))))
 
      (defn- attach-cleanup-diagnostic!
-       "Preserve the primary throwable while retaining a cleanup failure on
-       the ordinary JS Error/ExceptionInfo object for diagnostics."
-       [primary cleanup]
-       (when (and primary cleanup)
-         (try
-           (js/Object.defineProperty
-            primary "rfUiTestCleanupError"
-            #js {:value cleanup :configurable true})
-           (catch :default _ nil)))
-       primary)))
+       "Preserve the primary throwable AS THE THROWN VALUE while, when a secondary
+       cleanup failure is PRESENT, retaining it on the primary as
+       `rfUiTestCleanupError` for diagnostics. Presence — not truthiness — gates
+       the attach, so a falsy secondary is real. A primitive primary (nil, false,
+       a number) cannot receive `defineProperty`; the secondary then rides the
+       always-on console diagnostic instead, so it stays observable. The primary
+       reason is returned UNCHANGED either way — never coerced or replaced."
+       [primary secondary-present? secondary]
+       (when secondary-present?
+         (let [attached?
+               (try
+                 (js/Object.defineProperty
+                  primary "rfUiTestCleanupError"
+                  #js {:value secondary :configurable true})
+                 true
+                 (catch :default _ false))]
+           (when (and (not attached?) (exists? js/console))
+             (.warn js/console
+                    (str "[re-frame.ui.test] a with-root cleanup failure could "
+                         "not ride the primary rejection (a primitive reason "
+                         "cannot carry a diagnostic property); the primary is "
+                         "rethrown unchanged. Secondary cleanup error:")
+                    secondary))))
+       primary)
+
+     (defn ^:no-doc with-root-outcome
+       "The outcome policy of a `with-root` run, decided by failure PRESENCE
+       (never JS truthiness): a first mount/render/body/flush failure wins as the
+       rejection (a present secondary cleanup failure rides it as a diagnostic),
+       else a cleanup-only failure is the rejection, else the awaited body value
+       — which may itself be a legitimate nil/false — resolves. Returns
+       `[:reject reason]` or `[:resolve value]`. Extracted as the ONE place the
+       presence decision lives, so it is unit-checkable off the DOM."
+       [primary-present? primary secondary-present? secondary result]
+       (cond
+         primary-present?
+         [:reject (attach-cleanup-diagnostic! primary secondary-present? secondary)]
+
+         secondary-present? [:reject secondary]
+         :else              [:resolve result]))))
 
 #?(:cljs
    (defn- with-root*
@@ -557,8 +602,8 @@
            host-root     (volatile! nil)
            mounted-root  (volatile! nil)
            result        (volatile! nil)
-           primary-error (volatile! nil)
-           cleanup-error (volatile! nil)]
+           primary-error (volatile! absent)
+           cleanup-error (volatile! absent)]
        (.setAttribute container "data-rf-ui-test-root" "")
        (.appendChild js/document.body container)
        (->
@@ -601,12 +646,11 @@
                         (cleanup-step! cleanup-error #(.remove container)))))))
         (.then
          (fn []
-           (cond
-             @primary-error
-             (throw (attach-cleanup-diagnostic! @primary-error @cleanup-error))
-
-             @cleanup-error (throw @cleanup-error)
-             :else @result)))))))
+           (let [[outcome v] (with-root-outcome
+                              (recorded? primary-error) @primary-error
+                              (recorded? cleanup-error) @cleanup-error
+                              @result)]
+             (if (= :reject outcome) (throw v) v))))))))
 
 #?(:clj
    (defmacro with-root

--- a/implementation/ui/test/re_frame/ui/test_outcome_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/test_outcome_cljs_test.cljs
@@ -1,0 +1,48 @@
+(ns re-frame.ui.test-outcome-cljs-test
+  "Node-runnable presence check for the `with-root` outcome policy
+  (rf2-vxgfnd.201): a mount/render/body/flush/cleanup failure is tracked by
+  PRESENCE, never by JS truthiness, so a legitimately falsy reason (nil / false)
+  is a real failure — and a falsy body value is a real success, not a failure.
+
+  `with-root-outcome` is the ONE place that decision lives; pinning it here
+  exercises the fix off the DOM (the mounted end-to-end behaviour — real React
+  ownership + total teardown — is covered by the browser suite
+  `re-frame.ui.test-tier3-dom-cljs-test`). A mutation restoring a truthiness
+  check (e.g. `(cond primary [:reject primary] ...)` over the values instead of
+  the presence flags) turns these `is` assertions red."
+  (:require [cljs.test :refer [deftest is testing]]
+            [re-frame.ui.test :as uit]))
+
+(deftest with-root-outcome-tracks-failures-by-presence
+  (testing "a present PRIMARY failure rejects even when its reason is falsy"
+    (is (= [:reject false]
+           (uit/with-root-outcome true false false nil ::body-result))
+        "Promise.reject(false) from mount/render/body/flush is a real failure")
+    (is (= [:reject nil]
+           (uit/with-root-outcome true nil false nil ::body-result))
+        "Promise.reject(nil) is a real failure, not a swallowed success"))
+
+  (testing "a present CLEANUP-only failure rejects even when its reason is falsy"
+    (is (= [:reject false]
+           (uit/with-root-outcome false nil true false ::body-result)))
+    (is (= [:reject nil]
+           (uit/with-root-outcome false nil true nil ::body-result))))
+
+  (testing "an ABSENT failure resolves the awaited body value — falsy ones too"
+    (is (= [:resolve false]
+           (uit/with-root-outcome false nil false nil false))
+        "a body that returns false succeeds with false")
+    (is (= [:resolve nil]
+           (uit/with-root-outcome false nil false nil nil))
+        "a body that returns nil succeeds with nil")
+    (is (= [:resolve ::ok]
+           (uit/with-root-outcome false nil false nil ::ok))))
+
+  (testing "first-failure ordering: a present primary wins over a present cleanup"
+    (let [primary (js/Error. "primary")
+          cleanup (js/Error. "cleanup")
+          [k v]   (uit/with-root-outcome true primary true cleanup nil)]
+      (is (= :reject k))
+      (is (identical? primary v) "the primary reason is the rejection")
+      (is (= "cleanup" (.-message (unchecked-get v "rfUiTestCleanupError")))
+          "the secondary cleanup failure rides the object primary as a diagnostic"))))

--- a/implementation/ui/test/re_frame/ui/test_tier3_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/test_tier3_dom_cljs_test.cljs
@@ -286,6 +286,93 @@
                      (is (= before (mounted-baseline)))
                      (done))))))))
 
+;; --- rf2-vxgfnd.201: failure/teardown tracking by PRESENCE, not JS truthiness.
+;; A body/mount/flush/cleanup may reject with ANY value — including a falsy one
+;; (nil, false). Those are REAL failures and must not be reclassified as success;
+;; a body that legitimately returns nil/false is a REAL success and must not be
+;; reclassified as a failure. (Off-DOM decision coverage: test-outcome-cljs-test.)
+
+(deftest with-root-preserves-a-falsy-body-rejection-and-still-tears-down
+  (when (browser?)
+    (async done
+      (let [before (mounted-baseline)]
+        (-> (uit/with-root [_root [query-fixture]]
+              (js/Promise.reject false))
+            (.then
+             (fn [] (throw (js/Error. "reject(false) body unexpectedly resolved")))
+             (fn [e]
+               (is (false? e)
+                   "Promise.reject(false) is a real failure, not a swallowed success")
+               (is (= before (mounted-baseline))
+                   "a falsy rejection still settles after total teardown")
+               (uit/with-root [_root [query-fixture]]
+                 (js/Promise.reject nil))))
+            (.then
+             (fn [] (reject-unexpectedly! done "reject(nil) body unexpectedly resolved" nil))
+             (fn [e]
+               (is (nil? e) "Promise.reject(nil) is a real failure")
+               (is (= before (mounted-baseline)))
+               (done))))))))
+
+(deftest with-root-resolves-a-falsy-body-value
+  (when (browser?)
+    (async done
+      (-> (uit/with-root [_root [query-fixture]] false)
+          (.then
+           (fn [value]
+             (is (false? value)
+                 "a body returning false succeeds with false — not misread as a failure")
+             (uit/with-root [_root [query-fixture]] nil))
+           (fn [e] (reject-unexpectedly! done "false body value rejected" e)))
+          (.then
+           (fn [value]
+             (is (nil? value) "a body returning nil succeeds with nil")
+             (done))
+           (fn [e] (reject-unexpectedly! done "nil body value rejected" e)))))))
+
+(deftest with-root-preserves-a-falsy-flush-failure
+  (when (browser?)
+    (async done
+      (let [before (mounted-baseline)]
+        (-> (uit/with-root [_root [query-fixture]]
+              (uit/flush! #(throw false)))
+            (.then (fn [] (reject-unexpectedly! done "falsy flush failure resolved" nil))
+                   (fn [e]
+                     (is (false? e) "a flush thunk throwing false is a real failure")
+                     (is (= before (mounted-baseline))
+                         "a falsy flush rejection cannot strand mounted ownership")
+                     (done))))))))
+
+(deftest a-falsy-cleanup-failure-rides-the-primary-and-is-not-lost
+  (when (browser?)
+    (async done
+      (let [before  (mounted-baseline)
+            primary (ex-info "primary body failure" {:kind ::primary})]
+        (-> (uit/with-root [_root [throwing-cleanup-fixture {:cleanup-error false}]]
+              (throw primary))
+            (.then (fn [] (reject-unexpectedly! done "falsy-cleanup dual failure resolved" nil))
+                   (fn [e]
+                     (is (identical? primary e) "the primary reason is preserved and thrown")
+                     (is (false? (unchecked-get e "rfUiTestCleanupError"))
+                         "a FALSY cleanup failure still rides the object primary — presence, not truthiness")
+                     (is (= before (mounted-baseline)))
+                     (done))))))))
+
+(deftest a-falsy-primary-wins-over-a-truthy-cleanup-failure
+  (when (browser?)
+    (async done
+      (let [before  (mounted-baseline)
+            cleanup (js/Error. "cleanup failed")]
+        (-> (uit/with-root [_root [throwing-cleanup-fixture {:cleanup-error cleanup}]]
+              (js/Promise.reject false))
+            (.then (fn [] (reject-unexpectedly! done "falsy-primary + cleanup resolved" nil))
+                   (fn [e]
+                     (is (false? e)
+                         "a falsy PRIMARY failure wins as the rejection over a later cleanup failure")
+                     (is (= before (mounted-baseline))
+                         "both roots/containers are still reclaimed under a primitive primary")
+                     (done))))))))
+
 (deftest act-environment-is-restored-after-success-and-rejection
   (when (browser?)
     (async done


### PR DESCRIPTION
Fixes rf2-vxgfnd.201.

## Problem

`re-frame.ui.test/with-root` decided "did a failure occur?" by JS **truthiness** of the caught/rejected value, which is both the failure payload AND the sentinel. A JS body/mount/flush/cleanup may reject with ANY value — including a legitimately falsy one (`nil`, `false`, `0`) — so those real failures were silently reclassified as success.

Confirmed on current origin/main (transcribed inline logic):

- `with-root*` `primary-error`/`cleanup-error` start `(volatile! nil)`; the final decision is `(cond @primary-error … @cleanup-error … :else @result)`. `Promise.reject(false)` / `Promise.reject(nil)` from the body → the `cond` falls through to `:else` and **resolves** (normally `nil`) instead of rejecting with the original reason.
- `remember-first-error!` used `(when-not @slot …)`, so a falsy first failure (`false`/`nil`) was overwritten by a later error — first-failure ordering lost.

## Fix (presence, not truthiness)

Scope: `implementation/ui/src/re_frame/ui/test.cljc` only.

- A unique private `absent` sentinel; failure slots start at `absent`. A `recorded?` predicate (`(not (identical? @slot absent))`) is the presence test.
- `remember-first-error!` records the first reason by presence — a falsy first failure is kept and never overwritten.
- The final outcome decision is extracted to a pure `with-root-outcome` fn keyed on presence flags, returning `[:reject reason]` / `[:resolve value]`. A body that legitimately returns `nil`/`false` still resolves with that value.
- `attach-cleanup-diagnostic!` is presence-gated. It best-effort attaches a secondary cleanup failure to the primary as `rfUiTestCleanupError` (object-primary compat unchanged); when the primary is a **primitive** that cannot carry a property, the secondary rides the always-on `console.warn` route so it stays observable. The primary reason is thrown unchanged — never coerced or replaced.

This mirrors the presence convention already used in `client.cljs` / `substrate.cljs` / `reactive.cljc` (whose sibling occurrences are separate beads).

## Tests

- **`test_tier3_dom_cljs_test.cljs`** (browser gate — the faithful mounted home): falsy body rejection (`false` + `nil`) with total teardown; falsy body **value** resolves; falsy flush failure; a falsy cleanup failure rides an object primary (`rfUiTestCleanupError === false`); a falsy primary wins over a truthy cleanup.
- **`test_outcome_cljs_test.cljs`** (new, node-runnable): pins the `with-root-outcome` presence decision off the DOM.

## Red-before-fix

The `with-root-outcome` extraction makes the exact decision node-runnable. Reverting it to the truthiness form (`(cond primary … secondary … :else …)` — the defect) turns the node gate **red** with exactly 4 isolated failures in `test-outcome-cljs-test` (each falsy failure reported as `[:resolve …]` instead of `[:reject …]`); restoring presence → **green**.

## Quality gates

- `cd implementation && npm run test:cljs` — **9467 tests, 46461 assertions, 0 failures, 0 errors**.
- `cd implementation/ui && clojure -M:test` — **543 tests, 6669 assertions, 0 failures, 0 errors**.
- Browser DOM suite not run locally (CI owns the browser gate); the new `-dom-cljs-test` cases run there.
