### PR TITLE
docs(ui): settle guide fixture mechanics

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md
+++ b/ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md
@@ -41,9 +41,9 @@
    `../../../../docs/core/...`; §2.1 records the required `../core/...` relocation
    transform. One prose reference points outside ("design rationale lives one
    directory up", ⟨guide/README ¶1⟩); inline stage markers + stage notes and the README
-   stage-honesty paragraph remain; the **seven mandatory `;; guide:no-fixture` markers** exist
-   on the pages (added 2026-07-13 with the stage-truth reconciliation — the §2.4 set);
-   zero images ⟨guide/ greps 2026-07-12/13⟩.
+   stage-honesty paragraph remain; the **seven mandatory `;; guide:no-fixture` markers**
+   and **nine mandatory `;; guide:target dom` markers** exist on the pages (the §2.4
+   censuses); zero images ⟨guide/ greps 2026-07-12/15⟩.
 
 ## 1. Landing location + nav
 
@@ -157,7 +157,7 @@ input. Every transform below happens in it, once.
 | Intra-guide chapter links (`[02](02-views.md)` — ~30 sites, all same-dir relative) | **Keep unchanged**; README→index rename doesn't affect them (no chapter links back to README) |
 | Current `../../../../docs/core/...` links in README, 07, and 08 | **Rewrite every target to `../core/...`.** From `docs/ui/<page>.md`, that resolves inside `docs/core`; retaining the source-tree prefix would escape the repository. Exact target census follows below. |
 | ⟨guide/README ¶1⟩ "design rationale lives one directory up" | **Remove the clause.** The synthesis suite does not move; docs never link `spec/` ⟨AUTHORING §2⟩. The sentence becomes "This guide teaches the library as a user." |
-| ⟨guide/README ¶1⟩ the fixture-coverage statement | **Update to the move-time truth.** Since 2026-07-13 the README states exact coverage (Guide 08's Tier-1 fixture today, growing per stage); by S6 all S1–S5 chapters are active per the stage forcer, so the sentence becomes the full every-example promise. The "except fences marked `guide:no-fixture`" amendment lands with the extractor PR, not the move ⟨guide-fixture-pipeline §2 README amendment⟩ |
+| ⟨guide/README ¶1⟩ the fixture-coverage statement | **Update to the move-time truth.** The README currently names Guide 08's exact enrolled subset (Tier-1 deftest, intent projection, dispatch-to-sub loop, seeded-state render, sub-override door) and makes every other fence prospective. By S6 all S1–S5 chapters are active per the stage forcer, so the sentence becomes the full every-example promise. The "except fences marked `guide:no-fixture`" amendment lands with the extractor PR, not the move ⟨guide-fixture-pipeline §2 README amendment⟩ |
 | ⟨10-migration doc⟩ links to `drafts/reagent-compat-boundary.md` (×3) | **Replace with inline prose.** The draft doesn't move; its Reagent normative content promotes spec-side (004A at S7), and docs never link `spec/`. The page inlines only what the reader needs: the three React-interoperability granularities, ownership/teardown one-liners, and the load-bearing rule that every root/subtree uses the process's one boot-selected adapter. The interop doors never select a second adapter. |
 | ⟨10-migration doc⟩ synthesis-suite citations ("08 §2", "12 §2", "02 §3 table", "06 §1", "guide 03") | **Rewrite or drop.** "02 §3 table" → link `04-events.md` (the decision table's guide home); "guide 03" → `03-state.md`; "06 §1 subset check" → `11-ssr.md`; stage-plumbing citations ("08 §2", "12 §2", delta numbers) → **drop** — program management is not reader content |
 | Provenance parentheticals: "Blessed-table verdict; qualifier added 2026-07-12" ⟨guide/02 L73–74⟩, "delta #2, ruled 2026-07-12; 12 §2" ⟨10-migration⟩, "(an Xray addition staged behind its integration review)" ⟨guide/09⟩, the migration doc's **Status:** line | **Strip.** "No bead ids in prose. Pages state current truth" ⟨AUTHORING §Honesty⟩. The *facts* stay (wave-2 status, S7 freeze); the ruling ledger goes |
@@ -206,7 +206,7 @@ template → **docs/guide + skills** → CI → benchmarks ⟨12 §3 S6⟩), S1�
   its no-fixture marker (§2.4).
 - **README stage-honesty paragraph** ⟨guide/README L22–28⟩: rewritten down to one
   sentence on the wave-2 names ("Wave-2 names (…) are not v1 and only ever appear with
-  that qualifier."). The S1-default framing and the marker convention are obsolete once
+  that qualifier."). The current-versus-future marker framing is obsolete once
   no S1–S5 markers remain.
 
 ### 2.3 British spelling + house admonitions
@@ -232,13 +232,13 @@ template → **docs/guide + skills** → CI → benchmarks ⟨12 §3 S6⟩), S1�
 - **Pull-quote check**: chapters already carry their one-liner contracts in prose; no
   forced takeaway boxes added.
 
-### 2.4 Fence markers: add the mandatory ones now, freeze the fences
+### 2.4 Fence markers: marker-complete now, then freeze the fences
 
-The seven mandatory markers are **already on the pages** (re-censused after #5894), so the
-extractor PR touches zero pages. The pipeline's
+The mandatory waiver and target markers are **already on the pages**, so the extractor
+PR touches zero pages. The pipeline's
 fence contract makes unmarked elisions and unmarked wave-2 fences an extractor *error*
 ⟨guide-fixture-pipeline §2⟩. **The move PR verifies the census** — any fence added
-since must carry its marker; the set as of 2026-07-13:
+since must carry its marker; the waiver set as of 2026-07-15:
 
 | Fence | Marker |
 |---|---|
@@ -250,8 +250,26 @@ since must carry its marker; the set as of 2026-07-13:
 | 11 `render-static` call (`{…}`) | `;; guide:no-fixture — illustrative fragment` |
 | 14 `data/render` | `;; guide:no-fixture — wave-2, does not ship in v1` |
 
-(Exact census per ⟨guide-fixture-pipeline §0 constraint 2⟩; re-count at execution — the
-completeness pass may have changed the set.) Everything else about fence bodies is
+The DOM-target set as of 2026-07-15 is exact and marker-complete:
+
+| Fence | Marker |
+|---|---|
+| 01 whole-app mount | `;; guide:target dom` |
+| 05 `frame-root` mount | `;; guide:target dom` |
+| 05 multi-frame page mount | `;; guide:target dom` |
+| 06 dashboard mount | `;; guide:target dom` |
+| 08 mounted read-only test | `;; guide:target dom` |
+| 08 mounted write test | `;; guide:target dom` |
+| 11 authored two-root mounts | `;; guide:target dom` |
+| 11 direct host-tier root | `;; guide:target dom` |
+| 11 hydration | `;; guide:target dom` |
+
+Every other Clojure fence defaults to the structural JVM target. The golden census
+enumerates these nine fence ids and fails if any marker is removed or if a newly
+host-dependent fence is left unclassified.
+
+(Exact censuses per ⟨guide-fixture-pipeline §0 constraint 2⟩; re-count at execution — the
+guide may have changed the set.) Everything else about fence bodies is
 **byte-stable through the move**: the drift-comparison normalisations already strip
 `;; guide:*` lines and CRLF, so added markers don't break bridge-fixture comparison
 ⟨guide-fixture-pipeline §5⟩, and any other fence edit would.

--- a/ai/findings/new-substrate-synthesis/drafts/guide-fixture-pipeline.md
+++ b/ai/findings/new-substrate-synthesis/drafts/guide-fixture-pipeline.md
@@ -1,17 +1,18 @@
 # DRAFT — The guide-fixture pipeline (making the README promise real at scale)
 
-> **Status: DRAFT · 2026-07-12 · re-based 2026-07-13** to two changed facts: the
+> **Status: DRAFT · 2026-07-12 · re-based 2026-07-15** to current guide and stage facts: the
 > synthesis tree (guide pages included) has been **force-tracked in git since #5800**,
 > so "CI cannot read the pages" is no longer true; and ⟨guide/README ¶1⟩ now states
-> *exact* fixture coverage (guide 09 Tier-1 today, growing with the stages) rather
+> *exact* fixture coverage (Guide 08's enrolled Tier-1 subset today) rather
 > than a universal claim. The universal every-example-runs promise is this pipeline's
 > **target**, not the current state. The normative sources are
 > ⟨07-testing §7 — the guide as a test surface⟩ and the G-14 honest remainder
 > (⟨implementation/ui/test/re_frame/ui/g14_compile_budget_jvm_test.clj docstring⟩:
 > *"guide-fixtures CI cost needs the guide-examples corpus (08 §3)"*, landed via #5703).
 > One fixture exists as precedent:
-> ⟨implementation/ui/test/re_frame/ui/test_guide09_fixture_jvm_test.clj⟩ (the S1d
-> worker's hand-lift of guide 09 §Tier 1). A completeness pass is expanding the guide
+> ⟨implementation/ui/test/re_frame/ui/test_guide08_fixture_jvm_test.clj⟩ (originally
+> Guide 09 before the learning-order renumber; its S1 hand-lift was de-adapted at S2).
+> A completeness pass is expanding the guide
 > now — more chapters, more examples, stage markers on not-yet-shipped surfaces — so
 > this design targets that shape, not today's snapshot. Open items are tagged
 > **[S3-CONFIRM]**.
@@ -31,29 +32,26 @@ this repo.
    S2–S5, what runs in CI stays checked-in test source; the tracked pages are available
    to any local script (and to a future gate) but nothing derives fixtures from them
    yet.
-2. **Fences come in dialects.** Census (originally 52/51 on 2026-07-12; re-censused
-   after the guide completeness pass the same day and re-verified by the correctness
-   pass — the elided and wave-2 sets below unchanged): **51 fences across the 11
-   pages**, of which **50** are ` ```clojure ` and 1 is an unlanguaged output block
-   (guide 06's Xray timeline). Of the 50 Clojure fences, at least four are deliberately illustrative
+2. **Fences come in dialects.** The 2026-07-15 numbered-chapter census is **68 fences
+   across 12 pages**: **66** are ` ```clojure ` and two are non-Clojure output blocks.
+   Including the README's convention fence makes the whole guide tree 69/67 across 13
+   files. Of the chapter Clojure fences, four are deliberately illustrative
    fragments carrying elisions — guide 01's `deps.edn` stub (`{…}`), guide 03's
    conditional-read one-liner (`… ✓`), guide 05's `media-bridge` body (`…)`), guide
-   08's `render-static` call (`{…}`) — and one (guide 02's `data/render`) names a
+   11's `render-static` call (`{…}`) — and two (guides 02 and 14 `data/render`) name a
    **wave-2** artefact that does not exist in v1 ⟨12 §2 blessed table⟩. "Every example
    compiles" cannot naively mean "every fence compiles"; the contract must make the
    exceptions *visible on the page* or the promise rots silently. (As of 2026-07-13
-   those five fences carry their `;; guide:no-fixture` markers on the page — the §2
+   those seven fences carry their `;; guide:no-fixture` markers on the page — the §2
    mandatory set, added ahead of the S6 move.)
-3. **Stage markers are load-bearing.** The README's stage-honesty convention —
-   unmarked = Stage 1, `*(lands S2 — reactive subs)*` etc. — annotates whole chapters
-   (stage notes), sections (header markers), and single bullets ⟨guide/README §Stage
-   honesty; grep evidence across all 10 chapters⟩. A fixture for an `*(lands S2)*`
-   example must **activate with S2, not fail before it** — and must not be silently
-   absent either, or "everything green" means "nothing ran". The S1d precedent handled
-   this by *adapting*: sub reads became props, `dispatch!` usage was reshaped to the S1
-   structural subset, and the docstring recorded each adaptation
-   ⟨test_guide09_fixture_jvm_test.clj lines 2–10, 34–40⟩. That adaptation ledger is the
-   seed of the stage-gating design in §3.
+3. **Stage markers are load-bearing.** An unmarked fence describes behaviour shipped
+   on main and is therefore active. Only an explicit `*(lands S<N>)*` marker parks a
+   future surface. Historical minimum landing stages are separate metadata sourced
+   from the frozen per-verb surface matrix or an explicit manifest field; marker
+   absence never supplies one, and the classifier never guesses from symbols. The S1
+   Guide 09 bridge historically adapted sub reads and dispatch, but the renamed Guide
+   08 fixture removed both adaptations when S2 shipped. That completed audit record,
+   not a live exception, is the seed of the stage-gating design in §3.
 
 ## 1. Extraction model — recommendation
 
@@ -62,7 +60,7 @@ Three candidate models, one recommendation.
 | Model | Mechanism | Strengths | Why it fails as the *whole* answer here |
 |---|---|---|---|
 | **(A) Literate extraction** | a script parses guide `.md` fences into generated test namespaces | single source of truth; page↔fixture drift impossible by construction | the extractor is S6 work by plan (constraint 1 — the pages are CI-readable, but no extractor exists before the docs move); a bare fence lacks everything the S1d worker had to invent — ns preamble, requires, the fixture app surface (`fixture-catalog`, event registrations, the reset-runtime fixture), and assertions for non-test fences — so "parse fences" alone under-specifies the pipeline |
-| **(B) Mirrored fixtures** | hand-maintained fixture files 1:1 with chapters, drift-checked against the page | works **today**, needing nothing beyond the tracked pages, with human judgment for stage adaptation — this is exactly the S1d precedent | at guide scale (51 fences and growing) hand-mirroring is a standing tax; the drift gate is structurally weak while adaptations are legitimate (an adapted fixture *should* differ from its fence, so byte-comparison either fails spuriously or gets normalised into meaninglessness); and no comparison harness exists before S6 to make the check mechanical |
+| **(B) Mirrored fixtures** | hand-maintained fixture files 1:1 with chapters, drift-checked against the page | works **today**, needing nothing beyond the tracked pages, with human judgment for stage adaptation — this is exactly the S1d precedent | at guide scale (68 fences and growing) hand-mirroring is a standing tax; the drift gate is structurally weak while adaptations are legitimate (an adapted fixture *should* differ from its fence, so byte-comparison either fails spuriously or gets normalised into meaninglessness); and no comparison harness exists before S6 to make the check mechanical |
 | **(C) Annotation-driven extraction** | fence-level markers (eligibility, stage, target, fixture id) drive a generator; per-chapter scaffolds supply context; assertions live in companion files | keeps the page the source of truth **and** makes the exceptions visible in the page source; stage markers become machine-readable; the manifest falls out for free | still lands at S6 with the docs move (constraint 1); needs marker + scaffold conventions defined up front or the completeness pass authors fences the extractor can't consume |
 
 **Recommendation: (C) annotation-driven extraction is the pipeline, landing at S6 with
@@ -113,6 +111,11 @@ promise holds unless a fence visibly waives it, on the page, with a reason.
    `ui/view`, `ui/portal` ⟨12 §2⟩) must carry the no-fixture marker — wave-2 does not
    ship, so nothing can compile it. The extractor cross-checks fence symbols against
    the §2 blessed table's wave-2 rows and rejects an unmarked wave-2 fence.
+4. **Host target explicit.** Every fence that mounts, hydrates, owns a React root, uses
+   `ui.test/with-root`, or touches `js/document` carries `;; guide:target dom`.
+   Structural fences carry no target marker and default to JVM. The nine-fence golden
+   census rejects a missing marker or an unclassified new host fence; marker absence
+   never silently routes host code.
 
 **The marker vocabulary** (first line(s) of the fence body, ordinary Clojure comments —
 visible in the page source and in the rendered page, which is the point):
@@ -120,23 +123,42 @@ visible in the page source and in the rendered page, which is the point):
 | Marker | Meaning |
 |---|---|
 | `;; guide:no-fixture — <reason>` | this fence is illustrative; it is *not* a CI fixture. Reason is mandatory and renders on the page. Expected uses: elided install stubs (01 `deps.edn`), deliberate fragments kept fragmentary for prose flow, wave-2 surfaces (02 `data/render`: `;; guide:no-fixture — wave-2, does not ship in v1`) |
-| `;; guide:stage S<N>` | stage override when the fence's stage differs from what the enclosing section/chapter markers imply. Default inference: nearest enclosing header marker `*(lands S<N>…)*`, else the chapter stage note, else S1 (the README convention). Most fences need no marker — the prose markers are already machine-readable |
-| `;; guide:target dom` | route this fence to the DOM-target generated namespace (browser tier) instead of the default JVM tier — mount/hydrate fences that touch `js/document` (§4). Default target is `jvm` |
+| `;; guide:stage S<N>` | explicit future-stage override when the fence differs from the nearest enclosing `*(lands S<N>…)*` marker. With no fence or enclosing marker, the fence is active because it describes shipped behaviour; absence is not stage metadata |
+| `;; guide:target dom` | route this fence to the DOM-target generated namespace (browser tier) instead of the default JVM tier — mount, hydration, direct root ownership, `ui.test/with-root`, or `js/document` (§4). Default target is `jvm` for structural fences |
 | `;; guide:fixture <id>` | optional stable id for a fence, for companion-assertion reference and manifest rows. Default id: `<chapter>-<ordinal>` |
 
 Nothing else. The vocabulary is closed, like every other grammar in this program;
 a fence carrying an unknown `guide:` marker is an extractor error.
 
+**Stage classification is deliberately asymmetric.** First read an explicit fence,
+section, or chapter marker. Park the fence only when that marker names an unshipped
+stage; activate it once that stage ships. With no marker, activate the fence. An
+unmarked fence is active because it describes current shipped behaviour; it does not
+imply S1. If a historical minimum is retained, read it only from the frozen per-verb
+surface matrix or explicit manifest metadata. Reject any row that derives a historical
+minimum from marker absence or guesses one from symbols.
+
+Golden classifier corpus (reader status and historical metadata are separate columns):
+
+| Form | Reader marker | Reader status before S3 | Historical minimum | Source |
+|---|---|---|---|---|
+| Guide 01 event-vector form | unmarked | active | S1 | frozen surface matrix |
+| Guide 03 `sub` form | unmarked | active | S2 | frozen surface matrix |
+| Guide 03 `local` form | `lands S3` | parked before S3 | S3 | explicit page marker |
+
+The extractor golden test mutates the Guide 03 `sub` row back to an absence→S1
+fallback and requires that classification to fail.
+
 **Scope note — inline code spans are out.** The promise binds *fenced examples*. Prose
-one-liners and inline spans (guide 09's selector bullets, decision-table cells) are
+one-liners and inline spans (Guide 08's selector bullets, decision-table cells) are
 covered opportunistically — the S1d precedent lifted two of them as extra deftests, and
 bridge fixtures may keep doing so — but they are not counted, not manifest rows, and
 their absence is not a promise violation. Trying to extract inline spans is how
 literate pipelines drown.
 
 **README amendment at S6** (one sentence, honesty): once every chapter is active, the
-README's exact-coverage statement (re-based 2026-07-13 — it names guide 09's fixture as
-the only one live today) becomes the full promise, gaining "— except the handful marked
+README's exact-coverage statement (re-based 2026-07-15 — it names Guide 08's enrolled
+Tier-1 subset as the only live coverage) becomes the full promise, gaining "— except the handful marked
 `guide:no-fixture` on the page, each with its reason", plus the marker convention in
 the stage-honesty paragraph. Until then coverage is stated exactly on the README and
 counted per chapter by the manifest (§3).
@@ -152,31 +174,41 @@ that CI asserts — skipped-not-silent.**
 chapter:
 
 ```clojure
-{:chapter "09-testing"
- :fixture-ns 're-frame.ui.test-guide09-fixture-jvm-test
- :status :active                       ; :active | :parked
- :stage :s1                            ; the stage whose shipping activates/activated it
- :fences {:eligible 3 :waived 0}       ; census at last lift
- :adapted [{:section "Tier 1" :what "sub reads → props" :until :s2}
-           {:section "Tier 1" :what "dispatch!-driven loop → structural subset" :until :s2}]
- :lifted "2026-07-12"}
+{:chapter "08-testing"
+ :fixture-ns 're-frame.ui.test-guide08-fixture-jvm-test
+ :status :active
+ :minimum-stage :s1
+ :minimum-stage-source :frozen-surface-matrix
+ :enrolled {:fences 1 :prose-checks 4}
+ :adapted []
+ :lifted "2026-07-12"
+ :last-reconciled :s2}
 ```
 
-`:adapted` is the S1d docstring ledger promoted to data: every stage-driven deviation
-from the page is enumerable, so "de-adapt guide 09" at S2 is a mechanical checklist,
-not a re-read.
+`:minimum-stage` is historical metadata, never inferred from an absent reader marker.
+`:adapted` contains current deviations only. Guide 08 (formerly Guide 09)
+de-adaptation completed at S2, so the current manifest input is empty and passes with
+shipped stages `#{:s1 :s2}`.
+
+Historical audit record — explicitly not current manifest input:
+
+| Former Guide 09 S1 bridge adaptation | Disposition |
+|---|---|
+| `sub` reads represented as props | retired at S2; executable fixture uses compiled `sub` |
+| dispatch loop reduced to the structural subset | retired at S2; executable fixture proves dispatch → sub → re-render |
 
 **The manifest gate** (one JVM deftest beside the manifest, discovered by the ordinary
 cognitect runner — zero new CI wiring) asserts:
 
 1. every `:active` row's namespace exists and was discovered this run;
-2. every `:parked` row's `:stage` is **not** in the shipped-stages set — i.e. *a
+2. every `:parked` row's explicit `:park-until` is **not** in the shipped-stages set — i.e. *a
    shipped stage may have no parked rows*. This is the activation forcer: when the S2
    epic flips shipped-stages to `#{:s1 :s2}`, the gate goes red until every
-   `:stage :s2` row is activated (fixture landed, adaptations removed). Activation
+   `:park-until :s2` row is activated (fixture landed, adaptations removed). Activation
    rides the stage's own wave because the gate makes anything else red;
-3. every `:adapted` entry's `:until` stage is not shipped (same forcer, finer grain —
-   guide 09 is `:active` at S1 but its two adaptations park on S2);
+3. every current `:adapted` entry's explicit `:park-until` stage is not shipped (the
+   same forcer at finer grain); completed adaptations stay in the historical audit
+   record above, outside manifest input;
 4. every guide chapter has a row (the completeness pass adds chapters; a chapter with
    no row is red). Bridge-era source for "every chapter": the manifest itself carries
    the chapter list — the tracked pages are CI-readable, but with no extractor before
@@ -191,17 +223,15 @@ shipped, an adaptation that outlived its stage, a chapter with no row. "Everythi
 green" therefore *cannot* mean "nothing ran": green means "everything the manifest
 says is active ran, and nothing the manifest says is parked should have been active".
 
-**Shipped-stages anchor.** The gate needs one authoritative "which stages have shipped"
-value. Recommend a single set declared beside the manifest, bumped by the stage epic's
-gate-wiring bead (the ⟨12 §3⟩ standing rule — every stage's gates wire in-stage —
-already creates that bead). **[S3-CONFIRM]** whether the S2 epic prefers deriving this
-from an existing artefact-level stage var instead of a test-tree set; either works, one
-must be named authoritative.
+**Shipped-stages anchor.** The current set is `#{:s1 :s2}`. The future gate needs one
+authoritative value declared beside the manifest and bumped by each stage epic's gate
+wiring. **[S3-CONFIRM]** whether that stays a test-tree set or derives from an existing
+artefact-level stage var; either works, one must be named authoritative.
 
-**End-state stage gating (S6).** The extractor reads the page's own stage markers
+**End-state stage gating (S6).** The extractor reads explicit page stage markers
 (chapter stage notes, header markers, `;; guide:stage` overrides), consults
-shipped-stages, and routes each fence: shipped → generated namespace; unshipped →
-manifest `:parked` row. Post-S6 all of S1–S5 has shipped, so parking then only concerns
+shipped-stages, and routes each fence: absent/shipped marker → generated namespace;
+unshipped marker → manifest `:parked` row. Post-S6 all of S1–S5 has shipped, so parking then only concerns
 S6/S7-marked content (`->react` *(lands S6)*, Story *(rides S6)*) and future-stage
 markers the completeness pass adds — the mechanism outlives the bridge.
 
@@ -213,17 +243,17 @@ default assertion per fence kind — companions add more, never less:
 
 | Fence kind | Default assertion | Precedent / source |
 |---|---|---|
-| **`deftest` fence** (01 §Prove-it, 04 §plan-select, 09 §Tier 1, 10 §Tests) | self-asserting — lift verbatim; the fence *is* the fixture | S1d `add-button-carries-intent` is guide 09's block at verbatim shape |
+| **`deftest` fence** (01 §Prove-it, 04 §plan-select, 08 §Tier 1, 10 §Tests) | self-asserting — lift verbatim; the fence *is* the fixture | `add-button-carries-intent` is Guide 08's block at verbatim shape |
 | **View/dataflow definition fence** (`defview` / `reg-event` / `reg-sub` bodies: 02, 03, 04 §form, 10 §state-shape) | compiles + registers + **render-succeeds**: `ui.test/render` against a scaffold-supplied frame and props returns a tree, and `(ui.test/find tree <view-id>)` finds the boundary node | the scaffold's render-cases table is the generalisation of S1d's invented `fixture-catalog`; view-id findability per ⟨drafts/ui-test-selector-grammar.md §view-sel⟩ |
-| **Intent example** ("what does this button do") | `find`/`attrs` equality on the event vector, read through the projections, never keyword lookup on the node | S1d `intent-assertion-respelled-through-attrs`; ⟨guide 09 §Tier 1 ground rules⟩ |
-| **State-drive example** (`dispatch!` → re-render → assert) | dispatch on a real frame, re-render, assert the new tree — *(S2; parked/adapted until then per §3)* | S1d `drive-state-with-real-events` (adapted form) |
+| **Intent example** ("what does this button do") | `find`/`attrs` equality on the event vector, read through the projections, never keyword lookup on the node | `intent-assertion-respelled-through-attrs`; ⟨guide 08 §Tier 1 ground rules⟩ |
+| **State-drive example** (`dispatch!` → re-render → assert) | dispatch on a real frame, re-render, assert the new tree | Guide 08 `drive-state-through-the-real-sub`, active since S2 |
 | **Didactic-error example** (02 `:key`-reserved, 03 sub-in-loop, 04 loop-captured vector, 06's build-time roster, 08 duplicate-root) | **compile-error-with-id**: macroexpansion throws, and the error carries the catalogued id — asserting the guide's *claim*, not a message string | the ui suite's `analyze_reject` / `error_roster` shape; Spec 009 catalogue discipline ⟨guide 06 §Loud, early, didactic⟩ |
-| **Mount/host fence** (`js/document…`: 01 §whole-app, 05 §frame-root, 08 §host tier, 10 §Mount) | JVM tier takes the fence's non-host forms (the S1d move); the mount form itself routes `;; guide:target dom` → generated `*_dom_cljs_test.cljs`, default assertion mount-succeeds + unmount-total | S1d lifted the defviews and skipped the mount; DOM suffix convention per ⟨TESTING.md §Kinds — browser unit⟩ |
+| **Mount/host fence** (`ui/mount`, `ui.test/with-root`, host-tier roots: guides 01, 05, 06, 08, 11) | every such fence routes through its explicit `;; guide:target dom` marker → generated `*_dom_cljs_test.cljs`; structural fences default to JVM | nine-fence census in ⟨guide-docs-move-plan §2.4⟩; DOM suffix convention per ⟨TESTING.md §Kinds — browser unit⟩ |
 | **Config/infra fence** (01 `deps.edn`) | none — `guide:no-fixture` | install surface, not API |
 
 Two rules ride along from the precedent, verbatim into the pipeline contract: reads go
 through `ui.test/attrs` / `ui.test/text` (a fixture keyword-looking-up a node field is
-a review reject — it "silently misses" ⟨guide 09⟩), and every fixture app surface the
+a review reject — it "silently misses" ⟨guide 08⟩), and every fixture app surface the
 scaffold invents must be `.cljc`-honest (the guide's own Tier-1 ground rule).
 
 **Scaffolds.** Per chapter, one hand-maintained file in the test tree
@@ -291,12 +321,11 @@ activation, riding the owning stage's epic (they are that stage's proof rows per
 
 | Stage | Guide fixture work riding it |
 |---|---|
-| **now (S1 remainder)** | manifest + manifest gate land (S1-scoped, parked rows for everything unshipped); S1-eligible chapters mirrored: 01 (subless subset), 02 (templates, spread, `ui/html`, compile-error roster claims), 08 (structural/JVM-tree subset). Guide 09 already shipped (S1d) — its manifest row gains the `:adapted` ledger |
-| **S2** | activate/de-adapt: 01 (full counter — sub path), 03 §sub + §lease, 05 (frames runtime), 09 (de-adapt: `dispatch!`, drive-state), 10 (tiles, `dispatch!` tests), 07 (narrow-read economics fences, if the completeness pass adds any) |
+| **S1–S2 completed** | Guide 08's bridge fixture (formerly Guide 09) is active at `implementation/ui/test/re_frame/ui/test_guide08_fixture_jvm_test.clj`. Guide 08 (formerly Guide 09) de-adaptation completed at S2: compiled `sub` and dispatch → sub → re-render now run directly; its current `:adapted` input is empty. Other chapter enrolment remains prospective |
 | **S3** | 03 §local + §effect, 04 (whole chapter: placeholders, `ui/event`, sync door, decision table, loop rules), 02 §error-boundary + `.react` tier, 06 (runtime-warning ids + `ui.tool` fences), 10 §risky-part |
-| **S4** | 02 §presence + §custom-elements; `flush-presence!` examples in 09 |
-| **S5** | 08 §hydration + §render-static + §client-only flip |
-| **S6 (W2/W3, with W9 for CI wiring)** | **the pipeline**: extractor + marker grammar enforcement + scaffolds (converted from bridge fixtures) + generated-namespace wiring + manifest generation/freshness gate + drift gate for surviving adapted regions + README amendment; bridge fixtures retired chapter-by-chapter as extraction takes over (verbatim-lifted deftests move to page-extracted namespaces; invented app surfaces become scaffolds; hand files die). Plus content that itself lands S6: 02 `->react`, 09 §Story |
+| **S4** | 02 §presence + §custom-elements; `flush-presence!` examples in 08 |
+| **S5** | 11 §hydration + §render-static + §client-only flip |
+| **S6 (W2/W3, with W9 for CI wiring)** | **the pipeline**: extractor + marker grammar enforcement + scaffolds (converted from bridge fixtures) + generated-namespace wiring + manifest generation/freshness gate + drift gate for surviving adapted regions + README amendment; bridge fixtures retired chapter-by-chapter as extraction takes over (verbatim-lifted deftests move to page-extracted namespaces; invented app surfaces become scaffolds; hand files die). Plus content that itself lands S6: 02 `->react`, 08 §Story |
 
 **CI wiring shape.** Bridge era: zero new wiring — fixtures are ordinary
 `test_guideNN_fixture_jvm_test.clj` files under `implementation/ui/test/`, discovered
@@ -324,7 +353,7 @@ when W9 lands it.
 wall-clock budget assertion over the guide-fixture namespaces to the ui JVM suite
 (suggest ≤ 10 s total at S2 scale, revisited per stage — **[S3-CONFIRM]** the number
 with the S2 corpus in hand). The fixtures are Tier-1 JVM renders — "milliseconds,
-never flake on timing" ⟨guide 09⟩ — so the budget is a pathology tripwire in the G-14
+never flake on timing" ⟨guide 08⟩ — so the budget is a pathology tripwire in the G-14
 style, not a performance target.
 
 **Demand-bar coupling (free win).** ⟨07-testing §7⟩: "The examples corpus feeds the

--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -50,6 +50,7 @@ namespace under `src/`, and an `index.html` with a `<div id="root">`.
 ## The whole app
 
 ```clojure
+;; guide:target dom
 (ns my.app
   (:require [re-frame.core :as rf]
             [re-frame.ui :as ui :refer [defview sub]]))

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -7,6 +7,7 @@ names say which verb they perform.
 ## `frame-root` — ensure
 
 ```clojure
+;; guide:target dom
 (ui/mount [ui/frame-root {:id :app :initial-events [[:app/init]]}
             [app-view]]
           root-el)
@@ -37,6 +38,7 @@ Mixing them up fails loudly with a did-you-mean: `frame-root` given `:frame`, or
 Frames are **isolated**. A page can mount several:
 
 ```clojure
+;; guide:target dom
 (ui/mount [:div.page
            [ui/frame-root {:id :shop   :initial-events [[:shop/init]]}   [shop-app]]
            [ui/frame-root {:id :assist :initial-events [[:assist/init]]} [assistant]]]

--- a/ai/findings/new-substrate-synthesis/guide/06-worked-app.md
+++ b/ai/findings/new-substrate-synthesis/guide/06-worked-app.md
@@ -134,6 +134,7 @@ dashboard:
 ## Mount
 
 ```clojure
+;; guide:target dom
 (defn ^:export run []
   (rf/init! ui/adapter)
   (ui/mount [ui/frame-root {:id :dash :initial-events [[:dash/init]]}

--- a/ai/findings/new-substrate-synthesis/guide/08-testing.md
+++ b/ai/findings/new-substrate-synthesis/guide/08-testing.md
@@ -36,6 +36,11 @@ mounted CLJS test namespace, use the same fixture with `ui/adapter` and `:async?
 `ui.test/render` runs the real view against a real frame on the JVM — real
 subscriptions, real registrations, no React:
 
+Guide 08's enrolled fixture covers the Tier-1 deftest, intent projection,
+dispatch-to-sub loop, seeded-state render, and sub-override door. The selector and
+literal-root fences below, plus the Tier-2 and Tier-3 examples, remain prospective
+pipeline enrolment.
+
 ```clojure
 (deftest add-button-carries-intent
   (rf/with-new-frame
@@ -166,6 +171,7 @@ rides an object primary as `rfUiTestCleanupError`, matching `with-root` itself:
 Read-only:
 
 ```clojure
+;; guide:target dom
 (deftest search-box-really-mounts
   (async done
     (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:query ""}]]})]
@@ -181,6 +187,7 @@ When the test *writes*, put the write inside `flush!`'s act boundary and await e
 Promise:
 
 ```clojure
+;; guide:target dom
 (deftest search-commits-the-latest-query
   (async done
     (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:query ""}]]})]

--- a/ai/findings/new-substrate-synthesis/guide/11-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/11-ssr.md
@@ -67,6 +67,7 @@ from the mounted view's registered id — the [01](01-getting-started.md) counte
 zero ceremony. Author identity the moment a page outgrows that:
 
 ```clojure
+;; guide:target dom
 (ui/mount [ui/frame-root {:id :shop} [product-panel]] left-el
           {:root-id :panel/left})
 (ui/mount [ui/frame-root {:id :shop} [product-panel]] right-el
@@ -83,6 +84,7 @@ zero ceremony. Author identity the moment a page outgrows that:
 Hosts needing more control than `mount` use the host tier directly:
 
 ```clojure
+;; guide:target dom
 (def root (ui/create-root el {:root-id :page/shop}))
 (ui/render! root [ui/frame-root {:id :shop :initial-events [[:shop/init]]}
                    [shop-app]])
@@ -96,6 +98,7 @@ place (the hot-reload path from [01](01-getting-started.md)).
 Hydration is the same tier *(lands S5)*:
 
 ```clojure
+;; guide:target dom
 (ui/hydrate-root (js/document.getElementById "shop-root")
                  [ui/frame-root {:id :shop} [shop-app]])
 ```

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -75,14 +75,16 @@ Code assumes:
 Other body forms (`local`, `effect`, `lease`, `frame`, `presence-phase`) are referred
 the same way when a chapter needs them — one convention, every chapter.
 
-**Stage honesty.** The library ships in stages. Unmarked examples are the ruled
-contract and, where noted on a page, already on main. Surfaces that land later carry a
-short marker such as *(lands S3)*. Wave-2 names (`ui/element`, `ui/view`, `ui/portal`,
-`re-frame.ui.data/render`) are not v1 and only appear with that qualifier.
+**Stage honesty.** The library ships in stages. Unmarked examples describe behaviour
+shipped on main. Surfaces that land later carry a short marker such as *(lands S3)*.
+Wave-2 names (`ui/element`, `ui/view`, `ui/portal`, `re-frame.ui.data/render`) are not
+v1 and only appear with that qualifier.
 
 **True snippets.** Fences are written to run as guide fixtures where the pipeline covers
 them. A fence that is schematic or wave-2 says so with a `;; guide:no-fixture` comment
-on the fence itself.
+on the fence itself. Guide 08's enrolled fixture covers the Tier-1 deftest, intent
+projection, dispatch-to-sub loop, seeded-state render, and sub-override door. Its
+remaining fences and every other chapter are prospective pipeline enrolment.
 
 ---
 

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -2,8 +2,8 @@
   "Focused truth gates for the tracked pre-publication re-frame.ui guide.
 
   These assertions protect the ruled lifecycle recipe, guide-wide rendering
-  boundary, Xray S3 surface, and S6 relocation plan until the guide moves to
-  docs/ui."
+  boundary, fixture-marker mechanics, Xray S3 surface, and S6 relocation plan
+  until the guide moves to docs/ui."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
@@ -54,6 +54,29 @@
 (defn- target-path
   [target]
   (first (str/split target #"#" 2)))
+
+(defn- clojure-fences
+  [chapter]
+  (map-indexed
+    (fn [index [_ body]]
+      {:id   (str chapter "#" (inc index))
+       :body body})
+    (re-seq #"(?ms)^```clojure[^\r\n]*\r?\n(.*?)^```\s*$"
+            (slurp-guide chapter))))
+
+(defn- host-fence?
+  [{:keys [body]}]
+  (boolean
+    (re-find #"ui/(?:mount|hydrate-root|create-root|render!|unmount!)|ui\.test/with-root|js/document"
+             body)))
+
+(defn- dom-target?
+  [{:keys [body]}]
+  (boolean (re-find #"\A;; guide:target dom\r?\n" body)))
+
+(defn- one-line
+  [text]
+  (str/replace text #"\s+" " "))
 
 (deftest lifecycle-recipe-is-installed-and-owned
   (let [getting-started (slurp-guide "01-getting-started.md")
@@ -189,6 +212,69 @@
     (is (not (str/includes? readme
                             "../../../../docs/core/frames.md"))
         "compatibility-only Frames teaching must not be a canonical continuation")))
+
+(deftest fixture-stage-and-guide09-ledger-stay-current
+  (let [readme (slurp-guide "README.md")
+        testing-guide (slurp-guide "08-testing.md")
+        pipeline (slurp (root-file
+                          "ai/findings/new-substrate-synthesis/drafts/guide-fixture-pipeline.md"))]
+    (testing "marker absence means active shipped behaviour, never an S1 fallback"
+      (is (str/includes? (one-line readme)
+                         "Unmarked examples describe behaviour shipped on main."))
+      (is (str/includes? (one-line pipeline)
+                         "An unmarked fence is active because it describes current shipped behaviour; it does not imply S1."))
+      (doseq [golden-row ["Guide 01 event-vector form | unmarked | active | S1 | frozen surface matrix"
+                          "Guide 03 `sub` form | unmarked | active | S2 | frozen surface matrix"
+                          "Guide 03 `local` form | `lands S3` | parked before S3 | S3 | explicit page marker"]]
+        (is (str/includes? pipeline golden-row)
+            (str "missing stage-classifier golden row: " golden-row)))
+      (is (not (re-find #"(?i)(?:unmarked\s*=\s*(?:stage\s*)?1|else\s+(?:stage\s*)?1)"
+                        pipeline))
+          "restoring marker absence as the S1 fallback must fail"))
+    (testing "the formerly Guide 09 S1 bridge adaptations retired when S2 shipped"
+      (doseq [page [readme testing-guide]]
+        (is (str/includes?
+              (one-line page)
+              "Guide 08's enrolled fixture covers the Tier-1 deftest, intent projection, dispatch-to-sub loop, seeded-state render, and sub-override door.")))
+      (is (str/includes?
+            pipeline
+            "implementation/ui/test/re_frame/ui/test_guide08_fixture_jvm_test.clj"))
+      (is (str/includes? pipeline ":adapted []"))
+      (is (zero? (count (re-seq #":until\s+:s2" pipeline)))
+          "no active formerly-Guide-09 adaptation may remain parked on shipped S2")
+      (is (str/includes? (one-line pipeline)
+                         "Guide 08 (formerly Guide 09) de-adaptation completed at S2")))))
+
+(deftest every-host-fence-declares-the-dom-target
+  (let [fences (mapcat clojure-fences chapter-files)
+        host-ids (->> fences (filter host-fence?) (map :id) set)
+        dom-ids  (->> fences (filter dom-target?) (map :id) set)
+        plan     (slurp (root-file
+                          "ai/findings/new-substrate-synthesis/drafts/guide-docs-move-plan.md"))
+        expected #{"01-getting-started.md#3"
+                   "05-frames.md#1"
+                   "05-frames.md#3"
+                   "06-worked-app.md#6"
+                   "08-testing.md#7"
+                   "08-testing.md#8"
+                   "11-ssr.md#2"
+                   "11-ssr.md#3"
+                   "11-ssr.md#4"}]
+    (is (= expected host-ids)
+        "the reviewed host-fence census changed; classify the changed fence explicitly")
+    (is (= expected dom-ids)
+        "every and only host-dependent fence must carry `;; guide:target dom`; structural fences default to JVM")
+    (doseq [plan-row ["01 whole-app mount | `;; guide:target dom`"
+                      "05 `frame-root` mount | `;; guide:target dom`"
+                      "05 multi-frame page mount | `;; guide:target dom`"
+                      "06 dashboard mount | `;; guide:target dom`"
+                      "08 mounted read-only test | `;; guide:target dom`"
+                      "08 mounted write test | `;; guide:target dom`"
+                      "11 authored two-root mounts | `;; guide:target dom`"
+                      "11 direct host-tier root | `;; guide:target dom`"
+                      "11 hydration | `;; guide:target dom`"]]
+      (is (str/includes? plan plan-row)
+          (str "move-plan target census omits " plan-row)))))
 
 (deftest simulated-docs-ui-relocation-keeps-every-guide-link-in-repo
   (let [source-prefix "../../../../docs/core/"


### PR DESCRIPTION
Settles the guide fixture mechanics in the new-substrate-synthesis guide and its fixture-pipeline draft, and aligns the docs move plan.

Recovered from a worker branch that completed the work but stranded before pushing or opening a PR.