### PR TITLE
fix(trace): neutralize outer continuation authority in public trace listeners (rf2-eaxnai)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -110,6 +110,28 @@
   []
   (continuing?))
 
+(defn- snapshot-continuation
+  "Capture the CURRENT continuation predicate as a standalone thunk that
+  re-reads the caller's exact authority regardless of any later dynamic
+  rebinding of `*continuation-predicate*`.
+
+  `deliver!` hands this snapshot to the PUBLIC trace-listener fan-out as the
+  before/after `continue?` check, then rebinds `*continuation-predicate*` to
+  the neutral scope for the listener bodies themselves. That split is the whole
+  of rf2-eaxnai: a listener's nested authored work (dispatch / destroy /
+  create — e.g. a same-id successor's `:initial-events` seed) runs under the
+  ordinary always-continue authority, while the delivery loop's own checks
+  still consult the caller's exact incarnation predicate so destroying the
+  current incarnation still suppresses the REMAINING listener fan-out.
+
+  The captured predicate is the live incarnation closure, so the snapshot
+  re-checks the registry on each call — a listener that destroys the outer
+  incarnation flips a later `(snapshot)` call to false without the snapshot
+  ever reading the (now neutral) dynamic var."
+  []
+  (let [p *continuation-predicate*]
+    (fn [] (or (nil? p) (p)))))
+
 (defn ^:no-doc call-with-structural-delivery
   "Deliver a structural trace without bare-id epoch/policy attribution and
   without any per-frame ring retention.
@@ -562,10 +584,23 @@
   reacts to A's structural terminal fact by dispatching or emitting its OWN
   legitimate nested work into a same-id successor B or an unrelated frame C
   must run that work under NORMAL scope — normal epoch capture, its own
-  frame-no-emit policy, and normal per-frame ring retention — rather than
-  inheriting A's retentionless/no-capture/no-policy scope. A listener that
+  frame-no-emit policy, normal per-frame ring retention, AND the neutral
+  continuation scope (rf2-eaxnai) — rather than inheriting A's
+  retentionless/no-capture/no-policy/exact-owner scope. A listener that
   explicitly re-requests structural semantics via
-  `call-with-structural-delivery` re-binds the flags false and is honoured."
+  `call-with-structural-delivery` re-binds the flags false and is honoured.
+
+  The exact-owner continuation is the fourth axis restored to ordinary defaults
+  here (rf2-eaxnai): the outer envelope may be fenced to A's exact incarnation
+  (`call-with-continuation-predicate`), but that fence exists to suppress
+  A's own remaining framework-owned trace stages after A is lost — it must NOT
+  leak into a public listener's nested authored work. Before this fix a listener
+  that destroyed A and created same-id B with `:initial-events` had B's seed
+  `dispatch-sync!` consult `continuation-live?`, inherit A's now-false predicate,
+  and get silently dropped at `build-envelope` — leaving B live with `{}` and no
+  recovery (make-frame's reuse/no-reseed law). The neutral rebinding frees the
+  listener body; the `outer-continue?` snapshot below preserves the loop's exact
+  before/after suppression of A's remaining fan-out."
   [event]
   (when (and *epoch-capture-enabled?* (continuing?))
     (deliver-to-epoch-capture! event))
@@ -573,21 +608,29 @@
   ;; A, do not deliver the same stale event into tooling/rings/listeners.
   (when (continuing?)
     (when-let [deliver-tooling (late-bind/get-fn-cached :trace.tooling/deliver!)]
-      ;; Capture the outer envelope's ring-retention decision BEFORE restoring
-      ;; ordinary defaults, then pass it explicitly for the outer ring push. The
+      ;; Capture the outer envelope's ring-retention decision AND the caller's
+      ;; exact continuation predicate BEFORE restoring ordinary defaults. The
       ;; tooling hook (in the sibling ns, which cannot see these vars) reads
       ;; `retain?` from the argument, not the dynamic var — so restoring the
       ;; flags to their ordinary defaults around the whole call leaves the outer
       ;; ring push governed by the captured structural decision while any
       ;; listener-triggered nested emit runs under normal scope (rf2-vf2qke).
-      (let [retain? *ring-retention-enabled?*]
+      ;; `outer-continue?` (rf2-eaxnai) is the same idea for the exact-owner
+      ;; continuation: the loop's before/after `continue?` checks consult this
+      ;; snapshot (retaining A's predicate so A destruction suppresses A's
+      ;; remaining listeners), while `*continuation-predicate*` is neutralised in
+      ;; the binding below so each listener BODY's nested authored work is not
+      ;; strangled by A's now-false predicate.
+      (let [retain?         *ring-retention-enabled?*
+            outer-continue? (snapshot-continuation)]
         (binding [*epoch-capture-enabled?*  true
                   *frame-policy-enabled?*   true
-                  *ring-retention-enabled?* true]
+                  *ring-retention-enabled?* true
+                  *continuation-predicate*  nil]
           (try
-            (deliver-tooling event continuing? retain?)
+            (deliver-tooling event outer-continue? retain?)
             (catch #?(:clj Throwable :cljs :default) e
-              (when (continuing?) (throw e)))))))))
+              (when (outer-continue?) (throw e)))))))))
 
 (defn- hoist-projected-sensitive
   "Hoist a classification-projection-stamped `[:tags :sensitive?]` up to

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -694,7 +694,17 @@
   evidence into the successor's ring. The default `true` arity preserves the
   ordinary emit path. Retention is the ONLY thing gated; listener fan-out is
   unconditional so the required terminal fact reaches live consumers exactly
-  once either way."
+  once either way.
+
+  `continue?` (rf2-eaxnai) is the caller's exact-owner continuation SNAPSHOT.
+  The before/after checks below consult it so that if a listener destroys the
+  outer incarnation A, the remaining listener fan-out is suppressed. It is a
+  standalone snapshot rather than a live read of the (private, unreachable
+  here) `*continuation-predicate*` precisely because `re-frame.trace/deliver!`
+  neutralises that dynamic var around this whole call — a listener BODY's
+  nested authored work (dispatch / destroy / create + `:initial-events` seed)
+  must run under ordinary always-continue authority, not inherit A's fence.
+  So the callback runs neutral while these checks retain A's predicate."
   ([event continue?] (deliver-to-tooling! event continue? true))
   ([event continue? retain?]
    (when retain? (push-to-ring! event))

--- a/implementation/core/test/re_frame/trace_listener_continuation_neutral_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_continuation_neutral_cljs_test.cljc
@@ -1,0 +1,182 @@
+(ns re-frame.trace-listener-continuation-neutral-cljs-test
+  "rf2-eaxnai — a PUBLIC trace listener body must run under a NEUTRAL continuation
+  scope for its own nested authored work, while the surrounding delivery loop
+  still checks the caller's EXACT continuation predicate before and after each
+  callback.
+
+  ## The defect
+
+  When a framework-owned lifecycle trace is fenced to an exact incarnation A
+  (`re-frame.trace/call-with-continuation-predicate` bound to
+  `frame/event-continuation-live?` — this is what a cold `reg-flow`'s
+  first-registration / replacement / clear emit does, rf2-pwum1g / rf2-rxsldx),
+  the public listener fan-out runs INSIDE that binding. Before this fix, a
+  listener that destroyed A and created same-id incarnation B with
+  `:initial-events` had B's seed `dispatch-sync!` consult `trace/continuation-live?`,
+  inherit A's now-FALSE predicate, and get silently dropped at `build-envelope`
+  (`(when (trace/continuation-live?) ...)` returns nil ⇒ the seed is never
+  enqueued). B was left live with `{}`, and make-frame's reuse/no-reseed law
+  meant a later re-ensure could not recover the seed.
+
+  ## The reproduction
+
+  This exercises the SAME code path a cold `reg-flow` uses — a `trace/emit!`
+  wrapped in `call-with-continuation-predicate` bound to A's incarnation — but
+  synthetically, so the proof lives in core (where the fix lives) and rides both
+  `npm run test:cljs` and `clojure -M:test`. The seam is DELIBERATELY the
+  public-listener boundary: the fenced emit fires with A live, the FIRST listener
+  (the already-entered delivery that may stand) destroys A and creates same-id B
+  with an `:initial-events` seed, and the SUBSEQUENT listener must be suppressed.
+
+  Two teeth, red-before / green-after:
+    * B's seed runs exactly once and its db is initialized (the listener body ran
+      under neutral scope), and re-ensuring B does not replay it.
+    * an UNRELATED frame's nested `dispatch-sync` from the same listener body —
+      issued AFTER A is destroyed — still runs (neutral scope frees it too).
+
+  One guard, green-before / green-after: the remaining A listener is suppressed
+  after A is destroyed (the loop's before/after checks retain A's exact
+  predicate — the outer fence, unchanged by this fix). The companion control
+  deftest pins the other side: a NON-destroying first listener does not
+  over-suppress the subsequent listener.
+
+  Everything runs SYNCHRONOUSLY on the single host thread — the listener destroys
+  A and publishes B reentrantly inside emission — so the ordering is
+  deterministic without threads. The two listeners live in a 2-entry array-map,
+  which preserves insertion order on both hosts, so the destroyer (registered
+  FIRST) fans out first."
+  (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace                :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- reg-test-events! []
+  ;; Pure handlers. `:seed` initializes B's db AND bumps a db-level run counter,
+  ;; so a wrongful replay would show `:seed-count 2`. `:mark` is the unrelated
+  ;; frame's nested-dispatch write.
+  (rf/reg-event :trace.neutral/seed
+    (fn [{:keys [db]} _]
+      {:db (-> db (assoc :seeded :ok) (update :seed-count (fnil inc 0)))}))
+  (rf/reg-event :trace.neutral/mark
+    (fn [{:keys [db]} _] {:db (assoc db :marked true)})))
+
+(defn- fire-fenced-emit!
+  "Fire a synthetic trace emit fenced to `[frame-id token]`'s exact incarnation —
+  the same shape a cold `reg-flow` uses for its lifecycle traces. Listeners see
+  `:operation :rf.test/fenced-emit`."
+  [frame-id token]
+  (trace/call-with-continuation-predicate
+    #(frame/event-continuation-live? frame-id token)
+    (fn []
+      (trace/emit! :rf.registry :rf.test/fenced-emit {:frame frame-id}))))
+
+(deftest listener-body-runs-neutral-while-fence-suppresses-a-tail
+  (reg-test-events!)
+  (let [a-id       :trace.neutral/subject   ;; A and same-id successor B
+        c-id       :trace.neutral/unrelated
+        b-live?    (atom nil)
+        b-token    (atom nil)
+        b-db       (atom ::unset)           ;; B's db AT callback time (the bead's :b-db)
+        later-hits (atom 0)                 ;; the bead's :later-a-listener-hits
+        armed?     (atom true)]
+    (rf/make-frame {:id c-id})
+    (rf/make-frame {:id a-id})
+    (let [a-token (frame/frame-incarnation-token a-id)]
+      ;; Listener 1 (FIRST → fans out first): the DESTROYER — the already-entered
+      ;; delivery. Destroys A, creates same-id B with a seed, then does UNRELATED
+      ;; nested work into C. All of this is a listener body: it must run neutral.
+      (trace/register-listener! ::destroyer
+        (fn [ev]
+          (when (and (= :rf.test/fenced-emit (:operation ev))
+                     (compare-and-set! armed? true false))
+            (frame/destroy-frame! a-id)
+            (rf/make-frame {:id a-id :initial-events [[:trace.neutral/seed]]})
+            (reset! b-token (frame/frame-incarnation-token a-id))
+            (reset! b-live? (some? (frame/frame-incarnation-token a-id)))
+            (reset! b-db (rf/app-db-value a-id))
+            ;; Unrelated-frame nested dispatch AFTER A is destroyed — before the
+            ;; fix this too was strangled by A's now-false predicate.
+            (rf/dispatch-sync [:trace.neutral/mark] {:frame c-id}))))
+      ;; Listener 2 (SECOND → subsequent): must NOT fire once A is destroyed.
+      (trace/register-listener! ::later-a
+        (fn [ev]
+          (when (= :rf.test/fenced-emit (:operation ev))
+            (swap! later-hits inc))))
+      (try
+        (fire-fenced-emit! a-id a-token)
+
+        ;; --- tooth 1: the listener body ran under neutral scope ---
+        (is (true? @b-live?) "B is live after the callback")
+        (is (not (identical? a-token @b-token))
+            "B is a DISTINCT same-id incarnation, not A")
+        (is (= {:seeded :ok :seed-count 1} @b-db)
+            "B's :initial-events seed ran during the callback and initialized B's
+             db — the listener body was NOT strangled by A's dead predicate
+             (before the fix this was {})")
+        (is (= 1 (:seed-count (rf/app-db-value a-id)))
+            "B's seed ran EXACTLY once")
+
+        ;; --- tooth 2: unrelated-frame nested dispatch was unaffected ---
+        (is (= {:marked true} (rf/app-db-value c-id))
+            "the listener's nested dispatch into an UNRELATED frame ran under
+             neutral scope (before the fix it was dropped once A was destroyed)")
+
+        ;; --- guard: the outer fence still suppresses A's remaining fan-out ---
+        (is (zero? @later-hits)
+            "the SUBSEQUENT listener was suppressed after A was destroyed — the
+             delivery loop retained A's exact predicate for its before/after
+             checks")
+
+        ;; --- tooth 1 (cont.): re-ensuring B does not replay the seed ---
+        (rf/make-frame {:id a-id :initial-events [[:trace.neutral/seed]]})
+        (is (= 1 (:seed-count (rf/app-db-value a-id)))
+            "re-ensuring the LIVE B re-records but does NOT replay :initial-events")
+        (is (= {:seeded :ok :seed-count 1} (rf/app-db-value a-id))
+            "B's db is unchanged by the re-ensure")
+        (finally
+          (trace/unregister-listener! ::destroyer)
+          (trace/unregister-listener! ::later-a))))))
+
+(deftest non-destroying-listener-does-not-over-suppress-subsequent-listener
+  ;; Mutation guard for the loop's before/after check. When the first listener
+  ;; leaves A LIVE (and merely does its own unrelated nested work under neutral
+  ;; scope), the subsequent listener MUST still receive A's fenced event — the
+  ;; snapshot predicate must not over-fence. A snapshot that always read false
+  ;; would silently swallow this.
+  (reg-test-events!)
+  (let [a-id      :trace.neutral/live-subject
+        c-id      :trace.neutral/live-unrelated
+        first-hit (atom 0)
+        later-hit (atom 0)]
+    (rf/make-frame {:id c-id})
+    (rf/make-frame {:id a-id})
+    (let [a-token (frame/frame-incarnation-token a-id)]
+      (trace/register-listener! ::observer
+        (fn [ev]
+          (when (= :rf.test/fenced-emit (:operation ev))
+            (swap! first-hit inc)
+            ;; nested unrelated work, A stays live
+            (rf/dispatch-sync [:trace.neutral/mark] {:frame c-id}))))
+      (trace/register-listener! ::subsequent
+        (fn [ev]
+          (when (= :rf.test/fenced-emit (:operation ev))
+            (swap! later-hit inc))))
+      (try
+        (fire-fenced-emit! a-id a-token)
+        (is (= 1 @first-hit) "the first listener received A's fenced event")
+        (is (= 1 @later-hit)
+            "the SUBSEQUENT listener also received it — the live-owner fan-out is
+             not over-fenced by the neutralization")
+        (is (identical? a-token (frame/frame-incarnation-token a-id))
+            "A remained the live incarnation throughout")
+        (is (= {:marked true} (rf/app-db-value c-id))
+            "the first listener's nested unrelated dispatch ran normally")
+        (finally
+          (trace/unregister-listener! ::observer)
+          (trace/unregister-listener! ::subsequent))))))


### PR DESCRIPTION
## What

Neutralize outer continuation authority inside the PUBLIC trace-listener fan-out (rf2-eaxnai, P1 bug).

### The defect

PR #5904/#5897 correctly fenced a cold `reg-flow`'s first-registration / replacement / clear trace to an exact incarnation A via `trace/call-with-continuation-predicate`. But the public listener fan-out runs **inside** that binding. When a listener destroys A and creates same-id incarnation B with `:initial-events`, B's seed `dispatch-sync!` reaches `re-frame.router/build-envelope`, whose whole body is gated by `(when (trace/continuation-live?) ...)`. `continuation-live?` reads `*continuation-predicate*` — still bound to A's now-**false** predicate — so `build-envelope` returns nil and the seed is silently dropped. B is left live with `{}`, and make-frame's reuse/no-reseed law means a later re-ensure cannot recover it.

- Suppression site: `implementation/core/src/re_frame/router.cljc:230` (`build-envelope` gate) reached via `dispatch-sync!` at `router.cljc:3864`.
- Root cause: `implementation/core/src/re_frame/trace.cljc` `deliver!` restored epoch-capture / frame-policy / ring-retention to ordinary defaults for listener bodies (rf2-vf2qke) but left `*continuation-predicate*` bound to A's fence — the fourth axis was never neutralized.

### The fix (central, at the trace/tooling delivery boundary)

`implementation/core/src/re_frame/trace.cljc` `deliver!`:
1. Snapshot the caller's exact continuation predicate **before** neutralizing (`snapshot-continuation`).
2. Add `*continuation-predicate* nil` to the binding that already restores the other three axes, so each listener **body**'s nested authored work (dispatch / destroy / create + `:initial-events` seed) runs under ordinary always-continue authority.
3. Pass the **snapshot** as the tooling loop's `continue?` so the before/after checks still retain A's predicate — destroying A still suppresses A's remaining listeners.

`deliver-to-tooling!` is unchanged in behavior (docstring note added). No new public var, no new error-id, no new late-bind key — so no API-manifest / Spec 009 / late-bind-directory change. The single boundary covers registration, replacement, and clear/other callers with no flow-local patches.

## Quality gates

- **Focused core JVM** (`clojure -M:test`, `implementation/core`) — new test namespace: `Ran 2 tests containing 12 assertions. 0 failures, 0 errors.`
- **Failing-before / passing-after proof**: with the `deliver!` neutralization reverted, the new test is RED exactly per the bead (`:b-db {}`, `:seed-count nil`, unrelated-frame dispatch dropped, unrecoverable after re-ensure) — `5 failures`; with the fix, GREEN.
- **Focused JVM regression batch** (trace / incarnation-fence / structural-retention / listener-error-isolation): `Ran 129 tests containing 623 assertions. 0 failures, 0 errors.`
- **Full core JVM suite** (`clojure -M:test`): `Ran 2010 tests containing 9346 assertions. 0 failures, 0 errors.`
- **`npm run test:cljs`** (core + cross-artefact node build; runs the new `*-cljs-test.cljc` under CLJS and the existing flows incarnation cljs test): `Ran 9604 tests containing 47190 assertions. 0 failures, 0 errors.`

Not run (per brief): `test:browser`, full spine.

## Coverage

New cross-host test `implementation/core/test/re_frame/trace_listener_continuation_neutral_cljs_test.cljc` (`.cljc`, `-cljs-test` → runs on JVM and CLJS):
- A listener destroys A and creates same-id B with an `:initial-events` seed → seed runs **exactly once**, B's db is initialized, re-ensuring B does **not** replay it.
- The same listener's nested dispatch into an **unrelated** frame (issued after A is destroyed) still runs.
- A's remaining listener is suppressed after destruction (outer fence intact).
- Control deftest: a **non-destroying** first listener does not over-suppress the subsequent listener.
