### PR TITLE
fix(xray): surface canonical :rf.sub/skip evidence in the Reactive panel (rf2-ty5r5o)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -661,29 +661,35 @@ ninth L4 tab. The L4 set is locked at 8.
 **Decision: collapsed disclosure by default, dim when expanded.**
 
 - Default: footer line `[Show N unchanged subs ▾]` collapsed.
-- Expanded: rendered inline within step 7 at 60% text opacity
+- Expanded: the memo-hit subs render dim at 60% text opacity
   (`:text-tertiary` token).
-- Operator can pin "always expand unchanged" via Settings → View → "Show
-  unchanged subs in cascade" (default OFF).
+- Operator can pin "always expand unchanged" via the
+  `:show-unchanged-subs?` Settings pin (`:general` section; default OFF).
 
 Rationale: unchanged subs are coverage signal, not signal-of-the-moment.
 Hiding by default keeps the dense view scannable; the toggle preserves
 the "I want to see what DIDN'T fire" affordance.
 
-**Data-availability (rf2-vxgfnd.22).** The projection tier
-(`reactive-panel-subs/project-record`) carries NO `subs-skipped` slot. A
-memo-hit (input-unchanged short-circuit) emits NO `:sub-runs` row — the
-substrate's `sub-run-row` hardcodes `:recomputed? true`, and a
-`:rf.sub/skip` memo-hit rides only `:trace-events` — so `:subs-ran` is
-the whole run-set. Surfacing *skipped* subs (the "what DIDN'T fire"
-coverage above) awaits the `:rf.sub/skipped` attribution op (§12, not yet
-landed); it MUST NOT be reconstructed by filtering `:sub-runs` on
-`(complement :recomputed?)`, which is structurally always empty — a
-projected slot that shape produced was doubly-dead (unproducible AND
-consumed by no panel: the §3.2 flow graph reads `:level-1/2-subs` /
-`:view-rows` / `:sub-readers`). The graph's `unchanged` (dashed,
-short-circuited) nodes are subs that RAN with `:value-changed? false`,
-NOT memo-hit skips.
+**Data-availability (rf2-ty5r5o).** The disclosure is fed by the
+canonical `:rf.sub/skip` op the substrate ALREADY emits — a memo-hit
+(input-value-equal short-circuit) emits NO `:sub-runs` row (the
+substrate's `sub-run-row` hardcodes `:recomputed? true`) but rides
+`:trace-events` as a `:rf.sub/skip` (`re-frame.subs.memo/emit-sub-skip!`,
+tags `:rf.sub/id` / `:rf.sub/query-v` / `:rf.sub/reason` `:input-value-equal`
+/ `:rf.sub/input-paths-unchanged`). `reactive-panel-subs/project-record`
+reads those ops off `:trace-events` into a distinct `:subs-skipped` slice
+(`skipped-subs`), de-duplicated by sub-id and EXCLUDING any sub that also
+recomputed this epoch — so `:subs-skipped` stays cleanly distinct from
+`:subs-ran`. It is NOT reconstructed by filtering `:sub-runs` on
+`(complement :recomputed?)`, which is structurally always empty. The
+graph's `unchanged` (dashed, short-circuited) nodes are subs that RAN with
+`:value-changed? false` (a recompute that produced the same value) — a
+DIFFERENT category from a memo-hit skip, and the panel never conflates the
+two. The disclosure open-state (`:show-unchanged?` on `:rf.xray/reactive-
+data`) is the OR of the panel-local quick-toggle
+(`:rf.xray/reactive-show-unchanged?`, flipped by
+`:rf.xray/reactive-toggle-unchanged`) and the `:show-unchanged-subs?`
+Settings pin.
 
 ### §3.4.1 ViewCell invalidation evidence (re-frame.ui substrate · rf2-vxgfnd.146)
 
@@ -808,7 +814,7 @@ general JavaScript heap claim (rf2-vxgfnd.149). Tool absence stays zero-cost.
 
 | From | Reads |
 |---|---|
-| Focused epoch record | `:rf.sub/run`, `:rf.sub/skipped` (new — §11), `:rf.view/render` / `:rf.view/rendered` — read from the focused epoch record's `:trace-events` (rf2-rly4a — same `focus.epoch-id` scope as Trace, so Reactive + Trace stay correlated) |
+| Focused epoch record | `:rf.sub/run`, `:rf.sub/skip` (memo hit → `:subs-skipped`, §3.4), `:rf.view/render` / `:rf.view/rendered` — read from the focused epoch record's `:trace-events` (rf2-rly4a — same `focus.epoch-id` scope as Trace, so Reactive + Trace stay correlated) |
 | Registries | Sub metadata (input-paths, signal-fn), view metadata (file:line) |
 | App-db | Seed-path resolution from the epoch's diff (§4) |
 | re-frame.ui evidence projection | `:rf.xray/viewcell-evidence` → `viewcell-evidence/rows` — the CUMULATIVE bounded per-ViewCell invalidation accumulators Xray owns via `re-frame.ui.tool.evidence` (§3.4.1; NOT epoch-scoped) |
@@ -842,9 +848,10 @@ SUBSCRIPTIONS** sections read the view-unmount / sub-dispose ops from the same e
    given sub) need the deref-subs sink (spec'd, absent in the current build) or sub-cache
    reader introspection. Until it lands, the `×N (shared)` annotation + the precise
    "reactive vs parent re-render" tag render only for edges the triggering-view key resolves.
-3. **`:rf.sub/skipped`** ("considered, didn't recompute") appears only when skips happen;
-   `:rf.sub/value-changed? false` carries the changed/not story regardless, so the dashed
-   `no change` node renders from the run-set alone.
+3. **`:rf.sub/skip`** ("considered, didn't recompute" — the memo hit) appears only when skips
+   happen; it feeds the §3.4 `:subs-skipped` disclosure, NOT the graph. `:rf.sub/value-changed?
+   false` carries the changed/not story regardless, so the dashed `no change` graph node renders
+   from the run-set alone.
 
 ### §3.6 Cross-panel navigation
 
@@ -5131,7 +5138,7 @@ What the panel design needs from the substrate (per §1.4 captured-not-replayed)
 | Bounded per-epoch capture | Cap at **50 subs + 100 views per epoch**. The substrate enforces at capture time; the panel shows `+N more` overflow indicator (existing component, `panels/overflow_indicator.cljc`). |
 | Buffer retention | Substrate-owned. Xray documents the operator surface as **Settings → Buffer → Epoch history** (current ~100; configurable). |
 | Evicted-epoch UX | Per §10.7 — placeholder string in every panel. |
-| Sub `:skipped` op | New trace op needed (`:rf.sub/skipped`) — current trace has `:rf.sub/run` only. Without `:skipped`, the "unchanged subs" disclosure in §3.4 cannot render coverage. |
+| Sub skip op | **Landed** — the substrate emits `:rf.sub/skip` on a memo hit (`re-frame.subs.memo/emit-sub-skip!`); it rides `:trace-events` and feeds the §3.4 "unchanged subs" disclosure via `:subs-skipped` (rf2-ty5r5o). No new op needed. |
 
 ### §11.4 B.10 Open sub-decisions
 
@@ -5181,7 +5188,7 @@ prerequisites.
 | Contract | Op key | Payload sketch | Used by |
 |---|---|---|---|
 | **View re-render attribution** | `:rf.view/rendered` | `{:rf.view/id :ns/Component :file ".../X.cljs" :line N :rf.view/cause-event-id <id> :caused-by-paths [...] :rf.trace/dispatch-id <id>}` | Reactive panel · Trace panel · §3.5 |
-| **Sub skip attribution** | `:rf.sub/skipped` | `{:rf.sub/id :s/foo :reason :input-unchanged :rf.trace/dispatch-id <id>}` | Reactive panel "unchanged subs" disclosure · §3.4 |
+| **Sub skip attribution** (rf2-ty5r5o) | `:rf.sub/skip` | `{:rf.sub/id :s/foo :rf.sub/query-v [...] :rf.sub/reason :input-value-equal :rf.sub/input-paths-unchanged [...]}` — **Landed** (`re-frame.subs.memo/emit-sub-skip!`); rides `:trace-events`, projected to `:subs-skipped`. | Reactive panel "unchanged subs" disclosure · §3.4 |
 | **Sub value-change + cascade attribution** (rf2-l1jz8) | `:rf.sub/run` | `{:rf.sub/id :s/foo :query-v [...] :value-changed? <bool> :prev-value <v> :value <v> :cascade? <bool> :cause-sub [query-id args]-or-nil}` — value slots redacted at the marks chokepoint; threaded onto the epoch record's `:sub-runs` projection. **Landed** in the framework substrate (Spec 009 §`:rf.sub/run`, Spec-Schemas §`:rf/epoch-record` `:sub-runs`). | Reactive panel "SUBS WHOSE VALUE CHANGED" (§3.1.1.2) + "SUBS THAT CASCADED" (§3.1.1.3) |
 | **Cascade aggregate** | `:rf.cascade/captured` | `{:rf.trace/dispatch-id <id> :subs-ran N :subs-skipped N :views-rendered N :flows-recomputed N}` | Optional — emitted at end-of-epoch for fast L2 badge / Reactive summary line |
 | **Dispatch-origin tag** | (on existing `:rf.event/dispatched`) | `:tags :rf.event/origin <origin-kw>` per §1.5 taxonomy (landed) | Epoch panel DISPATCH step · L2 row prefix · filter pills |
@@ -5225,10 +5232,12 @@ real beads after approving this doc.
   §1.5 taxonomy. All call sites in `re-frame.core` + adapter mounts.
   Gates: Epoch panel DISPATCH step, L2 row prefix, B.10 dispatch-origin display.
 
-- **rf2-?????** — *Substrate: add `:rf.sub/skipped` trace op.* Emit at
-  sub-evaluation skip site (input-unchanged short-circuit). Carries
-  `:rf.sub/id` + `:reason` + `:rf.trace/dispatch-id`. Gates: Reactive panel
-  "unchanged subs" disclosure (§3.4).
+- **DONE (rf2-ty5r5o)** — *Substrate: `:rf.sub/skip` trace op.* The memo
+  wrappers emit `:rf.sub/skip` at the input-value-equal short-circuit
+  (`re-frame.subs.memo/emit-sub-skip!`), carrying `:rf.sub/id` /
+  `:rf.sub/query-v` / `:rf.sub/reason` / `:rf.sub/input-paths-unchanged`; it
+  rides `:trace-events`. The Reactive panel's §3.4 "unchanged subs"
+  disclosure consumes it via `:subs-skipped` (rf2-ty5r5o).
 
 - **rf2-?????** — *Substrate: add `:rf.view/rendered` trace op per
   substrate adapter.* One per Reagent / UIx / Helix; instrumented at the
@@ -5239,9 +5248,9 @@ real beads after approving this doc.
   of-epoch summary op with subs/views/flows counts. Cheap; emitted every
   epoch. Gates: L2 badge "cascade size", Reactive header summary line.
 
-- **rf2-?????** — *Substrate: add `:rf.flow/skipped` trace op.* Mirror
-  `:rf.sub/skipped` for flows. Gates: Epoch panel FLOW step dim-row
-  rendering.
+- **rf2-?????** — *Substrate: add `:rf.flow/skipped` trace op.* Mirror the
+  landed `:rf.sub/skip` (rf2-ty5r5o) for flows. Gates: Epoch panel FLOW
+  step dim-row rendering.
 
 - **rf2-?????** — *Substrate: focused-event-only attribution gate.*
   Runtime extension reads a per-frame `:rf.xray/focused-dispatch-id`
@@ -5270,7 +5279,7 @@ real beads after approving this doc.
 - **rf2-?????** — *Xray: Reactive panel rebuild + rename.* Rename L3
   tab display label `Views` → `Reactive` (key stays `:views`). Replace
   panel content with sub cascade + view re-render (§3). Depends on
-  substrate `:rf.sub/skipped` + `:rf.view/rendered`.
+  substrate `:rf.sub/skip` (landed, rf2-ty5r5o) + `:rf.view/rendered`.
 
 - **rf2-?????** — *Xray: App-db panel — downstream-subs overlay.* Add
   the hover popover at §4.4 that lists subs/views downstream of each

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -12,14 +12,23 @@
   emits (`:rf.sub/computed` / `:rf.sub/skipped`), pinning subs-ran to
   zero regardless of how many subs actually ran.
 
-  - `:sub-runs` → subs-ran; every `:sub-runs` row is a genuine recompute
-    (the substrate's `sub-run-row` hardcodes `:recomputed? true` and a
-    `:rf.sub/skip` memo-hit projects NO `:sub-runs` row — it rides only
-    `:trace-events`), so there is no memo-hit / `subs-skipped` split to
-    surface here. Each row carries `:value-changed?`. Surfacing skipped
-    (memo-hit) subs awaits the `:rf.sub/skipped` attribution op (spec/021
-    §12) — it MUST NOT be reconstructed by filtering `:sub-runs` on
-    `(complement :recomputed?)`, which is structurally always empty.
+  - `:sub-runs`  → subs-ran; every `:sub-runs` row is a genuine recompute
+    (the substrate's `sub-run-row` hardcodes `:recomputed? true`). Each
+    row carries `:value-changed?` — a `:value-changed? false` recompute is
+    a sub that RAN but produced the same value (a dashed, short-circuited
+    graph node), which is DISTINCT from a memo-hit skip below.
+  - `:subs-skipped` → the memo-hit `:rf.sub/skip` evidence (spec/021 §3.4).
+    The substrate emits a canonical `:rf.sub/skip` op on `:trace-events`
+    (NOT a `:sub-runs` row) when a reaction was reactively considered but
+    its input was value-equal to last-seen, so the user body did NOT
+    recompute (`re-frame.subs.memo/emit-sub-skip!`). `project-record`
+    reads those ops off `:trace-events` — de-duplicated by sub-id and
+    excluding any sub that ALSO recomputed this epoch (a sub that ran DID
+    fire; it is a `:subs-ran` row, not an unchanged/short-circuited one),
+    so `:subs-skipped` stays cleanly distinct from `:subs-ran`. This is the
+    'what DIDN'T fire' coverage the panel's collapsed unchanged-subs
+    disclosure surfaces. It is NOT reconstructed by filtering `:sub-runs`
+    on `(complement :recomputed?)` — that shape is structurally empty.
   - `:renders`  → views-rendered (`:render-key` → top-level `:view-id`)
   - flow counts → tallied from `:trace-events` (`:rf.flow/computed` /
     `:rf.flow/skip`), the one slice with no structured projection.
@@ -76,6 +85,9 @@
          :level-1-subs    [{:sub-id _ :changed? _ :coord _ :readers [...]} ...]
          :level-2-subs    [{:sub-id _ :changed? _ :inputs [...] :coord _
                             :readers [...]} ...]
+         :subs-skipped    [{:sub-id _ :query-v _ :reason _
+                            :input-paths-unchanged [...]} ...]
+         :show-unchanged? <bool>        ; disclosure open-state (§3.4)
          :sub-readers     {<sub-id> [<view-id> ...] ...}
          :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
          :counts          {:subs-ran N
@@ -99,9 +111,13 @@
   truncates the `:subs` list honestly with a `+N more` overflow per the
   Spec 009 event-bundle-cap posture.
 
-  Per spec/021 §3.4 the panel's 'Show unchanged subs' disclosure is
-  view-local (panel UI state); the always-expand override lives in
-  Settings (`:rf.xray/show-unchanged-subs?` · `:general` section).
+  Per spec/021 §3.4 the panel's 'Show N unchanged subs' disclosure is
+  collapsed by default. Its open-state (`:show-unchanged?`) is the OR of
+  two axes composed into `:rf.xray/reactive-data`: the panel-local
+  quick-toggle (`:rf.xray/reactive-show-unchanged?`, flipped by
+  `:rf.xray/reactive-toggle-unchanged`) and the always-expand Settings pin
+  (`[:rf.xray/setting :general :show-unchanged-subs?]`). Either axis
+  visibly expands the disclosure to the dim memo-hit rows.
 
   ## Install
 
@@ -465,6 +481,53 @@
        {:level-1 [] :level-2 []}
        (or subs-ran [])))))
 
+;; ---- memo-hit skip evidence (spec/021 §3.4) -------------------------------
+
+(defn skipped-subs
+  "Project the epoch's memo-hit `:rf.sub/skip` evidence into distinct
+  'unchanged sub' rows for the §3.4 disclosure.
+
+  The substrate emits a canonical `:rf.sub/skip` op on `:trace-events`
+  (NOT a `:sub-runs` row) when a reaction was reactively considered but
+  its input was value-equal to last-seen, so the user body did NOT
+  recompute (`re-frame.subs.memo/emit-sub-skip!`). Each op's tags carry
+  `:rf.sub/id` / `:rf.sub/query-v` / `:rf.sub/reason` (`:input-value-equal`)
+  / `:rf.sub/input-paths-unchanged` (`[]` for a layer-1 sub; the upstream
+  `:<-` query-vectors for a layer-n sub).
+
+  Each projected row `{:sub-id _ :query-v _ :reason _ :input-paths-unchanged
+  [...]}`. De-duplicated by sub-id (first-seen — a post-settle deref burst
+  can memo-hit the same sub repeatedly) and EXCLUDING any sub-id present in
+  `ran-ids` (a sub that recomputed this epoch DID fire — it is a
+  `:subs-ran` row, so it must not ALSO appear in the 'what DIDN'T fire'
+  coverage; this keeps `:subs-skipped` cleanly distinct from `:subs-ran`,
+  the two categories the panel must never conflate).
+
+  `ran-ids` is the set of `:sub-id`s in `:subs-ran`. nil-safe on both args."
+  [trace-events ran-ids]
+  (let [ran (or ran-ids #{})]
+    (:rows
+     (reduce
+      (fn [{:keys [seen] :as acc} ev]
+        (if (= :rf.sub/skip (op-kw ev))
+          (let [tags   (:tags ev)
+                sub-id (or (:rf.sub/id tags) (:sub-id tags))]
+            (if (or (nil? sub-id)
+                    (contains? seen sub-id)
+                    (contains? ran sub-id))
+              acc
+              (-> acc
+                  (update :seen conj sub-id)
+                  (update :rows conj
+                          {:sub-id                sub-id
+                           :query-v               (:rf.sub/query-v tags)
+                           :reason                (:rf.sub/reason tags)
+                           :input-paths-unchanged (or (:rf.sub/input-paths-unchanged tags)
+                                                      [])}))))
+          acc))
+      {:seen #{} :rows []}
+      (or trace-events [])))))
+
 ;; ---- record projection ----------------------------------------------------
 
 (defn project-record
@@ -483,10 +546,12 @@
 
   `:sub-runs` entries carry `:sub-id` / `:query-v` / `:recomputed?` /
   `:value-changed?`. Every `:sub-runs` row is a genuine recompute
-  (`:recomputed? true` — the substrate's `sub-run-row` hardcodes it; a
-  `:rf.sub/skip` memo-hit emits NO `:sub-runs` row), so there is no
-  memo-hit / `subs-skipped` split — `:subs-ran` IS the run-set. The view
-  rows ride the phase-A rf2-9hoos fields on the view-render ops.
+  (`:recomputed? true` — the substrate's `sub-run-row` hardcodes it), so
+  `:subs-ran` IS the run-set. Memo-hit skips are a SEPARATE slice
+  (`:subs-skipped`), projected from the canonical `:rf.sub/skip` ops on
+  `:trace-events` by `skipped-subs` (excluding subs that also ran, so the
+  two slices never conflate). The view rows ride the phase-A rf2-9hoos
+  fields on the view-render ops.
 
   Returns the map shape documented in the ns docstring (sans the
   focus / frame / dispatch-id keys; those come from the spine sub)."
@@ -501,12 +566,15 @@
          flows-comp    (count (get grouped :rf.flow/computed []))
          flows-skipped (count (get grouped :rf.flow/skip []))
          changed-set   (changed-sub-id-set ran)
+         ran-ids       (into #{} (map :sub-id) ran)
+         skipped       (skipped-subs trace-events ran-ids)
          readers       (sub-readers trace-events)
          {:keys [level-1 level-2]} (partition-subs-by-level ran topology readers)
          v-rows        (view-rows trace-events changed-set)
          unmounted     (unmounted-views trace-events)
          destroyed     (destroyed-subscriptions trace-events)]
      {:subs-ran        ran
+      :subs-skipped    skipped
       :views-rendered  renders
       :level-1-subs    level-1
       :level-2-subs    level-2
@@ -515,6 +583,7 @@
       :unmounted-views unmounted
       :destroyed-subs  destroyed
       :counts          {:subs-ran         (count ran)
+                        :subs-skipped     (count skipped)
                         :views-rendered   (count renders)
                         :view-rows        (count v-rows)
                         :unmounted-views  (count unmounted)
@@ -637,10 +706,20 @@
       (boolean (get db :reactive/show-unchanged?))))
 
   ;; -- composite the view reads --------------------------------------
+  ;;
+  ;; The two `show-unchanged` inputs resolve the §3.4 disclosure open-state
+  ;; reactively: the panel-local quick-toggle
+  ;; (`:rf.xray/reactive-show-unchanged?`) OR the always-expand Settings
+  ;; pin (`[:rf.xray/setting :general :show-unchanged-subs?]`). Composing
+  ;; them here (rather than reading them in the view) keeps the disclosure
+  ;; a pure reactive function of app-db — flipping either axis recomputes
+  ;; the composite and re-renders the panel.
   (rf/reg-sub :rf.xray/reactive-data
     :<- [:rf.xray/focus]
     :<- [:rf.xray/epoch-history]
-    (fn [[focus history] _query]
+    :<- [:rf.xray/reactive-show-unchanged?]
+    :<- [:rf.xray/setting :general :show-unchanged-subs?]
+    (fn [[focus history panel-unchanged? config-unchanged?] _query]
       (let [record   (focused-epoch-record history (:epoch-id focus))
             ;; Static topology snapshot — read once per event-bundle. Free
             ;; (registry-only); used to partition L1 / L2+ subs and
@@ -654,6 +733,7 @@
                 :dispatch-id  (:dispatch-id focus)
                 :triggered-by (when record (triggered-by record))
                 :seed-paths   (when record (seed-paths record))
+                :show-unchanged?   (boolean (or panel-unchanged? config-unchanged?))
                 :has-event-bundle? (some? record)}))))
 
   ;; -- ViewCell evidence ownership reactivity bridge (rf2-vxgfnd.286) --

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -31,8 +31,14 @@
   - **shared subscription** → a sub read by ≥2 views fans out to N view
     nodes; the node carries a `×N` annotation.
 
-  Below the graph two list sections complete the panel:
+  Below the graph a collapsed disclosure + two list sections complete the
+  panel:
 
+  - **Show N unchanged subs** (§3.4) — the memo-hit coverage: subs
+    reactively considered this epoch whose input was value-equal, so they
+    short-circuited without recomputing (canonical `:rf.sub/skip` →
+    `:subs-skipped`). Collapsed by default; the per-panel toggle / Settings
+    pin expands it to the dim rows.
   - **UNMOUNTED VIEWS** — views whose component unmounted this epoch.
   - **DESTROYED SUBSCRIPTIONS** — subs cleaned up when their last reader
     unmounted (data-availability honest: empty until the sub-dispose op
@@ -452,6 +458,66 @@
           :style destroyed-caption-style}
       "Subscriptions cleaned up when their last reader unmounted"]]))
 
+;; ---- unchanged subs disclosure (spec/021 §3.4) ------------------------
+;;
+;; The memo-hit coverage — subs reactively considered this epoch whose
+;; input was value-equal, so they short-circuited without recomputing
+;; (the canonical `:rf.sub/skip` evidence, projected to `:subs-skipped`).
+;; Coverage signal, not signal-of-the-moment, so it is collapsed by
+;; default behind a footer `[Show N unchanged subs ▾]` line; the open-
+;; state (`:show-unchanged?`) is the OR of the panel-local quick-toggle
+;; and the Settings always-expand pin, resolved in the composite sub.
+
+(def ^:private unchanged-toggle-style
+  {:appearance "none" :border "none" :background "none"
+   :padding "6px 0" :cursor "pointer"
+   :font-family sans-stack :font-size "11px" :font-weight 600
+   :letter-spacing "0.4px"
+   :color (:text-tertiary tokens)})
+
+(def ^:private unchanged-row-style
+  {:display "flex" :align-items "center" :gap "12px"
+   :padding "6px 14px"
+   :border-top (str "1px solid " (:border-subtle tokens))
+   :font-family mono-stack :font-size "12px"
+   ;; §3.4 — rendered at 60% opacity (:text-tertiary): coverage, dimmed.
+   :color (:text-tertiary tokens)})
+
+(defn- unchanged-subs-section
+  "The 'Show N unchanged subs' footer disclosure (spec/021 §3.4).
+
+  Renders nothing when no sub was memo-hit this epoch. Otherwise a footer
+  toggle button; collapsed by default, expanded (per-panel toggle OR the
+  `:show-unchanged-subs?` Settings pin — both fold into `:show-unchanged?`)
+  it lists the memo-hit subs dim. The button dispatches the panel-local
+  `:rf.xray/reactive-toggle-unchanged` quick-toggle."
+  [data]
+  (let [rows  (:subs-skipped data)
+        n     (count rows)
+        open? (boolean (:show-unchanged? data))]
+    (when (pos? n)
+      [:section {:data-testid "rf-xray-reactive-unchanged-section"
+                 :style section-margin-top-style}
+       [:button {:data-testid "rf-xray-reactive-unchanged-toggle"
+                 :data-open   (str open?)
+                 :aria-expanded (str open?)
+                 :on-click    (fn [_e]
+                                (rf/dispatch [:rf.xray/reactive-toggle-unchanged]))
+                 :style       unchanged-toggle-style}
+        (str (if open? "Hide" "Show") " " n " unchanged sub" (when (not= 1 n) "s")
+             " " (if open? "▴" "▾"))]
+       (when open?
+         (into [:div {:data-testid "rf-xray-reactive-unchanged-list"
+                      :style       list-card-style}]
+               (for [{:keys [sub-id]} rows]
+                 ^{:key (str sub-id)}
+                 [:div {:data-testid (str "rf-xray-reactive-unchanged-row-"
+                                          (id-slug sub-id))
+                        :style       unchanged-row-style}
+                  [:span {:style {:flex 1}} (format-id sub-id)]
+                  [:span {:style {:font-family sans-stack :font-size "10px"}}
+                   "input unchanged · memo hit"]])))])))
+
 ;; EP-0025: the STANDING `:public`-claim declassification audit section is
 ;; REMOVED — classification no longer propagates input → output, so there is no
 ;; `:rf.egress/output-sensitivity :rf.egress/public` declassify claim to surface.
@@ -601,6 +667,7 @@
          [:section {:data-testid "rf-xray-reactive-flow-section"}
           (section-label "flow" "Reactive Flow" {:title-case? true})
           (flow-graph data)]
+         (unchanged-subs-section data)
          (unmounted-views-section data)
          (destroyed-subs-section data)
          (viewcell-evidence-section)

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -11,10 +11,12 @@
   spec/018):
 
   - `:sub-runs` entry → `{:sub-id _ :query-v _ :recomputed? true}`; the
-    substrate's `sub-run-row` hardcodes `:recomputed? true` and a
-    `:rf.sub/skip` memo-hit projects NO `:sub-runs` row, so `:subs-ran`
-    IS the run-set — there is no producible memo-hit / `subs-skipped`
-    split (see the `project-record` fabrication note below).
+    substrate's `sub-run-row` hardcodes `:recomputed? true`, so `:subs-ran`
+    IS the run-set.
+  - `:rf.sub/skip` op on `:trace-events` → the memo-hit evidence
+    (`re-frame.subs.memo/emit-sub-skip!`), projected to the distinct
+    `:subs-skipped` slice (spec/021 §3.4) — a sub reactively considered
+    whose input was value-equal, so it did NOT recompute.
   - `:renders`  entry → `{:render-key [view-id idx] ...}`.
   - flow ops on `:trace-events` → `:rf.flow/computed` / `:rf.flow/skip`.
 
@@ -39,6 +41,18 @@
   {:render-key [view-id 0] :triggered-by nil :elapsed-ms nil})
 
 (defn- flow-ev [op] {:operation op})
+
+(defn- skip-ev
+  "A `:rf.sub/skip` memo-hit trace event as the substrate emits it
+  (`re-frame.subs.memo/emit-sub-skip!`) — rides `:trace-events`, NOT
+  `:sub-runs`."
+  ([sub-id] (skip-ev sub-id []))
+  ([sub-id input-paths-unchanged]
+   {:operation :rf.sub/skip
+    :tags      {:rf.sub/id                    sub-id
+                :rf.sub/query-v               [sub-id]
+                :rf.sub/reason                :input-value-equal
+                :rf.sub/input-paths-unchanged input-paths-unchanged}}))
 
 ;; ---- focused-epoch-record ---------------------------------------------
 
@@ -100,16 +114,72 @@
           "order preserved from :sub-runs")
       (is (= 3 (-> p :counts :subs-ran))))))
 
-;; NOTE (rf2-vxgfnd.22): the deleted `project-subs-skipped` +
-;; `project-subs-split-by-recomputed` deftests fabricated `:recomputed?
-;; false` `:sub-runs` rows — a shape the SUBSTRATE NEVER EMITS
-;; (`sub-run-row` hardcodes `:recomputed? true`; a `:rf.sub/skip` memo-hit
-;; projects no `:sub-runs` row). The projected `:subs-skipped` slot they
-;; asserted on was doubly-dead — permanently `[]` (unproducible) AND
-;; consumed by no panel (the flow graph reads `:level-1/2-subs` /
-;; `:view-rows` / `:sub-readers`). Surfacing memo-hit subs awaits the real
-;; `:rf.sub/skipped` attribution op (spec/021 §12); it must NOT be
-;; reconstructed by filtering `:sub-runs` on `(complement :recomputed?)`.
+;; ---- project-record: subs skipped (memo-hit :rf.sub/skip) -------------
+;;
+;; The canonical `:rf.sub/skip` evidence (rf2-ty5r5o) — the substrate
+;; emits it on `:trace-events` (NOT `:sub-runs`) on a memo hit; the
+;; projection reads it into the distinct `:subs-skipped` slice. This
+;; replaces the deleted fabricated `:recomputed? false` sub-run tests
+;; (a shape the substrate never emits).
+
+(deftest skipped-subs-reads-rf-sub-skip-ops
+  (testing "skipped-subs projects each :rf.sub/skip op off :trace-events —
+            de-duplicated by sub-id — carrying the memo-hit tags."
+    (let [events [(skip-ev :user/name)
+                  (skip-ev :cart/eligibility [[:cart/state]])
+                  (skip-ev :user/name)] ; dup → once
+          rows   (subs/skipped-subs events #{})]
+      (is (= [:user/name :cart/eligibility] (mapv :sub-id rows))
+          "distinct memo-hit subs, first-seen order")
+      (is (= :input-value-equal (-> rows first :reason)))
+      (is (= [] (-> rows first :input-paths-unchanged))
+          "layer-1 skip carries [] input-paths-unchanged")
+      (is (= [[:cart/state]] (-> rows second :input-paths-unchanged))
+          "layer-2 skip names its upstream query-vectors"))))
+
+(deftest skipped-subs-excludes-subs-that-also-ran
+  (testing "rf2-ty5r5o — a sub that RECOMPUTED this epoch DID fire, so it is
+            a :subs-ran row and MUST NOT also appear in :subs-skipped (the
+            two categories stay distinct); a pure memo-hit survives."
+    (let [events [(skip-ev :read-a)     ; also ran (below) → excluded
+                  (skip-ev :derived-a)] ; pure skip → kept
+          rows   (subs/skipped-subs events #{:read-a})]
+      (is (= [:derived-a] (mapv :sub-id rows))
+          ":read-a is excluded (it ran); :derived-a survives"))))
+
+(deftest skipped-subs-nil-safe
+  (is (= [] (subs/skipped-subs nil nil)))
+  (is (= [] (subs/skipped-subs [] #{}))
+      "no skip ops → empty")
+  (is (= [] (subs/skipped-subs [(flow-ev :rf.flow/skip)] #{}))
+      "a :rf.flow/skip is NOT a sub skip"))
+
+(deftest project-record-surfaces-subs-skipped-distinct-from-ran
+  (testing "rf2-ty5r5o — project-record reads the memo-hit :rf.sub/skip
+            evidence into :subs-skipped, kept DISTINCT from :subs-ran even
+            when a :subs-ran row carries :value-changed? false (a recompute
+            that produced the same value is NOT a memo-hit skip)."
+    (let [record {:sub-runs     [{:sub-id :read-a :query-v [:read-a]
+                                  :recomputed? true :value-changed? false}] ; RAN, value unchanged
+                  :trace-events [(skip-ev :read-a)              ; also skipped → excluded
+                                 (skip-ev :derived-a [[:read-a]])]}
+          p      (subs/project-record record)]
+      ;; :read-a ran with :value-changed? false → a subs-ran row.
+      (is (= [:read-a] (mapv :sub-id (:subs-ran p))))
+      (is (= [false] (mapv :value-changed? (:subs-ran p)))
+          "a value-changed? false recompute stays in subs-ran (NOT skipped)")
+      ;; only the pure memo-hit lands in :subs-skipped.
+      (is (= [:derived-a] (mapv :sub-id (:subs-skipped p)))
+          ":subs-skipped names only the sub that skipped without running")
+      (is (= 1 (-> p :counts :subs-ran)))
+      (is (= 1 (-> p :counts :subs-skipped))))))
+
+(deftest project-empty-record-zeroes-subs-skipped
+  (testing "rf2-ty5r5o — empty / nil record → [] :subs-skipped + 0 count."
+    (doseq [r [nil {}]]
+      (let [p (subs/project-record r)]
+        (is (= [] (:subs-skipped p)))
+        (is (= 0 (-> p :counts :subs-skipped)))))))
 
 ;; ---- project-record: views rendered -----------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/reactive_data_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/reactive_data_e2e_cljs_test.cljs
@@ -107,9 +107,9 @@
 (deftest reactive-data-composite-shape-holds-through-real-pipeline
   (testing "rf2-vxgfnd.22 — the composite `:rf.xray/reactive-data` resolves
             its documented shape over a REAL cascade: the flow-graph slots
-            (`:level-1-subs` / `:view-rows` / `:sub-readers`) are present
-            and `:subs-ran` is the whole run-set (no `:subs-skipped` slot —
-            Finding A)."
+            (`:level-1-subs` / `:view-rows` / `:sub-readers`) are present,
+            `:subs-ran` is the run-set, and the `:subs-skipped` memo-hit
+            slice is present (rf2-ty5r5o — empty here, no memo hit driven)."
     (e2e/with-host-and-xray-frames
       {:install-host counter/install-and-init!}
       (fn []
@@ -119,10 +119,79 @@
           (is (contains? d :level-1-subs))
           (is (contains? d :view-rows))
           (is (contains? d :sub-readers))
-          (is (not (contains? d :subs-skipped))
-              "Finding A — no doubly-dead :subs-skipped slot survives")
+          (is (contains? d :subs-skipped)
+              "rf2-ty5r5o — the :subs-skipped memo-hit slice is a real slot")
+          (is (= [] (:subs-skipped d))
+              "no memo hit driven → empty (a run alone is not a skip)")
           ;; :counter/value reads app-db directly → a Level-1 sub.
           (is (some #(= :counter/value (:sub-id %)) (:level-1-subs d))
               (str ":counter/value should partition to Level 1 (reads "
                    "app-db directly). level-1-subs: "
                    (pr-str (:level-1-subs d)))))))))
+
+;; ---- causal memo-hit → :subs-skipped (rf2-ty5r5o) ----------------------
+
+(defn- install-ab-host!
+  "A tiny host whose LAYER-2 sub (`:ab/derived-a`) composes a LAYER-1 sub
+  (`:ab/read-a`) — the shape that lets a real cascade drive BOTH categories
+  the panel must keep distinct in ONE epoch: bumping the UNRELATED `:b`
+  path forces `:ab/read-a` to RECOMPUTE (db changed) but its VALUE is
+  unchanged (`:a` held), so its layer-2 reader `:ab/derived-a` sees a
+  value-equal input and MEMO-HITS — the substrate emits a canonical
+  `:rf.sub/skip` for it.
+
+  Dispatches `[:ab/init]` at install (like the counter fixture's
+  `install-and-init!`) so a cascade EXISTS when Xray installs — that seeds
+  Xray's target frame to this host frame (`default-target-frame` is nil /
+  UNSELECTED, so an install with no cascade would leave the epoch-history
+  mirror empty)."
+  []
+  (rf/reg-event :ab/init   (fn [_ _] {:db {:a 0 :b 0}}))
+  (rf/reg-event :ab/bump-b (fn [{:keys [db]} _] {:db (update db :b inc)}))
+  (rf/reg-sub :ab/read-a (fn [db _] (:a db)))
+  (rf/reg-sub :ab/derived-a :<- [:ab/read-a] (fn [a _] (* 10 a)))
+  (rf/dispatch-sync [:ab/init])
+  nil)
+
+(deftest reactive-data-subs-skipped-names-real-memo-hit
+  (testing "rf2-ty5r5o — a REAL memo hit (the layer-2 `:ab/derived-a` whose
+            layer-1 input `:ab/read-a` recomputed to the SAME value after an
+            unrelated `:b` bump) emits a canonical `:rf.sub/skip` that
+            back-fills into the epoch and reaches `:rf.xray/reactive-data`'s
+            `:subs-skipped` — kept DISTINCT from `:subs-ran` (which carries
+            the value-changed? false recompute of `:ab/read-a`). No injection
+            seam; drives the substrate's real emit-skip path."
+    (e2e/with-host-and-xray-frames
+      {:install-host install-ab-host!}
+      (fn []
+        (rf/with-frame e2e/default-host-frame
+          (let [r (rf/subscribe [:ab/derived-a])]
+            @r                                  ; prime the memo (first-run)
+            (rf/dispatch-sync [:ab/bump-b] {:frame e2e/default-host-frame})
+            @r                                  ; read-a recomputes (value 0, unchanged)
+            @r))                                ; derived-a memo-hits → :rf.sub/skip
+        (e2e/sync-xray-trace-mirror!)
+        (e2e/sync-xray-epoch-history!)
+        (let [d       (e2e/sub-xray [:rf.xray/reactive-data])
+              skipped (:subs-skipped d)
+              ran     (:subs-ran d)
+              ran-ids (into #{} (map :sub-id) ran)
+              skip-ids (into #{} (map :sub-id) skipped)]
+          (is (contains? skip-ids :ab/derived-a)
+              (str ":subs-skipped must name the real memo-hit sub "
+                   ":ab/derived-a — the :rf.sub/skip evidence the panel "
+                   "drops today. reactive-data: "
+                   (pr-str (select-keys d [:subs-ran :subs-skipped :counts]))))
+          (let [row (some #(when (= :ab/derived-a (:sub-id %)) %) skipped)]
+            (is (= :input-value-equal (:reason row))
+                "the skip row carries the canonical :input-value-equal reason")
+            (is (= [[:ab/read-a]] (:input-paths-unchanged row))
+                "the layer-2 skip names its upstream :ab/read-a query-vector"))
+          ;; distinctness: the memo-hit sub is NOT in the run-set, and the
+          ;; recompute that produced the same value stays in the run-set.
+          (is (not (contains? ran-ids :ab/derived-a))
+              ":ab/derived-a skipped — it must NOT appear in :subs-ran")
+          (is (not (contains? skip-ids :ab/read-a))
+              ":ab/read-a recomputed (it fired) — it must NOT appear in :subs-skipped")
+          (is (pos? (-> d :counts :subs-skipped))
+              ":counts :subs-skipped tallies the real memo-hit set"))))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -468,8 +468,8 @@
    :rf.xray.trace/focused-event-bundle
    ;; Reactive panel (rf2-wyvf2 · spec/021 §3 · renamed from Views per
    ;; §11.5; tab key stays `:views`, display label rebases). Reads the
-   ;; focused cascade's `:trace-events` for the substrate ops landed in
-   ;; PRs #1728 + #1729 (`:rf.view/rendered`, `:rf.sub/skipped`,
+   ;; focused cascade's `:trace-events` for the substrate ops
+   ;; (`:rf.view/rendered`, `:rf.sub/skip` memo-hit → `:subs-skipped`,
    ;; `:rf.cascade/captured`).
    :rf.xray/reactive-data
    :rf.xray/reactive-show-unchanged?
@@ -1445,11 +1445,36 @@
     (rf/with-frame :rf/xray
       (let [data @(rf/subscribe [:rf.xray/reactive-data])]
         (is (contains? data :subs-ran))
-        ;; rf2-vxgfnd.22 — no `:subs-skipped` slot: the substrate emits no
-        ;; memo-hit `:sub-runs` row, so `:subs-ran` is the whole run-set.
-        (is (not (contains? data :subs-skipped)))
+        ;; rf2-ty5r5o — the memo-hit `:subs-skipped` slice is a real slot
+        ;; (fed by canonical `:rf.sub/skip` ops); empty when no cascade is
+        ;; focused, DISTINCT from `:subs-ran`.
+        (is (contains? data :subs-skipped))
+        (is (= [] (:subs-skipped data)))
         (is (contains? data :views-rendered))
         (is (false? (:has-event-bundle? data)))))))
+
+(deftest sub-reactive-data-show-unchanged-resolves-both-axes
+  (testing "rf2-ty5r5o — the §3.4 disclosure open-state (`:show-unchanged?`
+            on :rf.xray/reactive-data, the flag the panel view reads) is the
+            OR of the panel-local quick-toggle
+            (:rf.xray/reactive-toggle-unchanged) AND the
+            :show-unchanged-subs? Settings pin. Either axis visibly changes
+            it; collapsed by default."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (is (false? (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data])))
+          "collapsed by default")
+      ;; panel-local quick-toggle axis
+      (rf/dispatch-sync [:rf.xray/reactive-toggle-unchanged])
+      (is (true? (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data])))
+          "the per-panel toggle expands the disclosure")
+      (rf/dispatch-sync [:rf.xray/reactive-toggle-unchanged])
+      (is (false? (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data])))
+          "toggling back collapses it")
+      ;; Settings always-expand pin axis
+      (rf/dispatch-sync [:rf.xray/settings-update :general :show-unchanged-subs? true])
+      (is (true? (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data])))
+          "the Settings pin expands the disclosure independently"))))
 
 ;; ---- (4) high-value event contracts -------------------------------------
 

--- a/tools/xray/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_views.cljs
@@ -15,15 +15,17 @@
   `project-record` reads:
 
     - `:sub-runs`     — `[{:sub-id :query-v :recomputed? :value-changed?
-                           :value :prev-value} ...]`; drives the L1/L2
+                           :value :prev-value} ...]`; every row is a genuine
+                        recompute (`:recomputed? true`). Drives the L1/L2
                         sub tables + the `changed-set` that classifies
                         each view's render reason.
-    - `:trace-events` — the view-side capture ops the flow graph reads:
-                        `:rf.view/rendered` (with `:rf.view/id` /
-                        `:rf.view/render-key` / `:rf.view/mount?` /
-                        `:rf.view/deref-subs` / `:rf.view/triggered-by`
-                        / `:rf.view/elapsed-ms`) + `:rf.view/unmounted`
-                        + `:rf.sub/dispose`.
+    - `:trace-events` — the capture ops the panel reads off the raw stream:
+                        the view-side `:rf.view/rendered` (with `:rf.view/id`
+                        / `:rf.view/render-key` / `:rf.view/mount?` /
+                        `:rf.view/deref-subs` / `:rf.view/triggered-by` /
+                        `:rf.view/elapsed-ms`) + `:rf.view/unmounted` +
+                        `:rf.sub/dispose`, AND the memo-hit `:rf.sub/skip`
+                        evidence the §3.4 'unchanged subs' disclosure reads.
     - `:event`        — the trigger event (the cascade's seed).
 
   ## Render-cause chips (rf2-bhi3t)
@@ -51,9 +53,13 @@
 ;; substrate emit-site shape `reactive_panel_subs` reads.
 
 (defn- sub-run
-  "One `:sub-runs` entry. `recomputed?` splits genuine recomputes
-  (subs-ran) from memo-hit skips (subs-skipped); `value-changed?`
-  feeds the per-view render-reason `changed-set`."
+  "One `:sub-runs` entry — a genuine RECOMPUTE, exactly as the substrate's
+  `sub-run-row` emits it (`:recomputed? true` is hardcoded there; a
+  memo-hit projects NO `:sub-runs` row — it rides `:trace-events` as a
+  `:rf.sub/skip`, built by `skip-ev` below). `value-changed?` feeds the
+  per-view render-reason `changed-set`; a `:value-changed? false` recompute
+  is a sub that ran but produced the same value (a dashed, short-circuited
+  graph node) — DISTINCT from a memo-hit skip."
   [sub-id recomputed? value-changed? prev-value value]
   {:sub-id         sub-id
    :query-v        [sub-id]
@@ -61,6 +67,20 @@
    :value-changed? value-changed?
    :prev-value     prev-value
    :value          value})
+
+(defn- skip-ev
+  "A `:rf.sub/skip` memo-hit trace event in the exact shape the substrate
+  emits (`re-frame.subs.memo/emit-sub-skip!`) — the canonical evidence the
+  Reactive panel's 'unchanged subs' disclosure (spec/021 §3.4) reads off
+  `:trace-events`. `input-paths-unchanged` is `[]` for a layer-1 sub, the
+  upstream `:<-` query-vectors for a layer-n sub."
+  ([sub-id] (skip-ev sub-id []))
+  ([sub-id input-paths-unchanged]
+   {:operation :rf.sub/skip
+    :tags      {:rf.sub/id                    sub-id
+                :rf.sub/query-v               [sub-id]
+                :rf.sub/reason                :input-value-equal
+                :rf.sub/input-paths-unchanged input-paths-unchanged}}))
 
 (defn- rendered-ev
   "A `:rf.view/rendered` trace event in the shape `view-rows` reads.
@@ -128,11 +148,14 @@
      [(sub-run :cart/state       true  true  {:phase :idle} {:phase :submitting})
       (sub-run :cart/can-submit? true  true  false true)
       (sub-run :cart/items       true  false [{:id :apple}] [{:id :apple}])
-      (sub-run :cart/total       true  false 195 195)
-      (sub-run :user/name        false false "Ada" "Ada")
-      (sub-run :cart/eligibility false false true true)]
+      (sub-run :cart/total       true  false 195 195)]
      :trace-events
-     [(rendered-ev :checkout/CheckoutButton [:CheckoutButton 0] false
+     [;; Two memo-hit skips — the canonical `:rf.sub/skip` evidence the
+      ;; §3.4 disclosure surfaces (real trace-event shape, NOT a fabricated
+      ;; `:recomputed? false` sub-run the substrate never emits).
+      (skip-ev :user/name)
+      (skip-ev :cart/eligibility)
+      (rendered-ev :checkout/CheckoutButton [:CheckoutButton 0] false
                    [[:cart/can-submit?]] 0.9 :cart/can-submit?)
       (rendered-ev :cart.banner/StateBanner [:StateBanner 0] false
                    [[:cart/state]] 0.7 :cart/state)


### PR DESCRIPTION
## Summary

The Reactive panel dropped the memo-hit `:rf.sub/skip` evidence the substrate already ships. `reactive-panel-subs/project-record` read only the `:sub-runs` recompute projection and ignored the canonical `:rf.sub/skip` ops on the epoch record's `:trace-events` (emitted by `re-frame.subs.memo/emit-sub-skip!`), so a real memo hit never reached `:rf.xray/reactive-data` or the panel — while spec/021 still promised a collapsed "Show N unchanged subs" disclosure and the toggle / event / sub / config plumbing sat active but inert. This finishes the substrate-to-panel path against the shipped op.

## What changed

- **`project-record`** now projects `:rf.sub/skip` ops off `:trace-events` into a distinct `:subs-skipped` slice (`skipped-subs`) — de-duplicated by sub-id and **excluding any sub that also recomputed this epoch**, so memo-hit skips stay cleanly distinct from `:value-changed? false` recomputes (a sub that ran but produced the same value stays a dashed graph node in `:subs-ran`).
- **The composite `:rf.xray/reactive-data`** resolves the §3.4 disclosure open-state (`:show-unchanged?`) as the OR of the panel-local quick-toggle (`:rf.xray/reactive-show-unchanged?`) and the `:show-unchanged-subs?` Settings pin.
- **The panel view** renders the collapsed `[Show N unchanged subs ▾]` footer that expands to the dim memo-hit rows (previously the toggle/event/sub/config plumbing was inert).
- **Gallery + tests** use the real `:rf.sub/skip` trace-event shape instead of fabricated `:recomputed? false` sub-runs the substrate never emits.
- **A causal CLJS e2e** drives a real memo hit through the substrate path (a layer-2 sub whose layer-1 input recomputed to the same value after an unrelated bump), asserting `:subs-skipped` names the sub and stays distinct from `:subs-ran` — no injection seam.
- **spec/021 + the registry comment** adopt the shipped `:rf.sub/skip` spelling and drop the "awaits a future `:rf.sub/skipped` op" premise (§3.4 / §3.5 / §11.3 / §12 / §13).

No new trace op or compatibility layer is introduced; nothing in `implementation/` was changed (the producer was cited read-only).

## Quality gates

- `tools/xray` JVM (`clojure -M:test`): **1265 tests, 5899 assertions, 0 failures**.
- CLJS node gate (`npm run test:cljs`): **9667 tests, 47584 assertions, 0 failures** — includes the causal e2e (`reactive-data-subs-skipped-names-real-memo-hit`, which fails before this change since `:subs-skipped` did not exist) and the composite disclosure-toggle test.
- `panel-gallery` shadow build compiles clean (703 files, 0 warnings).
- clj-kondo on all changed files: 0 errors, 0 warnings.

Browser/feature gates not run (this change is covered by the node CLJS + JVM gates; the panel view is a pure function of the projected data).
