### PR TITLE
fix(ui): causal Shadow compile membership instead of wall-clock stamp ordering (rf2-ialoij)

### DIFF
--- a/implementation/scripts/check-ui-final-schedule.cjs
+++ b/implementation/scripts/check-ui-final-schedule.cjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-// rf2-vxgfnd.195 — the FIFTH real-Shadow arm for final-schedule reconciliation,
-// replacing the synthetic JVM fixtures that fabricate build state and
-// :compiled-at stamps (compiler_digest_carrier_jvm_test.clj's
-// later-prepare-hook-forced-recompile / metadata-only / missing-provenance
-// arms). Those cannot prove Shadow hook deep-merge/order, an actual build-local
-// :compile-prepare hook, real sequential/parallel scheduling, output-marker
-// retention, or fail-loud behaviour.
+// rf2-vxgfnd.195 / rf2-ialoij — the FIFTH real-Shadow arm for final-schedule
+// reconciliation, complementing the synthetic JVM fixtures that fabricate build
+// state and outputs (compiler_digest_carrier_jvm_test.clj's
+// later-prepare-hook-forced-recompile / colliding-and-backwards-stamps /
+// metadata-only / missing-provenance arms). Those cannot prove Shadow hook
+// deep-merge/order, an actual build-local :compile-prepare hook, real
+// sequential/parallel scheduling, output-marker retention, or fail-loud
+// behaviour — but here the FRESH `:js` object Shadow's real compile path
+// allocates is genuine, not a hand-built stand-in.
 //
 // This gate drives ONE real Shadow 3.4.10 warm watch daemon per compile mode
 // through:
@@ -20,9 +22,10 @@
 //      retained output and rewrites its source viewless, forcing Shadow to
 //      recompile app-a AFTER re-frame.ui observed the schedule. app-a was NOT
 //      pre-touched at prepare, so ONLY reconcile-final-schedule at :compile-
-//      finish (reading Shadow's advanced :compiled-at stamp) can evict it. The
-//      accepted row is evicted, the digest moves, and app-b (a true cache hit)
-//      stays byte-identical;
+//      finish (reading Shadow's causal per-source compile evidence — app-a's
+//      fresh, :cached false output carrying a new :js artifact object) can evict
+//      it. The accepted row is evicted, the digest moves, and app-b (a true
+//      cache hit) stays byte-identical;
 //   4. a FAIL-LOUD pass — a build-local hook drops re-frame.ui's per-pass
 //      :pass-output provenance from the open scratch; reconciliation must FAIL
 //      the build rather than silently reconcile against an assumed-empty
@@ -30,8 +33,13 @@
 // Both the PARALLEL (:ui-final-schedule) and SEQUENTIAL
 // (:ui-final-schedule-seq, :parallel-build false) compile schedules are proven.
 //
-// TEETH (documented mutation/revert; run at development time, NOT committed —
-// build_hook.clj is production compiler code this test-only bead does not edit):
+// TEETH (documented mutation/revert; run at development time, NOT committed):
+//   * Restore build-hook/compiled-this-pass?'s old wall-clock body (a
+//     `(> now then)` on :compiled-at, rf2-ialoij) — a real-host recompile whose
+//     fresh output lands in the SAME millisecond as its prepare snapshot is then
+//     misread as untouched, so app-a's ghost can survive the FORCED-EVICT pass.
+//     The deterministic same-/backwards-stamp misclassification is proven
+//     unconditionally by the digest-carrier JVM arms.
 //   * Delete the `(reconcile-final-schedule build-state)` call in
 //     re-frame.ui.compiler.build-hook/hook's :compile-finish branch → the
 //     FORCED-EVICT pass keeps app-a's ghost row (a-present stays true,

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -12,24 +12,26 @@
 
   0. reconcile against Shadow's FINAL authoritative compile schedule — every
      CLJS source actually compiled THIS pass is pre-touched too. Membership is
-     read from Shadow's AUTHORITATIVE per-source compile evidence, never
-     output-object identity and never wall-clock ordering: a source counts as
-     recompiled iff its finish-time output `:compiled-at` stamp advanced past
-     the stamp in the prepare snapshot. Shadow writes `:compiled-at` EXACTLY
-     inside `do-compile-cljs-resource`, so the stamp advances iff Shadow really
-     (re)compiled the source this pass; a warm cache hit keeps its retained
-     object and stamp. Keying on the stamp — not the object reference — is
-     immune to a later non-scheduling hook that replaces a retained output's
-     object (via assoc/update-in) while PRESERVING its stamp, and — because it
-     compares each source's own before/after stamp, never a pass boundary —
-     immune to the millisecond collision where a retained warm output's stamp
-     equals the next pass start. A later `:compile-prepare` hook (Shadow
-     deep-merges build-local hooks after `:build-defaults` and lets them mutate
-     build state) can force a source to recompile AFTER re-frame.ui observed the
-     schedule; reading the finish-time compile stamps, not the intermediate
-     prepare schedule, closes that hook-order gap so a forced recompile that
-     removed a source's final `ui/defview` evicts its accepted row instead of
-     leaving a ghost view;
+     read from Shadow's CAUSAL per-source compile evidence, never output-map
+     identity and never a wall-clock stamp relationship: a source counts as
+     recompiled iff Shadow marked its finish output freshly compiled (`:cached
+     false`) carrying a `:js` artifact object distinct from the one snapshotted
+     at prepare. Shadow allocates that fresh `:js` string and stamps `:cached
+     false` EXACTLY inside its `do-compile-cljs-resource` compile path, so both
+     facts hold iff Shadow really (re)compiled the source this pass; a warm cache
+     hit keeps its retained output object (same `:js`), and a disk-cache load is
+     `:cached true`. Keying on the fresh `:js` object — not the whole output map
+     — is immune to a later non-scheduling hook that replaces a retained output's
+     MAP (via assoc/update-in) while PRESERVING its nested `:js`, and — because it
+     reads Shadow's own compile provenance rather than comparing `:compiled-at`
+     milliseconds — immune to the same-/backwards-millisecond stamp a `>` test
+     misreads as untouched (leaving a ghost accepted view). A later
+     `:compile-prepare` hook (Shadow deep-merges build-local hooks after
+     `:build-defaults` and lets them mutate build state) can force a source to
+     recompile AFTER re-frame.ui observed the schedule; reading the finish-time
+     compile evidence, not the intermediate prepare schedule, closes that
+     hook-order gap so a forced recompile that removed a source's final
+     `ui/defview` evicts its accepted row instead of leaving a ghost view;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -114,46 +116,57 @@
      build-sources)))
 
 (defn- compiled-this-pass?
-  "Shadow's AUTHORITATIVE fresh-compile evidence for one source, robust to
-  output-object replacement.
+  "Shadow's CAUSAL fresh-compile evidence for one source, free of any wall-clock
+  stamp comparison.
 
-  Shadow writes `:compiled-at` (`System/currentTimeMillis`) EXACTLY inside
-  `do-compile-cljs-resource` — the actual compile path — so the stamp advances
-  iff Shadow really (re)compiled the source THIS pass. A warm cache hit keeps
-  its prior output object and stamp; a later non-scheduling `:compile-prepare`
-  hook that only annotates or normalizes a retained output (assoc/update-in)
-  yields a NEW object but PRESERVES `:compiled-at`. So the source was compiled
-  this pass iff its finish-time stamp advanced past the prepare-snapshot stamp
-  (a missing snapshot stamp — a freshly scheduled or output-reset source —
-  counts as advanced; Shadow's clock only ever moves forward for a real
-  compile). Keying on the stamp — never the object reference — is immune to the
-  metadata-mutation false positive that raw `identical?` produced, and — because
-  it compares the source's own before/after stamp, never a wall-clock pass
-  boundary — immune to the collision where a retained warm output's stamp equals
-  the next pass start."
+  Shadow's compile path — `do-compile-cljs-resource`, reached ONLY through
+  `maybe-compile-cljs` — is the sole producer of a freshly compiled output: it
+  allocates a brand-new `:js` artifact string (its own `StringWriter`) and stamps
+  `:cached false` on it. A disk-cache load stamps `:cached true` with a distinct
+  deserialized `:js`. A warm cache HIT keeps the prior output object untouched
+  (`generate-output-for-source` returns it; par-compile's `already-compiled`
+  skips it), so the SAME `:js` object survives the pass. A later non-scheduling
+  `:compile-prepare` hook that only annotates or normalizes a retained output
+  (assoc/update-in) yields a NEW output MAP but — assoc preserving nested values —
+  PRESERVES the identical `:js` object.
+
+  So a source was (re)compiled THIS pass iff Shadow marked its finish output
+  freshly compiled (`:cached` is `false` — never a cache load, never a retained
+  annotation of one) AND that output carries a DIFFERENT `:js` artifact object
+  than the one re-frame.ui snapshotted at `:compile-prepare`:
+
+  - `:cached false` rejects a disk-cache load (fresh `:js`, but no macro rerun);
+  - a fresh `:js` object rejects both a warm cache hit (same output object, same
+    `:js`) and a metadata-only mutation (new map, but the nested `:js` is the
+    same object) — the two false positives raw whole-output `identical?` produced.
+
+  Neither test is `>`, `>=`, `!=`, `not=`, or any other relationship on the
+  `:compiled-at` wall clock, so a genuine EQUAL-stamp or BACKWARDS-stamp recompile
+  (same-millisecond `System/currentTimeMillis`, clock skew, a non-monotonic clock)
+  is still classified as a recompile, while a metadata annotation and a warm cache
+  hit are never misread as one."
   [final-output snapshot-output]
-  (let [now  (:compiled-at final-output)
-        then (:compiled-at snapshot-output)]
-    (and (integer? now)
-         (or (not (integer? then))
-             (> now then)))))
+  (and (false? (:cached final-output))
+       (not (identical? (:js final-output) (:js snapshot-output)))))
 
 (defn- actually-recompiled-member-nss
   "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
   THIS pass, read from the FINAL build-state at `:compile-finish` — after every
   schedule-mutating `:compile-prepare` hook and after compilation ran —
-  distinguished by Shadow's AUTHORITATIVE per-source compile stamp, never
-  output-object identity or wall-clock ordering.
+  distinguished by Shadow's CAUSAL per-source compile evidence, never output-map
+  identity and never a wall-clock stamp relationship.
 
   `pass-output` is the `:output` map re-frame.ui snapshotted at
   `:compile-prepare` (the outputs Shadow was about to compile from). See
-  `compiled-this-pass?`: a source counts as recompiled iff its finish-time
-  `:compiled-at` advanced past its snapshot stamp — the evidence Shadow's own
-  compile path carries. This is immune both to a later hook replacing a retained
-  output's OBJECT while preserving its stamp (raw `identical?` misread the fresh
-  object as a recompile and evicted an untouched accepted view) and to the
-  millisecond stamp collision with a pass boundary, and it does not depend on
-  the build-local hook merge order re-frame.ui cannot control."
+  `compiled-this-pass?`: a source counts as recompiled iff Shadow marked its
+  finish output freshly compiled (`:cached false`) with a `:js` artifact object
+  distinct from its snapshot — the evidence Shadow's own compile path carries.
+  This is immune to a later hook replacing a retained output's whole MAP while
+  preserving its nested `:js` (raw whole-output `identical?` misread the fresh
+  map as a recompile and evicted an untouched accepted view), to a same- or
+  backwards-millisecond compile stamp (which a `>`/`>=` stamp test misreads as
+  untouched, leaving a ghost accepted view), and to the build-local hook merge
+  order re-frame.ui cannot control."
   [{:keys [build-sources sources output]} pass-output]
   (reduce
    (fn [acc resource-id]
@@ -410,10 +423,13 @@
       (let [build-state (reset-cold-ui-consumer-output build-state)]
         ;; Snapshot the `:output` map Shadow handed us BEFORE any compilation, so
         ;; `:compile-finish` can identify the sources Shadow actually recompiled
-        ;; this pass by their `:compiled-at` compile stamp — Shadow's own
-        ;; per-source compile evidence, robust to a later prepare hook mutating a
-        ;; retained output's OBJECT and immune to the millisecond stamp collision
-        ;; (rf2-vxgfnd.194, rf2-vxgfnd.255, rf2-vxgfnd.282).
+        ;; this pass by Shadow's own causal compile evidence — a `:cached false`
+        ;; finish output whose `:js` artifact object differs from this snapshot —
+        ;; robust to a later prepare hook mutating a retained output's whole MAP
+        ;; while preserving its nested `:js`, and free of any `:compiled-at`
+        ;; wall-clock comparison so same-/backwards-millisecond recompiles are
+        ;; still caught (rf2-vxgfnd.194, rf2-vxgfnd.255, rf2-vxgfnd.282,
+        ;; rf2-ialoij).
         (-> (build/prepare-shadow-build build-state
                                         build-id
                                         (member-nss build-state)

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -12,6 +12,17 @@
 (def ^:private app-a-rid [:cljs "app/a.cljs"])
 (def ^:private app-b-rid [:cljs "app/b.cljs"])
 
+(defn- fresh-js
+  "A DISTINCT String instance carrying `s`, modelling Shadow's
+  `(.toString StringWriter)`: every real `do-compile-cljs-resource` allocates a
+  brand-new `:js` object — never an interned literal — even when the emitted
+  bytes are byte-identical to a prior compile. `identical?` on that object is
+  precisely the causal recompile signal `compiled-this-pass?` keys on, so a test
+  literal (interned, shared across every occurrence) would falsely read as a warm
+  cache hit. Use this for the `:js` of any output that models a fresh compile."
+  ^String [^String s]
+  (String. s))
+
 (defn- shadow-state [build-id js]
   {:shadow.build/build-id build-id
    :shadow.build/stage :compile-prepare
@@ -212,13 +223,20 @@
         "zero carrier output cannot be mistaken for an accepted publication")))
 
 (deftest later-prepare-hook-forced-recompile-evicts-removed-view
-  ;; rf2-vxgfnd.194: a build-local :compile-prepare hook running AFTER the
-  ;; inherited re-frame.ui hook removes a source's retained output, forcing
-  ;; Shadow to recompile it after re-frame.ui observed the schedule. If that
-  ;; source removed its final ui/defview it contributes nothing, and — pre-fix —
-  ;; its accepted row survived as a ghost view because it was never pre-touched.
-  ;; The :compile-finish reconcile against Shadow's authoritative per-source
-  ;; compile stamp (`:compiled-at` advanced past the prepare snapshot) evicts it.
+  ;; rf2-vxgfnd.194 / rf2-ialoij: a build-local :compile-prepare hook running
+  ;; AFTER the inherited re-frame.ui hook removes a source's retained output,
+  ;; forcing Shadow to recompile it after re-frame.ui observed the schedule. If
+  ;; that source removed its final ui/defview it contributes nothing, and —
+  ;; pre-fix — its accepted row survived as a ghost view because it was never
+  ;; pre-touched. The :compile-finish reconcile against Shadow's CAUSAL per-source
+  ;; compile evidence (a `:cached false` finish output whose `:js` artifact is a
+  ;; fresh object) evicts it.
+  ;;
+  ;; The forced recompile here carries a `:compiled-at` stamp EQUAL to the prepare
+  ;; snapshot (a same-millisecond `System/currentTimeMillis`) and byte-identical
+  ;; `:js`, so nothing but Shadow's fresh-object provenance distinguishes it from a
+  ;; warm hit. A `(> now then)` stamp test would read it as untouched and leave the
+  ;; ghost; the causal test evicts it.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :ghost parallel?)
@@ -231,23 +249,26 @@
             "the accepted build declares both sources' views")
         ;; Warm pass: app.a + app.b both retain a stamped output, so re-frame.ui
         ;; pre-touches neither. A later prepare hook then removes app.a's output;
-        ;; app.a recompiles this pass — Shadow ADVANCES its `:compiled-at` stamp
-        ;; — contributing NO declaration. app.b stays a cache hit: its EXACT
-        ;; output object (and stamp) is retained unchanged across the pass.
-        (let [warm-b-output {:resource-id app-b-rid :js "app.b = {};"
+        ;; app.a recompiles this pass — Shadow allocates a FRESH `:js` object —
+        ;; contributing NO declaration, at the SAME `:compiled-at` stamp (1000).
+        ;; app.b stays a cache hit: its EXACT output object (same `:js`) is
+        ;; retained unchanged across the pass.
+        (let [warm-b-output {:resource-id app-b-rid :js (fresh-js "app.b = {};")
                              :compiled-at 1000 :cached false}
               warm-input (-> good
                              (assoc-in [:output carrier-rid :js]
                                        build-hook/digest-sentinel)
                              (assoc-in [:output app-a-rid]
-                                       {:resource-id app-a-rid :js "app.a = {};"
+                                       {:resource-id app-a-rid
+                                        :js (fresh-js "app.a = {};")
                                         :compiled-at 1000 :cached false})
                              (assoc-in [:output app-b-rid] warm-b-output))
               prepared (prepare warm-input)
               finished (-> prepared
                            (assoc-in [:output app-a-rid]
-                                     {:resource-id app-a-rid :js "app.a = {};"
-                                      :compiled-at 2000 :cached false})
+                                     {:resource-id app-a-rid
+                                      :js (fresh-js "app.a = {};")
+                                      :compiled-at 1000 :cached false})
                            finish)]
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
@@ -258,24 +279,27 @@
               "the forced-recompile ghost is evicted; the cache-hit sibling stays")
           (is (not (contains? (build/accepted-aggregate build/views finished)
                               :app/a-view))
-              "no ghost view survives the source's zero-declaration recompile")
+              "no ghost view survives the source's same-stamp zero-declaration recompile")
           (is (not= (build/accepted-build-digest good)
                     (build/accepted-build-digest finished))
               "evicting the ghost changes the accepted whole-build digest"))))))
 
-(deftest exact-provenance-distinguishes-colliding-warm-hit-from-real-recompile
-  ;; rf2-vxgfnd.255: final-schedule membership is decided by exact per-pass
-  ;; provenance — output-object identity — not a wall-clock `compiled-at >=
-  ;; pass-start` test. In ONE warm pass, under the SAME optimizer/compile
-  ;; controls (sequential + parallel):
-  ;;   * app.b is a genuine cache hit whose retained output object is unchanged,
-  ;;     yet carries a `:compiled-at` stamp that EXCEEDS any pass start (the
-  ;;     adversarial collision the bead reproduces) — it must stay accepted and
-  ;;     digest-stable;
-  ;;   * app.a is genuinely recompiled (a fresh output object) with the SAME
-  ;;     colliding stamp and removed its final view — it must be evicted.
-  ;; Restoring the timestamp-only membership test would flag app.b too (its
-  ;; stamp >= pass-start) and wrongly evict it, failing the survival assertion.
+(deftest causal-membership-survives-colliding-and-backwards-stamps
+  ;; rf2-vxgfnd.255 / rf2-ialoij: final-schedule membership is decided by Shadow's
+  ;; CAUSAL compile evidence — a `:cached false` finish output whose `:js` artifact
+  ;; is a fresh object — never a `:compiled-at` wall-clock relationship. Shadow
+  ;; stamps `:compiled-at` with `System/currentTimeMillis`, which can EQUAL or
+  ;; DECREASE across genuine compiles (same-ms, clock skew, a non-monotonic clock),
+  ;; so any `>`/`>=`/`!=` stamp test misclassifies. In ONE warm pass, under the
+  ;; SAME optimizer/compile controls (sequential + parallel):
+  ;;   * app.b is a genuine cache hit whose retained output object (same `:js`) is
+  ;;     unchanged, yet carries the maximal `:compiled-at` — it must stay accepted
+  ;;     and digest-stable;
+  ;;   * app.a is genuinely recompiled (a fresh `:js` object) and removed its final
+  ;;     view, but its stamp went BACKWARDS (Long/MAX_VALUE snapshot -> 1 finish) —
+  ;;     it must still be evicted.
+  ;; A `(> now then)` test reads app.a's backwards stamp as untouched (ghost
+  ;; survives) and would evict the max-stamp app.b; the causal test does neither.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :collide parallel?)
@@ -288,22 +312,24 @@
                (build/accepted-aggregate build/views good))
             "the accepted build declares both sources' views")
         ;; The EXACT same retained object stands in for app.b across prepare and
-        ;; finish (a true cache hit) even though its stamp collides with a fresh
-        ;; compile. app.a is replaced with a fresh output object.
-        (let [warm-b-output {:resource-id app-b-rid :js "app.b = {};"
+        ;; finish (a true cache hit at the maximal stamp). app.a is replaced with a
+        ;; fresh output object whose stamp is LOWER than its snapshot.
+        (let [warm-b-output {:resource-id app-b-rid :js (fresh-js "app.b = {};")
                              :compiled-at Long/MAX_VALUE :cached false}
               warm-input (-> good
                              (assoc-in [:output carrier-rid :js]
                                        build-hook/digest-sentinel)
                              (assoc-in [:output app-a-rid]
-                                       {:resource-id app-a-rid :js "app.a = {};"
-                                        :compiled-at 1 :cached true})
+                                       {:resource-id app-a-rid
+                                        :js (fresh-js "app.a = {};")
+                                        :compiled-at Long/MAX_VALUE :cached true})
                              (assoc-in [:output app-b-rid] warm-b-output))
               prepared (prepare warm-input)
               finished (-> prepared
                            (assoc-in [:output app-a-rid]
-                                     {:resource-id app-a-rid :js "app.a = {};"
-                                      :compiled-at Long/MAX_VALUE :cached false})
+                                     {:resource-id app-a-rid
+                                      :js (fresh-js "app.a = {};")
+                                      :compiled-at 1 :cached false})
                            (assoc-in [:output app-b-rid] warm-b-output)
                            finish)
               views-after (build/accepted-aggregate build/views finished)]
@@ -315,27 +341,27 @@
                     'app.b))
               "neither output-present warm source is pre-touched at prepare")
           (is (= {:app/b-view ["tfb-1" "hsb-1"]} views-after)
-              "the colliding-stamp warm hit survives; only the real recompile is evicted")
+              "the max-stamp warm hit survives; only the real recompile is evicted")
           (is (= b-before (get views-after :app/b-view))
               "app.b's accepted row is digest-stable across the warm pass")
           (is (not (contains? views-after :app/a-view))
-              "the genuinely recompiled zero-declaration source is evicted"))))))
+              "the genuinely recompiled zero-declaration source is evicted despite its backwards stamp"))))))
 
 (deftest metadata-only-output-mutation-is-not-a-recompile
-  ;; rf2-vxgfnd.282: output-object identity is NOT compile provenance. Shadow
-  ;; deep-merges build-local hooks after the inherited re-frame.ui hook, so a
-  ;; later :compile-prepare hook can annotate or normalize a source's
-  ;; STILL-VALID retained output with assoc/update-in — producing a NEW output
-  ;; object WITHOUT scheduling any compilation. Under raw `identical?`-of-output
-  ;; provenance re-frame.ui misreads that fresh object as a recompile,
-  ;; pre-touches the source, sees no registry macro, and silently EVICTS its
-  ;; accepted view — changing the whole-build digest. Shadow's authoritative
-  ;; fresh-compile evidence is the `:compiled-at` stamp it writes inside
-  ;; do-compile-cljs-resource: a metadata-only mutation preserves it, a real
-  ;; recompile advances it. Membership keys on the stamp, not the reference —
-  ;; so restoring the `identical?` test makes the survival arm below fail (the
-  ;; mutated object is not identical to the snapshot, so app.b is wrongly
-  ;; evicted). Both arms run in sequential and parallel compile modes.
+  ;; rf2-vxgfnd.282 / rf2-ialoij: a fresh output MAP is NOT compile provenance.
+  ;; Shadow deep-merges build-local hooks after the inherited re-frame.ui hook, so
+  ;; a later :compile-prepare hook can annotate or normalize a source's STILL-VALID
+  ;; retained output with assoc/update-in — producing a NEW output MAP (but, assoc
+  ;; preserving nested values, the SAME `:js` object) WITHOUT scheduling any
+  ;; compilation. Under raw whole-output `identical?` provenance re-frame.ui
+  ;; misread that fresh map as a recompile, pre-touched the source, saw no registry
+  ;; macro, and silently EVICTED its accepted view. Shadow's causal fresh-compile
+  ;; evidence is the fresh `:js` artifact object its compile path allocates: a
+  ;; metadata-only mutation preserves the SAME `:js` object, a real recompile
+  ;; allocates a new one. Membership keys on `:cached false` plus that `:js` object,
+  ;; NOT the whole-map reference and NOT the `:compiled-at` stamp — so the survival
+  ;; and eviction arms below are distinguished with the stamp held EQUAL. Both arms
+  ;; run in sequential and parallel compile modes.
   (doseq [parallel? [true false]]
     (let [mode (if parallel? "parallel" "sequential")
           good (-> (two-source-state :meta parallel?)
@@ -345,11 +371,12 @@
                    finish)
           digest-before (build/accepted-build-digest good)
           views-before  (build/accepted-aggregate build/views good)
-          ;; A warm accepted generation: both app.a and app.b retain a stamped
-          ;; output object; the carrier sentinel is reset so finish re-projects.
-          warm-a {:resource-id app-a-rid :js "app.a = {};"
+          ;; A warm accepted generation: both app.a and app.b retain a compiled
+          ;; output object (each with its own fresh `:js`); the carrier sentinel is
+          ;; reset so finish re-projects.
+          warm-a {:resource-id app-a-rid :js (fresh-js "app.a = {};")
                   :compiled-at 1000 :cached false}
-          warm-b {:resource-id app-b-rid :js "app.b = {};"
+          warm-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
                   :compiled-at 1000 :cached false}
           warm-input (-> good
                          (assoc-in [:output carrier-rid :js]
@@ -362,8 +389,8 @@
 
       (testing (str mode " — later hook only annotates app.b's retained output")
         ;; No source is scheduled this warm pass. A later build-local prepare hook
-        ;; replaces app.b's still-valid output with a NEW object that ONLY adds
-        ;; metadata; its `:compiled-at` stamp is untouched, so Shadow skips app.b.
+        ;; replaces app.b's still-valid output with a NEW map that ONLY adds
+        ;; metadata; assoc preserves the SAME `:js` object, so Shadow skips app.b.
         ;; app.b must survive byte-identical and the digest must not move.
         (let [prepared  (prepare warm-input)
               mutated-b (assoc warm-b :shadow.build/annotation :normalized)
@@ -371,9 +398,9 @@
                             (assoc-in [:output app-b-rid] mutated-b)
                             finish)]
           (is (not (identical? mutated-b warm-b))
-              "the later hook produced a fresh output object for app.b")
-          (is (= (:compiled-at warm-b) (:compiled-at mutated-b))
-              "but the metadata-only mutation preserved Shadow's compile stamp")
+              "the later hook produced a fresh output MAP for app.b")
+          (is (identical? (:js warm-b) (:js mutated-b))
+              "but the metadata-only mutation preserved Shadow's `:js` artifact object")
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
                     'app.b))
@@ -387,16 +414,19 @@
               "the whole-build digest is unchanged")))
 
       (testing (str mode " — companion: app.b output removed and recompiled")
-        ;; Same evidence, opposite verdict: the later hook instead REMOVES app.b's
-        ;; output and app.b genuinely recompiles (an ADVANCED `:compiled-at`)
-        ;; after its final defview was removed, contributing nothing. app.b is
-        ;; evicted; app.a stays a cache hit. Object identity would have flagged
-        ;; BOTH arms' app.b as recompiled; the stamp evidence distinguishes them.
+        ;; Same stamp (1000), opposite verdict: the later hook instead REMOVES
+        ;; app.b's output and app.b genuinely recompiles — a FRESH `:js` object at
+        ;; the SAME `:compiled-at` — after its final defview was removed,
+        ;; contributing nothing. app.b is evicted; app.a stays a cache hit. Whole-
+        ;; map identity would have flagged BOTH arms' app.b as recompiled and a
+        ;; stamp test would have missed this same-ms recompile; the fresh-`:js`
+        ;; evidence distinguishes them.
         (let [prepared (prepare warm-input)
               finished (-> prepared
                            (assoc-in [:output app-b-rid]
-                                     {:resource-id app-b-rid :js "app.b = {};"
-                                      :compiled-at 2000 :cached false})
+                                     {:resource-id app-b-rid
+                                      :js (fresh-js "app.b = {};")
+                                      :compiled-at 1000 :cached false})
                            finish)]
           (is (= {:app/a-view ["tfa-1" "hsa-1"]}
                  (build/accepted-aggregate build/views finished))

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
@@ -17,8 +17,10 @@
       re-frame.ui already observed the schedule) and rewrite its in-memory source
       to a VIEWLESS namespace (its final ui/defview removed). re-frame.ui saw
       app-a as an output-present cache hit and did NOT pre-touch it; only
-      `reconcile-final-schedule` at :compile-finish — reading Shadow's advanced
-      per-source :compiled-at stamp — can evict its now-absent accepted view.
+      `reconcile-final-schedule` at :compile-finish — reading Shadow's causal
+      per-source compile evidence (app-a's fresh, `:cached false` recompiled
+      output carries a new `:js` artifact object) — can evict its now-absent
+      accepted view.
 
     blind-provenance — model a hook that destroys the per-pass compile-schedule
       evidence: drop re-frame.ui's :pass-output snapshot from the open scratch.

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
@@ -38,8 +38,9 @@
 
   ;; SEQUENTIAL compile schedule (:parallel-build false). re-frame.ui's prepare
   ;; pre-touch takes its (nil? prior-output)/warnings branch here. The
-  ;; final-schedule reconciliation, keyed on Shadow's authoritative :compiled-at
-  ;; stamp, must evict identically in both modes.
+  ;; final-schedule reconciliation, keyed on Shadow's causal per-source compile
+  ;; evidence (a :cached false finish output whose fresh :js artifact differs from
+  ;; the prepare snapshot), must evict identically in both modes.
   :ui-final-schedule-seq
   {:target :browser
    :output-dir "../../../../../../out/ui-final-schedule-seq"


### PR DESCRIPTION
## Summary

The re-frame.ui Shadow build hook determined whether a source was recompiled in the current compile pass by comparing `:compiled-at` **wall-clock milliseconds** (`compiled-this-pass?` used `(> now then)`). Shadow assigns that stamp with `System/currentTimeMillis` inside `do-compile-cljs-resource`, so a genuine recompile can carry an **equal** (same-millisecond) or **decreasing** (clock skew, non-monotonic clock) stamp. A same-stamp zero-declaration recompile was then misread as untouched, leaving a **ghost accepted view** and a stale whole-build digest (rf2-ialoij, discovered auditing PR #5907).

### The wall-clock dependency
`implementation/ui/src/re_frame/ui/compiler/build_hook.clj:138` (pre-fix) — `compiled-this-pass?` returned `(> now then)` over each source's `:compiled-at` stamp.

### The causal fix
Membership is now read from Shadow's own **causal** compile evidence — no stamp relationship at all:

```clojure
(defn- compiled-this-pass? [final-output snapshot-output]
  (and (false? (:cached final-output))
       (not (identical? (:js final-output) (:js snapshot-output)))))
```

- `:cached false` is Shadow's fresh-compile marker (`maybe-compile-cljs` stamps it on the compile path; a disk-cache load is `:cached true`).
- A fresh `:js` **object** is what Shadow's compile path allocates per compile (`(.toString StringWriter)`). A warm cache hit retains the same output object (same `:js`); a metadata-only prepare-hook annotation via `assoc`/`update-in` replaces the output *map* but preserves the nested `:js` object.

Neither test is `>`, `>=`, `!=`, `not=`, or any other relationship on the `:compiled-at` wall clock, so equal-stamp and backwards-stamp recompiles classify correctly, while warm hits and metadata annotations are never misread. This reads Shadow's existing output fields — no second shadow state model, one compiler authority preserved.

### Misclassification proof (failing-before / passing-after)
Temporarily restoring the old `(> now then)` body turns the new digest-carrier JVM arms **red** — the same-stamp forced recompile and the backwards-stamp recompile both leave `:app/a-view` as a ghost and the digest unchanged — while the metadata-annotation and warm-hit **survival** arms stay green under both bodies. Restoring the causal body makes all arms green.

The tests now drive genuine **equal-stamp** (`later-prepare-hook-forced-recompile-evicts-removed-view`, `metadata-only-output-mutation-is-not-a-recompile` companion) and **backwards-stamp** (`causal-membership-survives-colliding-and-backwards-stamps`) recompiles in both parallel and sequential compile shapes — restoring the same-millisecond coverage the earlier `:compiled-at` change had dropped — plus the metadata-annotation non-compile (same `:js` object) and the fail-loud missing-provenance guard. Prose corrected across the hook, the `final_schedule` real-host fixture/config, and the `check-ui-final-schedule.cjs` runner.

## Quality gates

- `implementation/ui` `clojure -M:test` (full ui JVM gate, incl. digest-carrier + build-hook fixtures): **633 tests, 13104 assertions, 0 failures, 0 errors**.
- Red-before/green-after proof: old wall-clock `(> now then)` body → new equal/backwards-stamp arms fail (ghost survives); causal body → all green.
- `npm run test:cljs` not run — `build_hook.clj` is a JVM-only Shadow build hook, not reachable from any CLJS bundle (the sole CLJS reference is a string in a `digest-carrier` error message).
- `test:browser` / full spine not run (per brief; CI owns them). The real-host `check-ui-final-schedule.cjs` gate is unchanged in behaviour — a genuine Shadow recompile allocates a fresh `:js`, so the causal rule keeps it green; only its prose changed.

Closes rf2-ialoij.
