### PR TITLE
docs(spec): remove stale render app-db grammar from active Spec 004C (rf2-p9mmd)

### DIFF
--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -492,9 +492,9 @@ server in sight (guide 01):
 `(ui.test/render root-or-view opts)` accepts exactly two forms:
 
 1. **A view reference** (compile-resolved Var/symbol of a `defview`). Props ride
-   `{:props p}`. Frames ride `{:frame f}` XOR `{:app-db v}` (test frame minted); with
-   neither, structural rendering proceeds and any `sub` raises
-   `:rf.error/no-frame-context` — honest, not defaulted.
+   `{:props p}`. A frame rides `{:frame f}` — mint it with `rf/make-frame` +
+   `:initial-events`; with no frame, structural rendering proceeds and any `sub`
+   raises `:rf.error/no-frame-context` — honest, not defaulted.
 2. **A literal root form** — the same literal top-region grammar `mount` takes,
    wrappers included, tightened to exactly **one mounted view** per test root
    (§1.1's authored-`:root-id` multi-view allowance does not apply here; two views →
@@ -503,8 +503,9 @@ server in sight (guide 01):
    - `{:props p}` is **rejected** (didactic: props live in the form);
    - the form's `frame-root` plans run preflight ENSURE against the test registrar,
      minting fresh test frames from the plans;
-   - `{:frame f}`/`{:app-db v}` alongside a plan-bearing root form is **rejected**
-     (*"the root form owns its frames — pass a bare view to control the frame"*).
+   - `{:frame f}` alongside a plan-bearing root form is **rejected**
+     (*"the root form owns its frames — pass a bare view to control the frame"*);
+     with a plan-free form it combines.
      `[S1-CONFIRM]` — 07 §2 is silent on this combination; rejection is the
      conservative contract (no ambiguity about which frame is ambient).
 
@@ -544,5 +545,5 @@ unregisters (a leaked registration failing a later mount is a test-harness bug, 
    alongside the Spec 011 payload-encoding rows.
 2. **§7** — entry-point-closure scoping as the build-time projection of "one page" for
    duplicate root-id detection (vs. whole-build strictness).
-3. **§9** — rejection of `{:frame …}`/`{:app-db …}` combined with a plan-bearing root
+3. **§9** — rejection of `{:frame …}` combined with a plan-bearing root
    form in `ui.test/render`.


### PR DESCRIPTION
## Summary

Active v1-required Spec 004C §9 still taught the `ui.test/render` `{:app-db v}` option that PR #5955 removed. That PR's code refactor (`454ece548d`) closed the render opts and dropped the `ui.test/frame` helper; its docs reconciliation (`7e42110e2b`) fixed Specs 004/008/009/API but missed 004C, leaving active programmer/AI drift in the authoritative root/mount contract.

## Stale grammar removed (all in `spec/004C-Roots-and-Mount.md` §9 + register)

- L495 (form 1, view reference): `Frames ride {:frame f} XOR {:app-db v} (test frame minted)` → `A frame rides {:frame f} — mint it with rf/make-frame + :initial-events`.
- L506 (form 2, plan-bearing rejection): `{:frame f}/{:app-db v} alongside a plan-bearing root form is rejected` → `{:frame f} alongside a plan-bearing root form is rejected; with a plan-free form it combines`.
- L547 ([S1-CONFIRM] register #3): dropped the `/{:app-db …}` clause.

## Shipped behaviour proving the grammar stale

- `implementation/ui/src/re_frame/ui/test.cljc:836-843` — render opts are CLOSED to `:frame`, `:props` (bare-view only), `:sub-overrides`; any other key (including `:app-db`) is rejected. No `:app-db` construction door exists.
- `test.cljc:735`, `:1201-1202` — a test frame is minted by the caller with `rf/make-frame` + `:initial-events`.
- `test.cljc:848` — `{:frame …}` is rejected only on a plan-bearing root form; it combines with plan-free forms.
- The `ui.test/frame` helper no longer exists (removed in `454ece548d`).

Matches the one-grammar rule already applied to Specs 004/008/009/API in PR #5955. Narrow prose-only change; no runtime or public API change.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_keyword_catalogue_drift.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (only pre-existing INFO messages, no warnings)

Closes rf2-p9mmd.
