### PR TITLE
fix(examples): bring sibling SSR examples onto the corrected hydrate-root recipe (rf2-x1ldyv)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -376,17 +376,16 @@
 ;; See docs/ssr/concepts.md#deploy-drift-checks-come-along-for-free.
 (def app-frame :rf/default)
 
-;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
-;; it after each hot reload — edited views re-render into the same root and the
-;; already-hydrated frame. HYDRATE stays in `run` (once), so a reload never
-;; re-seeds over the interactive state.
+;; Re-render the current view into the RETAINED root. Tagged `^:dev/after-load`
+;; so shadow-cljs re-runs it after each hot reload — edited views re-render into
+;; the same root and the already-hydrated frame. It never creates a root and
+;; never re-hydrates: the root is established once in `run` (via `hydrate-root`
+;; when the server painted the page, `create-root` otherwise), and HYDRATE
+;; happens once there too, so a reload can't re-seed over the interactive state.
 #?(:cljs
-   (defn ^:dev/after-load mount! []
-     (when-let [el (and (exists? js/document)
-                        (js/document.getElementById "app"))]
-       (when-not @react-root
-         (reset! react-root (rdc/create-root el)))
-       (rdc/render @react-root
+   (defn ^:dev/after-load render! []
+     (when-let [root @react-root]
+       (rdc/render root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))
 
@@ -394,6 +393,24 @@
    (defn run []
      (rf/init! reagent-adapter/adapter)
      (rf/make-frame {:id app-frame :doc "resources-ssr client app-frame" :platform :client})
-     (ssr/hydrate! {:frame          app-frame
-                    :render-tree-fn (fn [] ((rf/view :app/root)))})
-     (mount!)))
+     ;; READ, HYDRATE, VERIFY against the app-frame. `hydrate!` seeds STATE only
+     ;; — it never touches the DOM — and hands back the payload it applied, or
+     ;; nil on a plain client load with no server render to adopt.
+     (let [el      (and (exists? js/document) (js/document.getElementById "app"))
+           payload (ssr/hydrate! {:frame          app-frame
+                                  :render-tree-fn (fn [] ((rf/view :app/root)))})
+           tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
+       (when el
+         (if payload
+           ;; Server-rendered: ADOPT the painted DOM. `hydrate-root` reconciles
+           ;; React against the server markup — same nodes, listeners attached,
+           ;; no re-paint — and returns the retained root. `create-root` +
+           ;; `render` would throw the server HTML away and mount fresh, the bug
+           ;; this branch avoids.
+           (reset! react-root (rdc/hydrate-root el tree))
+           ;; No payload means no server render — a plain first load. Mount a
+           ;; fresh root and render; a fresh entry serves from cache, a stale or
+           ;; absent one refetches per its policy.
+           (do
+             (reset! react-root (rdc/create-root el))
+             (rdc/render @react-root tree)))))))

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -282,19 +282,19 @@
 ;; [frames](../../../../docs/core/glossary.md#frame-identity-is-carried-not-found).
 #?(:cljs (def app-frame :rf/default))
 
-;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
-;; it after each hot reload — edited views re-render into the same root and the
-;; already-hydrated frame. HYDRATE + streaming install stay in `run` (once), so
-;; a reload never re-seeds over the interactive state.
+;; Re-render the current view into the RETAINED root. Tagged `^:dev/after-load`
+;; so shadow-cljs re-runs it after each hot reload — edited views re-render into
+;; the same root and the already-hydrated frame. It never creates a root and
+;; never re-hydrates: the root is established once in `run` (via `hydrate-root`
+;; when the server painted the page, `create-root` otherwise), and HYDRATE plus
+;; the streaming install happen once there too, so a reload can't re-seed over
+;; the interactive state.
 #?(:cljs
-   (defn ^:dev/after-load mount! []
-     (when-let [el (and (exists? js/document)
-                        (js/document.getElementById "app"))]
-       (when-not @react-root
-         (reset! react-root (rdc/create-root el)))
-       ;; Wrap the mount in `frame-provider` so every `dispatch` and
-       ;; `subscribe` inside the tree resolves to the frame we just hydrated.
-       (rdc/render @react-root
+   (defn ^:dev/after-load render! []
+     (when-let [root @react-root]
+       ;; Wrap the render in `frame-provider` so every `dispatch` and
+       ;; `subscribe` inside the tree resolves to the frame we hydrated.
+       (rdc/render root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :dashboard/root)]]))))
 
@@ -324,12 +324,31 @@
      ;; dispatch `:rf/hydrate` into the explicit `:frame`. This is the truth
      ;; the streamed deltas defer to. Hydrate BEFORE the first render so that
      ;; render runs against fully seeded app-db, not a half-filled one.
+     ;; `hydrate!` seeds STATE only — it never touches the DOM — and hands back
+     ;; the payload it applied, or nil on a plain client load with no server
+     ;; render to adopt.
      ;; (We leave out `:render-tree-fn` because this static demo's shell
      ;; carries a placeholder render-hash, so mismatch verification would warn
      ;; every time. A real streaming server stamps the genuine hash and passes
      ;; `:render-tree-fn` to switch mismatch detection on.)
-     (ssr/hydrate! {:frame app-frame})
-     (mount!)))
+     (let [el      (and (exists? js/document) (js/document.getElementById "app"))
+           payload (ssr/hydrate! {:frame app-frame})
+           tree    [rf/frame-provider {:frame app-frame} [(rf/view :dashboard/root)]]]
+       (when el
+         (if payload
+           ;; Server-streamed: ADOPT the painted DOM. Once the shell and every
+           ;; resolved chunk have landed, `hydrate-root` reconciles React
+           ;; against that server markup — same nodes, listeners attached, no
+           ;; re-paint — and returns the retained root. `create-root` + `render`
+           ;; would discard the server DOM and mount fresh, the bug this branch
+           ;; avoids.
+           (reset! react-root (rdc/hydrate-root el tree))
+           ;; No payload means the server never rendered this page — a plain
+           ;; first load. Mount a fresh root; the shell comes up from the
+           ;; client-side render alone.
+           (do
+             (reset! react-root (rdc/create-root el))
+             (rdc/render @react-root tree)))))))
 
 ;; The JVM headless test that walks the server stream end to end (shell →
 ;; per-card resolved chunks → final payload) lives over in


### PR DESCRIPTION
Follow-up to PR #6052 (rf2-fzza7u), which corrected the SSR docs + the named capability example (`examples/capabilities/ssr/ssr`) to a `hydrate-root` payload-backed boot. Two sibling SSR examples carried the same wrong pattern and are now brought onto the corrected recipe (rf2-x1ldyv).

## Problem

Both siblings booted every client through a `^:dev/after-load mount!` that unconditionally `create-root`ed `#app` and rendered fresh — discarding the server-painted DOM instead of adopting it. That is exactly the create-root-instead-of-hydrate-root bug #6052 fixed in the reference example.

- `examples/capabilities/ssr/ssr_streaming/core.cljc` (old `mount!`): `(when-not @react-root (reset! react-root (rdc/create-root el)))` then `render` — always `create-root`, never `hydrate-root`.
- `examples/capabilities/ssr/resources_ssr/core.cljc` (old `mount!`): same shape — `create-root` only.

## Corrected recipe (matches the reference)

`run` now captures the payload from `ssr/hydrate!` (which seeds STATE only, returns the applied payload or nil) and branches the mount:

- payload-backed boot -> `rdc/hydrate-root el tree` (React `hydrateRoot`, adopts server DOM);
- nil-payload (plain client) boot -> fresh `rdc/create-root` + `rdc/render`.

The retained-root re-render fn (renamed `mount!` -> `render!`) now only re-renders into the one retained root across HMR — it never creates a root and never re-hydrates. One retained root per container throughout. Streaming keeps its `streaming-install!` and its deliberate omission of `:render-tree-fn`; resources keeps `:render-tree-fn`.

## Quality gates

Each edited example compiles clean under its shadow build (foreground):

- `npx shadow-cljs compile examples/resources-ssr` -> Build completed. (221 files, 220 compiled, 0 warnings, 11.71s)
- `npx shadow-cljs compile examples/ssr-streaming` -> Build completed. (203 files, 202 compiled, 0 warnings, 15.43s)

APIs used (`rdc/hydrate-root` / `rdc/create-root` / `rdc/render`) are the shipped `reagent.dom.client` surface, the same ones the reference example uses. Examples are test-free by policy — no spec.cjs added.
