### PR TITLE
fix(ui): route compiler authority through the UI-private build carrier on Shadow outer-marker drift (rf2-vxgfnd.192)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -101,6 +101,31 @@
    :digest (fingerprint/build-digest [])
    :version 0})
 
+(def ^:private shadow-bridge-key
+  "Shadow's OUTER build-bridge marker. re-frame.ui recognizes it but does NOT
+  depend on it for build authority: a future Shadow rename/removal of this key
+  must not strand re-frame.ui's own private carrier."
+  :shadow.build.cljs-bridge/state)
+
+(def ^:private private-carrier-keys
+  "re-frame.ui's OWN compiler-env carrier keys — the accepted snapshot plus the
+  disposable scratch/overlay. Their presence is authoritative re-frame.ui build
+  ownership, independent of Shadow's outer marker."
+  [accepted-snapshot-key scratch-key repl-overlay-key])
+
+(defn- ui-owned-compiler-state?
+  "The ONE closed re-frame.ui compiler-ownership recognizer. A compiler-env map
+  is re-frame.ui-owned when it carries any of re-frame.ui's own private carrier
+  keys — the authority re-frame.ui itself established via the build hook — OR
+  Shadow's still-recognized outer bridge marker (the pre-hook window / legacy
+  path). Identity resolution, accepted/scratch reads, contribution writes, and
+  finish all gate on THIS predicate, so a drift of the outer marker cannot route
+  one build's authority onto another's while the private carrier is intact. Pure."
+  [compiler-state]
+  (boolean
+   (or (contains? compiler-state shadow-bridge-key)
+       (some #(contains? compiler-state %) private-carrier-keys))))
+
 #?(:clj
    (defn- compiler-env-atom []
      (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
@@ -108,10 +133,10 @@
          (when (instance? clojure.lang.IAtom v) v)))))
 
 #?(:clj
-   (defn- shadow-compiler-state []
+   (defn- ui-owned-compiler-state []
      (when-let [a (compiler-env-atom)]
        (let [s @a]
-         (when (contains? s :shadow.build.cljs-bridge/state) s)))))
+         (when (ui-owned-compiler-state? s) s)))))
 
 (defn accepted-snapshot
   "Return the accepted re-frame.ui snapshot carried by an explicit Shadow
@@ -156,37 +181,66 @@
   (boolean (some (comp true? :pass-open?) (vals @state))))
 
 #?(:clj
-   (defn- shadow-build-id
-     "The build id of the compile currently running on THIS thread, read from
-     the CLJS compiler env: `cljs.env/*compiler*` (an atom) ->
-     `:shadow.build.cljs-bridge/state` -> `:shadow.build/build-id`. A compiler
-     env is recognized as Shadow-shaped only when that outer bridge marker is
-     present. While a hook-opened pass is live, a recognized bridge with a
-     missing build-id leaf fails loudly rather than using the process-global
-     session fallback. A plain/no-marker compiler env returns nil and uses the
-     documented session fallback. A future migration of the OUTER bridge
-     marker is therefore not independently diagnosable here."
+   (defn- ambient-build-id
+     "The build id the current compilation belongs to, resolved from
+     re-frame.ui's OWN authority rather than Shadow's outer marker.
+
+     When the bound compiler-env carries re-frame.ui's private accepted carrier,
+     that carrier is authoritative: its `:build-id` is the answer. A private
+     carrier present with a MISSING build id, or with an id that DISAGREES with a
+     still-present Shadow bridge id, fails loudly — downgrading to the process
+     session fallback could route this compilation into a different parallel
+     build.
+
+     With no private carrier yet (the pre-hook window / legacy path) a
+     recognized Shadow bridge supplies the id; a recognized bridge missing its
+     leaf id while a pass is open still fails loudly. A plain/no-marker compiler
+     env returns nil and uses the documented session fallback."
      []
-     (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
-       (when-let [compiler-atom @compiler-var]
-         (let [compiler-state @compiler-atom
-               shadow-shaped? (contains? compiler-state
-                                         :shadow.build.cljs-bridge/state)
-               build-id (get-in compiler-state
-                                [:shadow.build.cljs-bridge/state
-                                 :shadow.build/build-id])]
-           (when (and shadow-shaped? (nil? build-id) (any-pass-open?))
+     (when-let [compiler-state (ui-owned-compiler-state)]
+       (let [private?   (some #(contains? compiler-state %) private-carrier-keys)
+             private-id (get-in compiler-state [accepted-snapshot-key :build-id])
+             shadow-id  (get-in compiler-state
+                                [shadow-bridge-key :shadow.build/build-id])]
+         (if private?
+           (cond
+             (nil? private-id)
              (throw
               (ex-info
-               (str "re-frame.ui compiler could not resolve shadow's build id "
-                    "while a build pass is open; refusing the session-build "
+               (str "re-frame.ui compiler found its private build carrier but no "
+                    "build id in the accepted snapshot; refusing the session-build "
                     "fallback because it can route this compilation into a "
                     "different parallel build")
-               {::error ::shadow-build-id-unresolved
-                :recovery :check-shadow-compiler-env
-                :expected-path [:shadow.build.cljs-bridge/state
-                                :shadow.build/build-id]})))
-           build-id)))))
+               {::error ::private-build-id-unresolved
+                :recovery :check-ui-build-carrier
+                :expected-path [accepted-snapshot-key :build-id]}))
+
+             (and (some? shadow-id) (not= shadow-id private-id))
+             (throw
+              (ex-info
+               (str "re-frame.ui compiler private build carrier id " private-id
+                    " disagrees with Shadow's still-present build id " shadow-id
+                    "; refusing to guess which build this compilation belongs to")
+               {::error ::private-build-id-shadow-disagreement
+                :recovery :check-ui-build-carrier
+                :private-build-id private-id
+                :shadow-build-id shadow-id}))
+
+             :else private-id)
+
+           ;; No private carrier yet: a recognized Shadow bridge supplies the id.
+           (do
+             (when (and (nil? shadow-id) (any-pass-open?))
+               (throw
+                (ex-info
+                 (str "re-frame.ui compiler could not resolve shadow's build id "
+                      "while a build pass is open; refusing the session-build "
+                      "fallback because it can route this compilation into a "
+                      "different parallel build")
+                 {::error ::shadow-build-id-unresolved
+                  :recovery :check-shadow-compiler-env
+                  :expected-path [shadow-bridge-key :shadow.build/build-id]})))
+             shadow-id))))))
 
 (defn current-build-id
   "The build id a contribution belongs to: the explicit `*build-id*`
@@ -194,7 +248,7 @@
   the last `begin-build!` id, else `::default`."
   []
   (or *build-id*
-      #?(:clj (shadow-build-id) :cljs nil)
+      #?(:clj (ambient-build-id) :cljs nil)
       @session-build
       ::default))
 
@@ -225,7 +279,7 @@
      an isolated overlay seeded from the accepted snapshot. Neither is an
      accepted successful-build authority."
      []
-     (when-let [compiler-state (shadow-compiler-state)]
+     (when-let [compiler-state (ui-owned-compiler-state)]
        (or (get compiler-state scratch-key)
            (get compiler-state repl-overlay-key)
            (assoc empty-slice
@@ -233,7 +287,7 @@
 
 #?(:clj
    (defn- ambient-accepted-slice []
-     (when-let [compiler-state (shadow-compiler-state)]
+     (when-let [compiler-state (ui-owned-compiler-state)]
        (assoc empty-slice
               :committed (:registries (accepted-snapshot compiler-state))))))
 
@@ -314,7 +368,7 @@
   [f]
   #?(:clj
      (if-let [compiler-atom (when-not *build-id* (compiler-env-atom))]
-       (if (contains? @compiler-atom :shadow.build.cljs-bridge/state)
+       (if (ui-owned-compiler-state? @compiler-atom)
          (let [updated (atom nil)]
            (swap! compiler-atom
                   (fn [compiler-state]
@@ -530,7 +584,7 @@
   plain-JVM fallback build's committed digest. Real Shadow tooling should use
   `accepted-build-digest` with an explicit retained build-state."
   ([]
-   (if-let [compiler-state #?(:clj (shadow-compiler-state) :cljs nil)]
+   (if-let [compiler-state #?(:clj (ui-owned-compiler-state) :cljs nil)]
      (:digest (accepted-snapshot compiler-state))
      (finalized-build-digest (current-build-id))))
   ([build-id]

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -260,6 +260,94 @@
     (is (= :plain-cljs (build/current-build-id))
         "a non-shadow compiler env uses the intended session build fallback")))
 
+;; ---------------------------------------------------------------------------
+;; Shadow OUTER-marker drift (rf2-vxgfnd.192): compiler authority must follow
+;; re-frame.ui's OWN private build carrier, not Shadow's implementation-detail
+;; outer `:shadow.build.cljs-bridge/state` bridge key. A Shadow rename/removal
+;; of that outer key while the private carrier stays intact must NOT downgrade
+;; identity, reads, or writes to the process/session fallback.
+;; ---------------------------------------------------------------------------
+
+(defn- drifted-env
+  "A compiler-env atom carrying re-frame.ui's private accepted + scratch carrier
+  for `build-id` but WITHOUT Shadow's outer bridge marker — the exact state a
+  Shadow rename/removal of that outer key produces while re-frame.ui's own
+  carrier stays intact."
+  [build-id members]
+  (atom (:compiler-env (build/prepare-shadow-build {} build-id (set members)
+                                                   (set members)))))
+
+(deftest drifted-outer-marker-routes-identity-through-private-carrier
+  ;; session-build names a DIFFERENT build, so a downgrade to the session
+  ;; fallback would return the wrong id.
+  (build/begin-build! :session-other)
+  (binding [cljs-env/*compiler* (drifted-env :app-a '#{app.a})]
+    (is (= :app-a (build/current-build-id))
+        "the private accepted carrier is authoritative once the outer marker drifts")))
+
+(deftest drifted-private-carrier-with-missing-build-id-fails-loud
+  (binding [cljs-env/*compiler*
+            (atom {build/accepted-snapshot-key {:registries {} :digest "d" :version 0}})]
+    (let [ex (try (build/current-build-id) nil
+                  (catch clojure.lang.ExceptionInfo ex ex))]
+      (is (some? ex) "a private carrier missing its build id must not downgrade")
+      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
+             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+
+(deftest private-carrier-disagreeing-with-present-shadow-id-fails-loud
+  (binding [cljs-env/*compiler*
+            (atom {build/accepted-snapshot-key {:build-id :app-a :registries {}
+                                                :digest "d" :version 1}
+                   :shadow.build.cljs-bridge/state {:shadow.build/build-id :app-b}})]
+    (let [ex (try (build/current-build-id) nil
+                  (catch clojure.lang.ExceptionInfo ex ex))]
+      (is (some? ex) "a private/shadow build-id disagreement must fail, not guess")
+      (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
+             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+
+(deftest canonical-shadow-marker-still-resolves-to-the-private-build-id
+  ;; The current (non-drifted) path: bridge marker present with an AGREEING id.
+  (binding [cljs-env/*compiler*
+            (atom {build/accepted-snapshot-key {:build-id :app-a :registries {}
+                                                :digest "d" :version 1}
+                   :shadow.build.cljs-bridge/state {:shadow.build/build-id :app-a}})]
+    (is (= :app-a (build/current-build-id))
+        "canonical marker + agreeing private id resolves to that id")))
+
+(deftest drifted-outer-marker-keeps-interleaved-builds-isolated
+  ;; The headline regression: two builds A and B, each drifted, interleaved.
+  ;; Rows must not cross and the session/global fallback must stay empty.
+  (build/begin-build! :session-global)
+  (let [env-a (drifted-env :A '#{app.a})
+        env-b (drifted-env :B '#{app.b})]
+    (binding [cljs-env/*compiler* env-a]
+      (build/contribute! build/views 'app.a :a/view ["tfa" "hsa"]))
+    (binding [cljs-env/*compiler* env-b]
+      (build/contribute! build/views 'app.b :b/view ["tfb" "hsb"]))
+    (binding [cljs-env/*compiler* env-a]
+      (build/contribute! build/views 'app.a2 :a/view2 ["tfa2" "hsa2"]))
+    (binding [cljs-env/*compiler* env-a]
+      (is (= #{:a/view :a/view2} (set (keys (build/aggregate build/views))))
+          "build A sees only its own rows"))
+    (binding [cljs-env/*compiler* env-b]
+      (is (= #{:b/view} (set (keys (build/aggregate build/views))))
+          "build B sees only its own rows"))
+    (is (= {} (build/aggregate build/views :session-global))
+        "the interleaved drifted writes never touched the session/global fallback")))
+
+(deftest private-resolution-distinct-from-a-same-valued-session-fallback
+  ;; The private carrier's build-id EQUALS the session-build value, yet routing
+  ;; must read the PRIVATE carrier — a test comparing only ids would pass wrongly.
+  (build/begin-build! :app)
+  (build/contribute! build/views 'fallback.ns :fallback/row ["tf-fb" "hs-fb"])
+  (build/commit-build! :app)
+  (binding [cljs-env/*compiler* (drifted-env :app '#{app.a})]
+    (build/contribute! build/views 'app.a :app/row ["tf-app" "hs-app"])
+    (is (= #{:app/row} (set (keys (build/aggregate build/views))))
+        "reads the private carrier's rows, not the coincidentally same-keyed session slice"))
+  (is (= #{:fallback/row} (set (keys (build/aggregate build/views :app))))
+      "the same-keyed session slice is untouched by the private-carrier writes"))
+
 (deftest explicit-view-id-collision-fails-in-either-compile-order
   (doseq [[first-ns second-ns] [['app.alpha 'app.beta]
                                 ['app.beta 'app.alpha]]]


### PR DESCRIPTION
## Problem

The re-frame.ui compiler recognized a Shadow compiler environment **only** by Shadow's OUTER private key `:shadow.build.cljs-bridge/state`. If Shadow renames or removes that outer bridge key while re-frame.ui's own private accepted/scratch carrier stays intact, `shadow-compiler-state`/`shadow-build-id` returned nil. Identity resolution, accepted-registry reads, contribution writes, element/property/descriptor lookups, and finish bookkeeping then silently fell back to the process/session build instead of the explicit private build id — so two interleaved builds could cross-route manifests and collision authority into one global slice, defeating the private carrier introduced precisely to make build identity authoritative.

This is the unresolved compatibility arm of CLOSED rf2-1rxznn (not reopened).

## Fix (`implementation/ui/src/re_frame/ui/compiler/build.cljc`)

- One closed compiler-ownership recognizer `ui-owned-compiler-state?`: a compiler-env is re-frame.ui-owned when it carries any of re-frame.ui's own private carrier keys (`::accepted-snapshot` / `::scratch` / `::repl-overlay`) **OR** Shadow's still-recognized outer bridge marker. Identity, accepted/scratch reads, contribution writes, and finish all now gate on this single predicate.
- `ambient-build-id` (replacing `shadow-build-id`) resolves the id from the **private accepted snapshot** first. A private carrier present with a **missing** build id, or one that **disagrees** with a still-present Shadow bridge id, throws a stable typed compiler error (`::private-build-id-unresolved` / `::private-build-id-shadow-disagreement`) rather than downgrading.
- The session/global fallback is retained only for genuinely plain CLJS/REPL envs carrying neither the private carrier nor a recognized Shadow bridge. No compatibility aliases for guessed future Shadow keys — re-frame.ui relies on its own carrier once the hook has established authority.

Because the fix is a single choke point, every ambient read/write helper (`aggregate`, `committed-aggregate`, `element-properties`, `pass-open?`, `finalized-build-digest`, `update-current-slice!`) is covered by construction — not only `current-build-id`.

## Red-before-fix

Six new regression tests in `compiler_build_jvm_test.clj` fail against current main and pass after the correction:

- against unmodified `build.cljc`: **10 failures, 0 errors** (all six drift tests red; the canonical-marker control stays green)
- after the fix: **0 failures, 0 errors**

Covered: drifted-marker identity routes through the private carrier; missing/disagreeing build id fails loud; canonical marker still resolves to the same private id; interleaved A/B builds stay isolated with the session/global fallback untouched; and private resolution is distinguished from a **same-valued** session fallback (ids match, contents differ — a test comparing only ids would pass wrongly).

## Quality gates

- `cd implementation/ui && clojure -M:test` — **554 tests, 6699 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` — **9476 tests, 46490 assertions, 0 failures, 0 errors** (includes the real-Shadow-compile ambient-build-id smoke)
- `cd implementation && npm run test:ui-digest-carrier` — **PASS** (exit 0)

No frozen public API change. Scope limited to `build.cljc` + its JVM tests.