### PR TITLE
fix(docs): keep edited Core live-cell experiments on their owning frames (rf2-zp5ych)

### DIFF
--- a/docs/core/coeffects.md
+++ b/docs/core/coeffects.md
@@ -279,7 +279,7 @@ A live order-placer. The durable facts — *when* each order was placed, *what* 
 
 Notice that `:demo.order/place` never calls `js/Date.` or `random-uuid`. The only ambient host read left — the locale formatting the displayed time — lives at the view, a render-time choice that never touches durable state.
 
-**Try it:** change the button's dispatch to `#(rf/dispatch [:demo.order/place {:id (random-uuid)}] {:rf.cofx {:rf/time-ms 1735732800000}})` (the ns-level `rf/dispatch`, which takes the opts map directly) and re-evaluate. Every order is now stamped that exact instant, because you handed the runtime the fact instead of letting it stamp the wall clock. And if you have an app running with [Xray](glossary.md#xray) open, focus the event's epoch and read its recordable coeffects — the exact facts this run folded, sitting right above the handler step.
+**Try it:** change the button's dispatch to `#(dispatch [:demo.order/place {:id (random-uuid)}] {:rf.cofx {:rf/time-ms 1735732800000}})` (the injected `dispatch` takes the opts map as its second argument, and it stays locked to this view's `:orders` [frame](glossary.md#frame) — so the order still lands where the list is subscribed) and re-evaluate. Every order is now stamped that exact instant, because you handed the runtime the fact instead of letting it stamp the wall clock. And if you have an app running with [Xray](glossary.md#xray) open, focus the event's epoch and read its recordable coeffects — the exact facts this run folded, sitting right above the handler step.
 
 ## Supplying facts in tests
 

--- a/docs/core/views.md
+++ b/docs/core/views.md
@@ -162,9 +162,13 @@ macOS) to evaluate, then click the buttons:
  [qty-stepper]]
 ```
 
-Change the last form to `[:div [qty-stepper] [qty-stepper]]` and re-evaluate.
-Click either stepper: both move. Neither owns the number — each is a window onto
-the same app-db value. There is no local copy to fall out of sync.
+Keep the `:demo` `frame-root` and change its child from `[qty-stepper]` to
+`[:div [qty-stepper] [qty-stepper]]`, then re-evaluate. Click either stepper:
+both move. Both mount under the same seeded `:demo` [frame](glossary.md#frame),
+so neither owns the number — each is a window onto the one app-db value. There is
+no local copy to fall out of sync. (Replacing the whole `frame-root` with the
+bare `[:div …]` would drop the `:demo` seed and land the steppers on an
+uninitialised frame — keep the wrapper.)
 
 ### The pure pipeline is complete
 


### PR DESCRIPTION
Fixes rf2-zp5ych. Two PR #5925 Try-it instructions moved the edited live-cell experiment off the frame that owns the displayed state, so following them verbatim produced no visible update (or an error).

## The defect

**`docs/core/views.md`** (Try-it at line 165). The instruction said *"Change the last form to `[:div [qty-stepper] [qty-stepper]]`"*. The last form is the whole `[rf/frame-root {:id :demo :initial-events [[:views.qty/initialise]]} [qty-stepper]]`. Replacing it wholesale drops the seeded `:demo` `frame-root`; the two steppers then mount on the playground's default frame (`:rf/default`, created but never seeded — `docs/tools/playground/sci/src/rf2_playground/sci.cljs:89,245`), so the span shows nothing and `+` runs `inc` on `nil`.

**`docs/core/coeffects.md`** (Try-it at line 282). The instruction switched the button to the **ns-level** `rf/dispatch`. Under the playground that is `playground-dispatch` (`sci.cljs:106-108`), which defaults `{:frame :rf/default}` — so the order lands on `:rf/default` while the view still subscribes to `:orders` (`frame-provider {:frame :orders}`). The order list never updates.

## The frame-ownership fix

- **views.md** — keep the `:demo` `frame-root` and change only its **child** to `[:div [qty-stepper] [qty-stepper]]`. Both steppers stay on the seeded `:demo` frame (start at 1, both move).
- **coeffects.md** — use the **injected** `dispatch` (drop the `rf/` qualifier) and pass the opts map as its second arg: `#(dispatch [:demo.order/place {:id (random-uuid)}] {:rf.cofx {:rf/time-ms 1735732800000}})`. The injected op comes from `make-capture-frame` (`implementation/core/src/re_frame/core.cljc:1179-1182`): its 2-arity form is `(dispatch-impl event (merge dispatch-opts opts {:frame frame}))` — per-call opts like `:rf.cofx` flow through, `{:frame frame}` is merged **last** so the captured `:orders` frame always wins. `dispatch-impl` **is** `router/dispatch!` (core.cljc:201), so `:rf.cofx` is honoured identically to the old path; only the frame is corrected. This is the bead's "or uses the captured dispatch" path.

Both edits are **prose-only** — the executable `cljs-rf2` blocks are unchanged; the base cells already ship correct.

## Scope note (playground harness — STOPPED)

The acceptance criterion *"automated playground smoke exercises the edited variants"* would require new cell cases in `docs/tools/playground/test/smoke.test.mjs` — the playground **harness** surface owned by rf2-io9mdr (PR #6064, pending-merge, off-limits this round). Filed as **rf2-gmjblu**, sequenced behind #6064. No harness files were touched here.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0.
- `python -m mkdocs build --strict` — exit 0 (only pre-existing INFO lines, none from these two pages; `glossary.md#frame` links resolve).
- Playground smoke / freshness: no gate reads these doc pages' prose (`smoke.test.mjs` uses inline cell strings), and the `cljs-rf2` blocks are unchanged — nothing to refresh.