### PR TITLE
fix(xray): migrate ViewCell reactivity bridge in an already-registered process (rf2-ykaq4u)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -89,6 +89,53 @@ NOT call `reset-for-test!`. Per-panel `install!` helpers run inside
 the same gate so panel-owned registrations inherit idempotency
 without re-doing the dance.
 
+### Schema version + live-upgrade migration seam (rf2-ykaq4u)
+
+The `compare-and-set!` boolean gate handles the ONE-TIME bulk install,
+but a boolean alone cannot express *"this process registered under OLD
+code and is now running NEW code that adds a handler the old install
+never ran"*. On `:after-load` the umbrella gate no-ops the whole leaf
+install, so a handler introduced by newer code — kept inside a per-panel
+`install!` — never reaches the already-registered process; it stays
+behind until a full page reload. The ViewCell evidence reactivity bridge
+stranded exactly this way in a pre-#5915 → current live upgrade: the
+umbrella was set, so the reloaded preload's `register-xray-handlers!`
+no-op'd, leaving the old epoch-only `:rf.xray/viewcell-evidence` sub
+cached and the ownership event/sub/listener + two-input evidence sub
+uninstalled — an evidence acquire/release could not invalidate a held
+Views subscription until an unrelated epoch pump.
+
+The fix is a SECOND axis alongside the boolean gate — a
+`schema-version` integer plus an `installed-schema` `defonce` stamp:
+
+- A **fresh boot** runs the whole leaf install (the current bridge
+  included) and stamps `installed-schema` CURRENT.
+- The **migration seam** runs INDEPENDENTLY of the umbrella gate: when
+  `installed-schema` is behind `schema-version` (nil ⇒ a
+  pre-schema-versioning process reads as schema 0), `migrate-schema!`
+  installs EXACTLY the bounded delta of handlers each newer version adds,
+  then stamps CURRENT. Each clause is additive, idempotent (re-frame's
+  registrar replaces in place), and gated on the process predating the
+  version that introduced its handler — so this is **NOT** an
+  unconditional whole-registry re-registration, only the missing delta,
+  and only for a process that is behind.
+- Once at `schema-version` (a fresh boot, or a completed upgrade) the
+  seam no-ops, so a current process re-loading itself emits no
+  handler-replaced flood and installs exactly one of each singleton sink
+  (e.g. the evidence ownership listener).
+
+Bump `schema-version` and pair it with a `migrate-schema!` clause
+whenever a change adds a handler an already-registered older process
+would otherwise never install. Version `1` is the ViewCell evidence
+reactivity bridge (see [spec/021 §3.4.1](./021-Dynamic-Panel-Designs.md)),
+installed via `reactive-panel/install-viewcell-evidence-bridge!` so the
+bridge stays panel-owned; `migrate-schema!` reaches it through the
+`reactive-panel` facade the orchestrator already requires. Tests drive
+the upgrade via `registry/simulate-legacy-registration!` (test-only:
+poses the umbrella-set / no-schema-stamp sentinels of a pre-#5915
+process); `reset-for-test!` clears both the boolean gate and the schema
+stamp.
+
 ### Production registration carries no test seams (rf2-e8330v / xxo3zz F3)
 
 `register-xray-handlers!` (and the per-panel `install!` helpers it

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
@@ -55,6 +55,14 @@
   []
   (view/reactive-panel))
 
+(def install-viewcell-evidence-bridge!
+  "See `reactive-panel-subs/install-viewcell-evidence-bridge!`. Re-exported
+  through the panel facade so the registry's schema-migration seam
+  (`registry/migrate-schema!`, rf2-ykaq4u) installs the ViewCell
+  reactivity bridge into a live-upgraded pre-#5915 process WITHOUT
+  reaching past the facade into the subs ns."
+  subs/install-viewcell-evidence-bridge!)
+
 (defn install!
   "Idempotent install for the Reactive panel's Xray-side
   registrations. Returns nil per the facade convention."

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -546,35 +546,30 @@
       (sequential? diff) (vec diff)
       :else [])))
 
-(defn install!
+(defn install-viewcell-evidence-bridge!
+  "Install the ViewCell evidence REACTIVITY BRIDGE — the ownership-
+  transition event, the ownership-revision sub, the evidence-ledger
+  listener that mirrors each transition into `:rf/xray` app-db, and the
+  two-input `:rf.xray/viewcell-evidence` query that reads the receipt-
+  fenced rows against an ownership-revision reactive input.
+
+  Extracted from `install!` (rf2-ykaq4u) so the registry's schema-
+  migration seam can install this bridge into an ALREADY-registered
+  pre-#5915 process. That process ran the umbrella idempotency gate under
+  the OLD code, so a subsequent `register-xray-handlers!` no-ops the whole
+  leaf install — a bridge reachable ONLY through `install!` would never
+  reach a live-upgraded process, leaving the old epoch-only evidence sub
+  cached and the ownership event/sub/listener absent. Registry
+  `migrate-schema!` calls this (via the `reactive-panel` facade) so the
+  live upgrade installs the current bridge without a page reload.
+
+  Idempotent: re-frame's registrar REPLACES each handler in place and
+  `set-ownership-listener!` is a single-sink `reset!`, so both a fresh
+  boot (via `install!`) and a migration re-arm leave EXACTLY ONE ownership
+  listener and the current two-input evidence sub — replacing the old
+  one-input sub emits at most one `:rf.warning/handler-replaced`, never a
+  flood."
   []
-  ;; -- panel-local UI state slot --------------------------------------
-  (rf/reg-sub :rf.xray/reactive-show-unchanged?
-    (fn [db _query]
-      (boolean (get db :reactive/show-unchanged?))))
-
-  ;; -- composite the view reads --------------------------------------
-  (rf/reg-sub :rf.xray/reactive-data
-    :<- [:rf.xray/focus]
-    :<- [:rf.xray/epoch-history]
-    (fn [[focus history] _query]
-      (let [record   (focused-epoch-record history (:epoch-id focus))
-            ;; Static topology snapshot — read once per event-bundle. Free
-            ;; (registry-only); used to partition L1 / L2+ subs and
-            ;; supply the inputs + code columns. Defensive try so a
-            ;; topology read never crashes the panel.
-            topology (try (subs-tooling/sub-topology) (catch :default _ nil))
-            proj     (project-record record topology)]
-        (merge proj
-               {:focus        focus
-                :frame        (:frame focus)
-                :dispatch-id  (:dispatch-id focus)
-                :triggered-by (when record (triggered-by record))
-                :seed-paths   (when record (seed-paths record))
-                :has-event-bundle? (some? record)}))))
-
-  ;; -- ViewCell evidence ownership reactivity bridge (rf2-vxgfnd.286) --
-  ;;
   ;; Ownership of the evidence projection is NOT app-db state, so an
   ;; acquire/release would not, on its own, invalidate the cumulative
   ;; evidence query below — a live subscription + rendered panel could
@@ -632,5 +627,57 @@
     :<- [:rf.xray/viewcell-evidence-ownership]
     (fn [[_history _ownership-rev] _query]
       (viewcell-evidence/rows)))
+  nil)
 
+(defn install!
+  []
+  ;; -- panel-local UI state slot --------------------------------------
+  (rf/reg-sub :rf.xray/reactive-show-unchanged?
+    (fn [db _query]
+      (boolean (get db :reactive/show-unchanged?))))
+
+  ;; -- composite the view reads --------------------------------------
+  (rf/reg-sub :rf.xray/reactive-data
+    :<- [:rf.xray/focus]
+    :<- [:rf.xray/epoch-history]
+    (fn [[focus history] _query]
+      (let [record   (focused-epoch-record history (:epoch-id focus))
+            ;; Static topology snapshot — read once per event-bundle. Free
+            ;; (registry-only); used to partition L1 / L2+ subs and
+            ;; supply the inputs + code columns. Defensive try so a
+            ;; topology read never crashes the panel.
+            topology (try (subs-tooling/sub-topology) (catch :default _ nil))
+            proj     (project-record record topology)]
+        (merge proj
+               {:focus        focus
+                :frame        (:frame focus)
+                :dispatch-id  (:dispatch-id focus)
+                :triggered-by (when record (triggered-by record))
+                :seed-paths   (when record (seed-paths record))
+                :has-event-bundle? (some? record)}))))
+
+  ;; -- ViewCell evidence ownership reactivity bridge (rf2-vxgfnd.286) --
+  ;; Registered via the extracted `install-viewcell-evidence-bridge!` so
+  ;; the registry schema-migration seam can install this same bridge into
+  ;; an already-registered pre-#5915 process where the umbrella idempotency
+  ;; gate no-ops the whole leaf install (rf2-ykaq4u).
+  (install-viewcell-evidence-bridge!)
+  nil)
+
+(defn install-legacy-viewcell-evidence-sub-for-test!
+  "TEST-ONLY (rf2-ykaq4u): register the PRE-#5915 epoch-only
+  `:rf.xray/viewcell-evidence` sub — the ONE-INPUT shape a pre-bridge
+  process cached (its only reactive axis was `:rf.xray/epoch-history`, so
+  an evidence acquire/release could not invalidate a held Views
+  subscription until an unrelated epoch pump). The live-upgrade fixture
+  installs this to model an already-registered old process whose bridge
+  the schema migration must install. Registered from THIS ns so its image-
+  assembly source coordinate matches the production sub the migration
+  re-registers (a different source ns would trip the duplicate-id image
+  guard). Never call from production. Returns nil."
+  []
+  (rf/reg-sub :rf.xray/viewcell-evidence
+    :<- [:rf.xray/epoch-history]
+    (fn [[_history] _query]
+      (viewcell-evidence/rows)))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -106,10 +106,82 @@
   ;; registration — pollutes the dev console on every reload).
   (atom false))
 
+;; ---- registration-schema version + live-upgrade migration seam -----------
+;;
+;; The `registered?` boolean above gates the ONE-TIME bulk install. But a
+;; boolean alone cannot express "this process registered under OLD code and
+;; is now running NEW code that adds a handler the old install never ran":
+;; on `:after-load` the umbrella gate no-ops the whole leaf install, so a
+;; handler introduced by newer code (kept inside a per-panel `install!`)
+;; never reaches the already-registered process — it stays behind until a
+;; full page reload (rf2-ykaq4u: the ViewCell reactivity bridge stranded
+;; exactly this way). The schema version is the SECOND axis: it records the
+;; registration schema the process last installed, so a live-upgraded
+;; process runs the bounded migration for each version it is behind.
+
+(def ^:private schema-version
+  "Current registration-schema version. Bump when a code change adds a
+  handler that an ALREADY-registered older process would otherwise never
+  install (the umbrella `registered?` gate no-ops its whole leaf install
+  on `:after-load`); pair each bump with a `migrate-schema!` clause below.
+
+  Version history:
+    1 — ViewCell evidence REACTIVITY BRIDGE (rf2-vxgfnd.286 / rf2-ykaq4u):
+        the ownership event/sub/listener + the two-input
+        `:rf.xray/viewcell-evidence` sub. A pre-#5915 process has the
+        umbrella set but this bridge absent (its cached
+        `:rf.xray/viewcell-evidence` sub is the old epoch-only one input);
+        the migration installs the current bridge so an evidence
+        acquire/release invalidates a held Views subscription immediately,
+        without a page reload."
+  1)
+
+(defonce ^:private installed-schema
+  ;; The registration-schema version this process has installed, or nil
+  ;; when it registered BEFORE schema-versioning existed — i.e. a pre-#5915
+  ;; process: the umbrella `registered?` is set, but this sentinel was
+  ;; never created/stamped, so it reads nil after the new code loads and
+  ;; the migration seam treats it as schema 0 (pre-bridge). `defonce`
+  ;; (module-lived) so a shadow `:after-load` PRESERVES the stamp across
+  ;; reloads — a current process re-loading itself no-ops the migration.
+  (atom nil))
+
+(defn- migrate-schema!
+  "Bring an already-registered older-schema process up to `schema-version`
+  by installing EXACTLY the handlers newer schema versions add — the
+  bounded live-upgrade seam (rf2-ykaq4u). `from` is the process's installed
+  schema (0 ⇒ pre-schema-versioning, i.e. a pre-#5915 process). Each clause
+  is additive, idempotent (re-frame's registrar replaces in place), and
+  gated on `from` predating the version that introduced its handler — so
+  this is NOT an unconditional whole-registry re-registration; only the
+  missing delta is installed, and only for a process that is behind."
+  [from]
+  (when (< from 1)
+    ;; schema 1 — the ViewCell evidence REACTIVITY BRIDGE. A pre-#5915
+    ;; process cached the OLD epoch-only `:rf.xray/viewcell-evidence` sub
+    ;; and never installed the ownership event/sub/listener, so an evidence
+    ;; acquire/release could not invalidate a held Views subscription until
+    ;; an unrelated epoch pump. Install the current bridge (re-registering
+    ;; the evidence sub as the two-input shape) so the upgrade is immediate,
+    ;; no page reload. Routed through the `reactive-panel` facade the
+    ;; orchestrator already requires — the bridge stays panel-owned.
+    (reactive-panel/install-viewcell-evidence-bridge!)))
+
 (defn register-xray-handlers!
   "Idempotent registration of Xray's :rf.xray/* events, subs, fxs.
   Called from `day8.re-frame2-xray.preload` at load time. Safe to
-  call multiple times — second + subsequent calls are no-ops."
+  call multiple times — second + subsequent calls are no-ops.
+
+  Two gates cooperate (rf2-ykaq4u):
+
+    1. the `registered?` umbrella — the ONE-TIME bulk install; a fresh
+       boot runs the whole leaf install (the current bridge included) and
+       stamps the schema current, so a same-process `:after-load` no-ops.
+    2. the schema-version migration seam — INDEPENDENT of the umbrella, so
+       an already-registered process running OLDER-schema code (umbrella
+       already set, bulk block no-ops) still installs the bounded delta of
+       handlers newer schema versions add. Once at `schema-version` this
+       no-ops too — no handler-replaced flood on repeat reloads."
   []
   (when (compare-and-set! registered? false true)
     ;; ---- cross-panel primitives ---------------------------------
@@ -1000,13 +1072,44 @@
     ;; chains. Collapses by `:id` so each interceptor appears once
     ;; with a chain-count. No simulate — interceptors are composition
     ;; primitives, not independently simulable.
-    (static-interceptors-panel/install!))
+    (static-interceptors-panel/install!)
+    ;; Fresh boot ran the whole leaf install (the current bridge included),
+    ;; so stamp the schema CURRENT — the migration seam below then no-ops
+    ;; on this process and on its own `:after-load` reloads.
+    (reset! installed-schema schema-version))
+  ;; ---- live-upgrade migration seam (rf2-ykaq4u) ----------------------
+  ;;
+  ;; INDEPENDENT of the umbrella gate above. An already-registered process
+  ;; running OLDER-schema code left `registered?` set, so the fresh-install
+  ;; block no-ops — but it may lack handlers newer schema versions add.
+  ;; Bring it up to `schema-version`, then stamp current. Idempotent: once
+  ;; at `schema-version` (a fresh boot, or a completed upgrade) this
+  ;; no-ops, so a current process re-loading itself emits no handler-
+  ;; replaced flood and installs exactly one ownership listener.
+  (when (< (or @installed-schema 0) schema-version)
+    (migrate-schema! (or @installed-schema 0))
+    (reset! installed-schema schema-version))
   nil)
 
 (defn reset-for-test!
-  "Reset the registry's idempotency sentinel so test fixtures can drive
-  multiple registration cycles. Test-only — never call from production
-  code."
+  "Reset the registry's idempotency sentinel + schema stamp so test
+  fixtures can drive multiple registration cycles from a clean slate.
+  Test-only — never call from production code."
   []
   (reset! registered? false)
+  (reset! installed-schema nil)
+  nil)
+
+(defn simulate-legacy-registration!
+  "TEST-ONLY: pose the sentinels to model a pre-#5915 already-registered
+  process — the umbrella idempotency gate SET (as the old full install
+  left it) with NO schema stamp (schema-versioning did not exist in the
+  old code, so `installed-schema` reads nil). A subsequent
+  `register-xray-handlers!` then no-ops the umbrella and reaches ONLY the
+  migration seam, exactly as a live shadow `:after-load` of new code onto
+  an old process does. Poses only the sentinels; the fixture registers
+  whatever legacy handler shape it needs. Never call from production."
+  []
+  (reset! registered? true)
+  (reset! installed-schema nil)
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -34,11 +34,14 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
             [re-frame.subs.tooling :as subs-tooling]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.tool.evidence :as evidence]
             [day8.re-frame2-xray.core :as core]
+            [day8.re-frame2-xray.epoch :as epoch]
             [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.panels.reactive-panel-subs :as reactive-panel-subs]
             ;; The REAL preload — its debug-gated boot block runs at load,
             ;; acquiring the evidence projection under Xray's identity.
             [day8.re-frame2-xray.preload]
@@ -438,3 +441,104 @@
     (xray-test-support/reset-all!)
     (is (= ::another-tool (evidence/installed-owner))
         "owner-checked reset never clobbers a foreign owner")))
+
+;; ===========================================================================
+;; LIVE UPGRADE — the reactivity bridge migrates into an ALREADY-registered
+;; pre-#5915 process (rf2-ykaq4u)
+;; ===========================================================================
+
+(defn- evidence-sub-input-ids
+  "The static `:<-` input sub-ids of `:rf.xray/viewcell-evidence`, read off
+  the live `sub-topology`. `[]` when the sub is unregistered."
+  []
+  (let [inputs (:inputs (get (subs-tooling/sub-topology) :rf.xray/viewcell-evidence))]
+    (map #(if (vector? %) (first %) %) (or inputs []))))
+
+(deftest live-upgrade-from-a-pre-bridge-process-installs-the-reactivity-bridge
+  ;; Model a pre-#5915 already-registered Xray process the way a live shadow
+  ;; `:after-load` of new code onto an old process presents it:
+  ;;   - the umbrella idempotency gate is SET (the OLD full install ran),
+  ;;   - the OLD epoch-only `:rf.xray/viewcell-evidence` sub is cached (its
+  ;;     `:rf.xray/epoch-history` input registered by the old full install),
+  ;;   - the ownership event/sub/listener + two-input evidence sub are ABSENT,
+  ;;   - NO schema stamp (schema-versioning did not exist in the old code).
+  ;;
+  ;; The runtime fixture restores a registrar SNAPSHOT that already carries
+  ;; the current bridge (the preload boot registered it before the snapshot
+  ;; was taken), so modelling the pre-bridge shape means actively
+  ;; DOWNGRADING: re-register the epoch-only evidence sub (replacing the
+  ;; two-input one) and remove the ownership event + sub. Both the
+  ;; epoch-history input and the old evidence sub come from their CANONICAL
+  ;; owner namespaces (never the test ns) so `make-frame`'s image assembly
+  ;; sees a single source coordinate per id, not a duplicate.
+  (epoch/install!)
+  (reactive-panel-subs/install-legacy-viewcell-evidence-sub-for-test!)
+  (registrar/unregister! :event :rf.xray/viewcell-evidence-ownership-changed)
+  (registrar/unregister! :sub :rf.xray/viewcell-evidence-ownership)
+  (viewcell-evidence/set-ownership-listener! nil)
+  (registry/simulate-legacy-registration!)
+  (rf/make-frame {:id :rf/xray})
+
+  (testing "PRECONDITION — the legacy shape lacks the reactivity bridge"
+    (is (nil? (registrar/handler :event :rf.xray/viewcell-evidence-ownership-changed))
+        "no ownership-transition event")
+    (is (nil? (registrar/handler :sub :rf.xray/viewcell-evidence-ownership))
+        "no ownership-revision sub")
+    (is (not (some #{:rf.xray/viewcell-evidence-ownership} (evidence-sub-input-ids)))
+        "the cached evidence sub is epoch-only — one input"))
+
+  ;; The live upgrade: the reloaded preload re-runs register-xray-handlers!.
+  ;; Under the pre-fix boolean-only gate this no-ops entirely (umbrella set)
+  ;; and the bridge stays absent; the schema-migration seam installs it.
+  (registry/register-xray-handlers!)
+
+  (testing "the migration installed the ownership event + revision sub, callable in :rf/xray"
+    (is (some? (registrar/handler :event :rf.xray/viewcell-evidence-ownership-changed)))
+    (is (some? (registrar/handler :sub :rf.xray/viewcell-evidence-ownership)))
+    (is (= 0 (rf/with-frame :rf/xray
+               @(rf/subscribe [:rf.xray/viewcell-evidence-ownership])))
+        "the ownership-revision sub reads its default in the :rf/xray frame"))
+
+  (testing "TOPOLOGY — :rf.xray/viewcell-evidence now depends on the ownership axis"
+    ;; The bead's registration-topology proof: the re-registered two-input
+    ;; sub replaced the cached epoch-only one.
+    (is (some #{:rf.xray/viewcell-evidence-ownership} (evidence-sub-input-ids))
+        "an acquire/release now recomputes the query without an epoch pump"))
+
+  (testing "acquire then release IMMEDIATELY invalidate a held Views subscription"
+    ;; The immediate-reactivity claim the PR made and the bug broke: on the
+    ;; plain-atom node adapter every deref recomputes, so this is the live
+    ;; held-subscription surface — the receipt fence keeps it honest.
+    (let [receipt (viewcell-evidence/acquire!)
+          cell    (reactive/make-cell ::live)
+          sub     (rf/with-frame :rf/xray
+                    (rf/subscribe [:rf.xray/viewcell-evidence]))]
+      (is (some? receipt) "Xray claimed a fresh span on the upgraded process")
+      (reactive/mark-dirty! cell 1)
+      (reactive/flush-pending!)
+      (is (seq @sub) "non-empty while Xray owns the span")
+      (viewcell-evidence/release-current!)
+      (is (= [] @sub)
+          "empty immediately after release — the migrated ownership axis
+           recomputed it, not a later epoch pump (no stale row)"))))
+
+(deftest live-upgrade-migration-is-idempotent-and-installs-one-listener
+  ;; A completed upgrade (or a fresh boot) must NOT re-migrate on the next
+  ;; `:after-load`: repeated register-xray-handlers! calls leave exactly one
+  ;; ownership listener and never re-replace the bridge in a flood.
+  (boot-xray!)
+  (is (some? (viewcell-evidence/acquire!)) "Xray owns a fresh span")
+  (let [rev-after-acquire (viewcell-evidence/ownership-revision)]
+    ;; Re-run register twice — the shadow `:after-load` shape on a
+    ;; current-schema process. The umbrella no-ops AND the migration seam
+    ;; no-ops (already at schema-version), so neither the ledger nor the
+    ;; listener is touched: the revision does not move.
+    (registry/register-xray-handlers!)
+    (registry/register-xray-handlers!)
+    (is (= rev-after-acquire (viewcell-evidence/ownership-revision))
+        "no re-migration on a current-schema reload — the ledger is untouched")
+    ;; The single wired listener drives exactly one revision bump per
+    ;; ownership transition: releasing the owned span bumps once.
+    (is (true? (viewcell-evidence/release-current!)))
+    (is (= (inc rev-after-acquire) (viewcell-evidence/ownership-revision))
+        "exactly one ownership listener — one transition, one revision bump")))


### PR DESCRIPTION
## Summary

The ViewCell evidence reactivity bridge (the ownership event/sub/listener + the two-input `:rf.xray/viewcell-evidence` sub, PR #5915) lives inside `reactive-panel-subs/install!`, reached only from `register-xray-handlers!`. That umbrella is guarded by the pre-existing `(defonce registered? (atom false))` boolean, which #5915 neither changed nor versioned.

**The defect (`registry.cljs`):** in the live-upgrade sequence #5915 targets, a pre-#5915 process already has `registered? = true`. On shadow `:after-load`, `register-xray-handlers!`'s `(compare-and-set! registered? false true)` gate no-ops the *entire* leaf install, so `reactive-panel/install!` (registry.cljs:1062) → `subs/install!` → the bridge never runs. The old one-input `:rf.xray/viewcell-evidence` sub stays cached and the ownership event/sub/listener are absent. A held Views subscription then keeps its pre-release row until an unrelated epoch pump or a full page reload — breaking the PR's immediate-reactivity claim. The pre-existing HMR test calls `acquire!` in a fresh current-code registry and never exercises the old-process → new-code path.

## The fix

A small **versioned, migration-aware installation seam** alongside the boolean gate:

- `schema-version` (integer) + `installed-schema` (`defonce` stamp) — the second axis. `nil` ⇒ a pre-schema-versioning (pre-#5915) process reads as schema 0.
- `migrate-schema!` runs **independently of the umbrella gate**: when a process is behind, it installs *exactly* the bounded delta each newer version adds. Schema 1 installs the ViewCell bridge.
- The bridge is extracted as `reactive-panel-subs/install-viewcell-evidence-bridge!` and re-exported through the `reactive-panel` facade the orchestrator already requires, so it stays panel-owned; `migrate-schema!` reaches it through the facade.
- A fresh boot runs the whole leaf install (bridge included) and stamps current, so the seam no-ops. A completed upgrade or same-process reload also no-ops — **no handler-replaced flood, exactly one ownership listener.** This is **not** an unconditional whole-registry re-registration; only the missing delta, only for a process that is behind.

## Re-migration proof

`live-upgrade-from-a-pre-bridge-process-installs-the-reactivity-bridge` (in `viewcell_evidence_cljs_test.cljs`) models a pre-#5915 process: umbrella set (`registry/simulate-legacy-registration!`), the epoch-only evidence sub cached (from its canonical ns to avoid an image-assembly duplicate-id), the ownership handlers unregistered, no schema stamp. It asserts the pre-bridge precondition, runs `register-xray-handlers!`, then proves the ownership event/sub are callable in `:rf/xray`, the evidence sub's topology now depends on `:rf.xray/viewcell-evidence-ownership`, and an acquire/release invalidates a held Views subscription immediately (no stale row). `live-upgrade-migration-is-idempotent-and-installs-one-listener` pins the idempotent-reload path. **Mutation teeth:** restoring the boolean-only gate turns the migration into a no-op and the upgrade fixture goes red (verified: 5 failures).

## Xray spec update

`tools/xray/spec/014-Registry-Catalogue.md` §Idempotency gains a *Schema version + live-upgrade migration seam* subsection documenting the two-axis contract, the bounded `migrate-schema!` clause pattern, and the test seam.

## Quality gates

- `npm run test:cljs` (full node-test): **9633 tests, 47459 assertions, 0 failures, 0 errors**
- `tools/xray` JVM (`clojure -M:test`): **1265 tests, 5899 assertions, 0 failures, 0 errors**
- Fail-before / pass-after confirmed via mutation (boolean-only gate → upgrade fixture red).
