### PR TITLE
docs(core): correct app-db guide's intro counter initialization account (rf2-kacp4s)

### DIFF
--- a/docs/core/app-db.md
+++ b/docs/core/app-db.md
@@ -19,9 +19,10 @@ Almost everything else in re-frame2 stays simple *because* of that.
 
 ## A complete live counter
 
-The intro counter started at `0` via a fallback when `:value` was missing. Here we
-make the initial value **explicit**, then put a second fact — `:step-size` — in the
-same map. Still one store. Click the buttons (edit the cell and press
+The intro counter already seeded `:value 0` through its `:initialise` event; the
+`(:value db 0)` in its subscription was a defensive display fallback, not the
+initializer. Here we extend that same initial map with a second fact — `:step-size` —
+so both begin explicit in one store. Click the buttons (edit the cell and press
 **`Ctrl-Enter`** / **`Cmd-Enter`** if you change the code):
 
 ```cljs-rf2


### PR DESCRIPTION
Fixes rf2-kacp4s.

## Summary

The `docs/core/app-db.md` "A complete live counter" section opened by claiming the
introduction counter "started at `0` via a fallback when `:value` was missing," and
framed this page as the one that first makes the initial value explicit. That
contradicts `docs/core/introduction.md`, which already seeds `{:value 0}` through its
`:initialise` event mounted via `:initial-events [[:initialise]]`
(`introduction.md:18-19,33`, restated at `introduction.md:121`). The `(:value db 0)`
in the intro's subscription (`introduction.md:26`) is only a defensive display
fallback, not the initializer — the same shape the real example uses
(`examples/core/counter/core.cljs:32-33,112-114`, whose sub at line 42 has no
fallback at all).

The false claim landed at the exact page handoff the transition is meant to clarify.

## Change

Rewrite the opening transition (prose only) so it truthfully states the introduction
already seeded `:value 0` via `:initialise`, notes the subscription `0` was a
defensive display fallback rather than the initializer, and frames this page as
extending that same initial map with a second fact, `:step-size`. The progressive
counter example, the code cell, and all links are unchanged. This also aligns the
opening with the section's own later line ("Both facts begin in the initial map").

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (no new warnings; app-db.md clean)
