### PR TITLE
ci: arm examples_compile on skills/re-frame2-pair/preload for PR-time coverage (rf2-k8yl5f)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -148,6 +148,26 @@ else
       tools/story/src/*|tools/story/testbeds/*|tools/story/deps.edn|tools/xray/src/*|tools/xray/testbeds/*|tools/xray/deps.edn|tools/machines-viz/src/*|tools/machines-viz/deps.edn)
         examples_compile=true
         ;;
+      # rf2-k8yl5f — the re-frame2-pair skill ships a dev-only preload
+      # (skills/re-frame2-pair/preload/re_frame2_pair/{runtime.cljs,pure.cljc})
+      # that shadow-cljs.edn adds as a :source-path
+      # (../skills/re-frame2-pair/preload) and injects into ~28 :examples/*
+      # dev builds via `:devtools :preloads [re-frame2-pair.runtime ...]`. A
+      # `compile` (unlike `release`) HONOURS :devtools/preloads, so the
+      # examples-compile coverage gate (npm run test:examples-compile →
+      # shadow-cljs compile) actually compiles this preload for every build
+      # that wires it — a preload-only change can therefore break that gate.
+      # But the classifier previously armed ONLY skills_structural on this path
+      # (the skills/re-frame2-pair/* case below), leaving examples_compile=false
+      # so a preload break surfaced only in the unconditional nightly
+      # examples-compile net (rf2-gzavkm follow-up), never at PR time. Arm
+      # examples_compile so the PR-time gate recompiles the example dev builds
+      # that inject it. (skills_structural still fires via the later
+      # skills/re-frame2-pair/* case; this widens coverage, it does not narrow
+      # it.)
+      skills/re-frame2-pair/preload/*)
+        examples_compile=true
+        ;;
     esac
 
     # rf2-vxgfnd.135 — tracked, authoritative pre-publication UI guide

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -596,6 +596,56 @@ test('cljs-examples-compile job uses the dedicated output and nightly retains fu
   assert.ok(compile < playwright, 'example compilation should fail before the browser download');
 });
 
+// rf2-k8yl5f — the re-frame2-pair skill ships a dev-only preload
+// (skills/re-frame2-pair/preload/re_frame2_pair/{runtime.cljs,pure.cljc}).
+// shadow-cljs.edn adds ../skills/re-frame2-pair/preload as a :source-path and
+// wires re-frame2-pair.runtime into ~28 :examples/* dev builds via
+// `:devtools :preloads`. `shadow-cljs compile` (the examples-compile coverage
+// gate — unlike `release`) HONOURS :devtools/preloads, so a preload-only
+// change compiles into every example dev build that injects it and can break
+// that gate. Before this bead the classifier armed ONLY skills_structural on
+// the preload path, so examples_compile=false and a preload break surfaced
+// only in the unconditional nightly examples-compile net (rf2-gzavkm), never
+// at PR time. These assertions lock the examples_compile arming while keeping
+// skills_structural (the preload is still skill material) and holding scope:
+// non-preload skill files must NOT drag in the heavy example-compile sweep.
+test('re-frame2-pair PRELOAD change arms examples_compile (injected into ~28 example dev builds) (rf2-k8yl5f)', () => {
+  const result = classify('skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs');
+  assert.equal(
+    result.examples_compile,
+    'true',
+    'a preload change compiles into every :examples/* dev build that injects re-frame2-pair.runtime; it must run the examples-compile gate',
+  );
+});
+
+test('re-frame2-pair PRELOAD .cljc change also arms examples_compile (rf2-k8yl5f)', () => {
+  const result = classify('skills/re-frame2-pair/preload/re_frame2_pair/pure.cljc');
+  assert.equal(result.examples_compile, 'true');
+});
+
+test('re-frame2-pair PRELOAD change STILL arms skills_structural (regression — it is skill material) (rf2-k8yl5f)', () => {
+  const result = classify('skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs');
+  assert.equal(
+    result.skills_structural,
+    'true',
+    'the preload lives under skills/re-frame2-pair/ so the structural skill gate must still fire; examples_compile widens coverage, it does not replace it',
+  );
+});
+
+test('NON-preload re-frame2-pair skill file does NOT arm examples_compile (scope discipline) (rf2-k8yl5f)', () => {
+  // Only the shipped preload compiles into the example builds. Other skill
+  // material (SKILL.md, references, the redaction guides) must NOT drag the
+  // heavy all-examples compile sweep into an ordinary skill-doc PR — it keeps
+  // its existing skills_structural-only classification.
+  const result = classify('skills/re-frame2-pair/SKILL.md');
+  assert.equal(
+    result.examples_compile,
+    'false',
+    'a non-preload skill file cannot change an example build; it must NOT arm examples_compile',
+  );
+  assert.equal(result.skills_structural, 'true');
+});
+
 // rf2-3kewru — G-12 Arm 2 shells out to `clojure -Stree`. The CLJS job
 // that owns `test:ui-isolation` must therefore provision the Clojure CLI;
 // Arm 1 alone cannot detect a declared-but-currently-unused adapter dep.


### PR DESCRIPTION
## Summary

The re-frame2-pair skill ships a dev-only preload — `skills/re-frame2-pair/preload/re_frame2_pair/{runtime.cljs,pure.cljc}`. `implementation/shadow-cljs.edn` adds `../skills/re-frame2-pair/preload` as a `:source-path` and injects `re-frame2-pair.runtime` into ~28 `:examples/*` dev builds via `:devtools :preloads`. Because `shadow-cljs compile` (unlike `release`) **honours** `:devtools/preloads`, the examples-compile coverage gate (`npm run test:examples-compile` → `shadow-cljs compile`) genuinely compiles this preload for every build that wires it — so a preload-only change can break that gate.

But the changed-surface classifier armed **only** `skills_structural` on the preload path (the `skills/re-frame2-pair/*` case), leaving `examples_compile=false`. A skills-preload-only change therefore got no PR-time example-compile coverage; a break surfaced only in the unconditional nightly examples-compile net (rf2-gzavkm follow-up). Pre-existing, not a #6003 regression.

## How `examples_compile` selects its surface today

- The classifier `.github/scripts/report-changed-surfaces.sh` arms `examples_compile` in a dedicated `case` block: `examples/*`, adapters, per-feature artefacts, build config, and `check-examples-compile.cjs` (lines 144–147), plus the Story/Xray/machines-viz closure compiled into examples (lines 148–150).
- `skills/re-frame2-pair/*` (line ~934) fired **only** `skills_structural` — the preload matched this and nothing armed `examples_compile`.
- `.github/workflows/test.yml`: `cljs-examples-compile` (line 1840) and `ui-scaffold-smoke` (line 1902) are already `if: needs.detect_changed_surfaces.outputs.examples_compile == 'true'` (lines 1843 / 1916). The job runs `npm run test:examples-compile` → `implementation/scripts/check-examples-compile.cjs` → a single `shadow-cljs compile` over every `:examples/*` build.

## The change (additive only)

- `.github/scripts/report-changed-surfaces.sh`: add a dedicated `skills/re-frame2-pair/preload/*` case that arms `examples_compile=true`. `skills_structural` still fires via the later `skills/re-frame2-pair/*` case — this widens coverage, it does not narrow it.
- `implementation/scripts/_changed-surfaces.test.cjs`: discovery tests pinning the `examples_compile` arming (both `runtime.cljs` and `pure.cljc`), the retained `skills_structural`, and scope discipline (a non-preload skill file like `SKILL.md` stays off `examples_compile`).
- `.github/workflows/test.yml` is **not touched** — the arming lives entirely in the classifier and the jobs are already gated on the output.

## Quality gates

- `bash -n report-changed-surfaces.sh` — syntax valid.
- Manual classify: `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` → `examples_compile=true` + `skills_structural=true`; `skills/re-frame2-pair/SKILL.md` → `examples_compile=false` + `skills_structural=true`.
- `node scripts/_changed-surfaces.test.cjs` → **153 passed** (incl. 4 new rf2-k8yl5f discovery tests).
- Compile proof — compiled a preload-wired example build the way the gate does: `shadow-cljs compile examples/two-frame-isolation` → `Build completed. (535 files, 534 compiled, 0 warnings, 73.53s)`. Confirmed the preload is genuinely in the closure: `out/examples/two-frame-isolation/cljs-runtime/re_frame2_pair.runtime.js` emitted + analysis caches for both `runtime.cljs` and `pure.cljc` present.

Closes rf2-k8yl5f.