### PR TITLE
fix(http): make managed-request stubs work inside pre-created sealed frames (rf2-bxc8kf)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -199,6 +199,52 @@
                 "the real :rf.http/managed fx was NEVER invoked — the helper
                  intercepted (pre-fix: this fired the real Fetch transport)")))))))
 
+;; ---- 6b. rf2-bxc8kf — stubs work inside a PRE-CREATED SEALED frame ---------
+;;
+;; CLJS counterpart of the JVM sealed-frame regression. `rf/make-frame {}`
+;; resolves + SEALS an image generation at construction; a dispatch into that
+;; frame value resolves `(kind, id)` through the frame's OWN sealed generation,
+;; NOT the global registrar. Pre-fix, `with-managed-request-stubs*` minted a
+;; fresh `:rf.test/managed-http-stub-<n>` fx-id and registered it INSIDE the
+;; scope — AFTER the frame had sealed — so the bound override redirected to an
+;; fx-id the sealed generation could not resolve, and the bare dispatch reached
+;; the real Fetch transport. The fix registers ONE stable override target at
+;; ns-load (in the sealed generation of every frame created after the require)
+;; and carries the per-scope route map on the `*scope-stubs*` dynamic var. A
+;; sentinel shadows `:rf.http/managed` — reaching it proves the override was
+;; absent. The dispatch targets the frame VALUE explicitly (`{:frame f}`), so
+;; the sealed-generation resolution path is exercised.
+
+(deftest stubs-intercept-inside-pre-created-sealed-frame-cljs-rf2-bxc8kf
+  (testing "rf2-bxc8kf — inside with-managed-request-stubs*, a dispatch-sync into
+            a PRE-CREATED sealed make-frame {} frame routes through the stub and
+            NEVER invokes the real :rf.http/managed transport"
+    (let [real-fx-invoked? (atom false)]
+      (fx/reg-fx :rf.http/managed
+                 (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
+      (rf/reg-event :bxc8kf/load
+        (fn [{:keys [db]} [_ msg reply]]
+          (if reply
+            {:db (assoc db :result reply)}
+            {:fx [[:rf.http/managed
+                   {:reply-to [:bxc8kf/load msg] :request {:method :get :url "/x"}
+                    :decode  :json}]]})))
+      ;; SEAL a generation at construction, THEN enter the stub scope.
+      (let [f (rf/make-frame {})]
+        (rf/with-managed-request-stubs*
+          {[:get "/x"] {:reply {:ok {:stubbed true}}}}
+          (fn []
+            (rf/dispatch-sync [:bxc8kf/load] {:frame f})
+            (let [db (rf/app-db-value f)]
+              (is (= :ok (get-in db [:result :status]))
+                  "the stubbed reply landed via the load-time-registered scope stub")
+              (is (= {:stubbed true} (get-in db [:result :value]))
+                  "the configured :ok value rode through the synthesised reply")
+              (is (false? @real-fx-invoked?)
+                  "the real :rf.http/managed fx was NEVER invoked in the sealed
+                   frame (pre-fix: the minted per-scope stub was unresolvable in
+                   the sealed generation, so this fired the real Fetch transport)"))))))))
+
 ;; ---- 7. with-managed-request-stubs* — failure mapping --------------------
 
 (deftest with-managed-request-stubs-failure-cljs

--- a/implementation/core/test/re_frame/fx_redirect_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/fx_redirect_classification_cljs_test.cljc
@@ -104,9 +104,9 @@
 (deftest redirected-managed-honours-dynamic-sensitive-flag
   (testing "the rf2-2siusz scenario shape: a :sensitive? true managed args map
             on a redirected stub's handled slot redacts through the ORIGINAL
-            :rf.http/managed id's DYNAMIC classification (the stub id — here a
-            per-scope minted :rf.test/* id — is unregistered and matches no
-            dynamic case)"
+            :rf.http/managed id's DYNAMIC classification (the stub id — an
+            unregistered :rf.test/* id here — matches no dynamic case, so the
+            :rf.fx/from :rf.http/managed provenance is what classifies)"
     (let [t (project {:operation :rf.fx/handled
                       :tags {:frame      :rf/default
                              :rf.fx/id   :rf.test/managed-http-stub-1

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -500,65 +500,116 @@
       (fx/clear-fx stub-fx-id)))
   nil)
 
-;; rf2-vn8qjv (issue 2) — `with-managed-request-stubs*` allocates a UNIQUE
-;; override fx-id per scope so nested scopes compose. The lower-level
-;; install/uninstall surface above keys off the single stable id (the
-;; documented `:fx-overrides` target); the scoped wrapper instead mints a
-;; fresh fx-id per invocation and binds the override to THAT id. An outer
-;; scope's fx and override therefore stay live and correctly-routed while a
-;; fully-nested inner scope installs, runs, and tears down its own distinct
-;; fx — no clobber, no order-dependence.
-(defonce ^:private scope-stub-counter (atom 0))
+;; rf2-bxc8kf — the scoped wrapper's override target is registered at
+;; NAMESPACE-LOAD time (below), NOT minted per scope, so it is present in the
+;; SEALED image generation of every frame created after this ns is required.
+;;
+;; The prior design (rf2-vn8qjv) minted a fresh `:rf.test/managed-http-stub-<n>`
+;; fx-id per invocation and registered it INSIDE `with-managed-request-stubs*`.
+;; That registration happened AFTER a pre-created frame had already sealed its
+;; image generation: `make-frame {}` resolves + seals a generation at
+;; construction, and a no-id/direct frame is deliberately EXCLUDED from `reg-*`
+;; auto-reprojection (`re-frame.frame/image-loaded-frame-ids` drops the reserved
+;; `:rf.frame/<gensym>` ids). So the bound `{:rf.http/managed <scope-id>}`
+;; override redirected to an fx-id the sealed generation could NOT resolve
+;; (`registrar/lookup` routes through the frame's generation, not the global
+;; registrar): the redirect fell through (`:rf.error/override-fallthrough`) and
+;; the REAL `:rf.http/managed` transport ran. The exact tutorial nesting
+;; `(with-new-frame [f (make-frame {})]
+;;    (with-managed-request-stubs … (dispatch-sync …)))`
+;; therefore escaped to the wire.
+;;
+;; The fix keeps ONE stable override target registered at load time — the same
+;; explicit-test-support-require gate the canned-stub fxs already ride — so it
+;; lands in the sealed generation of every frame created after this ns is
+;; required. The per-scope route map is carried by the dynamic var
+;; `*scope-stubs*` instead of by a per-scope fx-id: an inner scope's binding
+;; SHADOWS the outer's for its dynamic extent and restores it on exit, so nested
+;; scopes compose EXACTLY as the minted-id design did — an inner-scope dispatch
+;; keys off the inner route map; after the inner scope exits an outer-scope
+;; dispatch keys off the outer route map again — WITHOUT a per-scope registrar
+;; write the sealed generation cannot see. The lower-level install/uninstall
+;; surface above keeps its own separate stable `:rf.http/managed-test-stub` id
+;; (the documented hardcodable `:fx-overrides` target).
 
-(defn- next-scope-stub-id
-  "Mint a process-unique `:rf.test/managed-http-stub-<n>` fx-id for one
-  `with-managed-request-stubs*` scope. The id lives under the reserved
-  test-runner-internal `:rf.test/*` fx-stub family (Conventions §Reserved
-  namespaces) — NOT the fixed-and-additive `:rf.http/*` reserved namespace,
+(def ^:private ^:dynamic *scope-stubs*
+  "The route map (`{[method url] {:reply …}}`) the load-time scope-stub fx
+  (`scope-stub-fx-id`) consults for the current `with-managed-request-stubs*`
+  dynamic extent, or `::no-scope` outside any scope (rf2-bxc8kf). Bound —
+  SHADOWED for nesting — by `with-managed-request-stubs*`; read by the
+  `scope-stub-fx-id` handler. The override that routes to `scope-stub-fx-id` is
+  only ever bound ALONGSIDE this var, so `::no-scope` at fire time is a wiring
+  error (the internal target reached without the wrapper) — the handler fails
+  loud rather than synthesising a reply against a non-map route table."
+  ::no-scope)
+
+(def ^:private scope-stub-fx-id
+  "The STABLE `with-managed-request-stubs*` override target (rf2-bxc8kf).
+  Registered at ns-load (below), so it is resolvable through the SEALED image
+  generation of a frame created before the scope was entered. Lives under the
+  reserved test-runner-internal `:rf.test/*` fx-stub family (Conventions
+  §Reserved namespaces) — NOT the fixed-and-additive `:rf.http/*` namespace,
   whose member set is closed by Spec change and must never be minted into at
-  runtime. (The stable, documented `:fx-overrides` target keeps its own
-  `:rf.http/managed-test-stub` id; only this per-scope variant is minted.)"
-  []
-  (keyword "rf.test" (str "managed-http-stub-" (swap! scope-stub-counter inc))))
+  runtime."
+  :rf.test/managed-http-scope-stub)
+
+;; Registered at LOAD time (rf2-bxc8kf) alongside the canned-stub fxs — the same
+;; explicit-`re-frame.http.test-support`-require gate. The handler reads the
+;; current scope's route map from `*scope-stubs*` and delegates to the shared
+;; `stub-handler` (which runs the `:before` chain, keys the match off the
+;; post-`:before` url, and emits through the `:after` chain).
+(fx/reg-fx scope-stub-fx-id
+           {:doc "with-managed-request-stubs (scoped) synthesised stub — reads the
+                  current scope's route map from `*scope-stubs*` (rf2-bxc8kf).
+                  Registered at load time so a pre-created SEALED frame can
+                  resolve it as an `:fx-overrides` redirect target."}
+           (fn [frame-ctx args-map]
+             (when (= *scope-stubs* ::no-scope)
+               (throw (ex-info
+                        (str "`:rf.test/managed-http-scope-stub` fired outside a "
+                             "`with-managed-request-stubs` scope — this internal fx "
+                             "id is the wrapper's override target and must not be "
+                             "used as an `:fx-overrides` value directly. Wrap the "
+                             "dispatch in `with-managed-request-stubs` / "
+                             "`with-managed-request-stubs*` (or use the stable "
+                             "`:rf.http/managed-test-stub` id with "
+                             "`install-managed-request-stubs!`).")
+                        {:rf.fx/id scope-stub-fx-id})))
+             (stub-handler *scope-stubs* frame-ctx args-map)))
 
 (defn with-managed-request-stubs*
   "Function form: install stubs, route `:rf.http/managed` through them for
-  the dynamic extent of `thunk`, run `thunk`, then uninstall. Test-time
-  helper.
+  the dynamic extent of `thunk`, run `thunk`. Test-time helper.
 
-  `stubs` is `{[method url] {:reply <:ok|:failure>}}`. The wrapper mints a
-  process-unique stub fx-id for THIS scope (rf2-vn8qjv), registers the
-  route-map-consulting stub under it, and binds the lexical-scope
-  fx-override `{:rf.http/managed <scope-stub-id>}`
-  (`re-frame.router/*fx-overrides*`, the public `rf/with-fx-overrides`
-  seam) for the thunk's dynamic extent. So every `dispatch-sync` inside
-  the body auto-routes by `:request :method` + `:request :url` with NO
-  per-call `:fx-overrides` — matching the documented contract (Spec 014
-  §Testing). A dispatch that deliberately supplies its OWN `:fx-overrides`
-  still wins: the router merges the lexical default UNDER the per-call opt
-  (per-call > lexical > per-frame).
+  `stubs` is `{[method url] {:reply <:ok|:failure>}}`. The wrapper binds the
+  route map onto the dynamic var `*scope-stubs*` and binds the lexical-scope
+  fx-override `{:rf.http/managed <scope-stub-fx-id>}`
+  (`re-frame.router/*fx-overrides*`, the public `rf/with-fx-overrides` seam)
+  for the thunk's dynamic extent. `scope-stub-fx-id` is registered at ns-load
+  (rf2-bxc8kf), so it is resolvable through the SEALED image generation of a
+  frame created BEFORE the scope was entered — the exact tutorial nesting
+  `(with-new-frame [f (make-frame {})] (with-managed-request-stubs … …))` routes
+  through the stub instead of escaping to the real transport. Every
+  `dispatch-sync` inside the body auto-routes by `:request :method` +
+  `:request :url` with NO per-call `:fx-overrides` — matching the documented
+  contract (Spec 014 §Testing). A dispatch that deliberately supplies its OWN
+  `:fx-overrides` still wins: the router merges the lexical default UNDER the
+  per-call opt (per-call > lexical > per-frame).
 
-  Nesting composes: because each scope owns a distinct fx-id, an inner
-  `with-managed-request-stubs*` registers and tears down ITS id without
-  touching the outer scope's still-live fx + override. After the inner
-  scope exits, an outer-scope dispatch still routes to the outer stub."
+  Nesting composes: the stable override target reads the current scope's route
+  map from `*scope-stubs*`, and an inner `with-managed-request-stubs*` SHADOWS
+  that binding for its dynamic extent, restoring the outer scope's route map on
+  exit. So an inner-scope dispatch keys off the inner route map; after the inner
+  scope exits, an outer-scope dispatch keys off the outer route map again — no
+  per-scope registrar write, no order-dependence."
   [stubs thunk]
-  (let [scope-stub-id (next-scope-stub-id)]
-    (try
-      (fx/reg-fx scope-stub-id
-                 {:doc "with-managed-request-stubs (scoped) synthesised stub"}
-                 (fn [frame-ctx args-map]
-                   (stub-handler stubs frame-ctx args-map)))
-      ;; Bind the lexical-scope override so plain dispatches in the body
-      ;; route `:rf.http/managed` → this scope's route-map stub
-      ;; automatically. The thunk's dispatches run synchronously within
-      ;; this dynamic extent; per-call `:fx-overrides` still take
-      ;; precedence (router merge).
-      (binding [router/*fx-overrides* (merge router/*fx-overrides*
-                                             {:rf.http/managed scope-stub-id})]
-        (thunk))
-      (finally
-        (fx/clear-fx scope-stub-id)))))
+  ;; Both bindings unwind automatically on exit (normal OR exception) — no
+  ;; per-scope registration to tear down (rf2-bxc8kf). The `*scope-stubs*`
+  ;; binding SHADOWS an enclosing scope's route map for nesting.
+  (binding [*scope-stubs*             stubs
+            router/*fx-overrides*     (merge router/*fx-overrides*
+                                             {:rf.http/managed scope-stub-fx-id})]
+    (thunk)))
 
 #?(:clj
    (defmacro with-managed-request-stubs

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -1299,6 +1299,123 @@
         (is (= {:from :outer-a} (get-in db [:result-a :value]))
             "outer A scope still routed to the A stub — not cleared by inner B teardown")))))
 
+;; ---- 11a-bxc8kf. stubs work inside a PRE-CREATED SEALED frame --------------
+;;
+;; rf2-bxc8kf — the exact tutorial nesting creates a frame FIRST, then enters
+;; `with-managed-request-stubs`:
+;;   (with-new-frame [f (make-frame {})]
+;;     (with-managed-request-stubs … (dispatch-sync …)))
+;; `make-frame {}` resolves + SEALS an image generation at construction, and a
+;; no-id (direct) frame is deliberately EXCLUDED from `reg-*` auto-reprojection
+;; (`frame/image-loaded-frame-ids` drops the reserved `:rf.frame/<gensym>` ids).
+;; Pre-fix, `with-managed-request-stubs*` MINTED a fresh `:rf.test/managed-http-
+;; stub-<n>` fx-id and registered it INSIDE the scope — AFTER the frame had
+;; sealed. So the bound `{:rf.http/managed <scope-id>}` override redirected to an
+;; fx-id the sealed generation could not resolve (`registrar/lookup` routes
+;; through the frame's generation): the redirect fell through and the REAL
+;; `:rf.http/managed` transport ran (a `/x` dispatch produced an immediate
+;; `:rf.http/transport` error). The fix registers ONE STABLE override target at
+;; ns-load, so it lands in the sealed generation of every frame created after
+;; the require; the per-scope route map rides the dynamic var `*scope-stubs*`.
+;;
+;; These tests use a `with-new-frame` frame and read app-db off the frame VALUE
+;; (`app-db-value f`), not `:rf/default`, so the SEALED-generation resolution
+;; path is exercised. Adversarial reach-check: a sentinel shadows the real
+;; `:rf.http/managed` fx — reaching it proves the override was absent.
+
+(defn- await-frame-reply!
+  "Poll `f`'s app-db for `(pred db)`, returning the settling db. Mirrors
+  `await-reply!` but keyed to a `with-new-frame` frame VALUE rather than
+  `:rf/default`, so a SEALED-generation frame's reply is observable."
+  [f pred]
+  (test-support/poll-until
+    #(let [db (rf/app-db-value f)] (when (pred db) db))
+    {:timeout-ms 2000 :label "sealed-frame http-managed reply"}))
+
+(deftest stubs-intercept-inside-pre-created-sealed-frame-rf2-bxc8kf
+  (testing "rf2-bxc8kf — a plain dispatch-sync inside with-managed-request-stubs,
+            in a PRE-CREATED sealed `with-new-frame` frame, routes through the
+            configured stub and NEVER invokes the real :rf.http/managed transport"
+    (let [real-fx-invoked? (atom false)]
+      ;; Shadow the production fx slot with a sentinel — reaching it proves the
+      ;; override was absent (the pre-fix sealed-frame bug). Registered BEFORE
+      ;; make-frame so it is in the sealed generation either way.
+      (fx/reg-fx :rf.http/managed
+                 (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
+      (rf/reg-event :bxc8kf/load
+        (fn [{:keys [db]} [_ msg reply]]
+          (if reply
+            {:db (assoc db :result reply)}
+            {:fx [[:rf.http/managed
+                   {:reply-to [:bxc8kf/load msg] :request {:method :get :url "/x"}
+                    :decode  :json}]]})))
+      (rf/with-new-frame [f (rf/make-frame {})]
+        (rf/with-managed-request-stubs
+          {[:get "/x"] {:reply {:ok {:stubbed true}}}}
+          ;; Bare wrapper form — no per-call :fx-overrides.
+          (rf/dispatch-sync [:bxc8kf/load]))
+        (let [db (await-frame-reply! f #(some? (:result %)))]
+          (is (= :ok (get-in db [:result :status]))
+              "the stubbed reply landed via the load-time-registered scope stub")
+          (is (= {:stubbed true} (get-in db [:result :value]))
+              "the configured :ok value rode through the synthesised reply")
+          (is (false? @real-fx-invoked?)
+              "the real :rf.http/managed fx was NEVER invoked in the sealed frame
+               (pre-fix: the minted per-scope stub was unresolvable in the sealed
+               generation, so this fired the real transport)"))))))
+
+(deftest sealed-frame-nesting-isolation-rf2-bxc8kf
+  (testing "rf2-bxc8kf — nested scopes still isolate inside a sealed frame: the
+            inner B scope's route map shadows the outer A's for its extent, and
+            the outer A route map is restored when the inner scope exits (the
+            dynamic-var replacement for the minted-per-scope fx-id preserves the
+            rf2-vn8qjv nesting contract in the sealed-frame case)"
+    (rf/reg-event :bxc8kf/load-a
+      (fn [{:keys [db]} [_ msg reply]]
+        (if reply
+          {:db (assoc db :result-a reply)}
+          {:fx [[:rf.http/managed {:reply-to [:bxc8kf/load-a msg] :request {:method :get :url "/a"} :decode :json}]]})))
+    (rf/reg-event :bxc8kf/load-b
+      (fn [{:keys [db]} [_ msg reply]]
+        (if reply
+          {:db (assoc db :result-b reply)}
+          {:fx [[:rf.http/managed {:reply-to [:bxc8kf/load-b msg] :request {:method :get :url "/b"} :decode :json}]]})))
+    (rf/with-new-frame [f (rf/make-frame {})]
+      (rf/with-managed-request-stubs
+        {[:get "/a"] {:reply {:ok {:from :outer-a}}}}
+        (rf/with-managed-request-stubs
+          {[:get "/b"] {:reply {:ok {:from :inner-b}}}}
+          (rf/dispatch-sync [:bxc8kf/load-b])
+          (let [db (await-frame-reply! f #(some? (:result-b %)))]
+            (is (= {:from :inner-b} (get-in db [:result-b :value]))
+                "inner B scope routed to the B stub inside the sealed frame")))
+        ;; Inner scope exited — the outer A route map must be live again.
+        (rf/dispatch-sync [:bxc8kf/load-a])
+        (let [db (await-frame-reply! f #(some? (:result-a %)))]
+          (is (= {:from :outer-a} (get-in db [:result-a :value]))
+              "outer A scope route map restored after the inner B scope exit"))))))
+
+(deftest sealed-frame-per-call-override-still-wins-rf2-bxc8kf
+  (testing "rf2-bxc8kf — precedence (per-call > lexical > per-frame) is preserved
+            in a sealed frame: a per-call :fx-overrides on the dispatch beats the
+            wrapper-installed lexical default"
+    (let [chosen (atom nil)]
+      (rf/reg-fx :bxc8kf/explicit-override
+                 (fn [_frame-ctx _args] (reset! chosen :explicit) nil))
+      (rf/reg-event :bxc8kf/load-explicit
+        (fn [_ _]
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/explicit"} :decode :json}]]}))
+      (rf/with-new-frame [f (rf/make-frame {})]
+        (rf/with-managed-request-stubs
+          {[:get "/explicit"] {:reply {:ok {:via :stub}}}}
+          ;; The per-call override must beat the wrapper's lexical default.
+          (rf/dispatch-sync [:bxc8kf/load-explicit]
+                            {:fx-overrides {:rf.http/managed :bxc8kf/explicit-override}})
+          (is (= :explicit @chosen)
+              "the per-call :fx-overrides won over the wrapper's lexical default
+               in the sealed frame"))))))
+
 ;; ---- 11a-vn8qjv (lower-level). install/uninstall stack + no fx leak --------
 ;;
 ;; rf2-vn8qjv (issue 2) — the lower-level install/uninstall surface keeps the


### PR DESCRIPTION
## Summary

`with-managed-request-stubs*` failed to intercept `:rf.http/managed` when the stub scope was entered inside an **already-created, sealed** frame — the exact tutorial nesting:

```clojure
(with-new-frame [f (make-frame {})]
  (with-managed-request-stubs {[:get "/x"] {:reply {:ok …}}}
    (dispatch-sync [:load])))   ; ← escaped to the REAL transport
```

### Root cause

The wrapper minted a fresh `:rf.test/managed-http-stub-<n>` fx-id per invocation and registered it **inside** the scope — *after* the frame had already sealed its image generation. `make-frame {}` seals a generation at construction, and a no-id/direct frame is deliberately excluded from `reg-*` auto-reprojection (`re-frame.frame/image-loaded-frame-ids` drops the reserved `:rf.frame/<gensym>` ids). Inside a frame, `registrar/lookup` resolves fx handlers through the frame's **sealed generation**, not the global registrar — so the freshly-registered stub fx-id was unresolvable. The bound `{:rf.http/managed <scope-id>}` override fell through (`:rf.error/override-fallthrough`) and the real `:rf.http/managed` transport ran (`/x` → immediate `:rf.http/transport` error).

Existing helper tests passed because they use the ambient `:rf/default` frame (`ensure-default-frame!`), which carries **no** generation → fx lookup hits the global registrar, where the minted id *is* present.

### Fix

Register **one stable** override target (`:rf.test/managed-http-scope-stub`) at `re-frame.http.test-support` ns-load — the same explicit-require gate the canned-stub fxs already ride — so it lands in the sealed generation of every frame created after the require. The per-scope route map now rides the dynamic var `*scope-stubs*`: an inner scope's binding shadows the outer's for its extent and restores it on exit, preserving the rf2-vn8qjv nesting isolation with **no** per-scope registrar write the sealed generation cannot see.

The documented contract is unchanged: every dispatch in the body auto-routes by method+URL, and per-call `:fx-overrides` still win (per-call > lexical > per-frame). No spec/API/tutorial prose described the internal minted-per-scope mechanism, so no doc changes were needed.

### Tests

- **JVM** (`http_managed_test.clj`): sealed-frame interception (real fx never invoked), sealed-frame nesting isolation, sealed-frame per-call-override precedence.
- **CLJS** (`http_managed_cljs_test.cljs`): sealed-frame interception mirror.
- All three fail before the fix (real transport runs) and pass after.

## Quality gates

- `clojure -M:test` (http artefact, JVM): **491 tests, 3762 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime bundle): **9661 tests, 47558 assertions, 0 failures, 0 errors**
