### PR TITLE
fix(ui): bring re-frame.ui.test under API-manifest drift enforcement (rf2-vxgfnd.200)

### DIFF
--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -34,6 +34,19 @@
          day8/re-frame2-ssr      {:local/root "../../ssr"}
          day8/re-frame2-ssr-ring {:local/root "../../ssr-ring"}
          day8/re-frame2-epoch    {:local/root "../../epoch"}
+         ;; The compiled-view substrate artefact — BUILD-ONLY here (rf2-vxgfnd.200).
+         ;; Brings `re-frame.ui.test`'s JVM-loadable Tier-1 headless surface onto
+         ;; the generator classpath so `ns-publics` can existence-verify it, the
+         ;; same authoritative introspection re-frame.core gets. This is a
+         ;; build/governance read only — implementation/ui gains NO dependency on
+         ;; the generator, so production dependency graphs + advanced bundles are
+         ;; unchanged (day8/re-frame2-ui already depends on day8/re-frame2 core,
+         ;; already on this classpath). `re-frame.ui` itself stays a curated
+         ;; `:cljs-only` surface (its runtime targets React); only ui.test — whose
+         ;; Tier-1 render/find/find-all/text/attrs/flush! run headless ON the JVM
+         ;; — is JVM-enumerated. The CLJS reader-conditional surface is reconciled
+         ;; by the probe (see the probe test's re-frame.ui.test coverage).
+         day8/re-frame2-ui       {:local/root "../../ui"}
          ;; Tool artefacts with JVM-loadable (.cljc) public namespaces.
          day8/re-frame2-story    {:local/root "../../../tools/story"}
          day8/re-frame2-mcp-base {:local/root "../../../tools/mcp-base"}}

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -103,6 +103,29 @@
   []
   (-> (find-sidecar) slurp edn/read-string :cljs-only vec))
 
+(defmacro emit-classification-rows
+  "Expand to a literal vector of `{:namespace :var}` maps for the sidecar's
+   `:classification` entries whose namespace is `ns-str` (read from
+   `spec/api-manifest-metadata.edn` at macro-expansion time).
+
+   The `:cljs-only` rows the probe normally reconciles are the surfaces the
+   JVM generator CANNOT introspect. A `.cljc` namespace the generator DOES
+   own on the JVM (`re-frame.ui.test` — rf2-vxgfnd.200: its Tier-1 surface
+   runs headless on the JVM, so it lives in the generator's `jvm-namespaces`
+   and its rows are curated under `:classification`, not `:cljs-only`) still
+   needs its reader-conditional CLJS surface reconciled, so neither host can
+   silently expose an extra public. This macro projects that namespace's
+   classification rows into the same `{:namespace :var}` shape `reconcile`
+   consumes; the probe treats it exactly like a fully-rowed surface. Only
+   `:namespace`/`:var` are emitted — the probe checks EXISTENCE, not tier
+   (the JVM generator owns tier/kind for these rows)."
+  [ns-str]
+  (->> (-> (find-sidecar) slurp edn/read-string :classification)
+       (keep (fn [[[ns var] _]]
+               (when (= ns ns-str) {:namespace ns :var var})))
+       (sort-by :var)
+       vec))
+
 (defmacro emit-ns-publics
   "Expand to a literal vector of `[var-name kind]` pairs for the public
    vars of `ns-sym` (a quoted symbol), read from the CLJS analyzer's

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -62,7 +62,8 @@
   the shared `cljs-publics` + `cljs-probe` namespaces are the reusable
   mechanism for it (see rf2-2mtte PR notes)."
   (:require-macros [re-frame.api-manifest.cljs-publics
-                    :refer [emit-ns-publics emit-cljs-only-rows]])
+                    :refer [emit-ns-publics emit-cljs-only-rows
+                            emit-classification-rows]])
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.api-manifest.cljs-probe :as probe]
             ;; The covered CLJS-only namespaces. The `:require` forces the
@@ -95,7 +96,15 @@
             ;; (ui/src); the require forces its analysis so `emit-ns-publics`
             ;; reads the live CLJS publics. Fully-rowed, BOTH directions
             ;; checked — see the Coverage note and `fully-rowed` below.
-            [re-frame.ui]))
+            [re-frame.ui]
+            ;; rf2-vxgfnd.200 — the compiled-view substrate's testing surface.
+            ;; UNLIKE re-frame.ui (curated :cljs-only), `re-frame.ui.test`'s
+            ;; Tier-1 surface runs headless on the JVM, so it is JVM-INTROSPECTED
+            ;; (generator `jvm-namespaces` + :classification rows). This probe
+            ;; reconciles its reader-conditional CLJS surface against those rows
+            ;; (via `emit-classification-rows` below) so the CLJS host cannot
+            ;; silently expose an extra public. Fully-rowed, BOTH directions.
+            [re-frame.ui.test]))
 
 ;; ---------------------------------------------------------------------------
 ;; The live CLJS public surface, captured at compile time.
@@ -132,7 +141,11 @@
    ;; blessed it — the first-party `adapter` Var rf2-vxgfnd.103, and the `frame`
    ;; ops-bundle body form rf2-vxgfnd.184), so
    ;; re-frame.ui is in `fully-rowed` below (both directions checked).
-   "re-frame.ui"                                     (emit-ns-publics re-frame.ui)})
+   "re-frame.ui"                                     (emit-ns-publics re-frame.ui)
+   ;; rf2-vxgfnd.200 — re-frame.ui.test testing surface. JVM-introspected for
+   ;; its manifest rows (the generator owns tier/kind); the probe reconciles
+   ;; the live CLJS surface so a CLJS-only public addition reddens too.
+   "re-frame.ui.test"                                (emit-ns-publics re-frame.ui.test)})
 
 (def fully-rowed
   "Namespaces whose ENTIRE public surface must be rowed (direction 2).
@@ -147,12 +160,31 @@
   #{"re-frame.adapter.reagent"
     "re-frame.adapter.uix"
     "re-frame.adapter.helix"
-    "re-frame.ui"})
+    "re-frame.ui"
+    ;; rf2-vxgfnd.200 — direction-2 completeness on the CLJS side: a NEW
+    ;; public var added to re-frame.ui.test's CLJS surface without a manifest
+    ;; row → RED. Its rows come from :classification (JVM lane), fed in via
+    ;; `ui-test-rows` below, not :cljs-only.
+    "re-frame.ui.test"})
 
 (def cljs-only-rows
   "The `:cljs-only` rows from spec/api-manifest-metadata.edn, embedded at
    compile time (no runtime filesystem)."
   (emit-cljs-only-rows))
+
+(def ui-test-rows
+  "The `re-frame.ui.test` `:classification` rows (rf2-vxgfnd.200), projected
+   to `{:namespace :var}` so the probe reconciles them exactly like the
+   `:cljs-only` rows. `re-frame.ui.test` is JVM-introspected for its manifest
+   rows (its Tier-1 surface runs headless on the JVM), but its reader-
+   conditional CLJS surface must still be reconciled here so neither host can
+   silently expose an extra public."
+  (emit-classification-rows "re-frame.ui.test"))
+
+(def reconcile-rows
+  "Every row the probe reconciles: the `:cljs-only` surfaces plus the
+   JVM-owned `re-frame.ui.test` rows."
+  (into cljs-only-rows ui-test-rows))
 
 ;; ---------------------------------------------------------------------------
 ;; The probe.
@@ -160,7 +192,7 @@
 
 (deftest cljs-only-surface-in-sync
   (testing "live CLJS public surface reconciles with the :cljs-only rows"
-    (let [result (probe/reconcile live-publics cljs-only-rows fully-rowed)]
+    (let [result (probe/reconcile live-publics reconcile-rows fully-rowed)]
       (is (probe/in-sync? result)
           (probe/report result)))))
 

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -94,6 +94,13 @@
     re-frame.core
     re-frame.test-support
     re-frame.test-helpers
+    ;; The compiled-view substrate's testing surface (rf2-vxgfnd.200). Its
+    ;; sibling `re-frame.ui` is a curated :cljs-only surface (React runtime),
+    ;; but `re-frame.ui.test`'s Tier-1 render/find/find-all/text/attrs/dispatch!
+    ;; run HEADLESS on the JVM, so it is introspected here like re-frame.core —
+    ;; day8/re-frame2-ui rides the generator's BUILD-ONLY classpath (deps.edn).
+    ;; The reader-conditional CLJS surface is reconciled by the 2mtte probe.
+    re-frame.ui.test
     ;; Optional feature artefacts (public home namespaces).
     re-frame.schemas
     re-frame.machines

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1027,6 +1027,37 @@
   ["re-frame.test-helpers" "children"]              {:tier :testing :owner "008" :status "v1"}
 
   ;; =========================================================================
+  ;; re-frame.ui.test — the compiled-view substrate's testing surface
+  ;; (day8/re-frame2-ui; epic rf2-vxgfnd, Spec 004; contract in Spec 008).
+  ;; Unlike its sibling `re-frame.ui` (a curated :cljs-only surface — its
+  ;; runtime targets React), `re-frame.ui.test`'s Tier-1 surface runs
+  ;; HEADLESS on the JVM (`render` builds the structural tree; find /
+  ;; find-all / text / attrs / dispatch! query it), so it is JVM-INTROSPECTED
+  ;; — the generator classpath carries day8/re-frame2-ui BUILD-ONLY
+  ;; (rf2-vxgfnd.200) and `re-frame.ui.test` is in the generator's
+  ;; `jvm-namespaces`, giving the same authoritative `ns-publics` existence +
+  ;; :kind + :facade? derivation re-frame.core gets. The reader-conditional
+  ;; CLJS surface is reconciled by the 2mtte CLJS probe (fully-rowed, BOTH
+  ;; directions), so neither host can silently expose an extra public. The two
+  ;; ^:no-doc runtime halves (`render-view*` / `render-form*`) are dropped by
+  ;; the generator's `public-vars-of` carve-out; the CLJS-only `with-root*`
+  ;; owner + `with-root-outcome` (^:no-doc) are internal by classification.
+  ;; Tier 1 (S1): render / find / find-all / text / attrs / dispatch!.
+  ;; Tier 3 (S2): with-root / native-CSS query / (flush!)/(flush! thunk).
+  ;; S4's `flush-presence!` is NOT defined yet — it stays absent (no row)
+  ;; until its stage lands, then takes an ordinary manifest update.
+  ;; =========================================================================
+  ["re-frame.ui.test" "render"]    {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "find"]      {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "find-all"]  {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "text"]      {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "attrs"]     {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "dispatch!"] {:tier :testing :owner "008" :status "Spec-004 S1"}
+  ["re-frame.ui.test" "with-root"] {:tier :testing :owner "008" :status "Spec-004 S2"}
+  ["re-frame.ui.test" "query"]     {:tier :testing :owner "008" :status "Spec-004 S2"}
+  ["re-frame.ui.test" "flush!"]    {:tier :testing :owner "008" :status "Spec-004 S2"}
+
+  ;; =========================================================================
   ;; re-frame.schemas — optional artefact (day8/re-frame2-schemas), §010.
   ;; Introspection accessors are `tooling`; validator-install seams
   ;; `advanced`; the lower-level lifecycle/cache/validation helpers are

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 485,
+ :var-count 494,
  :tier-vocab
  [:front-porch
   :advanced
@@ -501,4 +501,13 @@
   {:namespace "re-frame.ui", :var "render!", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "spread", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "sub", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.ui", :var "unmount!", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}]}
+  {:namespace "re-frame.ui", :var "unmount!", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "attrs", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "dispatch!", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "find", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "find-all", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "flush!", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S2", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "query", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S2", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "render", :tier :testing, :kind :macro, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "text", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "with-root", :tier :testing, :kind :macro, :owner "008", :status "Spec-004 S2", :facade? false, :runtime-verified? true}]}


### PR DESCRIPTION
## Problem (rf2-vxgfnd.200)

`re-frame.ui.test` is a public namespace (spec/API.md §Compiled views declares it, contract in Spec 008), but it had **zero rows** in `spec/api-manifest.edn` / `spec/api-manifest-metadata.edn`. The generator's JVM classpath did not include `implementation/ui`, and the CLJS enumeration probe covered `re-frame.ui` but not `re-frame.ui.test`. So the drift gate stayed green if a supported test var was removed/renamed, an unapproved public was added, or visibility changed — unlike `re-frame.core`.

## Fix — mirror re-frame.core's JVM lane + reconcile the CLJS reader-conditional surface

Unlike its sibling `re-frame.ui` (a curated `:cljs-only` surface — its runtime targets React), `re-frame.ui.test`'s Tier-1 surface (`render` builds the structural tree; `find`/`find-all`/`text`/`attrs`/`dispatch!` query it) runs **headless on the JVM**, so it is JVM-introspected the same authoritative way `re-frame.core` is.

- **`implementation/scripts/api-manifest/deps.edn`** — add `day8/re-frame2-ui` as a BUILD-ONLY generator dependency (it already depends on core, already on the classpath). No runtime dependency is added to core/production; production dependency graphs + advanced bundles are unchanged.
- **`gen.clj`** — add `re-frame.ui.test` to `jvm-namespaces`, so `ns-publics` existence-verifies it and derives `:kind`/`:facade?` from live vars. The two `^:no-doc` runtime halves (`render-view*` / `render-form*`) are dropped by the existing carve-out; `with-root*` (private) + `with-root-outcome` (`^:no-doc`) stay internal by classification.
- **`spec/api-manifest-metadata.edn`** — add 9 `:classification` rows for the blessed surface, all `:tier :testing :owner "008"`. Tier 1 (S1): `render` / `find` / `find-all` / `text` / `attrs` / `dispatch!`. Tier 3 (S2): `with-root` / `query` / `flush!`. S4's `flush-presence!` stays absent (no row) until its stage lands.
- **`spec/api-manifest.edn`** — regenerated: 485 → 494 public vars (the 9 ui.test rows).
- **CLJS probe** (`cljs_publics.clj` + `cljs_manifest_probe_cljs_test.cljs`) — a new `emit-classification-rows` macro projects ui.test's JVM-owned rows into the probe, and `re-frame.ui.test` joins the probe's `fully-rowed` set. This reconciles the reader-conditional CLJS surface against the same rows, so **neither host can silently expose an extra public** (a CLJS-only addition the JVM lane can't see is still caught).

## Mutation-proof (the gate now reddens on an unmanifested ui.test surface change)

- **JVM lane** — add a plain public `(defn simulate! [] nil)` to `ui.test` → `clojure -M -m re-frame.api-manifest.gen --check` **FAILS (exit 2)**: `Public vars with no sidecar classification: re-frame.ui.test/simulate!`.
- **CLJS lane** — make it `#?(:cljs (defn simulate! [] nil))` (JVM-invisible) → `gen --check` stays **green** (the JVM host cannot see it, the exact gap), while the CLJS probe goes **RED**: `Live public vars with NO sidecar row (added to a fully-rowed ns): + re-frame.ui.test/simulate! (:fn)` (1 failure).

Both proofs reverted; the committed tree is clean.

## Quality gates (foreground, green)

- `clojure -M -m re-frame.api-manifest.gen --check` → OK (494 public vars in sync)
- `clojure -M -m re-frame.api-manifest.api-md-check` → OK (210 var-rows in sync)
- `implementation/scripts/api-manifest` `clojure -M:test` (reconciler regression + all projection checks: api-md / doc-api / doc-guide / skills) → 53 tests, 0 failures
- `implementation/ui` `clojure -M:test` → 555 tests, 0 failures
- `npm run test:cljs` (full node-test, includes the CLJS probe) → 9478 tests, 46507 assertions, 0 failures
- `python scripts/check_doc_slugs.py` → no broken links