### PR TITLE
fix(ui): de-dup dead binding slot in defview canonical plan for qualified-keys collision (rf2-7imr5y)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
@@ -18,12 +18,21 @@
     pattern natively; the CLJS emitter lowers exactly these units to property
     reads. Because the units are the host's collapse, the two emitters agree.
 
-  The critical property is COLLAPSE: when two entries bind the SAME local
-  (`{:keys [x] x :foo}`), the host's map-destructuring overwrite semantics keep
-  ONE binding with ONE winning lookup key (`x <- :x`), and so does this plan —
-  never two bindings, never a silent last-wins. Likewise a qualified group local
-  (`{:keys [acct/id]}`) keeps its qualified lookup key (`:acct/id`), never a bare
-  `:id`.")
+  The critical property is COLLAPSE at the host `bes` map: when two entries share
+  a `bes` KEY (`{:keys [x] x :foo}` — the group directive's `assoc` overwrites the
+  explicit `x`), the host keeps ONE binding with ONE winning lookup key
+  (`x <- :x`), and so does this plan — never two bindings, never a silent
+  last-wins. A qualified group local (`{:keys [acct/id]}`) keeps its qualified
+  lookup key (`:acct/id`), never a bare `:id`.
+
+  One residual case does NOT collapse here, deliberately: a qualified group local
+  whose bare NAME collides an explicit local (`{:keys [ns/x] x :other}`) keeps two
+  DISTINCT `bes` keys (`ns/x`, `x`) that both name-strip to the same local `x`. The
+  host binds it once via `let` last-wins (`x <- :ns/x`), but the two units must
+  stay separate HERE so the analyzer's scope walk judges each unit's lookup-key /
+  `:or` default against the scope live at ITS binding point. The defview header
+  parser (`header/collapse-entries`) folds these two units to the single winning
+  entry for its derived slots; the general scope walk keeps both.")
 
 (defn key-group-kw?
   "True for a `:keys`/`:strs`/`:syms` map-destructuring group directive (any
@@ -61,11 +70,15 @@
   threshold and the hash order are identical on CLJ and CLJS, so reproducing the
   transform here is faithful to both.
 
-  Two entries binding the SAME local COLLAPSE, exactly as the host's `bes` map
+  Two entries that share a `bes` KEY COLLAPSE, exactly as the host's `bes` map
   collapses them: `{:keys [x] x :foo}` yields the single unit `x <- :x` (the
   group directive's `assoc` overwrites the explicit entry's value), never two
   bindings and never a silent last-wins. A group local keeps its QUALIFIED
-  lookup key: `{:keys [acct/id]}` yields `id <- :acct/id`, never bare `:id`.
+  lookup key: `{:keys [acct/id]}` yields `id <- :acct/id`, never bare `:id`. A
+  qualified group local whose bare name collides an explicit local
+  (`{:keys [ns/x] x :other}`) keeps DISTINCT `bes` keys and so stays TWO units
+  binding one local via host last-wins — consumed in order by the scope walk;
+  the header parser (`collapse-entries`) folds them for its derived slots.
 
   `:as` is NOT included — it binds first, before `bes`, so the caller seeds it
   into scope. Each unit is `{:local-pattern p :key k :explicit? bool}`:

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -571,10 +571,13 @@
   native destructuring the JVM emitter uses — then ONE property-read per
   collapsed binding unit. The entries are already the host `bes` order with
   winning lookup slots (`parse-header` routed them through the ONE canonical
-  binding plan, `bp/assoc-binding-units`), so there is NOTHING left to sort or
-  de-collide here: two header entries binding the same local emit exactly one
-  read of the host's winning slot (never two, never a silent last-wins), and a
-  qualified `:keys` local reads its qualified slot. Emitting `:as` last, or the
+  binding plan, `bp/assoc-binding-units`, then `header/collapse-entries`), so
+  there is NOTHING left to sort or de-collide here: two header entries binding
+  the same local — whether they collided in the `bes` map or only after a
+  qualified group local name-strips onto an explicit local — already collapsed
+  in `parse-header` to one entry, so this emits exactly one read of the host's
+  winning slot (never two, never a silent last-wins), and a qualified `:keys`
+  local reads its qualified slot. Emitting `:as` last, or the
   entries in parse order, could resolve a dependent `:or` default to a different
   symbol on CLJS than on the JVM — including a public reactive authoring var."
   [header]

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -108,19 +108,45 @@
    b)
   nil)
 
+(defn- collapse-entries
+  "Keep exactly ONE entry per bound local (`:pattern`) — the host `bes`-order
+  WINNER, i.e. the LAST occurrence, the binding the host's `let` last-wins
+  actually establishes. `bp/assoc-binding-units` already collapses two units
+  that share a `bes` KEY (`{:keys [x] x :foo}` → the group's `assoc` overwrites
+  the explicit entry, one `x <- :x`). But a QUALIFIED group local whose bare
+  name collides an explicit local (`{:keys [ns/x] x :other}`) keeps two DISTINCT
+  `bes` keys (`ns/x`, `x`) that both name-strip to the same local `x`; those
+  arrive as two units binding one local via host last-wins. Left uncollapsed
+  they leave a DEAD slot (`:other` here) in the derived `:slots` — over-comparing
+  in the memo comparator (spurious re-renders), over-declaring in the manifest
+  `:prop-slots`, and silently accepting a never-bound key under CLOSED `:props`.
+  De-duping by `:pattern` here — keeping the last, host-winning entry — restores
+  the 'never two entries for one local' invariant so the derived slots carry no
+  key the view never binds. The winning entry stays in its `bes` position; a
+  same-key collision across DISTINCT locals (`{:keys [x] y :x}` — two locals,
+  one slot) is untouched (both patterns differ, so both survive; the slot
+  `distinct` folds the shared key)."
+  [entries]
+  (let [last-idx (into {} (map-indexed (fn [i e] [(:pattern e) i])) entries)]
+    (into [] (keep-indexed (fn [i e] (when (= i (last-idx (:pattern e))) e)))
+          entries)))
+
 (defn parse-header
   "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot
   :pattern :default}...], :slots [kw...], :children? bool, :binding-form}
 
   The binding `:entries` and `:slots` are the CANONICAL, host-faithful binding
-  units (`bp/assoc-binding-units`): one entry per bound local, in host
-  `destructure` `bes` order, carrying the WINNING lookup key after collapse. Two
-  header entries that bind the same local (`{:keys [x] x :foo}`) COLLAPSE to a
-  single `x <- :x` entry — never two, never a silent last-wins — and a qualified
-  group local (`{:keys [acct/id]}`) keeps its qualified slot `:acct/id`. Both
-  emitters, the schema slot order, the memo comparator and the manifest metadata
-  read these same collapsed entries, so no downstream path can re-collide or
-  strip a qualified key."
+  units (`bp/assoc-binding-units`, then `collapse-entries`): one entry per bound
+  local, in host `destructure` `bes` order, carrying the WINNING lookup key after
+  collapse. Two header entries that bind the same local COLLAPSE to a single
+  entry — never two, never a silent last-wins — whether they collide in the host
+  `bes` map (`{:keys [x] x :foo}` → `x <- :x`) or only after the qualified group
+  local name-strips onto an explicit local (`{:keys [ns/x] x :other}` → the host
+  last-wins `x <- :ns/x`, the explicit `:other` dropped). A qualified group local
+  (`{:keys [acct/id]}`) keeps its qualified slot `:acct/id`. Both emitters, the
+  schema slot order, the memo comparator and the manifest metadata read these
+  same collapsed entries, so no downstream path can re-collide, strip a qualified
+  key, or inherit a dead slot."
   [argv]
   (when-not (vector? argv)
     (fail :rf.ui.compile/bad-defview-args
@@ -145,16 +171,20 @@
               or-map  (get b :or {})
               _       (validate-header-map! b or-map)
               ;; ONE canonical, de-collided binding plan — the host `bes` order
-              ;; with winning lookup keys. Every downstream consumer reads these
-              ;; same entries, so none can re-collide or strip a qualified key.
-              entries (mapv (fn [{:keys [local-pattern key]}]
-                              (cond-> {:key key
-                                       :slot (slot-name key)
-                                       :pattern local-pattern}
-                                (and (symbol? local-pattern)
-                                     (contains? or-map local-pattern))
-                                (assoc :default (get or-map local-pattern))))
-                            (bp/assoc-binding-units b))
+              ;; with winning lookup keys. `collapse-entries` folds any two units
+              ;; that bind the SAME local (including the qualified-group-name
+              ;; collision `bp/assoc-binding-units` leaves as two) to the single
+              ;; host-winning entry, so no downstream consumer inherits a dead
+              ;; slot, re-collides, or strips a qualified key.
+              entries (collapse-entries
+                       (mapv (fn [{:keys [local-pattern key]}]
+                               (cond-> {:key key
+                                        :slot (slot-name key)
+                                        :pattern local-pattern}
+                                 (and (symbol? local-pattern)
+                                      (contains? or-map local-pattern))
+                                 (assoc :default (get or-map local-pattern))))
+                             (bp/assoc-binding-units b)))
               _ (doseq [s (keys or-map)]
                   (when-not (some #(= s (:pattern %)) entries)
                     (fail :rf.ui.compile/bad-defview-args

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -197,6 +197,46 @@
       (is (= (header/slot-name (host 'id)) (slot-of 'id)))
       (is (= "acct/id" (slot-of 'id))))))
 
+(deftest qualified-group-name-collision-collapses-no-dead-slot
+  ;; rf2-7imr5y — the residual collision the `bes`-map collapse does NOT catch:
+  ;; a QUALIFIED :keys group local (`ns/x`) whose bare name collides an explicit
+  ;; local (`x :other`). The two never share a `bes` KEY (`ns/x` ≠ `x`), so
+  ;; `assoc-binding-units` emits TWO units binding the same name-stripped local
+  ;; `x` via host `let` last-wins. Uncollapsed, that left a DEAD `:other` slot in
+  ;; the comparator/manifest; `header/collapse-entries` now folds it to the one
+  ;; host-winning entry `x <- :ns/x`.
+  (testing "binding VALUE stays host-faithful (x resolves to :ns/x, not :other)"
+    (let [pat '{:keys [ns/x] x :other}
+          host (host-local->key pat)
+          {:keys [locals slot-of]} (emitted [pat])]
+      (is (= {'x :ns/x} host)
+          "host last-wins binds x <- :ns/x; the explicit :other is dead")
+      (is (= '[x] locals)
+          "x is emitted EXACTLY ONCE — no duplicate read")
+      (is (= "ns/x" (slot-of 'x))
+          "CLJS reads the host's winning slot \"ns/x\", never dead \"other\"")
+      (is (= (header/slot-name (host 'x)) (slot-of 'x)))))
+  (testing "the collapsed slot is the ONLY declared slot — no dead :other"
+    (let [h (header/parse-header '[{:keys [ns/x] x :other}])]
+      (is (= [{:key :ns/x :slot "ns/x" :pattern 'x}] (:entries h))
+          "ONE entry, the winning :ns/x — never two entries for one local")
+      (is (= [:ns/x] (:slots h))
+          "the dead-shadowed :other does NOT survive as a declared slot")
+      (is (not (some #{:other} (:slots h)))
+          "no :other in the comparator/manifest slot set")))
+  (testing "the :or default rides the winning entry, not the dead one"
+    (let [h (header/parse-header '[{:keys [ns/x] x :other :or {x 9}}])]
+      (is (= [{:key :ns/x :slot "ns/x" :pattern 'x :default 9}] (:entries h))
+          "one entry: winning slot :ns/x carrying the x default")
+      (is (= [:ns/x] (:slots h)))))
+  (testing "real JVM native destructuring agrees — :ns/x wins, :other is dead"
+    (let [f (eval (list 'fn '[{:keys [ns/x] x :other}] 'x))]
+      (is (= 1 (f {:ns/x 1 :other 2})) "present :ns/x wins; :other is dead")
+      (is (nil? (f {:other 2}))         ":other never reaches x — absent :ns/x → nil"))
+    (let [g (eval (list 'fn '[{:keys [ns/x] x :other :or {x 9}}] 'x))]
+      (is (= 1 (g {:ns/x 1 :other 2})) "present :ns/x wins over :other and the default")
+      (is (= 9 (g {:other 2}))         "absent :ns/x → the :or default, never :other"))))
+
 (deftest real-jvm-native-binding-agrees-present-absent-defaulted
   ;; The JVM emitter emits `(let [<raw pattern> props] …)` — native
   ;; destructuring. Eval it and confirm the collapsed slot + default behave

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -252,6 +252,37 @@
   (is (nil? (header/props-schema-keys 'SomeSchemaVar))
       "non-literal schemas cannot be introspected — no closed-map enforcement"))
 
+(deftest qualified-group-name-collision-drops-the-dead-declared-slot
+  ;; rf2-7imr5y — header `{:keys [ns/x] x :other}`: the qualified group local
+  ;; `ns/x` name-strips onto the explicit local `x`; the host binds `x <- :ns/x`
+  ;; (last-wins) and the explicit `:other` lookup is DEAD (never bound). The
+  ;; collapse now drops `:other` from the declared slots, so it no longer
+  ;; over-declares in the manifest / over-compares in the memo comparator.
+  (testing "the dead-shadowed :other is not a declared slot; :ns/x is"
+    (let [hdr (header/parse-header '[{:keys [ns/x] x :other}])]
+      (is (= [:ns/x] (:slots hdr)) "only the host-winning :ns/x is declared")
+      (is (= [:ns/x] (header/declared-slots hdr nil)))))
+  ;; The observable BEHAVIOUR CHANGE (flagged in the PR): under a CLOSED :props
+  ;; schema the dead `:other` was silently ACCEPTED as a declared prop; after the
+  ;; collapse it is NOT declared, so passing it at a literal call site is a
+  ;; compile error. Correct — `:other` is never bound, so declaring it was the
+  ;; bug. Pinned via a self-render call site (exercises :self-closed-keys).
+  (testing "CLOSED :props now REJECTS the dead :other at a call site"
+    (is (nil? (expand-error
+               '(re-frame.ui/defview v {:props [:map [:ns/x :any]]}
+                  [{:keys [ns/x] x :other}] [v {:ns/x 1}])))
+        "the declared, host-winning :ns/x prop is accepted")
+    (is (= :rf.ui.compile/undeclared-prop
+           (expand-error
+            '(re-frame.ui/defview v {:props [:map [:ns/x :any]]}
+               [{:keys [ns/x] x :other}] [v {:other 1}])))
+        "the dead :other is no longer a declared prop — closed-map rejects it"))
+  (testing "OPEN :props (no schema) is unchanged — extra props stay legal"
+    (is (nil? (expand-error
+               '(re-frame.ui/defview v
+                  [{:keys [ns/x] x :other}] [v {:other 1}])))
+        "an open map accepts undeclared props, dead-shadowed or not")))
+
 ;; ---------------------------------------------------------------------------
 ;; custom-element (RULED grammar, closed)
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `rf2-7imr5y` (LOW/P3, Shape-3 review of #6075). For a defview header like
`{:keys [ns/x] x :other}` the canonical binding plan left a **dead comparator/
manifest slot** — restoring the collapse invariant the #6075 docstrings assert.

### The defect

The qualified `:keys` group local `ns/x` name-strips onto the explicit local
`x`, so `clojure.core/destructure` binds `x <- :ns/x` (`let` last-wins) and the
explicit `:other` lookup is **dead** — never bound to any local. Because `'ns/x`
and `'x` never share a host `bes` KEY, `bp/assoc-binding-units`
(`binding_plan.cljc`) faithfully emits **two units** both binding local `x`.
`header/parse-header` (`header.cljc:150-163`) then produced two `:entries` and
slots `[:other :ns/x]`, leaving `:other` as a dead declared slot:

- the memo comparator (`emit_cljs/comparator-form` over `declared-slots`)
  **over-compared** `:other` → spurious re-renders when `:other` changes and
  `:ns/x` does not;
- the manifest `:prop-slots` (`compiler.cljc:253-260`) **over-declared** it; and
- under a CLOSED `:props` schema it was **silently accepted** as a prop the view
  never binds.

This contradicted the "two entries binding one local COLLAPSE — never two"
invariant asserted in `header.cljc:117-119`, `binding_plan.cljc:21-25`,
`emit_cljs.cljc:575`. Binding VALUE was already host-faithful on both hosts
(#6075 fixed that); this is a comparator/manifest wart only.

### The fix

`header/collapse-entries` (`header.cljc`) folds the canonical units by bound
local (`:pattern`), keeping the **host bes-order winner** (the last, dead-shadowed
entry drops): one entry `x <- :ns/x`, slots `[:ns/x]`, no dead `:other`. The
already-correct cases are untouched — the `bes`-map collapse (`{:keys [x] x :foo}`
→ `:x`), qualified group locals (`{:keys [acct/id]}` → `:acct/id`), and distinct
locals sharing a slot (`{:keys [x] y :x}` → both read `:x`).

`bp/assoc-binding-units` **deliberately still exposes both units** — the
analyzer's scope walk (`analyze.cljc:458-468`) judges each unit's lookup-key /
`:or` default against the scope live at its binding point, so it needs both.
Only the header's derived slots collapse. The three invariant docstrings are
made precise about `bes`-key vs same-local collapse.

## Behaviour change — please confirm (clear-fix, flagged as instructed)

Removing `:other` from the declared slots changes **CLOSED-`:props`** acceptance:
previously `:other` was silently accepted as a declared prop; now, since it is
not declared, a literal call site passing `:other` under a CLOSED `:props` schema
raises `:rf.ui.compile/undeclared-prop`.

I judge this a **clear bug-fix, not a semantic decision** (so I proceeded rather
than stopping): the header double-binds `x`, the `:other` lookup is dead-shadowed
and never read, so declaring it was the same over-declaration bug that made the
comparator over-compare. Rejecting it is the safe direction — it surfaces the
author's double-binding mistake at compile time. **OPEN `:props` (the default,
absent schema) is unchanged** — extra props stay legal and invisible. Pinned by
a test either way; flagging for the owner to confirm.

## Adversarial proof

`binding_plan_host_faithful_jvm_test.clj` /
`qualified-group-name-collision-collapses-no-dead-slot`: the `{:keys [ns/x] x
:other}` shape yields ONE entry `{:key :ns/x :pattern x}`, slots `[:ns/x]` (no
`:other`), CLJS reads slot `"ns/x"`, and **real JVM native destructuring** (`(fn
[{:keys [ns/x] x :other}] x)` eval'd) binds `x <- :ns/x` with `:other` dead —
plus the `:or {x 9}` variant. `defview_grammar_jvm_test.clj` /
`qualified-group-name-collision-drops-the-dead-declared-slot` pins the CLOSED-
`:props` outcome (self-render call site): `:ns/x` accepted, dead `:other`
rejected, OPEN unchanged.

## Quality gates

All foreground, unpiped, in the worktree:

- `implementation/ui` JVM (`clojure -M:test`): **667 tests / 13356 assertions, 0 failures** (+2 deftests)
- `npm run test:ui`: **685 tests / 3516 assertions, 0 failures**
- `npm run test:cljs` (core-reachable — a compiler change reaches core): **9689 tests / 47668 assertions, 0 failures**
