### PR TITLE
docs(api): correct lease/sequester contracts + enforce re-frame.ui page/member coverage (cluster)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,9 +1,11 @@
 # The re-frame2 API
 
 This is the **complete public API reference** for the ClojureScript implementation of
-re-frame2. One page per public namespace. Entries use a fixed shape: **Kind**,
+re-frame2. One page per public namespace. Entries use a consistent shape: **Kind**,
 **Signature**, **Description** (contract, including error ids where they are part of
-the surface), **Example**.
+the surface), and an **Example** where a call is worth showing. The Example is
+optional — many contract-only surfaces (compile-time template forms, symbol-resolution
+vars) carry no runnable call — so its absence is not a gap.
 
 For the mental model, start with the [Core guide](../core/introduction.md). This
 corpus is deliberately terse: it states *what* you may call, not *why* the design
@@ -17,7 +19,7 @@ chose it.
 | Compiled views (`defview`, `mount`, `sub`) | [`re-frame.ui`](re-frame.ui.md) |
 | Optional capabilities | machines, routing, resources, flows, schemas, HTTP, SSR |
 | Substrate adapters | `re-frame.adapter.{reagent,uix,helix}` — or `re-frame.ui/adapter` |
-| Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md) |
+| Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md), [`re-frame.ui.test`](re-frame.ui.test.md) (compiled-view substrate) |
 | Production timing | [`re-frame.performance`](re-frame.performance.md) |
 
 **Facade vs owning namespace.** Many optional features re-export registration verbs
@@ -34,7 +36,12 @@ tracks vars.
 **Completeness.** Public vars in the manifest with tiers `:front-porch`,
 `:advanced`, `:adapter`, or `:testing` under `re-frame.*` are expected to appear on
 these pages (or as an explicit facade pointer). Tooling and implementation tiers are
-out of scope here.
+out of scope here. This is **enforced**: the api-manifest `doc-api-check` reconciles
+every eligible manifest namespace against `docs/api/`, so an eligible namespace with
+no page — or an eligible var with no member heading (`### \`var\``, or a
+`#### \`var\`` facade-pointer entry on the owning/facade page) — turns the CI check
+red. A member heading may be written bare (`### \`sub\``) or namespace-qualified
+(`### \`re-frame.machines/machine-transition\``).
 
 ## Namespaces
 
@@ -68,6 +75,7 @@ out of scope here.
 | [re-frame.adapter.helix](re-frame.adapter.helix.md) | Helix substrate |
 | [re-frame.test-support](re-frame.test-support.md) | Fixtures, registrar snapshot, poll, sequester |
 | [re-frame.test-helpers](re-frame.test-helpers.md) | Hiccup walkers, testids |
+| [re-frame.ui.test](re-frame.ui.test.md) | Compiled-view test surface: headless render + find/attrs/text, mounted DOM |
 | [re-frame.performance](re-frame.performance.md) | Compile-time User-Timing flags |
 
 ## Require patterns

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -104,14 +104,25 @@ own registrations again.
   ```
 - **Description**: Remove **one** app namespace's registration row for
   `(kind, id)` from the live registrar **and** the provenance source store.
-  Returns the captured source-store descriptor, or `nil` when absent. Reinstate
-  with `reinstate-app-registration!`.
+  `kind` is the **registrar kind** the id was registered under — `:route` for
+  routes, `:event` for events, `:sub` for subscriptions, and so on. The `(kind,
+  id)` pair must match the live registration: a mismatched kind captures nothing,
+  returns `nil`, and leaves the row registered. Returns the captured source-store
+  descriptor, or `nil` when absent. Reinstate with `reinstate-app-registration!`.
 - **Example**:
   ```clojure
-  ;; At ns load, after requiring the app under test:
+  ;; At ns load, after requiring the app under test. A per-app not-found route
+  ;; registers under registrar kind :route (NOT :event) — pass the kind the id
+  ;; was registered under.
   (defonce !not-found
-    (ts/sequester-app-registration! :event :rf.route/not-found
+    (ts/sequester-app-registration! :route :rf.route/not-found
                                     "my.app.routes"))
+
+  ;; A non-nil return is the captured descriptor — proof the route row was found
+  ;; and removed (a nil would mean the (kind, id) matched nothing). Reinstate it
+  ;; when this suite must see its own :rf.route/not-found again, e.g. from a
+  ;; per-test :init-fn:
+  ;;   (ts/reinstate-app-registration! !not-found)
   ```
 
 ### `reinstate-app-registration!`

--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -106,9 +106,17 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 
 - **Kind**: function (compile-time authoring form)
 - **Signature**: `(lease descriptor)`
-- **Description**: Declares resource interest while the view is mounted/visible. Does
-  not return data and does not fetch; read status via `(sub [:rf/resource …])`.
-  Leading declaration form in a `defview` body. Direct calls fail loud.
+- **Description**: Declares a mounted/visible view's interest in a resource, as a
+  declaration in the `defview` body (a `nil` descriptor is an inactive declaration).
+  Returns **no data** and does **no render-time work** — the render site only records
+  the desired ownership in the immutable render capture; it never mints an owner,
+  fetches, or dispatches during render. After the view's **connected, visible
+  commit**, the passive resource reconciler queues `:rf.resource/ensure` under an
+  app-minted `[:lease …]` owner, which **loads when the cache requires it** (a fetch
+  is a downstream consequence of that ensure, not render-time work). It **releases**
+  on disconnect / hide / unmount by dispatching `:rf.resource/release-owner`. Read the
+  resource's status and data passively with `sub` — `(sub [:rf/resource …])`. See the
+  [Resource lifecycle](../resources/concepts.md). Direct calls fail loud.
 
 ### `frame`
 
@@ -147,6 +155,74 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 - **Description**: Runtime prop-map merge through the **same conversion rule table**
   as the compiler. Legal in a DOM element's props position only:
   `[:div (ui/spread base attrs)]`. Direct call → `:rf.error/ui-spread-outside-template`.
+
+### `spread-safe`
+
+- **Kind**: function (template interop form)
+- **Signature**: `(spread-safe owned caller)`
+- **Description**: The **literal safe-spread policy** — the one attr passthrough a
+  component library can forward onto an internal element without clobbering owned props
+  or forfeiting the controlled guarantee. `owned` is a **literal** map of the
+  component's own props (analysed like an element's props map, so a controlled owned
+  site — a literal `:value` / `:checked` co-present with a handler — retains the sync
+  door); `caller` is the runtime attr map forwarded from the consumer. The
+  compiler-visible deny law, enforced in **every** build (not dev-only): the
+  structural / controlled / identity keys `:key` `:ref` `:value` `:checked` and the
+  component's owned `:on-*` handlers may not appear in `caller` — a literal offender is
+  the compile error `:rf.ui.compile/spread-safe-owned-key`, a runtime offender throws
+  `:rf.error/ui-tree-malformed`. Everything else passes and converts per the 004B rule
+  table; owned props win any collision and `:class` composes (owned classes first).
+  General `spread` remains the visible-cost escape and still forfeits the sync door.
+  Legal only in a DOM / custom-element props position.
+- **Errors**: direct call → `:rf.error/ui-spread-outside-template`.
+
+### `event`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(event [e] body…)`
+- **Description**: Committed `:on-*` handler form for a DOM / custom-element site whose
+  body needs the live native event. The body runs when the callback fires; its result
+  is the **event vector to dispatch**, or `nil` to dispatch nothing (a filter). The
+  callback sees the view's **committed** values and dispatches to the **committed**
+  frame — the same per-site-stable, retarget-safe machinery a literal event vector
+  rides. At a compiler-proven controlled site (a literal `:value` / `:checked`
+  co-present with the handler on `:on-input` / `:on-change` / `:on-before-input`) a
+  synchronous `event` whose result is a vector rides the **one synchronous door**
+  alongside a literal-vector handler. Any synchronous result other than a vector or
+  `nil` is a loud runtime diagnostic.
+- **Errors**: direct call → `:rf.error/ui-tree-malformed`.
+- **Example**:
+  ```clojure
+  [:input {:value (sub [:draft])
+           :on-input (ui/event [e] [:draft/set (.. e -target -value)])}]
+  ```
+
+### `render-fn`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(render-fn [args…] template)`
+- **Description**: A **pure render callback** for an internal library seam. The body is
+  a template lexically visible at the consumer call site, so both emitters compile it
+  (closed grammar, no runtime hiccup); it renders from its arguments alone. A render-fn
+  value is legal in exactly two positions: a component call-site prop value
+  (`[list {:row (ui/render-fn [i x] …)}]`) and a `slot` argument; the library invokes
+  it through `slot`. A render-fn body is **pure render phase** — `sub` / `lease` /
+  `frame` are allowed, but `dispatch` / hooks / local state / effects inside are
+  compile errors (a stateful replacement part is a pure slot body that mounts a static
+  `defview`, which owns its state).
+- **Errors**: direct call → `:rf.error/ui-tree-malformed`.
+
+### `slot`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(slot render-fn-value arg…)`
+- **Description**: The compiler-owned **invocation** of a `render-fn` value at a
+  library seam. `render-fn-value` is a `render-fn` (inline or carried through a prop)
+  or `nil`; any other value is a loud didactic error (`:rf.error/ui-tree-malformed`).
+  `nil` renders nothing; a render-fn renders with the supplied args, and its output
+  participates in the surrounding children exactly like any other child. Legal only in
+  a child position.
+- **Errors**: direct call → `:rf.error/ui-tree-malformed`.
 
 ## Roots and mounting
 

--- a/docs/api/re-frame.ui.test.md
+++ b/docs/api/re-frame.ui.test.md
@@ -1,0 +1,195 @@
+# re-frame.ui.test
+
+`re-frame.ui.test` is the **testing surface of the compiled-view substrate**
+(`re-frame.ui`). It is dev/test only — nothing in a production bundle may
+`:require` it (the bundle-isolation gate enforces this).
+
+It has two tiers that share nothing:
+
+- **Tier 1 — headless structural render.** `render` runs the real compiled view
+  against a real frame **on the JVM** and returns the versioned public **structural
+  tree** (a plain map). `find` / `find-all` query it with a closed selector grammar;
+  `attrs` / `text` are the read projections. Handlers are event vectors as data, so
+  "what does this button do" is an equality check — no DOM, no click simulation, no
+  flake.
+- **Tier 3 — mounted DOM.** `with-root` owns one real React mount with total
+  teardown; `query` answers a native CSS selector against that mounted root.
+
+Handing a CSS string to `find`, a structural tree to `query`, or a DOM element to
+`attrs` / `text` is a typed error (`:rf.error/ui-test-tier-mismatch`) that points at
+the other tier.
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.ui.test :as ui.test])
+```
+
+Test frames are minted with the canonical `rf/make-frame` + `:initial-events` (seed
+via `[:rf/set-db {…}]`) — one frame-init grammar, shared with production. The
+events and subs a view touches must be `.cljc` (the standard re-frame discipline) so
+the JVM render can resolve them.
+
+## Tier 1 — headless structural render
+
+### `render`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (render root-or-view)
+  (render root-or-view opts) → structural-tree
+  ```
+- **Description**: Run the real compiled view against a real frame on the JVM and
+  return the versioned public **structural tree** (the top node, stamped
+  `:rf.ui/tree-version`). Accepts exactly two forms: a **view reference** (the
+  compile-resolved `defview` var/symbol — props ride `{:props …}`, a frame rides
+  `{:frame …}`), or a **literal root form** (the same root grammar `ui/mount` takes;
+  `{:props …}` is rejected because props live in the form). A **plan-bearing** root
+  form (a top-region `frame-root`) OWNS its frames: its plans preflight **fresh
+  isolated** test frames before the render and tear them down after, so `{:frame …}`
+  alongside it is rejected. `opts` are closed: `:frame`, `:props` (view-reference form
+  only), `:sub-overrides` (a map of query vector → value, the explicit JVM read door).
+  Without a frame, rendering proceeds frameless and any frame-scoped read raises
+  honestly. Tier-1 renders the JVM structural subset — no effects, no host ops; `sub`
+  is the one-shot headless read. Expanding this macro in a CLJS build is a didactic
+  compile error (the client emitter targets React directly; mounted CLJS tests use the
+  Tier-3 surface).
+- **Example**:
+  ```clojure
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})
+        tree  (ui.test/render [product-card {:product p}] {:frame frame})]
+    (is (= [:cart/add 42]
+           (-> tree (ui.test/find :button) ui.test/attrs :on-click)))
+    (is (= "Add to cart"
+           (-> tree (ui.test/find :button) ui.test/text))))
+  ```
+
+### `find`
+
+- **Kind**: function
+- **Signature**: `(find tree selector) → node | nil`
+- **Description**: The **first** node of `tree` matching `selector`, in depth-first
+  pre-order (document order) — the tree node itself is tested first, then its
+  descendants. Returns the structural node (itself a valid `tree` argument, so finds
+  compose), or `nil` on no match (idiomatic nil-punning threads through). The closed
+  selector grammar: an **unqualified keyword** (element tag, exact), a **qualified
+  keyword** or **`defview` var** (view boundary), an **attr map** (each entry present
+  and `rf=` to the expected value in the attrs projection; events match by vector), or
+  a **pred fn** (the escape; receives map nodes). A CSS string, a vector selector, or
+  any other value is a typed error naming the alternative.
+- **Example**:
+  ```clojure
+  ;; compose finds to scope a query:
+  (-> tree (ui.test/find :form) (ui.test/find :button))
+  ```
+
+### `find-all`
+
+- **Kind**: function
+- **Signature**: `(find-all tree selector) → [node …]`
+- **Description**: **All** nodes of `tree` matching `selector`, as a vector in
+  document order (possibly empty — `[]` on no match). Same closed selector grammar as
+  `find`.
+
+### `attrs`
+
+- **Kind**: function
+- **Signature**: `(attrs node) → map | nil`
+- **Description**: The **merged attribute projection** of a structural node — the one
+  attribute read (a keyword lookup on a node reads its FIELDS, never its attributes).
+  For an **element**, `:attrs` merged with `:events` (collision-free by construction —
+  the compiler routes `:on-*` to `:events`; handler slots carry event vectors / option
+  maps / opaque markers **as data**). For a **view boundary**, the `:props` map. For a
+  **fragment / html** node, `{}` (total, not an error). `nil` → `nil` (threads through
+  a missed `find`). Intent assertion is an equality check on the projected handler.
+- **Example**:
+  ```clojure
+  (is (= [:cart/add 42]
+         (:on-click (ui.test/attrs (ui.test/find tree :button)))))
+  ```
+
+### `text`
+
+- **Kind**: function
+- **Signature**: `(text node) → string | nil`
+- **Description**: The concatenation of `node`'s text descendants in document order —
+  descending through elements, fragments, and view boundaries alike. Trusted-HTML
+  nodes contribute nothing (their content is unparsed markup). No whitespace
+  normalization beyond what the tree carries. `nil` → `nil` (nil-punning).
+
+## Tier 3 — mounted DOM
+
+### `with-root`
+
+- **Kind**: macro
+- **Signature**: `(with-root [root root-form] body…) → js/Promise`
+- **Description**: Mount the **literal** `root-form` into a connected, test-owned DOM
+  container, await the initial commit, invoke/await `body` with its opaque mounted
+  `root`, then await teardown of the React root and container on **every** exit.
+  Browser / jsdom only (a JVM expansion is a tier-mismatch error). The root form is
+  compiled by the same analyzer/emitter as `ui/render!`; each invocation mints a
+  private runtime root identity, so concurrent calls cannot collide or claim an
+  application's authored roots. Cleanup never masks a primary mount/body failure; a
+  secondary cleanup failure rides the primary rejection as `rfUiTestCleanupError`.
+  Await the returned Promise before asserting or starting another mounted operation.
+- **Example**:
+  ```clojure
+  (ui.test/with-root [root [ui/frame-root {:id :app :initial-events [[:app/init]]}
+                            [counter]]]
+    (-> (ui.test/flush! #(ui.test/dispatch! :app [:count/inc]))
+        (.then (fn [] (is (= "1" (.-textContent (ui.test/query root ".count"))))))))
+  ```
+
+### `query`
+
+- **Kind**: function
+- **Signature**: `(query root css-selector) → js/Element | nil`
+- **Description**: The Tier-3 live-DOM counterpart of `find`: a **mounted** root (from
+  `with-root`) + a **native CSS selector string**, answered by the host DOM's
+  `querySelector`. It shares nothing with the Tier-1 grammar — no `rf=` matching, no
+  structural projections, no view-id selectors; CSS is the whole contract. `root` must
+  be the live opaque value bound by `with-root`; the selector must be a string. A miss
+  returns `nil`, exactly like `querySelector`. Handing it a structural tree is a
+  tier-mismatch error pointing at `find`.
+
+## Driving state and draining work
+
+### `dispatch!`
+
+- **Kind**: function
+- **Signature**: `(dispatch! frame-target event) → nil`
+- **Description**: Real dispatch + drain into `frame-target` (a frame value or id):
+  processes `event` synchronously end-to-end, then drains any synchronously-enqueued
+  events to fixed point. Drive state with real events, re-render, and assert on the new
+  tree — no click simulation. Under a mounted (Tier-3) root, wrap it in `flush!` so the
+  React commit settles before you assert.
+
+### `flush!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  ;; JVM (Tier 1): synchronous
+  (flush!) → nil
+  ;; CLJS (Tier 3): Promise-backed
+  (flush!) → js/Promise
+  (flush! thunk) → js/Promise
+  ```
+- **Description**: Drain framework work to quiescence. On the **JVM** it synchronously
+  drains the host-agnostic ViewCell registry (there is no React tree to settle) and
+  returns `nil`. On **CLJS** it returns a Promise: the optional `thunk` runs inside
+  awaited React 19 `act`, then framework notifications and React commits alternate to a
+  fixed point — await the Promise before asserting or beginning another mounted
+  operation. Both paths are bounded by the shared convergence budget: a registry that
+  never quiesces fails loud with `:rf.error/flush-convergence-exceeded` rather than
+  spinning. Calling it inside an open event drain throws `:rf.error/flush-in-open-epoch`
+  (CLJS) / fails the shared open-drain guard.
+
+## See also
+
+- [`re-frame.ui`](re-frame.ui.md) — the compiled-view substrate under test (`defview`,
+  `mount`, `sub`, `frame-root`).
+- [`re-frame.test-support`](re-frame.test-support.md) — the runtime-state testing
+  surface (fixtures, registrar snapshot, `dispatch-sync`, `poll-until`).
+- [`re-frame.test-helpers`](re-frame.test-helpers.md) — the hiccup-tree assertion
+  helpers for the interpreted (non-compiled) substrates.

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -50,8 +50,27 @@
   KEYWORD-DRIFT GUARDS. The EP-0017 / EP-0011 / EP-0015 keyword-drift guards
   (`projection/keyword-drift-problems-over-files`) are folded in over the same
   scanned files — `spec/Privacy.md` is the EP-0015 privacy surface, so a
-  reintroduced retired `:rf.egress/*` profile keyword goes RED here too."
-  (:require [re-frame.api-manifest.gen :as gen]
+  reintroduced retired `:rf.egress/*` profile keyword goes RED here too.
+
+  PAGE + MEMBER COVERAGE (rf2-e5692s). The call-position discipline above
+  catches a docs/api/ reference to a REMOVED surface, but it cannot catch the
+  opposite drift: a public var the manifest carries that NO page documents
+  (docs/api/README.md promises one page per public namespace and an entry per
+  eligible var, yet nothing enforced it — `re-frame.ui.test`'s testing surface
+  and four `re-frame.ui` vars had no page/member entry). `check-coverage!`
+  reconciles the manifest AGAINST the corpus: every manifest var at an
+  ELIGIBLE tier (`:front-porch` / `:advanced` / `:adapter` / `:testing`, per
+  the README completeness clause) must have a `docs/api/<namespace>.md` page
+  and a member heading on it. A member heading is any `##`-`####` whose text is
+  one back-ticked identifier, reduced to its final `/`-segment — so a bare
+  `### \\`sub\\``, a namespace-qualified `### \\`re-frame.machines/x\\``, and a
+  facade-pointer `#### \\`reg-machine\\`` on the owning/facade page all count.
+  Deleting an eligible namespace's page (PAGE-MISSING) or a member's heading
+  (MEMBER-MISSING) turns this RED. The `:doc-api-coverage-exempt` sidecar key
+  (a set of `[namespace var]` pairs, empty/absent today) is the explicit escape
+  hatch for a var intentionally documented only as a facade pointer elsewhere."
+  (:require [clojure.string :as str]
+            [re-frame.api-manifest.gen :as gen]
             [re-frame.api-manifest.projection :as proj]))
 
 ;; The reference trees scanned. Each is an EXPECTED surface (it exists today
@@ -118,6 +137,132 @@
         ref   (proj/alias-call-references alias (proj/numbered-lines file))]
     (assoc ref :file (proj/repo-relative file))))
 
+;; ---------------------------------------------------------------------------
+;; Page + member coverage (rf2-e5692s).
+;; ---------------------------------------------------------------------------
+
+(def ^:private eligible-tiers
+  "The tiers docs/api/ is expected to document (README completeness clause).
+   `:tooling`, `:implementation`, `:internal-public`, and `:deprecated` are out
+   of scope for the human API reference."
+  #{:front-porch :advanced :adapter :testing})
+
+(def ^:private coverage-min-rows
+  "Non-vacuous floor (rf2-utvst-style) for the coverage reconciler. The manifest
+   carries ~180 eligible-tier rows today; this floor sits well below that, so it
+   trips ONLY if the committed manifest itself collapsed (which the primary
+   `gen --check` also catches) — never on ordinary corpus churn. Below the floor
+   the coverage check refuses a vacuous OK."
+  100)
+
+(defn- member-heading-names
+  "The set of bare member-var names a docs/api page documents: every markdown
+   heading (`##`-`####`) whose text is exactly ONE back-ticked identifier,
+   reduced to its final `/`-separated segment. So a bare `### \\`sub\\``, an
+   owning-namespace-qualified `### \\`re-frame.machines/machine-transition\\``,
+   and a facade-pointer `#### \\`reg-machine\\`` all cover their bare var name."
+  [^java.io.File file]
+  (into #{}
+        (keep (fn [[_ line]]
+                (when-let [[_ ident] (re-matches #"#{2,4}\s+`([^`]+)`.*"
+                                                 (str/trim line))]
+                  (last (str/split ident #"/")))))
+        (proj/numbered-lines file)))
+
+(defn- page-members
+  "`{namespace-str -> #{covered-bare-var-name ...}}` for each namespace in
+   `namespaces` whose `docs/api/<namespace>.md` EXISTS. A namespace ABSENT from
+   the returned map has no page (→ a PAGE-MISSING problem downstream)."
+  [namespaces]
+  (reduce (fn [acc ns-str]
+            (let [f (proj/repo-file "docs" "api" (str ns-str ".md"))]
+              (if (.isFile ^java.io.File f)
+                (assoc acc ns-str (member-heading-names f))
+                acc)))
+          {} namespaces))
+
+(defn coverage-problems
+  "Pure coverage reconciler (extracted so the page/member contract is
+   unit-testable with synthetic inputs). Returns the seq of problem maps.
+
+   `eligible-rows` — `[{:namespace :var} ...]` (already filtered to eligible tiers).
+   `members`       — `{namespace-str -> #{covered-var-name}}`; a namespace absent
+                     from this map has NO docs/api page.
+   `exempt`        — `#{[namespace-str var-str] ...}` explicit facade-pointer
+                     exemptions (the `:doc-api-coverage-exempt` sidecar key).
+
+   A namespace carrying eligible vars but no page yields ONE `:page-missing`
+   problem (the page problem subsumes its members). Otherwise each eligible var
+   with neither a covering member heading nor an exempt entry yields a
+   `:member-missing` problem."
+  [{:keys [eligible-rows members exempt]}]
+  (mapcat
+    (fn [[ns-str rows]]
+      (if-not (contains? members ns-str)
+        [{:kind :page-missing :namespace ns-str}]
+        (let [covered (get members ns-str)]
+          (keep (fn [{:keys [var]}]
+                  (when-not (or (contains? covered var)
+                                (contains? exempt [ns-str var]))
+                    {:kind :member-missing :namespace ns-str :var var}))
+                rows))))
+    (sort-by key (group-by :namespace eligible-rows))))
+
+(defn- report-coverage!
+  "Print a uniform OK/DRIFT report for the coverage reconciler and return the
+   boolean verdict. Enforces the non-vacuous floor before trusting an empty
+   problem list."
+  [problems eligible-count]
+  (cond
+    (< eligible-count coverage-min-rows)
+    (do (binding [*out* *err*]
+          (println (format (str "DRIFT: docs/api coverage extracted only %d eligible "
+                                 "manifest rows, below the non-vacuous floor of %d — "
+                                 "the committed manifest likely collapsed. Investigate "
+                                 "before trusting GREEN (regenerate the manifest).")
+                           eligible-count coverage-min-rows)))
+        false)
+
+    (empty? problems)
+    (do (println (format (str "OK: docs/api page+member coverage in sync (%d eligible "
+                              "manifest vars each have a page + member entry).")
+                         eligible-count))
+        true)
+
+    :else
+    (do (binding [*out* *err*]
+          (println "DRIFT: docs/api is missing required namespace pages or member entries.")
+          (println "Every eligible manifest var (tier :front-porch/:advanced/:adapter/:testing")
+          (println "under re-frame.*) needs a docs/api/<namespace>.md page AND a member heading")
+          (println "(### `var`, or a #### `var` facade-pointer entry on the owning/facade page).")
+          (println "Add the page/heading, or an explicit :doc-api-coverage-exempt sidecar entry")
+          (println "for a var documented only as a facade pointer elsewhere. Problems:")
+          (doseq [{:keys [kind namespace var]} (sort-by (juxt :namespace :var) problems)]
+            (case kind
+              :page-missing
+              (println (format "  PAGE:   docs/api/%s.md is missing (its namespace has eligible manifest vars)"
+                               namespace))
+              :member-missing
+              (println (format "  MEMBER: %s/%s has no member heading on docs/api/%s.md"
+                               namespace var namespace)))))
+        false)))
+
+(defn check-coverage!
+  "Reconcile every eligible manifest var against docs/api/ page + member
+   coverage. Returns true when every eligible namespace has a page and every
+   eligible var has a member heading (or an explicit facade-pointer exemption);
+   false (with a printed report) otherwise."
+  []
+  (let [rows          (proj/manifest-rows)
+        eligible-rows (filter #(contains? eligible-tiers (:tier %)) rows)
+        namespaces    (distinct (map :namespace eligible-rows))
+        members       (page-members namespaces)
+        exempt        (set (:doc-api-coverage-exempt (gen/read-sidecar)))
+        problems      (coverage-problems {:eligible-rows eligible-rows
+                                          :members       members
+                                          :exempt        exempt})]
+    (report-coverage! problems (count eligible-rows))))
+
 (defn check!
   []
   (let [rows          (proj/manifest-rows)
@@ -151,10 +296,16 @@
         ;; the EP-0015 surface, so a reintroduced retired `:rf.egress/*`
         ;; profile keyword goes RED here alongside any var-resolution drift.
         kw-problems   (proj/keyword-drift-problems-over-files files)
-        problems      (concat var-problems kw-problems)]
-    (proj/report-with-floor!
-      "spec/Privacy.md + docs/api/ + docs/story/api/"
-      (count references) min-references problems)))
+        problems      (concat var-problems kw-problems)
+        ;; (1) Call-position reference discipline + keyword-drift over the
+        ;; reference trees (the original rf2-vzupmg contract).
+        refs-ok       (proj/report-with-floor!
+                        "spec/Privacy.md + docs/api/ + docs/story/api/"
+                        (count references) min-references problems)
+        ;; (2) Page + member coverage of the manifest by docs/api/ (rf2-e5692s).
+        ;; Both reports print; the check is RED if EITHER fails.
+        coverage-ok   (check-coverage!)]
+    (and refs-ok coverage-ok)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
@@ -85,3 +85,65 @@
     (let [scoped (:doc-api-known-unmanifested-scoped (gen/read-sidecar))]
       (is (map? scoped)
           "the scoped allowlist must be a {name -> #{files}} map"))))
+
+;; ---------------------------------------------------------------------------
+;; Page + member coverage reconciler (rf2-e5692s).
+;; ---------------------------------------------------------------------------
+
+(def ^:private cov-rows
+  ;; Synthetic eligible manifest rows spanning two namespaces.
+  [{:namespace "re-frame.ui"      :var "defview"}
+   {:namespace "re-frame.ui"      :var "sub"}
+   {:namespace "re-frame.ui.test" :var "render"}
+   {:namespace "re-frame.ui.test" :var "find"}])
+
+(deftest coverage-clean-when-every-eligible-var-has-a-member
+  (testing "a namespace with a page whose member set covers every eligible var
+            (bare or ns-qualified, both reduced to the bare name) reconciles clean"
+    (is (empty? (c/coverage-problems
+                  {:eligible-rows cov-rows
+                   :members {"re-frame.ui"      #{"defview" "sub"}
+                             "re-frame.ui.test" #{"render" "find"}}
+                   :exempt #{}})))))
+
+(deftest coverage-flags-a-namespace-with-no-page
+  (testing "an eligible namespace ABSENT from the members map (no docs/api page)
+            yields ONE :page-missing problem that subsumes its members"
+    (let [probs (c/coverage-problems
+                  {:eligible-rows cov-rows
+                   :members {"re-frame.ui" #{"defview" "sub"}} ; ui.test page absent
+                   :exempt #{}})]
+      (is (= [{:kind :page-missing :namespace "re-frame.ui.test"}] probs)))))
+
+(deftest coverage-flags-a-member-whose-heading-was-removed
+  (testing "deleting a member's heading (an eligible var not in its page's member
+            set) turns the check RED — the teeth proof"
+    (let [probs (c/coverage-problems
+                  {:eligible-rows cov-rows
+                   :members {"re-frame.ui"      #{"defview"} ; `sub` heading removed
+                             "re-frame.ui.test" #{"render" "find"}}
+                   :exempt #{}})]
+      (is (= [{:kind :member-missing :namespace "re-frame.ui" :var "sub"}] probs)))))
+
+(deftest coverage-exempt-silences-a-facade-pointer-member
+  (testing "an explicit :doc-api-coverage-exempt [namespace var] pair silences a
+            member that is intentionally documented only as a facade pointer"
+    (is (empty? (c/coverage-problems
+                  {:eligible-rows cov-rows
+                   :members {"re-frame.ui"      #{"defview"}
+                             "re-frame.ui.test" #{"render" "find"}}
+                   :exempt #{["re-frame.ui" "sub"]}})))))
+
+(deftest live-doc-api-coverage-reconciles-clean
+  (testing "the committed manifest reconciles against docs/api/ with full page +
+            member coverage (the CI contract — every eligible var has a page and
+            a member heading)"
+    (is (true? (c/check-coverage!))
+        "live coverage drift: an eligible manifest var has no docs/api page or member heading")))
+
+(deftest coverage-exempt-sidecar-key-defaults-empty
+  (testing "the coverage-exempt sidecar key, when present, is a collection of
+            [namespace var] pairs (absent today → the checker defaults to #{})"
+    (let [exempt (:doc-api-coverage-exempt (gen/read-sidecar))]
+      (is (or (nil? exempt) (coll? exempt))
+          "the coverage-exempt allowlist must be a collection of [ns var] pairs (or absent)"))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
     - "re-frame.adapter.helix": api/re-frame.adapter.helix.md
     - "re-frame.test-support": api/re-frame.test-support.md
     - "re-frame.test-helpers": api/re-frame.test-helpers.md
+    - "re-frame.ui.test": api/re-frame.ui.test.md
 
   - Machines:
     # Landing routes; tutorial first (build), then the flat model, then


### PR DESCRIPTION
Cluster of two API-reference beads. `docs/api/*.md` are hand-authored (verified: only `spec/api-manifest.edn` is generator-written), so the corrections are hand-edits; the coverage gate extends the existing `doc-api-check`.

## rf2-kcd05e — Correct lease and sequester contracts

**sequester (`docs/api/re-frame.test-support.md`).** The example called `sequester-app-registration!` with kind `:event` for `:rf.route/not-found`. Routes register under registrar kind `:route` (`implementation/routing/src/re_frame/routing/registry.cljc:564` — `registrar/register! :route id meta'`), and the fn looks up `[kind id provenance-ns]` (`implementation/core/src/re_frame/test_support.cljc:185`), so the `:event` call matches nothing, returns `nil`, and leaves the route registered. Every shipped consumer uses `:route` (e.g. `realworld_cljs_test.cljs:139`). Corrected the example to `:route`, noted a non-nil return is proof the row was captured+removed, and clarified `kind` is the registrar kind.

**lease (`docs/api/re-frame.ui.md`).** Said lease "does not fetch". A connected committed lease queues `:rf.resource/ensure` (`implementation/ui/src/re_frame/ui/reactive.cljc:1942-1958`) under an app-minted `[:lease …]` owner, which loads when the cache requires it; the mounted lifecycle test observes one ensure at `:connected` mount (`implementation/ui/test/re_frame/ui/resource_lease_lifecycle_dom_cljs_test.cljs`). Rewrote to the accurate distinction — no returned data, no render-time work, ensure after connected visible commit (loading when required), release on disconnect/hide/unmount (`:rf.resource/release-owner`) — linking the Resource lifecycle and keeping `sub` as the passive read.

## rf2-e5692s — Enforce API page + member coverage for re-frame.ui surfaces

README promised one page per public namespace + an entry per eligible var, but `re-frame.ui.test` (9 vars) had no page and `re-frame.ui` was missing `event`, `render-fn`, `slot`, `spread-safe`; nothing enforced it.

- Added `docs/api/re-frame.ui.test.md` (9 members) + README + mkdocs nav.
- Added the four missing `re-frame.ui` member entries.
- Relaxed the README fixed-shape claim so the Example field is honestly optional (13 existing entries already omit it).
- Extended the existing `doc-api-check` with a manifest→page/member reconciler (`check-coverage!`): every eligible-tier var (`:front-porch`/`:advanced`/`:adapter`/`:testing`) needs a `docs/api/<ns>.md` page and a member heading (bare `### \`var\``, ns-qualified, or a `#### \`var\`` facade-pointer entry). Folded into `check!` so the existing `lint.yml` `doc-api-check` step enforces it — no workflow change. `:doc-api-coverage-exempt` sidecar key (default empty) is the explicit facade-pointer escape hatch. No hot-zone `spec/` file touched.

## Quality gates

Run from `implementation/scripts/api-manifest/` (JVM) and repo root (docs):

- `clojure -M -m re-frame.api-manifest.gen --check` → OK (498 public vars)
- `clojure -M -m re-frame.api-manifest.doc-api-check` → OK (312 references; 183 eligible vars each have a page + member entry)
- `clojure -M -m re-frame.api-manifest.api-md-check` → OK (214 var-rows)
- `clojure -M:test` (reconciler regression + new coverage tests) → 59 tests, 111 assertions, 0 failures, 0 errors
- `python scripts/check_doc_slugs.py` → exit 0
- `python -m mkdocs build --strict` → exit 0
- **Coverage teeth (live):** renaming a member heading (`### \`find\`` → broken) turned `doc-api-check` red (exit 1) naming `re-frame.ui.test/find`; restored to green. Pinned by unit tests `coverage-flags-a-namespace-with-no-page`, `coverage-flags-a-member-whose-heading-was-removed`, `coverage-exempt-silences-a-facade-pointer-member`.