### PR TITLE
fix(core): exact-incarnation cleanup for with-new-frame, Story replay, and SSR (rf2-moftbs)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -120,6 +120,21 @@
   frame values are local-only tokens)."
   :rf.frame/runnable-id)
 
+(def ^:const incarnation-token-key
+  "Reserved key on a frame VALUE carrying the EXACT incarnation-identity token
+  (the winning construction's `:drain-lock`, see `frame-incarnation-token`) the
+  `make-frame` call that produced the value installed (rf2-moftbs). Present ONLY
+  on a value handed back by a fresh/idempotent construction — the opaque
+  lifecycle-token AUTHORITY an owner (`with-new-frame`, Story replay, SSR
+  per-request) consumes at cleanup so its teardown destroys EXACTLY the
+  incarnation it created, never a same-id successor reseated in between. Absent
+  on a derived-read value (`live-frame` / `image-view-frames`) and on a frame-id
+  keyword — both of which stay ADDRESS-directed (destroy whatever incarnation is
+  currently live under the id). Internal — the value's representation is not an
+  app-facing data contract; this token is opaque authority, compared only by
+  identity."
+  :rf.frame/incarnation-token)
+
 (defn frame-value?
   "True when `x` is a live frame VALUE (`make-frame`'s return token — carries the
   `:rf.frame/object` marker), as opposed to a frame-id keyword. The structural
@@ -139,6 +154,19 @@
   (if (frame-value? frame-value)
     (get frame-value runnable-id-key)
     frame-value))
+
+(defn frame-value-incarnation-token
+  "Return the EXACT incarnation-identity token a fresh-construction frame VALUE
+  carries (its `:rf.frame/incarnation-token` — the installed `:drain-lock`), or
+  nil when `x` is a frame-id keyword, a derived-read frame value, or any value
+  built without a construction token (rf2-moftbs). A non-nil result is the
+  opaque teardown AUTHORITY the one-argument `destroy-frame!` consumes so an
+  owner's cleanup destroys EXACTLY the incarnation it created; nil selects the
+  ADDRESS-directed path (destroy whatever incarnation is currently live under
+  the id). Pure."
+  [x]
+  (when (frame-value? x)
+    (get x incarnation-token-key)))
 
 (defn frame-target->id
   "Normalize a public frame TARGET — a frame-id KEYWORD or a frame VALUE — to the
@@ -2496,6 +2524,19 @@
     {:recovery :use-a-distinct-frame-id
      :extra    {:frame id}}))
 
+(defn- deliver-incarnation-token!
+  "Hand the EXACT installed incarnation token to an optional construction
+  `token-sink` (a `volatile!`) from INSIDE the construction transaction
+  (rf2-moftbs). `make-frame` passes a sink so it can embed the token on the
+  returned frame VALUE without a post-return `frame-incarnation-token` re-sample
+  of the registry — a re-sample a concurrent `destroy-frame!` + same-id reseat
+  could race into handing back a successor's token. No-op when the caller passed
+  no sink (`make-anon-frame-record!`, the `:rf/default` fixture, and the engine
+  tests, which take the id return unchanged). Returns nil."
+  [token-sink token]
+  (when token-sink (vreset! token-sink token))
+  nil)
+
 (defn ^:no-doc upsert-frame!
   "PRIVATE frame ENGINE — atomic create-or-REFRESH (upsert) of the frame
   record for `id` (rf2-h1vqa4). Called by `re-frame.live-frame/make-frame`
@@ -2522,8 +2563,18 @@
   member, so seating/reseating must never bump the registration source-store
   generation (which would invalidate the resolved-image-generation cache,
   EP-0023) nor surface in image assembly. Frame introspection is
-  `frame-meta` / `frame-ids`, not the registrar query API."
-  [id metadata]
+  `frame-meta` / `frame-ids`, not the registrar query API.
+
+  Returns the frame `id` on a successful create OR re-register (the documented
+  keyword return every existing caller + engine test relies on). The optional
+  3-arity `token-sink` (a `volatile!`) is an OUT-channel: on success the exact
+  installed incarnation token (the record's `:drain-lock`) is delivered into it
+  from INSIDE the construction transaction, so `make-frame` can embed exact
+  authority on the returned frame VALUE with no post-return registry re-sample
+  (rf2-moftbs). Passing no sink (the 2-arity) is byte-identical for every
+  existing caller."
+  ([id metadata] (upsert-frame! id metadata nil))
+  ([id metadata token-sink]
   (let [;; The registry is keyed by the bare frame-id.
         config       (expand-preset metadata)
         ;; INTERNAL create-exclusive mode (rf2-vxgfnd.76): when the caller
@@ -2749,7 +2800,12 @@
                                                         :rf.frame/initial-db)})
                 (fire-frame-registered-hook! id)
                 (if (finalize-frame-construction! id owner policy-token)
-                  id
+                  ;; Hand back this exact incarnation's token (the record's
+                  ;; `:drain-lock` `try-install-new-frame!` installed and
+                  ;; finalization preserved by identity) from inside the
+                  ;; transaction so `make-frame` embeds exact authority with no
+                  ;; post-return re-sample (rf2-moftbs).
+                  (do (deliver-incarnation-token! token-sink installed-token) id)
                   (throw-frame-construction-in-progress!
                     id :lifecycle-dead :destruction))
                 (catch #?(:clj Throwable :cljs :default) e
@@ -2832,7 +2888,13 @@
                              {:frame id :config stored-config})
                 (fire-frame-registered-hook! id)
                 (if (finalize-frame-construction! id owner policy-token)
-                  id
+                  ;; Idempotent re-registration PRESERVES the incarnation's
+                  ;; `:drain-lock` by identity (the surgical swap-vals only
+                  ;; replaces config/generation/trace-policy/construction), so the
+                  ;; staged record's token IS the still-live incarnation token —
+                  ;; hand it back so a re-`make-frame` value carries the SAME
+                  ;; authority as the original (rf2-moftbs).
+                  (do (deliver-incarnation-token! token-sink (:drain-lock staged)) id)
                   (throw-frame-construction-in-progress!
                     id :lifecycle-dead :destruction))
                 (catch #?(:clj Throwable :cljs :default) e
@@ -2849,7 +2911,7 @@
                            (:trace-policy-token prior)))
                       (catch #?(:clj Throwable :cljs :default) _ nil)))
                   (throw e)))
-              (recur))))))))))
+              (recur)))))))))))
 
 (defn make-anon-frame-record!
   "INTERNAL anonymous-instance creation (EP-0024): generate a
@@ -2884,12 +2946,20 @@
   EP-0027 retired `:initial-db`: app-db seeding is now a setup event
   (`:initial-events`), so the constructed value no longer carries an
   `:rf.frame/initial-db` slot. EP-0026 (rf2-dlvmpc) retired the
-  `:rf.frame/capabilities` slot with the image-capability feature."
-  [{:keys [id runnable-id adapter]}]
+  `:rf.frame/capabilities` slot with the image-capability feature.
+
+  rf2-moftbs: a fresh/idempotent construction threads its EXACT incarnation
+  `token` (the installed `:drain-lock`) through here so the returned value
+  carries `:rf.frame/incarnation-token` — the opaque lifecycle-token authority
+  an owner consumes so its `destroy-frame!` is incarnation-EXACT. A nil `token`
+  (a derived-read value from `live-frame` / `image-view-frames`) omits the slot,
+  leaving that value ADDRESS-directed."
+  [{:keys [id runnable-id adapter token]}]
   (cond-> {object-marker         true
            runnable-id-key       runnable-id}
     (some? id)      (assoc :rf.frame/id id)
-    (some? adapter) (assoc :rf.frame/adapter adapter)))
+    (some? adapter) (assoc :rf.frame/adapter adapter)
+    (some? token)   (assoc incarnation-token-key token)))
 
 ;; ---- destruction ----------------------------------------------------------
 ;;
@@ -3711,13 +3781,33 @@
   unless `expected-incarnation-token` is still the live frame's identity token.
   The check is revalidated after acquiring that incarnation's `:drain-lock`,
   and the liveness flip CAS-checks the same token under the same lifecycle gate,
-  so a stale teardown can never destroy a fresh same-id incarnation. The
-  one-argument arity preserves ordinary destroy semantics by pinning the live
-  token at invocation and delegating to the incarnation-owned arity."
+  so a stale teardown can never destroy a fresh same-id incarnation.
+
+  The one-argument arity chooses its authority from the TARGET (rf2-moftbs):
+  a fresh-construction frame VALUE carries its EXACT incarnation token
+  (`frame-value-incarnation-token`), so the arity delegates to the
+  incarnation-owned two-argument arity with it — an owner (`with-new-frame`,
+  Story replay, SSR per-request) that destroys the value it created tears down
+  ONLY that incarnation, never a same-id successor reseated in between (a stale
+  carried token no-ops). A frame-id KEYWORD, or a token-less derived-read VALUE,
+  carries no authority and stays ADDRESS-directed: it pins whatever incarnation
+  is currently live under the id at invocation and delegates. So keyword/ID
+  destruction remains explicitly address-directed while a returned frame value
+  gains coherent lifecycle-token semantics."
   ([target]
-   (let [id (frame-target->id target)]
-     (when-let [expected-token (frame-incarnation-token id)]
-       (destroy-frame! target expected-token))))
+   ;; rf2-moftbs: a fresh-construction frame VALUE carries EXACT incarnation
+   ;; authority (`:rf.frame/incarnation-token` — the installed `:drain-lock`).
+   ;; Consume it so an owner's cleanup (`with-new-frame`, Story replay, SSR
+   ;; per-request) destroys ONLY the incarnation it created; a stale carried
+   ;; token no-ops through the two-argument arity (which revalidates liveness),
+   ;; leaving a same-id successor reseated in between intact. A frame-id KEYWORD
+   ;; or a token-less derived-read VALUE has no carried authority, so it stays
+   ;; ADDRESS-directed — pin whatever incarnation is currently live under the id.
+   (if-let [carried (frame-value-incarnation-token target)]
+     (destroy-frame! target carried)
+     (let [id (frame-target->id target)]
+       (when-let [expected-token (frame-incarnation-token id)]
+         (destroy-frame! target expected-token)))))
   ([target expected-incarnation-token]
   ;; Accept a frame VALUE or a frame-id keyword. Normalize a value to its id so
   ;; every keyed teardown step below targets the record; a keyword passes

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -767,23 +767,33 @@
      ;; the record-config (presets, classification, fx-overrides, …). Default-realm
      ;; (the collapse supersedes the public realm dimension), so the record is
      ;; keyed by the bare id.
-     (frame/upsert-frame! runnable-id record-config)
-     ;; Record which pool this generation was resolved against AFTER the engine
-     ;; commit returns successfully — see §Generation PROVENANCE above
-     ;; (rf2-rf3zgt): a later reprojection reads this back so it re-resolves
-     ;; against the SAME pool (explicit or live) rather than always falling
-     ;; through to the live store. Recorded on every SUCCESSFUL call (creation +
-     ;; hot-reload re-construction), so a re-`make-frame` that changes arity
-     ;; keeps the record current — and ordered after `upsert-frame!` (rf2-ktmto9,
-     ;; the failure-atomicity completion) so a FAILED creation records nothing
-     ;; and a FAILED re-construction preserves the OLD provenance row, matching
-     ;; the engine's own no-residue-on-failure contract.
-     (record-frame-generation-pool! runnable-id descriptors)
-     ;; Return the frame VALUE — the lifecycle token (generation not embedded;
-     ;; read from the record by id).
-     (frame/make-frame-value {:id          id
-                              :runnable-id runnable-id
-                              :adapter     adapter}))))
+     ;;
+     ;; rf2-moftbs: pass a `token-box` OUT-channel so the engine hands back the
+     ;; EXACT installed incarnation token (the record's `:drain-lock`) from
+     ;; INSIDE the construction transaction. Embedding it on the returned frame
+     ;; VALUE (below) is what gives an owner exact teardown authority — with NO
+     ;; post-return `frame-incarnation-token` re-sample that a concurrent
+     ;; destroy + same-id reseat could race into a successor's token.
+     (let [token-box (volatile! nil)]
+       (frame/upsert-frame! runnable-id record-config token-box)
+       ;; Record which pool this generation was resolved against AFTER the engine
+       ;; commit returns successfully — see §Generation PROVENANCE above
+       ;; (rf2-rf3zgt): a later reprojection reads this back so it re-resolves
+       ;; against the SAME pool (explicit or live) rather than always falling
+       ;; through to the live store. Recorded on every SUCCESSFUL call (creation +
+       ;; hot-reload re-construction), so a re-`make-frame` that changes arity
+       ;; keeps the record current — and ordered after `upsert-frame!` (rf2-ktmto9,
+       ;; the failure-atomicity completion) so a FAILED creation records nothing
+       ;; and a FAILED re-construction preserves the OLD provenance row, matching
+       ;; the engine's own no-residue-on-failure contract.
+       (record-frame-generation-pool! runnable-id descriptors)
+       ;; Return the frame VALUE — the lifecycle token (generation not embedded;
+       ;; read from the record by id). It carries the exact incarnation token
+       ;; (`@token-box`) so `destroy-frame!` of this value is incarnation-EXACT.
+       (frame/make-frame-value {:id          id
+                                :runnable-id runnable-id
+                                :adapter     adapter
+                                :token       @token-box})))))
 
 ;; ===========================================================================
 ;; Image hot reload (EP-0023 §Hot Reload, rf2-32siq3.10)

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -1607,3 +1607,95 @@
           "A is fully destroyed")
       (is (nil? (frame/frame :reent.b/worker))
           "B was successfully destroyed from inside A's :on-destroy"))))
+
+;; ---- rf2-moftbs — exact-incarnation cleanup via the frame VALUE ------------
+;;
+;; A fresh `make-frame` VALUE carries EXACT incarnation authority
+;; (`:rf.frame/incarnation-token` = the installed `:drain-lock`). The one-arg
+;; `destroy-frame!` of that value is incarnation-EXACT: it destroys ONLY the
+;; incarnation the value names, never a same-id successor reseated in between.
+;; A frame-id KEYWORD stays address-directed (destroys the current incarnation).
+
+(deftest make-frame-value-carries-exact-incarnation-token
+  (testing "the returned frame VALUE carries the live incarnation's token"
+    (let [va (rf/make-frame {:id :inc/tok :doc "A"})]
+      (is (frame/frame-value? va) "make-frame returns a frame VALUE")
+      (is (some? (frame/frame-value-incarnation-token va))
+          "the value carries an incarnation token")
+      (is (identical? (frame/frame-value-incarnation-token va)
+                      (frame/frame-incarnation-token :inc/tok))
+          "the carried token IS the live incarnation's :drain-lock")))
+  (testing "an idempotent re-make-frame carries the SAME (preserved) token"
+    (let [va (rf/make-frame {:id :inc/rereg :doc "A"})
+          vb (rf/make-frame {:id :inc/rereg :doc "A-refreshed"})]
+      (is (identical? (frame/frame-value-incarnation-token va)
+                      (frame/frame-value-incarnation-token vb))
+          "re-registration preserves :drain-lock, so both values name one incarnation"))))
+
+(deftest destroy-value-N-does-not-tear-down-successor-N+1
+  (testing "destroying a STALE frame VALUE (incarnation A) leaves a same-id
+            successor B alive, while ordinary cleanup of B's own value releases it"
+    (let [va      (rf/make-frame {:id :inc/x :doc "A"})
+          a-token (frame/frame-value-incarnation-token va)]
+      ;; Tear A down (address-directed) and re-seat a fresh incarnation B under
+      ;; the SAME id — a distinct incarnation with a distinct token.
+      (rf/destroy-frame! :inc/x)
+      (is (nil? (frame/frame :inc/x)) "A is gone after its address-directed destroy")
+      (let [vb      (rf/make-frame {:id :inc/x :doc "B"})
+            b-token (frame/frame-value-incarnation-token vb)]
+        (is (not (identical? a-token b-token)) "B is a distinct incarnation")
+        ;; The OWNER of the stale value A exits: destroying value-A must NOT
+        ;; reap B (the carried token is stale → the two-arg arity no-ops).
+        (rf/destroy-frame! va)
+        (is (some? (frame/frame :inc/x))
+            "B survives — the stale value-A teardown did not destroy incarnation N+1")
+        (is (identical? b-token (frame/frame-incarnation-token :inc/x))
+            "the live incarnation is still exactly B")
+        ;; Ordinary A-style cleanup still works: destroying B's OWN value fully
+        ;; releases B.
+        (rf/destroy-frame! vb)
+        (is (nil? (frame/frame :inc/x))
+            "B is fully released by destroying its own value")))))
+
+(deftest destroy-value-fully-releases-its-own-incarnation
+  (testing "destroying the LIVE value it was handed fully tears the frame down"
+    (let [va (rf/make-frame {:id :inc/solo :doc "solo"})]
+      (is (some? (frame/frame :inc/solo)) "the frame is live")
+      (rf/destroy-frame! va)
+      (is (nil? (frame/frame :inc/solo)) "destroying the value released the frame")
+      (is (nil? (frame/frame-incarnation-token :inc/solo)) "no incarnation remains"))))
+
+(deftest with-new-frame-exit-teardown-is-incarnation-exact
+  (testing "with-new-frame binds make-frame's VALUE; a body that destroys A and
+            reseats B under the same id must leave B alive on macro exit"
+    (let [b-token (atom nil)]
+      (rf/with-new-frame [f (rf/make-frame {:id :wnf/x :doc "A"})]
+        ;; Inside the scope: tear A down and re-seat a fresh B under the same id.
+        (rf/destroy-frame! :wnf/x)
+        (rf/make-frame {:id :wnf/x :doc "B"})
+        (reset! b-token (frame/frame-incarnation-token :wnf/x)))
+      ;; The macro's `finally (destroy-frame! f)` consumed value-A's stale token
+      ;; → a no-op against B.
+      (is (some? (frame/frame :wnf/x))
+          "B survives with-new-frame's exit teardown")
+      (is (identical? @b-token (frame/frame-incarnation-token :wnf/x))
+          "the surviving incarnation is exactly B")
+      (rf/destroy-frame! :wnf/x)))
+  (testing "ordinary with-new-frame cleanup releases exactly the incarnation it created"
+    (rf/with-new-frame [f (rf/make-frame {:id :wnf/y :doc "solo"})]
+      (is (some? (frame/frame :wnf/y)) "the frame is live inside the scope"))
+    (is (nil? (frame/frame :wnf/y))
+        "with-new-frame destroyed exactly the incarnation it created")))
+
+(deftest keyword-destroy-remains-address-directed
+  (testing "destroying by frame-id KEYWORD pins the CURRENT incarnation — the
+            address-directed semantics rf2-moftbs deliberately preserves"
+    (rf/make-frame {:id :addr/x :doc "A"})
+    (let [a-token (frame/frame-incarnation-token :addr/x)]
+      (rf/destroy-frame! :addr/x)                    ;; destroys A (the current one)
+      (rf/make-frame {:id :addr/x :doc "B"})         ;; reseat B under the same id
+      (let [b-token (frame/frame-incarnation-token :addr/x)]
+        (is (not (identical? a-token b-token)) "B is a distinct incarnation")
+        (rf/destroy-frame! :addr/x)                  ;; keyword → destroys CURRENT = B
+        (is (nil? (frame/frame :addr/x))
+            "a bare-id destroy targets whatever incarnation is currently live")))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -226,7 +226,7 @@
                         (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error]} opts]
     (fn ring-handler [request]
-      (let [{:keys [frame-id short-circuit]}
+      (let [{:keys [frame-id frame short-circuit]}
             (pipeline/setup-request-frame! opts request)]
         (if short-circuit
           short-circuit
@@ -262,7 +262,9 @@
               (lifecycle/safe-on-error on-error request t))
             (finally
               ;; Frame teardown also clears its per-request side channels.
-              (lifecycle/destroy-frame-quietly! frame-id))))))))
+              ;; Destroy the VALUE (incarnation-EXACT, rf2-moftbs); the keyword
+              ;; `frame-id` names the frame on any failure trace.
+              (lifecycle/destroy-frame-quietly! frame frame-id))))))))
 
 ;; ---- ssr-middleware -------------------------------------------------------
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -68,24 +68,34 @@
       (default-on-error request t))))
 
 (defn destroy-frame-quietly!
-  "Best-effort frame teardown. Exceptions during destroy must not mask
-  a real handler error; swallow + emit a `:warning` trace is preferred
+  "Best-effort per-request frame teardown. Exceptions during destroy must not
+  mask a real handler error; swallow + emit a `:warning` trace is preferred
   over propagation.
+
+  `frame-target` is the DESTROY target: the frame VALUE `make-frame` returned
+  (carrying the EXACT incarnation token, so teardown is incarnation-EXACT and
+  never reaps a same-id successor a request drain reseated — rf2-moftbs), or a
+  frame-id keyword (the construction-failure path, where no value exists yet and
+  address-directed cleanup of any partial row is correct). The optional
+  `diag-frame-id` names the frame on the failure trace so the `:frame` slot stays
+  a clean keyword even when a value is the destroy target; it defaults to
+  `frame-target` for the keyword call shape.
 
   Surfaces any destroy-time throw on the trace bus rather than
   silently swallowing it — keeps the error visible to dev tooling
   without escalating to a user-visible 500 (the handler-side error has
   already been materialised by the time this fn runs)."
-  [frame-id]
-  (try
-    (rf/destroy-frame! frame-id)
-    (catch Throwable t
-      (trace/emit! :warning :rf.ssr/destroy-frame-failed
-                   {:frame    frame-id
-                    :reason   (or (.getMessage t) (.getName (class t)))
-                    :ex-class (.getName (class t))
-                    :recovery :warned-and-skipped})
-      nil)))
+  ([frame-target] (destroy-frame-quietly! frame-target frame-target))
+  ([frame-target diag-frame-id]
+   (try
+     (rf/destroy-frame! frame-target)
+     (catch Throwable t
+       (trace/emit! :warning :rf.ssr/destroy-frame-failed
+                    {:frame    diag-frame-id
+                     :reason   (or (.getMessage t) (.getName (class t)))
+                     :ex-class (.getName (class t))
+                     :recovery :warned-and-skipped})
+       nil))))
 
 (defn resolve-root-view
   "Resolve the caller's `:root-view` opt to a hiccup vector. Accepts

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -142,9 +142,17 @@
 
 (defn setup-request-frame!
   "Register a per-request frame and populate the request slot. Returns
-  `{:frame-id frame-id}` on success, or `{:short-circuit ring-response}`
-  when setup fails (the caller short-circuits to that response, skipping
-  render).
+  `{:frame-id frame-id :frame frame-value}` on success, or
+  `{:short-circuit ring-response}` when setup fails (the caller short-circuits
+  to that response, skipping render).
+
+  `:frame` is the frame VALUE `make-frame` returns — it carries the EXACT
+  incarnation token, so the handler's teardown (`destroy-frame-quietly!`) is
+  incarnation-EXACT and can never reap a same-id successor a request drain
+  destroyed-and-reseated under the gensym id (rf2-moftbs). `:frame-id` (the bare
+  keyword) stays the address for every in-request operation (`with-frame`,
+  `flush-response-result!`, `app-db-value`, the writer thread name) — those are
+  correctly address-directed against the current incarnation.
 
   The slot is populated BEFORE `make-frame` so the synchronous
   `:initial-events` drain can resolve the `:rf.server/request` cofx (Spec
@@ -165,19 +173,25 @@
   (let [frame-id (keyword "rf.frame" (str (gensym "f")))]
     (ssr/set-request! frame-id request)
     (try
-      (rf/make-frame
-        (cond-> {:id        frame-id
-                 :doc       "ssr-ring per-request frame"
-                 :platform  :server
-                  ;; Resolve after `set-request!`: the function form can derive
-                  ;; durable event payloads while handlers use the request coeffect
-                  ;; for ambient reads.
-                 :initial-events (lifecycle/resolve-initial-events! initial-events request)}
-          fx-overrides (assoc :fx-overrides fx-overrides)
-          ssr          (assoc :ssr           ssr)))
-      {:frame-id frame-id}
+      ;; KEEP the frame VALUE — it carries the exact incarnation token the
+      ;; handler's teardown consumes for incarnation-EXACT cleanup (rf2-moftbs).
+      (let [frame-value
+            (rf/make-frame
+              (cond-> {:id        frame-id
+                       :doc       "ssr-ring per-request frame"
+                       :platform  :server
+                        ;; Resolve after `set-request!`: the function form can derive
+                        ;; durable event payloads while handlers use the request coeffect
+                        ;; for ambient reads.
+                       :initial-events (lifecycle/resolve-initial-events! initial-events request)}
+                fx-overrides (assoc :fx-overrides fx-overrides)
+                ssr          (assoc :ssr           ssr)))]
+        {:frame-id frame-id :frame frame-value})
       (catch Throwable t
         (ssr/clear-request! frame-id)
+        ;; Construction FAILED — no frame value was returned, so clean up any
+        ;; partial row address-directed by the gensym id (construction rollback
+        ;; is already exact internally, PR #5928).
         (lifecycle/destroy-frame-quietly! frame-id)
         ;; Setup runs outside the handler body's catch, so contain a failing
         ;; caller hook here as well.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -430,12 +430,15 @@
   contract). The 2-arg `ssr-response->ring-response` (no `content-type`)
   matches the non-streaming redirect path — a bodiless redirect has no
   meaningful Content-Type to default; `ssr-response->ring-response` ignores the
-  body arg on its `:redirect` branch (pipeline.clj)."
-  [resp frame-id]
+  body arg on its `:redirect` branch (pipeline.clj).
+
+  `frame` is the per-request frame VALUE (incarnation-EXACT teardown authority,
+  rf2-moftbs); `frame-id` remains the keyword for the failure trace."
+  [resp frame-id frame]
   (try
     (pipeline/ssr-response->ring-response resp nil)
     (finally
-      (lifecycle/destroy-frame-quietly! frame-id))))
+      (lifecycle/destroy-frame-quietly! frame frame-id))))
 
 (defn- stream-projected-error!
   "Materialise a projected 5xx as a plain-String error response on the
@@ -447,12 +450,16 @@
   continuations / `__rf_payload` / app-db. Shared by the drain-time 5xx branch
   and the post-shell recovered-to-nil 5xx branch of `stream-handler`. Per
   Spec 011 §Drain-time error classification + §Streaming pre-commit rule
-  (rf2-oytx7j)."
-  [frame-id resp public-error opts]
+  (rf2-oytx7j).
+
+  `frame` is the per-request frame VALUE (incarnation-EXACT teardown authority,
+  rf2-moftbs); `frame-id` remains the keyword the address-directed materialise +
+  the failure trace use."
+  [frame-id resp public-error opts frame]
   (try
     (pipeline/materialise-projected-error frame-id resp public-error opts)
     (finally
-      (lifecycle/destroy-frame-quietly! frame-id))))
+      (lifecycle/destroy-frame-quietly! frame frame-id))))
 
 (defn- render-shell-or-projected-error
   "Render the streaming shell on THIS (request) thread, BEFORE the chunked
@@ -478,13 +485,17 @@
   drains that buffer, and a projected 5xx then diverts to the non-streamed
   projected-error arm (`stream-projected-error!`) — no writer thread, no
   partial-state shell — rather than streaming the degraded shell under a 500
-  (rf2-oytx7j)."
-  [frame-id opts]
+  (rf2-oytx7j).
+
+  `frame` is the per-request frame VALUE (incarnation-EXACT teardown authority,
+  rf2-moftbs); `frame-id` remains the keyword the address-directed render +
+  projector + failure trace use."
+  [frame-id opts frame]
   (try
     (render-streaming-shell! frame-id opts)
     (catch Throwable t
       (let [err-resp (pipeline/project-render-throw->ring-response frame-id t opts)]
-        (lifecycle/destroy-frame-quietly! frame-id)
+        (lifecycle/destroy-frame-quietly! frame frame-id)
         (reduced err-resp)))))
 
 (defn- stream-rendered-response
@@ -519,8 +530,12 @@
   The writer runs on a daemon thread: one blocked on `.write` to the
   bounded 16 KiB pipe of a slow-loris client must NOT keep the JVM alive at
   shutdown. Its `finally` tears the frame down (off the response-close path,
-  via the slower destroy)."
-  [frame-id rendered resp2 content-type opts]
+  via the slower destroy).
+
+  `frame` is the per-request frame VALUE (incarnation-EXACT teardown authority,
+  rf2-moftbs); `frame-id` remains the keyword the address-directed materialise,
+  writer, thread name, and failure trace use."
+  [frame-id rendered resp2 content-type opts frame]
   (let [;; No body default-stamp here (we pass our own InputStream); `:body` is
         ;; assoc'd after the writer is wired below. Content-Length is already
         ;; stripped by the shared materialiser.
@@ -539,8 +554,9 @@
             (finally
               ;; The writer's own finally closes the pipe; the frame teardown
               ;; happens here so it does NOT block the response close on the
-              ;; slower destroy path.
-              (lifecycle/destroy-frame-quietly! frame-id))))
+              ;; slower destroy path. Destroy the VALUE (incarnation-EXACT,
+              ;; rf2-moftbs); the keyword names the frame on any failure trace.
+              (lifecycle/destroy-frame-quietly! frame frame-id))))
         ^String (str "rf2-ssr-streaming-" (name frame-id)))
       (.setDaemon true)
       (.start))
@@ -671,7 +687,7 @@
                         (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]
-      (let [{:keys [frame-id short-circuit]}
+      (let [{:keys [frame-id frame short-circuit]}
             (pipeline/setup-request-frame! opts request)]
         (if short-circuit
           short-circuit
@@ -689,16 +705,16 @@
               (cond
                 ;; Redirect precedence FIRST (Spec 011 §Redirect precedence).
                 (some? (:redirect response))
-                (redirect-response! response frame-id)
+                (redirect-response! response frame-id frame)
 
                 ;; A drain-time projected 5xx — NO shell, NO writer thread; a
                 ;; plain-String projected-error body on the request thread
                 ;; (Spec 011 §Streaming pre-commit rule, rf2-oytx7j).
                 (pipeline/projected-5xx? public-error)
-                (stream-projected-error! frame-id response public-error opts)
+                (stream-projected-error! frame-id response public-error opts frame)
 
                 :else
-                (let [rendered (render-shell-or-projected-error frame-id opts)]
+                (let [rendered (render-shell-or-projected-error frame-id opts frame)]
                   (if (reduced? rendered)
                     ;; Shell render threw — return the projected error page
                     ;; (frame already torn down inline).
@@ -718,7 +734,7 @@
                         ;; non-streaming handler's redirect-ignores-body parity
                         ;; for a future render-phase fx that learns to redirect.
                         (some? (:redirect resp2))
-                        (redirect-response! resp2 frame-id)
+                        (redirect-response! resp2 frame-id frame)
 
                         ;; A recovered-to-nil sub during the shell render
                         ;; buffered a fail-closed 5xx — take the NON-STREAMED
@@ -727,11 +743,11 @@
                         ;; shell-under-500 behaviour: a 5xx before the chunked
                         ;; head commits never ships a partial-state shell.
                         (pipeline/projected-5xx? err2)
-                        (stream-projected-error! frame-id resp2 err2 opts)
+                        (stream-projected-error! frame-id resp2 err2 opts frame)
 
                         :else
                         (stream-rendered-response
-                          frame-id rendered resp2 content-type opts)))))))
+                          frame-id rendered resp2 content-type opts frame)))))))
             (catch Throwable t
               ;; A get-response, redirect-materialisation, or head-materialisation
               ;; throw raised before the
@@ -742,6 +758,8 @@
               ;; it falls back to the locked `default-on-error` rather
               ;; than escaping as a raw container 500 with leaked
               ;; internals.
-              (try (lifecycle/destroy-frame-quietly! frame-id)
+              ;; Destroy the VALUE (incarnation-EXACT, rf2-moftbs); the keyword
+              ;; `frame-id` names the frame on any failure trace.
+              (try (lifecycle/destroy-frame-quietly! frame frame-id)
                    (catch Throwable _ nil))
               (lifecycle/safe-on-error on-error request t))))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -457,6 +457,51 @@
         (is (nil? (ssr/get-request fid))
             (str "no request slot leaks for frame " fid))))))
 
+;; ===========================================================================
+;; rf2-moftbs — the streaming terminal cleanup is incarnation-EXACT.
+;;
+;; The redirect branch is the deterministic inline-teardown path (no writer
+;; thread to wait on), so it is the clean seam to prove that a streaming
+;; terminal cleanup destroys the frame VALUE make-frame returned (carrying the
+;; exact incarnation token), not the bare gensym frame-id.
+;; ===========================================================================
+
+(deftest stream-handler-terminal-teardown-is-incarnation-exact
+  (testing "a streaming terminal cleanup (redirect inline teardown) destroys the
+            per-request frame VALUE — carrying the exact incarnation token — not
+            the bare gensym id, so it is incarnation-EXACT (rf2-moftbs)"
+    (rf/reg-event :rf.test.stream/redirect2
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
+    (rf/reg-view ^{:rf/id :test/should-not-stream2} should-not-stream2 []
+      [:div "should not render under redirect"])
+    (let [real-destroy    rf/destroy-frame!
+          teardown-target (atom ::none)
+          handler         (ssr-ring/stream-handler
+                            {:initial-events [[:rf.test.stream/redirect2]]
+                             :root-view [:test/should-not-stream2]
+                             :payload :rf.ssr.payload/whole-app-db})
+          baseline-fids   (disj (frame/frame-ids) :rf/default)]
+      (with-redefs [rf/destroy-frame!
+                    (fn [target & more]
+                      (when (and (= ::none @teardown-target)
+                                 (frame/frame-value? target))
+                        (reset! teardown-target target))
+                      (apply real-destroy target more))]
+        (let [response (handler {:uri "/secret" :request-method :get})]
+          (is (= 302 (:status response)) "redirect short-circuit on the wire")))
+      ;; N released: no per-request frame leaks after the inline teardown.
+      (is (empty? (clojure.set/difference (disj (frame/frame-ids) :rf/default)
+                                          baseline-fids))
+          "the per-request incarnation is fully released on the streaming redirect path")
+      ;; N+1 protected: the terminal teardown targeted the incarnation VALUE.
+      (is (frame/frame-value? @teardown-target)
+          "streaming terminal teardown targeted the make-frame VALUE, not the bare id")
+      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+          "the teardown target carries the exact incarnation token — so a same-id
+           successor (N+1) is left intact by the two-argument destroy"))))
+
 (deftest stream-handler-redirect-no-content-type-stamped
   (testing "rf2-ee38b.11: the streaming redirect path does NOT stamp a
             default Content-Type on the bodiless 302 — it agrees with the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -411,6 +411,43 @@
       (is (seq @destroyed)
           ":rf.frame/destroyed trace fired for the per-request frame"))))
 
+(deftest handler-per-request-teardown-is-incarnation-exact
+  (testing "the per-request frame teardown destroys the frame VALUE make-frame
+            returned (carrying the exact incarnation token), NOT the bare gensym
+            frame-id — so teardown is incarnation-EXACT and cannot reap a same-id
+            successor reseated in between while the request still returns 200
+            (rf2-moftbs)"
+    (register-articles-app! [{:id "x" :title "Article X"}])
+    (let [real-destroy    rf/destroy-frame!
+          teardown-target (atom ::none)
+          handler (ssr-ring/ssr-handler
+                    {:initial-events [[:rf/server-init]]
+                     :root-view      [:pages/articles]
+                     :fx-overrides   {:http/get :http/get.canned}
+                     :payload        :rf.ssr.payload/whole-app-db})
+          frames-before (set (rf/frame-ids))]
+      ;; Spy on the facade destroy the handler's `finally` calls. A clean request
+      ;; issues exactly ONE per-request-frame teardown, and (post-fix) it hands
+      ;; over the frame VALUE — not the bare gensym id.
+      (with-redefs [rf/destroy-frame!
+                    (fn [target & more]
+                      (when (and (= ::none @teardown-target)
+                                 (frame/frame-value? target))
+                        (reset! teardown-target target))
+                      (apply real-destroy target more))]
+        (let [response (handler {:uri "/" :request-method :get})]
+          (is (= 200 (:status response)) "the request rendered a 200")))
+      ;; N released: no per-request frame leaks into the registry.
+      (is (= frames-before (set (rf/frame-ids)))
+          "the per-request incarnation is fully released — no frame leak")
+      ;; N+1 protected: teardown targets the incarnation-carrying VALUE.
+      (is (frame/frame-value? @teardown-target)
+          "per-request teardown targeted the make-frame VALUE, not the bare gensym id")
+      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+          "the teardown target carries the exact incarnation token, so the
+           two-argument destroy no-ops against any same-id successor (N+1)
+           (proven end-to-end by re-frame.frame-lifecycle-test)"))))
+
 ;; ===========================================================================
 ;; ssr-handler — redirect short-circuit
 ;; ===========================================================================

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -422,17 +422,30 @@
 
   The replayed frame is allocated through `re-frame.core/make-frame` and —
   when this fn allocated it — torn down through `destroy-frame!` before
-  return, so a JVM test leaves no frame behind. A caller-supplied `:frame`
-  is left intact (the caller owns its lifecycle)."
+  return, so a JVM test leaves no frame behind. Teardown is INCARNATION-EXACT
+  (rf2-moftbs): it destroys the frame VALUE `make-frame` returned (which carries
+  the exact incarnation token), so a replay program that itself destroyed and
+  re-seated the same `frame-id` leaves the successor alive rather than reaping
+  it on exit. A caller-supplied `:frame` is left intact (the caller owns its
+  lifecycle)."
   ([artifact] (replay-run-artifact artifact nil))
   ([artifact {:keys [frame hooks frame-config] :as _opts}]
    (let [own-frame? (nil? frame)
          frame-id   (or frame (gen-replay-frame-id))
-         hooks      (or hooks boundary/headless-flush-hooks)]
-     (when own-frame?
-       (rf/make-frame (merge {:id  frame-id
-                              :doc "rf2-5x1wt.7 run-artifact replay frame"}
-                             frame-config)))
+         hooks      (or hooks boundary/headless-flush-hooks)
+         ;; When we allocate the replay frame, KEEP the frame VALUE `make-frame`
+         ;; returns: it carries the EXACT incarnation token (rf2-moftbs), so the
+         ;; `finally` teardown destroys ONLY the incarnation THIS replay created.
+         ;; The replay program may itself `destroy-frame!` and re-`make-frame`
+         ;; the SAME `frame-id` (a replayed reset composition); destroying by the
+         ;; bare `frame-id` keyword would then tear down the SUCCESSOR B while
+         ;; the run still reads `:pass`. Destroying the value no-ops against B
+         ;; (its carried token is stale), leaving B alive, while an ordinary
+         ;; A-only replay still tears A down.
+         own-frame-value (when own-frame?
+                           (rf/make-frame (merge {:id  frame-id
+                                                  :doc "rf2-5x1wt.7 run-artifact replay frame"}
+                                                 frame-config)))]
      (try
        ;; Re-install the artifact's `:network` route stubs (when any) for the
        ;; duration of the replay, so the `:fx-decisions` managed-stub redirect
@@ -450,5 +463,7 @@
                              :app-db     app-db}))))
        (finally
          (when own-frame?
-           (try (rf/destroy-frame! frame-id)
+           ;; Incarnation-EXACT teardown: destroy the VALUE we created, not the
+           ;; bare `frame-id` (rf2-moftbs).
+           (try (rf/destroy-frame! own-frame-value)
                 (catch #?(:clj Throwable :cljs :default) _ nil))))))))

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -322,6 +322,40 @@
           "the caller-supplied frame is NOT destroyed"))))
 
 ;; ===========================================================================
+;; rf2-moftbs — exact-incarnation teardown of the replay-allocated frame
+;; ===========================================================================
+
+(deftest replay-teardown-is-incarnation-exact
+  (testing "replay-run-artifact tears down the frame VALUE it created (carrying
+            the exact incarnation token), NOT the bare frame-id keyword — so a
+            same-id successor seated before teardown is left alive rather than
+            reaped while the run still reads :pass (rf2-moftbs)"
+    (rf/reg-event :rep/noop (fn [{:keys [db]} _] {:db (assoc db :ran true)}))
+    (let [real-destroy    rf/destroy-frame!
+          teardown-target (atom ::none)]
+      ;; Spy on the facade destroy the replay's `finally` calls. A clean replay
+      ;; issues exactly ONE facade `rf/destroy-frame!` — the own-frame teardown —
+      ;; and (post-fix) it hands over the frame VALUE, not the bare gensym id.
+      (with-redefs [rf/destroy-frame!
+                    (fn [target & more]
+                      (when (and (= ::none @teardown-target)
+                                 (frame/frame-value? target))
+                        (reset! teardown-target target))
+                      (apply real-destroy target more))]
+        (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:rep/noop]]]})
+              res (artifact/replay-run-artifact a)
+              fid (:frame res)]
+          (is (= :pass (:status res)) "the replay ran clean")
+          (is (not (contains? @frame/frames fid))
+              "the replay-allocated incarnation is fully released (N released)")))
+      (is (frame/frame-value? @teardown-target)
+          "teardown targeted the make-frame VALUE, not a bare frame-id keyword")
+      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+          "the teardown target carries the exact incarnation token — so the
+           two-argument destroy no-ops against any same-id successor (N+1),
+           leaving it alive (proven end-to-end by re-frame.frame-lifecycle-test)"))))
+
+;; ===========================================================================
 ;; EP-0017: recordable-coeffect envelopes survive run-artifact replay,
 ;; replayed under STRICT mint policy by default (rf2-srgvzp)
 ;; ===========================================================================


### PR DESCRIPTION
## Summary

PR #5928 made construction rollback exact, but three longer-lived owners still cleaned up **by frame ID**. If their body destroyed incarnation A and re-seated B under the same id, owner exit destroyed **B** (and Story returned `:pass` / SSR returned 200 while reaping the successor).

The fix hands **exact incarnation authority through the construction boundary**:

- `frame/upsert-frame!` gains an optional 3-arity `token-sink` (a `volatile!`) OUT-channel that delivers the installed `:drain-lock` from **inside** the construction transaction. `live-frame/make-frame` embeds it on the returned frame VALUE as `:rf.frame/incarnation-token` — so exact authority is acquired atomically with construction, **with no post-return `frame-incarnation-token` re-sample** a concurrent destroy+reseat could race.
- The one-argument `frame/destroy-frame!` now consumes that carried authority (delegating to the incarnation-owned two-argument arity). Destroying a VALUE tears down **only** the incarnation it named; a stale carried token no-ops (the 2-arg arity revalidates liveness), leaving a same-id successor intact.
- Frame-id **keyword** and derived-read (`live-frame` / `image-view-frames`) value destruction stay explicitly **address-directed** — no second public handle hierarchy.

The `upsert-frame!` **2-arity return is unchanged** (still the id), so every existing caller + engine test (`frame_construction_atomic`, `frame_upsert_linearization`) is byte-identical.

### Per-consumer defect → fix

| Consumer | Defect (pre-fix) | Fix |
|---|---|---|
| `with-new-frame` | `core_reg_view_macro.cljc:263` `(destroy-frame! ~sym)` → 1-arg arity `frame.cljc` normalized the value to an id and pinned the CURRENT incarnation | Shared `destroy-frame!` 1-arg now consumes the value's carried token; **the macro is unchanged** |
| Story replay | `artifact.cljc` discarded `make-frame`'s VALUE and did `(destroy-frame! frame-id)` (bare keyword → address-directed) | Keep the VALUE (`own-frame-value`) and destroy it |
| SSR (ssr-ring) | `pipeline/setup-request-frame!` discarded the VALUE; every teardown (`ring.clj`, all streaming terminal/error/cancel sites in `streaming.clj`) destroyed by bare gensym id | `setup-request-frame!` returns `:frame` (the VALUE); every teardown destroys it. `destroy-frame-quietly!` gains a diagnostic-id arity so the failure trace `:frame` stays a clean keyword |

### Adversarial proofs (≥1 per consumer)

Each proves **disposing incarnation N leaves a reseated N+1 alive while ordinary N cleanup fully releases N**:

- **Core** (`frame_lifecycle_test.clj`): `destroy-value-N-does-not-tear-down-successor-N+1`, `with-new-frame-exit-teardown-is-incarnation-exact`, `destroy-value-fully-releases-its-own-incarnation`, `make-frame-value-carries-exact-incarnation-token`, `keyword-destroy-remains-address-directed` (end-to-end).
- **Story** (`artifact_test.cljc`): `replay-teardown-is-incarnation-exact` — teardown targets the incarnation-carrying VALUE + N fully released.
- **SSR** (`ring_test.clj` / `ring_streaming_test.clj`): `handler-per-request-teardown-is-incarnation-exact` + `stream-handler-terminal-teardown-is-incarnation-exact`.

## Quality gates

All green (foreground, unpiped):

- `npm run test:cljs` (core + reagent node): **9667 tests / 47580 assertions, 0 failures, 0 errors**
- `implementation/core` JVM (`clojure -M:test`): **2020 tests / 9440 assertions, 0 failures**
- Story artefact (`tools/story` `clojure -M:test`): **1807 tests / 6666 assertions, 0 failures**
- SSR path — `implementation/ssr-ring` (`clojure -M:test`): **198 tests / 974 assertions, 0 failures**; `implementation/ssr` (`clojure -M:test`): **398 tests / 1693 assertions, 0 failures**

No new `re-frame.core` facade export or error-id: `frame-value-incarnation-token` lives in the non-enumerated `re-frame.frame`, `destroy-frame-quietly!`'s new arity in the non-enumerated `re-frame.ssr.ring.lifecycle` — no api-manifest / API.md / Spec 009 drift. No `epoch/` files touched (epoch fence respected).
