### PR TITLE
fix(core): make JVM observation provenance reload-safe (rf2-kia9st)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -292,13 +292,26 @@
 ;; map's class (`PersistentArrayMap`) is stable across reloads, so version
 ;; recognition is stable and repeated reloads stay idempotent.
 ;;
-;; A `WeakReference`-subclass identity-key ([[weak-identity-key]]) → `EmissionProvenance`.
-;; The inner `by-throwable` is a plain `HashMap` guarded by `locking` on that map
-;; (the node-records lock discipline); NOT a `WeakHashMap` — weakness comes from the
-;; `WeakReference` KEYS + ReferenceQueue expunge, IDENTITY from the keys' own
-;; `hashCode`/`equals`. `js/WeakMap` on CLJS is genuinely identity-keyed with
-;; ephemeron semantics and NO reload hazard (a page reload is a fresh JS realm), so
-;; CLJS keeps the bare `defonce` unchanged.
+;; A `WeakReference`-subclass identity-key ([[weak-identity-key]]) → a RELOAD-STABLE
+;; channel SET (rf2-kia9st). The inner `by-throwable` is a plain `HashMap` guarded by
+;; `locking` on that map (the node-records lock discipline); NOT a `WeakHashMap` —
+;; weakness comes from the `WeakReference` KEYS + ReferenceQueue expunge, IDENTITY
+;; from the keys' own `hashCode`/`equals`. `js/WeakMap` on CLJS is genuinely
+;; identity-keyed with ephemeron semantics and NO reload hazard (a page reload is a
+;; fresh JS realm), so CLJS keeps the bare `defonce` unchanged.
+;;
+;; The stored VALUE on the JVM is the [[EmissionProvenance]] token's raw channel SET
+;; (`#{:always-on :trace}` / `#{:trace}`), NOT the deftype instance (rf2-kia9st). The
+;; SAME reason the version carrier is a plain map, not a deftype, applies to the
+;; stored value: a namespace reload REDEFINES the deftype's class, so a retained
+;; old-class `EmissionProvenance` VALUE reads `(instance? EmissionProvenance …)` FALSE
+;; after a same-version reload and its throwable silently flips covered→uncovered.
+;; A persistent set's class (`PersistentHashSet`) and its interned keyword members are
+;; stable across reloads, so an entry attested before a reload stays covered after it.
+;; Two operations reading the map + queue through SEPARATE Var reads could also pair
+;; one holder's map with another holder's queue if a reload reconciliation interleaved
+;; between them; [[provenance-holder]] is the single coherent snapshot that closes that
+;; desync. CLJS stores the token unchanged.
 #?(:clj (def ^:private provenance-storage-version
           ;; Representation version of the private JVM provenance storage. BUMP when
           ;; the holder shape changes so a reload over an older root REPLACES it. v2
@@ -356,17 +369,21 @@
 #?(:clj (ensure-current-provenance-storage!))
 
 #?(:clj
-   (defn- provenance-map
-     "The current identity-keyed provenance `HashMap` (rf2-qqvgk1)."
-     ^java.util.Map []
-     (:by-throwable provenance-storage)))
-
-#?(:clj
-   (defn- provenance-ref-queue
-     "The current provenance `ReferenceQueue` — bundled with [[provenance-map]] in
-     the one holder so the two can never desync across a reload (rf2-qqvgk1)."
-     ^java.lang.ref.ReferenceQueue []
-     (:queue provenance-storage)))
+   (defn- provenance-holder
+     "ONE coherent snapshot of the reconciled provenance storage holder — a SINGLE
+     read of the `provenance-storage` Var (rf2-kia9st). Every attest / lookup /
+     expunge operation binds this ONCE and pulls BOTH its `:by-throwable` map and
+     its paired `:queue` ReferenceQueue from the returned value, NEVER through two
+     separate Var reads. `alter-var-root` publishes a holder replacement
+     atomically, so a single read always sees ONE complete holder — even if a
+     reload reconciliation ([[ensure-current-provenance-storage!]]) runs
+     concurrently or reentrantly. This closes the desync where the map came from
+     one holder and the queue from another: a key registered on holder B's queue
+     but installed in holder A's map is never enqueued to A's queue, so A never
+     expunges it (a weak leak) and it is undiscoverable from the live holder if B
+     wins. Callers must not re-read the Var mid-operation."
+     []
+     provenance-storage))
 
 #?(:clj
    (defn- weak-identity-key
@@ -413,14 +430,28 @@
   minted-and-bound is covered. A no-op-safe identity write; the entry dies with
   the throwable."
   [t provenance]
-  #?(:clj  (let [m (provenance-map)
-                 q (provenance-ref-queue)]
+  #?(:clj  (let [holder (provenance-holder)      ;; ONE coherent snapshot (rf2-kia9st)
+                 m      ^java.util.Map (:by-throwable holder)
+                 q      ^java.lang.ref.ReferenceQueue (:queue holder)]
              (locking m
                (expunge-stale-provenance! m q)
                ;; Store under a WEAK IDENTITY key (rf2-fs99nq): keyed by t's object
                ;; identity, never its own hashCode/equals; the key is registered on
-               ;; the ReferenceQueue so the entry is reclaimed once t is collected.
-               (.put ^java.util.Map m (weak-identity-key t q) provenance)))
+               ;; THIS holder's ReferenceQueue so the entry is reclaimed once t is
+               ;; collected. Map + queue come from the one `holder` snapshot, so the
+               ;; key can never be registered on a different holder's queue than the
+               ;; map it lands in (rf2-kia9st).
+               ;;
+               ;; The stored VALUE is the RELOAD-STABLE channels SET, NOT the
+               ;; `EmissionProvenance` deftype instance (rf2-kia9st): a real
+               ;; namespace reload REDEFINES the deftype's class, so a retained
+               ;; old-class instance reads `(instance? EmissionProvenance …)` FALSE
+               ;; afterward and its throwable flips covered→uncovered — an
+               ;; exact-once-coverage violation. A plain persistent set's class
+               ;; (`PersistentHashSet`) and its interned keyword members are stable
+               ;; across reloads, so the retained value still reads correctly. CLJS
+               ;; stores the token unchanged (a page reload is a fresh JS realm).
+               (.put m (weak-identity-key t q) (.-channels ^EmissionProvenance provenance))))
      :cljs (.set provenance-by-throwable t provenance))
   t)
 
@@ -439,31 +470,40 @@
   false, so trace coverage is never mistaken for always-on coverage
   (rf2-w55bh0)."
   [t]
-  (let [prov #?(:clj  (let [m (provenance-map)
-                            q (provenance-ref-queue)]
-                        (locking m
-                          (expunge-stale-provenance! m q)
-                          ;; A transient IDENTITY LOOKUP key (nil queue) — HashMap.get
-                          ;; discriminates by our key's `System/identityHashCode` +
-                          ;; referent `identical?`, NEVER t's own hashCode/equals
-                          ;; (rf2-fs99nq). So a distinct application throwable that is
-                          ;; `.equals`/hash-collides with a bound one reads uncovered,
-                          ;; and a throwable whose hashCode/equals THROWS cannot make
-                          ;; this lookup escape the drain's catch.
-                          (.get ^java.util.Map m (weak-identity-key t nil))))
-                ;; `WeakMap.prototype.get` returns undefined (never throws) for a
-                ;; non-object key, so a raw thrown value (CLJS permits
-                ;; `(throw :kw)` / `(throw "x")`) simply reads uncovered — NO guard
-                ;; is needed here. `js/WeakMap` is genuinely identity-keyed (reference
-                ;; keys), so CLJS carries none of the JVM `.equals`/`.hashCode`
-                ;; collision hazard (rf2-fs99nq). In particular do NOT guard with cljs
-                ;; `object?`: it is `(identical? (.-constructor x) js/Object)`, which
-                ;; is FALSE for an `ExceptionInfo` (its constructor is not
-                ;; `js/Object`), so it would wrongly exclude every real framework
-                ;; throwable and make the covered path never fire on CLJS.
-                :cljs (.get provenance-by-throwable t))]
-    (and (instance? EmissionProvenance prov)
-         (contains? (.-channels ^EmissionProvenance prov) :always-on))))
+  ;; `channels` is the reload-stable channel SET the source covered, or nil when t
+  ;; has no binding. On the JVM the stored VALUE already IS that set (rf2-kia9st);
+  ;; on CLJS the stored value is the `EmissionProvenance` token, so its channels are
+  ;; extracted here (belt-and-braces `instance?` — an app cannot write the private
+  ;; WeakMap anyway).
+  (let [channels
+        #?(:clj  (let [holder (provenance-holder)      ;; ONE coherent snapshot (rf2-kia9st)
+                       m      ^java.util.Map (:by-throwable holder)
+                       q      ^java.lang.ref.ReferenceQueue (:queue holder)]
+                   (locking m
+                     (expunge-stale-provenance! m q)
+                     ;; A transient IDENTITY LOOKUP key (nil queue) — HashMap.get
+                     ;; discriminates by our key's `System/identityHashCode` +
+                     ;; referent `identical?`, NEVER t's own hashCode/equals
+                     ;; (rf2-fs99nq). So a distinct application throwable that is
+                     ;; `.equals`/hash-collides with a bound one reads uncovered,
+                     ;; and a throwable whose hashCode/equals THROWS cannot make
+                     ;; this lookup escape the drain's catch. Map + queue are the
+                     ;; paired members of the ONE `holder` snapshot (rf2-kia9st).
+                     (.get m (weak-identity-key t nil))))
+           ;; `WeakMap.prototype.get` returns undefined (never throws) for a
+           ;; non-object key, so a raw thrown value (CLJS permits
+           ;; `(throw :kw)` / `(throw "x")`) simply reads uncovered — NO guard
+           ;; is needed here. `js/WeakMap` is genuinely identity-keyed (reference
+           ;; keys), so CLJS carries none of the JVM `.equals`/`.hashCode`
+           ;; collision hazard (rf2-fs99nq). In particular do NOT guard with cljs
+           ;; `object?`: it is `(identical? (.-constructor x) js/Object)`, which
+           ;; is FALSE for an `ExceptionInfo` (its constructor is not
+           ;; `js/Object`), so it would wrongly exclude every real framework
+           ;; throwable and make the covered path never fire on CLJS.
+           :cljs (let [prov (.get provenance-by-throwable t)]
+                   (when (instance? EmissionProvenance prov)
+                     (.-channels ^EmissionProvenance prov))))]
+    (boolean (and channels (contains? channels :always-on)))))
 
 ;; ---- ABI version guard -----------------------------------------------------
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -3318,6 +3318,132 @@
              "the cleared entry was expunged — private storage returned to baseline")))))
 
 ;; ===========================================================================
+;; rf2-kia9st — the JVM provenance is TRULY reload-safe: a REAL namespace reload
+;; (not merely the reconciliation helper) keeps a pre-reload attestation covered,
+;; and every operation reads its map + queue from ONE coherent holder snapshot.
+;;
+;; #5910 preserved a versioned holder but two hazards remained on current main:
+;;   1. A real `(require … :reload)` REDEFINES the `EmissionProvenance` deftype's
+;;      class. The defonce'd holder retained the provenance VALUE as an OLD-class
+;;      instance, so `(instance? EmissionProvenance …)` read FALSE afterward and a
+;;      throwable attested before the reload silently flipped covered→uncovered —
+;;      an exact-once-coverage violation the reconciliation-helper-only test never
+;;      exercised. The fix stores the reload-STABLE channel SET.
+;;   2. `attest-provenance!` / `source-covered-always-on?` fetched the map and the
+;;      ReferenceQueue through SEPARATE Var reads; a reload reconciliation
+;;      interleaving between them paired one holder's map with another's queue,
+;;      orphaning the entry / mismatching the queue. The fix takes ONE coherent
+;;      holder snapshot per operation ([[provenance-holder]]).
+;; JVM-only: CLJS uses `js/WeakMap` (ephemeron, fresh realm per page reload).
+;; ===========================================================================
+
+#?(:clj
+   (deftest jvm-provenance-survives-a-real-namespace-reload-covered-exactly-once
+     ;; rf2-kia9st acceptance 1 + 3: attest a REAL port-minted throwable, perform a
+     ;; REAL `(require … :reload)` (redefining the EmissionProvenance class), and prove
+     ;; the SAME throwable still reads covered afterward + the disposal drain adds NO
+     ;; duplicate wrapper (exact-once). Reverting the stored value to the deftype
+     ;; instance reddens this: the retained old-class instance reads instance? FALSE
+     ;; after the reload, flipping covered→uncovered.
+     (reg-items!)
+     (seed-items! [:a])
+     (let [setup         (obs/acquire! (items-target) (fn [_]))
+           _             (obs/release! setup)
+           ;; A REAL port-minted always-on throwable, bound #{:always-on :trace} by
+           ;; read-after-release's emit-then-throw. Held STRONGLY across the reload so
+           ;; only the class-redefinition — never GC — can flip its coverage.
+           a-throwable   (try (obs/read setup) (catch Throwable e e))
+           holder-before @#'obs/provenance-storage]
+       (is (= :rf.error/read-after-release (error-id a-throwable)))
+       (is (true? (#'obs/source-covered-always-on? a-throwable))
+           "covered before the reload")
+       ;; THE RELOAD — redefines EmissionProvenance's class; defonce keeps the holder
+       ;; and its entries, ensure-current-provenance-storage! reconciles (a no-op).
+       (require 're-frame.substrate.observation :reload)
+       (is (identical? holder-before @#'obs/provenance-storage)
+           "a same-version reload keeps the defonce'd holder — entries preserved")
+       (is (#'obs/current-provenance-storage? @#'obs/provenance-storage)
+           "the reload-reconciled holder is current-version")
+       (is (true? (#'obs/source-covered-always-on? a-throwable))
+           (str "the throwable attested BEFORE the reload STILL reads covered AFTER "
+                "it — the reload-stable channel-set value survives the deftype-class "
+                "redefinition (a retained EmissionProvenance instance would read "
+                "instance? FALSE against the new class and flip covered→uncovered)"))
+       (is (false? (#'obs/source-covered-always-on? (ex-info "unbound post-reload" {})))
+           "an unbound throwable still reads uncovered after the reload")
+       ;; Exact-once across the reload: a former owner whose on-change throws the
+       ;; pre-reload-attested throwable during a disposal drain must NOT add a
+       ;; duplicate callback-failure wrapper — its source coverage survived the reload.
+       (with-redefs [interop/next-tick (fn [_f] nil)]
+         (let [notes (atom [])
+               la    (obs/acquire! (items-target) (fn [_n] (throw a-throwable)))
+               lc    (obs/acquire! (items-target) (fn [n] (swap! notes conj n)))]
+           (force-dispose-node! [:obs/items])
+           (let [[_ records] (with-error-records
+                               #(obs/drain-pending-disposals! :disposed))
+                 wrapped     (filterv #(= :rf.error/observation-on-change-failed
+                                          (:error %))
+                                      records)]
+             (is (= 1 (count @notes)) "the healthy sibling was still notified")
+             (is (zero? (count wrapped))
+                 "the covered source stands across the reload — NO duplicate wrapper"))
+           (obs/release! la) (obs/release! lc))))))
+
+#?(:clj
+   (deftest jvm-attest-takes-one-coherent-holder-snapshot-under-a-reconciliation-interleave
+     ;; rf2-kia9st acceptance 2 + 4: attest reads its map + queue from ONE holder
+     ;; snapshot. Here a reconciliation is forced to interleave EXACTLY at attest's
+     ;; single holder read — the stub returns the live holder A and, as its side
+     ;; effect, moves the live storage Var forward to a fresh B. With one coherent
+     ;; snapshot the entry AND its weak-identity key both belong to A, so A expunges
+     ;; the entry when the throwable dies. The pre-fix two-read shape (map via one Var
+     ;; read, queue via a second) would read A then B — registering the key on B's
+     ;; queue while the entry landed in A's map, an orphan A can never expunge; that
+     ;; reversion reddens both the single-read count and the expunge-from-A proof.
+     (let [saved @#'obs/provenance-storage]
+       (try
+         (let [holder-a ^clojure.lang.IPersistentMap (#'obs/fresh-provenance-storage)
+               holder-b ^clojure.lang.IPersistentMap (#'obs/fresh-provenance-storage)
+               a-map    ^java.util.Map (:by-throwable holder-a)
+               a-queue  ^java.lang.ref.ReferenceQueue (:queue holder-a)
+               reads    (atom 0)]
+           (alter-var-root #'obs/provenance-storage (constantly holder-a))
+           (let [t-box (volatile! (ex-info "coherent-snapshot boom" {}))
+                 t-ref (java.lang.ref.WeakReference. ^Object @t-box)]
+             (with-redefs [obs/provenance-holder
+                           (fn []
+                             (swap! reads inc)
+                             ;; whichever holder is LIVE at this read (A on the first
+                             ;; read); then interleave a reconciliation to a fresh B.
+                             (let [live @#'obs/provenance-storage]
+                               (alter-var-root #'obs/provenance-storage
+                                               (constantly holder-b))
+                               live))]
+               (#'obs/attest-provenance! @t-box @#'obs/provenance-both-channels))
+             (is (= 1 @reads)
+                 "attest read the holder EXACTLY once — one coherent snapshot")
+             (is (= 1 (.size a-map))
+                 "the entry landed in the snapshotted holder A (no orphan)")
+             (is (zero? (.size ^java.util.Map (:by-throwable holder-b)))
+                 "the concurrently-installed live holder B never received this attest")
+             ;; No mismatched queue: the key was registered on A's OWN queue, so
+             ;; collecting the throwable + expunging A reclaims it. A key on B's queue
+             ;; (the pre-fix split) would leave a-map at size 1 forever.
+             (vreset! t-box nil)
+             (is (gc-until-cleared? t-ref)
+                 "the throwable is collectable — stored via neither key nor value")
+             (is (loop [i 0]
+                   (#'obs/expunge-stale-provenance! a-map a-queue)
+                   (cond
+                     (zero? (.size a-map)) true
+                     (>= i 40)             false
+                     :else (do (System/gc) (System/runFinalization) (recur (inc i)))))
+                 (str "expunge from the OWNING holder A reclaims the entry — its key "
+                      "was registered on A's queue, not B's (no mismatched queue)"))))
+         (finally
+           (alter-var-root #'obs/provenance-storage (constantly saved)))))))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 


### PR DESCRIPTION
## Problem

`re-frame.substrate.observation` (the internal observation port) binds an
`EmissionProvenance` token to each fail-loud throwable in a private, weak,
JVM-side holder, and the disposal drain reads it through
`source-covered-always-on?` to enforce exact-once callback-failure coverage.
PR #5910 versioned the holder, but two reload hazards remained on current main:

1. **Deftype-class redefinition flips coverage** — the JVM holder stored the
   provenance VALUE as an `EmissionProvenance` deftype instance. A real
   `(require 're-frame.substrate.observation :reload)` REDEFINES that class; the
   `defonce`'d holder retains old-class instances, so
   `(instance? EmissionProvenance …)` reads FALSE afterward and a throwable
   attested before the reload silently flips covered→uncovered — an exact-once
   violation the reconciliation-helper-only test never exercised
   (`observation.cljc` `attest-provenance!` / `source-covered-always-on?`).

2. **Map + queue from separate Var reads** — `attest-provenance!` and
   `source-covered-always-on?` fetched the `:by-throwable` map and the paired
   `:queue` ReferenceQueue through two SEPARATE reads of the `provenance-storage`
   Var. A reload reconciliation (`alter-var-root`) interleaving between them
   paired one holder's map with another holder's queue — the weak key registered
   on holder B's queue while the entry landed in holder A's map, so A never
   expunges it (a weak leak) and it is undiscoverable from the live holder if B
   wins.

## Fix

- Store the RELOAD-STABLE channel SET (`#{:always-on :trace}` / `#{:trace}`),
  not the deftype instance, as the JVM holder value. A `PersistentHashSet` and
  its interned keyword members are stable across reloads. CLJS is unchanged (a
  page reload is a fresh JS realm); its reader still extracts the token's
  channels — behaviour identical.
- Add a single `provenance-holder` accessor; `attest-provenance!` /
  `source-covered-always-on?` bind it ONCE and pull both the map and the queue
  from that one coherent snapshot, so a concurrent/reentrant reconciliation can
  never split map from queue.

No new public var or error-id (the accessor is private); no second registry.

## Reload proof (failing-before / passing-after)

Two new JVM regressions in `observation_port_cljs_test.cljc`:

- `jvm-provenance-survives-a-real-namespace-reload-covered-exactly-once` —
  attests a real port-minted throwable, performs a real `(require … :reload)`,
  proves it still reads covered and the disposal drain adds no duplicate wrapper.
- `jvm-attest-takes-one-coherent-holder-snapshot-under-a-reconciliation-interleave`
  — forces a holder replacement to interleave attest's single read, proves the
  entry + its queue key both belong to the snapshotted holder and expunge from
  the owning holder.

Reverting the fix reddens both: with the pre-fix representation the reload test
fails "STILL reads covered AFTER reload" (`instance?` false) + adds a duplicate
wrapper, and the interleave test fails the single-read count and the
expunge-from-owning-holder proof (key on B's queue, orphan in A's map). Verified
by temporary revert (4 failures), then restored.

## Quality gates

- `clojure -M:test -n re-frame.observation-port-cljs-test` (focused core JVM, incl. the two new reload regressions): **92 tests, 648 assertions, 0 failures, 0 errors**.
- `clojure -M:test` (full core JVM suite): **2015 tests, 9422 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (core CLJS node gate): **9631 tests, 47445 assertions, 0 failures, 0 errors**.
- No reflection warnings from `re-frame.substrate.observation` (`*warn-on-reflection*` is on).

JVM-only surface (`#?(:clj …)`); CLJS `js/WeakMap` path unchanged.
