### PR TITLE
docs(ssr): reconcile hydrate/streaming/head guides with shipped SSR behaviour (cluster)

### DIFF
--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -59,7 +59,7 @@ In words:
 3. The runtime **drains**: it keeps processing events — and every event those events dispatch — until the queue settles and app-db stops changing (the [run-to-completion](../core/glossary.md#drain--run-to-completion) guarantee). The settled state is what gets rendered, never a half-loaded intermediate.
 4. The root view renders to hiccup; `render-to-string` turns it into HTML.
 5. The server ships the HTML **plus** a serialised state payload.
-6. The client boots, dispatches `:rf/hydrate` with that payload, and renders. Its first render matches the server's HTML, so the existing DOM is adopted, not replaced.
+6. The client boots: `ssr/hydrate!` installs the payload (dispatches `:rf/hydrate`) *before* the first render, then the substrate **hydrates** the existing DOM (React's `hydrateRoot`, via the adapter). Because the first render matches the server's HTML, the DOM is adopted, not replaced.
 7. The per-request frame is destroyed — in a `finally`, on every exit path.
 
 Steps 2–4 run the handlers, subs, and views you already wrote; there's no separate "server code" to keep in sync with the client. And the per-request frame is *exactly* the frame from [Frames: isolated worlds](../core/frames.md) — no SSR-only variant.
@@ -185,21 +185,30 @@ The client's job is to land in the state the server finished in, without redoing
 ```clojure
 ;; Adapted from examples/capabilities/ssr/ssr/core.cljc — requires, alongside rf and ssr:
 ;;   [reagent.dom.client :as rdc]  [re-frame.adapter.reagent :as reagent-adapter]
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
-
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)          ;; installs the adapter — creates no frame
   (rf/make-frame {:id :app :platform :client})
-  (let [payload (ssr/hydrate! {:frame          :app
-                               :render-tree-fn (fn [] ((rf/view :app/root)))})]
-    (when-not payload
-      ;; No payload script — a client-only first load. Seed normally.
-      (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})))
-  (rdc/render react-root
-    [rf/frame-provider {:frame :app}
-     [(rf/view :app/root)]]))
+  (let [el      (js/document.getElementById "app")
+        payload (ssr/hydrate! {:frame          :app
+                               :render-tree-fn (fn [] ((rf/view :app/root)))})
+        tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
+    (if payload
+      ;; Server-rendered: ADOPT the existing DOM. `hydrate-root` reconciles
+      ;; React against the server markup — same nodes, listeners attached, no
+      ;; re-paint. (`create-root` + `render` would throw the server HTML away.)
+      (rdc/hydrate-root el tree)
+      ;; No payload script — a client-only first load. Fresh root, fresh render.
+      (do
+        (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
+        (rdc/render (rdc/create-root el) tree)))))
 ```
+
+`hydrate!` does the **state** half — read, install, verify — and returns the payload
+it applied (or `nil`). It deliberately does *not* touch the DOM mount. Adopting the
+server's painted DOM is the **substrate's** job and a separate call: hand the existing
+container to the adapter's `hydrate-root` (React's `hydrateRoot`), *not* `create-root`
++ `render`. The latter discards the server markup and mounts fresh — correct only for
+the no-payload, client-only branch.
 
 Two rules to hold onto:
 
@@ -355,7 +364,8 @@ Enforced by the platform gate and caught by the hash.
 ## A complete loop (server + client)
 
 Copy-paste shape. The adapter owns create / drain / render / payload / teardown;
-the client installs the payload before the first paint.
+the client installs the payload before the first paint, then `hydrate-root` adopts
+the server's DOM.
 
 ```clojure
 (ns app.ssr
@@ -385,19 +395,18 @@ the client installs the payload before the first paint.
         :root-view      [:app/root]                 ;; hiccup vector or 0-arity fn
         :payload        [:articles :session-user]})))  ;; required allowlist
 
-#?(:cljs (defonce react-root (rdc/create-root (js/document.getElementById "app"))))
-
 #?(:cljs
    (defn ^:export run []
      (rf/init! reagent-adapter/adapter)
      (rf/make-frame {:id :app :platform :client})
-     (let [payload (ssr/hydrate! {:frame          :app
-                                  :render-tree-fn (fn [] ((rf/view :app/root)))})]
-       (when-not payload
-         (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})))
-     (rdc/render react-root
-                 [rf/frame-provider {:frame :app}
-                  [(rf/view :app/root)]])))
+     (let [el      (js/document.getElementById "app")
+           payload (ssr/hydrate! {:frame          :app
+                                  :render-tree-fn (fn [] ((rf/view :app/root)))})
+           tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
+       (if payload
+         (rdc/hydrate-root el tree)                      ;; server-rendered: adopt the DOM
+         (do (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
+             (rdc/render (rdc/create-root el) tree)))))) ;; client-only: fresh root
 ```
 
 Same `:frame` on `hydrate!` and `frame-provider`. Full walk-through:

--- a/docs/ssr/head.md
+++ b/docs/ssr/head.md
@@ -48,10 +48,19 @@ app-db.
   that want the same metadata name the same head id.
 - **No `:head` is fine.** Default: `<title>` from frame metadata, plus `charset` and
   `viewport`.
-- **Mismatch detector covers the head.** The head rides the same render-tree hash as
-  the body ([When the renders disagree](concepts.md#when-the-renders-disagree)). On
-  the client, the head recomputes from the hydrated app-db + route slice — SPA route
-  changes keep `<title>` / `<meta>` current.
+- **Body and head hashes are separate channels.** The body render-tree hash rides
+  `:rf/render-hash` ([when the renders disagree](concepts.md#when-the-renders-disagree));
+  a reconstructible head emits a *separate*, optional `:rf/head-hash` (stamped
+  `data-rf-head-hash` on `<head>`), omitted when the head can't be recomputed — an
+  explicit `:head` string, or a degraded head. The bundled runtime compares only the
+  body hash; it ships **no** automatic head comparison. The head *model* is
+  reconstructible, so a host that wants the check recomputes `(rf/active-head
+  frame-id)` from the hydrated app-db + route slice and compares it to `:rf/head-hash`
+  itself — that wiring is the host's, not automatic.
+- **Keeping the document head current is the app's job.** There is no DOM-head
+  reconciler in v1. The first byte carries the server-rendered head; refreshing
+  `<title>` / `<meta>` on an SPA route change needs an app- or host-level head
+  manager.
 
 !!! warning "JSON-LD escaping is handled for you"
 

--- a/docs/ssr/streaming.md
+++ b/docs/ssr/streaming.md
@@ -32,10 +32,14 @@ Runnable tree:
      [:article/author-feed]]]])
 ```
 
-The streaming walker emits the shell with each `:fallback` in place and flushes
-immediately — first byte. Each boundary's subtree then streams as its own chunk,
-carrying a per-subtree app-db delta so that region's subscriptions see the right
-state on arrival.
+The streaming walker emits the shell on the first byte, with each boundary's
+`:fallback` markup carried inside an **inert** `<template data-rf2-suspense-fallback>`
+marker. A `<template>`'s content is inert by the HTML spec — a detached
+`DocumentFragment` that never paints — so the fallbacks are *not* visible first-byte
+UI. They become visible only once the client runtime (`ssr/streaming-install!`,
+below) materialises each inert `<template>` into a live, painted mount. Each
+boundary's subtree then streams as its own chunk, carrying a per-subtree app-db delta
+so that region's subscriptions see the right state when its resolved content swaps in.
 
 ## Failure isolation
 
@@ -58,7 +62,12 @@ Use the streaming Ring constructor (re-exported on `re-frame.ssr.ring`):
 ```
 
 On the client, opt in with `ssr/streaming-install!` (same carried `:frame` as
-`hydrate!`) so fallbacks swap for resolved chunks as they arrive.
+`hydrate!`). It does two jobs: it materialises the inert fallback `<template>`s into
+visible mounts, then swaps each mount's content for its resolved chunk — merging that
+chunk's delta — as the chunks arrive. A streaming page therefore *requires* the
+client runtime to paint fallbacks at all: a non-JS client sees the shell structure
+but no skeletons until the final payload lands and `hydrate!` renders everything at
+once.
 
 ??? note "Correctness lock"
 

--- a/docs/ssr/tutorial.md
+++ b/docs/ssr/tutorial.md
@@ -182,30 +182,34 @@ This hand-rolled version ships the *whole* app-db, which is fine for a demo and 
 
 ## Step 4 — wake it up: hydrate on the client
 
-The browser now has painted HTML and a payload sitting in the page. The client's job is to **adopt** both — install the state, attach listeners to the existing DOM — instead of throwing the HTML away and re-rendering from scratch. This step runs in the browser, so it needs the client build's requires; after that, one call does the work:
+The browser now has painted HTML and a payload sitting in the page. The client's job is to **adopt** both — install the state, attach listeners to the existing DOM — instead of throwing the HTML away and re-rendering from scratch. This step runs in the browser, so it needs the client build's requires; after that, the client boot installs the state and adopts the DOM:
 
 ```clojure
 ;; cf. examples/capabilities/ssr/ssr/core.cljc — the client entry point
 ;; client-side requires, alongside rf and ssr:
 ;;   #?(:cljs [reagent.dom.client :as rdc])
 ;;   #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])
-#?(:cljs (defonce react-root (rdc/create-root (js/document.getElementById "app"))))
-
 #?(:cljs
    (defn run []
      (rf/init! reagent-adapter/adapter)      ;; the browser substrate this time
      (rf/make-frame {:id :app :platform :client}) ;; the client's own, named frame
-     (let [payload (ssr/hydrate! {:frame          :app
-                                  :render-tree-fn (fn [] ((rf/view :app/root)))})]
-       (when-not payload
-         ;; nil ⇒ nobody server-rendered this page — a plain client-only load
-         (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})))
-     (rdc/render react-root
-                 [rf/frame-provider {:frame :app}
-                  [(rf/view :app/root)]])))
+     (let [el      (js/document.getElementById "app")
+           payload (ssr/hydrate! {:frame          :app
+                                  :render-tree-fn (fn [] ((rf/view :app/root)))})
+           tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
+       (if payload
+         ;; server-rendered ⇒ ADOPT the painted DOM with hydrate-root
+         (rdc/hydrate-root el tree)
+         ;; nil ⇒ nobody server-rendered this page — a plain client-only load:
+         ;; seed, then mount a fresh root
+         (do
+           (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
+           (rdc/render (rdc/create-root el) tree))))))
 ```
 
 `hydrate!` does three steps in a fixed order: **read** the `__rf_payload` script, **hydrate** — dispatch `[:rf/hydrate payload]` before the first render, installing the server's app-db *and* its runtime-db slice in one atomic move — and **verify** (Step 5). It returns the payload it applied, or `nil` when there wasn't one, which is how the code above answers "was this page server-rendered?" without sniffing the DOM.
+
+Those three steps are all **state**: `hydrate!` never touches the DOM mount. Adopting the server's painted markup is a *separate* call — `rdc/hydrate-root` (React's `hydrateRoot`), which reconciles against the existing DOM. `rdc/create-root` + `render` would discard that markup and mount fresh, so it's right only for the client-only branch. That split is the whole point of the `if` above: a server-rendered page hydrates the DOM it was handed; a cold client load builds a fresh root.
 
 **What you see:** the page was already painted before your JS loaded. When `run` finishes, nothing flashes — the client's first render matches the HTML, the articles are in app-db without any re-fetch, and clicking things dispatches events like any other re-frame2 app. (To see it live without wiring a build: the worked example ships a hand-authored `index.html` — a frozen snapshot of what its `handle-request` serves — and its `run` hydrates it exactly this way.)
 
@@ -295,7 +299,7 @@ Everything above, as the two halves you ship:
 | Half | Surface | You supply |
 |---|---|---|
 | Server | `ssr-ring/ssr-handler` | `:initial-events`, `:root-view`, **`:payload` allowlist** |
-| Client | `ssr/hydrate!` then mount | Same `:frame` as `frame-provider`; `:render-tree-fn` that *calls* the root view |
+| Client | `ssr/hydrate!` then `hydrate-root` (fresh `create-root` when there's no payload) | Same `:frame` as `frame-provider`; `:render-tree-fn` that *calls* the root view |
 
 Hand-rolled lifecycle (Steps 2–3) is still the right mental model when something
 misbehaves — the adapter is that sequence, packaged. Full copy-paste with both

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -40,8 +40,8 @@
    a genuine server stamps; see the comment in index.html). The pre-rendered
    markup sits in `<div id='app'>`, and the baked
    `<script id='__rf_payload'>` carries the state. The browser-side `run`
-   reads that payload, hydrates, verifies, and renders on top of the seeded
-   state — no flash, no re-fetch."
+   reads that payload, hydrates + verifies the state, then adopts the server
+   markup with `hydrate-root` — no flash, no re-fetch."
   (:require [re-frame.core :as rf]
             ;; A handful of these requires are here purely for their side
             ;; effect: loading the namespace registers something we lean on
@@ -381,10 +381,11 @@
   {:doc "Client-side init that runs even when the server never rendered this page."}
   (fn [{:keys [db]} _] {:db db}))
 
-;; The React root lives in an atom and gets created lazily inside `run`, never
-;; at namespace-load. The rule is that loading a namespace must not touch the
-;; DOM — so if several example namespaces get required together, none of them
-;; can race the others to slap a `create-root` onto the shared `#app`.
+;; The retained React root lives in an atom and gets created lazily inside `run`,
+;; never at namespace-load. The rule is that loading a namespace must not touch
+;; the DOM — so if several example namespaces get required together, none of them
+;; can race the others to slap a root onto the shared `#app`. One root per
+;; container, reused across hot reloads.
 #?(:cljs (defonce react-root (atom nil)))
 
 ;; The client's app-frame id. The app names its frame out loud and threads the
@@ -397,20 +398,17 @@
 ;; hydration target, plain and simple (see the note over in `handle-request`).
 (def app-frame :rf/default)
 
-;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
-;; it after each hot reload — edited views re-render into the same root and the
-;; already-hydrated frame. HYDRATE stays in `run` (once), so a reload never
-;; re-seeds over the interactive state.
+;; Re-render the current view into the RETAINED root. Tagged `^:dev/after-load`
+;; so shadow-cljs re-runs it after each hot reload — edited views re-render into
+;; the same root and the already-hydrated frame. It never creates a root and
+;; never re-hydrates: the root is established once in `run`, and HYDRATE happens
+;; once there too, so a reload can't re-seed over the interactive state.
 #?(:cljs
-   (defn ^:dev/after-load mount! []
-     (when-let [el (and (exists? js/document)
-                        (js/document.getElementById "app"))]
-       (when-not @react-root
-         (reset! react-root (rdc/create-root el)))
-       ;; Mount inside the app-frame's `frame-provider`, so every `dispatch` and
-       ;; `subscribe` down in the view tree resolves to the frame we just
-       ;; hydrated.
-       (rdc/render @react-root
+   (defn ^:dev/after-load render! []
+     (when-let [root @react-root]
+       ;; Render inside the app-frame's `frame-provider`, so every `dispatch` and
+       ;; `subscribe` down in the view tree resolves to the frame we hydrated.
+       (rdc/render root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))
 
@@ -435,21 +433,33 @@
      ;; afterward, get validated on the client just as they were on the server.
      ;; (Also no-op-safe on hot-reload.)
      (rf/reg-app-schema [:articles] {:frame app-frame} ArticlesSchema)
-     ;; One call, all three steps — READ, HYDRATE, VERIFY — against the same
-     ;; `app-frame` the mount below will use. The one subtlety is `:render-tree-fn`:
-     ;; VERIFY has to hash the *exact* tree the server hashed, or it'll cry
-     ;; mismatch over a difference that was never real. The server hashed
-     ;; `((rf/view :app/root))` — the view fn *called* — so we call it the same
-     ;; way here, not the `[(rf/view :app/root)]` vector form Reagent mounts.
-     ;; `hydrate!` returns the payload it applied, or nil on a plain client load.
-     (let [payload (ssr/hydrate! {:frame          app-frame
-                                  :render-tree-fn (fn [] ((rf/view :app/root)))})]
-       (when-not payload
-         ;; No payload means no server render — a plain first load. Run the
-         ;; app's own bootstrap against the frame; the page comes up showing the
-         ;; empty-articles fallback.
-         (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})))
-     (mount!)))
+     ;; READ, HYDRATE, VERIFY — all three against the same `app-frame` the mount
+     ;; below uses. The one subtlety is `:render-tree-fn`: VERIFY has to hash the
+     ;; *exact* tree the server hashed, or it'll cry mismatch over a difference
+     ;; that was never real. The server hashed `((rf/view :app/root))` — the view
+     ;; fn *called* — so we call it the same way here, not the
+     ;; `[(rf/view :app/root)]` vector form Reagent mounts. `hydrate!` seeds and
+     ;; verifies STATE only — it never touches the DOM — and returns the payload
+     ;; it applied, or nil on a plain client load.
+     (let [el      (and (exists? js/document) (js/document.getElementById "app"))
+           payload (ssr/hydrate! {:frame          app-frame
+                                  :render-tree-fn (fn [] ((rf/view :app/root)))})
+           tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
+       (when el
+         (if payload
+           ;; Server-rendered: ADOPT the painted DOM. `hydrate-root` reconciles
+           ;; React against the server markup — same nodes, listeners attached,
+           ;; no re-paint — and returns the retained root. `create-root` +
+           ;; `render` would throw the server HTML away and mount fresh, which is
+           ;; the bug this branch avoids.
+           (reset! react-root (rdc/hydrate-root el tree))
+           ;; No payload means no server render — a plain first load. Run the
+           ;; app's own bootstrap against the frame, then mount a fresh root; the
+           ;; page comes up showing the empty-articles fallback.
+           (do
+             (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})
+             (reset! react-root (rdc/create-root el))
+             (rdc/render @react-root tree)))))))
 
 ;; No tests in this file — and that's deliberate. The example tree stays
 ;; test-free so the source reads as pure demonstration; the headless tests that


### PR DESCRIPTION
Three SSR doc-accuracy fixes from the PR #5918 audit (rf2-2gotoc). Each guide claimed SSR behaviour the shipped code does not perform; each fix is grounded in `file:line` into the shipped runtime.

## rf2-fzza7u (P1) — hydrate the server DOM, don't create a fresh root

**False claim:** `docs/ssr/tutorial.md`, `docs/ssr/concepts.md`, and `examples/capabilities/ssr/ssr/core.cljc` booted a server-rendered page with `rdc/create-root` + `rdc/render`, while claiming "the existing DOM is adopted, not replaced" and "nothing flashes."

**What ships:** `ssr/hydrate!` installs + verifies **state** only and explicitly "does not inspect or own the DOM mount" (`implementation/ssr/src/re_frame/ssr/boot.cljc:1-11`, `146-274`); the `:rf/hydrate` handler replaces app-db/runtime-db (`implementation/ssr/src/re_frame/ssr/hydrate.cljc:228-284`). React DOM adoption is a **separate** call — `hydrate-root` (React's `hydrateRoot`), wired in both adapters (`implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs:32`, `implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs:258-273`). `create-root().render()` mounts fresh and discards the server markup.

**Corrected:** payload-backed startup uses `rdc/hydrate-root el tree`; a client-only load (nil payload) uses a fresh `create-root` + `render`. The capability example retains one root per container across HMR (`render!` on the retained root, never a second `create-root`); the `index.html` payload + server DOM already match, so hydration reconciles cleanly. Docs and example now share the one recipe.

## rf2-bgbght (P2) — streaming fallbacks ride inert templates

**False claim:** `docs/ssr/streaming.md` said the shell "emits each `:fallback` in place and flushes immediately — first byte" as visible UI.

**What ships:** each fallback is wrapped in an inert `<template data-rf2-suspense-fallback>` whose content is a detached `DocumentFragment` that never paints (`implementation/ssr/src/re_frame/ssr/streaming.cljc:97-114`, `implementation/ssr/src/re_frame/ssr/streaming/constants.cljc:38-45`). It becomes visible only when `streaming-install!` materialises it into a live `<rf-suspense>` mount; without the client runtime the region stays blank until the final `__rf_payload` (`implementation/ssr/src/re_frame/ssr/streaming/client.cljs:26-33`, `205-240`).

**Corrected:** the guide now says the first byte carries the shell plus inert boundary templates, and that visible fallbacks begin only once `streaming-install!` materialises them (and then swaps resolved chunks + merges deltas). No wire-protocol redesign.

## rf2-ttiv2i (P2) — head hash is a separate channel; no auto compare/reconcile

**False claim:** `docs/ssr/head.md` said the head "rides the same render-tree hash as the body," the "mismatch detector covers the head," and "the head recomputes ... SPA route changes keep `<title>` / `<meta>` current."

**What ships:** `:rf/render-hash` is **body-only** and the head emits a **separate, optional** `:rf/head-hash` (`data-rf-head-hash` on `<head>`), omitted for an explicit `:head` string or a degraded head (`implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj:153-189`; pinned by `implementation/ssr-ring/test/re_frame/ssr/ring_test.clj:881-961`). `verify-hydration!` compares only the body server-hash — the hydration metadata stores `:server-hash` + `:version`, never a head hash (`implementation/ssr/src/re_frame/ssr/hydrate.cljc:286-378`, `529-608`). No DOM-head reconciler ships. The head model *is* reconstructible (a host may recompute `rf/active-head` and compare to `:rf/head-hash`), which the guide now states as a host capability.

**Corrected:** the guide describes the two separate hash channels, states exactly what the runtime emits vs. what a host may reconstruct/compare, and says SPA document-head updates need an app/host head manager. No new head subsystem.

## Out of scope — follow-on

Two sibling SSR examples share the same `create-root`-instead-of-`hydrate-root` pattern but are **not** named by these beads, so they were left untouched: `examples/capabilities/ssr/ssr_streaming/core.cljc` and `examples/capabilities/ssr/resources_ssr/core.cljc`. Worth a follow-on to bring them onto the corrected recipe.

## Quality gates

- `python scripts/check_doc_slugs.py` — pass (exit 0, no output)
- `python -m mkdocs build --strict` — pass (exit 0; "Documentation built in 18.37 seconds"). Remaining INFO lines are pre-existing and unrelated to `docs/ssr/`.

Not run (per task scope): test spine / browser suites. The example's JVM tests (`implementation/core/test/re_frame/examples_test.clj` `ssr-example-client-hydration-*`) exercise `handle-request` + the hydration event/verify directly and do not touch the CLJS mount, so the `run`/`render!` change is orthogonal to them.
