### PR TITLE
fix(ui): classify property-props as semantic conversion data not optional diagnostics (rf2-vxgfnd.190)

### DIFF
--- a/implementation/ui/src/re_frame/ui/semantic.cljc
+++ b/implementation/ui/src/re_frame/ui/semantic.cljc
@@ -9,8 +9,11 @@
   SEMANTIC-NODE space — the exact input to normalized structural
   equivalence and the render fingerprint. Pinned, in order:
 
-    1. strip every `:rf.ui/*` reserved key (diagnostics never reach a
-       fingerprint);
+    1. remove every `:rf.ui/*` reserved key from the OUTPUT (no reserved
+       key reaches a fingerprint) — but `:rf.ui/property-props` is
+       SEMANTIC conversion input, not a diagnostic: step 5 consumes it
+       (property-classified custom-element props omitted) BEFORE the
+       marker is dropped, so removing it up front changes the result;
     2. splice view-boundary nodes (HTML has no view boundaries);
     3. splice fragment nodes;
     4. drop `:events` entirely and drop `:key` values (neither has HTML

--- a/implementation/ui/test/re_frame/ui/semantic_normalize_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/semantic_normalize_cljs_test.cljc
@@ -267,3 +267,53 @@
             (v1 {:rf.ui/presence {:phase :present}
                  :rf.ui/boundary :client-only
                  :children [{:tag :p :children ["a"]}]}))))))
+
+;; ---------------------------------------------------------------------------
+;; Reserved-key CLASSIFICATION (rf2-vxgfnd.190) — `:rf.ui/property-props` is
+;; SEMANTIC CONVERSION INPUT, not an optional diagnostic. N consumes it at
+;; step 5 (property-classified custom-element props are omitted from markup)
+;; and only THEN removes the marker from its output. Its presence is
+;; load-bearing: strip it and the property leaks into the attribute space,
+;; changing N's output and therefore the fingerprint. This is the exact
+;; distinction the `presence`/`boundary` diagnostics (above) do NOT have —
+;; those are droppable without semantic effect.
+;; ---------------------------------------------------------------------------
+
+(deftest property-props-is-semantic-conversion-input
+  (testing "the marker keeps a property-only custom-element prop OUT of markup"
+    (let [tree (v1 {:tag :my-widget
+                    :attrs {:model "v" :data-x "d"}
+                    :rf.ui/property-props #{:model}})
+          [node] (semantic/normalize tree)]
+      (is (= {:tag :my-widget :attrs {"data-x" "d"}} node)
+          "`:model` is a property (omitted); the plain attr survives")
+      (is (not (contains? (:attrs node) "model"))
+          "the property-only name never reaches the attribute space")
+      (is (not (contains? node :rf.ui/property-props))
+          "the marker key itself never appears in the semantic output")))
+
+  (testing "REMOVING the marker CHANGES semantics — it is not safe to strip
+            (falsifies any 'optional diagnostic' classification for it)"
+    (let [with-marker    (v1 {:tag :my-widget
+                              :attrs {:model "v"}
+                              :rf.ui/property-props #{:model}})
+          without-marker (v1 {:tag :my-widget
+                              :attrs {:model "v"}})
+          out-with       (semantic/normalize with-marker)
+          out-without    (semantic/normalize without-marker)]
+      (is (= [{:tag :my-widget}] out-with)
+          "with the marker, `:model` is a property and produces no attr")
+      (is (= [{:tag :my-widget :attrs {"model" "v"}}] out-without)
+          "without the marker, `:model` is serialised as an ordinary attribute")
+      (is (not= out-with out-without)
+          "stripping the reserved key changed N's output — the fingerprint
+           boundary moved; a consumer that treated it as a safe-to-strip
+           diagnostic would corrupt the semantic result")))
+
+  (testing "the marker only applies to custom-element (hyphenated) tags —
+            a plain HTML tag ignores it (no property classification exists)"
+    (is (= [{:tag :div :attrs {"model" "v"}}]
+           (semantic/normalize
+            (v1 {:tag :div :attrs {:model "v"}
+                 :rf.ui/property-props #{:model}})))
+        "on a plain element there is no property channel; the marker is inert")))

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -119,18 +119,38 @@ above) and in view-boundary `:props` (a fn-valued or foreign prop). The `:rf.ui/
 namespace is reserved (Conventions ripple in the rewrite), so author data can never
 collide with the marker.
 
-### Reserved diagnostic keys (`:rf.ui/*`)
+### Reserved `:rf.ui/*` keys — semantic vs diagnostic
 
-A closed v1 set of optional, reserved-namespace keys; **consumers MUST ignore unknown
-`:rf.ui/*` keys** and **normalization strips them all** (a broken/absent diagnostic
-never changes app semantics or a fingerprint — the 06 §2 posture, applied here):
+A closed v1 set of reserved-namespace keys. **Consumers MUST ignore *unknown*
+`:rf.ui/*` keys**, and **normalization removes every `:rf.ui/*` key from its output** —
+no reserved key survives into a semantic node or a fingerprint. But *absent from the
+output* is **not** *safe to strip from the input*: these keys fall into three roles,
+and only one is a droppable diagnostic.
 
-| Key | Where | Meaning |
-|---|---|---|
-| `:rf.ui/tree-version` | root node only | the schema-version integer; **1** for this document |
-| `:rf.ui/presence` | the fragment node a presence boundary renders as | `{:phase :present :timeout-ms n}` — the "presence metadata exposed structurally" of 06 §1; phase is always `:present` on the JVM |
-| `:rf.ui/boundary` | the fragment node wrapping a deterministic fallback | `:client-only` (the structural "fallbacks" evidence; `:portal` reserved for the wave-2 row) |
-| `:rf.ui/property-props` | custom-element element nodes | the set of `:attrs` keys classified as **properties** per the RULED `ui/custom-element` declaration; the serialiser omits them, normalization omits them |
+- **Semantic — consumers MUST honor.** Load-bearing **conversion input**: `N` and the
+  serialiser READ it *during* conversion and only then drop the marker. Its absence
+  **changes the semantic output and the fingerprint**, so it is not optional and a
+  consumer that strips it before conversion corrupts the result. `:rf.ui/property-props`
+  is the v1 member — the property classification it carries decides which `:attrs` keys
+  are omitted from markup (§Property-only and form-control special forms, §Custom
+  elements, and `N` step 5). It is **required whenever a property-only classification
+  exists** and must be consumed *before* the marker is removed from the output.
+- **Required gate.** `:rf.ui/tree-version` is neither droppable nor conversion input: it
+  is the root schema-version gate every consumer validates **first** (fail-loud on
+  missing / non-integer / unsupported — §Versioning, §The SSR consumption boundary). It
+  is stripped from the semantic output, but a tree without it is *malformed*, not "a
+  broken diagnostic".
+- **Diagnostic — genuinely optional.** Evidence-only keys a consumer may find absent,
+  broken, or stripped **without any semantic effect** (the 06 §2 posture: a broken or
+  absent diagnostic never changes app semantics or a fingerprint). `:rf.ui/presence` and
+  `:rf.ui/boundary` are the v1 members.
+
+| Key | Role | Where | Meaning |
+|---|---|---|---|
+| `:rf.ui/tree-version` | required gate | root node only | the schema-version integer (**1** for this document); validated first, then removed from `N`'s output |
+| `:rf.ui/property-props` | **semantic** | custom-element element nodes | the set of `:attrs` keys classified as **properties** per the RULED `ui/custom-element` declaration; **consumed** at conversion (the serialiser and `N` omit those props from markup — step 5) and only then removed from the output. Required whenever a property-only classification exists; **removing it changes semantics** — the props would leak back into the attribute space |
+| `:rf.ui/presence` | diagnostic | the fragment node a presence boundary renders as | `{:phase :present :timeout-ms n}` — the "presence metadata exposed structurally" of 06 §1; phase is always `:present` on the JVM |
+| `:rf.ui/boundary` | diagnostic | the fragment node wrapping a deterministic fallback | `:client-only` (the structural "fallbacks" evidence; `:portal` reserved for the wave-2 row) |
 
 ### Child normalization (canonical form)
 
@@ -157,9 +177,11 @@ map node — carrying `:rf.ui/tree-version 1`. Interior nodes carry no version (
 handed to `find` inherit their tree's). **Bump rules:** any change to the variant set,
 discrimination order, required/optional fields, canonical-form rules, normalization
 `N`, projection behaviour, the opaque marker, or a conversion-table row's *semantics*
-bumps the integer. Adding a new optional `:rf.ui/*` diagnostic key does **not** bump
-(consumers must-ignore). Consumers seeing an unsupported version fail loud (§SSR
-boundary names the error).
+bumps the integer. Adding a new optional **diagnostic** `:rf.ui/*` key does **not** bump
+(consumers must-ignore); adding or changing a **semantic** reserved key
+(§Reserved `:rf.ui/*` keys — e.g. `:rf.ui/property-props`) *does* bump, since it changes
+conversion. Consumers seeing an unsupported version fail loud (§SSR boundary names the
+error).
 
 ## Projections — how nodes are read
 
@@ -190,8 +212,12 @@ Intent assertion, respelled to this contract:
 `N(tree)` produces the **semantic-node tree** — the exact input to normalized
 structural equivalence (06 §1) and to the render fingerprint. Pinned, in order:
 
-1. **Strip** every `:rf.ui/*` reserved key (version, presence, boundary markers,
-   property-props *marker*) — diagnostics never reach a fingerprint.
+1. **Remove** every `:rf.ui/*` reserved key from the output (version, presence,
+   boundary, and the property-props *marker*) — no reserved key reaches a fingerprint.
+   The property-props marker is **semantic conversion input**, not a diagnostic: step 5
+   consumes it (property-classified props are omitted from markup) and only *then* is the
+   marker itself dropped. Stripping it *before* conversion is unsafe — it moves the
+   fingerprint boundary (§Reserved `:rf.ui/*` keys).
 2. **Splice** view-boundary nodes (children replace the node — HTML has no view
    boundaries; dev `data-rf2-*` annotation is excluded by the same rule).
 3. **Splice** fragment nodes.
@@ -381,7 +407,7 @@ shapes.
 ## Coverage — the implementer questions this contract answers
 
 - **Q10** (node schema incl. fragments, trusted HTML, events, keys, view boundaries,
-  presence metadata, fallbacks, text) — §Node schema + §Reserved diagnostic keys
+  presence metadata, fallbacks, text) — §Node schema + §Reserved `:rf.ui/*` keys
   (presence and fallback markers).
 - **Q11** (keyword lookup vs opaque; where event vectors live) — §Projections: plain
   maps, field reads public, attribute reads via `ui.test/attrs`, events under


### PR DESCRIPTION
Closes rf2-vxgfnd.190.

## Problem

Spec 004B's §"Reserved diagnostic keys (`:rf.ui/*`)" classified **every** `:rf.ui/*` key
as an optional diagnostic where *"a broken/absent diagnostic never changes app semantics
or a fingerprint"* — and listed `:rf.ui/property-props` in that table.

That is false for `:rf.ui/property-props`. `re-frame.ui.semantic/normalize` (N)
**consumes** it during conversion (`norm-element` → `final-attrs`,
`semantic.cljc:120-133,156-188`): the property classification it carries decides which
`:attrs` keys are omitted from custom-element markup. Remove the marker and those props
leak back into the attribute space — N's output, the fingerprint, and SSR markup all
change. A consumer that trusted the spec's "safe to strip" rule would corrupt the result.

The behaviour in code was already correct; the defect was the **normative
classification** — spec prose plus the `semantic.cljc` docstring framing, both calling a
load-bearing conversion input a droppable diagnostic. This is a reconciliation, not an
open design decision: property-props being semantic is already implemented, and already
stated in N step 5 and §Custom elements. So the fix aligns the classification with the
shipped, already-normative behaviour.

## Red-before-fix

No **behaviour** bug existed, so the fixture is a green regression-lock that
**falsifies the pre-fix prose** rather than turning a red test green. The load-bearing
assertion:

```clojure
(is (not= out-with out-without)
    "stripping the reserved key changed N's output — the fingerprint boundary moved")
```

where `out-with` normalizes `{:tag :my-widget :attrs {:model "v"} :rf.ui/property-props #{:model}}`
→ `[{:tag :my-widget}]` (property omitted), and `out-without` normalizes the same node
with the marker stripped → `[{:tag :my-widget :attrs {"model" "v"}}]` (property leaks
into markup). The inequality **directly contradicts** the pre-fix spec claim that a
stripped `:rf.ui/*` key "never changes app semantics or a fingerprint" — which is the
exact contradiction this bead reports.

## Fix

- **spec/004B** — replace the flat "Reserved diagnostic keys" section with a three-role
  classification (**semantic** MUST-honor / **required gate** / **diagnostic**
  genuinely-optional); `:rf.ui/property-props` is **semantic**, `:rf.ui/tree-version` is
  the required gate, `:rf.ui/presence` + `:rf.ui/boundary` stay diagnostic. Fix the
  blanket "never changes semantics" claim, N step 1 wording, the Versioning bump rule
  (a new *semantic* reserved key bumps), and the Q10 cross-reference.
- **`semantic.cljc`** — reconcile the N step-1 docstring: property-props is semantic
  conversion input consumed at step 5 before the marker is dropped, not a diagnostic.
- **`semantic_normalize_cljs_test.cljc`** — add
  `property-props-is-semantic-conversion-input` locking: (1) the marker keeps a
  property-only prop out of markup and the marker itself never appears in output;
  (2) removing it changes N's output (load-bearing); (3) it is inert on plain
  (non-hyphenated) tags. The existing `presence`/`boundary` test remains the
  contrast — those stay droppable-without-effect.

No second classification channel and no per-render scan were added — the single
`:rf.ui/property-props` key already carried on the node is the only mechanism.

## Quality gates

- `cd implementation/ui && clojure -M:test` — **544 tests, 6683 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` — **9466 tests, 46475 assertions, 0 failures, 0 errors**
- `python scripts/check_doc_slugs.py` — **exit 0** (no broken links from the section rename)
- Scope: `implementation/ui/src/re_frame/ui/semantic.cljc` + its normalize test + `spec/004B-UI-Tree-and-Conversion.md`. No touch to reactive / frames / viewcell / compiler / observation / core / spec 004/004C/009.
