### PR TITLE
fix(ui): reactive substrate timing — prune, falsy escape, checkpoint identity (cluster)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -2533,31 +2533,44 @@
   "Snapshot the still-LIVE cells of one incarnation's weak membership set
   (nil-safe — an absent entry is no members). The teardown-discovery read:
   a cleared ref is a collected — therefore unreachable, therefore never
-  reconnectable — cell with nothing left to reap; on CLJS its husk is
-  compacted away as it is encountered."
+  reconnectable — cell with nothing left to reap.
+
+  Every such READ also COMPACTS the outer registry, on BOTH hosts: neither host
+  removes the enclosing incarnation entry on its own — the CLJS
+  FinalizationRegistry is an OPTIONAL accelerator, and the JVM WeakHashMap
+  expunges the collected member (on `.isEmpty`/`.size`) but never the registry
+  entry that held it. So when the snapshot leaves the membership empty, the
+  now-empty incarnation entry is dropped here (rf2-vxgfnd.169) — the read is the
+  correctness path for both hosts, not just an accelerator on CLJS."
   ([members] (weak-live members nil))
   ([members incarnation]
    (if (nil? members)
      []
-     #?(:clj  (locking members (into [] members))
-        :cljs (let [refs ^js (:refs members)
-                    out  (array)]
-                (.forEach refs
-                          (fn [ref _ _]
-                            (if-some [cell (.deref ^js ref)]
-                              (.push out cell)
-                              (.delete refs ref))))
-                ;; FinalizationRegistry is only an accelerator. A host without
-                ;; it still converges synchronously whenever ownership is read.
-                (when (some? incarnation)
-                  (drop-root-entry-if-empty! incarnation members))
-                (vec out))))))
+     (let [snapshot
+           #?(:clj  (locking members (into [] members))
+              :cljs (let [refs ^js (:refs members)
+                          out  (array)]
+                      (.forEach refs
+                                (fn [ref _ _]
+                                  (if-some [cell (.deref ^js ref)]
+                                    (.push out cell)
+                                    (.delete refs ref))))
+                      (vec out)))]
+       (when (some? incarnation)
+         (drop-root-entry-if-empty! incarnation members))
+       snapshot))))
 
 (defn- weak-live-count
   [members incarnation]
   (if (nil? members)
     0
-    #?(:clj  (.size ^java.util.Set members)
+    #?(:clj  (let [n (.size ^java.util.Set members)]
+               ;; `.size` expunges the collected member from the WeakHashMap but
+               ;; not the enclosing registry entry — compact it too, so a count of
+               ;; a fully-collected incarnation also prunes it (rf2-vxgfnd.169).
+               (when (some? incarnation)
+                 (drop-root-entry-if-empty! incarnation members))
+               n)
        :cljs (count (weak-live members incarnation)))))
 
 ;; ---- reload migration (rf2-vxgfnd.168) ---------------------------------------
@@ -2718,11 +2731,12 @@
   empty incarnations drop on final teardown (rf2-vxgfnd.85 AC5), and a
   collected member simply stops counting (rf2-mc62sp)."
   ([]
-   ;; Synchronous compaction is the correctness path when the optional
-   ;; FinalizationRegistry accelerator is unavailable.
-   #?(:cljs (doseq [[incarnation members] @root-cells]
-              (weak-live members incarnation))
-      :clj nil)
+   ;; Read = compact, on BOTH hosts: the optional CLJS FinalizationRegistry only
+   ;; accelerates husk reaping, and the JVM WeakHashMap expunges collected members
+   ;; but never the now-empty incarnation entry. Compacting here makes a
+   ;; fully-collected generation stop being tracked (rf2-vxgfnd.169).
+   (doseq [[incarnation members] @root-cells]
+     (weak-live members incarnation))
    (count @root-cells))
   ([incarnation]
    (weak-live-count (get @root-cells incarnation) incarnation)))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -443,9 +443,12 @@
   ;;    :disconnect-provisional? bool ; DEV-only and ABSENT in production
   ;;                             ;   (rf2-vxgfnd.44): a just-emitted
   ;;                             ;   :disconnected interval that has NOT yet
-  ;;                             ;   settled past its synchronous commit. A
-  ;;                             ;   reconnect while still provisional is a
-  ;;                             ;   same-tick StrictMode dev replay (no hide);
+  ;;                             ;   settled past its synchronous checkpoint. A
+  ;;                             ;   reconnect while still provisional is
+  ;;                             ;   UNSETTLED/same-checkpoint evidence — a
+  ;;                             ;   StrictMode replay OR consecutive synchronous
+  ;;                             ;   commits, indistinguishable at the host, left
+  ;;                             ;   :unknown (rf2-vxgfnd.164);
   ;;                             ;   `settle-disconnect!` clears it. Production
   ;;                             ;   has no field, lookup, or provisional branch
   ;;    :committed {sid -> {:query exact-query :target target :value value
@@ -2314,15 +2317,20 @@
 ;; :reconnect}`); an explicit host/root teardown proves an unmount (`:unmounted
 ;; {:proof :host-teardown}`).
 ;;
-;; The settle qualifier is the rf2-vxgfnd.44 honesty fix: a reconnect within the
-;; SAME synchronous commit as its disconnect is NOT a hide — it is React
-;; StrictMode's dev mount→cleanup→remount replay, and asserting `:activity-hidden`
-;; for it would fabricate a proof the runtime never observed. So `disconnect!`
-;; marks each cleanup PROVISIONAL and `settle-disconnect!` (a microtask on CLJS)
-;; clears it once the disconnect outlives its commit; only a disconnect that
-;; survived a host yield can then be proven a hide. The field, lookup, settle,
-;; and reconnect branch are DEV-only; production has no StrictMode double-invoke
-;; and takes the ordinary reconnect-proof path directly.
+;; The settle qualifier is the rf2-vxgfnd.44 / rf2-vxgfnd.164 honesty fix: a
+;; reconnect that beats the settle is UNSETTLED / same-checkpoint evidence, and
+;; the runtime must NOT claim more than the host proves. It is consistent with a
+;; React StrictMode dev mount→cleanup→remount replay, but it does NOT identify
+;; one: two REAL commits can also complete in one synchronous stack (consecutive
+;; `flushSync` hide/reveal) before the settle microtask runs — the microtask
+;; separates JavaScript checkpoints, not React commits. With no exact host
+;; discriminator, asserting `:activity-hidden` would fabricate a proof never
+;; observed, so the interval honestly stays `:unknown`. So `disconnect!` marks
+;; each cleanup PROVISIONAL and `settle-disconnect!` (a microtask on CLJS) clears
+;; it once the disconnect outlives its checkpoint; only a disconnect that survived
+;; a host yield is then proven a hide. The field, lookup, settle, and reconnect
+;; branch are DEV-only; production has no StrictMode double-invoke and takes the
+;; ordinary reconnect-proof path directly.
 
 (defn lifecycle
   "The cell's current runtime state keyword."
@@ -2770,15 +2778,18 @@
 
 (defn settle-disconnect!
   "Settle `cell`'s open PROVISIONAL disconnect — mark it a disconnect that
-  outlived the synchronous commit that produced it, so a subsequent reconnect
-  honestly proves an Activity hide rather than a same-tick React StrictMode
-  replay (rf2-vxgfnd.44). No-op unless the cell is still `:disconnected` (a cell
-  already reconnected or torn down needs no settle). On CLJS `disconnect!` arms
-  this as a microtask — it fires after the synchronous commit unwinds and before
-  the next paint, so ONLY a same-commit StrictMode replay can reconnect ahead of
-  it; a genuine reveal (a later task) always finds the disconnect already
-  settled. A headless/JVM fixture calls this explicitly to model the host yield
-  of a real reveal. Returns nil."
+  outlived the synchronous CHECKPOINT that produced it, so a subsequent reconnect
+  can honestly prove an Activity hide (rf2-vxgfnd.44). No-op unless the cell is
+  still `:disconnected` (a cell already reconnected or torn down needs no settle).
+  On CLJS `disconnect!` arms this as a microtask — it fires after the synchronous
+  checkpoint unwinds and before the next paint. A reconnect that arrives BEFORE it
+  is UNSETTLED / same-checkpoint evidence the host does not further discriminate:
+  a StrictMode replay OR two real commits completing in one synchronous stack
+  (consecutive `flushSync` hide/reveal), so `connect!` leaves it `:unknown`. A
+  reconnect that arrives AFTER it is a settled disconnect — a genuine reveal
+  proven an Activity hide. The microtask separates JavaScript checkpoints, not
+  React commits (rf2-vxgfnd.164). A headless/JVM fixture calls this explicitly to
+  model the host yield of a real reveal. Returns nil."
   [^ViewCell cell]
   (when interop/debug-enabled?
     (let [st (state cell)]
@@ -2788,12 +2799,15 @@
 
 (defn- arm-disconnect-settle!
   "Arm the settle of `cell`'s provisional disconnect. On CLJS a host microtask
-  (`queue-microtask!`) that runs after the current synchronous commit unwinds
-  and before the next paint — so React StrictMode's synchronous
-  mount→cleanup→remount reconnects BEFORE it (a replay, un-annotated), while a
-  genuine reveal (a later task) reconnects after it (proven a hide). No
-  auto-settle on the JVM headless host (no StrictMode, no async render loop); a
-  fixture there settles explicitly."
+  (`queue-microtask!`) that runs after the current synchronous checkpoint unwinds
+  and before the next paint. A reconnect BEFORE it is UNSETTLED / same-checkpoint
+  — a StrictMode synchronous mount→cleanup→remount OR two real commits in one
+  synchronous stack (consecutive `flushSync` hide/reveal), indistinguishable at
+  the host, so it is left un-annotated (`:unknown`); a reconnect AFTER it is a
+  settled disconnect a genuine reveal proves a hide. The microtask separates
+  JavaScript checkpoints, not React commits (rf2-vxgfnd.164). No auto-settle on
+  the JVM headless host (no async render loop); a fixture there settles
+  explicitly."
   [^ViewCell cell]
   #?(:cljs (queue-microtask! (fn [] (settle-disconnect! cell)))
      :clj  nil))
@@ -2801,22 +2815,29 @@
 (defn- connect!
   "Commit-time lifecycle transition into `:connected`. A transition FROM
   `:disconnected` is a reconnect. A reconnect proves an Activity hide ONLY when
-  the prior disconnect had SETTLED — i.e. it outlived the synchronous commit
+  the prior disconnect had SETTLED — i.e. it outlived the synchronous checkpoint
   that produced it. A SETTLED-then-reconnected interval is a genuine hide→reveal
   and is annotated `:activity-hidden {:proof :reconnect}`. An UNSETTLED reconnect
-  is a React StrictMode dev replay — the same cell's effect
-  mount→cleanup→remount within ONE synchronous commit, where NO hide and NO
-  unmount happened — so it is NOT annotated: the runtime must not fabricate an
-  Activity-hide proof it never observed (rf2-vxgfnd.44). In production the
-  provisional field, lookup, and branch are elided (no StrictMode
-  double-invoke), so a reveal takes the reconnect-proof path directly."
+  is same-checkpoint evidence: it beat the settle. That is CONSISTENT WITH a React
+  StrictMode dev replay (mount→cleanup→remount within ONE synchronous commit), but
+  it is NOT PROOF of one — two real commits can also complete in a single
+  synchronous stack (consecutive `flushSync` hide/reveal) before the settle
+  microtask runs. The host supplies no exact discriminator, so the runtime
+  DECLINES to annotate: it fabricates no Activity-hide proof and claims no unique
+  StrictMode identity; the interval honestly stays `:disconnected {:reason
+  :unknown}` (rf2-vxgfnd.44, rf2-vxgfnd.164). In production the provisional field,
+  lookup, and branch are elided (no StrictMode double-invoke), so a reveal takes
+  the reconnect-proof path directly."
   [^ViewCell cell]
   (let [st @(state cell)]
     (when (= :disconnected (:lifecycle st))
       (if interop/debug-enabled?
         (if (:disconnect-provisional? st)
-          ;; same-tick StrictMode replay — the disconnect never settled; clear
-          ;; the provisional flag and DO NOT fabricate an Activity-hide proof.
+          ;; unsettled reconnect — beat the settle (a StrictMode replay OR two
+          ;; real commits in one synchronous stack; the host does not
+          ;; discriminate). Clear the provisional flag and DECLINE to annotate:
+          ;; fabricate no Activity-hide proof, claim no unique StrictMode identity
+          ;; (rf2-vxgfnd.164). The interval honestly stays :unknown.
           (swap! (state cell) assoc :disconnect-provisional? false)
           (annotate-open-disconnect! cell :activity-hidden :reconnect))
         (annotate-open-disconnect! cell :activity-hidden :reconnect)))
@@ -2852,11 +2873,13 @@
                   (-> m
                       (assoc :lifecycle :disconnected)
                       (update :intervals conj {:state :disconnected :reason :unknown}))))
-      ;; Same-tick StrictMode-replay guard (DEV-only — DCEs in production, which
-      ;; has no StrictMode double-invoke): mark this disconnect PROVISIONAL and
-      ;; arm its settle. A reconnect BEFORE the settle is a synchronous replay
-      ;; (mount→cleanup→remount in one commit — no hide); a reconnect AFTER it is
-      ;; a genuine reveal that `connect!` proves an Activity hide (rf2-vxgfnd.44).
+      ;; Unsettled-reconnect guard (DEV-only — DCEs in production, which has no
+      ;; StrictMode double-invoke): mark this disconnect PROVISIONAL and arm its
+      ;; settle. A reconnect BEFORE the settle is UNSETTLED/same-checkpoint (a
+      ;; StrictMode replay OR consecutive synchronous commits — the host does not
+      ;; discriminate, so `connect!` leaves it :unknown); a reconnect AFTER it is
+      ;; a genuine reveal `connect!` proves an Activity hide (rf2-vxgfnd.44,
+      ;; rf2-vxgfnd.164).
       (when interop/debug-enabled?
         (swap! st assoc :disconnect-provisional? true)
         (arm-disconnect-settle! cell))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -964,18 +964,27 @@
   listener is contained in its own try/catch so one throwing consumer cannot
   starve its sibling listeners on the same cell (mirroring the observation
   port's per-lease disposal containment); the FIRST escape is rethrown AFTER
-  every listener has been delivered — surfaced, never starving (rf2-owwbyl)."
+  every listener has been delivered — surfaced, never starving (rf2-owwbyl).
+
+  Escape PRESENCE is tracked independently of the escape's own value: JavaScript
+  permits throwing falsy values (`throw null`, `throw false`), so the first
+  escape is captured in a truthy wrapper `{:escaped? true :error e}` rather than
+  as the raw value. Using the value's truthiness as the presence test would lose
+  a thrown `nil` and let a later truthy escape overwrite a first thrown `false`,
+  violating the first-escape order/identity contract (rf2-vxgfnd.172). The
+  wrapper is allocated only when a listener actually throws, so the happy path
+  carries no overhead."
   [^ViewCell cell]
   (let [escape (reduce (fn [acc f]
                          (try
                            (f)
                            acc
                            (catch #?(:clj Throwable :cljs :default) e
-                             (or acc e))))
+                             (or acc {:escaped? true :error e}))))
                        nil
                        (vals (:listeners @(state cell))))]
-    (when (some? escape)
-      (throw escape))))
+    (when escape
+      (throw (:error escape)))))
 
 (defn- advance-revision!
   "Advance the cell's revision and notify subscribers — the host re-reads

--- a/implementation/ui/test/re_frame/ui/reactive_falsy_escape_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_falsy_escape_cljs_test.cljs
@@ -1,0 +1,107 @@
+(ns re-frame.ui.reactive-falsy-escape-cljs-test
+  "rf2-vxgfnd.172 — flush listener containment must preserve a FALSY escape.
+
+  `notify-listeners!` contains each listener so one throwing consumer cannot
+  starve its siblings, then rethrows the FIRST escape after every listener has
+  delivered (rf2-owwbyl). JavaScript permits throwing falsy values, so the
+  presence of an escape MUST be tracked independently of the escape's own
+  truthiness:
+
+    - a listener that `throw null`s is a real escape; the pre-fix `(or acc e)` +
+      `some?` presence test left the accumulator nil and silently lost it;
+    - a first listener that `throw false`s, followed by a truthy Error, had its
+      falsy first escape overwritten by the later truthy one — violating the
+      first-escape order/identity contract.
+
+  These are CLJS-only vectors (`throw null` / `throw false`); on the JVM a
+  Throwable is always truthy, so JVM behaviour is unchanged and this fixture is
+  `.cljs`. Existing fixtures throw only truthy `ex-info`, so they cannot detect
+  truthiness-based loss."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(defn- flush-capturing
+  "Drain the whole registry through the real `flush-pending!` primitive. Returns
+  `[:threw v]` carrying the EXACT rethrown escape value (which may be nil/false/
+  Error), or `:clean` when the flush completed without a rethrow."
+  []
+  (try (reactive/flush-pending!) :clean
+       (catch :default e [:threw e])))
+
+;; ===========================================================================
+;; A `throw null` is a real escape: it must be rethrown AFTER every same-cell
+;; and sibling-cell listener delivered — never silently swallowed.
+;; ===========================================================================
+
+(deftest throw-null-is-rethrown-after-all-listeners-deliver
+  (reactive/reset-scheduler!)
+  (let [same    (atom 0)
+        sibling (atom 0)
+        cell-a  (reactive/make-cell ::a)
+        cell-b  (reactive/make-cell ::b)]
+    ;; cell-a: a listener that throws JavaScript null, then a same-cell sibling.
+    (reactive/subscribe cell-a (fn [] (throw nil)))
+    (reactive/subscribe cell-a (fn [] (swap! same inc)))
+    ;; cell-b: a sibling-cell listener in the same batch.
+    (reactive/subscribe cell-b (fn [] (swap! sibling inc)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [outcome (flush-capturing)]
+      (testing "containment held — every same-cell AND sibling-cell listener delivered"
+        (is (= 1 @same)    "cell-a's second (same-cell) listener fired")
+        (is (= 1 @sibling) "cell-b's sibling-cell listener fired"))
+      (testing "the falsy escape is PRESERVED — `throw null` is rethrown exactly"
+        (is (= [:threw nil] outcome)
+            "pre-fix `(or acc nil)` + `some?` left the accumulator nil and lost it"))
+      (testing "no cell is left dirty/pending solely because a listener threw"
+        (is (= 0 (reactive/pending-cell-count)))))))
+
+;; ===========================================================================
+;; A first `throw false`, then a later truthy Error: the FIRST (false) wins.
+;; ===========================================================================
+
+(deftest first-false-escape-is-preserved-over-a-later-error
+  (reactive/reset-scheduler!)
+  (let [cell (reactive/make-cell ::c)]
+    ;; first listener throws JavaScript false; a later listener throws a truthy Error.
+    (reactive/subscribe cell (fn [] (throw false)))
+    (reactive/subscribe cell (fn [] (throw (ex-info "later" {:n 2}))))
+    (reactive/mark-dirty! cell 1)
+    (let [outcome (flush-capturing)]
+      (testing "the FIRST escape (false) is rethrown — not the later truthy Error"
+        (is (= [:threw false] outcome)
+            "pre-fix `(or acc e)` overwrote the falsy first escape with the later
+             truthy one, violating first-escape order/identity")))))
+
+;; ===========================================================================
+;; Truthy Error behaviour is UNCHANGED, and the scheduler drains clean after a
+;; throw — no cell stranded dirty/pending.
+;; ===========================================================================
+
+(deftest truthy-error-rethrown-and-scheduler-drains-clean-afterward
+  (reactive/reset-scheduler!)
+  (let [sibling (atom 0)
+        boom    (ex-info "boom" {})
+        cell-a  (reactive/make-cell ::a)
+        cell-b  (reactive/make-cell ::b)]
+    (reactive/subscribe cell-a (fn [] (throw boom)))
+    (reactive/subscribe cell-b (fn [] (swap! sibling inc)))
+    (reactive/mark-dirty! cell-a 1)
+    (reactive/mark-dirty! cell-b 2)
+    (let [outcome (flush-capturing)]
+      (is (= [:threw boom] outcome) "the exact truthy escape is rethrown by identity")
+      (is (= 1 @sibling) "the sibling cell still delivered before the rethrow"))
+    (testing "nothing lingers dirty solely because a listener threw"
+      (is (= 0 (reactive/pending-cell-count))))
+    (testing "a clean follow-up drain succeeds"
+      (reactive/mark-dirty! cell-b 3)
+      (is (= :clean (flush-capturing)) "the next drain flushes cleanly")
+      (is (= 2 @sibling)))))

--- a/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_reconcile_cljs_test.cljc
@@ -494,9 +494,10 @@
     (testing "a SETTLED disconnect then reconnect proves a genuine Activity hide"
       ;; Model the host yield of a genuine reveal: the disconnect outlived its
       ;; synchronous commit (on CLJS a microtask settles it; headless we settle
-      ;; explicitly). Only a SETTLED disconnect, on reconnect, proves a hide —
-      ;; an UNSETTLED same-commit reconnect is a StrictMode replay (rf2-vxgfnd.44,
-      ;; see `lifecycle-strictmode-replay-does-not-fabricate-hide-proof`).
+      ;; explicitly). Only a SETTLED disconnect, on reconnect, proves a hide — an
+      ;; UNSETTLED reconnect is same-checkpoint evidence the host does not further
+      ;; discriminate (a StrictMode replay OR consecutive synchronous commits;
+      ;; rf2-vxgfnd.44, rf2-vxgfnd.164, see the two `-honestly-unknown` tests below).
       (reactive/settle-disconnect! cell)
       (render+commit! cell [[:r/a]])
       (is (= :connected (reactive/lifecycle cell)))
@@ -506,14 +507,17 @@
           "the PRIOR interval is annotated — never the present"))))
 
 (deftest lifecycle-strictmode-replay-does-not-fabricate-hide-proof
-  ;; rf2-vxgfnd.44 — React StrictMode's dev effect double-invoke is
-  ;; mount→cleanup→remount within ONE synchronous commit: connect → disconnect →
-  ;; reconnect with NO host yield between them, so the disconnect never settles.
-  ;; That reconnect is NOT an Activity hide — the runtime observed neither a hide
-  ;; nor an unmount — and it must NOT be annotated `:activity-hidden` (the pre-fix
-  ;; false proof). Headless model of the replay: drive the sequence with NO
-  ;; `settle-disconnect!` before the reconnect, exactly as the synchronous
-  ;; StrictMode replay leaves it (the settle microtask has not yet fired).
+  ;; rf2-vxgfnd.44 / rf2-vxgfnd.164 — a reconnect that beats the settle is
+  ;; UNSETTLED / same-checkpoint evidence. A React StrictMode dev double-invoke
+  ;; (effect mount→cleanup→remount within ONE synchronous commit) is ONE cause:
+  ;; connect → disconnect → reconnect with NO host yield, so the disconnect never
+  ;; settles. But it is not the ONLY cause — two REAL commits can complete in a
+  ;; single synchronous stack too (consecutive `flushSync` hide/reveal, see
+  ;; `consecutive-commits-without-a-yield-are-honestly-unknown`). The host gives
+  ;; no exact discriminator, so the runtime DECLINES to annotate: it must NOT
+  ;; fabricate an `:activity-hidden` proof it never observed. Headless model:
+  ;; drive the sequence with NO `settle-disconnect!` before the reconnect, exactly
+  ;; as the not-yet-fired settle microtask leaves it.
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (reactive/make-cell ::v)]
@@ -521,15 +525,58 @@
     (is (= :connected (reactive/lifecycle cell)))
     (reactive/disconnect! cell)
     (is (= :disconnected (reactive/lifecycle cell)))
-    ;; NO settle — the replay reconnects within the same synchronous commit.
+    ;; NO settle — the reconnect beats the settle within the same synchronous stack.
     (render+commit! cell [[:r/a]])
-    (is (= :connected (reactive/lifecycle cell)) "the replay reconnects")
+    (is (= :connected (reactive/lifecycle cell)) "the reconnect lands")
     (is (= {:state :disconnected :reason :unknown}
            (peek (reactive/intervals cell)))
-        "the same-commit replay disconnect stays :unknown — NOT upgraded to
-         :activity-hidden; the runtime never observed a hide (rf2-vxgfnd.44)")
+        "the unsettled reconnect disconnect stays :unknown — NOT upgraded to
+         :activity-hidden; the host gave no hide-vs-replay discriminator
+         (rf2-vxgfnd.44, rf2-vxgfnd.164)")
     (is (not-any? #(= :activity-hidden (:reason %)) (reactive/intervals cell))
         "no interval carries a fabricated Activity-hide proof")))
+
+(deftest consecutive-commits-without-a-yield-are-honestly-unknown
+  ;; rf2-vxgfnd.164 — the microtask-vs-commit interleaving. A microtask separates
+  ;; JavaScript checkpoints, NOT React commits: two real commits can complete in
+  ;; one synchronous stack (`flushSync(hide); flushSync(reveal)`) with the leaf's
+  ;; layout effect torn down and recreated BEFORE the queued settle microtask
+  ;; runs. The reconnect therefore beats the settle exactly as a StrictMode replay
+  ;; would — indistinguishable at the host — so the honest floor is :unknown, not
+  ;; a fabricated `:activity-hidden`. Headless model of the two consecutive
+  ;; commits: disconnect then reconnect with NO settle (no host yield) between.
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[:r/a]])] ;; commit 0: connected
+    (is (= :connected (reactive/lifecycle cell)))
+    ;; commit 1 (flushSync hide): layout-effect cleanup disconnects, arming settle.
+    (reactive/disconnect! cell)
+    (is (= {:state :disconnected :reason :unknown}
+           (peek (reactive/intervals cell)))
+        "cleanup emits :disconnected {:reason :unknown} — no host signal yet")
+    ;; commit 2 (flushSync reveal): layout-effect setup reconnects in the SAME
+    ;; synchronous stack — the settle microtask has NOT run.
+    (render+commit! cell [[:r/a]])
+    (is (= :connected (reactive/lifecycle cell)) "the reveal reconnects")
+    (testing "two real commits in one stack are indistinguishable from a replay"
+      (is (= {:state :disconnected :reason :unknown}
+             (peek (reactive/intervals cell)))
+          "the unsettled reconnect honestly stays :unknown — the host supplied no
+           exact discriminator, so NO Activity-hide proof is fabricated for
+           consecutive synchronous commits (rf2-vxgfnd.164)")
+      (is (not-any? #(= :activity-hidden (:reason %)) (reactive/intervals cell))
+          "no interval carries a fabricated hide proof")))
+  ;; The delayed-reveal control: when the disconnect DOES outlive its checkpoint
+  ;; (a later task settles it), the reconnect honestly proves an Activity hide —
+  ;; the settled-evidence contract is unchanged.
+  (let [cell (render+commit! (reactive/make-cell ::w) [[:r/a]])]
+    (reactive/disconnect! cell)
+    (reactive/settle-disconnect! cell)                 ;; the settle fires (later task)
+    (render+commit! cell [[:r/a]])
+    (is (= {:state :disconnected :reason :activity-hidden :proof :reconnect}
+           (peek (reactive/intervals cell)))
+        "a SETTLED reconnect (delayed reveal) still proves :activity-hidden
+         {:proof :reconnect}")))
 
 (deftest lifecycle-host-teardown-proves-unmount
   (rf/reg-sub :r/a (fn [db _] (:a db)))

--- a/implementation/ui/test/re_frame/ui/reactive_reincarnation_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_reincarnation_dom_cljs_test.cljs
@@ -15,9 +15,25 @@
   revision, which re-renders SYNCHRONOUSLY inside the same `flushSync` — before
   any paint. The DOM reads the reincarnated value with no macrotask/paint between.
 
+  ## Act discipline (rf2-vxgfnd.163)
+
+  The timing-sensitive `flushSync` mount/rerender/unmount run inside React's OWN
+  `act(...)` — the repository's native `get-act`/`act!` pattern (the same shape as
+  `root-mount-dom-cljs-test` and core's shared React suite), NOT UIx/Helix/Reagent
+  machinery. `IS_REACT_ACT_ENVIRONMENT` is enabled per test and its prior value
+  restored on every exit, so the fixture neither depends on nor leaks the
+  shared-page flag. The corrective `flushSync` stays nested inside `act`, and the
+  synchronous DOM result is recorded INSIDE the callback — before `act` can drain
+  any later microtask/macrotask work — so the before-paint reincarnation
+  discriminator is preserved. A bounded, namespace-local console-error capture
+  counts React's \"not wrapped in act(...)\" diagnostic while FORWARDING every line
+  to the original console: removing the act boundary makes the mount emit that
+  warning, the capture counts it, and the zero-warning assertion goes RED.
+
   Browser-only bodies — `-dom-cljs-test$` opts into `:browser-test`; `:node-test`
   loads it too, where the DOM body gates on `(browser?)` and no-ops."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as react]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -31,13 +47,76 @@
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
 
+;; --- native React act pattern (rf2-vxgfnd.163; rf2-powx4d sweep template) ----
+;; React's OWN act(), enabled per-test in the fixture. NOT UIx/Helix/Reagent.
+
+(defn- get-act
+  "React's act() — React 19 promotes it to the React namespace proper
+  (react-dom/test-utils on 18)."
+  []
+  (or (when (exists? (.-act react)) (.-act react))
+      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- act!
+  "Run `thunk` inside React `act()`, returning the thunk's value. The
+  mount/rerender/unmount work commits synchronously under
+  IS_REACT_ACT_ENVIRONMENT (enabled per-test in the fixture), so the callback
+  runs eagerly and we capture its result."
+  [thunk]
+  (let [ret    (volatile! nil)
+        act-fn (get-act)]
+    (act-fn (fn [] (vreset! ret (thunk))))
+    @ret))
+
+;; --- bounded namespace-local act-warning capture (the guard's teeth) ---------
+
+(defn- act-warning?
+  "True iff `text` is React's 'not wrapped in act(...)' console diagnostic — the
+  exact warning the act boundary suppresses. Bounded and namespace-local; used
+  BOTH by the live capture and by the detector unit test, so the same predicate
+  the zero-warning assertion depends on is proven to match React's wording."
+  [text]
+  (and (string? text)
+       (boolean (re-find #"not wrapped in act" text))))
+
+(defn- with-console-error-capture
+  "Run `thunk` with `console.error` intercepted: every call is FORWARDED to the
+  original console (diagnostics preserved, never suppressed), and any
+  act-discipline warning increments `counter`. The original `console.error` is
+  restored on every exit."
+  [counter thunk]
+  (let [orig (.-error js/console)]
+    (set! (.-error js/console)
+          (fn [& args]
+            (when (some act-warning? args)
+              (swap! counter inc))
+            (.apply orig js/console (into-array args))))
+    (try (thunk) (finally (set! (.-error js/console) orig)))))
+
+(def ^:private prior-act-env (atom nil))
+
+;; Both :each fixtures are FN-form (the reincarnation correction is synchronous —
+;; no async settlement — so the default FN-form reset fixture is right). A map
+;; fixture here would mix types with the FN-form reset fixture and abort the ns.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
    {:adapter ui/adapter :ambient-frame nil})
   (fn [f]
+    (reset! prior-act-env
+            (when (browser?) (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)))
+    (enable-react-act-env!)
     (reactive/reset-scheduler!)
     (client/reset-live-roots!)
-    (try (f) (finally (reactive/reset-scheduler!) (client/reset-live-roots!)))))
+    (try (f)
+         (finally
+           (reactive/reset-scheduler!)
+           (client/reset-live-roots!)
+           (when (browser?)
+             (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) @prior-act-env))))))
 
 (def ^:private frame-kw :rre/frame)
 
@@ -56,25 +135,63 @@
     (do
       (register-app!)
       (rf/dispatch-sync [:rre/seed] {:frame frame-kw})
-      (let [c     (container)
-            armed (atom true)]
-        ;; Arm the :pre-acquire seam to reincarnate the frame ONCE, inside the
-        ;; mount's layout commit: destroy A (which the not-yet-connected leaf cell
-        ;; escapes — it enrols only at the post-publish connect!) and recreate B
-        ;; under the same id with a DIFFERENT value. The commit then acquires B's
-        ;; fresh node (a distinct node-key) while holding the render's probe of A.
-        (binding [reactive/*commit-barrier*
-                  (fn [phase _cell]
-                    (when (and @armed (= :pre-acquire phase))
-                      (reset! armed false)              ;; once — disarm the re-commit
-                      (frame/destroy-frame! frame-kw)
-                      (rf/make-frame {:id frame-kw})
-                      (frame/replace-app-db! frame-kw {:n 2})))]
-          (let [root (react-dom/flushSync
-                      #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
-                                 c {:root-id :rre/root}))]
-            (testing "the node-key reincarnation was corrected in the layout commit, before paint"
-              (is (= "2" (.-textContent (.querySelector c ".leaf")))
-                  "the corrective render fired synchronously inside flushSync (before
-                   any paint/macrotask) — the reincarnated value is on the DOM"))
-            (react-dom/flushSync #(ui/unmount! root))))))))
+      (let [c        (container)
+            armed    (atom true)
+            warnings (atom 0)
+            root     (volatile! nil)
+            dom-val  (volatile! nil)]
+        (try
+          ;; MOUNT + corrective RERENDER inside React act. The :pre-acquire seam
+          ;; reincarnates the frame ONCE, inside the mount's layout commit:
+          ;; destroy A (which the not-yet-connected leaf cell escapes — it enrols
+          ;; only at the post-publish connect!) and recreate B under the same id
+          ;; with a DIFFERENT value. The commit then acquires B's fresh node (a
+          ;; distinct node-key) while holding the render's probe of A.
+          (with-console-error-capture warnings
+            (fn []
+              (act!
+               (fn []
+                 (binding [reactive/*commit-barrier*
+                           (fn [phase _cell]
+                             (when (and @armed (= :pre-acquire phase))
+                               (reset! armed false)   ;; once — disarm the re-commit
+                               (frame/destroy-frame! frame-kw)
+                               (rf/make-frame {:id frame-kw})
+                               (frame/replace-app-db! frame-kw {:n 2})))]
+                   (vreset! root
+                            (react-dom/flushSync
+                             #(ui/mount [frame-provider {:frame frame-kw} [leaf {}]]
+                                        c {:root-id :rre/root})))
+                   ;; Record the DOM SYNCHRONOUSLY, inside the flushSync
+                   ;; checkpoint, before act can drain any microtask/macrotask —
+                   ;; preserving the before-paint reincarnation discriminator.
+                   (vreset! dom-val (.-textContent (.querySelector c ".leaf"))))))))
+          (testing "the node-key reincarnation was corrected in the layout commit, before paint"
+            (is (= "2" @dom-val)
+                "the corrective render fired synchronously inside flushSync (before
+                 any paint/macrotask) — the reincarnated value is on the DOM"))
+          (finally
+            ;; Guaranteed act-disciplined unmount — no live Root/ViewCell survives.
+            (with-console-error-capture warnings
+              (fn [] (when @root (act! #(ui/unmount! @root)))))))
+        (testing "the mount, corrective rerender, and unmount stayed inside act()"
+          (is (zero? @warnings)
+              "zero 'not wrapped in act(...)' warnings escaped the fixture"))
+        (is (empty? (client/live-root-ids))
+            "every Root was torn down in guaranteed cleanup — none survives")))))
+
+(deftest act-warning-detector-has-teeth
+  ;; rf2-vxgfnd.163 AC — a mutation removing the act boundary must make the
+  ;; namespace-local warning assertion go RED. Prove the exact predicate the
+  ;; zero-warning assertion depends on matches React's real act diagnostic —
+  ;; WITHOUT emitting a real warning (which would itself violate zero-warning).
+  (is (act-warning?
+       "Warning: An update to Leaf inside a test was not wrapped in act(...).")
+      "recognises React's act-discipline warning (React 18 phrasing)")
+  (is (act-warning?
+       "An update to ViewCell inside a test was not wrapped in act(...). When testing…")
+      "recognises the React 19 phrasing too")
+  (is (not (act-warning? "TypeError: querySelector is not a function"))
+      "an unrelated console.error is NOT mistaken for an act warning")
+  (is (not (act-warning? nil))
+      "nil is not an act warning — the classifier is string-guarded"))

--- a/implementation/ui/test/re_frame/ui/reactive_root_retention_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_retention_cljs_test.cljc
@@ -124,6 +124,32 @@
                  (swap! created conj ref)
                  ref))}))))
 
+#?(:cljs
+   (defn- controlled-finalization-registry
+     "A constructable FinalizationRegistry MODEL whose queued finalizers fire
+     only when the test invokes them explicitly — modelling a DELAYED finalizer
+     (rf2-vxgfnd.169). `register` records `{:held :token :callback}` into
+     `pending`; `unregister` removes by token and returns true (so the substrate
+     probe accepts it). The probe registers+unregisters a keyword-held sentinel,
+     so real member finalizers are exactly the map-held entries."
+     [pending]
+     (js/Proxy.
+      host-finalization-registry
+      #js {:construct
+           (fn [_ args _]
+             (let [callback (aget args 0)
+                   reg      (js-obj)]
+               (aset reg "register"
+                     (fn [_target held token]
+                       (swap! pending conj {:held held :token token
+                                            :callback callback})))
+               (aset reg "unregister"
+                     (fn [token]
+                       (swap! pending
+                              (fn [ps] (vec (remove #(identical? (:token %) token) ps))))
+                       true))
+               reg))})))
+
 ;; ===========================================================================
 ;; rf2-vxgfnd.170 — the three-arm JavaScript capability matrix
 ;; ===========================================================================
@@ -464,3 +490,128 @@
          (reactive/teardown-root! incarnation (fn [] nil))
          (is (= :dead (reactive/lifecycle hidden)))
          (is (= 0 (reactive/root-cell-count incarnation)))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.169 — the ALL-MEMBERS-COLLECTED path: after the LAST member of an
+;; incarnation collects, the now-empty OUTER registry entry must be pruned too,
+;; on BOTH hosts. The hidden-sibling fixture above keeps one member alive, so it
+;; only ever exercises last-EXPLICIT-departure — it masks this path.
+;; ===========================================================================
+
+#?(:clj
+   (deftest all-members-collected-drops-the-empty-incarnation-entry
+     ;; Forced-GC JVM coverage (the deterministic weak-clearing host): an
+     ;; incarnation whose SOLE cell is collected must leave the outer registry,
+     ;; and the global tracked count must return to baseline (rf2-vxgfnd.169).
+     (rf/reg-sub :ret/a (fn [db _] (:a db)))
+     (let [fid         (make-frame! :ret/frame {:a 1})
+           base        (reactive/root-cell-count)
+           incarnation (reactive/make-root-incarnation)
+           ;; the SOLE cell, held only WEAKLY — no hidden sibling, no strong ref.
+           ref         (let [cell (mount! ::solo incarnation fid [[:ret/a]])]
+                         (reactive/disconnect! cell)
+                         (java.lang.ref.WeakReference. cell))]
+       (is (= (inc base) (reactive/root-cell-count))
+           "precondition: the incarnation is tracked pre-GC")
+       (is (= 1 (reactive/root-cell-count incarnation)))
+       (testing "after the LAST cell collects, the empty incarnation entry is pruned"
+         (is (true? (gc-until #(nil? (.get ^java.lang.ref.WeakReference ref))))
+             "the sole member was collected — nothing strong retains it")
+         (is (= base (reactive/root-cell-count))
+             "the 0-arg GLOBAL tracked count returned to baseline — the now-empty
+              outer entry was pruned, not retained forever. RED pre-fix: the JVM
+              `weak-live` / `root-cell-count[]` never removed the outer entry")
+         (is (= 0 (reactive/root-cell-count incarnation))
+             "…and the per-incarnation live count is zero")))))
+
+#?(:cljs
+   (deftest all-members-collected-drops-empty-entry-without-a-reaper
+     ;; Compiled-CLJS coverage with FinalizationRegistry UNAVAILABLE: the
+     ;; opportunistic synchronous scan must compact the cleared husk AND drop the
+     ;; now-empty incarnation entry (rf2-vxgfnd.169).
+     (let [created     (atom [])
+           deref-calls (atom 0)
+           weak-ref    (controlled-weak-ref-constructor created deref-calls)]
+       (with-platform-capabilities!
+         weak-ref js/undefined                       ;; FinalizationRegistry ABSENT
+         (fn []
+           (reactive/ensure-platform-compatible! 'retention/prune)
+           (reset! created [])
+           (let [base        (reactive/root-cell-count)
+                 incarnation (reactive/make-root-incarnation)
+                 cell        (reactive/make-cell ::solo)]
+             (reactive/attach-root! cell incarnation)
+             (is (= (inc base) (reactive/root-cell-count)))
+             (is (= 1 (reactive/root-cell-count incarnation)))
+             ;; Model ordinary reconciliation collection: the sole member's weak
+             ;; ref clears, but NO deterministic teardown and NO reaper ran.
+             (.clearForTest (first @created))
+             (testing "opportunistic compaction drops the husk AND the empty entry"
+               (is (= base (reactive/root-cell-count))
+                   "the 0-arg global scan compacted the now-empty incarnation entry")
+               (is (= 0 (reactive/root-cell-count incarnation))))))))))
+
+#?(:cljs
+   (deftest explicit-teardown-of-a-member-empty-incarnation-removes-it
+     ;; The entry is present but its membership is already empty (collected):
+     ;; explicit root teardown must remove it deterministically (rf2-vxgfnd.169).
+     (let [created     (atom [])
+           deref-calls (atom 0)
+           weak-ref    (controlled-weak-ref-constructor created deref-calls)]
+       (with-platform-capabilities!
+         weak-ref js/undefined
+         (fn []
+           (reactive/ensure-platform-compatible! 'retention/empty-teardown)
+           (reset! created [])
+           (let [base        (reactive/root-cell-count)
+                 incarnation (reactive/make-root-incarnation)
+                 cell        (reactive/make-cell ::solo)]
+             (reactive/attach-root! cell incarnation)
+             ;; the member collects, leaving the entry PRESENT but member-empty
+             (.clearForTest (first @created))
+             (testing "explicit teardown of an already member-empty incarnation removes it"
+               (reactive/teardown-root! incarnation (fn [] nil))
+               (is (= base (reactive/root-cell-count)))
+               (is (= 0 (reactive/root-cell-count incarnation))))))))))
+
+#?(:cljs
+   (deftest delayed-finalizer-after-synchronous-removal-is-harmless
+     ;; A late FinalizationRegistry callback that fires AFTER synchronous
+     ;; compaction already removed the incarnation must not delete a replacement
+     ;; entry / new incarnation (rf2-vxgfnd.169).
+     (let [created     (atom [])
+           deref-calls (atom 0)
+           pending     (atom [])
+           weak-ref    (controlled-weak-ref-constructor created deref-calls)
+           final-reg   (controlled-finalization-registry pending)]
+       (with-platform-capabilities!
+         weak-ref final-reg
+         (fn []
+           (reactive/ensure-platform-compatible! 'retention/delayed)
+           (reset! created [])
+           (reset! pending [])
+           (let [inc-x  (reactive/make-root-incarnation)
+                 base   (reactive/root-cell-count)
+                 cell-a (reactive/make-cell ::a)]
+             (reactive/attach-root! cell-a inc-x)
+             (is (= 1 (reactive/root-cell-count inc-x)))
+             (let [fin (first (filter #(map? (:held %)) @pending))]
+               (is (some? fin) "the reaper registered A's collection finalizer")
+               ;; A collects; a SYNCHRONOUS scan removes X's now-empty entry NOW,
+               ;; BEFORE the (delayed) finalizer runs.
+               (.clearForTest (first @created))
+               (is (= base (reactive/root-cell-count))
+                   "synchronous compaction already dropped the empty incarnation")
+               ;; A NEW cell B re-attaches to X, re-creating the entry with a
+               ;; DIFFERENT membership set.
+               (let [cell-b (reactive/make-cell ::b)]
+                 (reactive/attach-root! cell-b inc-x)
+                 (is (= 1 (reactive/root-cell-count inc-x)))
+                 (testing "the DELAYED finalizer for A is harmless — identity-guarded"
+                   ((:callback fin) (:held fin))
+                   (is (= 1 (reactive/root-cell-count inc-x))
+                       "the late finalizer did NOT remove the replacement entry")
+                   (is (identical? inc-x (reactive/cell-root cell-b))
+                       "…nor the new incarnation's live member"))
+                 (reactive/teardown! cell-b)
+                 (is (= base (reactive/root-cell-count)))))))))))

--- a/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_incarnation_activity_dom_cljs_test.cljs
@@ -67,6 +67,7 @@
 (defn- container [] (js/document.createElement "div"))
 
 (def ^:private Activity react/Activity)
+(def ^:private StrictMode react/StrictMode)
 
 (defview leaf [_] [:span.leaf (str (sub [:ract/n]))])
 
@@ -191,3 +192,79 @@
                       "proven :activity-hidden {:proof :reconnect} — the registry never killed it"))
                 (react-dom/flushSync #(ui/unmount! root))
                 (done))))))))))
+
+;; ===========================================================================
+;; rf2-vxgfnd.164 — TWO REAL COMMITS IN ONE SYNCHRONOUS STACK are honestly
+;; :unknown. A microtask separates JavaScript checkpoints, NOT React commits, so
+;; the existing reveal fixture above (which yields a microtask between hide and
+;; reveal, letting the settle fire → :activity-hidden) cannot expose the
+;; ambiguity. Here the two commits are CONSECUTIVE — the reconnect beats the
+;; settle exactly as a StrictMode replay would, so no exact discriminator exists
+;; and the honest floor is :unknown, never a fabricated Activity-hide proof.
+;; ===========================================================================
+
+(deftest consecutive-flushsync-hide-reveal-is-honestly-unknown
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:ract/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [frame-provider {:frame frame-kw} [act-app {}]]
+                             c {:root-id :ract/root}))
+            cell (leaf-cell)]
+        (async done
+          (is (= "7" (.-textContent (.querySelector c ".leaf"))) "leaf mounted visible")
+          ;; commit 1 — HIDE (the proven dispatch → microtask → flushSync path):
+          ;; the reactive flush notifies React on its microtask, and flushSync
+          ;; commits the mode flip, firing the leaf's cleanup → disconnect! (which
+          ;; arms the settle microtask).
+          (rf/dispatch-sync [:ract/hide] {:frame frame-kw})
+          (js/queueMicrotask
+           (fn []
+             (react-dom/flushSync (fn []))
+             (is (= :disconnected (reactive/lifecycle cell))
+                 "the hide fired the leaf's cleanup — disconnected, settle armed")
+             ;; commit 2 — REVEAL, CONSECUTIVE in the SAME synchronous stack. No
+             ;; microtask yield: `flush-pending!` makes the notification synchronous
+             ;; and flushSync commits it BEFORE the settle microtask (armed at
+             ;; commit 1) has run.
+             (rf/dispatch-sync [:ract/show] {:frame frame-kw})
+             (reactive/flush-pending!)
+             (react-dom/flushSync (fn []))
+             (is (= :connected (reactive/lifecycle cell)) "the reveal reconnected")
+             ;; let the (now too-late) settle microtask run, then read the evidence.
+             (js/queueMicrotask
+              (fn []
+                (testing "consecutive commits are indistinguishable from a replay — honestly :unknown"
+                  (is (= :unknown (:reason (peek (reactive/intervals cell))))
+                      "the unsettled reconnect stays :unknown — no Activity hide fabricated
+                       for two real commits in one stack (rf2-vxgfnd.164)")
+                  (is (not-any? #(= :activity-hidden (:reason %)) (reactive/intervals cell))
+                      "no interval carries a fabricated :activity-hidden proof"))
+                (react-dom/flushSync #(ui/unmount! root))
+                (done))))))))))
+
+(deftest strictmode-replay-control-stays-unannotated
+  ;; The control (rf2-vxgfnd.164 AC2): a REAL React StrictMode dev double-invoke of
+  ;; the leaf's layout effect (setup→cleanup→setup within one mount commit) is a
+  ;; reconnect that also beats the settle. It must remain UNANNOTATED — same honest
+  ;; :unknown floor as the consecutive-commits case; the host cannot tell them
+  ;; apart, and NO :activity-hidden fact is fabricated.
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (do
+      (register-app!)
+      (rf/dispatch-sync [:ract/seed] {:frame frame-kw})
+      (let [c    (container)
+            root (react-dom/flushSync
+                  #(ui/mount [StrictMode {} [frame-provider {:frame frame-kw} [leaf {}]]]
+                             c {:root-id :ract/root}))
+            cell (leaf-cell)]
+        (is (= "7" (.-textContent (.querySelector c ".leaf"))) "leaf mounted under StrictMode")
+        (is (= :connected (reactive/lifecycle cell))
+            "after the dev double-invoke the leaf is connected")
+        (is (not-any? #(= :activity-hidden (:reason %)) (reactive/intervals cell))
+            "the StrictMode replay disconnect (if any) is NOT annotated an Activity hide")
+        (react-dom/flushSync #(ui/unmount! root))))))


### PR DESCRIPTION
Cluster of four reactive-substrate timing/lifecycle beads under the re-frame.ui EPIC (rf2-vxgfnd). All changes are confined to the ui substrate and its own reactive tests; PR #6001's six files, `observation.cljc`, `machines/test/`, `spec/*`, and `docs/api/` are untouched.

## What changed, per bead

**rf2-vxgfnd.163 (P3, test) — act-discipline the reactive reincarnation DOM fixture.**
The fixture mounted/rerendered/unmounted through raw `react-dom/flushSync` with no React `act` boundary, emitting three "not wrapped in act(...)" warnings the browser runner buffers but never fails on. Now mount, corrective rerender, and unmount run inside React's native `act()` (the `get-act`/`act!` pattern; `IS_REACT_ACT_ENVIRONMENT` enabled and restored per test), the corrective `flushSync` stays nested inside `act`, and the before-paint DOM value `"2"` is recorded synchronously inside the callback. A bounded namespace-local console-error capture counts the act warning while forwarding every line to the original console, so removing the act boundary turns the fixture red; a detector unit test pins the classifier on React's wording.

**rf2-vxgfnd.172 (P3, bug) — preserve falsy CLJS listener escapes.**
`notify-listeners!` tracked escape presence with `(or acc e)` + `some?`. In CLJS a listener may throw a falsy value: a thrown `null` was silently lost, and a first thrown `false` was overwritten by a later truthy escape — both violating the first-escape order/identity contract. Presence is now a truthy wrapper `{:escaped? true :error e}` (allocated only when a listener throws), rethrown by identity. JVM behaviour is unchanged.

**rf2-vxgfnd.169 (P2, bug) — prune empty root-incarnation entries after weak collection.**
Weak compaction dropped dead member refs but never removed the now-empty outer incarnation entry on the JVM: `weak-live`, `weak-live-count`, and `root-cell-count[]` skipped `drop-root-entry-if-empty!` in their `:clj` branches. Registry metadata therefore grew monotonically per root generation. Compaction is now incarnation-aware on both hosts — every ownership read that observes an empty membership set drops the outer entry through the existing identity/race guard, and a late finalizer after synchronous removal stays harmless.

**rf2-vxgfnd.164 (P3, bug) — stop treating a microtask checkpoint as exact React commit identity.**
The provisional-disconnect heuristic is honest in behaviour (an unsettled reconnect stays `:unknown`) but the prose claimed the flag identifies an exact React commit and uniquely identifies StrictMode, and that every genuine reveal arrives in a later task. Those claims are false: two real commits can complete in one synchronous stack (`flushSync(hide); flushSync(reveal)`) before the settle microtask runs — a microtask separates JavaScript checkpoints, not React commits. The source prose (provisional field doc, lifecycle-facts block, `settle-disconnect!`, `arm-disconnect-settle!`, `connect!`, the `disconnect*` guard) now calls a pre-settle reconnect unsettled/same-checkpoint evidence the host does not further discriminate — a StrictMode replay OR consecutive synchronous commits — so `:unknown` is the honest floor; the settled path still proves `:activity-hidden {:proof :reconnect}`. This aligns with the host-checkpoint contract owned by rf2-vxgfnd.166; it does not redefine it. No runtime behaviour changed.

## Failing-then-passing proof

**rf2-vxgfnd.169 (JVM, GC/weak-collection — the actual failure):**
`clojure -M:test -n re-frame.ui.reactive-root-retention-cljs-test`
- Pre-fix: `all-members-collected-drops-the-empty-incarnation-entry` FAILS — the global tracked count stayed `1` after the sole cell was collected: `actual: (not (= 0 1))`.
- Post-fix: PASS (global count returns to baseline; per-incarnation live count `0`).

**rf2-vxgfnd.172 (node, falsy throw):**
- Pre-fix: `throw-null-is-rethrown-after-all-listeners-deliver` and `first-false-escape-is-preserved-over-a-later-error` FAIL (`throw null` swallowed; `[:threw false]` vs the later Error).
- Post-fix: PASS.

**rf2-vxgfnd.164:** the runtime was already ownership-correct (unsettled reconnect → `:unknown`), so there is no behavioural failing-before — the defect was false observability prose. The new headless `consecutive-commits-without-a-yield-are-honestly-unknown` test is the genuine microtask-vs-commit interleaving (not a proxy): it drives disconnect→reconnect with no settle and pins `:unknown`, with a delayed-reveal control still proving `:activity-hidden`. The prose is corrected and a real-browser consecutive-`flushSync` fixture plus a StrictMode double-invoke control are added for CI.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| JVM ui suite | `clojure -M:test` (in `implementation/ui`) | **617 tests, 12712 assertions, 0 failures, 0 errors** |
| Node ui suite | `npx shadow-cljs compile node-test-ui && node out/node-test-ui.js` (in `implementation`) | **613 tests, 3126 assertions, 0 failures, 0 errors** (compile: 269 files, 0 warnings) |

Both focused `implementation/ui` suites (the transitive gate for `reactive.cljc`) are green. `npm run test:browser` was NOT run locally — CI owns the browser suite per the dispatch. The new `-dom-cljs-test` fixtures (.163 act-warning hygiene; .164 consecutive-`flushSync` + StrictMode control) compile clean in the node build and load their node no-op bodies; CI's `:browser-test` page exercises the DOM bodies.
