### PR TITLE
docs(ui): align expression and test-root contracts

### DIFF
--- a/ai/findings/new-substrate-synthesis/02-programming-model.md
+++ b/ai/findings/new-substrate-synthesis/02-programming-model.md
@@ -71,12 +71,14 @@ markup-returning `map`; keywords in child position; raw lazy seqs; unkeyed list 
 expressions hold ordinary Clojure *values* — value-opaque with respect to
 DOM/template interpretation — but their lexical *syntax* is audited for finite reactive
 ownership (every `sub`/`lease` is a compile-indexed site; sub-free views elide their
-ViewCell in production). The compiler accepts special/binder forms (`quote`, `fn`,
-`let`/`loop`/`letfn`, `try` — no reactive calls or unaudited macros in binding
-patterns/`:or` defaults), the audited transparent core macro set (`or` `and` `when`
-`when-not` `cond` `->` `->>` `some->` `some->>` `cond->` `cond->>`; a bare `sub`/`lease`
-reference below one is rejected), and ordinary function calls. **Every other macro —
-core or user — is rejected** (`:rf.ui.compile/unsupported-form`) because an unaudited
+ViewCell in production). The compiler accepts the binder-aware structural tier (`quote`,
+`fn`/`fn*`, `let`/`let*`, `loop`/`loop*`, `letfn`/`letfn*`, `try` — no reactive calls or
+unaudited macros in binding patterns/`:or` defaults), the audited transparent core macro
+set (`or` `and` `when` `when-not` `cond` `->` `->>` `some->` `some->>` `cond->`
+`cond->>`; a bare `sub`/`lease` reference below one is rejected), and ordinary function
+calls plus the evaluated-only host specials `if`, `do`, `throw`, `.`, `new`, and `set!`.
+The first tier is not an exhaustive host-special inventory. **Every other macro — core
+or user — is rejected** (`:rf.ui.compile/unsupported-form`) because an unaudited
 expansion could inject, duplicate, or defer a reactive call the manifest never sees.
 Recovery: a supported core form, an ordinary function, pass reactive values in, or a
 `defview` boundary. No double macroexpansion, no runtime dynamic sites, no fallback.

--- a/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
+++ b/ai/findings/new-substrate-synthesis/drafts/root-identity-and-mount.md
@@ -364,10 +364,10 @@ server in sight (guide 01):
    `:initial-events` (07 §2); with none, structural rendering proceeds and any `sub`
    raises `:rf.error/no-frame-context` — honest, not defaulted.
 2. **A literal root form** — the same top-region root grammar `mount` takes,
-   tightened so the form mounts exactly **ONE** view (root identity is that view's
-   id). A form with zero or two-plus views fails at expansion with
+   tightened so the form mounts exactly **one internal view** (root identity is that
+   view's id). A form with zero or two-plus views fails at expansion with
    `:rf.ui.compile/bad-test-root` — the shipped `ui.test/render` asserts this (a
-   fragment of two views has no single identity; wrap bare markup in a `defview`).
+   fragment of two views has no single identity; wrap the composition in one `defview`).
    Then:
    - `{:props p}` is **rejected** (didactic: props live in the form);
    - the form's `frame-root` plans run preflight ENSURE against the test registrar,

--- a/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
@@ -117,7 +117,8 @@
         "numeric children canonicalize via the tree builders")))
 
 ;; ---------------------------------------------------------------------------
-;; Form 2 — a literal root form (the same grammar mount takes)
+;; Form 2 — mount's literal top-region syntax, tightened to one mounted internal view
+;; (:rf.ui.compile/bad-test-root; wrap a multi-view composition in one defview)
 ;; ---------------------------------------------------------------------------
 
 (deftest literal-root-form-renders

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -177,12 +177,13 @@ authored invocation** — the manifest would falsely declare a sub-free view, pr
 would elide its ViewCell, and the hidden read would go stale or escape ownership. The
 expression grammar is therefore **closed**:
 
-- **Special / binder forms**, handled structurally with binder-aware traversal:
+- **Binder-aware structural forms**, handled with position-aware traversal:
   `quote` (never traversed — quoted data is not executable), `fn`/`fn*`, `let`/`let*`,
   `loop`/`loop*`, `letfn`/`letfn*`, `try`. Binding patterns and destructuring `:or`
   defaults may contain neither reactive calls nor unaudited macros — those positions
   are consumed by the host compiler, not expression rewriting, so they cannot own a
-  lexical render site (hoist the read into the view body and bind its value).
+  lexical render site (hoist the read into the view body and bind its value). This is
+  the binder-aware tier, not an exhaustive inventory of host special forms.
 - **The audited transparent macro set** — position-aware `clojure.core` / `cljs.core`
   macros whose arguments are host-independent expression slots with no user-authored
   binders: `or`, `and`, `when`, `when-not`, `cond`, `->`, `->>`, `some->`, `some->>`,
@@ -191,9 +192,11 @@ expression grammar is therefore **closed**:
   indexed site. A **bare** `sub`/`lease` **reference** below one is rejected: a
   threading step such as `(-> query sub)` would become an unindexed reactive call only
   after expansion, so the explicit `(sub query)` call is required.
-- **Ordinary function calls** — any function. A **simple** symbol/keyword head (a
-  plain fn/special-form name, a keyword lookup op) is not itself an evaluated
-  expression, so it is preserved verbatim and the arguments are analyzed. A
+- **Ordinary function calls and evaluated-only host special forms.** Any function call
+  uses this arm; so do `if`, `do`, `throw`, and interop `.`, `new`, and `set!`. A
+  **simple** symbol/keyword head (a plain fn/special-form name, a keyword lookup op) is
+  not itself an evaluated expression, so it is preserved verbatim and the arguments
+  are analyzed. A
   **computed callee** — a seq/vector/map/set in head position, e.g.
   `((if (sub [:op]) inc dec) 1)` — IS evaluated (Clojure evaluates the callee before
   its arguments), so it is analyzed under the same rules **before** the arguments: a

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -624,8 +624,11 @@ deletion wave.
 | **Tier 3 — mounted** | a mounted root (`with-root`) | browser/jsdom CI | a native CSS selector string, verbatim | host interop (real listeners, `(.-value el)`) |
 
 **S1 core surface (Tier-1, `.cljc`):** `render` / `find` / `find-all` / `query` / `text`
-/ `attrs`. `render` accepts a view reference or a literal root form (the same
-grammar `mount` takes), per [004C-Roots-and-Mount.md](004C-Roots-and-Mount.md) §9.
+/ `attrs`. `render` accepts a view reference or a literal root form. The literal form
+uses the same top-region grammar `mount` takes, wrappers included, but Tier 1 tightens
+it to exactly one mounted internal view. Zero or two-plus views fail expansion with
+`:rf.ui.compile/bad-test-root`; wrap a multi-view composition in one `defview`. See
+[004C-Roots-and-Mount.md](004C-Roots-and-Mount.md) §9.
 `find`/`find-all` run the closed selector grammar over Tier-1 trees; `query` is the
 Tier-3 live-DOM counterpart (CSS). **Node reading is the ruled projection** — `attrs`
 merges attributes + events on elements and props on view-boundary nodes; `(:on-click


### PR DESCRIPTION
## Summary

- define Spec 004's closed expression grammar as a binder-aware structural tier plus the evaluated-only host-special arm already implemented by the ordinary-call fallback
- qualify Tier-1 `ui.test/render`: it shares mount's literal top-region syntax but requires exactly one mounted internal view
- align the active synthesis mirror, retained root draft, and focused test heading; no analyzer, runtime, API, mount, or cardinality behavior changes

## Bead ledger

- `rf2-vxgfnd.224` — Spec 004 and the active programming-model mirror now name the two special-form tiers. The computed-callee law is unchanged; there is no analyzer or test-behavior diff for this bead.
- `rf2-vxgfnd.140` — Spec 008, retained root draft §9, and the focused test heading now state the exact-one-view Tier-1 rule, `:rf.ui.compile/bad-test-root`, and the one-wrapper-`defview` remedy.

Head SHA: `4b2d02deb3284173b5039a7f87c62b2bc26fe486`
Rebased base SHA: `4c4bbad83b0feaa5a7aad21a13720921a11af261`

## Pre-fix semantic evidence

- Macroexpanding a Tier-1 literal fragment containing two registered views failed with `:rf.ui.compile/bad-test-root` and reported two mounted views.
- Resolving the same analyzed two-view top region with authored `{:root-id :page/multi}` succeeded as `{:root-id :page/multi, :provenance :authored}`.
- Rendering one wrapper `defview` succeeded with the wrapper view id and tree schema version 1.

This demonstrated prose drift, not a missing implementation rule.

## Validation

- `clojure -M:test -n re-frame.ui.test-render-jvm-test -n re-frame.ui.root-analysis-cljs-test` — 57 tests, 180 assertions
- `python scripts/check_readme_links.py --ci`
- `python scripts/check_doc_slugs.py`
- `python scripts/check_ui_root_lifecycle_drift.py --ci` — 16 anchors clean
- `python -m mkdocs build --strict`
- `git diff origin/main...HEAD --check`