### PR TITLE
docs(core): finish frame-root wording in core frame-resolution guidance (rf2-6uaav)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -418,10 +418,12 @@
 ;;
 ;; Per Spec 002 §Frame target resolution — the carried invariant (EP-0002):
 ;; **frame identity is carried, not found.** A frame-scoped operation reads
-;; its frame from the causal token it holds — the dynamic scope a `with-frame`
-;; / frame-provider established, or a frame stamp it captured. It never
-;; *synthesises* one from absence: there is no process-global `:rf/default`
-;; floor that catches operations issued under no scope at all.
+;; its frame from the causal token it holds — the ambient scope established
+;; by `with-frame` (dynamic var) or by the closest enclosing frame boundary,
+;; a `frame-provider` (SCOPE) or a `frame-root` (ENSURE), or a frame stamp it
+;; captured. It never *synthesises* one from absence: there is no process-
+;; global `:rf/default` floor that catches operations issued under no scope
+;; at all.
 ;;
 ;; The rationale leads with **replay determinism + temporal non-locality**,
 ;; NOT purity (per EP-0002 §Resolved Decisions R1-R7):
@@ -574,9 +576,11 @@
                              "context — no carried frame stamp and no established "
                              "scope. Frame identity is carried, not found: declare "
                              "your root frame (rf/make-frame) and run the operation "
-                             "inside that scope (with-frame / a frame-provider), or "
-                             "pass an explicit {:frame <id>}. Per Spec 002 §The error "
-                             "and its ladder.")}
+                             "inside that scope (with-frame, or an enclosing frame "
+                             "boundary — a frame-provider that scopes an existing "
+                             "frame, or a frame-root that ensures one), or pass an "
+                             "explicit {:frame <id>}. Per Spec 002 §The error and "
+                             "its ladder.")}
           ;; Capture-site ancestry off the in-scope handler scope: the
           ;; cascade's dispatch-id correlates a stampless continuation back
           ;; to the cascade that captured the callback. nil outside any

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1499,9 +1499,10 @@
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity ambient form
   resolves the active frame through the carried-invariant scope/hold
-  chain via `frame/require-current-frame!` (EP-0002): a `with-frame` /
-  frame-provider scope (the `:adapter/current-frame` late-bind hook)
-  or a captured `*current-frame*` stamp. There is NO
+  chain via `frame/require-current-frame!` (EP-0002): a `with-frame`
+  scope, or the closest enclosing frame boundary — a `frame-provider`
+  (SCOPE) or a `frame-root` (ENSURE), via the `:adapter/current-frame`
+  late-bind hook — or a captured `*current-frame*` stamp. There is NO
   `:rf/default` floor — a subscribe issued under no established scope
   raises `:rf.error/no-frame-context` rather than silently reading the
   wrong frame. Pass the public opts form `(subscribe query-v {:frame


### PR DESCRIPTION
Finishes the `frame-root` wording in the core frame-resolution guidance (rf2-6uaav). PR #5947 corrected the active frame-context docstrings and #6014 swept the wider comments/error-strings, but three exhaustive descriptions still named `frame-provider` (SCOPE) without the equally valid `frame-root` (ENSURE) boundary. Both install the shared React-context frame boundary, so ambient resolution reaches a frame through either — the omissions misdirected implementers and anyone reading a public docstring or a live recovery message.

Prose-only, three-site correction. Zero runtime-logic changes.

## What was incomplete (file:line)

- `implementation/core/src/re_frame/frame.cljc` L421-422 — the carried-invariant comment: "the dynamic scope a `with-frame` / frame-provider established" (no `frame-root`).
- `implementation/core/src/re_frame/frame.cljc` L577 — the `:rf.error/no-frame-context` recovery `:reason` string: "inside that scope (with-frame / a frame-provider)" (no `frame-root`).
- `implementation/core/src/re_frame/subs.cljc` L1502-1503 — the `subscribe` docstring: "a `with-frame` / frame-provider scope" (no `frame-root`), inconsistent with its own correct inline comment directly below (L1538-1540).

## The finished wording

Each site now describes ambient resolution through `with-frame` plus the closest frame boundary, explicitly naming `frame-provider` (SCOPE) and `frame-root` (ENSURE), preserving the roots-ensure / providers-scope distinction:

- Carried-invariant comment: "the ambient scope established by `with-frame` (dynamic var) or by the closest enclosing frame boundary, a `frame-provider` (SCOPE) or a `frame-root` (ENSURE), or a frame stamp it captured."
- Recovery `:reason`: "run the operation inside that scope (with-frame, or an enclosing frame boundary — a frame-provider that scopes an existing frame, or a frame-root that ensures one), or pass an explicit {:frame <id>}." — both valid public choices, neither implying a hidden default.
- `subscribe` docstring: "a `with-frame` scope, or the closest enclosing frame boundary — a `frame-provider` (SCOPE) or a `frame-root` (ENSURE), via the `:adapter/current-frame` late-bind hook — or a captured `*current-frame*` stamp." Now matches the inline comment.

## Classified grep (other `frame-provider` occurrences)

Confirmed the remaining provider-only occurrences do not need this fix:

- `frame.cljc` L485-494 (`resolve-current-frame`), L781 (`bind-fn`), and `subs.cljc` L1538-1540 (subscribe inline comment) — already name both boundaries. No change.
- `frame.cljc` L620-703 — the `:rf.error/bad-frame-provider-arg` family is genuinely provider-specific: it validates `frame-provider`'s `:frame` arg; `frame-root` uses `:id` with a distinct `:rf.error/frame-root-missing-id`. No change.
- `frame.cljc` L178 — the value-normalization seam names `frame-provider` as a frame-value funnel; `frame-root` takes `:id`, not a frame value/target. Genuinely provider-specific. No change.

Out of this bead's scope (three named core resolution sites; no broad sweep) but noted for potential follow-up: the `:rf.error/frame-construction-in-handler` message (`frame.cljc` L2758/2775/2777) says "Frames are created by the VIEW (frame-provider)". That is frame-**creation** guidance, not frame-**resolution**; per the SCOPE/ENSURE split it is `frame-root` (ENSURE) that creates in the view while `frame-provider` (SCOPE) creates nothing — a separate accuracy question deserving its own bead. Independent spec prose (`spec/012-Routing.md`, `spec/009-Instrumentation.md`) and two test-ns docstrings also mention provider-only in resolution contexts; left untouched (hot-zone spec / non-core surfaces, no broad sweep).

## Quality gates

- `implementation/core` JVM (`clojure -M:test`): 2025 tests, 9452 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 9691 tests, 47673 assertions, 0 failures, 0 errors.
- No markdown docs page mirrors the changed wording (the `subscribe` docstring is not mirrored; the `:reason` string appears only in the compiled `docs/cljs/playground-rf2.js` bundle), so `mkdocs`/`check_doc_slugs.py` are not implicated. The SCI-bundle freshness gate (`scripts/check-playground-sci-freshness.sh`) checks only the machine-lifecycle marker keyword, not this prose, so the change does not affect it; the committed bundle is a build artifact regenerated on docs publish.

No tests assert on the changed prose strings (verified). No coordination collision with rf2-01ihi — all edits are in prose regions (a comment, a recovery `:reason`, a docstring), none touch the stale-frame-bundle fail-closed fence.
