### PR TITLE
fix(ui): reject malformed letfn* bindings through the typed compiler surface (rf2-rgqn9)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -79,6 +79,22 @@
 (defn- fn-form? [f]
   (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
 
+(defn- fn-init-shape?
+  "True when `init` is a structurally well-formed fn/fn* form — the only legal
+  shape for a HOST letfn* binding initializer. Bounded grammar check, not a full
+  semantic one: it guards `rw-fn` against a malformed body (a non-vector arity
+  otherwise throws a raw host `Don't know how to create ISeq` exception) and
+  rejects a non-fn initializer such as a bare `42` up front. Accepted shapes are
+  `(fn <name>? [argv] body*)` (single arity) and `(fn <name>? ([argv] body*)+)`
+  (one or more arity lists); every argv MUST be a vector."
+  [init]
+  (and (fn-form? init)
+       (let [tail (cond-> (rest init) (symbol? (second init)) rest)]
+         (cond
+           (vector? (first tail)) true
+           (seq tail)             (every? #(and (seq? %) (vector? (first %))) tail)
+           :else                  false))))
+
 (defn- raw-form? [e f]  (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fqns)))
 (defn- html-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-html-fqns)))
 (defn- raw-fn-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fn-fqns)))
@@ -625,10 +641,24 @@
                             {:form f})
                  (let [pairs (partition 2 bindings)
                        names (map first pairs)]
-                   (when-not (every? symbol? names)
-                     (env/fail! e :rf.ui.compile/bad-let
-                                "letfn* binding names must be symbols"
-                                {:form f}))
+                   ;; Bound the flat grammar BEFORE blindly rewriting each
+                   ;; initializer: a name must be a simple (unqualified) symbol
+                   ;; — the host only defaults simple-symbol locals — and each
+                   ;; initializer must be a well-formed fn/fn* form, else a bare
+                   ;; value (e.g. `42`) slips through to the host compiler and a
+                   ;; malformed arity throws a raw ISeq exception inside rw-fn.
+                   (doseq [[nm init] pairs]
+                     (when-not (simple-symbol? nm)
+                       (env/fail! e :rf.ui.compile/bad-let
+                                  (str "letfn* binding names must be simple "
+                                       "(unqualified) symbols; got " (pr-str nm))
+                                  {:form f}))
+                     (when-not (fn-init-shape? init)
+                       (env/fail! e :rf.ui.compile/bad-let
+                                  (str "each letfn* initializer must be a fn/fn* "
+                                       "form with a [argv] body or ([argv] body …) "
+                                       "arity lists; got " (pr-str init))
+                                  {:form f})))
                    (let [scope     (into locals names)
                          bindings* (with-same-meta
                                      bindings

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -448,7 +448,21 @@
           (ana-full '[:div {:title (letfn* [sub (fn* sub ([x] x))] (sub 3))}])]
       (is (empty? (:subs sites)) "the shadowed sub mints no reactive site")
       (is (= '(letfn* [sub (fn* sub ([x] x))] (sub 3))
-             (get-in ast [:props :attrs 0 :value]))))))
+             (get-in ast [:props :attrs 0 :value])))))
+  (testing "rf2-rgqn9 — single-arity and multi-arity fn* initializers are legal"
+    ;; The bounded shape validator must permit BOTH the `[argv] body` single
+    ;; arity and the `([argv] body …)` arity-list forms — not only the named
+    ;; multi-arity shape the earlier fixtures used.
+    (let [{:keys [ast sites]}
+          (ana-full '[:div {:title (letfn* [f (fn* [x] x)
+                                            g (fn* ([] 0) ([x] x))]
+                                     (f (g)))}])]
+      (is (empty? (:subs sites)))
+      (is (= '(letfn* [f (fn* [x] x)
+                       g (fn* ([] 0) ([x] x))]
+                (f (g)))
+             (get-in ast [:props :attrs 0 :value]))
+          "flat bindings with single- and multi-arity fn* initializers are kept verbatim"))))
 
 (deftest legitimate-value-flow-still-compiles
   ;; rf2-vxgfnd.252 — the escape guard rejects ONLY bare reactive authoring

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -383,6 +383,19 @@
   (is (= :rf.ui.compile/bad-let
          (reject-id '[:div {:title (letfn* [42 (fn* _ ([x] x))] 1)}]))
       "non-symbol binding name -> typed bad-let")
+  ;; rf2-rgqn9 — the flat-binding validator checked only vector parity + symbol?
+  ;; then blindly rewrote each initializer, so these three slipped through the
+  ;; typed surface (a bare value / qualified name were ACCEPTED and only failed
+  ;; in the later host compiler; a malformed fn* threw a raw ISeq exception).
+  (is (= :rf.ui.compile/bad-let
+         (reject-id '[:div {:title (letfn* [f 42] f)}]))
+      "a bare non-fn initializer -> typed bad-let (never accepted then host-failed)")
+  (is (= :rf.ui.compile/bad-let
+         (reject-id '[:div {:title (letfn* [f (fn* 42)] f)}]))
+      "a malformed fn* arity -> typed bad-let (never a raw IllegalArgumentException)")
+  (is (= :rf.ui.compile/bad-let
+         (reject-id '[:div {:title (letfn* [foo/bar (fn* [] 1)] foo/bar)}]))
+      "a qualified binding name -> typed bad-let (host rejects qualified locals)")
   (is (= :rf.ui.compile/sub-in-loop
          (reject-id '[:div {:title (letfn* [f (fn* f ([x] (sub [:q])))] (f 7))}]))
       "a reactive read inside a deferred local fn body is not a finite render site"))


### PR DESCRIPTION
## Summary

The re-frame.ui compiler's `rw-letfn*` flat-binding validator (in `implementation/ui/src/re_frame/ui/compiler/analyze.cljc`) checked only vector parity plus `symbol?`, then blindly rewrote each initializer. Three malformed `letfn*` shapes escaped the typed reject surface required by rf2-vxgfnd.221:

- `(letfn* [f 42] f)` â€” a bare non-fn initializer was **accepted** and failed later in the host compiler.
- `(letfn* [f (fn* 42)] f)` â€” a malformed `fn*` arity threw a **raw `IllegalArgumentException`** ("Don't know how to create ISeq from: java.lang.Long") from `rw-fn-arity` during analysis.
- `(letfn* [foo/bar (fn* [] 1)] foo/bar)` â€” a **qualified** binding name was accepted even though the host rejects qualified locals.

## Fix

`rw-letfn*` now bounds the flat grammar **before** recursive rewriting: each name must be a simple (unqualified) symbol and each initializer a well-formed `fn`/`fn*` form, both failing deterministically through the existing `:rf.ui.compile/bad-let` with useful guidance. A local `fn-init-shape?` predicate performs the bounded structural check (`(fn <name>? [argv] body*)` or `(fn <name>? ([argv] body*)+)`, every argv a vector). `simple-symbol?` collapses the non-symbol and qualified-name rejections into one predicate.

No new error id, no special-form roster, no grammar framework â€” the fix stays local per the held rf2-vxgfnd.224 ruling.

Legal flat `letfn*` forms retain exact shape, mutual recursion, local shadowing, outer-site lowering, and deferred-body rejection (all pre-existing accept/reject fixtures unchanged).

## Tests

- `analyze-reject` gains falsifiers for `[f 42]`, `(fn* 42)`, and a qualified name â€” each now `:rf.ui.compile/bad-let`.
- `analyze-accept` gains a single-arity + multi-arity `fn*` initializer case, guarding that the shape validator permits non-list arities.

## Quality gates

Functional gates (re-confirmed after rebase onto latest `origin/main`):

- `implementation/ui` JVM (`clojure -M:test`): 667 tests, 13349 assertions, 0 failures, 0 errors.
- `npm run test:cljs` (compiler is core-reachable): 9691 tests, 47678 assertions, 0 failures, 0 errors.

Failing-before / passing-after verified directly against the three counterexamples: all three escaped the typed surface on current main (two accepted, one raw `IllegalArgumentException`); all three now reject with `:rf.ui.compile/bad-let`, while the well-formed control still compiles.

### Lint gate — root cause: concurrency-cancellation, not a real lint error

The red `Lint required` on the prior push was a **stale-run / concurrency-cancellation artifact**, not a clj-kondo/Splint finding. `lint.yml` uses `concurrency: cancel-in-progress: true`; a newer run superseded the branch's older run and **cancelled all four upstream lint jobs** (`detect`, `clj-kondo`, `splint`, `api-manifest`). The `Lint required` aggregator runs `if: always()` and its `needs.*.result` was `cancelled, cancelled, cancelled, cancelled` -> `exit 1`. The failed job log confirms this literally (`needs results: cancelled, cancelled, cancelled, cancelled`) — no linter reported a diagnostic.

Local verification on the rebased diff:

- `clj-kondo --fail-level error` on all three changed files: **errors: 0** (exit 0). The 7 informational warnings are all at unrelated pre-existing lines (1441/1728/2029/2053/2099 + two single-file-lint unresolved-namespace artifacts in the test); **none fall inside the `letfn*` diff** (hunks at ~L79–101 and ~L641–665, both warning-free).
- Splint fails only on parse errors; the diff is valid Clojure (tests pass), so no parse error.
- `api-manifest` cannot drift: the change is a private compiler internal — no public var, `spec/API.md`, or manifest touched.

Fix: rebased the branch onto latest `origin/main` (was 5 commits behind; clean rebase, no conflicts — the main commits do not touch `analyze.cljc`) and force-pushed. This spawns a fresh, uncancelled lint run that goes green.
