### PR TITLE
test: destroyed-reason conformance enforces exact channel/reason tuples (rf2-9q1zn2)

### DIFF
--- a/implementation/machines/test/re_frame/destroyed_reason_channel_conformance_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_reason_channel_conformance_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.destroyed-reason-channel-conformance-test
-  "rf2-hh1jhc — the destroyed-reason CHANNEL/REASON MATRIX pin.
+  "rf2-hh1jhc / rf2-9q1zn2 — the destroyed-reason CHANNEL/REASON MATRIX pin.
 
   The runtime emits machine-destroy traces on two parallel channels
   (Spec 009 §Two-channel teardown):
@@ -13,37 +13,84 @@
       `:parent-unmount-cascade` (declared by 005 D6, no current emit
       site — parent-cascade teardowns stamp `:explicit`).
 
-  That matrix is documented on FOUR surfaces which historically drifted
-  apart (the rf2-hh1jhc contradiction: Spec-Schemas advertised four
-  reasons on the lifecycle channel while Spec 009 and the runtime carry
-  one). This test parses each surface and pins them against each other
-  and against the emit sites, so a future reason added to one channel's
-  docs while another surface silently drifts goes RED:
+  A reason belongs to EXACTLY ONE channel — the (channel, reason) pair is
+  the contract, not two independent sets. This test pins that matrix as
+  exact TUPLES against three kinds of evidence, so a channel move, a
+  changed pair, or a new/dynamic reason on any surface goes RED:
 
-    1. Spec 009 §`:op-type` vocabulary — the canonical matrix table
-       (`| :reason | Channel | Emitted by | Meaning |`).
-    2. Spec-Schemas §`:rf/trace-event` — the `:machine` family row's
-       fx-reason enumeration and the `:rf.machine.lifecycle/destroyed`
-       row's sole-reason contract.
-    3. Spec 005 §Final states D6 — the fx-channel enrichment vocabulary.
-    4. The emit sites themselves — a conservative literal source scan
-       (same style as `re-frame.error-catalogue-channel-conformance-test`):
-       every literal `:reason` stamped near a lifecycle-channel emit must
-       be a lifecycle reason; every literal fx-channel reason must be in
-       the documented fx set; a reason the matrix marks *reserved* must
-       not be stamped anywhere (implementing it forces the matrix co-edit).
+    A. Doc ↔ doc — the four normative surfaces are parsed and compared as
+       exact tuples (§`Authoritative surfaces` below):
+         1. Spec 009 §`:op-type` vocabulary — the canonical matrix table.
+         2. Spec-Schemas §`:rf/trace-event` — the fx `:machine`-family row
+            and the `:rf.machine.lifecycle/destroyed` sole-reason row.
+         3. Spec 005 §Final states D6 — the fx-channel enrichment vocab.
+         4. Cross-Spec-Interactions §route-change teardown — the positive
+            (fx-channel, `:explicit`) pair a view-unmount/route swap emits,
+            AND that the reserved reason is never reintroduced there.
 
-  JVM-only (`.clj`): it `slurp`s repo markdown + source files, which only
-  the JVM `clojure -M:test` runner can do. The runtime BEHAVIOUR of the
-  fx-channel reasons is already pinned live by
-  `re-frame.destroyed-trace-shape-test` (\":reason is one of :explicit /
-  :rf.machine/finished / :rf.machine/join-reaped\") and the lifecycle
-  channel by `frame_lifecycle_test/destroy-frame-cascade-emits-per-active-
-  machine`; this file pins the DOCS against those facts."
+    B. Emit sites (STRUCTURAL, fails closed) — every destroy emitter is
+       enumerated by READING the source forms (not a text regex), so the
+       (channel, reason) tuple at each choke point is pinned exactly.
+       A reason expression that is neither a documented literal for its
+       channel nor the sanctioned forwarding symbol `reason` is an
+       EXPLICIT failure with a source location — dynamic/unparsed reasons
+       fail closed instead of being silently skipped.
+
+    C. Executable fixtures — the runtime is DRIVEN and the emitted
+       (channel, reason) tuple is asserted for `:explicit`,
+       `:rf.machine/finished`, `:rf.machine/join-reaped` (fx channel) and
+       `:parent-frame-destroyed` (lifecycle channel). Mutating either
+       argument of any emit reds the matching fixture.
+
+  Authoritative surfaces: the 009 matrix table is the CANONICAL enum;
+  Spec-Schemas and 005 D6 RESTATE it; Cross-Spec documents the one
+  route-change pair. The emit sites are the RUNTIME truth; the executable
+  fixtures are the behavioural ground truth. Every layer must agree.
+
+  JVM-only (`.clj`): the doc/source layers `slurp` + reader-parse repo
+  markdown and source, which only the JVM `clojure -M:test` runner can do;
+  the executable layer drives the machine runtime on the plain-atom
+  substrate (the machines `.cljc` runtime runs on the JVM)."
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom])
+  (:import [java.io PushbackReader]))
+
+;; ---------------------------------------------------------------------------
+;; The ruling (rf2-hh1jhc) — the two channel vocabularies
+;; ---------------------------------------------------------------------------
+
+(def ^:private lifecycle-channel :rf.machine.lifecycle/destroyed)
+(def ^:private fx-channel        :rf.machine/destroyed)
+(def ^:private destroy-channels  #{lifecycle-channel fx-channel})
+
+(def ^:private expected-lifecycle-reasons
+  "The registrar channel's SOLE reason — frame-exit reaping."
+  #{:parent-frame-destroyed})
+
+(def ^:private expected-fx-reasons
+  "The fx channel's complete DOCUMENTED vocabulary (005 D6). Includes the
+  reserved `:parent-unmount-cascade` (no emit site — pinned separately).
+  Adding a reason means updating the 009 matrix, the Spec-Schemas rows,
+  005 D6, AND this literal — the co-edit is the point."
+  #{:rf.machine/finished :rf.machine/join-reaped :explicit :parent-unmount-cascade})
+
+(def ^:private expected-fx-emitted-reasons
+  "The subset of the fx vocabulary that is actually STAMPED at an emit site
+  (`:parent-unmount-cascade` is reserved and must never be emitted)."
+  #{:rf.machine/finished :rf.machine/join-reaped :explicit})
+
+(def ^:private forwarding-reason-sym
+  "The one sanctioned DYNAMIC `:reason` at an fx emit choke point: the bound
+  parameter `reason` that the fx terminal (`emit-destroyed!`) and its
+  forwarder (`destroy-resolved!`) pass through. Every other non-literal
+  reason expression at a destroy emitter fails closed."
+  'reason)
 
 ;; ---------------------------------------------------------------------------
 ;; File resolution (JVM test CWD is `implementation/machines/`)
@@ -80,7 +127,7 @@
        (filter (fn [f] (re-find #"\.clj[cs]?$" (.getName f))))))
 
 ;; ---------------------------------------------------------------------------
-;; Surface parsers
+;; Surface parsers (doc ↔ doc)
 ;; ---------------------------------------------------------------------------
 
 (def ^:private matrix-row-re
@@ -141,26 +188,19 @@
         [_ span] (when row (re-find #"`:reason` tag — one of (.*?`)\. " row))]
     (set (some-> span backticked-keywords))))
 
-;; ---------------------------------------------------------------------------
-;; The ruling (rf2-hh1jhc) — the two channel vocabularies
-;; ---------------------------------------------------------------------------
-
-(def ^:private lifecycle-channel :rf.machine.lifecycle/destroyed)
-(def ^:private fx-channel        :rf.machine/destroyed)
-
-(def ^:private expected-lifecycle-reasons
-  "The registrar channel's SOLE reason — frame-exit reaping."
-  #{:parent-frame-destroyed})
-
-(def ^:private expected-fx-reasons
-  "The fx channel's complete vocabulary (005 D6). `:parent-unmount-cascade`
-  is reserved (no emit site); the emitted subset is pinned separately.
-  Adding a reason means updating the 009 matrix, the Spec-Schemas rows,
-  005 D6, AND this literal — the co-edit is the point."
-  #{:rf.machine/finished :rf.machine/join-reaped :explicit :parent-unmount-cascade})
+(defn- cross-spec-route-teardown-tuple
+  "The POSITIVE (channel, reason) pair Cross-Spec-Interactions documents for
+  a route-change / view-unmount teardown: the sentence
+  `... emits the fx-substrate \\`:rf.machine/destroyed\\` with
+  \\`:reason :explicit\\``. Returns `[channel reason]` or nil."
+  []
+  (let [[_ ch reason]
+        (re-find #"emits the fx-substrate `(:rf\.machine[\w./-]*)` with `:reason (:[\w./-]+)`"
+                 (slurp cross-spec-file))]
+    (when ch [(keyword (subs ch 1)) (keyword (subs reason 1))])))
 
 ;; ---------------------------------------------------------------------------
-;; Doc ↔ doc conformance
+;; A. Doc ↔ doc conformance (exact tuples)
 ;; ---------------------------------------------------------------------------
 
 (deftest matrix-parses-and-assigns-each-reason-to-exactly-one-channel
@@ -173,7 +213,7 @@
                       (filter (fn [[_ n]] (> n 1))) (map first))]
         (is (empty? dups) (str "reasons on more than one matrix row: " (pr-str dups)))))
     (testing "only the two teardown channels appear"
-      (is (= #{lifecycle-channel fx-channel} (set (map :channel rows)))))))
+      (is (= destroy-channels (set (map :channel rows)))))))
 
 (deftest matrix-carries-the-ruled-channel-vocabularies
   (let [rows (parse-009-matrix)
@@ -192,85 +232,233 @@
 (deftest spec-schemas-lifecycle-row-is-single-reason
   (let [row (spec-schemas-lifecycle-row)]
     (is (some? row) "Spec-Schemas carries the `:rf.machine.lifecycle/destroyed` row")
-    (testing "the tags schema pins the sole reason"
+    (testing "the tags schema pins the sole reason as the LAST entry of the map"
       (is (str/includes? row ":reason :parent-frame-destroyed}")
-          "the row's `:tags` map must close with `:reason :parent-frame-destroyed`"))
+          "the row's `:tags` map must close with `:reason :parent-frame-destroyed`
+           (the closing brace pins it as an exact, single reason — an extra
+           reason in the map would break this)"))
     (testing "the row states the sole-reason contract"
       (is (str/includes? row "`:reason` is always `:parent-frame-destroyed`")))
-    (testing "no fx-only reason leaks into the lifecycle row"
-      (let [fx-only (disj expected-fx-reasons :explicit)
-            leaked  (set/intersection (set (backticked-keywords row)) fx-only)]
+    (testing "no OTHER matrix reason leaks into the lifecycle row"
+      (let [other-reasons (disj (set/union expected-fx-reasons expected-lifecycle-reasons)
+                                :parent-frame-destroyed)
+            leaked (set/intersection (set (backticked-keywords row)) other-reasons)]
         (is (empty? leaked)
-            (str "fx-channel reasons named in the lifecycle row: " (pr-str leaked)))
-        (is (not (str/includes? row "`:explicit`"))
-            "the lifecycle row must not name `:explicit` either")))))
+            (str "reasons other than :parent-frame-destroyed named in the lifecycle row: "
+                 (pr-str leaked)))))))
 
 (deftest spec-005-d6-matches-the-matrix
   (testing "005 D6's enrichment vocabulary equals the fx set"
     (is (= expected-fx-reasons (spec-005-d6-reasons)))))
 
-(deftest cross-spec-interactions-does-not-reassign-reasons
-  (testing "Cross-Spec-Interactions no longer pairs `:parent-unmount-cascade`
-            with the lifecycle channel (the rf2-hh1jhc contradiction); the
-            reserved reason should not appear there at all — teardown-on-
-            route-change is documented as the fx channel's `:explicit`"
+(deftest cross-spec-interactions-pins-the-route-teardown-tuple
+  (testing "Cross-Spec-Interactions documents the POSITIVE route-change
+            teardown pair as (fx-channel, :explicit) — a view-unmount / route
+            swap tears the machine down on the fx channel, NOT the frame-exit
+            lifecycle channel. Changing either half of the pair reds this."
+    (is (= [fx-channel :explicit] (cross-spec-route-teardown-tuple))
+        (str "Cross-Spec's route-change teardown sentence must document the "
+             "exact pair [" fx-channel " :explicit]; parsed: "
+             (pr-str (cross-spec-route-teardown-tuple)))))
+  (testing "the reserved reason is never reintroduced on the lifecycle channel
+            here (the rf2-hh1jhc contradiction) — teardown-on-route-change is
+            the fx channel's `:explicit`, not a lifecycle `:parent-unmount-cascade`"
     (is (not (str/includes? (slurp cross-spec-file) ":parent-unmount-cascade"))
         "reintroducing the reserved reason into Cross-Spec-Interactions
          requires the 009 matrix (and this test) to change first")))
 
 ;; ---------------------------------------------------------------------------
-;; Doc ↔ emit-site conformance (conservative literal scan)
+;; B. Emit sites — STRUCTURAL enumeration (reader-based; fails closed)
 ;; ---------------------------------------------------------------------------
+;;
+;; Rather than a text regex (which silently skips any `:reason` shape it does
+;; not literally match), we READ the source forms and structurally walk them
+;; to find every destroy emit choke point:
+;;
+;;   - `(trace/emit! <op-type> <channel> <arg>)` where <channel> is a destroy
+;;     channel — the CHANNEL choke;
+;;   - `(emit-destroyed! <arg-map>)` — the fx reason-origination call;
+;;   - `(destroy-resolved! _ _ <reason> …)` — the fx reason forwarder.
+;;
+;; Each site's `:reason` must be a documented literal for its channel, or the
+;; sanctioned forwarding symbol `reason`. Anything else — a foreign symbol, a
+;; computed expression, an undocumented keyword — is an explicit failure with
+;; a source location. A read error propagates rather than truncating the scan.
 
-(def ^:private lifecycle-reason-near-emit-re
-  "A literal `:reason` keyword within a bounded window after a lifecycle-
-  channel mention (emit site or its contract docstring). Non-greedy: the
-  FIRST `:reason` after each mention. Conservative — a miss under-reports,
-  never false-positives."
-  ;; the capture must END on a word char so a docstring's sentence-final
-  ;; period is not swallowed into the keyword (`:parent-frame-destroyed.`)
-  #"(?s):rf\.machine\.lifecycle/destroyed.{0,800}?:reason\s+(:[\w./-]*[\w-])")
+(defn- reader-ns-sym
+  "The `ns` symbol declared by `file` (its first top-level form)."
+  [file]
+  (with-open [r (PushbackReader. (io/reader file))]
+    (binding [*read-eval* false]
+      (let [form (read {:read-cond :allow :eof ::eof} r)]
+        (when (and (seq? form) (= 'ns (first form))) (second form))))))
 
-(def ^:private fx-literal-reason-res
-  "The fx channel's literal reason chokepoints:
-    - a literal `:reason` inside an `emit-destroyed!` argument map
-      (finalize's `:rf.machine/finished`),
-    - the literal reason arg of `destroy-resolved!` (`:explicit` /
-      `:rf.machine/join-reaped`),
-    - `emit-destroyed!`'s `:or {reason :explicit}` default."
-  [#"(?s)emit-destroyed!\s+\{.{0,400}?:reason\s+(:[\w./-]+)"
-   #"destroy-resolved!\s+frame-id\s+\S+\s+(:[\w./-]+)"
-   #":or\s+\{reason\s+(:[\w./-]+)\}"])
+(defn- read-source-forms
+  "Every top-level form of `file`, read with `:read-cond :allow` (the JVM
+  `:clj` view) and `*ns*` bound to the file's LOADED namespace so
+  auto-resolved (`::`) keywords resolve. Fails CLOSED: a read error
+  propagates (reds the gate) rather than silently truncating the scan."
+  [file]
+  (let [the-ns (or (find-ns (reader-ns-sym file))
+                   (create-ns (gensym "rf-destroy-scan")))]
+    (with-open [r (PushbackReader. (io/reader file))]
+      (binding [*read-eval* false *ns* the-ns]
+        (doall
+          (take-while #(not= ::eof %)
+                      (repeatedly #(read {:read-cond :allow :eof ::eof} r))))))))
 
-(defn- scan-sources [res]
+(defn- call-name
+  "The unqualified name of `form`'s head symbol (ignoring any ns alias), or
+  nil when `form` is not a symbol-headed list."
+  [form]
+  (when (and (seq? form) (symbol? (first form))) (name (first form))))
+
+(defn- reason-key-values
+  "Every value bound to a literal `:reason` key in any map literal nested in
+  `form` (digs through `cond->` / `assoc`-free map literals)."
+  [form]
+  (for [sf (tree-seq coll? seq form)
+        :when (and (map? sf) (contains? sf :reason))]
+    (:reason sf)))
+
+(defn- or-default-reasons
+  "Every `:or {reason <v>}` destructuring default bound to the SYMBOL
+  `reason` anywhere in `forms` (the fx terminal's default). Returns a set of
+  the bound values."
+  [forms]
+  (set
+    (for [form forms
+          sf (tree-seq coll? seq form)
+          :when (and (map? sf) (contains? sf 'reason))]
+      (get sf 'reason))))
+
+(defn- destroy-emit-files
+  "Production source files that carry a destroy emit choke point — a textual
+  pre-filter; each is then structurally parsed. Not hardcoded, so a NEW emit
+  site in a new file is picked up (and fails closed if its reason is dynamic)."
+  []
   (->> (source-files)
-       (mapcat (fn [f]
-                 (let [src (slurp f)]
-                   (mapcat #(map second (re-seq % src)) res))))
-       (map #(keyword (subs % 1)))
-       set))
+       (filter (fn [f]
+                 (let [s (slurp f)]
+                   (or (str/includes? s "emit-destroyed!")
+                       (str/includes? s "destroy-resolved!")
+                       (and (str/includes? s "trace/emit!")
+                            (or (str/includes? s (str fx-channel))
+                                (str/includes? s (str lifecycle-channel))))))))
+       vec))
 
-(deftest lifecycle-emit-sites-stamp-only-the-lifecycle-reason
-  (let [found (scan-sources [lifecycle-reason-near-emit-re])]
-    (is (seq src-roots) "source roots resolved from the test CWD")
-    (is (seq found) "the scan reached at least one lifecycle emit/contract site")
-    (is (set/subset? found expected-lifecycle-reasons)
-        (str "reasons stamped/documented at lifecycle-channel sites beyond "
-             expected-lifecycle-reasons ": "
-             (pr-str (set/difference found expected-lifecycle-reasons))))))
+(defn- enumerate-emit-sites
+  "Structurally walk every destroy-emit-bearing source file; return a vector
+  of findings pinning each (channel, reason) choke point."
+  [files]
+  (vec
+    (for [f files
+          form (read-source-forms f)
+          sf (tree-seq coll? seq form)
+          :when (seq? sf)
+          finding
+          (let [h (call-name sf), v (vec sf)]
+            (cond
+              (= h "emit!")
+              (let [ch (nth v 2 nil)]
+                (when (contains? destroy-channels ch)
+                  [{:kind :channel-emit :file (.getName f) :form sf
+                    :channel ch :reasons (vec (reason-key-values (nth v 3 nil)))}]))
 
-(deftest fx-emit-sites-stamp-only-documented-fx-reasons
-  (let [found (scan-sources fx-literal-reason-res)]
-    (is (seq found) "the scan reached the fx-channel literal chokepoints")
-    (testing "every literal fx reason is documented on the fx channel"
-      (is (set/subset? found expected-fx-reasons)
-          (str "undocumented fx-channel reasons: "
-               (pr-str (set/difference found expected-fx-reasons)))))
-    (testing "the frame-exit reason never rides the fx channel"
-      (is (not (contains? found :parent-frame-destroyed))))
-    (testing "the three documented-as-emitted reasons are real"
-      (doseq [r [:explicit :rf.machine/finished :rf.machine/join-reaped]]
-        (is (contains? found r) (str r " is stamped at an fx emit site"))))))
+              (= h "emit-destroyed!")
+              [{:kind :emit-destroyed :file (.getName f) :form sf
+                :reasons (vec (reason-key-values (nth v 1 nil)))}]
+
+              (= h "destroy-resolved!")
+              [{:kind :destroy-resolved :file (.getName f) :form sf
+                :reason (nth v 3 ::missing)}]
+
+              :else nil))]
+      finding)))
+
+(defn- valid-fx-reason?
+  "An fx-channel reason is valid iff it is the sanctioned forwarding symbol
+  `reason` or a documented, emitted fx keyword."
+  [r]
+  (or (= r forwarding-reason-sym)
+      (and (keyword? r) (contains? expected-fx-emitted-reasons r))))
+
+(defn- valid-lifecycle-reason? [r]
+  (and (keyword? r) (contains? expected-lifecycle-reasons r)))
+
+(defn- loc [finding]
+  (str (:file finding) " :: " (pr-str (:form finding))))
+
+(deftest emit-sites-pin-exact-channel-reason-tuples
+  (let [files    (destroy-emit-files)
+        findings (enumerate-emit-sites files)]
+    (testing "the structural scan reached the live emit sites"
+      (is (seq files) "destroy-emit-bearing source files resolved from the test CWD")
+      (is (seq findings) "at least one destroy emit choke point was enumerated"))
+
+    ;; --- per-site (channel, reason) validity: fails CLOSED on any reason that
+    ;;     is neither a documented literal for its channel nor forwarding `reason`.
+    (doseq [{:keys [kind channel reasons reason] :as fnd} findings]
+      (case kind
+        :channel-emit
+        (cond
+          (= channel lifecycle-channel)
+          (doseq [r reasons]
+            (is (valid-lifecycle-reason? r)
+                (str "lifecycle-channel emit must stamp a documented literal "
+                     "lifecycle reason " expected-lifecycle-reasons "; saw "
+                     (pr-str r) " at " (loc fnd))))
+          (= channel fx-channel)
+          (doseq [r reasons]
+            (is (valid-fx-reason? r)
+                (str "fx-channel emit must stamp a documented fx literal "
+                     expected-fx-emitted-reasons " or forward `reason`; saw "
+                     (pr-str r) " at " (loc fnd)))))
+
+        :emit-destroyed
+        (doseq [r reasons]                         ; 0 reasons = the :explicit default
+          (is (valid-fx-reason? r)
+              (str "emit-destroyed! must pass a documented fx literal "
+                   expected-fx-emitted-reasons " or forward `reason`; saw "
+                   (pr-str r) " at " (loc fnd))))
+
+        :destroy-resolved
+        (is (and (keyword? reason) (contains? expected-fx-emitted-reasons reason))
+            (str "destroy-resolved! must be called with a documented fx literal "
+                 expected-fx-emitted-reasons " (a dynamic reason here fails "
+                 "closed); saw " (pr-str reason) " at " (loc fnd)))))
+
+    ;; --- coverage: the emitted TUPLE SETS are exactly the matrix's.
+    (let [lifecycle-emits (filter #(and (= :channel-emit (:kind %))
+                                        (= lifecycle-channel (:channel %)))
+                                  findings)
+          fx-channel-emits (filter #(and (= :channel-emit (:kind %))
+                                         (= fx-channel (:channel %)))
+                                   findings)
+          lifecycle-reason-set (set (mapcat :reasons lifecycle-emits))
+          ;; every literal keyword that ORIGINATES an fx reason (emit-destroyed!
+          ;; map values + destroy-resolved! positional + the `:or` default)
+          fx-origination
+          (set/union
+            (set (filter keyword? (mapcat :reasons (filter #(= :emit-destroyed (:kind %)) findings))))
+            (set (filter keyword? (map :reason (filter #(= :destroy-resolved (:kind %)) findings))))
+            (or-default-reasons (mapcat read-source-forms files)))]
+      (testing "the lifecycle channel is emitted from BOTH the orchestrator and
+                the no-machines fallback, each with only the sole reason"
+        (is (<= 2 (count lifecycle-emits))
+            (str "expected >=2 lifecycle-channel emit sites (frame_destroy.cljc "
+                 "orchestrator + frame.cljc fallback); saw "
+                 (mapv :file lifecycle-emits)))
+        (is (= expected-lifecycle-reasons lifecycle-reason-set)
+            (str "lifecycle-channel emitted reasons must be exactly "
+                 expected-lifecycle-reasons "; saw " (pr-str lifecycle-reason-set))))
+      (testing "the fx channel has its terminal emit"
+        (is (seq fx-channel-emits) "the fx-channel `emit-destroyed!` terminal was found"))
+      (testing "the emitted fx reasons are EXACTLY the non-reserved fx set
+                (the reserved :parent-unmount-cascade never originates)"
+        (is (= expected-fx-emitted-reasons fx-origination)
+            (str "fx reasons originated at emit sites must be exactly "
+                 expected-fx-emitted-reasons "; saw " (pr-str fx-origination)))))))
 
 (deftest reserved-reasons-are-not-emitted
   (testing "a matrix row marked *reserved* must have NO emit site; stamping
@@ -286,3 +474,111 @@
               f (source-files)]
         (is (not (str/includes? (slurp f) (str r)))
             (str r " (reserved in the 009 matrix) appears in " (.getPath f)))))))
+
+;; ---------------------------------------------------------------------------
+;; C. Executable fixtures — drive the runtime, assert the exact emitted tuple
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest executable-explicit-destroy-emits-fx-explicit
+  (testing "an explicit teardown (declarative :spawn exit cascade) emits EXACTLY
+            (:rf.machine/destroyed, :explicit)"
+    (rf/reg-machine :dre/child {:initial :running :data {} :states {:running {}}})
+    (rf/reg-machine :dre/parent
+                    {:initial :idle
+                     :states  {:idle    {:on {:start :working}}
+                               :working {:spawn {:machine-id :dre/child}
+                                         :on    {:stop :idle}}}})
+    (mtest/with-trace-capture captured
+      (rf/dispatch-sync [:dre/parent [:start]])
+      (rf/dispatch-sync [:dre/parent [:stop]])          ; exit :working → destroy-single!
+      (let [fx (filter #(= fx-channel (:operation %)) @captured)]
+        (is (seq fx) "an fx-channel :rf.machine/destroyed fired")
+        (doseq [t fx]
+          (is (= [fx-channel :explicit] [(:operation t) (-> t :tags :reason)])
+              (str "explicit destroy must be the exact tuple [" fx-channel " :explicit]; saw "
+                   (pr-str [(:operation t) (-> t :tags :reason)]))))))))
+
+(deftest executable-finalize-emits-fx-finished
+  (testing "a machine reaching a :final? state auto-destroys as EXACTLY
+            (:rf.machine/destroyed, :rf.machine/finished)"
+    (rf/reg-machine :drf/child
+                    {:initial :running :data {}
+                     :states  {:running {:on {:end :done}} :done {:final? true}}})
+    (rf/reg-machine :drf/parent
+                    {:initial :working :states {:working {:spawn {:machine-id :drf/child}}}})
+    (mtest/with-trace-capture captured
+      (rf/dispatch-sync [:drf/parent [:rf.machine.spawn/spawned]])
+      (let [spawned (get-in (mtest/runtime-db)
+                            [:rf.runtime/machines :spawned :drf/parent [:working]])]
+        (rf/dispatch-sync [spawned [:end]]))          ; child → :final? → finalize
+      (let [fin (filter #(= :rf.machine/finished (-> % :tags :reason)) @captured)]
+        (is (seq fin) "a :rf.machine/finished destroy fired")
+        (doseq [t fin]
+          (is (= [fx-channel :rf.machine/finished] [(:operation t) (-> t :tags :reason)])
+              (str "finalize must be the exact tuple [" fx-channel " :rf.machine/finished]; saw "
+                   (pr-str [(:operation t) (-> t :tags :reason)]))))))))
+
+(deftest executable-join-reap-emits-fx-join-reaped
+  (testing "a LIVE (non-:final?) completed :spawn-all child reaped at join
+            resolution emits EXACTLY (:rf.machine/destroyed, :rf.machine/join-reaped)"
+    (let [mk-child (fn [parent-id done-kw error-kw]
+                     {:initial :running
+                      :data    {:id nil}
+                      :actions {:record-id     (fn [{d :data ev :event}] {:data (assoc d :id (second ev))})
+                                :dispatch-done (fn [{d :data}] {:fx [[:dispatch [parent-id [done-kw (:id d)]]]]})
+                                :dispatch-err  (fn [{d :data}] {:fx [[:dispatch [parent-id [error-kw (:id d)]]]]})}
+                      :states  {:running {:on {:set-id {:action :record-id}
+                                               :go     {:target :done   :action :dispatch-done}
+                                               :fail   {:target :failed :action :dispatch-err}}}
+                                :done   {}
+                                :failed {}}})]
+      (rf/reg-machine :drj/a (mk-child :drj/sup :asset/loaded :asset/failed))
+      (rf/reg-machine :drj/b (mk-child :drj/sup :asset/loaded :asset/failed))
+      (rf/reg-machine :drj/sup
+                      {:initial :idle
+                       :states  {:idle   {:on {:start :racing}}
+                                 :racing {:spawn-all
+                                          {:children [{:id :a :machine-id :drj/a :start [:set-id :a]}
+                                                      {:id :b :machine-id :drj/b :start [:set-id :b]}]
+                                           :join             :any
+                                           :on-child-done    :asset/loaded
+                                           :on-child-error   :asset/failed
+                                           :on-some-complete [:race/won]}}}})
+      (mtest/with-trace-capture captured
+        (rf/dispatch-sync [:drj/sup [:start]])
+        (let [a-id (get-in (mtest/runtime-db)
+                           [:rf.runtime/machines :spawned :drj/sup [:racing] :children :a])]
+          (rf/dispatch-sync [a-id [:go]])              ; :a completes → :any resolves → :a reaped
+          (let [reaped (filter #(and (= fx-channel (:operation %))
+                                     (= a-id (:actor-id (:tags %))))
+                               @captured)]
+            (is (seq reaped) "the reaped completed child fired an fx destroy")
+            (doseq [t reaped]
+              (is (= [fx-channel :rf.machine/join-reaped] [(:operation t) (-> t :tags :reason)])
+                  (str "join reap must be the exact tuple [" fx-channel " :rf.machine/join-reaped]; saw "
+                       (pr-str [(:operation t) (-> t :tags :reason)]))))))))))
+
+(deftest executable-frame-destroy-emits-lifecycle-parent-frame-destroyed
+  (testing "destroy-frame! with live machines emits EXACTLY
+            (:rf.machine.lifecycle/destroyed, :parent-frame-destroyed) per actor"
+    (rf/make-frame {:id :drl/auth :doc "destroyed-reason conformance frame"})
+    (rf/reg-machine :drl/child {:initial :running :data {} :states {:running {}}})
+    (rf/reg-machine :drl/boot
+                    {:initial :idle :data {}
+                     :states  {:idle {:on {:start {:action (fn [_]
+                                                             {:fx [[:rf.machine/spawn
+                                                                    {:machine-id :drl/child
+                                                                     :id-prefix  :drl/child}]]})}}}}})
+    (rf/dispatch-sync [:drl/boot [:start]] {:frame :drl/auth})
+    (mtest/with-trace-capture captured
+      (rf/destroy-frame! :drl/auth)
+      (let [lc (filter #(= lifecycle-channel (:operation %)) @captured)]
+        (is (seq lc) "a lifecycle-channel destroyed fired on frame destroy")
+        (doseq [t lc]
+          (is (= [lifecycle-channel :parent-frame-destroyed] [(:operation t) (-> t :tags :reason)])
+              (str "frame destroy must be the exact tuple [" lifecycle-channel
+                   " :parent-frame-destroyed]; saw "
+                   (pr-str [(:operation t) (-> t :tags :reason)]))))))))


### PR DESCRIPTION
## What

Closes the vacuous-gate looseness in the destroyed-reason channel/reason conformance test (`destroyed_reason_channel_conformance_test.clj`). Previously the gate advertised "pins the channel/reason matrix against the emit sites" but passed with a wrong channel, a wrong Cross-Spec pair, or an unparsed/dynamic reason. It now enforces EXACT `(channel, reason)` tuples across every normative surface and every runtime emit choke point.

The frozen matrix (rf2-hh1jhc), unchanged:

| reason | channel |
|---|---|
| `:parent-frame-destroyed` | `:rf.machine.lifecycle/destroyed` |
| `:rf.machine/finished` | `:rf.machine/destroyed` |
| `:rf.machine/join-reaped` | `:rf.machine/destroyed` |
| `:explicit` | `:rf.machine/destroyed` |
| `:parent-unmount-cascade` | `:rf.machine/destroyed` *(reserved, no emit site)* |

## Three enforcement layers

- **A. Doc ↔ doc (exact tuples)** — 009 matrix, Spec-Schemas fx/lifecycle rows, 005 D6 (already exact `=`), **plus a new Cross-Spec check** that parses and pins the POSITIVE route-change teardown pair `[:rf.machine/destroyed :explicit]` (the old test only checked the *absence* of the reserved reason).
- **B. Emit sites — STRUCTURAL, fails closed** — replaces the loose text regex with a reader-based form walk (`read` with `:read-cond :allow`, `*ns*` bound to each file's loaded namespace so `::` keywords resolve). Every `trace/emit!` to a destroy channel, every `emit-destroyed!`, and every `destroy-resolved!` is enumerated; its `:reason` must be a documented literal for its channel or the sanctioned forwarding symbol `reason`. Anything else — a foreign symbol, a computed expression, an undocumented keyword — is an explicit failure **with a source location**. A read error propagates rather than truncating the scan.
- **C. Executable fixtures** — drive the runtime and assert the exact emitted `(channel, reason)` tuple for `:explicit`, `:rf.machine/finished`, `:rf.machine/join-reaped` (fx channel) and `:parent-frame-destroyed` (lifecycle channel).

Source and specs are **unchanged** — this is a test-only tightening. No wrong channel/reason was found in the runtime; the gate was simply loose.

## Mutation proof (each was GREEN before, RED now)

| Mutation | Result |
|---|---|
| fx terminal emit → lifecycle channel (repro step 1) | **RED** — 6 failures: structural scan (`saw reason at traces.cljc :: (trace/emit! …)`) + executable fixtures |
| dynamic reason `:reason (identity :rf.machine/finished)` at finalize (repro step 3, compiling variant) | **RED** — structural scan fails closed with source location; executable fixture correctly stays green (runtime no-op) |
| finalize reason `:rf.machine/finished` → `:explicit` (valid literal) | **RED** — source coverage set + executable finalize fixture |
| Cross-Spec pair `:reason :explicit` → `:bogus` (repro step 2) | **RED** — `parsed: [:rf.machine/destroyed :bogus]` ≠ `[:rf.machine/destroyed :explicit]` |

(An unbound-symbol dynamic reason such as `{:reason bogus-reason}` fails to compile the runtime outright — a strictly stronger rejection than the gate.)

## Quality gates

- Focused: `clojure -M:test -n re-frame.destroyed-reason-channel-conformance-test` → **12 tests, 158 assertions, 0 failures** (was 9/144).
- Full machines: `clojure -M:test` (implementation/machines) → **1096 tests, 3805 assertions, 0 failures**.
- JVM-only `.clj` test change with no CLJS/node surface (CLJS builds ignore `.clj`); no source/spec touched, so `test:cljs` is unaffected.

Closes rf2-9q1zn2.
