### PR TITLE
docs(guide): make re-frame.ui Guide 07 a truthful executable server-data path (rf2-o6p1h6)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/07-servers.md
+++ b/ai/findings/new-substrate-synthesis/guide/07-servers.md
@@ -1,8 +1,8 @@
 # 07 — Talking to servers
 
-Views never fetch. They declare interest (`lease`) and read status (`sub`). Transport
-is ordinary re-frame2 effects and events — the same pipeline you already use for
-everything else. This chapter closes the loop the dashboard left open.
+Views never fetch. They declare interest (`lease`) and read status (`sub`).
+The fetch itself is ordinary re-frame2: an effect does the I/O and an event
+commits the result. This chapter closes the loop the dashboard left open.
 
 You should already be comfortable with [03](03-state.md)'s four inputs and
 [06](06-worked-app.md)'s tile shape.
@@ -12,11 +12,11 @@ You should already be comfortable with [03](03-state.md)'s four inputs and
 ```text
 view leases resource
         ↓
-resource system ensures (fetch / join in-flight)
+resource system ensures (first fetch / join in-flight)
         ↓
-fx / transport does the I/O
+:rf.http/managed transport does the I/O
         ↓
-success or failure event commits into app-db / resource cache
+the reply settles the resource cache (loaded + data, or error)
         ↓
 sub re-reads · view re-renders
 ```
@@ -26,122 +26,177 @@ Nothing in that pipeline is special to the view layer. The view's only jobs are
 
 ## End to end: a metrics feed
 
-### 1. Register the resource (core)
+The whole path below is proven by an enrolled JVM fixture
+(`re-frame.ui.guide-truth-jvm-test`) — register, ensure, settle, render — so the
+grammar here is executable, not illustrative.
 
-How you register resources is core re-frame2 territory — see the
-[resources guide](../../../../docs/core/where-state-lives.md) and your project's
-resource plan. Conceptually you have a resource id, params, and a fetch path that
-eventually dispatches an arrival event.
+### 1. Register the resource
 
-### 2. Transport as fx
-
-Wire HTTP, websocket, or SSE as ordinary effects. On success, dispatch a domain
-event — not a view callback:
+A resource is a named, cached read. `reg-resource` takes three slots — an id, a
+metadata map, and the `:request` handler that returns the fetch to run. The
+metadata's `:scope` is **required and fail-closed**: a global feed says so
+explicitly.
 
 ```clojure
-(rf/reg-event :metrics/latency-requested
-  (fn [{:keys [db]} _]
-    {:db (assoc-in db [:ui :latency :status] :loading)
-     ;; your project's HTTP / resource fx spelling
-     :fx [[:rf.http/managed
-           {:url    "/api/metrics/latency"
-            :on-ok  [:metrics/latency-arrived]
-            :on-err [:metrics/latency-failed]}]]}))
-
-(rf/reg-event :metrics/latency-arrived
-  (fn [{:keys [db]} [_ body]]
-    {:db (-> db
-             (assoc-in [:metrics :latency] body)
-             (assoc-in [:ui :latency :status] :loaded))}))
-
-(rf/reg-event :metrics/latency-failed
-  (fn [{:keys [db]} [_ err]]
-    {:db (assoc-in db [:ui :latency] {:status :error :error err})}))
+(rf/reg-resource :metrics/latency-feed
+  {:doc           "Rolling p95 latency, refreshed on demand."
+   :scope         :rf.scope/global    ; same numbers for everyone — an explicit claim
+   :params-schema [:map]}             ; this feed takes no params
+  (fn [_params _ctx]
+    {:request {:method :get :url "/api/metrics/latency"}
+     :decode  :json}))               ; :auto / :json / :text / a Malli schema / a fn
 ```
 
-Exact fx ids depend on your stack (`:rf.http/managed` is illustrative). The
-invariant: **I/O ends in events**, and events are the only writers.
+The runtime owns identity, cache scope, staleness, dedupe, and — crucially —
+reply addressing: your `:request` returns only the outgoing call, never the
+success/failure targets (those are supplied internally; see [Under the
+hood](#under-the-hood-the-managed-http-reply-envelope)). How resources fit the
+larger state picture is core territory — the
+[resources guide](../../../../docs/core/where-state-lives.md).
 
-### 3. View: lease + branch on status
+### 2. View: lease + branch on status
 
 ```clojure
 (ui/defview latency-tile []
   (lease {:resource :metrics/latency-feed})
   (let [{:keys [status data]} (sub [:rf/resource {:resource :metrics/latency-feed}])]
     (case status
-      :loading [:div.tile.skeleton "…"]
+      (:idle :loading) [:div.tile.skeleton "…"]
       :error   [:div.tile.error
                 "Feed unavailable"
-                [:button {:on-click [:metrics/latency-requested]} "Retry"]]
-      ;; :loaded and :fetching (prior data still visible mid-refresh)
+                [:button {:on-click [:rf.resource/refetch
+                                     {:resource :metrics/latency-feed}]}
+                 "Retry"]]
+      ;; :loaded and :fetching — prior data stays visible mid-refresh
       [:div.tile
        [:h3 "p95 latency"]
        [:strong (str (:p95 data) "ms")]])))
 ```
 
-- First visible lease → the resource is ensured (fetch starts or joins in-flight).
+- First visible lease → the resource is ensured (fetch starts, or joins an
+  in-flight one).
 - Last lease out → the system may wind down.
-- `:loading` / `:error` / `:loaded` / `:fetching` are **values you branch on** — no
-  Suspense, nothing hidden from Xray or tests.
+- `status` is one of `:idle` / `:loading` / `:fetching` / `:loaded` / `:error`
+  (the view-model also carries derived `:loading?` / `:fetching?` / `:stale?` /
+  `:has-data?`). They are **values you branch on** — no Suspense, nothing hidden
+  from Xray or tests.
+- The retry control's `:on-click` is a real event vector —
+  `[:rf.resource/refetch {:resource :metrics/latency-feed}]` re-runs the fetch
+  through the same path. Assert it as data ([08](08-testing.md)).
 
 !!! note "Lease vs route plans"
-    Loading that belongs to navigation or workflow should ride route/event resource
-    plans. Use `lease` when liveness genuinely follows *visible* UI — tiles, hover
-    cards, modals. See [03](03-state.md).
+    Loading that belongs to navigation or workflow should ride route/event
+    resource plans (below). Use `lease` when liveness genuinely follows
+    *visible* UI — tiles, hover cards, modals. See [03](03-state.md).
 
-## Testing the seam without a network
+### 3. Cause the load from navigation
 
-Headless tests never need a real HTTP client. Install the shared
-[test namespace fixture](08-testing.md#test-namespace-setup), then seed the state the
-resource would have produced or dispatch the arrival event yourself:
-
-```clojure
-(deftest latency-tile-shows-loaded-value
-  (rf/with-new-frame
-    [frame (rf/make-frame
-             {:initial-events
-              [[:rf/set-db
-                ;; shape depends on how your resource sub projects status/data;
-                ;; prefer dispatching your real :metrics/latency-arrived when possible
-                {}]]})]
-    ;; Prefer: drive through the real event
-    (ui.test/dispatch! frame [:metrics/latency-arrived {:p95 42}])
-    (let [tree (ui.test/render [latency-tile] {:frame frame})]
-      (is (str/includes? (ui.test/text tree) "42")))))
-```
-
-Or stub the resource sub for a pure presentation check:
-
-```clojure
-(rf/with-new-frame [frame (rf/make-frame {})]
-  (ui.test/render [latency-tile]
-    {:frame frame
-     :sub-overrides {[:rf/resource {:resource :metrics/latency-feed}]
-                     {:status :loaded :data {:p95 42}}}}))
-```
-
-Assert the retry button's intent as data when status is `:error` — same Tier-1 move
-as [08](08-testing.md).
-
-## Navigation and "user viewed this"
-
-There is no `:on-mount` event ([04](04-events.md)). Kick off loads from:
-
-- route `:on-match` (or your router's equivalent),
-- an event that opened the modal / selected the entity,
-- a machine transition,
-- or `lease` when visibility *is* the lifecycle.
+`lease` is the cause when visibility *is* the lifecycle. When the load belongs
+to a route or a user action instead, dispatch `:rf.resource/ensure` — the same
+event the lease reconciler dispatches under the hood:
 
 ```clojure
 ;; schematic — router spelling is core routing, not this guide
-(rf/reg-event :route/article
-  (fn [{:keys [db]} [_ {:keys [slug]}]]
-    {:db (assoc db :route {:name :article :slug slug})
-     :fx [[:dispatch [:article/ensure slug]]]}))
+(rf/reg-event :route/dashboard
+  (fn [{:keys [db]} _]
+    {:db db
+     :fx [[:dispatch [:rf.resource/ensure
+                      {:resource :metrics/latency-feed
+                       :owner    [:route :dashboard]}]]]}))
 ```
 
-The view for that route still only leases and reads — it does not start the fetch
-during render.
+The view for that route still only leases and reads — it does not start the
+fetch during render ([04](04-events.md): there is no `:on-mount` event; events
+are the only writers).
+
+## Under the hood: the managed-HTTP reply envelope
+
+When the resource fetches, the runtime lowers your `:request` into the
+`:rf.http/managed` effect, supplying `:request-id`, `:on-success`, and
+`:on-failure` itself. The transport appends a **uniform reply envelope** as the
+reply's last argument:
+
+```clojure
+{:status :ok    :value <decoded body>}        ; success
+{:status :error :error <:rf.http/* envelope>} ; failure
+```
+
+The resource's internal reply handlers verify the reply (frame + work-id +
+generation, so a stale or cross-frame reply can never overwrite newer data) and
+settle the cache entry — `:loaded` + `:data`, or `:error` + `:error`. A refresh
+whose reply fails keeps the prior data and records a `:refresh-error` instead.
+
+### Firing a request without a resource
+
+Sometimes you want one request wired straight to app-db — no cache, no lease.
+Then you address `:rf.http/managed` yourself and consume that same envelope. The
+authoring keys are `:request` (the outgoing call), optional `:decode`, and
+`:on-success` / `:on-failure` (an explicit `nil` silences a branch):
+
+```clojure
+(rf/reg-event :metrics/latency-requested
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:latency :status] :loading)
+     :fx [[:rf.http/managed
+           {:request    {:method :get :url "/api/metrics/latency"}
+            :decode     :json
+            :on-success [:metrics/latency-arrived]
+            :on-failure [:metrics/latency-failed]}]]}))
+
+(rf/reg-event :metrics/latency-arrived
+  (fn [{:keys [db]} [_ {:keys [value]}]]      ; envelope: {:status :ok :value …}
+    {:db (assoc db :latency {:status :loaded :p95 (:p95 value)})}))
+
+(rf/reg-event :metrics/latency-failed
+  (fn [{:keys [db]} [_ {:keys [error]}]]      ; envelope: {:status :error :error …}
+    {:db (assoc db :latency {:status :error :error error})}))
+```
+
+The view then reads ordinary app-db (`(sub [:metrics/latency])`). The invariant
+either way: **I/O ends in events, and events are the only writers.**
+
+## Testing the seam without a network
+
+Headless tests never touch a real HTTP client. Install the shared
+[test namespace fixture](08-testing.md#test-namespace-setup), register the
+resource, override `:rf.http/managed` with a capturing stub, then replay the
+transport's reply envelope yourself. Loading, success, failure, and retry all
+drive the **real** ensure → settle → sub path:
+
+```clojure
+(deftest latency-tile-loads-and-recovers
+  (rf/reg-resource :metrics/latency-feed
+    {:scope :rf.scope/global :params-schema [:map]}
+    (fn [_ _] {:request {:method :get :url "/api/metrics/latency"} :decode :json}))
+  (rf/with-new-frame
+    [frame (rf/make-frame {})]
+    ;; the view leases, so drive the cause the lease would — an ensure
+    (ui.test/dispatch! frame [:rf.resource/ensure
+                              {:resource :metrics/latency-feed
+                               :owner    [:lease :metrics 1]}])
+    ;; loading: the tile shows its skeleton
+    (is (str/includes? (ui.test/text (ui.test/render [latency-tile] {:frame frame}))
+                       "…"))
+    ;; success: replay {:status :ok :value …} → the tile renders 42
+    (ui.test/dispatch! frame (conj (:on-success @managed-args)
+                                   {:status :ok :value {:p95 42}}))
+    (is (str/includes? (ui.test/text (ui.test/render [latency-tile] {:frame frame}))
+                       "42"))))
+```
+
+`@managed-args` is whatever the capturing `:rf.http/managed` stub recorded (its
+`:on-success` is the runtime-owned `[:rf.resource.internal/succeeded …]` reply
+target). To pin a pure presentation state instead, stub the sub:
+
+```clojure
+(ui.test/render [latency-tile]
+  {:frame frame
+   :sub-overrides {[:rf/resource {:resource :metrics/latency-feed}]
+                   {:status :loaded :data {:p95 42}}}})
+```
+
+Assert the retry button's intent as data when status is `:error` — same Tier-1
+move as [08](08-testing.md).
 
 ## What not to do
 
@@ -149,6 +204,7 @@ during render.
 |---|---|
 | Fetch inside `defview` / `effect` as app logic | Bypasses events, epochs, Xray, time-travel |
 | Store "loading" only in React state | Invisible to tools; not shared; not SSR-friendly |
+| Write app-db from a handler while the view reads `[:rf/resource …]` | Two disjoint stores — the view never sees the write. Pick one seam per feature |
 | One giant `[:app/all-data]` sub for the page | Every byte change repaints everything — narrow reads ([10](10-performance.md)) |
 
 ## Where next

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -137,7 +137,8 @@ function assertBundleElision() {
     ownerMintSentinelAbsent: OWNER_MINT_SENTINEL,
     optionalResourcesSentinelAbsent: OPTIONAL_RESOURCES_SENTINEL,
     optionalResourcesManifestAbsent: 're_frame/resources.cljc and re_frame/resources/**',
-    uiDependencyBoundary: 'day8/re-frame2 present; day8/re-frame2-resources absent',
+    uiDependencyBoundary:
+      'production :deps: day8/re-frame2 present; day8/re-frame2-resources absent',
   };
 }
 
@@ -155,6 +156,28 @@ function assertNoProductionSentinels(blob) {
   for (const sentinel of SENTINELS) {
     if (blob.includes(sentinel)) fail(`advanced companion leaked ${sentinel}`);
   }
+}
+
+// Extract the PRODUCTION `:deps {…}` map text from a deps.edn string. The
+// dependency-boundary proof is scoped to this block: a `:test` alias's
+// `:extra-deps` never reaches the G-13 shadow builds (they resolve their
+// classpath from shadow-cljs.edn's own :source-paths, not ui/deps.edn's test
+// alias) and is out of scope. `:deps` occurs once at top level — `:extra-deps`
+// carries no `:deps` substring — so the first occurrence is the production map;
+// a balanced-brace scan returns exactly its text.
+function productionDepsBlock(depsEdn) {
+  const key = depsEdn.indexOf(':deps');
+  if (key < 0) fail('ui/deps.edn has no production :deps map');
+  const open = depsEdn.indexOf('{', key);
+  if (open < 0) fail('ui/deps.edn :deps is not a map');
+  let depth = 0;
+  for (let i = open; i < depsEdn.length; i += 1) {
+    const ch = depsEdn[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}' && (depth -= 1) === 0) return depsEdn.slice(open, i + 1);
+  }
+  fail('ui/deps.edn production :deps map is unbalanced');
+  return '';
 }
 
 function assertLeaseFreeAdvanced(blob, uiDepsOverride = null, mintControlBlob = null) {
@@ -206,10 +229,16 @@ function assertLeaseFreeAdvanced(blob, uiDepsOverride = null, mintControlBlob = 
   if (blob.includes(OPTIONAL_RESOURCES_SENTINEL)) {
     fail(`lease-free advanced companion retained optional Resources sentinel ${OPTIONAL_RESOURCES_SENTINEL}`);
   }
-  if (!/day8\/re-frame2\s+\{/.test(uiDeps)) {
+  // The dependency-boundary proof is about what production `re-frame.ui`
+  // pulls onto the classpath — NOT what a `:test` alias adds. The executable
+  // Guide-07 server-data fixture legitimately declares day8/re-frame2-resources
+  // under `:test` (it drives the real ensure/reply path), which never reaches
+  // the measured shadow builds. Scope the two checks to the production `:deps`.
+  const uiProdDeps = productionDepsBlock(uiDeps);
+  if (!/day8\/re-frame2\s+\{/.test(uiProdDeps)) {
     fail('UI dependency positive control omitted day8/re-frame2');
   }
-  if (/day8\/re-frame2-resources\s+\{/.test(uiDeps)) {
+  if (/day8\/re-frame2-resources\s+\{/.test(uiProdDeps)) {
     fail('UI artefact dependency boundary retained day8/re-frame2-resources');
   }
 }
@@ -396,9 +425,13 @@ function assertMutationTeeth(result) {
   }));
   const uiDeps = fs.readFileSync(path.join(IMPL, 'ui', 'deps.edn'), 'utf8');
   red.push(expectMutationFailure('optional Resources dependency leak', () => {
+    // Plant the forbidden dep INSIDE the production `:deps` map (not a test
+    // alias) — the boundary proof is scoped to production deps, so the tooth
+    // must inject the leak where the rule actually looks.
     assertLeaseFreeAdvanced(
       release.blob,
-      `${uiDeps}\nday8/re-frame2-resources {:local/root "../resources"}`,
+      uiDeps.replace(/(:deps\s*\{)/,
+        '$1day8/re-frame2-resources {:local/root "../resources"} '),
       mintControl.blob,
     );
   }));

--- a/implementation/ui/deps.edn
+++ b/implementation/ui/deps.edn
@@ -28,5 +28,16 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                       ;; TEST-ONLY deps for the executable Guide 07 server-data
+                       ;; fixture (re-frame.ui.guide-truth-jvm-test): it registers
+                       ;; a real resource, drives the actual ensure/reply +
+                       ;; runtime-cache path, and reads `[:rf/resource …]` in a
+                       ;; rendered view — so the optional resources + managed-HTTP
+                       ;; + schemas artefacts must be on the TEST classpath.
+                       ;; Production `re-frame.ui` never `:require`s any of them
+                       ;; (they depend on core; ui depends on core — no cycle).
+                       day8/re-frame2-resources {:local/root "../resources"}
+                       day8/re-frame2-http      {:local/root "../http"}
+                       day8/re-frame2-schemas   {:local/root "../schemas"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -3,10 +3,44 @@
 
   These assertions protect the ruled lifecycle recipe, guide-wide rendering
   boundary, fixture-marker mechanics, Xray S3 surface, and S6 relocation plan
-  until the guide moves to docs/ui."
+  until the guide moves to docs/ui.
+
+  Guide 07 (`07-servers.md`) is additionally proven EXECUTABLE here (rf2-o6p1h6):
+  the chapter's server-data path is not string-matched but RUN. A real resource
+  is registered with the shipped 3-slot `reg-resource` grammar, the actual
+  `:rf.resource/ensure` → `:rf.http/managed` lower → reply-envelope settle path
+  drives the runtime cache, and a rendered `latency-tile` reads that same state
+  through `[:rf/resource …]` — so `:loading`, success (rendered value 42),
+  failure, and the retry intent are proven through the real transport/resource
+  path, and the app-db counterpart (raw `:rf.http/managed` with
+  `:on-success`/`:on-failure` handlers consuming the uniform reply envelope) is
+  proven too. A false claim in the chapter reddens a deftest below, so the
+  transport / resource / app-db seams cannot drift apart.
+
+  The managed-HTTP transport is exercised WITHOUT a network: `:rf.http/managed`
+  is overridden with a capturing stub and the test replays the transport's
+  reply-event-append shape (`(conj on-success {:status :ok :value …})`), exactly
+  as `re-frame.resources-managed-http-cljs-test` does — so the runtime's real
+  reply handlers run against the genuine 3-element event the live transport
+  produces."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            ;; load-bearing side-effecting requires: register the resource
+            ;; events/subs + the managed-HTTP fx + the Malli validator these
+            ;; tests drive. Optional artefacts, pulled onto the ui TEST classpath
+            ;; (deps.edn :test) — production re-frame.ui never :requires them.
+            [re-frame.resources]
+            [re-frame.resources.test-support]
+            [re-frame.http.managed]
+            [re-frame.http.registry :as http-registry]
+            [re-frame.schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :refer [defview lease sub]]
+            [re-frame.ui.test :as uit]))
 
 (def chapter-files
   ["01-getting-started.md"
@@ -77,6 +111,185 @@
 (defn- one-line
   [text]
   (str/replace text #"\s+" " "))
+
+;; ===========================================================================
+;; Guide 07 — the EXECUTABLE server-data path (rf2-o6p1h6)
+;;
+;; Register a real resource, drive the actual ensure/reply + runtime-cache
+;; path, and read `[:rf/resource …]` in a rendered view. The transport is
+;; captured (no network); the test replays the transport's reply-envelope
+;; append shape so the runtime's genuine reply handlers settle the cache.
+;; ===========================================================================
+
+(def ^:private managed-args
+  "The last `:rf.http/managed` args the capturing stub recorded. Its runtime-
+  owned `:on-success` / `:on-failure` reply targets are replayed with the
+  transport's appended `{:status :ok :value …}` / `{:status :error :error …}`
+  envelope to settle the resource cache."
+  (atom nil))
+
+(defn- capturing-transport-fixture
+  "Override `:rf.http/managed` with a capturing no-op so the ensure/refetch
+  lower is inspectable and the reply is replayed explicitly — the resource
+  server-data path runs end-to-end without a live HTTP client."
+  [f]
+  (reset! managed-args nil)
+  (http-registry/clear-all-in-flight!)
+  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! managed-args args) nil))
+  (f)
+  (http-registry/clear-all-in-flight!))
+
+;; ---- the two views the chapter shows, verbatim in shape --------------------
+
+;; §2 — the resource tile: declares liveness with `lease`, reads status with a
+;; passive `[:rf/resource …]` sub, and branches on the real status set.
+(defview latency-tile []
+  (lease {:resource :metrics/latency-feed})
+  (let [{:keys [status data]} (sub [:rf/resource {:resource :metrics/latency-feed}])]
+    (case status
+      (:idle :loading) [:div.tile.skeleton "…"]
+      :error   [:div.tile.error
+                "Feed unavailable"
+                [:button {:on-click [:rf.resource/refetch
+                                     {:resource :metrics/latency-feed}]}
+                 "Retry"]]
+      ;; :loaded and :fetching — prior data stays visible mid-refresh
+      [:div.tile
+       [:h3 "p95 latency"]
+       [:strong (str (:p95 data) "ms")]])))
+
+;; §Firing a request without a resource — the app-db counterpart: the view
+;; reads ordinary app-db that the envelope-consuming handlers wrote.
+(defview latency-plain-tile []
+  (let [{:keys [status p95]} (sub [:metrics/latency])]
+    (case status
+      :loading [:div.tile.skeleton "…"]
+      :error   [:div.tile.error "Feed unavailable"]
+      :loaded  [:div.tile [:strong (str p95 "ms")]]
+      [:div.tile.skeleton "…"])))
+
+;; use-fixtures is evaluated AFTER the defviews above so the reset fixture's
+;; ns-load registrar baseline includes them (they survive the per-test reset).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  capturing-transport-fixture)
+
+(defn- reg-latency-feed!
+  "Register the `:metrics/latency-feed` resource with the exact shipped
+  3-slot grammar (id, metadata map, `:request` handler). The reset fixture
+  wipes the registry per test, so each test re-registers first."
+  []
+  (rf/reg-resource :metrics/latency-feed
+    {:doc           "Rolling p95 latency, refreshed on demand."
+     :scope         :rf.scope/global
+     :params-schema [:map]}
+    (fn [_params _ctx]
+      {:request {:method :get :url "/api/metrics/latency"}
+       :decode  :json})))
+
+(deftest guide07-resource-loading-and-success-render-the-real-cache
+  ;; §1–§2 + §Under the hood — the headline end-to-end: ensure → :loading, then
+  ;; the success reply envelope settles :loaded + data, rendered through
+  ;; `[:rf/resource …]` as 42.
+  (reg-latency-feed!)
+  (rf/with-new-frame
+    [frame (rf/make-frame {})]
+    ;; the cause the view's `lease` would drive at runtime
+    (uit/dispatch! frame [:rf.resource/ensure
+                          {:resource :metrics/latency-feed
+                           :owner    [:lease :metrics 1]}])
+    (testing "the resource lowered its :request into :rf.http/managed verbatim,
+              with runtime-owned reply addressing"
+      (let [req @managed-args]
+        (is (some? req) "the ensure reached the transport")
+        (is (= {:method :get :url "/api/metrics/latency"} (:request req)))
+        (is (= :json (:decode req)) "the Spec 014 :decode key rides through")
+        (is (= [:rf.resource.internal/succeeded]
+               (subvec (:on-success req) 0 1))
+            "reply addressing is runtime-owned, not app-authored")))
+    (testing ":loading — the tile branches to its skeleton"
+      (is (str/includes?
+            (uit/text (uit/render [latency-tile] {:frame frame})) "…")))
+    (testing "success — replay the {:status :ok :value …} envelope; the settled
+              cache value renders through the sub"
+      (uit/dispatch! frame (conj (:on-success @managed-args)
+                                 {:status :ok :value {:p95 42}}))
+      (let [tree (uit/render [latency-tile] {:frame frame})]
+        (is (str/includes? (uit/text tree) "42"))
+        (is (nil? (uit/find tree :button))
+            "the loaded tile carries no retry control")))))
+
+(deftest guide07-resource-failure-renders-error-and-retry-re-enters-the-path
+  ;; §2 retry intent — a first-load failure settles :error; the tile shows the
+  ;; error branch whose retry button carries a REAL refetch event; dispatching
+  ;; it re-enters the load path and the fresh reply recovers the value.
+  (reg-latency-feed!)
+  (rf/with-new-frame
+    [frame (rf/make-frame {})]
+    (uit/dispatch! frame [:rf.resource/ensure
+                          {:resource :metrics/latency-feed
+                           :owner    [:lease :metrics 1]}])
+    (testing "failure — replay the {:status :error :error …} envelope; the tile
+              branches to its error state and offers a real retry intent"
+      (uit/dispatch! frame (conj (:on-failure @managed-args)
+                                 {:status :error
+                                  :error  {:kind :rf.http/http-5xx :status 503}}))
+      (let [tree (uit/render [latency-tile] {:frame frame})]
+        (is (str/includes? (uit/text tree) "Feed unavailable"))
+        (is (= [:rf.resource/refetch {:resource :metrics/latency-feed}]
+               (:on-click (uit/attrs (uit/find tree :button))))
+            "the retry control carries a real refetch event as data")))
+    (testing "retry — the refetch the button intends re-enters :loading through
+              the same real transport path"
+      (reset! managed-args nil)
+      (uit/dispatch! frame [:rf.resource/refetch {:resource :metrics/latency-feed}])
+      (is (some? @managed-args) "the retry lowered a fresh fetch")
+      (is (str/includes?
+            (uit/text (uit/render [latency-tile] {:frame frame})) "…")
+          "the retry re-enters the skeleton"))
+    (testing "recovery — the retried fetch's own reply settles the value"
+      (uit/dispatch! frame (conj (:on-success @managed-args)
+                                 {:status :ok :value {:p95 42}}))
+      (is (str/includes?
+            (uit/text (uit/render [latency-tile] {:frame frame})) "42")))))
+
+(deftest guide07-raw-managed-http-writes-app-db-through-the-envelope
+  ;; §Firing a request without a resource — the app-db seam: a raw
+  ;; :rf.http/managed with :on-success/:on-failure whose handlers CONSUME the
+  ;; uniform reply envelope and write app-db, read back by an ordinary app sub.
+  (rf/reg-sub :metrics/latency (fn [db _] (:latency db)))
+  (rf/reg-event :metrics/latency-requested
+    (fn [{:keys [db]} _]
+      {:db (assoc-in db [:latency :status] :loading)
+       :fx [[:rf.http/managed
+             {:request    {:method :get :url "/api/metrics/latency"}
+              :decode     :json
+              :on-success [:metrics/latency-arrived]
+              :on-failure [:metrics/latency-failed]}]]}))
+  (rf/reg-event :metrics/latency-arrived
+    (fn [{:keys [db]} [_ {:keys [value]}]]      ; envelope: {:status :ok :value …}
+      {:db (assoc db :latency {:status :loaded :p95 (:p95 value)})}))
+  (rf/reg-event :metrics/latency-failed
+    (fn [{:keys [db]} [_ {:keys [error]}]]      ; envelope: {:status :error :error …}
+      {:db (assoc db :latency {:status :error :error error})}))
+  (rf/with-new-frame
+    [frame (rf/make-frame {})]
+    (uit/dispatch! frame [:metrics/latency-requested])
+    (testing "the raw :rf.http/managed carries the shipped contract keys"
+      (let [req @managed-args]
+        (is (= {:method :get :url "/api/metrics/latency"} (:request req)))
+        (is (= :json (:decode req)))
+        (is (= [:metrics/latency-arrived] (:on-success req)))
+        (is (= [:metrics/latency-failed] (:on-failure req)))))
+    (testing ":loading renders the skeleton from app-db"
+      (is (str/includes?
+            (uit/text (uit/render [latency-plain-tile] {:frame frame})) "…")))
+    (testing "the success handler consumes the envelope's :value into app-db;
+              the app sub reads it and the tile renders 42"
+      (uit/dispatch! frame (conj (:on-success @managed-args)
+                                 {:status :ok :value {:p95 42}}))
+      (is (str/includes?
+            (uit/text (uit/render [latency-plain-tile] {:frame frame})) "42")))))
 
 (deftest lifecycle-recipe-is-installed-and-owned
   (let [getting-started (slurp-guide "01-getting-started.md")


### PR DESCRIPTION
## What & why

`bd rf2-o6p1h6` (P1 bug, from the PR #5899 audit): Guide 07 (`07-servers.md`) promised a *Fetch server data end-to-end* path that could not run.

**What Guide 07 got wrong (vs the shipped path):**

- The `:rf.http/managed` example used invented top-level args `:url` / `:on-ok` / `:on-err`. The shipped contract (`re-frame.http.handlers/managed-handler`, `implementation/http/src/re_frame/http/handlers.cljc:159-171`, `:196`) is a `:request` envelope (`{:method :get :url ...}`), optional `:decode`, and `:on-success` / `:on-failure`, with the transport appending a **uniform reply envelope** (`{:status :ok :value ...}` / `{:status :error :error ...}`) as the reply's last arg (`re-frame.resources-managed-http-cljs-test` `reply-success!`/`reply-failure!`, `:104-115`).
- The handlers wrote ordinary app-db paths (`[:metrics :latency]`) while the tile read `[:rf/resource ...]` from the resource runtime cache (`re-frame.resources.subs/state-sub-fn`, `implementation/resources/src/re_frame/resources/subs.cljc:333`) — **two disjoint stores**.
- The shown test dispatched the app-db event, then asserted the *resource* read held `42`. No resource was ever registered (`rf/reg-resource`, `implementation/resources/src/re_frame/resources/registry.cljc:435`) or connected to the transport, so the read could never contain `42`.

**The corrected, coherent path (single end-to-end story):** register a resource with the shipped 3-slot grammar whose `:request` returns a managed-HTTP args map; the view `lease`s + reads `[:rf/resource ...]`; a route/event (or the lease reconciler) drives `:rf.resource/ensure`; the runtime owns reply addressing and settles the cache from the uniform envelope. The raw `:rf.http/managed`→app-db case is documented separately with the correct `:request`/`:decode`/`:on-success`/`:on-failure` keys and envelope-consuming handlers.

**Executable, not illustrative:** `re-frame.ui.guide-truth-jvm-test` is extended with a deterministic fixture (capturing transport, no network — the `resources-managed-http` technique) that registers `:metrics/latency-feed`, drives the real `ensure → reply → cache` path, and renders `latency-tile` through `[:rf/resource ...]` to prove **loading**, **success (rendered value 42)**, **failure**, and **retry intent** (the error tile's `[:rf.resource/refetch ...]` button re-enters the load path and recovers). A raw `:rf.http/managed → app-db → view` test guards the app-db seam too, so the transport / resource / app-db paths cannot drift apart. `resources`/`http`/`schemas` are added to the ui `:test` classpath only (production `re-frame.ui` never `:require`s them; no dependency cycle).

## Surface

- `ai/findings/new-substrate-synthesis/guide/07-servers.md` — the rewrite (core-link census preserved; no host fences / fixture markers added).
- `implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj` — executable server-data fixture (3 new deftests).
- `implementation/ui/deps.edn` — test-only resources/http/schemas deps.
- `implementation/scripts/run-ui-g13.cjs` — scope the G-13 dependency-boundary check to the production `:deps` map (see Quality gates).

Stayed within the fenced surface: no operator files (top-level chapters, `guide/03`, `guide/04`, `drafts/*`, `skill/*`), no compiler/SSR/reactive code, no hot-zone files.

## Quality gates

- `cd implementation && npm run test:ui-g13` → **G-13 PASS.** The `resources`/`http`/`schemas` test-alias deps had reddened this byte-exact push-economics gate. Root cause was *not* a byte/classpath shift: the `ui-g13`/`ui-g13-prod`/`ui-g13-mint-control` shadow builds compiled byte-clean (`0 warnings`) with every bundle-DCE proof passing; the gate's coarse dependency-boundary check simply grepped the *whole* `ui/deps.edn` text for `day8/re-frame2-resources {` and matched the `:test` alias. The G-13 shadow builds resolve their classpath from `shadow-cljs.edn`'s own `:source-paths`, never ui/deps.edn's test alias, so those deps never reach the measured bundle. Fix: scope the boundary proof to the production `:deps` map (balanced-brace extraction) and re-target the matching mutation tooth to inject the forbidden dep *inside* `:deps` so it still turns red. Byte-exact push economics and advanced-elision DCE proofs are untouched.
- `cd implementation/ui && clojure -M:test -n re-frame.ui.guide-truth-jvm-test` → **Ran 10 tests containing 370 assertions. 0 failures, 0 errors.** (3 new executable server-data deftests + the 7 existing string-truth gates.)
- `cd implementation && npm run test:ui` → **Ran 646 tests containing 3335 assertions. 0 failures, 0 errors.** (ui-adapter isolation PASS.)
- `python scripts/check_doc_slugs.py --synthesis-only --verbose` → **no broken links** (35 files scanned; the new in-page anchor resolves).

Rebased on latest `origin/main` (clean, no conflicts) before the fix.
