### PR TITLE
fix(ui): treat same-root preflight supersession as expected settlement (rf2-5ep117)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -449,7 +449,13 @@
   to `incarnation`. A prior UNCOMMITTED attempt is a SUPERSESSION: its receipt is
   aborted (only the OLD receipt — the new attempt proceeds to commit). Seated
   BEFORE `.render`, and identity-guarded to the live incarnation, so a same-id
-  reincarnation's entry is never seated by a stale caller. Returns nil."
+  reincarnation's entry is never seated by a stale caller.
+
+  The overtaking `receipt` is handed to the abort as the SUPERSEDING attempt: a
+  same-root write the new preflight already refreshed (rev1 → rev2) settles as
+  EXPECTED supersession, not a spurious `frame-preflight-evidence-mismatch`
+  (rf2-5ep117). Disjoint old writes the new attempt does not cover still abort
+  terminally. Returns nil."
   [root-id receipt incarnation]
   (let [superseded (volatile! nil)]
     (swap! live-roots
@@ -460,7 +466,7 @@
                      (assoc m root-id (assoc entry :pending-attempt receipt)))
                  m))))
     (when-some [old @superseded]
-      (frames/abort-preflight-attempt! old)))
+      (frames/abort-preflight-attempt! old receipt)))
   nil)
 
 (defn- settle-committed-attempt!

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -535,13 +535,50 @@
     (not= root-id (record-root-id record)) :record-root-mismatch
     :else nil))
 
+(defn- superseding-index
+  "Index a superseding attempt's receipt writes by `frame-id →
+  {:root-id :rev}` for the benign-supersession check. A nil receipt / no
+  writes yields `{}`. Only the render-supersession abort path (a later
+  `render!*` seating a new attempt for the SAME root) supplies one; every
+  other abort/finalize path passes none, so out-of-band stale settlements stay
+  dev-loud."
+  [superseding-receipt]
+  (into {}
+        (map (fn [{:keys [frame-id root-id rev]}]
+               [frame-id {:root-id root-id :rev rev}]))
+        (:writes superseding-receipt)))
+
+(defn- benign-supersession?
+  "True when an aborted write was LEGITIMATELY overtaken by the superseding
+  same-root attempt, so its revision mismatch is EXPECTED SETTLEMENT rather than
+  an authority failure. Suppression is precise: the superseding attempt must own
+  this exact frame-id, under the SAME root as the aborted write, and the CURRENT
+  record must BE that superseding write (its rev, its root). Anything else — a
+  foreign-root receipt, a pruned/missing record, a reincarnation, or a divergence
+  the superseding attempt does not account for — is NOT benign and stays
+  dev-loud. `superseding` is the `superseding-index` map (empty for the
+  non-supersession settlement paths, so those never suppress)."
+  [superseding receipt-root-id {:keys [frame-id root-id]} record]
+  (when-some [{sup-root :root-id sup-rev :rev} (get superseding frame-id)]
+    (and (= receipt-root-id root-id)            ; the aborted write names its own root
+         (= sup-root root-id)                   ; the superseding write is the SAME root
+         (some? record)
+         (= sup-rev (:rev record))              ; current authority IS that attempt
+         (= root-id (record-root-id record))))) ; still owned by that same root
+
 (defn- settle-writes!
   "CAS-settle all authorized writes, then emit each rejected entry exactly once.
 
   `settle-one` is pure `(fn [registry write record] registry')`. Evidence is
   accumulated during the pure reduction and fanned only after the CAS wins, so
-  contention can retry without duplicate diagnostics."
-  [phase receipt-root-id writes settle-one]
+  contention can retry without duplicate diagnostics.
+
+  `superseding` is the `superseding-index` of a same-root attempt that has
+  legitimately overtaken this one (empty for every path but render-supersession
+  abort). A rejected write that is a `benign-supersession?` of that attempt is
+  EXPECTED SETTLEMENT — the newer same-root receipt already owns the record — so
+  it neither mutates nor emits. Every other rejection stays dev-loud."
+  [phase receipt-root-id writes superseding settle-one]
   (when (seq writes)
     (loop []
       (let [before @installed-plans
@@ -551,7 +588,10 @@
                (let [record (get m frame-id)]
                  (if-let [reason (settlement-mismatch-reason
                                   receipt-root-id write record)]
-                   [m (conj mismatches [write record reason])]
+                   (if (benign-supersession? superseding receipt-root-id
+                                             write record)
+                     [m mismatches]      ; expected settlement — no mutate, no emit
+                     [m (conj mismatches [write record reason])])
                    [(settle-one m write record) mismatches])))
              [before []]
              writes)]
@@ -566,15 +606,22 @@
   and root authority. A mismatch never mutates and emits
   `:rf.error/frame-preflight-evidence-mismatch`. :fresh →
   `:mount-incomplete`; :live → `:preflight-attempt-failed`; :found-live is left
-  untouched."
-  [receipt-root-id writes]
-  (settle-writes!
-   :abort receipt-root-id writes
-   (fn [m {:keys [frame-id provenance]} _record]
-     (case provenance
-       :fresh (assoc-in m [frame-id :mount-incomplete] true)
-       :live  (assoc-in m [frame-id :preflight-attempt-failed] true)
-       m))))
+  untouched.
+
+  `superseding-receipt` (optional) is the same-root attempt that overtook this
+  one on the render-supersession path: a write it legitimately overtook settles
+  silently (`benign-supersession?`) instead of raising a spurious
+  revision-mismatch. Omitted for the mid-run catch — those writes have no
+  overtaking receipt."
+  ([receipt-root-id writes] (abort-writes! receipt-root-id writes nil))
+  ([receipt-root-id writes superseding-receipt]
+   (settle-writes!
+    :abort receipt-root-id writes (superseding-index superseding-receipt)
+    (fn [m {:keys [frame-id provenance]} _record]
+      (case provenance
+        :fresh (assoc-in m [frame-id :mount-incomplete] true)
+        :live  (assoc-in m [frame-id :preflight-attempt-failed] true)
+        m)))))
 
 (defn- finalize-writes!
   "A host boundary COMMITTED: mark every record this attempt still owns
@@ -583,7 +630,7 @@
   `:rf.error/frame-preflight-evidence-mismatch`."
   [receipt-root-id writes]
   (settle-writes!
-   :finalize receipt-root-id writes
+   :finalize receipt-root-id writes nil
    (fn [m {:keys [frame-id]} record]
      (assoc m frame-id
             (-> record
@@ -885,11 +932,20 @@
   render failed reads as never-scoped; an already-committed refresh / adopted
   boot frame keeps its committed scope). REV+ROOT-GUARDED — never clobbers an
   overtaking write; mismatches emit typed evidence and mutate nothing. A nil
-  receipt is a no-op. Returns nil."
-  [receipt]
-  (when-let [writes (:writes receipt)]
-    (abort-writes! (:root-id receipt) writes))
-  nil)
+  receipt is a no-op. Returns nil.
+
+  On the render-SUPERSESSION path — a later `render!*` seating a NEW attempt for
+  the SAME root aborts the older uncommitted one — pass that newer attempt's
+  `superseding-receipt`. A write it legitimately overtook (its record now the
+  superseding same-root attempt's) is EXPECTED SETTLEMENT: it settles silently,
+  with no spurious `:rf.error/frame-preflight-evidence-mismatch`. Every other
+  divergence (foreign root, missing/pruned record, reincarnation, a write the
+  superseding attempt does not account for) stays dev-loud (rf2-5ep117)."
+  ([receipt] (abort-preflight-attempt! receipt nil))
+  ([receipt superseding-receipt]
+   (when-let [writes (:writes receipt)]
+     (abort-writes! (:root-id receipt) writes superseding-receipt))
+   nil))
 
 ;; ---------------------------------------------------------------------------
 ;; frame-provider scope validation (shared by both hosts)

--- a/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
@@ -307,3 +307,131 @@
       (is (nil? (:rf.error/id
                  (thrown #(frames/execute-frame-plans! :root/a [(plan boot "cfab-aaaaaaaaaaa")])))))
       (is (= :root/a (:adopted-by (frames/installed-plan-entry boot)))))))
+
+;; ---------------------------------------------------------------------------
+;; (E) render-supersession settlement (rf2-5ep117): a later same-root attempt
+;; that overtakes an earlier one settles the OLD receipt as EXPECTED
+;; supersession — no `frame-preflight-evidence-mismatch` — while disjoint old
+;; writes still abort terminally and genuine authority mismatches stay dev-loud.
+;; The client's `seat-pending-attempt!` aborts the superseded receipt handing
+;; the overtaking receipt as the SUPERSEDING attempt; this drives that exact
+;; receipt-settlement contract directly.
+;; ---------------------------------------------------------------------------
+
+(defn- capture-mismatches
+  "Run `thunk` with an error listener installed; return the vector of
+  `:rf.error/frame-preflight-evidence-mismatch` records it emitted."
+  [thunk]
+  (let [records     (atom [])
+        listener-id (keyword "test" (str (gensym "supersession-evidence")))]
+    (error-emit/register-error-listener! listener-id #(swap! records conj %))
+    (try (thunk)
+         (finally (error-emit/unregister-error-listener! listener-id)))
+    (filterv #(= :rf.error/frame-preflight-evidence-mismatch (:error %)) @records)))
+
+(deftest same-root-config-change-supersession-emits-no-mismatch
+  (testing "a same-root A→B config-change render supersession settles the OLD
+            receipt with ZERO evidence-mismatch, and B remains the authoritative
+            committed attempt"
+    (let [fid    :sup/config-change
+          rcpt-a (frames/execute-frame-plans! :root/a [(plan fid "cfa-aaaaaaaaaaaaaa")])]
+      (is (= [:root/a] (mapv :root-id (:writes rcpt-a))))
+      (let [rcpt-b (frames/execute-frame-plans! :root/a [(plan fid "cfb-bbbbbbbbbbbbbb")])]
+        ;; B refreshed the same-root frame to a NEW rev; the record is now B's.
+        (is (= "cfb-bbbbbbbbbbbbbb" (:config-fingerprint (frames/installed-plan-entry fid)))
+            "B's refresh is the live record before the OLD receipt aborts")
+        (let [mismatches (capture-mismatches
+                          #(frames/abort-preflight-attempt! rcpt-a rcpt-b))]
+          (is (empty? mismatches)
+              "the overtaken same-root write is EXPECTED settlement, not a mismatch")
+          (let [entry (frames/installed-plan-entry fid)]
+            (is (= :root/a (owner-root entry)) "B still owns the record")
+            (is (= "cfb-bbbbbbbbbbbbbb" (:config-fingerprint entry)) "…at B's config")
+            (is (nil? (:mount-incomplete entry))
+                "aborting the OLD receipt did not clobber B's live record")))
+        ;; B commits and finalizes normally: it is the authoritative attempt.
+        (frames/finalize-preflight-attempt! rcpt-b)
+        (is (true? (:committed (frames/installed-plan-entry fid)))
+            "B finalizes as the authoritative committed attempt")))))
+
+(deftest supersession-suppresses-only-overtaken-writes-disjoint-still-abort
+  (testing "in one supersession abort, the frame the new attempt refreshed
+            settles silently while a disjoint old write the new attempt does NOT
+            cover is still terminally aborted"
+    (let [overtaken :sup/overtaken
+          disjoint  :sup/disjoint
+          rcpt-a (frames/execute-frame-plans!
+                  :root/a [(plan overtaken "cfo-oooooooooooooo")
+                           (plan disjoint  "cfd-dddddddddddddd")])]
+      (is (= #{overtaken disjoint} (set (map :frame-id (:writes rcpt-a)))))
+      ;; B refreshes ONLY the overtaken frame; disjoint keeps its rev1 record.
+      (let [rcpt-b (frames/execute-frame-plans!
+                    :root/a [(plan overtaken "cfo2-ooooooooooooo")])
+            mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt! rcpt-a rcpt-b))]
+        (is (empty? mismatches) "no spurious mismatch on the overtaken write")
+        (let [ov (frames/installed-plan-entry overtaken)
+              dj (frames/installed-plan-entry disjoint)]
+          (is (= "cfo2-ooooooooooooo" (:config-fingerprint ov))
+              "the overtaken record is B's, untouched by the abort")
+          (is (nil? (:mount-incomplete ov)))
+          (is (true? (:mount-incomplete dj))
+              "the disjoint old write is still terminally aborted"))))))
+
+(deftest genuine-revision-mismatch-without-a-covering-superseder-stays-loud
+  (testing "a revision mismatch the SUPERSEDING receipt does NOT account for (it
+            covers a different frame) is a genuine stale settlement and stays
+            dev-loud — the guard is not over-relaxed to any newer same-root rev"
+    (let [fid    :sup/loud
+          other  :sup/other
+          rcpt-a (frames/execute-frame-plans! :root/a [(plan fid "cfl-llllllllllllll")])]
+      ;; the record advances to a NEW rev via a plain same-root refresh …
+      (frames/execute-frame-plans! :root/a [(plan fid "cfl2-lllllllllllll")])
+      ;; … but the superseding receipt handed to the abort covers a DIFFERENT
+      ;; frame, so it cannot legitimize fid's overtaken write.
+      (let [rcpt-other (frames/execute-frame-plans! :root/a [(plan other "cft-tttttttttttttt")])
+            mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt! rcpt-a rcpt-other))]
+        (is (= 1 (count mismatches))
+            "the uncovered revision mismatch stays dev-loud")
+        (is (= :record-revision-mismatch (:reason (first mismatches)))
+            "…as a record-revision-mismatch")
+        (is (= fid (:frame (first mismatches))))))))
+
+(deftest cross-root-superseder-cannot-suppress-a-foreign-write
+  (testing "a superseding receipt naming a DIFFERENT root than the aborted write
+            never legitimizes it: cross-root authority mismatches stay dev-loud"
+    (let [fid    :sup/foreign
+          rcpt-a (frames/execute-frame-plans! :root/owner [(plan fid "cff-ffffffffffffff")])]
+      ;; the owner refreshes to a new rev (record is owner's, rev2) …
+      (frames/execute-frame-plans! :root/owner [(plan fid "cff2-fffffffffffff")])
+      ;; … but a FOREIGN controller presents rcpt-a under its own root AND a
+      ;; superseding receipt that also names the foreign root for fid. The
+      ;; receipt-root ≠ the write's owner root, so nothing is benign.
+      (let [foreign-superseder {:root-id :root/foreign
+                                :writes  [{:frame-id fid :root-id :root/foreign :rev 999999}]}
+            mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt!
+                          (assoc rcpt-a :root-id :root/foreign)
+                          foreign-superseder))]
+        (is (= 1 (count mismatches)) "the foreign settlement stays dev-loud")
+        (is (= :receipt-root-mismatch (:reason (first mismatches)))
+            "…as a receipt-root-mismatch, never suppressed by a same-frame superseder")
+        (is (nil? (:mount-incomplete (frames/installed-plan-entry fid)))
+            "the foreign controller never mutates the owner's record")))))
+
+(deftest reincarnation-not-suppressed-even-under-a-superseding-receipt
+  (testing "if the frame is destroyed after the superseding attempt refreshed it,
+            the OLD receipt's abort finds no record for it and stays dev-loud —
+            a pruned/reincarnated record is never a benign supersession"
+    (let [fid    :sup/reincarnated
+          rcpt-a (frames/execute-frame-plans! :root/a [(plan fid "cfr-rrrrrrrrrrrrrr")])
+          rcpt-b (frames/execute-frame-plans! :root/a [(plan fid "cfr2-rrrrrrrrrrrr")])]
+      ;; the frame is destroyed AFTER B refreshed it (record pruned) …
+      (frame/destroy-frame! fid)
+      (is (nil? (frames/installed-plan-entry fid)) "sanity: the record is pruned")
+      (let [mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt! rcpt-a rcpt-b))]
+        (is (= 1 (count mismatches))
+            "a pruned record is not a benign supersession — stays loud")
+        (is (= :record-missing (:reason (first mismatches))))))))


### PR DESCRIPTION
## Summary

A same-root config-changing A→B render supersession produced a false `:rf.error/frame-preflight-evidence-mismatch`. `render!*` runs the new preflight first, refreshing a same-root frame from rev1/config A to rev2/config B, then `seat-pending-attempt!` aborts the old rev1 receipt. Because the record now carries rev2, `abort-writes!` read the old write as a `:record-revision-mismatch` and emitted the diagnostic — even though the newer same-root attempt legitimately overtook it (the pending-owner mechanism from #5903; mandatory mismatch emission from #5994).

## The fix

`seat-pending-attempt!` now hands the **overtaking receipt** to the abort as the *superseding* attempt. Settlement gains explicit knowledge of it:

- A rejected write whose frame-id the superseding **same-root** attempt owns, and whose **current record IS that attempt's write** (its root + rev), is **expected settlement**: it neither mutates nor emits.
- Every other divergence — foreign-root receipt, missing/pruned record, reincarnation, or a write the superseding attempt does not account for — stays **dev-loud** and never mutates current authority.
- Disjoint old writes the new attempt does not cover still abort terminally.

Only the render-supersession path supplies a superseding receipt; `finalize` and every out-of-band abort (host-error / unmount / mid-run catch) pass none, so genuine stale-controller settlements remain loud. Public API is unchanged — this is an internal `re-frame.ui.frames` arity (`abort-preflight-attempt!` / `abort-writes!` / `settle-writes!`).

Spec 009's error-catalogue row is untouched: the reason-set and record shape are unchanged (only a spurious emission is suppressed). The Spec 004C / 009 / tooling prose reconciliation is the downstream `rf2-vxgfnd.249` this bead unblocks.

## Tests

New cross-host (JVM `clojure -M:test` + node `test:cljs`/`test:ui`) receipt-settlement fixtures in `preflight_authority_cljs_test.cljc` (section E):
- same-root A→B config-change supersession → **zero** mismatch, B commits authoritative;
- suppression is scoped to overtaken writes — a disjoint old write still aborts terminally;
- a revision mismatch the superseding receipt does not cover stays loud (`:record-revision-mismatch`);
- a cross-root superseder cannot suppress a foreign write (`:receipt-root-mismatch`);
- a reincarnated/pruned record stays loud (`:record-missing`).

Before/after on the identical scenario (using the retained 1-arg arity = old supersession behavior): **PRE-FIX 1 false mismatch → POST-FIX 0**.

Follow-up `rf2-9ydq8q` filed for the browser-gated DOM integration fixture (only executes under `test:browser`, out of scope for this worker's gates).

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **655 tests, 13245 assertions, 0 failures**
- `npm run test:ui`: **674 tests, 3467 assertions, 0 failures**
- `npm run test:cljs`: **9665 tests, 47576 assertions, 0 failures**

(`test:browser` and the full spine intentionally not run per dispatch brief.)