### PR TITLE
test(ui): pin slice-memo lifetime reconciliation across JVM and CLJS hosts (rf2-2mop6r)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1381,11 +1381,17 @@
   row). The table inside is created lazily on first cold probe, tagged with
   `(frame, frame-epoch, registry-epoch)` PLUS the exact frame-incarnation
   token, and invalidated on any mismatch — the token by identity, because the
-  epoch triple can tie across a same-id destroy+recreate (rf2-vxgfnd.160). On
-  CLJS the table is cleared by `queueMicrotask` so an abandoned slice's table
-  is released. The memo is an ECONOMY, never an authority — for a COMMITTING
-  reader the commit evidence comparison (invariant 5) corrects any staleness
-  before paint; the incarnation-complete tag additionally keeps a COMMIT-FREE
+  epoch triple can tie across a same-id destroy+recreate (rf2-vxgfnd.160). The
+  handle dies with its slice under ONE law — probes may share within a slice,
+  but no table or handle survives into a later render slice — which each host
+  reaches by its own mechanism, because their scheduling models differ: on the
+  JVM a thread-local render scope discards the table when the render thunk
+  returns (there is no microtask there), while on CLJS a module holder is
+  cleared at the `queueMicrotask` checkpoint so an abandoned slice's table is
+  released. `re-frame.ui.reactive` owns both. The memo is an ECONOMY, never an
+  authority — for a COMMITTING reader the commit evidence comparison
+  (invariant 5) corrects any staleness before paint; the
+  incarnation-complete tag additionally keeps a COMMIT-FREE
   reader (a Tier-1 probe outside a ViewCell, which has no commit step 5)
   correct on its own. Per Spec 006 §The slice-scoped probe memo."
   []

--- a/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
@@ -1,0 +1,258 @@
+(ns re-frame.ui.slice-memo-lifetime-census-jvm-test
+  "rf2-2mop6r — the slice-memo LIFETIME census.
+
+  The slice-scoped probe memo reaches ONE law by TWO host mechanisms, and the
+  authoritative prose must say so. Spec 006 §The slice-scoped probe memo once
+  stated the table was `cleared by queueMicrotask` UNCONDITIONALLY, applying the
+  CLJS module-holder mechanism to a JVM that has no microtask at all — there the
+  table is a thread-local render scope discarded synchronously when the render
+  thunk returns. The prose was reconciled per-host in 718a8dea16; this census is
+  the regression pin that commit did not carry.
+
+  The law, and why the mechanisms legitimately differ: the table dies with its
+  slice, so probes may share WITHIN one slice but no table or handle survives
+  into a LATER render slice. How a slice is BOUNDED is per-host because the
+  hosts' scheduling models genuinely differ — the JVM has no microtask queue, and
+  the single-threaded CLJS host needs no thread-local. Both reach the same law.
+
+  This census pins, in BOTH authoritative documents:
+
+    - each distinguishes the JVM thread-local render scope from the CLJS module
+      holder released at the microtask checkpoint;
+    - neither applies microtask lifetime to the JVM — the JVM span may name a
+      microtask ONLY to deny it;
+    - each states the shared law, attributed to BOTH hosts.
+
+  The census is a pure predicate over document text
+  (`slice-memo-lifetime-violations`), so the negative arm can prove it has teeth:
+  the ACTUAL pre-reconciliation Spec 006 wording (718a8dea16^) and single-fact
+  drift mutations of each live document must each be REJECTED, with the drift
+  helper asserting every mutation actually landed. A census that only ever sees
+  green prose proves nothing.
+
+  JVM-only by nature: it reads repository files, and the documents it gates are
+  host-agnostic. The RUNTIME lifetime contract is proven per-host by
+  `reactive-slice-memo-render-boundary-jvm-test` (the JVM thread-local scope) and
+  `reactive-slice-memo-incarnation-cljs-test` (the CLJS module holder)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Locating the authoritative documents
+;; ---------------------------------------------------------------------------
+
+(defn- repo-root
+  []
+  (or (some (fn [candidate]
+              (let [root (.getCanonicalFile (io/file candidate))]
+                (when (.isFile (io/file root "AGENTS.md"))
+                  root)))
+            (take 6 (iterate #(io/file % "..") (io/file "."))))
+      (throw (ex-info "Could not locate repository root" {}))))
+
+(def ^:private root (delay (repo-root)))
+
+(def ^:private documents
+  "The two authoritative texts for the slice-memo lifetime, and the markers
+  bounding the passage that carries it. Synthesis 03 is the ratified re-frame.ui
+  program plan (tracked via the force-added `new-substrate-synthesis` subtree);
+  Spec 006 is its promoted spec home."
+  [{:label "spec/006-ReactiveSubstrate.md"
+    :path  "spec/006-ReactiveSubstrate.md"
+    :from  "### The slice-scoped probe memo"
+    :to    "### Epoch finalization"}
+   {:label "ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md"
+    :path  "ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md"
+    :from  "**First-mount fan-out mitigation:**"
+    :to    "### The commit algorithm"}])
+
+(defn- normalize
+  "Collapse markdown line wrapping so a phrase wrapped across source lines still
+  matches as one string."
+  [text]
+  (str/trim (str/replace text #"\s+" " ")))
+
+(defn- slice-memo-section
+  "The slice-memo lifetime passage of `label`'s document, whitespace-normalized.
+  A missing marker throws rather than silently censusing an empty string — an
+  empty section would vacuously pass every `includes?` negation."
+  [{:keys [label path from to]}]
+  (let [text  (slurp (io/file @root path))
+        start (or (str/index-of text from)
+                  (throw (ex-info "slice-memo section start marker missing"
+                                  {:document label :marker from})))
+        tail  (subs text start)
+        end   (or (str/index-of tail to)
+                  (throw (ex-info "slice-memo section end marker missing"
+                                  {:document label :marker to})))]
+    (normalize (subs tail 0 end))))
+
+;; ---------------------------------------------------------------------------
+;; The census
+;; ---------------------------------------------------------------------------
+
+(def ^:private jvm-marker "**JVM")
+(def ^:private cljs-marker "**CLJS")
+
+(def ^:private jvm-microtask-denial
+  "The ONLY licensed mention of a microtask inside the JVM span."
+  "there is no microtask on the JVM")
+
+(def ^:private jvm-synchronous-discard
+  "synchronously when the render thunk returns")
+
+(def ^:private later-slice-law
+  "no table or handle survives into a later render slice")
+
+(def ^:private both-hosts-law-re
+  "The reconciliation's substance: ONE law, attributed to BOTH hosts."
+  #"(?i)both hosts[\s\S]{0,240}?enforce the (?:same|one) law")
+
+(def ^:private within-slice-sharing-re
+  #"(?i)(?:shar\w+[^.]{0,48}within (?:one|a) slice|within (?:one|a) slice[^.]{0,48}shar\w+)")
+
+(def ^:private microtask-re #"(?i)microtask")
+
+(defn slice-memo-lifetime-violations
+  "Census ONE slice-memo lifetime passage; return the SET of violations (empty =
+  conformant). Pure over text so the negative arm can prove the census rejects
+  real drift."
+  [section]
+  (let [jvm-at  (str/index-of section jvm-marker)
+        cljs-at (str/index-of section cljs-marker)
+        jvm     (when (and jvm-at cljs-at (< jvm-at cljs-at))
+                  (subs section jvm-at cljs-at))
+        cljs    (when cljs-at
+                  (let [tail (subs section cljs-at)
+                        end  (str/index-of tail "Both hosts")]
+                    (if end (subs tail 0 end) tail)))]
+    (cond-> #{}
+      ;; The passage must name the hosts at all. The pre-reconciliation text
+      ;; named neither, and so described ONE mechanism as if universal.
+      (nil? jvm)
+      (conj :jvm/span-missing)
+
+      (nil? cljs)
+      (conj :cljs/span-missing)
+
+      ;; JVM: a thread-local scope, discarded synchronously on return.
+      (and jvm (not (str/includes? jvm "thread-local")))
+      (conj :jvm/scope-not-thread-local)
+
+      (and jvm (not (str/includes? jvm jvm-synchronous-discard)))
+      (conj :jvm/synchronous-discard-missing)
+
+      (and jvm (not (str/includes? jvm jvm-microtask-denial)))
+      (conj :jvm/microtask-not-denied)
+
+      ;; THE drift this bead exists for: microtask LIFETIME attributed to a host
+      ;; that has no microtask. The span may name one only inside the denial.
+      (and jvm (re-find microtask-re (str/replace jvm jvm-microtask-denial "")))
+      (conj :jvm/microtask-lifetime-applied)
+
+      ;; CLJS keeps the microtask checkpoint it genuinely has.
+      (and cljs (not (str/includes? cljs "queueMicrotask")))
+      (conj :cljs/microtask-checkpoint-missing)
+
+      ;; The shared law, in both halves, attributed to both hosts.
+      (not (re-find both-hosts-law-re section))
+      (conj :law/not-attributed-to-both-hosts)
+
+      (not (re-find within-slice-sharing-re section))
+      (conj :law/within-slice-sharing-missing)
+
+      (not (str/includes? section later-slice-law))
+      (conj :law/later-slice-reuse-missing))))
+
+;; ---------------------------------------------------------------------------
+;; Positive arm — the live documents
+;; ---------------------------------------------------------------------------
+
+(deftest both-authoritative-documents-reconcile-slice-memo-lifetime
+  (doseq [{:keys [label] :as document} documents]
+    (testing label
+      (is (= #{} (slice-memo-lifetime-violations (slice-memo-section document)))
+          (str label " must distinguish the JVM thread-local render scope from "
+               "the CLJS microtask checkpoint, and state the one law both hosts "
+               "enforce")))))
+
+;; ---------------------------------------------------------------------------
+;; Negative arm — the census must REJECT drift
+;; ---------------------------------------------------------------------------
+
+(def ^:private pre-reconciliation-spec-006
+  "The ACTUAL Spec 006 lifetime passage before 718a8dea16 — the drift this bead
+  exists to prevent recurring. It applies `queueMicrotask` to every host and
+  names neither, so a reader on the JVM (which has no microtask) is told the
+  table is cleared by a mechanism that does not exist there."
+  "### The slice-scoped probe memo
+
+Probes are ownership-free, so N sibling sites probing the same query during one render
+pass (first-mount fan-out: N rows probing `[:orders/by-id id]`) would recompute shared
+derivation parents N times. The port permits one mitigation: a **slice-scoped pure memo
+table** — the optional `?slice-memo` argument to `probe`. Within one slice, probes
+share computed derivation parents; the table dies with the slice. No entry survives
+into cache state, ownership state, or a later slice.
+
+**Lifetime (S-3-settled).** There is no public React render-pass token; the table is
+scoped to the **current synchronous execution slice**: created lazily on first probe,
+cleared by `queueMicrotask`, and belt-and-braces tagged with
+`(frame, frame-epoch, registry-epoch)` — invalidated on any mismatch. A time-sliced
+pass spanning k slices builds k tables, so the economy is **once-per-slice, not
+once-per-pass** — bounded, allocation-trivial, and requiring zero React internals; an
+interrupted or abandoned slice's table becomes unreachable garbage.")
+
+(deftest census-rejects-the-historical-pre-reconciliation-wording
+  (testing "the pre-718a8dea16 Spec 006 text names no host and generalises the
+            CLJS microtask, so the census must reject it"
+    (is (= #{:jvm/span-missing
+             :cljs/span-missing
+             :law/not-attributed-to-both-hosts
+             :law/later-slice-reuse-missing}
+           (slice-memo-lifetime-violations (normalize pre-reconciliation-spec-006))))))
+
+(defn- drift
+  "Apply a single-fact drift to `section`, asserting the mutation actually
+  landed. A no-op replacement would leave the live (green) text in place and
+  make the negative arm vacuously pass."
+  [section match replacement]
+  (let [drifted (str/replace section match replacement)]
+    (when (= drifted section)
+      (throw (ex-info "drift fixture did not mutate the live text — the census
+                       anchors it targets have moved"
+                      {:match match})))
+    drifted))
+
+(def ^:private drifts
+  "Single-fact mutations of the LIVE text. Each is one edit away from green, so
+  the census is proven to catch MINIMAL drift, not merely wholly-other prose."
+  [{:label   "the JVM span gains microtask lifetime (the historical drift)"
+    :match   jvm-microtask-denial
+    :replace "the table is cleared by `queueMicrotask` at the microtask checkpoint"
+    :expect  :jvm/microtask-lifetime-applied}
+   {:label   "the JVM span loses its synchronous discard"
+    :match   jvm-synchronous-discard
+    :replace "eventually"
+    :expect  :jvm/synchronous-discard-missing}
+   {:label   "the later-slice reuse law is dropped"
+    :match   later-slice-law
+    :replace "the table stays reusable"
+    :expect  :law/later-slice-reuse-missing}
+   {:label   "the law is no longer attributed to both hosts"
+    :match   "Both hosts"
+    :replace "The CLJS host"
+    :expect  :law/not-attributed-to-both-hosts}
+   {:label   "the CLJS span loses its microtask checkpoint"
+    :match   "queueMicrotask"
+    :replace "a host callback"
+    :expect  :cljs/microtask-checkpoint-missing}])
+
+(deftest census-rejects-single-fact-drift-in-either-document
+  (doseq [{:keys [label] :as document} documents
+          :let [section (slice-memo-section document)]
+          {drift-label :label :keys [match replace expect]} drifts]
+    (testing (str label " — " drift-label)
+      (is (contains? (slice-memo-lifetime-violations (drift section match replace))
+                     expect)
+          (str "census must reject " label " when " drift-label)))))


### PR DESCRIPTION
Closes rf2-2mop6r.

## What the bead asked, and what was actually true

The bead reports Spec 006 stating the slice-memo table is `cleared by queueMicrotask` **unconditionally** — applying the CLJS mechanism to a JVM that has no microtask at all, where the table is a thread-local render scope discarded synchronously when the render thunk returns.

Verified every premise at `file:line` on current `main` (`d8be931598`) before changing anything:

| Acceptance criterion | State on main | Action |
| --- | --- | --- |
| Spec 006 + synthesis 03 distinguish JVM thread-local from CLJS microtask | **Already met** — `spec/006-ReactiveSubstrate.md:1543-1571`, `ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md:164-184` | none |
| Both state the shared law | **Already met** — 006:1565-1567, 03:174-177 | none |
| **A narrow wording census fails while either document drifts** | **NOT met** | **this PR** |
| `obs/make-slice-memo` docstring correct | Correct but **asymmetric** | tightened |

The prose was reconciled by **`718a8dea16`** — which cites this very bead. But its stat shows **only the two documents**; the census was never added. So this is *not* a duplicate to close: the prose ACs are met and need no further edit, while the regression pin that stops the drift recurring was missing. That pin is the work.

`spec/006-ReactiveSubstrate.md` is therefore **untouched** — no hot-zone conflict surface.

## The law, and why the substrate difference is legitimate

**The table dies with its slice: probes may share *within* one slice, but no table or handle survives into a *later* render slice.**

The difference in *mechanism* is legitimate and stays. It is not two laws — it is one law reached by two routes, because the hosts' scheduling models genuinely differ:

- **JVM** — no microtask queue exists, so the slice is a thread-local render scope (`*slice*` / `with-slice-memo`) discarded when the render thunk returns.
- **CLJS** — single-threaded, so no thread-local is needed; a module holder is released at the `queueMicrotask` checkpoint under a CAS guard.

What is *not* legitimate is the pre-fix text: describing one host's mechanism as universal. The slice's **boundary** is host-defined; the **law** is identical. The two descriptions never contradicted each other on the law — only on whether the CLJS mechanism was universal — so this is a drafting reconciliation, already ruled by the bead. **No design decision is needed from Mike.**

## The census

`implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj` gates both documents: each must name both hosts, neither may apply microtask lifetime to the JVM (the JVM span may name a microtask **only to deny it**, via the licensed `there is no microtask on the JVM`), and each must state the one law attributed to **both** hosts.

It is a pure predicate over document text (`slice-memo-lifetime-violations` → a set of violations), which lets the negative arm prove the census has teeth instead of only ever seeing green prose:

- the **actual pre-reconciliation Spec 006 wording** (recovered from `718a8dea16^`) is rejected with exactly `#{:jvm/span-missing :cljs/span-missing :law/not-attributed-to-both-hosts :law/later-slice-reuse-missing}`;
- **five single-fact drift mutations** of *each* live document are each rejected — every fixture is one edit from green, so the census is proven to catch *minimal* drift, not merely wholly-other prose;
- the `drift` helper **throws if a mutation does not land**, so an anchor that moves fails loudly rather than vacuously passing.

Beyond the unit arm, the gate was driven end-to-end: injecting the historical drift into the **real** `spec/006` file turned it red with `:jvm/microtask-lifetime-applied` + `:jvm/microtask-not-denied` (and tripped the anti-vacuity guard), then the file was reverted clean. AC 3 is demonstrated against the real artefact, not just synthetic strings.

`obs/make-slice-memo`'s docstring documented only the CLJS half of a per-host law — the same asymmetry that let the spec generalise. It now states the law and both mechanisms, deferring ownership to `re-frame.ui.reactive`. (The bead deemed it correct; this is a deliberate, in-fence clarity addition, not a correction.)

## Quality gates

Both hosts exercised — the bead is explicitly JVM-vs-CLJS, so a single-host result would leave it unproven.

| Gate | Result |
| --- | --- |
| `clojure -M:test` — `implementation/ui` (JVM; owns the census) | **pass** — 583 tests / 8528 assertions, 0 failures, 0 errors |
| `clojure -M:test` — `implementation/core` (JVM; owns the touched `observation.cljc`) | **pass** — 2006 tests / 9330 assertions, 0 failures, 0 errors |
| `npm run test:cljs` — node-runtime CLJS | **pass** — 9547 tests / 46918 assertions, 0 failures, 0 errors |
| New census alone (JVM) | **pass** — 3 tests / 13 assertions |
| Negative arm driven against the real `spec/006` | **red on injected drift, as designed**; file reverted clean |
| `re-frame.substrate.observation` load probe | **pass** — docstring reads, namespace loads |

**Deltas:** +3 tests / +13 assertions (all new; 10 of the 13 are adversarial — 2 docs × 5 drift fixtures — plus the historical-wording rejection).

Not run, with reason:
- `test:browser` / full pre-checkin spine — cold shadow-cljs + Chromium on a fresh worktree; CI owns them. The diff has **no runtime surface**: a JVM-only doc census plus a docstring. Consumer risk from `observation.cljc` was covered by gating `core` and `ui` on the JVM and the full CLJS node suite.
