### PR TITLE
docs(machines): finish join-authority carrier vocabulary — metadata is never a carrier (rf2-93r7eu)

### DIFF
--- a/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_exact_auth_cljs_test.cljc
@@ -67,8 +67,9 @@
 (defn- mk-child
   "A dispatching child: on `:go` / `:fail` it transitions to a PLAIN
   (non-`:final?`) terminal and dispatches its completion back to
-  `parent-id` — through its OWN handler boundary, so the runtime stamps the
-  `:rf/join-auth` attempt authentication."
+  `parent-id` — through its OWN handler boundary, so the runtime records its
+  exact join authority on the recordable `:rf.cofx` fact `:rf.machine/join-auth`
+  (via `stamp-join-completion-fx`; event metadata is never an authority carrier)."
   [parent-id]
   {:initial :running
    :data    {:id nil}

--- a/implementation/machines/test/re_frame/join_parallel_authority_select_test.clj
+++ b/implementation/machines/test/re_frame/join_parallel_authority_select_test.clj
@@ -35,7 +35,8 @@
 (defn- mk-worker
   "A worker child that dispatches `done-kw` / `err-kw` back to `parent-id`
   carrying its own `:worker` logical id — through its OWN handler boundary, so
-  the runtime stamps the exact `:rf/join-auth` for its region's attempt."
+  the runtime records the exact join authority on the recordable `:rf.cofx` fact
+  `:rf.machine/join-auth` for its region's attempt."
   [parent-id done-kw err-kw]
   {:initial :running
    :data    {:id nil}

--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -83,8 +83,10 @@
 (defn- mk-child
   "A dispatching child: on `:go` / `:fail` it transitions to a PLAIN
   (non-`:final?`) terminal and dispatches its completion back to
-  `parent-id` THROUGH its own handler boundary, so the runtime stamps the
-  `:rf/join-auth` attempt authentication (`stamp-join-completion-fx`)."
+  `parent-id` THROUGH its own handler boundary, so `stamp-join-completion-fx`
+  rewrites the completion into the `:rf.machine/join-dispatch` transport and
+  the runtime records its exact join authority on the recordable `:rf.cofx`
+  fact `:rf.machine/join-auth` (event metadata is never an authority carrier)."
   [parent-id]
   {:initial :running
    :data    {:id nil}


### PR DESCRIPTION
Finishes the join-authority carrier vocabulary sweep (rf2-93r7eu), post-nsbwft (#6077).

nsbwft removed event-vector `:rf/join-auth` metadata as an authority carrier entirely: `carrier-auth` now reads ONLY the protected recordable `[:rf/cofx :rf.machine/join-auth]` transport (populated by `:rf.machine/join-dispatch`). The canonical contract is: the recordable `:rf.machine/join-auth` coeffect fact is the SINGLE authority carrier; event-vector `:rf/join-auth` metadata is NEVER an authority carrier (not even a fallback).

nsbwft already reconciled the source docstrings (`join.cljc`, `registration.cljc`, `destroy.cljc`, `reply.cljc`) and the test BODIES/counterexamples. This PR mops up the tail: three spawn-all/join test-helper docstrings still described the runtime as stamping a bare `:rf/join-auth` "attempt authentication" — shorthand that now reads as event-vector metadata being the carrier, and inconsistent with the crisp sibling in `join_parallel_recordable_controls_cljs_test.cljc:40`.

## Changes

Docstrings only — no test names, bodies, or runtime logic changed. Each helper's `mk-child` / `mk-worker` docstring now anchors to the recordable transport:

- `spawn_all_authority_catalogue_test.clj` (`mk-child`) — names `stamp-join-completion-fx` rewriting into the `:rf.machine/join-dispatch` transport + recording on the recordable `:rf.cofx` fact `:rf.machine/join-auth`.
- `join_exact_auth_cljs_test.cljc` (`mk-child`) — records exact join authority on the recordable `:rf.cofx` fact `:rf.machine/join-auth`; event metadata is never an authority carrier.
- `join_parallel_authority_select_test.clj` (`mk-worker`) — records the exact join authority on the recordable `:rf.cofx` fact `:rf.machine/join-auth` for its region's attempt.

`:rf/join-auth` uses that KEEP (correct): the auth-tuple key inside the protected `:rf.machine/join-dispatch` payload / recordable `:rf.cofx` fact, counterexample forges via metadata that the tests prove FAIL, and prose stating metadata is never a carrier.

## Quality gates

- `implementation/machines` JVM (`clojure -M:test`): **1151 tests, 3931 assertions, 0 failures, 0 errors** (discovers + runs all three edited files, including the `*-cljs-test.cljc`).
- `npm run test:cljs`: **9686 tests, 47668 assertions, 0 failures, 0 errors**.
- Residue-proof grep — the signature "event-vector `:rf/join-auth` metadata presented as primary/durable authority carrier" returns **zero** matches across active machines source/tests, `tools/xray`, and adapter tests; every surviving metadata+carrier co-mention is a negation or a fail-closed counterexample.
