### PR TITLE
docs(machines): fix coeffect-level claim, copy-pasteable tutorial, handbook anchors (cluster)

### DIFF
--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -1,5 +1,7 @@
 # The model
 
+<a id="state-machines"></a>
+
 This page is the **flat machine model** — everything you need for a single-level
 state machine. Nested states, parallel regions, history, and actors grow the same
 grammar; each has its own page.
@@ -15,6 +17,7 @@ contracts.
 
 ## The idea
 
+<a id="a-machine-at-a-glance"></a>
 <a id="the-same-flow-as-a-transition-table"></a>
 
 You already write state machines: a `:status` keyword in app-db plus informal rules
@@ -131,6 +134,7 @@ Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
 ## Guards and actions
 
 <a id="guards-and-actions"></a>
+<a id="guards-actions-tags-and-after--the-recognition-kit"></a>
 
 Every callback receives one context map:
 
@@ -147,6 +151,8 @@ machine inside one snapshot for time-travel.
 
 ### Guards
 
+<a id="a-guard-is-a-yesno-gate"></a>
+
 Return truthy/falsey. No combinator DSL — compound logic is ordinary Clojure:
 
 ```clojure
@@ -156,12 +162,16 @@ Return truthy/falsey. No combinator DSL — compound logic is ordinary Clojure:
                       (and (seq (:email creds)) (seq (:password creds))))}
 ```
 
+<a id="name-them-or-inline-them"></a>
+
 Reference by id (`:guard :form-valid?`) or inline a one-liner. Prefer named ids —
 trace rows and Xray can address them.
 
 A list of transition candidates is tried in order; first guard that passes wins.
 
 ### Actions
+
+<a id="an-action-returns-effects"></a>
 
 Return **descriptions**, same idea as `reg-event`:
 
@@ -199,6 +209,8 @@ Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine` time
 
 ## Strict encapsulation
 
+<a id="strict-encapsulation--a-machine-sees-only-its-own-data"></a>
+
 A guard or action gets only `{:data :event :state :meta}` — never app-db. That is
 what keeps a machine's whole state inside one snapshot for time-travel and SSR.
 
@@ -227,6 +239,8 @@ moves the machine.
 
 ## The snapshot
 
+<a id="the-snapshot--state-data-tags"></a>
+
 ```clojure
 {:state :submitting
  :data  {:attempts 1 :error nil}
@@ -246,6 +260,7 @@ Optional **`:schemas {:data …}`** (Malli) validates `:data` at commit in dev a
 rolls back a bad transition.
 
 <a id="validating-a-machines-data"></a>
+<a id="validating-a-machines-completion-output"></a>
 
 Full rules: see schemas section of
 [`re-frame.machines` API](../api/re-frame.machines.md) and Spec 005 (authors).
@@ -308,6 +323,8 @@ Nested finals and parent `:on-done` live in
 
 ## Tags and automatic moves (pointers)
 
+<a id="tags-and-timers"></a>
+
 - **Tags** — label intent on states (`:tags #{:auth/busy}`); views ask
   `[:rf.machine/has-tag? id :auth/busy]` instead of enumerating state names.
   → [Tags](tags.md)
@@ -317,6 +334,7 @@ Nested finals and parent `:on-done` live in
 ## When the table grows
 
 <a id="when-the-machine-grows"></a>
+<a id="testing-transitions-are-pure-function-calls"></a>
 
 Same model, more keys — each page assumes this one:
 
@@ -335,6 +353,8 @@ Eventless loops and raise storms are depth-bounded (default 16); tripping aborts
 macrostep with a loud error — not a silent no-op.
 
 ## When to reach for a machine
+
+<a id="when-to-reach-for-a-machine--and-when-not"></a>
 
 **Yes:** named mutually exclusive stages; conditional transitions scattered as
 `when`s; the flow is worth drawing on a whiteboard.

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -211,8 +211,9 @@ Unresolved `:guard` / `:action` / `:target` names throw at `reg-machine` time
 
 <a id="strict-encapsulation--a-machine-sees-only-its-own-data"></a>
 
-A guard or action gets only `{:data :event :state :meta}` — never app-db. That is
-what keeps a machine's whole state inside one snapshot for time-travel and SSR.
+A guard or action gets `{:data :event :state :meta}` (plus `:rf.cofx` when it
+declares a coeffect, below) — never app-db. That is what keeps a machine's whole
+state inside one snapshot for time-travel and SSR.
 
 | Need | How |
 |---|---|

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -208,11 +208,15 @@ what keeps a machine's whole state inside one snapshot for time-travel and SSR.
 | Write outside the machine | Return `:fx [[:dispatch […]]]` — a real, named event |
 | Clock / random / host fact | Declare a [coeffect](../core/coeffects.md) on the guard or action — do **not** call `(js/Date.now)` |
 
+A declared coeffect arrives under **`:rf.cofx`** on the callback map — the causal
+token the router recorded, so the decision replays deterministically. Read it there,
+`(:rf/time-ms (:rf.cofx ctx))`; it is *not* a top-level `rf/time-ms` key.
+
 ```clojure
 :guards
 {:within-retry-window?
  {:rf.cofx/requires [:rf/time-ms]
-  :fn (fn [{:keys [data rf/time-ms]}]
+  :fn (fn [{:keys [data] {:keys [rf/time-ms]} :rf.cofx}]
         (< (- time-ms (:first-attempt-at data)) 60000))}}
 ```
 

--- a/docs/machines/examples.md
+++ b/docs/machines/examples.md
@@ -1,5 +1,7 @@
 # Examples
 
+<a id="machines-examples"></a>
+
 Runnable apps that exercise the machine grammar. Build a machine yourself first
 ([tutorial](tutorial.md) — ends with a complete login table), then skim
 [the model](concepts.md). Work these apps in order — each adds machinery.

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -1,9 +1,13 @@
 # Hierarchical state machines
 
+<a id="theyre-everywhere"></a>
+
 Some state is not a number in app-db — it is **which named stage you are in**, and
 which events may legally leave it. Login is idle, then submitting, then authed or
 error or locked-out. A websocket is connecting, open, reconnecting, closed. Those
 flows usually hide as enums and booleans scattered across handlers.
+
+<a id="first-class-support"></a>
 
 A **machine** makes that shape first-class: one data table of states and
 transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`, living in
@@ -42,6 +46,8 @@ Optional later: [examples](examples.md), [XState mapping](coming-from-xstate.md)
 @(rf/subscribe [:rf/machine :door])
 ;; => {:state :open :data {}}
 ```
+
+<a id="deeply-integrated"></a>
 
 `reg-machine` is sugar over `reg-event`. The snapshot rides runtime-db — undo, Xray,
 SSR, and tests share the same pipeline as the rest of the app.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -71,6 +71,8 @@ How the union is computed depends on the machine's shape:
 
 ## Querying with `[:rf.machine/has-tag? …]`
 
+<a id="querying-with-machine-has-tag"></a>
+
 The framework ships one **derived subscription** for the containment question — *does this machine's snapshot carry this tag?* There is no separate function sugar; every runtime-db read is a subscription vector:
 
 ```clojure

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -100,12 +100,13 @@ HTTP itself.
 - `:clear-error` — wipe the last error on a fresh submit
 - `:record-error` — bump `:attempts` and store a message
 - `:store-session` — dispatch an ordinary effect on success
-- **Candidate list** on failure — under three attempts → error UI; otherwise lock out
+- **Candidate list** on failure — the first two failures show the error; the third
+  records it and locks out (three attempts total)
 
 ```clojure
 :guards
 {:form-valid?       …
- :under-retry-limit (fn [{data :data}] (< (:attempts data) 3))}
+ :under-retry-limit (fn [{data :data}] (< (:attempts data) 2))}
 
 :actions
 {:clear-error
@@ -125,11 +126,14 @@ HTTP itself.
       :auth.login/failure [{:target :error-shown
                             :guard  :under-retry-limit
                             :action :record-error}
-                           {:target :locked-out}]}}
+                           {:target :locked-out
+                            :action :record-error}]}}
 ```
 
-A **vector of candidates** is tried in order; first guard that passes wins. After
-three failures, `:under-retry-limit` fails and the unguarded candidate locks out.
+A **vector of candidates** is tried in order; first guard that passes wins. The
+guard reads the *pre-action* `:attempts`, so it passes for the first two failures;
+on the third it fails and the fallback candidate records that final error before
+locking out — so the terminal failure is counted, not discarded.
 
 !!! note "`:data` merges"
 
@@ -146,7 +150,9 @@ three failures, `:under-retry-limit` fails and the unguarded candidate locks out
 
 Add an **`:entry`** action on `:submitting` that fires [managed HTTP](../async/http.md),
 and an **`:after`** deadline if the server stalls. Tag the state so views can ask
-"busy?" without naming it:
+"busy?" without naming it. Managed HTTP is its own artefact — require
+`[re-frame.http.managed]` at boot (it registers `:rf.http/managed`), or the effect
+resolves to `:rf.error/no-such-fx`:
 
 ```clojure
 :issue-request
@@ -165,7 +171,11 @@ and an **`:after`** deadline if the server stalls. Tag the state so views can as
 :submitting
 {:tags  #{:auth/busy}
  :entry :issue-request
- :after {8000 {:target :error-shown :action :record-timeout}}
+ :after {8000 [{:target :error-shown
+                :guard  :under-retry-limit
+                :action :record-timeout}
+               {:target :locked-out
+                :action :record-timeout}]}
  :on    {…}}   ;; success / failure as in step 3
 ```
 
@@ -174,7 +184,10 @@ on purpose — managed HTTP **appends** the [canonical reply envelope](../async/
 onto the inner event, so `:store-session` sees
 `[:auth.login/success {:status :ok :value {:token "…"} …}]`.
 
-`:after` arms on entry and cancels on exit. Deeper timer grammar:
+`:after` arms on entry and cancels on exit. A stall counts as an attempt too: the
+timeout carries the **same guarded candidate list** as a rejected login (an `:after`
+value takes the same shape as an `:on` clause), so the third stall — or the third
+failure — records its error and locks out. Deeper timer grammar:
 [Automatic transitions](automatic-transitions.md).
 
 ## Step 5 — render every state
@@ -230,14 +243,18 @@ No frame, no browser, no network:
     (is (= :submitting (:state (result/snap r))))
     (is (= :rf.http/managed (ffirst (result/fx r)))))   ;; :entry ran :issue-request
 
+  ;; Two failures already recorded (:attempts 2); the third is terminal.
   (let [r (machines/machine-transition
             login-flow
-            {:state :submitting :data {:attempts 3 :error nil}}
+            {:state :submitting :data {:attempts 2 :error nil}}
             ;; Pure-table test: invent the failure shape the action expects.
             ;; Live HTTP would append {:status :error :error …} instead.
             [:auth.login/failure {:error {:message "bad creds"}}])]
     (is (result/ok? r))
-    (is (= :locked-out (:state (result/snap r))))))
+    (is (= :locked-out (:state (result/snap r))))
+    ;; the terminal failure is still counted — attempts bumped, message stored
+    (is (= 3 (get-in (result/snap r) [:data :attempts])))
+    (is (= "bad creds" (get-in (result/snap r) [:data :error])))))
 ```
 
 More on Result accessors and Xray: [Inspecting and testing](inspecting-machines.md).
@@ -249,7 +266,8 @@ Everything above in one registration — the form you copy into a real app:
 ```clojure
 (ns app.login
   (:require [re-frame.core :as rf]
-            [re-frame.machines]))
+            [re-frame.machines]
+            [re-frame.http.managed]))   ;; registers :rf.http/managed — the :issue-request fx
 
 (rf/defmachine login-flow
   {:initial :idle
@@ -260,7 +278,7 @@ Everything above in one registration — the form you copy into a real app:
     (fn [{[_ creds] :event}]
       (and (seq (:email creds)) (seq (:password creds))))
     :under-retry-limit
-    (fn [{data :data}] (< (:attempts data) 3))}
+    (fn [{data :data}] (< (:attempts data) 2))}
 
    :actions
    {:clear-error
@@ -301,12 +319,17 @@ Everything above in one registration — the form you copy into a real app:
     :submitting
     {:tags  #{:auth/busy}
      :entry :issue-request
-     :after {8000 {:target :error-shown :action :record-timeout}}
+     :after {8000 [{:target :error-shown
+                    :guard  :under-retry-limit
+                    :action :record-timeout}
+                   {:target :locked-out
+                    :action :record-timeout}]}
      :on    {:auth.login/success {:target :authed :action :store-session}
              :auth.login/failure [{:target :error-shown
                                    :guard  :under-retry-limit
                                    :action :record-error}
-                                  {:target :locked-out}]}}
+                                  {:target :locked-out
+                                   :action :record-error}]}}
 
     :error-shown
     {:on {:auth.login/dismiss {:target :idle}

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -22,6 +22,8 @@ Forget this and the first `reg-machine` throws
 
 ## Step 1 — a table and a registration
 
+<a id="step-1--your-first-machine"></a>
+
 A machine is data: named states and which triggers move where.
 
 ```clojure
@@ -68,6 +70,8 @@ Outer handlers stay ordinary. They only wrap the machine address:
 
 ## Step 2 — a guard
 
+<a id="step-2--a-guard-refuse-an-invalid-submit"></a>
+
 Refuse empty credentials. Name the guard once; reference it from every arrow that
 needs it:
 
@@ -93,6 +97,8 @@ The guard reads credentials from **`:event`**, not app-db —
 [encapsulation](concepts.md#strict-encapsulation).
 
 ## Step 3 — actions and candidate lists
+
+<a id="step-3--an-action-and-the-data-fx-it-returns"></a>
 
 An **action** returns `{:data … :fx …}` like a pure event handler — it never calls
 HTTP itself.
@@ -224,6 +230,8 @@ Add another in-flight state later with the same `:auth/busy` tag and this view k
 working. Pattern: [Tags](tags.md).
 
 ## Step 6 — test a transition as a pure function
+
+<a id="step-6--test-it-a-transition-is-a-pure-function"></a>
 
 No frame, no browser, no network:
 

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -222,6 +222,75 @@ _FENCE_RE = re.compile(r"^(```|~~~)")
 _INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
 
 
+# rf2-t0ituo — Machines handbook compatibility-anchor manifest + source-comment
+# link gate.
+#
+# PR #5916 reorganized the Machines handbook and dropped ~20 generated heading
+# IDs. External bookmarks and in-repo source comments (`.clj` / `.cljs`
+# walkthroughs) still target them, but neither is a markdown link, so the corpus
+# scan above never sees the break. Two additions close the hole:
+#
+#   1. MACHINES_COMPAT_ANCHORS — the manifest of stable anchors that MUST resolve
+#      on their page. A reorg that drops one fails here even when nothing in the
+#      markdown corpus links to it (an external bookmark has no in-repo linker to
+#      catch the break).
+#   2. SOURCE_COMMENT_LINK_GLOBS — non-markdown source files whose comments point
+#      readers at handbook anchors. Every `docs/machines/<page>.md#anchor`
+#      substring is resolved and validated against the target page's slug index,
+#      so a stale comment link (or a reorg removing its target) fails here too.
+#
+# Both run only in the default (docs-corpus) scope, never under --synthesis-only.
+MACHINES_COMPAT_ANCHORS = {
+    "docs/machines/concepts.md": (
+        "state-machines",
+        "a-machine-at-a-glance",
+        "a-guard-is-a-yesno-gate",
+        "an-action-returns-effects",
+        "name-them-or-inline-them",
+        "strict-encapsulation--a-machine-sees-only-its-own-data",
+        "the-snapshot--state-data-tags",
+        "tags-and-timers",
+        "validating-a-machines-completion-output",
+        "testing-transitions-are-pure-function-calls",
+        "when-to-reach-for-a-machine--and-when-not",
+        # Also referenced by the nine_states / websocket example comments.
+        "guards-actions-tags-and-after--the-recognition-kit",
+    ),
+    "docs/machines/tutorial.md": (
+        "step-1--your-first-machine",
+        "step-2--a-guard-refuse-an-invalid-submit",
+        "step-3--an-action-and-the-data-fx-it-returns",
+        "step-6--test-it-a-transition-is-a-pure-function",
+    ),
+    "docs/machines/tags.md": (
+        "querying-with-machine-has-tag",
+    ),
+    "docs/machines/examples.md": (
+        "machines-examples",
+    ),
+    "docs/machines/index.md": (
+        "theyre-everywhere",
+        "first-class-support",
+        "deeply-integrated",
+    ),
+}
+
+# Source trees whose comments carry `docs/machines/<page>.md#anchor` references.
+SOURCE_COMMENT_LINK_GLOBS = (
+    "examples/**/*.clj",
+    "examples/**/*.cljs",
+    "examples/**/*.cljc",
+)
+
+# A `docs/machines/<page>.md#anchor` substring, however it is embedded (bare in a
+# `;;` comment, inside a markdown `[text](../../docs/...)` link, or in parens).
+# Any leading path segments (`../../../`) are ignored — the captured `docs/...`
+# tail is resolved repo-root-relative.
+_MACHINES_DOC_LINK_RE = re.compile(
+    r"(docs/machines/[A-Za-z0-9_-]+\.md)#([A-Za-z0-9_-]+)"
+)
+
+
 def _is_excluded(
     path: Path,
     repo_root: Path,
@@ -488,6 +557,60 @@ def _scan_retired_synthesis_ops(
     return hits
 
 
+def _check_machines_compat_anchors(
+    repo_root: Path,
+    slugs_for,
+) -> list[tuple[str, str]]:
+    """Validate every manifest compat anchor resolves on its page (rf2-t0ituo).
+
+    Returns (page-rel, anchor) for each manifest anchor absent from its page's
+    slug index. Pages missing from the working tree are skipped, so the
+    fixture-based self-tests — whose mini-repos carry no docs/machines tree —
+    stay unaffected.
+    """
+    missing: list[tuple[str, str]] = []
+    for page_rel, anchors in MACHINES_COMPAT_ANCHORS.items():
+        page = repo_root / page_rel
+        if not page.is_file():
+            continue
+        page_slugs = slugs_for(page)
+        for anchor in anchors:
+            if anchor not in page_slugs:
+                missing.append((page_rel, anchor))
+    return missing
+
+
+def _check_source_comment_links(
+    repo_root: Path,
+    slugs_for,
+) -> list[tuple[Path, int, str, str]]:
+    """Validate `docs/machines/*.md#anchor` links in source comments (rf2-t0ituo).
+
+    Scans SOURCE_COMMENT_LINK_GLOBS line by line for the handbook-anchor
+    substring and resolves each against the target page's slug index. Returns
+    (source-file, line-no, `page#anchor`, reason) for every broken reference.
+    A repo with no matching source files (the self-test fixtures) yields none.
+    """
+    broken: list[tuple[Path, int, str, str]] = []
+    for pattern in SOURCE_COMMENT_LINK_GLOBS:
+        for src in sorted(repo_root.glob(pattern)):
+            text = src.read_text(encoding="utf-8", errors="replace")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                for m in _MACHINES_DOC_LINK_RE.finditer(line):
+                    doc_rel, anchor = m.group(1), m.group(2)
+                    target = (repo_root / doc_rel).resolve()
+                    if not target.is_file():
+                        broken.append(
+                            (src, line_no, f"{doc_rel}#{anchor}", "missing target file")
+                        )
+                        continue
+                    if anchor not in slugs_for(target):
+                        broken.append(
+                            (src, line_no, f"{doc_rel}#{anchor}", "missing anchor")
+                        )
+    return broken
+
+
 def check(
     repo_root: Path,
     verbose: bool = False,
@@ -507,6 +630,13 @@ def check(
                               active synthesis instruction still asserts the
                               retired local-only / copy-from-mayor model for the
                               force-tracked synthesis subtree.
+        * MISSING COMPAT ANCHOR — (default scope, rf2-t0ituo) a manifest anchor
+                              in MACHINES_COMPAT_ANCHORS no longer resolves on
+                              its page (external bookmarks / source comments
+                              depend on it).
+        * BROKEN SOURCE-COMMENT LINK — (default scope, rf2-t0ituo) a
+                              `docs/machines/*.md#anchor` reference embedded in a
+                              non-markdown source comment does not resolve.
     """
     files = list(_iter_markdown(repo_root, synthesis_only=synthesis_only))
     if synthesis_only:
@@ -610,11 +740,21 @@ def check(
     if synthesis_only:
         retired_ops = _scan_retired_synthesis_ops(files, repo_root)
 
+    # rf2-t0ituo — the Machines compat-anchor manifest + source-comment link gate
+    # run only in the default docs scope (never under --synthesis-only).
+    compat_missing: list[tuple[str, str]] = []
+    source_comment_broken: list[tuple[Path, int, str, str]] = []
+    if not synthesis_only:
+        compat_missing = _check_machines_compat_anchors(repo_root, slugs_for)
+        source_comment_broken = _check_source_comment_links(repo_root, slugs_for)
+
     total = (
         len(broken_anchor)
         + len(broken_target)
         + len(ai_findings)
         + len(retired_ops)
+        + len(compat_missing)
+        + len(source_comment_broken)
     )
 
     if broken_target:
@@ -682,6 +822,39 @@ def check(
             "revision being implemented/reviewed -- not to copy it from the mayor "
             "checkout. If the line is genuinely historical, move it into a "
             "blockquote whose opener is marked HISTORICAL / non-operative.\n"
+        )
+
+    if compat_missing:
+        sys.stderr.write(
+            f"\n{len(compat_missing)} missing Machines compat anchor(s) "
+            "found (rf2-t0ituo):\n\n"
+        )
+        for page_rel, anchor in compat_missing:
+            sys.stderr.write(
+                f"  MISSING COMPAT ANCHOR: {page_rel}#{anchor}\n"
+            )
+        sys.stderr.write(
+            "\nFix: these anchors back external bookmarks and in-repo source "
+            "comments. Restore an `<a id=\"...\"></a>` for each on its page "
+            "(without duplicating a visible heading), or update "
+            "MACHINES_COMPAT_ANCHORS if the anchor is intentionally retired.\n"
+        )
+
+    if source_comment_broken:
+        sys.stderr.write(
+            f"\n{len(source_comment_broken)} broken source-comment link(s) into "
+            "the Machines handbook found (rf2-t0ituo):\n\n"
+        )
+        for src, line_no, dest, reason in source_comment_broken:
+            rel = src.relative_to(repo_root.resolve())
+            sys.stderr.write(
+                f"  BROKEN SOURCE-COMMENT LINK: {rel}:{line_no} -> {dest}\n"
+                f"      ({reason})\n"
+            )
+        sys.stderr.write(
+            "\nFix: point the comment at a live canonical heading, or restore a "
+            "compatibility anchor on the target page (and list it in "
+            "MACHINES_COMPAT_ANCHORS).\n"
         )
 
     if total == 0 and verbose:


### PR DESCRIPTION
Cluster of three doc-accuracy fixes on `docs/machines/`. Surface is docs-only; `implementation/machines/*` and `spec/005` are cited read-only (PR #6049 owns that source). No example or implementation source was edited.

## rf2-gqlhj5 — coeffect read from the wrong callback level
The strict-encapsulation example in `concepts.md` destructured `rf/time-ms` at the callback-map root. The runtime surfaces the recorded coeffect token under `:rf.cofx` (`implementation/machines/src/re_frame/machines/transition.cljc:308-315`, `callback-ctx`), so the root bind resolved to `nil`. Shipped tests read it the documented way — `(fn [{cofx :rf.cofx}] (:rf/time-ms cofx))` (`machine_world_inputs_ctx_test.clj:52-72`, `machine_cofx_attach_test.clj:81-92`). Fixed the example to read `(:rf/time-ms (:rf.cofx ctx))` while keeping machine-local `:data` at the root, and added prose pinning the token shape.

## rf2-099755 — tutorial not copy-pasteable; terminal failure discarded
- The complete namespace emitted `:rf.http/managed` without requiring `re-frame.http.managed` (registered at ns-load in `implementation/http/src/re_frame/http/managed.cljc:195`), so a copy-paste hit `:rf.error/no-such-fx`. Added the require.
- The retry guard read the pre-action `:attempts` with `(< attempts 3)`, so failures 1–3 stayed `:error-shown` and the *fourth* locked out while discarding its error. Switched to a genuine three-total-attempt policy: guard `(< attempts 2)`, and the `:locked-out` fallback (failure and timeout alike) now runs a recording action so the terminal failure is counted. `:after` uses a guarded candidate list — the same value grammar as `:on`, pinned by `after_value_forms_test.clj:168-187` (`after-guarded-vector-fallback-target-and-action`).
- Verified the documented `login-flow` against the shipped `machine-transition` engine (JVM): fail1/fail2 → `:error-shown` (attempts 1, 2); fail3 → `:locked-out` (attempts 3, error recorded); timeout from attempts 2 → `:locked-out` (attempts 3, "Server took too long." recorded). Step 6 now asserts that terminal-record behaviour.

## rf2-t0ituo — restore handbook anchors; gate them
Restored all 20 dropped pre-PR heading IDs as invisible `<a id>` compatibility anchors on their intended pages (no visible-heading duplication), plus `guards-actions-tags-and-after--the-recognition-kit` for the `nine_states` / `websocket` example comments. All 13 `docs/machines/*.md#anchor` references embedded in example source now resolve entirely from the docs side — **no example source was edited**. Extended `scripts/check_doc_slugs.py` with a compatibility-anchor manifest (validates the anchors survive future reorgs — external bookmarks have no other guardrail) and a source-comment link gate (validates `docs/machines/*.md#anchor` refs in `examples/**`); both default-scope only, verified to have teeth.

The `t0ituo` "repair source-comment links" clause did **not** push me into `implementation/machines/` source: the only affected comments live under `examples/`, and restoring the docs-side anchors makes every one resolve without touching source. Nothing under the PR #6049 fence was modified.

## Quality gates
- `python scripts/check_doc_slugs.py` → exit 0
- `python scripts/check_doc_slugs.py --self-test` → exit 0 (all fixtures pass; new checks no-op on fixture repos)
- `python -m mkdocs build --strict` → exit 0 (no warnings)
- Shipped-engine verification of the tutorial `login-flow` (three-total policy, failure + timeout) → all assertions passed
