### PR TITLE
rf2-tl82t0: document descriptor HMR fence contract

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -194,8 +194,12 @@
   "The COMPLETE Root Descriptor v1 for live root `root-id` (dev): its static
   core from the live-root registry, stamped with the current whole-build
   `:build-digest` (`current-build-digest`) — the client read-time projection
-  (Spec 004C §2). nil if `root-id` is not live, its entry carries no descriptor
-  yet (a `create-root` before its first `render!`), or in production."
+  (Spec 004C §2). During an active HMR digest fence, this returns the static
+  core with `:build-digest` nil. Consumers requiring a finalized-complete
+  descriptor must treat nil as not-yet-known; the static core alone does not
+  identify a build mid-fence. nil if `root-id` is not live, its entry carries
+  no descriptor yet (a `create-root` before its first `render!`), or in
+  production."
   [root-id]
   (when-let [d (:descriptor (get @live-roots root-id))]
     (assoc d :build-digest (current-build-digest))))
@@ -205,8 +209,11 @@
   + the current whole-build `:build-digest`. The CLIENT counterpart of the
   compiler's `re-frame.ui.compiler.root/descriptor-index` — the same shape and
   the same (byte-identical) digest — the Xray / tool read surface for the live
-  runtime descriptors. Roots still awaiting their first `render!` (no
-  descriptor yet) are omitted. Empty in production."
+  runtime descriptors. During an active HMR digest fence, every included value
+  remains its static core with `:build-digest` nil. Consumers requiring
+  finalized-complete descriptors must treat nil as not-yet-known; the static
+  core alone does not identify a build mid-fence. Roots still awaiting their
+  first `render!` (no descriptor yet) are omitted. Empty in production."
   []
   (let [bd (current-build-digest)]
     (into {}


### PR DESCRIPTION
## Summary

- Document that `descriptor` and `descriptor-index` preserve their static core during an active HMR digest fence while exposing `:build-digest nil`.
- State that finalized-complete consumers must treat a nil digest as not-yet-known and must not infer build identity from the static core alone.
- Make no logic or oracle changes.

## Why

The shipped field-level oracle already proves that a mounted descriptor fails closed at `:build-digest` during the HMR activation fence and restamps the exact digest after promotion. The public docstrings did not state that the descriptor map remains present or how finalized consumers should interpret nil.

## Quality gates

- `clj-kondo --fail-level error --lint implementation/ui/src/re_frame/ui/client.cljs` — PASS (0 errors, 0 warnings)
- `npm run test:ui-digest-carrier` — PASS (hookless fail-closed, mounted descriptor fence, exact recovery, overlapping activations)
- `npm run test:ui` — PASS (551 tests, 2,784 assertions; 0 failures, 0 errors)
- `scripts/test-fast-pr.sh` — not completed locally: the Git Bash run lingered quietly in the broad matrix and was stopped on lead direction; PR CI is authoritative for the broader spine