### PR TITLE
fix(subs): normalize inline image metadata across registration kinds (rf2-mt1cvi)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -371,6 +371,34 @@
 ;; metadata-only inline entry (no `:impl`) and every registered descriptor pass
 ;; through untouched.
 
+(defn- strip-descriptor-documentation
+  "Elide the registrar PURE-DOCUMENTATION keys (`registrar/pure-documentation-keys`
+  — `:doc`) from a lowered inline `descriptor` in PRODUCTION, at BOTH the
+  descriptor TOP LEVEL (where a kind's lowering spreads its authored metadata —
+  `lower-inline-event` hoists the run/enqueue-time flags, `lower-inline-sub` the
+  classification/schema slots) AND the descriptor's nested `:metadata` (the
+  introspection/dedupe copy EVERY inline kind carries). A `:metadata` that reduces
+  to empty is DROPPED rather than left as a bare `{}`, so a doc-ONLY inline entry
+  resurrects no stale nested map in production. Returns the normalized descriptor.
+
+  This is the ONE canonical, side-effect-free DOC-normalization boundary for every
+  supported inline kind — event, sub, fx, cofx (rf2-mt1cvi). It runs
+  `registrar/strip-pure-documentation` — the SAME primitive the public `reg-*`
+  registrar runs — so an inline registration pays no more production bytes than a
+  namespace-authored one, and inline registration semantics are kind-INDEPENDENT.
+  A NO-OP in dev (`interop/debug-enabled?` true), so development assembly retains
+  authored documentation for tooling / agent inspection. Idempotent — a descriptor
+  whose metadata its kind's lowering already normalized (the sub path) is
+  unchanged. Pure."
+  [descriptor]
+  (let [descriptor (registrar/strip-pure-documentation descriptor)]
+    (if (contains? descriptor :metadata)
+      (let [metadata (registrar/strip-pure-documentation (:metadata descriptor))]
+        (if (seq metadata)
+          (assoc descriptor :metadata metadata)
+          (dissoc descriptor :metadata)))
+      descriptor)))
+
 (defn lower-inline-descriptor
   "Lower ONE selected descriptor into its runnable shape when it is an inline
   descriptor carrying a real fn body (EP-0023 §Image Fragments).
@@ -381,40 +409,45 @@
   one), a metadata-only inline entry (no `:impl`), or a kind with no published
   lowering hook returns UNCHANGED. Pure modulo the late-bind lookup.
 
-  The `:sub` kind is the one kind whose lowering runs registrar-contract
-  metadata NORMALIZATION (validate retired/unknown keys + `:sensitive`/`:large`
-  classification, strip dev-only `:doc` in production — rf2-vxgfnd.219). It
-  ALONE therefore (a) needs the AUTHORED descriptor id so a retired/unknown-key
-  diagnostic names the author's subscription (e.g. `:counter/value`), never a
-  synthetic `:rf.image/inline-sub`, and (b) yields a NORMALIZED `:metadata` that
-  must REPLACE the descriptor's RAW nested `:metadata` — otherwise a production
-  image still carries dev-only `:doc` under `[:metadata …]` alongside the
-  doc-stripped top level, a second, divergent representation (rf2-vxgfnd.257).
-  Its return carries the metadata normalized ONCE (spread at top level AND under
-  `:metadata`); we let that normalized `:metadata` win over the descriptor's raw
-  copy. Selection/dedupe already ran (`lower-inline-descriptors` is a post-
-  selection map), so replacing `:metadata` here never decides a collision
-  winner. Other kinds keep the descriptor's own `:metadata` untouched."
+  DOC NORMALIZATION IS UNIFORM (rf2-mt1cvi). The registrar contract makes `:doc`
+  pure documentation stripped in production for every `reg-*` surface; this
+  boundary applies that SAME strip (`strip-descriptor-documentation`) to EVERY
+  lowered inline kind — at the descriptor TOP LEVEL and under the nested
+  `:metadata` — so a production image carries dev-only `:doc` for NO kind and
+  inline registration semantics are kind-independent. (Previously only `:sub`
+  was normalized: `:reg-event` leaked `:doc` at both the top level and under
+  `:metadata`, and `:reg-fx` / `:reg-cofx` under `:metadata` — rf2-mt1cvi.) The
+  strip is a no-op in dev, so authored documentation survives for inspection, and
+  it runs AFTER selection/dedupe (`lower-inline-descriptors` is a post-selection
+  map) so it never decides a collision winner.
+
+  The `:sub` lowering additionally validates retired/unknown registration keys +
+  `:sensitive`/`:large` classification (rf2-vxgfnd.219), so it ALONE needs the
+  AUTHORED descriptor id threaded in — a retired/unknown-key diagnostic then names
+  the author's subscription (e.g. `:counter/value`), never a synthetic
+  `:rf.image/inline-sub` (rf2-vxgfnd.257). Each kind keeps its own runnable slots
+  and metadata semantics (the descriptor wins every shared key — `:impl`,
+  provenance, `:kind` / `:id`); only the pure-documentation keys are elided."
   [descriptor]
   (if (and (:rf.provenance/inline descriptor)
            (contains? descriptor :impl))
     (if-let [lower (late-bind/get-fn
                      (keyword "image" (str "lower-inline-" (name (:kind descriptor)))))]
-      (if (= :sub (:kind descriptor))
-        ;; Thread the authored id; let the lowering's normalized :metadata win
-        ;; over the descriptor's raw copy (the descriptor otherwise wins every
-        ;; shared key — :impl / provenance / :kind / :id stay put). When the
-        ;; normalized metadata is empty (e.g. a doc-only map in production) the
-        ;; lowering omits :metadata, and the descriptor's raw copy is dropped
-        ;; rather than resurrected.
-        (let [lowered (lower (:id descriptor) (:metadata descriptor) (:impl descriptor))]
-          (-> (merge lowered descriptor)
-              (dissoc :metadata)
-              (merge (select-keys lowered [:metadata]))))
-        ;; Other kinds — merge runnable slots UNDER the descriptor's own keys
-        ;; (the descriptor wins on any shared key; the lowering only contributes
-        ;; :handler-fn + the per-kind runtime slots).
-        (merge (lower (:metadata descriptor) (:impl descriptor)) descriptor))
+      (strip-descriptor-documentation
+        (if (= :sub (:kind descriptor))
+          ;; Thread the AUTHORED id so the sub lowering's metadata diagnostics
+          ;; (retired/unknown key, bad classification) name the author's
+          ;; subscription. The lowering spreads its normalized metadata at top
+          ;; level; the descriptor wins every shared key (:impl / provenance /
+          ;; :kind / :id). The descriptor's raw nested :metadata wins the merge —
+          ;; `strip-descriptor-documentation` then elides its dev-only :doc,
+          ;; yielding the same doc-stripped nested map the lowering normalized.
+          (merge (lower (:id descriptor) (:metadata descriptor) (:impl descriptor))
+                 descriptor)
+          ;; Other kinds — merge runnable slots UNDER the descriptor's own keys
+          ;; (the descriptor wins on any shared key; the lowering only contributes
+          ;; :handler-fn + the per-kind runtime slots).
+          (merge (lower (:metadata descriptor) (:impl descriptor)) descriptor)))
       descriptor)
     descriptor))
 

--- a/implementation/core/test/re_frame/image_inline_metadata_normalization_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_inline_metadata_normalization_cljs_test.cljc
@@ -1,0 +1,143 @@
+(ns re-frame.image-inline-metadata-normalization-cljs-test
+  "rf2-mt1cvi — inline image metadata is DOC-normalized UNIFORMLY across every
+  supported inline registration kind: event, sub, fx, and cofx.
+
+  The registrar contract makes `:doc` PURE documentation stripped in production
+  for every `reg-*` surface (`registrar/strip-pure-documentation`). Inline image
+  assembly previously applied that contract to `:reg-sub` ONLY: a production-mode
+  reproduction through the REAL `re-frame.image` + `image-assembly/lower-inline-
+  descriptor` yielded `:reg-event` with `:doc` at BOTH the descriptor top level
+  AND its nested `:metadata`, and `:reg-fx` / `:reg-cofx` with `:doc` under
+  nested `:metadata` — only `:reg-sub` was clean. That paid unwanted production
+  bytes and made inline registration semantics kind-dependent (bead rf2-mt1cvi,
+  the cross-kind follow-up exposed by PR #5902).
+
+  This suite is the CROSS-KIND matrix + the production-elision SENTINEL. For each
+  supported inline kind it drives the LIVE image + assembly-side lowering (the
+  runnable descriptor a frame actually resolves — NOT a direct lowerer call) with
+  an adversarial `:doc` + a load-bearing witness key, and asserts:
+
+    * DEV (gate on): authored `:doc` survives — under the nested `:metadata`
+      (every kind), and at the top level for the kinds whose lowering spreads
+      authored metadata there (event, sub);
+    * PRODUCTION (gate off): `:doc` is absent at the descriptor top level AND
+      under nested `:metadata` for EVERY kind, while the load-bearing witness key
+      and the runnable slots are retained.
+
+  A mutation that reintroduces the raw metadata merge for any kind (dropping the
+  uniform `strip-descriptor-documentation` boundary) fails the production rows.
+
+  `.cljc` — the normalization is host-agnostic, so this runs under both
+  `clojure -M:test` (JVM) and `npm run test:cljs` (node CLJS). The four core kind
+  namespaces are required so their `:image/lower-inline-<kind>` publishers are
+  installed (they `set-fn!` at ns load); image-assembly cannot static-require
+  them (a cycle), so the test requires them directly to exercise the LIVE
+  lowering."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.interop        :as interop]
+            ;; Required so the late-bind lowering publishers are installed
+            ;; (each ns calls (late-bind/set-fn! :image/lower-inline-<kind> …) at
+            ;; load); exercised through image-assembly/lower-inline-descriptor.
+            [re-frame.events]
+            [re-frame.subs]
+            [re-frame.fx]
+            [re-frame.cofx]))
+
+;; ---------------------------------------------------------------------------
+;; The supported-kind matrix. `:spreads-meta?` marks the kinds whose lowering
+;; hoists authored metadata onto the descriptor TOP LEVEL (event via
+;; `event-handler-meta`, sub via the normalized-metadata spread) — those kinds
+;; must be clean of `:doc` at the top level too, not just under `:metadata`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private supported-kinds
+  [{:label "event" :kind :event :section :reg-event :spreads-meta? true
+    :body (fn [_cofx _event] {})}
+   {:label "sub"   :kind :sub   :section :reg-sub   :spreads-meta? true
+    :body (fn [_db _query] :ok)}
+   {:label "fx"    :kind :fx    :section :reg-fx    :spreads-meta? false
+    :body (fn [_args] nil)}
+   {:label "cofx"  :kind :cofx  :section :reg-cofx  :spreads-meta? false
+    :body (fn [] :v)}])
+
+(defn- assemble
+  "Assemble ONE inline registration of `section` through the LIVE `rf/image` +
+  assembly-side lowering and return the runnable descriptor a frame resolves.
+  `metadata` nil uses the 2-tuple `[id body]` form."
+  [section id metadata body]
+  (-> (image/image
+        {:id            :mt1cvi/inline-image
+         :registrations {section [(if (nil? metadata) [id body] [id metadata body])]}})
+      :rf.image/inline
+      first
+      asm/lower-inline-descriptor))
+
+;; ===========================================================================
+;; 1. DEV — authored documentation survives for every kind (tooling / agent
+;;    inspection). The default gate is ON.
+;; ===========================================================================
+
+(deftest dev-retains-authored-doc-across-every-kind
+  (doseq [{:keys [label kind section spreads-meta? body]} supported-kinds]
+    (testing (str "inline " label " — dev retains authored :doc")
+      (let [d (assemble section (keyword "counter" (str label "-doc"))
+                        {:doc "author note" :tags [:audit]} body)]
+        (is (= kind (:kind d)) "kind is preserved")
+        (is (= "author note" (get-in d [:metadata :doc]))
+            "nested [:metadata :doc] retained in dev")
+        (is (= [:audit] (get-in d [:metadata :tags]))
+            "the load-bearing witness key is nested")
+        (is (fn? (:handler-fn d)) "the runnable :handler-fn slot is installed")
+        (when spreads-meta?
+          (is (= "author note" (:doc d))
+              "kinds that spread metadata carry :doc at the top level too in dev")
+          (is (= [:audit] (:tags d))
+              "and the load-bearing witness key at the top level"))))))
+
+;; ===========================================================================
+;; 2. PRODUCTION SENTINEL — `:doc` is elided at BOTH the top level and under
+;;    nested `:metadata` for EVERY kind; load-bearing keys + runnable slots
+;;    survive. A mutation reintroducing the raw-metadata merge fails here.
+;; ===========================================================================
+
+(deftest production-strips-doc-everywhere-across-every-kind
+  (with-redefs [interop/debug-enabled? false]
+    (doseq [{:keys [label kind section spreads-meta? body]} supported-kinds]
+      (testing (str "inline " label " — production carries NO :doc anywhere")
+        (let [d (assemble section (keyword "counter" (str label "-prod"))
+                          {:doc "elided in prod" :tags [:audit]} body)]
+          (is (= kind (:kind d)) "kind is preserved")
+          (is (not (contains? d :doc))
+              "no top-level :doc in a production image, for any kind")
+          (is (not (contains? (:metadata d) :doc))
+              "no dev-only :doc under nested [:metadata …] in a production image")
+          (is (= [:audit] (get-in d [:metadata :tags]))
+              "the load-bearing witness key is retained under nested :metadata")
+          (is (fn? (:handler-fn d)) "the runnable :handler-fn slot survives")
+          (when spreads-meta?
+            (is (not (contains? d :doc))
+                "no top-level :doc even where the lowering spreads metadata")
+            (is (= [:audit] (:tags d))
+                "the load-bearing key is retained at the top level too")))))))
+
+;; ===========================================================================
+;; 3. PRODUCTION — a doc-ONLY inline entry resurrects no stale nested map for
+;;    ANY kind (the nested :metadata reduces to empty and is dropped).
+;; ===========================================================================
+
+(deftest production-doc-only-metadata-drops-the-nested-map-across-every-kind
+  (with-redefs [interop/debug-enabled? false]
+    (doseq [{:keys [label section body]} supported-kinds]
+      (testing (str "inline " label " — a doc-ONLY inline entry drops :metadata")
+        (let [d (assemble section (keyword "counter" (str label "-doc-only"))
+                          {:doc "only a note"} body)]
+          (is (not (contains? d :doc))
+              "no top-level :doc for a doc-only inline entry in production")
+          (is (not (contains? (:metadata d) :doc))
+              "no nested [:metadata :doc] — the doc-only map is not resurrected")
+          (is (nil? (:metadata d))
+              "the nested :metadata map is dropped once it reduces to empty")
+          (is (fn? (:handler-fn d))
+              "the runnable slot is still installed for a doc-only entry"))))))


### PR DESCRIPTION
## Summary

The registrar contract makes `:doc` pure documentation stripped in production for every `reg-*` surface (`registrar/strip-pure-documentation`), but inline image assembly applied that strip to `:reg-sub` only. A production-mode reproduction through the real `re-frame.image` + `image-assembly/lower-inline-descriptor` yielded `:reg-event` with `:doc` at **both** the descriptor top level and its nested `:metadata`, and `:reg-fx` / `:reg-cofx` with `:doc` under nested `:metadata`; only `:reg-sub` was clean. This paid unwanted production bytes and made inline registration semantics kind-dependent (the cross-kind follow-up exposed by PR #5902; closed rf2-vxgfnd.257 intentionally fixed only subscriptions).

## The inconsistency (file:line)

- `implementation/core/src/re_frame/image_assembly.cljc` `lower-inline-descriptor` — special-cased `:sub` (normalized `:metadata` won, doc-stripped); every other kind took `(merge (lower …) descriptor)`, so the descriptor's **raw** nested `:metadata` (with `:doc`) survived.
- `implementation/core/src/re_frame/events.cljc` `lower-inline-event` — `event-handler-meta` spreads the raw metadata at TOP LEVEL, so `:doc` leaked there too.
- `implementation/core/src/re_frame/fx.cljc` / `cofx.cljc` `lower-inline-fx` / `lower-inline-cofx` — return only runnable slots, so the descriptor's raw nested `:metadata` `:doc` survived.

## The normalization

Apply the registrar pure-documentation strip at ONE canonical, side-effect-free inline-assembly boundary — a new private `strip-descriptor-documentation` wrapping `lower-inline-descriptor` — for every supported inline kind (event, sub, fx, cofx). It runs `registrar/strip-pure-documentation` (the same primitive public `reg-*` runs) over the lowered descriptor's TOP LEVEL and its nested `:metadata`, and drops a `:metadata` that reduces to empty. It is a no-op in dev (development assembly retains authored documentation) and idempotent (the already-normalized sub path is unchanged). No fourth normalizer, no compatibility branch, no public API; each kind keeps its own runnable slots + metadata semantics, and the sub lowering still threads the authored id for its retired/unknown-key + classification diagnostics.

## Per-kind proof (production mode)

Reproduced through real `image/image` + `lower-inline-descriptor` with `{:doc "D" :tags [:a]}`:

| kind | OLD top-level `:doc` | OLD nested `[:metadata :doc]` | NEW top-level `:doc` | NEW nested `[:metadata :doc]` | NEW `:tags` retained |
|------|---|---|---|---|---|
| event | true | true | false | false | true |
| sub   | false | false | false | false | true |
| fx    | false | true | false | false | true |
| cofx  | false | true | false | false | true |

A new cross-kind matrix (`implementation/core/test/re_frame/image_inline_metadata_normalization_cljs_test.cljc`, `.cljc` → JVM + CLJS) drives an adversarial `:doc` case per kind, plus a production sentinel that fails if the raw-metadata merge is reintroduced for any kind, plus a doc-only case asserting the nested map is dropped.

## Quality gates

- Focused core JVM (`clojure -M:test -n` new ns + `subs-inline-normalization-cljs-test` + `ep0026-inline-grammar-cljs-test`): **Ran 20 tests, 154 assertions, 0 failures, 0 errors.**
- `npm run test:cljs` (core + reagent node build): **Ran 9605 tests, 47238 assertions, 0 failures, 0 errors.**
- Failing-before / passing-after demonstrated per kind (table above).
