### PR TITLE
fix(core): finish per-epoch render-law sweep incl. force-tracked (rf2-vxgfnd.167)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -537,8 +537,10 @@
   inside it throw `:rf.error/reentrant-graph-op` (dev-asserted). Bound only
   under `interop/debug-enabled?`, so production builds carry neither the
   binding nor the check (the #5704 dev-only-machinery-must-DCE idiom).
-  React-driven acquire/release — renders and commits *caused by* the
-  epoch-close notify — run after the fan-out returns and never see it."
+  React-driven acquire/release — the calls inside the renders and commits
+  the owner-notification schedules via `mark-dirty` (flushed at a later
+  pending host checkpoint, coalesced across a batch and decoupled from
+  epoch count) — run after the fan-out returns and never see it."
   false)
 
 (defn- assert-not-in-fan-out!

--- a/implementation/core/test/re_frame/observation_render_law_drift_test.clj
+++ b/implementation/core/test/re_frame/observation_render_law_drift_test.clj
@@ -1,0 +1,119 @@
+(ns re-frame.observation-render-law-drift-test
+  "rf2-vxgfnd.167 — the observation-port render-law drift gate.
+
+  The retired per-epoch render law (`rf2-vxgfnd.66` / PR #5790) falsely
+  equated an event/derivation EPOCH with a UI notification, component
+  render, or React commit — the shape that lets a reader infer that every
+  epoch closes a UI batch (`epoch-close notify` → React work). The shipped
+  scheduler does not work that way: an epoch is a WRITE / EVIDENCE unit; the
+  owner-notification's `mark-dirty` schedules a render/commit that flushes at
+  a later pending host checkpoint (coalesced across a batch), decoupled from
+  epoch count (the host-checkpoint contract itself is `rf2-vxgfnd.166`).
+
+  #5790's changed-file roster missed this force-tracked residue: the
+  `*in-owner-fan-out?*` docstring in `re-frame.substrate.observation` taught
+  `renders and commits *caused by* the epoch-close notify`. This gate is the
+  drift check that keeps the observation-port source free of that retired
+  equation — a seeded `epoch-close notify` (or a `render/react/notify per
+  epoch` claim) reddens it.
+
+  Scoped to the ONE core-substrate surface this worker owns
+  (`observation.cljc`, where the port's render-law prose lives). The
+  repo-wide force-tracked census (git-ls-files roster across the `ai/`
+  design tree, Spec 006/009, Story) is the broader `rf2-vxgfnd.167` sweep;
+  this file pins the observation-port slice.
+
+  JVM-only (`_test.clj`) by design — it reads the `.cljc` SOURCE TEXT via
+  `io/resource`, the same host-agnostic bytes both hosts compile, so no CLJS
+  runtime is involved (the `no-rf-default-floor-lint` / `doc-metadata-prod-
+  elision` gates use the same JVM-source-text idiom)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+(def ^:private observation-resource
+  "Classpath resource path of the observation-port source (`:paths [\"src\"]`
+  in the core `deps.edn` puts it on the classpath as a resource)."
+  "re_frame/substrate/observation.cljc")
+
+(defn- observation-source
+  "The observation-port `.cljc` SOURCE TEXT. Fail LOUD (not silently empty)
+  if the resource cannot be found, so a classpath change can never turn this
+  gate into a vacuous pass."
+  []
+  (let [url (io/resource observation-resource)]
+    (assert url (str "observation-port source not on the classpath: "
+                     observation-resource))
+    (slurp url)))
+
+;; ---------------------------------------------------------------------------
+;; Forbidden: the retired per-epoch UI render/notify law.
+;; ---------------------------------------------------------------------------
+;;
+;; These scan the RAW source (docstrings + comments included, NOT stripped):
+;; the retired law is taught in PROSE, so prose is exactly what must stay
+;; clean. Each pattern is case-insensitive.
+
+(def ^:private forbidden-render-law-res
+  "The retired-per-epoch-render-law shapes. `epoch-close` (or `epoch close`)
+  adjacent to UI-scheduling verbs is the exact #5790-missed residue; the
+  `<ui-verb> … per … epoch` shape catches the sibling `one notification /
+  render per epoch` / `rendered once per epoch` / `React work per input
+  epoch` phrasings. `commit` is deliberately EXCLUDED from the per-epoch arm
+  because the core spine's derivation-epoch cache/commit law is legitimate
+  per-epoch terminology (bead: must not be blindly replaced); the
+  `epoch-close` arm still catches an `epoch-close … commit` UI claim."
+  [;; `epoch-close notify` / `epoch close notification` / `epoch-close
+   ;; render|commit|react|batch` / `epoch close triggers|causes|fires` —
+   ;; the equation that an epoch's CLOSE drives UI work.
+   #"(?i)epoch[-\s]close\s+(?:notif|render|commit|react|batch|trigger|cause|fire)"
+   ;; A UI verb claimed to happen once per epoch: `render/react/notification
+   ;; per epoch`, `rendered once per (input) epoch`, `notification per
+   ;; re-frame2 epoch`.
+   #"(?i)(?:notif\w*|render\w*|react\w*)\s+(?:work\s+)?(?:once\s+)?per\s+(?:\S+\s+){0,2}epoch"])
+
+(defn- offending-lines
+  "`[line-no line]` pairs of `content` that carry a retired render-law claim."
+  [content]
+  (->> (str/split-lines content)
+       (map-indexed (fn [i line] [(inc i) line]))
+       (keep (fn [[n line]]
+               (when (some #(re-find % line) forbidden-render-law-res)
+                 [n (str/trim line)])))))
+
+(deftest observation-port-carries-no-retired-per-epoch-render-law
+  (testing "rf2-vxgfnd.167: the observation-port source no longer equates an
+            epoch with a UI notification / render / React commit — no
+            `epoch-close notify`, no `render/react/notification per epoch`.
+            An epoch is a write/evidence unit; `mark-dirty` schedules the
+            render/commit at a later host checkpoint (rf2-vxgfnd.166),
+            decoupled from epoch count."
+    (let [offenders (offending-lines (observation-source))]
+      (is (empty? offenders)
+          (str "The observation-port source teaches the RETIRED per-epoch "
+               "render law (an epoch-close does NOT cause a notification / "
+               "render / React commit — `mark-dirty` schedules UI work at a "
+               "later pending host checkpoint, decoupled from epoch count; "
+               "see rf2-vxgfnd.167 / .166). Offending "
+               observation-resource " lines:\n  "
+               (str/join "\n  "
+                         (for [[n line] offenders]
+                           (str observation-resource ":" n "  " line))))))))
+
+;; ---------------------------------------------------------------------------
+;; Adversarial (negative): the LEGITIMATE per-epoch EVIDENCE terminology must
+;; survive — the bead forbids a blind global scrub of every `epoch` mention.
+;; ---------------------------------------------------------------------------
+
+(deftest observation-port-preserves-legitimate-per-epoch-evidence-terms
+  (testing "rf2-vxgfnd.167: the sweep must PRESERVE the port's legitimate
+            per-epoch evidence axes (`:frame-epoch` / `:registry-epoch`) and
+            the derivation `commit-epoch` law — a blind textual scrub of
+            every `epoch` mention is itself a regression the bead calls out."
+    (let [src (observation-source)]
+      (doseq [term ["frame-epoch" "registry-epoch" "commit-epoch"]]
+        (is (str/includes? src term)
+            (str "legitimate per-epoch evidence term `" term "` was scrubbed "
+                 "from the observation-port source; rf2-vxgfnd.167 requires "
+                 "the per-epoch EVIDENCE/derivation-cache terminology be kept, "
+                 "only the retired per-epoch RENDER law removed."))))))


### PR DESCRIPTION
Finishes the `rf2-vxgfnd.167` per-epoch render-law sweep for the ONE core-substrate surface this worker owns: `implementation/core/src/re_frame/substrate/observation.cljc` (where the observation-port's render-law prose lives) and its core tests.

## What was uncovered

PR #5790 (`rf2-vxgfnd.66`) closed the tracked-surface sweep but its changed-file roster missed the force-tracked residue in the observation port. The `*in-owner-fan-out?*` docstring taught the **retired** per-epoch render law:

> `React-driven acquire/release — renders and commits *caused by* the epoch-close notify — run after the fan-out returns and never see it.`

The bead cited this at `observation.cljc:234-239`; ~300 lines of provenance code (rf2-9m4oy7 / rf2-fs99nq / rf2-qqvgk1) inserted above it since bead-filing shifted the residue to line **541** — the wording, not the line, is authoritative, and `epoch-close notify` was the sole occurrence in the file.

## The fix

Reworded the docstring so it no longer equates an epoch-close notification with React work. An epoch is a write/evidence unit; the owner-notification's `mark-dirty` schedules the render/commit, flushed at a later **pending host checkpoint** and coalesced across a batch — **decoupled from epoch count**. Scheduler-boundary wording is kept neutral and coordinated with `rf2-vxgfnd.166` (which owns the host-checkpoint contract decision), not re-litigated here.

## Failing-then-passing proof

New JVM source-text drift gate: `implementation/core/test/re_frame/observation_render_law_drift_test.clj` reads the `observation.cljc` source via `io/resource` (cwd-independent classpath resource) and asserts:

1. **No retired render law** — no `epoch-close notify` (nor `epoch-close render|commit|react|batch|trigger|cause|fire`) and no `render|react|notification per epoch` shape.
2. **Adversarial negative** — the LEGITIMATE per-epoch evidence terms (`frame-epoch`, `registry-epoch`, `commit-epoch`) MUST still be present, so a blind global scrub of every `epoch` mention also reddens the gate.

Proof it actually catches the missed case (not just what already worked):
- **Pre-fix source** (restored via `git checkout HEAD --`): gate **FAILS**, pinpointing `observation.cljc:541  epoch-close notify …` — `1 failures`.
- **Post-fix source**: gate **PASSES** — `0 failures`.

## Quality gates

All run from `implementation/core/`, foreground, unpiped.

- `clojure -M:test -n re-frame.observation-render-law-drift-test` (fixed source) → **Ran 2 tests / 4 assertions, 0 failures, 0 errors** (PASS)
- `clojure -M:test -n re-frame.observation-render-law-drift-test` (pre-fix source restored) → **Ran 2 tests / 4 assertions, 1 failures, 0 errors** (expected FAIL — pins the residue at line 541)
- `clojure -M:test -n re-frame.observation-port-cljs-test -n re-frame.observation-render-law-drift-test -n re-frame.doc-metadata-prod-elision-test` → **Ran 97 tests / 666 assertions, 0 failures, 0 errors** (PASS)

The observation-port contract test `:require`s `re-frame.substrate.observation`, so its green run proves the `.cljc` still compiles + loads after the docstring edit — the transitive-consumer gate for a text change.

**Node CLJS**: not run. The change is a pure docstring text edit with zero CLJS runtime surface, and the JVM gate compiled + loaded the identical shared `.cljc` (a docstring string literal reads identically under both hosts). This worktree carries no `node_modules`, so a node run would force a cold `npm install` + shadow-cljs compile — a hazard the project's operating notes flag (worktree `node_modules` junctions can empty the mayor tree) and a compile sink CI already owns.

## Out of scope (owned by other surfaces / workers)

The broader `rf2-vxgfnd.167` sweep spans surfaces off-limits to this worker; verified against current main and left for their owners:
- `ai/findings/new-substrate-codex/*` (6 named proposal/manual files), `guide/10-performance.md` — force-tracked design/manual tree.
- `spec/006-ReactiveSubstrate.md`, `spec/009-Instrumentation.md` — spec worker's surface.
- `tools/story/test/re_frame/story/play/evidence_test.cljc:214` (`rendered once per epoch -> 2`) — Story surface.
- The repo-wide `git ls-files`-based drift roster/gate that enumerates force-tracked files beneath gitignored dirs — repo-wide census, not core-substrate.

**Noted, no residue**: `implementation/ui/src/re_frame/ui/substrate.cljs:166` and `implementation/ui/test/.../reactive_epoch_cljs_test.cljc:593,599` already teach the CORRECT law ("NOT a per-epoch renderer", "never a per-epoch render") — not residue, and off-limits regardless.

No Spec 009 catalogue change is implied by this docstring edit (no new/changed error-id or instrumentation surface).
