### PR TITLE
test(ui): G-1 memo-matched on every workload + mutation at the real lowering site (rf2-vxgfnd.206)

### DIFF
--- a/implementation/scripts/run-ui-bench.cjs
+++ b/implementation/scripts/run-ui-bench.cjs
@@ -112,13 +112,35 @@ function emittedJsGolden() {
     /function\(\)\{return\{className:[^,]+,"data-priority":/g,
   );
 
+  // rf2-vxgfnd.206 — the two todo-row class-property lowerings must be present
+  // AND distinct, so the G-1 mutation control mutates the REAL lowering site.
+  //   NORMAL  (`v/todo-row`):               className is the single-flag
+  //           straight-line specialization — a comma-free string/ternary value
+  //           (`n(d)?"todo-item done":"todo-item"`). Counted by `todoLiteralProps`
+  //           above (its `className:[^,]+,"data-priority"` cannot match the
+  //           generic form, whose value carries commas).
+  //   GENERIC (`v/todo-row-generic-class`): className is the generic
+  //           `classes-str` vector/join over the `["todo-item", class-val(...)]`
+  //           vector (`(0,X.jsxs)("li",{className:CLASSES_STR(new VEC(...,
+  //           ["todo-item",CLASS_VAL(...)]...))`). The `["todo-item",` array
+  //           literal head survives Closure renaming; a specialized view can
+  //           never emit it. The mutation control benches THIS emit, so a
+  //           class-property specialization regressing to generic lowering (or
+  //           the control view being swapped back to the specialized shape)
+  //           moves this count and the runtime red control together.
+  const todoGenericClassLowering = countMatches(
+    src,
+    /\(0,[$\w]+(?:\.[$\w]+)*\.jsxs\)\("li",\{className:[$\w]+\(new [$\w.]+\([\w,.$]*\["todo-item",/g,
+  );
+
   const MIN_DIRECT = 10;
   const MIN_COMPILER_DIRECT = 20;
   console.log(
     `emitted-JS golden: ${direct} direct literal-tag jsx calls, ` +
       `${compilerDirect} compiler-direct module-property calls, ` +
       `${trap} IFn-fallback call sites, ` +
-      `${todoLiteralProps} direct todo literal / ${todoPropsIife} todo props IIFEs`,
+      `${todoLiteralProps} direct todo literal / ${todoPropsIife} todo props IIFEs, ` +
+      `${todoGenericClassLowering} generic classes-str class-property sites`,
   );
   if (direct < MIN_DIRECT) {
     console.error(
@@ -147,6 +169,17 @@ function emittedJsGolden() {
     console.error(
       'FAIL: the compiled todo row is not passing its compile-known props as ' +
         'one ordered object literal directly to jsxs.',
+    );
+    process.exit(1);
+  }
+  if (todoGenericClassLowering < 1) {
+    console.error(
+      'FAIL: the G-1 lowering-regression control candidate ' +
+        '(v/todo-list-generic-class) does not emit the generic classes-str ' +
+        'class-property lowering at the todo-row `li` site. The mutation must ' +
+        'exercise the REAL generic lowering (`className:classes-str(["todo-item"' +
+        ',...])`), not a proxy — otherwise the red control proves nothing about ' +
+        'the class-property specialization.',
     );
     process.exit(1);
   }

--- a/implementation/ui/bench/re_frame/ui/bench/hand.cljs
+++ b/implementation/ui/bench/re_frame/ui/bench/hand.cljs
@@ -36,6 +36,17 @@
                       (jsx/jsx "footer" #js {"aria-label" "footer" :tabIndex 0
                                              :children "(c) 2026 <re-frame2> & friends"})]}))
 
+;; `defview` wraps EVERY compiled view in `runtime/memo-view` (= React.memo)
+;; with a generated straight-line `rf=` comparator over its declared slots
+;; (emit-cljs `comparator-form`). The G-1 gate divides compiled/hand, so every
+;; hand DENOMINATOR must carry the SAME React.memo boundary and an equivalent
+;; comparator — otherwise the ratio measures the cost of crossing a memo
+;; boundary rather than the compiler's lowering overhead, and a React.memo cost
+;; change moves the gate with no lowering regression. static-tree declares no
+;; slots, so its compiled comparator is the always-equal `(fn [_ _] true)`.
+(def static-tree*-memo
+  (react/memo static-tree* (fn [_prev _next] true)))
+
 (defn counter* [^js props]
   (let [n       (unchecked-get props "n")
         step    (unchecked-get props "step")
@@ -74,6 +85,16 @@
                         (if (neg? n)
                           (jsx/jsx "p" #js {:className "neg" :children "negative"})
                           (jsx/jsx "p" #js {:className "pos" :children "non-negative"}))]})))
+
+;; counter declares slots n/step/locked? — match the generated straight-line
+;; rf= comparator over exactly those three slots.
+(def counter*-memo
+  (react/memo
+   counter*
+   (fn [^js prev ^js next]
+     (and (eq/rf= (unchecked-get prev "n") (unchecked-get next "n"))
+          (eq/rf= (unchecked-get prev "step") (unchecked-get next "step"))
+          (eq/rf= (unchecked-get prev "locked?") (unchecked-get next "locked?"))))))
 
 (defn todo-row* [^js props]
   (let [todo (unchecked-get props "todo")
@@ -181,3 +202,13 @@
                         (if (= state :error)
                           (jsx/jsx "hr" #js {})
                           nil)]})))
+
+;; status-panel declares slots state/message/retries — match the generated
+;; straight-line rf= comparator over exactly those three slots.
+(def status-panel*-memo
+  (react/memo
+   status-panel*
+   (fn [^js prev ^js next]
+     (and (eq/rf= (unchecked-get prev "state") (unchecked-get next "state"))
+          (eq/rf= (unchecked-get prev "message") (unchecked-get next "message"))
+          (eq/rf= (unchecked-get prev "retries") (unchecked-get next "retries"))))))

--- a/implementation/ui/bench/re_frame/ui/bench/main.cljs
+++ b/implementation/ui/bench/re_frame/ui/bench/main.cljs
@@ -36,7 +36,6 @@
             ["os" :as os]
             [re-frame.ui.bench.hand :as hand]
             [re-frame.ui.bench.views :as v]
-            [re-frame.ui.rules :as rules]
             [re-frame.ui.runtime :as rt]))
 
 ;; ---------------------------------------------------------------------------
@@ -51,14 +50,25 @@
           :priority (case (mod i 4) 0 :low 1 :med 2 :high 3 :low)})))
 
 (def cases
+  "Every gated workload names a memo-matched hand baseline (`:gate-hand`) that
+  carries the SAME React.memo boundary + an equivalent per-slot rf= comparator
+  the compiled `defview` emits (emit-cljs `comparator-form`), so each ratio
+  isolates the compiler's lowering overhead rather than the cost of the
+  always-memo policy. `:hand` is the unwrapped baseline (kept for byte-equality);
+  where `:policy-hand` names it the unwrapped comparison is reported separately
+  as explicit NON-GATING product-policy evidence."
   [{:id "static-tree"  :compiled v/static-tree  :hand hand/static-tree*
+    :gate-hand hand/static-tree*-memo
     :props {}}
    {:id "counter-42"   :compiled v/counter      :hand hand/counter*
+    :gate-hand hand/counter*-memo
     :props {:n 42 :step 10 :locked? false}}
    {:id "todos-20"     :compiled v/todo-list    :hand hand/todo-list*
     :gate-hand hand/todo-list*-memo
+    :policy-hand hand/todo-list*
     :props {:title "Twenty" :todos todos-20}}
    {:id "status-error" :compiled v/status-panel :hand hand/status-panel*
+    :gate-hand hand/status-panel*-memo
     :props {:state :error :message "boom & <bust> \"quoted\"" :retries 2}}])
 
 (def budget
@@ -155,19 +165,31 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- byte-equality! []
-  (let [fails (atom 0)]
+  (let [fails (atom 0)
+        check! (fn [id label c h]
+                 (when (not= c h)
+                   (swap! fails inc)
+                   (println "  BYTE-DIFF" id "against" label)
+                   (println "    compiled:" c)
+                   (println "    hand:    " h)))]
     (doseq [{:keys [id compiled hand gate-hand props]} cases]
       (let [pj (->props props)
             c  (render-html compiled pj)
             baselines (cond-> [["unwrapped hand" hand]]
                         gate-hand (conj ["memo-matched hand" gate-hand]))]
         (doseq [[label baseline] baselines]
-          (let [h (render-html baseline pj)]
-            (when (not= c h)
-              (swap! fails inc)
-              (println "  BYTE-DIFF" id "against" label)
-              (println "    compiled:" c)
-              (println "    hand:    " h))))))
+          (check! id label c (render-html baseline pj)))))
+    ;; The lowering-regression control candidate must render byte-identically to
+    ;; the todos-20 baselines — the mutation is ONLY the class-property lowering,
+    ;; so a byte diff would mean the control measures a different tree.
+    (let [{:keys [gate-hand hand props]}
+          (some #(when (= "todos-20" (:id %)) %) cases)
+          pj (->props props)
+          g  (render-html v/todo-list-generic-class pj)]
+      (check! "todos-20-generic-class-control" "memo-matched hand"
+              g (render-html gate-hand pj))
+      (check! "todos-20-generic-class-control" "unwrapped hand"
+              g (render-html hand pj)))
     (if (zero? @fails)
       (println "precheck: compiled HTML == every measured hand baseline byte-for-byte")
       (do (println "precheck FAILED:" @fails "baseline comparisons differ — ratios would be meaningless")
@@ -177,35 +199,36 @@
   (and (<= p50 (:p50 budget))
        (<= p95 (:p95 budget))))
 
-(defonce ^:private mutation-sink (volatile! nil))
-
-(defn- simulated-flag-map-lowering-regression! []
-  ;; Controlled equivalent of the slow shape caught while building G-1: do
-  ;; the generic classes-str vector/join work once per keyed row instead of
-  ;; the compiler's straight-line static-base + flag append. The separate
-  ;; loop is test-only mutation scaffolding; the volatile keeps Closure from
-  ;; proving the intentionally wasted result dead.
-  (doseq [{:keys [done?]} todos-20]
-    (vreset! mutation-sink
-             (rules/classes-str ["todo-item" (when done? "done")]))))
-
-(defn- lowering-regression-control []
-  (let [{:keys [compiled gate-hand props]}
+(defn- lowering-regression-control
+  "Faithful G-1 red control (rf2-vxgfnd.206): bench the REAL compiled todos-20
+  list whose row class-property is lowered through the generic classes-str path
+  (`v/todo-list-generic-class`) against the SAME memo-matched hand baseline the
+  todos-20 gate uses. The candidate differs from the gated `v/todo-list` at ONE
+  place — the class-property call site (generic `classes-str`/`class-val` join
+  instead of the single-flag straight-line specialization) — with byte-identical
+  output. So the ratio reddens for a genuine class-property lowering regression,
+  not for an injected side workload: there is no second traversal, no duplicate
+  specialized work, and no volatile timing sink. Swapping the candidate back to
+  the specialized `v/todo-list` drops this ratio under budget and fails the
+  `:detected?` assertion in `-main`."
+  []
+  (let [{:keys [gate-hand props]}
         (some #(when (= "todos-20" (:id %)) %) cases)
         pj (->props props)
-        r  (bench-pair #(do (simulated-flag-map-lowering-regression!)
-                            (render-html compiled pj))
+        r  (bench-pair #(render-html v/todo-list-generic-class pj)
                        #(render-html gate-hand pj)
                        opts)
         detected? (not (within-budget? (:ratio r)))]
     (println
      (str (if detected? "  CONTROL PASS " "  CONTROL FAIL ")
-          "todos-20 simulated generic flag-map lowering [must exceed budget]"
+          "todos-20 real generic classes-str class-property lowering [must exceed budget]"
           "  ratio p50=" (fixed4 (get-in r [:ratio :p50]))
           " p95=" (fixed4 (get-in r [:ratio :p95]))
           "  limits p50<=" (fixed4 (:p50 budget))
           " p95<=" (fixed4 (:p95 budget))))
-    {:id "todos-20-generic-flag-map-lowering"
+    {:id "todos-20-generic-classes-str-class-property-lowering"
+     :candidate "compiled todo-list, row class-property lowered via generic classes-str"
+     :baseline "memo-matched hand JSX"
      :expected "budget breach"
      :detected? detected?
      :ratio {:p50 (round4 (get-in r [:ratio :p50]))
@@ -224,17 +247,21 @@
   (byte-equality!)
   (let [results
         (vec
-         (for [{:keys [id compiled hand gate-hand props]} cases]
+         (for [{:keys [id compiled hand gate-hand policy-hand props]} cases]
            (let [pj (->props props)
                  cf #(render-html compiled pj)
-                 hf #(render-html hand pj)
                  gate-hf #(render-html (or gate-hand hand) pj)
                  r  (bench-pair cf gate-hf opts)
                  c  (:compiled r) h (:hand r)
                  r50 (get-in r [:ratio :p50])
                  r95 (get-in r [:ratio :p95])
                  ok? (within-budget? (:ratio r))
-                 policy-r (when gate-hand (bench-pair cf hf opts))
+                 ;; NON-GATING policy evidence: the compiled/UNWRAPPED-hand ratio,
+                 ;; reported only where `:policy-hand` names an unwrapped baseline
+                 ;; (todos-20 — the keyed list where the always-memo policy cost
+                 ;; is meaningful). It never feeds the gate decision.
+                 policy-r (when policy-hand
+                            (bench-pair cf #(render-html policy-hand pj) opts))
                  policy-c (:compiled policy-r)
                  policy-h (:hand policy-r)
                  policy-r50 (get-in policy-r [:ratio :p50])

--- a/implementation/ui/bench/re_frame/ui/bench/views.cljs
+++ b/implementation/ui/bench/re_frame/ui/bench/views.cljs
@@ -59,6 +59,43 @@
       [todo-row {:key (:id t) :todo t}])]
    [:p.count (count todos) " items"]])
 
+;; ---------------------------------------------------------------------------
+;; G-1 lowering-regression control fixture (rf2-vxgfnd.206)
+;;
+;; A REAL compiled emit of the todo row whose ONLY difference from `todo-row`
+;; is the `:class` lowering: writing the class as a dynamic expression over the
+;; static base drives the compiler down the GENERIC `classes-str`/`class-val`
+;; vector-join path (emit-cljs `class-form` `:else`) instead of the single-flag
+;; straight-line specialization (`(if done? "todo-item done" "todo-item")`).
+;; Output is byte-identical, so byte-equality still holds; the extra generic
+;; join work per keyed row is the exact regression the specialization comment
+;; (emit-cljs `class-form`) says it avoids. The G-1 mutation control benches
+;; `todo-list-generic-class` against the SAME memo-matched hand baseline the
+;; todos-20 gate uses, so it reddens for a genuine class-property lowering
+;; regression — no side loop, no volatile sink, no second traversal.
+(defview todo-row-generic-class
+  "todo-row with the class-property lowered through the generic classes-str
+  path (dynamic `:class` expr over the `.todo-item` static base) rather than
+  the single-flag straight-line specialization. Byte-identical output."
+  [{:keys [todo]}]
+  (let [{:keys [id label done? priority]} todo]
+    [:li.todo-item {:class (when done? "done") :data-priority priority :aria-hidden false}
+     [:input {:type :checkbox :checked done? :on-change [:todo/toggle id :rf.ui/checked]}]
+     [:span.label label]
+     (when (= priority :high) [:span.flag "HIGH"])]))
+
+(defview todo-list-generic-class
+  "todos-20 list built from generic-class rows — the G-1 lowering-regression
+  control candidate. Byte-identical to `todo-list`; only the row class-property
+  lowering differs."
+  [{:keys [title todos]}]
+  [:section.todos
+   [:h2 title]
+   [:ul.todo-ul
+    (for [t todos]
+      [todo-row-generic-class {:key (:id t) :todo t}])]
+   [:p.count (count todos) " items"]])
+
 (defview status-panel
   "Conditional multi-branch view (cond + when + if)."
   [{:keys [state message retries]}]


### PR DESCRIPTION
## What

Hardens the G-1 direct-render parity gate (`bench/**` + `scripts/run-ui-bench.cjs`) against two vacuous-gate weaknesses identified in rf2-vxgfnd.206. Gate-strengthening only — no `implementation/` core/compiler source touched.

### (a) Memo-matched on EVERY workload

Every compiled `defview` is wrapped in `runtime/memo-view` (= `React.memo`) with a generated per-slot `rf=` comparator (emit-cljs `comparator-form`). Previously only `todos-20` had a `:gate-hand` memo-matched baseline; `static-tree`, `counter-42`, and `status-error` were gated against BARE hand functions, so a `React.memo` cost change could move three ratios with no compiler-lowering regression.

Now every gated workload names a `:gate-hand` memo-matched baseline (`react/memo` over the hand render with an equivalent comparator — always-equal for the no-slot `static-tree`, per-slot `rf=` for the rest). The unwrapped-hand comparison is retained **only** as explicit NON-GATING policy evidence (`:policy-hand`, todos-20), so runtime is unchanged.

### (b) Mutation at the REAL lowering site

The old red control left the specialized compiled todo row intact and added a **separate** `classes-str` loop + volatile sink beside it — proving only that "a large side workload breaches budget," not that the class-property specialization regressing to generic lowering is detected. It could stay red even if the measured candidate were swapped for a hand implementation.

The control now benches a REAL compiled view, `v/todo-list-generic-class`, whose row `:class` is authored as a dynamic expression over the `.todo-item` static base (`{:class (when done? "done")}`). The compiler genuinely lowers that through the generic `classes-str`/`class-val` vector-join path (emit-cljs `class-form` `:else`) instead of the single-flag straight-line specialization (`(if done? "todo-item done" "todo-item")`). Output is **byte-identical** (byte-equality precheck covers it); it differs from the gated `v/todo-list` at ONE place — the class-property call site. No second traversal, no duplicate specialized work, no volatile timing sink.

The emitted-JS golden now asserts both shapes are present and distinct:
- normal row keeps the specialization: `(0,X.jsxs)("li",{className:n(d)?"todo-item done":"todo-item",…` (existing `todoLiteralProps`);
- mutation row uses generic lowering: `(0,X.jsxs)("li",{className:CLASSES_STR(new VEC(…["todo-item",CLASS_VAL(…)]…))` (new `todoGenericClassLowering`, keyed off the rename-stable `["todo-item",` array-literal head).

## Mutation-proof (control is coupled to the real lowering site)

| candidate (vs the same memo-matched hand baseline) | ratio p50 / p95 | gate |
| --- | --- | --- |
| `v/todo-list-generic-class` (real generic `classes-str` lowering) | ≈ 1.54 / 1.56 | CONTROL PASS → G-1 PASS |
| `v/todo-list` (specialization — mutation bypassed) | ≈ 1.00 / 1.04 | CONTROL FAIL → **G-1 FAIL (exit 1)** |

Bypassing the mutation drops the ratio under budget and reddens the gate, so the control detects a genuine class-property lowering regression — not an injected side workload.

## Quality gates

- `npm run test:ui-g1` (advanced release + emitted-JS golden + estimator/byte-equality/budget + red control) — **PASS**. Golden: `49 direct / 45 compiler-direct / 0 IFn-fallback / 1 direct todo literal / 0 todo props IIFEs / 1 generic classes-str class-property site`. All four workloads `[memo-matched hand baseline]` within 1.10 p50+p95; control ≈ 1.54.
- `implementation/ui: clojure -M:test` — **549 tests, 6697 assertions, 0 failures/errors**.
- Bypass run (throwaway, reverted): CONTROL FAIL, G-1 exit 1 — the coupling proof above.

Related: #5812 body updated with a dated final-disposition addendum (supersedes the stale "not merge-ready" conclusion; preserves the pre-optimization figures as historical evidence).
