### PR TITLE
fix(core): incarnation-fence capture-frame subscribe + value pin; precise ViewCell CAS docstring (cluster)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1146,41 +1146,87 @@
 ;;
 ;; The fence PINS the incarnation live at capture and treats a superseded target
 ;; as destroyed (recover-but-emit `:rf.error/frame-destroyed`, NOT a throw — these
-;; ops fire from host cleanup where a throw would break the host teardown). When
-;; the captured id was NOT live at capture (`capture-frame`'s 1-arity lock-to-id
-;; form used from outside any scope, or a not-yet-mounted id) nothing is pinned
-;; and the op stays address-directed — the documented dynamic-id semantics. This
-;; is the async-safe, recover-but-emit sibling of the SYNCHRONOUS throwing
-;; incarnation fence `re-frame.ui.frames/mint-frame-ops` already wraps the
-;; `(frame)` accessor bundle in.
+;; ops fire from host cleanup where a throw would break the host teardown). It
+;; applies UNIFORMLY to every op that resolves the target — `:dispatch`,
+;; `:dispatch-sync` (rf2-9pyles) AND `:subscribe` (rf2-tdjv7p, closing the same
+;; silent cross-incarnation retarget for the read op so subscribe cannot read a
+;; successor's app-db or leak a persisted reaction into its sub-cache). The pin
+;; is EXACT even over a frame VALUE: the value carries its own construction token
+;; (`:rf.frame/incarnation-token`, rf2-moftbs), preferred before the id-keyed
+;; registry lookup so `(capture-frame <value>)` pins the same incarnation
+;; `(capture-frame <id>)` does (rf2-vclh63). When the captured id was NOT live at
+;; capture (`capture-frame`'s 1-arity lock-to-id form used from outside any scope,
+;; a not-yet-mounted id, or a derived-read value carrying no token) nothing is
+;; pinned and the op stays address-directed — the documented dynamic-id
+;; semantics. This is the async-safe, recover-but-emit sibling of the SYNCHRONOUS
+;; throwing incarnation fence `re-frame.ui.frames/mint-frame-ops` already wraps
+;; the `(frame)` accessor bundle in (dispatch AND subscribe).
 
 (defn- capture-target-incarnation
-  "The EXACT incarnation token (`:drain-lock`) of frame id `frame-id` if it is
-  LIVE at capture, else nil. A capture over a live frame pins its incarnation;
-  a capture over an absent/not-yet-mounted id pins nothing (stays address-
-  directed). Namespace-qualified `frame/…` is never shadowed by a local `frame`."
-  [frame-id]
-  (frame/frame-incarnation-token frame-id))
+  "The EXACT incarnation token (`:drain-lock`) pinning the capture TARGET's live
+  incarnation, else nil (unpinned / address-directed). `frame-target` is a
+  keyword id OR a frame VALUE.
+
+  A construction frame VALUE carries its own exact token
+  (`:rf.frame/incarnation-token`, rf2-moftbs) — PREFER it so `(capture-frame
+  <value>)` pins the SAME incarnation `(capture-frame <id>)` does. The id-keyed
+  registry lookup (`frame-incarnation-token`) returns nil for a value map (the
+  registry is keyed by id, not by the value), so without this the value path
+  silently lost its pin (rf2-vclh63). A keyword id — or a derived-read value that
+  carries no construction token — falls to the id-keyed lookup: a live id pins,
+  an absent/not-yet-mounted id (or a derived-read value, whose map is not a
+  registry key) pins nothing. Namespace-qualified `frame/…` is never shadowed by
+  a local `frame`."
+  [frame-target]
+  (or (frame/frame-value-incarnation-token frame-target)
+      (frame/frame-incarnation-token frame-target)))
 
 (defn- capture-target-superseded?
-  "True when a pinned `captured-incarnation` no longer identifies `frame-id`'s
-  live frame — the exact captured incarnation was destroyed, whether the id is
-  now unclaimed or a same-id successor incarnation reseated. nil `captured-
-  incarnation` (an unpinned capture) is never superseded."
-  [frame-id captured-incarnation]
+  "True when a pinned `captured-incarnation` no longer identifies the capture
+  TARGET's live frame — the exact captured incarnation was destroyed, whether the
+  id is now unclaimed or a same-id successor incarnation reseated. `frame-target`
+  is NORMALIZED to its frame id (`frame-target->id`) before the liveness lookup so
+  a frame VALUE's carried token is compared against the current live incarnation
+  under its id — the id-keyed token lookup does not accept a value map, so without
+  this a pinned value would read nil-live and be spuriously superseded on every
+  op (rf2-vclh63). nil `captured-incarnation` (an unpinned capture) is never
+  superseded."
+  [frame-target captured-incarnation]
   (and (some? captured-incarnation)
-       (not (frame/frame-incarnation-live? frame-id captured-incarnation))))
+       (not (frame/frame-incarnation-live?
+              (frame/frame-target->id frame-target) captured-incarnation))))
 
 (defn- capture-dispatch!
   "Route a captured `:dispatch`/`:dispatch-sync` op through the incarnation fence:
   when the pinned incarnation is superseded, recover-but-emit `:rf.error/frame-
   destroyed` (never enqueue into a same-id successor); otherwise delegate to
   `dispatch-fn` (the `dispatch-impl` / `dispatch-sync-impl` alias, preserving the
-  single `with-redefs` interception seam)."
-  [dispatch-fn frame-id captured-incarnation event opts]
-  (if (capture-target-superseded? frame-id captured-incarnation)
-    (router/emit-captured-frame-superseded! event frame-id opts)
+  single `with-redefs` interception seam). `frame-target` is a keyword id OR a
+  frame VALUE; the recover-but-emit stamps the normalized frame id (identity for
+  a keyword) so the diagnostic carries an id, never a value map (rf2-vclh63)."
+  [dispatch-fn frame-target captured-incarnation event opts]
+  (if (capture-target-superseded? frame-target captured-incarnation)
+    (router/emit-captured-frame-superseded!
+      event (frame/frame-target->id frame-target) opts)
     (dispatch-fn event opts)))
+
+(defn- capture-subscribe!
+  "Route a captured `:subscribe` op through the SAME incarnation fence as
+  `capture-dispatch!` (rf2-tdjv7p): when the pinned incarnation is superseded,
+  recover-but-emit `:rf.error/frame-destroyed` and return nil — never resolve a
+  reaction against a same-id successor (which would read the successor's app-db
+  and cache a reaction in its sub-cache). Otherwise delegate to `subscribe-thunk`
+  (the live read, which itself applies the dev-only `:rf.trace/call-site`
+  wrapper). The async-safe, recover-but-emit sibling of the SYNCHRONOUS throwing
+  `re-frame.ui.frames/fence-subscribe`; reuses the dispatch fence's emit seam,
+  passing `subscribe-call-site` as the `:rf.trace/call-site` so the drop is
+  attributed to the subscribe coord."
+  [subscribe-thunk frame-target captured-incarnation query-v subscribe-call-site]
+  (if (capture-target-superseded? frame-target captured-incarnation)
+    (router/emit-captured-frame-superseded!
+      query-v (frame/frame-target->id frame-target)
+      {:rf.trace/call-site subscribe-call-site})
+    (subscribe-thunk)))
 
 (defn make-capture-frame
   "INTERNAL constructor for `capture-frame` (and the `reg-view` injection
@@ -1243,12 +1289,19 @@
        ([event opts] (capture-dispatch! dispatch-sync-impl frame captured-incarnation
                                         event (merge dispatch-opts opts {:frame frame}))))
      :subscribe
+     ;; rf2-tdjv7p: fence subscribe on the SAME incarnation pin as dispatch — a
+     ;; capture pinned to incarnation A whose frame was destroyed and reseated as
+     ;; a same-id successor B must NOT subscribe into B (reading B's app-db,
+     ;; caching a reaction in B's sub-cache); it recover-but-emits and returns nil.
      (fn subscribe-fn
        [query-v]
-       (if (and subscribe-call-site interop/debug-enabled?)
-         (trace/with-call-site subscribe-call-site
-           (subscribe-impl query-v {:frame frame}))
-         (subscribe-impl query-v {:frame frame})))}))
+       (capture-subscribe!
+         (fn []
+           (if (and subscribe-call-site interop/debug-enabled?)
+             (trace/with-call-site subscribe-call-site
+               (subscribe-impl query-v {:frame frame}))
+             (subscribe-impl query-v {:frame frame})))
+         frame captured-incarnation query-v subscribe-call-site))}))
 
 (defn capture-frame
   "Return a frame api — the keystone affordance for

--- a/implementation/core/test/re_frame/capture_frame_test.clj
+++ b/implementation/core/test/re_frame/capture_frame_test.clj
@@ -107,6 +107,81 @@
       (is (nil? (:touched? (rf/app-db-value :fh/other)))
           "the per-call :frame :fh/other was IGNORED — the handle is locked"))))
 
+;; ---- incarnation fence: a stale capture never retargets a same-id successor
+;;
+;; rf2-9pyles pinned the EXACT incarnation live at capture so a captured op
+;; cannot leak into a same-id successor reseated after the captured incarnation
+;; was destroyed. These pin the two consistency gaps closed on top of it:
+;;   - rf2-tdjv7p: the `:subscribe` op is fenced on the SAME pin as dispatch —
+;;     a superseded subscribe recover-but-emits (returns nil) rather than
+;;     silently resolving a reaction into the successor's sub-cache.
+;;   - rf2-vclh63: a capture over a frame VALUE pins the value's carried EXACT
+;;     incarnation token, so a value-capture fences identically to an id-capture
+;;     (before the fix the value path silently lost its pin).
+
+(deftest stale-capture-subscribe-does-not-retarget-same-id-successor
+  (testing "rf2-tdjv7p — a capture pinned to incarnation A, after A is destroyed
+            and a same-id successor B reseats, MUST NOT subscribe into B (reading
+            B's app-db, caching a reaction in B's sub-cache). It recover-but-
+            emits :rf.error/frame-destroyed and returns nil — the async-safe
+            sibling of the throwing synchronous (frame)-bundle subscribe fence."
+    (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
+    (rf/reg-sub :fh/value (fn [db _] (:value db)))
+    ;; Incarnation A of :fh/sub-stale, seeded with :A-value.
+    (rf/make-frame {:id :fh/sub-stale :doc "incarnation A"})
+    (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/sub-stale})
+    (let [{:keys [subscribe]} (rf/capture-frame :fh/sub-stale)] ; pins incarnation A
+      ;; Sanity: while A is live the captured subscribe reads A.
+      (is (= :A-value @(subscribe [:fh/value]))
+          "a LIVE capture's subscribe reads incarnation A")
+      ;; Destroy A; reseat a same-id successor B with DIFFERENT data.
+      (rf/destroy-frame! :fh/sub-stale)
+      (rf/make-frame {:id :fh/sub-stale :doc "incarnation B (successor)"})
+      (rf/dispatch-sync [:fh/seed :B-value] {:frame :fh/sub-stale})
+      (let [errs (atom [])]
+        (rf/register-listener! :trace ::sub-stale (fn [ev] (swap! errs conj ev)))
+        ;; Before the fix this returned a reaction reading B's :B-value; the
+        ;; fence makes it recover-but-emit and return nil.
+        (let [result (subscribe [:fh/value])]
+          (rf/unregister-listener! :trace ::sub-stale)
+          (is (nil? result)
+              "the superseded capture's subscribe returns nil — it did NOT
+               resolve a reaction into successor B")
+          (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+              "the superseded subscribe recover-but-emits :rf.error/frame-destroyed"))))))
+
+(deftest capture-frame-over-value-pins-exact-incarnation
+  (testing "rf2-vclh63 — (capture-frame <frame-value>) pins the value's EXACT
+            incarnation via its carried :rf.frame/incarnation-token, so a
+            dispatch through the capture after the frame is destroyed and a
+            same-id successor reseats recover-but-emits instead of mutating the
+            successor. A LIVE value-capture still dispatches into its frame — the
+            pin is exact, not a spurious supersession."
+    (rf/reg-event :fh/mark (fn [{:keys [db]} [_ v]] {:db (assoc db :mark v)}))
+    ;; Incarnation A — capture the construction VALUE (carries its exact token).
+    (let [frame-a (rf/make-frame {:id :fh/vpin :doc "incarnation A"})]
+      (is (some? (frame/frame-value-incarnation-token frame-a))
+          "precondition: a fresh make-frame VALUE carries its incarnation token (rf2-moftbs)")
+      (let [{:keys [dispatch-sync]} (rf/capture-frame frame-a)]
+        ;; Live path: the value-capture dispatches into incarnation A — the new
+        ;; pin must NOT spuriously supersede a live capture.
+        (dispatch-sync [:fh/mark :A-mark])
+        (is (= :A-mark (:mark (rf/app-db-value :fh/vpin)))
+            "a LIVE value-capture dispatches into its frame — the pin is exact, not spurious")
+        ;; Destroy A (incarnation-exact via the value) and reseat a same-id B.
+        (rf/destroy-frame! frame-a)
+        (rf/make-frame {:id :fh/vpin :doc "incarnation B (successor)"})
+        (let [errs (atom [])]
+          (rf/register-listener! :trace ::vpin (fn [ev] (swap! errs conj ev)))
+          ;; Before the fix the unpinned value-capture retargeted B and set
+          ;; :mark; the carried-token pin makes it recover-but-emit.
+          (dispatch-sync [:fh/mark :leaked])
+          (rf/unregister-listener! :trace ::vpin)
+          (is (nil? (:mark (rf/app-db-value :fh/vpin)))
+              "the stale value-capture did NOT mutate the same-id successor B")
+          (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+              "the superseded value-capture dispatch recover-but-emits :rf.error/frame-destroyed"))))))
+
 ;; ---- contract: (capture-frame) outside any scope RAISES (EP-0002) ---------
 ;;
 ;; rf2-jue6sp: the no-arg capture form captures ONLY when a real scope

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3529,25 +3529,37 @@
   authority had already moved. Re-reading the authority a third time only MOVES
   the race to between that read and the swap; it is not a linearization point.
 
-  ## The linearization
+  ## The linearization — two axes, two strengths
 
-  Validation and publication are ONE `compare-and-set!` transition over the
-  cell-state value read at the top of the loop (the `complete-flush!`
-  rf2-vxgfnd.180 idiom), so a pause interposed anywhere before the CAS cannot
-  publish a stale capture:
+  Validation and publication settle against the cell-state value read at the top
+  of the loop (the `complete-flush!` rf2-vxgfnd.180 idiom), but the two authority
+  axes do NOT carry the same guarantee — a distinction that matters for a future
+  maintainer or async-host author, so it is stated precisely:
 
-    - CELL-LOCAL axis — the capture generation is compared to `(:generation s)`
-      of the SAME snapshot `s` the CAS commits. A racing `advance-generation!`
+    - CELL-LOCAL axis — a GENUINE single-atom CAS linearization. The capture
+      generation is compared to `(:generation s)` of the SAME snapshot `s` the
+      `compare-and-set! st s published` commits. A racing `advance-generation!`
       is either already visible in `s` (→ `:stale`) or lands after the sample
       and FAILS the CAS (`st` ≠ `s`); the loop then re-reads and re-validates.
-    - REGISTRY axis — the view's HMR slot is sampled ONCE per attempt as an
-      authority TOKEN, and the publish CAS is GATED on that token still being
-      `identical?` to the live slot at the instant of the CAS. A same-view
-      re-registration swaps `view-generations` to a fresh slot object, so the
-      token gate fails and the loop re-reads a moved revision (→ `:stale`). The
-      publication never trusts a revision sampled earlier and gone stale; it
-      consults the slot IDENTITY at the linearization point, which a stale
-      revision read cannot fool.
+      Airtight even under genuine concurrency.
+    - REGISTRY axis — a BEST-EFFORT slot-IDENTITY gate, NOT a single-atom
+      linearization. The view's HMR slot is sampled ONCE per attempt as an
+      authority TOKEN; the publish gate is `(and (identical? token (get
+      @view-generations view-id)) (compare-and-set! st s published))` — TWO reads
+      of TWO different atoms (`view-generations` for the token, `st` for the
+      CAS). The token is checked IMMEDIATELY BEFORE the CAS, not fused atomically
+      WITH it. A same-view re-registration swaps `view-generations` to a fresh
+      slot object, so the token gate fails and the loop re-reads a moved revision
+      (→ `:stale`). A residual two-expression window remains (the `identical?`
+      read → the `st` CAS) in which a re-registration would leave `st` untouched
+      and let the CAS publish a stale-revision capture. That window is
+      UNREACHABLE on the single-threaded CLJS render host where HMR/registry
+      authority lives — JS never preempts between two non-yielding expressions
+      and no application/framework callback runs in it (`published` is computed
+      before the `if`) — and the whole authority arm is DCE'd in production (see
+      below). It reopens ONLY under genuinely unsynchronized multi-threaded
+      concurrent commit-of-the-same-view + re-registration, which is outside
+      re-frame2's per-frame single-threaded contract.
 
   The `*commit-barrier* :pre-publish` seam fires ONCE, between the first
   attempt's authority sample and its CAS, so a fixture can interpose either


### PR DESCRIPTION
Cluster of 3 small consistency fixes surfaced by the post-merge audit of the frame-incarnation lifecycle (#6072 rf2-moftbs + #6079 rf2-9pyles) and ViewCell publication (#6078). References: `ai/findings/2026-07-17-review-incarnation.md`, `ai/findings/2026-07-17-review-viewcell-reactive.md`.

## Changes

### rf2-tdjv7p (P3) — fence capture-frame's `:subscribe`
`make-capture-frame`'s `:subscribe` (`core.cljc`) was unfenced — a capture pinned to incarnation A, after A was destroyed and a same-id successor B reseated, silently subscribed into B (read B's app-db, cached a reaction in B's sub-cache) instead of recover-but-emitting. It now routes through a new `capture-subscribe!` — the async-safe sibling of the throwing synchronous `(frame)`-bundle `fence-subscribe`, mirroring the existing dispatch fence: a superseded subscribe recover-but-emits `:rf.error/frame-destroyed` and returns nil, never resolving a reaction into the successor. Reuses the existing `emit-captured-frame-superseded!` seam and the existing `:rf.error/frame-destroyed` id — **no new error-id, no Spec 009 / manifest change**.

### rf2-vclh63 (P4) — pin an incarnation over a frame VALUE
`capture-target-incarnation` pinned only via the id-keyed registry lookup, which returns nil for a frame VALUE (the registry is keyed by id, not by the value map) — so `(capture-frame <value>)` silently lost its pin even though the value carries its own exact `:rf.frame/incarnation-token` (rf2-moftbs). It now prefers the value's carried token. `capture-target-superseded?` is normalized (`frame-target->id`) so the pinned value's liveness is checked against the current live incarnation under its id — without this the newly-pinned value would read nil-live and be spuriously superseded on every op (a gap the finding's fix sketch missed). `capture-dispatch!` stamps the normalized id (identity for a keyword) so a value-target diagnostic carries an id, not a value map.

### rf2-lbvkqy (P3) — precise `publish-commit!` docstring
Docstring only. Reframed validation+publication so the cell-local axis is described as a genuine single-atom CAS linearization while the registry axis is a best-effort slot-identity gate consulted *immediately before* the CAS (two reads of two different atoms), sound because the residual `identical?`→CAS window is unreachable on the single-threaded render host and DCE'd in production. No code change.

## Tests
Two JVM tests added to `capture_frame_test.clj`, both failing-before/passing-after:
- `stale-capture-subscribe-does-not-retarget-same-id-successor` (tdjv7p): a stale capture's subscribe returns nil + recover-but-emits, does not retarget B.
- `capture-frame-over-value-pins-exact-incarnation` (vclh63): a value-capture pins its exact incarnation — live path still dispatches into its frame; stale path recover-but-emits, never mutates the successor.

Proven failing-before by temporarily reverting the two fences: exactly 4 failures (the 2 new tests' fence assertions), all pre-existing tests green; fences restored.

## Quality gates
- Core JVM (`clojure -M:test`): **2025 tests, 9452 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9689 tests, 47668 assertions, 0 failures, 0 errors**.
- No new error-id → error-catalogue channel-conformance ratchet satisfied (green in the JVM sweep); no Spec 009 / manifest edits required.

Commit split: lbvkqy (docstring) is separate; vclh63 + tdjv7p share one commit because they are one contiguous fence-family region in `core.cljc` and tdjv7p's subscribe fence structurally reuses vclh63's corrected `capture-target-superseded?`.
