### PR TITLE
fix(xray): align stale-completion docs+fixtures with post-resolution authority checks (rf2-w82021)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -391,9 +391,14 @@ machines / timers:
   the machine `:rf.machine.timer/stale-after`, the HTTP-supersession
   `:rf.http/stale-suppressed`, and the `:spawn-all` join's two
   exact-authority stale rows `:rf.machine.spawn-all/stale-completion`
-  (PRE-resolution exact-authority suppression) +
-  `:rf.machine.spawn-all/late-completion` (POST-resolution `:resolved?`-latched
-  straggler) — rf2-waawic / rf2-azcmd3 / rf2-hj4skn; the suffix heuristic
+  (an authority-suppressed completion carrier — the exact-authority /
+  closed-attempt fold gate runs BEFORE the resolution classification, so this
+  op covers ownership/authority suppression on BOTH sides of resolution,
+  rf2-ixjd48) +
+  `:rf.machine.spawn-all/late-completion` (the POST-resolution
+  `:resolved?`-latched EXACT-CURRENT straggler — the only carrier that passes
+  authority yet still arrives after its own join resolved) — rf2-waawic /
+  rf2-azcmd3 / rf2-hj4skn; the suffix heuristic
   catches `stale-suppress` / `suppressed` but NOT `stale-after`, and NOT the
   spawn-all `*-completion` names (which end in `-completion`, not
   `-completed`), so those ops are enumerated explicitly. The NON-DECISIVE

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -451,15 +451,21 @@
    :rf.route.nav-token/stale-suppressed    :stale-suppressed
    :rf.machine.timer/stale-after           :stale-suppressed
    :rf.http/stale-suppressed               :stale-suppressed
-   ;; rf2-hj4skn — the `:spawn-all` join's TWO exact-authority stale rows
-   ;; (005 §`:spawn-all` join-child completion / 009 §op-type vocabulary):
-   ;;   - `:rf.machine.spawn-all/stale-completion` — the PRE-resolution
-   ;;     exact-authority suppression: a completion carrier that failed the
-   ;;     fold gate (`:rf.reply/stale-reason` one of
-   ;;     `:rf.machine.spawn-all/attempt-unverified` /
+   ;; rf2-hj4skn / rf2-ixjd48 — the `:spawn-all` join's TWO exact-authority
+   ;; stale rows (005 §`:spawn-all` join-child completion / 009 §op-type
+   ;; vocabulary). The producer runs the exact-authority / closed-attempt fold
+   ;; gate BEFORE the resolved-vs-unresolved classification (join.cljc), so the
+   ;; two ops split on AUTHORITY, not on resolution state:
+   ;;   - `:rf.machine.spawn-all/stale-completion` — an AUTHORITY-SUPPRESSED
+   ;;     completion carrier that failed the fold gate, on EITHER side of
+   ;;     resolution (a post-resolution unstamped/superseded carrier is
+   ;;     suppressed HERE, never as a late-completion) (`:rf.reply/stale-reason`
+   ;;     one of `:rf.machine.spawn-all/attempt-unverified` /
    ;;     `.../attempt-superseded` / `.../duplicate-completion`);
    ;;   - `:rf.machine.spawn-all/late-completion` — the POST-resolution
-   ;;     `:resolved?`-latched straggler (`:rf.reply/stale-reason
+   ;;     `:resolved?`-latched straggler that is EXACT-CURRENT for its own
+   ;;     attempt (the only carrier that passes authority yet still arrives
+   ;;     after its own join resolved) (`:rf.reply/stale-reason
    ;;     :rf.machine.spawn-all/join-resolved`).
    ;; Both carry the canonical `:status :stale` / `:rf.reply/work-status
    ;; :suppressed` reply facts additively on the public `:child-id` / `:kind`

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_work_identity_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_work_identity_cljs_test.cljc
@@ -162,6 +162,73 @@
             (is (false? (:suppressed? arc-b))
                 "attempt A suppression never contaminates attempt B")))))))
 
+(deftest post-resolution-superseded-straggler-is-stale-completion-not-late
+  ;; rf2-ixjd48 / rf2-w82021 — THE POST-RESOLUTION AUTHORITY PATH, driven
+  ;; through the REAL producer (not a hand-authored trace). Attempt A's
+  ;; completion is held; the parent re-enters, attempt B is seeded and RESOLVES;
+  ;; THEN A's exact carrier drains against B's already-resolved join. The
+  ;; producer runs the exact-authority gate BEFORE the `:resolved?` branch
+  ;; (join.cljc), so A is classified `:attempt-superseded` `stale-completion` —
+  ;; NOT a `join-resolved` late-completion. This pins the behaviour the bead
+  ;; found the Xray docs/fixtures had framed as pre-resolution-only: authority
+  ;; suppression fires on the POST-resolution path too, and the Xray consumer
+  ;; must see an authority-suppression arc for attempt A, never a late-completion
+  ;; terminal.
+  (testing "a superseded straggler arriving AFTER the successor join resolved is
+            a stale-completion (:attempt-superseded), and NO late-completion fires"
+    (register-machines!)
+    (with-trace-recorder!
+      [traces {:pred #(contains?
+                       #{:rf.machine.spawn-all/stale-completion
+                         :rf.machine.spawn-all/late-completion
+                         :rf.machine.spawn-all/all-completed}
+                       (:operation %))}]
+      (rf/dispatch-sync [parent-id [:start]])
+      (let [attempt-a (:rf/attempt (join-state))
+            auth-a    (join-auth)]
+        (rf/dispatch-sync [parent-id [:abort]])
+        (rf/dispatch-sync [parent-id [:start]])
+        (let [attempt-b (:rf/attempt (join-state))]
+          (is (not= attempt-a attempt-b))
+          ;; Attempt B completes and RESOLVES first — the parent has no `:on`
+          ;; for `:join/done`, so it stays on `:racing` and the resolved join
+          ;; slot survives for the post-resolution probe.
+          (rf/dispatch-sync [fixed-child [:go]])
+          (is (true? (:resolved? (join-state))) "attempt B resolved")
+          ;; NOW A's exact carrier drains, POST-resolution, with attempt-A auth.
+          (rf/dispatch-sync
+            [parent-id (with-meta [:child/done :only]
+                         {:rf/join-auth auth-a})])
+          ;; (1) the producer emits a stale-completion, NOT a late-completion.
+          (let [ops (map :operation @traces)]
+            (is (some #{:rf.machine.spawn-all/stale-completion} ops)
+                "the superseded straggler emits stale-completion")
+            (is (not-any? #{:rf.machine.spawn-all/late-completion} ops)
+                "a post-resolution AUTHORITY failure is NOT a late-completion"))
+          ;; (2) the stale row carries the :attempt-superseded reason + attempt-A's
+          ;; OWN work identity (never attempt B's current one).
+          (let [stale  (->> @traces
+                            (filter #(= :rf.machine.spawn-all/stale-completion
+                                        (:operation %)))
+                            first)
+                work-a (get-in stale [:tags :rf.reply/work-id])]
+            (is (= :rf.machine.spawn-all/attempt-superseded
+                   (get-in stale [:tags :rf.reply/stale-reason]))
+                "post-resolution authority failure carries :attempt-superseded")
+            (is (= attempt-a (nth work-a 3))
+                "the superseded evidence carries attempt A's own token, not B's")
+            ;; (3) the Xray consumer classifies attempt A's arc as
+            ;; authority-suppression, and attempt B's resolved arc is untouched.
+            (let [arcs  (reply-envelope/races-by-work-id @traces)
+                  arc-a (get arcs work-a)]
+              (is (contains? (:phases arc-a) :stale-suppressed)
+                  "attempt A's arc is a stale-suppression in Xray")
+              (is (true? (:suppressed? arc-a)))
+              (is (some (fn [[wid arc]]
+                          (and (not= wid work-a) (= :ok (:terminal-status arc))))
+                        arcs)
+                  "attempt B resolved :ok, unaffected by A's post-resolution straggler"))))))))
+
 (deftest cancellation-only-attempt-closes-without-a-stale-carrier
   (testing "destroyed cancellation A and completed reuse B are two closed Xray arcs"
     (register-machines!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -269,13 +269,16 @@
     (is (= :stale-suppressed (re/phase-of :rf.route.nav-token/stale-suppressed)))
     ;; rf2-azcmd3 — HTTP supersession's superseded-attempt stale row.
     (is (= :stale-suppressed (re/phase-of :rf.http/stale-suppressed)))
-    ;; rf2-hj4skn — the `:spawn-all` join's TWO exact-authority stale rows.
-    ;; Neither name ends in a `-completed` / `stale-suppress` / `suppressed`
-    ;; suffix (`stale-completion` / `late-completion` end in `-completion`), so
-    ;; the heuristic returned nil for both until they were enumerated
-    ;; explicitly. `stale-completion` is the PRE-resolution exact-authority
-    ;; suppression; `late-completion` the POST-resolution `:resolved?`-latched
-    ;; straggler.
+    ;; rf2-hj4skn / rf2-ixjd48 — the `:spawn-all` join's TWO exact-authority
+    ;; stale rows. Neither name ends in a `-completed` / `stale-suppress` /
+    ;; `suppressed` suffix (`stale-completion` / `late-completion` end in
+    ;; `-completion`), so the heuristic returned nil for both until they were
+    ;; enumerated explicitly. The producer runs the exact-authority gate BEFORE
+    ;; the resolved-vs-unresolved classification, so the two ops split on
+    ;; AUTHORITY not resolution state: `stale-completion` is the
+    ;; authority-suppressed carrier on EITHER side of resolution;
+    ;; `late-completion` the POST-resolution `:resolved?`-latched EXACT-CURRENT
+    ;; straggler (the only carrier that passes authority yet arrives post-latch).
     (is (= :stale-suppressed (re/phase-of :rf.machine.spawn-all/stale-completion)))
     (is (= :stale-suppressed (re/phase-of :rf.machine.spawn-all/late-completion))))
   (testing "rf2-hj4skn — the NON-DECISIVE `:spawn-all` child terminal is a REAL
@@ -599,15 +602,22 @@
 
 ;; ---------------------------------------------------------------------------
 ;; (6b-spawn-all) The `:spawn-all` join's TWO exact-authority stale-completion
-;; operations (rf2-hj4skn). Both lower to `:stale-suppressed` and project the
-;; canonical `:rf.reply/*` work identity / status / work-status / stale-reason
-;; / correlation / completion time on the SAME uniform row a resource / HTTP
-;; suppression renders. The fixtures are RUNTIME-shaped per the 009 catalogue:
-;; `:tags {:actor-id :invoke-id :child-id :kind}` (the preserved public shape)
-;; PLUS the additive `:rf.reply/*` reply-envelope facts. Four `:rf.reply/
-;; stale-reason` classes: attempt-unverified / attempt-superseded /
-;; duplicate-completion (the PRE-resolution `stale-completion` classes) and
-;; join-resolved (the POST-resolution `late-completion` straggler).
+;; operations (rf2-hj4skn / rf2-ixjd48). Both lower to `:stale-suppressed` and
+;; project the canonical `:rf.reply/*` work identity / status / work-status /
+;; stale-reason / correlation / completion time on the SAME uniform row a
+;; resource / HTTP suppression renders. The fixtures are RUNTIME-shaped per the
+;; 009 catalogue: `:tags {:actor-id :invoke-id :child-id :kind}` (the preserved
+;; public shape) PLUS the additive `:rf.reply/*` reply-envelope facts.
+;;
+;; The producer runs the exact-authority / closed-attempt fold gate BEFORE the
+;; resolved-vs-unresolved classification (join.cljc — rf2-ixjd48), so the two
+;; ops split on AUTHORITY, not on resolution state. Four `:rf.reply/stale-reason`
+;; classes: attempt-unverified / attempt-superseded / duplicate-completion (the
+;; `stale-completion` authority-suppression classes, which fire on BOTH sides of
+;; resolution — see `spawn-all-post-resolution-authority-suppressed` below) and
+;; join-resolved (the `late-completion` EXACT-CURRENT post-resolution straggler,
+;; the only carrier that passes authority yet arrives after its own join
+;; resolved).
 ;; ---------------------------------------------------------------------------
 
 (defn- spawn-all-stale-row
@@ -628,8 +638,8 @@
           :rf.reply/completed-at completed-at}})
 
 (deftest spawn-all-stale-completions
-  (testing "rf2-hj4skn — a PRE-resolution `stale-completion` carrier that failed
-            the exact-authority fold gate (:attempt-unverified) projects the
+  (testing "rf2-hj4skn — a `stale-completion` carrier that failed the
+            exact-authority fold gate (:attempt-unverified) projects the
             full canonical reply identity on the uniform stale-suppressed row"
     (let [row (re/work-event-row
                 (spawn-all-stale-row
@@ -651,7 +661,7 @@
       (is (= 471 (:completed-at row)) "causal reply completion time surfaced")
       (is (some? (:correlation row)) "single-map correlation surfaced")
       (is (= "map" (:type (:correlation row))) "correlation summarized (PRIVACY)")))
-  (testing "rf2-hj4skn — the :attempt-superseded PRE-resolution class (a carrier
+  (testing "rf2-hj4skn — the :attempt-superseded authority class (a carrier
             bound to a prior attempt / wrong actor after respawn)"
     (let [row (re/work-event-row
                 (spawn-all-stale-row
@@ -663,7 +673,7 @@
       (is (= :rf.machine.spawn-all/attempt-superseded (:stale-reason row)))
       (is (= :stale (:status row)))
       (is (= :suppressed (:work-status row)))))
-  (testing "rf2-hj4skn — the :duplicate-completion PRE-resolution class (an
+  (testing "rf2-hj4skn — the :duplicate-completion authority class (an
             exact re-completion of an already-folded child)"
     (let [row (re/work-event-row
                 (spawn-all-stale-row
@@ -691,6 +701,81 @@
       (is (= :suppressed (:work-status row)))
       (is (= 474 (:completed-at row)))
       (is (some? (:correlation row))))))
+
+(deftest spawn-all-post-resolution-authority-suppressed
+  ;; rf2-ixjd48 / rf2-w82021 — the producer runs the exact-authority /
+  ;; closed-attempt fold gate BEFORE the resolved-vs-unresolved classification
+  ;; (join.cljc `intercept-spawn-all-event`: the `(nil? auth)` and
+  ;; `(not (join-auth-current? ...))` gates precede the `(:resolved? join-state)`
+  ;; branch). So a carrier that FAILS authority is emitted as
+  ;; `:rf.machine.spawn-all/stale-completion` REGARDLESS of resolution state —
+  ;; a post-resolution unstamped/superseded straggler is suppressed HERE, never
+  ;; as a `late-completion`. Only the EXACT-CURRENT post-resolution carrier
+  ;; reaches `late-completion` (`:join-resolved`). These fixtures are the
+  ;; RUNTIME-shaped traces the producer emits on the POST-resolution authority
+  ;; path — modelled on `join_exact_auth_cljs_test`'s
+  ;; `old-attempt-straggler-against-resolved-successor-is-superseded`
+  ;; counterexample (an old-attempt carrier draining AFTER its successor
+  ;; resolved). The projection must classify them as authority-suppression
+  ;; (`:stale-suppressed` + the authority reason), NOT as a `:join-resolved`
+  ;; late-completion, and must carry the CARRIER's OWN (prior-attempt) work
+  ;; identity rather than the current attempt's.
+  (testing "an old-attempt straggler draining AFTER the successor join resolved
+            is a `stale-completion` :attempt-superseded — NOT a late-completion.
+            The row carries attempt A's OWN spawned/generation identity (the
+            producer never borrows the current attempt B's)."
+    (let [;; attempt A (the superseded straggler) vs attempt B (current, resolved)
+          row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 74 :op :rf.machine.spawn-all/stale-completion
+                   :child-id :fetch-user :spawned-id :fetch-user#A :generation 1
+                   :stale-reason :rf.machine.spawn-all/attempt-superseded
+                   :completed-at 475}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :rf.machine.spawn-all/attempt-superseded (:stale-reason row))
+          "authority reason surfaced, NOT :join-resolved")
+      (is (not= :rf.machine.spawn-all/join-resolved (:stale-reason row))
+          "a post-resolution authority failure is NOT a late-completion straggler")
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))
+      (is (= :suppressed (:work-status row)))
+      (is (= [:rf.work/machine :fetch-user#A [:hydrating :spawn-all] 1] (:work-id row))
+          "the carrier's OWN (attempt-A) work identity rides — not the successor's")))
+  (testing "a post-resolution UNSTAMPED carrier (never flowed through the child
+            boundary — or a strict replay that stripped the recordable auth
+            fact) is a `stale-completion` :attempt-unverified, again NOT a
+            late-completion"
+    (let [row (re/work-event-row
+                (spawn-all-stale-row
+                  {:id 75 :op :rf.machine.spawn-all/stale-completion
+                   :child-id :fetch-prefs :spawned-id :fetch-prefs#1 :generation 1
+                   :stale-reason :rf.machine.spawn-all/attempt-unverified
+                   :completed-at 476}))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :rf.machine.spawn-all/attempt-unverified (:stale-reason row)))
+      (is (not= :rf.machine.spawn-all/join-resolved (:stale-reason row)))
+      (is (= :stale (:status row)))
+      (is (= :suppressed (:work-status row)))))
+  (testing "both post-resolution authority-suppressed carriers flow into the
+            cross-family stale tally under :machine with NO panel-specific code —
+            the same uniform surface a pre-resolution suppression uses"
+    (let [trace [(spawn-all-stale-row
+                   {:id 76 :op :rf.machine.spawn-all/stale-completion
+                    :child-id :fetch-user :spawned-id :fetch-user#A :generation 1
+                    :stale-reason :rf.machine.spawn-all/attempt-superseded
+                    :completed-at 477})
+                 (spawn-all-stale-row
+                   {:id 77 :op :rf.machine.spawn-all/stale-completion
+                    :child-id :fetch-prefs :spawned-id :fetch-prefs#1 :generation 1
+                    :stale-reason :rf.machine.spawn-all/attempt-unverified
+                    :completed-at 478})]
+          sup   (re/stale-suppressions trace)]
+      (is (= 2 (count sup)))
+      (is (every? #(= :stale-suppressed (:phase %)) sup))
+      (is (= {:machine 2} (re/stale-tally-by-kind trace)))
+      (is (= #{:rf.machine.spawn-all/attempt-superseded
+               :rf.machine.spawn-all/attempt-unverified}
+             (into #{} (map :stale-reason) sup))))))
 
 ;; ---------------------------------------------------------------------------
 ;; (6b-spawn-all-races) The spawn-all stale rows flow into the cross-family


### PR DESCRIPTION
## Summary

Xray's spec/013, the reply-envelope `op->phase` source comment, and the spawn-all stale fixtures had framed `:rf.machine.spawn-all/stale-completion` as **pre-resolution-only**. That contradicts the shipped producer.

The producer (`implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc`, `intercept-spawn-all-event`) runs the exact-authority / closed-attempt fold gate **before** the `:resolved?` classification (rf2-ixjd48 / #5951 — commit 499bf8b97e "validate join completion authority before post-resolution attribution"):

- `(nil? auth)` → `stale-completion` `:attempt-unverified` (line ~946)
- `(not (join-auth-current? …))` → `stale-completion` `:attempt-superseded` (line ~956)
- `(:resolved? join-state)` → `late-completion` `:join-resolved` (line ~981)

So `stale-completion` fires for authority-suppressed carriers (unverified / superseded / duplicate) on **both** sides of resolution; `late-completion` is reserved for the **exact-current** post-resolution straggler. The runtime's own `suppress-stale-completion!` docstring already states "this op covers the ownership/authority suppression classes on BOTH the pre- and post-resolution paths", and `join_exact_auth_cljs_test`'s `old-attempt-straggler-against-resolved-successor-is-superseded` is the counterexample. Runtime behaviour was already correct — only the Xray docs/fixtures lagged. No core/ui runtime change.

## Changes (all under `tools/xray/`)

- **spec/013-Trace-Consumer.md** — reframed the two spawn-all stale ops: `stale-completion` = authority-suppression on both sides of resolution (rf2-ixjd48); `late-completion` = post-resolution exact-current straggler.
- **panels/reply_envelope.cljc** — corrected the `op->phase` source comment to the authority-vs-resolution split (comment only; no code change).
- **panels/reply_envelope_cljs_test.cljc** — reframed the phase/section/testing comments off "PRE-resolution"; added `spawn-all-post-resolution-authority-suppressed` projection tests pinning post-resolution `attempt-superseded` / `attempt-unverified` carriers as `stale-completion` (not `late-completion`), including the cross-family tally.
- **panels/machine_work_identity_cljs_test.cljc** — added an actual-producer e2e test `post-resolution-superseded-straggler-is-stale-completion-not-late`: resolves attempt B, drains attempt A's superseded carrier post-resolution, and asserts the runtime emits `stale-completion` (`:attempt-superseded`), no `late-completion`, and Xray's `races-by-work-id` classifies A as an authority-suppression arc. This exercises the real post-resolution authority check, not a proxy.

Spec updated in the same PR per the tools/xray spec-lockstep rule.

## Follow-up (out of scope)

The framework specs `spec/009-Instrumentation.md` and `spec/005-StateMachines.md` still frame `stale-completion` as "the pre-resolution exact-authority / closed-attempt suppression" — the same lag, on off-limits hot-zone files. Worth a follow-up bead to reconcile the producer-side spec prose.

## Quality gates

- `clojure -M:test` (tools/xray, JVM) — **1265 tests, 5901 assertions, 0 failures, 0 errors** (full artefact).
- Targeted: `machine-work-identity-cljs-test` + `reply-envelope-cljs-test` — 23 tests, 341 assertions, 0 failures (incl. the new post-resolution e2e + projection tests).
- `scripts/check_retired_composition_vocab.py` — clean (exit 0).
- The `.cljc` tests are dual-target; the consolidated node-test build and the browser xray-feature-gate are CI-owned (not run locally — changes are pure-data projection + docs, no UI/feature-matrix surface).
