### PR TITLE
fix(ui): retire exact root-reporter authority after manual quarantine recovery (rf2-nd7z9h)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -1375,6 +1375,14 @@
           quarantined?
           (try
             (reclaim-consumed-container! root)
+            ;; rf2-nd7z9h — the terminal reclaim proved this consumed surface
+            ;; free, so this exact incarnation's reporter authority is spent:
+            ;; retire it BEFORE releasing the claim so `live-reporters` cannot
+            ;; strongly retain a dead incarnation across recovery cycles (nor
+            ;; leave stale reporter-deferred teardown authority for its old
+            ;; token). A FAILED reclaim throws above and skips both retirement and
+            ;; release, keeping quarantine AND reporter authority fail-closed.
+            (reactive/retire-root-reporter! (:root-incarnation current))
             (release-root! root-id root)
             (catch :default recovery-error
               (vswap! errors conj recovery-error)))
@@ -1400,6 +1408,11 @@
                   ;; `unmount!*` just classified this exact root as cleanup-failed.
                   ;; Successful adapter reclaim proves the surface free; the
                   ;; identity fence prevents a stale snapshot releasing a successor.
+                  ;; rf2-nd7z9h — retire this incarnation's reporter authority too,
+                  ;; between the successful reclaim and the claim release, so the
+                  ;; reporter ledger returns to baseline (a failed reclaim throws
+                  ;; above and retains both quarantine and reporter authority).
+                  (reactive/retire-root-reporter! (root-incarnation-of root-id))
                   (release-root! root-id root)
                   (catch :default recovery-error
                     (vswap! errors conj recovery-error)))))))))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3107,6 +3107,47 @@
       (vreset! (:fired sig) true)))
   nil)
 
+(defn retire-root-reporter!
+  "Terminally retire `incarnation`'s reporter authority at a SUCCESSFUL exact
+  adapter/manual quarantine recovery (rf2-nd7z9h). A throwing host `.unmount`
+  aborts before React runs the reporter's mount-lifetime cleanup, so
+  `report-root-teardown!` never fires and the incarnation stays STRONGLY held in
+  `live-reporters`. Adapter-wide recovery then reclaims the consumed container and
+  releases the client's `live-roots` claim — but `release-root!` alone touches
+  only `live-roots`, so WITHOUT this retirement the reporter ledger keeps one dead
+  token per recovery cycle plus stale reporter-deferred teardown authority (a
+  later `teardown-root!` for the retired incarnation would be classified DEFERRED
+  off a reporter that can never settle).
+
+  Call ONLY once the terminal container reclaim has completed: the reporter
+  authority is then spent, so retiring it lets a subsequent `teardown-root!` for
+  this incarnation settle SYNCHRONOUSLY and returns the ledger to BASELINE across
+  repeated recovery cycles. Reuses the exact identity-keyed strong set — no second
+  registry. Idempotent (`disj`), and — unlike `report-root-teardown!` — it does
+  NOT touch the in-flight teardown-settle signal, because recovery runs after the
+  throwing thunk has already unwound. A late real-React `report-root-teardown!`
+  for this same incarnation is thereafter a harmless no-op whose identity check
+  still cannot settle a same-id SUCCESSOR incarnation. Returns nil."
+  [incarnation]
+  (when (some? incarnation)
+    (swap! live-reporters disj incarnation))
+  nil)
+
+(defn live-reporter-count
+  "The number of root incarnations whose committed reporter is still live
+  (tool/test read). A cleanup-failure quarantine whose container reclaim has
+  completed is retired (`retire-root-reporter!`), so repeated
+  mount → throwing-cleanup → adapter-reclaim cycles return this to baseline
+  instead of accreting one strong token per cycle (rf2-nd7z9h)."
+  []
+  (count @live-reporters))
+
+(defn live-reporter?
+  "Whether `incarnation`'s committed reporter is still live (tool/test read).
+  A retired predecessor reads false while a same-id successor reads true."
+  [incarnation]
+  (contains? @live-reporters incarnation))
+
 (defn- settle-deferred-root!
   "Settle a DEFERRED host teardown (rf2-vxgfnd.182). The host `.unmount` returned
   but scheduled this root's teardown for a later microtask, so its cells are

--- a/implementation/ui/test/re_frame/ui/adapter_public_root_disposal_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/adapter_public_root_disposal_dom_cljs_test.cljs
@@ -561,3 +561,262 @@
             (.then (fn [] (done))
                    (fn [e]
                      (unexpected! done "commit-phase adapter disposal rejected" e))))))))
+
+;; ===========================================================================
+;; rf2-nd7z9h — retire the exact root-reporter authority after a SUCCESSFUL
+;; manual/adapter quarantine recovery.
+;;
+;; PR #5911 added `live-reporters`, a STRONG set of committed root-incarnation
+;; tokens. A throwing host `.unmount` never runs the reporter's mount-lifetime
+;; cleanup, so `report-root-teardown!` never fires; adapter-wide recovery clears
+;; the consumed container and calls `release-root!` (which dissociates
+;; `live-roots` only), STRONGLY RETAINING the dead incarnation in
+;; `live-reporters` — one leaked token per recovery cycle, plus stale
+;; reporter-deferred teardown authority for the old token. These fixtures pin
+;; that a SUCCESSFUL terminal reclaim now also retires the reporter authority,
+;; while a FAILED reclaim (and an isolated `unmount!`) keeps both quarantine and
+;; reporter authority fail-closed.
+;; ===========================================================================
+
+(defn- mount-retire-probe!
+  "Mount a public compiled Root (every root render commits a `root-commit-reporter`,
+  so its incarnation enrols in `live-reporters`) under a LITERAL root-id — the
+  `ui/mount` macro validates :root-id at expansion, so each id must be a literal."
+  [container which]
+  (case which
+    :sync         (ui/mount [admission-probe] container
+                            {:root-id :adapter-public/retire-sync})
+    :baseline     (ui/mount [admission-probe] container
+                            {:root-id :adapter-public/retire-baseline})
+    :succ         (ui/mount [admission-probe] container
+                            {:root-id :adapter-public/retire-succ})
+    :fail-closed  (ui/mount [admission-probe] container
+                            {:root-id :adapter-public/retire-fail-closed})
+    :reclaim-fail (ui/mount [admission-probe] container
+                            {:root-id :adapter-public/retire-reclaim-fail})))
+
+(deftest recovered-throwing-root-old-token-teardown-settles-synchronously
+  (when (browser?)
+    (async done
+      (let [container (js/document.createElement "div")
+            root*     (volatile! nil)
+            old-inc   (volatile! nil)
+            cleanup   (js/Error. "retire-sync host cleanup failed")]
+        (-> (act-promise
+             #(vreset! root* (mount-retire-probe! container :sync)))
+            (.then
+             (fn []
+               (vreset! old-inc
+                        (:root-incarnation
+                         (client/live-root-entry :adapter-public/retire-sync)))
+               (is (some? @old-inc))
+               (is (true? (reactive/live-reporter? @old-inc))
+                   "a committed root holds live reporter authority")
+               ;; Replace only this exact host handle's unmount seam so the
+               ;; adapter's synchronous failure fallback (reclaim + release) runs.
+               (let [^client/Root root @root*]
+                 (set! (.-unmount (.-react-root root)) (fn [] (throw cleanup))))
+               (is (identical? cleanup
+                               (thrown-value #((:dispose-adapter! ui/adapter))))
+                   "the throwing host cleanup error still propagates")))
+            (.then
+             (fn []
+               (is (= #{} (client/live-root-ids)))
+               (is (false? (reactive/live-reporter? @old-inc))
+                   "successful reclaim retired the old incarnation's reporter")
+               ;; A no-signal `teardown-root!` for the RETIRED old token settles
+               ;; SYNCHRONOUSLY — no live reporter to await. Before the fix the
+               ;; retained token classifies it reporter-DEFERRED, so `on-settled`
+               ;; would fire a microtask later and this volatile stay false here.
+               (let [settled (volatile! false)]
+                 (reactive/teardown-root! @old-inc (fn [] nil)
+                                          (fn [] (vreset! settled true)))
+                 (is (true? @settled)
+                     "a teardown of the retired old token is synchronously terminal"))))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "sync-teardown proof rejected" e))))))))
+
+(deftest repeated-throwing-recovery-returns-reporter-ledger-to-baseline
+  (when (browser?)
+    (async done
+      (let [reporter-base (reactive/live-reporter-count)
+            root-base     (client/live-root-ids)
+            cleanup       (js/Error. "retire-baseline host cleanup failed")
+            run-cycle
+            (fn run-cycle [n]
+              (if (zero? n)
+                (js/Promise.resolve nil)
+                (let [container (js/document.createElement "div")
+                      root*     (volatile! nil)]
+                  (-> (act-promise
+                       #(vreset! root* (mount-retire-probe! container :baseline)))
+                      (.then
+                       (fn []
+                         (is (= (inc reporter-base) (reactive/live-reporter-count))
+                             "a committed root adds exactly one reporter token")
+                         (let [^client/Root root @root*]
+                           (set! (.-unmount (.-react-root root))
+                                 (fn [] (throw cleanup))))
+                         (is (identical?
+                              cleanup
+                              (thrown-value #((:dispose-adapter! ui/adapter)))))
+                         ;; The dead incarnation's reporter authority is retired at
+                         ;; the successful reclaim — the ledger is back to baseline,
+                         ;; not one strong token heavier.
+                         (is (= reporter-base (reactive/live-reporter-count))
+                             "adapter reclaim retired the reporter — ledger at baseline")
+                         (is (= root-base (client/live-root-ids)))
+                         (run-cycle (dec n))))))))]
+        (-> (run-cycle 4)
+            (.then
+             (fn []
+               (is (= reporter-base (reactive/live-reporter-count))
+                   "after many recovery cycles the reporter ledger is at baseline,
+                    not grown one strong token per cycle")))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "reporter-ledger baseline proof rejected" e))))))))
+
+(deftest late-predecessor-reporter-cleanup-cannot-affect-successor
+  (when (browser?)
+    (async done
+      (let [container (js/document.createElement "div")
+            pred*     (volatile! nil)
+            pred-inc  (volatile! nil)
+            succ-inc  (volatile! nil)
+            cleanup   (js/Error. "retire-succ predecessor cleanup failed")]
+        (-> (act-promise
+             #(vreset! pred* (mount-retire-probe! container :succ)))
+            (.then
+             (fn []
+               (vreset! pred-inc
+                        (:root-incarnation
+                         (client/live-root-entry :adapter-public/retire-succ)))
+               (is (true? (reactive/live-reporter? @pred-inc)))
+               (let [^client/Root root @pred*]
+                 (set! (.-unmount (.-react-root root)) (fn [] (throw cleanup))))
+               ;; isolated unmount! quarantines fail-closed; adapter destroy then
+               ;; reclaims (the `quarantined?` recovery branch, seam 1).
+               (is (identical? cleanup (thrown-value #(client/unmount!* @pred*))))
+               (is (true? (:cleanup-failure?
+                           (client/live-root-entry :adapter-public/retire-succ))))
+               (act-promise rf/destroy-adapter!)))
+            (.then
+             (fn []
+               (is (= #{} (client/live-root-ids)))
+               (is (false? (reactive/live-reporter? @pred-inc))
+                   "the reclaimed quarantine retired the predecessor reporter")
+               (rf/init! ui/adapter)
+               ;; the exact id + container re-mounts a fresh incarnation
+               (act-promise #(mount-retire-probe! container :succ))))
+            (.then
+             (fn []
+               (vreset! succ-inc
+                        (:root-incarnation
+                         (client/live-root-entry :adapter-public/retire-succ)))
+               (is (not (identical? @pred-inc @succ-inc))
+                   "the same-id successor is a distinct incarnation")
+               (is (true? (reactive/live-reporter? @succ-inc)))
+               ;; A LATE real-React reporter cleanup for the RETIRED predecessor:
+               ;; idempotent (`disj`) + identity-checked, so it clears nothing of
+               ;; the same-id successor.
+               (reactive/report-root-teardown! @pred-inc)
+               (is (false? (reactive/live-reporter? @pred-inc))
+                   "the retired predecessor stays retired (idempotent)")
+               (is (true? (reactive/live-reporter? @succ-inc))
+                   "the successor's reporter authority is untouched")
+               (act-promise rf/destroy-adapter!)))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "late-predecessor idempotency proof rejected" e))))))))
+
+(deftest public-unmount-alone-fails-closed-and-retains-reporter-authority
+  (when (browser?)
+    (async done
+      (let [container (js/document.createElement "div")
+            root*     (volatile! nil)
+            inc*      (volatile! nil)
+            cleanup   (js/Error. "retire-fail-closed host cleanup failed")]
+        (-> (act-promise
+             #(vreset! root* (mount-retire-probe! container :fail-closed)))
+            (.then
+             (fn []
+               (vreset! inc*
+                        (:root-incarnation
+                         (client/live-root-entry :adapter-public/retire-fail-closed)))
+               (is (true? (reactive/live-reporter? @inc*)))
+               (let [^client/Root root @root*]
+                 (set! (.-unmount (.-react-root root)) (fn [] (throw cleanup))))
+               (is (identical? cleanup (thrown-value #(client/unmount!* @root*))))
+               ;; No reclaim proof: the container is not advertised free, the claim
+               ;; stays quarantined, AND the reporter authority is RETAINED —
+               ;; retirement belongs only at a SUCCESSFUL exact recovery.
+               (let [entry (client/live-root-entry :adapter-public/retire-fail-closed)]
+                 (is (true? (:tearing-down? entry)))
+                 (is (true? (:cleanup-failure? entry))))
+               (is (contains? (client/live-root-ids)
+                              :adapter-public/retire-fail-closed)
+                   "the unproven container is not advertised free")
+               (is (true? (reactive/live-reporter? @inc*))
+                   "isolated unmount! retains reporter authority (no reclaim proof)")
+               ;; adapter destroy then reclaims + retires, leaving a clean registry.
+               (act-promise rf/destroy-adapter!)))
+            (.then
+             (fn []
+               (is (= #{} (client/live-root-ids)))
+               (is (false? (reactive/live-reporter? @inc*))
+                   "the later adapter reclaim retired the reporter authority")))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "unmount-alone fail-closed proof rejected" e))))))))
+
+(deftest failed-container-reclaim-retains-quarantine-and-reporter-authority
+  (when (browser?)
+    (async done
+      (let [container    (js/document.createElement "div")
+            root*        (volatile! nil)
+            inc*         (volatile! nil)
+            cleanup      (js/Error. "retire-reclaim-fail host cleanup failed")
+            reclaim-boom (js/Error. "container reclaim failed")]
+        (-> (act-promise
+             #(vreset! root* (mount-retire-probe! container :reclaim-fail)))
+            (.then
+             (fn []
+               (vreset! inc*
+                        (:root-incarnation
+                         (client/live-root-entry :adapter-public/retire-reclaim-fail)))
+               (is (true? (reactive/live-reporter? @inc*)))
+               (let [^client/Root root @root*]
+                 (set! (.-unmount (.-react-root root)) (fn [] (throw cleanup)))
+                 ;; Force the adapter's terminal container reclaim to FAIL: the
+                 ;; surface is never proven free, so recovery must retain BOTH the
+                 ;; quarantine AND the reporter authority. Retiring the reporter
+                 ;; BEFORE a proven reclaim is the mutation this fixture pins.
+                 (set! (.-replaceChildren (.-container root))
+                       (fn [] (throw reclaim-boom))))
+               (is (identical? cleanup
+                               (thrown-value #((:dispose-adapter! ui/adapter))))
+                   "the primary host cleanup error still surfaces")))
+            (.then
+             (fn []
+               (let [entry (client/live-root-entry :adapter-public/retire-reclaim-fail)]
+                 (is (true? (:tearing-down? entry))
+                     "a failed reclaim keeps the claim quarantined")
+                 (is (true? (:cleanup-failure? entry))))
+               (is (contains? (client/live-root-ids)
+                              :adapter-public/retire-reclaim-fail))
+               (is (true? (reactive/live-reporter? @inc*))
+                   "a failed reclaim retains reporter authority (never retire before
+                    a reclaim proves the surface free)")
+               ;; Repair the reclaim seam and recover cleanly, so the fixture
+               ;; teardown starts from an empty registry (and prove a subsequent
+               ;; successful reclaim now retires the reporter).
+               (js/Reflect.deleteProperty (.-container @root*) "replaceChildren")
+               (thrown-value #((:dispose-adapter! ui/adapter)))
+               (is (= #{} (client/live-root-ids)))
+               (is (false? (reactive/live-reporter? @inc*))
+                   "the repaired reclaim finally retired the reporter authority")))
+            (.then (fn [] (done))
+                   (fn [e]
+                     (unexpected! done "failed-reclaim fail-closed proof rejected" e))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -587,3 +587,78 @@
        (reactive/disconnect! outer)))
     (is (= :dead (reactive/lifecycle outer))
         "the outer window survived the nested one and proved its own cell")))
+
+;; ===========================================================================
+;; rf2-nd7z9h — retire the exact root-reporter authority after a SUCCESSFUL
+;; manual/adapter quarantine recovery.
+;;
+;; A throwing host `.unmount` aborts before React runs the reporter's cleanup,
+;; so `report-root-teardown!` never fires and the committed incarnation stays
+;; STRONGLY held in `live-reporters`. Adapter-wide recovery reclaims the consumed
+;; container and releases the client claim, but `release-root!` touches only the
+;; client registry — so WITHOUT `retire-root-reporter!` the reporter ledger keeps
+;; one dead token per recovery cycle plus stale reporter-DEFERRED teardown
+;; authority for the old token. These reactive-level proofs run on node
+;; (`test:cljs`) AND JVM (`clojure -M:test`); the end-to-end adapter-drain wiring
+;; is pinned by the browser `adapter-public-root-disposal-dom-cljs-test`.
+;; ===========================================================================
+
+(deftest retire-root-reporter-flips-a-deferred-teardown-to-synchronous
+  ;; A committed reporter makes a subsequent no-signal `teardown-root!` DEFERRED
+  ;; (the cell-less deferral pinned above). After the terminal reclaim retires the
+  ;; reporter authority, the SAME no-signal teardown for that old token settles
+  ;; SYNCHRONOUSLY — there is no live reporter left to await, on every host.
+  (let [inc     (reactive/make-root-incarnation)
+        settled (atom false)]
+    (reactive/report-root-commit! inc)
+    (is (true? (reactive/live-reporter? inc)) "the committed root holds reporter authority")
+    (reactive/retire-root-reporter! inc)
+    (is (false? (reactive/live-reporter? inc))
+        "successful reclaim retired the incarnation's reporter authority")
+    (reactive/teardown-root! inc
+                             (fn [] nil)                 ;; no cleanup, no sentinel
+                             (fn [] (reset! settled true)))
+    (is (true? @settled)
+        "a no-signal teardown of the RETIRED old token is synchronously terminal —
+         never reporter-deferred (a registry-only recovery would hold it)")))
+
+(deftest retiring-committed-incarnations-returns-the-reporter-ledger-to-baseline
+  ;; Repeated commit → throwing-cleanup → reclaim must return the strong ledger to
+  ;; baseline rather than accreting one token per recovery cycle. Retirement is
+  ;; idempotent, so a late real-React cleanup for an already-retired token is safe.
+  (let [base (reactive/live-reporter-count)
+        incs (vec (repeatedly 5 reactive/make-root-incarnation))]
+    (doseq [i incs] (reactive/report-root-commit! i))
+    (is (= (+ base 5) (reactive/live-reporter-count))
+        "five committed roots each add one reporter token")
+    (doseq [i incs] (reactive/retire-root-reporter! i))
+    (is (= base (reactive/live-reporter-count))
+        "every retired incarnation left the ledger — back to baseline, not grown")
+    (doseq [i incs] (reactive/retire-root-reporter! i))
+    (is (= base (reactive/live-reporter-count)) "retirement is idempotent")))
+
+(deftest a-late-reporter-cleanup-for-a-retired-predecessor-cannot-affect-a-successor
+  ;; After recovery retires the predecessor, a same-id successor commits fresh. A
+  ;; LATE real-React `report-root-teardown!` for the retired predecessor must be a
+  ;; harmless no-op: idempotent (`disj`) and identity-checked, it clears nothing of
+  ;; the distinct successor incarnation.
+  (let [pred (reactive/make-root-incarnation)
+        succ (reactive/make-root-incarnation)]
+    (reactive/report-root-commit! pred)
+    (reactive/retire-root-reporter! pred)                ;; the terminal reclaim retires pred
+    (reactive/report-root-commit! succ)                  ;; the same-id successor commits
+    (is (not (identical? pred succ)) "the successor is a distinct incarnation")
+    (is (false? (reactive/live-reporter? pred)))
+    (is (true? (reactive/live-reporter? succ)))
+    ;; the retired predecessor's late real-React cleanup eventually fires
+    (reactive/report-root-teardown! pred)
+    (is (false? (reactive/live-reporter? pred)) "idempotent — predecessor stays retired")
+    (is (true? (reactive/live-reporter? succ))
+        "the successor's reporter authority is untouched by the late predecessor cleanup")
+    (testing "the successor still settles through its OWN reporter signal"
+      (let [settled (atom false)]
+        (reactive/teardown-root! succ
+                                 (fn [] (reactive/report-root-teardown! succ))
+                                 (fn [] (reset! settled true)))
+        (is (true? @settled) "its own synchronous reporter teardown settles it")
+        (is (false? (reactive/live-reporter? succ)) "…and clears its authority")))))


### PR DESCRIPTION
## Summary

PR #5911's `live-reporters` is a **strong** set of committed root-incarnation tokens. On a throwing host `.unmount`, React aborts before running the reporter's mount-lifetime cleanup, so `report-root-teardown!` never fires. Adapter-wide recovery clears the consumed container and calls `release-root!` — which dissociates `live-roots` only — so `live-reporters` **strongly retains the dead incarnation**: one leaked token per recovery cycle, plus stale reporter-*deferred* teardown authority for the old token (a later `teardown-root!` for it is misclassified DEFERRED off a reporter that can never settle).

### The leak
- `implementation/ui/src/re_frame/ui/reactive.cljc:1135` — `live-reporters` (strong set); `report-root-teardown!` (line 3086) is the only path that disjoins, and it never runs on a throwing `.unmount`.
- `implementation/ui/src/re_frame/ui/client.cljs` `drain-live-roots!` — both recovery seams (`quarantined?` branch and the `:else` post-`unmount!*` catch) previously ran `reclaim-consumed-container!` + `release-root!` only, never retiring the reporter.

### The fix
- **`reactive/retire-root-reporter!`** (`reactive.cljc`) — disjoins the incarnation from the identity-keyed strong set. No second registry; unlike `report-root-teardown!` it does not touch the in-flight settle signal (recovery runs after the throwing thunk unwound).
- **`client.cljs`** — both `drain-live-roots!` recovery seams call `retire-root-reporter!` **between** the proven `reclaim-consumed-container!` and `release-root!`. A **failed** reclaim throws first, so retirement is skipped and **both quarantine and reporter authority stay fail-closed**. An isolated `unmount!` still fails closed and never retires (no reclaim proof).
- `report-root-teardown!` stays idempotent (`disj`) and identity-checked, so a late real-React cleanup for the retired predecessor cannot settle a same-id successor.
- Added tool/test readers `live-reporter-count` / `live-reporter?`.

### Proofs (the four acceptance criteria)
Browser real-DOM throwing-root fixture (`adapter_public_root_disposal_dom_cljs_test.cljs`), extended:
1. **synchronous teardown** — after recovery, a no-signal `teardown-root!` for the captured old token settles synchronously (not reporter-deferred).
2. **ledger baseline** — many mount → throwing-cleanup → reclaim cycles return `live-reporters` to baseline (no per-cycle token growth).
3. **idempotent late cleanup** — a late `report-root-teardown!` for the retired predecessor cannot clear/affect a same-id successor.
4. **failed-reclaim fail-closed** — a failed container reclaim retains both quarantine and reporter authority; isolated `unmount!` alone stays fail-closed and does not advertise the container free.

Because the DOM fixture is `(when (browser?) …)`-gated (executes only under the browser gate), an **executable node+JVM** reactive-level fixture (`reactive_root_teardown_cljs_test.cljc`) additionally pins the retirement primitive directly — ledger baseline, deferred→synchronous flip, and successor safety. A mutation probe neutering the retirement fails exactly these four assertions (verified locally), confirming failing-before/passing-after.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **644 tests, 13162 assertions, 0 failures** (+3 new reactive proofs).
- `npm run test:ui`: **660 tests, 0 failures** (node-test-ui build compiles the extended DOM fixture cleanly; browser-gated assertions execute under CI's `test:browser`).
- `npm run test:cljs`: **9639 tests, 47458 assertions, 0 failures** (+3 new reactive proofs run on the node host).
- Mutation-teeth check: neutering `retire-root-reporter!` → 4 focused assertion failures; reverted → green.

No compiler / `ui.cljc` / spec / API surfaces touched. No spec references the reporter ledger — internal reference-impl lifecycle detail only.
