### PR TITLE
docs(machines): teach parent-owned parallel always rounds

### DIFF
--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -82,7 +82,7 @@ You read the `:state` map through one ordinary subscription — `@(rf/subscribe 
 
 ## Each region has its own `:initial`
 
-Every region declares its own `:initial`, just like a flat machine — a region missing `:initial` is a registration-time error. At machine boot the initial snapshot's `:state` is the map of each region's initial cascade: a flat region lands on its `:initial` keyword; a compound region descends its `:initial` chain to a leaf. Each region's `:entry` cascade runs once at boot, and each region's birth `:always` settles independently as part of the initial step.
+Every region declares its own `:initial`, just like a flat machine — a region missing `:initial` is a registration-time error. At machine boot the initial snapshot's `:state` is the map of each region's initial cascade: a flat region lands on its `:initial` keyword; a compound region descends its `:initial` chain to a leaf. Every region's `:entry` cascade runs once, for every region, *before* any eventless work begins. Only then does the machine settle its `:always` transitions — and it settles them the same way it settles them after an event: the parent runs [frozen rounds](#always-stabilization-is-parent-owned) across the whole configuration until nothing more is enabled. A region's birth `:always` guard can therefore read where its siblings landed, because every sibling has already entered.
 
 So immediately after the machine above starts, before any event:
 
@@ -111,8 +111,9 @@ In the nine-states machine, dispatching `:fetch-started` reaches all three regio
 ;; :state {:data :loading :form :neutral :mode :active}
 
 (rf/dispatch-sync [:ui/nine-states [:fetch-succeeded {:items [{:id 1} {:id 2}]}]])
-;; :data handles it: :loading → :resolving (running :set-items), then the
-;; region's own :always cascade reads the now-2 :items and falls through to :some.
+;; :data handles it: :loading → :resolving (running :set-items). The event set
+;; having applied, the first eventless round reads the now-2 :items and the
+;; :resolving cascade lands on :some — all within this one macrostep.
 ;; :state {:data :some :form :neutral :mode :active}  ·  :data {:items [{:id 1} {:id 2}] ...}
 ```
 
@@ -143,7 +144,9 @@ If you wanted that event to count *once*, you'd register the coordinating action
 
 !!! note "A subtle, load-bearing rule — selection is order-independent"
 
-    The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches SCXML, where a parallel macrostep selects against the pre-event configuration. (It matters most for the next section.)
+    The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches SCXML, where a parallel macrostep selects against the pre-event configuration.
+
+    The same select-then-apply shape governs `:always` too, once the event set has landed — the parent repeats it per [round](#always-stabilization-is-parent-owned) until the machine is quiescent. It's one idea, applied twice.
 
 ## The root `:on`: an ancestor fallback
 
@@ -236,14 +239,14 @@ The precise variant reads the sibling's state value directly:
 
 Prefer the **tag** query: a tag is a named, tool-legible render-state, and it holds up when a sibling region refactors its internal state names.
 
-!!! note "Both keys are frozen"
+!!! note "Both keys are frozen — per selection round"
 
-    `:tags` and `:all-state` reflect the **frozen pre-broadcast snapshot** — the sibling configuration as of the *start* of the macrostep. A region's guard never sees a sibling's *same-event* move during selection (regions are genuinely simultaneous), which is exactly why selection is declaration-order-independent. A region reading its *own* state uses `:state` (which does evolve through its own `:always` loop); `:tags` / `:all-state` are the mechanism for reading *siblings*, and they're frozen. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because it has no siblings to read; its own `:state` already answers *where am I?*.
+    `:tags` and `:all-state` are frozen for the **selection round** that is currently choosing transitions, not for the whole macrostep. Within a round every co-selected region reads the *same* sibling view, so no region can observe a sibling's move from the set being selected alongside it — which is exactly why selection is declaration-order-independent. Between rounds the view is **re-frozen**, so each round sees the complete result of the one before it. A region reading its *own* state uses `:state`; `:tags` / `:all-state` are the mechanism for reading *siblings*. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because it has no siblings to read; its own `:state` already answers *where am I?*.
 
-The two `dispatch-sync` calls above are **separate events**, which is why each `:submit` reads the prior committed config. If you need a *single* event to flip `:form` to `:valid` **and** advance `:checkout` in the same breath, two statechart-idiomatic paths re-couple them — they differ in *when* convergence lands:
+The two `dispatch-sync` calls above are **separate events**, which is why each `:submit` reads the prior committed config. If you need a *single* event to flip `:form` to `:valid` **and** advance `:checkout` in the same breath, two statechart-idiomatic paths re-couple them. Both converge inside the one macrostep; they differ in *which* mechanism carries the dependency:
 
-- **`:raise` — converges in the SAME macrostep.** `:form`'s `:complete` action returns `:fx [[:raise [:form-valid]]]`; that internal event re-broadcasts across every region (next microstep, still inside the one atomic macrostep), and `:checkout`'s `:on {:form-valid …}` resolves it against the now-`:valid` `:form`. This is the strictly-same-macrostep path.
-- **A guarded `:always` reading the sibling — converges on the NEXT EVENT.** `:checkout` carries `{:always {:target :submitting :guard :form-valid?}}`. A *plain* sibling move doesn't trigger an in-macrostep re-broadcast, so this re-selects against the committed `:form/valid` on the next event delivered — it fires, just one event later.
+- **`:raise` — the region announces the news.** `:form`'s `:complete` action returns `:fx [[:raise [:form-valid]]]`; that internal event re-broadcasts across every region on the next microstep, and `:checkout`'s `:on {:form-valid …}` resolves it against the now-`:valid` `:form`. Reach for it when the sibling should react to an *event* — something happened — and when you want the dependency written down as a name.
+- **A guarded `:always` reading the sibling — the region notices the condition.** `:checkout` carries `{:always {:target :submitting :guard :form-valid?}}`. Once the event set has applied, the parent's first eventless round evaluates that guard against the updated configuration and `:checkout` moves — in the **same** macrostep, before it commits. Reach for it when the sibling should track a *condition* — the world now looks like this — without the announcing region needing to know anyone is listening.
 
 Both are bounded by the `:always-depth-limit` / `:raise-depth-limit` (default 16), so neither can spin.
 
@@ -251,14 +254,73 @@ Both are bounded by the `:always-depth-limit` / `:raise-depth-limit` (default 16
 
 Each region's state-node keys are **scoped to that region**:
 
-- **`:always`** — the microstep loop runs *per region*. After a region's transition, that region's new state's `:always` entries are checked and settle to *that region's* fixed point; siblings aren't re-evaluated for `:always` on this region's microstep. (That's exactly the `:resolving → :empty | :some | :too-many` cascade in the nine-states `:data` region.)
+- **`:always`** — a region's `:always` entries target states *inside that region*: the `:resolving → :empty | :some | :too-many` cascade in the nine-states `:data` region can only land on `:data`'s own states, never on a sibling's. But **targeting is not stabilization**. *Which* `:always` transitions fire, and *when* the loop is finished, is decided by the **parent** across the whole configuration — see [below](#always-stabilization-is-parent-owned). Keep those two ideas apart and the rest of this section follows.
 - **`:after`** — a timer arms / cancels on *its region's* state entry / exit. A sibling region transitioning does **not** cancel this region's in-flight `:after` timer; each region keeps its own timer epoch.
 - **`:spawn`** — a region's [`:spawn`](glossary.md#spawn)-bearing state starts and tears down child actors bound to *that region's* state; siblings never see the spawn / destroy cascade.
 - **`:entry` / `:exit`** — fire on the region's own transitions, never on a sibling's.
 
 !!! note "`:raise` is the exception — it BROADCASTS"
 
-    A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as SCXML delivers a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every region's `:always` settling — commits **once, atomically**, bounded by the `:raise-depth-limit`.
+    A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as SCXML delivers a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every eventless round — commits **once, atomically**, bounded by the `:raise-depth-limit`. Eventless work has priority: the parent settles `:always` to a fixed point before it dequeues the next raise.
+
+## `:always` stabilization is parent-owned
+
+A region chooses *where* its `:always` transitions go. The **parent** decides *when* they fire. After the selected event transitions have applied, the parent repeats one **round** until nothing is left to do:
+
+1. **Freeze** the current whole configuration and `:data`.
+2. **Select** every regional `:always` transition enabled against that one frozen view.
+3. **Apply** the whole selected set, in region-declaration order.
+
+Then it freezes again and goes round once more, until a round selects nothing. Only then does the macrostep commit. So the loop is not *"each region settles itself"* — it is *"the machine settles, one whole-configuration round at a time"*.
+
+That distinction is worth one worked example. Three regions, one dispatch:
+
+```clojure
+(rf/reg-machine :ui/gate
+  {:type :parallel
+   :data {:ready? false :cleared? false}
+
+   :guards  {:ready?   (fn [{:keys [data]}] (:ready? data))
+             :cleared? (fn [{:keys [data]}] (:cleared? data))}
+
+   :actions {:mark-ready (fn [{d :data}] {:data (assoc d :ready? true)})
+             :clear      (fn [{d :data}] {:data (assoc d :cleared? true)})}
+
+   :regions
+   {:source {:initial :idle
+             :states  {:idle {:on {:go {:target :sent :action :mark-ready}}}
+                       :sent {}}}
+
+    :gate   {:initial :closed
+             :states  {:closed {:always [{:guard :ready? :target :open :action :clear}]}
+                       :open   {}}}
+
+    :audit  {:initial :waiting
+             :states  {:waiting {:always [{:guard :cleared? :target :logged}]}
+                       :logged  {}}}}})
+
+(rf/dispatch-sync [:ui/gate [:go]])
+;; => {:state {:source :sent :gate :open :audit :logged}
+;;     :data  {:ready? true :cleared? true}}
+```
+
+One event; all three regions moved. Here is how, round by round:
+
+**The event set applies first.** `:go` is broadcast; only `:source` handles it, and its `:mark-ready` action sets `:ready?`. Every selected event action runs to completion **before** any `:always` is considered — so the first round already sees the finished work of the event.
+
+**Round 1 — selection is frozen.** The parent freezes the configuration and `:data` (`:ready?` true, `:cleared?` false) and asks every region what is enabled. `:gate` is: its `:ready?` guard passes, so `:closed → :open` is selected. `:audit` is **not**: its `:cleared?` guard reads the frozen `:data`, where `:cleared?` is still false. The parent then applies the selected set — `:gate` moves and its `:clear` action sets `:cleared?`. Note what *didn't* happen: `:audit` did not move in this round, even though by the time the round finished applying, its guard's condition held. Selection was decided before any of it applied.
+
+**Round 2 — the view is re-frozen.** A new round, a new freeze: `:cleared?` is now true. `:audit`'s guard passes, and `:waiting → :logged` is selected and applied. This is the payoff of re-freezing — each round sees the previous round's completed result.
+
+**Round 3 — the fixed point.** Nothing is enabled. The loop stops and the macrostep commits, publishing `{:source :sent :gate :open :audit :logged}` as one atomic step. External observers never see the intermediate rounds; they see one dispatch and one new configuration.
+
+The same process runs at **birth**, once every region's `:entry` cascade has completed — which is why a birth `:always` guard can read where its siblings landed.
+
+Two consequences worth naming:
+
+**Reordering the regions cannot change the outcome.** Because each round selects against a frozen view, no region's guard can ever observe a sibling's move from the set being selected alongside it. Declaration order governs only the *apply* order within a round — action and `:fx` order, and how `:data` accumulates — never *which* transitions are chosen. Write regions whose actions touch disjoint `:data` keys and their order stops mattering entirely.
+
+**Failure is bounded and atomic.** `:always-depth-limit` (default 16) counts parent **rounds**, not transitions — a round in which five regions move is one round. If a machine spins past the limit, or a guard or action throws, the **whole** macrostep fails and rolls back: no snapshot is published and no effects run. There is no half-settled configuration to reason about, which is what makes the fixed point safe to lean on.
 
 ## Tags compose across regions
 

--- a/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
@@ -55,6 +55,18 @@
        machine's `:regions` declarations yields the SAME selected
        configuration (region selection is set-like, declaration-order
        independent) — generalised from the fixed-case deftests.
+    9. PARENT-OWNED PARALLEL `:always` ROUNDS — eventless stabilization in
+       a parallel machine belongs to the PARENT, not to each region. After
+       the complete selected event set applies, the parent freezes the
+       whole configuration + `:data` for ONE selection round, selects every
+       enabled regional `:always` against that frozen view, applies the
+       preselected set in region order, and re-freezes for the next round
+       until quiescent — all before the same macrostep commits. So a
+       region's `:always` guard reading a SIBLING's same-macrostep `:data`
+       write converges in THIS macrostep, and reordering the regions cannot
+       change the resolved configuration or data. Invariant 8 pins selection
+       for regions that are independent by construction; this one pins the
+       law for regions that are deliberately COUPLED across the freeze.
 
   ## Why a hand-rolled seeded PRNG (not clojure.test.check)
 
@@ -270,29 +282,31 @@
 
 ;; ---- independent-region parallel generator (for INVARIANT 8) ---------------
 ;;
-;; Selection order-sensitivity after rf2-lq5yo3. The parallel broadcast now
-;; SELECTS every region's EVENT transition against ONE frozen pre-event view
-;; (incl. `:data`) before any region applies, so an `:on` GUARD reading shared
-;; `:data` is declaration-order-INDEPENDENT — it never sees a sibling's same-
-;; macrostep `:data` write. The ONE residual order-sensitive SELECTION is a
-;; guarded `:always` reading a sibling's same-macrostep `:data` write:
-;; `:always` microsteps run in the APPLY phase against the region's EVOLVING
-;; `:data` (Spec 005:1731 — the blessed per-region drain), so reordering the
-;; regions can change what a `:data`-reading `:always` guard sees, hence the
-;; selected leaf. That is documented, correct behaviour (NOT a bug); the
-;; shared-`:data` VALUE flow it rides on is tested separately
-;; (`parallel-shared-data-flows-through-regions`, parallel_test §6).
+;; Both parallel selection phases are frozen select-then-apply. The event
+;; broadcast SELECTS every region's transition against ONE frozen pre-event
+;; view (incl. `:data`) before any region applies; the parent then owns the
+;; eventless stabilization, selecting every enabled regional `:always` against
+;; ONE frozen post-event view, applying that set in region order, and
+;; re-freezing per round to a fixed point (Spec 005 §Per-region `:always` /
+;; `:after` / `:spawn` scoping). No region drains a local `:always` tail, so
+;; no guard in either phase can observe a sibling's mid-set write.
 ;;
-;; The declaration-order-INDEPENDENCE invariant the bead names is about
-;; SELECTION being set-like for INDEPENDENT regions. To test it without
-;; conflating the residual `:always`-`:data` coupling OR the (separately-
-;; covered) shared-`:data` VALUE flow, this generator draws regions that are
-;; independent BY CONSTRUCTION: their `:always` guards are CONSTANT
-;; (`:g/true` / `:g/false`, never the `:data`-reading `:g/even?`) and their
-;; `:on` edges carry NO action (no shared-`:data` writes — so the committed
-;; `:data` VALUE, which still accumulates in declaration order, cannot feed a
-;; later event's frozen selection differently across orderings). Reordering such regions cannot change behaviour,
-;; so any divergence is a genuine selection / broadcast bug.
+;; What declaration order STILL governs is APPLY ordering — action / `:fx`
+;; order and `:data` accumulation. Two regions writing the same `:data` key
+;; non-commutatively therefore end on different committed `:data` per
+;; ordering, which is correct behaviour, not a selection bug. This generator
+;; isolates the SELECTION invariant from that legitimate accumulation
+;; ordering by drawing regions that are independent BY CONSTRUCTION: their
+;; `:always` guards are CONSTANT (`:g/true` / `:g/false`, never the
+;; `:data`-reading `:g/even?`) and their `:on` edges carry NO action (no
+;; shared-`:data` writes at all). Reordering such regions cannot change
+;; behaviour, so any divergence is a genuine selection / broadcast bug.
+;;
+;; The COUPLED cross-region case — a region's `:always` guard reading a
+;; sibling's same-macrostep `:data` write — is not excluded from the suite;
+;; it is the subject of INVARIANT 9 below, which keeps order-independence
+;; testable by constraining the writes to be commutative rather than by
+;; removing them.
 
 (defn- gen-independent-on-map
   "Like `gen-on-map` but every edge is a BARE target (no `:action`), so a
@@ -812,16 +826,30 @@
             SAME selected configuration (+ tag union) for the same event
             sequence — region selection is set-like, declaration-order
             independent. Regions are independent by construction (constant
-            guards, no shared-:data writes); the SEPARATELY-tested shared-
-            :data sequential-flow coupling (parallel_test §6) legitimately
-            depends on declaration order and is excluded here by design."
+            guards, no shared-:data writes), which isolates SELECTION from
+            the apply-phase :data accumulation that declaration order does
+            legitimately govern. Cross-region :always coupling is covered by
+            INVARIANT 9, which keeps the writes commutative instead."
     (let [reorder-regions
           (fn [machine]
-            ;; rebuild the regions map in reversed key order; reinstall the
-            ;; region cache so the reordered spec is a fresh, valid machine.
-            (let [rs   (:regions machine)
-                  rev  (into {} (map (fn [k] [k (get rs k)]) (reverse (keys rs))))]
-              (parallel/install-region-cache (assoc machine :regions rev))))
+            ;; Rebuild the regions map in reversed key order AND declare the
+            ;; matching `:region-order` explicitly.
+            ;;
+            ;; Declaring it is LOAD-BEARING, not belt-and-braces:
+            ;; `normalise-region-order` is idempotent by keyset — it returns a
+            ;; machine that already carries a valid `:region-order` UNCHANGED,
+            ;; and reversing the `:regions` map leaves the keyset identical. So
+            ;; re-installing the cache over an already-normalised machine keeps
+            ;; the ORIGINAL order and the "reorder" silently no-ops, making this
+            ;; property vacuous. Restating `:region-order` is the supported
+            ;; author-facing mechanism and is validated as an exact permutation.
+            (let [rs    (:regions machine)
+                  order (vec (reverse (keys rs)))
+                  rev   (into {} (map (fn [k] [k (get rs k)])) order)]
+              (parallel/install-region-cache
+                (-> machine
+                    (assoc :regions rev)
+                    (assoc :region-order order)))))
           failure
           (loop [i 0, s 8008]
             (if (= i 300)
@@ -842,3 +870,252 @@
                   :else (recur (inc i) (lcg-next s2))))))]
       (is (nil? failure)
           (str "declaration-order-independence property failed: " (pr-str failure))))))
+
+;; ---- INVARIANT 9: parent-owned parallel `:always` rounds -------------------
+;;
+;; The law (Spec 005 §Per-region `:always` / `:after` / `:spawn` scoping):
+;; `:always` TARGETING stays region-scoped, but `:always` STABILIZATION is
+;; PARENT-owned. Once the complete selected event set has applied, the parent
+;; freezes the whole configuration + `:data`, selects every enabled regional
+;; `:always` against that one frozen view, applies the preselected set in
+;; region order, then RE-FREEZES and repeats to a fixed point — all inside the
+;; one macrostep, before it commits. Two consequences this family pins:
+;;
+;;   (a) SAME-MACROSTEP CONVERGENCE — a region's `:always` guard reading a
+;;       sibling's same-macrostep `:data` write fires in THIS macrostep (the
+;;       first post-event round observes the complete event set), not on some
+;;       later event.
+;;   (b) ORDER INDEPENDENCE ACROSS THE COUPLING — because every round selects
+;;       against a frozen view, reordering the regions cannot change which
+;;       `:always` set is selected in any round, hence cannot change the
+;;       resolved configuration or data.
+;;
+;; The superseded region-local model — settle each region's `:always` loop
+;; before visiting the next region — satisfies NEITHER. Under it, a region
+;; drained BEFORE the sibling it watches has applied sees no flag and strands;
+;; move that region later in the declaration and it converges. That order
+;; sensitivity is exactly what this property detects (see the pinned
+;; `parallel-always-round-*` deftests below for the minimal counterexample).
+;;
+;; DISCRIMINATION BY CONSTRUCTION — every write here is COMMUTATIVE: a region
+;; only ever writes its OWN two flag keys, and only ever to the constant
+;; `true`. Disjoint key sets + constant values ⇒ apply-order cannot change the
+;; resulting `:data`, so `:data` accumulation ordering (which declaration
+;; order DOES legitimately govern) is removed as a confound. Any divergence
+;; across orderings therefore indicts SELECTION semantics, not effect order —
+;; which is what makes a failure here a real signal rather than a re-statement
+;; of apply-order.
+
+(def ^:private cross-region-names [:rA :rB :rC])
+
+(defn- flag-key   [rn] (keyword (str "flag-"  (name rn))))
+(defn- flag2-key  [rn] (keyword (str "flag2-" (name rn))))
+(defn- flag-action  [rn] (keyword "a" (str "flag-"  (name rn))))
+(defn- flag2-action [rn] (keyword "a" (str "flag2-" (name rn))))
+(defn- flag-guard   [rn] (keyword "g" (str "flag-"  (name rn) "?")))
+(defn- flag2-guard  [rn] (keyword "g" (str "flag2-" (name rn) "?")))
+
+(def ^:private cross-region-actions
+  "Region-OWNED, COMMUTATIVE writes: region `rn` writes only `flag-rn` /
+  `flag2-rn`, and only ever to `true`. The regions' written key sets are
+  disjoint and the values constant, so applying the same set in ANY region
+  order yields the same `:data` map."
+  (reduce (fn [acc rn]
+            (assoc acc
+                   (flag-action rn)  (fn [{d :data}] {:data (assoc d (flag-key rn) true)})
+                   (flag2-action rn) (fn [{d :data}] {:data (assoc d (flag2-key rn) true)})))
+          {}
+          cross-region-names))
+
+(def ^:private cross-region-guards
+  "SIBLING-reading `:always` guards — the cross-region `:data` dependency the
+  parent-round law is about. Each reads a flag some OTHER region owns."
+  (reduce (fn [acc rn]
+            (assoc acc
+                   (flag-guard rn)  (fn [{d :data}] (true? (get d (flag-key rn))))
+                   (flag2-guard rn) (fn [{d :data}] (true? (get d (flag2-key rn))))))
+          {}
+          cross-region-names))
+
+(defn- cross-region-body
+  "One region body for the parent-round family. `self` owns its flags;
+  `watched` is the SIBLING whose flags this region's `:always` guards read.
+
+    :s0 --ev--> :s1            (event action writes flag-SELF)
+    :s0/:s1 :always{flag-WATCHED?} --> :s2   (action writes flag2-SELF)
+    :s2     :always{flag2-WATCHED?} --> :s3  (the SECOND round's edge)
+
+  Tier 1 (`:s0`/`:s1` → `:s2`) needs the sibling's EVENT write, so it can only
+  fire in a post-event round. Tier 2 (`:s2` → `:s3`) needs the sibling's
+  tier-1 ALWAYS write, so it can only fire in a round AFTER that one — which
+  is what exercises the RE-FREEZE between rounds rather than a single round.
+  No `:always` targets its declaring state (`:rf.error/machine-always-self-loop`
+  would reject that), and `:s3` is terminal, so every draw reaches a fixed
+  point well inside the depth limit."
+  [state self watched]
+  (let [ev     (nth event-pool (rnd state (count event-pool)))
+        tier2? (zero? (rnd (lcg-next state) 2))
+        tier1  [{:guard (flag-guard watched) :target :s2 :action (flag2-action self)}]
+        body   {:initial :s0
+                :states
+                (cond-> {:s0 {:tags   #{(keyword (name self) "s0")}
+                              :on     {ev {:target :s1 :action (flag-action self)}}
+                              :always tier1}
+                         :s1 {:tags   #{(keyword (name self) "s1")}
+                              :always tier1}
+                         :s2 {:tags #{(keyword (name self) "s2")}}}
+                  tier2?
+                  (-> (assoc-in [:s2 :always]
+                                [{:guard (flag2-guard watched) :target :s3}])
+                      (assoc :s3 {:tags #{(keyword (name self) "s3")}})))}]
+    [body (lcg-next (lcg-next state))]))
+
+(defn- gen-cross-region-parallel-machine
+  "Draw a parallel machine whose 2..3 regions are deliberately COUPLED across
+  the eventless freeze: region i's `:always` guards read region (i+1 mod n)'s
+  flags, so the watch relation is a cycle and every region both feeds and
+  reads a sibling. Returns `[machine next]`."
+  [state]
+  (let [n     (+ 2 (rnd state 2))
+        names (vec (take n cross-region-names))
+        [regions s']
+        (loop [i 0, s (lcg-next state), acc {}]
+          (if (= i n)
+            [acc s]
+            (let [self      (nth names i)
+                  watched   (nth names (mod (inc i) n))
+                  [body s1] (cross-region-body s self watched)]
+              (recur (inc i) s1 (assoc acc self body)))))]
+    [(parallel/install-region-cache
+       {:type    :parallel
+        :data    {}
+        :guards  (merge shared-guards cross-region-guards)
+        :actions (merge shared-actions cross-region-actions)
+        :regions regions})
+     s']))
+
+(defn- permutations
+  "Every ordering of `coll` (distinct elements). `coll` here is 2..3 region
+  names, so this stays at most 6 orderings."
+  [coll]
+  (if (<= (count coll) 1)
+    [(vec coll)]
+    (vec (mapcat (fn [x]
+                   (map #(vec (cons x %)) (permutations (remove #{x} coll))))
+                 coll))))
+
+(defn- reorder-regions-by
+  "Rebuild `machine`'s `:regions` in `order` and reinstall the region cache, so
+  the reordered spec is a fresh, valid machine whose canonical `:region-order`
+  is `order`.
+
+  `:region-order` is restated EXPLICITLY because `normalise-region-order` is
+  idempotent by keyset: a machine already carrying a valid `:region-order` is
+  returned unchanged, and permuting `:regions` does not change the keyset — so
+  re-installing alone would keep the original order and silently no-op the
+  reorder. An explicit `:region-order` is the supported author-facing
+  mechanism and is validated as an exact permutation of the keyset."
+  [machine order]
+  (let [rs (:regions machine)]
+    (parallel/install-region-cache
+      (-> machine
+          (assoc :regions (into {} (map (fn [k] [k (get rs k)])) order))
+          (assoc :region-order (vec order))))))
+
+(deftest prop-parallel-always-rounds-are-parent-owned
+  (testing "a parallel machine whose regions' :always guards read a SIBLING's
+            same-macrostep :data write resolves to the SAME configuration and
+            the SAME :data under EVERY :regions declaration order — parent-owned
+            frozen rounds, not per-region drains. Writes are commutative by
+            construction (disjoint region-owned keys, constant values), so
+            apply-order cannot explain a divergence; only selection can."
+    (let [failure
+          (loop [i 0, s 9009]
+            (if (= i 300)
+              nil
+              (let [[m s1]   (gen-cross-region-parallel-machine s)
+                    [evs s2] (gen-events s1)
+                    orders   (permutations (vec (keys (:regions m))))
+                    base     (:snap (last (run-sequence m evs)))
+                    bad      (some (fn [order]
+                                     (let [m'  (reorder-regions-by m order)
+                                           fin (:snap (last (run-sequence m' evs)))]
+                                       (cond
+                                         (not= (:state base) (:state fin))
+                                         {:why :state-differs :order order
+                                          :base (:state base) :got (:state fin)}
+                                         (not= (:data base) (:data fin))
+                                         {:why :data-differs :order order
+                                          :base (:data base) :got (:data fin)}
+                                         (not= (:tags base) (:tags fin))
+                                         {:why :tags-differ :order order
+                                          :base (:tags base) :got (:tags fin)})))
+                                   orders)]
+                (if bad
+                  ;; MINIMIZED counterexample: the region bodies + the event
+                  ;; sequence are the whole repro. The `:guards` / `:actions`
+                  ;; vocabularies are fixed and shared, and printing them would
+                  ;; bury the signal under fn objects — so report the shape,
+                  ;; not the machine.
+                  [:parent-round-divergence
+                   {:regions      (:regions m)
+                    :region-order (:region-order m)
+                    :events       evs
+                    :divergence   bad}]
+                  (recur (inc i) (lcg-next s2))))))]
+      (is (nil? failure)
+          (str "parent-owned-always-rounds property failed: " (pr-str failure))))))
+
+;; The MINIMAL counterexample the property above generalises — pinned by hand
+;; so the discriminating shape is readable, and so a regression names itself
+;; instead of arriving as a random seed. `:rB` watches `:rA`; only `:rA`
+;; handles the event.
+;;
+;;   region-local drain, order [:rA :rB] → :rA applies+drains, THEN :rB drains
+;;                                          and sees flag-rA  ⇒ {:rA :s1 :rB :s2}
+;;   region-local drain, order [:rB :rA] → :rB drains FIRST, no flag yet, and
+;;                                          STRANDS at :s0    ⇒ {:rA :s1 :rB :s0}
+;;   parent-owned rounds, EITHER order   → the whole event set applies first,
+;;                                          then round 1 observes flag-rA
+;;                                                             ⇒ {:rA :s1 :rB :s2}
+
+(def ^:private watcher-machine-regions
+  {:rA {:initial :s0
+        :states  {:s0 {:on {:e0 {:target :s1 :action :a/flag-rA}}}
+                  :s1 {}}}
+   :rB {:initial :s0
+        :states  {:s0 {:always [{:guard :g/flag-rA? :target :s2}]}
+                  :s2 {}}}})
+
+(defn- watcher-machine [order]
+  (parallel/install-region-cache
+    {:type    :parallel
+     :data    {}
+     :guards  (merge shared-guards cross-region-guards)
+     :actions (merge shared-actions cross-region-actions)
+     :regions (into {} (map (fn [k] [k (get watcher-machine-regions k)])) order)}))
+
+(deftest parallel-always-round-converges-in-the-same-macrostep
+  (testing "a sibling-reading :always converges in the SAME macrostep as the
+            event that enables it — the first post-event round observes the
+            complete applied event set (NOT 'settles on the next event')"
+    (let [m (watcher-machine [:rA :rB])
+          r (machines/machine-transition m (initial-snapshot m) [:e0])]
+      (is (result/ok? r))
+      (is (= {:rA :s1 :rB :s2} (:state (result/snap r)))
+          ":rB's :always read :rA's same-macrostep flag write and moved in THIS
+           macrostep — one dispatch, no second event")
+      (is (true? (:flag-rA (:data (result/snap r)))))))
+  (testing "and it does so under EITHER declaration order — the region-local
+            drain strands :rB at :s0 when :rB is declared first; parent-owned
+            frozen rounds cannot, because the whole event set applies before
+            any :always round selects"
+    (let [final (fn [order]
+                  (let [m (watcher-machine order)]
+                    (:state (result/snap
+                              (machines/machine-transition
+                                m (initial-snapshot m) [:e0])))))]
+      (is (= {:rA :s1 :rB :s2} (final [:rA :rB])))
+      (is (= {:rA :s1 :rB :s2} (final [:rB :rA]))
+          "declaring the WATCHER first must not strand it — this is the
+           assertion the superseded region-local drain fails"))))


### PR DESCRIPTION
Closes rf2-1rdo4j. Closes rf2-42xtcd.

PR #5801 reversed the parallel `:always` model, but the public guide and the randomized oracle both still carried the pre-#5801 region-local law. The guide told users the opposite of the observable result; the property tier excluded, by construction, the exact dependency #5801 fixed.

## rf2-42xtcd — the oracle now covers the parent-round law

Added **INVARIANT 9**: a generated family of 2..3 regions deliberately *coupled across the eventless freeze*. Region i's `:always` guards read region (i+1 mod n)'s flags, so every region both feeds and reads a sibling; tier-2 edges depend on a sibling's tier-1 `:always` write, which exercises the **re-freeze between rounds** rather than a single round. The property asserts resolved state/data/tags are identical under **every** declaration order.

Discrimination is **proven, not assumed**. Mutating the engine back to the old law — region-local `:always` drain in the event apply phase, parent-owned rounds removed — turns the tier RED:

```
{:why :state-differs, :order [:rB :rC :rA],
 :base {:rA :s2, :rB :s1, :rC :s2}, :got {:rB :s2, :rC :s2, :rA :s2}}
```

and the pinned watcher strands at `{:rB :s0, :rA :s1}`. The mutation was local to my worktree and **reverted**; no engine file is touched by this PR.

Two design points worth review:

- **Why the writes are commutative.** Each region writes only its own flag keys, only ever to `true`. Disjoint keys + constant values ⇒ apply-order cannot change the resulting `:data`. That removes the one thing declaration order *does* legitimately govern, so a failure indicts **selection** semantics rather than restating effect order.
- **A latent vacuity fixed in INVARIANT 8.** Found while proving the new property discriminates: my first mutation run stayed green. Cause — `normalise-region-order` is idempotent **by keyset**: it returns a machine already carrying a valid `:region-order` unchanged, and permuting the `:regions` map does not change the keyset. So re-installing the region cache kept the **original** order and the reorder silently no-opped. The pre-existing INVARIANT 8 reorder had the same bug and has been vacuous since `:region-order` was introduced. Both helpers now restate `:region-order` explicitly (the supported author-facing mechanism, validated as an exact permutation).

## rf2-1rdo4j — the guide now teaches the ratified law

Rewrote the birth / frozen-view-lifetime / convergence-timing / scoping sections. Removed claims that birth always-loops "settle independently", that sibling views stay frozen "for the whole macrostep", that a sibling-reading guard converges "on the NEXT EVENT", and that always-loops run "per region" with siblings never re-evaluated.

The distinction the old text collapsed is now explicit throughout: **a region owns where its `:always` transitions target; the parent owns when they fire.** Targeting is region-scoped; stabilization is not.

One compact three-region example (`:ui/gate`) carries the whole model on a single dispatch: event actions all apply before any `:always`; round 1's selection is frozen, so `:audit` does *not* move even though that round's own apply enables it; round 2 re-freezes and `:audit` moves; round 3 finds nothing and commits. Closes on the two consequences — reordering regions cannot change the outcome, and a depth breach or throwing guard/action rolls the whole macrostep back with nothing published. `:always-depth-limit` is documented as counting parent **rounds**, not transitions.

Per pre-alpha stance, the reversed law is not preserved as compatibility advice.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test` (machines JVM artefact) | **PASS** — 1106 tests, 3858 assertions, 0 failures, 0 errors |
| Property ns focused (`-n re-frame.machine-property-cljs-test`) | **PASS** — 10 tests, 21 assertions, 0 failures (8 → 10 deftests) |
| Discrimination probe (engine mutated to old law, then reverted) | **RED as required** — 2 failures: the property + the pinned counterexample. Confirms the tier is not blind. Full suite under the mutation: 64 failures, i.e. the mutation was real and broad. |
| `mkdocs build --strict` | **PASS** — exit 0, no warnings; new anchor verified present in built HTML with resolving inbound hrefs |
| `npm run test:cljs` (CLJS/node property run) | **SKIPPED** — no `node_modules` in this fresh worktree, and `npm install` here has previously destroyed the mayor checkout's real `node_modules` via junction-following. The file is `*-cljs-test.cljc`, auto-discovered by both the JVM and `:node-test` runners, and the added code is pure portable Clojure (shared LCG, no host interop); the explicit `:region-order` fix also removes the last dependency on map-iteration order, which was the one genuine CLJ/CLJS divergence risk. CI owns this gate. |
| `test:browser` / full pre-checkin spine | **SKIPPED** — CI owns these; cold shadow-cljs + Chromium on a fresh worktree, per dispatch brief. |

## Notes

- **No engine or spec change was required.** The runtime already implements the ratified law correctly; this PR aligns the docs and the oracle to it. `spec/005-StateMachines.md`, `transition.cljc` and `spawn.cljc` are untouched (fenced — another worker holds them this tick).
- **Follow-on filed: rf2-nyn544.** The rf2-1rdo4j acceptance criterion "a focused docs/fixture check protects the load-bearing terminology from reverting" is *not* delivered here — it needs a new file, which is outside this agent's ownership fence. The law itself is protected executably (INVARIANT 9 + the pinned deftests); what remains unguarded is the *guide* reverting while the engine stays correct.
