### PR TITLE
test(machines): replace vacuous region-local parallel-always fixture with a parent-round proof (rf2-0847jc)

### DIFF
--- a/spec/conformance/fixtures/parallel-always-cascade-per-region.edn
+++ b/spec/conformance/fixtures/parallel-always-cascade-per-region.edn
@@ -2,50 +2,138 @@
 ;;
 ;; Per [005 §Per-region `:always` / `:after` / `:spawn` scoping]
 ;; (../../005-StateMachines.md#per-region-always--after--spawn-scoping):
-;; the macrostep's `:always` microstep loop runs PER REGION. After a
-;; region's event-driven transition, that region's new state's `:always`
-;; entries are checked; matching guards fire transitions in that
-;; region. Sibling regions are not re-evaluated for `:always` on the
-;; transitioning region's microstep.
+;; a region's `:always` transition TARGET / cascade is region-scoped (it
+;; moves that region's own state, never a sibling's), but stabilization is
+;; PARENT-OWNED. After the complete selected event set applies, the parent
+;; selects EVERY enabled regional `:always` against ONE frozen whole-machine
+;; snapshot, applies that preselected set in region-declaration order, and
+;; repeats to quiescence — a single macrostep converging across all regions.
+;; This supersedes the rejected region-local drain model (PR #5801): the
+;; parent does NOT settle one region's `:always` before a sibling's event
+;; action has applied, and declaration order never changes which set is
+;; selected.
 ;;
-;; This fixture exercises a region whose `:initial` state's `:always`
-;; guard already passes after an action sets the data — the macrostep
-;; settles to the post-`:always` state in one dispatch.
+;; Two invariants are proven, corresponding to the two halves of the law:
+;;
+;;   Call 1 — REGION-SCOPED TARGET. A region's `:always` advances only that
+;;   region (`:a → :resolved`); the sibling region that does not participate
+;;   is untouched (`:b` stays `:x`). This is the "region-scoped cascade" half.
+;;
+;;   Calls 2 & 3 — PARENT-OWNED ROUND (the load-bearing distinction). Both
+;;   regions handle the same event `:go`, each writing its own shared-`:data`
+;;   flag (`:a?` / `:b?`); each region's `:mid` `:always` is guarded on BOTH
+;;   flags. Under the ratified engine the event set applies to BOTH regions
+;;   FIRST (both flags set), so the first frozen `:always` round selects both
+;;   regions and both reach `:resolved` in the same macrostep. Call 2 declares
+;;   the regions `[:a :b]`, Call 3 declares them `[:b :a]`; both converge to
+;;   the SAME `{:a :resolved :b :resolved}` / `{:a? true :b? true}`, proving
+;;   declaration-order invariance.
+;;
+;;   Discrimination (mutation gate): a REGION-LOCAL drain — one region
+;;   stabilizing its `:always` before the sibling region's `:go` action has
+;;   written its flag — strands the first-declared region at `:mid` (its
+;;   guard sees only its own flag), producing `{:a :mid :b :resolved}` for
+;;   Call 2 and `{:a :resolved :b :mid}` for Call 3. Both discriminating
+;;   calls therefore REDDEN under region-local draining while Call 1 (region-
+;;   scoped target, shared by both models) stays green. The vacuous single-
+;;   region predecessor passed under either model; these do not.
 
 {:fixture/id           :machine/parallel-always-cascade-per-region
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/parallel-regions :fsm/eventless-always}
- :fixture/doc          "After a region's :on transition fires, that region's :always microstep cascade runs scoped to the region; sibling regions are unaffected. The action sets `:left-ready? true`, which makes the :always guard pass and advances :left to :resolved in the same macrostep."
+ :fixture/doc          "Region `:always` targets are region-scoped but stabilization is parent-owned. Call 1 proves the region-scoped target (a region's `:always` advances only that region). Calls 2/3 prove the parent-owned round: both regions' `:go` actions apply before the first frozen `:always` round, so a guard requiring BOTH regions' flags fires for both regions in the same macrostep — reaching `{:a :resolved :b :resolved}` regardless of `[:a :b]` vs `[:b :a]` declaration order. A region-local drain would strand the first-declared region at `:mid`."
 
  :fixture/registry
  {:machine-action
-  {:par/mark-ready {:doc "Sets :left-ready? true on the shared :data."}}
+  {:par/arm-a  {:doc "Sets :a-armed? true on the shared :data (region-scoped call)."}
+   :par/mark-a {:doc "Sets :a? true on the shared :data (region :a handled :go)."}
+   :par/mark-b {:doc "Sets :b? true on the shared :data (region :b handled :go)."}}
   :machine-guard
-  {:par/ready? {:doc "True when :left-ready? is true."}}}
+  {:par/a-armed? {:doc "True when :a-armed? is true."}
+   :par/both?    {:doc "True only when BOTH :a? and :b? are true (needs both regions' :go actions)."}}}
 
  :fixture/handlers
  {:machine-action
-  {:par/mark-ready [[:set [:left-ready?] true]]}
+  {:par/arm-a  [[:set [:a-armed?] true]]
+   :par/mark-a [[:set [:a?] true]]
+   :par/mark-b [[:set [:b?] true]]}
   :machine-guard
-  {:par/ready? [[:fn := [:get [:left-ready?]] true]]}}
+  {:par/a-armed? [[:fn := [:get [:a-armed?]] true]]
+   :par/both?    [[:fn :and [:get [:a?]] [:get [:b?]]]]}}
 
  :fixture/calls
+ ;; Call 1 — region-scoped `:always` target. Region :a handles :arm (sets
+ ;; :a-armed?) and its :always advances :a → :resolved in the same macrostep;
+ ;; region :b declines :arm and is untouched. The always TARGET is region-
+ ;; scoped: only :a moves.
  [{:call         :machine-transition
    :definition
-   {:type    :parallel
-    :data    {:left-ready? false}
-    :guards  {:ready? :par/ready?}
-    :actions {:mark-ready :par/mark-ready}
-    :regions {:left  {:initial :idle
-                      :states
-                      {:idle     {:always [{:guard :ready? :target :resolved}]
-                                  :on     {:prep {:target :idle :action :mark-ready}}}
-                       :resolved {}}}
-              :right {:initial :a
-                      :states  {:a {}}}}}
-   :snapshot     {:state {:left :idle :right :a}
-                  :data  {:left-ready? false}}
-   :event        [:prep]
-   :expect-next-snapshot {:state {:left :resolved :right :a}
-                          :data  {:left-ready? true}}
+   {:type         :parallel
+    :data         {:a-armed? false}
+    :region-order [:a :b]
+    :guards       {:a-armed? :par/a-armed?}
+    :actions      {:arm-a :par/arm-a}
+    :regions {:a {:initial :idle
+                  :states  {:idle     {:always [{:guard :a-armed? :target :resolved}]
+                                       :on     {:arm {:target :idle :action :arm-a}}}
+                            :resolved {}}}
+              :b {:initial :x
+                  :states  {:x {}}}}}
+   :snapshot     {:state {:a :idle :b :x} :data {:a-armed? false}}
+   :event        [:arm]
+   :expect-next-snapshot {:state {:a :resolved :b :x}
+                          :data  {:a-armed? true}}
+   :expect-effects       []}
+
+  ;; Call 2 — parent-owned round, declaration order [:a :b]. Broadcasting :go
+  ;; applies BOTH regions' actions first (:a? and :b? both set), so the first
+  ;; frozen :always round selects both :mid regions (guard :both? passes for
+  ;; each against the one frozen snapshot) and both reach :resolved in this
+  ;; macrostep. A region-local drain would settle :a's :always before :b's :go
+  ;; action ran → :a stranded at :mid → {:a :mid :b :resolved}.
+  {:call         :machine-transition
+   :definition
+   {:type         :parallel
+    :data         {:a? false :b? false}
+    :region-order [:a :b]
+    :guards       {:both? :par/both?}
+    :actions      {:mark-a :par/mark-a :mark-b :par/mark-b}
+    :regions {:a {:initial :idle
+                  :states  {:idle     {:on     {:go {:target :mid :action :mark-a}}}
+                            :mid      {:always [{:guard :both? :target :resolved}]}
+                            :resolved {}}}
+              :b {:initial :idle
+                  :states  {:idle     {:on     {:go {:target :mid :action :mark-b}}}
+                            :mid      {:always [{:guard :both? :target :resolved}]}
+                            :resolved {}}}}}
+   :snapshot     {:state {:a :idle :b :idle} :data {:a? false :b? false}}
+   :event        [:go]
+   :expect-next-snapshot {:state {:a :resolved :b :resolved}
+                          :data  {:a? true :b? true}}
+   :expect-effects       []}
+
+  ;; Call 3 — parent-owned round, declaration order [:b :a]. Identical machine,
+  ;; regions declared in the reverse order. The ratified engine is declaration-
+  ;; order invariant, so this converges to the SAME
+  ;; {:a :resolved :b :resolved} / {:a? true :b? true} as Call 2. A region-
+  ;; local drain reverses the strand → {:a :resolved :b :mid}.
+  {:call         :machine-transition
+   :definition
+   {:type         :parallel
+    :data         {:a? false :b? false}
+    :region-order [:b :a]
+    :guards       {:both? :par/both?}
+    :actions      {:mark-a :par/mark-a :mark-b :par/mark-b}
+    :regions {:a {:initial :idle
+                  :states  {:idle     {:on     {:go {:target :mid :action :mark-a}}}
+                            :mid      {:always [{:guard :both? :target :resolved}]}
+                            :resolved {}}}
+              :b {:initial :idle
+                  :states  {:idle     {:on     {:go {:target :mid :action :mark-b}}}
+                            :mid      {:always [{:guard :both? :target :resolved}]}
+                            :resolved {}}}}}
+   :snapshot     {:state {:a :idle :b :idle} :data {:a? false :b? false}}
+   :event        [:go]
+   :expect-next-snapshot {:state {:a :resolved :b :resolved}
+                          :data  {:a? true :b? true}}
    :expect-effects       []}]}


### PR DESCRIPTION
## What

Replaces the vacuous `parallel-always-cascade-per-region.edn` conformance fixture with a **parent-owned round** proof. The old fixture had only one region with an enabled `:always`, so both the rejected region-local drain model **and** the ratified parent-owned engine (PR #5801) satisfied it — a normative conformance row that blessed the superseded behaviour and supplied a vacuous portability gate for the load-bearing distinction.

## The gap (verified)

- The shipped fixture drove a single region's `:always`; its prose asserted stabilization runs "PER REGION" and siblings are not re-evaluated (the rejected model), contradicting Spec 005 §Per-region `:always` scoping (`spec/005-StateMachines.md:1802-1811`), which already ratifies **parent-owned** rounds: after the complete event set applies, the parent selects **every** enabled regional `:always` against one frozen whole-machine snapshot and repeats to quiescence.
- True semantics read from `implementation/machines/src/re_frame/machines/parallel.cljc` (`select-always-matches` / `apply-always-round` / `drain-parent-queue`): the event broadcast applies to **all** regions first, then frozen `:always` rounds run across all regions to convergence in the same macrostep. **Semantics are correct; only the fixture was stale.**

## New fixture (3 calls)

- **Call 1 — region-scoped target.** A region's `:always` advances only that region (`:a → :resolved`); the non-participating sibling `:b` stays `:x`. Proves the "region-scoped cascade" half (still true under §1806).
- **Calls 2 & 3 — parent-owned round (the discriminator).** Both regions handle `:go`, each writing its own shared-`:data` flag (`:a?` / `:b?`); each region's `:mid` `:always` is guarded on **both** flags. Under the ratified engine the event set applies to both regions first (both flags set), so the first frozen `:always` round selects both regions and both reach `:resolved` in the same macrostep. Call 2 declares regions `[:a :b]`, Call 3 declares `[:b :a]`; both converge to the **same** `{:a :resolved :b :resolved}` / `{:a? true :b? true}` — proving declaration-order invariance and that all event actions apply before the first `:always` round.

## Mutation-proof (fixture reddens under region-local draining)

Ran the fixture through the machines conformance runner against the real engine and against a faithful region-local drain (each region runs a flat event + local `:always` settle threading shared `:data`), applied via `with-redefs` on the private `parallel-machine-transition` — **`parallel.cljc` on disk was never modified**:

```
=== REAL engine ===
{:fixture-id :machine/parallel-always-cascade-per-region, :calls-run 3, :passed? true, :failures []}

=== REGION-LOCAL mutation ===
:passed? false
  Call 2 [:a :b]  expected {:a :resolved :b :resolved}  actual {:a :mid :b :resolved}   ← region :a stranded
  Call 3 [:b :a]  expected {:a :resolved :b :resolved}  actual {:a :resolved :b :mid}   ← region :b stranded
  Call 1          (region-scoped target — stays green under both models)
```

Both discriminating calls redden under region-local draining (the first-declared region strands at `:mid` because its guard sees only its own flag), while the region-scoped-target call stays green. The vacuous predecessor passed under either model; these do not.

## Scope notes

- `spec/005-StateMachines.md` **unchanged**: its §Per-region `:always` / `:after` / `:spawn` scoping prose (`:1802-1811`) already ratifies parent-owned rounds; the fixture-list link now points to correct prose (acceptance criterion 5 satisfied without a spec edit). Filename kept, so the existing relative link and capability-table reference (`:4318`) still resolve.
- `implementation/machines/test/re_frame/parallel_test.clj:167` `parallel-always-cascade-per-region` is a **unit test** (not the conformance harness); its assertions test region-scoped **targets** (`:left` advances, `:right` unaffected) — true under both models per §1806 — so it is correct and left untouched. Engine-level parent-round invariants (order-invariance, event-before-eventless, birth convergence, shared round identity, eventless-before-raised FIFO, atomic depth rollback, one-publication) remain fully covered by `parallel_always_round_cljs_test.cljc` (untouched).
- `parallel.cljc` read-only per the concurrent parallel.cljc owner (bvwv4q); not edited.

## Quality gates

- `cd implementation/machines && clojure -M:test` — **1093 tests, 0 failures, 0 errors**. Fixture confirmed runnable (caps `#{:fsm/parallel-regions :fsm/eventless-always}`), `:calls-run 3, :passed? true`.
- `cd implementation && npm run test:cljs` — **9478 tests / 46505 assertions, 0 failures, 0 errors** (the shared `.cljc` corpus runner executes the `:machine-transition` calls on CLJS too).
- mkdocs/check_doc_slugs: not run — no `.md` changed (spec/005 untouched; filename kept so no link churn).

Closes rf2-0847jc.
