### PR TITLE
fix(ui): preserve quoted compiler data and correct frame guidance

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -117,6 +117,8 @@
   [ast]
   (letfn [(project [x]
             (cond
+              (and (seq? x) (= 'quote (first x))) x
+
               (runtime-sub-form? x)
               (with-meta (list 're-frame.ui/sub (project (nth x 2))) (meta x))
 
@@ -823,7 +825,7 @@
                                 (str "bare " (name kind) " reference below macro "
                                      head " would become an unindexed reactive "
                                      "call after expansion. Write the explicit "
-                                     "(" (name kind) " query) call")
+                                     (reactive-direct-form kind) " call")
                                 {:form f :macro head})
                      (with-same-meta
                        f

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -46,20 +46,26 @@
 
 (defn- hoist-literal-sub-queries
   [st form]
-  (walk/postwalk
-   (fn [x]
-     (if (ana/runtime-sub-form? x)
-       (let [[runtime sid query] x]
-         (if (literal-data? query)
-           (let [query-sym
-                 (or (get-in @st [:sub-queries query])
-                     (let [sym (hoist! st :query query)]
-                       (swap! st assoc-in [:sub-queries query] sym)
-                       sym))]
-             (with-meta (list runtime sid query-sym) (meta x)))
-           x))
-       x))
-   form))
+  (letfn [(hoist-one [x]
+            (if (ana/runtime-sub-form? x)
+              (let [[runtime sid query] x]
+                (if (literal-data? query)
+                  (let [query-sym
+                        (or (get-in @st [:sub-queries query])
+                            (let [sym (hoist! st :query query)]
+                              (swap! st assoc-in [:sub-queries query] sym)
+                              sym))]
+                    (with-meta (list runtime sid query-sym) (meta x)))
+                  x))
+              x))
+          (visit [x]
+            ;; `quote` is data, not executable compiler output. Returning the
+            ;; exact form preserves its payload spelling and metadata while the
+            ;; lower-level walk remains post-order everywhere executable.
+            (if (and (seq? x) (= 'quote (first x)))
+              x
+              (walk/walk visit hoist-one x)))]
+    (visit form)))
 
 ;; ---------------------------------------------------------------------------
 ;; Handlers

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -433,6 +433,29 @@
           (ana/template-fingerprint-projection (:ast changed-query))))
         "site id is projected out, but the semantic query remains")))
 
+(deftest quoted-runtime-sub-lookalikes-are-fingerprint-opaque
+  (let [runtime  're-frame.ui.reactive/sub-read
+        quoted   (with-meta
+                   (list 'quote (list runtime :quoted/sid [:quoted/query]))
+                   {:line 17 :column 9})
+        ast      {:op :expr :form (list 'str quoted)}
+        projected (ana/template-fingerprint-projection ast)
+        digest   (fn [sid query]
+                   (fingerprint/template-fingerprint
+                    (ana/template-fingerprint-projection
+                     {:op :expr
+                      :form (list 'str
+                                  (list 'quote (list runtime sid query)))})))]
+    (is (= ast projected)
+        "fingerprint projection preserves quoted internal-looking data exactly")
+    (is (identical? quoted (second (:form projected)))
+        "the quote form itself is opaque, preserving its spelling and metadata")
+    (is (apply distinct?
+               [(digest :quoted/sid-a [:quoted/query])
+                (digest :quoted/sid-b [:quoted/query])
+                (digest :quoted/sid-a [:quoted/other-query])])
+        "quoted lookalike sid and query data both remain part of build identity")))
+
 (deftest metadata-loss-reacquires-safely-instead-of-transferring-an-ordinal
   (let [old (analyze-site-fixture :clj {:line 1} '[:div (sub [:a])])
         edited (analyze-site-fixture

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -2,7 +2,8 @@
   "Template-grammar REJECT table: every rejected form throws a compile
   error carrying {:rf.ui.compile/error <id>} — the S1e didactic-message
   roster keys off these ids. Runs on both hosts (injected resolution)."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.analyze-accept-cljs-test :refer [mk-env mk-self-env]]))
 
@@ -154,6 +155,21 @@
       "a local shadowing sub is an ordinary call, never a reactive site")
   (is (nil? (reject-id '[:div {:title '((if p sub inc) [:q])}]))
       "quoted data is inert — never an invocation target"))
+
+(deftest indirect-frame-diagnostic-recommends-the-zero-arity-form
+  (let [ex (try
+             (ana/analyze (mk-env) '[:div {:title (-> x frame)}])
+             nil
+             (catch #?(:clj clojure.lang.ExceptionInfo
+                       :cljs cljs.core/ExceptionInfo) ex
+               ex))
+        message (some-> ex ex-message)]
+    (is (= :rf.ui.compile/unsupported-form
+           (:rf.ui.compile/error (ex-data ex))))
+    (is (str/includes? message "(frame)")
+        "the didactic repair is the frozen zero-arity frame form")
+    (is (not (str/includes? message "frame query"))
+        "the diagnostic never recommends the invalid argument-taking form")))
 
 (deftest or-default-value-escape
   ;; rf2-dzyqis — the sibling gap PR #5874 (.252) left open. reject-reactive-

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -393,6 +393,40 @@
                      literal-cljs)))
         "the hot call itself carries only scalar sid + query")))
 
+(deftest quoted-runtime-sub-lookalikes-never-hoist
+  (let [runtime 're-frame.ui.reactive/sub-read
+        payload {:marker ::quoted-lookalikes
+                 :list   (list runtime :fake/list [:q/list])
+                 :vector [(list runtime :fake/vector [:q/vector])]
+                 :map    {(list runtime :fake/key [:q/key])
+                          (list runtime :fake/value [:q/value])}
+                 :set    #{(list runtime :fake/set [:q/set])}}
+        quoted  (list 'quote payload)
+        forms   (emit-cljs/emit-defview
+                 {:vname 'quoted-lookalikes
+                  :view-id :app.probe/quoted-lookalikes
+                  :display-name "app.probe/quoted-lookalikes"
+                  :docstring nil
+                  :header (header/parse-header [])
+                  :slots []
+                  :ast {:op :expr :form (list 'str quoted)}
+                  :manifest {:view-id :app.probe/quoted-lookalikes
+                             :hook-signature "hs1-fixed"
+                             :sites {:subs []}}
+                  :closed-keys nil
+                  :children? false})
+        emitted-quote
+        (some (fn [x]
+                (when (and (seq? x)
+                           (= 'quote (first x))
+                           (= ::quoted-lookalikes (:marker (second x))))
+                  x))
+              (tree-seq coll? seq forms))]
+    (is (= quoted emitted-quote)
+        "lists, vectors, map keys/values, and sets beneath quote round-trip unchanged")
+    (is (not (str/includes? (pr-str forms) "quoted-lookalikes$query$"))
+        "a quoted internal-looking form never synthesizes a module query def")))
+
 (deftest file-pass-registration-does-not-embed-a-per-view-digest
   (build/begin-build! ::file '#{app.file})
   (try


### PR DESCRIPTION
## Summary

- Keep quoted internal-looking `sub-read` data completely opaque to both template-fingerprint projection and post-emission literal-query hoisting.
- Preserve nested quoted lists, vectors, maps, sets, metadata, and authored sid/query data while retaining existing hoisting for executable compiler-owned reads.
- Make transparent-macro escape diagnostics recommend the kind-correct direct form: `(sub query)`, `(lease descriptor)`, or zero-arity `(frame)`.

## Root cause

Both compiler traversals recognized the serialized `re-frame.ui.reactive/sub-read` list shape while recursively walking through `quote`, so ordinary quoted data could be rewritten and its authored sid removed from build identity. The transparent-macro diagnostic independently constructed every remediation as `(<kind> query)`, which is invalid for `frame` and misleading for `lease`.

## Impact

Quoted data now round-trips unchanged and fingerprints exactly as authored. The indirect-frame error directs authors to a valid repair without changing the closed Spec 004 grammar, public API, or runtime behavior.

## Quality gates

- Red mutation fixture before the fix: focused JVM run reported 7 expected failures across quote preservation/fingerprint identity/query-def synthesis and the invalid `(frame query)` message.
- `clojure -M:test -n re-frame.ui.analyze-accept-cljs-test -n re-frame.ui.analyze-reject-cljs-test -n re-frame.ui.defview-grammar-jvm-test` — 74 tests, 392 assertions, 0 failures.
- `clojure -M:test` in `implementation/ui` — 564 tests, 8,156 assertions, 0 failures; G-14 green.
- `npm run test:ui` — 553 tests, 2,790 assertions, 0 failures; adapter-isolation green.
- `npm run test:ui-g1` — emitted-JS golden, production isolation, byte-parity, regression control, and p50/p95 budgets green on rerun. The first run had a marginal timing-only `counter-42` p95 sample of 1.1121 against 1.10; rerun was 1.0196 with identical deterministic checks green.
- `git diff --check` — clean.

## Tracking

- rf2-vxgfnd.218
- rf2-vxgfnd.233
