### PR TITLE
fix(ui): harden reactive runtime tail

### DIFF
--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -15,6 +15,8 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui', 'viewcell.cljs');
+const REACTIVE_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui',
+                                  'reactive.cljc');
 const ANALYZER_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui',
                                   'compiler', 'analyze.cljc');
 const BUNDLE = path.join(ROOT, 'out', 'browser-test-prod-elision', 'js', 'test.js');
@@ -33,6 +35,11 @@ const source = fs.readFileSync(SOURCE, 'utf8');
 const occurrences = source.split(SENTINEL).length - 1;
 if (occurrences !== 1) {
   fail(`expected exactly one source sentinel, found ${occurrences}`);
+}
+
+const reactiveSource = fs.readFileSync(REACTIVE_SOURCE, 'utf8');
+if (!reactiveSource.includes('disconnect-provisional?')) {
+  fail('provisional-disconnect source positive-control sentinel is absent');
 }
 
 const analyzerSource = fs.readFileSync(ANALYZER_SOURCE, 'utf8');
@@ -56,7 +63,11 @@ for (const forbidden of [
   'hmr-body-revision',
   'hmr-remount-generation',
   'hmr-descriptor',
-  'hmr-inner'
+  'hmr-inner',
+  // rf2-vxgfnd.165: the advanced fixture roots make-cell, disconnect!, the
+  // settle seam, and reconnect. Any unconditional state member OR reconnect
+  // lookup therefore carries this keyword into the bundle and fails here.
+  'disconnect-provisional'
 ]) {
   if (bundle.includes(forbidden)) {
     fail(`development site/HMR diagnostic survived advanced output: ${forbidden}`);

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -440,13 +440,14 @@
   ;;                             ;   identity that SURVIVES an Activity hide, so
   ;;                             ;   root teardown reaps a cell hidden before its
   ;;                             ;   window (rf2-vxgfnd.85; see `root-cells`)
-  ;;    :disconnect-provisional? bool ; DEV-only (rf2-vxgfnd.44): a just-emitted
+  ;;    :disconnect-provisional? bool ; DEV-only and ABSENT in production
+  ;;                             ;   (rf2-vxgfnd.44): a just-emitted
   ;;                             ;   :disconnected interval that has NOT yet
   ;;                             ;   settled past its synchronous commit. A
   ;;                             ;   reconnect while still provisional is a
   ;;                             ;   same-tick StrictMode dev replay (no hide);
-  ;;                             ;   `settle-disconnect!` clears it. false/absent
-  ;;                             ;   in production (no StrictMode double-invoke)
+  ;;                             ;   `settle-disconnect!` clears it. Production
+  ;;                             ;   has no field, lookup, or provisional branch
   ;;    :committed {sid -> {:query exact-query :target target :value value
   ;;                        :lease lease|nil}}
   ;;                             ; lexical site records. `:lease nil` survives
@@ -488,13 +489,13 @@
                :generation     generation
                :lifecycle      :fresh
                :root           nil
-               :disconnect-provisional? false
                :committed      {}
                :revision       0
                :dirty?         false
                :evidence       nil
                :listeners      {}
-               :intervals      []})))))
+               :intervals      []}
+        interop/debug-enabled? (assoc :disconnect-provisional? false))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dev-only view slots — stable shell + exact body revision (03 §10)
@@ -585,12 +586,62 @@
      :before (get old-slots view-id)
      :prepared prepared}))
 
+(defn- report-hmr-listener-escape!
+  "Surface the FIRST contained listener failure from one DEV publication.
+
+  Reporting is deliberately bounded to one warning per publication and is
+  itself contained: diagnostic machinery can neither change a committed HMR
+  outcome nor replace the registrar failure that caused a rollback."
+  [view-id phase slot error]
+  #?(:cljs
+     (try
+       (when (exists? js/console)
+         (.warn js/console
+                (str "[re-frame.ui] an HMR publication listener threw while "
+                     "notifying view " (pr-str view-id) " after " (name phase)
+                     " revision " (:hmr-body-revision slot)
+                     " — the throw was CONTAINED, every snapshotted sibling "
+                     "still ran, and the publication outcome remains "
+                     "authoritative. Cause: "
+                     (if (nil? error)
+                       "nil"
+                       (error/ex-message-safe error)))))
+       (catch :default _ nil))
+     :clj nil))
+
+(defn- notify-view-listeners!
+  "Notify a snapshot of `slot`'s listeners, containing every failure.
+
+  The explicit `:failed?` bit preserves first-failure identity even when
+  JavaScript throws false or nil. Later failures are contained but do not
+  replace the bounded diagnostic's first cause."
+  [view-id phase slot]
+  (let [listeners (vec (vals (:hmr-listeners slot)))
+        first-failure
+        (reduce (fn [failure listener]
+                  (try
+                    (listener)
+                    failure
+                    (catch #?(:clj Throwable :cljs :default) error
+                      (if (:failed? failure)
+                        failure
+                        {:failed? true :error error}))))
+                {:failed? false :error nil}
+                listeners)]
+    (when (and interop/debug-enabled? (:failed? first-failure))
+      (report-hmr-listener-escape!
+       view-id phase slot (:error first-failure)))
+    nil))
+
 (defn commit-view-descriptor!
   "Commit a prepared view publication and notify mounted shells exactly once.
 
   A re-entrant registration for the same id supersedes an older transaction;
-  only the transaction whose token is still current may notify. Returns the
-  complete current slot snapshot."
+  only the transaction whose token is still current may notify. Notification
+  walks a pre-delivery listener snapshot and contains each listener failure,
+  so every sibling runs and no observer can turn a successful commit into a
+  registrar failure. A re-entrant winner remains authoritative while the outer
+  snapshot finishes. Returns the complete current slot snapshot."
   [{:keys [view-id publication-token]}]
   (let [[old-slots slots]
         (swap-vals! view-generations update view-id
@@ -604,8 +655,7 @@
                                 (:hmr-publication-token current-before))
         published (get slots view-id)]
     (when committed?
-      (doseq [listener (vals (:hmr-listeners published))]
-        (listener)))
+      (notify-view-listeners! view-id :commit published))
     published))
 
 (defn rollback-view-descriptor!
@@ -618,8 +668,10 @@
   candidate exposed a different hook shape, restoration advances remount
   generation again. A failed first registration becomes an unavailable
   tombstone at a fresh revision. Listener subscriptions made in flight are
-  retained. Returns true only when this publication performed the compensation;
-  a stale publication returns false."
+  retained. Compensation notification uses the same snapshotted, per-listener
+  containment as commit, so observer failures cannot replace the primary
+  registrar failure or starve siblings. Returns true only when this publication
+  performed the compensation; a stale publication returns false."
   [{:keys [view-id publication-token before]}]
   (let [[old-slots slots]
         (swap-vals!
@@ -653,8 +705,7 @@
                                   (:hmr-publication-token current-before))
         restored (get slots view-id)]
     (when rolled-back?
-      (doseq [listener (vals (:hmr-listeners restored))]
-        (listener)))
+      (notify-view-listeners! view-id :rollback restored))
     rolled-back?))
 
 (defn register-view-descriptor!
@@ -1261,7 +1312,7 @@
                    (error/ex-message-safe error))))
      :clj nil))
 
-(defn- enrol-dirty!
+(defn- enrol-dirty-window!
   "The PRODUCTION scheduling core — ONE linearizable pending-window enrolment
   transition (rf2-vxgfnd.180). In a SINGLE `swap-vals!` on the cell state,
   perform the `:dirty?` false→true flip and — in DEV/tool builds only — fold the
@@ -1282,8 +1333,7 @@
   enrolment from that swap's own false→true edge, makes a concurrent mark
   linearize cleanly EITHER before completion's capture (its evidence joins the
   captured window) OR after its clear (a fresh next window is enrolled)."
-  ([^ViewCell cell] (enrol-dirty! cell nil))
-  ([^ViewCell cell payload]
+  [^ViewCell cell payload]
    ;; `interop/debug-enabled?` is a STANDALONE top-level gate (not folded into the
    ;; swap-fn body as `(and interop/debug-enabled? payload)`) so Closure DCEs the
    ;; evidence-folding swap-fn — and every reference it carries into `fold-evidence`
@@ -1291,15 +1341,26 @@
    ;; bundle, exactly as the prod-elision gate proves. Both arms are ONE
    ;; `swap-vals!`, so the evidence fold and the `:dirty?` false→true flip stay a
    ;; single atomic transition on each host (rf2-vxgfnd.180).
-   (let [st (state cell)
-         [old _] (if interop/debug-enabled?
-                   (swap-vals! st (fn [s]
-                                    (cond-> (assoc s :dirty? true)
-                                      payload (update :evidence fold-evidence payload))))
-                   (swap-vals! st (fn [s] (assoc s :dirty? true))))]
-     (when-not (:dirty? old)
-       (swap! dirty-cells conj cell)
-       (schedule-flush!)))))
+  (let [st (state cell)
+        [old _] (if interop/debug-enabled?
+                  (swap-vals! st (fn [s]
+                                   (cond-> (assoc s :dirty? true)
+                                     payload (update :evidence fold-evidence payload))))
+                  (swap-vals! st (fn [s] (assoc s :dirty? true))))]
+    (when-not (:dirty? old)
+      (swap! dirty-cells conj cell)
+      (schedule-flush!))))
+
+(defn- enrol-dirty!
+  "Enrol one pending window. On the JVM, serialize the cell dirty edge and
+  registry insertion with `reset-scheduler!`'s detach-and-clear transition, so
+  a racing mark linearizes wholly before reset or becomes a fresh post-reset
+  enrolment. CLJS is single-threaded and pays no locking path."
+  ([^ViewCell cell] (enrol-dirty! cell nil))
+  ([^ViewCell cell payload]
+   #?(:clj  (locking dirty-cells
+              (enrol-dirty-window! cell payload))
+      :cljs (enrol-dirty-window! cell payload))))
 
 (defn mark-dirty!
   "The `on-change` body / test seam: enrol `cell` for a coalesced flush
@@ -1636,10 +1697,18 @@
   @last-sink-escape)
 
 (defn reset-scheduler!
-  "Test support: drop every pending notification and the slice memo without
-  advancing any revision — a clean slate between fixtures. Returns nil."
+  "Test support: detach every pending cell, clear its dirty/evidence window,
+  and reset scheduler/tool registries without advancing a revision or notifying
+  a listener — a clean slate between fixtures. A concurrent JVM mark linearizes
+  before the detach (and is cleared) or after it (and remains freshly enrolled).
+  Returns nil."
   []
-  (reset! dirty-cells #{})
+  (letfn [(detach-and-clear! []
+            (let [[detached _] (swap-vals! dirty-cells (constantly #{}))]
+              (doseq [cell detached]
+                (swap! (state cell) assoc :dirty? false :evidence nil))))]
+    #?(:clj  (locking dirty-cells (detach-and-clear!))
+       :cljs (detach-and-clear!)))
   (reset! flush-scheduled? false)
   (reset! slice-memo* nil)
   (reset! live-cells #{})
@@ -2233,9 +2302,9 @@
 ;; for it would fabricate a proof the runtime never observed. So `disconnect!`
 ;; marks each cleanup PROVISIONAL and `settle-disconnect!` (a microtask on CLJS)
 ;; clears it once the disconnect outlives its commit; only a disconnect that
-;; survived a host yield can then be proven a hide. DEV-only — production has no
-;; StrictMode double-invoke, so `:disconnect-provisional?` is never set and a
-;; reveal is proven exactly as before.
+;; survived a host yield can then be proven a hide. The field, lookup, settle,
+;; and reconnect branch are DEV-only; production has no StrictMode double-invoke
+;; and takes the ordinary reconnect-proof path directly.
 
 (defn lifecycle
   "The cell's current runtime state keyword."
@@ -2567,9 +2636,10 @@
   settled. A headless/JVM fixture calls this explicitly to model the host yield
   of a real reveal. Returns nil."
   [^ViewCell cell]
-  (let [st (state cell)]
-    (when (= :disconnected (:lifecycle @st))
-      (swap! st assoc :disconnect-provisional? false)))
+  (when interop/debug-enabled?
+    (let [st (state cell)]
+      (when (= :disconnected (:lifecycle @st))
+        (swap! st assoc :disconnect-provisional? false))))
   nil)
 
 (defn- arm-disconnect-settle!
@@ -2593,16 +2663,18 @@
   is a React StrictMode dev replay — the same cell's effect
   mount→cleanup→remount within ONE synchronous commit, where NO hide and NO
   unmount happened — so it is NOT annotated: the runtime must not fabricate an
-  Activity-hide proof it never observed (rf2-vxgfnd.44). In production
-  `:disconnect-provisional?` is never set (no StrictMode double-invoke), so a
-  reveal is proven exactly as before."
+  Activity-hide proof it never observed (rf2-vxgfnd.44). In production the
+  provisional field, lookup, and branch are elided (no StrictMode
+  double-invoke), so a reveal takes the reconnect-proof path directly."
   [^ViewCell cell]
   (let [st @(state cell)]
     (when (= :disconnected (:lifecycle st))
-      (if (:disconnect-provisional? st)
-        ;; same-tick StrictMode replay — the disconnect never settled; clear the
-        ;; provisional flag and DO NOT fabricate an Activity-hide proof.
-        (swap! (state cell) assoc :disconnect-provisional? false)
+      (if interop/debug-enabled?
+        (if (:disconnect-provisional? st)
+          ;; same-tick StrictMode replay — the disconnect never settled; clear
+          ;; the provisional flag and DO NOT fabricate an Activity-hide proof.
+          (swap! (state cell) assoc :disconnect-provisional? false)
+          (annotate-open-disconnect! cell :activity-hidden :reconnect))
         (annotate-open-disconnect! cell :activity-hidden :reconnect)))
     (swap! (state cell) assoc :lifecycle :connected)
     ;; Enrol in the live-cell registry (idempotent — a set) so a frame-destroy

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -97,7 +97,10 @@
   registrar success. A registrar throw compensates monotonically: the prior
   descriptor (or an unavailable first-load tombstone) is republished at a fresh
   revision and mounted shells are notified once, so no provisional render can
-  commit or strand a cell on a revision that moved backwards."
+  commit or strand a cell on a revision that moved backwards. Publication
+  listener failures are contained by the reactive authority after every
+  snapshotted sibling runs; because commit is outside the registrar catch, an
+  observer can never masquerade as registrar failure or trigger rollback."
   [id render-fn compare-fn display-name manifest]
   (let [{:keys [outer inner]}
         (reactive/ensure-view-shells! id #(make-view-shells id))
@@ -120,8 +123,6 @@
                   :rf.ui/compiled? true
                   :rf.ui/manifest manifest}
            (:doc manifest) (assoc :doc (:doc manifest))))
-        (reactive/commit-view-descriptor! publication)
-        outer
         (catch :default e
           ;; A registrar hook may have synchronously published a newer winner.
           ;; Restore diagnostic names only when this transaction also restored
@@ -129,7 +130,9 @@
           (when (reactive/rollback-view-descriptor! publication)
             (set! (.-displayName inner) old-inner-name)
             (set! (.-displayName outer) old-outer-name))
-          (throw e))))))
+          (throw e)))
+      (reactive/commit-view-descriptor! publication)
+      outer)))
 
 ;; ---------------------------------------------------------------------------
 ;; Dispatch — the S1 seam

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -8,7 +8,8 @@
   No DOM: renderToStaticMarkup exercises the render path; handler fns are
   plucked from the element tree and invoked with fake events against the
   S1 dispatch hook."
-  (:require [clojure.test :refer [deftest is use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is use-fixtures]]
             ["react-dom/server" :as rds]
             [re-frame.registrar :as registrar]
             [re-frame.ui :as ui :refer [defview]]
@@ -18,6 +19,28 @@
 (defn- render [el] (rds/renderToStaticMarkup el))
 (defn- current-render [id] (:render-fn (reactive/view-descriptor id)))
 (defn- current-compare [id] (:compare-fn (reactive/view-descriptor id)))
+
+(defn- with-captured-console-warn
+  [thunk]
+  (let [prior (.-warn js/console)
+        calls (atom [])]
+    (set! (.-warn js/console)
+          (fn [& args] (swap! calls conj (mapv str args))))
+    (try
+      {:value (thunk) :warnings @calls}
+      (finally
+        (set! (.-warn js/console) prior)))))
+
+(defn- register-hmr-version!
+  [id version hook-signature display-name]
+  (rt/register-view!
+   id
+   (fn [_props] version)
+   (fn [_prev _next] true)
+   display-name
+   {:view-id id
+    :hook-signature hook-signature
+    :version version}))
 
 (defonce dispatches (atom []))
 
@@ -449,6 +472,136 @@
       (is (identical? cmp2 (:compare-fn descriptor)))
       (is (= "hs1-b" (get-in descriptor [:manifest :hook-signature]))
           "listener observes descriptor and both revisions from one publication"))))
+
+(deftest hmr-publication-listener-failure-never-starves-siblings-or-rolls-back-commit
+  ;; rf2-vxgfnd.215 — drive a throw before, between, and after the two good
+  ;; listeners. A bare doseq aborts at the throw, skips whichever siblings
+  ;; follow it, and runtime/register-view! then falsely treats the committed
+  ;; publication as registrar failure.
+  (doseq [order [[:throw :a :b] [:a :throw :b] [:a :b :throw]]]
+    (let [label   (name (first order))
+          id      (keyword "hmr-listener-order" (str (hash order)))
+          shell   (register-hmr-version! id 0 "hs-order" (str "Order-" label))
+          seen    (atom [])
+          stops   (mapv (fn [entry]
+                          (reactive/subscribe-view!
+                           id
+                           (case entry
+                             :throw #(throw (js/Error. (str "boom-" label)))
+                             :a     #(swap! seen conj :a)
+                             :b     #(swap! seen conj :b))))
+                        order)
+          {:keys [value warnings]}
+          (with-captured-console-warn
+            #(register-hmr-version! id 1 "hs-order" (str "Order-" label)))]
+      (doseq [stop stops] (stop))
+      (is (identical? shell value)
+          "a post-commit listener failure is not reported as registration failure")
+      (is (= [:a :b] @seen) "both good siblings run exactly once in every ordering")
+      (is (= 1 (reactive/view-generation id)))
+      (is (= 0 (reactive/view-remount-generation id)))
+      (is (= 1 (get-in (reactive/view-descriptor id) [:manifest :version])))
+      (is (identical? shell (registrar/handler :view id))
+          "registrar and descriptor authority remain committed and coherent")
+      (is (= 1 (count warnings)) "one bounded warning reports the publication failure")
+      (let [warning (str/join " " (first warnings))]
+        (is (str/includes? warning (pr-str id)) "warning names the view")
+        (is (str/includes? warning "commit") "warning names the publication phase")
+        (is (str/includes? warning "revision 1") "warning names the committed revision")))))
+
+(deftest hmr-publication-detects-falsy-thrown-values-by-presence
+  ;; JS permits `throw false` and `throw null`. First-failure selection must
+  ;; carry an explicit presence bit; `or`, `some?`, and truthiness all lose one
+  ;; of these values and can silently report a later error instead.
+  (doseq [[label thrown-value expected] [[:false false "false"] [:null nil "nil"]]]
+    (let [id    (keyword "hmr-falsy-listener" (name label))
+          _     (register-hmr-version! id 0 "hs-falsy" (str "Falsy-" (name label)))
+          seen  (atom 0)
+          stop1 (reactive/subscribe-view! id #(throw thrown-value))
+          stop2 (reactive/subscribe-view! id #(throw (js/Error. "secondary")))
+          stop3 (reactive/subscribe-view! id #(swap! seen inc))
+          {:keys [warnings]}
+          (with-captured-console-warn
+            #(register-hmr-version! id 1 "hs-falsy" (str "Falsy-" (name label))))]
+      (stop1) (stop2) (stop3)
+      (is (= 1 @seen) "a falsy throw cannot starve a later sibling")
+      (is (= 1 (count warnings)))
+      (is (str/includes? (str/join " " (first warnings)) expected)
+          "the first falsy thrown value, not the secondary error, is reported"))))
+
+(deftest hmr-publication-listener-set-is-snapshotted-before-delivery
+  (let [id      ::listener-snapshot
+        _       (reactive/register-view-descriptor! id "hs-snapshot" {:version 0})
+        seen    (atom [])
+        changed (atom false)
+        stop-b  (volatile! nil)
+        stop-c  (volatile! nil)
+        stop-a  (reactive/subscribe-view!
+                 id
+                 (fn []
+                   (swap! seen conj :a)
+                   (when (compare-and-set! changed false true)
+                     (@stop-b)
+                     (vreset! stop-c
+                              (reactive/subscribe-view! id #(swap! seen conj :c))))))]
+    (vreset! stop-b (reactive/subscribe-view! id #(swap! seen conj :b)))
+    (reactive/register-view-descriptor! id "hs-snapshot" {:version 1})
+    (is (= [:a :b] @seen)
+        "unsubscribe/subscribe during fan-out affects only the next publication")
+    (reactive/register-view-descriptor! id "hs-snapshot" {:version 2})
+    (is (= [:a :b :a :c] @seen))
+    (stop-a)
+    (when @stop-c (@stop-c))))
+
+(deftest reentrant-hmr-publication-owns-its-snapshot-and-newer-revision
+  (let [id     ::reentrant-listener-publication
+        _      (reactive/register-view-descriptor! id "hs-reentrant" {:version 0})
+        seen   (atom [])
+        nested (atom false)
+        stop-a (reactive/subscribe-view!
+                id
+                (fn []
+                  (let [version (:version (reactive/view-descriptor id))]
+                    (swap! seen conj [:a version])
+                    (when (and (= 1 version) (compare-and-set! nested false true))
+                      (reactive/register-view-descriptor!
+                       id "hs-reentrant" {:version 2})))))
+        stop-b (reactive/subscribe-view!
+                id #(swap! seen conj [:b (:version (reactive/view-descriptor id))]))]
+    (reactive/register-view-descriptor! id "hs-reentrant" {:version 1})
+    (stop-a) (stop-b)
+    (is (= [[:a 1] [:a 2] [:b 2] [:b 2]] @seen)
+        "nested publication completes its own snapshot before the outer resumes")
+    (is (= 2 (:version (reactive/view-descriptor id)))
+        "the outer transaction never rolls back the nested winner")
+    (is (= 2 (reactive/view-generation id)))))
+
+(deftest rollback-listener-failure-preserves-primary-and-completes-compensation
+  (let [id       ::rollback-listener-failure
+        shell    (register-hmr-version! id 0 "hs-rb-a" "RollbackListenerV1")
+        primary  (js/Error. "registrar primary")
+        seen     (atom 0)
+        stop-bad (reactive/subscribe-view! id #(throw (js/Error. "rollback listener")))
+        stop-ok  (reactive/subscribe-view! id #(swap! seen inc))
+        {:keys [value warnings]}
+        (with-captured-console-warn
+          #(try
+             (with-redefs [registrar/register! (fn [& _] (throw primary))]
+               (register-hmr-version! id 1 "hs-rb-b" "RollbackListenerV2"))
+             ::unexpected-success
+             (catch :default e e)))]
+    (stop-bad) (stop-ok)
+    (is (identical? primary value)
+        "a rollback listener failure cannot mask the registrar's primary failure")
+    (is (= 1 @seen) "compensation still reaches the good sibling")
+    (is (= 2 (reactive/view-generation id)) "rollback is a fresh monotone publication")
+    (is (= 2 (reactive/view-remount-generation id)))
+    (is (= 0 (get-in (reactive/view-descriptor id) [:manifest :version])))
+    (is (identical? shell (registrar/handler :view id)))
+    (is (= "RollbackListenerV1" (.-displayName shell))
+        "the primary registrar failure still restores the prior diagnostic name")
+    (is (= 1 (count warnings)))
+    (is (str/includes? (str/join " " (first warnings)) "rollback"))))
 
 (deftest failed-first-registration-publishes-unavailable-compensation
   (let [id ::failed-publication

--- a/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_epoch_cljs_test.cljc
@@ -27,8 +27,10 @@
       finds the registry already drained and cannot double-advance (the
       safety the dev-tier `:rf.error/flush-in-open-epoch` signal, whose
       typed throw + Spec 009 catalogue row ride the S2f 009 batch, sits atop);
-    - DISCARD ON DISCONNECT/TEARDOWN — an unmounted cell leaves the registry
-      without a stale flush;
+    - DISCARD ON DISCONNECT/TEARDOWN/RESET — an unmounted cell leaves the
+      registry without a stale flush; the test-support reset also clears every
+      detached cell's dirty/evidence window, and a racing mark is coherently
+      pre-reset-cleared or post-reset-enrolled;
     - THE SLICE-SCOPED PROBE MEMO — `sub-read` threads one memo per slice, so
       sibling probes compute shared derivation parents once.
 
@@ -374,6 +376,86 @@
     (is (= :dead (reactive/lifecycle cell)))
     (is (= 0 (reactive/pending-cell-count)) "teardown drops the pending flush")))
 
+(deftest scheduler-reset-clears-detached-cell-state-and-opens-a-fresh-window
+  ;; rf2-vxgfnd.181 — clearing only the registry strands this cell: its dirty
+  ;; flag remains true, epoch 2 folds into epoch 1, and the false->true enrolment
+  ;; edge never happens. Reset owns the detached cells as well as the set.
+  (let [cell (reactive/make-cell ::reset-cell)
+        hits (atom 0)]
+    (reactive/subscribe cell (fn [] (swap! hits inc)))
+    (reactive/mark-dirty! cell 1)
+    (is (= 1 (reactive/pending-cell-count)))
+    (is (= {:first-epoch 1 :latest-epoch 1 :count 1}
+           (select-keys (reactive/pending-evidence cell)
+                        [:first-epoch :latest-epoch :count])))
+
+    (reactive/reset-scheduler!)
+    (is (false? (reactive/dirty? cell))
+        "every cell detached from the registry is clean")
+    (is (nil? (reactive/pending-evidence cell))
+        "the pre-reset evidence window is gone")
+    (is (= 0 (reactive/pending-cell-count)))
+    (is (= 0 (reactive/revision cell)) "reset never advances the revision")
+    (is (= 0 @hits) "reset never notifies")
+
+    (reactive/mark-dirty! cell 2)
+    (is (true? (reactive/dirty? cell)))
+    (is (= 1 (reactive/pending-cell-count))
+        "epoch 2 crosses a fresh false->true edge and re-enrols")
+    (is (= {:first-epoch 2 :latest-epoch 2 :count 1}
+           (select-keys (reactive/pending-evidence cell)
+                        [:first-epoch :latest-epoch :count]))
+        "evidence cannot span the fixture reset")
+    (is (= 1 (reactive/flush-pending!)))
+    (is (= 1 (reactive/revision cell)))
+    (is (= 1 @hits))))
+
+#?(:clj
+   (deftest reset-versus-mark-linearizes-to-a-post-reset-enrolment
+     ;; Deterministically pause reset AFTER it detaches the registry but BEFORE
+     ;; it clears the detached cell. The scheduler lock must keep the epoch-2
+     ;; mark outside that ownership window. Without the lock the mark returns
+     ;; while the cell is still dirty, skips enrolment, and reset erases it.
+     (let [cell       (reactive/make-cell ::reset-race)
+           hits       (atom 0)
+           detached   (java.util.concurrent.CountDownLatch. 1)
+           release    (java.util.concurrent.CountDownLatch. 1)
+           mark-start (java.util.concurrent.CountDownLatch. 1)
+           real-swap  swap-vals!]
+       (reactive/subscribe cell (fn [] (swap! hits inc)))
+       (reactive/mark-dirty! cell 1)
+       (with-redefs [clojure.core/swap-vals!
+                     (fn [a f & args]
+                       (let [result (apply real-swap a f args)]
+                         ;; The registry is the only set-valued atom touched by
+                         ;; reset. Pause after its atomic detach while reset
+                         ;; still owns the scheduler lock.
+                         (when (set? (first result))
+                           (.countDown detached)
+                           (.await release 5 java.util.concurrent.TimeUnit/SECONDS))
+                         result))]
+         (let [reset-f (future (reactive/reset-scheduler!))]
+           (is (.await detached 5 java.util.concurrent.TimeUnit/SECONDS)
+               "reset reached the deterministic detach boundary")
+           (let [mark-f (future
+                          (.countDown mark-start)
+                          (reactive/mark-dirty! cell 2))]
+             (is (.await mark-start 5 java.util.concurrent.TimeUnit/SECONDS))
+             (is (= ::blocked (deref mark-f 250 ::blocked))
+                 "a mark cannot enter the detached-but-not-cleared window")
+             (.countDown release)
+             (is (nil? (deref reset-f 5000 ::reset-timeout)))
+             (is (nil? (deref mark-f 5000 ::mark-timeout)))
+             (is (true? (reactive/dirty? cell)))
+             (is (= 1 (reactive/pending-cell-count))
+                 "the racing mark linearized after reset and is registered")
+             (is (= {:first-epoch 2 :latest-epoch 2 :count 1}
+                    (select-keys (reactive/pending-evidence cell)
+                                 [:first-epoch :latest-epoch :count])))
+             (is (= 1 (reactive/flush-pending!)))
+             (is (= 1 (reactive/revision cell)))
+             (is (= 1 @hits))))))))
+
 ;; ===========================================================================
 ;; The slice-scoped probe memo — sibling probes share derivation parents
 ;; ===========================================================================
@@ -507,7 +589,8 @@
 ;; and evidence stay independent — one dirty enrolment / one render, yet the
 ;; debug plane retains enough to attribute that render to its contributing
 ;; movement (first/latest epoch, a cause set, a capped target vector + a
-;; dropped-count) WITHOUT forcing a render per epoch.
+;; bounded `:dropped` set whose `:dropped-exact?` flag records saturation)
+;; WITHOUT forcing a render per epoch.
 
 (deftest n-invalidations-in-one-drain-preserve-bounded-evidence
   ;; N invalidations with DISTINCT epochs fold before one flush: ONE revision

--- a/implementation/ui/test/re_frame/ui/tool_evidence_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_elision_prod_test.cljs
@@ -11,7 +11,11 @@
 
   Behaviourally: in production the debug evidence plane does not exist, so
   the projection is inert — install is a refused no-op, nothing is owned,
-  nothing is retained, and a driven scheduler flush accrues no evidence.
+  nothing is retained, and a driven scheduler flush accrues no evidence. The
+  real ViewCell lifecycle is also rooted through connect → disconnect → settle
+  → reconnect: production takes the ordinary reconnect annotation directly,
+  while the companion bundle scan proves the provisional state/decision path
+  is absent rather than merely false at runtime.
 
   The normal DEBUG-build counterparts (tool-evidence-cljs-test /
   tool-evidence-dom-cljs-test) supply the positive controls: the same calls
@@ -46,3 +50,26 @@
       (is (= 1 (reactive/revision cell)) "…while scheduling works as ever")
       (is (= 1 @hits))
       (is (nil? (evidence/projection)) "and the projection retained nothing"))))
+
+(defn- commit-empty!
+  [cell]
+  (let [[_ capture] (reactive/with-capture cell (fn [] nil))]
+    (reactive/commit! cell capture)))
+
+(deftest advanced-production-viewcell-has-no-provisional-disconnect-machinery
+  (let [cell (reactive/make-cell ::prod-lifecycle)]
+    (commit-empty! cell)
+    (is (= :connected (reactive/lifecycle cell)))
+    (reactive/disconnect! cell)
+    (is (= {:state :disconnected :reason :unknown}
+           (peek (reactive/intervals cell))))
+    ;; Root the public test seam in this exact advanced bundle. Its DEBUG body
+    ;; must fold away with the provisional state keyword it would otherwise set.
+    (reactive/settle-disconnect! cell)
+    (commit-empty! cell)
+    (is (= :connected (reactive/lifecycle cell)))
+    (is (= {:state :disconnected
+            :reason :activity-hidden
+            :proof :reconnect}
+           (peek (reactive/intervals cell)))
+        "production reconnect follows the ordinary lifecycle path directly")))


### PR DESCRIPTION
## Summary

Closes `rf2-vxgfnd.165`, `rf2-vxgfnd.181`, and `rf2-vxgfnd.215` as one coupled reactive-runtime tail.

- DEV-gates the StrictMode provisional-disconnect field, settle body, lookup, and branch while keeping the ordinary production reconnect proof rooted.
- Makes scheduler reset detach and clean each pending ViewCell atomically with JVM mark enrolment, without advancing revisions or notifying listeners.
- Snapshots HMR publication listeners, contains each listener failure, reports only the first failure after every sibling runs, and narrows registrar rollback to actual registrar failures.
- Adds deterministic adversarial JVM/CLJS/HMR/advanced-elision coverage. No public API, compatibility path, or `spec/*` changes.

## Root cause

Three ownership boundaries were incomplete: provisional lifecycle state was initialized unconditionally, reset discarded only the dirty registry rather than the ViewCells it owned, and HMR listener fan-out ran as a bare `doseq` inside the registrar transaction catch. Those shapes respectively retained DEV machinery in production, stranded dirty/evidence state across reset, and let an observer throw falsify an already-committed publication (or mask rollback's primary registrar failure).

## Red → green evidence

- `rf2-vxgfnd.165`: before the fix, the advanced gate failed with `development site/HMR diagnostic survived advanced output: disconnect-provisional`; after the fix the scan and mounted production lifecycle fixture pass.
- `rf2-vxgfnd.181`: before the fix, the focused JVM namespace reported 14 failures (dirty/evidence survived reset, the fresh mark never re-enrolled/flushed, and the deterministic reset-vs-mark boundary did not linearize); after the fix it reports 20 tests / 187 assertions, all green.
- `rf2-vxgfnd.215`: before the fix, listener throws escaped, later siblings were starved, commit was misreported as registrar failure, falsy throws were lost, and rollback listener failure masked the primary. The adversarial CLJS cases now pass for throw-before/between/after, false/null, snapshot mutation, reentrancy, commit, and rollback.

## Quality gates

- `clojure -M:test` from `implementation/ui` — 563 tests, 8,172 assertions
- `clojure -M:test -n re-frame.ui.reactive-epoch-cljs-test` — 20 tests, 187 assertions
- `clojure -M:test -n re-frame.ui.reactive-hmr-matrix-cljs-test` — 13 tests, 55 assertions
- `clojure -M:test -n re-frame.ui.reactive-hmr-authority-fence-cljs-test` — 11 tests, 86 assertions
- `clojure -M:test -n re-frame.ui.reactive-reconcile-cljs-test` — 29 tests, 113 assertions
- `npm run test:ui` — adapter isolation PASS; 557 tests, 2,847 assertions
- `npm run test:browser-prod-elision` — bundle scan PASS; 89 browser tests, 328 assertions
- `clj-kondo --lint <changed UI files> --fail-level error` — 0 errors
- `node --check implementation/scripts/check-ui-mounted-prod-elision.cjs` — PASS
- changed-surface classifier for UI source/test paths — `cljs_prod=true`
- `git diff --check` — PASS
