### PR TITLE
test(ci): make changed-surface discovery portable (rf2-n8kkum)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1336,10 +1336,11 @@ function classifyViaGitDiscovery(buildHistory) {
     for (const key of Object.keys(env)) {
       if (key.startsWith('GIT_')) delete env[key];
     }
-    const out = execFileSync('bash', [SCRIPT_PATH], {
+    const out = execFileSync('bash', ['-s'], {
       cwd: tmp,
       env,
       encoding: 'utf8',
+      input: fs.readFileSync(SCRIPT_PATH),
     });
     return Object.fromEntries(
       out


### PR DESCRIPTION
## Summary

- execute the authored changed-surface classifier through `bash -s` instead of passing a host-native absolute path to Bash
- keep the exact script bytes, real two-commit scratch repositories, and both production Git discovery branches intact

## Quality gates

- PASS — Windows PowerShell: `node implementation/scripts/_changed-surfaces.test.cjs` (`144 passed`)
- PASS — Ubuntu/WSL: `node implementation/scripts/_changed-surfaces.test.cjs` (`144 passed`)
- PASS — red-path proof: raw Windows script argv fails all 8 discovery launches with `C:Users... No such file or directory`
- PASS — semantic mutation: removing `--no-renames` fails exactly the UI-to-docs deleted-endpoint assertion (`implementation_jvm`: `false !== true`)
- RUNNING — Ubuntu/WSL: `scripts/test-fast-pr.sh` (Python 3 command shim only; no gate skipped)