### PR TITLE
fix(ui): align create-root macro kind, required root-id, and option grammar across code/004C/API (rf2-vxgfnd.189)

### DIFF
--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -229,14 +229,17 @@ id" gap is closed here:
 | `:identifier-prefix` | rendering | string fed to React's `identifierPrefix` (`use-id`). Default: `"rf2-" + root-id-slug + "-"` (§1) — `:page/shop` → `"rf2-page_Sshop-"`. (06 §2's `"rf2-shop-"` example is an authored value, not the derived default.) |
 | `:on-uncaught-error` `:on-caught-error` `:on-recoverable-error` | host | plain CLJS fns passed to the React root options. Host-tier option maps are **not** template positions — the §02 §3 handler boundary law does not apply here. Invoked by React outside the re-frame2 commit path; to dispatch they must go through a live frame handle. |
 
-Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) must be **compile-time
-literals** at `mount`/`create-root` sites — they feed the descriptor and build-time
-duplicate detection. Host-behaviour opts may be runtime values.
+Identity opts must be **compile-time literals** at `mount`/`create-root` sites — they feed
+the descriptor and build-time duplicate detection; host-behaviour opts may be runtime
+values. `:disambiguator` is a **`mount`-only** derivation opt — it modifies how the root-id
+is derived from the mounted view. `create-root` fixes identity with **no root form to
+derive from**, so its identity set is `:root-id` / `:identifier-prefix` only; supplying
+`:disambiguator` there is a compile error (`:rf.ui.compile/bad-root-opts`).
 
 **The full host-tier signature set:**
 
 ```clojure
-(ui/create-root dom-node opts)        ; ⇒ Root. Identity fixed here, for the Root's lifetime.
+(ui/create-root dom-node opts)        ; ⇒ Root. Identity fixed here for the Root's lifetime; authored :root-id REQUIRED (no root form to derive from).
 (ui/render! root root-form)           ; render/re-render the literal root form into the Root.
 (ui/hydrate-root dom-node root-form)  ; ⇒ Root. Hydrating mount; identity comes FROM the manifest (§4).
 (ui/hydrate-root dom-node root-form opts)  ; opts: host-behaviour tier only (error callbacks).
@@ -257,12 +260,18 @@ duplicate detection. Host-behaviour opts may be runtime values.
 - **Every root-form-accepting entry point requires the literal root form at the call
   site** — `mount`, `render!`, `hydrate-root`, `render-static`, and `ui.test/render`
   (§8) alike; the same compile error rejects runtime-assembled vectors everywhere.
-  The CLJS realisation implements `render!`/`hydrate-root` as macros expanding to
-  underlying host fns over the compiled root template. `[S1-CONFIRM]` — the blessed
-  12 §2 table labels `create-root`/`render!`/`hydrate-root`/`unmount!` "fns"; the
-  physics above make `render!`/`hydrate-root` macros in realisation. This is a
-  **kind-label erratum only** (no name, arity, or surface change); route to Mike as a
-  row-level delta per the 12 §4 protocol.
+- **Verb kinds (ratified, shipped S1).** `mount`, `create-root`, `render!`, and
+  `hydrate-root` are **macros**; `unmount!` is a plain **function**. The four macros must
+  see their argument shape at compile time — `mount`/`render!`/`hydrate-root` keep the
+  literal root form's AST closed and extract the static frame plans, and `create-root`
+  fixes literal identity opts (feeding the descriptor and build-time duplicate detection).
+  `unmount!` takes a live Root value, has no form to compile, and stays a function. This
+  is the shipped surface — `re-frame.ui`'s var metadata and the generated public manifest
+  classify each verb exactly so — and it settles the earlier `[S1-CONFIRM]` kind-label
+  question; the stale "all fns" labelling and its route-to-Mike delta are retired. The
+  compile-time contract is locked by the frozen roster: an unauthored `create-root`
+  identity is `:rf.ui.compile/missing-root-id`, and an out-of-grammar opt (a stray
+  `:disambiguator` among them) is `:rf.ui.compile/bad-root-opts`.
 - Frame preflight (ENSURE + `:initial-events` drain, exactly once, before React) runs
   before the first `render!` on a Root and before `hydrate-root`'s hydration — timing
   and semantics owned by [Spec 002](002-Frames.md); this draft only pins *what is extracted*
@@ -496,11 +505,9 @@ unregisters (a leaked registration failing a later mount is a test-harness bug, 
 
 ## [S1-CONFIRM] register
 
-1. **§3** — `render!`/`hydrate-root` kind label in the blessed 12 §2 table ("fns" vs
-   macro realisation over host fns). Kind-label erratum only; row-level delta to Mike.
-2. **§4** — the manifest script element's concrete attribute/type convention; pin
+1. **§4** — the manifest script element's concrete attribute/type convention; pin
    alongside the Spec 011 payload-encoding rows.
-3. **§7** — entry-point-closure scoping as the build-time projection of "one page" for
+2. **§7** — entry-point-closure scoping as the build-time projection of "one page" for
    duplicate root-id detection (vs. whole-build strictness).
-4. **§9** — rejection of `{:frame …}`/`{:app-db …}` combined with a plan-bearing root
+3. **§9** — rejection of `{:frame …}`/`{:app-db …}` combined with a plan-bearing root
    form in `ui.test/render`.

--- a/spec/API.md
+++ b/spec/API.md
@@ -245,7 +245,7 @@ The multi-frame surface is organised by **intent**, not mechanism (a front-porch
 | `error-boundary` | M | `(ui/error-boundary {:fallback … :reset-key … :on-error […]} child)` | S3 | advanced | The explicit error component; `:on-error` dispatches after the failing commit through a captured live frame. |
 | `client-only` | M | `(ui/client-only {:fallback tpl} client-tpl)` | S3 → S5 | advanced | Browser-only subtree; mandatory capability-free fallback; one root phase-flip swaps all sites (per [011](011-SSR.md)). |
 | `mount` | M | `(ui/mount root-form dom-node ?opts)` | S1 | front-porch | Macro over a literal root form; carries root identity in opts (Root Descriptor v1, [Spec 004C](004C-Roots-and-Mount.md)). |
-| `create-root` | M | `(ui/create-root dom-node opts)` → Root | S1 | advanced | Identity fixed for the Root's lifetime. |
+| `create-root` | M | `(ui/create-root dom-node opts)` → Root | S1 | advanced | Identity fixed for the Root's lifetime; authored `:root-id` **required** — no root form to derive from, so a missing id is `:rf.ui.compile/missing-root-id` and `:disambiguator` is invalid ([Spec 004C](004C-Roots-and-Mount.md)). |
 | `render!` | M | `(ui/render! root root-form)` | S1 | advanced | Render/re-render the literal root form into a Root. |
 | `hydrate-root` | M | `(ui/hydrate-root dom-node root-form ?opts)` → Root | S1 → S5 | advanced | Hydrating mount; identity comes FROM the manifest (supplying client identity opts is `:rf.error/root-manifest-invalid`). |
 | `unmount!` | Fn | `(ui/unmount! root)` | S1 | advanced | Total teardown; unregisters the root-id. |


### PR DESCRIPTION
## What

Reconciles `spec/004C-Roots-and-Mount.md` and `spec/API.md` to the already-shipped `ui/create-root` compile-time surface. The promoted root contract and the API table contradicted the shipped macro; this aligns the specs to the code.

Recorded truth (from `implementation/ui/src/re_frame/ui.cljc` + `.../compiler/root.cljc`, the `re-frame.ui` var metadata, and the generated public manifest):

- **Verb kinds:** `mount`, `create-root`, `render!`, `hydrate-root` are **macros**; `unmount!` is a **function**.
- **create-root requires an authored `:root-id`** — it fixes identity with no root form to derive from, so a missing id is a compile error (`:rf.ui.compile/missing-root-id`).
- **`:disambiguator` is a `mount`-only derivation opt** and is **invalid for `create-root`** (`:rf.ui.compile/bad-root-opts`); create-root's identity set is `:root-id` / `:identifier-prefix` only.
- Retires the stale 004C `[S1-CONFIRM]` kind-label erratum (and its register item) that labelled the verbs "fns" and routed the question to Mike.

## Recording-vs-inventing determination

**Recording (reconciliation), not inventing.** The shipped compiler is authoritative and unchanged. `ui/create-root` already: is a `defmacro` (`ui.cljc:164`), requires an authored `:root-id` (`root.cljc:708` → `:rf.ui.compile/missing-root-id`), and rejects `:disambiguator` (`root.cljc:700` → `:rf.ui.compile/bad-root-opts`; `create-root-opt-keys` excludes it). API.md already labelled the verbs `M`/`Fn` correctly (a prior bead fixed the kind cells); the live defect was entirely 004C's stale erratum plus 004C/API prose that under-stated the required-`:root-id`/invalid-`:disambiguator` grammar. No unsettled grammar question required a Mike ruling — the code settles it — so this proceeded as recording.

## Red-before-fix

**N/A — no code changed.** This is a docs/spec reconciliation to shipped behaviour. The compile-time contract stays locked by existing frozen-roster fixtures, all green on this base:

- `implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc:482-488` — `create-root` missing-`:root-id` → `:rf.ui.compile/missing-root-id`.
- `implementation/ui/test/re_frame/ui/root_analysis_cljs_test.cljc:329-354` — root-opts validation → `:rf.ui.compile/bad-root-opts` (closed key set; `:root-id`+`:disambiguator` contradiction).
- `implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj:275` — `export-surface-is-exactly-the-blessed-set`.

Both ids are in the frozen roster (`error_roster_cljs_test.cljc:99-113`). The contract now cites these ids explicitly.

## Scope note

Per dispatch fence, this PR touches only `spec/004C` + `spec/API.md`. The non-normative working docs the bead also lists (`drafts/root-identity-and-mount.md`, `12-implementation-plan.md`) are out of this worker's scope.

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `clojure -M -m re-frame.api-manifest.gen --check` — PASS (`spec/api-manifest.edn` in sync, 485 public vars)
- `clojure -M -m re-frame.api-manifest.api-md-check` — PASS (`spec/API.md` projection in sync, 210 var-rows)
- `implementation/ui` `clojure -M:test` — PASS (543 tests, 6668 assertions, 0 failures/0 errors)
- `mkdocs --strict` — not on PATH (skipped)
- `npm run test:cljs` — not run: zero code changed (docs-only reconciliation); the ui JVM suite exercises the macro + all cited fixtures.

Closes rf2-vxgfnd.189.
