### PR TITLE
fix(ui): metadata-free evidence scalar projection + honest prune (cluster)

### DIFF
--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -99,7 +99,20 @@
   ViewCells, host values, records and arbitrary sequences become an opaque
   marker. That is deliberately a COPY, not a serializer: no metadata,
   identity-bearing object or query→cell back-edge can enter the long-lived
-  weak-registry value. Ordinary bounded EDN remains exact."
+  weak-registry value. Ordinary bounded EDN remains exact.
+
+  METADATA is the subtle leak (rf2-vxgfnd.94.17). Among the scalar leaves only
+  the SYMBOL is metadata-capable — `(with-meta 'q {:cell cell})` is a legal
+  target value whose metadata can hold the very ViewCell the entry is
+  weak-keyed by, so returning the symbol verbatim roots the key. (nil, boolean,
+  number, char and string are not `IMeta`; a keyword is interned and rejects
+  metadata on both hosts; a record is already opaque.) A metadata-bearing
+  symbol is REBUILT from its ns/name — value-equal, provably free of any hidden
+  field — and marked inexact, because dropping the metadata changed what the
+  original carried. Collection metadata needs no special case: every collection
+  branch reconstructs a fresh value, so container-level metadata never
+  survives; a metadata-bearing symbol NESTED in one is stripped by the same leaf
+  rule on the recursion."
   ([x] (project-target-value x 0 (volatile! target-node-cap)))
   ([x depth budget]
    (if-not (pos? @budget)
@@ -119,13 +132,20 @@
            [bounded-marker false])
 
          (keyword? x)
+         ;; Interned, not IMeta on either host — no back-edge possible.
          (if (<= (count (str x)) target-string-cap)
            [x true]
            [bounded-marker false])
 
          (symbol? x)
          (if (<= (count (str x)) target-string-cap)
-           [x true]
+           (if (nil? (meta x))
+             [x true]
+             ;; Metadata-bearing: rebuild from ns/name so no metadata map (and
+             ;; thus no ViewCell it may hold) enters the retained value, and
+             ;; mark the loss — the projected symbol is value-equal but no
+             ;; longer carries what the original did.
+             [(symbol (namespace x) (name x)) false])
            [bounded-marker false])
 
          (reactive/cell? x)

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -393,7 +393,16 @@
   nil)
 
 (defn- store-live-entries!
-  "Snapshot live `[cell entry]` pairs, pruning dead cells and cleared refs."
+  "Snapshot live `[cell entry]` pairs, pruning dead cells and cleared refs.
+
+  TWO exits, not one (rf2-un54gv). `:dead` is the PROVEN end — a teardown path
+  said so, and the row goes immediately. But an ordinary React reconciliation
+  unmount proves nothing: the cell only ever reaches `:disconnected`, exactly as
+  an Activity hide does, so a lifecycle predicate can never distinguish them.
+  That cell leaves through the OTHER exit — its weak key is collected once React
+  drops the last owner, and the read compacts whatever the host has cleared.
+  Pruning on `:disconnected` would evict live Activity-hidden rows; pruning only
+  on `:dead` would pin every unmount forever. Both exits are load-bearing."
   [store]
   (if (nil? store)
     []
@@ -403,8 +412,21 @@
            ;; Materialize first: mutating WeakHashMap during reduce iteration
            ;; would invalidate its iterator.
            (reduce (fn [out [cell entry]]
-                     (if (= :dead (reactive/lifecycle cell))
+                     (cond
+                       ;; A WeakHashMap entry OUTLIVES its referent: the key
+                       ;; can clear between this materialization and the read
+                       ;; below (the iterator holds only the CURRENT key
+                       ;; strongly), so `getKey` hands back nil. That is the
+                       ;; ordinary-unmount exit — skip the row and let the map
+                       ;; expunge it, never `.remove` nil (which would target a
+                       ;; genuine null-key mapping).
+                       (nil? cell)
+                       out
+
+                       (= :dead (reactive/lifecycle cell))
                        (do (.remove members cell) out)
+
+                       :else
                        (conj out [cell entry])))
                    []
                    (into [] members))))

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -259,9 +259,55 @@
         (cond-> (false? (:targets-exact? ev)) (assoc :targets-exact? false)
                 (false? (:dropped-exact? ev)) (assoc :dropped-exact? false)))))
 
+(defn- reproject-accrual
+  "Re-run one accrual retained across a reload through the CURRENT bounded
+  projection (rf2-vxgfnd.94.18).
+
+  A store built by an earlier head holds values its head's copier admitted —
+  at the pre-projection heads, RAW target keys including query→ViewCell cycles.
+  Recognizing such a store's host weak machinery is not enough: a migrated row
+  carrying a raw key still owns its own weak key and pins it forever. Every
+  retained value must go through TODAY's copier.
+
+  This IS the delivery path — `project-batch-evidence` then `fold-target` —
+  so a migrated row is indistinguishable from one accreted fresh: the same
+  bounded shown sample, the same distinct-loss partition, the same honesty.
+  Counters (`:count`, `:batches`, epochs, causes) are already bounded plain
+  data and carry over verbatim; `:targets` keeps its first-seen order.
+
+  Exactness only ever LOWERS. Re-projection can discover loss the legacy record
+  never marked, but it can never prove an exactness the legacy floor already
+  denied — the fold starts FROM the stored accrual, so a stored `false` stays
+  false. A row is never reset merely to simplify the migration, and an exact
+  value is never fabricated."
+  [acc]
+  (let [acc0 (merge empty-accrual acc)
+        ev   (project-batch-evidence acc0)]
+    (-> acc0
+        (assoc :targets [] :dropped #{})
+        (as-> a (reduce fold-target a (concat (:targets ev) (:dropped ev))))
+        (cond-> (false? (:targets-exact? ev)) (assoc :targets-exact? false)
+                (false? (:dropped-exact? ev)) (assoc :dropped-exact? false)))))
+
+(defn- sanitize-entry
+  "Re-project one retained row's accrual, preserving its `:cell-id` ordinal and
+  `:view-id` (stable identity axes, never target values)."
+  [entry]
+  (cond-> entry
+    (some? (:evidence entry)) (update :evidence reproject-accrual)))
+
 ;; ---- projection state --------------------------------------------------------
 
-(def ^:private ^:const weak-store-tag ::weak-cell-entries-v1)
+(def ^:private ^:const weak-store-tag
+  ;; The CURRENT retained-value contract version. A store carrying EXACTLY this
+  ;; tag has had every entry through today's `project-target-value`; any other
+  ;; shape — an older tag, or the untagged defrecord/strong-map stores left by
+  ;; earlier heads — is LEGACY, and its entries are re-projected on migration
+  ;; (rf2-vxgfnd.94.18). BUMP THIS whenever the copier changes what a retained
+  ;; value may hold: v1 admitted metadata-bearing symbols, whose metadata could
+  ;; hold the very ViewCell the entry is weak-keyed by (rf2-vxgfnd.94.17).
+  ::weak-cell-entries-v2)
+
 (def ^:private ^:const weak-store-tag-key ::weak-cell-entries)
 
 (defn- new-weak-cell-entries
@@ -287,12 +333,15 @@
                                (.delete members holder))))})))
 
 (defn- weak-cell-entries?
-  "Recognize the reload-stable tagged map AND the exact same host structure
-  left by the pre-tag defrecord implementation. Constructor identity is not
-  stable across a CLJS :after-load; these host fields are."
+  "Recognize a weak store of ANY vintage — a tagged map (current or older) and
+  the exact same host structure left by the pre-tag defrecord implementation.
+  Constructor identity is not stable across a CLJS :after-load; these host
+  fields are. Recognition means only that the HOST MACHINERY is reusable; it
+  says nothing about whether the retained VALUES meet the current contract —
+  that is `weak-store-current?`."
   [x]
   (and (map? x)
-       (or (= weak-store-tag (get x weak-store-tag-key))
+       (or (contains? x weak-store-tag-key)
            (and (contains? x :members)
                 (contains? x :by-cell)
                 (contains? x :next-ordinal)
@@ -304,13 +353,13 @@
                      (instance? js/WeakMap (:by-cell x))
                      (some? (:next-ordinal x))))))
 
-(defn- tag-weak-cell-entries
-  "Drop a reload-specific record constructor while preserving its exact host
-  weak maps, reaper and ordinal mint."
+(defn- weak-store-current?
+  "True when `store` carries EXACTLY the current retained-value contract tag —
+  its entries are already projected by today's copier and migration is a no-op.
+  A recognized store with an older tag, or none at all, is legacy: reuse its
+  host weak machinery, but trust none of its values."
   [store]
-  (if (= weak-store-tag (get store weak-store-tag-key))
-    store
-    (assoc (into {} store) weak-store-tag-key weak-store-tag)))
+  (= weak-store-tag (get store weak-store-tag-key)))
 
 (defn- store-next-ordinal!
   [store]
@@ -391,6 +440,47 @@
          (when-some [reaper (:reaper store)]
            (.unregister ^js reaper holder)))))
   nil)
+
+(defn- store-sanitize-entries!
+  "Re-project EVERY entry a legacy store retained, IN PLACE — same host weak
+  maps, same reaper registrations, same ordinal mint, same rows in the same
+  order. Only the retained VALUES change (rf2-vxgfnd.94.18).
+
+  In place is the point: rebuilding the store would re-register the reaper and
+  re-key the weak maps for rows this tier does not own, and rewrapping without
+  re-projecting would keep the raw query→cell back-edges the migration exists
+  to break."
+  [store]
+  #?(:clj
+     (let [members ^java.util.Map (:members store)]
+       (locking members
+         ;; Materialize first (see `store-live-entries!`), and skip a key that
+         ;; cleared in between — its row is already garbage.
+         (doseq [[cell entry] (into [] members)
+                 :when (some? cell)]
+           (.put members cell (sanitize-entry entry)))))
+     :cljs
+     (let [members ^js (:members store)]
+       (.forEach members
+                 (fn [holder _ _]
+                   (aset holder "entry" (sanitize-entry (aget holder "entry")))))))
+  nil)
+
+(defn- migrate-weak-store!
+  "Bring a recognized weak store up to the CURRENT retained-value contract,
+  reusing its exact host weak maps, reaper and ordinal mint, and drop any
+  reload-specific record constructor.
+
+  IDEMPOTENT: a store already carrying the current tag is returned untouched,
+  so repeated `:after-load` re-arms do no work. Anything older has its entries
+  re-projected before it is re-tagged — the tag is a claim about the values,
+  and promoting a legacy store without sanitizing it would make that claim a
+  lie (rf2-vxgfnd.94.18)."
+  [store]
+  (if (weak-store-current? store)
+    store
+    (do (store-sanitize-entries! store)
+        (assoc (into {} store) weak-store-tag-key weak-store-tag))))
 
 (defn- store-live-entries!
   "Snapshot live `[cell entry]` pairs, pruning dead cells and cleared refs.
@@ -496,7 +586,9 @@
   ;;
   ;; `defonce` is module-lived; normalize-state migrates both a pre-weak strong
   ;; map and the former defrecord-shaped weak store on first post-reload access
-  ;; without losing retained Activity evidence, host registrations or ordinals.
+  ;; without losing retained Activity evidence, host registrations or ordinals —
+  ;; and re-projects their pre-projection values on the way, so no legacy row
+  ;; migrates still owning its own weak key (rf2-vxgfnd.94.18).
   ;; In production the var root is literally nil: no atom, weak registry, or
   ;; ordinal mint is allocated (rf2-vxgfnd.149).
   (when interop/debug-enabled?
@@ -520,9 +612,19 @@
      :cljs (f)))
 
 (defn- normalize-state
-  "Migrate the pre-weak persistent ViewCell map preserved by `state*` across a
-  reload. Activity-retained rows and ordinals survive; closed state owns no
-  registry."
+  "Bring the value `defonce` preserved verbatim across a reload up to the
+  current contract. TWO legacy store shapes exist, and BOTH hold values an
+  earlier copier admitted — so recognizing a shape is where the migration
+  starts, not where it ends (rf2-vxgfnd.94.18):
+
+    - a recognized weak store from an earlier head (including the pre-tag
+      defrecord): its host weak machinery is REUSED and its entries are
+      re-projected in place;
+    - the pre-weak persistent ViewCell map: rebuilt into a fresh weak store,
+      seeding each still-live row's SANITIZED entry under a weak key.
+
+  Either way Activity-retained rows, their ordinals and their order survive,
+  and no raw target/query value does. Closed state owns no registry."
   [{:keys [owner entries next-ordinal] :as s}]
   (cond
     (nil? owner)
@@ -530,14 +632,14 @@
 
     (weak-cell-entries? entries)
     (-> s
-        (assoc :entries (tag-weak-cell-entries entries))
+        (assoc :entries (migrate-weak-store! entries))
         (dissoc :next-ordinal))
 
     :else
     (let [store (new-weak-cell-entries)]
       (doseq [[cell entry] entries
               :when (not= :dead (reactive/lifecycle cell))]
-        (store-seed-entry! store cell entry))
+        (store-seed-entry! store cell (sanitize-entry entry)))
       (store-set-next-at-least! store (or next-ordinal 0))
       (-> s (assoc :entries store) (dissoc :next-ordinal)))))
 

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -382,6 +382,176 @@
              "hosts without FinalizationRegistry compact on read")))))
 
 ;; ===========================================================================
+;; Compatible HMR migration — legacy stores are SANITIZED, not just re-homed
+;; ===========================================================================
+
+(defn- legacy-accrual
+  "The exact accrual a PRE-projection head accreted: RAW target keys, claimed
+  exact — its copier did not exist yet, so it had nothing to be inexact about."
+  [targets dropped]
+  {:first-epoch    1
+   :latest-epoch   2
+   :count          3
+   :batches        1
+   :causes         #{:value}
+   :targets        (vec targets)
+   :targets-exact? true
+   :dropped        (set dropped)
+   :dropped-exact? true})
+
+(defn- legacy-entry
+  [ord vid evidence]
+  {:cell-id ord :view-id vid :evidence evidence})
+
+(deftest compatible-hmr-sanitizes-a-legacy-strong-map-store
+  ;; The pre-weak head kept `:entries` as a STRONG persistent map keyed by
+  ;; ViewCell, whose values retained raw query→cell cycles. A compatible reload
+  ;; rebuilds that into the weak store — and must run every retained value
+  ;; through TODAY's copier on the way. Seeding the rows verbatim would migrate
+  ;; each cycle intact, and a weak key its own value reaches is pinned forever.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [state* @#'evidence/state*
+        direct (connect-empty! (reactive/make-cell ::legacy-direct))
+        nested (connect-empty! (reactive/make-cell ::legacy-nested))
+        plain  (connect-empty! (reactive/make-cell ::legacy-plain))]
+    (swap! state* assoc
+           :entries      {direct (legacy-entry
+                                  7 ::legacy-direct
+                                  (legacy-accrual [[:sub fid [::q direct]]] []))
+                          nested (legacy-entry
+                                  9 ::legacy-nested
+                                  (legacy-accrual
+                                   [[:sub fid [::q {:nested {:cell nested}}]]] []))
+                          plain  (legacy-entry
+                                  11 ::legacy-plain
+                                  (legacy-accrual [[:sub fid [::q 1]]] []))}
+           :next-ordinal 12)
+
+    (is (true? (evidence/install! ::tool-a)) "the reload is a compatible re-arm")
+
+    (testing "raw direct/nested cycles are RE-PROJECTED, not rewrapped"
+      (doseq [vid [::legacy-direct ::legacy-nested]]
+        (let [ev (:evidence (entry-for vid))]
+          (is (= {:rf.ui.evidence/opaque :dynamic} (get-in ev [:targets 0 2 1]))
+              "the retained query is opaque — no cell survives the migration")
+          (is (false? (:targets-exact? ev))
+              "…and the legacy `exact` claim is corrected, not carried over")
+          (is (false? (:dropped-exact? ev))))))
+
+    (testing "ordinals and order survive; bounded counters carry over verbatim"
+      (is (= [7 9 11] (mapv :cell-id (evidence/projection))))
+      (is (= [::legacy-direct ::legacy-nested ::legacy-plain]
+             (mapv :view-id (evidence/projection))))
+      (let [ev (:evidence (entry-for ::legacy-direct))]
+        (is (= 3 (:count ev)) "occurrence counters are already bounded plain data")
+        (is (= 1 (:batches ev)))
+        (is (= 1 (:first-epoch ev)))
+        (is (= 2 (:latest-epoch ev)))
+        (is (= #{:value} (:causes ev))))
+      (is (= bounded-evidence-keys
+             (set (keys (:evidence (entry-for ::legacy-direct)))))
+          "migration adds no keys"))
+
+    (testing "an already-bounded legacy row is NOT reset, nor falsely degraded"
+      (let [ev (:evidence (entry-for ::legacy-plain))]
+        (is (= [[:sub fid [::q 1]]] (:targets ev)) "its exact value survives")
+        (is (true? (:targets-exact? ev)) "…and its exactness is not thrown away")
+        (is (true? (:dropped-exact? ev)))))
+
+    (testing "the preserved ordinal mint advances past the legacy high-water mark"
+      (let [fresh (reactive/make-cell ::legacy-fresh)]
+        (reactive/mark-dirty! fresh 1)
+        (reactive/flush-pending!)
+        (is (<= 12 (:cell-id (entry-for ::legacy-fresh))))))
+
+    (testing "repeated HMR is idempotent — the store now carries the current tag"
+      (let [before (evidence/projection)]
+        (is (true? (evidence/install! ::tool-a)))
+        (is (true? (evidence/install! ::tool-a)))
+        (is (= before (evidence/projection))
+            "re-projecting an already-projected row changes nothing")))))
+
+(deftest compatible-hmr-sanitizes-a-recognized-but-legacy-weak-store
+  ;; The shape the prior head left behind: a store recognized by host structure
+  ;; (the pre-tag defrecord) or by an OLDER tag. Recognition proves the weak
+  ;; MACHINERY is reusable; it proves nothing about the retained VALUES, which
+  ;; an earlier copier admitted raw. Re-tagging such a store without
+  ;; re-projecting it promotes a lie — the tag is a claim about the values.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [state* @#'evidence/state*
+        cell   (connect-empty! (reactive/make-cell ::legacy-weak))
+        store  (:entries @state*)]
+    (#'evidence/store-seed-entry!
+     store cell
+     (legacy-entry 5 ::legacy-weak
+                   (legacy-accrual [[:sub fid [::q cell]]]
+                                   [[:sub fid [::dropped cell]]])))
+    (swap! state* assoc :entries
+           (->PreReloadWeakCellEntries (:members store) (:by-cell store)
+                                       (:next-ordinal store) (:reaper store)))
+
+    (is (true? (evidence/install! ::tool-a)) "constructor churn is compatible")
+
+    (testing "the raw entry is re-projected IN PLACE"
+      (let [row (entry-for ::legacy-weak)
+            ev  (:evidence row)]
+        (is (= {:rf.ui.evidence/opaque :dynamic} (get-in ev [:targets 0 2 1]))
+            "the shown target's cycle is broken")
+        (is (every? (fn [tk] (not (reactive/cell? (get-in tk [2 1]))))
+                    (:dropped ev))
+            "…and so is the OMITTED target's — the loss set retains no cell")
+        (is (false? (:targets-exact? ev)))
+        (is (false? (:dropped-exact? ev)))
+        (is (= 5 (:cell-id row)) "the ordinal survives the migration")))
+
+    (testing "the existing host machinery is REUSED, not rebuilt"
+      (let [after (:entries @state*)]
+        (is (identical? (:members store) (:members after)))
+        (is (identical? (:by-cell store) (:by-cell after)))
+        (is (identical? (:next-ordinal store) (:next-ordinal after)))
+        (is (identical? (:reaper store) (:reaper after))
+            "the existing reaper is retained, not double-armed")))
+
+    (testing "repeated HMR is idempotent"
+      (let [before (evidence/projection)]
+        (is (true? (evidence/install! ::tool-a)))
+        (is (= before (evidence/projection)))))))
+
+#?(:clj
+   (deftest legacy-migration-releases-the-raw-cycle-weak-key
+     ;; The retention proof (rf2-vxgfnd.94.18). A legacy row's raw query→cell
+     ;; cycle is a back-edge from the entry VALUE to its own weak KEY, and a
+     ;; WeakHashMap whose value reaches its key never collects that entry. So a
+     ;; migration that merely re-homes the rows keeps pinning every one of them
+     ;; for the projection's lifetime — the exact retention the weak store was
+     ;; built to end. RED when migration seeds entries unchanged.
+     (is (true? (evidence/install! ::tool-a)))
+     (let [state* @#'evidence/state*
+           _      (swap! state* assoc :entries {} :next-ordinal 0)
+           refs   (mapv
+                   (fn [[vid ord query-fn]]
+                     ;; the cell stays inside this lambda: only a WeakReference
+                     ;; escapes, so the store is its last strong referent
+                     (let [cell (connect-empty! (reactive/make-cell vid))]
+                       (reactive/disconnect! cell)
+                       (swap! state* update :entries assoc cell
+                              (legacy-entry
+                               ord vid
+                               (legacy-accrual [[:sub fid (query-fn cell)]] [])))
+                       (java.lang.ref.WeakReference. cell)))
+                   [[::legacy-weak-direct 3 (fn [c] [::q c])]
+                    [::legacy-weak-nested 4 (fn [c] [::q {:nested {:cell c}}])]])]
+       (is (true? (evidence/install! ::tool-a))
+           "the compatible reload migrates the legacy strong map")
+       (is (= 2 (count (evidence/projection))) "both legacy rows migrated")
+       (is (true? (gc-until #(every?
+                              (fn [^java.lang.ref.WeakReference ref]
+                                (nil? (.get ref)))
+                              refs)))
+           "no migrated raw query→cell path survives to own its own weak key")
+       (is (= [] (evidence/projection))))))
+
+;; ===========================================================================
 ;; Cross-batch loss honesty (the rf2-vxgfnd.74 axis, cumulative tier)
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -444,6 +444,36 @@
       (is (= [] (evidence/projection))))))
 
 #?(:clj
+   (deftest cleared-weak-key-compaction-drops-the-row-and-spares-the-survivor
+     ;; The OTHER prune exit (rf2-un54gv). `:dead` is the proven end, but an
+     ;; ordinary unmount is never proven — it leaves through weak collection,
+     ;; and a WeakHashMap entry OUTLIVES its referent: the read materializes
+     ;; entries whose keys can clear before `getKey` runs (the iterator holds
+     ;; only the CURRENT key strongly), handing back nil. Model that exactly,
+     ;; the way the CLJS sibling fakes a cleared WeakRef — a null-keyed mapping
+     ;; beside a live one. RED before the fix: `lifecycle` NPEs on the cleared
+     ;; key and takes the whole projection read down with it.
+     (is (true? (evidence/install! ::xray)))
+     (let [state*   @#'evidence/state*
+           base     (:entries @state*)
+           survivor (reactive/make-cell ::survivor)
+           members  (doto (java.util.HashMap.)
+                      (.put nil {:cell-id  0
+                                 :view-id  ::cleared
+                                 :evidence one-target-evidence})
+                      (.put survivor {:cell-id  1
+                                      :view-id  ::survivor
+                                      :evidence one-target-evidence}))]
+       (swap! state* assoc :entries (assoc base :members members))
+       (is (= [::survivor] (mapv :view-id (evidence/projection)))
+           "a collected weak key prunes the row — it does not throw")
+       (is (true? (.containsKey members nil))
+           "the cleared mapping is left for the host map to expunge; a nil-key
+            `.remove` would target a genuine null-key mapping instead")
+       (is (true? (.containsKey members survivor))
+           "…and the live row is untouched"))))
+
+#?(:clj
    (deftest ordinary-unmount-churn-is-weak-while-activity-retention-survives
      ;; The exact ambiguity that forbids pruning merely on :disconnected:
      ;; React runs the same cleanup for an ordinary conditional/keyed unmount

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -326,6 +326,83 @@
            (first (:targets (:evidence (entry-for ::ordinary)))))
         "ordinary bounded EDN remains exact")))
 
+(deftest metadata-bearing-symbol-targets-are-stripped-and-marked-inexact
+  ;; rf2-vxgfnd.94.17. A symbol is the only metadata-capable scalar leaf, and
+  ;; its metadata can hold the ViewCell the entry is weak-keyed by. The copier
+  ;; must return a metadata-free value (no back-edge) AND stop claiming exact.
+  (is (true? (evidence/install! ::xray)))
+  (let [sink          (evidence/installed-sink)
+        direct-cell   (reactive/make-cell ::meta-direct)
+        nested-cell   (reactive/make-cell ::meta-nested)
+        coll-cell     (reactive/make-cell ::meta-coll)
+        ordinary-cell (reactive/make-cell ::sym-ordinary)]
+    ;; DIRECT: the query IS a metadata-bearing symbol whose meta holds the cell
+    (publish-target! sink direct-cell [:sub fid (with-meta 'q {:cell direct-cell})])
+    ;; NESTED: the metadata-bearing symbol sits two collections deep
+    (publish-target! sink nested-cell
+                     [:sub fid [::q [(with-meta 'deep {:cell nested-cell})]]])
+    ;; ADVERSARIAL: metadata on the COLLECTION itself (reconstruction must drop it)
+    (publish-target! sink coll-cell
+                     [:sub fid (with-meta [::q 1] {:cell coll-cell})])
+    ;; CONTROL: an ordinary metadata-free symbol stays semantically exact
+    (publish-target! sink ordinary-cell [:sub fid [::q 'plain]])
+
+    (testing "a DIRECT metadata-bearing symbol is stripped to a bare value"
+      (let [ev  (:evidence (entry-for ::meta-direct))
+            sym (get-in ev [:targets 0 2])]
+        (is (= 'q sym) "value semantics preserved (symbol equality ignores meta)")
+        (is (nil? (meta sym)) "…but no metadata/back-reference is retained")
+        (is (false? (:targets-exact? ev)) "dropped metadata is marked as loss")
+        (is (false? (:dropped-exact? ev)))))
+
+    (testing "a NESTED metadata-bearing symbol is stripped in place"
+      (let [ev  (:evidence (entry-for ::meta-nested))
+            sym (get-in ev [:targets 0 2 1 0])]
+        (is (= 'deep sym))
+        (is (nil? (meta sym)) "the nested symbol carries no metadata")
+        (is (false? (:targets-exact? ev)))))
+
+    (testing "collection-level metadata never survives reconstruction"
+      (let [ev  (:evidence (entry-for ::meta-coll))
+            tk  (get-in ev [:targets 0])
+            q   (get tk 2)]
+        (is (= [::q 1] q) "the collection value is preserved")
+        (is (nil? (meta q)) "…without its metadata")
+        (is (nil? (meta tk)) "nor does the target vector keep metadata")))
+
+    (testing "an ordinary metadata-free symbol remains exact"
+      (let [ev (:evidence (entry-for ::sym-ordinary))]
+        (is (= [:sub fid [::q 'plain]] (get-in ev [:targets 0]))
+            "ordinary bounded EDN with a plain symbol is verbatim")
+        (is (nil? (meta (get-in ev [:targets 0 2 1]))))
+        (is (true? (:targets-exact? ev)) "…and honestly exact")
+        (is (true? (:dropped-exact? ev)))))))
+
+#?(:clj
+   (deftest metadata-bearing-symbol-does-not-defeat-weak-keys
+     ;; The retention proof for rf2-vxgfnd.94.17. `(with-meta 'q {:cell cell})`
+     ;; is a back-edge from the target VALUE, through symbol metadata, to the
+     ;; ViewCell the entry is weak-keyed by — exactly the shape a bounded copier
+     ;; is supposed to make impossible. RED at PR #5998's head, which returned
+     ;; the symbol (and its metadata) unchanged.
+     (is (true? (evidence/install! ::xray)))
+     (let [sink (evidence/installed-sink)
+           refs (mapv
+                 (fn [[vid query-fn]]
+                   (let [cell (connect-empty! (reactive/make-cell vid))]
+                     (publish-target! sink cell [:sub fid (query-fn cell)])
+                     (reactive/disconnect! cell)
+                     (java.lang.ref.WeakReference. cell)))
+                 [[::meta-weak-direct (fn [cell] (with-meta 'q {:cell cell}))]
+                  [::meta-weak-nested
+                   (fn [cell] [::q [(with-meta 'deep {:cell cell})]])]])]
+       (is (true? (gc-until #(every?
+                              (fn [^java.lang.ref.WeakReference ref]
+                                (nil? (.get ref)))
+                              refs)))
+           "symbol metadata roots neither a direct nor a nested weak key")
+       (is (= [] (evidence/projection))))))
+
 #?(:clj
    (deftest direct-and-nested-query-cycles-do-not-defeat-weak-keys
      (is (true? (evidence/install! ::xray)))


### PR DESCRIPTION
Cluster of three bugs in `re-frame.ui.tool.evidence` — the first-party Xray
projection over the ViewCell DEBUG invalidation-evidence plane (rf2-vxgfnd.75).
The through-line: retained evidence must never form a back-edge that roots a
weak-keyed ViewCell, and the projection's exactness/loss markers must stay
truthful. All three fixes are DEBUG-only (the whole plane DCEs out of
production). Public projection contract (keys, order, bounded-evidence-keys)
is unchanged, so the xray consumer is behaviorally unaffected.

Committed smallest-cleanup → biggest-correctness-fix.

## rf2-un54gv (P4) — prune collected weak keys, not only `:dead`
The registry is weak-keyed so an ordinarily-unmounted cell (never proven
`:dead`, indistinguishable from an Activity hide by any lifecycle predicate)
is meant to leave through weak collection. On the JVM that exit was
unreachable: a `WeakHashMap` entry OUTLIVES its referent, and the read
materializes entries before dereferencing them, so a key collected in between
handed back nil and `lifecycle` NPE'd on it — taking the whole projection read
down. `store-live-entries!` now skips a cleared key (letting the host map
expunge it) alongside the existing `:dead` prune. The CLJS side already handled
its cleared-ref equivalent.

## rf2-vxgfnd.94.18 (P1) — sanitize legacy evidence during compatible HMR
A weak store preserved across `:after-load` holds values the head that
accreted them admitted — at pre-projection heads, raw query→ViewCell cycles.
Recognizing the store's host machinery was not enough: a migrated row carrying
a raw key still owned its own weak key and pinned the cell forever, even though
fresh captures were sanitized. The retained-value contract is now versioned
(`::weak-cell-entries-v2`); migration re-projects every legacy entry through
today's copier IN PLACE (same host weak maps, reaper, ordinals and order — only
values change), and a store already carrying the current tag migrates as a
no-op (idempotent re-arm). Exactness only ever lowers — a stored honest floor
is never fabricated back to exact.

## rf2-vxgfnd.94.17 (P1) — strip metadata from scalar projections
The copier promised no retained value can hold a ViewCell, but returned
symbols verbatim and claimed `:targets-exact? true`. A symbol is the one
metadata-capable scalar leaf, and its metadata can hold the very cell the entry
is weak-keyed by, so `(with-meta 'q {:cell cell})` rooted the weak key on both
hosts while the projection still read as exact. A metadata-bearing symbol is
now rebuilt from its ns/name (value-equal, provably free of any hidden field)
and marked inexact. Other scalar leaves need no change (nil/boolean/number/
char/string are not `IMeta`; a keyword is interned and rejects metadata on both
hosts); collection metadata never survived reconstruction anyway, and a nested
metadata-bearing symbol is stripped by the same leaf rule on the recursion.

Each fix carries a red-proven fixture (verified failing against the pre-fix
behaviour, including JVM GC weak-reference retention proofs for both .94.17 and
.94.18), and every proof covers BOTH hosts per the beads.

## Quality gates
- `cd implementation/ui && clojure -M:test` (ui JVM suite): **605 tests, 8671 assertions, 0 failures, 0 errors** — PASS
- `cd implementation && npm run test:cljs` (node CLJS suite, `cljs-test$`, includes the `.cljc` tool-evidence tests on the CLJS host): **9557 tests, 47008 assertions, 0 failures, 0 errors** — PASS

Red-proofs (each fix temporarily reverted, tests confirmed failing, then restored):
- rf2-un54gv: NPE on the cleared weak key took the projection read down (1 error) — PASS after fix
- rf2-vxgfnd.94.18: 12 failures incl. the JVM weak-key retention proof — PASS after fix
- rf2-vxgfnd.94.17: 7 failures incl. the JVM weak-key retention proof — PASS after fix

`test:browser` and the full spine were NOT run (CI owns those).
