### PR TITLE
fix(ui): custom-element reload ledger identity + reentrant commit (cluster)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -747,15 +747,38 @@
 ;;                                thrown / aborted reload never commits — the last
 ;;                                known-good manifest survives.
 ;;
-;; Ownership is [build-id ns-sym] so two builds sharing one atom (a shared JVM /
-;; a test) reconcile independently — evicting one build's source can never drop
-;; another's rows. The emitted 3-arg registration uses ns-only ownership under
-;; the sole ::default build (one compiled bundle = one build, its own atoms); the
-;; explicit build-scoped arities exist for multi-build reconciliation and tests.
+;; Ownership is [build-id ns-sym] so two builds sharing one atom (two bundles in
+;; one JS realm, a shared JVM, a test) reconcile independently — evicting one
+;; build's source can never drop another's rows.
+;;
+;; That key is only worth its weight if `build-id` is a REAL identity, and every
+;; participant in a cycle agrees on it (rf2-vxgfnd.142). It used to be the
+;; placeholder `::default` on every real path — emitted registrations, both
+;; lifecycle hooks, the reset producer — with a second identity reachable only
+;; from a test-only arity. Two real builds sharing a realm therefore collapsed
+;; into one row at [::default ns], and reloading one could evict or replace the
+;; other's contribution. Now `current-build-id` resolves shadow's own build name
+;; and is the default for EVERY arity in the protocol, so an emitted registration
+;; and the cycle that reconciles it cannot key a row differently. The explicit
+;; build-scoped arities remain the seam for multi-build reconciliation and tests.
 ;;
 ;; Production never opens a cycle (`notify-reload!` is a dev-only hook), so every
 ;; registration writes through directly and classification stays a plain lookup —
 ;; all reconciliation machinery is reload-only.
+;;
+;; ## Bounded by shadow's reload surface (the honest edge)
+;;
+;; Per-build isolation reaches exactly as far as shadow's runtime seam allows.
+;; `before-load-src` calls each SHADOW_NS_RESET callback with the reloaded ns and
+;; NOTHING else, and lifecycle hooks are invoked with no arguments after being
+;; resolved by name off the SHARED `$CLJS` object. So a callback learns which
+;; build is reloading only from the identity BAKED INTO ITS OWN BUNDLE — which is
+;; exactly what `current-build-id` reads. Two bundles, each with their own copy of
+;; this namespace, are therefore isolated: each copy carries its own build's name
+;; and reconciles only its own rows. Two builds that share ONE copy of this
+;; namespace (one `$CLJS`, one set of atoms, one `defonce`d producer) cannot be
+;; told apart by any mechanism shadow exposes, because the hooks themselves are
+;; then a single shared singleton.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. The LIVE aggregate
@@ -784,7 +807,52 @@
   reload-cycles
   (atom {}))
 
-(def ^:private default-build ::default)
+(def ^:private default-build
+  "The owner token for a source registering outside any real Shadow build: the
+  JVM tree builder, a plain-JVM/REPL host, a `:node-test` bundle, and every
+  `:advanced` production bundle (which never reloads, so its ledger key is inert)."
+  ::default)
+
+#?(:cljs
+   (defn- shadow-build-id
+     "The REAL build identity of the bundle this code is running in, or nil when
+     there is no Shadow dev build (production, a bare node bundle, a test host).
+
+     shadow-cljs compiles `(name build-id)` into every devtools-enabled build as
+     the `shadow.cljs.devtools.client.env/build-id` closure-define, and PREPENDS
+     that namespace to the module entries — so it is already loaded and defined
+     before any app code (and therefore before any emitted
+     `register-custom-element!`) runs. It is a STABLE identity: the build's own
+     name, not the content/build digest, so it does not change when sources do.
+
+     Read by NAME off `$CLJS`, the way shadow reads its own reload lifecycle fns,
+     rather than by requiring the devtools client — the devtools client must never
+     be reachable from library code that ships to production. `js/goog.DEBUG` gates
+     the sole call site, so `:advanced` constant-folds this away entirely."
+     []
+     (let [root (or (unchecked-get js/goog.global "$CLJS") js/goog.global)
+           v    (js/goog.getObjectByName "shadow.cljs.devtools.client.env.build_id" root)]
+       (when (and (string? v) (seq v))
+         (keyword v)))))
+
+(defn current-build-id
+  "The build identity the ledger keys this host's sources under — ONE rule, shared
+  by every arity default in the reload protocol (`register-custom-element!`,
+  `notify-reload!`, `note-reloaded-sources!`, `commit-reload!`, and the installed
+  `reload-source-reset!` producer). Because they all resolve it the same way, an
+  emitted registration and the reload cycle that reconciles it can never disagree
+  about who owns a row (rf2-vxgfnd.142).
+
+  In a real Shadow dev build this is that build's OWN name (`:app`); everywhere
+  else — production, JVM, a bare node bundle — there is no Shadow build to name and
+  it is `::default`. Resolved per call rather than cached: it is dev-only, called
+  once per declaration at load and once per reload hook (never per render), and a
+  cache would only create a window in which an early miss became permanent."
+  []
+  #?(:cljs (if ^boolean js/goog.DEBUG
+             (or (shadow-build-id) default-build)
+             default-build)
+     :clj  default-build))
 
 (defn- rebuild-live!
   "Rebuild the live aggregate as the merge of every ledger source's map — the
@@ -804,7 +872,7 @@
   last-known-good until `commit-reload!`); otherwise — initial load, production —
   it writes through directly. Ownership is [build-id ns-sym]; the 3-arg emit uses
   the sole ::default build."
-  ([tag decl ns-sym] (register-custom-element! tag decl ns-sym default-build))
+  ([tag decl ns-sym] (register-custom-element! tag decl ns-sym (current-build-id)))
   ([tag decl ns-sym build-id]
    (let [source [build-id ns-sym]]
      (if (contains? @reload-cycles build-id)
@@ -820,7 +888,7 @@
   from here stage instead of mutating the live aggregate; opening a fresh cycle
   discards any staging left by a previously ABORTED reload. Production never hot-
   reloads, so this never fires there."
-  ([] (notify-reload! default-build))
+  ([] (notify-reload! (current-build-id)))
   ([build-id]
    (swap! reload-cycles assoc build-id {:staged {} :touched #{}})
    nil))
@@ -832,7 +900,7 @@
   rf2-vxgfnd.77). `sources` is a coll of ns-syms (paired with `build-id`) or
   ready-made [build ns] pairs. A no-op when no cycle is open; unions into the
   cycle so it can be called repeatedly."
-  ([sources] (note-reloaded-sources! sources default-build))
+  ([sources] (note-reloaded-sources! sources (current-build-id)))
   ([sources build-id]
    (when (contains? @reload-cycles build-id)
      (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
@@ -848,7 +916,7 @@
   in one swap. shadow-cljs runs after-load only on a SUCCESSFUL reload, so an
   aborted reload never reaches here and the last known-good manifest survives.
   A no-op when no cycle is open."
-  ([] (commit-reload! default-build))
+  ([] (commit-reload! (current-build-id)))
   ([build-id]
    (when-let [{:keys [staged touched]} (get @reload-cycles build-id)]
      (let [sources (into (set (keys staged)) touched)]
@@ -932,7 +1000,7 @@
      (initial load / production). `ns` is a CLJS ns symbol; a string is coerced.
      `build-id` is the build whose producer is calling (the installed trampoline
      passes its own owner); the 1-arg arity uses the ambient build."
-     ([ns] (reload-source-reset! ns default-build))
+     ([ns] (reload-source-reset! ns (current-build-id)))
      ([ns build-id]
       (note-reloaded-sources! [(cond-> ns (string? ns) symbol)] build-id)
       nil)))
@@ -984,7 +1052,7 @@
      []
      (when ^boolean js/goog.DEBUG
        (let [arr      (or js/goog.global.SHADOW_NS_RESET #js [])
-             build-id default-build]
+             build-id (current-build-id)]
          (set! (.-SHADOW_NS_RESET js/goog.global) arr)
          (let [i (tagged-producer-index arr build-id)
                f (make-reload-source-producer build-id)]

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -737,15 +737,23 @@
 ;;                                cannot emit for itself (absence cannot
 ;;                                self-report). Optional: absent, only the
 ;;                                staged sources are reconciled.
-;;   (commit-reload! [build?])    ^:dev/after-load — COMMIT atomically: every
-;;                                staged source REPLACES its whole prior
+;;   (commit-reload! [build?])    ^:dev/after-load — COMMIT: reconcile the ledger
+;;                                (every staged source REPLACES its whole prior
 ;;                                contribution, every reloaded-but-unstaged /
 ;;                                removed source is EVICTED, untouched sources are
-;;                                kept, and the live aggregate is rebuilt from the
-;;                                reconciled ledger in ONE swap. shadow-cljs runs
+;;                                kept) AND close the cycle in ONE atomic swap,
+;;                                then publish the aggregate. shadow-cljs runs
 ;;                                after-load only on a SUCCESSFUL reload, so a
 ;;                                thrown / aborted reload never commits — the last
 ;;                                known-good manifest survives.
+;;
+;; The whole protocol reads and writes ONE authoritative value (`ledger-state`:
+;; live `:sources` + in-flight `:cycles`), so the reload cycle is a LINEARIZABLE
+;; state transition (rf2-vxgfnd.144). The public `custom-elements` aggregate is a
+;; pure projection published AFTER each transition, never interleaved with it —
+;; so a watch that reentrantly registers during publication observes an already-
+;; closed cycle and write-through's into the next generation instead of staging
+;; into a cycle the commit is about to discard.
 ;;
 ;; Ownership is [build-id ns-sym] so two builds sharing one atom (two bundles in
 ;; one JS realm, a shared JVM, a test) reconcile independently — evicting one
@@ -789,23 +797,28 @@
   (atom {}))
 
 (defonce ^{:private true
-           :doc "[build-id ns-sym] -> {tag decl} — the per-source committed
-  contribution ledger (the runtime mirror of the compile-side build ledger). The
-  live aggregate is the merge of every source's map, so a source whose file is
-  deleted, or whose last declaration is dropped, vanishes the moment its ledger
-  row is reconciled away — no surviving declaration required."}
-  element-sources
-  (atom {}))
+           :doc "The ONE authoritative ledger value (rf2-vxgfnd.144). A single
+  atom so cycle open/close, staged-row ownership and the ledger transition are a
+  LINEARIZABLE state change — check-then-act on the reload cycle can never be
+  split across two atoms and interleaved:
 
-(defonce ^{:private true
-           :doc "build-id -> {:staged {[build ns] {tag decl}} :touched #{[build ns]}}
-  for each build whose reload cycle is IN FLIGHT (absent = no cycle → direct
-  write-through). `:staged` accumulates this cycle's re-registrations, held back
-  from the live aggregate until commit; `:touched` is the reloaded/removed source
-  set `note-reloaded-sources!` records — the sources to reconcile even when they
-  staged nothing (zero-declaration / deletion)."}
-  reload-cycles
-  (atom {}))
+    {:sources {[build-id ns-sym] {tag decl}}   ; the per-source committed ledger
+     :cycles  {build-id {:staged {[b ns] {tag decl}} :touched #{[b ns]}}}}
+
+  `:sources` is the runtime mirror of the compile-side build ledger — a source
+  whose file is deleted, or whose last declaration is dropped, vanishes the
+  moment its row is reconciled away, no surviving declaration required. `:cycles`
+  holds each build's IN-FLIGHT reload (absent = no cycle → direct write-through):
+  `:staged` accumulates the cycle's re-registrations, held back from the live
+  aggregate until commit; `:touched` is the reloaded/removed source set
+  `note-reloaded-sources!` records — the sources to reconcile even when they
+  staged nothing (zero-declaration / deletion).
+
+  The public `custom-elements` aggregate is a pure PROJECTION of `:sources`,
+  published (one `reset!`) AFTER each authoritative transition completes — never
+  interleaved with it."}
+  ledger-state
+  (atom {:sources {} :cycles {}}))
 
 (def ^:private default-build
   "The owner token for a source registering outside any real Shadow build: the
@@ -854,32 +867,74 @@
              default-build)
      :clj  default-build))
 
-(defn- rebuild-live!
-  "Rebuild the live aggregate as the merge of every ledger source's map — the
-  live registry is a PURE FUNCTION of the ledger. One `reset!` (sources merged in
-  a stable order), so consumers never observe a partial manifest."
+(defn- aggregate
+  "The public aggregate as the merge of every ledger source's map — the live
+  registry is a PURE FUNCTION of `:sources`. Sources merged in a stable order so
+  the projection is deterministic regardless of ledger insertion order."
+  [sources]
+  (reduce (fn [agg src] (merge agg (get sources src)))
+          {}
+          (sort-by str (keys sources))))
+
+(defn- publish!
+  "Republish the public aggregate as a pure projection of the CURRENT ledger
+  `:sources`. Called AFTER an authoritative `ledger-state` transition, never
+  interleaved with it, so a reentrant `register-custom-element!` a watch fires
+  during this publish sees the already-transitioned ledger.
+
+  Uses `swap!` reading the LIVE ledger (not a captured snapshot) so that under JVM
+  contention the projection retries and recomputes from the latest `:sources` —
+  it can never overwrite a concurrent write-through's row with a stale aggregate.
+  On CLJS it is a single uncontended recompute."
   []
-  (reset! custom-elements
-          (reduce (fn [agg src] (merge agg (get @element-sources src)))
-                  {}
-                  (sort-by str (keys @element-sources))))
+  (swap! custom-elements (fn [_] (aggregate (:sources @ledger-state))))
   nil)
+
+(defn- reconcile-sources
+  "Fold one build's committed cycle into `:sources`: every STAGED source replaces
+  its whole prior contribution; every reconciled source that staged NOTHING (a
+  zero-declaration edit or a removed/deleted file flagged via `:touched`) is
+  evicted; untouched sources are kept."
+  [sources staged touched]
+  (reduce (fn [l src]
+            (if-let [decls (get staged src)]
+              (assoc l src decls)     ; re-declared: replace whole contribution
+              (dissoc l src)))        ; zero-declaration / removed: evict
+          sources
+          (into (set (keys staged)) touched)))
 
 (defn register-custom-element!
   "Register `tag`'s runtime property classification under its declaring source.
   Emitted top-level by `ui/custom-element`, so it re-runs on every ns hot-reload.
   While a reload cycle is open for the build it STAGES (the live aggregate stays
   last-known-good until `commit-reload!`); otherwise — initial load, production —
-  it writes through directly. Ownership is [build-id ns-sym]; the 3-arg emit uses
-  the sole ::default build."
+  it writes through directly. Ownership is [build-id ns-sym]; the 3-arg emit
+  resolves the ambient build via `current-build-id`.
+
+  The stage-vs-write-through decision and the ledger write are ONE atomic
+  transition on `ledger-state` (rf2-vxgfnd.144): a registration can never read
+  'cycle open' and then have its stage recreate a cycle a concurrent commit just
+  removed. A write-through additionally publishes its one row; because it decided
+  against staging atomically, a commit that closed the cycle first cannot delete
+  this row (the closed cycle no longer names it), and a commit still open cannot
+  see it as staged (it went to `:sources`, not `:staged`) — the generation rule
+  the reentrancy fix relies on."
   ([tag decl ns-sym] (register-custom-element! tag decl ns-sym (current-build-id)))
   ([tag decl ns-sym build-id]
-   (let [source [build-id ns-sym]]
-     (if (contains? @reload-cycles build-id)
-       (swap! reload-cycles update-in [build-id :staged source]
-              (fnil assoc {}) tag decl)
-       (do (swap! element-sources update source (fnil assoc {}) tag decl)
-           (swap! custom-elements assoc tag decl))))
+   (let [source [build-id ns-sym]
+         [old _new]
+         (swap-vals! ledger-state
+                     (fn [{:keys [cycles] :as st}]
+                       (if (contains? cycles build-id)
+                         (update-in st [:cycles build-id :staged source]
+                                    (fnil assoc {}) tag decl)
+                         (update-in st [:sources source]
+                                    (fnil assoc {}) tag decl))))]
+     ;; The winning transition saw `old`; if `old` had no open cycle it was a
+     ;; write-through, so publish this row incrementally. (Staged registrations
+     ;; stay invisible until commit.)
+     (when-not (contains? (:cycles old) build-id)
+       (swap! custom-elements assoc tag decl)))
    tag))
 
 (defn ^:dev/before-load notify-reload!
@@ -890,7 +945,7 @@
   reloads, so this never fires there."
   ([] (notify-reload! (current-build-id)))
   ([build-id]
-   (swap! reload-cycles assoc build-id {:staged {} :touched #{}})
+   (swap! ledger-state assoc-in [:cycles build-id] {:staged {} :touched #{}})
    nil))
 
 (defn note-reloaded-sources!
@@ -902,34 +957,51 @@
   cycle so it can be called repeatedly."
   ([sources] (note-reloaded-sources! sources (current-build-id)))
   ([sources build-id]
-   (when (contains? @reload-cycles build-id)
-     (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
-       (swap! reload-cycles update-in [build-id :touched] (fnil into #{}) pairs)))
+   (swap! ledger-state
+          (fn [{:keys [cycles] :as st}]
+            (if (contains? cycles build-id)
+              (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
+                (update-in st [:cycles build-id :touched] (fnil into #{}) pairs))
+              st)))
    nil))
 
 (defn ^:dev/after-load commit-reload!
   "shadow-cljs hot-reload hook (dev only): COMMIT the open reload cycle for
-  `build-id` atomically. Every STAGED source replaces its whole prior
-  contribution; every source flagged by `note-reloaded-sources!` that staged
-  NOTHING (a zero-declaration edit or a deleted file) is evicted; untouched
-  sources are kept; then the live aggregate is rebuilt from the reconciled ledger
-  in one swap. shadow-cljs runs after-load only on a SUCCESSFUL reload, so an
-  aborted reload never reaches here and the last known-good manifest survives.
-  A no-op when no cycle is open."
+  `build-id`. The reconciliation AND the cycle close are ONE atomic transition on
+  `ledger-state`: `:sources` is reconciled (staged sources replace their whole
+  contribution; touched-but-unstaged sources are evicted; untouched sources are
+  kept) and the cycle is removed in the SAME swap. Only then is the aggregate
+  published.
+
+  This linearizes the commit against a reentrant registration (rf2-vxgfnd.144).
+  Publishing can synchronously fire a watch on `custom-elements` that calls
+  `register-custom-element!`; by then the cycle is ALREADY gone from
+  `ledger-state`, so that registration write-through's into a new generation and
+  survives, instead of staging into a cycle this commit then discards. The old
+  snapshot-then-`dissoc` shape published while the cycle was still open, so such a
+  registration staged and was dropped by the following `dissoc`.
+
+  shadow-cljs runs after-load only on a SUCCESSFUL reload, so an aborted reload
+  never reaches here and the last known-good manifest survives. A no-op when no
+  cycle is open."
   ([] (commit-reload! (current-build-id)))
   ([build-id]
-   (when-let [{:keys [staged touched]} (get @reload-cycles build-id)]
-     (let [sources (into (set (keys staged)) touched)]
-       (swap! element-sources
-              (fn [ledger]
-                (reduce (fn [l src]
-                          (if-let [decls (get staged src)]
-                            (assoc l src decls)   ; re-declared: replace whole contribution
-                            (dissoc l src)))      ; zero-declaration / removed: evict
-                        ledger
-                        sources)))
-       (rebuild-live!)
-       (swap! reload-cycles dissoc build-id)))
+   (let [[old _new]
+         (swap-vals! ledger-state
+                     (fn [{:keys [sources cycles] :as st}]
+                       (if-let [{:keys [staged touched]} (get cycles build-id)]
+                         (-> st
+                             (assoc :sources
+                                    (reconcile-sources sources staged touched))
+                             (update :cycles dissoc build-id))
+                         st)))]
+     ;; Publish only when THIS commit closed a cycle (the winning transition saw
+     ;; one in `old`). The cycle is gone from the ledger, so a reentrant
+     ;; registration during the publish takes the write-through path — it cannot
+     ;; be recaptured or dropped by this commit. `publish!` recomputes from the
+     ;; LIVE ledger, so a concurrent write-through's row is never clobbered.
+     (when (contains? (:cycles old) build-id)
+       (publish!)))
    nil))
 
 ;; ---------------------------------------------------------------------------
@@ -1075,9 +1147,24 @@
   ledger, and any in-flight reload cycles."
   []
   (reset! custom-elements {})
-  (reset! element-sources {})
-  (reset! reload-cycles {})
+  (reset! ledger-state {:sources {} :cycles {}})
   nil)
+
+(defn in-flight-cycles
+  "Test support: the set of build-ids with a reload cycle currently OPEN. A
+  quiescent ledger has none; a lingering entry after a commit settles is an
+  orphan cycle. Observability only — not a consumer API (classification reads
+  `custom-element-properties`)."
+  []
+  (set (keys (:cycles @ledger-state))))
+
+(defn projected-aggregate
+  "Test support: the aggregate the public `custom-elements` atom MUST equal — the
+  pure projection of the current ledger `:sources`. A settled ledger's published
+  aggregate always equals this; a divergence is a torn or clobbered projection.
+  Observability only."
+  []
+  (aggregate (:sources @ledger-state)))
 
 (defn custom-element-properties [tag]
   (get-in @custom-elements [tag :properties] #{}))

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -896,6 +896,31 @@
 ;;
 ;; Dev-only: the whole install is `js/goog.DEBUG`-gated, so `:advanced`
 ;; production carries no producer and never references SHADOW_NS_RESET.
+;;
+;; ## Why the installed callback is a TRAMPOLINE (rf2-vxgfnd.145)
+;;
+;; `SHADOW_NS_RESET` holds CALLBACK OBJECTS, and the install is `defonce`d (it
+;; must be: re-running it on every reload of this ns would append a duplicate).
+;; Pushing the `reload-source-reset!` fn OBJECT therefore pinned the object
+;; realized at FIRST load forever: hot-reloading rules.cljc rebinds the var to a
+;; new object, but the array kept calling the old one. That stayed invisible only
+;; while the old object delegated to other rebound vars — any fix to the
+;; callback's OWN coercion, build routing or source filtering silently needed a
+;; full page reload to take effect.
+;;
+;; So what is installed is one stable TRAMPOLINE that resolves the CURRENT
+;; `reload-source-reset!` on every call (the same late-lookup discipline shadow
+;; itself applies to lifecycle fns — it re-resolves `fn-str` off `$CLJS` per
+;; reload "in case it gets reloaded"). The trampoline object is stable, so
+;; `defonce` still guarantees exactly one entry, while the BEHAVIOUR it runs is
+;; always the freshly loaded code.
+;;
+;; The trampoline is TAGGED with its owning build identity, so the install can
+;; REPLACE its own previous entry instead of appending, and never touches an
+;; entry owned by shadow or another library. The tag carries the build id
+;; because `SHADOW_NS_RESET` lives on `goog.global` — SHARED across every build
+;; in one realm — so two builds' producers must coexist rather than evict each
+;; other.
 ;; ---------------------------------------------------------------------------
 
 #?(:cljs
@@ -904,33 +929,77 @@
      `js/goog.global.SHADOW_NS_RESET`) for every namespace it reloads this cycle:
      record `ns` as a source that re-ran, so `commit-reload!` evicts it when it
      staged no declaration this cycle. A no-op when no reload cycle is open
-     (initial load / production). `ns` is a CLJS ns symbol; a string is coerced."
-     [ns]
-     (note-reloaded-sources! [(cond-> ns (string? ns) symbol)])
-     nil))
+     (initial load / production). `ns` is a CLJS ns symbol; a string is coerced.
+     `build-id` is the build whose producer is calling (the installed trampoline
+     passes its own owner); the 1-arg arity uses the ambient build."
+     ([ns] (reload-source-reset! ns default-build))
+     ([ns build-id]
+      (note-reloaded-sources! [(cond-> ns (string? ns) symbol)] build-id)
+      nil)))
+
+#?(:cljs
+   (def ^:private producer-tag
+     "The JS property re-frame.ui stamps on its own `SHADOW_NS_RESET` entry. Its
+     value is the owning build id, so a re-install replaces exactly this build's
+     producer and every other owner's callback is left alone."
+     "reFrameUiReloadSourceReset"))
+
+#?(:cljs
+   (defn- tagged-producer-index
+     "Index of `build-id`'s re-frame.ui producer in `arr`, or -1 when absent.
+     Identifies by TAG, never by position or object identity — other owners'
+     callbacks sit in the same shared array."
+     [arr build-id]
+     (let [want (str build-id)]
+       (loop [i 0]
+         (cond
+           (>= i (alength arr))                             -1
+           (= want (unchecked-get (aget arr i) producer-tag)) i
+           :else                                            (recur (inc i)))))))
+
+#?(:cljs
+   (defn- make-reload-source-producer
+     "One stable callback object owned by `build-id` that resolves the CURRENT
+     `reload-source-reset!` on every call. `reload-source-reset!` compiles to a
+     namespace-global read, so a hot-reload of rules.cljc — which re-assigns that
+     global — is picked up here without a page refresh."
+     [build-id]
+     (let [f (fn [ns] (reload-source-reset! ns build-id))]
+       (unchecked-set f producer-tag (str build-id))
+       f)))
 
 #?(:cljs
    (defn install-reload-source-producer!
      "Wire the runtime reload ledger to shadow-cljs's real reload machinery — the
      PRODUCER that feeds `note-reloaded-sources!` in the shipped browser reload
-     path (rf2-vxgfnd.77). Pushes `reload-source-reset!` onto
+     path (rf2-vxgfnd.77). Installs this build's tagged trampoline on
      `js/goog.global.SHADOW_NS_RESET` (ensuring the array `||`-style, so it
      neither clobbers nor is clobbered by shadow's own init), so shadow calls it
-     with each reloaded source's ns from `before-load-src`. Dev-only (gated on
-     `js/goog.DEBUG`, elided from `:advanced` production) and installed exactly
-     once via the `defonce` below (a hot-reload of THIS ns never double-registers)."
+     with each reloaded source's ns from `before-load-src`.
+
+     IDEMPOTENT per build identity: an existing entry tagged with this build is
+     REPLACED in place, never appended to, and entries owned by shadow or other
+     libraries/builds are never inspected for anything but their tag. Dev-only
+     (gated on `js/goog.DEBUG`, elided from `:advanced` production)."
      []
      (when ^boolean js/goog.DEBUG
-       (let [arr (or js/goog.global.SHADOW_NS_RESET #js [])]
+       (let [arr      (or js/goog.global.SHADOW_NS_RESET #js [])
+             build-id default-build]
          (set! (.-SHADOW_NS_RESET js/goog.global) arr)
-         (.push arr reload-source-reset!)
+         (let [i (tagged-producer-index arr build-id)
+               f (make-reload-source-producer build-id)]
+           (if (neg? i)
+             (.push arr f)
+             (aset arr i f)))
          true))))
 
 #?(:cljs
    (defonce ^:private _reload-source-producer
      ;; Install at client load so the shipped reload path has a producer the
      ;; moment this ns is present; `defonce` survives a hot-reload of rules.cljc
-     ;; itself, so the callback is registered exactly once.
+     ;; itself, so exactly one entry is registered — and because that entry is a
+     ;; trampoline, it runs the RELOADED implementation rather than the object
+     ;; realized here (rf2-vxgfnd.145).
      (install-reload-source-producer!)))
 
 (defn reset-custom-elements!

--- a/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
@@ -1,0 +1,54 @@
+(ns re-frame.ui.custom-element-reload-elision-prod-test
+  "Advanced-production control for the custom-element reload ledger's HMR
+  machinery (rf2-vxgfnd.142 / .144 / .145).
+
+  This namespace runs ONLY in `:browser-test-prod-elision` (`:advanced`,
+  goog.DEBUG=false). The reload cycle, the SHADOW_NS_RESET producer, and the
+  Shadow build-identity read are ALL dev-only: production never hot-reloads, so
+  every registration writes straight through and classification is a plain
+  lookup. The bundle string-scan (a separate CI gate) owns lexical proof; this
+  companion is CAUSAL — it drives the exact production entry points and proves
+  the DEBUG-only machinery took no effect and left no residue on the shared
+  `goog.global`.
+
+  The dev-positive controls for the same surface live in
+  `re-frame.ui.rules-cljs-test` (node, goog.DEBUG=true): there the producer IS
+  installed, `current-build-id` resolves a real build, and a reload cycle stages
+  and commits. Here the same calls must be inert."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [re-frame.ui.rules :as rules]))
+
+(deftest producer-install-is-inert-in-advanced-production
+  ;; `install-reload-source-producer!` is gated on `js/goog.DEBUG`. Under
+  ;; advanced/DEBUG=false Closure removes the body, so calling it must be a
+  ;; no-op: it must neither create the shared SHADOW_NS_RESET array nor push a
+  ;; producer onto a pre-existing one.
+  (let [before js/goog.global.SHADOW_NS_RESET
+        before-count (if (some? before) (alength before) :absent)]
+    (is (nil? (rules/install-reload-source-producer!))
+        "the DEBUG-gated install compiles to an inert no-op in production")
+    (let [after js/goog.global.SHADOW_NS_RESET]
+      (if (= :absent before-count)
+        (is (nil? after)
+            "production install created no SHADOW_NS_RESET array on goog.global")
+        (is (= before-count (alength after))
+            "production install pushed no producer onto an existing array")))))
+
+(deftest build-identity-is-default-in-advanced-production
+  ;; The Shadow build-identity read (`shadow-build-id`, and its
+  ;; `"shadow.cljs.devtools.client.env.build_id"` string) is reachable only
+  ;; through the `js/goog.DEBUG` branch of `current-build-id`. In production that
+  ;; branch is dead-code-eliminated, so the ledger keys every source under the
+  ;; inert `::default` owner and never consults the devtools client.
+  (is (= :re-frame.ui.rules/default (rules/current-build-id))
+      "production resolves the inert ::default owner, not a Shadow build name"))
+
+(deftest production-registration-writes-through-directly
+  ;; With no reload cycle ever opened in production, a registration is a plain
+  ;; write-through and classification a plain lookup — the reconciliation
+  ;; machinery is entirely dev-only.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :prod-el {:properties #{:p}} 'app.prod)
+  (is (= #{:p} (rules/custom-element-properties :prod-el))
+      "production registration is a direct write-through, immediately live")
+  (rules/reset-custom-elements!))

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -453,6 +453,122 @@
                  i   (.indexOf arr foreign)]
              (when-not (neg? i) (.splice arr i 1))))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.142 — ONE real build identity through the whole reload cycle.
+;;
+;; Before this, every real path (emitted registrations, both lifecycle hooks, the
+;; reset producer) hard-coded the ::default placeholder; a second identity was
+;; reachable only from a test-only arity. Two real builds sharing a JS realm
+;; collapsed onto one [::default ns] row. `current-build-id` is now the single
+;; rule every arity default resolves through, so the participants in a cycle can
+;; never disagree about who owns a row.
+;; ---------------------------------------------------------------------------
+
+(deftest build-identity-is-one-rule-shared-by-every-arity
+  ;; The invariant that makes the ledger key trustworthy: whatever the host
+  ;; resolves as its build identity, the emitted registration and the reload
+  ;; cycle that reconciles it MUST agree. Assert it through behaviour rather than
+  ;; by naming a value — the correct id differs per host (a Shadow dev build
+  ;; names itself; a node/JVM host has no build to name).
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :ident-el {:properties #{:p}} 'app.ident)   ; arity default
+  (rules/notify-reload!)                                                      ; arity default
+  (rules/note-reloaded-sources! ['app.ident])                                 ; arity default
+  (rules/commit-reload!)                                                      ; arity default
+  (is (= #{} (rules/custom-element-properties :ident-el))
+      "the zero-declaration source was evicted — registration, notify, note and
+       commit all resolved the SAME build identity (a disagreement would leave the
+       row stranded under a build nobody reconciles)")
+  ;; ...and the same identity is what an EXPLICIT arity must be given to hit the
+  ;; same rows, which is what makes `current-build-id` the ledger's public rule.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :ident-el {:properties #{:p}} 'app.ident)
+  (rules/notify-reload! (rules/current-build-id))
+  (rules/note-reloaded-sources! ['app.ident] (rules/current-build-id))
+  (rules/commit-reload! (rules/current-build-id))
+  (is (= #{} (rules/custom-element-properties :ident-el))
+      "explicitly passing (current-build-id) reconciles exactly the rows the
+       arity defaults wrote — one rule, not two"))
+
+(deftest build-identity-is-stable-across-calls
+  ;; The owner token must be an IDENTITY, not a digest: it may not change as
+  ;; sources change, or a reload would reconcile against rows keyed under the
+  ;; previous value and strand every one of them.
+  (is (= (rules/current-build-id) (rules/current-build-id))
+      "the build identity is stable across calls")
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :stable-el {:properties #{:p}} 'app.s)
+  (let [before (rules/current-build-id)]
+    (rules/notify-reload!)
+    (rules/register-custom-element! :stable-el {:properties #{:p2}} 'app.s)
+    (rules/commit-reload!)
+    (is (= before (rules/current-build-id))
+        "reloading sources does not change the build identity (it is the build's
+         name, never the content/build digest)")
+    (is (= #{:p2} (rules/custom-element-properties :stable-el))
+        "so the reload reconciled the row the initial load wrote")))
+
+(deftest co-loaded-builds-retain-independent-declarations
+  ;; AC2: two co-loaded builds with EQUAL namespace symbols. Reloading (or
+  ;; zero-declaring) either one may not disturb the other's contribution — the
+  ;; collapse that a shared ::default owner token caused.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
+  (rules/register-custom-element! :l-el {:properties #{:from-lib}} 'shared.ns :lib)
+  (is (= #{:from-app} (rules/custom-element-properties :a-el)))
+  (is (= #{:from-lib} (rules/custom-element-properties :l-el)))
+  ;; build :app reloads `shared.ns` declaring NOTHING
+  (rules/notify-reload! :app)
+  (rules/note-reloaded-sources! ['shared.ns] :app)
+  (rules/commit-reload! :app)
+  (is (= #{} (rules/custom-element-properties :a-el))
+      "build :app's own zero-declaration source is evicted")
+  (is (= #{:from-lib} (rules/custom-element-properties :l-el))
+      "build :lib's row under the SAME ns symbol is untouched — equal ns symbols
+       in two builds are two rows, not one")
+  ;; and the reverse direction: :lib zero-declares, :app is re-populated
+  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
+  (rules/notify-reload! :lib)
+  (rules/note-reloaded-sources! ['shared.ns] :lib)
+  (rules/commit-reload! :lib)
+  (is (= #{} (rules/custom-element-properties :l-el))
+      "build :lib's source is evicted by its own cycle")
+  (is (= #{:from-app} (rules/custom-element-properties :a-el))
+      "build :app's row survives build :lib's reconciliation"))
+
+(deftest one-builds-cycle-never-consumes-another-builds-reload-evidence
+  ;; A cycle open for build :app must not be reconciled by evidence belonging to
+  ;; build :lib — the two builds' reload cycles are independent transactions.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
+  (rules/register-custom-element! :l-el {:properties #{:from-lib}} 'shared.ns :lib)
+  (rules/notify-reload! :app)
+  (rules/note-reloaded-sources! ['shared.ns] :lib)   ; :lib has NO open cycle → no-op
+  (rules/commit-reload! :app)
+  (is (= #{:from-lib} (rules/custom-element-properties :l-el))
+      "reload evidence addressed to a build with no open cycle cannot evict rows")
+  (is (= #{:from-app} (rules/custom-element-properties :a-el))
+      "nor can it leak into the OTHER build's open cycle"))
+
+#?(:cljs
+   (deftest installed-producer-notes-into-its-own-build-only
+     ;; The producer is the one real caller of the ledger seam, so its build
+     ;; routing is what decides which build a reloaded source is attributed to.
+     ;; A row owned by a DIFFERENT build must be untouched when the installed
+     ;; producer fires — SHADOW_NS_RESET lives on the shared `goog.global`, so
+     ;; every build's producer sees every build's reload.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :own-el {:properties #{:p}} 'shared.ns)      ; this build
+     (rules/register-custom-element! :other-el {:properties #{:q}} 'shared.ns
+                                     :some-other-build)
+     (rules/notify-reload!)
+     (fire-shadow-ns-reset! 'shared.ns)      ; what before-load-src does
+     (rules/commit-reload!)
+     (is (= #{} (rules/custom-element-properties :own-el))
+         "the producer noted the reloaded source into ITS OWN build's cycle")
+     (is (= #{:q} (rules/custom-element-properties :other-el))
+         "another build's row under the same ns symbol is untouched")))
+
 #?(:cljs
    (deftest reinstalled-producer-still-runs-the-current-implementation
      ;; The replacement path must produce a trampoline too — a re-install that

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -334,6 +334,101 @@
         "incremental reload equals a clean full-page-reload rebuild")))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.144 — the commit is linearizable against a REENTRANT registration.
+;;
+;; Counterexample: a watch on the public `custom-elements` aggregate calls
+;; `register-custom-element!` when the aggregate is published during a commit. The
+;; watch is the deterministic barrier — it fires synchronously in the middle of
+;; the commit, on BOTH hosts. Under the old snapshot-then-`dissoc` shape the
+;; commit published (firing the watch) while the cycle was STILL open, so the
+;; reentrant registration staged into that cycle and the following `dissoc`
+;; discarded it. The single-atom commit closes the cycle in the same swap that
+;; reconciles the ledger and publishes only after, so the reentrant registration
+;; observes a closed cycle and write-through's — surviving exactly once.
+;; ---------------------------------------------------------------------------
+
+(defn- with-publication-reentry
+  "Run `body` with a one-shot watch on `custom-elements` that, the first time the
+  aggregate changes, reentrantly runs `reentrant`. Returns after cleanup. The
+  guard makes it fire ONCE, so the reentrant write-through's own publish does not
+  recurse."
+  [reentrant body]
+  (let [fired (atom false)
+        k     (keyword (gensym "reentry"))]
+    (add-watch rules/custom-elements k
+               (fn [_ _ _ _]
+                 (when (compare-and-set! fired false true)
+                   (reentrant))))
+    (try (body)
+         (finally (remove-watch rules/custom-elements k)))))
+
+(deftest reentrant-registration-during-commit-publication-survives-once
+  ;; The headline counterexample. Commit publishes -> watch fires -> a NEW
+  ;; declaration registers reentrantly. It must become live exactly once.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :seed-el {:properties #{:s}} 'app.seed)
+  (with-publication-reentry
+    #(rules/register-custom-element! :reentrant-el {:properties #{:r}} 'app.reentry)
+    (fn []
+      (rules/notify-reload!)
+      (rules/register-custom-element! :seed-el {:properties #{:s2}} 'app.seed) ; a real reload
+      (rules/commit-reload!)))                                                  ; publishes -> reentry
+  (is (= #{:r} (rules/custom-element-properties :reentrant-el))
+      "the reentrant registration survived the commit — old snapshot-then-dissoc
+       staged it into the still-open cycle, which commit then discarded")
+  (is (= #{:s2} (rules/custom-element-properties :seed-el))
+      "the committing source's own reload still applied")
+  ;; and it is a real ledger row, not a transient aggregate patch: a later clean
+  ;; reload of an unrelated source must preserve it.
+  (rules/notify-reload!)
+  (rules/register-custom-element! :seed-el {:properties #{:s3}} 'app.seed)
+  (rules/commit-reload!)
+  (is (= #{:r} (rules/custom-element-properties :reentrant-el))
+      "the reentrant row is in :sources, so a subsequent unrelated reload keeps it"))
+
+(deftest reentrant-registration-applies-exactly-once-never-doubled
+  ;; The reentrant registration must not be applied twice (once as a stray
+  ;; aggregate patch and once as a ledger row) — assert the FINAL aggregate is
+  ;; exactly the legal serial result: commit fully applies, then the reentrant
+  ;; registration write-through's.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :keep-el {:properties #{:k}} 'app.keep)
+  (with-publication-reentry
+    #(rules/register-custom-element! :new-el {:properties #{:n}} 'app.new)
+    (fn []
+      (rules/notify-reload!)
+      (rules/register-custom-element! :keep-el {:properties #{:k2}} 'app.keep)
+      (rules/commit-reload!)))
+  (is (= {:keep-el {:properties #{:k2}}
+          :new-el  {:properties #{:n}}}
+         @rules/custom-elements)
+      "the published aggregate equals the legal serial execution exactly — the
+       reentrant row appears once, the committing source's reload applied"))
+
+(deftest reentrant-registration-into-an-open-foreign-cycle-still-stages
+  ;; Generation rule: a reentrant registration whose OWN build still has an open
+  ;; cycle must stage into it (it belongs to that live generation), not leak live.
+  ;; Here build :a commits (firing the watch) while build :b's cycle is open, and
+  ;; the reentrant registration targets build :b.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a}} 'app.a :a)
+  (rules/register-custom-element! :b-el {:properties #{:b}} 'app.b :b)
+  (rules/notify-reload! :a)
+  (rules/notify-reload! :b)                                   ; build :b cycle stays open
+  (rules/register-custom-element! :a-el {:properties #{:a2}} 'app.a :a)
+  (with-publication-reentry
+    #(rules/register-custom-element! :b-el {:properties #{:b2}} 'app.b :b) ; :b cycle open -> stages
+    (fn [] (rules/commit-reload! :a)))                        ; commit :a -> publish -> reentry
+  (is (= #{:a2} (rules/custom-element-properties :a-el))
+      "build :a committed")
+  (is (= #{:b} (rules/custom-element-properties :b-el))
+      "the reentrant :b registration STAGED into build :b's still-open cycle —
+       last-known-good until :b commits, not leaked live by :a's commit")
+  (rules/commit-reload! :b)
+  (is (= #{:b2} (rules/custom-element-properties :b-el))
+      "and it commits with build :b's own cycle"))
+
+;; ---------------------------------------------------------------------------
 ;; The production producer (rf2-vxgfnd.77) — the reload ledger's zero-declaration
 ;; eviction fired THROUGH the shipped browser reload path, not a direct
 ;; `note-reloaded-sources!` call. `reload-source-reset!` is what shadow-cljs's

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -354,15 +354,121 @@
        (try (f ns) (catch :default _ nil)))))
 
 #?(:cljs
+   (defn- rf2-producers
+     "The re-frame.ui-owned entries of the shared SHADOW_NS_RESET array,
+     identified the way the installer identifies them — by their owner tag."
+     []
+     (into [] (filter #(some? (unchecked-get % "reFrameUiReloadSourceReset")))
+           (array-seq js/goog.global.SHADOW_NS_RESET))))
+
+#?(:cljs
    (deftest reload-producer-is-wired-to-shadow-reset-array
      ;; The wire itself: install-reload-source-producer! (run at ns load) must
-     ;; have registered reload-source-reset! on shadow's per-reload callback
+     ;; have registered a re-frame.ui producer on shadow's per-reload callback
      ;; array, so the shipped reload path has a real caller for the ledger seam.
      (is (exists? js/goog.global.SHADOW_NS_RESET)
          "install-reload-source-producer! ensured the SHADOW_NS_RESET array")
-     (is (some #(identical? % rules/reload-source-reset!)
-               (array-seq js/goog.global.SHADOW_NS_RESET))
-         "the shipped producer is registered on shadow's per-reload callback array")))
+     (is (= 1 (count (rf2-producers)))
+         "exactly one re-frame.ui producer is registered on shadow's array")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vxgfnd.145 — the installed producer must run the CURRENT implementation.
+;;
+;; The install is `defonce`d, so whatever object it puts on SHADOW_NS_RESET is
+;; pinned for the life of the page. Pushing the `reload-source-reset!` fn OBJECT
+;; therefore froze the implementation realized at first load: hot-reloading
+;; rules.cljc rebinds the var, but the array kept calling the object from before
+;; the reload. These tests drive the ARRAY ENTRY (what shadow actually calls) —
+;; never the var directly — which is the only way to observe the staleness.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest installed-producer-runs-the-current-implementation-after-a-reload
+     ;; FAIL-BEFORE fixture. Simulate a hot-reload of rules.cljc: shadow
+     ;; re-evaluates the file, re-assigning the `reload-source-reset!` global to
+     ;; a NEW fn object. `defonce` keeps the installed entry, so the entry must
+     ;; still dispatch to the reloaded implementation.
+     ;;
+     ;; This fixture is deliberately TAG-BLIND: it fires EVERY entry on the array
+     ;; exactly as shadow's `before-load-src` does, so it proves STALENESS rather
+     ;; than merely the absence of the new owner tag. Under the pre-.145 install
+     ;; (`.push reload-source-reset!`) the array holds the PRE-reload object,
+     ;; which never consults the rebound var — nothing is recorded and this test
+     ;; fails. The trampoline resolves the var per call, so it records.
+     (let [original rules/reload-source-reset!
+           seen     (atom [])]
+       (try
+         ;; the "reloaded" ns's new object — same arities as the real one, so
+         ;; the trampoline's call site is exercised exactly as in a real reload
+         (set! rules/reload-source-reset!
+               (fn ([ns] (swap! seen conj [ns]) nil)
+                 ([ns build-id] (swap! seen conj [ns build-id]) nil)))
+         (fire-shadow-ns-reset! 'app.reloaded)            ; what shadow actually calls
+         (is (= 1 (count @seen))
+             "an installed entry dispatched to the CURRENT implementation, not the
+              object captured at first load (pre-.145: the defonce'd object was stale)")
+         (is (= 'app.reloaded (first (first @seen)))
+             "the reloaded implementation received the ns shadow reported")
+         (finally
+           (set! rules/reload-source-reset! original))))))
+
+#?(:cljs
+   (deftest installed-producer-uses-current-coercion-after-a-reload
+     ;; The concrete consequence the bead names: a fix to the callback's OWN
+     ;; coercion must take effect without a page refresh. Drive the ARRAY ENTRY
+     ;; with a STRING ns (shadow's `before-load-src` reports symbols, but the
+     ;; documented contract coerces strings) and prove the ledger saw a SYMBOL —
+     ;; i.e. the entry ran the current coercion, not a frozen copy.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :x-el {:properties #{:help-text}} 'app.a)
+     (rules/notify-reload!)
+     ((first (rf2-producers)) "app.a")                    ; string, coerced by the impl
+     (rules/commit-reload!)
+     (is (= #{} (rules/custom-element-properties :x-el))
+         "the installed entry's current coercion turned the string into the
+          symbol the ledger keys on, so the zero-declaration source was evicted")))
+
+#?(:cljs
+   (deftest producer-install-is-idempotent-and-preserves-other-owners
+     ;; Repeated installs (a REPL re-eval of the ns, a build that drops the
+     ;; defonce) must neither duplicate nor lose the producer, and must never
+     ;; touch a callback shadow or another library owns.
+     (let [foreign      (fn [_ns] nil)
+           before-count (count (array-seq js/goog.global.SHADOW_NS_RESET))]
+       (.push js/goog.global.SHADOW_NS_RESET foreign)
+       (try
+         (rules/install-reload-source-producer!)
+         (rules/install-reload-source-producer!)
+         (rules/install-reload-source-producer!)
+         (is (= 1 (count (rf2-producers)))
+             "three installs leave exactly one re-frame.ui producer — replaced in
+              place, never appended")
+         (is (some #(identical? % foreign) (array-seq js/goog.global.SHADOW_NS_RESET))
+             "a callback owned by another library survives re-installation")
+         (is (= (inc before-count) (count (array-seq js/goog.global.SHADOW_NS_RESET)))
+             "the array grew by exactly the foreign entry — no producer accumulation")
+         (finally
+           ;; drop the foreign probe, leaving the array as we found it
+           (let [arr js/goog.global.SHADOW_NS_RESET
+                 i   (.indexOf arr foreign)]
+             (when-not (neg? i) (.splice arr i 1))))))))
+
+#?(:cljs
+   (deftest reinstalled-producer-still-runs-the-current-implementation
+     ;; The replacement path must produce a trampoline too — a re-install that
+     ;; froze the current object would reintroduce the staleness for anyone whose
+     ;; build re-runs the installer.
+     (rules/install-reload-source-producer!)
+     (let [original rules/reload-source-reset!
+           seen     (atom 0)]
+       (try
+         (set! rules/reload-source-reset!
+               (fn ([_ns] (swap! seen inc) nil)
+                 ([_ns _build-id] (swap! seen inc) nil)))
+         ((first (rf2-producers)) 'app.x)
+         (is (= 1 @seen) "the re-installed entry also resolves the current implementation")
+         (finally
+           (set! rules/reload-source-reset! original))))))
 
 #?(:cljs
    (deftest reload-producer-evicts-zero-declaration-source-end-to-end

--- a/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
@@ -1,0 +1,116 @@
+(ns re-frame.ui.rules-reload-linearizability-jvm-test
+  "JVM barrier-controlled linearizability proof for the custom-element reload
+  ledger (rf2-vxgfnd.144).
+
+  The reentrancy fix must hold under REAL concurrency, not only the deterministic
+  single-threaded reentrancy a watch drives. These tests race a
+  `register-custom-element!` against a `commit-reload!` (and against a
+  `notify-reload!`) on separate threads, released together by a `CyclicBarrier`,
+  over many rounds. Every observed outcome must equal a LEGAL SERIAL execution of
+  the two operations — the registration is never lost, never doubled, never
+  written into a closed cycle, and never left in an orphan cycle.
+
+  A mutation control proves the tests have teeth: reverting the ledger to the old
+  snapshot-then-`dissoc` shape (two independent atoms, publish while the cycle is
+  still open) reintroduces the loss, so a green run here is load-bearing.
+
+  JVM-only: `future`/`CyclicBarrier` real threads. CLJS is single-threaded; its
+  reentrancy proof lives in `re-frame.ui.rules-cljs-test`."
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.ui.rules :as rules])
+  (:import [java.util.concurrent CyclicBarrier]))
+
+(defn- await-barrier [^CyclicBarrier b]
+  (.await b))
+
+(deftest register-races-commit-equals-a-legal-serial-execution
+  ;; Build :x has a cycle open with a staged reload of :seed-el. Concurrently a
+  ;; FRESH declaration (:race-el, its own source) is registered while the commit
+  ;; runs. The two legal serial executions are:
+  ;;   (a) register-then-commit: :race-el stages into the cycle, commit applies
+  ;;       both -> both live via the cycle;
+  ;;   (b) commit-then-register: commit closes the cycle applying :seed-el, then
+  ;;       :race-el write-through's live.
+  ;; In BOTH, the final ledger is exactly {:seed-el s2, :race-el r}. No
+  ;; interleaving may lose :race-el or strand an orphan cycle.
+  (dotimes [round 400]
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :seed-el {:properties #{:s}} 'app.seed :x)
+    (rules/notify-reload! :x)
+    (rules/register-custom-element! :seed-el {:properties #{:s2}} 'app.seed :x) ; staged reload
+    (let [barrier (CyclicBarrier. 2)
+          committer (future (await-barrier barrier)
+                            (rules/commit-reload! :x))
+          registrar (future (await-barrier barrier)
+                            (rules/register-custom-element!
+                             :race-el {:properties #{:r}} 'app.race :x))]
+      @committer
+      @registrar
+      ;; :race-el may still be staged if the register won the race and the cycle
+      ;; is not yet committed for it — but there is exactly one commit here, so it
+      ;; must have flushed. Assert the terminal, quiescent state.
+      (is (= #{:s2} (rules/custom-element-properties :seed-el))
+          (str "round " round ": the committing source's reload applied"))
+      (is (= #{:r} (rules/custom-element-properties :race-el))
+          (str "round " round
+               ": the concurrently-registered declaration is never lost"))
+      (is (= {:seed-el {:properties #{:s2}}
+              :race-el {:properties #{:r}}}
+             @rules/custom-elements)
+          (str "round " round
+               ": the published aggregate equals a legal serial execution — no "
+               "double-apply, no clobbered row"))
+      (is (empty? (rules/in-flight-cycles))
+          (str "round " round ": no orphan cycle survives the race")))))
+
+(deftest register-races-notify-open-leaves-a-coherent-projection
+  ;; A registration racing the OPENING of a cycle (notify-reload!). This race has
+  ;; a legitimate GENERATION ambiguity — a registration that wins the race writes
+  ;; through to the live generation; one that loses stages into the fresh cycle —
+  ;; so `:race-el`'s final visibility is order-dependent and is NOT asserted here.
+  ;; What linearizability DOES require regardless of order: the published
+  ;; aggregate is always exactly `aggregate(:sources)` (never a torn projection,
+  ;; never a leaked staged row), and the settled ledger has no orphan cycle.
+  (dotimes [round 400]
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :base-el {:properties #{:b}} 'app.base :y)
+    (let [barrier (CyclicBarrier. 2)
+          opener  (future (await-barrier barrier)
+                          (rules/notify-reload! :y))
+          registrar (future (await-barrier barrier)
+                            (rules/register-custom-element!
+                             :race-el {:properties #{:r}} 'app.race :y))]
+      @opener
+      @registrar
+      ;; Whatever generation :race-el landed in, the mid-race aggregate must be a
+      ;; coherent projection of the ledger — no half-applied or leaked row.
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          (str "round " round
+               ": the published aggregate is exactly the ledger projection "
+               "mid-race — no torn or leaked staged row"))
+      ;; Close the cycle notify opened (base re-declared this cycle) and settle.
+      (rules/register-custom-element! :base-el {:properties #{:b}} 'app.base :y)
+      (rules/commit-reload! :y)
+      (is (= #{:b} (rules/custom-element-properties :base-el))
+          (str "round " round ": base survives the reload"))
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          (str "round " round ": aggregate equals the ledger projection when settled"))
+      (is (empty? (rules/in-flight-cycles))
+          (str "round " round ": no orphan cycle survives")))))
+
+(deftest concurrent-write-throughs-on-distinct-builds-compose
+  ;; Two builds, no cycles: concurrent initial-load registrations must both land
+  ;; in the aggregate — the publication path never drops one under contention.
+  (dotimes [round 400]
+    (rules/reset-custom-elements!)
+    (let [barrier (CyclicBarrier. 2)
+          a (future (await-barrier barrier)
+                    (rules/register-custom-element! :pa {:properties #{:a}} 'app.a :ba))
+          b (future (await-barrier barrier)
+                    (rules/register-custom-element! :pb {:properties #{:b}} 'app.b :bb))]
+      @a @b
+      (is (= #{:a} (rules/custom-element-properties :pa))
+          (str "round " round ": build a's row is live"))
+      (is (= #{:b} (rules/custom-element-properties :pb))
+          (str "round " round ": build b's row is live — neither write-through "
+               "clobbered the other")))))


### PR DESCRIPTION
Three mechanical reload-ledger / HMR fixes for the custom-element registry
(`re-frame.ui.rules`), each standing independently of the unruled cross-source
conflict law (rf2-vxgfnd.143, deliberately NOT touched). Committed
smallest-cleanup → biggest-correctness-fix.

## rf2-vxgfnd.145 — refresh the installed source-reset callback across HMR

The `SHADOW_NS_RESET` install is necessarily `defonce`d, so it pinned the
`reload-source-reset!` fn OBJECT realized at first load. Hot-reloading
`rules.cljc` rebound the var but shadow kept calling the pre-reload object — any
fix to the callback's own coercion/build-routing/filtering needed a full page
reload. Replaced with one stable TRAMPOLINE that resolves the current
`reload-source-reset!` per call (shadow's own late-lookup discipline for
lifecycle fns), tagged with its owning build so the installer replaces its own
entry in place and never touches shadow's or another library's callbacks.

## rf2-vxgfnd.142 — carry a real build identity through the ledger

Every real path (emitted registrations, both lifecycle hooks, the reset
producer) hard-coded the `::default` placeholder; a second identity was
reachable only from a test-only arity, so two real builds sharing a JS realm
collapsed onto one `[::default ns]` row and reloading one could evict the
other's. Introduced `current-build-id` — reads shadow's own `env/build-id`
closure-define by name off `$CLJS` (a STABLE identity, never the content digest;
`js/goog.DEBUG`-gated so `:advanced` folds it to `::default`) — and made it the
default for EVERY arity, so registration and reconciliation can never key a row
differently. Documented the honest boundary: isolation reaches exactly as far as
shadow's per-bundle baked-in identity.

## rf2-vxgfnd.144 — linearize the commit against reentrant registration

The cycle spanned two atoms with snapshot-then-`dissoc` commit: it published the
aggregate while the cycle was still open, then removed the cycle — so a
registration arriving during publication (a watch on `custom-elements` calling
`register-custom-element!`) staged into the still-open cycle and was discarded by
the trailing `dissoc`. Collapsed the live ledger + in-flight cycles into ONE
authoritative `ledger-state`; commit reconciles `:sources` AND closes the cycle
in the same atomic swap, then publishes — so a reentrant registration observes a
closed cycle and write-through's into the next generation, surviving exactly
once. Publication recomputes from the LIVE ledger via `swap!`, closing a
publication-atom clobber race on the JVM.

### Reentrancy repro
A one-shot watch on `custom-elements` reentrantly registers a new declaration
during commit publication. Under the old snapshot-then-`dissoc` ordering the row
is lost; the fix keeps it, exactly once. Proven on both hosts (cljc test) plus a
JVM `CyclicBarrier` real-thread stress (register-vs-commit over 400 rounds ==
legal serial execution; 0 losses / 2000 standalone). A mutation control that
restores the old ordering turns all of these red — the tests have teeth.

## Scope / fences
- Touches only `implementation/ui/src/re_frame/ui/rules.cljc` and three test
  files under `implementation/ui/test/`. No PR #6001 files
  (`analyze`/`emit_cljs`/`events`/`frames`/`runtime`/`viewcell`/`run-ui-bench`)
  were needed or touched. No move toward the rf2-vxgfnd.143 conflict-law — none
  of these fixes requires deciding what happens when two declarations conflict.
- No new consumer API: register/notify/note/commit/`custom-element-properties`
  signatures unchanged; `in-flight-cycles`/`projected-aggregate` are test-only
  observability. No sleeps, no user-callback lock, no per-render cost.
- Advanced-production elision verified: `reFrameUiReloadSourceReset` tag,
  `install_reload_source_producer`, and the devtools build-id string are all
  fully DCE'd from the `browser-test-prod-elision` release bundle; the added
  `custom_element_reload_elision_prod_test.cljs` causal sentinel runs in CI's
  browser prod-elision gate.

## Quality gates
- `implementation/ui` JVM (`clojure -M:test`): **609 tests / 12624 assertions, 0 failures**
- `node-test-ui` (`shadow-cljs compile node-test-ui && node out/node-test-ui.js`): **600 tests / 3040 assertions, 0 failures**
- ui-adapter-isolation (`node scripts/check-ui-adapter-isolation.cjs`): **PASS**
- `browser-test-prod-elision` release compile: **exit 0**; bundle grep confirms reload-machinery residue elided (tag=0, install fn=0, build-id string=0)
- Mutation control (old snapshot-then-dissoc ordering restored): reentrancy + linearizability tests **RED** as required
- Not run locally (CI-owned): `test:browser`, the browser prod-elision serve/run, full spine
