### PR TITLE
docs(resources): reconcile concepts mutation-order/idle-state + landing request example with shipped runtime (cluster)

### DIFF
--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -131,6 +131,7 @@ Other causes use the same entry with a different **cause** recorded for the trac
   (let [state @(rf/subscribe [:rf/resource {:resource :realworld/article
                                             :params   {:slug slug}}])]
     (cond
+      (= :idle (:status state))                      [article-placeholder]
       (:loading? state)                              [article-skeleton]
       (and (:error state) (not (:has-data? state)))  [article-error (:error state)]
       :else
@@ -292,8 +293,11 @@ remembered in `onSuccess`:
      :decode  :json}))
 ```
 
-Success plan arms (fixed order): `:populates` → `:patches` → `:removes` →
-`:invalidates`.
+Success plan arms (fixed order): `:patches` → `:populates` → `:removes` →
+`:invalidates`. Patches run *before* populates, so when the same key is both
+patched and populated the **populate wins** — it is applied last, overwriting the
+patch. Invalidation runs last of all, over the tags the patch/populate did not
+already freshen.
 
 Execute and watch (instance id is app-chosen — reuse it for the sub):
 
@@ -359,9 +363,17 @@ Register → route causes → view projects. Copy-paste skeleton:
         state @(rf/subscribe [:rf/resource {:resource :app/article
                                             :params   {:slug slug}}])]
     (cond
-      (:loading? state) [skeleton]
-      (:error state)    [error-panel (:error state)]
-      :else             [article-body (:data state)])))
+      ;; :idle — nothing has caused a load yet (no route :resources / ensure hit)
+      (= :idle (:status state))                     [placeholder]
+      ;; :loading — first load, no usable data yet
+      (:loading? state)                             [skeleton]
+      ;; :error — first load failed, still no data (a failed *refresh* keeps :loaded)
+      (and (:error state) (not (:has-data? state))) [error-panel (:error state)]
+      ;; :loaded / :fetching — usable data; a background refresh keeps it visible
+      :else
+      [:<>
+       (when (:fetching? state) [refresh-indicator])   ;; refetching with data
+       [article-body (:data state)]])))
 ```
 
 ## Advanced (elsewhere)

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -25,7 +25,16 @@ leak boundary. Views *read* — they never fetch.
     {:request {:method :get :url (str "/api/articles/" slug)}
      :decode  :json}))
 
-;; a view only reads — no fetch on mount
+;; a view only reads — a subscription NEVER fetches
+@(rf/subscribe [:rf/resource {:resource :article :params {:slug "hello"}}])
+;; => {:status :idle …}  — registered, but nothing has caused a load yet
+
+;; a route or an event is the cause; here, an explicit ensure
+(rf/dispatch [:rf.resource/ensure {:resource :article
+                                   :params   {:slug "hello"}
+                                   :owner    [:lease :article "hello"]}])
+
+;; now the same passive read progresses
 @(rf/subscribe [:rf/resource {:resource :article :params {:slug "hello"}}])
 ;; => {:status :loading …}  then  {:status :loaded :data …}
 ```


### PR DESCRIPTION
Reconciles two `docs/resources/` pages with the shipped resources runtime. Both are P2 doc-accuracy bugs surfaced by the PR #5917 audit (rf2-2gotoc).

## rf2-5gj77s — concepts.md mutation order + idle read state

**Mutation success-plan order.** The page stated the arm order as `:populates` → `:patches` → `:removes` → `:invalidates`. The shipped runtime applies them **`:patches` → `:populates` → `:removes` → `:invalidates`** — see the success reply handler in `implementation/resources/src/re_frame/resources/mutation_events.cljc` (`apply-patches` → `rdb1` at :1670, `apply-populates` → `rdb2` at :1671, `apply-removes` → `rdb3` at :1679, `invalidation-plan` at :1708). Because populates run *after* patches, the **populate wins** on a key written by both — the code comment at mutation_events.cljc:1669 says so verbatim ("populate wins on a key written by both (it ran last)"). The tutorial page (`04-mutations-and-invalidation.md:225`) already stated the correct "patch/populate/remove first, then invalidate" order, so concepts.md was the lone outlier. Corrected the order and added the same-key-winner explanation.

**Idle read state.** Both view examples — the five-status projection and the copy-paste read-loop skeleton — handled loading/error then fell through to the loaded body, so an `:idle` snapshot rendered `[article-body nil]` despite the page teaching an `:idle` placeholder. A resource sub returns the idle empty-state projection when no entry exists (`implementation/resources/src/re_frame/resources/subs.cljc:344-348`, `state-sub-fn`); backed by `resources_runtime_cljs_test.cljc:679` (`passive-subs-project-the-entry`) and the lifecycle FSM (`state.cljc:668-691` `next-status`; `status-transition-fn-is-pure` test). Added an explicit `(= :idle (:status state))` branch to each example so all five statuses render, including refetching-with-data (`:fetching?`), with no nil passed to the loaded body.

## rf2-d21hug — index.md landing example causes no request

The opening view-only example claimed a passive `[:rf/resource …]` subscription progressed `{:status :loading …}` then `{:status :loaded …}`. A subscription never fetches (`subs.cljc:6-7` "No v1 subscription fetches"), and a registered-but-un-ensured read stays `:idle` (`subs.cljc:344-348`; `resources_runtime_cljs_test.cljc:685-689` asserts the idle projection and that "subscribing did not cause a fetch / entry"). This contradicted both shipped behaviour and the same page's own "a subscription that finds no entry stays `:idle` until something causes a load" (index.md Three lanes). Rewrote the example to be self-contained: show the `:idle` projection first, then an explicit `:rf.resource/ensure` cause driving loading → loaded.

No code was wrong — both fixes are on the docs side; the runtime and its tests already behave as the corrected docs now describe.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (17.3s; remaining INFO advisories are pre-existing links under spec/ core/ migration/, none in docs/resources/)
- Did not run the test spine or browser suites (docs-only change).
