### PR TITLE
docs(core): fix Views synthetic-event frame advice + add real DOM proof (rf2-xzgs3j)

### DIFF
--- a/docs/core/views.md
+++ b/docs/core/views.md
@@ -114,11 +114,15 @@ A static screen isn't much use. A view needs to read live application state, and
 
 This declares "I depend on this derived value. Re-run me when it changes." That's the only way a view learns application state. It doesn't read [app-db](glossary.md#app-db) directly, and it doesn't receive the value as an argument threaded down through ten ancestors. It asks the [derivation graph](glossary.md#the-derivation-graph) for exactly the slice it needs, *by name* — via a [query vector](glossary.md#query-vector), the `[id & args]` shape that names the subscription and keys its cache. (More on subscriptions in [Subscriptions](subscriptions.md).)
 
-**Sending events out: the view [dispatches](glossary.md#dispatch).** Wire a `dispatch` to an [event handler](glossary.md#event-handler):
+**Sending events out: the view [dispatches](glossary.md#dispatch).** Wire the view's `dispatch` to an [event handler](glossary.md#event-handler):
 
 ```clojure
-[:button {:on-click #(rf/dispatch [:cart/add id])} "Add"]
+[:button {:on-click #(dispatch [:cart/add id])} "Add"]
 ```
+
+(`dispatch` here is the local `reg-view` injects — bound to the view's
+[frame](glossary.md#frame), and captured so it still routes correctly when the
+click fires, *after* the render. More on that [below](#the-trap-a-callback-that-fires-after-render-has-no-frame).)
 
 A dispatch *announces that something happened* by handing the framework an [event](glossary.md#event) — a plain vector naming what occurred — and returns immediately. It does not change state. It does not know or care what the handler will do with it. The [event pipeline](glossary.md#event-pipeline) takes it from there: the handler runs, `app-db` moves, subscriptions repropagate, and at the very end this view re-renders to match. (The whole traversal is the [Introduction](introduction.md)'s subject.)
 
@@ -342,7 +346,7 @@ subs, and seed setup via `:initial-events`. That closes the pure pipeline stages
 |---|---|---|
 | Screen shows wrong data | Bad event or sub, not the view | Inspect data with [Xray](../xray/index.md); test handler/sub without a browser |
 | View re-renders too often | Sort/filter in the view, or too-coarse sub | Move work into a sub; [slow-view recipe](how-to/fix-a-slow-view.md) |
-| `:rf.error/no-frame-context` from a click path | Imperative listener / bare `defn` | Use `:on-*` attrs; register state-touching views |
+| `:rf.error/no-frame-context` from a click path | Bare `rf/dispatch` in a handler that fires after render, or an unregistered `defn` that dispatches | `reg-view` it and use the injected `dispatch`; for detached callbacks capture with `rf/capture-frame` |
 | List flickers or duplicates | Missing / colliding `^{:key …}` | Stable keys from data |
 | Anonymous noise in the trace | Unregistered state-touching children | House rule: `reg-view` for anything that subscribes |
 
@@ -354,25 +358,46 @@ what triggered it — that is how you answer "why did this re-render?" Registere
 views have names; plain helpers fall under `[:rf.view/anonymous nil]`. Dev-only;
 [elided](glossary.md#elide) in production.
 
-## The trap: imperative listeners lose the frame
+## The trap: a callback that fires after render has no frame
 
-Hiccup's `:on-*` attrs are wrapped so a `dispatch` inside them carries the frame.
-Anything you attach *imperatively* from a render body is not:
+A view's `:on-*` handler runs *later* — when the user clicks, not when the view
+renders. By then the render is over: the dynamic [frame](glossary.md#frame) scope
+has unwound and the [frame-provider](glossary.md#frame-provider)'s React context
+has been popped. The adapter does **not** re-wrap `:on-*` callbacks to restore it —
+[frame identity is carried, not found](glossary.md#frame-identity-is-carried-not-found).
+What survives that boundary is capturing the frame *at render time*, which is
+exactly what `reg-view`'s injected `dispatch` / `subscribe` do: each is a
+[`capture-frame`](glossary.md#capture-frame) op bound to the render frame. So reach
+for the injected `dispatch` — not a fresh, fully-qualified `rf/dispatch`:
 
 ```clojure
-;; WRONG — fires later with no frame → :rf.error/no-frame-context
+;; WRONG — `rf/dispatch` resolves the frame when the event fires, and by then
+;; there is none → :rf.error/no-frame-context
+[:div {:on-animation-end #(rf/dispatch [:tile/finished])}]
+
+;; RIGHT — the injected `dispatch` captured the frame at render, so it
+;; dispatches correctly after the render boundary
+[:div {:on-animation-end #(dispatch [:tile/finished])}]
+```
+
+Attaching a listener *imperatively* from a render body fails the same way, and
+worse: the callback still fires with no frame, **and** every re-render stacks
+another listener.
+
+```clojure
+;; WRONG — fires later with no frame, and leaks a listener per render
 [:div {:ref (fn [el]
               (when el
                 (.addEventListener el "animationend"
                   #(rf/dispatch [:tile/finished]))))}]
-
-;; RIGHT — synthetic prop; the adapter wraps the callback
-[:div {:on-animation-end #(rf/dispatch [:tile/finished])}]
 ```
 
 If there is no `:on-*` for what you need (`setTimeout`, `fetch`, observers,
 sockets), that work belongs in a registered [effect](effects.md), not the view.
-Even inside `reg-view`, imperative attach is wrong: re-renders stack listeners.
+When you must hold a `dispatch` for a genuinely detached callback — a socket
+message, a timer you own — capture it explicitly:
+`(:dispatch (rf/capture-frame))` returns a dispatch locked to the render frame
+that survives any async hop. [Frames](frames.md) is that pattern's home.
 
 ---
 

--- a/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
@@ -1,0 +1,174 @@
+(ns re-frame.views-synthetic-event-frame-dom-cljs-test
+  "Real-DOM proof for the Core Views guide's synthetic-event frame advice
+  (rf2-xzgs3j).
+
+  The `docs/core/views.md` §\"imperative listeners lose the frame\" section
+  previously claimed that Hiccup `:on-*` attrs are 'wrapped so a `dispatch`
+  inside them carries the frame', and marked a bare
+  `#(rf/dispatch [:tile/finished])` in an `:on-animation-end` prop as the
+  RIGHT pattern. That is FALSE of the shipped adapters. Neither the Reagent
+  adapter (`re-frame.adapter.reagent`) nor reagent-slim wraps `:on-*`
+  callbacks to re-establish a frame binding: the handler is a plain closure
+  React invokes LATER, on a fresh JS stack, with no render in progress. At
+  that point:
+
+    * the dynamic `re-frame.frame/*current-frame*` scope has unwound, and
+    * the frame-provider's React context value has been popped back to the
+      no-provider sentinel (context is a render-phase concept).
+
+  So a bare, fully-qualified `rf/dispatch` from an `:on-*` handler resolves
+  NO frame and — EP-0002, no `:rf/default` floor — raises
+  `:rf.error/no-frame-context` (see `re-frame.core/current-frame-id`,
+  implementation/core/src/re_frame/core.cljc:1118-1132, and
+  `frame/require-current-frame!`).
+
+  What actually carries the frame into a deferred callback is capturing it
+  at RENDER time. The `reg-view` macro injects `dispatch` / `subscribe`
+  locals that are exactly a `(rf/capture-frame)` op bundle
+  (core_reg_view_macro.cljc:185-192), so the UNqualified injected `dispatch`
+  closes over the render frame and dispatches correctly after the render
+  boundary. The same is true of an explicit `(:dispatch (rf/capture-frame))`
+  or an explicit `{:frame …}` on the dispatch.
+
+  This suite fires a REAL synthetic click on a mounted `reg-view` and pins
+  both halves of the corrected advice:
+
+    1. bare `#(rf/dispatch [:evt])`     → raises :rf.error/no-frame-context
+                                          and nothing lands.
+    2. injected `#(dispatch [:evt])`    → dispatches successfully; the
+                                          frame's app-db advances.
+
+  Browser-only — a genuine synthetic event needs a real React root + real
+  DOM the Node runner can't fake. The `-dom-cljs-test$` suffix (rf2-2hrj8)
+  opts this file into the `:browser-test` build; `:node-test` still loads it
+  (matches `cljs-test$`) and the DOM branch self-gates on `(browser?)`,
+  exiting early under :node-test where `js/document` is absent."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; `:ambient-frame nil` OPTS OUT of the fixture's default ambient
+;; `*current-frame*` :rf/default scope. It is load-bearing here: the whole
+;; point of the proof is that a synthetic-event handler fires with NO frame
+;; scope in effect. An ambient :rf/default binding would satisfy the bare
+;; `rf/dispatch` at click time and mask the very failure under test —
+;; exactly as it would mask nothing in production, where a real user click
+;; never runs under an ambient binding. `:async? true` because the working
+;; half awaits the async dispatch drain.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+
+;; ---- browser gate ----------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; Captures the error id a bare `rf/dispatch` raises from the click handler.
+;; A namespace-level atom so the `reg-view` body (spliced verbatim) can close
+;; over it; reset at the top of the test.
+(defonce ^:private raised (atom nil))
+
+;; The proof view. Defined with the `reg-view` MACRO (not `reg-view*`) so the
+;; UNqualified `dispatch` / `subscribe` below are the macro's render-time
+;; frame-captured injections — the exact surface the guide documents.
+;;
+;;   * `syn-bare`     uses fully-qualified `rf/dispatch` — the ambient form.
+;;                    It bypasses the injection and resolves the frame at
+;;                    CLICK time, when there is none. Wrapped in try/catch to
+;;                    capture the raised error id (mirrors the setTimeout
+;;                    regression in dispatch_frame_capture_cljs_test).
+;;   * `syn-captured` uses the injected `dispatch` — captured at render.
+(reg-view proof-view []
+  (let [n @(subscribe [:syn/n])]
+    [:div
+     [:span {:data-testid "syn-count"} n]
+     [:button {:data-testid "syn-bare"
+               :on-click (fn [_]
+                           (try
+                             (rf/dispatch [:syn/inc])
+                             (catch :default e
+                               (reset! raised (:rf.error/id (ex-data e))))))}
+      "bare rf/dispatch"]
+     [:button {:data-testid "syn-captured"
+               :on-click (fn [_] (dispatch [:syn/inc]))}
+      "injected dispatch"]]))
+
+(defn- query [mount-node testid]
+  (.querySelector mount-node (str "[data-testid='" testid "']")))
+
+(deftest synthetic-event-frame-advice-real-dom-proof
+  "rf2-xzgs3j — real synthetic click proves the corrected guide advice.
+
+   A `reg-view` mounted under a `frame-provider` carries two buttons. A real
+   DOM click on the bare `#(rf/dispatch …)` button raises
+   :rf.error/no-frame-context and lands nothing; a real DOM click on the
+   injected `#(dispatch …)` button dispatches successfully and the frame's
+   app-db advances after the render boundary."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — the :browser-test runner exercises the assertions")
+    (async done
+      (let [target     :syn/frame
+            done?      (atom false)
+            mount-node (.createElement js/document "div")
+            cleanup!   (fn []
+                         (try (.remove mount-node) (catch :default _ nil))
+                         (try (rf/destroy-frame! target) (catch :default _ nil)))
+            done!      (fn [] (when (compare-and-set! done? false true)
+                               (cleanup!) (done)))]
+        (reset! raised nil)
+        (.appendChild (.-body js/document) mount-node)
+        (rf/make-frame {:id target :doc "rf2-xzgs3j synthetic-event proof frame"})
+        (rf/reg-event :syn/init (fn [{:keys [db]} _] {:db (assoc db :n 0)}))
+        (rf/reg-event :syn/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+        (rf/reg-sub :syn/n (fn [db _] (:n db)))
+        (rf/dispatch-sync [:syn/init] {:frame target})
+        (let [root (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [rf/frame-provider {:frame target}
+                                  [proof-view]])))
+            (let [bare     (query mount-node "syn-bare")
+                  captured (query mount-node "syn-captured")]
+              (is (some? bare) "the bare-dispatch button mounted")
+              (is (some? captured) "the injected-dispatch button mounted")
+              (is (= 0 (:n (rf/app-db-value target)))
+                  "sanity: app-db seeded to {:n 0} before any click")
+
+              ;; ---- (1) bare rf/dispatch: fires later, no frame → raises ----
+              (.click bare)
+              (is (= :rf.error/no-frame-context @raised)
+                  (str "a real synthetic click on the bare `#(rf/dispatch …)` button "
+                       "raised :rf.error/no-frame-context (the render frame is gone "
+                       "by the time the event fires); got " (pr-str @raised)))
+              (is (= 0 (:n (rf/app-db-value target)))
+                  "the bare dispatch landed NOTHING — app-db is still {:n 0}")
+
+              ;; ---- (2) injected dispatch: captured at render → dispatches ----
+              (.click captured)
+              ;; The injected `dispatch` is async (router next-tick drain).
+              ;; Advance two macrotasks — one for the enqueue, one for the
+              ;; goog.async.nextTick drain — then assert the frame advanced.
+              (js/setTimeout
+                (fn []
+                  (js/setTimeout
+                    (fn []
+                      (is (= 1 (:n (rf/app-db-value target)))
+                          (str "a real synthetic click on the injected `#(dispatch …)` "
+                               "button dispatched successfully AFTER the render boundary "
+                               "— app-db advanced to {:n 1}; got "
+                               (pr-str (:n (rf/app-db-value target)))))
+                      (try (rdc/unmount root) (catch :default _ nil))
+                      (done!))
+                    10))
+                10))
+            (catch :default e
+              (is false (str "synthetic-event proof threw: " (pr-str e)))
+              (try (rdc/unmount root) (catch :default _ nil))
+              (done!))))))))


### PR DESCRIPTION
## Summary

`docs/core/views.md` gave **wrong advice** about handling React synthetic events with respect to frames. The "imperative listeners lose the frame" section (added by PR #5925) claimed:

> Hiccup's `:on-*` attrs are wrapped so a `dispatch` inside them carries the frame.

and marked a bare `#(rf/dispatch [:tile/finished])` in an `:on-animation-end` prop as the **RIGHT** pattern ("the adapter wraps the callback"). Both claims are false of the shipped adapters.

## The wrong advice vs shipped behaviour

Neither the Reagent adapter (`re-frame.adapter.reagent`) nor reagent-slim re-wraps `:on-*` callbacks — the adapter has no `:on-*` handling at all (`implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs`). An `:on-*` handler is a plain closure React invokes **later**, on a fresh JS stack, with no render in progress. By then:

- the dynamic `re-frame.frame/*current-frame*` scope has unwound, and
- the frame-provider's React context value has been popped back to the no-provider sentinel (context is a render-phase concept).

So a bare, fully-qualified `rf/dispatch` from an `:on-*` handler resolves **no** frame and — EP-0002, no `:rf/default` floor — raises `:rf.error/no-frame-context` (`re-frame.core/current-frame-id`, `implementation/core/src/re_frame/core.cljc:1118-1132`; `frame/require-current-frame!`). This is identical to the imperative `addEventListener` failure the doc already flagged.

## The corrected advice

What carries the frame into a deferred callback is capturing it **at render time**. The `reg-view` macro injects `dispatch` / `subscribe` locals that are exactly a `(rf/capture-frame)` op bundle bound to the render frame (`implementation/core/src/re_frame/core_reg_view_macro.cljc:185-192`), so the **unqualified injected `dispatch`** dispatches correctly after the render boundary; a fresh `rf/dispatch` does not.

Fixed three spots, all the same bug:
- The trap section: retitled, corrected the mechanism claim, and the RIGHT example now uses the injected `dispatch` (with `(:dispatch (rf/capture-frame))` for genuinely detached callbacks).
- The canonical dispatch-out example (was `#(rf/dispatch [:cart/add id])` in an `:on-click`) → injected `#(dispatch [:cart/add id])`, matching the doc's own live example.
- The "When things go wrong" table row that implied `:on-*` attrs carry the frame.

## The DOM proof

New `implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs` mounts a `reg-view` under a `frame-provider` in a real React root, fires a **genuine synthetic click** on each pattern, and asserts:

1. bare `#(rf/dispatch [:evt])` → raises `:rf.error/no-frame-context`; nothing lands (app-db unchanged).
2. injected `#(dispatch [:evt])` → dispatches successfully; the frame's app-db advances after the render boundary.

Follows the existing `-dom-cljs-test` pattern: `:node-test` loads it and self-gates on `(browser?)`; the `:browser-test` build runs the real assertions under Chromium.

## Was the code wrong?

No — the runtime behaviour is intended EP-0002. The Reagent adapter testbed (`adapter_testbed_reagent/core.cljs`) and `dispatch_frame_capture_cljs_test.cljs` both document a bare `rf/dispatch` from a deferred callback raising `:rf.error/no-frame-context` as correct. This is a **doc-only** fix.

## Quality gates

- `python scripts/check_doc_slugs.py` → exit 0 (no broken links/anchors).
- `python -m mkdocs build --strict` → exit 0 (only pre-existing spec/migration INFO notes).
- `npm run test:cljs` → **Ran 9661 tests containing 47556 assertions. 0 failures, 0 errors.** (new DOM test compiles + loads + self-gates green on the core-reachable node-test surface).
- Focused `:browser-test` under real Chromium (`shadow-cljs compile browser-test --config-merge {:ns-regexp "views-synthetic-event-frame-dom-cljs-test$"}` + `serve-and-run-browser-tests.cjs`) → **Ran 1 tests containing 6 assertions. 0 failures, 0 errors.** — the synthetic-event proof actually fires and passes.
