### PR TITLE
docs: sweep residual data-loop language to event pipeline (rf2-z3juq2)

### DIFF
--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -242,7 +242,7 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 
 - [`re-frame.core`](re-frame.core.md) — events, subs, frames (`make-frame`,
   `capture-frame`), boot (`init!`)
-- [Introduction](../core/introduction.md) — the pure dataflow loop this substrate
+- [Introduction](../core/introduction.md) — the pure event pipeline this substrate
   plugs into
 - Substrate design / UI guide under the synthesis suite (force-tracked findings) when
   reader-facing `docs/ui/` is not yet landed

--- a/examples/core/counter/README.md
+++ b/examples/core/counter/README.md
@@ -99,7 +99,7 @@ tool like Xray live in its own frame beside yours. The counter just
 uses exactly one.
 
 Everything else is left out on purpose: no schemas, no machines, no
-HTTP, no routing. Just the dataflow loop and the frame it runs in.
+HTTP, no routing. Just the event pipeline and the frame it runs in.
 
 ## Files
 

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -3,8 +3,8 @@
 
      [ documents list ]  [ markdown editor ]  [ live preview ]
 
-   The counter shows the dataflow loop with nothing in the way. This is
-   that same loop with more parts, and the lesson is that it doesn't
+   The counter shows the event pipeline with nothing in the way. This is
+   that same pipeline with more parts, and the lesson is that it doesn't
    change shape: one app-db holds the state, events are the only thing
    that change it, and the views are pure functions of subscriptions.
    Counter to multi-pane editor, same idea throughout.

--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -41,7 +41,7 @@ This is the re-frame2 sibling of v1 [`re-frame-pair`](https://github.com/day8/re
 
 re-frame is a reactive dataflow system — a DAG of derived values rooted in mutable state. `app-db` is the single source of truth; events are the only legal writes; subscriptions recompute as derived values; views re-render when their subs change. A coding agent that only edits `.cljs` files works against the static shape of that system and has no view of its dynamics at runtime.
 
-re-frame2-pair inverts this. It operates on the live browser runtime *and* on source files — but deliberately, with a protocol: REPL changes are ephemeral probes; source edits are committed changes coordinated with shadow-cljs hot-reload (§4.5). Every read and write runs through re-frame2's own vocabulary, so the data loop, the trace stream, the assembled epoch records, and the user's own instincts about the app all see the same thing Claude sees.
+re-frame2-pair inverts this. It operates on the live browser runtime *and* on source files — but deliberately, with a protocol: REPL changes are ephemeral probes; source edits are committed changes coordinated with shadow-cljs hot-reload (§4.5). Every read and write runs through re-frame2's own vocabulary, so the event pipeline, the trace stream, the assembled epoch records, and the user's own instincts about the app all see the same thing Claude sees.
 
 ### Non-goals
 

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -545,7 +545,7 @@
    record a synthetic `:rf/epoch-record` with `:event-id
    :rf.epoch/db-replaced` so that `restore-epoch` can rewind past the
    injection. Use sparingly — prefer `dispatch` for any change you want
-   the data loop to see.
+   the event pipeline to see.
 
    The `tap>` emission default-elides both `:previous`
    and `:next` slots when the raw-state gate is OFF (the published-

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -274,7 +274,7 @@ All five failures have `:op-type :error` and `:recovery :no-recovery`. The close
     (rf/restore-epoch! :app/main (:epoch-id pre))))
 ```
 
-**What the injection surface is not.** It is **not** a substitute for `dispatch` — handlers, interceptors, fx, and the trace stream all stay quiet during a replace. Use it only when bypass-the-pipeline-run is *required* (the four use cases above); for any change you want the data loop to see, dispatch a real event. The synthetic epoch's empty `:sub-runs` / `:renders` / `:effects` projections are the visible signal that no pipeline run ran.
+**What the injection surface is not.** It is **not** a substitute for `dispatch` — handlers, interceptors, fx, and the trace stream all stay quiet during a replace. Use it only when bypass-the-pipeline-run is *required* (the four use cases above); for any change you want the event pipeline to see, dispatch a real event. The synthetic epoch's empty `:sub-runs` / `:renders` / `:effects` projections are the visible signal that no pipeline run ran.
 
 ## Surface behaviour against destroyed frames
 


### PR DESCRIPTION
Sweeps the residual retired **data loop** / **dataflow loop** spelling (event-traversal sense) to the ruled canonical vocabulary **event pipeline** (structure) per the glossary + `docs/core/AUTHORING.md`. Closes rf2-z3juq2.

The whole tracked repo was re-searched case-insensitively for `data loop`, `dataflow loop`, `data-flow loop`, `turn of the loop`, `event cascade` (plus compound variants). All six inventory surfaces were confirmed present and fixed; no additional data-loop/dataflow-loop teaching surfaces existed beyond the inventory.

## Files changed (before -> after)

| File:line | Before | After |
|---|---|---|
| `spec/Tool-Pair.md:277` | "for any change you want the **data loop** to see" | "...the **event pipeline** to see" |
| `docs/api/re-frame.ui.md:245` | "the pure **dataflow loop** this substrate plugs into" | "the pure **event pipeline** this substrate plugs into" |
| `skills/re-frame2-pair/docs/initial-spec.md:44` | "so the **data loop**, the trace stream, the assembled epoch records" | "so the **event pipeline**, the trace stream, ..." |
| `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs:548` (comment) | "prefer `dispatch` for any change you want the **data loop** to see." | "...the **event pipeline** to see." |
| `examples/core/counter/README.md:102` | "Just the **dataflow loop** and the frame it runs in." | "Just the **event pipeline** and the frame it runs in." |
| `examples/core/notebook/core.cljs:6-7` (ns docstring) | "shows the **dataflow loop** ... This is that same **loop** with more parts" | "shows the **event pipeline** ... This is that same **pipeline** with more parts" |

All six refer to the pipeline **structure**, so **event pipeline** (not *pipeline run*) is the correct sense. The `.cljs` edits are pure docstring/comment changes -- no code semantics touched.

## Deliberately left (with reasons)

- **`docs/core/glossary.md:170`, `spec/002-Frames.md:1739`, `spec/Conventions.md:617/650/657/665`** -- the *authoritative* surfaces that deliberately name "event cascade" / "the loop" / "turn of the loop" **while teaching** they are retired in favour of event pipeline / pipeline run. Rewriting them would delete the deprecation record (bead guard).
- **`docs/EP/EP-0002:276`, `EP-0027:8/135/137/302/305/389`, `EP-0029:845`** -- enhancement-proposal design records (never a rendered teaching surface -- not copied into the built site per `docs.yml`), excluded from the prior pipeline-vocab spec sweep (rf2-glw1bh -> rf2-n5hjmv swept `spec/` + `docs/api`, not `docs/EP`). EP-0027's "the loop" names a *specific superseded mechanism* (`:initial-events`'s predecessor), not the event-traversal structure. Out of scope for a residual data-loop sweep.
- **`implementation/machines/.../transition.cljc:3305/3454`, `implementation/core/test/.../react_shared_suite.cljs:1496`** -- `event cascade` are adjacent code identifiers (`[machine snapshot event cascade]` params; a `cascade-ev` var), machines-domain cascade -- preserved per the ruling.
- **`.beads/issues.jsonl`** -- historical tracker records, not a teaching surface; owned by the mayor loop.
- Legitimate `loop` uses left untouched: "dispatch loop"/"no cascade" (runtime comment), `data-loop-index` DOM attr note, `per-flow loop`, reduce/play `through the loop`, `loopback-binding`.
- `ai/findings/re-frame-ui-guide.html` -- local-only/gitignored; never entered the diff.

## Acceptance

`git grep -in "data loop\|dataflow loop\|data-flow loop"` on tracked files (excluding `.beads/`) is **clean**.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Doc-slug validator (self-test) | `python scripts/check_doc_slugs.py --self-test --verbose` | PASS -- 20/20 self-tests |
| Doc-slug validator (live) | `python scripts/check_doc_slugs.py --verbose` | PASS -- 518 files, no broken links |
| MkDocs strict build | `python -m mkdocs build --strict` (spec/ + migration/ staged) | PASS -- exit 0, ~18s |
| Pair-skill authoring drift | `python scripts/check_skill_pair_authoring_drift.py --self-test` / `--verbose` | PASS -- 4 files, no drift |
| Skill<->MCP drift | `python scripts/check_skill_mcp_drift.py --self-test` / `--verbose` | PASS -- no drift |
| Examples policy | notebook `core.cljs` edit is docstring-only | PASS -- no code/test change (examples are test-free) |
