### PR TITLE
fix(gate): pin :tearing-down? evidence in the Root lifecycle drift gate (rf2-vizyct)

### DIFF
--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -425,6 +425,16 @@
         "the newer claim survives")
     (is (identical? newer (:root (client/live-root-entry :reg/id))))))
 
+;; The RUNTIME half of the Root lifecycle drift gate (rf2-vizyct) — asserting
+;; that each of the three claim/render diagnostics EMITS `:existing {…
+;; :tearing-down? true}` in its tearing-down arm — lives in
+;; `re-frame.ui.root-teardown-wiring-cljs-test`
+;; (`tearing-down-root-diagnostics-carry-complete-ownership-evidence`), which
+;; pins the full ex-data shape (key-set + message) for all three ids off one
+;; torn-down root. That is the implementation-side counterpart to the spec-009
+;; `:tearing-down? true` row-scoped drift teeth: strip the evidence from either
+;; the runtime emitters or the spec rows and a gate turns red.
+
 (deftest adapter-disposal-snapshots-one-root-generation-and-never-chases-a-replacement
   (let [c      (js-obj)
         old    (fake-root :reg/generation)

--- a/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_teardown_wiring_cljs_test.cljs
@@ -116,6 +116,11 @@
   ;; rf2-vxgfnd.277/.291: the three existing root diagnostics keep their IDs,
   ;; but the transitional ownership state must be machine-readable on every
   ;; admission/render arm. A throwing host gives a stable quarantined claim.
+  ;; This is the IMPLEMENTATION-side tooth of the Root lifecycle drift gate
+  ;; (rf2-vizyct): it pins the runtime `:existing {… :tearing-down? true}`
+  ;; ex-data, paired with the CONTRACT-side spec-009 row anchors in
+  ;; scripts/check_ui_root_lifecycle_drift.py — strip the evidence from either
+  ;; and a gate turns red.
   (let [container     (js-obj)
         site          {:file "teardown.cljs" :line 11 :column 7}
         arriving-site {:file "retry.cljs" :line 22 :column 3}

--- a/scripts/check_ui_root_lifecycle_drift.py
+++ b/scripts/check_ui_root_lifecycle_drift.py
@@ -102,6 +102,34 @@ TEETH = (
         "spec/009-Instrumentation.md",
         "| `:rf.error/root-not-live` | `:error` | diagnostic |",
     ),
+    # Row-scoped `:tearing-down? true` evidence teeth (rf2-vizyct). The row-ID
+    # teeth above pin only that the diagnostic EXISTS; they leave the conditional
+    # `:tearing-down? true` ex-data evidence — the exact settlement contract
+    # .277/.291 required this gate to protect — unpinned, so an edit deleting the
+    # `:tearing-down? true` shape from any/all three rows stayed green. Each
+    # anchor is a row-UNIQUE literal that CONTAINS the evidence, so removing it
+    # from one row (or all rows) turns exactly that row's tooth red and cannot
+    # slip past a surviving generic anchor elsewhere. These are the CONTRACT
+    # side; the IMPLEMENTATION side is pinned by the CLJS test
+    # `tearing-down-root-diagnostics-carry-complete-ownership-evidence`
+    # (re-frame.ui.root-teardown-wiring-cljs-test), which asserts each
+    # diagnostic emits `:existing {… :tearing-down? true}`. Strip the evidence
+    # from either the spec rows or the runtime emitters and a gate turns red.
+    Tooth(
+        "spec-009-duplicate-tearing-evidence",
+        "spec/009-Instrumentation.md",
+        "optional `:tearing-down? true`) + `:arriving` (client)",
+    ),
+    Tooth(
+        "spec-009-container-tearing-evidence",
+        "spec/009-Instrumentation.md",
+        "`:owner-root-id`, optional `:existing {:tearing-down? true}`",
+    ),
+    Tooth(
+        "spec-009-not-live-tearing-evidence",
+        "spec/009-Instrumentation.md",
+        "`:root-id`, optional `:existing {:tearing-down? true}`, `:recovery`",
+    ),
     Tooth(
         "api-settlement-lifecycle",
         "docs/api/re-frame.ui.md",


### PR DESCRIPTION
## Summary

The focused UI Root lifecycle drift gate (`scripts/check_ui_root_lifecycle_drift.py`) claimed mutation teeth for the diagnostic evidence, but its Spec 009 anchoring pinned only the three diagnostic **row IDs**. An in-memory edit removing all six `:tearing-down? true` occurrences from the `duplicate-root-id` / `root-container-in-use` / `root-not-live` rows left `missing_teeth []` and the self-test green — so the fast-PR gate could green-light deletion of the exact `:tearing-down?` settlement evidence that rf2-vxgfnd.277/.291 required it to protect.

### The gap (proven)

Removing all six `:tearing-down? true` occurrences from `spec/009-Instrumentation.md` (lines 2334 / 2336 / 2340, two per row) left the gate GREEN (`exit 0`, "contract clean") — no tooth referenced the evidence, only the row IDs (`spec-009-duplicate-id`, `spec-009-container-id`, `spec-009-not-live-id`).

### Fix

- **Contract side (the actual gap):** three narrow, row-UNIQUE teeth added to the gate, each a literal that CONTAINS the `:tearing-down? true` evidence for exactly one row (`spec-009-duplicate-tearing-evidence`, `spec-009-container-tearing-evidence`, `spec-009-not-live-tearing-evidence`). Removing the evidence from any one row — or all rows — turns exactly that row's tooth red and cannot slip past a surviving generic anchor elsewhere. The `--self-test` auto-covers each new tooth.
- **Implementation side (already covered):** the runtime `:existing {… :tearing-down? true}` ex-data for all three diagnostics is already pinned by the CLJS test `tearing-down-root-diagnostics-carry-complete-ownership-evidence` (`re-frame.ui.root-teardown-wiring-cljs-test`) — verified it bites (fails when the runtime evidence is stripped). Rather than duplicate it, the two sides are now cross-referenced (gate ⇄ runtime test) so the paired protection is discoverable. **No runtime logic changed.**

No `spec/009` prose change was needed: the `:tearing-down? true` evidence and the settlement/quarantine recovery wording are already present in all three rows; the teeth pin the existing text.

## Quality gates

- `python scripts/check_ui_root_lifecycle_drift.py` → `UI Root lifecycle contract clean (19 anchors).` (exit 0)
- `python scripts/check_ui_root_lifecycle_drift.py --self-test` → `self-test PASS (19 mutation teeth)` (exit 0)
- **Per-row mutation-turns-red proof** (each mutated independently, restored after):
  - remove ALL SIX `:tearing-down? true` (the original bug) → RED, all three new teeth report `anchor is absent` (previously GREEN)
  - mutate only the `duplicate-root-id` data cell → RED, `spec-009-duplicate-tearing-evidence` absent
  - mutate only the `root-container-in-use` data cell → RED, `spec-009-container-tearing-evidence` absent
  - mutate only the `root-not-live` data cell → RED, `spec-009-not-live-tearing-evidence` absent
- **Runtime tooth bites (temporary mutation, restored):** stripping `:tearing-down?` from the three runtime emitters turned `tearing-down-root-diagnostics-carry-complete-ownership-evidence` red (3 assertions).
- `shadow-cljs compile node-test-ui` + `node out/node-test-ui.js` → `Ran 678 tests containing 3481 assertions. 0 failures, 0 errors.`
- `python scripts/check_doc_slugs.py` → exit 0.
- `mkdocs build --strict` not run: no `spec/`/`docs/` files touched (contract teeth anchor existing spec text; no prose change).

Closes rf2-vizyct.
