### PR TITLE
fix(ui): linearize final ViewCell body authority with publication (rf2-77pb08)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3493,30 +3493,93 @@
                      A full destroy of the ACQUIRED incarnation + a fresh same-id
                      incarnation here proves the frame-close revalidation joins the
                      commit to the acquired incarnation's teardown, not the
-                     replacement id (rf2-vxgfnd.88)."
+                     replacement id (rf2-vxgfnd.88).
+    :pre-publish   — INSIDE `publish-commit!`, between that attempt's authority
+                     SAMPLE (the cell-state snapshot + the registered-slot token)
+                     and its publish CAS, fired exactly ONCE. An
+                     `advance-generation!` (cell-local axis) or a same-view
+                     re-registration (registry axis) here lands in EXACTLY the
+                     former check-to-use window and must be caught by the CAS /
+                     slot-token gate, never published (rf2-77pb08)."
   nil)
 
-(defn- stale-body-authority?
-  "DEV/HMR body-authority check (rf2-vxgfnd.214): true when `cap`'s captured
-  body generation no longer matches the cell's CURRENT authority — either the
-  cell-local revision `state-gen` (a FRESH read) or the authoritative registered
-  slot revision for `view-id`. A direct/headless caller with no registered slot
-  falls back to the cell-local contract (`registered-view-revision` nil ⇒ that
-  half no-ops).
+(defn- slot-body-revision
+  "The registered body revision carried by an ALREADY-SAMPLED HMR slot object
+  `slot` (nil when the slot is absent or was never registered). The publication
+  linearization captures the slot ONCE per attempt as its authority token and
+  reads the revision out of that exact sample, never re-derefing the live
+  registry between the token capture and the publish CAS."
+  [slot]
+  (when (:hmr-registered? slot)
+    (:hmr-body-revision slot)))
 
-  The commit's step-1 gate samples this authority ONCE, before the callback-
-  capable staging window; `commit*` re-consults it at the final publication
-  boundary so a re-registration landing mid-commit cannot publish under a stale
-  body. Callers gate the ENTIRE consult behind `interop/debug-enabled?`, so
-  production — where `use-cell` mints every cell at body revision 0 and never
-  advances it (the whole HMR slot is dev-only) — performs no registry lookup and
-  this predicate constant-folds away under goog.DEBUG=false."
-  [cap state-gen view-id]
-  (let [cap-gen (:generation cap)]
-    (or (not= cap-gen state-gen)
-        (boolean
-          (when-some [current (registered-view-revision view-id)]
-            (not= cap-gen current))))))
+(defn- publish-commit!
+  "Linearize the FINAL HMR body-authority validation WITH the state publication
+  as ONE operation (rf2-77pb08). Publishes `new-committed` (optionally
+  transformed by `accept-capture`) onto `cell` and returns `:published`, or
+  returns `:stale` having published NOTHING when the body authority moved.
+
+  ## The race this closes
+
+  The rf2-vxgfnd.214 fence sampled the cell generation + the registered-view
+  revision and THEN performed an INDEPENDENT `swap!` to publish — a check-to-use
+  gap. An `advance-generation!` (cell-local axis) or a same-view re-registration
+  (registry axis) landing AFTER the sample but BEFORE the swap published a
+  stale-generation capture that connected and owned leases while current
+  authority had already moved. Re-reading the authority a third time only MOVES
+  the race to between that read and the swap; it is not a linearization point.
+
+  ## The linearization
+
+  Validation and publication are ONE `compare-and-set!` transition over the
+  cell-state value read at the top of the loop (the `complete-flush!`
+  rf2-vxgfnd.180 idiom), so a pause interposed anywhere before the CAS cannot
+  publish a stale capture:
+
+    - CELL-LOCAL axis — the capture generation is compared to `(:generation s)`
+      of the SAME snapshot `s` the CAS commits. A racing `advance-generation!`
+      is either already visible in `s` (→ `:stale`) or lands after the sample
+      and FAILS the CAS (`st` ≠ `s`); the loop then re-reads and re-validates.
+    - REGISTRY axis — the view's HMR slot is sampled ONCE per attempt as an
+      authority TOKEN, and the publish CAS is GATED on that token still being
+      `identical?` to the live slot at the instant of the CAS. A same-view
+      re-registration swaps `view-generations` to a fresh slot object, so the
+      token gate fails and the loop re-reads a moved revision (→ `:stale`). The
+      publication never trusts a revision sampled earlier and gone stale; it
+      consults the slot IDENTITY at the linearization point, which a stale
+      revision read cannot fool.
+
+  The `*commit-barrier* :pre-publish` seam fires ONCE, between the first
+  attempt's authority sample and its CAS, so a fixture can interpose either
+  authority advance in EXACTLY that window and prove the gate holds.
+
+  DEV/HMR-only: production mints every cell at body revision 0 and never
+  advances it, so `interop/debug-enabled?` constant-folds the entire authority
+  arm — no `view-generations` deref, no token capture — leaving a single publish
+  CAS that succeeds first try on the single-threaded host."
+  [^ViewCell cell cap view-id new-committed accept-capture]
+  (let [st      (state cell)
+        cap-gen (:generation cap)
+        fired   (volatile! false)]
+    (loop []
+      (let [s     @st
+            token (when interop/debug-enabled? (get @view-generations view-id))]
+        (when (and (not @fired) (some? *commit-barrier*))
+          (vreset! fired true)
+          (*commit-barrier* :pre-publish cell))
+        (let [stale? (and interop/debug-enabled?
+                          (or (not= cap-gen (:generation s))
+                              (when-some [reg (slot-body-revision token)]
+                                (not= cap-gen reg))))]
+          (if stale?
+            :stale
+            (let [published (let [m* (assoc s :committed new-committed)]
+                              (if accept-capture (accept-capture m* cap) m*))]
+              (if (and (or (not interop/debug-enabled?)
+                           (identical? token (get @view-generations view-id)))
+                       (compare-and-set! st s published))
+                :published
+                (recur)))))))))
 
 (defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable
@@ -3689,36 +3752,38 @@
           ;; joins this commit to the acquired incarnation's teardown, not the
           ;; replacement id (rf2-vxgfnd.88).
           (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
-          ;; FINAL HMR-authority fence (rf2-vxgfnd.214). Step 1 samples the body
+          ;; FINAL HMR-authority fence + publication as ONE linearized operation
+          ;; (rf2-77pb08, completing rf2-vxgfnd.214). Step 1 samples the body
           ;; authority ONCE — before the :pre-acquire barrier, the acquire/cache
           ;; callbacks, and the :post-acquire barrier, EVERY one of which can
           ;; synchronously advance the authoritative body revision (a same-shell
-          ;; re-registration landing in the render→commit gap). Re-read the
-          ;; authority at the narrowest publication boundary — after all
-          ;; callback-capable work, with nothing callback-capable between here and
-          ;; the step-6 publish — and refuse to publish a stale-authority capture:
-          ;; release ONLY the newly staged leases in reverse acquisition order,
-          ;; leave the prior committed set / values / lifecycle untouched, and
-          ;; return :stale exactly as step 1 does (the re-registration already
-          ;; notified the shell, so a fresh render at the new body is inbound;
-          ;; unlike the candidate-current? incarnation path this needs no
-          ;; advance-revision!). DEV/HMR-only: production mints every cell at body
-          ;; revision 0 and never advances it, so the whole fence DCEs under
-          ;; goog.DEBUG=false — no registry lookup, no hot-path bookkeeping.
-          (if (and interop/debug-enabled?
-                   (stale-body-authority? cap (:generation @st) (:view-id st0)))
+          ;; re-registration landing in the render→commit gap). The .214 fence
+          ;; re-read the authority HERE and then performed an INDEPENDENT `swap!`
+          ;; to publish — a check-to-use gap in which an `advance-generation!`
+          ;; (cell-local axis) or a same-view re-registration (registry axis) could
+          ;; land and let a stale-generation capture publish and connect. A third
+          ;; read only MOVES that gap. `publish-commit!` instead FUSES the final
+          ;; validation and the step-6 publication into ONE compare-and-set!
+          ;; transition (cell-local axis) gated on the registered-slot identity
+          ;; token (registry axis), so no pause interposed before the CAS can
+          ;; publish a stale capture. On rejection it publishes NOTHING; we release
+          ;; ONLY the newly staged leases in reverse acquisition order, leaving the
+          ;; prior committed set / values / lifecycle untouched, and return :stale
+          ;; exactly as step 1 does (the re-registration already notified the shell,
+          ;; so a fresh render at the new body is inbound; unlike the
+          ;; candidate-current? incarnation path this needs no advance-revision!).
+          ;; DEV/HMR-only: production mints every cell at body revision 0 and never
+          ;; advances it, so the authority arm DCEs under goog.DEBUG=false — no
+          ;; registry lookup, no hot-path bookkeeping.
+          (if (= :stale (publish-commit! cell cap (:view-id st0)
+                                         new-committed accept-capture))
             (do
               (doseq [[_ record] (rseq staged)]
                 (obs/release! (:lease record)))
               :stale)
             (do
-              ;; step 6 — publish exact per-site query/value + dependency set
-              (swap! st
-                     (fn [m]
-                       (let [m* (assoc m :committed new-committed)]
-                         (if accept-capture
-                           (accept-capture m* cap)
-                           m*))))
+              ;; step 6 (publish exact per-site query/value + dependency set)
+              ;; already completed atomically inside publish-commit!.
               ;; step 7 — release dropped + retargeted prior leases
               (doseq [[_ record] to-release]
                 (obs/release! (:lease record)))

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
@@ -422,3 +422,153 @@
             (is (= held0 (reactive/resource-held cell)) "held owners preserved")
             (is (= ev0 (reactive/resource-lease-evidence cell))
                 "the accepted desired plan is unchanged — capture-2 never overwrote it")))))))
+
+;; ===========================================================================
+;; rf2-77pb08 — LINEARIZE the final body-authority validation WITH publication.
+;;
+;; PR #5938 (.214/.260) proved the fence catches an authority change landing at
+;; or before the final SAMPLE. But that fence sampled the authority and then
+;; performed an INDEPENDENT `swap!` to publish — a check-to-use gap: a
+;; concurrent `advance-generation!` (cell-local axis) or same-view
+;; re-registration (registry axis) landing AFTER the sample but BEFORE the swap
+;; published a stale generation-0 capture that connected and owned leases.
+;;
+;; `publish-commit!` fuses validation and publication into ONE compare-and-set!
+;; transition (cell-local axis) gated on the registered-slot identity token
+;; (registry axis). The `:pre-publish` seam fires ONCE, in EXACTLY that former
+;; gap — between an attempt's authority sample and its publish CAS — so these
+;; fixtures land the advance where nothing could catch it before, on BOTH the
+;; cell-local and registry authority axes, and prove nothing publishes.
+;;
+;; MUTATION TOOTH: revert `publish-commit!` to a sample-then-independent-swap
+;; (so the `:pre-publish` advance lands between the two) and every assertion
+;; below flips red — the interposed advance then publishes and connects.
+;; `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
+;; (`clojure -M:test`); the accompanying `-race-jvm-test` exercises the same CAS
+;; under GENUINE two-thread concurrency.
+;; ===========================================================================
+
+;; ---- Registry axis: a re-registration in the sample→publish window ----------
+;; The view's HMR slot is the token; a mid-window `register-view-generation!`
+;; swaps `view-generations` to a fresh slot object, failing the `identical?`
+;; gate so the loop re-reads a MOVED revision and rejects.
+
+(deftest pre-publish-registration-is-linearized-registry-axis
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::linz-registry-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)
+        cap  (capture-of cell [[::site [:r/a]]])]
+    (is (= 0 (:generation cap)) "capture formed at body revision 0")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [result (binding [reactive/*commit-barrier*
+                           (reregister-barrier vid :pre-publish hs0)]
+                   (reactive/commit! cell cap))]
+      (is (= :stale result)
+          "a re-registration interposed between the sample and the publish CAS is fenced")
+      (is (= :fresh (reactive/lifecycle cell)) "a fenced candidate never connects")
+      (is (empty? (reactive/committed-sites cell)) "no dependency set published")
+      (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")
+      (is (= 0 (reactive/revision cell))
+          "no revision advance — the shell's re-registration drives the re-render"))))
+
+;; ---- Cell-local axis: an advance-generation! in the sample→publish window ---
+;; A direct/unregistered cell: the registry arm no-ops, so the publish CAS over
+;; the sampled cell state is the SOLE catch. The interposed advance swaps `st`,
+;; so the compare-and-set! over the stale snapshot fails and the loop re-reads a
+;; MOVED generation and rejects.
+
+(deftest pre-publish-generation-advance-is-linearized-cell-local-axis
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::linz-cell-local-view          ;; deliberately NEVER registered
+        cell (reactive/make-cell vid 0)
+        cap  (capture-of cell [[::a [:r/a]]])]
+    (is (= 0 (:generation cap)) "capture formed at cell body generation 0")
+    (is (nil? (reactive/registered-view-revision vid))
+        "precondition: no registered slot — the cell-local CAS is the sole catch")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [result (binding [reactive/*commit-barrier*
+                           (fn [phase c]
+                             (when (= phase :pre-publish)
+                               (reactive/advance-generation! c 1)))]
+                   (reactive/commit! cell cap))]
+      (is (= :stale result)
+          "the interposed advance fails the publish compare-and-set! → :stale")
+      (is (= :fresh (reactive/lifecycle cell)) "a fenced candidate never connects")
+      (is (empty? (reactive/committed-sites cell)) "no dependency set published")
+      (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")
+      (is (= 1 (reactive/generation cell)) "the cell carries the advanced generation")
+      (is (= 0 (reactive/revision cell))
+          "no revision advance — the sync/remount drives the re-render"))))
+
+;; ---- Rollback in the sample→publish window: reverse order, exactly once -----
+;; A retained prior :a plus staged :b/:c: a mid-window re-registration must
+;; release ONLY :b/:c, in reverse acquisition order, exactly once, and preserve
+;; the retained :a and the prior committed set byte-for-byte.
+
+(deftest pre-publish-fence-releases-staged-in-reverse-exactly-once
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (rf/reg-sub :r/b (fn [db _] (:b db)))
+  (rf/reg-sub :r/c (fn [db _] (:c db)))
+  (seed! {:a 1 :b 2 :c 3})
+  (let [vid  ::linz-order-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))   ;; connect owning :a
+    (let [lease-a      (reactive/committed-lease cell (tk [:r/a]))
+          rev0         (reactive/revision cell)
+          acq          (atom [])
+          rel          (atom [])
+          real-acquire obs/acquire!
+          real-release obs/release!
+          lease->query (fn [lease]
+                         (some (fn [[l q]] (when (identical? l lease) q)) @acq))
+          cap          (capture-of cell [[::a [:r/a]] [::b [:r/b]] [::c [:r/c]]])]
+      (is (= :connected (reactive/lifecycle cell)))
+      (is (= 1 (ref-count [:r/a])) "prior committed lease installed")
+      (with-redefs [obs/acquire! (fn [target on-change]
+                                   (let [lease (real-acquire target on-change)]
+                                     (swap! acq conj [lease (:query target)])
+                                     lease))
+                    obs/release! (fn [lease]
+                                   (swap! rel conj (lease->query lease))
+                                   (real-release lease))]
+        (let [result (binding [reactive/*commit-barrier*
+                               (reregister-barrier vid :pre-publish hs0)]
+                       (reactive/commit! cell cap))]
+          (is (= :stale result) "the interposed re-registration fences the publish")
+          (is (= [[:r/b] [:r/c]] (mapv second @acq))
+              "only the NEW sites acquire (:a retained, never re-acquired)")
+          (is (= [[:r/c] [:r/b]] @rel)
+              "the staged leases released in REVERSE acquisition order")
+          (is (= 2 (count @rel)) "each staged lease released EXACTLY once")
+          (is (not (some #{[:r/a]} @rel)) "the RETAINED prior :a was never released")))
+      (testing "prior committed :a survives byte-for-byte"
+        (is (identical? lease-a (reactive/committed-lease cell (tk [:r/a])))
+            "the retained lease keeps its exact identity")
+        (is (= 1 (ref-count [:r/a])) ":a never re-acquired or released")
+        (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell))
+            "the published dependency set is unchanged — no staged site leaked")
+        (is (= :connected (reactive/lifecycle cell)) "lifecycle unchanged")
+        (is (= rev0 (reactive/revision cell)) "revision unchanged"))
+      (testing "BOTH staged leases were released"
+        (is (nil? (entry [:r/b])) ":b staged then released → zero-owner node")
+        (is (nil? (entry [:r/c])) ":c staged then released → zero-owner node")))))
+
+;; ---- The ordinary commit still publishes once through the linearized path ---
+
+(deftest pre-publish-clean-commit-publishes-once-through-cas
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid  ::linz-clean-view
+        _    (reactive/register-view-generation! vid hs0)
+        cell (reactive/make-cell vid 0)]
+    (testing "no interposed authority advance ⇒ the compare-and-set! publishes once"
+      (let [result (reactive/commit! cell (capture-of cell [[::a [:r/a]]]))]
+        (is (identical? cell result) "a clean commit returns the cell, not :stale")
+        (is (= :connected (reactive/lifecycle cell)))
+        (is (= #{(tk [:r/a])} (reactive/committed-target-keys cell)))
+        (is (= 1 (ref-count [:r/a])) "exactly one owner acquired")
+        (is (= 1 (:value (reactive/committed-site cell ::a))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_publication_linearize_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_publication_linearize_race_jvm_test.clj
@@ -1,0 +1,156 @@
+(ns re-frame.ui.reactive-publication-linearize-race-jvm-test
+  "rf2-77pb08 — the final ViewCell body-authority validation and the state
+  publication are ONE linearized compare-and-set! transition.
+
+  THE RACE (JVM-only; CLJS is single-threaded). PR #5938 fenced the final
+  publication against an HMR body-authority change, but the fence SAMPLED the
+  cell generation + registered-view revision and then performed an INDEPENDENT
+  `swap!` to publish. A concurrent `advance-generation!` (cell-local axis) or
+  same-view re-registration (registry axis) landing AFTER that sample but BEFORE
+  the swap published a generation-0 capture that connected and owned leases while
+  current authority was already generation/revision 1 — a check-to-use race.
+
+  These fixtures reproduce the window with a deterministic `CountDownLatch`
+  handoff (NO sleeps): the commit PARKS at the `:pre-publish` seam — fired inside
+  `publish-commit!` between an attempt's authority sample and its publish CAS — a
+  racing thread advances the authority, then the commit resumes. With the
+  linearization the publish CAS over the now-stale snapshot FAILS (cell-local
+  axis) or the registered-slot identity token has moved (registry axis), so the
+  loop re-validates and returns `:stale` having published/connected NOTHING.
+  Pre-fix (sample-then-independent-swap) the racing commit publishes and connects.
+
+  `.clj` (JVM-only) — a genuine two-thread interleaving; the barrier handoff means
+  only one thread mutates the substrate at a time, so this is a controlled
+  linearization probe, not a stress test."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                  :as rf]
+            [re-frame.frame                 :as frame]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.fingerprint        :as fp]
+            [re-frame.ui.reactive           :as reactive])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+(def ^:private hs0 (fp/hook-signature-hash {:locals [] :effects []}))
+
+(defn- sub-cache [] (:sub-cache (frame/frame fid)))
+(defn- entry [q] (get @(sub-cache) q))
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- capture-of [cell sites]
+  (second
+    (rf/with-frame fid
+      (reactive/with-capture
+        cell (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))))
+
+(defn- park-at-pre-publish
+  "A `*commit-barrier*` that, at `:pre-publish` (once), signals `parked` — the
+  authority sample is done — then blocks until `released` so a racing thread can
+  advance the authority in EXACTLY the sample→publish window."
+  [^CountDownLatch parked ^CountDownLatch released]
+  (fn [phase _cell]
+    (when (= phase :pre-publish)
+      (.countDown parked)
+      (.await released 5 TimeUnit/SECONDS))))
+
+;; ===========================================================================
+;; Cell-local axis: a concurrent advance-generation! fails the publish CAS
+;; ===========================================================================
+
+(deftest concurrent-generation-advance-at-pre-publish-fences-cell-local
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell     (reactive/make-cell ::race-cell-local 0)  ;; unregistered: CAS is sole catch
+        cap      (capture-of cell [[::site [:r/a]]])
+        parked   (CountDownLatch. 1)
+        released (CountDownLatch. 1)]
+    (is (= 0 (:generation cap)) "capture formed at cell body generation 0")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [committer (future
+                      (binding [reactive/*commit-barrier*
+                                (park-at-pre-publish parked released)]
+                        (reactive/commit! cell cap)))]
+      (.await parked 5 TimeUnit/SECONDS)
+      ;; racing thread — advance the cell body generation while the commit is
+      ;; parked between its authority sample and the publish CAS.
+      (reactive/advance-generation! cell 1)
+      (.countDown released)
+      (is (= :stale (deref committer 5000 ::timeout))
+          "the publish CAS over the stale snapshot failed → :stale, nothing published")
+      (testing "the stale generation-0 capture never published or connected"
+        (is (= :fresh (reactive/lifecycle cell)) "never connected")
+        (is (empty? (reactive/committed-target-keys cell)) "no dependency set published")
+        (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")
+        (is (= 1 (reactive/generation cell)) "the cell carries the advanced generation")
+        (is (= 0 (reactive/revision cell)) "no revision advance")))))
+
+;; ===========================================================================
+;; Registry axis: a concurrent re-registration moves the slot-identity token
+;; ===========================================================================
+
+(deftest concurrent-registration-at-pre-publish-fences-registry
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid      ::race-registry-view
+        _        (reactive/register-view-generation! vid hs0)
+        cell     (reactive/make-cell vid 0)
+        cap      (capture-of cell [[::site [:r/a]]])
+        parked   (CountDownLatch. 1)
+        released (CountDownLatch. 1)]
+    (is (= 0 (:generation cap)) "capture formed at body revision 0")
+    (is (nil? (entry [:r/a])) "precondition: nothing owns the node yet")
+    (let [committer (future
+                      (binding [reactive/*commit-barrier*
+                                (park-at-pre-publish parked released)]
+                        (reactive/commit! cell cap)))]
+      (.await parked 5 TimeUnit/SECONDS)
+      ;; racing thread — re-register the same view (advance the registered body
+      ;; revision) while the commit is parked in the sample→publish window.
+      (reactive/register-view-generation! vid hs0)
+      (.countDown released)
+      (is (= :stale (deref committer 5000 ::timeout))
+          "the moved slot-identity token failed the publish gate → :stale")
+      (testing "the stale revision-0 capture never published or connected"
+        (is (= :fresh (reactive/lifecycle cell)) "never connected")
+        (is (empty? (reactive/committed-target-keys cell)) "no dependency set published")
+        (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")
+        (is (= 0 (reactive/revision cell)) "no revision advance")))))
+
+;; ===========================================================================
+;; A disjoint commit under an UNRELATED view registration still publishes —
+;; the slot-identity token is per-view, so no global serialization.
+;; ===========================================================================
+
+(deftest concurrent-unrelated-registration-does-not-fence-a-fresh-commit
+  (rf/reg-sub :r/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [vid       ::race-owner-view
+        other-vid ::race-other-view
+        _         (reactive/register-view-generation! vid hs0)
+        _         (reactive/register-view-generation! other-vid hs0)
+        cell      (reactive/make-cell vid 0)
+        cap       (capture-of cell [[::site [:r/a]]])
+        parked    (CountDownLatch. 1)
+        released  (CountDownLatch. 1)]
+    (let [committer (future
+                      (binding [reactive/*commit-barrier*
+                                (park-at-pre-publish parked released)]
+                        (reactive/commit! cell cap)))]
+      (.await parked 5 TimeUnit/SECONDS)
+      ;; A DIFFERENT view re-registers in the window — our view's slot identity
+      ;; is untouched, so the token gate holds and the commit publishes.
+      (reactive/register-view-generation! other-vid hs0)
+      (.countDown released)
+      (is (identical? cell (deref committer 5000 ::timeout))
+          "an unrelated view's registration does not fence this commit")
+      (testing "the fresh capture published and connected normally"
+        (is (= :connected (reactive/lifecycle cell)))
+        (is (= 1 (:value (reactive/committed-site cell ::site))))
+        (is (= 1 (:ref-count (entry [:r/a]))) "exactly one owner acquired")))))


### PR DESCRIPTION
## What

The rf2-vxgfnd.214 fence made `commit*` re-read the HMR body authority at the final publication boundary, but that fence **sampled** the authority and then performed an **independent `swap!`** to publish — two operations, not one. A concurrent authority advance landing between the sample and the swap slipped through:

- **cell-local axis** — `advance-generation!` bumps `(:generation @st)` after the sample read it as matching; the independent swap then published the stale generation-0 capture, connecting it and owning leases.
- **registry axis** — a same-view re-registration (`register-view-generation!`) bumps `hmr-body-revision` in `view-generations` after `registered-view-revision` was sampled; the independent swap published under the stale revision.

Either way a stale generation-0 capture published, connected, and retained leases while current authority was already generation/revision 1 (`reactive.cljc` `commit*`, the `stale-body-authority?` check at the old fence, then the separate `(swap! st …)`).

## The fix

Fuse the final validation and the state publication into **one linearized operation**, `publish-commit!`, mirroring the `complete-flush!` (rf2-vxgfnd.180) `compare-and-set!` retry idiom already in this file:

- **cell-local axis** — the capture generation is compared to `(:generation s)` of the **same** cell-state snapshot the CAS commits, so a racing `advance-generation!` is either already visible in `s` (→ `:stale`) or **fails the `compare-and-set!`** and the loop re-validates. A genuine single-atom linearization.
- **registry axis** — the view's HMR slot is sampled once per attempt as an authority **token**; the publish CAS is gated on that slot still being `identical?` to the live slot. A same-view re-registration swaps `view-generations` to a **fresh slot object**, moving the token, so the loop re-reads a moved revision and rejects. The publication consults the slot **identity** at the linearization point rather than trusting a revision sampled earlier and gone stale — an extra best-effort read would only move the race.

A new `*commit-barrier* :pre-publish` seam fires **once**, between an attempt's authority sample and its publish CAS, so a fixture interposes either authority advance in exactly the former check-to-use window and proves nothing publishes.

**No scheduler, no global lock:** the cell-local CAS is per-cell; the registry token is per-view. DEV/HMR-only — `interop/debug-enabled?` constant-folds the whole authority arm away in production (elision probe still 52/52 absent), leaving a single publish CAS.

## Tests

- `reactive_hmr_authority_fence_cljs_test.cljc` (node + JVM): deterministic `:pre-publish` fixtures on **both** authority axes; reverse-order/exactly-once staged rollback with the prior committed set preserved byte-for-byte; the clean commit still publishes once through the CAS.
- `reactive_publication_linearize_race_jvm_test.clj` (JVM, two-thread): parks the commit at `:pre-publish` and advances authority on another thread, proving the CAS/token gate under genuine concurrency — and that an **unrelated** view's registration does not fence a fresh commit (no global serialization).
- **Mutation tooth:** reverting `publish-commit!` to the pre-fix sample-then-independent-swap flips 22 assertions red (the interposed advance then publishes and connects); restored, all green.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): 662 tests, 13298 assertions, 0 failures.
- `npm run test:ui`: 682 tests, 3516 assertions, 0 failures.
- `npm run test:cljs`: 9685 tests, 47663 assertions, 0 failures.
- `npm run test:elision`: production 52/52 absent — DEV/HMR-only elision contract intact.
