### PR TITLE
fix(routing): auth guard for raw-URL targets + cumulative race-safe loader tutorial + SPA-interception guidance (cluster)

### DIFF
--- a/docs/core/how-to/add-auth.md
+++ b/docs/core/how-to/add-auth.md
@@ -233,7 +233,10 @@ The fix is to normalise all three to one target, then redirect identically:
    non-navigation events (the guard short-circuits)."
   [[ev-id a b]]
   (case ev-id
-    :rf.route/navigate          {:id a :params (or b {})}            ;; programmatic nav
+    :rf.route/navigate          (if (map? a)                             ;; {:url ...} escape-hatch target
+                                  (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+                                    {:id route-id :params (or params {})})
+                                  {:id a :params (or b {})})              ;; route-id target
     :rf.route/url-requested           (let [{:keys [to params url]} a]     ;; route-link click
                                   (cond
                                     to  {:id to :params (or params {})}
@@ -268,7 +271,7 @@ Now the guard itself. An *event* interceptor's `ctx` splits into two halves: `:c
 
 Two helpers do the reading, and both are *pure* — they compute from their arguments without touching app-db, which is exactly why the guard can call them inline:
 
-- **`routing/match-url`** parses a URL string into a map — `{:route-id :params :query :fragment :validation-failed?}` — or `nil` when nothing matches. (Its inverse, `routing/route-url`, builds a URL from a route id and params.) Note the namespace: it lives in `re-frame.routing`, **not** on the `rf/` facade.
+- **`routing/match-url`** parses a URL string into a map — `{:route-id :params :query :fragment :validation-failed?}` — or `nil` when nothing matches. (Its inverse, `routing/route-url`, builds a URL from a route id and params.) Note the namespace: it lives in `re-frame.routing`, **not** on the `rf/` facade. `nav-target` reaches for it in **three** places: the link-click and URL-bar events carry a raw URL, and `:rf.route/navigate` accepts a `{:url "/settings"}` **escape-hatch target** (deep links, redirects) that is a URL, not a route id — resolve it the same way the runtime does, or a logged-out `[:rf.route/navigate {:url "/settings"}]` slips past the tag check.
 - **`rf/handler-meta`** reads back the metadata you stamped at registration. `(rf/handler-meta :route id)` returns that route's registration map; the guard pulls its `:tags` and checks for `:requires-auth`.
 
 The redirect works by *skip-and-dispatch*. `:rf/skip-handler?` — the public short-circuit primitive an interceptor's `:before` sets on its ctx — stops the original handler, so the protected slice never commits and its `:on-match` loads never fire. The guard then dispatches the login navigation itself.

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -493,7 +493,7 @@ There's one trap here, and it's the kind that passes every casual test. Navigati
 
     If you gate only the programmatic `:rf.route/navigate`, the guard *fails open* the moment someone types `/settings` into the address bar — the protected route loads with no user. The fix is to normalise all three navigation events to one shape, then gate once.
 
-That normaliser is `nav-target` below. The link-click and URL-bar cases carry a raw URL string rather than a route id, so it leans on `routing/match-url` to turn that URL back into a route:
+That normaliser is `nav-target` below. The link-click and URL-bar cases carry a raw URL string rather than a route id — and so can `:rf.route/navigate`, whose `{:url "/settings"}` *escape-hatch* target (deep links, redirects) is a URL, not a route id. All three lean on `routing/match-url` to turn that URL back into a route before the guard reads its `:tags`; skip it on the navigate branch and a logged-out `[:rf.route/navigate {:url "/settings"}]` walks in:
 
 ```clojure
 (defn- nav-target
@@ -501,7 +501,10 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
    nil for non-navigation events (the guard stands aside)."
   [[event-id a b]]
   (case event-id
-    :rf.route/navigate          {:id a :params (or b {})}
+    :rf.route/navigate          (if (map? a)                          ;; {:url ...} escape-hatch target
+                                  (when-let [m (routing/match-url (:url a))]
+                                    {:id (:route-id m) :params (or (:params m) {})})
+                                  {:id a :params (or b {})})            ;; route-id target
     :rf.route/url-requested           (if-let [to (:to a)]
                                   {:id to :params (or (:params a) {})}
                                   (when-let [m (routing/match-url (:url a))]

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -165,8 +165,18 @@ ranking cascade: [API `reg-route`](../api/re-frame.routing.md#reg-route).
 
 Real `<a href>` — hover, copy-link, cmd/middle-click work. Plain left-click becomes
 dispatch. `:target "_blank"` / `:download` are **not** SPA-intercepted (browser owns
-them). Plain `[:a {:href …}]` does a full navigation unless you install your own
-handler on `:rf.route/url-requested` (the policy seam every `route-link` uses).
+them). That interception is [`route-link`](#linking-from-views)'s job: its view body is
+the only thing that calls `.preventDefault` and dispatches `:rf.route/url-requested`,
+the seam the router listens on.
+
+A plain `[:a {:href …}]` you hand-write does **not** reach that seam — nothing dispatches
+`:rf.route/url-requested` for it, so it does a full page navigation. Installing a handler
+*on* `:rf.route/url-requested` can't change that: the event never fires for a plain anchor.
+Two honest ways to keep such a click in-app: render the link with
+[`route-link`](#linking-from-views) instead, or install one **document-level** click
+listener that decides eligibility itself — plain primary-button click, no modifier keys,
+no `:target`/`:download`, a same-origin in-app `href` — and dispatches
+`:rf.route/url-requested` on a match, letting the browser follow every click it rejects.
 
 ### Order of effects
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -285,6 +285,48 @@ Ownership is nav-token keyed: leave or supersede → release; late replies
 **suppressed**. Per-user data uses a scope resolver (`{:from-db …}`) — fails closed
 when logged out. Full story: [Resources model](../resources/concepts.md).
 
+### A hand-rolled async loader — capture the nav-token
+
+<a id="a-hand-rolled-async-loader"></a>
+
+`:on-match` and `:resources` are the everyday loaders. Roll your own async fetch instead
+and you inherit the one race they close for you: a reader opens article A, navigates to B
+before A's reply lands, and A's late reply overwrites B's page. Guard it by capturing the
+**navigation token** — the epoch the current navigation minted — when the load starts, and
+gating delivery on it. Two framework hooks do the work: the `:rf.route/nav-token` **cofx**
+injects the live token into an `:on-match`-reached handler, and the
+`:rf.route/with-nav-token` **fx** delivers a reply only while that captured token still
+matches the current slice — otherwise it suppresses the reply and fires
+`:rf.route.nav-token/stale-suppressed`.
+
+```clojure
+;; The loader: capture the live token, kick off your own fetch, and carry the
+;; token into the reply event.
+(rf/reg-event :app/load-article
+  {:rf.cofx/requires [:rf.route/nav-token]}            ;; inject the current epoch token
+  (fn [{:rf.route/keys [nav-token] rt :rf.db/runtime} _]
+    (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
+      ;; :app/fetch-article is YOUR async effect; on reply it dispatches
+      ;; :app/article-arrived with the captured token + the fetched payload.
+      {:fx [[:app/fetch-article {:id id :on-reply [:app/article-arrived nav-token id]}]]})))
+
+;; The completion: hand the CAPTURED token to :rf.route/with-nav-token. Fresh
+;; token → the :rf/reply-to target runs; stale (a newer navigation superseded it)
+;; → the reply is dropped before it can touch app-db.
+(rf/reg-event :app/article-arrived
+  (fn [_ [_ captured-token id payload]]
+    {:fx [[:rf.route/with-nav-token
+           {:rf/reply-to [:app/article-loaded id payload]
+            :nav-token   captured-token}]]}))
+
+(rf/reg-event :app/article-loaded
+  (fn [{:keys [db]} [_ id payload]]
+    {:db (assoc db :article/current payload)}))
+```
+
+`:resources` already does all of this — declare it and the race is closed for you.
+Hand-roll only when you need something the resource layer doesn't give you.
+
 ## Blocking a navigation
 
 <a id="blocking-a-navigation"></a>

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -52,7 +52,10 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
   [[ev-id a b]]
   (case ev-id
     :rf.route/navigate
-    {:id a :params (or b {})}
+    (if (map? a)                                       ;; {:url ...} escape-hatch target
+      (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+        {:id route-id :params (or params {})})
+      {:id a :params (or b {})})                        ;; route-id target — unchanged
 
     :rf.route/url-requested
     (let [{:keys [to params url]} a]
@@ -69,7 +72,12 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
 ```
 
 `match-url` is pure: URL string → match map, or `nil` when nothing resolves (garbage
-URLs short-circuit the guard rather than crash it).
+URLs short-circuit the guard rather than crash it). Note the `:rf.route/navigate` branch
+also leans on it: navigate accepts a `{:url "/settings"}` **escape-hatch target** (deep
+links, server-side redirects, any URL the app didn't build itself), and a raw URL is not a
+route id — so the guard resolves it through `match-url` exactly as the runtime does before
+reading the route's `:tags`. Guard only the route-id form and a logged-out
+`[:rf.route/navigate {:url "/settings"}]` walks straight in.
 
 ## 3. Redirect with skip-and-dispatch
 

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -132,7 +132,9 @@ Now the loader itself. It's a normal event handler, with one new thing to learn:
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
       ;; A real app starts an HTTP fetch here and lets a later event write the
-      ;; reply — see Managed HTTP (../async/http.md). We'll "load" locally.
+      ;; reply — see Managed HTTP (../async/http.md). If you hand-roll the fetch,
+      ;; capture the nav-token so a slow reply can't overwrite a newer page
+      ;; (concepts.md#a-hand-rolled-async-loader). We'll "load" locally.
       {:db (assoc db :article/current (get sample-articles id))})))
 
 (rf/reg-sub :article/current (fn [db _] (:article/current db)))
@@ -150,7 +152,7 @@ There's no special "loader data" hook, because the loader just wrote to [app-db]
 
 **What you see:** click through to `/articles/intro` and the title appears. Navigate to another article and the loader fires again with the new id; re-navigate to the *same* one and it doesn't. Open [Xray](../xray/index.md) and you'll see exactly those dispatches on the wire.
 
-> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [The model → Loaders](concepts.md#loaders-declaring-a-pages-data).
+> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [The model → Loaders](concepts.md#loaders-declaring-a-pages-data). Hand-rolling your own async fetch means owning that race yourself: capture the navigation token when the load starts and gate delivery on it, or a slow reply for one article overwrites the one you navigated to next — see [a hand-rolled async loader](concepts.md#a-hand-rolled-async-loader).
 
 ## Step 5 — when nothing matches: the 404
 
@@ -207,12 +209,17 @@ Declaring it also does two jobs automatically, the moment the frame is created �
 
 Our article pages should sit inside a shell — a section header, a "back to all articles" nav — without each page repeating it. In re-frame2, nesting is **data**: a child route names a `:parent`, and a subscription hands you the chain so you compose the shells yourself.
 
-Point the detail page at a parent:
+Point the detail page at a parent — and **carry the whole metadata map forward**.
+`reg-route` is full replacement, not a merge: re-registering `:app/article` with only
+`:parent` and `:params` would silently drop the `:on-match` loader you added in Step 4.
+Keep every key you still want:
 
 ```clojure
 (rf/reg-route :app/articles {} "/articles")
-(rf/reg-route :app/article  {:parent :app/articles
-                             :params [:map [:id :string]]} "/articles/:id")
+(rf/reg-route :app/article  {:parent   :app/articles
+                             :params   [:map [:id :string]]
+                             :on-match [[:app/load-article]]}   ;; kept from Step 4
+  "/articles/:id")
 ```
 
 Now `@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root-most first** — on `/articles/intro` it's `[:app/articles :app/article]`. Two jobs fall out of that vector:

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -213,7 +213,10 @@
 
 (defn- resolve-nav-target [[ev-id a _b]]
   (case ev-id
-    :rf.route/navigate {:id a :params (or _b {})}
+    :rf.route/navigate (if (map? a)                        ;; {:url ...} escape-hatch target
+                         (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+                           {:id route-id :params (or params {})})
+                         {:id a :params (or _b {})})        ;; route-id target
     :rf.route/url-requested  (let [{:keys [to params url]} a]
                          (cond
                            to  {:id to :params (or params {})}

--- a/implementation/routing/test/re_frame/routing_auth_guard_matrix_test.clj
+++ b/implementation/routing/test/re_frame/routing_auth_guard_matrix_test.clj
@@ -1,0 +1,127 @@
+(ns re-frame.routing-auth-guard-matrix-test
+  "Executable matrix pinning the canonical auth-guard recipe
+  (docs/routing/how-to/require-sign-in-on-a-route.md, docs/core/how-to/add-auth.md,
+  spec/012-Routing.md §Cross-cutting guards) across ALL FOUR navigation entry
+  points: route-id `:rf.route/navigate`, the raw-URL `{:url ...}` navigate
+  escape hatch, a `route-link` click (`:rf.route/url-requested`), and a URL-bar /
+  popstate / deep-link (`:rf.route/handle-url-change`).
+
+  rf2-e9k3dr — the recipe's `:rf.route/navigate` branch normalised its target as a
+  route id UNCONDITIONALLY. But `:rf.route/navigate` also accepts a `{:url \"/settings\"}`
+  target (the runtime resolves it through `match-url` — see
+  re_frame/routing/navigate.cljc:294), so a map target fell through as a route id:
+  `handler-meta` on a MAP returns nil, `:requires-auth` is missed, and the protected
+  route is entered — a fail-OPEN security hole on the most common escape-hatch path.
+
+  The recipe now mirrors the runtime — map targets normalise through `match-url`
+  before the tag read. This suite is the failing-before / passing-after guard: revert
+  the `:rf.route/navigate` branch to `{:id a :params (or b {})}` and the raw-URL rows
+  below flip from `true`/gated to `false`/open."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.routing :as routing]
+            [re-frame.routing.test-support]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+;; The canonical recipe's normaliser — the FIXED form (rf2-e9k3dr). Kept
+;; byte-faithful to the shipped docs so a drift between the doc recipe and this
+;; pin trips a test. `:rf.route/navigate` now branches on the target shape: a
+;; `{:url ...}` map is resolved through `match-url` exactly as the runtime does;
+;; a keyword is a route id, unchanged.
+(defn- nav-target [[ev-id a b]]
+  (case ev-id
+    :rf.route/navigate
+    (if (map? a)                                       ;; {:url ...} escape-hatch target
+      (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+        {:id route-id :params (or params {})})
+      {:id a :params (or b {})})                        ;; route-id target — unchanged
+
+    :rf.route/url-requested
+    (let [{:keys [to params url]} a]
+      (cond
+        to  {:id to :params (or params {})}
+        url (when-let [{:keys [route-id params]} (routing/match-url url)]
+              {:id route-id :params (or params {})})))
+
+    :rf.route/handle-url-change
+    (when-let [{:keys [route-id params]} (routing/match-url a)]
+      {:id route-id :params (or params {})})
+
+    nil))
+
+(defn- guard-decision
+  "The guard's protected-path decision for `event`, signed out:
+   nil   — not a resolvable navigation (guard stands aside),
+   true  — a `:requires-auth` route was targeted (guard redirects — fail CLOSED),
+   false — a public route was targeted (guard allows)."
+  [event]
+  (when-let [{:keys [id]} (nav-target event)]
+    (contains? (:tags (rf/handler-meta :route id)) :requires-auth)))
+
+(defn- register-routes! []
+  (rf/reg-route :app/home     {} "/")
+  (rf/reg-route :app/login    {} "/login")
+  (rf/reg-route :app/settings {:tags #{:requires-auth}} "/settings")
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ _] nil)))
+
+;; ---- The matrix: protected fails CLOSED on every door ---------------------
+
+(deftest auth-guard-matrix-fails-closed-across-all-doors
+  (register-routes!)
+
+  (testing "route-id :rf.route/navigate — protected gated, public allowed"
+    (is (true?  (guard-decision [:rf.route/navigate :app/settings]))
+        "route-id navigate to a :requires-auth route is gated")
+    (is (false? (guard-decision [:rf.route/navigate :app/home]))
+        "route-id navigate to a public route is allowed"))
+
+  (testing "raw-URL {:url ...} :rf.route/navigate — the rf2-e9k3dr fix"
+    (is (true?  (guard-decision [:rf.route/navigate {:url "/settings"}]))
+        "FAILING-BEFORE: a {:url ...} navigate to a protected route MUST be gated
+         — the old branch read handler-meta on the URL map, saw no tags, opened")
+    (is (false? (guard-decision [:rf.route/navigate {:url "/"}]))
+        "a {:url ...} navigate to a public route is allowed")
+    (is (true?  (guard-decision [:rf.route/navigate {:url "/settings?tab=x"}]))
+        "query string on the raw-URL target still resolves + gates"))
+
+  (testing "route-link click (:rf.route/url-requested) — both :to and :url forms"
+    (is (true?  (guard-decision [:rf.route/url-requested {:url "/settings"}]))
+        "a link click whose href resolves to a protected route is gated")
+    (is (true?  (guard-decision [:rf.route/url-requested {:to :app/settings}]))
+        "a :to link click to a protected route is gated")
+    (is (false? (guard-decision [:rf.route/url-requested {:url "/"}]))
+        "a link click to a public route is allowed"))
+
+  (testing "URL-bar / popstate / deep-link (:rf.route/handle-url-change)"
+    (is (true?  (guard-decision [:rf.route/handle-url-change "/settings"]))
+        "pasting / reloading a protected URL is gated")
+    (is (false? (guard-decision [:rf.route/handle-url-change "/"]))
+        "the home URL is allowed"))
+
+  (testing "unresolvable + non-navigation events short-circuit the guard"
+    (is (nil? (guard-decision [:rf.route/navigate {:url "/no/such/path"}]))
+        "a garbage raw-URL navigate is a non-match — the runtime routes it to
+         :rf.route/not-found, which is not a protected route")
+    (is (nil? (guard-decision [:rf.route/handle-url-change "/no/such/path"]))
+        "a garbage URL-bar entry is a non-match")
+    (is (nil? (guard-decision [:some/other-event 1 2]))
+        "an ordinary event is not a navigation — the guard stands aside")))
+
+;; ---- The recipe mirrors the SHIPPED runtime (verify against navigate.cljc) --
+
+(deftest runtime-resolves-raw-url-navigate-to-the-protected-route
+  (testing "the shipped :rf.route/navigate resolves a {:url ...} target through
+            match-url onto the real route-id — which is exactly WHY the recipe
+            must normalise the same way rather than trust the target to be a keyword"
+    (register-routes!)
+    (rf/dispatch-sync [:rf.route/navigate {:url "/settings"}])
+    (is (= :app/settings
+           (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                   [:rf.runtime/routing :current :route-id]))
+        "raw-URL navigate lands the slice on the protected route-id")
+    (is (= :app/settings (:route-id (routing/match-url "/settings")))
+        "match-url hands the recipe the same route-id the runtime used")))

--- a/implementation/routing/test/re_frame/routing_loader_tutorial_fixture_test.clj
+++ b/implementation/routing/test/re_frame/routing_loader_tutorial_fixture_test.clj
@@ -1,0 +1,103 @@
+(ns re-frame.routing-loader-tutorial-fixture-test
+  "Pins the routing tutorial's loader program (docs/routing/tutorial.md Steps 4 + 7)
+  and its race-safety story (docs/routing/concepts.md §A hand-rolled async loader).
+
+  rf2-1lu666 — two regressions in the progressive tutorial:
+
+  1. Step 7 re-registered `:app/article` with only `:parent` + `:params`, dropping the
+     Step 4 `:on-match` loader. `reg-route` → `registrar/register!` is FULL replacement
+     (re_frame/registrar.cljc:586 — `assoc-in [kind id] metadata`), so the final program
+     silently had no loader. `tutorial-step7-reregistration-*` pins the cumulative
+     program: the loader survives the Step 7 re-registration only when `:on-match` is
+     carried forward.
+
+  2. The tutorial recommends real HTTP but the hand-rolled-loader race lesson (capture the
+     nav-token, gate delivery) had been removed. `tutorial-loader-is-race-safe-*` is the
+     deterministic A-load → navigate-B → late-A fixture proving A's stale reply cannot
+     reach app delivery or app-db when the documented nav-token pattern is followed."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.routing.test-support]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+;; ---- rf2-1lu666 (1): reg-route is full replacement — Step 7 keeps the loader ----
+
+(deftest tutorial-step7-reregistration-keeps-the-loader
+  (testing "the cumulative tutorial: Step 7 must carry :on-match forward or the
+            Step 4 loader is silently deleted (reg-route is full replacement)"
+    ;; Step 4 — the route gets its loader.
+    (rf/reg-route :app/article
+      {:params [:map [:id :string]] :on-match [[:app/load-article]]} "/articles/:id")
+    (is (= [[:app/load-article]] (:on-match (rf/handler-meta :route :app/article)))
+        "Step 4 registered the loader")
+
+    ;; The BUG shape — Step 7 re-registers with :parent + :params but NO :on-match.
+    ;; Full replacement drops the loader. This assertion documents WHY the tutorial
+    ;; must repeat :on-match; it is the regression rf2-1lu666 guards.
+    (rf/reg-route :app/article
+      {:parent :app/articles :params [:map [:id :string]]} "/articles/:id")
+    (is (nil? (:on-match (rf/handler-meta :route :app/article)))
+        "re-registration without :on-match deletes the loader — full replacement")
+
+    ;; The FIXED Step 7 — carries :on-match forward alongside :parent.
+    (rf/reg-route :app/article
+      {:parent   :app/articles
+       :params   [:map [:id :string]]
+       :on-match [[:app/load-article]]} "/articles/:id")
+    (let [meta (rf/handler-meta :route :app/article)]
+      (is (= :app/articles (:parent meta))
+          "final registration keeps :parent")
+      (is (= [[:app/load-article]] (:on-match meta))
+          "final registration keeps the Step 4 loader"))))
+
+;; ---- rf2-1lu666 (2): the hand-rolled nav-token loader is race-safe ----
+
+(deftest tutorial-loader-is-race-safe-late-A-cannot-overwrite-B
+  (testing "A-load → navigate B → late-A: the documented nav-token loader suppresses
+            A's stale reply; only B reaches app delivery and app-db"
+    (rf/reg-route :app/article {:params [:map [:id :string]]} "/articles/:id")
+    (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+
+    ;; The concepts.md §A hand-rolled async loader program, verbatim in shape:
+    ;; terminal delivery …
+    (rf/reg-event :app/article-loaded
+      (fn [{:keys [db]} [_ _id payload]]
+        {:db (assoc db :article/current payload)}))
+    ;; … completion gates the reply on the captured token …
+    (rf/reg-event :app/article-arrived
+      (fn [_ [_ captured-token id payload]]
+        {:fx [[:rf.route/with-nav-token
+               {:rf/reply-to [:app/article-loaded id payload]
+                :nav-token   captured-token}]]}))
+
+    (let [captured (atom {})]
+      ;; … and the loader captures the live epoch token at scheduling time. The
+      ;; capture closes over `captured` so the test can replay A's reply LATE
+      ;; (out of order), modelling the real click-away race.
+      (rf/reg-event :app/load-article
+        {:rf.cofx/requires [:rf.route/nav-token]}
+        (fn [{:rf.route/keys [nav-token] rt :rf.db/runtime} _]
+          (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
+            (swap! captured assoc id nav-token)
+            {})))
+
+      ;; 1. Open A; loader captures A's token.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (rf/dispatch-sync [:app/load-article])
+      ;; 2. Navigate to B BEFORE A's reply lands; loader captures B's token.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/B"])
+      (rf/dispatch-sync [:app/load-article])
+      ;; 3. A's reply lands LATE, carrying A's stale token → suppressed.
+      (rf/dispatch-sync [:app/article-arrived (@captured "A") "A" "A-payload"])
+      ;; 4. B's reply lands, carrying the fresh token → delivered.
+      (rf/dispatch-sync [:app/article-arrived (@captured "B") "B" "B-payload"])
+
+      (is (not= (@captured "A") (@captured "B"))
+          "each navigation minted a distinct epoch token")
+      (is (every? some? (vals @captured))
+          "the cofx injected non-nil tokens (a nil token would mismatch every time)")
+      (is (= "B-payload" (:article/current (rf/app-db-value :rf/default)))
+          "only B reached app-db — A's late reply was suppressed by the nav-token"))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -1398,7 +1398,10 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
 (defn- nav-target [event]
   (let [[ev-id a b] event]
     (case ev-id
-      :rf.route/navigate          {:id a :params (or b {})}     ;; a = route-id
+      :rf.route/navigate          (if (map? a)                  ;; {:url ...} escape-hatch target
+                                    (when-let [{:keys [route-id params]} (rf/match-url (:url a))]
+                                      {:id route-id :params (or params {})})
+                                    {:id a :params (or b {})})  ;; a = route-id
       :rf.route/url-requested           (let [{:keys [to params url]} a]
                                     (cond
                                       to  {:id to :params (or params {})}
@@ -1433,6 +1436,8 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
 (rf/make-frame {:id :app
                 :interceptors [:app/section-lockout]})
 ```
+
+The `:rf.route/navigate` door itself carries **two target forms** (per [§Target form](#target-form--route-id-url-string-or-reserved)): a route-id, and the `{:url …}` escape hatch (deep links, redirects). A raw URL is not a route id, so the normaliser routes the `{:url …}` form through `match-url` exactly as the runtime does before the guard reads `handler-meta` — otherwise `[:rf.route/navigate {:url "/admin"}]` resolves `handler-meta` on a map, sees no tags, and slips past the gate. This is the target-union mirror of the three-door rule: cover both forms of the door too.
 
 Guards are interceptors, not a special routing mechanism. They are registered once and referenced by id; they compose — list multiple refs in the `:interceptors` chain and they layer in order. Prefer `:can-enter` when the policy belongs to one route; reach for a frame-`:interceptors` guard when it spans many routes uniformly, and cover all three doors when you do.
 


### PR DESCRIPTION
Routing-surface cluster: three audit-derived bugs from PR #5919 (discovered via rf2-11va2o). One worker owns the surface because the fixes span shared routing docs, the routing spec, and the routing artefact tests. **None required a routing-source change** — the shipped runtime is correct in all three cases; the docs/recipe/tutorial copies had drifted from it. Each fix is verified against shipped routing code.

## rf2-e9k3dr (P1) — auth guard for raw-URL navigate targets

The canonical auth-guard recipe normalised its `:rf.route/navigate` target as a route id **unconditionally**. But `:rf.route/navigate` also accepts a `{:url "/settings"}` escape-hatch target, which the runtime resolves through `match-url` (`implementation/routing/src/re_frame/routing/navigate.cljc:294`). So a map target fell through as a route id: `handler-meta` on a map returns `nil`, `:requires-auth` is missed, and the protected route is entered — a **fail-open** hole on the most common escape-hatch path. (Closed rf2-mzqd4.3 fixed the three event doors; this later target-union variant was missed.)

**Fix (docs/recipe truth-fix):** the `:rf.route/navigate` branch now mirrors the runtime — a `{:url ...}` target normalises through `match-url` before the tag read; route-id targets are unchanged. Synchronised across all five canonical copies: `docs/routing/how-to/require-sign-in-on-a-route.md`, `docs/core/how-to/add-auth.md`, `docs/resources/tutorial/03-auth-and-forms.md`, `examples/real-apps/realworld_resources/routing.cljs`, and `spec/012-Routing.md` (section-lockout recipe). No new public routing API.

**Proof:** `implementation/routing/test/re_frame/routing_auth_guard_matrix_test.clj` — an executable matrix over protected/public route-id navigate, raw-URL `{:url}` navigate, route-link (`:to` and `:url`), and URL-change entry, proving protected paths fail closed. Reverting the navigate branch to the old form flips the raw-URL rows open (failing-before confirmed: 3 failures on the raw-URL rows).

## rf2-1lu666 (P1) — cumulative, race-safe loader tutorial

Step 7 re-registered `:app/article` with only `:parent` + `:params`, dropping the Step 4 `:on-match` loader. `reg-route` → `registrar/register!` is **full replacement** (`implementation/core/src/re_frame/registrar.cljc:586` — `assoc-in [kind id] metadata`), so the final tutorial program silently had no loader.

**Fix (docs truth-fix — the loader API is correct and race-safe; the tutorial failed to use it):**
- Step 7 carries `:on-match` forward, with prose that `reg-route` replaces the whole metadata map.
- Restored the hand-rolled async loader lesson to `docs/routing/concepts.md` §Loaders — capture the `:rf.route/nav-token` cofx at load start and gate delivery on the `:rf.route/with-nav-token` fx (example verified against `routing_nav_token_test`). This is the section the API doc (`docs/api/re-frame.routing.md`) already points to for nav-token semantics, so restoring it makes that cross-reference truthful **without editing the off-limits `docs/api` tree**.
- Linked the loader at the tutorial's real-HTTP point.

**Proof:** `implementation/routing/test/re_frame/routing_loader_tutorial_fixture_test.clj` — pins the final `:app/article` metadata (both `:parent` and `:on-match` survive the Step 7 re-registration; a Step-7-without-`:on-match` shape is asserted to drop it) and a deterministic A-load → navigate-B → late-A fixture proving A's stale reply reaches neither app delivery nor app-db.

## rf2-had4wy (P3) — plain-anchor SPA interception guidance

`docs/routing/concepts.md` claimed a plain `[:a {:href ...}]` full-navigates "unless you install your own handler on `:rf.route/url-requested`" — impossible: a plain anchor never emits that event (only `route-link` does), so the named handler changes nothing.

**Fix (doc truth-fix):** replaced with the two honest options (matching `spec/012-Routing.md:578-582`) — render with `route-link`, or install one document-level eligible-click listener (plain primary click; no modifier/target/download; same-origin in-app href) that dispatches `:rf.route/url-requested` itself, deferring to the browser for rejected clicks. Cross-links the route-link section.

## Quality gates

- `clojure -M:test` (routing artefact, JVM): **427 tests, 2121 assertions, 0 failures, 0 errors** (includes both new test namespaces).
- `npm run test:cljs`: **9660 tests, 47555 assertions, 0 failures, 0 errors**.
- `python scripts/check_doc_slugs.py`: exit 0.
- `mkdocs build --strict`: exit 0. New in-page anchors (`#a-hand-rolled-async-loader`, `#target-form--route-id-url-string-or-reserved`) verified resolving in the built site.
- Failing-before / passing-after captured for rf2-e9k3dr (raw-URL rows) via a temporary revert of the test's navigate branch.
