### PR TITLE
fix(epoch): emit delayed-silence outside ledger locks to break the ledger↔drain-lock deadlock (rf2-8b9twg)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -376,15 +376,18 @@
   before A resumes (A must NOT re-emit the silence B already fired, even though A
   now wins the comparison); a cb re-registered to a fresh generation (must
   receive no stale signal). Each owed identity is published iff
-  `state/claim-delayed-silence!` grants it — a single atomic operation that
-  rechecks the CURRENT generation, the CURRENT live observers (read fresh, not a
-  stale pre-loop set), and any existing mark, then RESERVES a fresh monotonic seq
-  BEFORE external delivery. The seq is the total order the observer relies on;
-  two overlapping same-id publishers can never both claim. A reservation is
-  rolled back only if the external envelope delivery itself throws. The owed
-  identities are fanned in a deterministic (cb-id-ordered) sequence so a trace
-  listener re-arming a LATER identity during an EARLIER silence sees a stable,
-  linearizable order.
+  `state/claim-and-publish-delayed-silence!` grants it — the eligibility recheck
+  (CURRENT generation, CURRENT live observers read fresh not a stale pre-loop set,
+  any existing mark) plus the monotonic-seq RESERVATION run as ONE atomic claim
+  under both ledger locks; the claim then RELEASES the locks and emits the
+  GENERATION-QUALIFIED signal OUTSIDE them (rf2-8b9twg — the emit fans to
+  arbitrary listeners, one of which may `dispatch-sync` and acquire a frame's
+  `:drain-lock`, so it must not run under a ledger lock). The seq is the total
+  order the observer relies on; two overlapping same-id publishers can never both
+  claim. A reservation is rolled back only if the external envelope delivery
+  itself throws. The owed identities are fanned in a deterministic (cb-id-ordered)
+  sequence so a trace listener re-arming a LATER identity during an EARLIER
+  silence sees a stable, linearizable order.
 
   The id-keyed store DROP is compare-owned (`state/cleanup-frame-owner!`): it
   runs only while `owner-token` still owns the stores, so stale A can never
@@ -452,30 +455,37 @@
              #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                                   (:event-id record) :halted-destroy))
            (deliver-listener-snapshot! record listener-snapshot))
-         ;; PER-IDENTITY atomic-claim-AND-PUBLISH silencing (rf2-vxgfnd.285 /
-         ;; rf2-9bhne6). Iterate the owed identities in a deterministic cb-id
-         ;; order so the linearizable claim sees a stable sequence.
-         ;; `claim-and-publish-delayed-silence!` reserves the one signal AND runs
-         ;; the external emit inside ONE critical section holding BOTH ledger locks
-         ;; (registry → silence) — rechecking current generation, FRESH live
-         ;; observers, and any existing mark, writing the monotonic mark, then
-         ;; emitting, all before the locks release. Because listener replacement
-         ;; takes the registry lock, and drop / reset / the observation re-arm take
-         ;; silence-lock (the split that broke the single-monitor deadlock, rf2-9bhne6),
-         ;; the winning `(cb-id, observed-gen)` stays the authoritative generation
-         ;; THROUGH the emission: a concurrent registrar cannot make a fresh
-         ;; generation current in the reserve→emit window (rf2-9bhne6). Only a granted
-         ;; reservation emits; if the external delivery throws, the reservation is
-         ;; rolled back inside the same section and the fault propagates.
+         ;; PER-IDENTITY atomic-claim-THEN-PUBLISH silencing (rf2-vxgfnd.285 /
+         ;; rf2-9bhne6 / rf2-8b9twg). Iterate the owed identities in a
+         ;; deterministic cb-id order so the linearizable claim sees a stable
+         ;; sequence. `claim-and-publish-delayed-silence!` reserves the one signal
+         ;; under BOTH ledger locks (rechecking current generation, FRESH live
+         ;; observers, and any existing mark, then writing the monotonic mark),
+         ;; RELEASES the locks, and only THEN runs this external emit — so the
+         ;; foreign trace fan-out (a blessed listener may `dispatch-sync`,
+         ;; acquiring a frame's :drain-lock) never runs while a ledger lock is
+         ;; held. That is what breaks the ledger↔:drain-lock AB-BA deadlock
+         ;; rf2-9bhne6 introduced by emitting UNDER the locks (rf2-8b9twg).
+         ;; Generation authority survives WITHOUT the lock by QUALIFYING the emit
+         ;; with `observed-gen`: the reserved generation G is carried on the
+         ;; payload, so a same-id replacement H landing in the reserve→emit window
+         ;; is never mistaken as the silence's subject — a receiver whose current
+         ;; generation for cb-id != the carried `:observed-gen` self-filters the
+         ;; stale signal. Only a granted reservation emits; if the external
+         ;; delivery throws, the reservation is rolled back (under silence-lock)
+         ;; and the fault propagates.
          (doseq [[cb-id observed-gen] (sort-by (comp str key) silenced-cbs)]
            (state/claim-and-publish-delayed-silence!
              frame-id cb-id observed-gen baseline-silence-seq
              ;; The silencing fact belongs to destroyed A too; never let a
-             ;; same-id successor's trace policy suppress or capture it.
+             ;; same-id successor's trace policy suppress or capture it. The
+             ;; `:observed-gen` qualifier is what lets the emit run outside the
+             ;; ledger locks without reopening the G→H window (rf2-8b9twg).
              #(trace/call-with-structural-delivery
                 (fn []
                   (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                               {:frame frame-id :cb-id cb-id}))))))
+                               {:frame frame-id :cb-id cb-id
+                                :observed-gen observed-gen}))))))
         (finally
           ;; Close the deferred-silence window opened at snapshot time. When the
           ;; frame's last outstanding predecessor resolves, its marks are reclaimed.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1153,68 +1153,98 @@
 
   NOTE the reserve-then-emit-later split leaves a claim→emit window: a
   replacement landing after this returns but before the caller's external emit
-  makes a fresh generation current at the emission point, contrary to the
-  exact-generation contract (rf2-9bhne6). Callers that must keep the winning
-  generation authoritative THROUGH the emission use
-  `claim-and-publish-delayed-silence!`, which runs the emit inside this same
-  critical section. This reserve-only primitive remains for staged tests and any
-  caller whose emit provably cannot race a registry mutation."
+  makes a fresh generation current at the emission point. This reserve-only
+  primitive emits an UNQUALIFIED signal, so it remains only for staged tests and
+  any caller whose emit provably cannot race a registry mutation. Callers whose
+  emit CAN race a registry mutation use `claim-and-publish-delayed-silence!`,
+  which reserves here (under both locks), then emits a GENERATION-QUALIFIED
+  signal OUTSIDE the locks so a superseded generation's late emit self-filters at
+  the receiver (rf2-8b9twg)."
   [frame-id cb-id observed-gen baseline]
   (with-claim-locks
     #(eligible-and-reserve! frame-id cb-id observed-gen baseline)))
 
 (defn claim-and-publish-delayed-silence!
-  "Reserve AND publish the one delayed silence for `(frame-id, cb-id)` inside a
-  SINGLE critical section holding BOTH ledger locks (`with-claim-locks`:
-  listener-registry-lock → silence-lock), so the winning `(cb-id, observed-gen)`
-  stays the authoritative generation THROUGH the signal's emission (rf2-9bhne6).
+  "Reserve the one delayed silence for `(frame-id, cb-id)` under BOTH ledger locks
+  (`with-claim-locks`: listener-registry-lock → silence-lock), RELEASE the locks,
+  then run the external `publish!` OUTSIDE them (rf2-8b9twg).
 
   `publish!` is a 0-arg thunk that performs the external
-  `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs INSIDE the locks, after
-  the reservation and BEFORE they are released. Because `put-listener!` takes the
-  registry lock, and `drop-listener!` / `reset-listeners!` / the re-arm in
-  `record-observation!` take silence-lock (the wipes take both), a concurrent
-  registrar cannot make a fresh generation H current in the reserve→emit window:
-  its mutation blocks on the lock this claim holds until publication completes, so
-  either the silence is linearized before H becomes current, or — if H landed
-  first — the eligibility recheck fails and no silence fires. The forbidden
-  ordering (H current, THEN G's unqualified signal) is impossible.
+  `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs with NO ledger lock
+  held, so a same-id replacement CAN make a fresh generation H current in the
+  reserve→emit window. `publish!` MUST therefore qualify its emit with
+  `observed-gen` (the caller bakes it into the payload): the resulting
+  GENERATION-QUALIFIED signal SELF-FILTERS at the receiver — an observer whose
+  current generation for `cb-id` no longer equals the carried `observed-gen`
+  discards it. So the forbidden ordering (H current, THEN a signal attributed to
+  H) is impossible: the signal is attributed to G, and a receiver that sees G is
+  no longer current drops it. This SUPERSEDES the emit-under-lock mechanism of
+  rf2-9bhne6 — the generation stays authoritative through a data qualifier, not
+  through holding a lock across foreign code.
 
-  Returns true when the silence was published, false when ineligible. If
-  `publish!` throws, the reservation is rolled back (only while it still stands)
-  and the throw propagates — identical failed-delivery semantics to the
-  reserve-only `claim-delayed-silence!` + `rollback-delayed-silence!` pair, now
-  inside one critical section.
+  ## Why the emit MUST run OUTSIDE the ledger locks (rf2-8b9twg)
 
-  Deliberately-held critical section: `publish!` may fan an external trace out to
-  arbitrary listeners while the locks are held. Splitting the registry and
-  observation domains (rf2-9bhne6 deadlock follow-up) is what makes this safe
-  against a registration paused inside the `listeners` swap: `put-listener!`
-  holds ONLY the registry lock, so a fan-out re-arm (`record-observation!`, which
-  takes ONLY silence-lock) is never blocked behind it — the single-monitor
-  predecessor deadlocked exactly there. The cross-lock nesting to
-  `frame-owner-lock` remains a strict DAG: no path holds `frame-owner-lock` while
-  acquiring either ledger lock (the destroy recipe releases `frame-owner-lock` in
-  `cleanup-frame-owner!` before this fan, and the settle path's
-  `notify-listeners!`/`record-observation!` run after `commit-frame-owner-record!`
-  returns). Same-thread reentrant acquisition (a listener calling
-  `put-listener!`/`record-observation!` during the emit) is a no-op on the JVM
-  monitors and on the CLJS single thread."
+  `publish!` fans an external `trace/emit!` to ARBITRARY trace listeners, and a
+  framework-blessed listener may `dispatch-sync` (the rf2-1zxlsm contract; Xray
+  dispatch-syncs from its collector). `dispatch-sync` enters `drain-block!` /
+  `call-serialized-with-drain!`, which spin-CAS-acquires the target frame's
+  `:drain-lock` (`re-frame.router`, `re-frame.frame`). Meanwhile a thread DRAINING
+  a frame holds that frame's `:drain-lock` for the whole pass and, via
+  `settle!` → `notify-listeners!` → `record-observation!` re-arm (or a mid-drain
+  `drop-listener!` / destroy), acquires `silence-lock`/`registry-lock` UNDER the
+  held `:drain-lock`. Holding a ledger lock across the emit therefore inverts the
+  ledger locks against `:drain-lock`: hold-silence-lock → want-drain-lock (this
+  path) vs hold-drain-lock → want-silence-lock (the drainer) — an AB-BA HARD HANG.
+  rf2-9bhne6's deadlock-freedom argument reasoned ONLY about `frame-owner-lock`
+  and never considered `:drain-lock` / the router, so it missed this cycle.
+  Emitting OUTSIDE both ledger locks removes the foreign-code-under-lock edge
+  entirely: the fan-out may reach `:drain-lock` freely because no ledger lock is
+  held.
+
+  ## What the reservation-under-lock still buys
+
+  `eligible-and-reserve!` runs under BOTH locks so its three eligibility reads
+  (current generation == `observed-gen`, not-a-live-observer, mark-above-baseline)
+  stay coherent against a concurrent `put-listener!` (registry lock) and
+  `record-observation!` / wipe (silence-lock), and it writes the monotonic mark
+  that makes the claim the single linearization point — two overlapping
+  publishers can never both reserve. `observed-gen` is validated equal to the
+  current generation AT reservation time, and that is the generation `publish!`
+  qualifies the emit with.
+
+  Returns true when the silence was reserved+published, false when ineligible. If
+  `publish!` throws, the reservation is rolled back under `silence-lock` (only
+  while it still stands) — acquiring silence-lock ALONE keeps the global
+  registry→silence order (no inversion) — and the throw propagates.
+
+  Lock-order safety: the cross-lock nesting to `frame-owner-lock` remains a strict
+  DAG (no path holds `frame-owner-lock` while acquiring either ledger lock — the
+  destroy recipe releases it in `cleanup-frame-owner!` before this fan, and the
+  settle path's `notify-listeners!`/`record-observation!` run after
+  `commit-frame-owner-record!` returns), AND — the rf2-8b9twg correction — NO path
+  now holds either ledger lock while the emit fans to a listener that can acquire
+  `:drain-lock`, so the ledger↔`:drain-lock` cycle is gone."
   [frame-id cb-id observed-gen baseline publish!]
-  (with-claim-locks
-    (fn []
-      (when-let [reserved (eligible-and-reserve! frame-id cb-id observed-gen baseline)]
-        (try
-          (publish!)
-          true
-          (catch #?(:clj Throwable :cljs :default) ex
-            ;; External delivery failed — release OUR reservation (only while it
-            ;; still stands) so the one signal can be legitimately re-attempted,
-            ;; then propagate contained. Still under the lock, so no concurrent
-            ;; claim can interleave with the rollback.
+  (when-let [reserved (with-claim-locks
+                        (fn []
+                          (eligible-and-reserve! frame-id cb-id observed-gen baseline)))]
+    ;; Locks RELEASED. Emit the generation-qualified signal OUTSIDE both ledger
+    ;; locks so the foreign trace fan-out cannot reach a frame's :drain-lock while
+    ;; we hold a ledger lock — the ledger↔drain-lock AB-BA deadlock (rf2-8b9twg).
+    (try
+      (publish!)
+      true
+      (catch #?(:clj Throwable :cljs :default) ex
+        ;; External delivery failed — release OUR reservation (only while it still
+        ;; stands) so the one signal can be legitimately re-attempted, then
+        ;; propagate contained. Re-acquire silence-lock ALONE (registry→silence
+        ;; order preserved) for the prune; no concurrent claim can interleave with
+        ;; the compare-and-prune because it is a single silence-lock section.
+        (with-silence-lock
+          (fn []
             (when (= reserved (get-in @terminal-silence-marks [frame-id cb-id]))
-              (prune-terminal-silence-mark! frame-id cb-id))
-            (throw ex)))))))
+              (prune-terminal-silence-mark! frame-id cb-id))))
+        (throw ex)))))
 
 (defn rollback-delayed-silence!
   "Undo a `claim-delayed-silence!` reservation `reserved-seq` for `(frame, cb)`

--- a/implementation/epoch/test/re_frame/epoch_silencing_emit_deadlock_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_emit_deadlock_test.clj
@@ -1,0 +1,152 @@
+(ns re-frame.epoch-silencing-emit-deadlock-test
+  "rf2-8b9twg — the delayed-silence emit MUST fan out with NO ledger lock held.
+
+  ## The deadlock (introduced by rf2-9bhne6, closed here)
+
+  rf2-9bhne6 moved the external `:rf.epoch.cb/silenced-on-frame-destroy` emit
+  INSIDE both ledger locks (`claim-and-publish-delayed-silence!` ran `publish!`
+  under `with-claim-locks` = registry-lock + silence-lock) so the winning
+  generation stayed authoritative THROUGH the emission. But `publish!` is an
+  external `trace/emit!` that fans to ARBITRARY trace listeners, and a
+  framework-blessed listener may `dispatch-sync` (Xray dispatch-syncs from its
+  collector). `dispatch-sync` enters `drain-block!`, which spin-CAS-acquires the
+  target frame's `:drain-lock`. So the emit path is:
+
+      Order A:  hold silence-lock (+registry-lock)  ->  want :drain-lock
+
+  Meanwhile a thread holding a frame's `:drain-lock` acquires `silence-lock` under
+  it. This is the every-settle re-arm (`settle!` -> `notify-listeners!` ->
+  `record-observation!`), and — the variant this test drives — a COLD serialized
+  section (`frame/call-serialized-with-drain!`: a Tool-Pair state write, the
+  `destroy-frame!` recipe, any lifecycle op) that runs `record-observation!` /
+  `claim-and-publish` while holding the lock:
+
+      Order B:  hold :drain-lock  ->  want silence-lock
+
+  A + B is an AB-BA hard hang: T1 (cold destroy of frame G) holds silence-lock and
+  spins on frame F's :drain-lock; T2 (holding F's :drain-lock) blocks on
+  silence-lock. Neither makes progress. rf2-9bhne6's deadlock-freedom argument
+  only analysed `frame-owner-lock` and never `:drain-lock`, so it missed this.
+
+  Note the target frame's `:drain-lock` must be held by a path that does NOT set
+  `:in-sync-drain?` — a cold `call-serialized-with-drain!` section (this test) or
+  an async drainer. A concurrent `dispatch-sync` into a frame that is mid-SYNC-
+  drain is instead rejected as `:rf.error/dispatch-sync-in-handler` (the
+  `:in-sync-drain?` guard) and never reaches `drain-block!`, so a sync-drained
+  frame cannot be the deadlock target.
+
+  ## The fix (rf2-8b9twg)
+
+  `claim-and-publish-delayed-silence!` reserves the mark under both ledger locks,
+  RELEASES them, then emits OUTSIDE them; generation authority is preserved by
+  QUALIFYING the emit with `observed-gen` (self-filtering at the receiver) rather
+  than by holding a lock across the foreign fan-out. With no ledger lock held
+  during the emit, Order A's `silence-lock -> :drain-lock` edge is gone, so the
+  cycle cannot form.
+
+  ## This test
+
+  Reproduces the exact AB-BA interleave deterministically with latches:
+
+    * T2 holds frame F's `:drain-lock` via `frame/call-serialized-with-drain!`
+      (a cold section, so `:in-sync-drain?` is unset and a concurrent
+      dispatch-sync reaches `drain-block!`); inside it takes `silence-lock` via a
+      genuine `record-observation!` re-arm — Order B.
+    * T1 runs `claim-and-publish-delayed-silence!` for a deferred-silence frame;
+      its `publish!` `dispatch-sync`s into F — Order A,
+      (pre-fix) hold-silence-lock -> want-drain-lock.
+
+  Pre-fix (emit under the locks) this HANGS: both futures time out. The bounded
+  `deref` surfaces `::timeout` and the `(not= ::timeout ...)` assertions go RED
+  (verified: reverting `claim-and-publish` to the emit-under-lock shape wedges
+  both threads). Post-fix the emit runs outside the locks, so T2 takes
+  silence-lock freely, finishes its cold section, frees F's `:drain-lock`, and
+  T1's dispatch-sync then drains and returns — both futures COMPLETE (GREEN).
+
+  JVM-only by intent: `silence-lock` / `:drain-lock` are no-ops / uncontended on
+  the single CLJS thread. Run 2-core-pinned (`-J-XX:ActiveProcessorCount=2`) to
+  keep the interleave tight."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
+            [re-frame.epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- owe-silence!
+  "Register `cb`, observe `frame` under its current generation, then drop the
+  live observation so a delayed silence for `(frame, cb)` is genuinely owed —
+  exactly the state A's compare-owned cleanup leaves for a paused predecessor.
+  `claim-and-publish-delayed-silence!` for `(frame, cb)` then reaches `publish!`."
+  [frame token cb]
+  (rf/register-listener! :epoch cb (fn [_] nil))
+  (epoch-state/claim-frame-owner! frame token)
+  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+  (epoch-state/drop-frame-observation! frame))
+
+(defn- cb-generation [cb]
+  (:generation (get (epoch-state/listeners-snapshot) cb)))
+
+(deftest claim-and-publish-emit-into-a-dispatch-syncing-listener-does-not-deadlock-a-drain-lock-holder
+  ;; The regression: pre-fix HANGS (bounded-timeout -> RED), post-fix COMPLETES.
+  (let [drainee        :edl/drainee    ; live frame whose :drain-lock T2 holds
+        destroyed      :edl/destroyed  ; deferred-silence frame (epoch-state seam)
+        cb             ::edl-owed-cb    ; owed-silence subject (T1's claim)
+        other          ::edl-rearm-cb   ; Order-B silence-lock acquirer (drain-lock side)
+        token          (Object.)
+        t2-holds-drain (CountDownLatch. 1) ; T2 is inside its cold section, holding :drain-lock
+        t2-go          (CountDownLatch. 1) ; release T2 to take silence-lock
+        t1-in-publish  (CountDownLatch. 1) ; T1 reached publish! (pre-fix: ledger locks held)
+        await-s        (fn [^CountDownLatch l] (.await l (long 5) TimeUnit/SECONDS))]
+    (rf/make-frame {:id drainee :doc "drainee: holds :drain-lock, wants silence-lock"})
+    (rf/register-listener! :epoch other (fn [_] nil))
+    (let [other-gen (cb-generation other)]
+      (rf/reg-event :edl/probe (fn [{:keys [db]} _] {:db (assoc db :probed true)}))
+      ;; Owe a silence for (destroyed, cb) so T1's claim reaches publish!.
+      (owe-silence! destroyed token cb)
+      (try
+        (let [g  (cb-generation cb)
+              ;; T2: hold drainee's :drain-lock via a COLD serialized section
+              ;; (`:in-sync-drain?` stays unset, so T1's dispatch-sync reaches
+              ;; drain-block!), then take silence-lock via a genuine re-arm —
+              ;; Order B. `other` has not observed `drainee`, so this is a real
+              ;; transition that enters `with-silence-lock` (not the no-op).
+              t2 (future
+                   (frame/call-serialized-with-drain! drainee
+                     (fn []
+                       (.countDown t2-holds-drain)
+                       (await-s t2-go)
+                       (epoch-state/record-observation! other other-gen drainee))))]
+          (is (await-s t2-holds-drain)
+              "T2 holds the frame's :drain-lock (cold serialized section)")
+          (let [publish! (fn []
+                           ;; The blessed listener's `dispatch-sync` — into the
+                           ;; frame whose :drain-lock T2 holds, so it needs it.
+                           (.countDown t1-in-publish)
+                           (rf/dispatch-sync [:edl/probe] {:frame drainee}))
+                t1       (future (epoch-state/claim-and-publish-delayed-silence!
+                                   destroyed cb g 0 publish!))]
+            (is (await-s t1-in-publish)
+                "T1 reached the emit (pre-fix: still holding both ledger locks)")
+            ;; Release T2 to acquire silence-lock. Pre-fix T1 holds it -> T2 blocks
+            ;; while holding :drain-lock, and T1's dispatch-sync spins on
+            ;; :drain-lock -> AB-BA hard hang. Post-fix T1 holds no ledger lock ->
+            ;; T2 proceeds, frees :drain-lock, T1's dispatch-sync then completes.
+            (.countDown t2-go)
+            (let [t1-res (deref t1 8000 ::timeout)
+                  t2-res (deref t2 8000 ::timeout)]
+              (is (not= ::timeout t1-res)
+                  "claim-and-publish completed — the emit ran OUTSIDE the ledger locks (no ledger->drain-lock edge)")
+              (is (not= ::timeout t2-res)
+                  "the :drain-lock holder completed — no ledger<->:drain-lock deadlock")
+              (is (true? t1-res) "the silence was reserved+published"))))
+        (finally
+          (rf/unregister-listener! :epoch other)
+          (rf/unregister-listener! :epoch cb))))))

--- a/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
@@ -1,42 +1,44 @@
 (ns re-frame.epoch-silencing-generation-emission-test
-  "rf2-9bhne6 — the delayed-silence generation must stay AUTHORITATIVE THROUGH the
-  trace emission that publishes it.
+  "rf2-9bhne6 / rf2-8b9twg — the delayed-silence generation stays AUTHORITATIVE
+  through the trace emission that publishes it, WITHOUT holding a ledger lock
+  across the external fan-out.
 
-  ## The defect
+  ## Background
 
-  `on-frame-destroyed!` reserved a `(cb-id, generation)` silence under
-  `silence-lock`, RELEASED that lock, and only then called the external
-  `trace/emit!`. `put-listener!`, `drop-listener!`, `reset-listeners!` and the
-  observation re-arm in `record-observation!` did not participate in the lock at
-  all. So a registrar (a real JVM thread, or the deterministic seam these tests
-  drive) could replace generation G with a fresh generation H in the window
-  between the reservation and the emit. The unqualified `{:frame :cb-id}` silence
-  then fired for a cb whose current generation is H — a fresh generation that
-  never observed the destroyed frame. The forbidden ordering: H current FIRST,
-  THEN G's unqualified signal. The claim's three eligibility reads were likewise
-  not coherent against a concurrent registry mutation, because the lock excluded
-  those mutations.
+  rf2-9bhne6 kept the winning `(cb-id, observed-gen)` authoritative by running the
+  external `:rf.epoch.cb/silenced-on-frame-destroy` emit INSIDE both ledger locks
+  (`claim-and-publish-delayed-silence!` under `with-claim-locks`). That closed the
+  reserve→emit window in which a same-id replacement G→H could make a fresh
+  generation current before an UNQUALIFIED `{:frame :cb-id}` signal fired — but it
+  ran arbitrary listener code (which may `dispatch-sync` and acquire a frame's
+  `:drain-lock`) under the ledger locks, an AB-BA deadlock against a draining
+  thread (rf2-8b9twg; the dedicated regression lives in
+  `re-frame.epoch-silencing-emit-deadlock-test`).
 
-  ## The fix
+  ## The rf2-8b9twg mechanism (what these tests now pin)
 
-  `claim-and-publish-delayed-silence!` reserves AND runs the external emit inside
-  ONE `silence-lock` critical section, and `put-listener!` / `drop-listener!` /
-  `reset-listeners!` / the `record-observation!` re-arm now take that same lock.
-  So the winning `(cb-id, observed-gen)` stays authoritative through the emission
-  linearization point: a replacement in the reserve→emit window BLOCKS until
-  publication completes (silence linearized before H becomes current), or — if H
-  landed first — the eligibility recheck fails and no stale silence fires.
+  `claim-and-publish-delayed-silence!` reserves the mark under both ledger locks,
+  RELEASES them, then emits OUTSIDE them. Generation authority is preserved not by
+  the lock but by a DATA QUALIFIER: the emit carries `:observed-gen` (the reserved
+  generation G). A same-id replacement H landing in the reserve→emit window can no
+  longer be mistaken as the silence's subject — the signal is attributed to G, and
+  a receiver whose CURRENT generation for `cb-id` != the carried `:observed-gen`
+  SELF-FILTERS it. The forbidden ordering (H current, THEN a signal attributed to
+  H) is impossible: no unqualified signal is ever emitted.
 
-  JVM-only by intent (`silence-lock` is a no-op on the single CLJS thread; the
-  synchronous CLJS peers are covered by `re-frame.epoch-cljs-test`). The seam is
-  a `publish!` thunk that parks inside the critical section, letting a concurrent
-  registrar prove — via the lock — whether it can land before the emit.
+  Two invariants, both JVM-only (`silence-lock` / `registry-lock` are no-ops on
+  the single CLJS thread; the synchronous CLJS peers live in
+  `re-frame.epoch-cljs-test`):
 
-  Mutation teeth (red under the mutation, green with the fix):
-    * emit OUTSIDE the lock (the pre-fix shape) → a replacement lands in the
-      window → the sampled generation at emit is H, not G.
-    * drop `put-listener!` / `record-observation!` lock participation → the
-      mutation completes immediately instead of blocking on the held claim."
+    * TEST A — the emit runs OUTSIDE the ledger locks: while a claim's `publish!`
+      is parked, a concurrent `put-listener!` AND a concurrent `record-observation!`
+      re-arm complete IMMEDIATELY (they are NOT blocked). This is the direct
+      inverse of the old emit-under-lock behaviour and the unit-level proof that
+      the foreign-code-under-lock edge (the deadlock source) is gone.
+    * TEST B — the emitted signal is GENERATION-QUALIFIED: even when a same-id
+      replacement H lands DURING the emit window (concurrently, unblocked), the
+      wire signal carries `:observed-gen == G`, and the now-current generation is
+      H != G — so a receiver self-filters it. No G→H window is reopened."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
@@ -65,65 +67,16 @@
   (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
   (epoch-state/drop-frame-observation! frame))
 
-;; ---- generation authoritative THROUGH the emission -------------------------
+;; ---- TEST A: the emit runs OUTSIDE the ledger locks ------------------------
 
-(deftest generation-stays-authoritative-through-the-emission-linearization-point
-  ;; A registrar replaces cb's generation (G→H) in the window between the
-  ;; reservation and the external emit. Because `claim-and-publish` runs the emit
-  ;; INSIDE the same `silence-lock` section AND `put-listener!` participates in
-  ;; that lock, H cannot become current before G's signal is out: the registrar
-  ;; blocks until publication completes, so the generation sampled AT the emit is
-  ;; always G. TOOTH: emitting outside the lock lets H land first → sampled H.
-  (let [frame       :bhne6/thru-emit
-        cb          ::bhne6-thru-emit-cb
-        token       (Object.)
-        reached-emit (CountDownLatch. 1)
-        h-installed  (CountDownLatch. 1)
-        gen-at-emit  (atom ::unset)
-        published?   (atom ::unset)]
-    (owe-silence! frame token cb)
-    (try
-      (let [g        (cb-generation cb)
-            publish! (fn []
-                       ;; Inside the critical section, mark reserved. Signal the
-                       ;; registrar to attempt its replace, then wait (bounded)
-                       ;; for it to install H. Under the FIX the registrar's
-                       ;; put-listener! is blocked on the held lock, so this times
-                       ;; out and we sample G. Under an emit-outside-lock
-                       ;; regression H lands and we sample H.
-                       (.countDown reached-emit)
-                       (.await h-installed 1 TimeUnit/SECONDS)
-                       (reset! gen-at-emit (cb-generation cb)))
-            publisher (future
-                        (reset! published?
-                                (epoch-state/claim-and-publish-delayed-silence!
-                                  frame cb g 0 publish!)))
-            registrar (future
-                        (.await reached-emit 5 TimeUnit/SECONDS)
-                        ;; put-listener! participates in silence-lock → blocks
-                        ;; until the publisher releases it (after the emit).
-                        (rf/register-listener! :epoch cb (fn [_] nil))
-                        (.countDown h-installed))]
-        (is (not= ::timeout (deref publisher 5000 ::timeout)) "publisher completed")
-        (is (true? @published?) "the silence was published")
-        (is (= g @gen-at-emit)
-            "the winning generation G is still current at the emission point — a replacement could not land first")
-        (is (not= ::timeout (deref registrar 5000 ::timeout)) "registrar completed")
-        (is (not= g (cb-generation cb))
-            "the registrar's replacement H landed only AFTER publication completed"))
-      (finally
-        (rf/unregister-listener! :epoch cb)))))
-
-;; ---- registry + observation mutations serialize with the claim -------------
-
-(deftest registry-and-observation-mutations-serialize-with-the-silence-claim
-  ;; While a `claim-and-publish` holds `silence-lock` (parked in publish!), a
+(deftest emit-runs-outside-the-ledger-locks-so-a-concurrent-registrar-and-rearm-are-not-blocked
+  ;; While a `claim-and-publish` is parked in `publish!` (the external emit), a
   ;; concurrent registry replacement AND a concurrent observation re-arm both
-  ;; BLOCK until it releases. This is the coherence the eligibility reads rely on
-  ;; — no registry/observation mutation can interleave between the claim's
-  ;; individual reads. TEETH: dropping put-listener!'s (resp. record-observation!'s)
-  ;; lock lets the mutation complete immediately, so the "blocked" assertions
-  ;; flip.
+  ;; COMPLETE IMMEDIATELY — because the ledger locks were RELEASED before the emit
+  ;; (rf2-8b9twg). This is the inverse of rf2-9bhne6's emit-under-lock behaviour,
+  ;; and the unit-level proof that the fan-out reaches no ledger lock (so it can
+  ;; never invert against a frame's :drain-lock). TOOTH: putting the emit back
+  ;; under the locks re-blocks both mutations and flips these assertions to RED.
   (let [frame      :bhne6/serialize
         cb         ::bhne6-serialize-cb        ; the parked claim's subject
         other      ::bhne6-serialize-other     ; observation re-arm subject (owed)
@@ -135,7 +88,7 @@
         obs-done   (CountDownLatch. 1)]
     (owe-silence! frame token cb)
     ;; `other` also observes and is dropped, so a re-arm is a genuine transition
-    ;; that takes the lock (not the lock-free no-op fast path).
+    ;; that takes silence-lock (not the lock-free no-op fast path).
     (rf/register-listener! :epoch other (fn [_] nil))
     (epoch.listeners/notify-listeners! {:frame frame :epoch-id 2})
     (epoch-state/drop-frame-observation! frame)
@@ -154,20 +107,83 @@
             observer  (future (.await in-claim 5 TimeUnit/SECONDS)
                               (epoch-state/record-observation! other other-gen frame)
                               (.countDown obs-done))]
-        (is (.await in-claim 5 TimeUnit/SECONDS) "the claim is parked inside silence-lock")
-        (is (false? (.await put-done 500 TimeUnit/MILLISECONDS))
-            "put-listener! is blocked on silence-lock while the claim holds it")
-        (is (false? (.await obs-done 500 TimeUnit/MILLISECONDS))
-            "the record-observation! re-arm is blocked on silence-lock too")
+        (is (.await in-claim 5 TimeUnit/SECONDS) "the claim is parked inside publish!")
+        ;; The rf2-8b9twg guarantee: NO ledger lock is held during the emit, so
+        ;; both mutations proceed at once. (Under the pre-fix emit-under-lock code
+        ;; these awaits return false — the mutations block until `release`.)
+        (is (.await put-done 2 TimeUnit/SECONDS)
+            "put-listener! is NOT blocked — the emit holds no registry lock")
+        (is (.await obs-done 2 TimeUnit/SECONDS)
+            "the record-observation! re-arm is NOT blocked — the emit holds no silence-lock")
         (.countDown release)
         (is (not= ::timeout (deref claimer 5000 ::timeout)) "the claim completed")
-        (is (.await put-done 5000 TimeUnit/MILLISECONDS)
-            "put-listener! completes once the claim releases the lock")
-        (is (.await obs-done 5000 TimeUnit/MILLISECONDS)
-            "record-observation! completes once the claim releases the lock")
         (is (not= ::timeout (deref registrar 5000 ::timeout)) "registrar completed")
         (is (not= ::timeout (deref observer 5000 ::timeout)) "observer completed"))
       (finally
         (rf/unregister-listener! :epoch cb)
         (rf/unregister-listener! :epoch other)
         (rf/unregister-listener! :epoch reg-target)))))
+
+;; ---- TEST B: the emitted signal is generation-qualified --------------------
+
+(deftest silence-signal-is-generation-qualified-and-self-filters-a-replacement-in-the-emit-window
+  ;; A registrar replaces cb's generation (G→H) DURING the emit window — and,
+  ;; because the emit now runs outside the locks, it is NOT blocked, so H DOES
+  ;; become current before the emit returns. Yet the wire signal carries
+  ;; `:observed-gen == G` (the reserved generation, baked into the payload before
+  ;; the fan-out), and the current generation is H != G — so a receiver's
+  ;; `current-gen == observed-gen?` check drops it. The signal is attributed to G,
+  ;; never to H: no G→H window is reopened (rf2-8b9twg supersedes the
+  ;; emit-under-lock mechanism of rf2-9bhne6). TOOTH: dropping `:observed-gen` from
+  ;; the payload (the unqualified signal) removes the discriminator entirely.
+  (let [frame        :bhne6/thru-emit
+        cb           ::bhne6-thru-emit-cb
+        token        (Object.)
+        reached-emit (CountDownLatch. 1)  ; the silence emit reached the trace listener
+        h-installed  (CountDownLatch. 1)  ; the registrar's replacement H is current
+        captured     (atom [])            ; every silence event seen for cb
+        silence-key  ::bhne6-thru-emit-silencing]
+    ;; Register cb and let it OBSERVE the frame so the destroy snapshot owes it a
+    ;; silence under generation G (the real listeners path bakes G onto the wire).
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (epoch-state/claim-frame-owner! frame token)
+    (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+    ;; The trace listener captures the silence AND parks the emit open (outside the
+    ;; locks) so a concurrent registrar can land H before the emit returns.
+    (rf/register-listener! :trace silence-key
+      (fn [ev]
+        (when (and (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
+                   (= cb (:cb-id (:tags ev))))
+          (swap! captured conj (:tags ev))
+          (.countDown reached-emit)
+          (.await h-installed 5 TimeUnit/SECONDS))))
+    (try
+      (let [g   (cb-generation cb)
+            ;; Snapshot the terminal evidence WHILE cb still observes, so the
+            ;; per-identity claim owes cb→G. `on-frame-destroyed!` then drops the
+            ;; observation (compare-owned cleanup), reserves under the locks,
+            ;; releases, and emits the generation-qualified signal.
+            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            registrar (future
+                        (.await reached-emit 5 TimeUnit/SECONDS)
+                        ;; put-listener! is NOT blocked (the emit holds no lock),
+                        ;; so H becomes current DURING the emit window.
+                        (rf/register-listener! :epoch cb (fn [_] nil))
+                        (.countDown h-installed))
+            ;; Runs the real emit; blocks (in the trace listener) until H lands.
+            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+        (is (not= ::timeout (deref registrar 5000 ::timeout))
+            "the registrar installed H — put-listener! was not blocked by the emit")
+        (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")
+        (is (= 1 (count @captured)) "exactly one silence fired for cb")
+        (let [tags (first @captured)]
+          (is (= g (:observed-gen tags))
+              "the wire signal carries the RESERVED generation G, not the replacement H")
+          (is (= frame (:frame tags)) "and the frame it was silenced for")
+          (is (not= g (cb-generation cb))
+              "H became current DURING the emit window (the emit did not block the registrar)")
+          (is (not= (:observed-gen tags) (cb-generation cb))
+              "current-gen != carried observed-gen — a receiver SELF-FILTERS this stale signal (no G→H window)")))
+      (finally
+        (rf/unregister-listener! :epoch cb)
+        (rf/unregister-listener! :trace silence-key)))))


### PR DESCRIPTION
Closes rf2-8b9twg. Authoritative source: `ai/findings/2026-07-17-review-epoch-trace.md` (the #6051 adversarial audit).

## The deadlock

#6051 (rf2-9bhne6) moved the external `:rf.epoch.cb/silenced-on-frame-destroy` emit **inside** both ledger locks (`claim-and-publish-delayed-silence!` ran `publish!` under `with-claim-locks` = registry-lock + silence-lock) to keep the delayed-silence generation authoritative through emission. But `publish!` fans a `trace/emit!` to arbitrary listeners, and a framework-blessed listener may `dispatch-sync` (the rf2-1zxlsm contract; Xray dispatch-syncs from its collector) — entering `drain-block!`, which spin-CAS-acquires a frame's `:drain-lock`.

- **Order A (new):** hold `silence-lock` → want `:drain-lock`.
- **Order B (every-settle / cold-serialized / async drainer):** hold a frame's `:drain-lock` → acquire `silence-lock` (via a `record-observation!` re-arm, or a `call-serialized-with-drain!` section running the destroy recipe).

AB–BA hard hang. #6051's deadlock-freedom docstring reasoned only about `frame-owner-lock` and never `:drain-lock`, so it was **unsound**. JVM/dev-only (CLJS locks are no-ops; the silence path is `interop/debug-enabled?`-gated) → a CI/dev hang, not production.

## The fix

`claim-and-publish-delayed-silence!` now **reserves the mark under both ledger locks, releases them, then emits OUTSIDE them**. Generation authority is preserved not by holding a lock across foreign code but by a **data qualifier**: the emit carries `:observed-gen` (the reserved generation G). A same-id replacement H landing in the reserve→emit window can no longer be mistaken as the silence's subject — the signal is attributed to G, and a receiver whose current generation for `cb-id` ≠ the carried `:observed-gen` **self-filters** it. No path holds a ledger lock while the emit fans to a listener that can acquire `:drain-lock`, so the cycle cannot form. Rollback-on-throw re-acquires `silence-lock` alone (registry→silence order preserved).

Deadlock-freedom docstrings (`state.cljc` / `listeners.cljc`) corrected to enumerate `:drain-lock`/router; the stale reserve-only docstrings refreshed.

**Subtlety pinned in the regression:** the deadlock target frame's `:drain-lock` must be held by a path that does NOT set `:in-sync-drain?` (a cold `call-serialized-with-drain!` section, or an async drainer). A concurrent `dispatch-sync` into a *sync*-draining frame is rejected as `:rf.error/dispatch-sync-in-handler` and never reaches `drain-block!`, so a sync-drained frame cannot be the target.

## P1-escalation check

No first-party JVM trace/epoch listener `dispatch-sync`s during trace emit. Story's `:epoch` listener runs `on-epoch!` (never throws, no dispatch-sync); Xray's collector dispatch-syncs but is CLJS-only (no-op locks). The deadlock needs a **third-party** JVM listener → stays **P2** (not escalated).

## Wire-shape note (follow-up)

The emitted signal gains an additive `:observed-gen` tag key. The documented `:tags {:frame :cb-id}` shape lives in hot-zone files (`spec/009-Instrumentation.md`, `spec/API.md`, `spec/Tool-Pair.md`, `spec/Conventions.md`, `spec/Spec-Schemas.md`) and is out of this PR's epoch surface — a small sequential hot-zone spec touch should follow. No closed schema gates the tags (verified), so this PR stays green.

## Quality gates

Run 2-core-pinned (`-J-XX:ActiveProcessorCount=2`), foreground/unpiped.

**Proof (1) — deadlock regression (`epoch_silencing_emit_deadlock_test.clj`, NEW):** drives `claim-and-publish` emit (via `publish!` `dispatch-sync`) into the frame a second thread holds the `:drain-lock` of, whose cold section takes `silence-lock` via a genuine re-arm.
- **RED before the fix** — reverting `claim-and-publish` to the emit-under-lock shape wedges both threads; the bounded 8s `deref`s return `::timeout` (verified via a standalone driver: `*** DEADLOCK REPRODUCED (timeout) ***`).
- **GREEN after** — both futures complete; `claim-and-publish` returns true.

**Proof (2) — #6051 generation-authority barrier tests still pass (no G→H window reopened)** — `epoch_silencing_generation_emission_test.clj`, reframed to the new mechanism:
- Test A: while `publish!` is parked, a concurrent `put-listener!` and `record-observation!` re-arm complete immediately (NOT blocked) — the emit holds no ledger lock (inverse of the old emit-under-lock behaviour).
- Test B: a replacement H lands concurrently during the emit window (unblocked); the wire signal carries `:observed-gen == G` and current gen == H ≠ G, so a receiver self-filters it.

Gate results (all foreground):
- `implementation/epoch` `clojure -M:test` (2-core-pinned): **408 tests, 6090 assertions, 0 failures** — completes, no hang (includes the concurrency stress).
- New deadlock + reframed emission tests: **3 tests, 18 assertions, 0 failures**.
- `epoch-silencing-lineage-285` + `-aba`: **14 tests, 3627 assertions, 0 failures**.
- `npm run test:cljs`: **9689 tests, 47668 assertions, 0 failures**.

Did not run `test:browser` or the full spine (per brief).
