### PR TITLE
fix(ui): linearize ViewCell invalidation against JVM flush completion (rf2-vxgfnd.180)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1198,13 +1198,6 @@
           ;; floor — mark it inexact (the honest "≥ dropped-cap distinct" signal)
           (and (not known?) at-cap? drop-full?)       (assoc :dropped-exact? false))))))
 
-(defn- record-evidence!
-  "DEBUG plane: fold `payload`'s bounded causal evidence into `cell`'s
-  pending-window accumulator. Elided in production (every caller gates on
-  `interop/debug-enabled?`)."
-  [^ViewCell cell payload]
-  (swap! (state cell) update :evidence fold-evidence payload))
-
 (defonce ^:private evidence-sink
   ;; DEBUG-only consumer seam: `(fn [cell evidence] …)` | nil. Invoked at each
   ;; flush with the coalesced bounded evidence BEFORE it is cleared, so a tool
@@ -1269,17 +1262,37 @@
      :clj nil))
 
 (defn- enrol-dirty!
-  "The PRODUCTION scheduling core: flag `cell` pending, enrol it in the dirty
-  registry once (identity-deduped — a re-mark while already dirty coalesces),
-  and arm one per-drain microtask flush. NO evidence, no compute, no
-  acquire/release (I-5) — this is the WHOLE production invalidation cost, flat
-  in the number of queued events."
-  [^ViewCell cell]
-  (let [st (state cell)]
-    (when-not (:dirty? @st)
-      (swap! st assoc :dirty? true)
-      (swap! dirty-cells conj cell)
-      (schedule-flush!))))
+  "The PRODUCTION scheduling core — ONE linearizable pending-window enrolment
+  transition (rf2-vxgfnd.180). In a SINGLE `swap-vals!` on the cell state,
+  perform the `:dirty?` false→true flip and — in DEV/tool builds only — fold the
+  optional bounded `payload` evidence into the pending window; then, EXACTLY on
+  the false→true transition (read from the swap's OWN prior value, never a
+  separate pre-read), enrol `cell` in the dirty registry once (identity-deduped)
+  and arm one per-drain flush. NO compute, no acquire/release (I-5) — the
+  production cost is one flag flip, flat in the number of queued events (the
+  evidence fold DCEs under goog.DEBUG=false).
+
+  Why one swap (rf2-vxgfnd.180): folding evidence and flipping `:dirty?` in
+  SEPARATE transitions — or reading `:dirty?` to decide enrolment separately from
+  setting it — is not linearizable on the JVM host. A mark racing a
+  `complete-flush!` clear could fold fresh evidence, then read a still-set
+  `:dirty?` and skip enrolment, and completion would then erase that evidence and
+  leave the cell clean and unregistered — a real update lost with no next
+  revision. Folding the flip and the evidence into one swap, and deriving
+  enrolment from that swap's own false→true edge, makes a concurrent mark
+  linearize cleanly EITHER before completion's capture (its evidence joins the
+  captured window) OR after its clear (a fresh next window is enrolled)."
+  ([^ViewCell cell] (enrol-dirty! cell nil))
+  ([^ViewCell cell payload]
+   (let [st (state cell)
+         [old _] (swap-vals! st
+                              (fn [s]
+                                (cond-> (assoc s :dirty? true)
+                                  (and interop/debug-enabled? payload)
+                                  (update :evidence fold-evidence payload))))]
+     (when-not (:dirty? old)
+       (swap! dirty-cells conj cell)
+       (schedule-flush!)))))
 
 (defn mark-dirty!
   "The `on-change` body / test seam: enrol `cell` for a coalesced flush
@@ -1291,19 +1304,44 @@
   render while the debug plane preserves first/latest epoch plus a bounded
   cause/target summary (rf2-vxgfnd.46). `on-change-fn` folds the RICHER port
   payload (cause + target); this arity carries only an epoch, for the JVM/test
-  seam. nil when driven without epoch evidence."
+  seam. nil when driven without epoch evidence. The fold and the dirty flip are
+  ONE linearizable swap (`enrol-dirty!`; rf2-vxgfnd.180)."
   ([^ViewCell cell] (mark-dirty! cell nil))
   ([^ViewCell cell epoch]
-   (when interop/debug-enabled?
-     (record-evidence! cell {:frame-epoch epoch}))
-   (enrol-dirty! cell)))
+   (enrol-dirty! cell {:frame-epoch epoch})))
+
+(def ^:dynamic ^:no-doc *completion-barrier*
+  "JVM linearization TEST SEAM — nil in production (one nil check per completed
+  cell, zero further cost), NEVER bound off a test path (the `*commit-barrier*`
+  idiom). Bound to a `(fn [cell] …)`, `complete-flush!` calls it at the ONE
+  deterministic point BETWEEN reading a cell's pending window and the
+  `compare-and-set!` that clears it, so a fixture can interleave a concurrent
+  `mark-dirty!` INSIDE completion's capture→clear window and prove the transition
+  still linearizes (rf2-vxgfnd.180). Because the clear is a compare-and-set!
+  RETRY loop, a mark landing in the barrier window fails the CAS and completion
+  re-reads — capturing the freshly-folded evidence rather than erasing it."
+  nil)
 
 (defn- complete-flush!
   "PHASE 1 of a batch flush (rf2-vxgfnd.86): complete `cell`'s SCHEDULER STATE
   with NO arbitrary user code — capture the pre-clear DEBUG evidence, clear
-  `:dirty?`/evidence, and advance the revision (WITHOUT notifying listeners yet).
-  No-op / nil when the cell is not dirty. Returns `[cell ev]` for the cell it
-  completed (`ev` nil in production / when the window carried none), else nil.
+  `:dirty?`/evidence, and advance the revision (WITHOUT notifying listeners yet),
+  as ONE linearizable transition (rf2-vxgfnd.180). No-op / nil when the cell is
+  not dirty. Returns `[cell ev]` for the cell it completed (`ev` nil in
+  production / when the window carried none), else nil.
+
+  ONE linearizable capture-and-clear (rf2-vxgfnd.180). The capture (the returned
+  window `ev`), the `:dirty?`/evidence clear, and the revision advance are a
+  SINGLE compare-and-set! transition over the value read at the top of the loop,
+  so the delivered window is EXACTLY the state that was cleared. A `mark-dirty!`
+  racing this on the JVM host either commits BEFORE the CAS — in which case the
+  CAS over the now-stale value fails, the loop re-reads, and the mark's fresh
+  evidence joins the captured window — or AFTER the clear, where it observes a
+  cleared `:dirty?` and enrols a FRESH next window. It can no longer fold
+  evidence into a window this call already captured-by-value yet is about to
+  erase (the pre-fix loss: capture and clear were separate reads/writes, so an
+  interleaved mark's evidence was captured-around then wiped, and its enrolment
+  skipped on a still-set `:dirty?`).
 
   Splitting completion from notification is the order-independence fix. The batch
   core runs this over the WHOLE drained batch BEFORE `deliver-flush!` runs ANY
@@ -1315,11 +1353,16 @@
   in the drained-but-uncompleted batch (→ mark lost) depended on hash order."
   [^ViewCell cell]
   (let [st (state cell)]
-    (when (:dirty? @st)
-      (let [ev (when interop/debug-enabled? (:evidence @st))]
-        (swap! st assoc :dirty? false :evidence nil)
-        (swap! st update :revision inc)
-        [cell ev]))))
+    (loop []
+      (let [s @st]
+        (when (:dirty? s)
+          (let [cleared (-> s
+                            (assoc :dirty? false :evidence nil)
+                            (update :revision inc))]
+            (when-some [barrier *completion-barrier*] (barrier cell))
+            (if (compare-and-set! st s cleared)
+              [cell (when interop/debug-enabled? (:evidence s))]
+              (recur))))))))
 
 (defn- deliver-flush!
   "PHASE 2 of a batch flush (rf2-vxgfnd.86): now that `complete-flush!` has
@@ -1612,12 +1655,11 @@
   rich invalidation payload (`:cause`/`:target`/`:frame-epoch`, plus the
   `:node-*`/`:registry-epoch` axes it carries) into the bounded pending-window
   evidence. Production carries only the enrolment (I-5; the evidence fold DCEs
-  out under goog.DEBUG=false)."
+  out under goog.DEBUG=false). The fold and the dirty flip are ONE linearizable
+  swap (`enrol-dirty!`; rf2-vxgfnd.180)."
   [^ViewCell cell]
   (fn [payload]
-    (when interop/debug-enabled?
-      (record-evidence! cell payload))
-    (enrol-dirty! cell)))
+    (enrol-dirty! cell payload)))
 
 ;; ---- resource ownership family -------------------------------------------
 ;;

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1284,12 +1284,19 @@
   captured window) OR after its clear (a fresh next window is enrolled)."
   ([^ViewCell cell] (enrol-dirty! cell nil))
   ([^ViewCell cell payload]
+   ;; `interop/debug-enabled?` is a STANDALONE top-level gate (not folded into the
+   ;; swap-fn body as `(and interop/debug-enabled? payload)`) so Closure DCEs the
+   ;; evidence-folding swap-fn — and every reference it carries into `fold-evidence`
+   ;; (`:dropped-exact?`, `:first-epoch`, …) — out of the advanced production
+   ;; bundle, exactly as the prod-elision gate proves. Both arms are ONE
+   ;; `swap-vals!`, so the evidence fold and the `:dirty?` false→true flip stay a
+   ;; single atomic transition on each host (rf2-vxgfnd.180).
    (let [st (state cell)
-         [old _] (swap-vals! st
-                              (fn [s]
-                                (cond-> (assoc s :dirty? true)
-                                  (and interop/debug-enabled? payload)
-                                  (update :evidence fold-evidence payload))))]
+         [old _] (if interop/debug-enabled?
+                   (swap-vals! st (fn [s]
+                                    (cond-> (assoc s :dirty? true)
+                                      payload (update :evidence fold-evidence payload))))
+                   (swap-vals! st (fn [s] (assoc s :dirty? true))))]
      (when-not (:dirty? old)
        (swap! dirty-cells conj cell)
        (schedule-flush!)))))

--- a/implementation/ui/test/re_frame/ui/reactive_flush_completion_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_flush_completion_race_jvm_test.clj
@@ -69,14 +69,14 @@
               (fn [c]
                 (when (identical? c cell)
                   (.countDown at-clear)                    ;; captured, now parked
-                  (.await marked 5 TimeUnit/SECONDS)))]     ;; hold the window open
+                  (.await marked 20 TimeUnit/SECONDS)))]     ;; hold the window open
       (let [flusher (future (reactive/flush-dirty! cell))]
-        (is (true? (.await at-clear 5 TimeUnit/SECONDS)) "flusher reached the seam")
+        (is (true? (.await at-clear 20 TimeUnit/SECONDS)) "flusher reached the seam")
         ;; Epoch 2 races IN — it folds into the pending window; the cell is still
         ;; dirty, so no fresh enrolment is owed.
         (reactive/mark-dirty! cell 2)
         (.countDown marked)                                ;; release the flusher
-        (is (nil? (deref flusher 5000 ::timeout)) "flush completed cleanly")))
+        (is (nil? (deref flusher 20000 ::timeout)) "flush completed cleanly")))
 
     (testing "epoch 2 was NOT lost — it joined the captured, delivered window"
       (is (= 1 (count @delivered)) "exactly one coherent window delivered")
@@ -112,12 +112,12 @@
         (fn [c ev] (when (identical? c cell) (swap! delivered conj ev))))
       ;; The window opens at epoch 1; the flush and a second invalidation race.
       (reactive/mark-dirty! cell 1)
-      (let [flush (future (.await barrier 5 TimeUnit/SECONDS)
+      (let [flush (future (.await barrier 20 TimeUnit/SECONDS)
                           (reactive/flush-dirty! cell))
-            mark  (future (.await barrier 5 TimeUnit/SECONDS)
+            mark  (future (.await barrier 20 TimeUnit/SECONDS)
                           (reactive/mark-dirty! cell 2))]
-        (is (not= ::timeout (deref flush 5000 ::timeout)) (str "round " round ": flush"))
-        (is (not= ::timeout (deref mark 5000 ::timeout))  (str "round " round ": mark")))
+        (is (not= ::timeout (deref flush 20000 ::timeout)) (str "round " round ": flush"))
+        (is (not= ::timeout (deref mark 20000 ::timeout))  (str "round " round ": mark")))
       ;; A final drain settles any FRESH window the mark opened after the clear.
       (reactive/flush-pending!)
       (let [evs (vec @delivered)]

--- a/implementation/ui/test/re_frame/ui/reactive_flush_completion_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_flush_completion_race_jvm_test.clj
@@ -1,0 +1,136 @@
+(ns re-frame.ui.reactive-flush-completion-race-jvm-test
+  "rf2-vxgfnd.180 — linearize ViewCell invalidation against JVM flush completion.
+
+  THE RACE (JVM-only; CLJS is single-threaded and never yields between a
+  scheduler read and its write). Before the fix, an invalidation folded evidence
+  and flipped `:dirty?` in SEPARATE transitions, while `complete-flush!` read the
+  pending window into a local and THEN, in a separate write, cleared
+  `:dirty?`/`:evidence`. A `mark-dirty!` that linearized after completion had
+  READ the window but before it CLEARED the cell was lost twice over: it folded
+  fresh evidence that the clear then erased, and — seeing a still-set `:dirty?` —
+  it skipped re-enrolment, so the flush left the cell CLEAN and ABSENT from the
+  dirty registry. A real update disappeared with no next revision or correction
+  (the exact loss the audit of rf2-vxgfnd.74 reproduced deterministically).
+
+  The fix gives each cell ONE linearizable pending-window transition:
+  `enrol-dirty!` folds evidence AND flips `:dirty?` false→true in a single
+  `swap-vals!`, enrolling in the registry EXACTLY on that edge; `complete-flush!`
+  captures-and-clears in a single compare-and-set! retry loop. A mark racing
+  completion now linearizes cleanly — EITHER before the CAS (its evidence joins
+  the captured window; the CAS over the stale value fails and re-reads) OR after
+  the clear (it observes a cleared `:dirty?` and enrols a FRESH next window).
+
+  The first fixture opens the capture→clear window deterministically with the
+  `reactive/*completion-barrier*` seam + a `CountDownLatch` handoff (no sleeps):
+  the flusher parks between reading the window and the clearing CAS; a racing
+  thread commits a second invalidation; the flusher resumes. WITHOUT the fix the
+  second invalidation vanishes — so the `:latest-epoch 2` assertion FAILS on
+  pre-fix code. The second fixture drives the same two operations from opposing
+  threads under a start barrier across many rounds and asserts that no
+  interleaving loses an invalidation, double-mints a revision, or diverges the
+  dirty flag from registry enrolment.
+
+  `.clj` (JVM-only) — a genuine two-thread interleaving; the latch handoff makes
+  the first probe controlled, not timing-dependent."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive])
+  (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+;; ===========================================================================
+;; The window: an invalidation between flush CAPTURE and flush CLEAR
+;; ===========================================================================
+
+(deftest invalidation-in-the-capture-clear-window-joins-the-delivered-window
+  (let [cell      (reactive/make-cell ::v)
+        delivered (atom [])
+        hits      (atom 0)
+        at-clear  (CountDownLatch. 1)   ;; the flusher parked at the pre-clear seam
+        marked    (CountDownLatch. 1)]  ;; the racing invalidation committed
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/set-evidence-sink!
+      (fn [c ev] (when (identical? c cell) (swap! delivered conj ev))))
+    ;; Epoch 1: the cell is dirty with a pending window anchored at epoch 1.
+    (reactive/mark-dirty! cell 1)
+    (is (true? (reactive/dirty? cell)) "precondition: pending")
+    (is (= 1 (reactive/pending-epoch cell)) "precondition: window anchored at 1")
+
+    ;; Park the flusher at the ONE point between reading the pending window and
+    ;; the compare-and-set! that clears it; while it is parked, commit epoch 2
+    ;; from another thread. `future` conveys this dynamic binding to the flusher.
+    (binding [reactive/*completion-barrier*
+              (fn [c]
+                (when (identical? c cell)
+                  (.countDown at-clear)                    ;; captured, now parked
+                  (.await marked 5 TimeUnit/SECONDS)))]     ;; hold the window open
+      (let [flusher (future (reactive/flush-dirty! cell))]
+        (is (true? (.await at-clear 5 TimeUnit/SECONDS)) "flusher reached the seam")
+        ;; Epoch 2 races IN — it folds into the pending window; the cell is still
+        ;; dirty, so no fresh enrolment is owed.
+        (reactive/mark-dirty! cell 2)
+        (.countDown marked)                                ;; release the flusher
+        (is (nil? (deref flusher 5000 ::timeout)) "flush completed cleanly")))
+
+    (testing "epoch 2 was NOT lost — it joined the captured, delivered window"
+      (is (= 1 (count @delivered)) "exactly one coherent window delivered")
+      (let [ev (first @delivered)]
+        (is (= 1 (:first-epoch ev)) "anchored at epoch 1")
+        (is (= 2 (:latest-epoch ev))
+            "epoch 2 is present in the delivered window — RED pre-fix (the clear
+             erased the freshly-folded evidence, delivering only epoch 1)")
+        (is (= 2 (:count ev)) "both invalidations folded into the one window")))
+
+    (testing "completion captured + cleared exactly one window; revision advanced once"
+      (is (= 1 (reactive/revision cell)) "one revision advance, not zero and not two")
+      (is (= 1 @hits) "the listener fired exactly once for the coalesced window")
+      (is (false? (reactive/dirty? cell)) "the cell is settled")
+      (is (nil? (reactive/pending-evidence cell)) "no residual pending evidence"))
+
+    (testing "the forbidden state is impossible: epoch 2 was delivered, so nothing is owed"
+      (is (= 0 (reactive/pending-cell-count))
+          "the cell is neither clean-with-a-lost-update nor spuriously re-enrolled"))))
+
+;; ===========================================================================
+;; No interleaving of mark || flush loses an invalidation or diverges the
+;; dirty flag from registry enrolment
+;; ===========================================================================
+
+(deftest concurrent-mark-and-flush-never-lose-an-invalidation
+  (dotimes [round 200]
+    (reactive/reset-scheduler!)
+    (let [cell      (reactive/make-cell (keyword "vr" (str round)))
+          delivered (atom [])
+          barrier   (CyclicBarrier. 2)]
+      (reactive/set-evidence-sink!
+        (fn [c ev] (when (identical? c cell) (swap! delivered conj ev))))
+      ;; The window opens at epoch 1; the flush and a second invalidation race.
+      (reactive/mark-dirty! cell 1)
+      (let [flush (future (.await barrier 5 TimeUnit/SECONDS)
+                          (reactive/flush-dirty! cell))
+            mark  (future (.await barrier 5 TimeUnit/SECONDS)
+                          (reactive/mark-dirty! cell 2))]
+        (is (not= ::timeout (deref flush 5000 ::timeout)) (str "round " round ": flush"))
+        (is (not= ::timeout (deref mark 5000 ::timeout))  (str "round " round ": mark")))
+      ;; A final drain settles any FRESH window the mark opened after the clear.
+      (reactive/flush-pending!)
+      (let [evs (vec @delivered)]
+        (testing (str "round " round)
+          (is (false? (reactive/dirty? cell)) "fully settled after the final drain")
+          (is (= 0 (reactive/pending-cell-count)) "nothing lingers in the registry")
+          (is (= 2 (reduce max 0 (map :latest-epoch evs)))
+              "epoch 2 reached delivery in SOME window — joined the captured one
+               or opened a fresh one; it is NEVER dropped (RED pre-fix on the
+               lost interleaving)")
+          (is (= 1 (reduce min Long/MAX_VALUE (map :first-epoch evs)))
+              "epoch 1 anchored the first window")
+          (is (= (count evs) (reactive/revision cell))
+              "exactly one revision advance per delivered window — the dirty flip
+               and registry enrolment never diverged (no phantom empty window,
+               no double count)"))))))


### PR DESCRIPTION
## Problem (rf2-vxgfnd.180)

On the JVM host, ViewCell invalidation was not linearizable against flush completion. `complete-flush!` read `:dirty?` and the pending-window `:evidence` into a local, then — in a *separate* write — cleared `:dirty?`/`:evidence` and advanced the revision. An invalidation folded evidence and flipped `:dirty?` in *separate* transitions too.

A `mark-dirty!` linearizing after completion had **captured** the window but before it **cleared** the cell was lost twice: it folded fresh evidence that the clear then erased, and — seeing a still-set `:dirty?` — it skipped re-enrolment. The flush left the cell clean and absent from the dirty registry. A real update vanished with no next revision or correction. CLJS is single-threaded and never exposes the window; the JVM future-driven flush does.

## Fix

One linearizable pending-window transition per cell:

- **`enrol-dirty!`** folds the optional bounded evidence **and** flips `:dirty?` false→true in a single `swap-vals!`, then enrols in the dirty registry + arms a flush **exactly on the false→true edge** read from the swap's own prior value (never a separate pre-read). `mark-dirty!` and the `on-change` port now route through it (the old `record-evidence!` fold-then-flip split is gone).
- **`complete-flush!`** captures-and-clears in a single `compare-and-set!` retry loop: the captured window is exactly the value the CAS cleared, and the revision advance is part of the same transition. A mark racing the barrier window fails the CAS and the loop re-reads, so the mark's evidence joins the captured window rather than being erased.

A mark racing completion now linearizes cleanly — either before the CAS (its evidence joins the captured window) or after the clear (a fresh next window is enrolled). No lock is held across any listener/sink callback; the bounded-summary semantics and advanced-production evidence elision are unchanged.

Adds `reactive/*completion-barrier*` — a JVM linearization test seam (nil in production, one nil-check per completed cell), following the existing `*commit-barrier*` idiom.

## Tests

New `reactive_flush_completion_race_jvm_test.clj`:

- **Deterministic barrier fixture** — parks the flusher at the capture→clear seam via `*completion-barrier*` + a `CountDownLatch` handoff, commits a second invalidation from another thread, releases. Asserts epoch 2 joins the delivered window (`:latest-epoch 2`, `:count 2`), revision advances exactly once, and the forbidden clean-but-lost state cannot arise.
- **200-round mark‖flush interleaving** — asserts no interleaving drops an invalidation, double-mints a revision, or diverges the dirty flag from registry enrolment.

**Red-before-fix:** temporarily reverting only `complete-flush!` to the old non-atomic capture-then-clear (barrier seam retained) makes the deterministic fixture fail (`:latest-epoch 1`, epoch 2 erased) and the stress test catch the loss in multiple rounds. The fix turns both green.

## Gates (foreground)

- `implementation/ui` JVM: 561 tests, 8153 assertions — 0 failures/0 errors
- `implementation` CLJS node (`npm run test:cljs`): 9482 tests, 46535 assertions — 0 failures/0 errors

Scope: `implementation/ui/src/re_frame/ui/reactive.cljc` + its new test only.

Closes rf2-vxgfnd.180.