### PR TITLE
test(ui): replace synthetic digest-carrier obligations with real Shadow host gates (rf2-vxgfnd.195)

### DIFF
--- a/implementation/.gitignore
+++ b/implementation/.gitignore
@@ -2,3 +2,4 @@
 .shadow-cljs/
 node_modules/
 out/
+target/

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -31,6 +31,7 @@
     "test:ui": "npm run test:ui-isolation && node out/node-test-ui.js",
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && shadow-cljs compile node-test-ui && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-digest-carrier": "node scripts/check-ui-digest-carrier.cjs",
+    "test:ui-final-schedule": "node scripts/check-ui-final-schedule.cjs",
     "test:ui-g1": "node scripts/run-ui-bench.cjs",
     "test:ui-g13": "node scripts/run-ui-g13.cjs",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",

--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -821,7 +821,18 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.stack || error.message || String(error));
-  process.exitCode = 1;
-});
+// rf2-vxgfnd.195 — the fifth real-host arm. Runs after the browser proof has
+// torn down its own Shadow daemon, so the two never contend. It drives its OWN
+// self-contained Shadow config (no browser) proving final-schedule
+// reconciliation: an inherited re-frame.ui hook running before a build-local
+// :compile-prepare hook that forces a viewless recompile, evicting the accepted
+// row in both sequential and parallel modes, and failing loud when the per-pass
+// schedule evidence is unavailable.
+const { run: runFinalSchedule } = require('./check-ui-final-schedule.cjs');
+
+main()
+  .then(runFinalSchedule)
+  .catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  });

--- a/implementation/scripts/check-ui-final-schedule.cjs
+++ b/implementation/scripts/check-ui-final-schedule.cjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+'use strict';
+
+// rf2-vxgfnd.195 — the FIFTH real-Shadow arm for final-schedule reconciliation,
+// replacing the synthetic JVM fixtures that fabricate build state and
+// :compiled-at stamps (compiler_digest_carrier_jvm_test.clj's
+// later-prepare-hook-forced-recompile / metadata-only / missing-provenance
+// arms). Those cannot prove Shadow hook deep-merge/order, an actual build-local
+// :compile-prepare hook, real sequential/parallel scheduling, output-marker
+// retention, or fail-loud behaviour.
+//
+// This gate drives ONE real Shadow 3.4.10 warm watch daemon per compile mode
+// through:
+//   1. cold accept — both app-a and app-b declare a view;
+//   2. a CONTROL warm pass — an unrelated viewless trigger edit; re-frame.ui
+//      sees app-a as an output-present cache hit and does NOT pre-touch it;
+//      both accepted rows and the whole-build digest are unchanged;
+//   3. a FORCED-EVICT warm pass — a build-local :compile-prepare hook (inherited
+//      re-frame.ui hook runs FIRST, this hook deep-merged AFTER) removes app-a's
+//      retained output and rewrites its source viewless, forcing Shadow to
+//      recompile app-a AFTER re-frame.ui observed the schedule. app-a was NOT
+//      pre-touched at prepare, so ONLY reconcile-final-schedule at :compile-
+//      finish (reading Shadow's advanced :compiled-at stamp) can evict it. The
+//      accepted row is evicted, the digest moves, and app-b (a true cache hit)
+//      stays byte-identical;
+//   4. a FAIL-LOUD pass — a build-local hook drops re-frame.ui's per-pass
+//      :pass-output provenance from the open scratch; reconciliation must FAIL
+//      the build rather than silently reconcile against an assumed-empty
+//      schedule.
+// Both the PARALLEL (:ui-final-schedule) and SEQUENTIAL
+// (:ui-final-schedule-seq, :parallel-build false) compile schedules are proven.
+//
+// TEETH (documented mutation/revert; run at development time, NOT committed —
+// build_hook.clj is production compiler code this test-only bead does not edit):
+//   * Delete the `(reconcile-final-schedule build-state)` call in
+//     re-frame.ui.compiler.build-hook/hook's :compile-finish branch → the
+//     FORCED-EVICT pass keeps app-a's ghost row (a-present stays true,
+//     view-count stays 2, digest unchanged) → this gate goes RED.
+//   * Make reconcile-final-schedule proceed silently when :pass-output is absent
+//     (drop the missing-pass-provenance throw) → the FAIL-LOUD pass SUCCEEDS
+//     instead of failing → this gate goes RED.
+// Both were exercised red-before-green during development.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  spawnHarnessProcess,
+  terminateProcessTree,
+} = require('./lib/local-browser-harness.cjs');
+
+const IMPL = path.join(__dirname, '..');
+const FIX = path.join(
+  IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'final_schedule',
+);
+const APP_A = path.join(FIX, 'app_a.cljs');
+const APP_B = path.join(FIX, 'app_b.cljs');
+const TRIGGER = path.join(FIX, 'trigger.cljs');
+const TARGET = path.join(IMPL, 'target', 'ui-final-schedule');
+const FORCE_MARKER = path.join(TARGET, 'force-recompile-app-a');
+const BLIND_MARKER = path.join(TARGET, 'blind-provenance');
+const TIMEOUT = 120000;
+
+const BUILDS = [
+  { id: 'ui-final-schedule', mode: 'parallel' },
+  { id: 'ui-final-schedule-seq', mode: 'sequential' },
+];
+
+function fail(message) {
+  throw new Error(`FAIL: ${message}`);
+}
+
+function observeFile(buildId) {
+  return path.join(TARGET, `observe-${buildId}.jsonl`);
+}
+
+function readRecords(buildId) {
+  const f = observeFile(buildId);
+  if (!fs.existsSync(f)) return [];
+  return fs.readFileSync(f, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+}
+
+function bool(line, key) {
+  const m = line.match(new RegExp(`:${key} (true|false)`));
+  return m ? m[1] === 'true' : null;
+}
+function num(line, key) {
+  const m = line.match(new RegExp(`:${key} (-?\\d+)`));
+  return m ? Number(m[1]) : null;
+}
+function str(line, key) {
+  const m = line.match(new RegExp(`:${key} "([^"]*)"`));
+  return m ? m[1] : null;
+}
+function bFp(line) {
+  // :b-fp is the LAST key; its value is a pr-str of app-b's [tf hs] vector,
+  // i.e. a Clojure string with escaped quotes. Capture it verbatim up to the
+  // record's closing brace, and compare the raw image across passes.
+  const m = line.match(/:b-fp (.+)\}\s*$/);
+  return m ? m[1] : null;
+}
+
+function lastOfStage(buildId, stage) {
+  const recs = readRecords(buildId).filter((l) => l.includes(`:stage :${stage}`));
+  return recs.length ? recs[recs.length - 1] : null;
+}
+function countStage(buildId, stage) {
+  return readRecords(buildId).filter((l) => l.includes(`:stage :${stage}`)).length;
+}
+
+function editTrigger(marker) {
+  const src = fs.readFileSync(TRIGGER, 'utf8');
+  const next = src.replace(/final-schedule-trigger-marker:\S+/,
+    `final-schedule-trigger-marker:${marker}`)
+    .replace(/\(def trigger :\S+\)/, `(def trigger :${marker})`);
+  if (next === src) fail(`trigger edit was a no-op for marker ${marker}`);
+  fs.writeFileSync(TRIGGER, next);
+}
+
+function watch(buildId) {
+  const child = spawnHarnessProcess(process.execPath, [
+    require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL] }),
+    'watch', buildId,
+  ], { cwd: FIX, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+
+  let successes = 0;
+  let failures = 0;
+  let transcript = '';
+  let buf = '';
+  const waiters = [];
+  function settle() {
+    for (let i = waiters.length - 1; i >= 0; i -= 1) {
+      const w = waiters[i];
+      const c = w.kind === 'success' ? successes : failures;
+      if (c > w.after) { clearTimeout(w.timer); waiters.splice(i, 1); w.resolve(c); }
+    }
+  }
+  function ingest(chunk) {
+    const t = chunk.toString();
+    transcript += t;
+    process.stdout.write(t);
+    const lines = (buf + t).split(/\r?\n/);
+    buf = lines.pop();
+    for (const l of lines) {
+      if (l.includes(`[:${buildId}] Build completed.`)) successes += 1;
+      if (l.includes(`[:${buildId}] Build failure:`)) failures += 1;
+    }
+    settle();
+  }
+  child.stdout.on('data', ingest);
+  child.stderr.on('data', ingest);
+  child.on('exit', (code, signal) => {
+    const err = new Error(
+      `shadow watch exited before proof completed (code=${code}, signal=${signal})`,
+    );
+    while (waiters.length) { const w = waiters.pop(); clearTimeout(w.timer); w.reject(err); }
+  });
+  function wait(kind, after) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(
+        `timed out waiting for ${buildId} ${kind} after count ${after}\n${transcript.slice(-3000)}`,
+      )), TIMEOUT);
+      waiters.push({ kind, after, resolve, reject, timer });
+      settle();
+    });
+  }
+  return {
+    child,
+    waitSuccess: (after) => wait('success', after),
+    waitFailure: (after) => wait('failure', after),
+    successCount: () => successes,
+    failureCount: () => failures,
+    transcript: () => transcript,
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Poll until the observe file has a NEW finish (or prepare) record beyond the
+// count captured before the pass, so a slow disk flush cannot race the assert.
+async function awaitRecord(buildId, stage, priorCount) {
+  for (let i = 0; i < 100; i += 1) {
+    if (countStage(buildId, stage) > priorCount) return;
+    await sleep(50);
+  }
+  fail(`no new :${stage} observe record appeared for ${buildId}`);
+}
+
+async function driveBuild({ id, mode }) {
+  console.log(`\n=== ${id} (${mode} compile schedule) ===`);
+  fs.mkdirSync(TARGET, { recursive: true });
+  fs.rmSync(observeFile(id), { force: true });
+  fs.rmSync(FORCE_MARKER, { force: true });
+  fs.rmSync(BLIND_MARKER, { force: true });
+
+  const w = watch(id);
+  try {
+    // 1. Cold accept.
+    await w.waitSuccess(0);
+    await awaitRecord(id, 'finish', 0);
+    const cold = lastOfStage(id, 'finish');
+    if (!(bool(cold, 'a-present') && bool(cold, 'b-present') && num(cold, 'view-count') === 2)) {
+      fail(`${id}: cold accept did not declare both views (${cold})`);
+    }
+    const digest0 = str(cold, 'digest');
+    const bFp0 = bFp(cold);
+    if (!/^bd1-[0-9a-f]{16}$/.test(digest0)) fail(`${id}: cold digest invalid (${digest0})`);
+    console.log(`  cold accept: both views, digest ${digest0}`);
+
+    // 2. CONTROL warm pass — viewless trigger edit, no markers.
+    let sc = w.successCount();
+    let fc = countStage(id, 'finish');
+    editTrigger('control');
+    await w.waitSuccess(sc);
+    await awaitRecord(id, 'finish', fc);
+    const ctlPrep = lastOfStage(id, 'prepare');
+    const ctlFin = lastOfStage(id, 'finish');
+    if (bool(ctlPrep, 'app-a-output-present') !== true) {
+      fail(`${id}: control — app-a was not an output-present cache hit (${ctlPrep})`);
+    }
+    if (bool(ctlPrep, 'app-a-pretouched') !== false) {
+      fail(`${id}: control — re-frame.ui pre-touched a cache-hit source (${ctlPrep})`);
+    }
+    if (!(bool(ctlFin, 'a-present') && bool(ctlFin, 'b-present') && num(ctlFin, 'view-count') === 2)) {
+      fail(`${id}: control pass lost a view (${ctlFin})`);
+    }
+    if (str(ctlFin, 'digest') !== digest0) {
+      fail(`${id}: viewless trigger edit moved the digest (${str(ctlFin, 'digest')} != ${digest0})`);
+    }
+    console.log('  control warm pass: both views survive, digest stable, app-a not pre-touched');
+
+    // 3. FORCED-EVICT warm pass — build-local hook forces a viewless recompile.
+    fs.writeFileSync(FORCE_MARKER, 'x');
+    sc = w.successCount();
+    fc = countStage(id, 'finish');
+    editTrigger('force');
+    await w.waitSuccess(sc);
+    await awaitRecord(id, 'finish', fc);
+    const forcePrep = lastOfStage(id, 'prepare');
+    const forceFin = lastOfStage(id, 'finish');
+    if (bool(forcePrep, 'app-a-output-present') !== true) {
+      fail(`${id}: forced-evict — app-a was not output-present at re-frame.ui prepare (${forcePrep})`);
+    }
+    // The load-bearing proof: app-a is NOT pre-touched at prepare, so the ONLY
+    // mechanism that can evict it is final-schedule reconciliation at finish.
+    if (bool(forcePrep, 'app-a-pretouched') !== false) {
+      fail(`${id}: forced-evict — app-a was pre-touched at prepare; reconcile would be moot (${forcePrep})`);
+    }
+    if (bool(forceFin, 'a-present') !== false) {
+      fail(`${id}: forced-evict — app-a's ghost view survived (reconcile-final-schedule did not evict it) (${forceFin})`);
+    }
+    if (bool(forceFin, 'b-present') !== true || num(forceFin, 'view-count') !== 1) {
+      fail(`${id}: forced-evict — expected exactly app-b to remain (${forceFin})`);
+    }
+    const digest1 = str(forceFin, 'digest');
+    if (digest1 === digest0) {
+      fail(`${id}: forced-evict — evicting app-a did not change the whole-build digest (${digest1})`);
+    }
+    if (!/^bd1-[0-9a-f]{16}$/.test(digest1)) fail(`${id}: forced-evict digest invalid (${digest1})`);
+    if (bFp(forceFin) !== bFp0) {
+      fail(`${id}: forced-evict — app-b's cache-hit row was not byte-identical (${bFp(forceFin)} != ${bFp0})`);
+    }
+    console.log(`  forced-evict pass: app-a evicted via reconcile, app-b byte-identical, digest ${digest0} -> ${digest1}`);
+    fs.rmSync(FORCE_MARKER, { force: true });
+
+    // 4. FAIL-LOUD pass — build-local hook destroys per-pass provenance.
+    fs.writeFileSync(BLIND_MARKER, 'x');
+    const failBefore = w.failureCount();
+    const finBefore = countStage(id, 'finish');
+    editTrigger('blind');
+    await w.waitFailure(failBefore);
+    await sleep(300);
+    const tx = w.transcript();
+    if (!/refusing to reconcile against an assumed-empty compile schedule/.test(tx) &&
+        !/missing-pass-provenance/.test(tx)) {
+      fail(`${id}: fail-loud — build failed but not with the missing-provenance diagnostic\n${tx.slice(-1500)}`);
+    }
+    if (countStage(id, 'finish') !== finBefore) {
+      fail(`${id}: fail-loud — a candidate was finalized despite unavailable schedule evidence`);
+    }
+    console.log('  fail-loud pass: unavailable schedule evidence failed the build before publication');
+    fs.rmSync(BLIND_MARKER, { force: true });
+
+    console.log(`  PASS ${id}`);
+  } finally {
+    fs.writeFileSync(TRIGGER, triggerOriginal);
+    fs.rmSync(FORCE_MARKER, { force: true });
+    fs.rmSync(BLIND_MARKER, { force: true });
+    await terminateProcessTree(w.child, { timeoutMs: 5000 });
+  }
+}
+
+let triggerOriginal;
+
+async function run() {
+  const appAOriginal = fs.readFileSync(APP_A, 'utf8');
+  const appBOriginal = fs.readFileSync(APP_B, 'utf8');
+  triggerOriginal = fs.readFileSync(TRIGGER, 'utf8');
+  if (!/final-schedule-trigger-marker:v1/.test(triggerOriginal)) {
+    fail('trigger fixture is not at its checked-in v1 marker');
+  }
+  // Fresh slate: a prior run's cache/output/markers must not mask a regression.
+  fs.rmSync(TARGET, { recursive: true, force: true });
+  fs.rmSync(path.join(IMPL, 'out', 'ui-final-schedule'), { recursive: true, force: true });
+  fs.rmSync(path.join(IMPL, 'out', 'ui-final-schedule-seq'), { recursive: true, force: true });
+  try {
+    for (const build of BUILDS) {
+      await driveBuild(build);
+    }
+    console.log('\nui final-schedule reconciliation: PASS (parallel + sequential)');
+  } finally {
+    fs.writeFileSync(APP_A, appAOriginal);
+    fs.writeFileSync(APP_B, appBOriginal);
+    fs.writeFileSync(TRIGGER, triggerOriginal);
+  }
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/app_a.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/app_a.cljs
@@ -1,0 +1,9 @@
+(ns re-frame.ui.digest-probe.final-schedule.app-a
+  "Fixture source A. The runner rewrites the single marker below to REMOVE this
+  source's final ui/defview between warm passes; the build-local hook then forces
+  A to recompile after re-frame.ui observed the schedule."
+  (:require [re-frame.ui :as ui]))
+
+;; final-schedule-app-a-marker:present
+(ui/defview a-view []
+  [:div "app-a-view-v1"])

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/app_b.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/app_b.cljs
@@ -1,0 +1,9 @@
+(ns re-frame.ui.digest-probe.final-schedule.app-b
+  "Fixture source B. A stable cache-hit sibling whose accepted view must survive
+  A's forced recompile. The runner rewrites B's marker only to TRIGGER a warm
+  pass without touching A on disk."
+  (:require [re-frame.ui :as ui]))
+
+;; final-schedule-app-b-marker:v1
+(ui/defview b-view []
+  [:div "app-b-view-v1"])

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/client.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/client.cljs
@@ -1,0 +1,9 @@
+(ns re-frame.ui.digest-probe.final-schedule.client
+  "The UI-client entry that pulls the compiler-owned digest carrier and both
+  fixture views into ONE real Shadow build graph, so `ui-client-build?` holds and
+  re-frame.ui projects a whole-build digest across A's and B's accepted rows."
+  (:require [re-frame.ui.client]
+            [re-frame.ui.digest-carrier]
+            [re-frame.ui.digest-probe.final-schedule.app-a]
+            [re-frame.ui.digest-probe.final-schedule.app-b]
+            [re-frame.ui.digest-probe.final-schedule.trigger]))

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
@@ -1,0 +1,109 @@
+(ns re-frame.ui.digest-probe.final-schedule.hook
+  "Test-only build-local hook for the final-schedule reconciliation fixture
+  (rf2-vxgfnd.195).
+
+  This hook is deep-merged AFTER the inherited re-frame.ui compile hook (the one
+  configured in :build-defaults), so at every stage Shadow runs re-frame.ui's
+  hook first and this one second — the real deep-merge/order the production
+  `reconcile-final-schedule` defends against, proven by config rather than by a
+  hand-built build-state.
+
+  Its behaviour at :compile-prepare is driven by runner-controlled marker files,
+  so one warm Shadow watch daemon can be walked through several passes with no
+  config edits:
+
+    force-recompile-app-a — model a later prepare hook that MUTATES build state:
+      remove app-a's retained output (so Shadow reschedules it to compile AFTER
+      re-frame.ui already observed the schedule) and rewrite its in-memory source
+      to a VIEWLESS namespace (its final ui/defview removed). re-frame.ui saw
+      app-a as an output-present cache hit and did NOT pre-touch it; only
+      `reconcile-final-schedule` at :compile-finish — reading Shadow's advanced
+      per-source :compiled-at stamp — can evict its now-absent accepted view.
+
+    blind-provenance — model a hook that destroys the per-pass compile-schedule
+      evidence: drop re-frame.ui's :pass-output snapshot from the open scratch.
+      `reconcile-final-schedule` must then FAIL LOUD at :compile-finish rather
+      than silently reconcile against an assumed-empty schedule.
+
+  The :compile-finish arm records the accepted snapshot Shadow retained (version,
+  digest, full accepted view aggregate) plus a prepare-time observation of
+  whether re-frame.ui pre-touched app-a — the evidence the runner uses to prove
+  the eviction came from FINAL-schedule reconciliation, not the prepare-time
+  pre-touch. Pure JVM dev-build tooling; never part of any CLJS bundle."
+  (:require [clojure.java.io :as io]
+            [re-frame.ui.compiler.build :as build]))
+
+;; Shadow runs with CWD = this fixture directory (the runner spawns it there),
+;; so climb back to implementation/target — the same gitignored tree the
+;; :cache-root uses — rather than littering target under the test source tree.
+(def ^:private out-dir
+  (io/file "../../../../../../target" "ui-final-schedule"))
+(def ^:private force-marker (io/file out-dir "force-recompile-app-a"))
+(def ^:private blind-marker (io/file out-dir "blind-provenance"))
+
+(def ^:private app-a-ns 're-frame.ui.digest-probe.final-schedule.app-a)
+(def ^:private a-view-id :re-frame.ui.digest-probe.final-schedule.app-a/a-view)
+(def ^:private b-view-id :re-frame.ui.digest-probe.final-schedule.app-b/b-view)
+
+(defn- app-a-rid [{:keys [build-sources sources]}]
+  (some (fn [rid] (when (= app-a-ns (get-in sources [rid :ns])) rid))
+        build-sources))
+
+(defn- observe-file [build-id]
+  (io/file out-dir (str "observe-" (name build-id) ".jsonl")))
+
+(defn- record! [build-id m]
+  (let [f (observe-file build-id)]
+    (io/make-parents f)
+    (spit f (str (pr-str (assoc m :build-id (name build-id))) "\n") :append true)))
+
+(defn hook
+  {:shadow.build/stages #{:compile-prepare :compile-finish}}
+  [{build-id :shadow.build/build-id
+    stage    :shadow.build/stage
+    :as      build-state}]
+  (case stage
+    :compile-prepare
+    (let [rid     (app-a-rid build-state)
+          scratch (get-in build-state [:compiler-env build/scratch-key])
+          touched (:touched scratch)
+          force?  (.exists force-marker)
+          blind?  (.exists blind-marker)]
+      (record! build-id
+               {:stage :prepare
+                :app-a-output-present (some? (get-in build-state [:output rid]))
+                :app-a-pretouched (boolean (contains? (set touched) app-a-ns))
+                :force force?
+                :blind blind?})
+      (cond-> build-state
+        ;; A later prepare hook forcing a viewless recompile of an output-present
+        ;; cache-hit source: remove its output AND remove its final ui/defview.
+        (and rid force?)
+        (-> (update :output dissoc rid)
+            (assoc-in [:sources rid :source]
+                      (str "(ns " app-a-ns
+                           " (:require [re-frame.ui :as ui]))\n"
+                           ";; final-schedule fixture: viewless forced recompile\n")))
+
+        ;; A later hook that destroys the per-pass provenance re-frame.ui needs to
+        ;; reconcile: drop the :pass-output snapshot from the open scratch.
+        (and blind? scratch)
+        (update-in [:compiler-env build/scratch-key] dissoc :pass-output)))
+
+    :compile-finish
+    (let [snap  (build/accepted-snapshot build-state)
+          views (build/accepted-aggregate build/views build-state)]
+      (record! build-id
+               {:stage :finish
+                :version (:version snap)
+                :digest (:digest snap)
+                :view-count (count views)
+                :a-present (contains? views a-view-id)
+                :b-present (contains? views b-view-id)
+                ;; A stable string image of app-b's accepted row, so the runner
+                ;; can prove the cache-hit sibling stayed byte-identical (output
+                ;; marker retained) across app-a's forced recompile.
+                :b-fp (pr-str (get views b-view-id))})
+      build-state)
+
+    build-state))

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
@@ -1,0 +1,50 @@
+;; Real Shadow 3.4.10 fixture for final-schedule reconciliation (rf2-vxgfnd.195).
+;;
+;; A genuine UI client build whose INHERITED re-frame.ui compile hook (configured
+;; in :build-defaults, so Shadow deep-merges it FIRST) runs before a build-local
+;; :compile-prepare hook (this build's own :build-hooks, deep-merged AFTER). The
+;; build-local hook forces a source to recompile after re-frame.ui already
+;; observed the compile schedule at :compile-prepare — the exact deep-merge/order
+;; gap `reconcile-final-schedule` closes at :compile-finish.
+;;
+;; Kept independent of implementation/shadow-cljs.edn on purpose: its defining
+;; property is a REAL, inherited build-default hook running before a real
+;; build-local hook, proved by config rather than by a hand-built build-state.
+{:source-paths ["../../../../../../core/src"
+                "../../../../../src"
+                "../../../.."]
+ :cache-root "../../../../../../target/ui-final-schedule/shadow-cache"
+ :cache-blockers #{re-frame.ui}
+ :js-options {:js-package-dirs ["../../../../../../node_modules"]}
+ ;; The production compile hook is inherited here EXACTLY as real consumer builds
+ ;; inherit it — from :build-defaults — so Shadow deep-merges it ahead of this
+ ;; build's own :build-hooks.
+ :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
+ :builds
+ {;; PARALLEL compile schedule (Shadow's default: executor present, parallel
+  ;; build). re-frame.ui's prepare pre-touch keys cache-hit detection on
+  ;; (map? prior-output) in this branch.
+  :ui-final-schedule
+  {:target :browser
+   :output-dir "../../../../../../out/ui-final-schedule"
+   :asset-path "."
+   :modules
+   {:main {:entries [re-frame.ui.digest-probe.final-schedule.client]}}
+   ;; Deep-merged AFTER the inherited re-frame.ui compile hook: this build-local
+   ;; :compile-prepare hook forces app-a to recompile once re-frame.ui has
+   ;; already observed the schedule, and its :compile-finish arm records the
+   ;; accepted snapshot Shadow retained.
+   :build-hooks [(re-frame.ui.digest-probe.final-schedule.hook/hook)]}
+
+  ;; SEQUENTIAL compile schedule (:parallel-build false). re-frame.ui's prepare
+  ;; pre-touch takes its (nil? prior-output)/warnings branch here. The
+  ;; final-schedule reconciliation, keyed on Shadow's authoritative :compiled-at
+  ;; stamp, must evict identically in both modes.
+  :ui-final-schedule-seq
+  {:target :browser
+   :output-dir "../../../../../../out/ui-final-schedule-seq"
+   :asset-path "."
+   :compiler-options {:parallel-build false}
+   :modules
+   {:main {:entries [re-frame.ui.digest-probe.final-schedule.client]}}
+   :build-hooks [(re-frame.ui.digest-probe.final-schedule.hook/hook)]}}}

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/trigger.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/trigger.cljs
@@ -1,0 +1,9 @@
+(ns re-frame.ui.digest-probe.final-schedule.trigger
+  "A VIEWLESS source the runner rewrites to trigger a warm watch pass WITHOUT
+  editing app-a or app-b on disk. Because it declares no ui/defview, editing it
+  moves nothing in the accepted view aggregate, so any digest change observed
+  across the forced-recompile pass is attributable solely to app-a's eviction —
+  never to a fingerprint change in an edited view source.")
+
+;; final-schedule-trigger-marker:v1
+(def trigger :v1)


### PR DESCRIPTION
Adds the **fifth real-Shadow arm** for final-schedule reconciliation (rf2-vxgfnd.195 NOTES / PR #5864 audit expansion). The merged JVM fixtures in `compiler_digest_carrier_jvm_test.clj` (`later-prepare-hook-forced-recompile`, `metadata-only-output-mutation`, `missing-per-pass-provenance`) fabricate build state and `:compiled-at` stamps, so they cannot prove Shadow hook deep-merge/order, an actual build-local `:compile-prepare` hook, real sequential/parallel scheduling, output-marker retention, or fail-loud behaviour. Those synthetic arms are kept as the narrower unit layer; this PR layers a real-host integration falsifier on top of them.

### What is now real

A new **self-contained** Shadow fixture (`implementation/ui/test/re_frame/ui/digest_probe/final_schedule/`) — so **no top-level `shadow-cljs.edn` change**. A genuine UI-client build whose **inherited** `re-frame.ui` compile hook (in `:build-defaults`, deep-merged FIRST) runs before a **build-local** `:compile-prepare` hook (deep-merged AFTER). One warm Shadow 3.4.10 watch daemon per compile mode is driven through:

1. **cold accept** — `app-a` and `app-b` each declare a view;
2. **control warm pass** — a viewless trigger edit; `re-frame.ui` sees `app-a` as an output-present cache hit and does **not** pre-touch it; both rows + digest unchanged;
3. **forced-evict warm pass** — the build-local hook removes `app-a`'s retained output and rewrites its source viewless, forcing Shadow to recompile `app-a` **after** `re-frame.ui` observed the schedule. Because `app-a` is **not pre-touched at prepare**, only `reconcile-final-schedule` at `:compile-finish` (keyed on Shadow's advanced `:compiled-at` stamp) can evict it. The accepted row is evicted, the whole-build digest moves, and `app-b` (a true cache hit) stays **byte-identical**;
4. **fail-loud pass** — the build-local hook drops `re-frame.ui`'s per-pass `:pass-output` provenance; reconciliation **fails the build** with `missing-pass-provenance` rather than silently reconciling against an assumed-empty schedule.

Proven in **both** parallel (`:ui-final-schedule`) and sequential (`:ui-final-schedule-seq`, `:parallel-build false`) compile schedules.

This closes the synthetic gaps the NOTES enumerate: **deep-merge/order** (config-proven, not hand-built state), an **actual build-local `:compile-prepare` hook**, **real scheduling** (both modes), **output-marker retention** (`app-b` byte-identical), and **fail-loud** on unavailable schedule evidence.

### Teeth (red-before-green)

`build_hook.clj` is production compiler code and is **not** modified in this PR. The teeth were exercised at development time via a documented mutation/revert:

- Deleting the `(reconcile-final-schedule build-state)` call → the forced-evict pass keeps `app-a`'s ghost row (`a-present` stays true, `view-count` 2, digest unchanged) → **RED** (assertion fails, exit 1).
- Dropping the `missing-pass-provenance` throw → the fail-loud pass reports `Build completed` instead of `Build failure` → the gate can no longer observe the required failure → **RED**.

The narrower synthetic JVM unit tests remain green throughout.

### Wiring

`scripts/check-ui-final-schedule.cjs` is standalone-runnable (`npm run test:ui-final-schedule`) and is chained onto `check-ui-digest-carrier.cjs`, so it runs under the existing `ui_gates` CI step (no `.github/workflows/test.yml` change). `target/` added to `implementation/.gitignore` so the fixture's shadow-cache can never be committed.

### Scope note

This PR delivers the final-schedule reconciliation arm the bead NOTES prioritise. The four broader DESCRIPTION obligations (two-daemon warm-cache reconstruction, real REPL isolation, overlapping build lifecycles, advanced-browser elision consumer) are **not** in this PR and remain open work for follow-up.

## Quality gates

- `node scripts/check-ui-final-schedule.cjs` — **PASS** (parallel + sequential; cold accept -> control -> forced-evict -> fail-loud each mode).
- Teeth: reconcile-disabled and fail-loud-disabled each confirmed **RED** at dev time, then reverted (`build_hook.clj` pristine).
- `clojure -M:test` (JVM ui artefact) — **625 tests, 12771 assertions, 0 failures, 0 errors** (synthetic digest-carrier unit tests intact).
- `npm run test:script-policy` — **PASS** (spawn/teardown/changed-surfaces policies).
- No changes to `build_hook.clj`, `build.cljc`, top-level `shadow-cljs.edn`, or `.github/workflows/*`.
