### PR TITLE
ci: tighten UI throughput and synthesis gates

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -42,6 +42,7 @@ cljs_node_test=false
 ui_gates=false
 adapter_diagnostic=false
 cljs_browser=false
+examples_compile=false
 cljs_prod=false
 bundle_isolation=false
 reagent_slim_bundle=false
@@ -54,6 +55,7 @@ story_xray_browser=false
 tenant_switcher_smoke=false
 skills_structural=false
 playground=false
+synthesis_docs=false
 
 mark_all() {
   implementation_jvm=true
@@ -61,6 +63,7 @@ mark_all() {
   ui_gates=true
   adapter_diagnostic=true
   cljs_browser=true
+  examples_compile=true
   cljs_prod=true
   bundle_isolation=true
   reagent_slim_bundle=true
@@ -73,6 +76,7 @@ mark_all() {
   tenant_switcher_smoke=true
   skills_structural=true
   playground=true
+  synthesis_docs=true
 }
 
 # rf2-k9ekz — predicate: does `$1` look like a Story/Xray runtime
@@ -129,6 +133,33 @@ if [ "$files" = "__ALL__" ]; then
 else
   while IFS= read -r file; do
     [ -z "$file" ] && continue
+
+    # rf2-gzavkm — compile every standalone example build only when the
+    # changed surface can alter one of those builds. This is deliberately
+    # separate from `cljs_browser`: core still gets its focused browser/node/
+    # production gates at PR time, while the full example-build sweep moves
+    # to the nightly safety net for core-only changes. Story/Xray and
+    # machines-viz remain here because example builds load the Xray preload
+    # and Story hosts, whose compiled closure includes machines-viz.
+    case "$file" in
+      examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/ui/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
+        examples_compile=true
+        ;;
+      tools/story/src/*|tools/story/testbeds/*|tools/story/deps.edn|tools/xray/src/*|tools/xray/testbeds/*|tools/xray/deps.edn|tools/machines-viz/src/*|tools/machines-viz/deps.edn)
+        examples_compile=true
+        ;;
+    esac
+
+    # rf2-vxgfnd.135 — tracked, authoritative pre-publication UI guide
+    # material gets a narrow gate without classifying unrelated ai/ scratch
+    # or pulling the guide into MkDocs before S6. The checker and focused JVM
+    # fixture arm their own job so a gate edit cannot avoid its proof.
+    case "$file" in
+      ai/findings/new-substrate-synthesis/guide/*|ai/findings/new-substrate-synthesis/drafts/*|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj)
+        synthesis_docs=true
+        ;;
+    esac
+
     case "$file" in
       .github/workflows/test.yml|.github/workflows/expensive-tests.yml|.github/scripts/report-changed-surfaces.sh|TESTING.md)
         mark_all
@@ -938,6 +969,7 @@ emit cljs_node_test "$cljs_node_test"
 emit ui_gates "$ui_gates"
 emit adapter_diagnostic "$adapter_diagnostic"
 emit cljs_browser "$cljs_browser"
+emit examples_compile "$examples_compile"
 emit cljs_prod "$cljs_prod"
 emit bundle_isolation "$bundle_isolation"
 emit reagent_slim_bundle "$reagent_slim_bundle"
@@ -950,3 +982,4 @@ emit story_xray_browser "$story_xray_browser"
 emit tenant_switcher_smoke "$tenant_switcher_smoke"
 emit skills_structural "$skills_structural"
 emit playground "$playground"
+emit synthesis_docs "$synthesis_docs"

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -64,6 +64,12 @@ jobs:
       - name: npm install
         run: npm ci
 
+      # rf2-gzavkm — core-only PRs no longer queue the all-examples compile.
+      # Keep that transitive safety net unconditional in the nightly/manual
+      # full sweep, before the browser download so compile failures stay cheap.
+      - name: Compile every standalone example build (nightly coverage net)
+        run: npm run test:examples-compile
+
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
       ui_gates: ${{ steps.detect.outputs.ui_gates }}
       adapter_diagnostic: ${{ steps.detect.outputs.adapter_diagnostic }}
       cljs_browser: ${{ steps.detect.outputs.cljs_browser }}
+      examples_compile: ${{ steps.detect.outputs.examples_compile }}
       cljs_prod: ${{ steps.detect.outputs.cljs_prod }}
       bundle_isolation: ${{ steps.detect.outputs.bundle_isolation }}
       reagent_slim_bundle: ${{ steps.detect.outputs.reagent_slim_bundle }}
@@ -79,6 +80,7 @@ jobs:
       tenant_switcher_smoke: ${{ steps.detect.outputs.tenant_switcher_smoke }}
       skills_structural: ${{ steps.detect.outputs.skills_structural }}
       playground: ${{ steps.detect.outputs.playground }}
+      synthesis_docs: ${{ steps.detect.outputs.synthesis_docs }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -504,6 +506,63 @@ jobs:
 
       - name: Validate README inventories (layout-map <-> disk + count claims)
         run: python scripts/check_readme_inventories.py --verbose
+
+  # rf2-vxgfnd.135 — the pre-publication re-frame.ui synthesis guide is
+  # tracked and authoritative, but intentionally does not enter MkDocs until
+  # S6. Give exactly guide/** + active drafts/** their own link/anchor pass,
+  # then run the existing focused guide-truth fixture. This job is separate
+  # from docs.yml so publication/navigation remain unchanged.
+  synthesis-docs:
+    name: re-frame.ui synthesis guide (links + focused truth)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.synthesis_docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Markdown slugifier
+        run: pip install -r requirements.txt
+
+      - name: Self-test the synthesis link/anchor scope
+        run: python scripts/check_doc_slugs.py --self-test --verbose
+
+      - name: Validate and enumerate tracked synthesis guide/drafts
+        run: python scripts/check_doc_slugs.py --synthesis-only --verbose
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-ui-guide-${{ hashFiles('implementation/ui/deps.edn', 'implementation/core/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-ui-
+            ${{ runner.os }}-clj-
+
+      - name: Run focused guide truth fixture (including Guide 09)
+        working-directory: implementation/ui
+        run: clojure -M:test -n re-frame.ui.guide-truth-jvm-test
 
   jvm-core:
     name: JVM core (clojure -M:test)
@@ -1587,6 +1646,12 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -1767,16 +1832,15 @@ jobs:
   # coverage guarantee (the example builds are still compiled + warning-
   # checked in CI on the same surface).
   #
-  # SURFACE GATING. Fires on the SAME `cljs_browser` surface the inline
-  # step did — report-changed-surfaces.sh sets cljs_browser=true for a
-  # generic examples/** source edit (the regression source) AND for a
-  # shadow-cljs.edn build-decl change (a newly-declared example build) AND
-  # for every implementation code surface. No new surface output is needed:
-  # the coverage condition is unchanged, only the host job moved.
+  # SURFACE GATING (rf2-gzavkm). Fires on the dedicated `examples_compile`
+  # surface: examples, build config, adapters/UI, feature artefacts, and the
+  # Story/Xray closure compiled into examples. Core-only changes keep their
+  # focused PR gates and rely on the unconditional nightly example compile;
+  # they no longer queue this perennial long-tail job on every PR.
   cljs-examples-compile:
     name: CLJS (compile every standalone example build, coverage gate)
     needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.cljs_browser == 'true'
+    if: needs.detect_changed_surfaces.outputs.examples_compile == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -3624,6 +3688,7 @@ jobs:
       - verify-version-lockstep
       - verify-skill-mcp-drift
       - verify-readme-links
+      - synthesis-docs
       - jvm-core
       - jvm-ui
       - cljs-ui-g1

--- a/TESTING.md
+++ b/TESTING.md
@@ -16,6 +16,7 @@ This table is also the command catalogue: each kind names the command that runs 
 | **JVM unit** — per-artefact `clojure -M:test` | fast | CLJC logic + pure helpers per artefact; the adapter probes double as classpath/deps wiring checks. |
 | **Security tier** — `test:security` (also rides `test:cljs`) | fast | Adversarial-property nets on redaction / escaping / egress boundaries: hostile-input corpus + generated shapes, each verified to go RED if the protection is reverted. |
 | **Lockstep + drift** — fast-pr spine | fast | Version drift between coordinated artefacts; skill / MCP-server schema drift. |
+| **Tracked synthesis guide** — `python scripts/check_doc_slugs.py --synthesis-only --verbose` + focused `re-frame.ui.guide-truth-jvm-test` | fast | Enumerates and validates links/anchors in the pre-publication `re-frame.ui` guide + active drafts, then pins the ruled guide claims (including Guide 09) without publishing them through MkDocs before S6. |
 | **JS harness self-tests** — `test:script-policy`, `test:script-helpers` | fast | The Node-side plumbing that runs everything else. |
 | **Skills structural** — `skills-structural` job | fast | Skill manifests + shared content stay valid against the schema. |
 | **Browser unit** — `test:browser` | medium | DOM-dependent tests only (`*_dom_cljs_test.cljs`): real React mounts, context tier, browser-only runtime features. |
@@ -59,7 +60,7 @@ The classifier maps "what files changed" → "which expensive jobs fire." The fu
 
 1. **Agent pre-checkin** — `scripts/test-fast-pr.sh` plus the surface-specific commands for the files touched (find them in the Kinds table).
 2. **PR CI** — `.github/workflows/test.yml`. Always: lockstep + skill/MCP drift, core JVM, CLJS node integration, JS harness self-tests, docs link validation on docs PRs. Expensive jobs fire only on their changed surface, and browser gates run their smoke tiers.
-3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/bundle matrix, full Story/Xray sweeps, template smoke, live MCP conformance.
+3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/bundle matrix, unconditional all-examples compile, full Story/Xray sweeps, template smoke, live MCP conformance.
 4. **Release** — `.github/workflows/release.yml` plus the latest green expensive run on the release candidate.
 
 **The Story/Xray two-tier split.** The `story-xray-browser` PR job runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`; the full sweep runs nightly. The dominant cost is testbed compilation, so both tiers share a keyed shadow-cljs compile cache that any source change busts. When adding an Xray scenario, tag it `smoke: true` (in `tools/xray/testbeds/feature_matrix/scenarios.cjs`) only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
@@ -96,6 +97,7 @@ The classifier is the **source of truth for "which jobs run when"** on a PR: the
 | `adapter_diagnostic` | an adapter artefact changes | the skip-ok classpath probes |
 | `cljs_node_test` | anything compiled into `:node-test` changes (core, adapters, feature artefacts, conformance fixtures, build config + scripts, story/xray src+test CLJS, machines-viz) | the consolidated `cljs` job |
 | `cljs_browser` | a `:browser-test`-covered surface changes (incl. machines-viz DOM suites) | the Playwright `cljs-browser` job |
+| `examples_compile` | a surface that can change a standalone example build changes: `examples/**`, build config, adapters, UI/feature artefacts, Story/Xray/machines-viz, or the checker itself; core-only changes use the unconditional nightly net | `cljs-examples-compile` |
 | `cljs_prod` | a release-probe-covered surface changes (including `implementation/ui/**`) | the prod-elision / schemas-boundary probes |
 | `bundle_isolation` | a bundle-boundary surface changes (adapters, `implementation/ui/**`, build scripts, probe examples, package metadata) | `bundle-isolation` |
 | `reagent_slim_bundle` | the Slim adapter, its example, or its check script changes | `reagent-slim-bundle-isolation` |
@@ -108,6 +110,7 @@ The classifier is the **source of truth for "which jobs run when"** on a PR: the
 | `tenant_switcher_smoke` | `testbeds/tenant_switcher/**` or `implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs` change | the `tenant-switcher-testbed-smoke` browser job |
 | `skills_structural` | `skills/re-frame2-pair/*`, `skills/re-frame2-setup/*`, or `skills/shared/*` change | `skills-structural` |
 | `playground` | the playground tool, a committed playground bundle, or `implementation/machines/*` changes (the SCI bundle bakes the machines artefact in) | `tools-playground` |
+| `synthesis_docs` | tracked `ai/findings/new-substrate-synthesis/{guide,drafts}/**`, the synthesis link checker, or its focused guide-truth fixture changes; unrelated `ai/` scratch is excluded | `synthesis-docs` — enumerated links/anchors + focused Guide 09 truth fixture |
 
 **Blast radius**: a change to either workflow file, the classifier script, or `TESTING.md` sets every output `true` — anything that re-tiers the matrix must re-run the matrix. `implementation/core/*` fans out to almost everything (core regressions can break every downstream invariant), deliberately excepting the two Playwright gates noted above.
 

--- a/ai/findings/new-substrate-synthesis/drafts/ui-test-selector-grammar.md
+++ b/ai/findings/new-substrate-synthesis/drafts/ui-test-selector-grammar.md
@@ -7,7 +7,7 @@
 > earlier direct-keyword-lookup promise is removed; view-id selectors match the tree's
 > view-boundary node (OPEN-1 resolved). The one page for the `ui.test/find`/`query`
 > selector language, required before Stage 1. Contract context:
-> [07-testing §2](../07-testing.md), [guide/09-testing.md](../guide/09-testing.md).
+> [07-testing §2](../07-testing.md), [guide/08-testing.md](../guide/08-testing.md).
 > Demand bar per [08-delivery §3](../08-delivery.md): every form below names its
 > consumer; no speculative combinators.
 

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -528,6 +528,117 @@ test('implementation/package.json still arms cljs_node_test (regression — it d
   assert.equal(result.cljs_node_test, 'true');
 });
 
+// rf2-gzavkm — the standalone example-build compiler is intentionally NOT
+// coupled to the broad browser surface. Core changes keep their ordinary
+// browser proofs but defer the expensive all-examples compile to the nightly
+// safety net; surfaces that can directly change an example build still run it
+// at PR time.
+test('example compilation has a dedicated changed-surface output (rf2-gzavkm)', () => {
+  const directSurfaces = [
+    'examples/core/counter/core.cljs',
+    'implementation/shadow-cljs.edn',
+    'implementation/package.json',
+    'implementation/package-lock.json',
+    'implementation/deps.edn',
+    'implementation/adapters/uix/src/re_frame/adapter/uix.cljs',
+    'implementation/ui/src/re_frame/ui/rules.cljc',
+    'implementation/epoch/src/re_frame/epoch.cljc',
+    'implementation/schemas/src/re_frame/schemas.cljc',
+    'implementation/machines/src/re_frame/machines.cljc',
+    'implementation/routing/src/re_frame/routing.cljc',
+    'implementation/flows/src/re_frame/flows.cljc',
+    'implementation/http/src/re_frame/http.cljc',
+    'implementation/ssr/src/re_frame/ssr.cljc',
+    'implementation/ssr-ring/src/re_frame/ssr/ring.clj',
+    'implementation/resources/src/re_frame/resources.cljc',
+    'implementation/security/src/re_frame/security.cljc',
+    'implementation/scripts/check-examples-compile.cjs',
+    'tools/story/src/re_frame/story.cljs',
+    'tools/xray/src/day8/re_frame2_xray/preload.cljs',
+    'tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs',
+  ];
+  for (const file of directSurfaces) {
+    assert.equal(
+      classify(file).examples_compile,
+      'true',
+      `${file} can change the compiled example closure`,
+    );
+  }
+
+  for (const file of [
+    'implementation/core/src/re_frame/core.cljc',
+    'implementation/scripts/check-elision.cjs',
+    'testbeds/tenant_switcher/core.cljs',
+    'tools/xray/test/day8/re_frame2_xray/core_test.clj',
+    'tools/xray/spec/017-Test-Coverage-Matrix.md',
+    'spec/006-ReactiveSubstrate.md',
+  ]) {
+    assert.equal(
+      classify(file).examples_compile,
+      'false',
+      `${file} cannot change a standalone example build`,
+    );
+  }
+});
+
+test('cljs-examples-compile job uses the dedicated output and nightly retains full coverage (rf2-gzavkm)', () => {
+  const prBlock = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs-examples-compile');
+  assert.match(
+    prBlock,
+    /if: needs\.detect_changed_surfaces\.outputs\.examples_compile == 'true'/,
+  );
+  const nightly = fs.readFileSync(EXPENSIVE_WORKFLOW, 'utf8');
+  const nightlyBlock = jobBlock(nightly, 'browser-bundle-and-story-gates');
+  const compile = nightlyBlock.indexOf('npm run test:examples-compile');
+  const playwright = nightlyBlock.indexOf('npx playwright install --with-deps chromium');
+  assert.notEqual(compile, -1, 'nightly must retain the all-examples compile');
+  assert.notEqual(playwright, -1, 'nightly browser gate must install Chromium');
+  assert.ok(compile < playwright, 'example compilation should fail before the browser download');
+});
+
+// rf2-3kewru — G-12 Arm 2 shells out to `clojure -Stree`. The CLJS job
+// that owns `test:ui-isolation` must therefore provision the Clojure CLI;
+// Arm 1 alone cannot detect a declared-but-currently-unused adapter dep.
+test('cljs job provisions Clojure CLI before the G-12 isolation gate (rf2-3kewru)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs');
+  const setup = block.indexOf('name: Set up Clojure CLI');
+  const gate = block.indexOf('npm run test:ui-isolation');
+  assert.notEqual(setup, -1, 'cljs job must install Clojure CLI for G-12 Arm 2');
+  assert.notEqual(gate, -1, 'cljs job must run the UI isolation gate');
+  assert.ok(setup < gate, 'Clojure CLI setup must precede the G-12 isolation gate');
+  assert.match(block, /DeLaGuardo\/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2/);
+});
+
+// rf2-vxgfnd.135 — the tracked synthesis guide/drafts are authoritative
+// working material but deliberately remain outside MkDocs until S6. They get
+// one narrow, non-vacuous link/anchor + guide-truth job instead.
+test('tracked synthesis guide and active drafts arm their focused docs gate only (rf2-vxgfnd.135)', () => {
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/guide/09-debugging.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(classify('scripts/check_doc_slugs.py').synthesis_docs, 'true');
+  assert.equal(
+    classify('implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj').synthesis_docs,
+    'true',
+  );
+  assert.equal(classify('ai/findings/unrelated-scratch.md').synthesis_docs, 'false');
+});
+
+test('synthesis-docs job runs the opt-in link scan and focused guide truth fixture (rf2-vxgfnd.135)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'synthesis-docs');
+  assert.match(block, /if: needs\.detect_changed_surfaces\.outputs\.synthesis_docs == 'true'/);
+  assert.match(block, /check_doc_slugs\.py --synthesis-only/);
+  assert.match(block, /clojure -M:test -n re-frame\.ui\.guide-truth-jvm-test/);
+
+  const aggregator = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'all-required-passed');
+  assert.match(aggregator, /- synthesis-docs\r?\n/);
+});
+
 // rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
 // job-level gated (needs + if), NOT trigger-filtered, and the
 // pull_request trigger must stay unfiltered so the aggregator is always

--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -3,7 +3,9 @@
 Each subdirectory is a self-contained mini-repo the validator script
 treats as a real corpus when invoked with `--repo-root <fixture-dir>`.
 Required minimum: a top-level `mkdocs.yml` (so the repo-root guard
-accepts the directory) and at least one `.md` file under `docs/`.
+accepts the directory) and at least one `.md` file under the scope the
+fixture exercises (`docs/` by default, or the exact synthesis guide/drafts
+roots for `--synthesis-only`).
 
 Run all fixtures via:
 
@@ -29,3 +31,6 @@ Fixtures:
 | `ai_findings_dir_link_flagged`     | 1               | Link into the bare `ai/findings/` directory is flagged (rf2-l7yj8)                 |
 | `blockquoted_heading_ok`           | 0               | Link into a blockquoted heading (`> #### Foo`, incl. nested) resolves (rf2-869k9m) |
 | `indented_heading_not_indexed`     | 1               | Negative control: an *indented bare* `#` line still mints no anchor (rf2-869k9m)   |
+| `synthesis_broken_target`          | default 0 / synthesis 1 | The unchanged default corpus excludes the guide; opt-in catches a missing target (rf2-vxgfnd.135) |
+| `synthesis_broken_anchor`          | default 0 / synthesis 1 | The unchanged default corpus excludes the guide; opt-in catches a missing anchor (rf2-vxgfnd.135) |
+| `synthesis_valid_narrow_scope`     | 0               | Exactly guide + drafts are enumerated; unrelated broken `ai/` scratch remains excluded |

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/ai/findings/new-substrate-synthesis/guide/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/ai/findings/new-substrate-synthesis/guide/index.md
@@ -1,0 +1,3 @@
+# Guide
+
+[Wrong anchor](target.md#missing-section)

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/ai/findings/new-substrate-synthesis/guide/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/ai/findings/new-substrate-synthesis/guide/target.md
@@ -1,0 +1,1 @@
+# Real section

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_anchor/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: synthesis-broken-anchor

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_target/ai/findings/new-substrate-synthesis/guide/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_target/ai/findings/new-substrate-synthesis/guide/index.md
@@ -1,0 +1,3 @@
+# Guide
+
+[Missing chapter](missing.md)

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_target/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_broken_target/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: synthesis-broken-target

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/drafts/design.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/drafts/design.md
@@ -1,0 +1,3 @@
+# Design
+
+[Guide](../guide/index.md#guide)

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/guide/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/guide/index.md
@@ -1,0 +1,3 @@
+# Guide
+
+[Active design](../drafts/design.md#design)

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/unrelated/scratch.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/unrelated/scratch.md
@@ -1,0 +1,3 @@
+# Unrelated scratch
+
+[This broken target must remain outside the synthesis scope](missing.md)

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: synthesis-valid-narrow-scope

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -73,17 +73,44 @@ DEFAULT_ROOTS = (
     "migration",
 )
 
+# Tracked, authoritative pre-publication re-frame.ui material. This is an
+# explicit opt-in scope: it must not widen the default docs/MkDocs corpus or
+# sweep unrelated ai/ scratch. S6 owns publication; this gate owns only links
+# and anchors while the source remains here.
+SYNTHESIS_ROOTS = (
+    "ai/findings/new-substrate-synthesis/guide",
+    "ai/findings/new-substrate-synthesis/drafts",
+)
+
+# Diff-ready spec drafts author their links for the file's eventual `spec/`
+# location, not for the temporary drafts/ directory. Validate that intended
+# link context explicitly. The target path also supplies existing headings for
+# same-file anchors in amendment fragments; a not-yet-created target (004A)
+# still contributes its `spec/` parent as the relative-link base.
+DRAFT_LANDING_TARGETS = {
+    "ai/findings/new-substrate-synthesis/drafts/spec-004-rewrite-draft.md":
+        "spec/004-Views.md",
+    "ai/findings/new-substrate-synthesis/drafts/spec-004A-reagent-compat-appendix.md":
+        "spec/004A-Reagent-Compat.md",
+    "ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md":
+        "spec/006-ReactiveSubstrate.md",
+    "ai/findings/new-substrate-synthesis/drafts/spec-009-ui-catalogue-rows.md":
+        "spec/009-Instrumentation.md",
+    "ai/findings/new-substrate-synthesis/drafts/spec-011-ui-tree-amendment.md":
+        "spec/011-SSR.md",
+}
+
 # Tools live one tier deeper: tools/<tool-name>/spec/**/*.md.
 TOOLS_ROOT = "tools"
 
 # Paths whose markdown should never be scanned.
 EXCLUDE_DIR_NAMES = frozenset({
-    "findings",      # exploratory working substrate
+    "findings",      # default excludes exploratory work; synthesis opt-in is exact
     "node_modules",
     "site",          # mkdocs build output
     ".git",
     ".beads",
-    "ai",            # gitignored AI working tree
+    "ai",            # default excludes AI work; tracked synthesis opt-in is exact
     "__pycache__",
 })
 
@@ -160,11 +187,21 @@ _FENCE_RE = re.compile(r"^(```|~~~)")
 _INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
 
 
-def _is_excluded(path: Path, repo_root: Path) -> bool:
+def _is_excluded(
+    path: Path,
+    repo_root: Path,
+    *,
+    allow_ai_findings: bool = False,
+) -> bool:
     """Return True if path lies under a directory we should skip."""
     rel = path.relative_to(repo_root)
     parts = set(rel.parts)
-    if parts & EXCLUDE_DIR_NAMES:
+    excluded_names = EXCLUDE_DIR_NAMES
+    if allow_ai_findings:
+        # Safe only because `_iter_markdown` applies this exception beneath
+        # the two exact SYNTHESIS_ROOTS, never to an arbitrary ai/ path.
+        excluded_names = excluded_names - {"ai", "findings"}
+    if parts & excluded_names:
         return True
     for ex in EXCLUDE_DIR_REL:
         try:
@@ -175,24 +212,38 @@ def _is_excluded(path: Path, repo_root: Path) -> bool:
     return False
 
 
-def _iter_markdown(repo_root: Path) -> Iterable[Path]:
+def _iter_markdown(
+    repo_root: Path,
+    *,
+    synthesis_only: bool = False,
+) -> Iterable[Path]:
     """Yield absolute paths to every in-scope .md file."""
-    roots = []
-    for d in DEFAULT_ROOTS:
-        p = repo_root / d
-        if p.is_dir():
-            roots.append(p)
-    tools = repo_root / TOOLS_ROOT
-    if tools.is_dir():
-        for tool in sorted(tools.iterdir()):
-            spec = tool / "spec"
-            if spec.is_dir():
-                roots.append(spec)
+    roots: list[tuple[Path, bool]] = []
+    if synthesis_only:
+        for d in SYNTHESIS_ROOTS:
+            p = repo_root / d
+            if p.is_dir():
+                roots.append((p, True))
+    else:
+        for d in DEFAULT_ROOTS:
+            p = repo_root / d
+            if p.is_dir():
+                roots.append((p, False))
+        tools = repo_root / TOOLS_ROOT
+        if tools.is_dir():
+            for tool in sorted(tools.iterdir()):
+                spec = tool / "spec"
+                if spec.is_dir():
+                    roots.append((spec, False))
 
     seen: set[Path] = set()
-    for root in roots:
+    for root, allow_ai_findings in roots:
         for path in sorted(root.rglob("*.md")):
-            if _is_excluded(path, repo_root):
+            if _is_excluded(
+                path,
+                repo_root,
+                allow_ai_findings=allow_ai_findings,
+            ):
                 continue
             ap = path.resolve()
             if ap in seen:
@@ -301,7 +352,13 @@ def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
             yield line_no, m.group(1)
 
 
-def _resolve_target(linker: Path, dest_path: str, repo_root: Path) -> Path | None:
+def _resolve_target(
+    linker: Path,
+    dest_path: str,
+    repo_root: Path,
+    *,
+    relative_base: Path | None = None,
+) -> Path | None:
     """Resolve a (possibly relative) link path against the linker's directory.
 
     Returns the absolute Path to the target file, or None if resolution would
@@ -313,18 +370,26 @@ def _resolve_target(linker: Path, dest_path: str, repo_root: Path) -> Path | Non
     """
     if not dest_path:
         return linker  # same-file anchor
-    try:
-        if dest_path.startswith("/"):
-            target = (repo_root / dest_path.lstrip("/")).resolve()
-        else:
-            target = (linker.parent / dest_path).resolve()
-    except (OSError, ValueError):
-        return None
-    try:
-        target.relative_to(repo_root.resolve())
-    except ValueError:
-        return None
-    return target
+    bases = [repo_root] if dest_path.startswith("/") else [linker.parent]
+    if relative_base and relative_base != linker.parent:
+        bases.append(relative_base)
+
+    candidates: list[Path] = []
+    for base in bases:
+        try:
+            target = (
+                base / (dest_path.lstrip("/") if dest_path.startswith("/") else dest_path)
+            ).resolve()
+            target.relative_to(repo_root.resolve())
+        except (OSError, ValueError):
+            continue
+        candidates.append(target)
+        # Drafts mix links to neighbouring source material with links authored
+        # for their landing directory. Prefer the real source-neighbour when
+        # present, then fall through to the explicit landing context.
+        if target.is_file():
+            return target
+    return candidates[-1] if candidates else None
 
 
 def _is_ai_findings_link(path_part: str) -> bool:
@@ -351,7 +416,12 @@ def _is_ai_findings_link(path_part: str) -> bool:
     return False
 
 
-def check(repo_root: Path, verbose: bool = False) -> int:
+def check(
+    repo_root: Path,
+    verbose: bool = False,
+    *,
+    synthesis_only: bool = False,
+) -> int:
     """Validate every in-repo markdown link.  Return broken-link count.
 
     Flags three distinct defects:
@@ -362,7 +432,21 @@ def check(repo_root: Path, verbose: bool = False) -> int:
                               gitignored working artefacts; inline a sentence
                               summary instead.
     """
-    files = list(_iter_markdown(repo_root))
+    files = list(_iter_markdown(repo_root, synthesis_only=synthesis_only))
+    if synthesis_only:
+        if not files:
+            sys.stderr.write(
+                "error: synthesis link gate matched zero markdown files under "
+                f"{', '.join(SYNTHESIS_ROOTS)}; refusing a vacuous pass.\n"
+            )
+            return 1
+        sys.stderr.write(
+            f"synthesis link gate files ({len(files)}):\n"
+        )
+        for path in files:
+            sys.stderr.write(
+                f"  {path.relative_to(repo_root.resolve()).as_posix()}\n"
+            )
     if verbose:
         sys.stderr.write(f"scanning {len(files)} markdown files...\n")
 
@@ -379,6 +463,10 @@ def check(repo_root: Path, verbose: bool = False) -> int:
     broken_target: list[tuple[Path, int, str, str]] = []
     ai_findings: list[tuple[Path, int, str]] = []
     for path in files:
+        path_rel = path.relative_to(repo_root.resolve()).as_posix()
+        landing_rel = DRAFT_LANDING_TARGETS.get(path_rel)
+        landing_target = (repo_root / landing_rel).resolve() if landing_rel else None
+        relative_base = landing_target.parent if landing_target else None
         for line_no, dest in _extract_links(path):
             # External / non-file references — out of scope.
             if dest.startswith(("http://", "https://", "mailto:", "tel:", "//")):
@@ -403,7 +491,10 @@ def check(repo_root: Path, verbose: bool = False) -> int:
             if path_part == "":
                 if not anchor:
                     continue
-                if anchor not in slugs_for(path):
+                same_file_slugs = set(slugs_for(path))
+                if landing_target and landing_target.is_file():
+                    same_file_slugs.update(slugs_for(landing_target))
+                if anchor not in same_file_slugs:
                     broken_anchor.append(
                         (path, line_no, dest, str(path.relative_to(repo_root.resolve())))
                     )
@@ -416,7 +507,12 @@ def check(repo_root: Path, verbose: bool = False) -> int:
             if not path_part.endswith(".md"):
                 continue
 
-            target = _resolve_target(path, path_part, repo_root)
+            target = _resolve_target(
+                path,
+                path_part,
+                repo_root,
+                relative_base=relative_base,
+            )
             if target is None:
                 # Path escapes the repo — treat as external reference, skip.
                 continue
@@ -519,6 +615,14 @@ def main(argv: list[str]) -> int:
             "scripts/_test_fixtures/check_doc_slugs/ and exit."
         ),
     )
+    parser.add_argument(
+        "--synthesis-only",
+        action="store_true",
+        help=(
+            "Scan only the tracked re-frame.ui synthesis guide and active "
+            "drafts. Enumerates every matched file and fails if the scope is empty."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.self_test:
@@ -536,7 +640,11 @@ def main(argv: list[str]) -> int:
         )
         return 2
 
-    broken = check(repo_root, verbose=args.verbose)
+    broken = check(
+        repo_root,
+        verbose=args.verbose,
+        synthesis_only=args.synthesis_only,
+    )
     return 0 if broken == 0 else 1
 
 
@@ -601,11 +709,96 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # rf2-vxgfnd.135 — prove the new scope is explicit and has real teeth:
+    # both defects remain invisible to the unchanged default corpus, then fail
+    # when the narrow synthesis scope is selected. The valid fixture also
+    # proves both roots are enumerated while unrelated ai/ scratch stays out.
+    synthesis_cases: list[tuple[str, int]] = [
+        ("synthesis_broken_target", 1),
+        ("synthesis_broken_anchor", 1),
+        ("synthesis_valid_narrow_scope", 0),
+    ]
+    for fixture, expected in synthesis_cases:
+        root = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not (root / "mkdocs.yml").is_file():
+            sys.stderr.write(
+                f"self-test FAIL: fixture {fixture!r} missing mkdocs.yml at {root}\n"
+            )
+            failures += 1
+            continue
+
+        saved_stderr = sys.stderr
+        sys.stderr = _DevNull()
+        try:
+            default_got = check(root, verbose=False)
+            synthesis_got = check(root, verbose=False, synthesis_only=True)
+        finally:
+            sys.stderr = saved_stderr
+
+        if default_got != 0:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} leaked into the default corpus "
+                f"(broken={default_got}, expected 0)\n"
+            )
+            failures += 1
+        elif synthesis_got == expected:
+            if verbose:
+                sys.stderr.write(
+                    f"self-test PASS: {fixture} "
+                    f"(default=0, synthesis={synthesis_got})\n"
+                )
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} expected synthesis broken={expected}, "
+                f"got {synthesis_got}\n"
+            )
+            failures += 1
+
+    narrow_root = _SELF_TEST_FIXTURE_ROOT / "synthesis_valid_narrow_scope"
+    narrow_files = {
+        path.relative_to(narrow_root).as_posix()
+        for path in _iter_markdown(narrow_root, synthesis_only=True)
+    }
+    expected_narrow_files = {
+        "ai/findings/new-substrate-synthesis/guide/index.md",
+        "ai/findings/new-substrate-synthesis/drafts/design.md",
+    }
+    if narrow_files != expected_narrow_files:
+        sys.stderr.write(
+            "self-test FAIL: synthesis scope inventory mismatch: "
+            f"expected {sorted(expected_narrow_files)}, got {sorted(narrow_files)}\n"
+        )
+        failures += 1
+    elif verbose:
+        sys.stderr.write(
+            "self-test PASS: synthesis scope enumerates guide + drafts only\n"
+        )
+
+    empty_root = _SELF_TEST_FIXTURE_ROOT / "valid_link"
+    saved_stderr = sys.stderr
+    sys.stderr = _DevNull()
+    try:
+        empty_got = check(empty_root, verbose=False, synthesis_only=True)
+    finally:
+        sys.stderr = saved_stderr
+    if empty_got != 1:
+        sys.stderr.write(
+            "self-test FAIL: empty synthesis scope did not fail closed "
+            f"(got broken={empty_got}, expected 1)\n"
+        )
+        failures += 1
+    elif verbose:
+        sys.stderr.write(
+            "self-test PASS: empty synthesis scope refuses a vacuous pass\n"
+        )
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+        sys.stderr.write(
+            f"all {len(cases) + len(synthesis_cases) + 2} self-tests passed.\n"
+        )
     return 0
 
 


### PR DESCRIPTION
## Summary

- give the all-examples compile gate its own changed-surface output, skipping core-only PRs while preserving unconditional nightly coverage
- provision Clojure CLI in the CLJS job so G-12 Arm 2 executes in CI
- add an explicit, non-vacuous synthesis guide/drafts link-and-anchor gate plus the focused guide-truth fixture

Closes rf2-gzavkm (Phase 1)
Closes rf2-3kewru
Closes rf2-vxgfnd.135

## Red-before-green evidence

The policy tests were written first and failed on five missing contracts: no `examples_compile` output, the examples job still piggybacked `cljs_browser`, the CLJS job lacked setup-clojure, no `synthesis_docs` output, and no synthesis-docs job. The existing checker also reported the synthesis guide absent from its 518-file default corpus. New controlled fixtures prove broken synthesis targets and anchors were invisible to the unchanged default scope and fail in the explicit scope.

## Validation

- `bash -n .github/scripts/report-changed-surfaces.sh`
- `node implementation/scripts/_changed-surfaces.test.cjs` — 149 passed
- `node implementation/scripts/_lint-workflow-policy.test.cjs` — 4 passed
- `python -m py_compile scripts/check_doc_slugs.py`
- `python scripts/check_doc_slugs.py --self-test --verbose` — 18 passed
- `python scripts/check_doc_slugs.py --verbose` — 518 files, clean
- `python scripts/check_doc_slugs.py --synthesis-only --verbose` — 34 files enumerated, clean
- `clojure -M:test -n re-frame.ui.guide-truth-jvm-test` — 5 tests, 322 assertions
- both edited workflows parsed with PyYAML
- `git diff --check origin/main...HEAD`

The full repository suite was intentionally not run for this CI-policy/docs slice.