### PR TITLE
docs(spec): align frozen Reagent ViewMeta schema with the fields reg-view emits (rf2-vxgfnd.178)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -457,21 +457,19 @@ The metadata map accepted by `reg-interceptor` ([EP-0022](../docs/EP/EP-0022-reg
 > **Owner:** [004-Views §Removed forms — normative absences](004-Views.md#removed-forms--normative-absences)
 > **Status:** v1-required
 
-The metadata map accepted by `reg-view` / `reg-view*` (the frozen stock-Reagent compatibility tier — Spec-Schemas is its live registry-slot-shape carrier per the [004 §Removed forms](004-Views.md#removed-forms--normative-absences) transition annex). The `^{:rf/id ...}` symbol-meta override on the `reg-view` symbol surfaces in the stamped registry slot as `:rf/id` per [Conventions §`reg-view` auto-id derivation rule](Conventions.md#reg-view-auto-id-derivation-rule).
+The metadata map accepted by `reg-view` / `reg-view*` (the frozen stock-Reagent compatibility tier — Spec-Schemas is its live registry-slot-shape carrier per the [004 §Removed forms](004-Views.md#removed-forms--normative-absences) transition annex). **Registry identity is distinct from slot metadata.** The `^{:rf/id ...}` symbol-meta override *selects the registry key* the view registers under (the id, per [Conventions §`reg-view` auto-id derivation rule](Conventions.md#reg-view-auto-id-derivation-rule)); the macro consumes it to choose the id and then removes it from the stamped slot, so `:rf/id` is **not** a slot-metadata field. The fields below are what actually lands in the slot.
 
 ```clojure
 (def ViewMeta
   [:merge
    RegistrationMetadata
    [:map
-    [:rf/id        {:optional true} :keyword]                                ;; explicit id override (auto-derived from *ns* + symbol when absent)
-    [:rf/args      {:optional true} [:vector :symbol]]                       ;; the macro-captured args-vector symbols (defn-shape introspection)
-    [:rf/form      {:optional true} [:enum :form-1 :form-2 :form-3]]         ;; the view body's Reagent form discriminator
-    [:rf/props     {:optional true} :any]                                    ;; Malli schema for the view's props (when supplied); the canonical props-schema slot, resolved first-match over `[:rf/props :schema]` (not composed — `:rf/props` wins outright over `:schema` for the view-args boundary) per [010](010-Schemas.md)
+    [:reagent2/form {:optional true} [:enum :reagent2/form-1 :reagent2/form-2]] ;; compile-time Reagent form-shape tag; stamped by the `reg-view` macro ONLY when reagent-slim is on the classpath (an additive perf hint — the runtime detection in `reagent2.impl.component/wrap-render` is the load-bearing path). Absent on UIx / Helix builds and on the `reg-view*` plain-fn surface. Form classification is binary — there is no `:reagent2/form-3`.
+    [:rf/props      {:optional true} :any]                                     ;; Malli schema for the view's props (when the author attaches it as symbol metadata, e.g. `^{:rf/props S}`); the canonical props-schema slot, resolved first-match over `[:rf/props :schema]` (not composed — `:rf/props` wins outright over `:schema` for the view-args boundary) per [010](010-Schemas.md)
     ]])
 ```
 
-`:rf/args` / `:rf/form` are stamped by the `reg-view` macro at expansion time; `reg-view*` (the plain-fn surface) carries neither — programmatic registrations have no args-vector to capture (per [004 §Removed forms — normative absences](004-Views.md#removed-forms--normative-absences)). `:rf/props` is an optional user-supplied props schema; in dynamic hosts the framework can validate props against it at render-time-boundary in dev builds (per [010](010-Schemas.md)).
+`:reagent2/form` is stamped by the `reg-view` macro at expansion time *only when reagent-slim is on the classpath* — `expand-reg-view` classifies the body via `reagent2.impl.component/classify-form-body` (`requiring-resolve`d, so core carries no static reagent-slim dep) and stamps `{:reagent2/form :reagent2/form-1|:reagent2/form-2}` onto the slot. UIx / Helix-only builds and the `reg-view*` plain-fn surface stamp no form tag (per [004 §Removed forms — normative absences](004-Views.md#removed-forms--normative-absences)). `:rf/props` is an optional user-supplied props schema (attached as symbol metadata and surviving into the slot); in dynamic hosts the framework can validate props against it at render-time-boundary in dev builds (per [010](010-Schemas.md)).
 
 **Note — `:schema` is canonical.** Both Story and the framework read the `:schema` key (there is no `:spec` alias). See [MIGRATION §M-54](../migration/from-re-frame-v1/README.md#m-54-schema-vocabulary-unification--spec--schema) for the v1→v2 rename.
 


### PR DESCRIPTION
## Problem

The frozen Reagent `:rf/view-meta` (`ViewMeta`) schema in `spec/Spec-Schemas.md` claimed `reg-view` stamps three slot-metadata fields that the macro never emits:

- `:rf/id` — the macro *consumes* `:rf/id` to choose the registry KEY, then explicitly `dissoc`s it from slot metadata (`implementation/core/src/re_frame/core_reg_view_macro.cljc:114`). It is registry identity, not a slot field.
- `:rf/args` — never emitted anywhere in the implementation (grep-confirmed absent).
- `:rf/form [:enum :form-1 :form-2 :form-3]` — never emitted; doubly fictitious (wrong key AND a `:form-3` value that no code path produces). The macro's real form field is `:reagent2/form`, with values `:reagent2/form-1` / `:reagent2/form-2` — only two forms classify (`reagent2.impl.component/classify-form-body`).

A frozen compatibility contract must describe what the frozen runtime actually guarantees, or tools/migration code may depend on always-absent metadata.

## Recording-vs-inventing determination: RECORD REALITY

Confirmed by reading both the macro (`expand-reg-view`) and the frozen schema: **the shipped emission is the truth; the frozen-but-inaccurate schema is the defect.** The macro's slot metadata is `(dissoc sym-meta :rf/id + reader-pos keys)` plus `:doc` (base `RegistrationMetadata`) plus `:reagent2/form` (only when reagent-slim is on the classpath). No emission change is warranted — this is the simplest pre-alpha correction (reconcile the schema to the code), per the bead's default assumption and Required Correction.

## Change (docs-only, `spec/Spec-Schemas.md`)

- Removed the three unimplemented fields (`:rf/id`, `:rf/args`, `:rf/form`) from `ViewMeta`.
- Replaced the fictitious `:rf/form` with the actually-emitted `:reagent2/form` (`[:enum :reagent2/form-1 :reagent2/form-2]`, optional; stamped only under reagent-slim) — one spelling, backed by executable tests (`implementation/adapters/reagent-slim/test/.../component_test.clj`, `implementation/core/test/re_frame/reg_view_test.clj`).
- Kept `:rf/props` (genuinely survives the `dissoc` when the author attaches it as symbol metadata — the one previously-documented field that was correct).
- Corrected the surrounding prose to distinguish registry identity (the key `:rf/id` selects) from slot metadata, and to describe `:reagent2/form` stamping accurately.

## Acceptance criteria

- `handler-meta :view` conforms to the documented `ViewMeta` for every surface: `:reagent2/form` (optional, reagent-slim only) + `:rf/props` (optional, author-supplied) + base `RegistrationMetadata`. No aspirational/fictitious slot remains.
- Registry identity (`:rf/id` selects the key) is now clearly distinguished from stored slot metadata.
- The retained form-classification field has one spelling (`:reagent2/form`) with executable tests; `:rf/form`/`:reagent2/form` are no longer ambiguously duplicated.
- No UIx/Helix/slim schema additions; no code/emission change.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0.
- `python -m mkdocs build --strict` — exit 0 (Spec-Schemas.md builds; only pre-existing unrelated INFO links).
- `implementation/core` `clojure -M:test -n re-frame.reg-view-test` — 13 tests, 37 assertions, 0 failures, 0 errors (reg-view contract intact, including the `:reagent2/form` fold path).
- `npm run test:cljs` not run locally: docs-only change touching no CLJS code, fresh worktree has no node_modules (cold install + shadow-cljs compile = large sink for zero incremental signal); the reg-view macro logic is fully exercised JVM-side above. CI owns the CLJS spine.