### PR TITLE
fix(ui): make custom-element declarations deterministic (rf2-vxgfnd.141, rf2-vxgfnd.143)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -339,7 +339,36 @@
     ;; declaring ns so a hot-reload that DROPS this declaration evicts its
     ;; stale runtime row — the runtime arm of the same eviction model
     ;; (rf2-vxgfnd.48).
-    (build/contribute! build/elements ns-sym tag {:properties props})
+    ;;
+    ;; The ONE cross-source declaration law (rf2-vxgfnd.143, delegated ruling
+    ;; 2026-07-15 Option A): rf=-equal duplicates co-exist; a CONTRADICTORY
+    ;; declaration of the same tag from another source fails ATOMICALLY with
+    ;; both [build-id ns-sym] anchors and leaves the last-known-good aggregate
+    ;; unchanged. Which of two contradicting sources expands second decides
+    ;; only WHERE the failure is anchored — never who wins, and never whether
+    ;; the build fails. `:declarations` evidence is sorted, so it is identical
+    ;; under every source / evaluation / build-order permutation.
+    (let [decl {:properties props}]
+      (when-let [{:keys [conflict]} (build/contribute-element-checked!
+                                     ns-sym tag decl)]
+        (let [build-id (build/current-build-id)
+              rows (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                 [{:build build-id
+                                   :ns (:owner conflict)
+                                   :properties (:properties (:declaration conflict) #{})}
+                                  {:build build-id :ns ns-sym :properties props}]))]
+          (fail :rf.ui.compile/custom-element-conflict
+                (str "conflicting (ui/custom-element " tag " ...) declarations — "
+                     (str/join " vs "
+                               (map (fn [{:keys [ns properties]}]
+                                      (str ns " declares :properties "
+                                           (pr-str (vec (sort properties)))))
+                                    rows))
+                     ". One tag has ONE property manifest: delete the duplicate "
+                     "declaration, or make both sources declare an IDENTICAL "
+                     ":properties set (identical declarations may co-exist). "
+                     "re-frame.ui will not pick a winner by compile order")
+                {:tag tag :declarations rows}))))
     `(re-frame.ui.rules/register-custom-element!
       ~tag {:properties ~props} '~ns-sym)))
 

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -42,7 +42,8 @@
 
   `state` plus begin/commit/abort below remain only as a plain-JVM/test harness
   for the same pure slice transitions. They are not Shadow build authority."
-  (:require [re-frame.ui.fingerprint :as fingerprint]))
+  (:require [re-frame.ui.eq :as eq]
+            [re-frame.ui.fingerprint :as fingerprint]))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry ids (opaque keys naming the five build-scoped registries)
@@ -54,6 +55,7 @@
 (def plans       ::plans)        ; Layer-1 frame-plan index
 (def descriptors ::descriptors)  ; Root Descriptor index
 (def elements    ::elements)     ; compile-time custom-element declarations
+(def ^:private element-declarations ::element-declarations) ; tag -> owning ns
 
 ;; ---------------------------------------------------------------------------
 ;; State
@@ -507,6 +509,102 @@
                          (write-slice views source view-id digest)))))))
     @outcome))
 
+(defn- element-conflict-row
+  "Pure: one side of a custom-element contradiction, rendered as deterministic
+  evidence. `build-id` + `ns` are the ruled `[build-id ns-sym]` anchor pair."
+  [build-id source decl]
+  {:build build-id
+   :ns source
+   :properties (:properties decl #{})})
+
+(defn elements-conflict
+  "Pure DEFENCE-IN-DEPTH detector: the first cross-source non-`rf=`-equal
+  same-tag collision in a per-source `registries` map (`{source {reg-id {k v}}}`),
+  or nil.
+
+  `contribute-element-checked!` is the write BARRIER — it is the law, and it
+  makes a conflicting row unable to enter a slice in the first place. This
+  function re-derives the same verdict from finalized rows so that NO
+  aggregation path can ever pick a winner by merge order, even if a row
+  arrived by some route that bypassed the barrier. Sources are folded in
+  sorted order and the losing pair is reported with BOTH anchors sorted the
+  same way, so the evidence is identical under every source permutation."
+  [build-id registries]
+  (let [conflict (fn [tag owner prior source decl]
+                   {::conflict
+                    {:tag tag
+                     :declarations
+                     (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                   [(element-conflict-row build-id owner prior)
+                                    (element-conflict-row build-id source decl)]))}})
+        step (fn [seen source]
+               (reduce-kv
+                (fn [seen tag decl]
+                  (let [[owner prior] (get seen tag)]
+                    (cond
+                      (nil? owner)          (assoc seen tag [source decl])
+                      (eq/rf= prior decl)   seen  ; duplicates co-exist
+                      :else                 (reduced (conflict tag owner prior
+                                                               source decl)))))
+                seen
+                (get-in registries [source elements])))
+        outcome (reduce (fn [seen source]
+                          (let [next (step seen source)]
+                            (if (::conflict next) (reduced next) next)))
+                        {}
+                        (sort-by str (keys registries)))]
+    (::conflict outcome)))
+
+(defn contribute-element-checked!
+  "Atomically contribute ONE custom-element declaration under the ruled
+  cross-source conflict law (rf2-vxgfnd.143, delegated ruling 2026-07-15
+  Option A — fail atomically; never a merge/winner law).
+
+  Inside ONE `swap!`, `source`'s `tag` -> `decl` is admitted iff every OTHER
+  live source's declaration of `tag` is `rf=`-equal to it. `rf=`-equal
+  duplicates co-exist (idempotent — two namespaces may legitimately state the
+  same fact); a non-`rf=`-equal declaration from a DIFFERENT source is a
+  contradiction and is REJECTED without writing, so the losing row never
+  enters the ledger and the last-known-good aggregate is left untouched.
+
+  A source never conflicts with ITSELF across passes: during an open pass the
+  source's COMMITTED rows are excluded (it is being replaced wholesale), and
+  on the no-pass REPL path a re-evaluated declaration simply replaces its own
+  prior row. Its STAGED rows are NOT excluded, so two contradictory
+  declarations of one tag inside a single compile of one namespace do fail —
+  those are two live declarations, not a replacement.
+
+  Owner provenance is written in the SAME `swap!` as the declaration, so the
+  rejected side can always be anchored to BOTH `[build-id ns-sym]` pairs.
+  Returns nil on success, or `{:conflict {:owner <ns> :declaration <decl>}}`
+  without writing."
+  [source tag decl]
+  (let [outcome (atom nil)]
+    (update-current-slice!
+     (fn [slice]
+       (let [other-decl (get (effective slice elements source) tag)
+             other-owner (get (effective slice element-declarations source) tag)
+             ;; Own STAGED row only: a second, contradictory declaration of the
+             ;; same tag in the same pass of the same ns. Committed/no-pass rows
+             ;; are the source replacing itself and must stay admissible.
+             own-decl (when (:pass-open? slice)
+                        (get-in slice [:staged source elements tag]))
+             conflict (cond
+                        (and (some? other-decl) (not (eq/rf= other-decl decl)))
+                        {:owner other-owner :declaration other-decl}
+
+                        (and (some? own-decl) (not (eq/rf= own-decl decl)))
+                        {:owner source :declaration own-decl}
+
+                        :else nil)]
+         (if conflict
+           (do (reset! outcome {:conflict conflict}) slice)
+           (do (reset! outcome nil)
+               (-> slice
+                   (write-slice element-declarations source tag source)
+                   (write-slice elements source tag decl)))))))
+    @outcome))
+
 ;; ---------------------------------------------------------------------------
 ;; Pass boundaries
 ;; ---------------------------------------------------------------------------
@@ -628,6 +726,22 @@
          :build-id build-id
          :recovery :configure-ui-build-hook-once})))
     (let [after (-> scratch commit-slice (keep-members (set members)))
+          ;; Defence in depth (rf2-vxgfnd.143): `contribute-element-checked!`
+          ;; is the barrier, so a contradiction cannot reach here. Re-deriving
+          ;; the verdict from the FINALIZED rows — once per pass, not per read —
+          ;; means no aggregation can publish a merge-order winner even if a row
+          ;; arrived by a route that bypassed the barrier.
+          _ (when-let [c (elements-conflict build-id (:committed after))]
+              (throw
+               (ex-info
+                (str "re-frame.ui found contradictory custom-element declarations "
+                     "for " (:tag c) " in the finalized build; refusing to publish "
+                     "a merge-order winner")
+                {::error ::custom-element-conflict
+                 :build-id build-id
+                 :recovery :reconcile-custom-element-declarations
+                 :tag (:tag c)
+                 :declarations (:declarations c)})))
           digest (digest-for-slice after)
           snapshot {:build-id build-id
                     :registries (:committed after)

--- a/implementation/ui/test/re_frame/ui/custom_element_conflict_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_conflict_jvm_test.clj
@@ -1,0 +1,259 @@
+(ns re-frame.ui.custom-element-conflict-jvm-test
+  "THE ONE cross-source custom-element declaration law (rf2-vxgfnd.143;
+  delegated ruling 2026-07-15, Option A — fail atomically).
+
+  Before this law the same tag had TWO different winner rules — direct
+  registration published the LAST evaluated call, while an aggregate rebuild
+  merged ledger rows in sorted OWNER order — so an unrelated reload could flip
+  the effective property manifest without either conflicting declaration
+  changing, and the compiler's own aggregate merged with no conflict check at
+  all. Three silent-precedence paths, each keyed on incidental order.
+
+  The law, applied identically wherever declarations are aggregated:
+
+    - `rf=`-equal declarations of one tag MAY co-exist across sources
+      (idempotent — two namespaces are allowed to state the same fact);
+    - a NON-`rf=`-equal declaration of the same tag from a DIFFERENT source is
+      a contradiction: it fails atomically, carries BOTH `[build-id ns-sym]`
+      anchors, and leaves the last-known-good aggregate unchanged;
+    - a source never conflicts with ITSELF across passes (re-declaration
+      replaces its own row), but two contradictory declarations inside ONE
+      pass of one namespace are two LIVE declarations and do fail;
+    - no path ever picks a winner — not last-call, not sorted owner, not
+      compile order.
+
+  THE DETERMINISM DISCIPLINE (why these tests are permutation folds, not
+  single happy-path cases): a law that merely *fails somewhere* is not the
+  same as a law that fails IDENTICALLY. Every conflict test below drives BOTH
+  contribution orders and asserts the two runs produce byte-identical
+  `:declarations` evidence. Under the old last-writer/sorted-merge behaviour a
+  permutation changed the WINNER; under a naive fix a permutation still
+  changes the reported EVIDENCE. Both are caught here."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler :as compiler]
+            [re-frame.ui.compiler.build :as build]))
+
+(use-fixtures :each
+  (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
+
+;; ---------------------------------------------------------------------------
+;; Harness — the REAL `ui/custom-element` macro body, with a controllable
+;; declaring namespace (the ledger's source key).
+;; ---------------------------------------------------------------------------
+
+(defn- declare-element!
+  "Run the real `ui/custom-element` macro body with `ns-sym` bound as the
+  declaring namespace. Returns nil on success; the thrown ExceptionInfo on a
+  compile error."
+  [ns-sym tag properties]
+  (binding [*ns* (create-ns ns-sym)]
+    (try
+      (compiler/custom-element*
+       (with-meta (list 'custom-element tag {:properties properties})
+         {:line 1})
+       {} tag {:properties properties})
+      nil
+      (catch clojure.lang.ExceptionInfo ex ex))))
+
+(defn- declare-ok!
+  "Declare, asserting it was ADMITTED (the law must not reject this)."
+  [ns-sym tag properties]
+  (let [ex (declare-element! ns-sym tag properties)]
+    (is (nil? ex)
+        (str ns-sym " declaring " tag " " (pr-str properties)
+             " must be admitted — got " (some-> ex ex-message)))
+    ex))
+
+(defn- props [tag] (build/element-properties tag))
+
+(defn- conflict-data
+  "The conflict ex-data of a rejected declaration, or nil when admitted."
+  [ex]
+  (when ex
+    (let [d (ex-data ex)]
+      (when (= :rf.ui.compile/custom-element-conflict (:rf.ui.compile/error d))
+        (select-keys d [:tag :declarations])))))
+
+;; ---------------------------------------------------------------------------
+;; rf=-equal duplicates co-exist
+;; ---------------------------------------------------------------------------
+
+(deftest rf-equal-duplicates-from-two-sources-coexist
+  ;; Two namespaces stating the SAME fact is not a contradiction — the law
+  ;; rejects disagreement, not redundancy.
+  (declare-ok! 'a.ns :x-card #{:model :help-text})
+  (declare-ok! 'z.ns :x-card #{:model :help-text})
+  (is (= #{:model :help-text} (props :x-card))
+      "an rf=-equal duplicate leaves the manifest intact"))
+
+(deftest rf-equal-duplicate-admission-is-order-independent
+  (doseq [order [['a.ns 'z.ns] ['z.ns 'a.ns]]]
+    (build/reset-build!)
+    (doseq [ns-sym order]
+      (declare-ok! ns-sym :x-card #{:model}))
+    (is (= #{:model} (props :x-card))
+        (str "duplicates co-exist under order " (pr-str order)))))
+
+;; ---------------------------------------------------------------------------
+;; The headline: conflicting declarations fail atomically + identically
+;; ---------------------------------------------------------------------------
+
+(deftest conflicting-declarations-fail-atomically
+  (declare-ok! 'z.ns :x-el #{:z})
+  (let [ex (declare-element! 'a.ns :x-el #{:a})
+        data (conflict-data ex)]
+    (is (some? data) "the contradicting declaration is REJECTED, not merged")
+    (is (= :x-el (:tag data)) "evidence names the tag")
+    (is (= [{:build :re-frame.ui.compiler.build/default :ns 'a.ns :properties #{:a}}
+            {:build :re-frame.ui.compiler.build/default :ns 'z.ns :properties #{:z}}]
+           (:declarations data))
+        "evidence carries BOTH [build-id ns-sym] anchors, sorted")
+    (is (= #{:z} (props :x-el))
+        "the last-known-good aggregate is UNCHANGED — the loser never entered")))
+
+(deftest conflict-evidence-is-identical-under-every-permutation
+  ;; THE determinism proof. Under the retired last-call-wins / sorted-merge
+  ;; behaviour, swapping these two lines swapped the WINNER. The law must make
+  ;; the permutation unobservable: same verdict, same evidence, both ways.
+  (let [run (fn [[first-ns first-props second-ns second-props]]
+              (build/reset-build!)
+              (declare-ok! first-ns :x-el first-props)
+              (conflict-data (declare-element! second-ns :x-el second-props)))
+        forward (run ['z.ns #{:z} 'a.ns #{:a}])
+        reverse (run ['a.ns #{:a} 'z.ns #{:z}])]
+    (is (some? forward) "z-then-a conflicts")
+    (is (some? reverse) "a-then-z conflicts")
+    (is (= forward reverse)
+        (str "conflict evidence must be IDENTICAL under source permutation — "
+             "which source expands second may decide only WHERE the error is "
+             "anchored, never the verdict or the evidence"))))
+
+(deftest conflict-is-not-decided-by-sorted-owner-order
+  ;; The retired `rebuild-live!` merged ledger rows in sorted owner order, so
+  ;; the alphabetically-LAST source silently won. Both directions must now
+  ;; fail, and neither source's properties may become "the answer" by winning
+  ;; a sort: the tag keeps exactly the FIRST admitted declaration and the
+  ;; contradiction is surfaced, never resolved.
+  (testing "alphabetically-earlier source declares first"
+    (build/reset-build!)
+    (declare-ok! 'a.ns :x-el #{:a})
+    (is (some? (conflict-data (declare-element! 'z.ns :x-el #{:z})))
+        "a-then-z must fail (sorted-merge would have let z win silently)")
+    (is (= #{:a} (props :x-el)) "no sorted-order winner"))
+  (testing "alphabetically-later source declares first"
+    (build/reset-build!)
+    (declare-ok! 'z.ns :x-el #{:z})
+    (is (some? (conflict-data (declare-element! 'a.ns :x-el #{:a})))
+        "z-then-a must fail (last-call-wins would have let a win silently)")
+    (is (= #{:z} (props :x-el)) "no last-call winner")))
+
+(deftest conflict-message-names-both-sources-and-the-escape
+  (declare-ok! 'z.ns :x-el #{:z})
+  (let [msg (ex-message (declare-element! 'a.ns :x-el #{:a}))]
+    (doseq [fragment ["a.ns" "z.ns" ":x-el" "IDENTICAL" "will not pick a winner"]]
+      (is (.contains msg fragment)
+          (str "conflict message must name " (pr-str fragment) " — got: " msg)))))
+
+(deftest disjoint-tags-never-conflict
+  (declare-ok! 'a.ns :x-card #{:model})
+  (declare-ok! 'z.ns :x-badge #{:count})
+  (is (= #{:model} (props :x-card)))
+  (is (= #{:count} (props :x-badge))))
+
+;; ---------------------------------------------------------------------------
+;; Self-replacement vs. two live declarations
+;; ---------------------------------------------------------------------------
+
+(deftest same-source-redeclaration-replaces-and-never-conflicts
+  ;; A source never conflicts with itself: the REPL/no-pass path upserts, so
+  ;; re-evaluating a changed declaration must replace its own row.
+  (declare-ok! 'a.ns :x-el #{:a})
+  (declare-ok! 'a.ns :x-el #{:b})
+  (is (= #{:b} (props :x-el))
+      "a source re-declaring its own tag replaces its own row"))
+
+(deftest same-source-redeclaration-across-passes-replaces
+  (build/begin-build! ::default)
+  (declare-ok! 'a.ns :x-el #{:a})
+  (build/commit-build! ::default)
+  (is (= #{:a} (props :x-el)))
+  ;; A hot-reload pass: the same source re-declares a CHANGED manifest. Its
+  ;; committed row is being replaced wholesale — not a contradiction.
+  (build/begin-build! ::default)
+  (declare-ok! 'a.ns :x-el #{:b})
+  (build/commit-build! ::default)
+  (is (= #{:b} (props :x-el))
+      "the source's own committed row is replaced, not conflicted"))
+
+(deftest two-contradictory-declarations-in-one-pass-of-one-ns-fail
+  ;; Distinct from replacement: both declarations are LIVE in the same compile
+  ;; of the same file, so the file contradicts itself.
+  (build/begin-build! ::default)
+  (declare-ok! 'a.ns :x-el #{:a})
+  (let [data (conflict-data (declare-element! 'a.ns :x-el #{:b}))]
+    (is (some? data)
+        "two live contradictory declarations in one pass of one ns must fail")
+    (is (= #{:a} (props :x-el)) "the first admitted declaration stands"))
+  (build/abort-build! ::default))
+
+(deftest rf-equal-redeclaration-in-one-pass-is-idempotent
+  (build/begin-build! ::default)
+  (declare-ok! 'a.ns :x-el #{:a})
+  (declare-ok! 'a.ns :x-el #{:a})
+  (build/commit-build! ::default)
+  (is (= #{:a} (props :x-el))))
+
+;; ---------------------------------------------------------------------------
+;; Build isolation — the law is per-build, never process-global
+;; ---------------------------------------------------------------------------
+
+(deftest contradictory-declarations-in-different-builds-do-not-conflict
+  ;; Two builds legitimately compile the same tag with different manifests.
+  ;; The law is scoped to [build-id tag]; a sibling build is not a conflicting
+  ;; "source".
+  (binding [build/*build-id* :build-a]
+    (declare-ok! 'app.ns :x-el #{:a}))
+  (binding [build/*build-id* :build-b]
+    (declare-ok! 'app.ns :x-el #{:b}))
+  (is (= #{:a} (build/element-properties :x-el :build-a)))
+  (is (= #{:b} (build/element-properties :x-el :build-b))))
+
+;; ---------------------------------------------------------------------------
+;; The pure aggregation detector (defence in depth)
+;; ---------------------------------------------------------------------------
+
+(defn- registries
+  "A per-source registries map: `{ns-sym {tag properties}}` -> the slice shape."
+  [m]
+  (reduce-kv (fn [acc ns-sym decls]
+               (assoc acc ns-sym
+                      {build/elements
+                       (reduce-kv (fn [d tag ps] (assoc d tag {:properties ps}))
+                                  {} decls)}))
+             {} m))
+
+(deftest elements-conflict-detects-cross-source-contradiction
+  (is (nil? (build/elements-conflict
+             ::b (registries {'a.ns {:x-el #{:a}} 'z.ns {:x-el #{:a}}})))
+      "rf=-equal rows across sources are not a conflict")
+  (is (nil? (build/elements-conflict
+             ::b (registries {'a.ns {:x-el #{:a}} 'z.ns {:x-badge #{:a}}})))
+      "different tags are not a conflict")
+  (let [c (build/elements-conflict
+           ::b (registries {'a.ns {:x-el #{:a}} 'z.ns {:x-el #{:z}}}))]
+    (is (= :x-el (:tag c)) "the contradiction is detected from finalized rows")
+    (is (= [{:build ::b :ns 'a.ns :properties #{:a}}
+            {:build ::b :ns 'z.ns :properties #{:z}}]
+           (:declarations c)))))
+
+(deftest elements-conflict-evidence-is-permutation-stable
+  ;; A merge-order-sensitive detector would report whichever row it happened to
+  ;; visit second. Clojure's small-map ordering makes that easy to miss by
+  ;; accident, so assert it directly: the evidence must not depend on which
+  ;; source is enumerated first.
+  (let [a-first (build/elements-conflict
+                 ::b (registries {'a.ns {:x-el #{:a}} 'z.ns {:x-el #{:z}}}))
+        z-first (build/elements-conflict
+                 ::b (registries {'z.ns {:x-el #{:z}} 'a.ns {:x-el #{:a}}}))]
+    (is (= a-first z-first)
+        "the detector's evidence is identical under source permutation")))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -94,6 +94,8 @@
     :rf.ui.compile/unknown-option
     :rf.ui.compile/bad-view-id
     :rf.ui.compile/bad-custom-element
+    ;; the ONE cross-source custom-element declaration law (rf2-vxgfnd.143)
+    :rf.ui.compile/custom-element-conflict
     ;; root identity + mount surface (S1c, rf2-vxgfnd.3 — folded into
     ;; the frozen set by the S1f sweep, rf2-vxgfnd.6)
     :rf.ui.compile/bad-root-id
@@ -140,8 +142,13 @@
                              runtime-root-form / frame-root-misplaced /
                              bad-frame-root
     root_mount_jvm_test      client-entry-on-jvm
-    test_render_jvm_test     bad-test-render-form / bad-test-root"
-  #{:rf.ui.compile/bad-root-id
+    test_render_jvm_test     bad-test-render-form / bad-test-root
+    custom_element_conflict_jvm_test
+                             custom-element-conflict (needs TWO declaring
+                             sources in one build — not reachable by
+                             macroexpanding a single form)"
+  #{:rf.ui.compile/custom-element-conflict
+    :rf.ui.compile/bad-root-id
     :rf.ui.compile/bad-disambiguator
     :rf.ui.compile/bad-root-opts
     :rf.ui.compile/no-single-mounted-view


### PR DESCRIPTION
Lands the **compile-time half** of the ruled custom-element declaration law (rf2-vxgfnd.143). Two pieces of the cluster are **held, not done** — both hit a fence, and each is explained below with what it needs. Please read *Outcome per bead* before merging: this is a partial cluster PR.

## Outcome per bead

### rf2-vxgfnd.143 — conflict law: compile-time arm LANDED, runtime arm HELD

Implements the delegated ruling (2026-07-15) **Option A — fail atomically** on the compile side, where property classification is actually baked:

- **`build/contribute-element-checked!`** — the single write barrier, and the law. `rf=`-equal duplicates co-exist (idempotent — two namespaces may state the same fact); a non-`rf=`-equal declaration of the same tag from a *different* source is rejected **without writing**, so the losing row never enters the ledger and the last-known-good aggregate is untouched. A source never conflicts with *itself* across passes (re-declaration replaces its own row), but two **live** contradictory declarations inside one pass of one namespace do fail — mirroring `contribute-view-checked!`'s staged/committed posture.
- **`build/elements-conflict`** — a pure detector that re-derives the same verdict from *finalized rows*, wired once per pass into `shadow-finish-candidate`. Defence in depth: no aggregation can publish a merge-order winner even if a row arrived by a route bypassing the barrier.
- **`:rf.ui.compile/custom-element-conflict`** — the new compile error, carrying **both `[build-id ns-sym]` anchors sorted deterministically**, so evidence is identical under every permutation. Which source expands second decides only *where* the failure is anchored — never who wins, never whether it fails.

The ruling names three silent-precedence paths: the compiler aggregate merged with **no conflict check**, direct registration was **last-call-wins**, reload commit was a **sorted-owner merge**. This PR closes the first.

**HELD — the runtime arm (`rules.cljc`).** The ruling requires a runtime `:rf.error/custom-element-conflict` mirroring `:rf.error/frame-payload-conflict`, plus **Spec 009 catalogue rows**. `spec/009-Instrumentation.md` is a hot-zone file *and* has a live worker on it, so per my dispatch fence I stopped rather than edit it. This is a real gate, not a nicety: `scripts/check_keyword_catalogue_drift.py` CHECK A enforces **totality** — every `:rf.error/*` literal emitted by `implementation/` must have a 009 row — so adding the id without the row turns CI red. I verified the gate green both before and after this diff.

I deliberately did **not** ship a half-runtime-law. Silently refusing a conflicting direct registration would be **first-wins** — still order-dependent, i.e. a third precedence rule rather than a fix. The runtime arm is coherent only *with* its anchored throw.

> **Finding that de-risks the hold:** with the compile-time law in place, the runtime's two divergent rules become **observationally identical**. Last-call-wins and sorted-merge differ *only* when the ledger holds non-`rf=`-equal rows for one tag — which compiled code can no longer produce, because the build now fails atomically first. The bead's headline repro (an unrelated reload flipping `#{:a}` to `#{:z}`) is now reachable only by hand-calling the internal `register-custom-element!`. The runtime arm remains correct defence-in-depth work, but it is no longer load-bearing for shipped code.

### rf2-vxgfnd.141 — NOT done (out-of-fence architecture)

Not started, and I do not think it should be squeezed into this PR. `.141` requires the effective manifest to be a deterministic compiler input **available before view/template analysis**. `.143` does not deliver that: it makes two *declarations* consistent, whereas `.141`'s race is between a **declaration and a consumer** — `(defview card [] [:x-card {:model model}])` compiled before `(ui/custom-element :x-card {:properties #{:model}})` reads an empty manifest and emits `:model` as an **attribute**; reversed, it emits a **JS property**. Cross-namespace without a `:require` edge the order is arbitrary, and no recompile is triggered.

Macroexpansion cannot fix this from inside itself — a declaration that has not yet expanded is not observable. It needs a **source-harvest phase**: read each build source's top-level forms at `:compile-prepare`, extract declarations, and seed the slice before any view analyzes. That is tractable *because the grammar was ruled for it* (declarations are top-level, literal, compile-resolvable — `:properties` must be a literal set), but it lands in `build_hook.clj` plus a new harvest ns plus consumer-dependency tracking plus digest participation — all outside my stated fence (`build.cljc` / `rules.cljc`), and it is genuinely bead-sized architecture.

One in-fence sub-finding worth its own follow-up: `digest-for-slice` folds **only `views` rows**, and a view's `template-fp` fingerprints the *source template*, not its lowering. So two builds with identical view sources but different declarations produce the **same build digest** — a real build-identity gap, and one of `.141`'s acceptance criteria ("the relevant effective declaration dependency participates in freshness/build identity"). I left it alone rather than half-fix `.141`.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test` (ui artefact JVM — the owning suite) | **PASS — 594 tests, 8571 assertions, 0 failures, 0 errors** (+12 tests / +94 assertions from this PR's new suite) |
| `scripts/check_keyword_catalogue_drift.py` | **PASS (exit 0)** — also baselined green *before* the diff, to prove the new compile-only id needs no Spec 009 row |
| `npm run test:cljs` | **SKIPPED** — fresh worktree has no `node_modules`; cold npm install plus shadow-cljs compile is the documented worker-stranding trap. This diff has **no CLJS runtime surface**: it is JVM macroexpansion-time compiler code plus a JVM test, and `rules.cljc` (the only runtime custom-element path) is untouched. CI owns it. |
| `npm run test:browser` | **SKIPPED** — per dispatch brief (CI owns it); no DOM surface in this diff. |

### Rigour: the tests could actually fail on the bug

Assertion-count growth alone only proves the happy path, so the new suite (`custom_element_conflict_jvm_test.clj`, 12 deftests) is built as **permutation folds** — each conflict case drives **both** contribution orders and asserts the two runs produce identical `:declarations` evidence:

- `conflict-evidence-is-identical-under-every-permutation` — the determinism proof. Under the retired last-call-wins, swapping two lines swapped the **winner**; under a naive fix, a permutation still swaps the reported **evidence**. Both fail this test.
- `conflict-is-not-decided-by-sorted-owner-order` — drives a-then-z *and* z-then-a, pinning that neither the sorted-merge winner nor the last-call winner survives.
- `elements-conflict-evidence-is-permutation-stable` — same discipline on the pure detector, asserted directly because Clojure's small-map ordering makes accidental order-sensitivity easy to miss.
- Negative/adversarial cases per surface: `rf=`-equal duplicates must **not** fail; disjoint tags must not conflict; same-source re-declaration (REPL and across passes) must replace, not conflict; two contradictory declarations in one pass of one ns **must** fail; contradictory declarations in **different builds** must not conflict (the law is `[build-id tag]`-scoped).

## Fence notes

- `compiler.cljc` is edited though outside my stated fence — the bead's ruling explicitly directs the `contribute!` to `contribute-checked!` switch at that call site, and the bead is authoritative over the brief. Not hot-zone, no in-flight worker.
- No hot-zone file touched. No public/frozen API change. No per-render lookup, no declaration-before-use ceremony, no runtime fallback classification.
- Beads left **OPEN** — neither is fully satisfied; closing either would be a false close.

Refs rf2-vxgfnd.143 (partial), rf2-vxgfnd.141 (not started).
