### PR TITLE
test(story): fix undeclared-var warnings in open-in-editor test (rf2-dmooyv)

### DIFF
--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -51,6 +51,33 @@
 (use-fixtures :each {:before reset-editor!
                      :after  reset-editor!})
 
+;; ---- navigator seam helpers (rf2-muvs8) ----------------------------------
+;;
+;; The click-time navigation seam (`set-navigator!`) is swappable so tests
+;; capture navigation without mutating `js/window.location`. These two
+;; helpers are shared across the whole file — including
+;; `open!-denylist-gates-pre-resolved-uri` below — so they live here, above
+;; their first use, rather than beside the click-time deftests (a forward
+;; reference would trip the CLJS `:undeclared-var` analyzer).
+
+(defn- with-stub-navigator
+  "Swap the navigator seam for `stub-fn` for the duration of `body-fn`.
+  Restores the original navigator afterward (even on throw)."
+  [stub-fn body-fn]
+  (let [prev (open-in-editor/set-navigator! stub-fn)]
+    (try
+      (body-fn)
+      (finally
+        (open-in-editor/set-navigator! prev)))))
+
+(defn- capturing-navigator
+  "Build a navigator fn that pushes its URI argument onto the shared
+  `calls` atom. Returns `[navigator-fn, calls-atom]`."
+  []
+  (let [calls (atom [])
+        nav   (fn [uri] (swap! calls conj uri))]
+    [nav calls]))
+
 ;; ---- chip rendering ------------------------------------------------------
 
 (deftest open-chip-renders-anchor-with-href
@@ -365,25 +392,10 @@
 ;; handlers) are diagnosable from devtools without a debugger break.
 ;;
 ;; These tests pin the click-time contract: clicking the chip invokes
-;; the navigator with the same URI carried in the :href.
-
-(defn- with-stub-navigator
-  "Swap the navigator seam for `stub-fn` for the duration of `body-fn`.
-  Restores the original navigator afterward (even on throw)."
-  [stub-fn body-fn]
-  (let [prev (open-in-editor/set-navigator! stub-fn)]
-    (try
-      (body-fn)
-      (finally
-        (open-in-editor/set-navigator! prev)))))
-
-(defn- capturing-navigator
-  "Build a navigator fn that pushes its URI argument onto the shared
-  `calls` atom. Returns `[navigator-fn, calls-atom]`."
-  []
-  (let [calls (atom [])
-        nav   (fn [uri] (swap! calls conj uri))]
-    [nav calls]))
+;; the navigator with the same URI carried in the :href. The
+;; `with-stub-navigator` / `capturing-navigator` seam helpers used here
+;; are defined in the helpers section near the top of the file (they are
+;; first used earlier, by `open!-denylist-gates-pre-resolved-uri`).
 
 (deftest click-handler-calls-navigator-with-uri
   (testing "rf2-muvs8 — clicking the chip invokes the navigator seam


### PR DESCRIPTION
## Summary

The node-test build (`shadow-cljs compile node-test`) emitted two
`:undeclared-var` warnings for `tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs`:

- `capturing-navigator` (used at 166:24)
- `with-stub-navigator` (used at 167:8)

Both `defn-` helpers were defined near the bottom of the file (the
click-time navigation block) but first *used* far earlier, by
`open!-denylist-gates-pre-resolved-uri`. CLJS compiles top-level forms in
order, so a use preceding the `defn-` is an undeclared forward reference.
The JVM `:test` runner (`clojure -M:test`) tolerates forward refs, which is
why the warnings only surfaced in the CLJS node-test build.

**Fix:** relocate the two helper `defn-`s into a helpers section directly
after the fixtures, above their first use. Pure move — no assertion or
behaviour change; the click-time comment block keeps a pointer to the new
location.

## Quality gates

- `shadow-cljs compile node-test` — both target `:undeclared-var` warnings
  (`capturing-navigator` / `with-stub-navigator`) are **gone** (verified by
  grepping the compile log before vs. after). The only remaining
  `:undeclared-var` warning is the pre-existing, unrelated
  `re-frame.late-bind/clear-fn!` in a different file, out of scope here.
- `node out/node-test.js` — **9660 tests, 47555 assertions, 0 failures, 0 errors.**

Closes rf2-dmooyv.
