### PR TITLE
docs(spec): assign compiled root preflight to 004C, not Spec 002's two-pass React contract (rf2-vxgfnd.177)

### DIFF
--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -273,9 +273,18 @@ derive from**, so its identity set is `:root-id` / `:identifier-prefix` only; su
   identity is `:rf.ui.compile/missing-root-id`, and an out-of-grammar opt (a stray
   `:disambiguator` among them) is `:rf.ui.compile/bad-root-opts`.
 - Frame preflight (ENSURE + `:initial-events` drain, exactly once, before React) runs
-  before the first `render!` on a Root and before `hydrate-root`'s hydration — timing
-  and semantics owned by [Spec 002](002-Frames.md); this draft only pins *what is extracted*
-  (§6).
+  before the first `render!` on a Root and before `hydrate-root`'s hydration. **This
+  compiled host-root sequencing — preflight completing before `createRoot`/`render!`
+  and before hydration ever touches the container — is owned here.** Spec 002 owns only
+  what each preflight step *does*:
+  [`make-frame` construction](002-Frames.md#make-frame--atomic-create-and-register-and-the-canonical-config-grammar),
+  its [idempotent-replacement ENSURE](002-Frames.md#duplicate-id--idempotent-replacement)
+  (create-if-absent, reuse-no-reseed), and the synchronous, ordered `:initial-events`
+  drain those sections define. That is the whole Spec-002 debt — pointedly **not** its
+  frozen/transitional [`frame-root` two-pass contract](002-Frames.md#frame-root--the-ensure-component-cljs-reference)
+  (empty first render → commit-phase `useLayoutEffect` ENSURE → populated second render),
+  which runs the *opposite* order and scopes a component subtree, not a host root. This
+  draft only pins *what is extracted* (§6).
 
 ## 4. Element locators
 


### PR DESCRIPTION
## Problem

004C §3's frame-preflight bullet delegated the compiled host-root preflight — ENSURE + `:initial-events` drain, run **before** `createRoot`/`render!`/hydration — to `[Spec 002](002-Frames.md)` as a whole-document citation ("timing and semantics owned by Spec 002").

Spec 002 contains no host-root contract. Its only nearby React mechanism is the frozen/transitional `frame-root` **two-pass** contract (empty first render → commit-phase `useLayoutEffect` ENSURE → populated second render) — the *opposite* sequence, for a component subtree rather than a host root. Following the link sent a fresh implementer to an adjacent, incompatible lifecycle and left it unclear which sequence is authoritative.

The shipped compiled substrate (`implementation/ui/src/re_frame/ui/client.cljs`) already preflights **before** React touches the container, exactly as 004C states locally. Only the normative *home* of that sequencing was misfiled.

## The move

Ownership of the **compiled host-root sequencing** now sits in 004C ("is owned here"). The Spec 002 links are narrowed from a whole-document citation to three exact anchors for the pieces the preflight *composes*:

- `make-frame` construction
- idempotent-replacement ENSURE (create-if-absent, reuse-no-reseed)
- the synchronous, ordered `:initial-events` drain

The frozen/transitional `frame-root` two-pass contract is now explicitly named as the *opposite* order and kept distinct — it is pointedly **not** what the host-root preflight cites.

No behaviour change: this is a spec-ownership reconciliation. Spec 002 needed no edit — it never claimed the host-root contract (zero references to `createRoot`/`render!`/`hydrate-root`/host-root), so there was nothing to shed; touching its hot-zone two-pass contract would only risk blurring it. `client.cljs` docstrings were already correctly scoped (they attribute only the ENSURE/`:initial-events` *semantics* to Spec 002 and state the compiled *sequencing* locally), so no code change.

Closes the mis-assignment flagged in rf2-vxgfnd.177 (gh-5795).

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (validates the 3 new cross-file anchor links against the real MkDocs heading-slug index)
- `python scripts/check_readme_links.py` — PASS
- `mkdocs build --strict` — skipped (mkdocs not on PATH in this env; CI runs it)
- UI CLJS tests — not run (docs-only; `client.cljs` unchanged)