### PR TITLE
fix(ui): collapse defview header collisions through the canonical host binding plan (rf2-qa5wkd)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -12,6 +12,7 @@
   branches. Rejected forms throw compile errors with
   {:rf.ui.compile/error <id>} ex-data (the S1e roster keys off the ids)."
   (:require [clojure.string :as str]
+            [re-frame.ui.compiler.binding-plan :as bp]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.fingerprint :as fingerprint]
@@ -345,69 +346,6 @@
       (contains? lease-fqns fqn) :lease
       (contains? frame-fqns fqn) :frame)))
 
-(defn- key-group-kw?
-  "True for a `:keys`/`:strs`/`:syms` map-destructuring group directive (any
-  namespace: `:person/keys` too). Its map-entry VALUE is a vector of symbols;
-  its keys are keyword/string/symbol LITERALS, never evaluated expressions."
-  [k]
-  (and (keyword? k) (contains? #{"keys" "strs" "syms"} (name k))))
-
-(defn- key-group-directive-fn
-  "The lookup-key transform host `destructure` applies to a `:keys`/`:strs`/
-  `:syms` group directive `mk` (any namespace). This is the SHARED CLJ/CLJS
-  transform — both hosts run `destructure` on the JVM at macro-expansion time —
-  reproduced verbatim so the produced key (and, through it, the map's iteration
-  order) matches the host exactly."
-  [mk]
-  (let [mkns (namespace mk)]
-    (case (name mk)
-      "keys" #(keyword (or mkns (namespace %)) (name %))
-      "syms" #(list 'quote (symbol (or mkns (namespace %)) (name %)))
-      "strs" str)))
-
-(defn- assoc-binding-units
-  "The associative-destructuring binding units of map `pattern`, in the EXACT
-  host `destructure` `bes` order — the ONE canonical, host-faithful binding
-  plan (`reject-reactive-binding!` scope checking and the CLJS header emitter
-  both consume it, so neither can drift from the other or from the host).
-
-  It reproduces `destructure`'s remaining-bindings transformation rather than
-  invoking a general macroexpander: start from `(dissoc pattern :as :or)`, then
-  for each group directive — in the order it appears in the pattern's keys —
-  `dissoc` the directive and `assoc` each expanded local exactly as the host
-  does, and read the units off `(seq bes)` in the resulting map-iteration order.
-  Small patterns stay a `PersistentArrayMap` (insertion order); at nine or more
-  remaining bindings the host promotes to a `PersistentHashMap` and the order
-  becomes hash-driven. Because every host computes this on the JVM the 8→9
-  threshold and the hash order are identical on CLJ and CLJS, so reproducing the
-  transform here is faithful to both.
-
-  `:as` is NOT included — it binds first, before `bes`, so the caller seeds it
-  into scope. Each unit is `{:local-pattern p :key-expr e}`: for an explicit
-  `{p key-expr}` entry `p` is the local pattern and `key-expr` its EVALUATED
-  lookup-key expression; for a group local `p` is the simple symbol and the key
-  is the produced literal (a keyword/string/quoted symbol — never a reactive
-  escape). The units are consumed in order so each binding's default/lookup-key
-  is judged against the scope established BEFORE it — never against a symbol the
-  same pattern binds later, and never in an order the host would not use."
-  [pattern]
-  (let [start      (dissoc pattern :as :or)
-        transforms (reduce (fn [t k] (if (key-group-kw? k) (assoc t k true) t))
-                           {} (keys pattern))
-        explicit   (set (keys (reduce dissoc start (keys transforms))))
-        bes        (reduce
-                    (fn [bes [mk _]]
-                      (let [f (key-group-directive-fn mk)]
-                        (reduce (fn [b s] (assoc b s (f s)))
-                                (dissoc bes mk)
-                                (get bes mk))))
-                    start
-                    transforms)]
-    (for [[bb bk] bes]
-      (if (contains? explicit bb)
-        {:local-pattern bb :key-expr bk}
-        {:local-pattern (symbol (name bb)) :key-expr nil}))))
-
 (defn- check-portable-map-shape!
   "Reject the nonportable associative-destructuring shapes the host tolerates
   but that bind ambiguously across analysis and emission (or across CLJ/CLJS):
@@ -421,7 +359,7 @@
   [e pattern]
   (doseq [[k _] pattern]
     (cond
-      (or (= k :as) (= k :or) (key-group-kw? k)) nil
+      (or (= k :as) (= k :or) (bp/key-group-kw? k)) nil
 
       (keyword? k)
       (env/fail! e :rf.ui.compile/unsupported-form
@@ -507,25 +445,27 @@
     ;; Associative destructuring. Close the portable grammar first, then thread
     ;; scope in host `destructure` order. `:as` binds the whole map FIRST (host
     ;; order), so it is in scope for every key default. Then the key bindings are
-    ;; established sequentially (`assoc-binding-units` = the host `bes` order):
+    ;; established sequentially (`bp/assoc-binding-units` = the host `bes` order):
     ;; each key's default AND each explicit lookup-key expression is evaluated
     ;; against the scope BEFORE that key's own local is bound — the local is
-    ;; added only after, and never in an order the host would not use.
+    ;; added only after, and never in an order the host would not use. Only an
+    ;; `:explicit?` unit's `:key` is a user-written expression that can hide a
+    ;; reactive-authoring escape; a group local's key is a produced literal.
     (do
       (check-portable-map-shape! e pattern)
       (let [defaults (:or pattern)
             scope    (cond-> scope (:as pattern) (conj (:as pattern)))]
         (reduce
-         (fn [scope {:keys [local-pattern key-expr]}]
-           (when key-expr
+         (fn [scope {:keys [local-pattern key explicit?]}]
+           (when explicit?
              (reject-binding-escape! e scope "destructuring lookup-key expression"
-                                     pattern key-expr))
+                                     pattern key))
            (when (and (symbol? local-pattern) (contains? defaults local-pattern))
              (reject-binding-escape! e scope "destructuring :or default"
                                      pattern (get defaults local-pattern)))
            (check-binding-scope! e scope local-pattern))
          scope
-         (assoc-binding-units pattern))))
+         (bp/assoc-binding-units pattern))))
 
     :else scope))
 
@@ -554,15 +494,13 @@
 
 (defn header-binding-order
   "The explicit/group local-patterns of a defview header map `binding-form`, in
-  host `destructure` `bes` order (`:as` excluded — it binds first). The CLJS
-  header emitter consumes this so its property-read bindings land in the same
-  order the JVM native destructuring would use; a dependent `:or` default then
-  resolves to the same symbol on both hosts and no public authoring var can
-  survive through a reordered default. One plan (`assoc-binding-units`), both
-  emitters. Returns nil for a non-map header (`[sym]` ≡ `{:as sym}`)."
+  host `destructure` `bes` order (`:as` excluded — it binds first). One plan
+  (`bp/assoc-binding-units`), so a dependent `:or` default resolves to the same
+  symbol on both hosts and no public authoring var can survive through a
+  reordered default. Returns nil for a non-map header (`[sym]` ≡ `{:as sym}`)."
   [binding-form]
   (when (map? binding-form)
-    (mapv :local-pattern (assoc-binding-units binding-form))))
+    (bp/binding-order binding-form)))
 
 (defn- impure-slot-fail!
   "The didactic rejection for a reactive read inside a `ui/render-fn` slot

--- a/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
@@ -1,0 +1,105 @@
+(ns re-frame.ui.compiler.binding-plan
+  "The ONE canonical, host-faithful associative-destructuring binding plan.
+
+  A map destructuring pattern (`{:keys [x] x :foo}`, `{:keys [acct/id]}`, …)
+  has EXACTLY ONE meaning: whatever `clojure.core/destructure` binds. Both hosts
+  run `destructure` on the JVM at macro-expansion time, so reproducing its
+  remaining-bindings transformation here — rather than invoking a general
+  macroexpander — yields a plan that is faithful to CLJ and CLJS alike.
+
+  This plan is the SINGLE authority every consumer routes through, so none can
+  drift from another or from the host:
+
+  - the analyzer's reactive-binding scope walk (`analyze/check-binding-scope!`);
+  - the defview header parser (`header/parse-header`), whose emitted binding
+    units, schema slots, comparator inputs and manifest metadata are all read
+    off these collapsed entries;
+  - and, transitively, both emitters — the JVM emitter destructures the raw
+    pattern natively; the CLJS emitter lowers exactly these units to property
+    reads. Because the units are the host's collapse, the two emitters agree.
+
+  The critical property is COLLAPSE: when two entries bind the SAME local
+  (`{:keys [x] x :foo}`), the host's map-destructuring overwrite semantics keep
+  ONE binding with ONE winning lookup key (`x <- :x`), and so does this plan —
+  never two bindings, never a silent last-wins. Likewise a qualified group local
+  (`{:keys [acct/id]}`) keeps its qualified lookup key (`:acct/id`), never a bare
+  `:id`.")
+
+(defn key-group-kw?
+  "True for a `:keys`/`:strs`/`:syms` map-destructuring group directive (any
+  namespace: `:person/keys` too). Its map-entry VALUE is a vector of symbols;
+  its keys are keyword/string/symbol LITERALS, never evaluated expressions."
+  [k]
+  (and (keyword? k) (contains? #{"keys" "strs" "syms"} (name k))))
+
+(defn key-group-directive-fn
+  "The lookup-key transform host `destructure` applies to a `:keys`/`:strs`/
+  `:syms` group directive `mk` (any namespace). This is the SHARED CLJ/CLJS
+  transform — both hosts run `destructure` on the JVM at macro-expansion time —
+  reproduced verbatim so the produced key (and, through it, the map's iteration
+  order) matches the host exactly."
+  [mk]
+  (let [mkns (namespace mk)]
+    (case (name mk)
+      "keys" #(keyword (or mkns (namespace %)) (name %))
+      "syms" #(list 'quote (symbol (or mkns (namespace %)) (name %)))
+      "strs" str)))
+
+(defn assoc-binding-units
+  "The associative-destructuring binding units of map `pattern`, in the EXACT
+  host `destructure` `bes` order — the ONE canonical, host-faithful binding
+  plan every consumer shares, so none can drift from another or from the host.
+
+  It reproduces `destructure`'s remaining-bindings transformation rather than
+  invoking a general macroexpander: start from `(dissoc pattern :as :or)`, then
+  for each group directive — in the order it appears in the pattern's keys —
+  `dissoc` the directive and `assoc` each expanded local exactly as the host
+  does, and read the units off `(seq bes)` in the resulting map-iteration order.
+  Small patterns stay a `PersistentArrayMap` (insertion order); at nine or more
+  remaining bindings the host promotes to a `PersistentHashMap` and the order
+  becomes hash-driven. Because every host computes this on the JVM the 8→9
+  threshold and the hash order are identical on CLJ and CLJS, so reproducing the
+  transform here is faithful to both.
+
+  Two entries binding the SAME local COLLAPSE, exactly as the host's `bes` map
+  collapses them: `{:keys [x] x :foo}` yields the single unit `x <- :x` (the
+  group directive's `assoc` overwrites the explicit entry's value), never two
+  bindings and never a silent last-wins. A group local keeps its QUALIFIED
+  lookup key: `{:keys [acct/id]}` yields `id <- :acct/id`, never bare `:id`.
+
+  `:as` is NOT included — it binds first, before `bes`, so the caller seeds it
+  into scope. Each unit is `{:local-pattern p :key k :explicit? bool}`:
+  `:local-pattern` is the bound local (a simple symbol for a group local, or the
+  written local pattern — possibly nested — for an explicit `{p key}` entry);
+  `:key` is the WINNING lookup key after collapse (an EVALUATED expression for an
+  explicit entry, or the produced literal keyword/string/quoted-symbol for a
+  group local); `:explicit?` marks the units whose `:key` is a user-written
+  expression (a scope walk must judge those for a reactive-authoring escape; a
+  group literal never is). The units are consumed in order so each binding's
+  default/lookup-key is judged against the scope established BEFORE it — never
+  against a symbol the same pattern binds later, and never in an order the host
+  would not use."
+  [pattern]
+  (let [start      (dissoc pattern :as :or)
+        transforms (reduce (fn [t k] (if (key-group-kw? k) (assoc t k true) t))
+                           {} (keys pattern))
+        explicit   (set (keys (reduce dissoc start (keys transforms))))
+        bes        (reduce
+                    (fn [bes [mk _]]
+                      (let [f (key-group-directive-fn mk)]
+                        (reduce (fn [b s] (assoc b s (f s)))
+                                (dissoc bes mk)
+                                (get bes mk))))
+                    start
+                    transforms)]
+    (for [[bb bk] bes]
+      (if (contains? explicit bb)
+        {:local-pattern bb :key bk :explicit? true}
+        {:local-pattern (symbol (name bb)) :key bk :explicit? false}))))
+
+(defn binding-order
+  "The local-patterns of map `pattern`, in host `destructure` `bes` order
+  (`:as` excluded — it binds first). One plan (`assoc-binding-units`), so a
+  dependent `:or` default resolves to the same symbol on every host."
+  [pattern]
+  (mapv :local-pattern (assoc-binding-units pattern)))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -568,25 +568,22 @@
 (defn header-bindings
   "The CLJS header `let` bindings, in canonical host `destructure` order
   (rf2-vxgfnd.283): `:as` binds the whole props map FIRST — matching the JVM
-  native destructuring the JVM emitter uses — then the property-read entries in
-  the host `bes` order supplied by the ONE shared binding plan
-  (`ana/header-binding-order`). Emitting `:as` last, or the entries in parse
-  order, could resolve a dependent `:or` default to a different symbol on CLJS
-  than on the JVM — including a public reactive authoring var. Ordering by the
-  shared plan keeps both emitters and the scope check on one order. `sort-by` is
-  stable, so any entry the plan does not enumerate keeps its relative place."
+  native destructuring the JVM emitter uses — then ONE property-read per
+  collapsed binding unit. The entries are already the host `bes` order with
+  winning lookup slots (`parse-header` routed them through the ONE canonical
+  binding plan, `bp/assoc-binding-units`), so there is NOTHING left to sort or
+  de-collide here: two header entries binding the same local emit exactly one
+  read of the host's winning slot (never two, never a silent last-wins), and a
+  qualified `:keys` local reads its qualified slot. Emitting `:as` last, or the
+  entries in parse order, could resolve a dependent `:or` default to a different
+  symbol on CLJS than on the JVM — including a public reactive authoring var."
   [header]
-  (let [order   (ana/header-binding-order (:binding-form header))
-        idx     (when order (zipmap order (range)))
-        entries (cond->> (:entries header)
-                  idx (sort-by (fn [{:keys [pattern]}]
-                                 (get idx pattern (count order)))))]
-    (concat
-     (when (:as-sym header)
-       [(:as-sym header) `(re-frame.ui.runtime/props->map ~props-sym)])
-     (mapcat (fn [{:keys [slot pattern default]}]
-               [pattern (slot-read slot default)])
-             entries))))
+  (concat
+   (when (:as-sym header)
+     [(:as-sym header) `(re-frame.ui.runtime/props->map ~props-sym)])
+   (mapcat (fn [{:keys [slot pattern default]}]
+             [pattern (slot-read slot default)])
+           (:entries header))))
 
 (defn comparator-form
   "The generated straight-line rf= comparator (RULED: Object.is OR = per

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -24,7 +24,8 @@
     `:children` in the header declares child acceptance (Q4); `:ref`
     declaration is the S3 forwarding spelling and is rejected at S1.
   - `:strs`/`:syms` are outside the props ABI (slots are keywords)."
-  (:require [re-frame.ui.compiler.env :as env]))
+  (:require [re-frame.ui.compiler.binding-plan :as bp]
+            [re-frame.ui.compiler.env :as env]))
 
 (defn- fail [id msg data]
   (throw (env/compile-error id msg data)))
@@ -36,7 +37,13 @@
   [k]
   (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k)))
 
-(defn- entry [k pattern]
+(defn- reserved-slot-check!
+  "A view prop keyword may not be a reserved React slot. `:key` feeds React's
+  key slot; `:ref` forwarding is the S3 spelling. Both are rejected wherever the
+  author names them — a `:keys [key]` group symbol or an explicit `{p :key}`
+  value alike — judged on what was WRITTEN, so the canonical collapse can never
+  hide a reserved declaration."
+  [k]
   (when (= k :key)
     (fail :rf.ui.compile/key-prop-declared
           (str ":key cannot be a view prop — it is reserved (it feeds React's "
@@ -47,11 +54,73 @@
     (fail :rf.ui.compile/ref-prop-declared-s1
           ":ref forwarding is declared per view and lands S3 — remove the :ref binding (conservative S1 pin)"
           {:key k}))
-  {:key k :slot (slot-name k) :pattern pattern})
+  k)
+
+(defn- validate-header-map!
+  "Judge a header map's SHAPE on what the author wrote, before the canonical
+  plan collapses it: `:or` must be a map; `:strs`/`:syms` are outside the props
+  ABI; a group needs a vector of symbols; a non-group keyword key is
+  unsupported; an explicit entry's lookup value must be a prop keyword; and no
+  produced slot may be a reserved `:key`/`:ref`. Collapse must never SUPPRESS a
+  diagnostic, so these run on the raw entries, not the de-collided units."
+  [b or-map]
+  (when-not (map? or-map)
+    (fail :rf.ui.compile/bad-defview-args
+          ":or needs a map of binding-symbol -> default"
+          {:or or-map}))
+  (reduce-kv
+   (fn [_ k v]
+     (cond
+       (= k :as) nil
+       (= k :or) nil
+
+       (and (keyword? k) (contains? #{"strs" "syms"} (name k)))
+       (fail :rf.ui.compile/bad-defview-args
+             (str k " is outside the props ABI — prop slots are keywords; use "
+                  ":keys")
+             {:key k})
+
+       (and (keyword? k) (= "keys" (name k)))
+       (do (when-not (and (vector? v) (every? symbol? v))
+             (fail :rf.ui.compile/bad-defview-args
+                   (str k " needs a vector of symbols") {:form v}))
+           (doseq [s v]
+             (reserved-slot-check! (if-let [ns* (namespace k)]
+                                     (keyword ns* (name s))
+                                     (keyword (name s))))))
+
+       (keyword? k)
+       (fail :rf.ui.compile/bad-defview-args
+             (str "unsupported header key " k " — supported: :keys,"
+                  " :<ns>/keys, :or, :as, and {pattern :prop-key} entries")
+             {:key k})
+
+       :else
+       ;; {pattern :prop-key} — pattern may itself destructure
+       (do (when-not (keyword? v)
+             (fail :rf.ui.compile/bad-defview-args
+                   (str "header entry {" (pr-str k) " " (pr-str v)
+                        "} — the right side must be a prop keyword")
+                   {:entry [k v]}))
+           (reserved-slot-check! v)))
+     nil)
+   nil
+   b)
+  nil)
 
 (defn parse-header
   "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot
-  :pattern :default}...], :slots [kw...], :children? bool, :binding-form}"
+  :pattern :default}...], :slots [kw...], :children? bool, :binding-form}
+
+  The binding `:entries` and `:slots` are the CANONICAL, host-faithful binding
+  units (`bp/assoc-binding-units`): one entry per bound local, in host
+  `destructure` `bes` order, carrying the WINNING lookup key after collapse. Two
+  header entries that bind the same local (`{:keys [x] x :foo}`) COLLAPSE to a
+  single `x <- :x` entry — never two, never a silent last-wins — and a qualified
+  group local (`{:keys [acct/id]}`) keeps its qualified slot `:acct/id`. Both
+  emitters, the schema slot order, the memo comparator and the manifest metadata
+  read these same collapsed entries, so no downstream path can re-collide or
+  strip a qualified key."
   [argv]
   (when-not (vector? argv)
     (fail :rf.ui.compile/bad-defview-args
@@ -74,68 +143,23 @@
         (map? b)
         (let [as-sym  (get b :as)
               or-map  (get b :or {})
-              _       (when-not (map? or-map)
-                        (fail :rf.ui.compile/bad-defview-args
-                              ":or needs a map of binding-symbol -> default"
-                              {:or or-map}))
-              entries
-              (reduce-kv
-               (fn [acc k v]
-                 (cond
-                   (= k :as) acc
-                   (= k :or) acc
-
-                   (and (keyword? k) (contains? #{"strs" "syms"} (name k)))
-                   (fail :rf.ui.compile/bad-defview-args
-                         (str k " is outside the props ABI — prop slots are "
-                              "keywords; use :keys")
-                         {:key k})
-
-                   (and (keyword? k) (= "keys" (name k)))
-                   (do (when-not (and (vector? v) (every? symbol? v))
-                         (fail :rf.ui.compile/bad-defview-args
-                               (str k " needs a vector of symbols") {:form v}))
-                       (into acc
-                             (map (fn [s]
-                                    (entry (if-let [ns* (namespace k)]
-                                             (keyword ns* (name s))
-                                             (keyword (name s)))
-                                           (symbol (name s)))))
-                             v))
-
-                   (keyword? k)
-                   (fail :rf.ui.compile/bad-defview-args
-                         (str "unsupported header key " k " — supported: :keys,"
-                              " :<ns>/keys, :or, :as, and {pattern :prop-key}"
-                              " entries")
-                         {:key k})
-
-                   :else
-                   ;; {pattern :prop-key} — pattern may itself destructure
-                   (do (when-not (keyword? v)
-                         (fail :rf.ui.compile/bad-defview-args
-                               (str "header entry {" (pr-str k) " " (pr-str v)
-                                    "} — the right side must be a prop keyword")
-                               {:entry [k v]}))
-                       (conj acc (entry v k)))))
-               []
-               b)
-              defaults (into {}
-                             (keep (fn [{:keys [pattern] :as en}]
-                                     (when (and (symbol? pattern)
-                                                (contains? or-map pattern))
-                                       [(:key en) (get or-map pattern)])))
-                             entries)
+              _       (validate-header-map! b or-map)
+              ;; ONE canonical, de-collided binding plan — the host `bes` order
+              ;; with winning lookup keys. Every downstream consumer reads these
+              ;; same entries, so none can re-collide or strip a qualified key.
+              entries (mapv (fn [{:keys [local-pattern key]}]
+                              (cond-> {:key key
+                                       :slot (slot-name key)
+                                       :pattern local-pattern}
+                                (and (symbol? local-pattern)
+                                     (contains? or-map local-pattern))
+                                (assoc :default (get or-map local-pattern))))
+                            (bp/assoc-binding-units b))
               _ (doseq [s (keys or-map)]
                   (when-not (some #(= s (:pattern %)) entries)
                     (fail :rf.ui.compile/bad-defview-args
                           (str ":or key " s " does not match any bound slot symbol")
                           {:or or-map})))
-              entries (mapv (fn [en]
-                              (if (contains? defaults (:key en))
-                                (assoc en :default (get defaults (:key en)))
-                                en))
-                            entries)
               slots   (into [] (distinct) (map :key entries))]
           {:mode (if as-sym :as :named)
            :as-sym as-sym

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -11,6 +11,7 @@
   here is a match on both hosts — the `.cljc` reject table pins the CLJS path
   end to end."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
             [re-frame.ui.compiler.header :as header]))
@@ -107,3 +108,113 @@
           cljs (emit-local-order argv)]
       (is (= host cljs)
           (str "JVM host order == CLJS emission order for " (pr-str argv))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-qa5wkd — colliding headers COLLAPSE through the one canonical plan
+;;
+;; The order tests above use DISTINCT locals, so they cannot catch a header
+;; whose entries bind the SAME local (`{:keys [x] x :foo}`) or a qualified
+;; group local (`{:keys [acct/id]}`). Those are where a plan that only reorders
+;; parse-order entries (or re-derives them, stripping the namespace) diverges
+;; from the host: CLJS would emit two bindings (silent last-wins on :foo) or
+;; read a bare :id, while the JVM native destructuring collapses to one winning
+;; slot. These fixtures pin the collapse against REAL `clojure.core/destructure`
+;; and a REAL eval'd native binding (what the JVM emitter emits).
+;; ---------------------------------------------------------------------------
+
+(defn- host-local->key
+  "{simple-local -> host lookup KEYWORD} from real `clojure.core/destructure`
+  (the ground truth both emitters must reproduce; gensym scaffolding dropped)."
+  [pat]
+  (->> (destructure [pat 'the-map])
+       (partition 2)
+       (keep (fn [[l init]]
+               (when (and (symbol? l)
+                          (not (re-find #"^(map__|vec__|seq__|first__|p__|the-map)"
+                                        (name l)))
+                          (seq? init) (= 'clojure.core/get (first init)))
+                 [l (nth init 2)])))
+       (into {})))
+
+(defn- read-slot
+  "The props slot STRING a CLJS header binding `read` fetches — the sole
+  `cljs.core/unchecked-get` in either the plain or the `:or`-defaulted shape."
+  [read]
+  (let [found (volatile! nil)]
+    (walk/postwalk
+     (fn [x]
+       (when (and (seq? x) (= 'cljs.core/unchecked-get (first x)))
+         (vreset! found (nth x 2)))
+       x)
+     read)
+    @found))
+
+(defn- emitted
+  "{:locals [sym...] :slot-of {sym slot-str}} the CLJS header emitter produces —
+  `:locals` in emission order so a DUPLICATE emission of one local is visible."
+  [argv]
+  (let [pairs (partition 2 (emit-cljs/header-bindings (header/parse-header argv)))]
+    {:locals  (mapv first pairs)
+     :slot-of (into {} (keep (fn [[l r]] (when (symbol? l) [l (read-slot r)])) pairs))}))
+
+(deftest explicit-keys-collision-collapses-to-one-host-slot
+  (testing "same local from :keys and an explicit entry collapses to ONE binding, both source orders"
+    (doseq [pat '[{:keys [x] x :foo}     ; :keys before explicit
+                  {x :foo :keys [x]}]]   ; explicit before :keys
+      (let [host (host-local->key pat)
+            {:keys [locals slot-of]} (emitted [pat])]
+        (is (= {'x :x} host)
+            (str ":keys wins the host lookup slot for " (pr-str pat)))
+        (is (= '[x] locals)
+            (str "x is bound EXACTLY ONCE — not duplicated for " (pr-str pat)))
+        (is (= (header/slot-name (host 'x)) (slot-of 'x))
+            (str "CLJS reads the host's winning slot :x, NEVER a silent "
+                 "last-wins on :foo, for " (pr-str pat)))
+        (is (= "x" (slot-of 'x))
+            (str "the one read targets slot \"x\" for " (pr-str pat))))))
+  (testing "the collapsed slot is the ONLY declared slot (no dead :foo in the comparator/manifest)"
+    (is (= [:x] (:slots (header/parse-header '[{:keys [x] x :foo}])))
+        "the dead explicit :foo entry does not survive as a declared slot")))
+
+(deftest qualified-keys-local-keeps-the-host-lookup-key
+  (testing "a qualified :keys symbol reads its QUALIFIED slot, never the bare name"
+    (let [pat '{:keys [acct/id]}
+          host (host-local->key pat)
+          {:keys [locals slot-of]} (emitted [pat])]
+      (is (= {'id :acct/id} host) "host reads :acct/id")
+      (is (= '[id] locals) "binds the name-only local id")
+      (is (= "acct/id" (slot-of 'id))
+          "CLJS reads slot \"acct/id\", NEVER bare \"id\"")
+      (is (= (header/slot-name (host 'id)) (slot-of 'id)))
+      (is (= [:acct/id] (:slots (header/parse-header [pat])))
+          "the declared slot keeps the qualified key")))
+  (testing "namespaced group vs explicit collision keeps the host's winning slot"
+    (let [pat '{:acct/keys [id] id :other}
+          host (host-local->key pat)
+          {:keys [locals slot-of]} (emitted [pat])]
+      (is (= {'id :acct/id} host) ":acct/keys wins over the explicit :other")
+      (is (= '[id] locals) "collapsed to one binding")
+      (is (= (header/slot-name (host 'id)) (slot-of 'id)))
+      (is (= "acct/id" (slot-of 'id))))))
+
+(deftest real-jvm-native-binding-agrees-present-absent-defaulted
+  ;; The JVM emitter emits `(let [<raw pattern> props] …)` — native
+  ;; destructuring. Eval it and confirm the collapsed slot + default behave
+  ;; exactly as the CLJS-side entry (winning key :x, default 9) claims.
+  (let [pat '{:keys [x] x :foo :or {x 9}}
+        f   (eval (list 'fn [pat] 'x))   ; (fn [<pattern>] x) — native destructuring
+        en  (first (:entries (header/parse-header [pat])))]
+    (testing "the CLJS-side entry names the collapsed winning slot + default"
+      (is (= :x (:key en)))
+      (is (= "x" (:slot en)))
+      (is (= 9 (:default en))))
+    (testing "real native destructuring reads :x (never the collapsed-away :foo)"
+      (is (= 1 (f {:x 1 :foo 2})) "present :x wins; :foo is dead")
+      (is (= 9 (f {:foo 2}))      "absent :x → the :or default, not :foo")
+      (is (nil? (f {:x nil}))     "present-nil :x stays nil (default is absent-only")
+      (is (= 5 (f {:x 5})))))
+  (testing "a genuine collision with no :keys shadow still reads the host slot"
+    (let [pat '{:keys [x] x :foo}
+          f   (eval (list 'fn [pat] 'x))]
+      (is (= :a (f {:x :a :foo :b})) "reads :x")
+      (is (nil? (f {:foo :b}))       "absent :x, no default → nil, never :foo"))))


### PR DESCRIPTION
## Problem

The defview header parser derived its binding entries independently of the one host-faithful binding plan. `parse-header` (`header.cljc`) retained every raw map entry and the CLJS emitter (`emit_cljs/header-bindings`) merely stable-**sorted** them. The result: two header entries binding the **same local** produced two property reads, and a qualified `:keys` local was lowered to a bare slot — both diverging from the JVM's native destructuring.

Confirmed on `main` (real `clojure.core/destructure` vs the CLJS emission):

| header | JVM native (emit-jvm) | CLJS (emit-cljs, before) |
|---|---|---|
| `{:keys [x] x :foo}` | `x <- (get m :x)` | `x <- props["x"]` **then** `x <- props["foo"]` → silent last-wins on `:foo` |
| `{:keys [acct/id]}` | `id <- (get m :acct/id)` | `id <- props["id"]` → bare, wrong slot |

The canonical collapse already existed (`assoc-binding-units`, `analyze.cljc`) but was used only for scope-checking and `header-binding-order` — which discarded the winning lookup key. The JVM emitter uses native destructuring directly, so only the CLJS path was wrong. Hence the split authority.

## Fix

Route header parsing, emitted lets, schema slots, the memo comparator and manifest metadata through the **one** canonical plan:

- Extract the host-faithful transform into `re-frame.ui.compiler.binding-plan`, and make it carry **complete** units — the collapsed local, the **winning** lookup key (qualified keys preserved), and an `:explicit?` marker for the scope walk.
- `parse-header` validates the raw map first (every existing diagnostic preserved — collapse can never suppress one), then builds its `:entries`/`:slots` from the de-collided units.
- `emit-cljs/header-bindings` emits exactly one read per unit — no re-sort, no re-collision.
- `analyze/check-binding-scope!` and `header-binding-order` now consume the shared plan.

After the fix: `{:keys [x] x :foo}` → one binding `x <- :x`, slots `[:x]`; `{:keys [acct/id]}` → `id <- :acct/id`, slots `[:acct/id]`. Both source orders, present/absent/defaulted props, and namespaced-group-vs-explicit collisions agree between the two emitters.

## Adversarial coverage

`binding_plan_host_faithful_jvm_test.clj` gains three deftests that pin the collapse against **real** `clojure.core/destructure` and a **real eval'd native binding** (what emit-jvm emits): the same local from `:keys` + explicit collapses to one host slot in both orders; a qualified `:keys` local keeps its qualified slot (never bare); and native destructuring reads the winning key for present / absent / defaulted / present-nil props. A mutation restoring duplicate emission (count > 1) or bare-slot qualified lowering fails these. The pre-existing collision fixture used **distinct** locals and could not catch this.

No new public facade var or error-id (the new vars are internal to `re-frame.ui.compiler.*`; the frozen error roster is unchanged), so no api-manifest row is required.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **658 tests, 13275 assertions, 0 failures, 0 errors**
- `npm run test:ui`: **675 tests, 3468 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (core-reachable): **9681 tests, 47628 assertions, 0 failures, 0 errors**

Failing-before / passing-after: `{:keys [x] x :foo}` mis-bound `x <- :foo` and `{:keys [acct/id]}` mis-bound the bare `:id` slot on CLJS while the JVM read `:x` / `:acct/id`; both now collapse to the host's winning slot on both hosts.
