### PR TITLE
fix(machines): require cancellation tombstones in the spawn-all authority schema (rf2-y7venl)

### DIFF
--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -12,14 +12,21 @@
 
     1. SCHEMA — the `:spawned` slot union has THREE legal runtime arms
        (Spec-Schemas §`Machines`): the `:spawn` leaf keyword, the LIVE
-       child-bearing `InvokeAllJoinState` (with `:rf/attempt` REQUIRED — a
-       token-less join is not a valid live shape; `join.cljc`'s fold gate
-       requires a non-nil exact match), and the childless REJECT sentinel
-       `InvokeAllRejectedState` (`{:closed true}`, only `:rf/spawn-all-rejected?
-       true`). A real unregistered-child `:spawn-all` fixture validates the
-       COMPLETE `:rf.runtime/machines` runtime-db against the extracted
-       `Machines` form during the legal pre-parent-exit interval; a sentinel
-       carrying `:children`/authority, and a token-less live join, both fail.
+       child-bearing `InvokeAllJoinState` (with `:rf/attempt` AND the
+       `:cancelled` tombstone set REQUIRED — a token-less or tombstone-less join
+       is not a valid live shape; `join.cljc`'s fold gate requires a non-nil
+       exact match and consults `:cancelled` to suppress a resurrected
+       completion), and the childless REJECT sentinel `InvokeAllRejectedState`
+       (`{:closed true}`, only `:rf/spawn-all-rejected? true`). A real
+       unregistered-child `:spawn-all` fixture validates the COMPLETE
+       `:rf.runtime/machines` runtime-db against the extracted `Machines` form
+       during the legal pre-parent-exit interval; a sentinel carrying
+       `:children`/authority, and a token-less live join, both fail. Every
+       runtime-owned required join key is guarded by a compact key-completeness
+       plus targeted-mutation check, and the `:cancelled` tombstone is proven
+       end-to-end: an explicitly cancelled child leaves a tombstone the schema
+       REQUIRES and the runtime HONOURS, so a late authority cannot resurrect it
+       (rf2-y7venl).
 
     2. CATALOGUE — `:rf.machine.spawn-all/child-completed` emits
        `:rf.reply/correlation` (Spec 009 detailed row + `join.cljc`), carrying
@@ -115,6 +122,49 @@
   (rf/dispatch-sync [parent-kw [:start]])
   (join-state parent-kw [:racing]))
 
+(defn- reg-destroyable-join-parent!
+  "Like `reg-join-parent!` for an `:all` join, but the parent exposes a `:kill`
+  event that imperatively tears down a named spawned child WHILE IT IS STILL
+  IN-PROGRESS — an authenticated explicit teardown, so the runtime records a
+  cancellation TOMBSTONE. Returns the seeded live join state."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine child-a-kw (mk-child parent-kw))
+  (rf/reg-machine child-b-kw (mk-child parent-kw))
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :actions {:kill-child (fn [{ev :event}]
+                             {:fx [[:rf.machine/destroy (second ev)]]})}
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        ;; runs after the join is seeded; internal transition
+                        ;; (action only, no target) so the join slot survives.
+                        :on {:kill {:action :kill-child}}}}})
+  (rf/dispatch-sync [parent-kw [:start]])
+  (join-state parent-kw [:racing]))
+
+;; The runtime-owned REQUIRED keys `spawn-all-init-fx` seeds on every live
+;; child-bearing join (Spec-Schemas §InvokeAllJoinState). Weakening any of these
+;; to `{:optional true}` in the authoritative document, or omitting one, must
+;; turn the key-completeness proof red.
+(def ^:private expected-runtime-owned-join-keys
+  #{:children :done :failed :cancelled :resolved? :spec :rf/attempt})
+
+(defn- schema-required-keys
+  "The set of REQUIRED (non-`{:optional true}`) map keys of an extracted malli
+  `:map` schema form — read straight off the compiled schema so the check
+  tracks the authoritative document, not a hand-copied key list."
+  [schema]
+  (->> (m/children (m/schema schema))
+       (remove #(:optional (second %)))
+       (map first)
+       set))
+
 ;; ---------------------------------------------------------------------------
 ;; 1. SCHEMA — `:rf/attempt` is REQUIRED on a live child-bearing join
 ;; ---------------------------------------------------------------------------
@@ -139,7 +189,95 @@
            required in the authoritative document, not optional"))))
 
 ;; ---------------------------------------------------------------------------
-;; 1b. SCHEMA — the childless REJECT sentinel is a THIRD legal `:spawned` arm,
+;; 1a. SCHEMA — EVERY runtime-owned join key is REQUIRED (key-completeness +
+;;     targeted mutation), while the map stays intentionally OPEN
+;; ---------------------------------------------------------------------------
+
+(deftest live-join-guards-every-runtime-owned-required-key
+  (testing "rf2-y7venl — the extracted `InvokeAllJoinState` requires EXACTLY the
+            runtime-owned seed keys `spawn-all-init-fx` writes (key-completeness:
+            weakening any to `{:optional true}` or omitting one shrinks the
+            required set and turns this red), a real runtime join carries every
+            one, dropping ANY single required key FAILS the extracted schema
+            (targeted mutation), and yet an EXTRA bookkeeping key still validates
+            — the join map is intentionally OPEN, not `{:closed true}`."
+    (let [j (reg-join-parent! :sac/pk :sac/pka :sac/pkb
+                              {:join :all :on-all-complete [:all/done]})]
+      ;; key-completeness: the authoritative schema's required set is exactly the
+      ;; runtime-owned seed key set — no drift in either direction.
+      (is (= expected-runtime-owned-join-keys (schema-required-keys InvokeAllJoinState))
+          (str "the extracted InvokeAllJoinState requires exactly the "
+               "runtime-owned seed keys; found: "
+               (schema-required-keys InvokeAllJoinState)))
+      (is (m/validate InvokeAllJoinState j)
+          (str "the runtime join validates; explain: " (m/explain InvokeAllJoinState j)))
+      ;; targeted mutation: the runtime seed carries every required key, and
+      ;; dropping any single one fails the extracted schema.
+      (doseq [k expected-runtime-owned-join-keys]
+        (is (contains? j k) (str "the runtime seed carries the required key " k))
+        (is (not (m/validate InvokeAllJoinState (dissoc j k)))
+            (str "dropping the required key " k " FAILS the extracted schema")))
+      ;; intentional open-map extensibility preserved.
+      (is (m/validate InvokeAllJoinState (assoc j :rf/future-bookkeeping 1))
+          "an extra runtime bookkeeping key still validates — the join stays open"))))
+
+;; ---------------------------------------------------------------------------
+;; 1b. SCHEMA + BEHAVIOUR — a cancelled child leaves a `:cancelled` TOMBSTONE the
+;;     schema REQUIRES and the runtime HONOURS (late authority cannot resurrect)
+;; ---------------------------------------------------------------------------
+
+(deftest cancelled-child-tombstone-is-required-and-honoured
+  (testing "rf2-y7venl — an authenticated IN-PROGRESS explicit teardown of a
+            spawned child durably records a `:cancelled` tombstone: the live
+            tombstoned join validates against the extracted `InvokeAllJoinState`,
+            dissociating `:cancelled` FAILS it (the tombstone set is REQUIRED,
+            not optional — an open map would otherwise accept the dissoc), and a
+            LATE exact-authenticated completion carrier for the cancelled child
+            is SUPPRESSED as a duplicate terminal. A late/rejoining authority can
+            never resurrect or mis-attribute a cancelled child."
+    (let [j         (reg-destroyable-join-parent! :sac/tomb :sac/tomba :sac/tombb)
+          spawned-a (get-in j [:children :a])
+          ;; the exact join authority a late carrier would present — captured
+          ;; from the LIVE attempt so it is genuinely exact-current, not forged.
+          auth      {:parent-id  :sac/tomb
+                     :invoke-id  [:racing]
+                     :child-id   :a
+                     :spawned-id spawned-a
+                     :attempt    (:rf/attempt j)}]
+      (is (= #{} (:cancelled j)) "the live seed carries an empty tombstone set")
+      ;; Tear child :a down while it is still IN-PROGRESS; :b keeps running so
+      ;; the `:all` join is unresolved and the slot stays live for probing.
+      (rf/dispatch-sync [:sac/tomb [:kill spawned-a]])
+      (let [tombstoned (join-state :sac/tomb [:racing])]
+        (is (= #{:a} (:cancelled tombstoned))
+            "the authenticated in-progress teardown durably tombstones child :a")
+        (is (false? (:resolved? tombstoned))
+            "the :all join is NOT resolved — :b is still live")
+        ;; the live TOMBSTONED join validates against the extracted schema ...
+        (is (m/validate InvokeAllJoinState tombstoned)
+            (str "the tombstoned join validates; explain: "
+                 (m/explain InvokeAllJoinState tombstoned)))
+        ;; ... and dissociating the tombstone FAILS it — the key is REQUIRED, so
+        ;; a runtime that stopped seeding `:cancelled` would be caught here.
+        (is (not (m/validate InvokeAllJoinState (dissoc tombstoned :cancelled)))
+            "dissociating :cancelled FAILS the extracted schema — the tombstone is required")
+        ;; a LATE exact-authenticated completion carrier for :a cannot resurrect it.
+        (mtest/reset-captured!)
+        (rf/dispatch-sync [:sac/tomb (with-meta [:child/done :a]
+                                       {:rf/join-auth auth})])
+        (let [after (join-state :sac/tomb [:racing])
+              stale (first (mtest/events-of :rf.machine.spawn-all/stale-completion))]
+          (is (= #{} (:done after))
+              "the late exact-auth carrier did NOT fold — :a is never marked done")
+          (is (= #{:a} (:cancelled after))
+              "the tombstone is unchanged — the cancelled child is not resurrected")
+          (is (some? stale) "a stale-completion suppression fired for the late carrier")
+          (is (= :rf.machine.spawn-all/duplicate-completion
+                 (:rf.reply/stale-reason (:tags stale)))
+              "the late carrier is classified a duplicate terminal against the tombstone"))))))
+
+;; ---------------------------------------------------------------------------
+;; 1c. SCHEMA — the childless REJECT sentinel is a THIRD legal `:spawned` arm,
 ;;     and the COMPLETE Machines runtime-db validates with it present
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/machines/test/re_frame/spawn_all_schema_extract.clj
+++ b/implementation/machines/test/re_frame/spawn_all_schema_extract.clj
@@ -67,8 +67,11 @@
 
 (defn canonical-invoke-all-join-schema
   "The canonical `InvokeAllJoinState` `[:map …]` form, extracted from
-  Spec-Schemas.md. `:rf/attempt` is REQUIRED here (the authoritative document);
-  a token-less child-bearing join is not a valid live shape."
+  Spec-Schemas.md. Every enumerated key is REQUIRED here (the authoritative
+  document): `:rf/attempt` (a token-less child-bearing join is not a valid live
+  shape) and the `:cancelled` explicit-teardown TOMBSTONE set (a tombstone-less
+  live join cannot honour a cancellation, so a late authority could resurrect a
+  cancelled child — rf2-y7venl)."
   []
   (extract-def-form (spec-schemas-text) 'InvokeAllJoinState))
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2587,15 +2587,24 @@ A frame owns two durable partitions held as one physical frame-state container (
    [:children  [:map-of :keyword :keyword]]                                   ;; child-id → spawned-id
    [:done      [:set :keyword]]                                               ;; user-ids that signalled :on-child-done
    [:failed    [:set :keyword]]                                               ;; user-ids that signalled :on-child-error
+   [:cancelled [:set :keyword]]                                               ;; REQUIRED on every live child-bearing join. The exact-attempt authenticated explicit-teardown TOMBSTONE set: user-ids the runtime durably closed by CANCELLATION for THIS attempt. `spawn-all-init-fx` ALWAYS seeds it `#{}` at the same instant it mints `:rf/attempt` (so a live join can never be tombstone-less — not a valid live shape); `destroy.cljc`'s `prepare-join-child-teardown!` conj's a logical child id here inside the exact durable write when an authenticated IN-PROGRESS child is explicitly torn down, BEFORE exit callbacks / snapshot removal / the terminal destroyed trace. `join.cljc`'s fold gate consults it (`(contains? (:cancelled join-state) child-id)`) to SUPPRESS an already-queued/delayed exact-auth completion as a duplicate terminal — so a late/rejoining authority can never RESURRECT or mis-attribute a cancelled child (rf2-y7venl). A new join attempt re-seeds a fresh `#{}`, so no tombstone crosses re-entry. The childless REJECT sentinel (`InvokeAllRejectedState`, below) carries NO `:cancelled` and NO `:children`, so it never validates as an InvokeAllJoinState; the tombstone set is required rather than optional. This map stays intentionally OPEN (no `{:closed true}`) — the runtime may carry additional bookkeeping keys — but every key enumerated here is a REQUIRED runtime-owned slot the authority proof guards by targeted mutation.
    [:resolved? :boolean]                                                      ;; latch flips once the join condition resolves
    [:spec      :map]                                                          ;; back-reference for the join intercept
    [:rf/attempt :int]])                                                       ;; REQUIRED on every live child-bearing join. Opaque monotonic per-attempt token minted at seed by spawn-all-init-fx; stamped into each child's :rf/join-child so the fold gate binds every completion carrier to the exact join attempt (rf2-nvxehu; 005 §Exact-authority fold gate). `spawn-all-init-fx` ALWAYS mints it before the per-child spawns run, and `join.cljc`'s fold gate requires a non-nil exact match, so a token-less join is permanently unable to accept a completion — not a valid live shape. The pre-per-child REJECT sentinel (an unregistered sibling TYPE) is a SEPARATE shape (`InvokeAllRejectedState`, below) carrying `:rf/spawn-all-rejected?` and NO `:children`, so it never validates as an InvokeAllJoinState; the token is required rather than optional. Treat as opaque — int today, per-session accident-gating.
 
 (def InvokeAllRejectedState
   ;; The pre-per-child REJECT SENTINEL `spawn-all-init-fx` seeds at the join
-  ;; slot `[:rf.runtime/machines :spawned <parent> <invoke>]` when a `:spawn-all`
-  ;; names an UNREGISTERED child TYPE. The whole invoke rejects ATOMICALLY
-  ;; before any live join-state is seeded (rf2-qb1j5z; 005 §Spawn-and-join via
+  ;; slot `[:rf.runtime/machines :spawned <parent> <invoke>]` when its
+  ;; invoke-level admission preflight fail-closes any child in the set. The
+  ;; preflight is authoritative for EVERY current fail-closed invoke-level
+  ;; admission cause — today two DISJOINT ones: (1) an UNREGISTERED child TYPE
+  ;; (no inline `:definition`; rf2-qb1j5z) — a never-running spec-less child
+  ;; would never dispatch `:on-child-done`, hanging an `:all` join forever; and
+  ;; (2) a spawn-time CHILD `[:schemas :data]` REJECTION (rf2-7u8gen) — a child
+  ;; whose materialised `:data` fails its own data-schema, which would otherwise
+  ;; publish a live join naming a child that has no snapshot and can never emit
+  ;; completion. Either cause rejects the WHOLE invoke ATOMICALLY
+  ;; before any live join-state is seeded (005 §Spawn-and-join via
   ;; `:spawn-all` §atomic reject): rather than a live `InvokeAllJoinState`, the
   ;; slot holds this CLOSED single-key marker carrying ONLY
   ;; `:rf/spawn-all-rejected? true` and — critically — NO `:children` and NO


### PR DESCRIPTION
## Summary

The #5933 extracted-schema proof was false-greening. The machines runtime made `:cancelled` a required per-attempt tombstone set — `spawn-all-init-fx` always seeds `:cancelled #{}` and `join.cljc`'s fold gate consults it (`(contains? (:cancelled join-state) child-id)`) to suppress a resurrected completion — but canonical `InvokeAllJoinState` in `spec/Spec-Schemas.md` omitted the key. Because the malli map is open, the extracted schema validated **both** a real runtime join **and** `(dissoc join :cancelled)`, so the supposedly authoritative gate could not detect this runtime/schema drift.

## The gap

- `spec/Spec-Schemas.md` §`InvokeAllJoinState` (line ~2584) omitted `:cancelled`, while `spawn.cljc:855,931` seeds it and `join.cljc:1067` / `destroy.cljc:418-425` read/write it. Open-map validation hid the drift.

## The fix

- **Schema.** `InvokeAllJoinState` now REQUIRES `[:cancelled [:set :keyword]]`, documented as the exact-attempt authenticated explicit-teardown TOMBSTONE set (a late/rejoining authority can never resurrect or mis-attribute a cancelled child).
- **Proof (compact key-completeness + targeted mutation).** `live-join-guards-every-runtime-owned-required-key` asserts the schema's required-key set equals the runtime-owned seed set, that dropping **any** single required key fails the extracted schema, and that an **extra** bookkeeping key still validates (intentional open-map extensibility preserved).
- **Adversarial end-to-end.** `cancelled-child-tombstone-is-required-and-honoured` drives a real `:spawn-all`, tears down child `:a` in-progress (explicit cancellation → `:cancelled #{:a}`), validates the live tombstoned join against the extracted schema, shows `(dissoc … :cancelled)` FAILS it, then dispatches a **late exact-authenticated** completion carrier for `:a` and proves it is suppressed as `:rf.machine.spawn-all/duplicate-completion` — the tombstone is unchanged, `:a` is never resurrected.
- **Rejected-sentinel prose.** `InvokeAllRejectedState` now covers both current fail-closed invoke-level admission causes (unregistered child type + spawn-time child `[:schemas :data]` rejection), without implying live join authority.

Runtime source is unchanged — the cancel path already emits tombstones; this restores the authoritative executable proof. `spec/005` already documents `:cancelled` as the per-attempt tombstone set (§join-state shape, §Exact-authority fold gate), so it is unchanged.

## Failing-before / passing-after

Reverting the markdown to omit `:cancelled` (the pre-fix state): the old `:rf/attempt` test still false-greens, but the two new tests correctly go RED — key-completeness reports `found: #{:children :done :rf/attempt :spec :resolved? :failed}` (missing `:cancelled`) and "dissociating :cancelled FAILS the extracted schema — the tombstone is required". Renaming the markdown key turns 7 assertions red.

## Quality gates

- `implementation/machines` JVM (`clojure -M:test`): **1149 tests, 3920 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9671 tests, 47586 assertions, 0 failures, 0 errors**.
- Focused `re-frame.spawn-all-authority-catalogue-test`: **8 tests, 60 assertions, 0 failures** green after fix; RED with the markdown mutation (verified both key-rename and key-absent).

No new public var or error-id (the `:cancelled` join-state key is internal runtime bookkeeping), so no manifest / API.md / Spec-009 rows changed.

Note: `spec/Spec-Schemas.md` is a hot-zone file; this edit is confined to the `InvokeAllJoinState` / `InvokeAllRejectedState` region required by the bead's acceptance criteria.