### PR TITLE
docs(ui-guide): distinguish reg-view from defview compiler

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
+++ b/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
@@ -15,6 +15,10 @@ template at build time. Element vectors become direct element construction; `:cl
 every analyser and both emitters see through them. Subtrees the compiler can prove
 inert hoist to module constants and are built once, at load.
 
+Contrast the frozen stock-Reagent path: `reg-view` is registration and frame injection
+only — the body is not lowered — so it is not "the same compiler under another name".
+The migration map is [13 — From other worlds](13-from-other-worlds.md).
+
 This is also why the template grammar is closed. A dynamic tag head, an unkeyed list,
 a `sub` inside a loop, an unaudited macro in expression position — each would put
 something into your view the compiler cannot see through, and everything downstream

--- a/ai/findings/new-substrate-synthesis/guide/13-from-other-worlds.md
+++ b/ai/findings/new-substrate-synthesis/guide/13-from-other-worlds.md
@@ -41,6 +41,33 @@ use it when a habit from elsewhere misleads.
 
 Step 1 does **not** rewrite your views. Step 2 is this guide's programming model.
 
+### `reg-view` is not the same kind of thing as `defview`
+
+A common confusion if you already know re-frame2: **`reg-view` is not a template
+compiler.** It is a registration macro. It defs the symbol, derives a registry id,
+and injects frame-bound `dispatch` / `subscribe` as lexical locals (with source
+coordinates). The view body is spliced **verbatim** — no code-walking, no hiccup
+lowering. Under the frozen stock-Reagent tier, templates still go through Reagent at
+runtime; handlers are still ordinary closures.
+
+`defview` is different in kind: the template (and data handlers) are **compiled** —
+direct React in the browser, a structural tree on the JVM, closed grammar, ownership
+sites. That is why this guide can promise no interpreter on the hot path and the walls
+in [14](14-compile-time-limits.md). Migrating views is step 2 for that reason — not a
+rename of `reg-view`.
+
+What that means while you still sit on the Reagent tier:
+
+- Hiccup stays interpreted; event vectors as handlers, `local` / `effect` / `lease` /
+  `presence`, and dual-host emission are **not** products of `reg-view`.
+- Form-3 / `create-class` cannot use the app-facing `reg-view` lane — they register
+  through `reg-view*` (no auto-inject; capture the frame yourself).
+- The bulk rewrite table below is step 2: Form-1 bodies become `defview`, not
+  "smarter `reg-view`".
+
+Mechanism for the new path: [12](12-how-it-works.md). Full migration tiers: the
+synthesis suite's migration note one directory up.
+
 ### Mechanical rewrites (the bulk)
 
 | Reagent | Here |

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -53,7 +53,9 @@ Chapters 08–14 are depth: open them when you need them. Chapter 14 is the
 
 **Coming from Reagent?** Hiccup mostly transfers. The big habit change is **events as
 vectors** and **`(sub …)` without deref** — read [04](04-events.md) carefully, then
-[13](13-from-other-worlds.md).
+[13](13-from-other-worlds.md). Do not equate re-frame2's `reg-view` with this library's
+compiler: `reg-view` registers and injects frame locals; `defview` lowers templates —
+[13 §From Reagent](13-from-other-worlds.md) spells out the difference.
 
 **Coming from React / UIx / Helix?** You will not write hooks, deps arrays, or
 `memo` wrappers in ordinary views. Start at [01](01-getting-started.md), then use


### PR DESCRIPTION
## Summary

- Clarifies a common misread: re-frame2 `reg-view` is registration + frame injection, not a template compiler; `defview` is the first real view compiler in this stack.
- Primary home: guide chapter 13 (From Reagent), with short pointers from the guide README and chapter 12 (How it works).

## Why

Readers who already know re-frame2 hear "compiler" and map it onto `reg-view`. That confuses migration (step 2 is not a rename) and undercuts why this guide can promise no interpreter, dual-host emission, and a closed grammar.

## Test plan

- [ ] Read the three edited pages as a Reagent arriver: README → 13 → 12
- [ ] Confirm no new chapter and no main-track (01–07) digression
- [ ] Confirm tracked synthesis guide paths only (force-tracked `ai/findings/new-substrate-synthesis/`)