### PR TITLE
fix(epoch): clean exact-owner stores on destroy even when snapshot evidence is nil (rf2-hclxos)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -391,10 +391,16 @@
 
   The id-keyed store DROP is compare-owned (`state/cleanup-frame-owner!`): it
   runs only while `owner-token` still owns the stores, so stale A can never
-  erase a fresh same-id B. PUBLICATION of A's already-snapshotted terminal
-  record and its structural trailers is INDEPENDENT of winning that comparison —
-  the evidence was bound to A's exact incarnation before dissoc and is A's to
-  deliver whether or not A still owns the stores (rf2-vxgfnd.151). Live
+  erase a fresh same-id B. That drop runs UNCONDITIONALLY of terminal-evidence —
+  cleanup authority is the frame-id + owner-token, not the snapshot bundle — so a
+  throwing pre-dissoc snapshot hook (nil terminal-evidence, PR #5939) still frees
+  A's history / buffer / observation / last-settled-epoch / mount attribution and
+  no same-id successor inherits them (rf2-hclxos). PUBLICATION of A's already-
+  snapshotted terminal record and its structural trailers is INDEPENDENT of
+  winning that comparison AND conditional on a non-nil bundle — the evidence was
+  bound to A's exact incarnation before dissoc and is A's to deliver whether or
+  not A still owns the stores (rf2-vxgfnd.151); a nil bundle bound nothing and
+  publishes nothing. Live
   observation is re-read INSIDE each per-identity claim AFTER the compare-owned
   cleanup, so a winning cleanup has already dropped this incarnation's own stamps
   while a losing one leaves the successor's — exactly the re-arm evidence the
@@ -410,37 +416,48 @@
                          frame-id fs-before fs-after committed-at)))
   ([frame-id owner-token terminal-evidence]
    ;; Sole-condition `interop/debug-enabled?` gate so :advanced + goog.DEBUG=false
-   ;; dead-code-eliminates this whole publish path (Spec 009 §Production builds);
-   ;; the nil-bundle check nests INSIDE it, never folded into the gate condition.
-   ;; A non-nil bundle means `snapshot-terminal-destroy-evidence!` participated
-   ;; (debug on) and opened the deferred-silence window; that is the exact
-   ;; condition under which we must publish AND close it. A nil bundle (no epoch
-   ;; layer) opened nothing and has nothing to publish.
+   ;; dead-code-eliminates this whole path (Spec 009 §Production builds). Two
+   ;; concerns split INSIDE the gate: (1) exact-owner STORE CLEANUP runs
+   ;; UNCONDITIONALLY of terminal-evidence; (2) terminal-record/silencing
+   ;; PUBLICATION stays conditional on a non-nil bundle. Neither is folded into
+   ;; the gate condition itself.
    (when interop/debug-enabled?
+     ;; (1) EXACT-OWNER STORE CLEANUP — runs whether or not terminal-evidence is
+     ;; nil. Cleanup authority is the frame-id + owner-token, NOT the snapshot
+     ;; bundle: a throwing `:epoch/snapshot-frame-destroyed` hook yields nil
+     ;; terminal-evidence (frame.cljc converts the throw to nil — PR #5939), but the
+     ;; destroyed incarnation's id-keyed stores must STILL be dropped or a same-id
+     ;; successor B inherits A's history / buffer / observation / last-settled-epoch
+     ;; / mount attribution (rf2-hclxos). The drop stays compare-owned
+     ;; (`cleanup-frame-owner!`): A erases ONLY its own stores while `owner-token`
+     ;; still owns them, so a stale A that lost the comparison to a claimed same-id
+     ;; B no-ops and leaves B untouched (fail-closed, no cross-incarnation wipe).
+     ;; The return value is intentionally ignored for the silencing decision below —
+     ;; winning this comparison is NOT the same fact as "no successor re-armed the
+     ;; observers" (a claim without delivery loses it; a re-arm-then-destroy wins
+     ;; it), which the per-identity claim resolves precisely.
+     (state/cleanup-frame-owner!
+       frame-id owner-token
+       (fn []
+         ;; Data-only exact-owner transaction: no external callback runs
+         ;; between owner comparison and the complete drop.
+         (state/drop-frame-observation! frame-id)
+         (state/drop-frame-history! frame-id)
+         (state/drop-frame-buffer! frame-id)
+         (state/drop-last-settled-epoch! frame-id)
+         (state/drop-frame-mount-attribution! frame-id)
+         true))
+     ;; (2) TERMINAL-RECORD + SILENCING PUBLICATION — conditional on a non-nil
+     ;; bundle. A non-nil bundle means `snapshot-terminal-destroy-evidence!`
+     ;; participated (debug on) and opened the deferred-silence window; that is the
+     ;; exact condition under which we must publish AND close it. A nil bundle (the
+     ;; snapshot hook threw, or no epoch layer) opened no window and bound no
+     ;; evidence — it publishes and fabricates nothing (#5939), yet the store
+     ;; cleanup above already ran.
      (when terminal-evidence
        (try
         (let [{:keys [record listener-snapshot silenced-cbs baseline-silence-seq]}
               terminal-evidence]
-         ;; Compare-owned store drop: A erases ONLY its own id-keyed stores. If a
-         ;; same-id B has already claimed them, this no-ops and leaves B untouched.
-         ;; The return value is intentionally ignored for the silencing decision —
-         ;; winning this comparison is NOT the same fact as "no successor re-armed
-         ;; the observers" (a claim without delivery loses it; a re-arm-then-destroy
-         ;; wins it), which the per-identity claim below resolves precisely. The
-         ;; DROP itself still runs here so a winning A frees its stores (and leaves
-         ;; the live observation ledger showing the successor's re-arm evidence
-         ;; when A loses).
-         (state/cleanup-frame-owner!
-           frame-id owner-token
-           (fn []
-             ;; Data-only exact-owner transaction: no external callback runs
-             ;; between owner comparison and the complete drop.
-             (state/drop-frame-observation! frame-id)
-             (state/drop-frame-history! frame-id)
-             (state/drop-frame-buffer! frame-id)
-             (state/drop-last-settled-epoch! frame-id)
-             (state/drop-frame-mount-attribution! frame-id)
-             true))
          ;; Publish A's terminal RECORD + trailers regardless of the cleanup
          ;; comparison — the evidence was snapshotted before dissoc and belongs to
          ;; A's incarnation (rf2-vxgfnd.151). A late predecessor terminal record may

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -4007,6 +4007,96 @@
       (is (zero? (reduce + 0 (map count (vals (state/terminal-silence-marks-snapshot)))))
           "a nil bundle opens no deferred-silence window — no mark accreted (bounded)"))))
 
+;; ---- rf2-hclxos — nil terminal-evidence STILL cleans the exact-owner stores ----
+;;
+;; PR #5939 made a nil terminal-evidence bundle PUBLISH nothing when the pre-dissoc
+;; `:epoch/snapshot-frame-destroyed` hook throws (frame.cljc converts the throw to
+;; nil). But cleanup authority comes SEPARATELY from the frame-id + owner-token, so
+;; `on-frame-destroyed!` must still DROP the destroyed incarnation's id-keyed stores
+;; even when the bundle is nil. Before the fix the exact-owner `cleanup-frame-owner!`
+;; transaction nested INSIDE `(when terminal-evidence ...)`, so a snapshot failure
+;; suppressed cleanup too and a same-id successor B inherited A's history /
+;; observation / buffer / last-settled-epoch / mount attribution.
+;;
+;; This regression drives the throwing-snapshot repro through the FULL destroy path
+;; and proves: (1) the destroyed id's public history is [] after destroy; (2) a
+;; same-id successor B, BEFORE its first epoch, inherits none of A's records (no
+;; `[:audit/seed]`, distinct token); (3) the #5939 non-fabrication invariant still
+;; holds — no `:halted-destroy` record, no owed silence, no accreted mark. The
+;; sibling #5939 (`terminal-publish-noops-on-nil-bundle-no-fabrication`) and #5956
+;; integrated fixtures never READ destroyed / pre-first-epoch successor history; this
+;; one does. Reverting the cleanup beneath the evidence guard fails assertion (1).
+
+(deftest destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil
+  (testing "a throwing :epoch/snapshot-frame-destroyed hook yields nil terminal-
+            evidence (#5939), but the destroyed incarnation's id-keyed epoch stores
+            are STILL dropped — cleanup authority is the frame-id + owner-token, not
+            the snapshot bundle — so a same-id successor B inherits nothing (rf2-hclxos)"
+    (let [id            :test/nil-evidence-cleanup
+          cb            ::nil-evidence-cb
+          records       (atom [])
+          traces        (record-trace!)
+          original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+      (rf/make-frame {:id id})
+      (rf/reg-event :seed (fn [_ _] {:db {:audit/seed :from-A}}))
+      ;; cb OBSERVES A: delivery of the settled :seed record stamps its observation
+      ;; of the frame, so a FABRICATING publish would have a real observer to
+      ;; (wrongly) silence — making the non-fabrication assertion meaningful.
+      (rf/register-listener! :epoch cb (fn [r] (swap! records conj r)))
+      (rf/dispatch-sync [:seed] {:frame id})
+      (reset! records [])                          ; drop the :seed :ok record
+      (let [a-token (frame/frame-incarnation-token id)]
+        ;; A settled one epoch: its id-keyed history holds the [:audit/seed] record.
+        (is (= 1 (count (rf/epoch-history id)))
+            "A settled one epoch before destroy")
+        (is (= :from-A (get-in (first (rf/epoch-history id)) [:db-after :audit/seed]))
+            "A's settled record carries [:audit/seed] :from-A")
+        (try
+          ;; Fail the PRE-dissoc snapshot for this id (delegate every other id):
+          ;; destroy-frame! converts the throw to nil terminal-evidence and threads
+          ;; it to on-frame-destroyed! (#5939). Teardown is best-effort — it does
+          ;; NOT abort — so destroy-frame! returns normally.
+          (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+            (fn [& args]
+              (if (= id (first args))
+                (throw (ex-info "snapshot blew" {:why :test}))
+                (when original-snap (apply original-snap args)))))
+          (rf/destroy-frame! id)
+
+          ;; (1) EXACT-OWNER STORE CLEANUP ran despite the nil bundle — the destroyed
+          ;;     id's history is [] (it still equalled A's [:audit/seed] before fix).
+          (is (= [] (rf/epoch-history id))
+              "destroyed id's epoch-history is [] even though the snapshot threw")
+          (is (nil? (frame/frame-incarnation-token id))
+              "A is fully destroyed — no live incarnation owns the id")
+
+          ;; (2) #5939 NON-FABRICATION still holds: the nil bundle publishes nothing.
+          (is (empty? (filterv #(= :halted-destroy (:outcome %)) @records))
+              "no :halted-destroy record is fabricated from the nil bundle")
+          (is (empty? (filterv #(= :rf.epoch.cb/silenced-on-frame-destroy
+                                    (:operation %))
+                               @traces))
+              "no silencing fires — the snapshot that would have owed it produced nothing")
+          (is (zero? (reduce + 0 (map count
+                                      (vals (state/terminal-silence-marks-snapshot)))))
+              "a nil bundle opens no deferred-silence window — no mark accreted (bounded)")
+
+          ;; (3) SAME-ID SUCCESSOR B, BEFORE its first epoch, inherits nothing.
+          (rf/make-frame {:id id})
+          (let [b-token (frame/frame-incarnation-token id)]
+            (is (some? b-token) "same-id B is live after A's destroy")
+            (is (not= a-token b-token)
+                "B is a FRESH incarnation — distinct token from destroyed A")
+            (is (= [] (rf/epoch-history id))
+                "same-id B exposes no A history before its first epoch")
+            (is (not-any? #(= :from-A (get-in % [:db-after :audit/seed]))
+                          (rf/epoch-history id))
+                "B carries none of A's [:audit/seed] records"))
+          (finally
+            (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
+            (when (frame/frame id) (rf/destroy-frame! id))
+            (rf/unregister-listener! :epoch cb)))))))
+
 ;; ---- capture-buffer cross-contamination from out-of-drain emits -----------
 ;;
 ;; The `capture-event!` fn must skip every `:rf.epoch/*` op the namespace


### PR DESCRIPTION
## The defect

`re-frame.epoch.listeners/on-frame-destroyed!` nested the exact-owner
`state/cleanup-frame-owner!` transaction inside `(when terminal-evidence ...)`
(`implementation/epoch/src/re_frame/epoch/listeners.cljc`, the 3-arity body).
PR #5939 converts a throwing pre-dissoc `:epoch/snapshot-frame-destroyed` hook
to nil `terminal-evidence` in `frame.cljc` (correct). But because cleanup was
nested under the evidence guard, a snapshot failure suppressed not just
fabrication of a terminal record but **also** cleanup of the destroyed
incarnation's id-keyed history / buffer / observation / last-settled-epoch /
mount attribution. A same-id successor B inherited destroyed A's stores:
`rf/epoch-history` for the id still equalled A's history, and B exposed A's
`[:audit/seed]` record before its first epoch.

## The fix — cleanup / publish split

Cleanup authority comes from the frame-id + owner-token, not from
`terminal-evidence`. `on-frame-destroyed!` now runs the exact-owner store
cleanup **unconditionally** (still inside the `interop/debug-enabled?` gate,
still compare-owned via `cleanup-frame-owner!` — fail-closed, exact-incarnation
guarded, so a stale predecessor that lost the comparison to a claimed same-id B
no-ops and never wipes B). Publication of the terminal record + per-identity
silencing (and the paired `close-silence-lineage!` in the `finally`) stays
conditional on a non-nil bundle, because only a non-nil bundle opened the
deferred-silence window. `frame.cljc`'s throwing-hook -> nil conversion is
unchanged.

## Incarnation-isolation proof

Added `destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil` to
`implementation/epoch/test/re_frame/epoch_test.clj`. It drives the throwing
`:epoch/snapshot-frame-destroyed` repro through the full `destroy-frame!` path
and asserts: (1) the destroyed id's `rf/epoch-history` is `[]` after destroy;
(2) a same-id successor B, before its first epoch, inherits none of A's records
(no `[:audit/seed]`, distinct incarnation token); (3) the #5939 non-fabrication
invariant still holds — no `:halted-destroy` record, no owed silence, no
accreted deferred-silence mark. Under the old nesting the 3 store-leak
assertions fail while the #5939 assertions stay green; after the fix all 11
assertions pass.

## Invariants

- #5939 (nil-bundle publishes/fabricates nothing) — still holds; publication
  stays evidence-gated. Sibling `terminal-publish-noops-on-nil-bundle-no-fabrication`
  and the core integrated peer remain green.
- #6085 / rf2-8b9twg (emit-outside-locks, `:observed-gen`) — the hoisted
  cleanup-fn is data-only and uses the `frame-owner-lock`, not the ledger locks,
  so no ledger lock is held across an external emit. The epoch concurrency stress
  completes (no hang).

## Quality gates

- `implementation/epoch` JVM (`clojure -M:test`): 409 tests, 6101 assertions, 0 failures, 0 errors (concurrency stress completed).
- `npm run test:cljs`: 9691 tests, 47673 assertions, 0 failures, 0 errors.
- Fail-before/pass-after: the new regression fails the 3 store-leak assertions under the old nesting, passes after the split.

Closes rf2-hclxos.
