### PR TITLE
fix(ui): emit recursive defviews against their current-namespace Var (rf2-rr26cq)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -267,6 +267,13 @@
                   :capabilities (capabilities ast)
                   :sites sites}
         args    {:vname vname
+                 ;; The canonical current-namespace Var a self-recursive head
+                 ;; must emit AGAINST — identical to the `:fqn` env/classify-head
+                 ;; stamps on an exact self component node (rf2-rr26cq). A bare
+                 ;; self head resolves through a same-named `:refer` on CLJS
+                 ;; (refers outrank local defs in cljs.analyzer/resolve-var), so
+                 ;; both emitters target THIS fqn, not the authored spelling.
+                 :self-fqn (symbol (str ns-sym) (str vname))
                  :view-id view-id
                  :display-name display-name
                  :docstring docstring

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -421,8 +421,20 @@
                               [["ref" (:form ref-a)]])
                             (when (some? children-form)
                               [["children" children-form]])))
-        multi?   (> nch 1)]
-    (jsx-runtime-call multi? (:sym node) props-form key-info)))
+        multi?   (> nch 1)
+        ;; A self-recursive head (the exact view being compiled) MUST target the
+        ;; current-namespace Var (its canonical `:fqn`), never the authored
+        ;; spelling: the render fn is a separate `$render` def emitted BEFORE the
+        ;; view's own `(def …)`, so a bare self head would resolve through any
+        ;; same-named `:refer` (cljs.analyzer/resolve-var checks `:uses` ahead of
+        ;; `:defs`) and capture the public authoring Var. `emit-defview` reads the
+        ;; recorded flag to forward-`declare` the Var so the qualified reference
+        ;; is not undeclared. Unrelated foreign/view heads keep their spelling.
+        self-fqn (:self-fqn @st)
+        self?    (and (some? self-fqn) (= (:fqn node) self-fqn))
+        head-sym (if self? (:fqn node) (:sym node))]
+    (when self? (swap! st assoc :self-ref? true))
+    (jsx-runtime-call multi? head-sym props-form key-info)))
 
 (defn- row-key-expr [body]
   (or (get-in body [:props :key :expr]) (get-in body [:key :expr])))
@@ -606,8 +618,8 @@
 
 (defn emit-defview
   [{:keys [vname view-id display-name docstring header slots ast manifest
-           closed-keys children? lease-declarations]}]
-  (let [st         (new-state vname)
+           closed-keys children? lease-declarations self-fqn]}]
+  (let [st         (doto (new-state vname) (swap! assoc :self-fqn self-fqn))
         body       (->> (emit-node ast st false)
                         (hoist-literal-sub-queries st))
         leases     (mapv #(update % :descriptor
@@ -665,6 +677,12 @@
                      docstring   (assoc :doc docstring)
                      closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]
     `(do
+       ;; A self-recursive view forward-declares its Var so the `$render` fn
+       ;; (emitted before the view's own `(def …)`) may reference the
+       ;; current-namespace Var by its qualified name without an undeclared-Var
+       ;; warning — and so the declaration, not a same-named `:refer`, owns the
+       ;; name at the reference site. Non-recursive views emit unchanged.
+       ~@(when (:self-ref? @st) [`(declare ~vname)])
        ~@(:defs @st)
        (defn ~render-sym [~props-sym]
          ~inner)

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -14,6 +14,13 @@
 
 (def ^:private props-sym 'rf-ui-props)
 
+;; The canonical current-namespace Var of the view being emitted, bound by
+;; `emit-defview` around its body. A self-recursive component head targets THIS
+;; fqn (matching its `:fqn`) rather than the authored spelling, so the emitted
+;; call names the current-namespace Var explicitly instead of relying on the
+;; enclosing `defn`'s intern order to shadow a same-named `:refer` (rf2-rr26cq).
+(def ^:dynamic *self-fqn* nil)
+
 (declare emit-node)
 
 ;; ---------------------------------------------------------------------------
@@ -207,7 +214,9 @@
                              (some-> (re-frame.ui.tree/children ~@child-forms)
                                      re-frame.ui.tree/child-vec))
                      props-map)
-        call      `(~(:sym node) ~props-form)]
+        self?     (and (some? *self-fqn*) (= (:fqn node) *self-fqn*))
+        head-sym  (if self? (:fqn node) (:sym node))
+        call      `(~head-sym ~props-form)]
     (if (:present? key-info)
       `(assoc ~call :key ~(:expr key-info))
       call)))
@@ -294,8 +303,8 @@
 
 (defn emit-defview
   [{:keys [vname view-id docstring header ast manifest closed-keys children?
-           lease-declarations]}]
-  (let [body     (emit-node ast)
+           lease-declarations self-fqn]}]
+  (let [body     (binding [*self-fqn* self-fqn] (emit-node ast))
         bind     (:binding-form header)
         lease-binds
         (vec

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -2,11 +2,17 @@
   "Real CLJS-analyzer resolution proofs for the expression macro barrier."
   (:require [cljs.analyzer :as cljs-analyzer]
             [cljs.analyzer.api :as cljs-api]
+            [cljs.compiler :as cljs-comp]
             [cljs.core]
             [cljs.env :as cljs-env]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [re-frame.ui.compiler.analyze :as analyze]
+            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.emit-jvm :as emit-jvm]
             [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.compiler.header :as header]
             [re-frame.ui.compiler.root :as root]))
 
 (defmacro user-binder
@@ -228,3 +234,146 @@
       (testing "a legal element root still analyzes through the root compiler"
         (is (= :element
                (:op (:ast (root/analyze-root (referred-env aenv nil) 'ui/mount '[:div "x"])))))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-rr26cq — emit a recursive self head against the current-namespace Var
+;; ---------------------------------------------------------------------------
+;;
+;; The .274 analyzer proofs above stop at classification (the self head is an
+;; internal :view). But the CLJS emitter splits the render fn (`<v>$render`)
+;; from the view's own `(def <v> …)`, so the render fn FORWARD-references the
+;; view before its def. A self head emitted as the raw authored spelling
+;; therefore resolves through the same-named `:refer` — cljs.analyzer/resolve-var
+;; checks `:uses` (refers) BEFORE `:defs` — and captures the public authoring
+;; Var (`re-frame.ui/sub`) in the emitted JavaScript. The fix carries the
+;; canonical `:fqn` (the current-namespace Var) for the self component node and
+;; forward-`declare`s it. These rows drive the REAL emitters and compile the
+;; emitted self head to REAL JavaScript through cljs.compiler.
+
+(defn- self-emit-args
+  "Package emit args for `(defview <verb> [] [<verb> {}])` exactly as
+  `compiler/defview**` does — the self view named `verb` recurses on a bare
+  `[verb {}]` self head in the referred cljs.user namespace."
+  [aenv verb]
+  (let [e   (referred-env aenv verb)
+        ast (analyze/analyze e [verb {}])]
+    {:vname verb
+     :self-fqn (symbol "cljs.user" (name verb))
+     :view-id (keyword "cljs.user" (name verb))
+     :display-name (str "cljs.user/" (name verb))
+     :docstring nil
+     :header (header/parse-header [])
+     :slots []
+     :lease-declarations []
+     :ast ast
+     :manifest {:view-id (keyword "cljs.user" (name verb)) :sites {} :children? false}
+     :closed-keys nil
+     :children? false}))
+
+(defn- jsx-tag-syms
+  "The symbol component heads the CLJS emitter placed in jsx-runtime `js*`
+  calls (`(0,<rt>.jsx)(<tag>,<props>)`); the tag is the 3rd js* argument after
+  the template and the runtime alias."
+  [form]
+  (let [hits (atom [])]
+    (walk/postwalk
+     (fn [x]
+       (when (and (seq? x) (= 'js* (first x)) (string? (second x))
+                  (str/includes? (second x) ".jsx"))
+         (let [tag (nth x 3 nil)]
+           (when (symbol? tag) (swap! hits conj tag))))
+       x)
+     form)
+    @hits))
+
+(defn- call-head-syms
+  "Every seq head symbol whose NAME matches `verb` — on the JVM emit form the
+  only such head is the self component call `(cljs.user/<verb> {…})`."
+  [form verb]
+  (let [hits (atom [])]
+    (walk/postwalk
+     (fn [x]
+       (when (and (seq? x) (symbol? (first x)) (= (name (first x)) (name verb)))
+         (swap! hits conj (first x)))
+       x)
+     form)
+    @hits))
+
+(defn- emit-var-js
+  "Real cljs.compiler JavaScript for a var-reference symbol in cljs.user
+  (warnings silenced — the point is the munged target, not the diagnostic)."
+  [aenv sym]
+  (binding [cljs-analyzer/*cljs-warnings*
+            (zipmap (keys cljs-analyzer/*cljs-warnings*) (repeat false))]
+    (cljs-comp/emit-str
+     (cljs-analyzer/analyze (assoc aenv :context :expr) sym))))
+
+(deftest real-cljs-self-head-emits-against-current-namespace-var
+  ;; rf2-rr26cq accept rows. Reverting the emitter to the raw authored `:sym`
+  ;; re-captures `re-frame.ui/<verb>` in the emitted JavaScript and drops the
+  ;; forward declaration, failing every row below.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (doseq [verb '[sub lease frame]]
+        (let [self-fqn  (symbol "cljs.user" (name verb))
+              args      (self-emit-args aenv verb)
+              cljs-form (emit-cljs/emit-defview args)
+              jvm-form  (emit-jvm/emit-defview args)
+              cljs-heads (jsx-tag-syms cljs-form)]
+          (testing (str "CLJS: the self head is the current-namespace fqn (" verb ")")
+            (is (seq cljs-heads) "a self component call is emitted")
+            (is (every? #(= self-fqn %) cljs-heads)
+                (str "every self head is cljs.user/" verb ", never the bare refer"))
+            (is (not-any? #(= verb %) cljs-heads)
+                "the raw authored spelling never reaches a jsx head"))
+          (testing (str "CLJS: the view forward-declares its own Var (" verb ")")
+            (is (some #(and (seq? %) (= 'clojure.core/declare (first %))
+                            (= verb (second %)))
+                      cljs-form)
+                "a (declare <verb>) precedes the render fn")
+            (is (some #(and (seq? %) (= 'def (first %)) (= verb (second %)))
+                      cljs-form)
+                "the def still targets the bare current-namespace name"))
+          (testing (str "CLJS: the emitted self head compiles to cljs.user." (name verb))
+            (doseq [h cljs-heads]
+              (let [js (emit-var-js aenv h)]
+                (is (= (str "cljs.user." (name verb)) js)
+                    (str "self head " h " munges to the current-namespace Var"))
+                (is (not (str/includes? js (str "re_frame.ui." (name verb))))
+                    "zero authoring-Var reference in the emitted JavaScript"))))
+          (testing (str "JVM: the self call targets the current-namespace fqn (" verb ")")
+            (let [jvm-heads (call-head-syms jvm-form verb)]
+              (is (seq jvm-heads) "a self component call is emitted")
+              (is (every? #(= self-fqn %) jvm-heads)
+                  (str "every JVM self call head is cljs.user/" verb)))))))))
+
+(deftest a-bare-authored-self-head-would-capture-the-authoring-var
+  ;; The counterfactual the fix defeats: were the emitter to keep the raw
+  ;; authored spelling, that bare head compiles to the REFERRED authoring Var —
+  ;; the exact defect rf2-rr26cq closes. This pins the JavaScript delta so a
+  ;; regression is legible, not silent.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (doseq [verb '[sub lease frame]]
+        (is (= (str "re_frame.ui." (name verb)) (emit-var-js aenv verb))
+            (str "a bare " verb " head resolves through the refer to the authoring Var"))
+        (is (= (str "cljs.user." (name verb))
+               (emit-var-js aenv (symbol "cljs.user" (name verb))))
+            (str "the qualified " verb " head resolves to the current-namespace Var"))))))
+
+(deftest a-non-recursive-defview-emits-no-self-declaration
+  ;; Preserve unrelated behavior: a view that does NOT reference itself emits no
+  ;; forward declaration and no fqn rewrite — the self-head machinery is inert.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [e    (referred-env aenv 'panel)
+            ast  (analyze/analyze e [:div "x"])
+            args {:vname 'panel :self-fqn 'cljs.user/panel :view-id :cljs.user/panel
+                  :display-name "cljs.user/panel" :docstring nil
+                  :header (header/parse-header []) :slots [] :lease-declarations []
+                  :ast ast
+                  :manifest {:view-id :cljs.user/panel :sites {} :children? false}
+                  :closed-keys nil :children? false}
+            form (emit-cljs/emit-defview args)]
+        (is (not-any? #(and (seq? %) (= 'clojure.core/declare (first %))) form)
+            "a non-recursive view emits no (declare …)")))))


### PR DESCRIPTION
Fixes rf2-rr26cq.

## Problem

The `re-frame.ui` compiler EMIT step lowered a self-recursive component head using the raw authored `:sym` instead of the canonical `:fqn`. On CLJS the render function is a separate `<v>$render` def emitted BEFORE the view's own `(def <v> …)`, so a bare self head forward-references the view and resolves through any same-named `:refer`. `cljs.analyzer/resolve-var` checks `:uses` (refers) at line 1403 AHEAD of `:defs` (local defs) at line 1416, so a `(declare)` cannot redirect a bare symbol — the reference captures the public authoring Var in the emitted JavaScript.

Concretely, `(defview sub [] [sub {}])` in a namespace that refers `re-frame.ui/sub` emitted the render call against `re_frame.ui.sub` rather than `cljs.user.sub`.

- Defect site (CLJS): `emit_cljs.cljc` `emit-component` — `(jsx-runtime-call multi? (:sym node) …)`.
- Defect site (JVM): `emit_jvm.cljc` `emit-view` — `` `(~(:sym node) ~props-form) ``. The JVM path resolved correctly only by accident of `defn` intern order (the enclosing `(defn <v> …)` interns the Var before the body compiles).

## Fix

- `compiler.cljc` carries the canonical `:self-fqn` (`<ns>/<vname>`, identical to the `:fqn` `env/classify-head` stamps on an exact self node) into the emit args.
- Both emitters emit an exact self head against that fqn (matched via each self node's `:fqn`); the authored spelling is diagnostic only. Unrelated foreign/view heads keep their spelling.
- The CLJS emitter forward-`declare`s the view's Var when the view self-references, so the qualified render-fn reference is not undeclared and the declaration — not a refer — owns the name at the reference site. Non-recursive views emit unchanged (no `declare`).
- The JVM emitter names the Var explicitly for uniformity and intern-order independence.

## Proof (failing-before / passing-after, both emitters)

New real-host tests in `compiler_macro_resolution_jvm_test.clj` (production `cljs.analyzer.api/resolve`, a namespace that refers `re-frame.ui/{sub,lease,frame}`):

- CLJS self head compiles through **`cljs.compiler`** to `cljs.user.<verb>` with **zero** `re_frame.ui.<verb>` reference; the view forward-declares its Var; the def targets the current-namespace name.
- JVM self call head is the current-namespace fqn `cljs.user/<verb>`.
- Counterfactual pinned: the bare authored head compiles to `re_frame.ui.<verb>` (the defect), the qualified head to `cljs.user.<verb>`.
- A non-recursive view emits no forward declaration (unrelated behavior preserved).

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`, incl. export-conformance + `defview_grammar_jvm_test`): **647 tests, 13219 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (core+reagent node build; rides the manifest/roster probe): **9640 tests, 47507 assertions, 0 failures, 0 errors**.
- `npm run test:ui` (incl. ui-adapter bundle-isolation): **661 tests, 3433 assertions, 0 failures, 0 errors**.
- `gen --check` / `api-md-check`: N/A — no public var or `:rf.ui.compile/*` error-id added (the only new symbol is the internal compile-time dynamic var `emit-jvm/*self-fqn*`, absent from every production bundle).
- `mkdocs build --strict`: N/A — no spec prose touched (the self-head classification contract already lives in the analyzer; emission-against-current-ns-Var is an implementation correctness detail, not a normative surface).
- Not run (per brief): `test:browser`, full spine.
