### PR TITLE
fix(trace): preserve per-listener order + authoritative silence generation across nested emissions (cluster)

### DIFF
--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -680,6 +680,63 @@
 ;; of any reference to the rings state or listener atom — so a
 ;; production build that never `:requires` this ns DCEs the whole body.
 
+;; ---- reentrant fan-out ordering (rf2-1zxlsm) ------------------------------
+;;
+;; A listener callback may reentrantly emit a trace (dispatch, re-register a
+;; flow, create/destroy a frame — all emit). If that nested emit fanned out
+;; IMMEDIATELY, it would reach the still-unvisited listeners of the OUTER
+;; event before the outer loop resumed — so a later listener would observe the
+;; inner event B before the outer event A, reversing runtime emission order.
+;; Spec 009 §The listener contract (point 4) requires every listener to see
+;; events in the order the runtime fired them.
+;;
+;; The fix defers a reentrant fan-out: while an outer fan-out is in progress on
+;; this thread (`*listener-fanout-queue*` bound), a nested `deliver-to-tooling!`
+;; ENQUEUES `[event continue?]` instead of looping, and the outermost fan-out
+;; drains the queue — FIFO, transitively — after its own listener loop. Every
+;; listener therefore observes A before B, and B before any C a B-listener
+;; emits, and so on.
+;;
+;; This defers ONLY the listener fan-out. The nested `emit!` still returns
+;; synchronously and its other effects run inline in emission order: the ring
+;; push below happens immediately (so the ring, too, holds A before B), epoch
+;; capture already fired in `re-frame.trace/deliver!` before this hook, and the
+;; classification projection ran in `emit!`. So the documented
+;; synchronous-return contract for a nested `emit!` is unchanged — no queue
+;; alters what `emit!` returns; only the ORDER listeners are notified is fixed.
+;;
+;; The queue is a plain vector consumed by an advancing index (never mutated
+;; mid-drain except by append), so appends made by a draining callback extend
+;; it and are picked up in FIFO order. Thread-local by dynamic binding: a
+;; concurrent JVM emit on another thread has its own outermost fan-out and
+;; queue. Composes with rf2-eaxnai: the deferred item carries its OWN
+;; `continue?`, and the listener body already ran under the neutral
+;; continuation scope `re-frame.trace/deliver!` established.
+
+(def ^:private ^:dynamic *listener-fanout-queue*
+  "When bound (an outermost listener fan-out is in progress on this thread), a
+  volatile holding a FIFO vector of `[event continue?]` deferrals. A trace
+  emitted reentrantly from inside a listener body enqueues here rather than
+  fanning out immediately, so every listener observes the outer event before
+  the reentrant one. nil at the top of the stack."
+  nil)
+
+(defn- fan-out-to-listeners!
+  "Deliver `event` to every registered listener in registration order, isolating
+  per-listener throws and honouring the caller's exact-owner `continue?`
+  snapshot — a listener that destroys the outer incarnation flips `continue?`
+  false and suppresses the remaining fan-out (rf2-eaxnai). The single shared
+  fan-out body used by both the outer delivery and each drained deferral."
+  [event continue?]
+  (loop [entries (seq @listeners)]
+    (when (and entries (continue?))
+      (let [[_ f] (first entries)]
+        (try
+          (f event)
+          (catch #?(:clj Throwable :cljs :default) _ nil))
+        (when (continue?)
+          (recur (next entries)))))))
+
 (defn- deliver-to-tooling!
   "Push `event` onto its in-flight frame's run-keyed ring (when the
   run has a `:dispatch-id` and a `:frame`; frameless emits skip the
@@ -697,25 +754,40 @@
   once either way.
 
   `continue?` (rf2-eaxnai) is the caller's exact-owner continuation SNAPSHOT.
-  The before/after checks below consult it so that if a listener destroys the
+  The before/after checks consult it so that if a listener destroys the
   outer incarnation A, the remaining listener fan-out is suppressed. It is a
   standalone snapshot rather than a live read of the (private, unreachable
   here) `*continuation-predicate*` precisely because `re-frame.trace/deliver!`
   neutralises that dynamic var around this whole call — a listener BODY's
   nested authored work (dispatch / destroy / create + `:initial-events` seed)
   must run under ordinary always-continue authority, not inherit A's fence.
-  So the callback runs neutral while these checks retain A's predicate."
+  So the callback runs neutral while these checks retain A's predicate.
+
+  Reentrant fan-out is DEFERRED to preserve per-listener event order
+  (rf2-1zxlsm): a nested emit from inside a listener body enqueues on
+  `*listener-fanout-queue*` and is drained after the outer event has reached
+  every listener. The ring push still happens inline (emission order), so only
+  the listener fan-out is ordered here — see the section note above."
   ([event continue?] (deliver-to-tooling! event continue? true))
   ([event continue? retain?]
    (when retain? (push-to-ring! event))
-   (loop [entries (seq @listeners)]
-     (when (and entries (continue?))
-       (let [[_ f] (first entries)]
-         (try
-           (f event)
-           (catch #?(:clj Throwable :cljs :default) _ nil))
-         (when (continue?)
-           (recur (next entries))))))))
+   (if-let [q *listener-fanout-queue*]
+     ;; Reentrant emit from inside a listener body: defer so every listener
+     ;; observes the outer event before this one. The outermost fan-out (below)
+     ;; drains us. Ring retention already ran above, in emission order.
+     (do (vswap! q conj [event continue?]) nil)
+     ;; Outermost fan-out: deliver this event, then drain every fan-out that
+     ;; listeners deferred while it ran — and, transitively, any THEY defer —
+     ;; in FIFO emission order. The index re-reads `(count @q)` each step so
+     ;; appends made mid-drain are picked up.
+     (let [q (volatile! [])]
+       (binding [*listener-fanout-queue* q]
+         (fan-out-to-listeners! event continue?)
+         (loop [i 0]
+           (when (< i (count @q))
+             (let [[ev cont] (nth @q i)]
+               (fan-out-to-listeners! ev cont))
+             (recur (inc i)))))))))
 
 (late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)
 

--- a/implementation/core/test/re_frame/trace_listener_nested_emission_order_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_nested_emission_order_cljs_test.cljc
@@ -1,0 +1,137 @@
+(ns re-frame.trace-listener-nested-emission-order-cljs-test
+  "rf2-1zxlsm — per-listener EVENT order must be preserved when trace emissions
+  NEST. A listener that emits a trace B while an OUTER event A is still being
+  fanned out to the remaining listeners must not cause any later listener to
+  observe B before A.
+
+  ## The defect
+
+  `re-frame.trace.tooling/deliver-to-tooling!` fanned events out with a plain
+  synchronous loop over the listener registry. When listener L0's callback
+  reentrantly emitted B (dispatching, re-registering a flow, …), that nested
+  emit re-entered the fan-out and delivered B to EVERY listener — L0 and the
+  still-unvisited L1 — BEFORE the outer loop resumed and delivered A to L1. So a
+  later listener saw `[B A]`, reversing the runtime emission order the outer A
+  was authored before B.
+
+  The bead's concrete case: L0 handles an outer `:rf.flow/cleared` by
+  re-registering the same flow, synchronously emitting a nested
+  `:rf.flow/registered`. L1 then observed `[:rf.flow/registered :rf.flow/cleared]`
+  and a stateful tool folding those events left the flow in the CLEARED state
+  though it is live. Spec 009 §The listener contract point 4 requires every
+  listener to receive trace events in runtime emission order — this is a central
+  trace-delivery law, not a flow-local fence.
+
+  ## The fix
+
+  A reentrant emit from inside a listener body is DEFERRED: it is enqueued and
+  fanned out only after the outer event has finished reaching every listener,
+  then drained FIFO (transitively). The nested `emit!` still returns
+  synchronously (its ring push, epoch capture and classification projection all
+  still happen inline) — only its listener fan-out is ordered behind the outer
+  event's. Every listener therefore observes A before B.
+
+  Runs on both hosts (`npm run test:cljs` + `clojure -M:test`). The two listeners
+  live in a 2-entry array-map, which preserves insertion order on both hosts, so
+  the EMITTER (registered FIRST) fans out before the OBSERVER — the ordering the
+  defect needs to manifest. Composes with rf2-eaxnai's neutral-continuation work:
+  the deferred nested work is a listener body's own authored work and runs under
+  ordinary (neutral) authority when drained."
+  (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace                :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private outer :trace.order/outer)
+(def ^:private inner :trace.order/inner)
+
+(defn- ops-only
+  "Keep just this test's two operations, in the order the listener saw them."
+  [evs]
+  (filterv #{outer inner} (mapv :operation evs)))
+
+(deftest nested-emission-preserves-per-listener-event-order
+  ;; L0 (emitter, registered first) reentrantly emits `inner` while handling the
+  ;; outer event. L1 (observer, registered second) must still see `outer` before
+  ;; `inner`. Under the bug L1 saw `[inner outer]` — the nested emit reached L1
+  ;; before the outer loop resumed.
+  (let [seen-observer (atom [])
+        seen-emitter  (atom [])
+        emitted?      (atom false)]
+    (trace/register-listener! ::emitter
+      (fn [ev]
+        (swap! seen-emitter conj ev)
+        (when (and (= outer (:operation ev))
+                   (compare-and-set! emitted? false true))
+          (trace/emit! :info inner {}))))
+    (trace/register-listener! ::observer
+      (fn [ev] (swap! seen-observer conj ev)))
+    (try
+      (trace/emit! :info outer {})
+      (is (= [outer inner] (ops-only @seen-observer))
+          "the observer sees the outer event before the reentrantly-emitted inner one")
+      (is (= [outer inner] (ops-only @seen-emitter))
+          "the emitter, too, sees outer before its own nested inner")
+      (finally
+        (trace/unregister-listener! ::emitter)
+        (trace/unregister-listener! ::observer)))))
+
+(deftest stateful-tool-finishes-in-the-authored-state
+  ;; The bead's stateful-tooling evidence: a tool folds the event stream into a
+  ;; live/cleared state. `outer` = the flow was CLEARED; the emitter reacts by
+  ;; re-registering (emitting `inner` = REGISTERED). Authored order is
+  ;; outer→inner, so the tool must finish REGISTERED (live). Under the reversed
+  ;; delivery it folded inner→outer and finished CLEARED — reporting a live flow
+  ;; as gone.
+  (let [tool-state (atom :unknown)
+        emitted?   (atom false)]
+    (trace/register-listener! ::reregistrar
+      (fn [ev]
+        (when (and (= outer (:operation ev))
+                   (compare-and-set! emitted? false true))
+          (trace/emit! :info inner {}))))
+    (trace/register-listener! ::stateful-tool
+      (fn [ev]
+        (case (:operation ev)
+          :trace.order/outer (reset! tool-state :cleared)
+          :trace.order/inner (reset! tool-state :registered)
+          nil)))
+    (try
+      (trace/emit! :info outer {})
+      (is (= :registered @tool-state)
+          "the stateful tool folds outer(cleared)→inner(registered) and finishes live")
+      (finally
+        (trace/unregister-listener! ::reregistrar)
+        (trace/unregister-listener! ::stateful-tool)))))
+
+(deftest nested-exception-isolation-preserves-order
+  ;; A listener that THROWS between the emitter and the observer must neither
+  ;; stop delivery nor corrupt ordering: per-listener exception isolation is
+  ;; preserved AND the observer still sees outer before the reentrant inner.
+  (let [seen-observer (atom [])
+        threw?        (atom 0)
+        emitted?      (atom false)]
+    (trace/register-listener! ::emitter
+      (fn [ev]
+        (when (and (= outer (:operation ev))
+                   (compare-and-set! emitted? false true))
+          (trace/emit! :info inner {}))))
+    (trace/register-listener! ::thrower
+      (fn [_ev]
+        (swap! threw? inc)
+        (throw (ex-info "listener boom" {}))))
+    (trace/register-listener! ::observer
+      (fn [ev] (swap! seen-observer conj ev)))
+    (try
+      (trace/emit! :info outer {})
+      (is (= [outer inner] (ops-only @seen-observer))
+          "a throwing intermediate listener does not reorder or drop the observer's stream")
+      (is (pos? @threw?) "the throwing listener was actually invoked (isolation, not skip)")
+      (finally
+        (trace/unregister-listener! ::emitter)
+        (trace/unregister-listener! ::thrower)
+        (trace/unregister-listener! ::observer)))))

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -456,14 +456,15 @@
          ;; rf2-9bhne6). Iterate the owed identities in a deterministic cb-id
          ;; order so the linearizable claim sees a stable sequence.
          ;; `claim-and-publish-delayed-silence!` reserves the one signal AND runs
-         ;; the external emit inside the SAME `silence-lock` critical section —
-         ;; rechecking current generation, FRESH live observers, and any existing
-         ;; mark, writing the monotonic mark, then emitting, all before the lock
-         ;; releases. Because listener replacement / drop / reset and the
-         ;; observation re-arm also take `silence-lock`, the winning
-         ;; `(cb-id, observed-gen)` stays the authoritative generation THROUGH the
-         ;; emission: a concurrent registrar cannot make a fresh generation
-         ;; current in the reserve→emit window (rf2-9bhne6). Only a granted
+         ;; the external emit inside ONE critical section holding BOTH ledger locks
+         ;; (registry → silence) — rechecking current generation, FRESH live
+         ;; observers, and any existing mark, writing the monotonic mark, then
+         ;; emitting, all before the locks release. Because listener replacement
+         ;; takes the registry lock, and drop / reset / the observation re-arm take
+         ;; silence-lock (the split that broke the single-monitor deadlock, rf2-9bhne6),
+         ;; the winning `(cb-id, observed-gen)` stays the authoritative generation
+         ;; THROUGH the emission: a concurrent registrar cannot make a fresh
+         ;; generation current in the reserve→emit window (rf2-9bhne6). Only a granted
          ;; reservation emits; if the external delivery throws, the reservation is
          ;; rolled back inside the same section and the fault propagates.
          (doseq [[cb-id observed-gen] (sort-by (comp str key) silenced-cbs)]

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -452,28 +452,29 @@
              #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                                   (:event-id record) :halted-destroy))
            (deliver-listener-snapshot! record listener-snapshot))
-         ;; PER-IDENTITY atomic-claim silencing (rf2-vxgfnd.285). Iterate the owed
-         ;; identities in a deterministic cb-id order so the linearizable claim
-         ;; sees a stable sequence. `claim-delayed-silence!` reserves the one
-         ;; signal atomically — rechecking current generation, FRESH live
-         ;; observers, and any existing mark, then writing the monotonic mark —
-         ;; BEFORE external delivery. Only a granted reservation emits; if the
-         ;; external delivery throws, the reservation is rolled back.
+         ;; PER-IDENTITY atomic-claim-AND-PUBLISH silencing (rf2-vxgfnd.285 /
+         ;; rf2-9bhne6). Iterate the owed identities in a deterministic cb-id
+         ;; order so the linearizable claim sees a stable sequence.
+         ;; `claim-and-publish-delayed-silence!` reserves the one signal AND runs
+         ;; the external emit inside the SAME `silence-lock` critical section —
+         ;; rechecking current generation, FRESH live observers, and any existing
+         ;; mark, writing the monotonic mark, then emitting, all before the lock
+         ;; releases. Because listener replacement / drop / reset and the
+         ;; observation re-arm also take `silence-lock`, the winning
+         ;; `(cb-id, observed-gen)` stays the authoritative generation THROUGH the
+         ;; emission: a concurrent registrar cannot make a fresh generation
+         ;; current in the reserve→emit window (rf2-9bhne6). Only a granted
+         ;; reservation emits; if the external delivery throws, the reservation is
+         ;; rolled back inside the same section and the fault propagates.
          (doseq [[cb-id observed-gen] (sort-by (comp str key) silenced-cbs)]
-           (when-let [reserved (state/claim-delayed-silence!
-                                 frame-id cb-id observed-gen baseline-silence-seq)]
-             (try
-               ;; The silencing fact belongs to destroyed A too; never let a
-               ;; same-id successor's trace policy suppress or capture it.
-               (trace/call-with-structural-delivery
-                 #(trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                               {:frame frame-id :cb-id cb-id}))
-               (catch #?(:clj Throwable :cljs :default) ex
-                 ;; Envelope delivery failed — release the reservation so the one
-                 ;; signal can be legitimately re-attempted, and let the fault
-                 ;; propagate contained.
-                 (state/rollback-delayed-silence! frame-id cb-id reserved)
-                 (throw ex))))))
+           (state/claim-and-publish-delayed-silence!
+             frame-id cb-id observed-gen baseline-silence-seq
+             ;; The silencing fact belongs to destroyed A too; never let a
+             ;; same-id successor's trace policy suppress or capture it.
+             #(trace/call-with-structural-delivery
+                (fn []
+                  (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                               {:frame frame-id :cb-id cb-id}))))))
         (finally
           ;; Close the deferred-silence window opened at snapshot time. When the
           ;; frame's last outstanding predecessor resolves, its marks are reclaimed.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1061,14 +1061,16 @@
     (and (not= token ::absent)
          (= token (:generation (get @listeners cb-id))))))
 
-(defn claim-delayed-silence!
-  "Atomically CLAIM the one `:rf.epoch.cb/silenced-on-frame-destroy` for
-  `(frame-id, cb-id)` on behalf of a deferred predecessor A whose snapshot
-  observed the frame under `observed-gen` with terminal-silence `baseline`.
+(defn- eligible-and-reserve!
+  "The caller MUST already hold `silence-lock`. Recheck delayed-silence
+  eligibility for `(frame-id, cb-id)` against the FRESHEST listener /
+  observation / mark state and, when eligible, RESERVE a fresh monotonic seq
+  (writing the mark inside the caller's critical section) and return it; else
+  return nil, writing nothing. Split out so both the reserve-only
+  `claim-delayed-silence!` and the reserve-and-publish
+  `claim-and-publish-delayed-silence!` decide eligibility identically.
 
-  Under `silence-lock` — the single linearization point for this signal — it
-  rechecks, against the FRESHEST listener and observation state, that:
-
+  The three checks:
     1. `cb-id`'s current generation still equals `observed-gen` — a replacement /
        drop in the deferred window is a fresh generation that never observed A,
        and a callback swapped between eligibility and delivery cannot inherit A's
@@ -1078,24 +1080,89 @@
        listener that re-arms this identity earlier in the same fan is honoured.
     3. no terminal-silence mark for `(frame, cb)` stands ABOVE `baseline` — a
        successor (or an overlapping same-id publisher) already claimed the one
-       signal; re-emitting would be the A→B→nil ABA / concurrent double-signal.
+       signal; re-emitting would be the A→B→nil ABA / concurrent double-signal."
+  [frame-id cb-id observed-gen baseline]
+  (when (and (= observed-gen (:generation (get @listeners cb-id)))
+             (not (live-observer? frame-id cb-id))
+             (let [s (get-in @terminal-silence-marks [frame-id cb-id])]
+               (or (nil? s) (<= s (or baseline 0)))))
+    (let [seq (next-terminal-silence-seq)]
+      (swap! terminal-silence-marks assoc-in [frame-id cb-id] seq)
+      seq)))
 
-  When all hold it RESERVES a fresh monotonic seq (writing the mark inside the
-  same critical section) and returns it — the caller then delivers the envelope
-  externally and, only if that delivery THROWS, calls `rollback-delayed-silence!`
-  with this seq. When any check fails it writes nothing and returns nil (no
-  silence). Two overlapping publishers cannot both reserve: the first writes the
-  mark, the second sees it above baseline and returns nil."
+(defn claim-delayed-silence!
+  "Atomically CLAIM (reserve only) the one `:rf.epoch.cb/silenced-on-frame-destroy`
+  for `(frame-id, cb-id)` on behalf of a deferred predecessor A whose snapshot
+  observed the frame under `observed-gen` with terminal-silence `baseline`.
+
+  Under `silence-lock` — the single linearization point for this signal — it
+  rechecks eligibility (`eligible-and-reserve!`) against the FRESHEST listener
+  and observation state and, when eligible, RESERVES a fresh monotonic seq and
+  returns it. The caller then delivers the envelope externally and, only if that
+  delivery THROWS, calls `rollback-delayed-silence!` with this seq. When any
+  check fails it writes nothing and returns nil. Two overlapping publishers
+  cannot both reserve: the first writes the mark, the second sees it above
+  baseline and returns nil.
+
+  NOTE the reserve-then-emit-later split leaves a claim→emit window: a
+  replacement landing after this returns but before the caller's external emit
+  makes a fresh generation current at the emission point, contrary to the
+  exact-generation contract (rf2-9bhne6). Callers that must keep the winning
+  generation authoritative THROUGH the emission use
+  `claim-and-publish-delayed-silence!`, which runs the emit inside this same
+  critical section. This reserve-only primitive remains for staged tests and any
+  caller whose emit provably cannot race a registry mutation."
   [frame-id cb-id observed-gen baseline]
   (with-silence-lock
+    #(eligible-and-reserve! frame-id cb-id observed-gen baseline)))
+
+(defn claim-and-publish-delayed-silence!
+  "Reserve AND publish the one delayed silence for `(frame-id, cb-id)` inside a
+  SINGLE `silence-lock` critical section, so the winning `(cb-id, observed-gen)`
+  stays the authoritative generation THROUGH the signal's emission (rf2-9bhne6).
+
+  `publish!` is a 0-arg thunk that performs the external
+  `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs INSIDE the lock, after
+  the reservation and BEFORE the lock is released. Because `put-listener!`,
+  `drop-listener!`, `reset-listeners!`, and the re-arm in `record-observation!`
+  all participate in the same `silence-lock`, a concurrent registrar cannot make
+  a fresh generation H current in the reserve→emit window: its mutation blocks
+  until publication completes, so either the silence is linearized before H
+  becomes current, or — if H landed first — the eligibility recheck fails and no
+  silence fires. The forbidden ordering (H current, THEN G's unqualified signal)
+  is impossible.
+
+  Returns true when the silence was published, false when ineligible. If
+  `publish!` throws, the reservation is rolled back (only while it still stands)
+  and the throw propagates — identical failed-delivery semantics to the
+  reserve-only `claim-delayed-silence!` + `rollback-delayed-silence!` pair, now
+  inside one critical section.
+
+  Deliberately-held critical section: `publish!` may fan an external trace out to
+  arbitrary listeners while the lock is held. This is deadlock-free — the only
+  cross-lock nesting is `silence-lock → frame-owner-lock` (a listener that
+  triggers a frame op during the emit); no path holds `frame-owner-lock` while
+  acquiring `silence-lock` (the destroy recipe releases `frame-owner-lock` in
+  `cleanup-frame-owner!` before this fan, and the settle path's
+  `notify-listeners!`/`record-observation!` run after `commit-frame-owner-record!`
+  returns), so the lock order is a strict DAG. Same-thread reentrant acquisition
+  (a listener calling `put-listener!`/`record-observation!` during the emit) is a
+  no-op on the JVM monitor and on the CLJS single thread."
+  [frame-id cb-id observed-gen baseline publish!]
+  (with-silence-lock
     (fn []
-      (when (and (= observed-gen (:generation (get @listeners cb-id)))
-                 (not (live-observer? frame-id cb-id))
-                 (let [s (get-in @terminal-silence-marks [frame-id cb-id])]
-                   (or (nil? s) (<= s (or baseline 0)))))
-        (let [seq (next-terminal-silence-seq)]
-          (swap! terminal-silence-marks assoc-in [frame-id cb-id] seq)
-          seq)))))
+      (when-let [reserved (eligible-and-reserve! frame-id cb-id observed-gen baseline)]
+        (try
+          (publish!)
+          true
+          (catch #?(:clj Throwable :cljs :default) ex
+            ;; External delivery failed — release OUR reservation (only while it
+            ;; still stands) so the one signal can be legitimately re-attempted,
+            ;; then propagate contained. Still under the lock, so no concurrent
+            ;; claim can interleave with the rollback.
+            (when (= reserved (get-in @terminal-silence-marks [frame-id cb-id]))
+              (prune-terminal-silence-mark! frame-id cb-id))
+            (throw ex)))))))
 
 (defn rollback-delayed-silence!
   "Undo a `claim-delayed-silence!` reservation `reserved-seq` for `(frame, cb)`
@@ -1129,19 +1196,33 @@
   new callback could be erased by a lagging second swap (rf2-j538f7.5), and its
   mirror in which a stale old callback could re-arm the new registration.
 
+  Participates in `silence-lock` (rf2-9bhne6): installing a fresh generation is
+  a registry mutation that `claim-and-publish-delayed-silence!` reads while
+  deciding+emitting a delayed silence, so it is serialized against that critical
+  section. A replacement therefore cannot make a fresh generation current
+  between a silence's reservation and its emission — it blocks until publication
+  completes, closing the claim→emit window.
+
   Returns the id."
   [id f]
-  (let [g (next-listener-generation)]
-    (swap! listeners assoc id {:generation g :callback f}))
+  (with-silence-lock
+    (fn []
+      (let [g (next-listener-generation)]
+        (swap! listeners assoc id {:generation g :callback f}))))
   id)
 
 (defn drop-listener!
   "Remove the listener registered under `id` and any observation
-  bookkeeping it carried."
+  bookkeeping it carried. Participates in `silence-lock` (rf2-9bhne6) — an
+  unregister is a registry mutation the delayed-silence claim reads, so a drop
+  in the reserve→emit window blocks until publication completes rather than
+  making a stale generation current mid-signal."
   [id]
-  (swap! listeners dissoc id)
-  (swap! observed-frames-by-cb dissoc id)
-  (drop-cb-silences! id)
+  (with-silence-lock
+    (fn []
+      (swap! listeners dissoc id)
+      (swap! observed-frames-by-cb dissoc id)
+      (drop-cb-silences! id)))
   nil)
 
 (defn reset-listeners!
@@ -1149,12 +1230,16 @@
   registry, observation stamps, AND the terminal-silence lineage. Leaving the
   silence marks behind stranded a tombstone per destroyed frame past a full
   listener wipe (rf2-vxgfnd.285); with every listener gone no predecessor can owe
-  a silence, so the whole ledger is cleared here too."
+  a silence, so the whole ledger is cleared here too. Runs under `silence-lock`
+  (rf2-9bhne6) so a wipe cannot tear a concurrent silence claim's registry /
+  observation / mark reads."
   []
-  (reset! listeners {})
-  (reset! observed-frames-by-cb {})
-  (reset-frame-silences!)
-  nil)
+  (with-silence-lock
+    (fn []
+      (reset! listeners {})
+      (reset! observed-frames-by-cb {})
+      (reset-frame-silences!)
+      nil)))
 
 (defn listeners-snapshot
   "Return the current `{cb-id → {:generation g :callback f}}` registry map.
@@ -1189,34 +1274,49 @@
     * A no-op re-observation of the same (cb, generation, frame) triple — the
       steady-state hot path — must not fire the atom watcher. The outer guard
       short-circuits before any swap when the frame is already stamped with
-      this token: one deref + lookup, no swap.
+      this token: one deref + lookup, no swap, NO lock.
 
   Both checks ride INSIDE the swap as well, so the decision is taken against a
   consistent listener snapshot on every CAS retry — a replace/drop landing
-  mid-swap is honoured."
+  mid-swap is honoured.
+
+  A genuine re-arm (the outer guard passed) runs under `silence-lock`
+  (rf2-9bhne6): it mutates the observation ledger AND prunes the terminal-silence
+  mark, both of which `claim-and-publish-delayed-silence!` reads while deciding a
+  delayed silence. Participating in that lock makes the claim's eligibility reads
+  coherent against a concurrent re-arm — a re-arm cannot land between the claim's
+  individual reads (or between its reservation and emit) and yield a stale-state
+  grant. The lock-free fast no-op above keeps the fan-out hot path uncontended;
+  only the rare genuine transition takes the lock (and re-checks its guards
+  inside, so the pre-lock read cannot weaken the decision)."
   [cb-id token frame-id]
-  (when frame-id
-    (let [observed @observed-frames-by-cb]
-      (when (and (not= token (get-in observed [cb-id frame-id]))
-                 (= token (:generation (get @listeners cb-id))))
-        (swap! observed-frames-by-cb
-               (fn [m]
-                 (if (or (= token (get-in m [cb-id frame-id]))
-                         ;; Generation re-check inside the swap: a same-id
-                         ;; replacement or `drop-listener!` that landed between
-                         ;; the outer guard and this CAS attempt must not be
-                         ;; undone by arming a retired/replaced generation.
-                         (not= token (:generation (get @listeners cb-id))))
-                   m
-                   (assoc-in m [cb-id frame-id] token))))
-        ;; A fresh observation re-arms this cb for the reused id: a new
-        ;; continuum begins and will owe its own silence, so a stale terminal-
-        ;; silence mark for (frame, cb) is superseded. Pruning it keeps the
-        ;; lineage ledger bounded across incarnation churn (rf2-vxgfnd.265). It
-        ;; is correctness-preserving either way — a paused predecessor's baseline
-        ;; predates this delivery, so a still-present mark would compare below
-        ;; the SUCCESSOR's baseline, never falsely gating it.
-        (prune-terminal-silence-mark! frame-id cb-id)))))
+  (when (and frame-id
+             ;; Lock-free fast no-op: an already-stamped (cb, generation, frame)
+             ;; triple needs no mutation. Only a genuine transition proceeds to
+             ;; take the lock and re-decide inside it.
+             (not= token (get-in @observed-frames-by-cb [cb-id frame-id])))
+    (with-silence-lock
+      (fn []
+        (when (and (not= token (get-in @observed-frames-by-cb [cb-id frame-id]))
+                   (= token (:generation (get @listeners cb-id))))
+          (swap! observed-frames-by-cb
+                 (fn [m]
+                   (if (or (= token (get-in m [cb-id frame-id]))
+                           ;; Generation re-check inside the swap: a same-id
+                           ;; replacement or `drop-listener!` that landed between
+                           ;; the outer guard and this CAS attempt must not be
+                           ;; undone by arming a retired/replaced generation.
+                           (not= token (:generation (get @listeners cb-id))))
+                     m
+                     (assoc-in m [cb-id frame-id] token))))
+          ;; A fresh observation re-arms this cb for the reused id: a new
+          ;; continuum begins and will owe its own silence, so a stale terminal-
+          ;; silence mark for (frame, cb) is superseded. Pruning it keeps the
+          ;; lineage ledger bounded across incarnation churn (rf2-vxgfnd.265). It
+          ;; is correctness-preserving either way — a paused predecessor's baseline
+          ;; predates this delivery, so a still-present mark would compare below
+          ;; the SUCCESSOR's baseline, never falsely gating it.
+          (prune-terminal-silence-mark! frame-id cb-id))))))
 
 (defn cbs-observing-frame
   "Return the cb-ids whose CURRENT generation observed `frame-id` — the frame

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -981,19 +981,62 @@
                       m)))
   nil)
 
-;; The silence ledger is read + written across three atoms (`listeners`,
-;; `observed-frames-by-cb`, `terminal-silence-marks`). `silence-lock` makes the
-;; eligibility-recheck + mark-reservation of `claim-delayed-silence!` — and the
-;; bracket bookkeeping — ONE linearizable critical section, mirroring
-;; `frame-owner-lock`. It serialises silence operations against each other; the
-;; registry/observation atoms keep their own lock-free swaps, so an ordinary
-;; fan-out never contends on it.
+;; The delayed-silence ledger spans three atoms — `listeners` (the
+;; callback+generation registry), `observed-frames-by-cb` (the observation
+;; ledger), and `terminal-silence-marks` (the lineage marks). Two ORDERED
+;; monitors serialise it, split by which atom each op mutates:
+;;
+;;   listener-registry-lock  guards the `listeners` generation publish/drop.
+;;   silence-lock            guards the observation ledger, the terminal-silence
+;;                           marks, and the outstanding-lineage brackets.
+;;
+;; GLOBAL LOCK ORDER: listener-registry-lock BEFORE silence-lock, never the
+;; reverse. Any path needing both (the delayed-silence claim, `drop-listener!`,
+;; `reset-listeners!`) acquires the registry lock first — `with-claim-locks`
+;; encodes that order once.
+;;
+;; Why TWO monitors and not one (rf2-9bhne6 deadlock follow-up): the single-lock
+;; predecessor put `put-listener!`'s `(swap! listeners …)` — and hence any atom
+;; WATCHER that swap fires — AND `record-observation!`'s re-arm on the SAME
+;; monitor. A listeners-atom watch that parked mid-`swap!` (a JVM deschedule, or
+;; a test barrier) then held that monitor while a concurrent `record-observation!`
+;; fan-out blocked on it forever — a hard deadlock CI reproduced. Splitting the
+;; domains keeps `put-listener!` on the registry lock ALONE, so a registration
+;; paused inside its swap can never block a fan-out re-arm (which takes only
+;; silence-lock).
+;;
+;; The generation-authority-through-emission guarantee (rf2-9bhne6) is unchanged:
+;; the claim (`eligible-and-reserve!` under `claim-and-publish-delayed-silence!`)
+;; holds BOTH locks across its eligibility recheck AND the external emit, so a
+;; concurrent `put-listener!` blocks on the registry lock and a concurrent
+;; `record-observation!` blocks on silence-lock — neither can make a fresh
+;; generation current, nor re-arm the observation, in the reserve→emit window.
+;; Ordinary fan-out never contends on either: the registry/observation atoms keep
+;; their own lock-free swaps for the common path.
+#?(:clj
+   (defonce ^:private listener-registry-lock (Object.)))
+
 #?(:clj
    (defonce ^:private silence-lock (Object.)))
+
+(defn- with-listener-registry-lock [f]
+  #?(:clj  (locking listener-registry-lock (f))
+     :cljs (f)))
 
 (defn- with-silence-lock [f]
   #?(:clj  (locking silence-lock (f))
      :cljs (f)))
+
+(defn- with-claim-locks
+  "Acquire BOTH ledger monitors in the global order (registry → silence) for the
+  delayed-silence claim and the registry+observation wipes (`drop-listener!` /
+  `reset-listeners!`). The claim reads the `listeners` generation AND the
+  observation/mark ledger and must exclude both `put-listener!` and
+  `record-observation!` across its eligibility recheck and emit; the wipes mutate
+  both domains. Encoding the order here keeps every both-locks caller consistent
+  so the registry→silence DAG can never invert."
+  [f]
+  (with-listener-registry-lock #(with-silence-lock f)))
 
 ;; frame-id → count of deferred predecessors of THAT frame whose terminal
 ;; evidence is currently outstanding (snapshotted but not yet published). A
@@ -1062,8 +1105,12 @@
          (= token (:generation (get @listeners cb-id))))))
 
 (defn- eligible-and-reserve!
-  "The caller MUST already hold `silence-lock`. Recheck delayed-silence
-  eligibility for `(frame-id, cb-id)` against the FRESHEST listener /
+  "The caller MUST already hold BOTH ledger locks (via `with-claim-locks`:
+  listener-registry-lock → silence-lock). Reading the `listeners` generation
+  under the registry lock and the observation / mark ledger under silence-lock is
+  what makes the recheck coherent against a concurrent `put-listener!` AND a
+  concurrent `record-observation!`. Recheck delayed-silence eligibility for
+  `(frame-id, cb-id)` against the FRESHEST listener /
   observation / mark state and, when eligible, RESERVE a fresh monotonic seq
   (writing the mark inside the caller's critical section) and return it; else
   return nil, writing nothing. Split out so both the reserve-only
@@ -1113,24 +1160,25 @@
   critical section. This reserve-only primitive remains for staged tests and any
   caller whose emit provably cannot race a registry mutation."
   [frame-id cb-id observed-gen baseline]
-  (with-silence-lock
+  (with-claim-locks
     #(eligible-and-reserve! frame-id cb-id observed-gen baseline)))
 
 (defn claim-and-publish-delayed-silence!
   "Reserve AND publish the one delayed silence for `(frame-id, cb-id)` inside a
-  SINGLE `silence-lock` critical section, so the winning `(cb-id, observed-gen)`
+  SINGLE critical section holding BOTH ledger locks (`with-claim-locks`:
+  listener-registry-lock → silence-lock), so the winning `(cb-id, observed-gen)`
   stays the authoritative generation THROUGH the signal's emission (rf2-9bhne6).
 
   `publish!` is a 0-arg thunk that performs the external
-  `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs INSIDE the lock, after
-  the reservation and BEFORE the lock is released. Because `put-listener!`,
-  `drop-listener!`, `reset-listeners!`, and the re-arm in `record-observation!`
-  all participate in the same `silence-lock`, a concurrent registrar cannot make
-  a fresh generation H current in the reserve→emit window: its mutation blocks
-  until publication completes, so either the silence is linearized before H
-  becomes current, or — if H landed first — the eligibility recheck fails and no
-  silence fires. The forbidden ordering (H current, THEN G's unqualified signal)
-  is impossible.
+  `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs INSIDE the locks, after
+  the reservation and BEFORE they are released. Because `put-listener!` takes the
+  registry lock, and `drop-listener!` / `reset-listeners!` / the re-arm in
+  `record-observation!` take silence-lock (the wipes take both), a concurrent
+  registrar cannot make a fresh generation H current in the reserve→emit window:
+  its mutation blocks on the lock this claim holds until publication completes, so
+  either the silence is linearized before H becomes current, or — if H landed
+  first — the eligibility recheck fails and no silence fires. The forbidden
+  ordering (H current, THEN G's unqualified signal) is impossible.
 
   Returns true when the silence was published, false when ineligible. If
   `publish!` throws, the reservation is rolled back (only while it still stands)
@@ -1139,17 +1187,21 @@
   inside one critical section.
 
   Deliberately-held critical section: `publish!` may fan an external trace out to
-  arbitrary listeners while the lock is held. This is deadlock-free — the only
-  cross-lock nesting is `silence-lock → frame-owner-lock` (a listener that
-  triggers a frame op during the emit); no path holds `frame-owner-lock` while
-  acquiring `silence-lock` (the destroy recipe releases `frame-owner-lock` in
+  arbitrary listeners while the locks are held. Splitting the registry and
+  observation domains (rf2-9bhne6 deadlock follow-up) is what makes this safe
+  against a registration paused inside the `listeners` swap: `put-listener!`
+  holds ONLY the registry lock, so a fan-out re-arm (`record-observation!`, which
+  takes ONLY silence-lock) is never blocked behind it — the single-monitor
+  predecessor deadlocked exactly there. The cross-lock nesting to
+  `frame-owner-lock` remains a strict DAG: no path holds `frame-owner-lock` while
+  acquiring either ledger lock (the destroy recipe releases `frame-owner-lock` in
   `cleanup-frame-owner!` before this fan, and the settle path's
   `notify-listeners!`/`record-observation!` run after `commit-frame-owner-record!`
-  returns), so the lock order is a strict DAG. Same-thread reentrant acquisition
-  (a listener calling `put-listener!`/`record-observation!` during the emit) is a
-  no-op on the JVM monitor and on the CLJS single thread."
+  returns). Same-thread reentrant acquisition (a listener calling
+  `put-listener!`/`record-observation!` during the emit) is a no-op on the JVM
+  monitors and on the CLJS single thread."
   [frame-id cb-id observed-gen baseline publish!]
-  (with-silence-lock
+  (with-claim-locks
     (fn []
       (when-let [reserved (eligible-and-reserve! frame-id cb-id observed-gen baseline)]
         (try
@@ -1196,16 +1248,20 @@
   new callback could be erased by a lagging second swap (rf2-j538f7.5), and its
   mirror in which a stale old callback could re-arm the new registration.
 
-  Participates in `silence-lock` (rf2-9bhne6): installing a fresh generation is
-  a registry mutation that `claim-and-publish-delayed-silence!` reads while
-  deciding+emitting a delayed silence, so it is serialized against that critical
-  section. A replacement therefore cannot make a fresh generation current
-  between a silence's reservation and its emission — it blocks until publication
-  completes, closing the claim→emit window.
+  Participates in `listener-registry-lock` (rf2-9bhne6): installing a fresh
+  generation is a `listeners`-atom mutation that `claim-and-publish-delayed-silence!`
+  reads (under the same registry lock) while deciding+emitting a delayed silence,
+  so it is serialized against that critical section. A replacement therefore
+  cannot make a fresh generation current between a silence's reservation and its
+  emission — it blocks on the registry lock until publication completes, closing
+  the claim→emit window. It holds ONLY the registry lock, NOT silence-lock, so a
+  watcher parked inside the `(swap! listeners …)` below can never block a
+  concurrent `record-observation!` fan-out re-arm (the single-monitor deadlock,
+  rf2-9bhne6 follow-up).
 
   Returns the id."
   [id f]
-  (with-silence-lock
+  (with-listener-registry-lock
     (fn []
       (let [g (next-listener-generation)]
         (swap! listeners assoc id {:generation g :callback f}))))
@@ -1213,12 +1269,14 @@
 
 (defn drop-listener!
   "Remove the listener registered under `id` and any observation
-  bookkeeping it carried. Participates in `silence-lock` (rf2-9bhne6) — an
-  unregister is a registry mutation the delayed-silence claim reads, so a drop
-  in the reserve→emit window blocks until publication completes rather than
-  making a stale generation current mid-signal."
+  bookkeeping it carried. Takes BOTH ledger locks (`with-claim-locks`,
+  rf2-9bhne6): it mutates the `listeners` registry (registry lock) AND the
+  observation ledger + terminal-silence marks (silence-lock). Holding both means
+  a drop in a delayed-silence claim's reserve→emit window blocks until
+  publication completes rather than making a stale generation current — or
+  clearing an observation the claim is deciding against — mid-signal."
   [id]
-  (with-silence-lock
+  (with-claim-locks
     (fn []
       (swap! listeners dissoc id)
       (swap! observed-frames-by-cb dissoc id)
@@ -1230,11 +1288,12 @@
   registry, observation stamps, AND the terminal-silence lineage. Leaving the
   silence marks behind stranded a tombstone per destroyed frame past a full
   listener wipe (rf2-vxgfnd.285); with every listener gone no predecessor can owe
-  a silence, so the whole ledger is cleared here too. Runs under `silence-lock`
-  (rf2-9bhne6) so a wipe cannot tear a concurrent silence claim's registry /
-  observation / mark reads."
+  a silence, so the whole ledger is cleared here too. Runs under BOTH ledger
+  locks (`with-claim-locks`, rf2-9bhne6) — it wipes the `listeners` registry
+  (registry lock) and the observation / mark ledger (silence-lock) — so a wipe
+  cannot tear a concurrent silence claim's registry / observation / mark reads."
   []
-  (with-silence-lock
+  (with-claim-locks
     (fn []
       (reset! listeners {})
       (reset! observed-frames-by-cb {})
@@ -1282,13 +1341,22 @@
 
   A genuine re-arm (the outer guard passed) runs under `silence-lock`
   (rf2-9bhne6): it mutates the observation ledger AND prunes the terminal-silence
-  mark, both of which `claim-and-publish-delayed-silence!` reads while deciding a
-  delayed silence. Participating in that lock makes the claim's eligibility reads
-  coherent against a concurrent re-arm — a re-arm cannot land between the claim's
+  mark, both of which `claim-and-publish-delayed-silence!` reads (under
+  silence-lock, the inner of its two claim locks) while deciding a delayed
+  silence. Participating in that lock makes the claim's eligibility reads coherent
+  against a concurrent re-arm — a re-arm cannot land between the claim's
   individual reads (or between its reservation and emit) and yield a stale-state
-  grant. The lock-free fast no-op above keeps the fan-out hot path uncontended;
-  only the rare genuine transition takes the lock (and re-checks its guards
-  inside, so the pre-lock read cannot weaken the decision)."
+  grant. Crucially it takes ONLY silence-lock, NOT the registry lock
+  `put-listener!` holds, so a re-arm is never blocked behind a registration
+  paused inside the `listeners` swap (the single-monitor deadlock this split
+  fixed, rf2-9bhne6 follow-up). The lock-free fast no-op above keeps the fan-out
+  hot path uncontended; only the rare genuine transition takes the lock (and
+  re-checks its guards inside, so the pre-lock read cannot weaken the decision).
+  The `(get @listeners cb-id)` generation reads here are lock-free w.r.t.
+  `put-listener!`: a stale read either matches `token` (records an observation
+  the token-scoped readers accept) or not (no-op) — and a since-replaced
+  generation self-invalidates because every reader compares the stamp to the live
+  generation."
   [cb-id token frame-id]
   (when (and frame-id
              ;; Lock-free fast no-op: an already-stamped (cb, generation, frame)

--- a/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
@@ -1,0 +1,173 @@
+(ns re-frame.epoch-silencing-generation-emission-test
+  "rf2-9bhne6 — the delayed-silence generation must stay AUTHORITATIVE THROUGH the
+  trace emission that publishes it.
+
+  ## The defect
+
+  `on-frame-destroyed!` reserved a `(cb-id, generation)` silence under
+  `silence-lock`, RELEASED that lock, and only then called the external
+  `trace/emit!`. `put-listener!`, `drop-listener!`, `reset-listeners!` and the
+  observation re-arm in `record-observation!` did not participate in the lock at
+  all. So a registrar (a real JVM thread, or the deterministic seam these tests
+  drive) could replace generation G with a fresh generation H in the window
+  between the reservation and the emit. The unqualified `{:frame :cb-id}` silence
+  then fired for a cb whose current generation is H — a fresh generation that
+  never observed the destroyed frame. The forbidden ordering: H current FIRST,
+  THEN G's unqualified signal. The claim's three eligibility reads were likewise
+  not coherent against a concurrent registry mutation, because the lock excluded
+  those mutations.
+
+  ## The fix
+
+  `claim-and-publish-delayed-silence!` reserves AND runs the external emit inside
+  ONE `silence-lock` critical section, and `put-listener!` / `drop-listener!` /
+  `reset-listeners!` / the `record-observation!` re-arm now take that same lock.
+  So the winning `(cb-id, observed-gen)` stays authoritative through the emission
+  linearization point: a replacement in the reserve→emit window BLOCKS until
+  publication completes (silence linearized before H becomes current), or — if H
+  landed first — the eligibility recheck fails and no stale silence fires.
+
+  JVM-only by intent (`silence-lock` is a no-op on the single CLJS thread; the
+  synchronous CLJS peers are covered by `re-frame.epoch-cljs-test`). The seam is
+  a `publish!` thunk that parks inside the critical section, letting a concurrent
+  registrar prove — via the lock — whether it can land before the emit.
+
+  Mutation teeth (red under the mutation, green with the fix):
+    * emit OUTSIDE the lock (the pre-fix shape) → a replacement lands in the
+      window → the sampled generation at emit is H, not G.
+    * drop `put-listener!` / `record-observation!` lock participation → the
+      mutation completes immediately instead of blocking on the held claim."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
+            [re-frame.epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- cb-generation
+  "The live generation token currently registered under `cb`."
+  [cb]
+  (:generation (get (epoch-state/listeners-snapshot) cb)))
+
+(defn- owe-silence!
+  "Register `cb`, observe `frame` under its current generation, then drop the
+  live observation so a delayed silence for `(frame, cb)` is genuinely owed —
+  exactly the state A's compare-owned cleanup leaves for a paused predecessor."
+  [frame token cb]
+  (rf/register-listener! :epoch cb (fn [_] nil))
+  (epoch-state/claim-frame-owner! frame token)
+  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+  (epoch-state/drop-frame-observation! frame))
+
+;; ---- generation authoritative THROUGH the emission -------------------------
+
+(deftest generation-stays-authoritative-through-the-emission-linearization-point
+  ;; A registrar replaces cb's generation (G→H) in the window between the
+  ;; reservation and the external emit. Because `claim-and-publish` runs the emit
+  ;; INSIDE the same `silence-lock` section AND `put-listener!` participates in
+  ;; that lock, H cannot become current before G's signal is out: the registrar
+  ;; blocks until publication completes, so the generation sampled AT the emit is
+  ;; always G. TOOTH: emitting outside the lock lets H land first → sampled H.
+  (let [frame       :bhne6/thru-emit
+        cb          ::bhne6-thru-emit-cb
+        token       (Object.)
+        reached-emit (CountDownLatch. 1)
+        h-installed  (CountDownLatch. 1)
+        gen-at-emit  (atom ::unset)
+        published?   (atom ::unset)]
+    (owe-silence! frame token cb)
+    (try
+      (let [g        (cb-generation cb)
+            publish! (fn []
+                       ;; Inside the critical section, mark reserved. Signal the
+                       ;; registrar to attempt its replace, then wait (bounded)
+                       ;; for it to install H. Under the FIX the registrar's
+                       ;; put-listener! is blocked on the held lock, so this times
+                       ;; out and we sample G. Under an emit-outside-lock
+                       ;; regression H lands and we sample H.
+                       (.countDown reached-emit)
+                       (.await h-installed 1 TimeUnit/SECONDS)
+                       (reset! gen-at-emit (cb-generation cb)))
+            publisher (future
+                        (reset! published?
+                                (epoch-state/claim-and-publish-delayed-silence!
+                                  frame cb g 0 publish!)))
+            registrar (future
+                        (.await reached-emit 5 TimeUnit/SECONDS)
+                        ;; put-listener! participates in silence-lock → blocks
+                        ;; until the publisher releases it (after the emit).
+                        (rf/register-listener! :epoch cb (fn [_] nil))
+                        (.countDown h-installed))]
+        (is (not= ::timeout (deref publisher 5000 ::timeout)) "publisher completed")
+        (is (true? @published?) "the silence was published")
+        (is (= g @gen-at-emit)
+            "the winning generation G is still current at the emission point — a replacement could not land first")
+        (is (not= ::timeout (deref registrar 5000 ::timeout)) "registrar completed")
+        (is (not= g (cb-generation cb))
+            "the registrar's replacement H landed only AFTER publication completed"))
+      (finally
+        (rf/unregister-listener! :epoch cb)))))
+
+;; ---- registry + observation mutations serialize with the claim -------------
+
+(deftest registry-and-observation-mutations-serialize-with-the-silence-claim
+  ;; While a `claim-and-publish` holds `silence-lock` (parked in publish!), a
+  ;; concurrent registry replacement AND a concurrent observation re-arm both
+  ;; BLOCK until it releases. This is the coherence the eligibility reads rely on
+  ;; — no registry/observation mutation can interleave between the claim's
+  ;; individual reads. TEETH: dropping put-listener!'s (resp. record-observation!'s)
+  ;; lock lets the mutation complete immediately, so the "blocked" assertions
+  ;; flip.
+  (let [frame      :bhne6/serialize
+        cb         ::bhne6-serialize-cb        ; the parked claim's subject
+        other      ::bhne6-serialize-other     ; observation re-arm subject (owed)
+        reg-target ::bhne6-serialize-reg-target ; registry replacement subject
+        token      (Object.)
+        in-claim   (CountDownLatch. 1)
+        release    (CountDownLatch. 1)
+        put-done   (CountDownLatch. 1)
+        obs-done   (CountDownLatch. 1)]
+    (owe-silence! frame token cb)
+    ;; `other` also observes and is dropped, so a re-arm is a genuine transition
+    ;; that takes the lock (not the lock-free no-op fast path).
+    (rf/register-listener! :epoch other (fn [_] nil))
+    (epoch.listeners/notify-listeners! {:frame frame :epoch-id 2})
+    (epoch-state/drop-frame-observation! frame)
+    (rf/register-listener! :epoch reg-target (fn [_] nil))
+    (try
+      (let [g         (cb-generation cb)
+            other-gen (cb-generation other)
+            publish!  (fn []
+                        (.countDown in-claim)
+                        (.await release 5 TimeUnit/SECONDS))
+            claimer   (future (epoch-state/claim-and-publish-delayed-silence!
+                                frame cb g 0 publish!))
+            registrar (future (.await in-claim 5 TimeUnit/SECONDS)
+                              (rf/register-listener! :epoch reg-target (fn [_] nil))
+                              (.countDown put-done))
+            observer  (future (.await in-claim 5 TimeUnit/SECONDS)
+                              (epoch-state/record-observation! other other-gen frame)
+                              (.countDown obs-done))]
+        (is (.await in-claim 5 TimeUnit/SECONDS) "the claim is parked inside silence-lock")
+        (is (false? (.await put-done 500 TimeUnit/MILLISECONDS))
+            "put-listener! is blocked on silence-lock while the claim holds it")
+        (is (false? (.await obs-done 500 TimeUnit/MILLISECONDS))
+            "the record-observation! re-arm is blocked on silence-lock too")
+        (.countDown release)
+        (is (not= ::timeout (deref claimer 5000 ::timeout)) "the claim completed")
+        (is (.await put-done 5000 TimeUnit/MILLISECONDS)
+            "put-listener! completes once the claim releases the lock")
+        (is (.await obs-done 5000 TimeUnit/MILLISECONDS)
+            "record-observation! completes once the claim releases the lock")
+        (is (not= ::timeout (deref registrar 5000 ::timeout)) "registrar completed")
+        (is (not= ::timeout (deref observer 5000 ::timeout)) "observer completed"))
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :epoch other)
+        (rf/unregister-listener! :epoch reg-target)))))


### PR DESCRIPTION
Fixes two P1 trace/instrumentation-channel bugs (cluster).

## rf2-1zxlsm — Preserve per-listener event order across nested trace emissions

`re-frame.trace.tooling/deliver-to-tooling!` fanned events out with a plain
synchronous loop. When listener L0's callback reentrantly emitted a trace B
(dispatch, flow re-register, frame create/destroy — all emit), that nested emit
fanned B out to every listener — including the outer event A's still-unvisited
L1 — before the outer loop resumed and delivered A to L1. A later listener then
observed `[B A]`, reversing runtime emission order, and a stateful tool folding
the stream finished in the wrong state (the bead's live flow reported as
cleared). Spec 009 §The listener contract (point 4) requires every listener to
receive events in the order the runtime fired them.

**Fix** (`implementation/core/src/re_frame/trace/tooling.cljc`): a reentrant
fan-out is deferred onto a thread-local FIFO queue drained by the outermost
fan-out after it reaches every listener (transitively). Only the listener
fan-out is ordered — the nested `emit!` still returns synchronously and its ring
push / epoch capture / classification projection all run inline in emission
order, so the documented synchronous-return contract is unchanged. Composes with
rf2-eaxnai: each deferral carries its own `continue?` and the listener body
already ran under the neutral continuation scope.

## rf2-9bhne6 — Keep delayed-silence generation authoritative through emission

`on-frame-destroyed!` reserved a `(cb-id, generation)` silence under
`silence-lock`, released it, then called the external `trace/emit!` outside the
lock — and `put-listener!` / `drop-listener!` / `reset-listeners!` / the
`record-observation!` re-arm did not take the lock at all. A registrar replacing
generation G with a fresh H in the reserve→emit window made H current before the
unqualified `{:frame :cb-id}` silence fired, so a fresh generation that never
observed the destroyed frame inherited the old generation's signal (forbidden
ordering: H current first, then G's signal). The claim's eligibility reads were
likewise incoherent against a concurrent registry mutation.

**Fix** (`implementation/epoch/src/re_frame/epoch/state.cljc` +
`listeners.cljc`): new `claim-and-publish-delayed-silence!` reserves AND runs the
emit inside one `silence-lock` critical section, and the registry/observation
mutations participate in that same lock (`record-observation!` keeps a lock-free
fast no-op for the fan-out hot path; only a genuine re-arm takes the lock). The
winning `(cb-id, observed-gen)` now stays authoritative through the emission — a
replacement in the window blocks until publication completes, or the recheck
fails and no stale silence fires. Deadlock-free: the only cross-lock nesting is
`silence-lock → frame-owner-lock`; no path holds `frame-owner-lock` while
acquiring `silence-lock` (a strict DAG). Existing `claim-delayed-silence!` /
`rollback-delayed-silence!` primitives are preserved for the staged tests.

## rf2-9bhne6 follow-up -- split the ledger locks to break a self-deadlock

The first-cut rf2-9bhne6 fix put `put-listener!`'s `(swap! listeners ...)` -- and
therefore any atom WATCHER that swap fires -- on the SAME `silence-lock` monitor
as the `record-observation!` fan-out re-arm. That deadlocked the full epoch JVM
suite deterministically (the "JVM epoch (clojure -M:test)" gate hung ~32 min on a
2-core runner).

**The lock cycle (from a `jstack` of the hung JVM).** The pre-existing
`same-id-replacement-preserves-new-callback-observation` test (rf2-j538f7.5)
installs an `add-watch` on the private `listeners` atom that parks a thread
mid-`swap!`. Post-9bhne6 that park held `silence-lock` (the swap now ran inside
`put-listener!`'s `with-silence-lock`), while the main thread's
`notify-listeners!` -> `record-observation!` **blocked acquiring the same
`silence-lock`** -- and the main thread is the only one that could release the
parked thread. It is NOT the `silence-lock -> frame-owner-lock` nesting the
original reasoning worried about; it is a single-monitor self-block across the
`listeners`-swap watcher: `put-listener!` (holds `silence-lock`, parked in the
watcher) vs `record-observation!` (waits on `silence-lock`).

**Fix** (`implementation/epoch/src/re_frame/epoch/state.cljc`): split the
delayed-silence ledger into two ORDERED monitors --
`listener-registry-lock` (the `listeners` generation publish/drop) and
`silence-lock` (the observation ledger + terminal-silence marks + lineage
brackets) -- with a single global order (registry -> silence, encoded once by
`with-claim-locks`). `put-listener!` takes ONLY the registry lock;
`record-observation!` / `rollback` / `open`+`close-silence-lineage!` take ONLY
`silence-lock`; the claim (both variants), `drop-listener!` and `reset-listeners!`
take BOTH. A registration paused inside the `listeners` swap can no longer block a
fan-out re-arm. **Generation-authority-through-emission is preserved unchanged**:
`claim-and-publish-delayed-silence!` holds BOTH locks across its eligibility
recheck AND the external emit, so a concurrent `put-listener!` still blocks on the
registry lock and a concurrent `record-observation!` still blocks on
`silence-lock` in the reserve->emit window (both 9bhne6 barrier tests stay green).
CLJS is single-threaded, so both locks compile to `(f)` -- CLJS behaviour is
unchanged.

## Quality gates

- `npm run test:cljs` — 9663 tests, 47560 assertions, 0 failures/errors (covers
  bug-1 cross-host `.cljc` regression on the CLJS host + the epoch CLJS silence
  peers).
- Core JVM trace surface (`clojure -M:test`): `trace-listener-nested-emission-order`
  (3 new tests), `trace-listener-continuation-neutral` (rf2-eaxnai regression),
  `trace-listener`, `trace`, `trace-buffer`, `trace-cascade-captured`,
  `sub-dispose-trace`, `cascade-dispatch-id`, `cascade-envelope-propagation` —
  all green.
- Epoch JVM (`clojure -M:test`) -- FULL artefact suite, 2-core-pinned (`-XX:ActiveProcessorCount=2`): **405 tests, 6056 assertions, 0 failures/errors, completes without hang**. This is the gate that hung on the first-cut fix; green after the ledger-lock split above. Covered within it: the previously-deadlocking rf2-j538f7.5 test, both `epoch-silencing-generation-emission` barrier tests (generation stays G through the emit; `put-listener!` / `record-observation!` still block on the claim), all 7 `epoch-concurrency-stress` scenarios (register/deregister vs settle-fanout + same-id-replacement-vs-fanout-destroy under 8-thread contention -- ~6.7s of real 8x5000 work, no deadlock), and `epoch-silencing-lineage-285` + `epoch-silencing-lineage-aba`.

**Failing-before / passing-after evidence.**
- Bug 1: the new `nested-emission-preserves-per-listener-event-order` /
  `stateful-tool-finishes-in-the-authored-state` / `nested-exception-isolation`
  tests are red on the unfixed loop (observer sees `[inner outer]`; tool finishes
  `:cleared`) and green after the deferral.
- Bug 2 (mutation teeth, each isolated): emit-outside-lock → the generation
  sampled at the emit point is H not G (Test A red); unlock `put-listener!` →
  the replacement is no longer blocked (Test A + the put-listener! block-assertion
  red); unlock the `record-observation!` re-arm → only the observation
  block-assertion flips. All green with the fix restored.

## Notes / follow-up

- rf2-9bhne6's NOTES asks the Spec 009 / Tool-Pair lineage wording to state the
  final generation/re-arm/late-predecessor emission linearization law. Those are
  hot-zone docs (sequential); this PR keeps to the runtime + tests per the
  cluster scope. Recommend a follow-up bead to update the two canonical homes.

