### PR TITLE
fix(core): suppress watchable NaN-to-NaN fan-out under the rf= movement law (rf2-vxgfnd.185)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1769,12 +1769,22 @@
 (defn- make-watch-handler
   "Per-lease change watch: constant-work — advance the node record with the
   DELIVERED new value (no recompute, per I-5) and fan the mark-dirty payload
-  to this lease's own `on-change`."
+  to this lease's own `on-change`.
+
+  The fan-out is gated on the SAME movement law that governs node-version
+  advancement — the core-local `node-value=` `rf=` spelling, NOT raw `not=`
+  (rf2-vxgfnd.185). A watchable host notifies its watches on EVERY write,
+  value-blind, so a NaN→NaN recompute fires this callback with `prev`/`nu`
+  both NaN; raw `not=` treats NaN≠NaN and would fan a `:cause :value`
+  notification for NO value movement, while `advance-node-record!` (also
+  `node-value=`) leaves the version unchanged — a value-movement notification
+  without value movement that dirties a downstream ViewCell against a stable
+  node. Sharing `node-value=` here keeps the two decisions from drifting."
   [state]
   (fn observation-watch [_key _ref prev nu]
     (let [st @state]
       (when (and (= :live (:status st))
-                 (not= prev nu))
+                 (not (node-value= prev nu)))
         ;; The watch only fires while its reaction is live, so `lease-reaction`
         ;; resolves; the `when-some` is belt-and-braces for a JVM weak reaction.
         (when-some [rx (lease-reaction st)]

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -397,6 +397,77 @@
       (is (= 1 (:version (obs/read lease)))))
     (obs/release! lease)))
 
+;; ===========================================================================
+;; rf2-vxgfnd.185 — the watchable change-watch fan-out obeys the SAME movement
+;; law (`node-value=`, NaN-inclusive) that governs node-version advancement, so
+;; the two cannot drift. A watchable host whose derived value recomputes NaN→NaN
+;; fires its `add-watch` UNCONDITIONALLY (clojure/cljs atoms notify on every
+;; reset!, value-blind), but NaN=NaN under the movement law: there is no value
+;; movement, so the port must emit NO `:cause :value` notification. Raw `not=`
+;; treated NaN≠NaN and spuriously fanned out — a value-movement notification
+;; without value movement, dirtying a downstream ViewCell while the node version
+;; (governed by the same `node-value=`) stayed put.
+;;
+;; The plain-atom adapter's derived values are NOT watchable, so the port's real
+;; acquire path never installs this watch; the value-movement fan-out is a
+;; reactive/watchable-host surface. This fixture wires the PRODUCTION
+;; make-watch-handler onto a raw watchable atom EXACTLY as build-node-lease!
+;; does (weak-ref'd reaction in the state + add-watch + baseline observe), so it
+;; exercises the real callback on both hosts.
+;; ===========================================================================
+
+(defn- wire-node-watch!
+  "Install a node lease's change watch onto watchable `host`, mirroring
+  build-node-lease!'s wiring: the PRODUCTION make-watch-handler over the host, a
+  weak-ref'd reaction in the state map, and a baseline observation seeding the
+  node record at the host's current value. Notifications flow to `on-change`.
+  Returns the lease `state` atom (its `:last` holds the observed version)."
+  [host frame-id target on-change]
+  (let [state (atom {:lease-kind :node
+                     :target     target
+                     :frame-id   frame-id
+                     :query-v    (:query target)
+                     :reaction   (#'obs/weak-reaction-ref host)
+                     :on-change  on-change
+                     :status     :live})]
+    (add-watch host (gensym "rf-obs-lease")
+               (#'obs/make-watch-handler state))
+    (let [[rec v] (#'obs/observe-node! host)]
+      (swap! state assoc :last {:value    v
+                                :version  (:version rec)
+                                :node-key (:node-key rec)}))
+    state))
+
+(deftest watchable-nan-to-nan-recompute-does-not-fan-out-value-movement
+  (let [target (items-target)
+        notes  (atom [])
+        host   (atom ##NaN)
+        state  (wire-node-watch! host fid target
+                                 (fn [n] (swap! notes conj n)))
+        base-v (:version (:last @state))]
+    (is (= 0 base-v) "the baseline observation minted the node at version 0")
+    (testing "a NaN→NaN host recompute fires the watch but is NO movement"
+      ;; clojure/cljs atoms notify watches on EVERY reset!, value-blind — so the
+      ;; watch DOES fire with prev=NaN, nu=NaN, exercising the fan-out gate.
+      (reset! host ##NaN)
+      (is (empty? @notes)
+          "no :cause :value notification for a NaN→NaN no-movement recompute
+           (raw not= would spuriously fan out — NaN≠NaN natively)")
+      (is (= base-v (:version (:last @state)))
+          "the node version did not advance — NaN=NaN under the movement law"))
+    (testing "a REAL value movement fans out exactly once + advances the version"
+      (let [n-before (count @notes)]
+        (reset! host 5)
+        (is (= 1 (- (count @notes) n-before))
+            "exactly one :cause :value notification for real movement")
+        (let [note (last @notes)]
+          (is (= :value (:cause note)))
+          (is (= target (:target note)))
+          (is (= (inc base-v) (:node-version note))
+              "the notification carries the once-advanced node version")
+          (is (= (inc base-v) (:version (:last @state)))
+              "the lease's last-observed version advanced exactly once"))))))
+
 (deftest registry-epoch-advances-on-sub-registration
   (reg-items!)
   (seed-items! [:a])


### PR DESCRIPTION
## What

`make-watch-handler` (the watchable change-watch in `substrate/observation.cljc`) gated its `:cause :value` fan-out on raw `not=`, while `advance-node-record!` versions the node on the core-local `node-value=` `rf=` movement law (NaN-inclusive). A watchable host notifies its watches on **every** write, value-blind — so a `NaN→NaN` recompute fires the callback with `prev`/`nu` both `NaN`. Raw `not=` treats `NaN ≠ NaN` and fanned a value-movement notification for **no** value movement, while `advance-node-record!` (`node-value=`) left the version unchanged — a false fan-out that dirties a downstream ViewCell against a stable node.

Fix: gate the fan-out on the same `node-value=` movement law, so version advancement and fan-out cannot drift. One-line change (`(not= prev nu)` → `(not (node-value= prev nu))`) plus a docstring. O(1), same watch callback, no normalization pass, no second equality abstraction.

Closes rf2-vxgfnd.185.

## Red-before-fix

New `.cljc` fixture `watchable-nan-to-nan-recompute-does-not-fan-out-value-movement` wires the **production** `make-watch-handler` onto a raw watchable atom exactly as `build-node-lease!` does (weak-ref'd reaction + `add-watch` + baseline observe), on both hosts. Against unmodified `origin/main` the `NaN→NaN` assertion failed:

```
FAIL: no :cause :value notification for a NaN→NaN no-movement recompute
expected: (empty? @notes)
  actual: (not (empty? [{:cause :value ... :node-key 1, :node-version 0, :frame-epoch 0, :registry-epoch 2}]))
```

The leaked notification carries `:node-version 0` — a value-movement notification against an unmoved version, matching the bead's exact-head JVM probe. The real-move block (exactly-one notification, version advances once) is a positive control that passes before and after the fix; the `NaN→NaN` assertion is the sole flip. Green after the fix.

## Quality gates

- Core JVM `clojure -M:test` — 1991 tests / 9191 assertions, 0 failures
- Machines JVM `clojure -M:test` (cross-artefact consumer) — 1093 tests / 3791 assertions, 0 failures
- Node CLJS `npm run test:cljs` — 9462 tests / 46459 assertions, 0 failures

## Scope

`substrate/observation.cljc` + its port test only. Public seams unchanged. Does not touch `spine.cljs` (native derived fan-out — same movement law, owned by a separate bead).
